### PR TITLE
ci: skip unit tests on Markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       non-md: ${{ steps.filter.outputs.non-md }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,29 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      non-md: ${{ steps.filter.outputs.non-md }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Filter non-Markdown changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            non-md:
+              - '!(**/*.md)'
+              - '!(**/*.md)/**'
+
   unit-tests:
     name: Unit Tests
+    needs: changes
+    if: needs.changes.outputs.non-md == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       non-md: ${{ steps.filter.outputs.non-md }}
     steps:


### PR DESCRIPTION
## Summary
- Add a `changes` job that uses `dorny/paths-filter` to detect non-Markdown file changes.
- Gate the `unit-tests` job on `needs.changes.outputs.non-md == 'true'` so docs-only commits skip the .NET test run.
- Workflow still completes successfully, preserving any required-status-check setups.

## Test plan
- [ ] Open a docs-only PR and confirm `unit-tests` is skipped while the workflow reports success.
- [ ] Open a code-change PR and confirm `unit-tests` runs as before.
- [ ] Open a mixed PR (code + docs) and confirm `unit-tests` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)