### PR TITLE
Add GitHub Actions CI for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore
+        run: dotnet restore tests/Reactor.Tests/Reactor.Tests.csproj
+
+      - name: Test
+        run: dotnet test tests/Reactor.Tests/Reactor.Tests.csproj --no-restore --logger "console;verbosity=normal"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     name: Unit Tests
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c0f7d5c7f4f9b55b6f3f14a6f2c3c1d52f8a1c2e # v4
         with:
           dotnet-version: 9.0.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     name: Unit Tests
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@c0f7d5c7f4f9b55b6f3f14a6f2c3c1d52f8a1c2e # v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: 9.0.x
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running `dotnet test tests/Reactor.Tests` on every PR and push to `main`
- Uses `windows-latest` since the test project targets `net9.0-windows10.0.22621.0` (WinUI)
- Scopes restore/test to the `Reactor.Tests.csproj` project graph to avoid building WinUI host apps and samples on every PR

## Test plan
- [ ] Workflow runs on this PR and passes
- [ ] Workflow runs on subsequent PRs
- [ ] Workflow runs on push to `main`

Verified locally: 3518 passed, 0 failed, 46 skipped.

Generated with [Claude Code](https://claude.com/claude-code)