### PR TITLE
Sync from ADO: Clean up Reactor build warnings (PR 15346990)

### DIFF
--- a/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj
+++ b/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>

--- a/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -2,7 +2,6 @@ using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Data;
 using Microsoft.UI.Reactor.Layout;
 using Microsoft.UI.Reactor.Controls;
-using Microsoft.UI.Reactor.Controls;
 using Microsoft.UI.Xaml;
 using Windows.System;
 using static Microsoft.UI.Reactor.Factories;
@@ -828,7 +827,7 @@ public class DataGridComponent<T> : Component<DataGridElement<T>>
             if (el.AllowColumnResize || el.AllowColumnReorder)
             {
                 // Overlay the header content and optional resize grip / reorder handler.
-                var overlayChildren = new List<Element?>
+                var overlayChildren = new List<Element>
                 {
                     headerContent.Grid(row: 0, column: 0)
                 };

--- a/Reactor/Controls/DataGrid/DataGridState.cs
+++ b/Reactor/Controls/DataGrid/DataGridState.cs
@@ -1,6 +1,5 @@
 using Microsoft.UI.Reactor.Data;
 using Microsoft.UI.Reactor.Controls.Validation;
-using Microsoft.UI.Reactor.Controls.Validation;
 
 namespace Microsoft.UI.Reactor.Controls;
 

--- a/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
+++ b/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
@@ -179,7 +179,7 @@ public class PropertyGridComponent : Component<PropertyGridElement>
                 }
             };
 
-            var fullEditorContent = meta.FullEditor(currentValue, onChange);
+            var fullEditorContent = meta.FullEditor(currentValue!, onChange);
             editor = FlexRow(
                 editor.Flex(grow: 1),
                 Button("\u2026", () => { })

--- a/Reactor/Core/Reconciler.Update.cs
+++ b/Reactor/Core/Reconciler.Update.cs
@@ -1518,7 +1518,9 @@ public sealed partial class Reconciler
             // The factory keeps its identity; existing realized items
             // stay mounted. On next scroll or layout, GetElementCore
             // uses the updated viewBuilder to produce new content.
+#pragma warning disable CS8305 // ElementFactory is evaluation-only; we control WinUI versions and rely on this API.
             if (repeater.ItemTemplate is ElementFactory existingFactory && n.TryUpdateFactory(existingFactory))
+#pragma warning restore CS8305
             {
                 // Item count may have changed — update the source
                 var newSource = n.GetItemsSource();

--- a/Reactor/Yoga/FlexPanel.cs
+++ b/Reactor/Yoga/FlexPanel.cs
@@ -11,7 +11,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Reactor.Layout;
-using Microsoft.UI.Reactor.Layout;
 using Windows.Foundation;
 
 namespace Microsoft.UI.Reactor.Layout;


### PR DESCRIPTION
Mirroring the latest merge on the ADO source-of-truth (`andersonch.Patch` / PR 15346990) into the GitHub mirror.

## Upstream commit

`8550e0d` — Clean up Reactor build warnings after Duct rename

- Remove duplicate `using` directives (CS0105) in DataGrid and FlexPanel left behind by the Duct → Reactor rename
- Fix latent nullable warnings: CS8604 in PropertyGridComponent and CS8620 in DataGridComponent overlay children
- `#pragma warning disable CS8305` around the `ElementFactory` usage in `Reconciler.Update` — we control the WinUI version and rely on this API
- Set `PlatformTarget=AnyCPU` on `Reactor.Localization.Generator.csproj` so the source-generator DLL is arch-neutral instead of inheriting `Platform=x64` and tripping CS8034 on load

## Verification (from upstream PR)

- [x] Full rebuild of Reactor — 0 warnings, 0 errors
- [x] `dotnet test tests/Reactor.Tests` — 3515 passed, 0 failed
- [x] AppTests self-test — 0 failures
- [x] stress_perf 50% @ 7s across all 6 variants — clean

## Sync policy

Going forward, each ADO merge gets pushed to a `sync/ado-<sha>` branch here and opens a PR — no more force-pushes to `main`.