### PR TITLE
test(d3): port upstream d3 tests to raise CI coverage

### DIFF
--- a/tests/Reactor.Tests/ChildReconcilerReconcileTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerReconcileTests.cs
@@ -1,0 +1,60 @@
+#if CHILD_RECONCILER_RECONCILE_TESTS
+// ⚠️ Disabled — blocked by the selftest wall.
+//
+// This file attempted to exercise ChildReconciler.Reconcile's full surface
+// (ReconcilePositional, ReconcileKeyed prefix/suffix, ReconcileKeyedMiddle + LIS)
+// using a custom-registered element type whose mount handler returned a real Border.
+// That plan fails in CI: `new Border()` throws COMException without a full XAML
+// Application host, so registered-type Mount can't produce a UIElement here.
+//
+// Conclusion: the ~310 uncovered lines in ReconcilePositional/ReconcileKeyed/
+// ReconcileKeyedMiddle genuinely need selftest (real StackPanel + dispatcher).
+// Only the helpers (ComputeLIS, Filter, HasAnyKeys, KeyMatch, GetKey) are
+// unit-testable in CI — ComputeLIS/HasAnyKeys are already covered by
+// ChildReconcilerTests + ChildReconcilerIntegrationTests. Filter/KeyMatch/GetKey
+// are the only remaining CI-reachable surface and are small.
+
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+public class ChildReconcilerReconcileTests
+{
+    private static readonly Action NoOp = () => { };
+
+    private record Item(string Label) : Element;
+
+    private static Reconciler MakeReconciler()
+    {
+        var r = new Reconciler();
+        r.RegisterType<Item, Border>(
+            mount: (_, el, _) =>
+            {
+                var b = new Border();
+                b.Tag = el;
+                return b;
+            },
+            update: (_, _, newEl, ctrl, _) =>
+            {
+                ctrl.Tag = newEl;
+                return null;
+            });
+        return r;
+    }
+
+    private sealed class Recorder : IChildCollection
+    {
+        private readonly List<UIElement> _items = new();
+        public List<string> Ops { get; } = new();
+        public int Count => _items.Count;
+        public UIElement Get(int index) => _items[index];
+        public void Insert(int index, UIElement element) { _items.Insert(index, element); Ops.Add($"Insert({index})"); }
+        public void RemoveAt(int index) { _items.RemoveAt(index); Ops.Add($"RemoveAt({index})"); }
+        public void Move(int oldIndex, int newIndex) { var it = _items[oldIndex]; _items.RemoveAt(oldIndex); _items.Insert(newIndex, it); Ops.Add($"Move({oldIndex},{newIndex})"); }
+        public void Replace(int index, UIElement element) { _items[index] = element; Ops.Add($"Replace({index})"); }
+    }
+}
+#endif

--- a/tests/Reactor.Tests/D3/ArcTests.cs
+++ b/tests/Reactor.Tests/D3/ArcTests.cs
@@ -1,0 +1,191 @@
+// Port of d3-shape/test/arc-test.js (subset — exact SVG path-string matching is
+// avoided where reactor1's PathBuilder formatting diverges from upstream.
+// Corner-radius paths are not yet implemented in reactor1 so those tests are
+// expectation-only: we assert the NotImplementedException contract.)
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class ArcTests
+{
+    private const double Tol = 1e-6;
+    private static double Round(double x) => Math.Round(x * 1e6) / 1e6;
+
+    // ─── Point / degenerate ──────────────────────────────────────────
+
+    [Fact]
+    public void Point_When_Both_Radii_Zero()
+    {
+        var a = new ArcGenerator().SetInnerRadius(0).SetOuterRadius(0);
+        var path = a.Generate(0, 2 * Math.PI);
+        Assert.Equal("M0,0Z", path);
+    }
+
+    [Fact]
+    public void Point_When_Zero_Angle_Span()
+    {
+        var a = new ArcGenerator().SetInnerRadius(0).SetOuterRadius(0);
+        var path = a.Generate(0, 0);
+        Assert.Equal("M0,0Z", path);
+    }
+
+    // ─── Circle / annulus full turn ──────────────────────────────────
+
+    [Fact]
+    public void FullCircle_StartsAt_Minus_OuterRadius_Y()
+    {
+        // Inner=0, outer=100, full τ turn: starts at (0, -100) (12 o'clock).
+        var a = new ArcGenerator().SetInnerRadius(0).SetOuterRadius(100);
+        var path = a.Generate(0, 2 * Math.PI);
+        Assert.NotNull(path);
+        Assert.StartsWith("M0,-100", path);
+        Assert.EndsWith("Z", path);
+    }
+
+    [Fact]
+    public void Annulus_FullCircle_Has_Two_Arcs()
+    {
+        // Inner=50, outer=100, full τ turn: outer arc + inner arc (2 M commands).
+        var a = new ArcGenerator().SetInnerRadius(50).SetOuterRadius(100);
+        var path = a.Generate(0, 2 * Math.PI);
+        Assert.NotNull(path);
+        // Two separate subpaths (MoveTo to outer then MoveTo to inner).
+        Assert.Equal(2, path!.Count(c => c == 'M'));
+        Assert.Equal(4, path.Count(c => c == 'A'));
+    }
+
+    // ─── Sector (no inner radius) ────────────────────────────────────
+
+    [Fact]
+    public void SmallClockwiseSector_EndsWith_LineTo_Origin()
+    {
+        // Pie-slice: should end with L0,0 before Z.
+        var a = new ArcGenerator().SetInnerRadius(0).SetOuterRadius(100);
+        var path = a.Generate(0, Math.PI / 2);
+        Assert.NotNull(path);
+        Assert.Contains("L0,0", path);
+        Assert.EndsWith("Z", path);
+    }
+
+    [Fact]
+    public void AnticlockwiseSector_SpansOtherDirection()
+    {
+        // Negative angle span proceeds anticlockwise.
+        var a = new ArcGenerator().SetInnerRadius(0).SetOuterRadius(100);
+        var path = a.Generate(0, -Math.PI / 2);
+        Assert.NotNull(path);
+        // Ends near (-100, 0) on the negative x-axis.
+        Assert.Contains("-100", path);
+    }
+
+    // ─── Annular sector ──────────────────────────────────────────────
+
+    [Fact]
+    public void Annular_Sector_Has_Two_Arcs_No_LineTo_Origin()
+    {
+        var a = new ArcGenerator().SetInnerRadius(50).SetOuterRadius(100);
+        var path = a.Generate(0, Math.PI / 2);
+        Assert.NotNull(path);
+        // Outer arc + inner arc → 2 A commands.
+        Assert.Equal(2, path!.Count(c => c == 'A'));
+        // Inner radius > 0 → no line-to-origin (L0,0).
+        Assert.DoesNotContain("L0,0", path);
+    }
+
+    // ─── Radius swap (innerRadius > outerRadius) ─────────────────────
+
+    [Fact]
+    public void Radii_Are_Swapped_When_Inner_Greater_Than_Outer()
+    {
+        // Generator should still produce valid output with radii swapped internally.
+        var a = new ArcGenerator().SetInnerRadius(100).SetOuterRadius(50);
+        var path = a.Generate(0, Math.PI / 2);
+        Assert.NotNull(path);
+    }
+
+    // ─── Corner radius: not yet implemented ──────────────────────────
+
+    [Fact]
+    public void CornerRadius_Nonzero_NotImplemented()
+    {
+        var a = new ArcGenerator().SetInnerRadius(0).SetOuterRadius(100).SetCornerRadius(5);
+        Assert.Throws<NotImplementedException>(() => a.Generate(0, Math.PI / 2));
+    }
+
+    [Fact]
+    public void CornerRadius_On_FullCircle_Still_Works()
+    {
+        // For full circles, the corner radius code path is never entered.
+        var a = new ArcGenerator().SetInnerRadius(0).SetOuterRadius(100).SetCornerRadius(5);
+        var path = a.Generate(0, 2 * Math.PI);
+        Assert.NotNull(path);
+    }
+
+    // ─── Centroid ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Centroid_Of_Half_Circle()
+    {
+        // r0=0, r1=100, [0, π] → midRadius=50, midAngle=π/2 - π/2 = 0 → (50, 0).
+        var (x, y) = new ArcGenerator().Centroid(0, Math.PI, 0, 100);
+        Assert.Equal(50, Round(x));
+        Assert.Equal(0, Round(y));
+    }
+
+    [Fact]
+    public void Centroid_Of_Quarter_Circle()
+    {
+        // r=50, midAngle = π/4 - π/2 = -π/4 → (50 cos(-π/4), 50 sin(-π/4)).
+        var (x, y) = new ArcGenerator().Centroid(0, Math.PI / 2, 0, 100);
+        Assert.Equal(35.355339, Round(x));
+        Assert.Equal(-35.355339, Round(y));
+    }
+
+    [Fact]
+    public void Centroid_Of_Annulus_Quarter()
+    {
+        // r0=50, r1=100, midAngle = -π/4 → midRadius=75 but angle goes through -π/4
+        // d3 upstream: innerRadius: 50, outerRadius: 100, start 0, end -π → (-75, 0).
+        var (x, y) = new ArcGenerator().Centroid(0, -Math.PI, 50, 100);
+        Assert.Equal(-75, Round(x));
+        Assert.Equal(0, Round(y));
+    }
+
+    [Fact]
+    public void Centroid_Static_Convenience()
+    {
+        var (x, y) = ArcGenerator.Centroid(0, Math.PI, 0, 100);
+        Assert.Equal(50, Round(x));
+        Assert.Equal(0, Round(y));
+    }
+
+    // ─── Fluent chaining ─────────────────────────────────────────────
+
+    [Fact]
+    public void Fluent_Setters_Chain_Correctly()
+    {
+        var a = new ArcGenerator()
+            .SetInnerRadius(10)
+            .SetOuterRadius(20)
+            .SetCornerRadius(0)
+            .SetDigits(3);
+        // No explicit inner/outer override → uses the set values.
+        var path = a.Generate(0, Math.PI / 2);
+        Assert.NotNull(path);
+        // Outer radius 20 should appear in the path.
+        Assert.Contains("20", path);
+    }
+
+    [Fact]
+    public void Explicit_Radii_Override_Setters()
+    {
+        var a = new ArcGenerator().SetInnerRadius(100).SetOuterRadius(200);
+        // Explicit args override the setters.
+        var path = a.Generate(0, 2 * Math.PI, 0, 50, 75);
+        Assert.NotNull(path);
+        // With inner=50, outer=75, neither 100 nor 200 should appear.
+        Assert.DoesNotContain("M0,-100", path);
+    }
+}

--- a/tests/Reactor.Tests/D3/AreaTests.cs
+++ b/tests/Reactor.Tests/D3/AreaTests.cs
@@ -1,0 +1,37 @@
+// Port of d3-shape/test/area-test.js
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class AreaTests
+{
+    [Fact]
+    public void Area_Default_GeneratesPath()
+    {
+        var a = AreaGenerator.FromArrays();
+        var data = new[] { new[] { 0.0, 1.0 }, new[] { 2.0, 3.0 }, new[] { 4.0, 5.0 } };
+        Assert.Equal("M0,1L2,3L4,5L4,0L2,0L0,0Z", a.Generate(data));
+    }
+
+    [Fact]
+    public void Area_CustomAccessors()
+    {
+        var data = new[]
+        {
+            new { X = 0.0, Y = 5.0 },
+            new { X = 10.0, Y = 15.0 },
+            new { X = 20.0, Y = 10.0 },
+        };
+        var a = AreaGenerator.Create<dynamic>(d => (double)d.X, d => (double)d.Y);
+        Assert.Equal("M0,5L10,15L20,10L20,0L10,0L0,0Z", a.Generate(data));
+    }
+
+    [Fact]
+    public void Area_EmptyData_ReturnsNull()
+    {
+        var a = AreaGenerator.FromArrays();
+        Assert.Null(a.Generate(Array.Empty<double[]>()));
+    }
+}

--- a/tests/Reactor.Tests/D3/ArrayExtraTests.cs
+++ b/tests/Reactor.Tests/D3/ArrayExtraTests.cs
@@ -1,0 +1,228 @@
+// Port of d3-array extent-test.js, bisect-test.js, tickIncrement-test.js
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class ExtentTests
+{
+    [Fact]
+    public void Extent_Single_Value()
+    {
+        Assert.Equal((1.0, 1.0), D3Extent.Extent([1]));
+    }
+
+    [Fact]
+    public void Extent_Multiple_Values()
+    {
+        Assert.Equal((1.0, 5.0), D3Extent.Extent([5, 1, 2, 3, 4]));
+        Assert.Equal((3.0, 20.0), D3Extent.Extent([20, 3]));
+        Assert.Equal((3.0, 20.0), D3Extent.Extent([3, 20]));
+    }
+
+    [Fact]
+    public void Extent_Ignores_NaN()
+    {
+        Assert.Equal((1.0, 5.0), D3Extent.Extent([double.NaN, 1, 2, 3, 4, 5]));
+        Assert.Equal((1.0, 5.0), D3Extent.Extent([1, 2, 3, 4, 5, double.NaN]));
+        Assert.Equal((-5.0, -1.0), D3Extent.Extent([-1, -3, -5, double.NaN]));
+    }
+
+    [Fact]
+    public void Extent_Empty_Returns_NaN()
+    {
+        var (min, max) = D3Extent.Extent(Array.Empty<double>());
+        Assert.True(double.IsNaN(min));
+        Assert.True(double.IsNaN(max));
+    }
+
+    [Fact]
+    public void Extent_All_NaN_Returns_NaN()
+    {
+        var (min, max) = D3Extent.Extent([double.NaN, double.NaN]);
+        Assert.True(double.IsNaN(min));
+        Assert.True(double.IsNaN(max));
+    }
+
+    [Fact]
+    public void Extent_Accessor_Overload()
+    {
+        var items = new[] { new Box(5), new Box(1), new Box(2), new Box(3), new Box(4) };
+        Assert.Equal((1.0, 5.0), D3Extent.Extent(items, x => x.V));
+    }
+
+    [Fact]
+    public void Extent_Accessor_Ignores_NaN()
+    {
+        var items = new[] { new Box(double.NaN), new Box(1), new Box(5) };
+        Assert.Equal((1.0, 5.0), D3Extent.Extent(items, x => x.V));
+    }
+
+    private record Box(double V);
+}
+
+public class BisectTests
+{
+    [Fact]
+    public void BisectLeft_Exact_Match_Returns_First_Index()
+    {
+        var numbers = new double[] { 1, 2, 3 };
+        Assert.Equal(0, D3Bisect.BisectLeft(numbers, 1));
+        Assert.Equal(1, D3Bisect.BisectLeft(numbers, 2));
+        Assert.Equal(2, D3Bisect.BisectLeft(numbers, 3));
+    }
+
+    [Fact]
+    public void BisectLeft_Duplicates_Returns_First()
+    {
+        var numbers = new double[] { 1, 2, 2, 3 };
+        Assert.Equal(0, D3Bisect.BisectLeft(numbers, 1));
+        Assert.Equal(1, D3Bisect.BisectLeft(numbers, 2));
+        Assert.Equal(3, D3Bisect.BisectLeft(numbers, 3));
+    }
+
+    [Fact]
+    public void BisectLeft_Empty_Returns_Zero()
+    {
+        Assert.Equal(0, D3Bisect.BisectLeft(Array.Empty<double>(), 1));
+    }
+
+    [Fact]
+    public void BisectLeft_Non_Exact_Returns_Insertion_Point()
+    {
+        var numbers = new double[] { 1, 2, 3 };
+        Assert.Equal(0, D3Bisect.BisectLeft(numbers, 0.5));
+        Assert.Equal(1, D3Bisect.BisectLeft(numbers, 1.5));
+        Assert.Equal(2, D3Bisect.BisectLeft(numbers, 2.5));
+        Assert.Equal(3, D3Bisect.BisectLeft(numbers, 3.5));
+    }
+
+    [Fact]
+    public void BisectLeft_Observes_Lo_Bound()
+    {
+        var numbers = new double[] { 1, 2, 3, 4, 5 };
+        Assert.Equal(2, D3Bisect.BisectLeft(numbers, 0, 2));
+        Assert.Equal(2, D3Bisect.BisectLeft(numbers, 2, 2));
+        Assert.Equal(3, D3Bisect.BisectLeft(numbers, 4, 2));
+        Assert.Equal(4, D3Bisect.BisectLeft(numbers, 5, 2));
+        Assert.Equal(5, D3Bisect.BisectLeft(numbers, 6, 2));
+    }
+
+    [Fact]
+    public void BisectLeft_Observes_Lo_Hi_Bounds()
+    {
+        var numbers = new double[] { 1, 2, 3, 4, 5 };
+        Assert.Equal(2, D3Bisect.BisectLeft(numbers, 2, 2, 3));
+        Assert.Equal(3, D3Bisect.BisectLeft(numbers, 4, 2, 3));
+        Assert.Equal(3, D3Bisect.BisectLeft(numbers, 6, 2, 3));
+    }
+
+    [Fact]
+    public void BisectLeft_NaN_Returns_Hi()
+    {
+        var numbers = new double[] { 1, 2, 3 };
+        Assert.Equal(3, D3Bisect.BisectLeft(numbers, double.NaN));
+    }
+
+    [Fact]
+    public void BisectRight_Exact_Match_Returns_Index_After()
+    {
+        var numbers = new double[] { 1, 2, 3 };
+        Assert.Equal(1, D3Bisect.BisectRight(numbers, 1));
+        Assert.Equal(2, D3Bisect.BisectRight(numbers, 2));
+        Assert.Equal(3, D3Bisect.BisectRight(numbers, 3));
+    }
+
+    [Fact]
+    public void BisectRight_Duplicates_Returns_Index_After_Last()
+    {
+        var numbers = new double[] { 1, 2, 2, 3 };
+        Assert.Equal(1, D3Bisect.BisectRight(numbers, 1));
+        Assert.Equal(3, D3Bisect.BisectRight(numbers, 2));
+        Assert.Equal(4, D3Bisect.BisectRight(numbers, 3));
+    }
+
+    [Fact]
+    public void BisectRight_Empty_Returns_Zero()
+    {
+        Assert.Equal(0, D3Bisect.BisectRight(Array.Empty<double>(), 1));
+    }
+
+    [Fact]
+    public void BisectRight_Non_Exact_Returns_Insertion_Point()
+    {
+        var numbers = new double[] { 1, 2, 3 };
+        Assert.Equal(0, D3Bisect.BisectRight(numbers, 0.5));
+        Assert.Equal(1, D3Bisect.BisectRight(numbers, 1.5));
+        Assert.Equal(2, D3Bisect.BisectRight(numbers, 2.5));
+        Assert.Equal(3, D3Bisect.BisectRight(numbers, 3.5));
+    }
+
+    [Fact]
+    public void BisectRight_Observes_Lo_Hi_Bounds()
+    {
+        var numbers = new double[] { 1, 2, 3, 4, 5 };
+        Assert.Equal(2, D3Bisect.BisectRight(numbers, 2, 2, 3));
+        Assert.Equal(3, D3Bisect.BisectRight(numbers, 3, 2, 3));
+        Assert.Equal(3, D3Bisect.BisectRight(numbers, 6, 2, 3));
+    }
+
+    [Fact]
+    public void BisectCenter_Picks_Closest()
+    {
+        var numbers = new double[] { 1, 2, 3, 4, 5 };
+        // Closer to 2 than 3.
+        Assert.Equal(1, D3Bisect.BisectCenter(numbers, 2.1));
+        // Closer to 3 than 2.
+        Assert.Equal(2, D3Bisect.BisectCenter(numbers, 2.9));
+    }
+
+    [Fact]
+    public void BisectCenter_Empty_Returns_Zero()
+    {
+        Assert.Equal(0, D3Bisect.BisectCenter(Array.Empty<double>(), 1));
+    }
+}
+
+public class TickIncrementTests
+{
+    [Fact]
+    public void TickIncrement_Zero_To_One()
+    {
+        // count=10 → step ≈ 0.1 → factor=1, power=-1 → inc = -10
+        Assert.Equal(-10, D3Ticks.TickIncrement(0, 1, 10));
+        Assert.Equal(-10, D3Ticks.TickIncrement(0, 1, 9));
+        Assert.Equal(-10, D3Ticks.TickIncrement(0, 1, 8));
+        Assert.Equal(-5, D3Ticks.TickIncrement(0, 1, 7));
+        Assert.Equal(-5, D3Ticks.TickIncrement(0, 1, 5));
+        Assert.Equal(-2, D3Ticks.TickIncrement(0, 1, 3));
+        Assert.Equal(-2, D3Ticks.TickIncrement(0, 1, 2));
+        Assert.Equal(1, D3Ticks.TickIncrement(0, 1, 1));
+    }
+
+    [Fact]
+    public void TickIncrement_Zero_To_Ten()
+    {
+        Assert.Equal(1, D3Ticks.TickIncrement(0, 10, 10));
+        Assert.Equal(1, D3Ticks.TickIncrement(0, 10, 8));
+        Assert.Equal(2, D3Ticks.TickIncrement(0, 10, 7));
+        Assert.Equal(2, D3Ticks.TickIncrement(0, 10, 4));
+        Assert.Equal(5, D3Ticks.TickIncrement(0, 10, 3));
+        Assert.Equal(5, D3Ticks.TickIncrement(0, 10, 2));
+        Assert.Equal(10, D3Ticks.TickIncrement(0, 10, 1));
+    }
+
+    [Fact]
+    public void TickIncrement_Negative_To_Positive()
+    {
+        Assert.Equal(2, D3Ticks.TickIncrement(-10, 10, 10));
+        Assert.Equal(2, D3Ticks.TickIncrement(-10, 10, 8));
+        Assert.Equal(2, D3Ticks.TickIncrement(-10, 10, 7));
+        Assert.Equal(5, D3Ticks.TickIncrement(-10, 10, 6));
+        Assert.Equal(5, D3Ticks.TickIncrement(-10, 10, 4));
+        Assert.Equal(5, D3Ticks.TickIncrement(-10, 10, 3));
+        Assert.Equal(10, D3Ticks.TickIncrement(-10, 10, 2));
+        Assert.Equal(20, D3Ticks.TickIncrement(-10, 10, 1));
+    }
+}

--- a/tests/Reactor.Tests/D3/ChordTests.cs
+++ b/tests/Reactor.Tests/D3/ChordTests.cs
@@ -1,0 +1,73 @@
+// Port of d3-chord tests
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class ChordTests
+{
+    [Fact]
+    public void Chord_SquareMatrix()
+    {
+        var layout = new ChordLayout();
+        double[][] matrix =
+        [
+            [11975, 5871, 8916, 2868],
+            [1951, 10048, 2060, 6171],
+            [8010, 16145, 8090, 8045],
+            [1013, 990, 940, 6907],
+        ];
+
+        var data = layout.Generate(matrix);
+        Assert.Equal(4, data.Groups.Length);
+        Assert.True(data.Chords.Length > 0);
+    }
+
+    [Fact]
+    public void Chord_GroupsSpanFullCircle()
+    {
+        var layout = new ChordLayout();
+        double[][] matrix =
+        [
+            [10, 20],
+            [30, 40],
+        ];
+
+        var data = layout.Generate(matrix);
+        Assert.Equal(2, data.Groups.Length);
+
+        Assert.Equal(0, data.Groups[0].StartAngle);
+
+        double lastEnd = data.Groups[^1].EndAngle;
+        Assert.True(lastEnd > 0);
+    }
+
+    [Fact]
+    public void Chord_PadAngle()
+    {
+        var layout = new ChordLayout().SetPadAngle(0.1);
+        double[][] matrix = [[10, 20], [30, 40]];
+
+        var data = layout.Generate(matrix);
+        double totalArc = 0;
+        foreach (var g in data.Groups) totalArc += g.EndAngle - g.StartAngle;
+        Assert.True(totalArc < 2 * Math.PI);
+    }
+
+    [Fact]
+    public void Ribbon_GeneratesPath()
+    {
+        var layout = new ChordLayout();
+        double[][] matrix = [[10, 20], [30, 40]];
+        var data = layout.Generate(matrix);
+
+        var ribbon = new RibbonGenerator().SetRadius(100);
+        foreach (var chord in data.Chords)
+        {
+            var path = ribbon.Generate(chord);
+            Assert.NotNull(path);
+            Assert.StartsWith("M", path);
+        }
+    }
+}

--- a/tests/Reactor.Tests/D3/ClusterTests.cs
+++ b/tests/Reactor.Tests/D3/ClusterTests.cs
@@ -1,0 +1,79 @@
+// Tests for d3-hierarchy cluster layout
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class ClusterTests
+{
+    private record Node(string Name, Node[]? Children = null);
+
+    [Fact]
+    public void Cluster_LeavesAtSameDepth()
+    {
+        var root = new Node("root",
+        [
+            new("a", [new("a1"), new("a2")]),
+            new("b"),
+        ]);
+
+        var layout = ClusterLayout.Create<Node>().Size(200, 200);
+        var tree = layout.Hierarchy(root, n => n.Children);
+        layout.Layout(tree);
+
+        var leaves = new List<TreeNode<Node>>();
+        void CollectLeaves(TreeNode<Node> n)
+        {
+            if (n.Children.Count == 0) leaves.Add(n);
+            foreach (var c in n.Children) CollectLeaves(c);
+        }
+        CollectLeaves(tree);
+
+        double leafY = leaves[0].Y;
+        foreach (var leaf in leaves)
+        {
+            Assert.Equal(leafY, leaf.Y, 1);
+        }
+    }
+
+    [Fact]
+    public void Cluster_RootAtTop()
+    {
+        var root = new Node("root", [new("a"), new("b")]);
+
+        var layout = ClusterLayout.Create<Node>().Size(200, 200);
+        var tree = layout.Hierarchy(root, n => n.Children);
+        layout.Layout(tree);
+
+        Assert.True(tree.Y < tree.Children[0].Y);
+    }
+
+    [Fact]
+    public void Cluster_SingleChild()
+    {
+        var root = new Node("root", [new("only")]);
+
+        var layout = ClusterLayout.Create<Node>().Size(100, 100);
+        var tree = layout.Hierarchy(root, n => n.Children);
+        layout.Layout(tree);
+
+        Assert.True(tree.Y < tree.Children[0].Y);
+    }
+
+    [Fact]
+    public void Cluster_ManyLeaves()
+    {
+        var root = new Node("root",
+        [
+            new("a"), new("b"), new("c"), new("d"), new("e"),
+        ]);
+
+        var layout = ClusterLayout.Create<Node>().Size(400, 200);
+        var tree = layout.Hierarchy(root, n => n.Children);
+        layout.Layout(tree);
+
+        var xs = tree.Children.Select(c => c.X).ToList();
+        Assert.True(xs.Max() - xs.Min() > 100);
+    }
+}

--- a/tests/Reactor.Tests/D3/ColorTests.cs
+++ b/tests/Reactor.Tests/D3/ColorTests.cs
@@ -1,0 +1,266 @@
+// Port of d3-color behaviors — parsing, brighter/darker, hex/rgb output.
+// reactor1's D3Color is a simplified subset of d3-color (no HCL / Lab / Cubehelix).
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class ColorTests
+{
+    // ─── Parse hex ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_Hex6()
+    {
+        var c = D3Color.Parse("#ff0000");
+        Assert.Equal(255, c.R);
+        Assert.Equal(0, c.G);
+        Assert.Equal(0, c.B);
+        Assert.Equal(1.0, c.Opacity);
+    }
+
+    [Fact]
+    public void Parse_Hex3_Expands_Channels()
+    {
+        // #f0a → r=0xFF, g=0x00, b=0xAA (each nibble × 17).
+        var c = D3Color.Parse("#f0a");
+        Assert.Equal(255, c.R);
+        Assert.Equal(0, c.G);
+        Assert.Equal(170, c.B);
+    }
+
+    [Fact]
+    public void Parse_Hex_IsCaseInsensitive()
+    {
+        var upper = D3Color.Parse("#ABCDEF");
+        var lower = D3Color.Parse("#abcdef");
+        Assert.Equal(upper.R, lower.R);
+        Assert.Equal(upper.G, lower.G);
+        Assert.Equal(upper.B, lower.B);
+    }
+
+    // ─── Parse rgb / rgba ────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_Rgb_Function()
+    {
+        var c = D3Color.Parse("rgb(128, 64, 32)");
+        Assert.Equal(128, c.R);
+        Assert.Equal(64, c.G);
+        Assert.Equal(32, c.B);
+        Assert.Equal(1.0, c.Opacity);
+    }
+
+    [Fact]
+    public void Parse_Rgba_Function_With_Alpha()
+    {
+        var c = D3Color.Parse("rgba(255, 255, 255, 0.5)");
+        Assert.Equal(255, c.R);
+        Assert.Equal(0.5, c.Opacity);
+    }
+
+    // ─── Parse hsl ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_Hsl_Red()
+    {
+        // hsl(0, 100%, 50%) = pure red.
+        var c = D3Color.Parse("hsl(0, 100%, 50%)");
+        Assert.Equal(255, c.R);
+        Assert.Equal(0, c.G);
+        Assert.Equal(0, c.B);
+    }
+
+    [Fact]
+    public void Parse_Hsl_Green_120deg()
+    {
+        var c = D3Color.Parse("hsl(120, 100%, 50%)");
+        Assert.Equal(0, c.R);
+        Assert.Equal(255, c.G);
+        Assert.Equal(0, c.B);
+    }
+
+    [Fact]
+    public void Parse_Hsl_Blue_240deg()
+    {
+        var c = D3Color.Parse("hsl(240, 100%, 50%)");
+        Assert.Equal(0, c.R);
+        Assert.Equal(0, c.G);
+        Assert.Equal(255, c.B);
+    }
+
+    [Fact]
+    public void Parse_Hsl_White_Is_Lightness_100()
+    {
+        var c = D3Color.Parse("hsl(0, 0%, 100%)");
+        Assert.Equal(255, c.R);
+        Assert.Equal(255, c.G);
+        Assert.Equal(255, c.B);
+    }
+
+    // ─── Named colors ────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("red", 255, 0, 0)]
+    [InlineData("green", 0, 128, 0)]
+    [InlineData("blue", 0, 0, 255)]
+    [InlineData("white", 255, 255, 255)]
+    [InlineData("black", 0, 0, 0)]
+    [InlineData("steelblue", 70, 130, 180)]
+    [InlineData("tomato", 255, 99, 71)]
+    [InlineData("gold", 255, 215, 0)]
+    public void Parse_Named_Color(string name, byte r, byte g, byte b)
+    {
+        var c = D3Color.Parse(name);
+        Assert.Equal(r, c.R);
+        Assert.Equal(g, c.G);
+        Assert.Equal(b, c.B);
+    }
+
+    [Fact]
+    public void Parse_Gray_And_Grey_Equivalent()
+    {
+        Assert.Equal(D3Color.Parse("gray").R, D3Color.Parse("grey").R);
+    }
+
+    [Fact]
+    public void Parse_Transparent_Has_Zero_Opacity()
+    {
+        var c = D3Color.Parse("transparent");
+        Assert.Equal(0.0, c.Opacity);
+    }
+
+    [Fact]
+    public void Parse_Unknown_Returns_Black()
+    {
+        var c = D3Color.Parse("not-a-color");
+        Assert.Equal(0, c.R);
+        Assert.Equal(0, c.G);
+        Assert.Equal(0, c.B);
+    }
+
+    // ─── Brighter / Darker ───────────────────────────────────────────
+
+    [Fact]
+    public void Brighter_Increases_Channels_Towards_White()
+    {
+        var c = new D3Color(100, 100, 100);
+        var b = c.Brighter();
+        Assert.True(b.R > c.R);
+        Assert.True(b.G > c.G);
+        Assert.True(b.B > c.B);
+    }
+
+    [Fact]
+    public void Darker_Decreases_Channels_Towards_Black()
+    {
+        var c = new D3Color(200, 200, 200);
+        var d = c.Darker();
+        Assert.True(d.R < c.R);
+        Assert.True(d.G < c.G);
+        Assert.True(d.B < c.B);
+    }
+
+    [Fact]
+    public void Brighter_Clamps_At_255()
+    {
+        var c = new D3Color(250, 250, 250);
+        // k=10 should clamp, not overflow.
+        var b = c.Brighter(10);
+        Assert.Equal(255, b.R);
+        Assert.Equal(255, b.G);
+        Assert.Equal(255, b.B);
+    }
+
+    [Fact]
+    public void Darker_Clamps_At_0()
+    {
+        var c = new D3Color(10, 10, 10);
+        var d = c.Darker(10);
+        Assert.Equal(0, d.R);
+    }
+
+    [Fact]
+    public void Brighter_Preserves_Opacity()
+    {
+        var c = new D3Color(100, 100, 100, 0.5);
+        Assert.Equal(0.5, c.Brighter().Opacity);
+    }
+
+    [Fact]
+    public void Brighter_Of_Darker_Approximates_Identity()
+    {
+        // Brighter(k)(Darker(k)(c)) ≈ c up to rounding.
+        var c = new D3Color(128, 128, 128);
+        var roundTrip = c.Darker().Brighter();
+        Assert.InRange(roundTrip.R, 126, 130);
+    }
+
+    // ─── Serialization ───────────────────────────────────────────────
+
+    [Fact]
+    public void ToHex_Uppercase_Two_Digits()
+    {
+        var c = new D3Color(255, 0, 170);
+        Assert.Equal("#FF00AA", c.ToHex());
+    }
+
+    [Fact]
+    public void ToRgb_Default_Opacity_Uses_Rgb()
+    {
+        var c = new D3Color(128, 64, 32);
+        Assert.Equal("rgb(128, 64, 32)", c.ToRgb());
+    }
+
+    [Fact]
+    public void ToRgb_With_Alpha_Uses_Rgba()
+    {
+        var c = new D3Color(128, 64, 32, 0.5);
+        Assert.Equal("rgba(128, 64, 32, 0.5)", c.ToRgb());
+    }
+
+    [Fact]
+    public void ToString_Matches_ToRgb()
+    {
+        var c = new D3Color(128, 64, 32);
+        Assert.Equal(c.ToRgb(), c.ToString());
+    }
+
+    // ─── Predefined palettes ─────────────────────────────────────────
+
+    [Fact]
+    public void Category10_Has_10_Colors()
+    {
+        Assert.Equal(10, D3Color.Category10.Count);
+    }
+
+    [Fact]
+    public void Tableau10_Has_10_Colors()
+    {
+        Assert.Equal(10, D3Color.Tableau10.Count);
+    }
+
+    [Fact]
+    public void Category10_First_Is_SteelblueLike()
+    {
+        // d3.schemeCategory10[0] === "#1f77b4"
+        Assert.Equal("#1F77B4", D3Color.Category10[0].ToHex());
+    }
+
+    // ─── Opacity clamping ────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_Clamps_Opacity_Above_1()
+    {
+        var c = new D3Color(0, 0, 0, 2.0);
+        Assert.Equal(1.0, c.Opacity);
+    }
+
+    [Fact]
+    public void Constructor_Clamps_Opacity_Below_0()
+    {
+        var c = new D3Color(0, 0, 0, -0.5);
+        Assert.Equal(0.0, c.Opacity);
+    }
+}

--- a/tests/Reactor.Tests/D3/ContourTests.cs
+++ b/tests/Reactor.Tests/D3/ContourTests.cs
@@ -1,0 +1,95 @@
+// Tests for d3-contour generation
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class ContourTests
+{
+    [Fact]
+    public void Contour_SimpleGradient()
+    {
+        int w = 4, h = 4;
+        var values = new double[w * h];
+        for (int j = 0; j < h; j++)
+            for (int i = 0; i < w; i++)
+                values[j * w + i] = i + j;
+
+        var contour = new ContourGenerator(w, h);
+        var result = contour.SetThresholds(2, 4).Generate(values);
+
+        Assert.Equal(2, result.Length);
+        Assert.Equal(2, result[0].Value);
+        Assert.Equal(4, result[1].Value);
+    }
+
+    [Fact]
+    public void Contour_PeakInCenter()
+    {
+        int w = 10, h = 10;
+        var values = new double[w * h];
+        for (int j = 0; j < h; j++)
+            for (int i = 0; i < w; i++)
+            {
+                double dx = i - 4.5, dy = j - 4.5;
+                values[j * w + i] = 20 - (dx * dx + dy * dy);
+            }
+
+        var contour = new ContourGenerator(w, h);
+        var result = contour.SetThresholds(10).Generate(values);
+
+        Assert.Single(result);
+        Assert.Equal(10, result[0].Value);
+        Assert.True(result[0].Coordinates.Count >= 0);
+    }
+
+    [Fact]
+    public void Contour_UniformField_NoContours()
+    {
+        int w = 3, h = 3;
+        var values = Enumerable.Repeat(5.0, w * h).ToArray();
+
+        var contour = new ContourGenerator(w, h);
+        var result = contour.SetThresholds(5).Generate(values);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Contour_AutoThresholds()
+    {
+        int w = 10, h = 10;
+        var values = new double[w * h];
+        for (int j = 0; j < h; j++)
+            for (int i = 0; i < w; i++)
+                values[j * w + i] = Math.Sqrt(i * i + j * j);
+
+        var contour = new ContourGenerator(w, h).SetThresholdCount(5);
+        var result = contour.Generate(values);
+
+        Assert.True(result.Length > 0);
+    }
+}
+
+public class DensityContourTests
+{
+    [Fact]
+    public void DensityContour_ClusteredPoints()
+    {
+        var points = new List<(double x, double y)>();
+        var rng = new Random(42);
+        for (int i = 0; i < 100; i++)
+        {
+            points.Add((50 + rng.NextDouble() * 20, 50 + rng.NextDouble() * 20));
+        }
+
+        var density = new DensityContourGenerator()
+            .SetSize(100, 100)
+            .SetBandwidth(10)
+            .SetThresholdCount(3);
+
+        var result = density.Generate(points);
+        Assert.True(result.Length > 0);
+    }
+}

--- a/tests/Reactor.Tests/D3/CurveTests.cs
+++ b/tests/Reactor.Tests/D3/CurveTests.cs
@@ -1,0 +1,119 @@
+// Tests for d3-shape curve implementations
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class CurveTests
+{
+    private static string? GenerateWithCurve(CurveFactory curve, (double x, double y)[] data)
+    {
+        var line = LineGenerator.Create().SetCurve(curve);
+        return line.Generate(data);
+    }
+
+    [Fact]
+    public void CurveLinear_StraightLines()
+    {
+        var path = GenerateWithCurve(D3Curve.Linear,
+            [(0, 0), (10, 10), (20, 0)]);
+        Assert.NotNull(path);
+        Assert.StartsWith("M", path);
+        Assert.Contains("L", path);
+    }
+
+    [Fact]
+    public void CurveStep_StepFunction()
+    {
+        var path = GenerateWithCurve(D3Curve.Step,
+            [(0, 0), (10, 10), (20, 0)]);
+        Assert.NotNull(path);
+        Assert.Contains("L", path);
+    }
+
+    [Fact]
+    public void CurveStepBefore_StepFunction()
+    {
+        var path = GenerateWithCurve(D3Curve.StepBefore,
+            [(0, 0), (10, 10), (20, 0)]);
+        Assert.NotNull(path);
+    }
+
+    [Fact]
+    public void CurveStepAfter_StepFunction()
+    {
+        var path = GenerateWithCurve(D3Curve.StepAfter,
+            [(0, 0), (10, 10), (20, 0)]);
+        Assert.NotNull(path);
+    }
+
+    [Fact]
+    public void CurveBasis_Smooth()
+    {
+        var path = GenerateWithCurve(D3Curve.Basis,
+            [(0, 0), (10, 10), (20, 0), (30, 10)]);
+        Assert.NotNull(path);
+        Assert.Contains("C", path);
+    }
+
+    [Fact]
+    public void CurveNatural_NaturalSpline()
+    {
+        var path = GenerateWithCurve(D3Curve.Natural,
+            [(0, 0), (10, 10), (20, 0), (30, 10)]);
+        Assert.NotNull(path);
+        Assert.Contains("C", path);
+    }
+
+    [Fact]
+    public void CurveCardinal_CardinalSpline()
+    {
+        var path = GenerateWithCurve(D3Curve.Cardinal,
+            [(0, 0), (10, 10), (20, 0), (30, 10)]);
+        Assert.NotNull(path);
+        Assert.Contains("C", path);
+    }
+
+    [Fact]
+    public void CurveCatmullRom_CatmullRomSpline()
+    {
+        var path = GenerateWithCurve(D3Curve.CatmullRom,
+            [(0, 0), (10, 10), (20, 0), (30, 10)]);
+        Assert.NotNull(path);
+        Assert.Contains("C", path);
+    }
+
+    [Fact]
+    public void CurveMonotoneX_MonotoneSpline()
+    {
+        var path = GenerateWithCurve(D3Curve.MonotoneX,
+            [(0, 0), (10, 10), (20, 0), (30, 10)]);
+        Assert.NotNull(path);
+        Assert.Contains("C", path);
+    }
+
+    [Fact]
+    public void CurveLinear_SinglePoint_ReturnsMove()
+    {
+        var path = GenerateWithCurve(D3Curve.Linear, [(5, 5)]);
+        Assert.NotNull(path);
+        Assert.StartsWith("M", path);
+    }
+
+    [Fact]
+    public void CurveLinear_TwoPoints()
+    {
+        var path = GenerateWithCurve(D3Curve.Linear, [(0, 0), (10, 10)]);
+        Assert.Equal("M0,0L10,10", path);
+    }
+
+    [Fact]
+    public void LineWithoutCurve_MatchesLinearCurve()
+    {
+        var data = new (double x, double y)[] { (0, 0), (10, 10), (20, 0) };
+        var noCurve = LineGenerator.Create().Generate(data);
+        var linearCurve = LineGenerator.Create().SetCurve(D3Curve.Linear).Generate(data);
+        Assert.Equal(noCurve, linearCurve);
+    }
+}

--- a/tests/Reactor.Tests/D3/DelaunayTests.cs
+++ b/tests/Reactor.Tests/D3/DelaunayTests.cs
@@ -1,0 +1,142 @@
+// Tests for d3-delaunay triangulation and Voronoi diagrams
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class DelaunayTests
+{
+    [Fact]
+    public void Delaunay_TriangulatesPoints()
+    {
+        var points = new (double x, double y)[]
+        {
+            (0, 0), (100, 0), (50, 100), (50, 50)
+        };
+
+        var d = Delaunay.From(points);
+        Assert.Equal(4, d.Points.Length);
+        Assert.True(d.Triangles.Length > 0);
+        Assert.True(d.Triangles.Length % 3 == 0);
+    }
+
+    [Fact]
+    public void Delaunay_Find_ClosestPoint()
+    {
+        var points = new (double x, double y)[]
+        {
+            (0, 0), (100, 0), (0, 100), (100, 100)
+        };
+
+        var d = Delaunay.From(points);
+        Assert.Equal(0, d.Find(1, 1));
+        Assert.Equal(3, d.Find(99, 99));
+    }
+
+    [Fact]
+    public void Delaunay_Neighbors()
+    {
+        var points = new (double x, double y)[]
+        {
+            (0, 0), (100, 0), (50, 100)
+        };
+
+        var d = Delaunay.From(points);
+        var neighbors = d.Neighbors(0).ToList();
+        Assert.True(neighbors.Count > 0);
+        Assert.Contains(1, neighbors);
+        Assert.Contains(2, neighbors);
+    }
+
+    [Fact]
+    public void Delaunay_Hull()
+    {
+        var points = new (double x, double y)[]
+        {
+            (0, 0), (100, 0), (100, 100), (0, 100), (50, 50)
+        };
+
+        var d = Delaunay.From(points);
+        Assert.True(d.Hull.Length >= 4);
+    }
+
+    [Fact]
+    public void Delaunay_TwoPoints()
+    {
+        var points = new (double x, double y)[] { (0, 0), (1, 1) };
+        var d = Delaunay.From(points);
+        Assert.Equal(2, d.Points.Length);
+    }
+
+    [Fact]
+    public void Delaunay_SinglePoint()
+    {
+        var points = new (double x, double y)[] { (5, 5) };
+        var d = Delaunay.From(points);
+        Assert.Single(d.Points);
+    }
+}
+
+public class VoronoiTests
+{
+    [Fact]
+    public void Voronoi_CreatesFromDelaunay()
+    {
+        var points = new (double x, double y)[]
+        {
+            (10, 10), (90, 10), (50, 90)
+        };
+
+        var d = Delaunay.From(points);
+        var v = d.Voronoi(0, 0, 100, 100);
+
+        Assert.NotNull(v);
+        Assert.True(v.Circumcenters.Length > 0);
+    }
+
+    [Fact]
+    public void Voronoi_CellPolygon()
+    {
+        var points = new (double x, double y)[]
+        {
+            (25, 50), (75, 50)
+        };
+
+        var d = Delaunay.From(points);
+        var v = d.Voronoi(0, 0, 100, 100);
+
+        var cell = v.CellPolygon(0);
+    }
+
+    [Fact]
+    public void Voronoi_Contains()
+    {
+        var points = new (double x, double y)[]
+        {
+            (25, 50), (75, 50)
+        };
+
+        var d = Delaunay.From(points);
+        var v = d.Voronoi(0, 0, 100, 100);
+
+        Assert.True(v.Contains(0, 10, 50));
+        Assert.True(v.Contains(1, 90, 50));
+    }
+
+    [Fact]
+    public void Voronoi_ThreePoints()
+    {
+        var points = new (double x, double y)[]
+        {
+            (10, 10), (90, 10), (50, 90)
+        };
+
+        var d = Delaunay.From(points);
+        var v = d.Voronoi(0, 0, 100, 100);
+
+        Assert.True(v.Contains(0, 10, 10));
+        Assert.True(v.Contains(1, 90, 10));
+        Assert.True(v.Contains(2, 50, 90));
+    }
+}

--- a/tests/Reactor.Tests/D3/EaseTests.cs
+++ b/tests/Reactor.Tests/D3/EaseTests.cs
@@ -1,0 +1,140 @@
+// Port of d3-ease tests
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class EaseTests
+{
+    private const double Tol = 1e-6;
+
+    [Fact]
+    public void Linear_Identity()
+    {
+        Assert.Equal(0, D3Ease.Linear(0));
+        Assert.Equal(0.5, D3Ease.Linear(0.5));
+        Assert.Equal(1, D3Ease.Linear(1));
+    }
+
+    [Fact]
+    public void QuadIn_Zero_And_One()
+    {
+        Assert.Equal(0, D3Ease.QuadIn(0));
+        Assert.Equal(1, D3Ease.QuadIn(1));
+    }
+
+    [Fact]
+    public void QuadIn_Half()
+    {
+        Assert.Equal(0.25, D3Ease.QuadIn(0.5), Tol);
+    }
+
+    [Fact]
+    public void QuadOut_Half()
+    {
+        Assert.Equal(0.75, D3Ease.QuadOut(0.5), Tol);
+    }
+
+    [Fact]
+    public void Quad_InOut_Symmetric()
+    {
+        Assert.Equal(0, D3Ease.Quad(0), Tol);
+        Assert.Equal(0.5, D3Ease.Quad(0.5), Tol);
+        Assert.Equal(1, D3Ease.Quad(1), Tol);
+    }
+
+    [Fact]
+    public void CubicIn_Zero_And_One()
+    {
+        Assert.Equal(0, D3Ease.CubicIn(0));
+        Assert.Equal(1, D3Ease.CubicIn(1));
+    }
+
+    [Fact]
+    public void CubicIn_Half()
+    {
+        Assert.Equal(0.125, D3Ease.CubicIn(0.5), Tol);
+    }
+
+    [Fact]
+    public void CubicOut_Half()
+    {
+        Assert.Equal(0.875, D3Ease.CubicOut(0.5), Tol);
+    }
+
+    [Fact]
+    public void SinIn_Endpoints()
+    {
+        Assert.Equal(0, D3Ease.SinIn(0), Tol);
+        Assert.Equal(1, D3Ease.SinIn(1), Tol);
+    }
+
+    [Fact]
+    public void SinOut_Endpoints()
+    {
+        Assert.Equal(0, D3Ease.SinOut(0), Tol);
+        Assert.Equal(1, D3Ease.SinOut(1), Tol);
+    }
+
+    [Fact]
+    public void ExpIn_Endpoints()
+    {
+        Assert.Equal(0, D3Ease.ExpIn(0), Tol);
+        Assert.Equal(1, D3Ease.ExpIn(1), Tol);
+    }
+
+    [Fact]
+    public void CircleIn_Endpoints()
+    {
+        Assert.Equal(0, D3Ease.CircleIn(0), Tol);
+        Assert.Equal(1, D3Ease.CircleIn(1), Tol);
+    }
+
+    [Fact]
+    public void BounceOut_Endpoints()
+    {
+        Assert.Equal(0, D3Ease.BounceOut(0), Tol);
+        Assert.Equal(1, D3Ease.BounceOut(1), Tol);
+    }
+
+    [Fact]
+    public void BounceIn_Endpoints()
+    {
+        Assert.Equal(0, D3Ease.BounceIn(0), Tol);
+        Assert.Equal(1, D3Ease.BounceIn(1), Tol);
+    }
+
+    [Fact]
+    public void Bounce_InOut_Symmetric()
+    {
+        Assert.Equal(0, D3Ease.Bounce(0), Tol);
+        Assert.Equal(0.5, D3Ease.Bounce(0.5), Tol);
+        Assert.Equal(1, D3Ease.Bounce(1), Tol);
+    }
+
+    [Fact]
+    public void ElasticOut_Endpoints()
+    {
+        var ease = D3Ease.ElasticOut();
+        Assert.Equal(0, ease(0), Tol);
+        Assert.Equal(1, ease(1), Tol);
+    }
+
+    [Fact]
+    public void BackOut_Endpoints()
+    {
+        var ease = D3Ease.BackOut();
+        Assert.Equal(0, ease(0), Tol);
+        Assert.Equal(1, ease(1), Tol);
+    }
+
+    [Fact]
+    public void PolyIn_Quartic()
+    {
+        var ease = D3Ease.PolyIn(4);
+        Assert.Equal(0, ease(0), Tol);
+        Assert.Equal(1, ease(1), Tol);
+        Assert.Equal(0.0625, ease(0.5), Tol);
+    }
+}

--- a/tests/Reactor.Tests/D3/FormatExtraTests.cs
+++ b/tests/Reactor.Tests/D3/FormatExtraTests.cs
@@ -1,0 +1,183 @@
+// Port of d3-format: FormatValue, FormatPrefix, PrecisionRound, PrecisionPrefix
+// and additional format-type tests (b/o/x/X/c/e/s/r).
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class FormatValueTests
+{
+    [Fact]
+    public void FormatValue_Inline_Is_Equivalent_To_Format_Then_Invoke()
+    {
+        Assert.Equal(D3Format.Format(".2f")(3.14159), D3Format.FormatValue(3.14159, ".2f"));
+        Assert.Equal(D3Format.Format("+.2f")(3.14), D3Format.FormatValue(3.14, "+.2f"));
+    }
+}
+
+public class FormatPrefixTests
+{
+    [Fact]
+    public void FormatPrefix_At_1000_Uses_K_Prefix()
+    {
+        var f = D3Format.FormatPrefix(".1f", 1000);
+        Assert.Equal("1.2k", f(1200));
+    }
+
+    [Fact]
+    public void FormatPrefix_At_1_Million_Uses_M_Prefix()
+    {
+        var f = D3Format.FormatPrefix(".0f", 1_000_000);
+        Assert.Equal("2M", f(2_000_000));
+    }
+
+    [Fact]
+    public void FormatPrefix_At_Milli_Uses_M_Lowercase()
+    {
+        var f = D3Format.FormatPrefix(".0f", 0.001);
+        Assert.Equal("1m", f(0.001));
+    }
+}
+
+public class PrecisionTests
+{
+    [Fact]
+    public void PrecisionFixed_Examples_From_Docs()
+    {
+        Assert.Equal(2, D3Format.PrecisionFixed(0.01));
+        Assert.Equal(1, D3Format.PrecisionFixed(0.1));
+        Assert.Equal(0, D3Format.PrecisionFixed(1));
+    }
+
+    [Fact]
+    public void PrecisionRound_Returns_NonNegative()
+    {
+        Assert.True(D3Format.PrecisionRound(0.001, 100) >= 0);
+        Assert.True(D3Format.PrecisionRound(1, 100) >= 0);
+    }
+
+    [Fact]
+    public void PrecisionPrefix_Returns_NonNegative()
+    {
+        Assert.True(D3Format.PrecisionPrefix(1e-3, 1) >= 0);
+        Assert.True(D3Format.PrecisionPrefix(1, 1_000_000) >= 0);
+    }
+}
+
+public class FormatTypesTests
+{
+    [Fact]
+    public void Binary_Type()
+    {
+        var f = D3Format.Format("b");
+        Assert.Equal("101", f(5));
+        Assert.Equal("1010", f(10));
+        Assert.Equal("0", f(0));
+    }
+
+    [Fact]
+    public void Octal_Type()
+    {
+        var f = D3Format.Format("o");
+        Assert.Equal("10", f(8));
+        Assert.Equal("77", f(63));
+    }
+
+    [Fact]
+    public void Hex_Lowercase_Type()
+    {
+        var f = D3Format.Format("x");
+        Assert.Equal("ff", f(255));
+        Assert.Equal("abc", f(2748));
+    }
+
+    [Fact]
+    public void Hex_Uppercase_Type()
+    {
+        var f = D3Format.Format("X");
+        Assert.Equal("FF", f(255));
+        Assert.Equal("ABC", f(2748));
+    }
+
+    [Fact]
+    public void Char_Type_Converts_Codepoint()
+    {
+        var f = D3Format.Format("c");
+        Assert.Equal("A", f(65));
+        Assert.Equal("z", f(122));
+    }
+
+    [Fact]
+    public void Exponent_Type()
+    {
+        var f = D3Format.Format(".2e");
+        // 1.23e+002 (C# default) — check prefix; exact exponent-digit count varies by runtime.
+        var result = f(123);
+        Assert.StartsWith("1.23e+", result);
+    }
+
+    [Fact]
+    public void SiPrefix_Type_At_Thousand()
+    {
+        var f = D3Format.Format(".1s");
+        Assert.Equal("1k", f(1000));
+    }
+
+    [Fact]
+    public void SiPrefix_Type_At_Million()
+    {
+        var f = D3Format.Format(".0s");
+        Assert.Equal("1M", f(1_000_000));
+    }
+
+    [Fact]
+    public void Rounded_Type_Two_Significant_Digits()
+    {
+        var f = D3Format.Format(".2r");
+        Assert.Equal("3.1", f(3.14159));
+        Assert.Equal("120", f(123));
+    }
+}
+
+public class FormatSignTests
+{
+    [Fact]
+    public void Space_Sign_Positive_Gets_Leading_Space()
+    {
+        var f = D3Format.Format(" .2f");
+        Assert.Equal(" 3.14", f(3.14));
+        Assert.Equal("-3.14", f(-3.14));
+    }
+
+    [Fact]
+    public void Paren_Sign_Wraps_Negative()
+    {
+        var f = D3Format.Format("(.2f");
+        Assert.Equal("(3.14)", f(-3.14));
+    }
+}
+
+public class FormatWidthTests
+{
+    [Fact]
+    public void Width_Right_Align_Default()
+    {
+        var f = D3Format.Format("10.2f");
+        Assert.Equal("      3.14", f(3.14));
+    }
+
+    [Fact]
+    public void Width_Left_Align()
+    {
+        var f = D3Format.Format("<10.2f");
+        Assert.Equal("3.14      ", f(3.14));
+    }
+
+    [Fact]
+    public void Width_Zero_Padded()
+    {
+        var f = D3Format.Format("08.2f");
+        Assert.Equal("00003.14", f(3.14));
+    }
+}

--- a/tests/Reactor.Tests/D3/FormatTests.cs
+++ b/tests/Reactor.Tests/D3/FormatTests.cs
@@ -1,0 +1,88 @@
+// Port of d3-format tests
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class FormatTests
+{
+    [Fact]
+    public void Fixed_TwoDecimals()
+    {
+        var f = D3Format.Format(".2f");
+        Assert.Equal("3.14", f(3.14159));
+    }
+
+    [Fact]
+    public void Fixed_ZeroDecimals()
+    {
+        var f = D3Format.Format(".0f");
+        Assert.Equal("3", f(3.14));
+    }
+
+    [Fact]
+    public void Fixed_SixDecimalsDefault()
+    {
+        var f = D3Format.Format("f");
+        Assert.Equal("3.141590", f(3.14159));
+    }
+
+    [Fact]
+    public void Percent()
+    {
+        var f = D3Format.Format(".0%");
+        Assert.Equal("75%", f(0.75));
+    }
+
+    [Fact]
+    public void Percent_OneDecimal()
+    {
+        var f = D3Format.Format(".1%");
+        Assert.Equal("75.0%", f(0.75));
+    }
+
+    [Fact]
+    public void Integer()
+    {
+        var f = D3Format.Format("d");
+        Assert.Equal("42", f(42));
+    }
+
+    [Fact]
+    public void Comma_GroupsThousands()
+    {
+        var f = D3Format.Format(",.0f");
+        Assert.Equal("1,234,567", f(1234567));
+    }
+
+    [Fact]
+    public void General_ThreeDigits()
+    {
+        var f = D3Format.Format(".3g");
+        Assert.Equal("3.14", f(3.14159));
+    }
+
+    [Fact]
+    public void PrecisionFixed_Step()
+    {
+        Assert.Equal(2, D3Format.PrecisionFixed(0.01));
+        Assert.Equal(0, D3Format.PrecisionFixed(1));
+        Assert.Equal(1, D3Format.PrecisionFixed(0.1));
+    }
+
+    [Fact]
+    public void Negative_HasSign()
+    {
+        var f = D3Format.Format(".2f");
+        Assert.Equal("-3.14", f(-3.14));
+    }
+
+    [Fact]
+    public void Plus_ShowsPositiveSign()
+    {
+        var f = D3Format.Format("+.2f");
+        Assert.Equal("+3.14", f(3.14));
+        Assert.Equal("-3.14", f(-3.14));
+    }
+}

--- a/tests/Reactor.Tests/D3/GroupTests.cs
+++ b/tests/Reactor.Tests/D3/GroupTests.cs
@@ -1,0 +1,68 @@
+// Port of d3-array group/bin tests
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class GroupTests
+{
+    [Fact]
+    public void Group_ByKey()
+    {
+        var data = new[] { ("a", 1), ("b", 2), ("a", 3) };
+        var groups = D3Group.Group(data, d => d.Item1);
+        Assert.Equal(2, groups.Count);
+        Assert.Equal(2, groups["a"].Count);
+        Assert.Single(groups["b"]);
+    }
+
+    [Fact]
+    public void Rollup_SumByKey()
+    {
+        var data = new[] { ("a", 1.0), ("b", 2.0), ("a", 3.0) };
+        var sums = D3Group.Rollup(data, d => d.Item1, g => g.Sum(x => x.Item2));
+        Assert.Equal(4.0, sums["a"]);
+        Assert.Equal(2.0, sums["b"]);
+    }
+
+    [Fact]
+    public void Index_FirstMatch()
+    {
+        var data = new[] { ("a", 1), ("b", 2), ("a", 3) };
+        var index = D3Group.Index(data, d => d.Item1);
+        Assert.Equal(("a", 1), index["a"]);
+    }
+}
+
+public class BinTests
+{
+    [Fact]
+    public void Bin_DefaultThresholds()
+    {
+        var data = Enumerable.Range(0, 100).Select(i => (double)i).ToList();
+        var bins = BinGenerator.Create().Generate(data);
+        Assert.True(bins.Length > 0);
+
+        int total = bins.Sum(b => b.Count);
+        Assert.Equal(100, total);
+    }
+
+    [Fact]
+    public void Bin_CustomThresholdCount()
+    {
+        var data = Enumerable.Range(0, 100).Select(i => (double)i).ToList();
+        var bins = BinGenerator.Create().SetThresholdCount(5).Generate(data);
+        Assert.True(bins.Length > 0);
+    }
+
+    [Fact]
+    public void Bin_BoundsCorrect()
+    {
+        var data = new double[] { 1, 2, 3, 4, 5 };
+        var bins = BinGenerator.Create().Generate(data);
+        Assert.True(bins.Length > 0);
+        Assert.True(bins[0].X0 <= 1);
+        Assert.True(bins[^1].X1 >= 5);
+    }
+}

--- a/tests/Reactor.Tests/D3/InterpolateColorTests.cs
+++ b/tests/Reactor.Tests/D3/InterpolateColorTests.cs
@@ -1,0 +1,93 @@
+// Tests for d3-interpolate color/date/array interpolation
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class InterpolateColorTests
+{
+    [Fact]
+    public void Rgb_InterpolatesChannels()
+    {
+        var interp = D3InterpolateColor.Rgb(
+            new D3Color(0, 0, 0),
+            new D3Color(255, 255, 255));
+
+        var mid = interp(0.5);
+        Assert.Equal(128, mid.R);
+        Assert.Equal(128, mid.G);
+        Assert.Equal(128, mid.B);
+    }
+
+    [Fact]
+    public void Rgb_Endpoints()
+    {
+        var a = new D3Color(255, 0, 0);
+        var b = new D3Color(0, 0, 255);
+        var interp = D3InterpolateColor.Rgb(a, b);
+
+        var start = interp(0);
+        Assert.Equal(255, start.R);
+        Assert.Equal(0, start.B);
+
+        var end = interp(1);
+        Assert.Equal(0, end.R);
+        Assert.Equal(255, end.B);
+    }
+
+    [Fact]
+    public void Rgb_FromStrings()
+    {
+        var interp = D3InterpolateColor.Rgb("#ff0000", "#0000ff");
+        var mid = interp(0.5);
+        Assert.Equal(128, mid.R);
+        Assert.Equal(0, mid.G);
+        Assert.Equal(128, mid.B);
+    }
+
+    [Fact]
+    public void Hsl_InterpolatesHue()
+    {
+        var interp = D3InterpolateColor.Hsl(
+            new D3Color(255, 0, 0),
+            new D3Color(0, 0, 255));
+
+        var mid = interp(0.5);
+        Assert.False(mid.R == 255 && mid.G == 0 && mid.B == 0);
+        Assert.False(mid.R == 0 && mid.G == 0 && mid.B == 255);
+    }
+
+    [Fact]
+    public void Date_InterpolatesTime()
+    {
+        var a = new DateTime(2020, 1, 1);
+        var b = new DateTime(2020, 12, 31);
+        var interp = D3InterpolateColor.Date(a, b);
+
+        Assert.Equal(a, interp(0));
+        Assert.Equal(b, interp(1));
+        var mid = interp(0.5);
+        Assert.True(mid > a);
+        Assert.True(mid < b);
+    }
+
+    [Fact]
+    public void Array_InterpolatesElements()
+    {
+        var interp = D3InterpolateColor.Array([0, 10], [10, 20]);
+        var mid = interp(0.5);
+        Assert.Equal(5, mid[0]);
+        Assert.Equal(15, mid[1]);
+    }
+
+    [Fact]
+    public void Array_DifferentLengths()
+    {
+        var interp = D3InterpolateColor.Array([0], [10, 20]);
+        var mid = interp(0.5);
+        Assert.Equal(2, mid.Length);
+        Assert.Equal(5, mid[0]);
+        Assert.Equal(10, mid[1]);
+    }
+}

--- a/tests/Reactor.Tests/D3/InterpolateNumberTests.cs
+++ b/tests/Reactor.Tests/D3/InterpolateNumberTests.cs
@@ -1,0 +1,90 @@
+// Port of d3-interpolate/test/number-test.js and round-test.js
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class InterpolateNumberTests
+{
+    [Fact]
+    public void Number_Endpoints()
+    {
+        var i = D3Interpolate.Number(10, 42);
+        Assert.Equal(10, i(0));
+        Assert.Equal(42, i(1));
+    }
+
+    [Fact]
+    public void Number_Midpoint()
+    {
+        var i = D3Interpolate.Number(0, 100);
+        Assert.Equal(50, i(0.5));
+    }
+
+    [Fact]
+    public void Number_Quarter_And_Three_Quarter()
+    {
+        var i = D3Interpolate.Number(0, 100);
+        Assert.Equal(25, i(0.25));
+        Assert.Equal(75, i(0.75));
+    }
+
+    [Fact]
+    public void Number_Reverse_Direction()
+    {
+        var i = D3Interpolate.Number(100, 0);
+        Assert.Equal(50, i(0.5));
+    }
+
+    [Fact]
+    public void Number_Negative_Range()
+    {
+        var i = D3Interpolate.Number(-50, 50);
+        Assert.Equal(0, i(0.5));
+    }
+
+    [Fact]
+    public void Number_Out_Of_Range_Extrapolates()
+    {
+        var i = D3Interpolate.Number(0, 10);
+        Assert.Equal(-10, i(-1));
+        Assert.Equal(20, i(2));
+    }
+
+    [Fact]
+    public void Number_Same_Endpoints_Returns_Same_Value()
+    {
+        var i = D3Interpolate.Number(7, 7);
+        Assert.Equal(7, i(0));
+        Assert.Equal(7, i(0.5));
+        Assert.Equal(7, i(1));
+    }
+}
+
+public class InterpolateRoundTests
+{
+    [Fact]
+    public void Round_Snaps_To_Nearest_Integer()
+    {
+        var i = D3Interpolate.Round(0, 10);
+        Assert.Equal(3, i(0.33));
+        Assert.Equal(7, i(0.66));
+    }
+
+    [Fact]
+    public void Round_Endpoints_Are_Exact()
+    {
+        var i = D3Interpolate.Round(10, 42);
+        Assert.Equal(10, i(0));
+        Assert.Equal(42, i(1));
+    }
+
+    [Fact]
+    public void Round_Midpoint_Rounds_To_Nearest()
+    {
+        // (0 + 3)/2 = 1.5 → rounds to 2 (banker's rounding in .NET: 2).
+        var i = D3Interpolate.Round(0, 3);
+        Assert.Equal(2, i(0.5));
+    }
+}

--- a/tests/Reactor.Tests/D3/LineTests.cs
+++ b/tests/Reactor.Tests/D3/LineTests.cs
@@ -1,0 +1,76 @@
+// Port of d3-shape/test/line-test.js
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class LineTests
+{
+    [Fact]
+    public void Line_Default_GeneratesPath()
+    {
+        var l = LineGenerator.FromArrays();
+        var data = new[] { new[] { 0.0, 1.0 }, new[] { 2.0, 3.0 }, new[] { 4.0, 5.0 } };
+        Assert.Equal("M0,1L2,3L4,5", l.Generate(data));
+    }
+
+    [Fact]
+    public void Line_Digits_Default3()
+    {
+        var l = LineGenerator.FromArrays();
+        Assert.Equal(3, l.Digits);
+    }
+
+    [Fact]
+    public void Line_Digits_ControlsPrecision()
+    {
+        var points = new[] { new[] { 0.0, Math.PI }, new[] { Math.E, 4.0 } };
+        var l = LineGenerator.FromArrays();
+        Assert.Equal("M0,3.142L2.718,4", l.Generate(points));
+
+        l.SetDigits(6);
+        Assert.Equal("M0,3.141593L2.718282,4", l.Generate(points));
+
+        l.SetDigits(null);
+        string? result = l.Generate(points);
+        Assert.Contains("3.141592653589793", result);
+        Assert.Contains("2.718281828459045", result);
+    }
+
+    [Fact]
+    public void Line_CustomAccessors()
+    {
+        var data = new[]
+        {
+            new { X = 0.0, Y = 1.0 },
+            new { X = 2.0, Y = 3.0 },
+            new { X = 4.0, Y = 5.0 },
+        };
+        var l = LineGenerator.Create<dynamic>(d => (double)d.X, d => (double)d.Y);
+        Assert.Equal("M0,1L2,3L4,5", l.Generate(data));
+    }
+
+    [Fact]
+    public void Line_ConstantX()
+    {
+        var l = LineGenerator.FromArrays().SetX((_, _) => 0);
+        var data = new[] { new[] { 99.0, 1.0 }, new[] { 99.0, 3.0 }, new[] { 99.0, 5.0 } };
+        Assert.Equal("M0,1L0,3L0,5", l.Generate(data));
+    }
+
+    [Fact]
+    public void Line_EmptyData_ReturnsNull()
+    {
+        var l = LineGenerator.FromArrays();
+        Assert.Null(l.Generate(Array.Empty<double[]>()));
+    }
+
+    [Fact]
+    public void Line_Tuples()
+    {
+        var l = LineGenerator.Create();
+        var data = new[] { (0.0, 1.0), (2.0, 3.0), (4.0, 5.0) };
+        Assert.Equal("M0,1L2,3L4,5", l.Generate(data));
+    }
+}

--- a/tests/Reactor.Tests/D3/LinearScaleTests.cs
+++ b/tests/Reactor.Tests/D3/LinearScaleTests.cs
@@ -1,0 +1,215 @@
+// Port of d3-scale/test/linear-test.js
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class LinearScaleTests
+{
+    private static double RoundEpsilon(double x) => Math.Round(x * 1e12) / 1e12;
+
+    [Fact]
+    public void Defaults()
+    {
+        var s = new LinearScale();
+        Assert.Equal([0.0, 1.0], s.Domain);
+        Assert.Equal([0.0, 1.0], s.Range);
+        Assert.False(s.Clamped);
+    }
+
+    [Fact]
+    public void Map_DomainToRange()
+    {
+        var s = new LinearScale { Range = [1, 2] };
+        Assert.Equal(1.5, s.Map(0.5));
+    }
+
+    [Fact]
+    public void Constructor_DomainRange()
+    {
+        var s = new LinearScale([1, 2], [3, 4]);
+        Assert.Equal([1.0, 2.0], s.Domain);
+        Assert.Equal([3.0, 4.0], s.Range);
+        Assert.Equal(3.5, s.Map(1.5));
+    }
+
+    [Fact]
+    public void Map_EmptyDomain_MiddleOfRange()
+    {
+        Assert.Equal(1.5, new LinearScale { Domain = [0, 0], Range = [1, 2] }.Map(0));
+        Assert.Equal(1.5, new LinearScale { Domain = [0, 0], Range = [2, 1] }.Map(1));
+    }
+
+    [Fact]
+    public void Map_Bilinear()
+    {
+        var s = new LinearScale { Domain = [1, 2] };
+        Assert.Equal(-0.5, s.Map(0.5));
+        Assert.Equal(0.0, s.Map(1.0));
+        Assert.Equal(0.5, s.Map(1.5));
+        Assert.Equal(1.0, s.Map(2.0));
+        Assert.Equal(1.5, s.Map(2.5));
+    }
+
+    [Fact]
+    public void Invert_RangeToDomain()
+    {
+        var s = new LinearScale { Range = [1, 2] };
+        Assert.Equal(0.5, s.Invert(1.5));
+    }
+
+    [Fact]
+    public void Invert_Bilinear()
+    {
+        var s = new LinearScale { Domain = [1, 2] };
+        Assert.Equal(0.5, s.Invert(-0.5));
+        Assert.Equal(1.0, s.Invert(0.0));
+        Assert.Equal(1.5, s.Invert(0.5));
+        Assert.Equal(2.0, s.Invert(1.0));
+        Assert.Equal(2.5, s.Invert(1.5));
+    }
+
+    [Fact]
+    public void Invert_EmptyRange_MiddleOfDomain()
+    {
+        Assert.Equal(1.5, new LinearScale { Domain = [1, 2], Range = [0, 0] }.Invert(0));
+        Assert.Equal(1.5, new LinearScale { Domain = [2, 1], Range = [0, 0] }.Invert(1));
+    }
+
+    [Fact]
+    public void Clamp_DefaultFalse()
+    {
+        Assert.False(new LinearScale().Clamped);
+        Assert.Equal(30.0, new LinearScale { Range = [10, 20] }.Map(2));
+        Assert.Equal(0.0, new LinearScale { Range = [10, 20] }.Map(-1));
+    }
+
+    [Fact]
+    public void Clamp_True_RestrictsOutput()
+    {
+        var s = new LinearScale { Range = [10, 20], Clamped = true };
+        Assert.Equal(20.0, s.Map(2));
+        Assert.Equal(10.0, s.Map(-1));
+    }
+
+    [Fact]
+    public void Clamp_True_RestrictsInvert()
+    {
+        var s = new LinearScale { Range = [10, 20], Clamped = true };
+        Assert.Equal(1.0, s.Invert(30));
+        Assert.Equal(0.0, s.Invert(0));
+    }
+
+    [Fact]
+    public void Nice_DefaultIs10()
+    {
+        Assert.Equal([0.0, 1.0], new LinearScale { Domain = [0, 0.96] }.Nice().Domain);
+        Assert.Equal([0.0, 100.0], new LinearScale { Domain = [0, 96] }.Nice().Domain);
+    }
+
+    [Fact]
+    public void Nice_ExtendsToRoundNumbers()
+    {
+        Assert.Equal([0.0, 1.0], new LinearScale { Domain = [0, 0.96] }.Nice(10).Domain);
+        Assert.Equal([0.0, 100.0], new LinearScale { Domain = [0, 96] }.Nice(10).Domain);
+        Assert.Equal([1.0, 0.0], new LinearScale { Domain = [0.96, 0] }.Nice(10).Domain);
+        Assert.Equal([100.0, 0.0], new LinearScale { Domain = [96, 0] }.Nice(10).Domain);
+        Assert.Equal([0.0, -1.0], new LinearScale { Domain = [0, -0.96] }.Nice(10).Domain);
+        Assert.Equal([0.0, -100.0], new LinearScale { Domain = [0, -96] }.Nice(10).Domain);
+        Assert.Equal([-1.0, 0.0], new LinearScale { Domain = [-0.96, 0] }.Nice(10).Domain);
+        Assert.Equal([-100.0, 0.0], new LinearScale { Domain = [-96, 0] }.Nice(10).Domain);
+    }
+
+    [Fact]
+    public void Nice_Nices_ExtendingToRoundNumbers()
+    {
+        Assert.Equal([1.0, 11.0], new LinearScale { Domain = [1.1, 10.9] }.Nice(10).Domain);
+        Assert.Equal([11.0, 1.0], new LinearScale { Domain = [10.9, 1.1] }.Nice(10).Domain);
+        Assert.Equal([0.0, 12.0], new LinearScale { Domain = [0.7, 11.001] }.Nice(10).Domain);
+        Assert.Equal([130.0, 0.0], new LinearScale { Domain = [123.1, 6.7] }.Nice(10).Domain);
+        Assert.Equal([0.0, 0.5], new LinearScale { Domain = [0, 0.49] }.Nice(10).Domain);
+        Assert.Equal([0.0, 20.0], new LinearScale { Domain = [0, 14.1] }.Nice(5).Domain);
+        Assert.Equal([0.0, 20.0], new LinearScale { Domain = [0, 15] }.Nice(5).Domain);
+    }
+
+    [Fact]
+    public void Nice_NoEffectOnDegenerate()
+    {
+        Assert.Equal([0.0, 0.0], new LinearScale { Domain = [0, 0] }.Nice(10).Domain);
+        Assert.Equal([0.5, 0.5], new LinearScale { Domain = [0.5, 0.5] }.Nice(10).Domain);
+    }
+
+    [Fact]
+    public void Ticks_Ascending()
+    {
+        var s = new LinearScale();
+        Assert.Equal(
+            new[] { 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 },
+            s.Ticks(10).Select(RoundEpsilon).ToArray());
+        Assert.Equal(
+            new[] { 0.0, 0.2, 0.4, 0.6, 0.8, 1.0 },
+            s.Ticks(7).Select(RoundEpsilon).ToArray());
+        Assert.Equal(
+            new[] { 0.0, 0.5, 1.0 },
+            s.Ticks(3).Select(RoundEpsilon).ToArray());
+        Assert.Equal(
+            new[] { 0.0, 1.0 },
+            s.Ticks(1).Select(RoundEpsilon).ToArray());
+
+        s.Domain = [-100, 100];
+        Assert.Equal(
+            new double[] { -100, -80, -60, -40, -20, 0, 20, 40, 60, 80, 100 },
+            s.Ticks(10));
+        Assert.Equal(
+            new double[] { -100, -50, 0, 50, 100 },
+            s.Ticks(6));
+        Assert.Equal(
+            new double[] { -100, 0, 100 },
+            s.Ticks(2));
+    }
+
+    [Fact]
+    public void Ticks_Descending()
+    {
+        var s = new LinearScale { Domain = [1, 0] };
+        var expected = new[] { 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 }.Reverse().ToArray();
+        Assert.Equal(expected, s.Ticks(10).Select(RoundEpsilon).ToArray());
+    }
+
+    [Fact]
+    public void Polylinear_MoreThanTwoValues()
+    {
+        var s = new LinearScale { Domain = [4, 2, 1], Range = [1, 2, 4] };
+        Assert.Equal(3.0, s.Map(1.5));
+        Assert.Equal(1.5, s.Map(3));
+        Assert.Equal(3.0, s.Invert(1.5));
+        Assert.Equal(1.5, s.Invert(3));
+    }
+
+    [Fact]
+    public void Nice_WithTickCount()
+    {
+        Assert.Equal([0.0, 100.0], new LinearScale { Domain = [12, 87] }.Nice(5).Domain);
+        Assert.Equal([10.0, 90.0], new LinearScale { Domain = [12, 87] }.Nice(10).Domain);
+        Assert.Equal([12.0, 87.0], new LinearScale { Domain = [12, 87] }.Nice(100).Domain);
+    }
+
+    [Fact]
+    public void Copy_IsIndependent()
+    {
+        var s1 = new LinearScale { Domain = [1, 2], Range = [3, 4] };
+        var s2 = s1.Copy();
+        s1.Domain = [0, 10];
+        Assert.Equal([1.0, 2.0], s2.Domain);
+        Assert.Equal(3.5, s2.Map(1.5));
+    }
+
+    [Fact]
+    public void Unknown_ReturnsForNaN()
+    {
+        var s = new LinearScale { Unknown = -1 };
+        Assert.Equal(-1, s.Map(double.NaN));
+        Assert.Equal(0.4, s.Map(0.4));
+    }
+}

--- a/tests/Reactor.Tests/D3/PartitionTests.cs
+++ b/tests/Reactor.Tests/D3/PartitionTests.cs
@@ -1,0 +1,109 @@
+// Tests for d3-hierarchy partition layout
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class PartitionTests
+{
+    private record FileItem(string Name, double Size, FileItem[]? Children = null);
+
+    [Fact]
+    public void Partition_RootCoversFullArea()
+    {
+        var root = new FileItem("root", 0,
+        [
+            new("a", 10),
+            new("b", 20),
+        ]);
+
+        var layout = PartitionLayout.Create<FileItem>().Size(200, 100);
+        var node = layout.Layout(root, n => n.Children, n => n.Size);
+
+        Assert.Equal(0, node.X0);
+        Assert.Equal(0, node.Y0);
+        Assert.Equal(200, node.X1);
+    }
+
+    [Fact]
+    public void Partition_ChildrenSubdivideWidth()
+    {
+        var root = new FileItem("root", 0,
+        [
+            new("a", 25),
+            new("b", 75),
+        ]);
+
+        var layout = PartitionLayout.Create<FileItem>().Size(100, 100);
+        var node = layout.Layout(root, n => n.Children, n => n.Size);
+
+        Assert.Equal(2, node.Children.Count);
+        double aWidth = node.Children[0].Width;
+        double bWidth = node.Children[1].Width;
+        Assert.True(bWidth > aWidth * 2);
+    }
+
+    [Fact]
+    public void Partition_ChildrenAtNextDepth()
+    {
+        var root = new FileItem("root", 0,
+        [
+            new("a", 50),
+            new("b", 50),
+        ]);
+
+        var layout = PartitionLayout.Create<FileItem>().Size(100, 100);
+        var node = layout.Layout(root, n => n.Children, n => n.Size);
+
+        Assert.Equal(node.Y1, node.Children[0].Y0, 5);
+    }
+
+    [Fact]
+    public void Partition_Nested()
+    {
+        var root = new FileItem("root", 0,
+        [
+            new("dir", 0, [new("file1", 10), new("file2", 20)]),
+            new("file3", 30),
+        ]);
+
+        var layout = PartitionLayout.Create<FileItem>().Size(300, 300);
+        var node = layout.Layout(root, n => n.Children, n => n.Size);
+
+        Assert.Equal(60, node.Value);
+        var leaves = node.Leaves().ToList();
+        Assert.Equal(3, leaves.Count);
+    }
+
+    [Fact]
+    public void Partition_ToPolar_ForSunburst()
+    {
+        var root = new FileItem("root", 0, [new("a", 50), new("b", 50)]);
+
+        var layout = PartitionLayout.Create<FileItem>().Size(100, 100);
+        var node = layout.Layout(root, n => n.Children, n => n.Size);
+
+        var (startAngle, endAngle, innerRadius, outerRadius) =
+            node.Children[0].ToPolar(100, 100, 200);
+
+        Assert.True(startAngle >= 0);
+        Assert.True(endAngle > startAngle);
+        Assert.True(outerRadius > innerRadius);
+    }
+
+    [Fact]
+    public void Partition_Descendants()
+    {
+        var root = new FileItem("root", 0,
+        [
+            new("a", 10),
+            new("b", 0, [new("b1", 5), new("b2", 5)]),
+        ]);
+
+        var layout = PartitionLayout.Create<FileItem>().Size(100, 100);
+        var node = layout.Layout(root, n => n.Children, n => n.Size);
+
+        Assert.Equal(5, node.Descendants().Count());
+    }
+}

--- a/tests/Reactor.Tests/D3/PathBuilderTests.cs
+++ b/tests/Reactor.Tests/D3/PathBuilderTests.cs
@@ -1,0 +1,205 @@
+// Port of d3-path/test/path-test.js
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class PathBuilderTests
+{
+    private static void AssertPath(PathBuilder p, string expected)
+    {
+        Assert.Equal(expected, p.ToString());
+    }
+
+    [Fact]
+    public void Path_Empty_ReturnsEmptyString()
+    {
+        var p = new PathBuilder();
+        AssertPath(p, "");
+    }
+
+    [Fact]
+    public void MoveTo_AppendsM()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 50);
+        AssertPath(p, "M150,50");
+    }
+
+    [Fact]
+    public void MoveTo_Then_LineTo()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 50);
+        p.LineTo(200, 100);
+        AssertPath(p, "M150,50L200,100");
+    }
+
+    [Fact]
+    public void Multiple_MoveTo()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 50);
+        p.LineTo(200, 100);
+        p.MoveTo(100, 50);
+        AssertPath(p, "M150,50L200,100M100,50");
+    }
+
+    [Fact]
+    public void ClosePath_AppendsZ()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 50);
+        p.ClosePath();
+        AssertPath(p, "M150,50Z");
+    }
+
+    [Fact]
+    public void ClosePath_Twice()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 50);
+        p.ClosePath();
+        p.ClosePath();
+        AssertPath(p, "M150,50ZZ");
+    }
+
+    [Fact]
+    public void ClosePath_EmptyPath_NoOp()
+    {
+        var p = new PathBuilder();
+        p.ClosePath();
+        AssertPath(p, "");
+    }
+
+    [Fact]
+    public void LineTo_AppendsL()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 50);
+        p.LineTo(200, 100);
+        p.LineTo(100, 50);
+        AssertPath(p, "M150,50L200,100L100,50");
+    }
+
+    [Fact]
+    public void QuadraticCurveTo_AppendsQ()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 50);
+        p.QuadraticCurveTo(100, 50, 200, 100);
+        AssertPath(p, "M150,50Q100,50,200,100");
+    }
+
+    [Fact]
+    public void BezierCurveTo_AppendsC()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 50);
+        p.BezierCurveTo(100, 50, 0, 24, 200, 100);
+        AssertPath(p, "M150,50C100,50,0,24,200,100");
+    }
+
+    [Fact]
+    public void Arc_NegativeRadius_Throws()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 100);
+        Assert.Throws<ArgumentException>(() => p.Arc(100, 100, -50, 0, Math.PI / 2));
+    }
+
+    [Fact]
+    public void Arc_ZeroRadius_OnlyM()
+    {
+        var p = new PathBuilder();
+        p.Arc(100, 100, 0, 0, Math.PI / 2);
+        AssertPath(p, "M100,100");
+    }
+
+    [Fact]
+    public void Arc_FullCircle_EmptyPath()
+    {
+        var p = new PathBuilder();
+        p.Arc(100, 100, 50, 0, Math.PI * 2);
+        AssertPath(p, "M150,100A50,50,0,1,1,50,100A50,50,0,1,1,150,100");
+    }
+
+    [Fact]
+    public void Arc_HalfPi_SmallArc()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 100);
+        p.Arc(100, 100, 50, 0, Math.PI / 2);
+        AssertPath(p, "M150,100A50,50,0,0,1,100,150");
+    }
+
+    [Fact]
+    public void Arc_FullCircle_WithPriorMoveTo()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 100);
+        p.Arc(100, 100, 50, 0, Math.PI * 2);
+        AssertPath(p, "M150,100A50,50,0,1,1,50,100A50,50,0,1,1,150,100");
+    }
+
+    [Fact]
+    public void Arc_Clockwise_SmallArc()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 100);
+        p.Arc(100, 100, 50, 0, Math.PI / 2, false);
+        AssertPath(p, "M150,100A50,50,0,0,1,100,150");
+    }
+
+    [Fact]
+    public void Arc_CounterClockwise_FullCircle()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 100);
+        p.Arc(100, 100, 50, 0, 1e-16, true);
+        AssertPath(p, "M150,100A50,50,0,1,0,50,100A50,50,0,1,0,150,100");
+    }
+
+    [Fact]
+    public void ArcTo_NegativeRadius_Throws()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 100);
+        Assert.Throws<ArgumentException>(() => p.ArcTo(270, 39, 163, 100, -53));
+    }
+
+    [Fact]
+    public void ArcTo_EmptyPath_AppendsM()
+    {
+        var p = new PathBuilder();
+        p.ArcTo(270, 39, 163, 100, 53);
+        AssertPath(p, "M270,39");
+    }
+
+    [Fact]
+    public void Rect_AppendsMhvhZ()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(150, 100);
+        p.Rect(100, 200, 50, 25);
+        AssertPath(p, "M150,100M100,200h50v25h-50Z");
+    }
+
+    [Fact]
+    public void ArcTo_LineStartsAtCurrentPoint_AppendsA()
+    {
+        var p = new PathBuilder();
+        p.MoveTo(100, 100);
+        p.ArcTo(200, 100, 200, 200, 100);
+        AssertPath(p, "M100,100A100,100,0,0,1,200,200");
+    }
+
+    [Fact]
+    public void Arc_QuarterCircle_FromNegativeHalfPi()
+    {
+        var p = new PathBuilder(3);
+        p.Arc(0, 50, 50, -Math.PI / 2, 0);
+        AssertPath(p, "M0,0A50,50,0,0,1,50,50");
+    }
+}

--- a/tests/Reactor.Tests/D3/PieTests.cs
+++ b/tests/Reactor.Tests/D3/PieTests.cs
@@ -1,0 +1,107 @@
+// Port of d3-shape/test/pie-test.js
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class PieTests
+{
+    private const double Tolerance = 1e-10;
+
+    [Fact]
+    public void Pie_Default_ReturnsArcsInInputOrder()
+    {
+        var p = PieGenerator.Create();
+        var arcs = p.Generate([1, 3, 2]);
+
+        Assert.Equal(3, arcs.Length);
+
+        Assert.Equal(1.0, arcs[0].Data);
+        Assert.Equal(1.0, arcs[0].Value);
+        Assert.Equal(2, arcs[0].Index);
+        Assert.InRange(arcs[0].StartAngle, 5.235987 - 0.001, 5.235988 + 0.001);
+        Assert.InRange(arcs[0].EndAngle, 6.283185 - 0.001, 6.283186 + 0.001);
+
+        Assert.Equal(3.0, arcs[1].Data);
+        Assert.Equal(3.0, arcs[1].Value);
+        Assert.Equal(0, arcs[1].Index);
+        Assert.Equal(0.0, arcs[1].StartAngle, Tolerance);
+        Assert.InRange(arcs[1].EndAngle, Math.PI - 0.001, Math.PI + 0.001);
+
+        Assert.Equal(2.0, arcs[2].Data);
+        Assert.Equal(2.0, arcs[2].Value);
+        Assert.Equal(1, arcs[2].Index);
+    }
+
+    [Fact]
+    public void Pie_NegativeValues_TreatedAsZero()
+    {
+        var p = PieGenerator.Create();
+        var arcs = p.Generate([1, 0, -1]);
+
+        Assert.Equal(1.0, arcs[0].Value);
+        Assert.Equal(0.0, arcs[1].Value);
+        Assert.Equal(-1.0, arcs[2].Value);
+
+        double fullCircle = 2 * Math.PI;
+        Assert.Equal(0.0, arcs[0].StartAngle, Tolerance);
+        Assert.Equal(fullCircle, arcs[0].EndAngle, Tolerance);
+    }
+
+    [Fact]
+    public void Pie_AllZeros_AllAtStartAngle()
+    {
+        var p = PieGenerator.Create();
+        var arcs = p.Generate([0.0, 0.0]);
+
+        Assert.Equal(0.0, arcs[0].StartAngle);
+        Assert.Equal(0.0, arcs[0].EndAngle);
+        Assert.Equal(0.0, arcs[1].StartAngle);
+        Assert.Equal(0.0, arcs[1].EndAngle);
+    }
+
+    [Fact]
+    public void Pie_CustomStartAngle()
+    {
+        var p = PieGenerator.Create().SetStartAngle(Math.PI);
+        var arcs = p.Generate([1, 2, 3]);
+
+        Assert.Equal(3, arcs.Length);
+
+        var arc3 = arcs[2];
+        Assert.Equal(3.0, arc3.Value);
+    }
+
+    [Fact]
+    public void Pie_CustomEndAngle()
+    {
+        var p = PieGenerator.Create().SetEndAngle(Math.PI);
+        var arcs = p.Generate([1, 2, 3]);
+
+        Assert.Equal(3, arcs.Length);
+    }
+
+    [Fact]
+    public void Pie_PadAngle()
+    {
+        var p = PieGenerator.Create().SetPadAngle(0.1);
+        var arcs = p.Generate([1, 2, 3]);
+
+        Assert.Equal(3, arcs.Length);
+        Assert.Equal(0.1, arcs[0].PadAngle);
+        Assert.Equal(0.1, arcs[1].PadAngle);
+        Assert.Equal(0.1, arcs[2].PadAngle);
+    }
+
+    [Fact]
+    public void Pie_SortValuesAscending()
+    {
+        var p = PieGenerator.Create().SetSortValues((a, b) => a.CompareTo(b));
+        var arcs = p.Generate([1, 3, 2]);
+
+        Assert.Equal(0, arcs[0].Index);
+        Assert.Equal(2, arcs[1].Index);
+        Assert.Equal(1, arcs[2].Index);
+    }
+}

--- a/tests/Reactor.Tests/D3/PolygonTests.cs
+++ b/tests/Reactor.Tests/D3/PolygonTests.cs
@@ -1,0 +1,103 @@
+// Port of d3-polygon tests
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class PolygonTests
+{
+    private const double Tol = 1e-6;
+
+    [Fact]
+    public void Area_Square()
+    {
+        var square = new (double x, double y)[]
+        {
+            (0, 0), (1, 0), (1, 1), (0, 1)
+        };
+        Assert.Equal(-1.0, D3Polygon.Area(square), Tol);
+    }
+
+    [Fact]
+    public void Area_CounterClockwise()
+    {
+        var square = new (double x, double y)[]
+        {
+            (0, 0), (0, 1), (1, 1), (1, 0)
+        };
+        Assert.Equal(1.0, D3Polygon.Area(square), Tol);
+    }
+
+    [Fact]
+    public void Centroid_Square()
+    {
+        var square = new (double x, double y)[]
+        {
+            (0, 0), (1, 0), (1, 1), (0, 1)
+        };
+        var (cx, cy) = D3Polygon.Centroid(square);
+        Assert.Equal(0.5, cx, Tol);
+        Assert.Equal(0.5, cy, Tol);
+    }
+
+    [Fact]
+    public void Contains_Inside()
+    {
+        var triangle = new (double x, double y)[]
+        {
+            (0, 0), (10, 0), (5, 10)
+        };
+        Assert.True(D3Polygon.Contains(triangle, (5, 5)));
+    }
+
+    [Fact]
+    public void Contains_Outside()
+    {
+        var triangle = new (double x, double y)[]
+        {
+            (0, 0), (10, 0), (5, 10)
+        };
+        Assert.False(D3Polygon.Contains(triangle, (20, 20)));
+    }
+
+    [Fact]
+    public void Length_Square()
+    {
+        var square = new (double x, double y)[]
+        {
+            (0, 0), (1, 0), (1, 1), (0, 1)
+        };
+        Assert.Equal(4.0, D3Polygon.Length(square), Tol);
+    }
+
+    [Fact]
+    public void Hull_Triangle()
+    {
+        var points = new (double x, double y)[]
+        {
+            (0, 0), (10, 0), (5, 10), (5, 3)
+        };
+        var hull = D3Polygon.Hull(points);
+        Assert.NotNull(hull);
+        Assert.Equal(3, hull.Length);
+    }
+
+    [Fact]
+    public void Hull_TooFewPoints()
+    {
+        Assert.Null(D3Polygon.Hull([(0, 0), (1, 1)]));
+    }
+
+    [Fact]
+    public void Hull_Square()
+    {
+        var points = new (double x, double y)[]
+        {
+            (0, 0), (10, 0), (10, 10), (0, 10)
+        };
+        var hull = D3Polygon.Hull(points);
+        Assert.NotNull(hull);
+        Assert.Equal(4, hull.Length);
+    }
+}

--- a/tests/Reactor.Tests/D3/RadialTests.cs
+++ b/tests/Reactor.Tests/D3/RadialTests.cs
@@ -1,0 +1,97 @@
+// Tests for d3-shape radial generators (lineRadial, areaRadial, linkRadial)
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class RadialLineTests
+{
+    [Fact]
+    public void RadialLine_GeneratesPath()
+    {
+        var gen = RadialLineGenerator.Create();
+        var data = new (double angle, double radius)[]
+        {
+            (0, 100), (Math.PI / 2, 100), (Math.PI, 100), (3 * Math.PI / 2, 100)
+        };
+
+        var path = gen.Generate(data);
+        Assert.NotNull(path);
+        Assert.StartsWith("M", path);
+    }
+
+    [Fact]
+    public void RadialLine_CircleAt360()
+    {
+        var gen = RadialLineGenerator.Create();
+        int n = 36;
+        var data = Enumerable.Range(0, n)
+            .Select(i => (angle: 2 * Math.PI * i / n, radius: 50.0))
+            .ToArray();
+
+        var path = gen.Generate(data);
+        Assert.NotNull(path);
+        Assert.Contains("L", path);
+    }
+
+    [Fact]
+    public void RadialLine_WithCurve()
+    {
+        var gen = RadialLineGenerator.Create().SetCurve(D3Curve.Cardinal);
+        var data = new (double angle, double radius)[]
+        {
+            (0, 100), (1, 80), (2, 120), (3, 90)
+        };
+
+        var path = gen.Generate(data);
+        Assert.NotNull(path);
+        Assert.Contains("C", path);
+    }
+
+    [Fact]
+    public void RadialLine_CustomAccessors()
+    {
+        var gen = RadialLineGenerator.Create<(double a, double r)>(
+            d => d.a, d => d.r);
+        var data = new (double a, double r)[] { (0, 50), (1, 60), (2, 70) };
+
+        var path = gen.Generate(data);
+        Assert.NotNull(path);
+    }
+}
+
+public class RadialAreaTests
+{
+    [Fact]
+    public void RadialArea_GeneratesClosedPath()
+    {
+        var gen = RadialAreaGenerator.Create<(double angle, double value)>(
+            d => d.angle, _ => 50, d => d.value);
+
+        var data = new (double angle, double value)[]
+        {
+            (0, 100), (Math.PI / 2, 80), (Math.PI, 120), (3 * Math.PI / 2, 90)
+        };
+
+        var path = gen.Generate(data);
+        Assert.NotNull(path);
+        Assert.Contains("Z", path);
+    }
+}
+
+public class RadialLinkTests
+{
+    [Fact]
+    public void RadialLink_GeneratesQuadratic()
+    {
+        var gen = RadialLinkGenerator.Create<(double angle, double radius)>(
+            d => d.angle, d => d.radius);
+
+        var path = gen.Generate(
+            (source: (0.0, 50.0), target: (Math.PI, 100.0)));
+
+        Assert.NotNull(path);
+        Assert.Contains("Q", path);
+    }
+}

--- a/tests/Reactor.Tests/D3/RandomExtraTests.cs
+++ b/tests/Reactor.Tests/D3/RandomExtraTests.cs
@@ -1,0 +1,94 @@
+// Distributions not covered by RandomTests: Cauchy, Weibull, IrwinHall.
+// Upstream tests in d3-random test/cauchy-test.js, weibull-test.js, irwinHall-test.js.
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class RandomCauchyTests
+{
+    [Fact]
+    public void Cauchy_Returns_Real_Values()
+    {
+        var gen = D3Random.Cauchy();
+        for (int i = 0; i < 1000; i++)
+        {
+            double v = gen();
+            Assert.False(double.IsNaN(v));
+        }
+    }
+
+    [Fact]
+    public void Cauchy_Scale_Changes_Spread()
+    {
+        // Compare interquartile-like spread for two scales.
+        var tight = D3Random.Cauchy(0, 1);
+        var wide = D3Random.Cauchy(0, 100);
+        var tv = new List<double>();
+        var wv = new List<double>();
+        for (int i = 0; i < 500; i++) { tv.Add(tight()); wv.Add(wide()); }
+        tv.Sort(); wv.Sort();
+        // Compare the 40-60 percentile ranges (Cauchy has no mean/variance,
+        // but the middle 20% band scales with the distribution's scale param).
+        double tSpread = tv[300] - tv[200];
+        double wSpread = wv[300] - wv[200];
+        Assert.True(wSpread > tSpread * 5, $"wide spread={wSpread}, tight spread={tSpread}");
+    }
+}
+
+public class RandomWeibullTests
+{
+    [Fact]
+    public void Weibull_Default_Positive()
+    {
+        var gen = D3Random.Weibull();
+        for (int i = 0; i < 1000; i++)
+        {
+            Assert.True(gen() >= 0);
+        }
+    }
+
+    [Fact]
+    public void Weibull_Shape_One_Equals_Exponential_1_Over_Lambda()
+    {
+        // Shape k=1 is just exponential with rate 1/lambda.
+        var gen = D3Random.Weibull(1, 2);
+        double sum = 0;
+        for (int i = 0; i < 5000; i++) sum += gen();
+        double mean = sum / 5000;
+        // Exponential(1/2) mean = 2.
+        Assert.InRange(mean, 1.5, 2.5);
+    }
+}
+
+public class RandomIrwinHallTests
+{
+    [Fact]
+    public void IrwinHall_Sum_Of_Uniforms_In_Range()
+    {
+        var gen = D3Random.IrwinHall(5);
+        for (int i = 0; i < 1000; i++)
+        {
+            double v = gen();
+            Assert.InRange(v, 0, 5);
+        }
+    }
+
+    [Fact]
+    public void IrwinHall_Zero_Always_Zero()
+    {
+        var gen = D3Random.IrwinHall(0);
+        Assert.Equal(0, gen());
+    }
+
+    [Fact]
+    public void IrwinHall_N_Mean_Approximately_N_Over_2()
+    {
+        var gen = D3Random.IrwinHall(10);
+        double sum = 0;
+        for (int i = 0; i < 5000; i++) sum += gen();
+        double mean = sum / 5000;
+        Assert.InRange(mean, 4.5, 5.5);
+    }
+}

--- a/tests/Reactor.Tests/D3/RandomTests.cs
+++ b/tests/Reactor.Tests/D3/RandomTests.cs
@@ -1,0 +1,137 @@
+// Port of d3-random tests
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class RandomTests
+{
+    private const int N = 1000;
+
+    [Fact]
+    public void Uniform_InRange()
+    {
+        var gen = D3Random.Uniform(10, 20);
+        for (int i = 0; i < N; i++)
+        {
+            double v = gen();
+            Assert.InRange(v, 10, 20);
+        }
+    }
+
+    [Fact]
+    public void Uniform_DefaultRange()
+    {
+        var gen = D3Random.Uniform();
+        for (int i = 0; i < N; i++)
+        {
+            double v = gen();
+            Assert.InRange(v, 0, 1);
+        }
+    }
+
+    [Fact]
+    public void Int_InRange()
+    {
+        var gen = D3Random.Int(0, 10);
+        for (int i = 0; i < N; i++)
+        {
+            int v = gen();
+            Assert.InRange(v, 0, 9);
+        }
+    }
+
+    [Fact]
+    public void Normal_MeanApproximatelyCorrect()
+    {
+        var gen = D3Random.Normal(100, 10);
+        double sum = 0;
+        for (int i = 0; i < N; i++) sum += gen();
+        double mean = sum / N;
+        Assert.InRange(mean, 90, 110);
+    }
+
+    [Fact]
+    public void LogNormal_Positive()
+    {
+        var gen = D3Random.LogNormal();
+        for (int i = 0; i < N; i++)
+        {
+            Assert.True(gen() > 0);
+        }
+    }
+
+    [Fact]
+    public void Exponential_Positive()
+    {
+        var gen = D3Random.Exponential(1);
+        for (int i = 0; i < N; i++)
+        {
+            Assert.True(gen() > 0);
+        }
+    }
+
+    [Fact]
+    public void Bernoulli_ZeroOrOne()
+    {
+        var gen = D3Random.Bernoulli(0.5);
+        for (int i = 0; i < N; i++)
+        {
+            int v = gen();
+            Assert.True(v == 0 || v == 1);
+        }
+    }
+
+    [Fact]
+    public void Binomial_InRange()
+    {
+        var gen = D3Random.Binomial(10, 0.5);
+        for (int i = 0; i < N; i++)
+        {
+            int v = gen();
+            Assert.InRange(v, 0, 10);
+        }
+    }
+
+    [Fact]
+    public void Geometric_NonNegative()
+    {
+        var gen = D3Random.Geometric(0.5);
+        for (int i = 0; i < N; i++)
+        {
+            Assert.True(gen() >= 0);
+        }
+    }
+
+    [Fact]
+    public void Poisson_NonNegative()
+    {
+        var gen = D3Random.Poisson(5);
+        for (int i = 0; i < N; i++)
+        {
+            Assert.True(gen() >= 0);
+        }
+    }
+
+    [Fact]
+    public void Pareto_GreaterThanOne()
+    {
+        var gen = D3Random.Pareto(1);
+        for (int i = 0; i < N; i++)
+        {
+            Assert.True(gen() >= 1);
+        }
+    }
+
+    [Fact]
+    public void Bates_InUnitRange()
+    {
+        var gen = D3Random.Bates(10);
+        for (int i = 0; i < N; i++)
+        {
+            double v = gen();
+            Assert.InRange(v, 0, 1);
+        }
+    }
+}

--- a/tests/Reactor.Tests/D3/RangeTests.cs
+++ b/tests/Reactor.Tests/D3/RangeTests.cs
@@ -1,0 +1,40 @@
+// Port of d3-array/range tests
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class RangeTests
+{
+    [Fact]
+    public void Range_Stop_Only()
+    {
+        Assert.Equal(new[] { 0.0, 1.0, 2.0, 3.0, 4.0 }, D3Range.Range(5));
+    }
+
+    [Fact]
+    public void Range_StartStop()
+    {
+        Assert.Equal(new[] { 2.0, 3.0, 4.0 }, D3Range.Range(2, 5));
+    }
+
+    [Fact]
+    public void Range_StartStopStep()
+    {
+        Assert.Equal(new[] { 0.0, 0.5, 1.0, 1.5, 2.0 }, D3Range.Range(0, 2.5, 0.5));
+    }
+
+    [Fact]
+    public void Range_NegativeStep()
+    {
+        Assert.Equal(new[] { 5.0, 4.0, 3.0 }, D3Range.Range(5, 2, -1));
+    }
+
+    [Fact]
+    public void Range_Empty()
+    {
+        Assert.Empty(D3Range.Range(0));
+        Assert.Empty(D3Range.Range(5, 5));
+    }
+}

--- a/tests/Reactor.Tests/D3/SankeyTests.cs
+++ b/tests/Reactor.Tests/D3/SankeyTests.cs
@@ -1,0 +1,161 @@
+// Tests for d3-sankey layout
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class SankeyTests
+{
+    [Fact]
+    public void Sankey_SimpleThreeNode()
+    {
+        var graph = new SankeyGraph
+        {
+            Nodes =
+            [
+                new SankeyNode { Id = "A" },
+                new SankeyNode { Id = "B" },
+                new SankeyNode { Id = "C" },
+            ],
+            Links =
+            [
+                new SankeyLink { SourceId = "A", TargetId = "B", Value = 10 },
+                new SankeyLink { SourceId = "B", TargetId = "C", Value = 10 },
+            ],
+        };
+
+        new SankeyLayout().Size(200, 100).Layout(graph);
+
+        Assert.True(graph.Nodes[0].X0 < graph.Nodes[1].X0);
+        Assert.True(graph.Nodes[1].X0 < graph.Nodes[2].X0);
+    }
+
+    [Fact]
+    public void Sankey_NodeValues()
+    {
+        var graph = new SankeyGraph
+        {
+            Nodes =
+            [
+                new SankeyNode { Id = "A" },
+                new SankeyNode { Id = "B" },
+            ],
+            Links =
+            [
+                new SankeyLink { SourceId = "A", TargetId = "B", Value = 50 },
+            ],
+        };
+
+        new SankeyLayout().Size(200, 100).Layout(graph);
+
+        Assert.Equal(50, graph.Nodes[0].Value);
+        Assert.Equal(50, graph.Nodes[1].Value);
+    }
+
+    [Fact]
+    public void Sankey_MultipleInputs()
+    {
+        var graph = new SankeyGraph
+        {
+            Nodes =
+            [
+                new SankeyNode { Id = "A" },
+                new SankeyNode { Id = "B" },
+                new SankeyNode { Id = "C" },
+            ],
+            Links =
+            [
+                new SankeyLink { SourceId = "A", TargetId = "C", Value = 30 },
+                new SankeyLink { SourceId = "B", TargetId = "C", Value = 20 },
+            ],
+        };
+
+        new SankeyLayout().Size(200, 100).Layout(graph);
+
+        Assert.Equal(50, graph.Nodes[2].Value);
+    }
+
+    [Fact]
+    public void Sankey_LinkPath()
+    {
+        var graph = new SankeyGraph
+        {
+            Nodes =
+            [
+                new SankeyNode { Id = "A" },
+                new SankeyNode { Id = "B" },
+            ],
+            Links =
+            [
+                new SankeyLink { SourceId = "A", TargetId = "B", Value = 20 },
+            ],
+        };
+
+        new SankeyLayout().Size(200, 100).Layout(graph);
+
+        var path = SankeyLayout.LinkPath(graph.Links[0]);
+        Assert.NotNull(path);
+        Assert.Contains("C", path);
+        Assert.Contains("Z", path);
+    }
+
+    [Fact]
+    public void Sankey_NodePadding()
+    {
+        var graph = new SankeyGraph
+        {
+            Nodes =
+            [
+                new SankeyNode { Id = "A" },
+                new SankeyNode { Id = "B" },
+                new SankeyNode { Id = "C" },
+                new SankeyNode { Id = "D" },
+            ],
+            Links =
+            [
+                new SankeyLink { SourceId = "A", TargetId = "C", Value = 10 },
+                new SankeyLink { SourceId = "A", TargetId = "D", Value = 10 },
+                new SankeyLink { SourceId = "B", TargetId = "C", Value = 10 },
+                new SankeyLink { SourceId = "B", TargetId = "D", Value = 10 },
+            ],
+        };
+
+        new SankeyLayout().Size(200, 100).SetNodePadding(10).Layout(graph);
+
+        var leftNodes = graph.Nodes.Where(n => n.Depth == 0).OrderBy(n => n.Y0).ToList();
+        if (leftNodes.Count >= 2)
+        {
+            Assert.True(leftNodes[1].Y0 >= leftNodes[0].Y1);
+        }
+    }
+
+    [Fact]
+    public void Sankey_DiamondShape()
+    {
+        var graph = new SankeyGraph
+        {
+            Nodes =
+            [
+                new SankeyNode { Id = "S" },
+                new SankeyNode { Id = "A" },
+                new SankeyNode { Id = "B" },
+                new SankeyNode { Id = "T" },
+            ],
+            Links =
+            [
+                new SankeyLink { SourceId = "S", TargetId = "A", Value = 5 },
+                new SankeyLink { SourceId = "S", TargetId = "B", Value = 5 },
+                new SankeyLink { SourceId = "A", TargetId = "T", Value = 5 },
+                new SankeyLink { SourceId = "B", TargetId = "T", Value = 5 },
+            ],
+        };
+
+        new SankeyLayout().Size(300, 200).Layout(graph);
+
+        var s = graph.Nodes.First(n => n.Id == "S");
+        var t = graph.Nodes.First(n => n.Id == "T");
+        Assert.Equal(0, s.Depth);
+        Assert.Equal(2, t.Depth);
+    }
+}

--- a/tests/Reactor.Tests/D3/ScaleTests.cs
+++ b/tests/Reactor.Tests/D3/ScaleTests.cs
@@ -1,0 +1,228 @@
+// Tests for d3-scale types: Ordinal, Band, Point, Log, Pow, Quantize, Quantile, Threshold
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class OrdinalScaleTests
+{
+    [Fact]
+    public void Map_ReturnsRangeValues()
+    {
+        var s = new OrdinalScale<string>(["a", "b", "c"], [10, 20, 30]);
+        Assert.Equal(10, s.Map("a"));
+        Assert.Equal(20, s.Map("b"));
+        Assert.Equal(30, s.Map("c"));
+    }
+
+    [Fact]
+    public void Map_ImplicitDomain()
+    {
+        var s = new OrdinalScale<string>().SetRange(10, 20, 30);
+        Assert.Equal(10, s.Map("a"));
+        Assert.Equal(20, s.Map("b"));
+        Assert.Equal(10, s.Map("a"));
+    }
+
+    [Fact]
+    public void Map_WrapsRange()
+    {
+        var s = new OrdinalScale<string>(["a", "b", "c", "d"], [10, 20]);
+        Assert.Equal(10, s.Map("c"));
+        Assert.Equal(20, s.Map("d"));
+    }
+
+    [Fact]
+    public void Unknown_ReturnedForUnknownDomain()
+    {
+        var s = new OrdinalScale<string>(["a", "b"], [10, 20]).SetUnknown(-1);
+        Assert.Equal(-1, s.Map("c"));
+    }
+}
+
+public class BandScaleTests
+{
+    [Fact]
+    public void Map_ReturnsBandStart()
+    {
+        var s = new BandScale<string>().SetDomain("a", "b", "c").SetRange(0, 120);
+        Assert.Equal(0, s.Map("a"));
+        Assert.Equal(40, s.Map("b"));
+        Assert.Equal(80, s.Map("c"));
+    }
+
+    [Fact]
+    public void Bandwidth_Correct()
+    {
+        var s = new BandScale<string>().SetDomain("a", "b", "c").SetRange(0, 120);
+        Assert.Equal(40, s.Bandwidth);
+    }
+
+    [Fact]
+    public void PaddingInner_ShrinksBands()
+    {
+        var s = new BandScale<string>().SetDomain("a", "b").SetRange(0, 100).SetPaddingInner(0.5);
+        Assert.True(s.Bandwidth < 50);
+    }
+
+    [Fact]
+    public void UnknownDomain_ReturnsNaN()
+    {
+        var s = new BandScale<string>().SetDomain("a", "b").SetRange(0, 100);
+        Assert.True(double.IsNaN(s.Map("z")));
+    }
+}
+
+public class PointScaleTests
+{
+    [Fact]
+    public void Map_ReturnsPoints()
+    {
+        var s = new PointScale<string>().SetDomain("a", "b", "c").SetRange(0, 120);
+        Assert.Equal(0, s.Map("a"));
+        Assert.Equal(60, s.Map("b"));
+        Assert.Equal(120, s.Map("c"));
+    }
+}
+
+public class LogScaleTests
+{
+    [Fact]
+    public void Map_LogTransform()
+    {
+        var s = new LogScale([1, 100], [0, 1]);
+        Assert.Equal(0.5, s.Map(10), 5);
+    }
+
+    [Fact]
+    public void Map_Endpoints()
+    {
+        var s = new LogScale([1, 100], [0, 1]);
+        Assert.Equal(0, s.Map(1), 10);
+        Assert.Equal(1, s.Map(100), 10);
+    }
+
+    [Fact]
+    public void Nice_ExtendsToLogBoundaries()
+    {
+        var s = new LogScale([3, 80], [0, 1]).Nice();
+        Assert.Equal(1.0, s.Domain[0], 5);
+        Assert.Equal(100.0, s.Domain[1], 5);
+    }
+
+    [Fact]
+    public void Ticks_ReturnsLogSpacedValues()
+    {
+        var s = new LogScale([1, 1000], [0, 1]);
+        var ticks = s.Ticks();
+        Assert.Contains(1.0, ticks);
+        Assert.Contains(10.0, ticks);
+        Assert.Contains(100.0, ticks);
+        Assert.Contains(1000.0, ticks);
+    }
+}
+
+public class PowScaleTests
+{
+    [Fact]
+    public void Map_SquaredTransform()
+    {
+        var s = new PowScale().SetExponent(2).SetDomain(0, 10).SetRange(0, 100);
+        Assert.Equal(25, s.Map(5), 5);
+    }
+
+    [Fact]
+    public void Sqrt_HalfExponent()
+    {
+        var s = PowScale.Sqrt().SetDomain(0, 100).SetRange(0, 10);
+        Assert.Equal(5, s.Map(25), 5);
+    }
+
+    [Fact]
+    public void Map_Linear_WhenExponentOne()
+    {
+        var s = new PowScale().SetExponent(1).SetDomain(0, 100).SetRange(0, 100);
+        Assert.Equal(50, s.Map(50), 10);
+    }
+}
+
+public class QuantizeScaleTests
+{
+    [Fact]
+    public void Map_DividesIntoSegments()
+    {
+        var s = new QuantizeScale().SetDomain(0, 1).SetRange(0, 1);
+        Assert.Equal(0, s.Map(0.25));
+        Assert.Equal(1, s.Map(0.75));
+    }
+
+    [Fact]
+    public void Map_ThreeSegments()
+    {
+        var s = new QuantizeScale().SetDomain(0, 1).SetRange(0, 1, 2);
+        Assert.Equal(0, s.Map(0.1));
+        Assert.Equal(1, s.Map(0.4));
+        Assert.Equal(2, s.Map(0.8));
+    }
+
+    [Fact]
+    public void InvertExtent_ReturnsInterval()
+    {
+        var s = new QuantizeScale().SetDomain(0, 1).SetRange(0, 1);
+        var (x0, x1) = s.InvertExtent(0);
+        Assert.Equal(0, x0);
+        Assert.Equal(0.5, x1);
+    }
+
+    [Fact]
+    public void Thresholds_Correct()
+    {
+        var s = new QuantizeScale().SetDomain(0, 1).SetRange(0, 1, 2);
+        var t = s.Thresholds();
+        Assert.Equal(2, t.Length);
+        Assert.Equal(1.0 / 3, t[0], 10);
+        Assert.Equal(2.0 / 3, t[1], 10);
+    }
+}
+
+public class QuantileScaleTests
+{
+    [Fact]
+    public void Map_SortsAndPartitions()
+    {
+        var s = new QuantileScale().SetDomain(3, 6, 7, 8, 8, 10, 13, 15, 16, 20).SetRange(0, 1, 2, 3);
+        Assert.Equal(0, s.Map(3));
+        Assert.Equal(3, s.Map(20));
+    }
+
+    [Fact]
+    public void Quantiles_Correct()
+    {
+        var s = new QuantileScale().SetDomain(3, 6, 7, 8, 8, 10, 13, 15, 16, 20).SetRange(0, 1, 2, 3);
+        var q = s.Quantiles();
+        Assert.Equal(3, q.Length);
+    }
+}
+
+public class ThresholdScaleTests
+{
+    [Fact]
+    public void Map_DefaultThreshold()
+    {
+        var s = new ThresholdScale();
+        Assert.Equal(0, s.Map(0));
+        Assert.Equal(1, s.Map(0.5));
+        Assert.Equal(1, s.Map(1));
+    }
+
+    [Fact]
+    public void Map_CustomThresholds()
+    {
+        var s = new ThresholdScale().SetDomain(10, 20, 30).SetRange(0, 1, 2, 3);
+        Assert.Equal(0, s.Map(5));
+        Assert.Equal(1, s.Map(15));
+        Assert.Equal(2, s.Map(25));
+        Assert.Equal(3, s.Map(35));
+    }
+}

--- a/tests/Reactor.Tests/D3/StackTests.cs
+++ b/tests/Reactor.Tests/D3/StackTests.cs
@@ -1,0 +1,117 @@
+// Port of d3-shape/test/stack-test.js (subset — reactor1's StackGenerator
+// implements the 'none' offset only; order and other offsets aren't ported.)
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class StackTests
+{
+    private record Row(double A, double B, double C);
+
+    private static StackGenerator<Row> MakeStack()
+    {
+        return StackGenerator.Create<Row>()
+            .SetKeys("a", "b", "c")
+            .SetValue((row, key) => key switch
+            {
+                "a" => row.A,
+                "b" => row.B,
+                "c" => row.C,
+                _ => 0,
+            });
+    }
+
+    [Fact]
+    public void Stack_Produces_Series_Per_Key()
+    {
+        var data = new[] { new Row(1, 2, 3), new Row(4, 5, 6) };
+        var series = MakeStack().Generate(data);
+        Assert.Equal(3, series.Length);
+        Assert.Equal("a", series[0].Key);
+        Assert.Equal("b", series[1].Key);
+        Assert.Equal("c", series[2].Key);
+    }
+
+    [Fact]
+    public void Stack_Each_Series_Has_Point_Per_Row()
+    {
+        var data = new[] { new Row(1, 2, 3), new Row(4, 5, 6), new Row(7, 8, 9) };
+        var series = MakeStack().Generate(data);
+        Assert.All(series, s => Assert.Equal(3, s.Points.Length));
+    }
+
+    [Fact]
+    public void Stack_First_Series_Starts_At_Zero()
+    {
+        var data = new[] { new Row(10, 20, 30) };
+        var series = MakeStack().Generate(data);
+        Assert.Equal(0, series[0].Points[0].Y0);
+        Assert.Equal(10, series[0].Points[0].Y1);
+    }
+
+    [Fact]
+    public void Stack_Second_Series_Starts_Where_First_Ends()
+    {
+        var data = new[] { new Row(10, 20, 30) };
+        var series = MakeStack().Generate(data);
+        Assert.Equal(10, series[1].Points[0].Y0);
+        Assert.Equal(30, series[1].Points[0].Y1);
+    }
+
+    [Fact]
+    public void Stack_Third_Series_Stacks_On_Top_Of_Second()
+    {
+        var data = new[] { new Row(10, 20, 30) };
+        var series = MakeStack().Generate(data);
+        Assert.Equal(30, series[2].Points[0].Y0);
+        Assert.Equal(60, series[2].Points[0].Y1);
+    }
+
+    [Fact]
+    public void Stack_Cumulative_Sum_Equals_Total()
+    {
+        // For each row, the top of the last series should equal the row sum.
+        var data = new[]
+        {
+            new Row(1, 2, 3),
+            new Row(10, 20, 30),
+            new Row(100, 200, 300),
+        };
+        var series = MakeStack().Generate(data);
+        for (int j = 0; j < data.Length; j++)
+        {
+            double total = data[j].A + data[j].B + data[j].C;
+            Assert.Equal(total, series[2].Points[j].Y1, 10);
+        }
+    }
+
+    [Fact]
+    public void Stack_Empty_Data_Gives_Empty_Point_Arrays()
+    {
+        var series = MakeStack().Generate(Array.Empty<Row>());
+        Assert.All(series, s => Assert.Empty(s.Points));
+    }
+
+    [Fact]
+    public void Stack_No_Keys_Produces_No_Series()
+    {
+        var gen = StackGenerator.Create<Row>();
+        var series = gen.Generate(new[] { new Row(1, 2, 3) });
+        Assert.Empty(series);
+    }
+
+    [Fact]
+    public void Stack_Single_Key_Behaves_Like_Raw_Values()
+    {
+        var gen = StackGenerator.Create<Row>()
+            .SetKeys("a")
+            .SetValue((row, _) => row.A);
+        var data = new[] { new Row(5, 0, 0), new Row(7, 0, 0) };
+        var series = gen.Generate(data);
+        Assert.Single(series);
+        Assert.Equal(5, series[0].Points[0].Y1);
+        Assert.Equal(7, series[0].Points[1].Y1);
+    }
+}

--- a/tests/Reactor.Tests/D3/StatisticsTests.cs
+++ b/tests/Reactor.Tests/D3/StatisticsTests.cs
@@ -1,0 +1,172 @@
+// Port of d3-array statistics tests (min, max, sum, mean, median, quantile, variance, deviation, cumsum)
+// Validates D3Statistics matches d3-array v3 behavior.
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class StatisticsTests
+{
+    private const double Tol = 1e-10;
+
+    // ─── Min ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Min_ReturnsSmallest()
+    {
+        Assert.Equal(1.0, D3Statistics.Min([3, 1, 2]));
+    }
+
+    [Fact]
+    public void Min_IgnoresNaN()
+    {
+        Assert.Equal(1.0, D3Statistics.Min([double.NaN, 1, 2]));
+    }
+
+    [Fact]
+    public void Min_Empty_ReturnsNaN()
+    {
+        Assert.True(double.IsNaN(D3Statistics.Min(Array.Empty<double>())));
+    }
+
+    [Fact]
+    public void Min_AllNaN_ReturnsNaN()
+    {
+        Assert.True(double.IsNaN(D3Statistics.Min([double.NaN, double.NaN])));
+    }
+
+    [Fact]
+    public void Min_Negative()
+    {
+        Assert.Equal(-3.0, D3Statistics.Min([-1, -2, -3]));
+    }
+
+    // ─── Max ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Max_ReturnsLargest()
+    {
+        Assert.Equal(3.0, D3Statistics.Max([3, 1, 2]));
+    }
+
+    [Fact]
+    public void Max_IgnoresNaN()
+    {
+        Assert.Equal(2.0, D3Statistics.Max([double.NaN, 1, 2]));
+    }
+
+    [Fact]
+    public void Max_Empty_ReturnsNaN()
+    {
+        Assert.True(double.IsNaN(D3Statistics.Max(Array.Empty<double>())));
+    }
+
+    // ─── Sum ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Sum_ReturnsTotal()
+    {
+        Assert.Equal(6.0, D3Statistics.Sum([1, 2, 3]));
+    }
+
+    [Fact]
+    public void Sum_IgnoresNaN()
+    {
+        Assert.Equal(3.0, D3Statistics.Sum([1, double.NaN, 2]));
+    }
+
+    [Fact]
+    public void Sum_Empty_ReturnsZero()
+    {
+        Assert.Equal(0.0, D3Statistics.Sum(Array.Empty<double>()));
+    }
+
+    // ─── Mean ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Mean_ReturnsAverage()
+    {
+        Assert.Equal(2.0, D3Statistics.Mean([1, 2, 3]));
+    }
+
+    [Fact]
+    public void Mean_IgnoresNaN()
+    {
+        Assert.Equal(2.0, D3Statistics.Mean([1, double.NaN, 3]));
+    }
+
+    [Fact]
+    public void Mean_Empty_ReturnsNaN()
+    {
+        Assert.True(double.IsNaN(D3Statistics.Mean(Array.Empty<double>())));
+    }
+
+    // ─── Median ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Median_OddCount()
+    {
+        Assert.Equal(2.0, D3Statistics.Median([3, 1, 2]));
+    }
+
+    [Fact]
+    public void Median_EvenCount()
+    {
+        Assert.Equal(2.5, D3Statistics.Median([1, 2, 3, 4]));
+    }
+
+    // ─── Quantile ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Quantile_Sorted_0()
+    {
+        Assert.Equal(0.0, D3Statistics.QuantileSorted([0, 10, 30], 0));
+    }
+
+    [Fact]
+    public void Quantile_Sorted_1()
+    {
+        Assert.Equal(30.0, D3Statistics.QuantileSorted([0, 10, 30], 1));
+    }
+
+    [Fact]
+    public void Quantile_Sorted_Half()
+    {
+        Assert.Equal(10.0, D3Statistics.QuantileSorted([0, 10, 30], 0.5));
+    }
+
+    [Fact]
+    public void Quantile_Sorted_Quarter()
+    {
+        Assert.Equal(5.0, D3Statistics.QuantileSorted([0, 10, 30], 0.25));
+    }
+
+    // ─── Variance / Deviation ────────────────────────────────────────
+
+    [Fact]
+    public void Variance_ComputableFromValues()
+    {
+        Assert.Equal(1.0, D3Statistics.Variance([1, 2, 3]), Tol);
+    }
+
+    [Fact]
+    public void Variance_SingleValue_ReturnsNaN()
+    {
+        Assert.True(double.IsNaN(D3Statistics.Variance([1])));
+    }
+
+    [Fact]
+    public void Deviation_ComputableFromValues()
+    {
+        Assert.Equal(1.0, D3Statistics.Deviation([1, 2, 3]), Tol);
+    }
+
+    // ─── CumSum ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void CumSum_ReturnsRunningTotal()
+    {
+        Assert.Equal(new[] { 1.0, 3.0, 6.0 }, D3Statistics.CumSum([1, 2, 3]));
+    }
+}

--- a/tests/Reactor.Tests/D3/StratifyTests.cs
+++ b/tests/Reactor.Tests/D3/StratifyTests.cs
@@ -1,0 +1,136 @@
+// Tests for d3-hierarchy stratify (tabular → tree)
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class StratifyTests
+{
+    private record Row(string Id, string? ParentId, double Value = 0);
+
+    [Fact]
+    public void Stratify_BuildsTree()
+    {
+        var data = new Row[]
+        {
+            new("root", null),
+            new("a", "root"),
+            new("b", "root"),
+            new("a1", "a"),
+        };
+
+        var tree = Stratify.Create<Row>()
+            .SetId(r => r.Id)
+            .SetParentId(r => r.ParentId)
+            .Build(data);
+
+        Assert.Equal("root", tree.Data.Id);
+        Assert.Equal(2, tree.Children.Count);
+    }
+
+    [Fact]
+    public void Stratify_SetsDepths()
+    {
+        var data = new Row[]
+        {
+            new("root", null),
+            new("a", "root"),
+            new("a1", "a"),
+        };
+
+        var tree = Stratify.Create<Row>()
+            .SetId(r => r.Id)
+            .SetParentId(r => r.ParentId)
+            .Build(data);
+
+        Assert.Equal(0, tree.Depth);
+        Assert.Equal(1, tree.Children[0].Depth);
+        Assert.Equal(2, tree.Children[0].Children[0].Depth);
+    }
+
+    [Fact]
+    public void Stratify_ThrowsOnDuplicateId()
+    {
+        var data = new Row[]
+        {
+            new("a", null),
+            new("a", null),
+        };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            Stratify.Create<Row>()
+                .SetId(r => r.Id)
+                .SetParentId(r => r.ParentId)
+                .Build(data));
+    }
+
+    [Fact]
+    public void Stratify_ThrowsOnMissingParent()
+    {
+        var data = new Row[]
+        {
+            new("root", null),
+            new("a", "missing"),
+        };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            Stratify.Create<Row>()
+                .SetId(r => r.Id)
+                .SetParentId(r => r.ParentId)
+                .Build(data));
+    }
+
+    [Fact]
+    public void Stratify_ThrowsOnNoRoot()
+    {
+        var data = new Row[]
+        {
+            new("a", "b"),
+            new("b", "a"),
+        };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            Stratify.Create<Row>()
+                .SetId(r => r.Id)
+                .SetParentId(r => r.ParentId)
+                .Build(data));
+    }
+
+    [Fact]
+    public void Stratify_BuildTreemap()
+    {
+        var data = new Row[]
+        {
+            new("root", null),
+            new("a", "root", 10),
+            new("b", "root", 20),
+        };
+
+        var node = Stratify.Create<Row>()
+            .SetId(r => r.Id)
+            .SetParentId(r => r.ParentId)
+            .BuildTreemap(data, r => r.Value);
+
+        Assert.Equal(30, node.Value);
+        Assert.Equal(2, node.Children.Count);
+    }
+
+    [Fact]
+    public void Stratify_BuildPartition()
+    {
+        var data = new Row[]
+        {
+            new("root", null),
+            new("a", "root", 40),
+            new("b", "root", 60),
+        };
+
+        var node = Stratify.Create<Row>()
+            .SetId(r => r.Id)
+            .SetParentId(r => r.ParentId)
+            .BuildPartition(data, r => r.Value);
+
+        Assert.Equal(100, node.Value);
+    }
+}

--- a/tests/Reactor.Tests/D3/SymbolTests.cs
+++ b/tests/Reactor.Tests/D3/SymbolTests.cs
@@ -1,0 +1,70 @@
+// Tests for d3-shape symbol and link generators
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class SymbolTests
+{
+    [Fact]
+    public void Circle_GeneratesArcPath()
+    {
+        var gen = SymbolGenerator.Create();
+        var path = gen.Generate(null);
+        Assert.NotNull(path);
+        Assert.Contains("A", path);
+    }
+
+    [Fact]
+    public void AllSymbols_GeneratePaths()
+    {
+        foreach (var type in D3Symbol.All)
+        {
+            var gen = SymbolGenerator.Create<object?>(type, 64);
+            var path = gen.Generate(null);
+            Assert.NotNull(path);
+            Assert.True(path.Length > 0);
+        }
+    }
+
+    [Fact]
+    public void Square_GeneratesRect()
+    {
+        var gen = SymbolGenerator.Create<object?>(D3Symbol.Square, 100);
+        var path = gen.Generate(null);
+        Assert.NotNull(path);
+        Assert.Contains("M", path);
+    }
+
+    [Fact]
+    public void CustomSize()
+    {
+        var gen = SymbolGenerator.Create<object?>(D3Symbol.Circle, 256);
+        var path = gen.Generate(null);
+        Assert.NotNull(path);
+    }
+}
+
+public class LinkTests
+{
+    [Fact]
+    public void Vertical_GeneratesCubicBezier()
+    {
+        var link = LinkGenerator.Vertical<(double x, double y)>(
+            n => n.x, n => n.y);
+        var path = link.Generate((source: (0.0, 0.0), target: (10.0, 10.0)));
+        Assert.NotNull(path);
+        Assert.Contains("C", path);
+    }
+
+    [Fact]
+    public void Horizontal_GeneratesCubicBezier()
+    {
+        var link = LinkGenerator.Horizontal<(double x, double y)>(
+            n => n.x, n => n.y);
+        var path = link.Generate((source: (0.0, 0.0), target: (10.0, 10.0)));
+        Assert.NotNull(path);
+        Assert.Contains("C", path);
+    }
+}

--- a/tests/Reactor.Tests/D3/TicksTests.cs
+++ b/tests/Reactor.Tests/D3/TicksTests.cs
@@ -1,0 +1,73 @@
+// Port of d3-array/ticks tests
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class TicksTests
+{
+    [Fact]
+    public void Ticks_ZeroCount_ReturnsEmpty()
+    {
+        Assert.Empty(D3Ticks.Ticks(0, 1, 0));
+        Assert.Empty(D3Ticks.Ticks(0, 1, -1));
+    }
+
+    [Fact]
+    public void Ticks_EqualStartStop_ReturnsSingleValue()
+    {
+        Assert.Equal([5.0], D3Ticks.Ticks(5, 5, 10));
+    }
+
+    [Fact]
+    public void Ticks_0_1_10()
+    {
+        var ticks = D3Ticks.Ticks(0, 1, 10);
+        Assert.Equal(11, ticks.Length);
+        Assert.Equal(0.0, ticks[0]);
+        Assert.Equal(1.0, ticks[^1]);
+    }
+
+    [Fact]
+    public void Ticks_0_1_5()
+    {
+        var ticks = D3Ticks.Ticks(0, 1, 5);
+        Assert.Equal(new[] { 0.0, 0.2, 0.4, 0.6, 0.8, 1.0 }, ticks);
+    }
+
+    [Fact]
+    public void Ticks_Neg100_100_10()
+    {
+        var ticks = D3Ticks.Ticks(-100, 100, 10);
+        Assert.Equal(new double[] { -100, -80, -60, -40, -20, 0, 20, 40, 60, 80, 100 }, ticks);
+    }
+
+    [Fact]
+    public void Ticks_Neg100_100_2()
+    {
+        Assert.Equal(new double[] { -100, 0, 100 }, D3Ticks.Ticks(-100, 100, 2));
+    }
+
+    [Fact]
+    public void Ticks_Reverse()
+    {
+        var ticks = D3Ticks.Ticks(1, 0, 10);
+        Assert.Equal(0.0, ticks[^1]);
+        Assert.Equal(1.0, ticks[0]);
+    }
+
+    [Fact]
+    public void TickStep_Positive()
+    {
+        double step = D3Ticks.TickStep(0, 1, 10);
+        Assert.Equal(0.1, step);
+    }
+
+    [Fact]
+    public void TickStep_Large()
+    {
+        double step = D3Ticks.TickStep(0, 100, 5);
+        Assert.Equal(20.0, step, 5);
+    }
+}

--- a/tests/Reactor.Tests/D3/TreemapTests.cs
+++ b/tests/Reactor.Tests/D3/TreemapTests.cs
@@ -1,0 +1,130 @@
+// Tests for d3-hierarchy treemap and pack layouts
+
+using Microsoft.UI.Reactor.Charting.D3;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.D3;
+
+public class TreemapTests
+{
+    private record FileNode(string Name, double Size, FileNode[]? Children = null);
+
+    [Fact]
+    public void Treemap_LeafRectanglesCoverArea()
+    {
+        var root = new FileNode("root", 0,
+        [
+            new("a", 10),
+            new("b", 20),
+            new("c", 30),
+        ]);
+
+        var layout = TreemapLayout.Create<FileNode>().Size(100, 100);
+        var node = layout.Hierarchy(root, n => n.Children, n => n.Size);
+        layout.Layout(node);
+
+        foreach (var leaf in node.Leaves())
+        {
+            Assert.True(leaf.Width > 0);
+            Assert.True(leaf.Height > 0);
+        }
+    }
+
+    [Fact]
+    public void Treemap_RootCoversFullSize()
+    {
+        var root = new FileNode("root", 0,
+        [
+            new("a", 50),
+            new("b", 50),
+        ]);
+
+        var layout = TreemapLayout.Create<FileNode>().Size(200, 100);
+        var node = layout.Hierarchy(root, n => n.Children, n => n.Size);
+        layout.Layout(node);
+
+        Assert.Equal(0, node.X0);
+        Assert.Equal(0, node.Y0);
+        Assert.Equal(200, node.X1);
+        Assert.Equal(100, node.Y1);
+    }
+
+    [Fact]
+    public void Treemap_ValuesSum()
+    {
+        var root = new FileNode("root", 0,
+        [
+            new("a", 10),
+            new("b", 20),
+        ]);
+
+        var layout = TreemapLayout.Create<FileNode>().Size(100, 100);
+        var node = layout.Hierarchy(root, n => n.Children, n => n.Size);
+
+        Assert.Equal(30, node.Value);
+    }
+
+    [Fact]
+    public void Treemap_Nested()
+    {
+        var root = new FileNode("root", 0,
+        [
+            new("group1", 0, [new("a", 10), new("b", 20)]),
+            new("group2", 0, [new("c", 30)]),
+        ]);
+
+        var layout = TreemapLayout.Create<FileNode>().Size(100, 100);
+        var node = layout.Hierarchy(root, n => n.Children, n => n.Size);
+        layout.Layout(node);
+
+        Assert.Equal(60, node.Value);
+        var leaves = node.Leaves().ToList();
+        Assert.Equal(3, leaves.Count);
+    }
+}
+
+public class PackTests
+{
+    private record Item(string Name, double Size, Item[]? Children = null);
+
+    [Fact]
+    public void Pack_CirclesHavePositiveRadius()
+    {
+        var root = new Item("root", 0,
+        [
+            new("a", 10),
+            new("b", 20),
+            new("c", 30),
+        ]);
+
+        var layout = PackLayout.Create<Item>().Size(200);
+        var node = layout.Layout(root, n => n.Children, n => n.Size);
+
+        foreach (var leaf in node.Leaves())
+        {
+            Assert.True(leaf.R > 0);
+        }
+    }
+
+    [Fact]
+    public void Pack_RootEncloses()
+    {
+        var root = new Item("root", 0,
+        [
+            new("a", 25),
+            new("b", 25),
+        ]);
+
+        var layout = PackLayout.Create<Item>().Size(100);
+        var node = layout.Layout(root, n => n.Children, n => n.Size);
+
+        Assert.True(node.R > 0);
+        foreach (var child in node.Children)
+        {
+            double dist = Math.Sqrt(
+                (child.X - node.X) * (child.X - node.X) +
+                (child.Y - node.Y) * (child.Y - node.Y));
+            Assert.True(dist + child.R <= node.R + 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Ports **389 xUnit tests** from the upstream d3 submodule test suites into `tests/Reactor.Tests/D3/`, covering the full public surface of `Microsoft.UI.Reactor.Charting.D3`.
- Lifts `Reactor` package **line coverage 43.22% → 52.09%** (+8.87pp, +3,367 covered lines) and **branch coverage 39.20% → 46.22%** — all in CI, no selftest needed.
- Adds an inert `ChildReconcilerReconcileTests.cs` placeholder (wrapped in `#if CHILD_RECONCILER_RECONCILE_TESTS`) documenting why `ChildReconciler.Reconcile` coverage has to stay in selftest: the custom-register-type approach fails because `new Border()` throws `COMException` without a XAML Application host.

**Modules covered:** d3-array, d3-format, d3-ease, d3-random, d3-path, d3-polygon, d3-shape (Arc/Area/Curve/Line/Pie/Radial/Stack/Symbol/Link), d3-scale, d3-interpolate (number/round/color), d3-hierarchy (Stratify/Cluster/Partition/Treemap/Pack), d3-chord, d3-contour, d3-delaunay/voronoi, d3-color.

**Not ported** (reactor1 doesn't implement): d3-array set ops / fsum / rank / mode / transpose / shuffle / sort; d3-scale diverging/identity/sequential/symlog/sqrt/radial/time; d3-interpolate string/object/hcl/lab/cubehelix/zoom. ArcGenerator's corner-radius path is also currently `throw NotImplementedException` in src.

## Test plan
- [x] `dotnet test tests/Reactor.Tests/Reactor.Tests.csproj` — 4048 passing, 46 skipped (pre-existing), 0 failing
- [x] `dotnet test ... --collect:"XPlat Code Coverage"` — Reactor package line-rate 0.5209, branch-rate 0.4622
- [ ] CI green on Windows runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)