### PR TITLE
docs: add Blazor as a Microsoft framework in comparative analysis

### DIFF
--- a/docs/compare/blazor.md
+++ b/docs/compare/blazor.md
@@ -1,0 +1,645 @@
+# Blazor — Framework Analysis
+
+**Purpose:** Critical technical analysis for comparison against the other Microsoft UI frameworks (WinForms, WPF, WinUI 3, Reactor) and the competitor lineup (SwiftUI, Compose, React, Flutter, Avalonia).
+
+**Version analyzed:** Blazor in .NET 9 (Nov 2024) and .NET 10 (Nov 2025), part of ASP.NET Core.
+
+---
+
+## Overview
+
+Blazor is Microsoft's component-based UI framework for building interactive web UIs with C# instead of JavaScript, first released in 2020 as part of ASP.NET Core 3.1. It is Microsoft's *web* answer to React/Vue/Angular — but it also has a desktop-hosting side door (**Blazor Hybrid** via `BlazorWebView` in WPF, WinForms, and MAUI) that makes it relevant alongside the desktop stack. In this analysis Blazor is categorized as a **Microsoft framework** — a peer of WinForms/WPF/WinUI 3/Reactor — because its primary delivery is Microsoft-owned and its Hybrid mode directly overlaps Reactor's problem domain.
+
+Blazor is the only declarative, component-based UI framework Microsoft ships today. Its architecture is conceptually close to React (tree-diffing reconciler, parameter-driven data flow, a virtual-DOM-style render tree) but its reactivity model is notably manual (`StateHasChanged()`), its routing uses Razor's `@page` directive strings, and its form/validation story is genuinely excellent.
+
+The .NET 8 "Blazor United" effort (shipped Nov 2023, refined through .NET 10) consolidated what used to be separate Server and WebAssembly project templates into a single **Blazor Web App** that can mix four render modes per component: Static SSR, Interactive Server, Interactive WebAssembly, and Interactive Auto. The .NET 10 release (Nov 2025) shrank the `blazor.web.js` bundle by ~76% (183 KB → 43 KB) and introduced `[PersistentState]` for prerender → interactive handoff.
+
+---
+
+## 1. Declarative Model & Syntax
+
+**Razor:** Blazor components are `.razor` files — a templating language that mixes HTML-like markup with C# expressions. The Razor compiler emits a C# class derived from `ComponentBase` with a `BuildRenderTree(RenderTreeBuilder builder)` method. `@code { }` blocks hold component logic. `@if`, `@foreach`, `@bind` are C#-side directives that compile to standard control flow.
+
+**Strengths:**
+- Razor co-locates markup and logic in a single `.razor` file, comparable to JSX's co-location story
+- Full C# expressiveness inside `@{ }` — type-safe, LSP-aware, refactorable
+- Control flow uses native C# (`@if`, `@foreach`, `@switch`) rather than special directives
+- Mature tooling in Visual Studio and JetBrains Rider (syntax highlighting, IntelliSense, refactoring, Roslyn analyzers)
+- TypeScript equivalent is unnecessary — you already have C# end-to-end
+
+**Weaknesses:**
+- Razor is a separate language requiring a build step; error messages can reference generated code rather than the `.razor` source
+- No compile-time view validation on parameter types vs. passed values (unlike SwiftUI's type-checked body or Compose's compiler plugin enforcing `@Composable`)
+- Three syntax concepts to learn: HTML, Razor directives, and C# — vs SwiftUI/Compose which are pure Swift/Kotlin
+- Markup-and-code mixing is less composable than function-as-component models (can't easily pass a "piece of view" around as a first-class value beyond `RenderFragment`)
+
+**Sources:** [ASP.NET Core Razor components (Microsoft Learn)](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/)
+
+---
+
+## 2. Component Architecture
+
+**ComponentBase:** Every Razor component derives from `ComponentBase` (unless you implement `IComponent` directly). Parameters are public properties annotated with `[Parameter]`. Parent→child data flow uses parameters; child→parent uses `EventCallback<T>`.
+
+**Key patterns:**
+- **`[Parameter]`** — input property, bound from parent markup
+- **`[CascadingParameter]`** — receives value from ancestor `<CascadingValue>` component (Blazor's Context equivalent)
+- **`EventCallback<T>`** — typed event delegate that **auto-triggers a re-render of the subscriber** (see §3)
+- **`RenderFragment` / `RenderFragment<T>`** — first-class "piece of UI" values, equivalent to React children / render props
+- **`[SupplyParameterFromQuery]`** / **`[SupplyParameterFromForm]`** — bind to URL or form data
+- **`IComponentRenderMode`** — attribute-driven per-component render mode (Server/WebAssembly/Auto)
+
+**Lifecycle hooks:** `OnInitialized`/`OnInitializedAsync`, `OnParametersSet`/`OnParametersSetAsync`, `OnAfterRender`/`OnAfterRenderAsync`, `ShouldRender`, `Dispose`. Roughly equivalent to React's class-component lifecycle before hooks existed.
+
+**Strengths:**
+- Type-safe parameter passing — the Razor compiler enforces parameter types at component call sites
+- `RenderFragment` is first-class — a `@RenderFragment` can be stored, passed, and invoked like any C# value
+- `EventCallback<T>` is an elegant primitive (more on this below)
+- Source generators + `partial class` split let you keep `.razor` markup and `.razor.cs` code-behind cleanly separated
+- `<CascadingValue IsFixed="true">` is an explicit perf opt-in — ancestors that never change don't subscribe descendants to re-render
+
+**Weaknesses:**
+- **Class-based components are a generation behind function-as-component models** (React hooks, SwiftUI structs, Compose `@Composable` functions). There is no hook equivalent in core Blazor
+- Cross-cutting logic reuse requires base classes or mixins via interfaces — no equivalent to React custom hooks or Compose composables
+- `[CascadingParameter]` is coarser than React Context — it has no selector story, consumers re-render on any change unless `IsFixed="true"`
+- Lifecycle method proliferation (5 overrides, each with sync/async variants) is verbose compared to hooks
+- `StateHasChanged()` leaks into component code as explicit re-render triggers (see §3)
+
+**Sources:** `src/Components/Components/src/ComponentBase.cs`, `src/Components/Components/src/CascadingValue.cs`
+
+---
+
+## 3. State Management & Reactivity
+
+**The `StateHasChanged` model:** Blazor has **no automatic reactivity tracking**. The render pipeline runs when `ComponentBase.StateHasChanged()` is called, which the framework does automatically in three cases (verified in `ComponentBase.cs`):
+
+1. After a lifecycle method completes (`OnInitialized`, `OnParametersSet`, `OnAfterRender`)
+2. After a parameter change from a parent
+3. After an `EventCallback` fires — `ComponentBase.HandleEventAsync` calls `StateHasChanged()` immediately after invoking the delegate (ComponentBase.cs:355-367: "This just saves the developer the trouble of putting `StateHasChanged()`")
+
+Anything else — a timer tick, a SignalR push, a property change on an injected service, a background `Task` completion, a JS interop callback, an `INotifyPropertyChanged` event — **requires explicit `StateHasChanged()` calls**, typically via `InvokeAsync(StateHasChanged)` to marshal onto the renderer's sync context.
+
+**Built-in primitives:** None beyond fields on the component class. Blazor does not ship `useState`, signals, or an observable store.
+
+**Ecosystem libraries (filling the gap):**
+- **Fluxor** — Redux-style unidirectional state (the de facto enterprise choice)
+- **Blazor-State** — MediatR-based state management
+- **Skclusive.Mobx.Observable** — MobX port for auto-tracking
+- **phork-blazor-reactivity** — lightweight reactive state library
+
+**Strengths:**
+- Explicit render model is easy to reason about — no "why did this re-render?" mystery
+- `EventCallback<T>` eliminates `StateHasChanged()` boilerplate for the common case (child event → parent re-render)
+- No dependency-array bugs (the #1 React bug category doesn't exist)
+
+**Weaknesses:**
+- **This is Blazor's biggest ergonomic weakness.** SwiftUI `@Observable`, React hooks, Compose Snapshot, Vue reactivity, and Solid signals all converge on automatic dependency tracking. Blazor does not
+- `InvokeAsync(StateHasChanged)` sync-context marshaling is a concept developers must learn and apply correctly
+- `[CascadingParameter]` has no selector — all consumers re-render on any change (same problem React Context has, with no ecosystem fix)
+- External state stores (services, `INotifyPropertyChanged`, observables) require manual wiring to `StateHasChanged()`
+
+**Sources:** `src/Components/Components/src/ComponentBase.cs` (HandleEventAsync, StateHasChanged)
+
+---
+
+## 4. Rendering & Performance
+
+**Render tree with sequence numbers:** Blazor uses a virtual-DOM-like **render tree** but with a key architectural optimization: the Razor compiler injects **compile-time sequence numbers** into every `OpenElement`/`AddContent`/`AddAttribute` call. At diff time, the renderer uses these sequence numbers to do a **linear-time diff** rather than React's general tree-diffing algorithm. This is why Microsoft's docs explicitly discourage writing `BuildRenderTree` by hand — incorrect sequence numbers produce pathological diffs.
+
+**RenderBatch + Dispatcher:** The renderer collects changes into a `RenderBatch` and dispatches them to the appropriate output (HTML diffs over SignalR, direct DOM patches in WebAssembly, WebView2 in Hybrid). Batching consolidates multiple state changes into a single update.
+
+**Render mode impact on performance:**
+- **Static SSR** — zero client JS, fastest initial load, no interactivity
+- **Interactive Server** — sub-ms UI updates after connection, but each interaction is a SignalR round-trip (latency-sensitive)
+- **Interactive WebAssembly** — zero network per interaction, but a hefty initial download (runtime + framework + app, often hundreds of KB even post-trim)
+- **Interactive Auto** — starts as Server, upgrades to WebAssembly in the background
+
+**WASM specifics:** AOT (`<RunAOTCompilation>true</RunAOTCompilation>`) improves runtime perf but *increases* payload. `WasmStripILAfterAOT` strips IL from AOT-compiled methods. IL trimming is on by default for publish builds.
+
+**Strengths:**
+- Compile-time sequence numbers are a genuine architectural win — O(n) diffs instead of React's O(n³→n) heuristic
+- `ShouldRender` override is the explicit perf escape hatch (equivalent to `React.memo`)
+- `@key` directive stabilizes identity across list reorders (same role as React's `key`)
+- `<CascadingValue IsFixed="true">` opts out of re-subscription for values that never change
+- Server mode's DOM-diff-over-wire is extremely efficient *when latency is low*
+- Render mode per component lets you put interactivity only where needed
+
+**Weaknesses:**
+- **WebAssembly initial download remains the headline complaint.** GitHub issue `dotnet/aspnetcore#41909` ("Blazor wasm size and load time is the worst and biggest problem ever") captures the community sentiment. Even trimmed/AOT'd, the floor is hundreds of KB before app code
+- Server mode is **latency-sensitive** — every click is a round-trip; users far from the server see tens-to-hundreds of ms perceived lag
+- Server mode is **stateful on the server** — circuits consume memory per connected user, eviction on disconnect loses UI state (`[PersistentState]` in .NET 10 helps but is opt-in)
+- No concurrent rendering / priority-based scheduling (unlike React 18's Fiber + transitions)
+- No compiler-based auto-memoization (unlike React Compiler 1.0)
+
+**Sources:** [Blazor RenderTree Explained (InfoQ)](https://www.infoq.com/articles/blazor-rendertree-explained/), [ASP.NET Core Blazor rendering performance (Microsoft Learn)](https://learn.microsoft.com/en-us/aspnet/core/blazor/performance/rendering), [dotnet/aspnetcore#41909](https://github.com/dotnet/aspnetcore/issues/41909)
+
+---
+
+## 5. Layout System
+
+Blazor renders to HTML in all render modes (including Hybrid, which hosts HTML in a WebView). Layout is entirely **CSS-delegated** — Flexbox, Grid, utility frameworks (Tailwind), whatever. Blazor has no framework-level layout primitive.
+
+**Strengths:**
+- Full CSS ecosystem — Flexbox, Grid, container queries, anything the browser supports
+- Tailwind integrates cleanly
+- Responsive design is a CSS concern (media queries, container queries), not a framework concern
+
+**Weaknesses:**
+- **No framework-level layout abstraction** — same criticism as React
+- No equivalent to WinUI 3's `Grid` or Reactor's `FlexPanel` (because it's just CSS)
+- No built-in responsive breakpoint system
+
+**Rating: B+** — Delegating to CSS is fine; the ecosystem is powerful; Blazor contributes nothing on top.
+
+---
+
+## 6. Styling & Theming
+
+**CSS Isolation (scoped CSS):** The one distinctive Blazor styling feature. A `MyComponent.razor` file can have a sibling `MyComponent.razor.css`; the Razor build rewrites selectors with a generated `b-xxxxxxx` attribute that gets added to every element the component renders. This provides per-component CSS scoping without runtime cost.
+
+**Limitation:** CSS isolation's `b-xxx` attribute is only added to elements the component directly renders. **Third-party component libraries don't participate** — they're precompiled with their own (or no) scoping, so `.my-class` selectors in your isolated CSS won't reach MudBlazor/Radzen/Fluent UI Blazor internals. Proposal `dotnet/aspnetcore#63091` tracks a fix, unshipped at time of writing.
+
+**Design system:** Blazor has no built-in look-and-feel beyond raw HTML. The ecosystem fills this:
+- **Microsoft Fluent UI Blazor** (`Microsoft.FluentUI.AspNetCore.Components`) — official Microsoft library, wraps FAST web components
+- **MudBlazor** — Material-inspired, community favorite, MIT licensed
+- **Radzen.Blazor** — free + paid IDE tooling
+- **Telerik**, **Syncfusion**, **DevExpress** — commercial, comprehensive
+
+**Theming:** Handled by whichever component library you choose; no framework-level theme abstraction.
+
+**Strengths:**
+- CSS isolation without runtime cost is genuinely nice
+- Plain CSS + CSS custom properties give native theming
+- Multiple strong component libraries exist
+
+**Weaknesses:**
+- **No built-in design system** — every project must pick and configure
+- **CSS isolation doesn't extend to third-party components** — open since 2020s-era, unfixed
+- No compile-time validation of class name references
+
+**Rating: B** — Ecosystem solutions are strong; framework-level story is thin.
+
+---
+
+## 7. Navigation
+
+**`@page` directive:** Components annotate themselves with `@page "/products/{id:int}"` to register routes. Multiple `@page` directives per component are allowed. The `Router` component (in `Components.Routing`) walks the route table and renders the matching component.
+
+**Route constraints:** `bool`, `datetime`, `decimal`, `double`, `float`, `guid`, `int`, `long`, `nonfile` (newer). Regex constraints supported in recent versions.
+
+**`NavigationManager`:** Injected service for programmatic navigation, URI parsing, and `LocationChanged`/`LocationChanging` events.
+
+**Type safety:** Route templates are **string literals with no compile-time type safety**. `NavigateTo("/products/abc")` does not verify against the `{id:int}` constraint at build time. Community libraries (Blazor.StrongRouter and friends) attempt to solve this, but nothing is canonical.
+
+**Strengths:**
+- Route constraints cover the common primitive types
+- Multi-route per component works cleanly
+- `NavigationManager`'s `LocationChanging` event (with cancellation) is good for unsaved-changes guards
+- URL-based deep linking is native (it's the web)
+
+**Weaknesses:**
+- **No type-safe route navigation** — React's TanStack Router, Compose Nav 3, and Reactor's typed-record routes are all ahead here
+- No nested-route composition equivalent to React Router v6+ layouts (though `_Layout.razor` provides some of this)
+- Lazy loading of routes is possible but configuration-heavy
+
+**Rating: B** — Functional and mature; weak on type safety compared to modern alternatives.
+
+**Sources:** `src/Components/Components/src/Routing/Router.cs`, [ASP.NET Core Blazor routing (Microsoft Learn)](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing)
+
+---
+
+## 8. Animation
+
+Blazor has **no first-class animation system**. Options:
+- **CSS transitions and animations** — zero-JS, limited to what CSS can express
+- **Blazor.Animate**, **blazor-transition-group**, **Toolbelt.Blazor.ViewTransition** — small community libraries, fragmented
+- **JS interop** to larger JS animation libraries (GSAP, Motion) — possible but awkward
+- **View Transitions API** (browser-native) — accessible via JS interop
+
+**Strengths:**
+- CSS transitions are free and perform well for simple cases
+- View Transitions API (shipping in browsers) gives cross-page transitions
+
+**Weaknesses:**
+- **No framework-level animation support** — exit animations in particular are awkward because Blazor removes DOM nodes synchronously when state changes
+- Ecosystem libraries are small and fragmented — nothing approaching Motion for React, SwiftUI's `.animation()`, or Compose's animation APIs
+- `@key` + CSS transitions is the "standard" pattern but requires careful DOM manipulation to work
+
+**Rating: C** — CSS is a floor, not a ceiling; Blazor adds nothing above it.
+
+---
+
+## 9. Accessibility
+
+Blazor's accessibility story is **"inherit whatever HTML you render."** Microsoft Learn's Blazor accessibility guidance is essentially "use semantic HTML + ARIA attributes correctly." The framework provides:
+- No accessibility primitives beyond what HTML offers
+- No framework-level automation tree (unlike WinUI 3's UIA inheritance)
+- No accessibility linting or analyzers shipped with the framework
+
+What you get "for free" depends entirely on the component library:
+- **Fluent UI Blazor** — FAST components manage ARIA automatically
+- **Telerik** — targets WCAG 2.2 and WAI-ARIA 1.2
+- **Syncfusion** — claims WCAG 2.2 / Section 508 / ADA compliance
+
+**Strengths:**
+- Web accessibility standards (semantic HTML, ARIA, keyboard nav) are the most mature accessibility model on any platform
+- Screen readers, high-contrast modes, zoom, and keyboard nav are browser-platform features
+- Quality component libraries provide comprehensive a11y out of the box
+
+**Weaknesses:**
+- **Framework contributes nothing on top of HTML** — same limitation as React
+- Custom components (comboboxes, date pickers, dialogs) must be built accessibly from scratch
+- No static analysis for a11y violations at the framework level (unlike `eslint-plugin-jsx-a11y` for React)
+- Accessibility is entirely a library/developer concern
+
+**Rating: B** — Web a11y is solid; Blazor adds nothing.
+
+---
+
+## 10. Input & Gestures
+
+**Input events:** Blazor wraps DOM events with typed `.NET` event handlers (`@onclick`, `@onchange`, `@onkeydown`, etc.). Arguments are typed (`MouseEventArgs`, `KeyboardEventArgs`, `ChangeEventArgs`). Event delegation is to the renderer root. Stop-propagation and prevent-default are declarative: `@onclick:stopPropagation="true"`.
+
+**Form inputs:** First-class `<InputText>`, `<InputNumber>`, `<InputDate>`, `<InputCheckbox>`, `<InputSelect>`, `<InputRadioGroup>`, `<InputTextArea>`, `<InputFile>` wrap native inputs with two-way binding, validation integration, and accessibility markup.
+
+**Gestures:** No built-in gesture system. Touch events (`@ontouchstart`, etc.) are available; drag-drop via HTML5 drag events; anything richer requires JS interop.
+
+**Strengths:**
+- Typed event argument types are safer than React's `SyntheticEvent`
+- Declarative `stopPropagation`/`preventDefault` is ergonomic
+- The `<Input*>` components are genuinely polished — validation, binding, and accessibility integrated
+- Form actions via `EditForm` + `[SupplyParameterFromForm]` (§19) make server-rendered forms first-class
+
+**Weaknesses:**
+- **No gesture system** — same gap as React
+- Multi-touch / pinch / pan require JS interop or third-party libs
+- No equivalent to Flutter's gesture arena or SwiftUI's gesture composition
+
+**Rating: B+** — Strong inputs, weak gestures.
+
+---
+
+## 11. Developer Experience
+
+**Tooling:**
+- **Visual Studio 2022/2025** — first-class Razor support, IntelliSense, refactoring
+- **JetBrains Rider** — also strong; implemented its own WASM debugger in 2023
+- **VS Code** — via C# Dev Kit + Blazor extension; less polished than VS
+- **Hot Reload** — works across Server, WebAssembly, Hybrid in .NET 9+. Razor edits, C# method bodies, CSS generally reload. Structural changes (adding a `[Parameter]`, removing a component) often require a restart. The `microsoft/vscode-dotnettools` repo has a long-running Hot Reload reliability tracker
+- **Browser DevTools** — standard web DevTools work (F12 in the browser)
+- **No DevTools-equivalent for Blazor components** — no tree inspector, no parameter inspector, no render-count profiler. This is a notable gap vs React DevTools, Flutter Widget Inspector, Compose Layout Inspector
+
+**Ecosystem libraries:**
+- **Fluent UI Blazor** (Microsoft, MIT)
+- **MudBlazor** (Material-inspired, MIT, community favorite)
+- **Radzen.Blazor** (free + paid IDE)
+- **Telerik**, **Syncfusion**, **DevExpress** (commercial)
+
+**Debugging:**
+- **Server mode** — standard .NET debugging, works cleanly
+- **WebAssembly** — debug proxy bridges browser → .NET; fragile, breakpoints before proxy attaches (e.g., early `Program.cs`) don't always hit
+- **Hybrid** — in-process .NET debugging + WebView inspector; better than pure WASM
+
+**Strengths:**
+- Mature Roslyn-based tooling (years of investment)
+- Hot Reload works well for common edits
+- Unified C# end-to-end reduces context switching
+- Rider's WASM debugger is good
+
+**Weaknesses:**
+- **No component DevTools** — can't inspect the render tree, parameter values, or render counts the way React/Compose developers can
+- WASM debugging complexity (debug proxy handshake, timing issues)
+- Hot Reload reliability issues on VS Code
+- Project setup for Blazor Web App requires understanding four render modes before you can choose confidently
+
+**Rating: B** — Tooling is mature; component DevTools are the big gap.
+
+---
+
+## 12. Platform Reach & Ecosystem
+
+**Platforms:**
+- **Web** (primary) — browser via WebAssembly or Server (SignalR)
+- **Desktop** — Blazor Hybrid in WPF, WinForms (Windows), MAUI (Windows, Mac); hosts Razor components in a `BlazorWebView` backed by WebView2/WKWebView
+- **Mobile** — Blazor Hybrid in .NET MAUI (iOS, Android)
+- **Static site generation** — Blazor Web App can produce prerendered-only pages
+
+**Ecosystem scale:** Small compared to React (~34k Blazor customers per Telerik's 2025 numbers; React's ecosystem is orders of magnitude larger). Growing, but Stack Overflow coverage, NuGet package selection, and tutorial availability are all meaningfully behind React/Vue.
+
+**Strengths:**
+- **Unified codebase across web + desktop + mobile** via Hybrid — arguably the broadest platform reach of any Microsoft framework
+- C# all the way (no JavaScript learning curve for .NET teams)
+- Microsoft-backed, first-party
+
+**Weaknesses:**
+- **Hybrid rendering is not native** — BlazorWebView hosts HTML in a WebView, so desktop/mobile apps don't get platform-native controls, native accessibility trees, or platform-native look-and-feel
+- Smaller ecosystem than React/Vue
+- WebAssembly initial-load cost on web
+- Platform API access in Hybrid requires JS interop bridges for anything not exposed by MAUI
+
+**Rating: B+** — Platform reach via Hybrid is broad; "not native" is the headline caveat for desktop/mobile.
+
+---
+
+## 13. Testing
+
+**bUnit:** The canonical Blazor component-testing library. Microsoft Learn officially endorses it in the Blazor testing docs. Features:
+- Render components in isolation, pass parameters, inject services, fire events
+- Assert on rendered markup via semantic HTML comparer (whitespace/attribute-order insensitive)
+- Mock `IJSRuntime` with `bUnit.JSInterop`
+- xUnit, NUnit, MSTest, TUnit compatible
+- Milliseconds per test (vs seconds for Playwright/Selenium)
+
+**E2E:** Playwright, Selenium, or Cypress hit a real browser.
+
+**Strengths:**
+- **bUnit is the best testing story of any Microsoft UI framework** — fast, semantic, renderer-level, officially supported
+- Semantic HTML comparer produces non-brittle assertions
+- Mock infrastructure for JS interop, NavigationManager, auth state is built in
+
+**Weaknesses:**
+- No JavaScript execution in bUnit — must mock `IJSRuntime`
+- Testing streaming rendering and Server Component async behavior is complex
+- No visual/golden testing built in (third-party tools required)
+- Hybrid-mode testing (WebView hosting) is an E2E concern, not bUnit's scope
+
+**Rating: A-** — bUnit's renderer-level approach is the right architecture; mature and well-documented.
+
+**Sources:** [bUnit](https://bunit.dev/), [Test Razor components (Microsoft Learn)](https://learn.microsoft.com/en-us/aspnet/core/blazor/test)
+
+---
+
+## 14. Error Handling & Resilience
+
+**Error Boundaries:** Blazor has `<ErrorBoundary>` — a component that catches unhandled exceptions in its descendants and renders `ErrorContent` instead. `Recover()` resets the boundary after the error is resolved. This puts Blazor in a small group with React and Reactor as the only component frameworks with first-class error boundaries.
+
+**Unhandled errors:**
+- **Server mode** — circuit errors are logged and shown in a default `<div id="blazor-error-ui">` overlay; circuit disconnects on unhandled errors in some modes
+- **WebAssembly** — errors log to browser console; default UI overlay same as Server
+- **Hybrid** — .NET exception handling via the host app's global handlers
+
+**Strengths:**
+- **`<ErrorBoundary>` is a genuine advantage** — SwiftUI, Compose, Flutter, Avalonia, and WinUI 3 all lack this
+- `Recover()` lets boundaries reset after transient failures
+- Standard .NET exception handling applies (try/catch, AggregateException, etc.) — no callback-hell patterns
+
+**Weaknesses:**
+- Doesn't catch errors in event handlers unless the event handler itself throws synchronously within a render
+- `async void` or detached async tasks can still escape boundaries
+- Recovery UX patterns (retry, rollback, offline) are app responsibility, not framework-provided
+
+**Rating: B+** — Error boundaries put Blazor ahead of every competitor except React (tied) and Reactor (tied).
+
+---
+
+## 15. Data Loading & Async
+
+**Server-side rendering with streaming:** .NET 8+ introduced **streaming rendering** — a component can mark a `<section>` as `@attribute [StreamRendering(true)]`, and the server sends initial markup immediately and streams in updates as async data resolves. Equivalent to React Server Components + Suspense for the SSR case.
+
+**Interactive modes:** Async data is typically loaded in `OnInitializedAsync` / `OnParametersSetAsync`. The component shows a loading state while the `Task` is pending, then re-renders when it completes (framework calls `StateHasChanged()` automatically).
+
+**`[PersistentState]` (.NET 10):** Data fetched during prerender can be serialized into the page and rehydrated during interactive boot — eliminates double-fetching when transitioning from SSR to Interactive modes.
+
+**No Suspense equivalent in interactive mode.** Server streaming rendering is the closest thing, and only works in the SSR phase.
+
+**Strengths:**
+- `OnInitializedAsync` is simple and works reliably
+- Streaming rendering is a legitimate answer to declarative loading boundaries in SSR
+- `[PersistentState]` closes the prerender → interactive double-fetch gap
+- `async`/`await` is native — no callback patterns
+- Auto-`StateHasChanged` after lifecycle async completion removes boilerplate
+
+**Weaknesses:**
+- **No Suspense equivalent in Interactive Server/WebAssembly** — manual loading-state boolean patterns are the norm
+- No declarative "this whole subtree is waiting" boundary like React's `<Suspense>`
+- No built-in caching/retry/deduplication (no TanStack Query equivalent)
+- Cancellation on component disposal requires manual `CancellationTokenSource` plumbing
+
+**Rating: B+** — Streaming rendering is strong; interactive async is manual; no ecosystem caching layer equivalent to TanStack Query.
+
+---
+
+## 16. Lists & Virtualization
+
+**`<Virtualize>` component:** Blazor ships a built-in `<Virtualize TItem="TItem" ItemsProvider="...">` component that virtualizes large lists by rendering only the visible viewport items. Supports both in-memory collections (`Items`) and async item providers (`ItemsProvider`) for server-side pagination.
+
+**`QuickGrid`:** Microsoft ships an official `QuickGrid` component (in `Microsoft.AspNetCore.Components.QuickGrid`) — a simple high-performance data grid with sorting, paging, column templates, and Entity Framework integration via `IQueryable`. Not as full-featured as commercial grids (Telerik, Syncfusion) but solid.
+
+**Third-party:** MudBlazor, Radzen, Telerik, Syncfusion, DevExpress all ship data grids with features beyond QuickGrid (grouping, editing, filtering, export).
+
+**Strengths:**
+- **Built-in virtualization** — Blazor has a built-in answer where React notably does not
+- `<Virtualize>` handles both fixed-size and dynamic-size items
+- `ItemsProvider` async pattern enables seamless server-side pagination
+- `QuickGrid` is official and `IQueryable`-native
+
+**Weaknesses:**
+- No built-in grouping (unlike WPF's `ICollectionView`)
+- `<Virtualize>` has no horizontal/grid-of-items variant (vertical list only)
+- QuickGrid is deliberately simple — serious LOB scenarios still use commercial grids
+- No dynamic item height measurement as smooth as react-virtuoso
+
+**Rating: B+** — Built-in virtualization + QuickGrid is a solid foundation; commercial grids fill the high-end.
+
+---
+
+## 17. Internationalization & Localization
+
+**Architecture:** Uses ASP.NET Core's standard `IStringLocalizer<T>` and `.resx` files. `RequestLocalizationMiddleware` sets `CultureInfo.CurrentCulture` / `CurrentUICulture` per request. Locale-based formatting (`DateTime`, `decimal`, `NumberFormatInfo`) is native .NET.
+
+**Blazor-specific:**
+- `BlazorWebAssemblyLoadAllGlobalizationData` — option to load all ICU data vs. locale-specific subset (size trade-off)
+- `Microsoft.Extensions.Localization` integrates with Razor components (`@inject IStringLocalizer<MyComponent> L`)
+
+**Strengths:**
+- Inherits the mature .NET i18n stack (`CultureInfo`, `IStringLocalizer`, resource managers)
+- ICU support via WASM globalization bundle
+- Runtime culture switching works cleanly in Server mode
+
+**Weaknesses:**
+- **No built-in CLDR plural/gender rules** — same gap as WPF/WinUI 3. Requires third-party (e.g., `PluralizationServices` or a custom ICU MessageFormat layer)
+- ICU WASM bundle is large (~8 MB uncompressed) if you load all locales
+- RTL is a CSS concern (`dir="rtl"` or `direction: rtl`) with no framework abstraction
+- Compile-time validation of resource keys is not native (third-party analyzers exist)
+
+**Rating: B+** — Mature .NET i18n inheritance; no framework-level plural/gender; same rating as WinUI 3.
+
+---
+
+## 18. Interop & Incremental Adoption
+
+**Razor Class Libraries (RCLs):** Reusable component packages — the standard sharing mechanism. An RCL built on .NET 8 works across Server, WebAssembly, and Hybrid.
+
+**JS Interop:**
+- **`IJSRuntime.InvokeAsync<T>`** — call arbitrary JS from .NET
+- **`[JSInvokable]`** — expose .NET methods callable from JS
+- **`IJSObjectReference` + ES modules** — isolated per-component JS modules (recommended pattern)
+
+**Hosting Blazor in existing apps:**
+- **ASP.NET Core** — `app.MapRazorComponents<App>()` adds Blazor to any ASP.NET Core app
+- **WPF/WinForms** — `BlazorWebView` is a control you drop into a `Window`/`Form`; configures DI, root component, host HTML
+- **MAUI** — same BlazorWebView pattern, cross-platform
+- **Hybrid embedding direction** — Blazor-in-WPF works; WPF-in-Blazor does not (Blazor renders HTML, not XAML)
+
+**Strengths:**
+- **BlazorWebView is the closest thing to Reactor in the Microsoft ecosystem** — declarative components hosted inside a native desktop shell
+- JS interop is typed and well-documented
+- RCLs work across all three render modes
+- Same Razor components work in Blazor Web App and Blazor Hybrid — genuinely shared UI code across web and desktop
+
+**Weaknesses:**
+- **BlazorWebView is a WebView-hosted renderer** — you don't get native platform controls, native UIA/accessibility tree, or native platform look. It's HTML-in-a-WebView
+- In Blazor Server mode, every JS interop call is a network round-trip
+- Render mode mismatches between Web App and Hybrid cause feature drift (e.g., MAUI Hybrid rejects per-component `@rendermode`)
+- Bidirectional embedding (native → Blazor → native) requires multiple WebView instances or careful state coordination
+- Platform API access (file pickers, drag-drop, OS dialogs) requires MAUI APIs or custom JS interop bridges — the #1 real-world Hybrid complaint
+
+**Rating: A-** — BlazorWebView's ability to reuse web components on desktop is genuinely valuable; the "not actually native" caveat is the defining trade-off.
+
+**Sources:** [ASP.NET Core Blazor Hybrid (Microsoft Learn)](https://learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/), [Host a Blazor web app in a .NET MAUI app using BlazorWebView (Microsoft Learn)](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/blazorwebview)
+
+---
+
+## 19. Forms & Data Entry
+
+**`<EditForm>`:** Blazor's form component (verified in `src/Components/Web/src/Forms/EditForm.cs`). Given a `Model` parameter, it constructs an `EditContext` that tracks touched/modified/valid state per field, cascades it to descendants via `<CascadingValue IsFixed="true">`, and provides `OnSubmit`, `OnValidSubmit`, and `OnInvalidSubmit` event callbacks. Mutually exclusive: using `OnSubmit` makes the developer responsible for manually calling `EditContext.Validate()`; using `OnValidSubmit`/`OnInvalidSubmit` triggers implicit validation on submit.
+
+**`<DataAnnotationsValidator>`:** A component you drop inside `<EditForm>` that wires standard `System.ComponentModel.DataAnnotations` attributes (`[Required]`, `[StringLength]`, `[Range]`, `[EmailAddress]`, custom `[ValidationAttribute]`) into `EditContext`'s validation pipeline.
+
+**Typed inputs:** `<InputText>`, `<InputNumber<T>>`, `<InputDate<T>>`, `<InputCheckbox>`, `<InputSelect<T>>`, `<InputRadioGroup<T>>`, `<InputTextArea>`, `<InputFile>`. All inherit from `InputBase<TValue>` and provide two-way binding (`@bind-Value`), validation state visualization (`valid`/`invalid` CSS classes), and accessibility markup.
+
+**`<ValidationMessage For="@(() => model.Property)">`:** Renders per-field error messages. Uses an expression tree to statically identify the field.
+
+**`<ValidationSummary>`:** Renders all current errors.
+
+**Server-side form handling (`<EditForm>` + SSR):** Blazor Web App's static SSR mode supports full server-rendered form posting via `[SupplyParameterFromForm]`, antiforgery tokens (`<AntiforgeryToken>`), and POST-based form submission — without JavaScript. `data-enhance` on the form enables streaming SSR enhancement without a full page reload.
+
+**Strengths:**
+- **This is Blazor's crown jewel.** The most comprehensive form/validation system of any modern declarative framework
+- Data-annotation-driven validation is declarative and reuses validation attributes already common in .NET models
+- Expression-tree field identification (`@(() => model.Property)`) is compile-checked against the model
+- Typed inputs cover all the common cases with sensible defaults
+- Works in both interactive and static SSR modes — forms can be progressive-enhancement-compatible
+- Integrates with ASP.NET Core antiforgery
+
+**Weaknesses:**
+- `DataAnnotationsValidator` validates only the top-level object by default — nested/collection validation requires `ObjectGraphDataAnnotationsValidator` from an extension package
+- No built-in async validation beyond whatever custom `ValidationAttribute` subclasses provide
+- Input masking is not built in (no `<InputText Mask="...">`)
+- No built-in multi-step / wizard form framework
+- WPF's `BindingGroup` (transactional edits) and `ErrorTemplate` (custom error visuals at binding level) remain unmatched
+
+**Rating: A-** — Best declarative-framework form system by a significant margin. Second only to WPF's full depth (transactional edits, custom error templates).
+
+**Sources:** `src/Components/Web/src/Forms/EditForm.cs`, `src/Components/Forms/src/DataAnnotationsValidator.cs`, [ASP.NET Core Blazor forms validation (Microsoft Learn)](https://learn.microsoft.com/en-us/aspnet/core/blazor/forms/validation)
+
+---
+
+## Summary Ratings
+
+| Category | Grade | Notes |
+|---|---|---|
+| Declarative Syntax | B+ | Razor is mature and type-safe; separate language, verbose vs function components |
+| Component Architecture | B | Class-based + `EventCallback`/`RenderFragment` are clean; no hooks |
+| State & Reactivity | C+ | `StateHasChanged` is manual; no automatic tracking; no built-in store |
+| Rendering & Performance | B | Compile-time sequence numbers are clever; WASM download + Server latency are real |
+| Layout | B+ | CSS delegation; same as React |
+| Styling & Theming | B | CSS isolation is unique; doesn't cover third-party components; no built-in design system |
+| Navigation | B | `@page` routes are functional; no compile-time type safety |
+| Animation | C | No framework support; CSS transitions only |
+| Accessibility | B | Inherits web a11y; framework contributes nothing |
+| Input & Gestures | B+ | Strong typed inputs; no gesture system |
+| Developer Experience | B | Mature tooling; no component DevTools |
+| Platform Reach | B+ | Web + Desktop + Mobile via Hybrid (non-native) |
+| Testing | A- | bUnit is excellent; renderer-level; officially supported |
+| Error Handling | B+ | `<ErrorBoundary>` puts Blazor in a small group with React and Reactor |
+| Data Loading & Async | B+ | Streaming rendering for SSR; manual for interactive |
+| Lists & Virtualization | B+ | `<Virtualize>` built-in; QuickGrid official; no grouping |
+| Internationalization | B+ | Inherits .NET i18n stack; no built-in plural/gender |
+| Interop & Adoption | A- | BlazorWebView hosts in WPF/WinForms/MAUI; not native |
+| Forms & Data Entry | A- | Crown jewel; best declarative form system besides WPF's |
+
+---
+
+## Takeaways for Reactor
+
+**Blazor is Reactor's closest philosophical cousin inside Microsoft.** Both are C#-first declarative component frameworks. But they make opposite bets:
+
+| | Blazor Hybrid | Reactor |
+|---|---|---|
+| **Renderer** | HTML in a WebView | Native WinUI 3 controls |
+| **Controls** | HTML elements | Native UIElement tree |
+| **Accessibility** | Manual ARIA | UIA (automatic from WinUI) |
+| **Look & feel** | Browser-chrome HTML | Native Windows + Fluent Design |
+| **Animation** | CSS transitions | Composition API |
+| **Platform reach** | Web + Desktop + Mobile | Windows only |
+
+### What Reactor should steal
+
+1. **`<EditForm>` + `<DataAnnotationsValidator>` + typed inputs.** Highest-leverage feature. Reactor's validation system (B grade) could close more ground toward WPF (A) by adopting a Blazor-style wrapper around data-annotation-driven validation with typed `InputText`/`InputNumber` components.
+2. **`EventCallback<T>` semantics.** An event type that auto-re-renders the subscriber on the correct sync context. Small primitive, large ergonomic win.
+3. **Compile-time sequence numbers for O(n) diffing.** If Reactor ever adds a compiled DSL or source generator over its method-call syntax, bake in the sequence-number invariant.
+4. **bUnit-style renderer-level testing.** Reactor's testing gap (no component-level framework) is what bUnit solves for Blazor. Same architecture should work — a mock visual tree, direct assertion on the element graph.
+5. **Built-in `<Virtualize>` + `QuickGrid`.** Reactor already has a DataGrid; a lighter-weight `QuickGrid` equivalent for simple sortable/pageable scenarios would broaden adoption.
+
+### What Reactor should keep avoiding
+
+1. **Manual `StateHasChanged()`.** Hooks with auto-tracking (`UseState`, `UseObservable`) should stay the default. Don't let anyone "simplify" by exposing a manual render trigger.
+2. **String-literal routes with no compile-time type safety.** Reactor's typed-record routes are a lead worth protecting.
+3. **CSS-isolation-style scoping that breaks for third-party components.** Whatever theming abstraction grows, test it against library-author scenarios day 1.
+4. **Per-host feature incompatibilities** (MAUI Hybrid rejects `@rendermode`). Component code should be invariant under hosting choice.
+
+### Where Reactor structurally wins
+
+- **Native controls.** BlazorWebView's "not actually native" is the defining caveat. Reactor renders real WinUI 3 controls with real UIA, real Composition, real Fluent Design
+- **No WebAssembly payload.** Reactor inherits WinUI 3's native startup
+- **In-process only.** No circuit latency, no debug proxy, no JS interop marshaling
+- **Compositor animations.** Reactor's 5 compositor properties are limiting, but they're genuinely GPU-accelerated, independent-thread animations. Blazor has CSS transitions
+
+### Where Blazor structurally wins
+
+- **Platform reach.** One codebase → Web + Windows + Mac + iOS + Android. No Microsoft framework matches this (Avalonia is the closest non-MS option)
+- **Forms.** `<EditForm>` is the single best form/validation story in any declarative framework today
+- **Error boundaries.** Shared with React and Reactor — a small club
+- **Testing.** bUnit's renderer-level approach is the testing gold standard Reactor should aspire to
+- **Ecosystem of component libraries.** MudBlazor, Fluent UI Blazor, Telerik, Syncfusion, DevExpress all ship production-ready component sets — Reactor's ecosystem is effectively just Reactor itself
+
+---
+
+## Sources
+
+### Microsoft Learn
+- [Blazor Overview](https://learn.microsoft.com/en-us/aspnet/core/blazor/)
+- [Blazor render modes](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes)
+- [Blazor Hybrid](https://learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/)
+- [BlazorWebView in .NET MAUI](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/blazorwebview)
+- [Blazor forms validation](https://learn.microsoft.com/en-us/aspnet/core/blazor/forms/validation)
+- [Blazor routing](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing)
+- [Blazor CSS isolation](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/css-isolation)
+- [Blazor rendering performance](https://learn.microsoft.com/en-us/aspnet/core/blazor/performance/rendering)
+- [Blazor app download size](https://learn.microsoft.com/en-us/aspnet/core/blazor/performance/app-download-size)
+- [WebAssembly build tools and AOT](https://learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-build-tools-and-aot)
+- [Test Razor components](https://learn.microsoft.com/en-us/aspnet/core/blazor/test)
+- [Cascading values and parameters](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/cascading-values-and-parameters)
+- [PersistentState (.NET 10)](https://learn.microsoft.com/en-us/aspnet/core/blazor/state-management/prerendered-state-persistence)
+
+### ASP.NET Core source (`~/code/aspnetcore`)
+- `src/Components/Components/src/ComponentBase.cs` — `StateHasChanged`, `HandleEventAsync`
+- `src/Components/Components/src/EventCallback.cs` — event-callback semantics
+- `src/Components/Components/src/Routing/Router.cs` — route matching
+- `src/Components/Web/src/Forms/EditForm.cs` — form + EditContext wiring
+- `src/Components/Forms/src/DataAnnotationsValidator.cs` — validation integration
+- `src/Components/WebView/WebView/src/WebViewManager.cs` — Hybrid host runtime
+
+### Industry context
+- [.NET 10 Has Arrived — What's Changed for Blazor (Telerik, Nov 2025)](https://www.telerik.com/blogs/net-10-has-arrived-heres-whats-changed-blazor)
+- [Blazor in .NET 10: What's New and Why It Finally Feels Complete (dev.to)](https://dev.to/mashrulhaque/blazor-in-net-10-the-features-that-actually-matter-nc1)
+- [ASP.NET Core in .NET 10 (InfoQ, Dec 2025)](https://www.infoq.com/news/2025/12/asp-net-core-10-release/)
+- [Blazor RenderTree Explained (InfoQ)](https://www.infoq.com/articles/blazor-rendertree-explained/)
+- [Is Blazor Production-Ready in 2025? (Code With Kazik)](https://codewithkazik.com/is-blazor-production-ready-in-2025-lets-find-out)
+- [dotnet/aspnetcore#41909 — WASM size is the worst problem](https://github.com/dotnet/aspnetcore/issues/41909)
+- [dotnet/aspnetcore#63091 — CSS isolation for third-party components](https://github.com/dotnet/aspnetcore/issues/63091)
+- [dotnet/maui#32515 — WPF BlazorWebView broken in .NET 10](https://github.com/dotnet/maui/issues/32515)
+- [bUnit — a testing library for Blazor components](https://bunit.dev/)
+- [Fluent UI Blazor](https://github.com/microsoft/fluentui-blazor)
+- [MudBlazor](https://mudblazor.com/)

--- a/docs/compare/overview.md
+++ b/docs/compare/overview.md
@@ -19,6 +19,7 @@ relative to the industry.
 | Microsoft | WinForms | Windows | 2002 |
 | Microsoft | WPF | Windows | 2006 |
 | Microsoft | WinUI 3 | Windows | 2021 |
+| Microsoft | [Blazor](blazor.md) | Web (+ Desktop/Mobile via Hybrid WebView) | 2020 |
 | Microsoft | Reactor | Windows (on WinUI 3) | Pre-release |
 
 ---
@@ -99,27 +100,27 @@ to understand the gap, not to declare winners.
 
 ### Microsoft Frameworks
 
-| Category | WinForms | WPF | WinUI 3 | Reactor |
-|---|---|---|---|---|
-| **Declarative Syntax** | F | C+ | C+ | B |
-| **Component Architecture** | D | B- | B- | B+ |
-| **State & Reactivity** | D | B | B | B+ |
-| **Rendering & Performance** | C+ | B | B+ | B- |
-| **Layout** | D+ | A- | A- | B+ |
-| **Styling & Theming** | D | A- | A | B- |
-| **Navigation** | F | C | C+ | B+ |
-| **Animation** | F | B+ | A | C+ |
-| **Accessibility** | D+ | A- | A | B |
-| **Input & Gestures** | C | B+ | B+ | C |
-| **Developer Experience** | B | B- | B- | C+ |
-| **Platform Reach** | D | D | D | D |
-| **Testing** | D+ | B | B- | B- |
-| **Error Handling** | C | C | C | B |
-| **Data Loading & Async** | D+ | B | B | B+ |
-| **Lists & Virtualization** | C+ | A- | A- | B+ |
-| **Internationalization** | C+ | B | B+ | B+ |
-| **Interop & Adoption** | B+ | A- | B+ | A- |
-| **Forms & Data Entry** | B | A | B | B |
+| Category | WinForms | WPF | WinUI 3 | Blazor | Reactor |
+|---|---|---|---|---|---|
+| **Declarative Syntax** | F | C+ | C+ | B+ | B |
+| **Component Architecture** | D | B- | B- | B | B+ |
+| **State & Reactivity** | D | B | B | C+ | B+ |
+| **Rendering & Performance** | C+ | B | B+ | B | B- |
+| **Layout** | D+ | A- | A- | B+ | B+ |
+| **Styling & Theming** | D | A- | A | B | B- |
+| **Navigation** | F | C | C+ | B | B+ |
+| **Animation** | F | B+ | A | C | C+ |
+| **Accessibility** | D+ | A- | A | B | B |
+| **Input & Gestures** | C | B+ | B+ | B+ | C |
+| **Developer Experience** | B | B- | B- | B | C+ |
+| **Platform Reach** | D | D | D | B+ | D |
+| **Testing** | D+ | B | B- | A- | B- |
+| **Error Handling** | C | C | C | B+ | B |
+| **Data Loading & Async** | D+ | B | B | B+ | B+ |
+| **Lists & Virtualization** | C+ | A- | A- | B+ | B+ |
+| **Internationalization** | C+ | B | B+ | B+ | B+ |
+| **Interop & Adoption** | B+ | A- | B+ | A- | A- |
+| **Forms & Data Entry** | B | A | B | A- | B |
 
 ---
 
@@ -144,6 +145,10 @@ constructors are the weakest of the four but still declarative.
 - **WinUI 3 (C+):** Same XAML model as WPF/UWP with minor improvements.
   `x:Bind` is compile-time checked (unlike WPF's runtime binding), which
   is a genuine advantage, but the syntax is equally verbose
+- **Blazor (B+):** Razor mixes HTML-like markup with C# via `@` directives.
+  Full C# expressiveness inside `@{}` blocks, type-safe parameter passing,
+  mature Roslyn-based tooling. Separate language requiring a build step and
+  more verbose than function-as-component models, but more readable than XAML
 - **Reactor (B):** C# method calls with `params` arrays. Closer to Flutter's
   constructor style than SwiftUI/Compose's block syntax. Modifier chains
   (`.Bold().FontSize(24)`) are ergonomic. The main weakness is bracket-
@@ -151,7 +156,8 @@ constructors are the weakest of the four but still declarative.
   builders. Still, it's the most readable declarative option on Windows
 
 **Gap:** WPF/WinUI3's XAML is ~15 years behind modern declarative syntax.
-Reactor closes roughly half the gap to competitors.
+Blazor's Razor closes most of the gap (B+); Reactor closes roughly half the
+gap with its method-call syntax (B).
 
 ---
 
@@ -172,6 +178,11 @@ Flutter's StatefulWidget two-class pattern is the most verbose.
   but architecturally sound
 - **WinUI 3 (B-):** Same model as WPF with `x:Bind` improvements. Community
   Toolkit MVVM source generators reduce boilerplate significantly
+- **Blazor (B):** Class-based `ComponentBase` with `[Parameter]`/
+  `[CascadingParameter]`. `EventCallback<T>` is a clean child→parent event
+  primitive that auto-re-renders the subscriber. `RenderFragment` is a
+  first-class "piece of UI" value. No hooks equivalent — class-based
+  composition is a generation behind function-as-component models
 - **Reactor (B+):** React-style function components with hooks. Context system,
   memoization. The mental model transfers from React cleanly. No slots
   pattern (unlike Compose's named slot APIs), but children via params work
@@ -197,6 +208,12 @@ libraries. Flutter provides only `setState()`.
 - **WinUI 3 (B):** `x:Bind` (compiled) is faster and safer than WPF's
   reflection-based binding. CommunityToolkit.Mvvm source generators
   (`[ObservableProperty]`) dramatically reduce boilerplate
+- **Blazor (C+):** `ComponentBase.StateHasChanged()` is a manual render trigger.
+  Framework auto-calls it after lifecycle methods, parameter changes, and
+  `EventCallback` invocations; everything else (timers, observables, async
+  callbacks) requires `InvokeAsync(StateHasChanged)`. No built-in state
+  store — ecosystem uses Fluxor, Blazor-State, observable libraries. **No
+  automatic reactivity tracking** — Blazor's biggest ergonomic weakness
 - **Reactor (B+):** React-style hooks (UseState, UseReducer, UseEffect, UseMemo,
   UseContext). Context for shared state. UseObservable bridges to MVVM.
   No fine-grained property tracking (unlike SwiftUI's @Observable), but the
@@ -204,8 +221,11 @@ libraries. Flutter provides only `setState()`.
 
 **Gap:** No Microsoft framework has automatic fine-grained state tracking.
 WPF/WinUI3's INotifyPropertyChanged is functionally equivalent to Flutter's
-approach (manual notification). Reactor's hooks match React's model. None match
-SwiftUI/Compose's automatic observation.
+approach (manual notification). Blazor's `StateHasChanged` is more manual
+still — the framework auto-triggers only for lifecycle, parameters, and
+`EventCallback`, leaving observable/timer/async scenarios as developer
+responsibility. Reactor's hooks match React's model. None match SwiftUI/
+Compose's automatic observation.
 
 ---
 
@@ -227,6 +247,12 @@ concurrent rendering with priority scheduling. SwiftUI's AttributeGraph.
 - **WinUI 3 (B+):** Composition layer provides independent animation thread
   at 60fps even when UI thread is blocked. Better than WPF for modern
   scenarios. `x:Phase` for incremental list loading
+- **Blazor (B):** Compile-time sequence numbers injected by the Razor compiler
+  enable linear-time render-tree diffing (architecturally clever vs React's
+  general tree diff). Four render modes (Static SSR, Interactive Server,
+  Interactive WebAssembly, Interactive Auto). Server mode is latency-sensitive
+  (every interaction is a SignalR round-trip); WebAssembly has a significant
+  initial download cost even post-trim. No concurrent rendering
 - **Reactor (B-):** Single-threaded reconciler. No concurrent rendering. Known
   GC pressure from modifier chain allocations. No profiling tools. However,
   reconciler correctness is solid and perf experiments are underway
@@ -256,6 +282,10 @@ system). Flutter's constraint model is powerful but has a steep learning curve.
   modern frameworks
 - **WinUI 3 (A-):** Inherits WPF's panel model plus RelativePanel (constraint-
   based) and AdaptiveTrigger for responsive layouts. Strong
+- **Blazor (B+):** Delegates entirely to CSS — Flexbox, Grid, container queries.
+  Full CSS ecosystem compatibility including in Hybrid (WebView hosts HTML).
+  No framework-level layout primitive, but CSS is the most capable layout
+  system available
 - **Reactor (B+):** FlexPanel (full Flexbox implementation) is ambitious and
   useful — provides layout capabilities WinUI itself doesn't have. Grid is
   stringly-typed (`["*", "Auto", "200"]`). No custom layout protocol
@@ -289,6 +319,11 @@ Material-centric.
 - **WinUI 3 (A):** Fluent Design with Mica/Acrylic materials. Lightweight
   styling (override resources without re-templating). ThemeResource for
   automatic light/dark/high-contrast. This is a genuine strength
+- **Blazor (B):** CSS isolation (`MyComponent.razor.css` auto-scoped with
+  `b-xxx` attribute) is the distinctive feature — zero-runtime scoped CSS per
+  component. Limitation: third-party components don't participate (open issue
+  dotnet/aspnetcore#63091). No built-in design system — ecosystem relies on
+  Fluent UI Blazor, MudBlazor, Telerik, Syncfusion, DevExpress
 - **Reactor (B-):** 37 semantic theme tokens (accent, text, surface, control,
   stroke, signal colors) with `Theme.Ref(key)` for custom resources.
   ResourceBuilder supports 5 resource types (color string, Brush, ThemeRef,
@@ -326,6 +361,11 @@ notoriously complex.
   use MVVM navigation via ContentControl + DataTemplate
 - **WinUI 3 (C+):** NavigationView + Frame.Navigate(typeof(Page)). Functional
   but imperative and not type-safe for parameters
+- **Blazor (B):** `@page "/products/{id:int}"` directive with route constraints
+  (bool, int, long, guid, datetime, etc.), `NavigationManager` for programmatic
+  nav, `LocationChanging` with cancellation for unsaved-changes guards. URL-
+  native deep linking. **No type-safe navigation** — `NavigateTo(string)` is
+  not compile-checked against route templates
 - **Reactor (B+):** Type-safe routes via C# records, developer-owned back stack,
   GPU-powered composition-layer transitions, lifecycle guards, LRU caching,
   serialization, deep linking with `DeepLinkMap<TRoute>` supporting URI
@@ -364,6 +404,10 @@ has no built-in animation.
   implicit animations, connected animations, expression animations, spring
   animations. **Best animation system of any Microsoft framework and
   competitive with the best competitors.** This is WinUI 3's crown jewel
+- **Blazor (C):** No framework-level animation. CSS transitions/animations are
+  the floor. Small fragmented ecosystem (Blazor.Animate, blazor-transition-
+  group, Toolbelt.ViewTransition). Exit animations are awkward because Blazor
+  removes DOM nodes synchronously on state change
 - **Reactor (C+):** Spring, ease, and linear curves on compositor properties
   (Opacity, Offset, Scale, Rotation, CenterPoint). Enter **and exit**
   transitions now work — the ChildReconciler defers removal until exit
@@ -403,6 +447,11 @@ gaps on web.
 - **WinUI 3 (A):** Full UIA support, same as UWP. All standard controls
   accessible. High contrast mode via theme resources. Narrator integration
   is strong. Competitive with SwiftUI
+- **Blazor (B):** Inherits web accessibility — semantic HTML + ARIA attributes
+  + keyboard events. Framework contributes nothing on top (same as React).
+  Quality depends entirely on component library choice: Fluent UI Blazor,
+  Telerik (WCAG 2.2), Syncfusion (WCAG 2.2 / Section 508 / ADA) all provide
+  comprehensive a11y
 - **Reactor (B):** 16+ accessibility modifiers covering automation name, help
   text, landmarks, heading levels, live regions (Polite/Assertive), required
   fields, position-in-set, hierarchy level, tab navigation, and accessibility
@@ -456,6 +505,11 @@ capable. React has no built-in gesture system.
   UIElement.Focus() for focus management
 - **WinUI 3 (B+):** Same as WPF with improved touch/pen support. Composition
   interaction for smooth gesture-driven animations
+- **Blazor (B+):** Typed event argument types (`MouseEventArgs`,
+  `KeyboardEventArgs`, `ChangeEventArgs`) — safer than React's `SyntheticEvent`.
+  Declarative `@onclick:stopPropagation="true"` / `:preventDefault="true"`.
+  Typed form inputs (`<InputText>`, `<InputNumber>`, `<InputDate>`) with
+  two-way binding and validation integration. No gesture system
 - **Reactor (C):** Semantic events (OnClick, OnToggle) are good. Commanding
   system provides focus-scoped keyboard accelerators. But no gesture system,
   no pointer enter/exit, no right-click/double-click without `.Set()`. Most
@@ -486,6 +540,12 @@ and Preview are excellent.
 - **WinUI 3 (B-):** XAML Hot Reload, Live Visual Tree. But packaging complexity,
   deployment issues, smaller community for troubleshooting. Documentation
   has gaps for advanced scenarios
+- **Blazor (B):** Mature Roslyn-based tooling in Visual Studio and JetBrains
+  Rider. Hot Reload works across Server, WebAssembly, and Hybrid modes (Razor
+  edits, C# method bodies, CSS); reliability issues on VS Code. Unified C#
+  end-to-end. **No component DevTools** — no render tree inspector, no
+  parameter inspector, no render-count profiler. WebAssembly debugging has
+  debug-proxy handshake fragility
 - **Reactor (C+):** Hot reload works (via WinUI 3 XAML Hot Reload). Preview is
   screenshot-only. No DevTools for component inspection. No recomposition
   count tracking. No profiling tools
@@ -507,9 +567,15 @@ Native. Compose Multiplatform now covers Android, iOS, Desktop, Web.
 SwiftUI covers all Apple platforms.
 
 **Microsoft assessment:**
-- **All Microsoft frameworks (D):** Windows only. Full stop. WPF and WinForms
-  have no cross-platform story. WinUI 3 is Windows-only by design. Reactor
-  inherits WinUI 3's limitation
+- **WinForms, WPF, WinUI 3, Reactor (D):** Windows only. Full stop. WPF and
+  WinForms have no cross-platform story. WinUI 3 is Windows-only by design.
+  Reactor inherits WinUI 3's limitation
+- **Blazor (B+):** **The only Microsoft framework with genuine cross-platform
+  reach.** Same Razor components run on Web (Server/WASM), Windows (WPF,
+  WinForms, MAUI), Mac/iOS/Android (MAUI) via `BlazorWebView`. Caveat: Hybrid
+  renders HTML in a WebView, not platform-native controls — you don't get
+  native UIA, native look, or platform controls. Platform API access requires
+  MAUI APIs or JS interop bridges
 
 **Avalonia note:** Avalonia is the .NET ecosystem's answer to this gap,
 covering 7 platforms (Windows, macOS, Linux, iOS, Android, WebAssembly,
@@ -519,11 +585,15 @@ framework from the Microsoft stack — it self-renders via Skia rather than
 using platform controls, and its mobile/web platforms are less mature than
 its desktop story.
 
-**Gap:** This is the largest gap between Microsoft frameworks and competitors.
-Every competitor targets multiple platforms. All Microsoft options target one.
-This is an inherent architectural constraint, not a fixable bug. Avalonia
-provides a cross-platform path for .NET developers but requires leaving the
-WinUI 3/WPF ecosystem (unless using XPF for WPF binary compat).
+**Gap:** This is the largest gap between Microsoft's *native* frameworks and
+competitors. WinForms, WPF, WinUI 3, and Reactor target one platform.
+**Blazor Hybrid is the only first-party Microsoft framework that targets
+multiple platforms** — at the cost of rendering in a WebView rather than
+native controls. Avalonia provides a cross-platform native-ish path for .NET
+developers but requires leaving the WinUI 3/WPF ecosystem (unless using XPF
+for WPF binary compat). The architectural trade-off is clear: Blazor Hybrid
+prioritizes code reuse over native fidelity; WinUI 3/Reactor prioritize
+native fidelity over code reuse.
 
 ---
 
@@ -543,6 +613,11 @@ is fast and comprehensive. SwiftUI has the weakest testing story.
   WinAppDriver/FlaUI. Binding errors are silent at runtime (a testing gap)
 - **WinUI 3 (B-):** MVVM + `x:Bind` compile-time checking catches binding
   errors. UI testing via WinAppDriver. Test infrastructure still evolving
+- **Blazor (A-):** **bUnit is the best testing story in the Microsoft
+  ecosystem** — renderer-level component tests, semantic HTML assertions
+  (whitespace/attribute-order insensitive), officially endorsed by Microsoft
+  Learn, xUnit/NUnit/MSTest/TUnit compatible, milliseconds per test. Mocked
+  `IJSRuntime` and `NavigationManager` built in
 - **Reactor (B-):** Pure C# function components are unit-testable. ErrorBoundary
   exists. Navigation has 146+ unit tests (including 29 stress tests covering
   concurrency, serialization, and deep linking). DataGrid has 1,600+ state
@@ -550,9 +625,10 @@ is fast and comprehensive. SwiftUI has the weakest testing story.
   tests exist for DataGrid, WinForms interop (13 tests), and accessibility
   interactions. No component-level testing framework
 
-**Gap:** WPF's MVVM testability is on par with competitors. The main gap is
-the lack of component-level testing frameworks (equivalent to ComposeTestRule
-or React Testing Library). Reactor's ErrorBoundary is a genuine advantage over
+**Gap:** WPF's MVVM testability is on par with competitors. **Blazor's bUnit
+closes the component-testing gap entirely** — it's the renderer-level equivalent
+of ComposeTestRule / React Testing Library and is the best testing story in the
+Microsoft ecosystem. Reactor's ErrorBoundary is a genuine advantage over
 SwiftUI, Compose, and Flutter.
 
 ---
@@ -572,12 +648,18 @@ view errors.
   blessing). No error boundary concept
 - **WinUI 3 (C):** Application.UnhandledException. `x:Bind` compile-time
   checking prevents binding errors. No error boundary
+- **Blazor (B+):** `<ErrorBoundary>` component with `Recover()` method. Puts
+  Blazor in a small group with React and Reactor as the only component
+  frameworks with first-class error boundaries. Circuit-level unhandled
+  errors in Server mode trigger a default UI overlay
 - **Reactor (B):** ErrorBoundary component exists — this is a **genuine
   differentiator.** Neither SwiftUI nor Compose has this. Only React provides
   equivalent functionality. Reactor is ahead of every competitor except React
 
-**Gap:** Reactor is competitive or ahead. This is one of only two categories
-(alongside commanding) where a Microsoft framework leads the industry.
+**Gap:** Both Blazor and Reactor are competitive or ahead. Error boundaries
+are one of only two categories (alongside commanding) where Microsoft
+frameworks lead the industry. Blazor and Reactor share this with React —
+a small club.
 
 ---
 
@@ -602,6 +684,12 @@ runtime. Flutter's `FutureBuilder` is built-in but considered low-level.
 - **WinUI 3 (B):** Same async/await + MVVM pattern as WPF with
   `DispatcherQueue` instead of `Dispatcher`. `ISupportIncrementalLoading`
   for automatic pagination in lists. No built-in async loading framework
+- **Blazor (B+):** Streaming rendering (`@attribute [StreamRendering(true)]`)
+  is the SSR equivalent of Suspense — initial markup sent immediately, async
+  content streams in. `[PersistentState]` (.NET 10) closes the prerender →
+  interactive double-fetch gap. Auto-`StateHasChanged` after `OnInitializedAsync`
+  removes boilerplate. No Suspense equivalent in Interactive mode — manual
+  loading-state booleans. No built-in caching/retry (no TanStack Query peer)
 - **Reactor (B+):** `UseEffect` provides lifecycle-scoped side effects matching
   React's model. `UseState` for loading/error management. `UseObservable`
   bridges async ViewModel patterns. No built-in Suspense equivalent, but
@@ -636,6 +724,11 @@ React has **no built-in virtualization** — a genuine gap.
   `GridView` with container recycling. `x:Phase` for incremental loading.
   `ContainerContentChanging` for efficient recycling. `ISupportIncrementalLoading`
   for automatic pagination
+- **Blazor (B+):** `<Virtualize>` built-in for vertical lists (sync `Items` or
+  async `ItemsProvider`). **QuickGrid** is Microsoft's official simple data grid
+  with `IQueryable` integration (sorting, paging, column templates). Commercial
+  grids (Telerik, Syncfusion, DevExpress) cover high-end scenarios. No built-in
+  grouping, no horizontal/grid-of-items virtualization
 - **Reactor (B+):** Typed `ListView<T>`/`GridView<T>` with `viewBuilder` pattern
   and `ContainerContentChanging` recycling. `LazyVStack<T>`/`LazyHStack<T>`
   via `ItemsRepeater`. `ElementPool` for interactive control recycling (capped
@@ -685,6 +778,11 @@ has no built-in i18n.
   XAML resource binding. `ResourceLoader` for code access. No plural/gender
   built-in. `ApplicationLanguages.PrimaryLanguageOverride` for per-app language.
   RTL via `FlowDirection`
+- **Blazor (B+):** Inherits the mature .NET i18n stack — `IStringLocalizer<T>`,
+  `.resx`, `CultureInfo`, `NumberFormatInfo`. ICU support via WASM globalization
+  bundle (size trade-off). Runtime culture switching works cleanly in Server
+  mode. **No built-in CLDR plural/gender rules** — same gap as WPF/WinUI 3.
+  RTL is a CSS concern
 - **Reactor (B+):** ICU MessageFormat on top of WinUI's `.resw` system.
   `Context<IntlAccessor?>` provides context-based locale propagation.
   CLDR plural/gender/select support — **addresses WinUI 3's biggest i18n gap**.
@@ -717,6 +815,13 @@ is mature. Flutter's add-to-app works but platform views are costly.
 - **WinUI 3 (B+):** XAML Islands for WPF/WinForms hosting. WebView2 for web
   content. `AppWindow` for Win32 access. Migration from UWP is non-trivial
   (sandbox removal, API changes)
+- **Blazor (A-):** `BlazorWebView` hosts Razor components inside WPF, WinForms,
+  and MAUI. Same Razor components work in Blazor Web App and Blazor Hybrid —
+  genuinely shared UI code across web, desktop, and mobile. `IJSRuntime` +
+  `[JSInvokable]` for typed JS interop. Razor Class Libraries are the
+  reusable packaging unit. Caveat: Hybrid renders HTML in a WebView (not
+  native controls); platform API access requires MAUI APIs or JS interop
+  bridges. "Not actually native" is the defining trade-off
 - **Reactor (A-):** **Best interop story in the Microsoft ecosystem.**
   `ReactorHostControl` drops into any WinUI XAML layout — no `ReactorApp` required.
   `XamlHostElement`/`XamlPageElement` embed existing XAML in Reactor trees.
@@ -768,6 +873,16 @@ built-in validation.
   min/max/increment validation. No built-in validation framework (unlike WPF).
   CommunityToolkit.Mvvm's `ObservableValidator` fills the gap. `XYFocus` for
   directional navigation (gamepad/Xbox)
+- **Blazor (A-):** **`<EditForm>` + `<DataAnnotationsValidator>` + typed
+  `<Input*>` components is the most comprehensive form/validation story of
+  any modern declarative framework.** `EditContext` tracks per-field touched/
+  modified/valid state; expression-tree field identification (`@(() =>
+  m.Prop)`) is compile-checked against the model; typed inputs (`InputText`,
+  `InputNumber<T>`, `InputDate<T>`, `InputCheckbox`, `InputSelect<T>`,
+  `InputRadioGroup<T>`, `InputFile`) wrap native inputs with two-way binding,
+  validation state visualization, and accessibility markup. Works in both
+  Interactive and Static SSR with antiforgery integration. Only WPF's full
+  depth (BindingGroup, ErrorTemplate) is ahead
 - **Reactor (B):** Full validation system with `ValidationContext` (thread-safe,
   multi-error, multi-severity, touched/dirty state tracking, internal vs.
   external messages). 10+ built-in validators (Required, MinLength, MaxLength,
@@ -791,12 +906,14 @@ built-in validation.
 **Gap:** WPF's form/validation system is **ahead of every competitor** — no
 declarative framework has equivalent depth (transactional edits, multiple
 errors per field, binding-level validation rules, custom error templates).
-This is WPF's most underappreciated strength. Reactor has closed significant
-ground here (from C+ to B) with automatic validation, FormField rendering,
-and a comprehensive validator library. It's now comparable to Compose's
-approach (good primitives, explicit wiring) and approaching Flutter's
-`Form.validate()` integration. The remaining gap to WPF is in template
-customization and binding-level validation integration.
+This is WPF's most underappreciated strength. **Blazor's `<EditForm>` is a
+close second (A-)** — the best form story of any modern declarative framework
+and the feature most worth learning from. Reactor has closed significant
+ground (from C+ to B) with automatic validation, FormField rendering, and a
+comprehensive validator library — comparable to Compose's approach and
+approaching Flutter's `Form.validate()` integration. The remaining gap to
+Blazor/WPF is in data-annotation-driven validation, template customization,
+and binding-level validation integration.
 
 ---
 
@@ -804,7 +921,7 @@ customization and binding-level validation integration.
 
 | Category | Competitor Median | Best MS | MS Grade | Gap |
 |---|---|---|---|---|
-| Declarative Syntax | A- | Reactor (B) | B | **1 grade behind** |
+| Declarative Syntax | A- | Blazor (B+) | B+ | **Half grade behind** |
 | Component Architecture | A- | Reactor (B+) | B+ | **Half grade behind** |
 | State & Reactivity | B+ | Reactor (B+) | B+ | **Matched** |
 | Rendering & Performance | B+ | WinUI 3 (B+) | B+ | **Matched** |
@@ -813,54 +930,63 @@ customization and binding-level validation integration.
 | Navigation | B+ | Reactor (B+) | B+ | **Matched** |
 | Animation | B+ | WinUI 3 (A) | A | **Ahead** |
 | Accessibility | B+ | WinUI 3 (A) | A | **Ahead** |
-| Input & Gestures | B+ | WPF/WinUI 3 (B+) | B+ | **Matched** |
-| Developer Experience | A- | WinForms (B) | B | **1 grade behind** |
-| Platform Reach | A- | All (D) | D | **3+ grades behind** |
-| Testing | B+ | WPF (B) | B | **Half grade behind** |
-| Error Handling | C+ | Reactor (B) | B | **Ahead** |
-| Data Loading & Async | A- | Reactor (B+) | B+ | **Half grade behind** |
+| Input & Gestures | B+ | WPF/WinUI 3/Blazor (B+) | B+ | **Matched** |
+| Developer Experience | A- | WinForms/Blazor (B) | B | **1 grade behind** |
+| Platform Reach | A- | Blazor (B+) | B+ | **Half grade behind** |
+| Testing | B+ | Blazor (A-) | A- | **Ahead** |
+| Error Handling | C+ | Blazor (B+) | B+ | **Ahead** |
+| Data Loading & Async | A- | Blazor/Reactor (B+) | B+ | **Half grade behind** |
 | Lists & Virtualization | B+ | WPF/WinUI 3 (A-) | A- | **Ahead** |
-| Internationalization | B+ | Reactor (B+) | B+ | **Matched** |
-| Interop & Adoption | A- | Reactor (A-) | A- | **Matched** |
+| Internationalization | B+ | Blazor/Reactor/WinUI 3 (B+) | B+ | **Matched** |
+| Interop & Adoption | A- | Blazor/Reactor (A-) | A- | **Matched** |
 | Forms & Data Entry | B | WPF (A) | A | **Ahead** |
 
 ### Where Microsoft leads or matches:
 1. **Forms & Data Entry** (WPF) — The richest validation system of any
    framework. INotifyDataErrorInfo, ValidationRule, ErrorTemplate, BindingGroup.
-   No competitor matches this depth
-2. **Lists & Virtualization** (WPF/WinUI 3) — VirtualizingStackPanel,
-   ItemsRepeater, ICollectionView. Ahead of all competitors at the median
-3. **Animation** (WinUI 3) — Composition API is world-class. Ahead of the
+   No competitor matches this depth. **Blazor's `<EditForm>` (A-) is a close
+   second** and the best form story of any modern declarative framework
+2. **Testing** (Blazor) — bUnit is the renderer-level equivalent of
+   ComposeTestRule / React Testing Library. **Ahead of the competitor median**
+   (A- vs B+) and the best testing story in the Microsoft ecosystem
+3. **Lists & Virtualization** (WPF/WinUI 3) — VirtualizingStackPanel,
+   ItemsRepeater, ICollectionView. Ahead of all competitors at the median.
+   Blazor's built-in `<Virtualize>` + QuickGrid covers the web side
+4. **Animation** (WinUI 3) — Composition API is world-class. Ahead of the
    competitor median (B+)
-4. **Accessibility** (WPF/WinUI 3) — UIA is the most comprehensive a11y API.
+5. **Accessibility** (WPF/WinUI 3) — UIA is the most comprehensive a11y API.
    Ahead of the competitor median (B+)
-5. **Styling & Theming** (WPF/WinUI 3) — WPF's ControlTemplate is unmatched;
+6. **Styling & Theming** (WPF/WinUI 3) — WPF's ControlTemplate is unmatched;
    WinUI 3's Fluent Design is competitive. Matched or ahead of median (A-)
-6. **Layout** (WPF/WinUI 3) — Panel system matches the best competitors
-7. **Error Handling** (Reactor) — ErrorBoundary is ahead of all but React
-8. **Interop & Adoption** (Reactor) — UseObservable bridges unmodified MVVM
-   ViewModels; ReactorHostControl drops into existing WinUI windows;
-   XamlIslandControl drops into WinForms with designer support
-9. **Rendering** (WinUI 3) — Composition layer's independent animation thread
-   is competitive
-10. **Navigation** (Reactor) — Architecturally competitive with Compose Nav 3
-11. **Commanding** (Reactor) — No competitor has this. Unique differentiator
+7. **Layout** (WPF/WinUI 3) — Panel system matches the best competitors
+8. **Error Handling** (Blazor/Reactor) — `<ErrorBoundary>` in both Blazor
+   (B+) and Reactor (B) is ahead of all but React
+9. **Interop & Adoption** (Blazor/Reactor) — Both A-. Blazor's BlazorWebView
+   hosts in WPF/WinForms/MAUI (web components on desktop, not native);
+   Reactor's `UseObservable` + `ReactorHostControl` + `XamlIslandControl`
+   drops native declarative UI into existing WinUI/WinForms
+10. **Rendering** (WinUI 3) — Composition layer's independent animation thread
+    is competitive
+11. **Navigation** (Reactor) — Architecturally competitive with Compose Nav 3
+12. **Commanding** (Reactor) — No competitor has this. Unique differentiator
 
 ### Where Microsoft lags significantly:
-1. **Platform Reach** — Windows-only vs 2-7 platforms. Unbridgeable without
-   Avalonia/Uno. Avalonia now covers 7 platforms from .NET
+1. **Platform Reach (native frameworks)** — WinForms, WPF, WinUI 3, and
+   Reactor are Windows-only vs 2-7 platforms for competitors. Unbridgeable
+   without Avalonia/Uno. Blazor Hybrid is the only first-party way out, at
+   the cost of rendering HTML in a WebView rather than native controls
 2. **Developer Experience** — No equivalent to React DevTools, Flutter hot
-   reload, or Compose Layout Inspector
-3. **Declarative Syntax** — XAML is a generation behind; Reactor narrows the gap
-   but C# lacks the language features of Swift/Kotlin. Note: Avalonia
-   modernizes XAML (compiled bindings, CSS-like styling) but the syntax
-   remains fundamentally XAML
-4. **Testing** — No component-level testing framework. Avalonia's headless
-   testing is the best XAML-framework testing story but still behind
-   Compose/React's semantics-based approach
+   reload, or Compose Layout Inspector in *any* Microsoft framework including
+   Blazor and Reactor
+3. **Declarative Syntax** — XAML is a generation behind; Blazor's Razor and
+   Reactor's method-call syntax both narrow the gap but C# lacks the language
+   features of Swift/Kotlin. Avalonia modernizes XAML (compiled bindings,
+   CSS-like styling) but the syntax remains fundamentally XAML
+4. **State & Reactivity** — No Microsoft framework has automatic fine-grained
+   tracking. Blazor's `StateHasChanged` is notably the most manual of the set
 5. **Data Loading & Async** — No lifecycle-scoped async primitives (vs
    `.task`, `LaunchedEffect`, Suspense). MVVM async patterns work but are
-   imperative
+   imperative. Blazor's streaming rendering is SSR-only
 
 ---
 
@@ -919,6 +1045,50 @@ and styling. The gaps are in the declarative programming model (still XAML
 competitors), and platform reach. The Windows App SDK is active but
 adoption has been slower than hoped.
 
+### Blazor — "The Web Framework With a Desktop Side Door"
+
+**Best for:** Web apps written in C# end-to-end; LOB apps where form/
+validation depth matters; teams that need to ship the same UI across web,
+desktop, and mobile without learning JavaScript.
+
+**Profile:** Microsoft's only modern declarative component framework. Razor
+components mix HTML-like markup with C# via `@` directives, compiling to
+C# classes derived from `ComponentBase`. Four render modes (Static SSR,
+Interactive Server, Interactive WebAssembly, Interactive Auto) let different
+parts of an app pick different interactivity models. **Forms are Blazor's
+crown jewel** — `<EditForm>` + `<DataAnnotationsValidator>` + typed `<Input*>`
+components make it the best form/validation story of any modern declarative
+framework. **`<ErrorBoundary>`** puts Blazor in a small club with React and
+Reactor. **bUnit** is the best testing story in the Microsoft ecosystem.
+**`<Virtualize>` and QuickGrid** are built-in. Compile-time sequence numbers
+enable linear-time render-tree diffing.
+
+**Blazor Hybrid** (`BlazorWebView` in WPF/WinForms/MAUI) makes Blazor the
+only first-party Microsoft framework with genuine cross-platform reach —
+at the cost of rendering HTML in a WebView rather than platform-native
+controls. You don't get native UIA trees, native platform controls, or
+native look-and-feel. Platform API access requires MAUI APIs or JS interop
+bridges. `[PersistentState]` (.NET 10) closes the prerender → interactive
+double-fetch gap; streaming rendering is an SSR Suspense equivalent.
+
+**Biggest weaknesses:** `StateHasChanged()` is a manual render trigger —
+no automatic reactivity tracking. No component DevTools. WebAssembly
+initial download is hefty (hundreds of KB even post-trim). Server mode
+is latency-sensitive. No type-safe route navigation. Class-based
+components are a generation behind function-as-component models. No
+built-in animation system beyond CSS transitions.
+
+**Competitive position:** Blazor competes on the **same playing field as
+React, SwiftUI, and Compose** as a declarative component framework — the
+only Microsoft framework that does. It is **ahead of the competitor median
+in testing (A- vs B+) and error handling**, tied in interop, and close
+behind on forms (WPF still wins). Its main competitor positioning is vs
+React — with the value prop being "C# end-to-end and Microsoft support" at
+the cost of a smaller ecosystem. Vs Reactor, it sits across an architectural
+divide: Blazor Hybrid reuses web components on desktop (non-native);
+Reactor renders native WinUI 3 controls from a React-style component
+model (native, Windows-only).
+
 ### Reactor — "The Declarative Experiment"
 
 **Best for:** Teams wanting React-style declarative UI on WinUI 3 with
@@ -967,18 +1137,26 @@ remains before production-readiness.
 
 ## Key Takeaways
 
-### 1. The platform reach gap is structural — but Avalonia is a real option
+### 1. The platform reach gap is structural — Blazor and Avalonia are the two escape hatches
 
-Every competitor targets multiple platforms. All Microsoft frameworks target
-one. This is not a temporary deficit — it's an architectural reality.
-**Avalonia is now the strongest cross-platform .NET UI framework**, covering
-7 platforms with 30K+ GitHub stars and production use at JetBrains, Autodesk,
-and NASA. It is the only .NET framework with Linux desktop support and the
-first with native Linux accessibility (AT-SPI2). For teams that need cross-
-platform .NET, Avalonia is a credible choice — though its mobile/web
-platforms are less mature than desktop, and its self-rendering model means
-apps don't look platform-native. Teams committed to Windows-only still
-benefit from WPF/WinUI 3/Reactor's deeper platform integration.
+Every competitor targets multiple platforms. Microsoft's *native* frameworks
+(WinForms, WPF, WinUI 3, Reactor) all target one. Two first-party-or-adjacent
+escape hatches exist, each with a distinct trade-off:
+
+- **Blazor Hybrid** ships the same Razor components across web, WPF,
+  WinForms, MAUI (Windows/Mac/iOS/Android). The cost is rendering HTML in
+  a WebView rather than platform-native controls — no native UIA, no native
+  controls, no native look. Microsoft-owned and first-party
+- **Avalonia** covers 7 platforms with 30K+ GitHub stars and production use
+  at JetBrains, Autodesk, and NASA. Only .NET framework with Linux desktop
+  support and native Linux accessibility (AT-SPI2). Self-renders via Skia
+  (also non-native look), but closer to WinUI 3 in architecture than Blazor.
+  Third-party
+
+Teams committed to Windows-only still benefit from WPF/WinUI 3/Reactor's
+deeper platform integration. Teams that need cross-platform .NET have a
+real choice between Blazor (web-style components, WebView) and Avalonia
+(XAML-style components, Skia). Neither gives native platform controls.
 
 ### 2. WinUI 3 is stronger than its reputation
 
@@ -989,7 +1167,32 @@ the most powerful animation system across all frameworks analyzed. The gap
 is in developer experience and the declarative programming model, not in
 the underlying platform.
 
-### 3. Reactor addresses the right gaps
+### 3. Blazor is Reactor's closest cousin — but the bets are opposite
+
+Blazor and Reactor are both C#-first declarative component frameworks in the
+Microsoft ecosystem. They make opposite bets on the most important
+architectural choice:
+
+| | Blazor Hybrid | Reactor |
+|---|---|---|
+| **Renderer** | HTML in a WebView | Native WinUI 3 controls |
+| **Controls** | HTML elements | Native UIElement tree |
+| **Accessibility** | Manual ARIA | UIA (automatic from WinUI) |
+| **Look & feel** | Browser-chrome HTML | Native Windows + Fluent Design |
+| **Animation** | CSS transitions | Composition API |
+| **Component model** | Class-based + `StateHasChanged` | Function-as-component + hooks |
+| **Platform reach** | Web + Desktop + Mobile | Windows only |
+| **Forms** | `<EditForm>` (A-) | FormField + validators (B) |
+| **Testing** | bUnit (A-) | Unit tests per component (B-) |
+
+**Blazor's form story, testing infrastructure, and error boundary are three
+features Reactor should learn from directly.** Blazor's `StateHasChanged`
+model, string-literal routing, and class-based components are three things
+Reactor already does better. **Reactor's native-rendering, native-UIA,
+native-look positioning is its structural advantage over Blazor Hybrid on
+Windows desktop** — positioning that's worth stating explicitly in marketing.
+
+### 4. Reactor addresses the right gaps
 
 Reactor's declarative model, navigation, and commanding are not random feature
 additions — they directly address the areas where WPF/WinUI 3 are weakest
@@ -1006,14 +1209,16 @@ linking with wildcards and query strings, diagnostics), and interop
 remaining gaps are animation depth (5 compositor properties), developer
 tooling (no inspector or profiler), and `LabeledBy()` no-op.
 
-### 4. Error handling is an industry-wide gap
+### 5. Error handling is an industry-wide gap — but Microsoft has two answers
 
 React's ErrorBoundary is the only production-quality error containment
-mechanism in any major declarative UI framework. SwiftUI, Compose, and
-Flutter all crash the app on view-level errors. Reactor's ErrorBoundary
-is a genuine differentiator that should be more prominently marketed.
+mechanism among the big competitor set. SwiftUI, Compose, and Flutter all
+crash the app on view-level errors. **Both Blazor (`<ErrorBoundary>`) and
+Reactor (`ErrorBoundary`) ship error boundaries** — putting two Microsoft
+frameworks in a small club with React. This is a genuine Microsoft-ecosystem
+differentiator that's under-marketed.
 
-### 5. State management is converging on automatic observation
+### 6. State management is converging on automatic observation
 
 SwiftUI's `@Observable`, Compose's Snapshot system, and signals-based
 frameworks (SolidJS, Angular Signals, Vue's reactivity) all converge on
@@ -1027,21 +1232,25 @@ ecosystem, but they still require explicit subscription rather than automatic
 tracking. This is the most impactful architectural gap to close across the
 entire .NET UI landscape.
 
-### 6. WPF's form/validation system is an underappreciated asset
+### 7. WPF's form/validation system is an underappreciated asset — and Blazor's is the best modern version
 
 WPF's two-way binding engine with `INotifyDataErrorInfo`, `ValidationRule`,
 `ErrorTemplate`, `BindingGroup`, and `IValueConverter`/`IMultiValueConverter`
 is the most comprehensive form validation system of any framework in this
-analysis. No declarative framework comes close. Reactor has closed significant
-ground with automatic validation, FormField rendering, 10+ validators, and
-ValidationVisualizer — now comparable to Compose/Flutter's approach. But
-WPF's transactional editing (BindingGroup), custom error templates
-(ErrorTemplate), and binding-level validation rules remain unmatched. For
-LOB applications — which are the core use case for Windows desktop — WPF's
-depth here is a critical competitive advantage that Reactor should continue
-to learn from.
+analysis. **Blazor's `<EditForm>` + `<DataAnnotationsValidator>` + typed
+`<Input*>` components (A-) is the best form story of any modern declarative
+framework** — it inherits .NET's `DataAnnotations` attributes, adds
+expression-tree field identification, and integrates with ASP.NET Core
+antiforgery. Reactor has closed significant ground (from C+ to B) with
+automatic validation, FormField rendering, 10+ validators, and
+ValidationVisualizer. But WPF's transactional editing (BindingGroup), custom
+error templates (ErrorTemplate), and binding-level validation rules remain
+unmatched, and Blazor's data-annotation-driven validation is still ahead
+of Reactor's explicit-validator approach. For LOB applications — which are
+the core use case for Windows desktop — Reactor should study both WPF's
+depth and Blazor's declarative pattern.
 
-### 7. Interop is Reactor's strongest selling point for adoption
+### 8. Interop is Reactor's strongest selling point for adoption
 
 Reactor's `ReactorHostControl` (drop into existing WinUI XAML), `UseObservable`
 (bridge unmodified MVVM ViewModels with one line), `XamlHostElement`
@@ -1053,7 +1262,7 @@ matters because the realistic path for Reactor adoption is not greenfield apps
 without a rewrite. With WinForms interop, Reactor now covers the two largest
 Windows desktop frameworks as adoption entry points.
 
-### 8. Avalonia validates the self-rendering cross-platform approach for .NET
+### 9. Avalonia validates the self-rendering cross-platform approach for .NET
 
 Avalonia's trajectory mirrors Flutter's: self-render everything via Skia for
 pixel-perfect cross-platform consistency, accept the trade-off of non-native
@@ -1069,7 +1278,7 @@ need macOS/Linux (via XPF). It does not compete with Reactor's declarative
 model — Avalonia is still MVVM/class-based — but it competes directly with
 WPF for new desktop development where cross-platform is a requirement.
 
-### 9. No framework is complete
+### 10. No framework is complete
 
 Every framework has embarrassing gaps:
 - **SwiftUI:** No error boundaries, no official testing, type-checker issues,
@@ -1086,6 +1295,10 @@ Every framework has embarrassing gaps:
   no lifecycle-scoped async
 - **WinUI 3:** Packaging complexity, small community, Windows-only, no
   plural/gender i18n
+- **Blazor:** Manual `StateHasChanged` (no auto-reactivity), no component
+  DevTools, hefty WebAssembly payload, Server-mode latency sensitivity,
+  CSS isolation doesn't cover third-party components, no type-safe routing,
+  Hybrid renders in a WebView (not native), no built-in animation system
 - **Reactor:** Animation limited to 5 compositor properties, no DevTools or
   component inspector, `LabeledBy()` no-op, SemanticPanel is a workaround
   not true per-component AutomationPeer, `.Set()` escape hatch still
@@ -1106,12 +1319,15 @@ most for your specific application.
 - [Avalonia Analysis](avalonia.md) — Cross-platform .NET XAML framework
 
 ### Microsoft frameworks
+- [Blazor Analysis](blazor.md) — Microsoft's component-based web/hybrid framework
 - [Reactor Critical Review](../critical-review.md) — Detailed Reactor analysis
 - [WinUI 3 Gap Analysis](../spec/duct-winui3-gap-analysis.md) — Reactor vs WinUI 3 coverage
 - [Microsoft Learn: WinForms Overview](https://learn.microsoft.com/en-us/dotnet/desktop/winforms/overview)
 - [Microsoft Learn: WPF Architecture](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/wpf-architecture)
 - [Microsoft Learn: Windows App SDK](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/)
 - [Microsoft Learn: WinUI 3](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/)
+- [Microsoft Learn: Blazor](https://learn.microsoft.com/en-us/aspnet/core/blazor/)
+- [Microsoft Learn: Blazor Hybrid](https://learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/)
 - [Microsoft Learn: Composition API](https://learn.microsoft.com/en-us/windows/uwp/composition/)
 - [Microsoft Learn: UI Automation](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/ui-automation-of-a-wpf-custom-control)
 


### PR DESCRIPTION
## Summary

- Adds `docs/compare/blazor.md` — a full 19-category analysis of Blazor grounded in the ASP.NET Core source tree (verified against `EventCallback`, `ComponentBase.HandleEventAsync`, `EditForm`, `Router`)
- Integrates Blazor into `docs/compare/overview.md` as a peer of WinForms / WPF / WinUI 3 / Reactor, with per-category bullets, updated scorecard, gap-analysis rerank, and a new framework profile
- Adds a new Key Takeaway contrasting Blazor and Reactor's opposite architectural bets (WebView-hosted HTML vs native WinUI controls)

## Positioning shifts in the overview

- **Testing**: moves from a Microsoft lag to a Microsoft lead — Blazor's bUnit (A-) beats the competitor median (B+)
- **Platform Reach**: no longer uniformly D — Blazor Hybrid (B+) is the only first-party cross-platform answer, trading native fidelity for reach
- **Forms**: Blazor's `<EditForm>` (A-) takes second place behind WPF (A), and is the best form story of any modern declarative framework
- **Error Handling**: `<ErrorBoundary>` in both Blazor (B+) and Reactor (B) puts two Microsoft frameworks in a small club with React

Note: this PR is documentation-only — no code changes.

## Test plan

- [ ] Review `docs/compare/blazor.md` for accuracy — especially grade rationale and claims verified against `~/code/aspnetcore/src/Components/`
- [ ] Review `docs/compare/overview.md` scorecard updates and gap-analysis rerank
- [ ] Confirm the new "Blazor is Reactor's closest cousin" takeaway lands the opposite-bets framing correctly
- [ ] Check links: `docs/compare/overview.md` → `blazor.md` resolves
- [ ] Verify no unrelated changes in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)