### PR TITLE
docs(020): refine async resources spec after design review

### DIFF
--- a/docs/specs/020-async-resources-design.md
+++ b/docs/specs/020-async-resources-design.md
@@ -23,7 +23,7 @@
 11. [DataGrid Integration](#11-datagrid-integration)
 12. [Use Cases We Cover Well](#12-use-cases-we-cover-well)
 13. [Where This Doesn't Fit](#13-where-this-doesnt-fit)
-14. [Design Decisions (D1–D14)](#14-design-decisions)
+14. [Design Decisions (D1–D18)](#14-design-decisions)
 15. [Open Questions](#15-open-questions)
 16. [Implementation Phases](#16-implementation-phases)
 
@@ -219,7 +219,7 @@ public abstract record AsyncValue<T>
     /// <summary>Refetching with stale data still on screen (stale-while-revalidate).</summary>
     public sealed record Reloading(T Previous) : AsyncValue<T>;
 
-    // Convenience match — mirrors Riverpod's .when().
+    // Convenience shorthand — see §5.1.
     public TResult Match<TResult>(
         Func<TResult> loading,
         Func<T, TResult> data,
@@ -234,6 +234,42 @@ public abstract record AsyncValue<T>
             _             => throw new UnreachableException()
         };
 }
+```
+
+### 5.1 Matching on `AsyncValue<T>`
+
+The idiomatic form is a C# switch expression. The compiler enforces
+exhaustiveness on the sealed hierarchy (CS8509), pattern destructuring
+pulls the payload out directly, and there are no delegate allocations per
+render — which matters when the same `Match` runs per-row inside a
+virtualized `DataGrid`.
+
+```csharp
+return user switch
+{
+    AsyncValue<User>.Loading          => Skeleton().Height(120),
+    AsyncValue<User>.Data(var u)      => VStack(Heading(u.Name), Text(u.Email)),
+    AsyncValue<User>.Reloading(var u) => VStack(Heading(u.Name), Text(u.Email)).Opacity(0.6),
+    AsyncValue<User>.Error(var ex)    => Text($"Failed: {ex.Message}").Foreground(Red),
+};
+```
+
+The switch also supports guards (`Data d when d.Value.IsStale => ...`),
+per-arm debugging breakpoints, and partial matches where the compiler
+warns on the uncovered cases — all things a helper method can't give you.
+
+**When to use `.Match()`:** as a convenience when (a) you explicitly want
+`Reloading` to render the same tree as `Data` and don't want to duplicate
+the expression, or (b) you're in a non-hot-path site where the two or
+three delegate allocations per call are irrelevant and you prefer the
+named-argument reading. Everywhere else, prefer the switch.
+
+```csharp
+// Both read Reloading as Data — fallback is automatic.
+return user.Match(
+    loading: () => Skeleton().Height(120),
+    data:    u  => VStack(Heading(u.Name), Text(u.Email)),
+    error:   e  => Text($"Failed: {e.Message}").Foreground(Red));
 ```
 
 ### Why four states, not three
@@ -280,17 +316,25 @@ public sealed record ResourceOptions(
 
 1. On first render, the hook computes a cache key = `CacheKey ?? (calling hook
    identity + deps)` and looks it up in `QueryCache`.
-2. **Cache miss** → synchronously return `Loading`; schedule the fetcher on
-   the thread pool with a fresh `CancellationToken`.
+2. **Cache miss** → invoke `fetcher(ct)` once. If the returned `Task<T>` is
+   already in the `RanToCompletion` state (synchronous/hot-cached fetchers,
+   in-memory test doubles), unwrap it and return `Data(result)` on this same
+   render — no `Loading` flash. If the task is faulted synchronously, return
+   `Error(exception)` directly. Otherwise, return `Loading` synchronously and
+   schedule the continuation on the thread pool.
 3. **Cache hit, fresh** (age ≤ `StaleTime`) → return `Data(cached)` without
    fetching.
 4. **Cache hit, stale** → return `Reloading(cached)` and kick off a refetch.
-5. When a fetch completes, store the result in the cache and trigger
-   re-render of every component subscribed to that key.
+5. When an async fetch completes, the continuation marshals back to the UI
+   dispatcher captured at hook registration, stores the result in the cache,
+   and triggers re-render of every component subscribed to that key.
 6. When `deps` change, **cancel** the in-flight token for the old key and
    re-evaluate from step 1 with the new key. The old result stays in cache.
-7. On unmount, unsubscribe from the cache key. If this was the last
-   subscriber, start the `CacheTime` eviction timer.
+7. On unmount, cancel the in-flight token and unsubscribe from the cache key.
+   If this was the last subscriber, start the `CacheTime` eviction timer. A
+   fetch that was already cached before unmount remains in cache until the
+   timer expires; a fetch still in-flight at unmount is cancelled and its
+   result is dropped (see D15).
 
 ### 6.3 Example
 
@@ -303,22 +347,43 @@ class UserProfile : Component<UserProfileProps>
             fetcher: ct => Api.GetUserAsync(Props.UserId, ct),
             deps: [Props.UserId]);
 
-        return user.Match(
-            loading:   () => Skeleton().Height(120),
-            data:      u  => VStack(Heading(u.Name), Text(u.Email)),
-            reloading: u  => VStack(Heading(u.Name), Text(u.Email)).Opacity(0.6),
-            error:     e  => Text($"Failed: {e.Message}").Foreground(Red));
+        return user switch
+        {
+            AsyncValue<User>.Loading          => Skeleton().Height(120),
+            AsyncValue<User>.Data(var u)      => VStack(Heading(u.Name), Text(u.Email)),
+            AsyncValue<User>.Reloading(var u) => VStack(Heading(u.Name), Text(u.Email)).Opacity(0.6),
+            AsyncValue<User>.Error(var ex)    => Text($"Failed: {ex.Message}").Foreground(Red),
+        };
     }
 }
 ```
+
+See §5.1 for when `.Match()` is the better tool (explicit
+`Reloading`-as-`Data` fallback; cold paths where allocations don't matter).
 
 ### 6.4 Design points
 
 - `deps` is `object[]` to match `UseEffect` / `UseMemo` convention from spec
   009. Equality uses `ValueEqualityComparer` (same as `UseMemo`).
-- The hook **never** runs the fetcher during render — always on the thread
-  pool via `Task.Run`, with continuation back to the UI dispatcher. This
-  matches `DataPageCache.FetchBlockAsync` today.
+- **Threading.** `Render()` runs on the UI thread (enforced by
+  `RenderContext.AssertUIThread`, `RenderContext.cs:17-22`). The hook invokes
+  `fetcher(ct)` *from* the UI thread, but the fetcher body must do its actual
+  work on the thread pool (e.g., `Task.Run`, `HttpClient.SendAsync`). The hook
+  captures the UI dispatcher at registration time and uses it to marshal the
+  continuation — DataGrid's per-caller `DispatcherQueue.TryEnqueue` pattern
+  (`DataGridComponent.cs:54`) moves into the hook, so consumers no longer
+  hand-roll it.
+- **Sync-complete fast path.** A fetcher that returns an already-completed
+  `Task<T>` (in-memory cache, pre-seeded test data, `ValueTask`-fast-path)
+  resolves to `Data(result)` inside the *same* render that created the hook.
+  No intermediate `Loading` state, no flicker. The transition `Loading →
+  Data` happens across two renders only when the fetch is actually
+  asynchronous.
+- **Re-render short-circuit.** When a cache entry changes, subscribed
+  components re-render, but the hook compares the new `AsyncValue<T>` against
+  the last value it returned (record equality) and skips re-render if equal.
+  This matches the reconciler's memoization conventions and keeps
+  background-refresh churn from causing render storms.
 - The `CancellationToken` passed to the fetcher is cancelled when (a) `deps`
   change, (b) the component unmounts, or (c) the cache entry is manually
   invalidated.
@@ -355,6 +420,13 @@ public sealed class InfiniteResource<TItem>
     public LoadState LoadState { get; }           // Loading | Idle | EndOfList | Error(e)
     public bool HasMore { get; }
 
+    // Pull-model access for virtualized controls (LazyVStack, VirtualList,
+    // TreeView, DataGrid). Returns the item if its page is cached, or null
+    // if the slot is still loading. Calling ItemAt on an unloaded index
+    // triggers (or coalesces into) a fetch for the containing page.
+    public TItem? ItemAt(int index);
+    public void EnsureRange(int firstIndex, int lastIndex);
+
     public void FetchNext();
     public void Retry();
     public void Refresh();                         // invalidate cache, refetch from page 1
@@ -380,9 +452,14 @@ public abstract record LoadState
 4. **Placeholder slots**: `Items` is length `LoadedItemCount + placeholdersForInflightPages`.
    Consumers can treat `null` as "a row that will appear soon" (DataGrid uses
    this exact shape today — see `DataGridComponent.cs:490`).
-5. **Deps change** → cancel in-flight pages, clear `Items`, restart from
+5. **Pull-model access**: `ItemAt(i)` returns the item at `i` if its page is
+   loaded, else `null` and schedules a fetch for the containing page (coalesced
+   with any in-flight request for the same page). `EnsureRange(first, last)`
+   is the batched form used by virtualized controls when the viewport shifts.
+   Both are no-ops past the known end of the list.
+6. **Deps change** → cancel in-flight pages, clear `Items`, restart from
    page 1. Previous pages stay in cache under the old key for fast back-nav.
-6. **`Refresh()`** → keep deps, but invalidate the cache entry and refetch.
+7. **`Refresh()`** → keep deps, but invalidate the cache entry and refetch.
 
 ### 7.3 Adapter for `IDataSource<T>`
 
@@ -409,6 +486,30 @@ public static class DataSourceResource
 
 This means today's `GraphQLDataSource` and `ListDataSource` work with the
 new hooks without modification.
+
+### 7.4 Consumption from virtualized controls
+
+The hook intentionally serves *all* virtualized list controls in the
+framework, not just `DataGrid`. The existing controls split on consumption
+shape:
+
+| Control | Shape | How it consumes `InfiniteResource<T>` |
+|---|---|---|
+| `DataGrid` | Pull (range-based) | `EnsureRange(first, last)` on viewport change; `ItemAt(i)` during row render |
+| `LazyVStack` / `LazyHStack` | Pull (per-index `viewBuilder`) | `ItemAt(i)` inside the view builder; `null` → render placeholder |
+| `VirtualListComponent` | Pull (`RenderItem(index)`) | Same as `LazyVStack` |
+| `TreeView` (when it lands) | Pull (per-node lazy expand) | Each expanded node holds its own `InfiniteResource<TChild>` |
+| `StackPanel` / `VStack` | Eager | Use `UseResource<IReadOnlyList<T>>`, not `UseInfiniteResource`. The whole list is `AsyncValue`-matched at the container level; no placeholder story per-item. |
+
+"Render a placeholder when the slot is still loading" collapses to the same
+contract everywhere: the view builder gets `T?`, and `null` means *render
+your loading presentation* (skeleton, shimmer, spinner — the control's
+choice). No per-control async-awareness is required beyond that.
+
+Non-virtualized containers (`StackPanel`, `VStack`, `HStack`) deliberately
+don't participate in the infinite-resource contract — for a short list, the
+right shape is `UseResource<IReadOnlyList<T>>` and a single
+`AsyncValue.Match` at the container, not a per-slot placeholder dance.
 
 ---
 
@@ -739,7 +840,8 @@ is the primary surface. No thrown-`Task` / Suspense.
 **Rationale:** C# exhaustive-match warnings on sealed records give compile-time
 guarantees Suspense can't. The reconciler stays dumb (no fiber-style unwind
 and retry). The mental model matches what Reactor devs already write. The
-ergonomic gap vs. React Suspense is small once you've written `.Match()`.
+ergonomic gap vs. React Suspense is small once you've written the switch
+expression (see §5.1).
 
 **Considered:** A throw-Task mechanism where the reconciler catches
 `AwaitException` and re-renders when the task completes. Rejected: requires
@@ -870,40 +972,101 @@ an `IObservable<AsyncValue<T>>`.
 debugging simple and matches every other hook. If someone needs Rx, they can
 bridge at the fetcher level.
 
+### D15. Unmount cancels in-flight fetches; no `KeepAliveOnUnmount`
+
+**Decision:** When the last subscriber of a cache key unmounts, any in-flight
+fetch for that key is cancelled and its partial result is dropped. Already-
+completed entries stay in the cache until `CacheTime` expires; in-flight work
+does not. There is no opt-in `KeepAliveOnUnmount` flag.
+
+**Rationale:** Tab switches and navigations where "the fetch should survive"
+are better modelled by hoisting the data owner above the tab boundary — the
+`UseResource` lives in the persistent parent, and both tabs read from the
+same cache entry. That pattern is already idiomatic in Reactor (context
+providers, shared parent state) and doesn't need a hook-level knob.
+
+A `KeepAliveOnUnmount` flag would also raise a subtle reconnection problem:
+when a component remounts while a detached fetch is still pending, the hook
+has to identify and attach to the in-flight task from cache. Doable, but it
+trades the current crisp lifecycle (subscriber-count drops to zero →
+cancel) for a fuzzier one (cancel *unless someone remounts first*), and the
+observable behavior now depends on precise timing of unmount-and-remount.
+Not worth the complexity until a concrete use case requires it.
+
+**Considered:** A per-hook `KeepAliveOnUnmount: true` that detaches the fetch
+and lets it populate the cache even with zero subscribers. Rejected for v1
+on the grounds above. Re-evaluate if real usage produces a pattern that
+genuinely can't be solved by hoisting.
+
+### D16. Cache keys are flat strings, not structured arrays
+
+**Decision:** `ResourceOptions.CacheKey` is `string?`, and
+`MutationOptions.InvalidateKeys` is `string[]`. No array-keyed (TanStack
+`['user', userId, 'profile']`) variant.
+
+**Rationale:** The main argument for structured keys is prefix-invalidation
+ergonomics. `QueryCache.InvalidatePattern(string prefix)` already covers
+that use case without committing the entire API to array-shaped keys, and
+flat strings compose cleanly with interpolation (`$"user/{id}/profile"`).
+If structured keys prove necessary later, they're an additive change —
+flat strings are the conservative v1 baseline.
+
+### D17. Scroll preservation on `Refresh()` is a DataGrid concern
+
+**Decision:** `InfiniteResource<T>.Refresh()` handles data reload only. The
+viewport-level "preserve scroll across refresh" UX sits in the consuming
+control (DataGrid today, LazyVStack / TreeView when they land).
+
+**Rationale:** Scroll position is a rendering / viewport concern that varies
+per control (row height, virtualization window, selection restore,
+measurement timing). Pushing it into the hook would make `InfiniteResource`
+care about things it shouldn't — and each control would still want to
+override the policy anyway. DataGrid already owns analogous viewport work
+for its 32ms settle timer (`DataGridComponent.cs:56-90`); scroll-preserve
+on refresh is a small extension of that.
+
+**Hook contract needed to support this:** `InfiniteResource<T>` exposes
+(a) stable `Items` length during refresh where the server's total count
+hasn't changed (the consumer may want to keep showing current rows until
+the new page 1 lands — phase 3 can decide whether that's opt-in via a
+`RefreshMode` enum or the default), (b) a discrete `LoadState` transition
+on refresh start so consumers can snapshot scroll state, and (c) item
+identity via `RowKey` (spec 017) so re-arrivals can be matched against
+pre-refresh rows.
+
+### D18. Persisted resources serialize `Data` only
+
+**Decision:** When a resource hook is combined with spec 009's `PersistState`
+/ `UsePersisted` mechanism, only the `Data(Value)` case is serialized. On
+remount, the hook rehydrates to `Data(persistedValue)` and then behaves
+like a cache hit: fresh (skip fetch) if within `StaleTime`, stale (return
+`Reloading(persisted)` + refetch) otherwise.
+
+**Rationale:** `Loading` and `Reloading` are tied to a `CancellationToken`
+and an in-flight `Task<T>` — neither survives an unmount, let alone a
+process restart. `Error` is rarely what you want to replay. `Data` is the
+only state with meaningful continuity. Persisting anything else invites
+subtle bugs ("why am I stuck in Loading forever after a reload?").
+
 ---
 
 ## 15. Open Questions
 
-1. **Should `ResourceOptions.CacheKey` support structured keys** (a
-   `string[]` array, like TanStack Query's `['user', userId, 'profile']`),
-   or is a flat string enough? Structured keys enable `InvalidatePattern`
-   by prefix-matching; flat strings are simpler. Leaning flat for v1.
+1. **Focus revalidation (window-activated refetch).** TanStack Query's
+   signature feature: on `CoreWindow.Activated` (and
+   `CoreApplication.Resuming`), iterate the cache and refetch anything
+   past its `StaleTime`, deduping concurrent requests. Long-running
+   dashboards (HeadTrax-style tools left open all day) benefit strongly;
+   short-session tools (regedit) benefit little and risk unwanted
+   background traffic. Tentative plan: defer to phase 4 behind a feature
+   flag, off by default, with `ResourceOptions.RefetchOnWindowFocus` as
+   the per-query opt-out. Throttle default ~30s so rapid Alt-Tabbing
+   doesn't thrash. Revisit when we have real-app usage data.
 
-2. **Focus revalidation (window-activated refetch)** — TanStack Query's
-   killer feature. Worth adding for WinUI? Depends on whether our apps are
-   long-running dashboards (yes) or short-session tools (no). Defer to
-   phase 3 with a feature flag.
-
-3. **How do we teach "don't call `UseResource` conditionally"?** Same Rules
-   of Hooks problem React has. Spec 009 already establishes this; this spec
-   inherits it. Should the analyzer (Reactor.Analyzers) get a specific
-   diagnostic for this?
-
-4. **`InvalidateKeys` in `MutationOptions` takes `string[]`** — what's the
-   relationship with structured keys (Q1)? Need to settle Q1 first.
-
-5. **Should `UseInfiniteResource.Refresh()` preserve scroll position?** It
-   should, but that's a DataGrid-level concern, not a hook-level one. Need
-   to confirm the hook exposes enough for the grid to handle it.
-
-6. **Persistence story for `AsyncValue<T>` across unmount/remount**
-   (`PersistState` from spec 009 §5) — does it make sense to persist an
-   in-flight fetch? Or only the final `Data` value? Leaning: persist `Data`
-   only, re-fetch on remount if no cache hit.
-
-7. **The regedit `ValueList` and HeadTrax `EmployeeGrid`** — which one do we
-   port first as a dogfood sample? HeadTrax is real HTTP; regedit is in-
-   memory. HeadTrax is the better test.
+(Other questions from the original draft — structured vs flat cache keys,
+scroll preservation on `Refresh()`, persistence story for `AsyncValue<T>`,
+first dogfood target — have been resolved; see D16, D17, D18, and §16
+Phase 1 respectively.)
 
 ---
 
@@ -915,23 +1078,49 @@ bridge at the fetcher level.
 2. `QueryCache` with TTL, invalidate, context-installable.
 3. `UseResource<T>` hook with cancellation, stale-while-revalidate.
 4. Unit tests: cache hit/miss, deps-change cancellation, stale-while-revalidate
-   transitions, error path.
-5. Sample: port `UserProfile`-style fetch in a new demo component.
+   transitions, error path, sync-complete fast path (§6.2, §6.4).
+5. **TestApp dogfood — `AsyncValueSamples` page.** A dedicated sample page
+   added to the existing TestApp, not a new app. The page is structured as
+   layered scenarios that can be exercised interactively and captured in
+   the TestApp's existing snapshot tests:
+   - **1a. Deterministic fake fetcher.** `Task.Delay(ms)` + configurable
+     succeed / fail / cancel buttons. Validates each `AsyncValue` state
+     transition visually.
+   - **1b. Sync-complete fetcher.** Returns `Task.FromResult` directly.
+     Confirms no `Loading` flash on first render (D16 neighbor).
+   - **1c. Deps-change cancellation.** Text input drives `deps`; type fast,
+     confirm only the last request's result lands.
+   - **1d. Two siblings, one cache key.** Validates dedup + shared re-render.
+   - **1e. Cache hit across remount.** Unmount/remount within `CacheTime`,
+     confirm instant `Data` (or `Reloading` past `StaleTime`).
 
 **Exit criteria:** A dev can write a single-fetch component end-to-end using
-only `UseResource`, no `UseEffect + UseState` plumbing.
+only `UseResource`, no `UseEffect + UseState` plumbing. All five
+`AsyncValueSamples` scenarios pass in the TestApp's snapshot suite.
 
-### Phase 2 — Infinite
+### Phase 2 — Infinite (still TestApp-only)
 
 1. `UseInfiniteResource<TItem, TCursor>` on top of the phase-1 cache.
 2. `DataSourceResource.UseDataSource` adapter for `IDataSource<T>`.
-3. Parity tests against `DataPageCache<T>`: same LRU eviction, same
+3. Pull-model API (`ItemAt`, `EnsureRange`) per §7.1.
+4. Parity tests against `DataPageCache<T>`: same LRU eviction, same
    placeholder semantics, same cancellation on deps change.
-4. Sample: port the HeadTrax `EmployeeGrid` to `UseInfiniteResource`
-   without going through DataGrid.
+5. **TestApp dogfood — extend `AsyncValueSamples`.** Same page, more layers:
+   - **2a. `LazyVStack` backed by `UseInfiniteResource`** — the smallest
+     virtualized consumer. Validates pull-model via `ItemAt`, placeholder
+     rendering on `null` slots, and scroll-driven page fetch.
+   - **2b. Search-as-you-type over an infinite list.** Deps-change + pull
+     model combined; confirms that stale pages cancel cleanly mid-scroll.
+   - **2c. `Refresh()` with scroll preservation** (consumer-side — LazyVStack
+     captures scroll before refresh, restores after; see D17).
+   - **2d. Port the regedit `ValueList`** (in-memory, low-risk) as the
+     first real-world consumer.
 
 **Exit criteria:** `UseInfiniteResource` passes every scenario
-`DataPageCache<T>` passes today, driven from unit tests.
+`DataPageCache<T>` passes today (parity tests) plus the TestApp scenarios
+above. regedit `ValueList` is on the new hook. Still no DataGrid
+dependency at this point — HeadTrax `EmployeeGrid` port happens in phase 3
+alongside the DataGrid migration.
 
 ### Phase 3 — Mutations & DataGrid migration
 
@@ -942,17 +1131,42 @@ only `UseResource`, no `UseEffect + UseState` plumbing.
    paths in CI; assert identical reconciliation results on the selfhost
    test suite.
 4. Port `DataGridState.BeginAsyncCommit` family to `UseMutation`.
-5. Delete `DataPageCache` once the feature flag is flipped by default.
+5. Port HeadTrax `EmployeeGrid` — the first real-HTTP, real-DataGrid
+   consumer — once the feature flag is enabled by default.
+6. Delete `DataPageCache` once HeadTrax has been stable on the new path
+   through at least one release cycle.
 
 **Exit criteria:** No public API changes to DataGrid; `DataPageCache.cs`
-deleted; all selfhost DataGrid tests green on the new path.
+deleted; all selfhost DataGrid tests green on the new path; HeadTrax
+`EmployeeGrid` ported and in production.
 
 ### Phase 4 — Polish
 
 1. `Pending` element.
-2. Focus revalidation (if it survives the Q2 debate).
-3. Analyzer diagnostics for rules-of-hooks violations specific to resource
-   hooks.
+2. Focus revalidation (per §15 Q1), feature-flagged and off by default,
+   with `ResourceOptions.RefetchOnWindowFocus` per-query opt-out.
+3. **Analyzer diagnostics — expanded work item.** Resource hooks inherit
+   the rules-of-hooks problem from spec 009, but the analyzer coverage is
+   thin today across *all* hooks, not just these. Treat this as a broader
+   deliverable — tracked in `Reactor.Analyzers` under new `REACTOR_HOOKS_*`
+   diagnostic IDs:
+   - **Conditional hook calls.** `UseResource` / `UseState` / any
+     `Use*` inside `if`, `for`, `while`, `try`, or early-return branches.
+   - **Out-of-order hook calls across renders.** Hook call-site ordering
+     differs between two render paths of the same component.
+   - **Missing deps.** Value captured in the `fetcher` (or
+     `UseEffect` / `UseMemo` lambda) that isn't in `deps`.
+   - **Non-stable deps.** New object literal, new array, or new lambda
+     passed as a dep each render (causes unnecessary refetches /
+     re-runs).
+   - **Hook called outside `Render()` or a custom-hook function.**
+   - **`UseResource` with a non-idempotent fetcher** (heuristic —
+     fetcher name matches `GenerateRandom`, `Create`, `Post`, etc.).
+
+   Scope note: the first three diagnostics are pre-existing gaps that
+   should ship before or alongside this spec so resource hooks aren't
+   the first concrete motivator. Worth filing as its own tracking
+   issue / spec amendment if the list keeps growing.
 4. Docs: porting guide from `UseEffect + UseState` to `UseResource`; a
    separate cookbook entry for infinite scroll.
 5. Evaluate `UseStream<T>` scope and file a follow-up spec if warranted.


### PR DESCRIPTION
## Summary

Refines spec 020 (async resources) based on the design-review conversation on issue #14. Most of the open questions are now resolved as decisions (D15–D18); one remains open (focus revalidation, deferred to phase 4).

Key changes:

- **Matching.** Lead with C# switch expressions as idiomatic; demote `.Match()` to a convenience for the `Reloading`-as-`Data` fallback case. Switch avoids per-render delegate allocations in hot paths (DataGrid row rendering) and gets exhaustiveness from the compiler for free.
- **Sync-complete fast path.** A fetcher that returns an already-completed `Task<T>` resolves to `Data` on the same render — no `Loading` flicker for in-memory sources or test doubles.
- **Threading made explicit.** UI dispatcher captured at hook registration; the `DataGridComponent.cs:54` dispatch pattern moves into the hook so consumers stop hand-rolling it.
- **Pull-model API on `InfiniteResource<T>`.** New `ItemAt` / `EnsureRange` methods; §7.4 documents how `LazyVStack`, `VirtualList`, `TreeView`, and `DataGrid` consume them, and why non-virtualized containers should use `UseResource<IReadOnlyList<T>>` instead.
- **Four new design decisions.** D15 (cancel-on-unmount; hoist for cross-tab sharing), D16 (flat string cache keys), D17 (scroll preservation is a consumer concern), D18 (PersistState serializes `Data` only).
- **Phase 1/2 reworked as TestApp-first.** Layered `AsyncValueSamples` page (1a–1e, then 2a–2d) exercises each state transition in isolation before the first real consumer (regedit `ValueList`). DataGrid + HeadTrax `EmployeeGrid` port moves to Phase 3.
- **Phase 4 analyzer item expanded.** Six concrete `REACTOR_HOOKS_*` diagnostics covering rules-of-hooks violations across *all* hooks, not just resource ones.

Spec-only change; no runtime code touched. Tracks issue #14.

## Test plan

- [ ] Skim §5.1 switch-expression example against current C# 12 behavior (sealed-hierarchy exhaustiveness, tuple-deconstruction on records).
- [ ] Confirm the Phase 1 TestApp dogfood plan (AsyncValueSamples 1a–1e) lines up with existing TestApp snapshot-test conventions.
- [ ] Confirm D17's hook contract (stable `Items`, discrete `LoadState` refresh signal, `RowKey` identity) is actually exposable on `InfiniteResource<T>` before Phase 2 implementation starts.
- [ ] Double-check that D15 (cancel on unmount, no `KeepAliveOnUnmount`) doesn't conflict with any navigation-lifecycle expectations in spec 011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)