### PR TITLE
fix(reconciler): preserve Grid children on child type flip (#34)

### DIFF
--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -270,14 +270,23 @@ public sealed partial class Reconciler : IDisposable
             var replacement = Update(oldElement, newElement, existingControl, requestRerender);
             // If Update returned a completely new control (full remount path),
             // unmount the old control to clean up event handlers and component state.
+            // Use Unmount (not UnmountAndPool) so the pool path does not eagerly
+            // detach the old control from its parent — the caller will overwrite
+            // the slot via an indexer assignment (e.g. g.Children[i] = replacement)
+            // and WinUI's parent bookkeeping handles detach as part of the swap.
+            // UnmountAndPool.DetachFromParent would remove the child here, shifting
+            // subsequent sibling indices and corrupting a positional parent update.
             if (replacement is not null && replacement != existingControl)
-                UnmountAndPool(existingControl);
+                Unmount(existingControl);
             return replacement ?? existingControl;
         }
 
-        // Type changed — unmount+pool old tree, then mount new tree
-        // (so pooled controls are available for rent during mount).
-        UnmountAndPool(existingControl);
+        // Type changed — unmount the old tree (without detaching from parent),
+        // then mount the new tree. Caller replaces the old slot in its parent
+        // collection; WinUI detaches the old control as part of that indexer
+        // assignment. Detaching eagerly here would shift sibling indices and
+        // corrupt positional updates over the remaining children.
+        Unmount(existingControl);
         return Mount(newElement, requestRerender);
     }
 

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -265,27 +265,32 @@ public sealed partial class Reconciler : IDisposable
         Element oldElement, Element newElement,
         UIElement existingControl, Action requestRerender)
     {
+        // Contract: when we return a replacement (either from Update remounting or
+        // from a type-change full remount), the caller must place it in the parent
+        // collection — e.g. `g.Children[i] = replacement`. WinUI's indexer assignment
+        // detaches the old control from its parent as part of the swap, so we must
+        // leave the parent collection alone here. The UnmountAndPool path would
+        // invoke ElementPool.Return.DetachFromParent, which synchronously removes
+        // the old child from the parent's Children collection before the caller's
+        // assignment runs; that shifts subsequent sibling indices and corrupts any
+        // positional update loop that was iterating over the collection (see #34,
+        // where DataGrid row cells were dropped off the end during inline-edit flips).
+        //
+        // Trade-off: the replaced control is no longer handed back to ElementPool.
+        // Pooling is a performance optimization; correctness dominates here. Type
+        // flips are uncommon in practice (inline edit transitions, ErrorBoundary
+        // remounts) so the lost reuse is minor. A follow-up could reintroduce
+        // pool-return by having the caller invoke a post-swap pool hook once the
+        // old control is detached, but doing so safely across every Reconcile
+        // caller is out of scope for this fix.
         if (CanUpdate(oldElement, newElement))
         {
             var replacement = Update(oldElement, newElement, existingControl, requestRerender);
-            // If Update returned a completely new control (full remount path),
-            // unmount the old control to clean up event handlers and component state.
-            // Use Unmount (not UnmountAndPool) so the pool path does not eagerly
-            // detach the old control from its parent — the caller will overwrite
-            // the slot via an indexer assignment (e.g. g.Children[i] = replacement)
-            // and WinUI's parent bookkeeping handles detach as part of the swap.
-            // UnmountAndPool.DetachFromParent would remove the child here, shifting
-            // subsequent sibling indices and corrupting a positional parent update.
             if (replacement is not null && replacement != existingControl)
                 Unmount(existingControl);
             return replacement ?? existingControl;
         }
 
-        // Type changed — unmount the old tree (without detaching from parent),
-        // then mount the new tree. Caller replaces the old slot in its parent
-        // collection; WinUI detaches the old control as part of that indexer
-        // assignment. Detaching eagerly here would shift sibling indices and
-        // corrupt positional updates over the remaining children.
         Unmount(existingControl);
         return Mount(newElement, requestRerender);
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
@@ -364,4 +364,118 @@ internal static class DataGridEditFixtures
                 anyHas24);
         }
     }
+
+    /// <summary>
+    /// Regression for GitHub #34. When a child element's type flips inside a Grid
+    /// (TextBlock → TextBox → TextBlock — e.g. a DataGrid cell entering and leaving
+    /// inline-edit mode), the row Grid used to drop the trailing cell and retarget
+    /// the intermediate cell's AutomationName to a sibling's stale value. Root cause:
+    /// <c>ReconcileImperative</c> called <c>UnmountAndPool</c> on the replaced
+    /// control, whose <c>ElementPool.Return</c> → <c>DetachFromParent</c> removed
+    /// the old child from the Grid's <c>Children</c> collection *before* the caller's
+    /// <c>g.Children[i] = replacement</c> assignment, shifting siblings down by one.
+    /// After the shift, the final-column update path hit <c>i &gt;= g.Children.Count</c>
+    /// and broke out of the loop, leaving the trailing cell dropped and one
+    /// sibling's AutomationName carrying the flipped cell's text.
+    ///
+    /// This fixture mounts a tiny hand-rolled Grid whose middle child flips between
+    /// <c>Text</c> and <c>TextField</c> based on a state bit, then asserts the
+    /// Grid's child count and per-child <c>AutomationProperties.Name</c> values
+    /// survive the flip and the flip-back.
+    /// </summary>
+    internal class CellTypeFlipPreservesTrailingCells(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            Action<bool>? setEditing = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (editing, setEd) = ctx.UseState(false);
+                setEditing = setEd;
+
+                // Four children matching the DataGrid row layout: [Id][Name][Cat][Price].
+                // Middle child flips between Text and TextField based on `editing`.
+                var nameCell = editing
+                    ? (Element)TextField("Alice", _ => { }).Padding(2)
+                    : (Element)TextBlock("Alice").Padding(8, 4);
+
+                return Grid(
+                    new[] { "60", "140", "120", "100" },
+                    new[] { "*" },
+                    TextBlock("1").Padding(8, 4).Grid(row: 0, column: 0),
+                    nameCell.Grid(row: 0, column: 1),
+                    TextBlock("Widgets").Padding(8, 4).Grid(row: 0, column: 2),
+                    TextBlock("$10.00").Padding(8, 4).Grid(row: 0, column: 3)
+                );
+            });
+
+            await Harness.Render(300);
+
+            // Sanity: all four cells present and correctly named at mount.
+            H.Check("CellFlip_Initial_Id", H.FindText("1") is not null);
+            H.Check("CellFlip_Initial_Name", H.FindText("Alice") is not null);
+            H.Check("CellFlip_Initial_Cat", H.FindText("Widgets") is not null);
+            H.Check("CellFlip_Initial_Price", H.FindText("$10.00") is not null);
+
+            var rowGrid = H.FindControl<Microsoft.UI.Xaml.Controls.Grid>(
+                g => g.ColumnDefinitions.Count == 4);
+            H.Check("CellFlip_RowGridMounted", rowGrid is not null);
+            if (rowGrid is null || setEditing is null) return;
+
+            var initialChildCount = rowGrid.Children.Count;
+            H.Check($"CellFlip_Initial_ChildCount ({initialChildCount})",
+                initialChildCount == 4);
+
+            // 1. Flip middle cell to TextBox (TextBlock → TextBox replacement).
+            setEditing(true);
+            await Harness.Render(200);
+
+            H.Check($"CellFlip_AfterEnter_ChildCount ({rowGrid.Children.Count})",
+                rowGrid.Children.Count == 4);
+            H.Check("CellFlip_AfterEnter_PriceStillVisible",
+                H.FindText("$10.00") is not null);
+            H.Check("CellFlip_AfterEnter_CategoryStillVisible",
+                H.FindText("Widgets") is not null);
+            var textBoxAfterEnter = H.FindControl<TextBox>(tb => tb.Text == "Alice");
+            H.Check("CellFlip_AfterEnter_EditorMounted", textBoxAfterEnter is not null);
+
+            // 2. Flip back to TextBlock (TextBox → TextBlock replacement).
+            setEditing(false);
+            await Harness.Render(200);
+
+            H.Check($"CellFlip_AfterExit_ChildCount ({rowGrid.Children.Count})",
+                rowGrid.Children.Count == 4);
+            H.Check("CellFlip_AfterExit_PriceStillVisible",
+                H.FindText("$10.00") is not null);
+            H.Check("CellFlip_AfterExit_CategoryStillVisible",
+                H.FindText("Widgets") is not null);
+
+            // 3. Critical check: trailing cell's AutomationProperties.Name has
+            //    NOT been overwritten with a sibling's text (which would indicate
+            //    the shift-corruption bug from #34). A TextBlock showing "$10.00"
+            //    mounted by the default caption helper must have Name = "$10.00".
+            var priceTb = rowGrid.Children.OfType<TextBlock>()
+                .FirstOrDefault(tb => tb.Text == "$10.00");
+            H.Check("CellFlip_AfterExit_PriceCellPresent", priceTb is not null);
+            if (priceTb is not null)
+            {
+                var priceName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(priceTb);
+                H.Check($"CellFlip_PriceAutomationNameIntact (name='{priceName}')",
+                    string.IsNullOrEmpty(priceName) || priceName == "$10.00");
+            }
+
+            // 4. And the middle cell's AutomationName must be "Alice", not stale.
+            var nameTb = rowGrid.Children.OfType<TextBlock>()
+                .FirstOrDefault(tb => tb.Text == "Alice");
+            H.Check("CellFlip_AfterExit_NameCellPresent", nameTb is not null);
+            if (nameTb is not null)
+            {
+                var uiName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(nameTb);
+                H.Check($"CellFlip_NameAutomationNameIntact (name='{uiName}')",
+                    string.IsNullOrEmpty(uiName) || uiName == "Alice");
+            }
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
@@ -452,10 +452,13 @@ internal static class DataGridEditFixtures
             H.Check("CellFlip_AfterExit_CategoryStillVisible",
                 H.FindText("Widgets") is not null);
 
-            // 3. Critical check: trailing cell's AutomationProperties.Name has
-            //    NOT been overwritten with a sibling's text (which would indicate
-            //    the shift-corruption bug from #34). A TextBlock showing "$10.00"
-            //    mounted by the default caption helper must have Name = "$10.00".
+            // 3. Critical check: trailing cell's AutomationProperties.Name must
+            //    equal its visible text. Under the #34 bug, the failure mode was
+            //    either (a) Name cleared to empty by ElementPool.CleanElement on
+            //    the replaced sibling, or (b) Name holding a neighbouring cell's
+            //    stale caption after the Grid.Children shift. Require an exact
+            //    match so both modes are caught — allowing empty would silently
+            //    regress into the UIA-opaque state the issue reports.
             var priceTb = rowGrid.Children.OfType<TextBlock>()
                 .FirstOrDefault(tb => tb.Text == "$10.00");
             H.Check("CellFlip_AfterExit_PriceCellPresent", priceTb is not null);
@@ -463,10 +466,11 @@ internal static class DataGridEditFixtures
             {
                 var priceName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(priceTb);
                 H.Check($"CellFlip_PriceAutomationNameIntact (name='{priceName}')",
-                    string.IsNullOrEmpty(priceName) || priceName == "$10.00");
+                    priceName == "$10.00");
             }
 
-            // 4. And the middle cell's AutomationName must be "Alice", not stale.
+            // 4. And the middle cell's AutomationName must be "Alice", not stale
+            //    or empty. Same reasoning as above.
             var nameTb = rowGrid.Children.OfType<TextBlock>()
                 .FirstOrDefault(tb => tb.Text == "Alice");
             H.Check("CellFlip_AfterExit_NameCellPresent", nameTb is not null);
@@ -474,7 +478,7 @@ internal static class DataGridEditFixtures
             {
                 var uiName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(nameTb);
                 H.Check($"CellFlip_NameAutomationNameIntact (name='{uiName}')",
-                    string.IsNullOrEmpty(uiName) || uiName == "Alice");
+                    uiName == "Alice");
             }
         }
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -404,6 +404,7 @@ internal static class SelfTestFixtureRegistry
         "DataGrid_EditCellColumnPlacement",
         "DataGrid_RapidSelection",
         "DataGrid_ExternalStateUpdate",
+        "DataGrid_CellTypeFlipPreservesTrailingCells",
         // DataGrid incremental paging
         "DataGrid_IncrementalLoadVerification",
         "DataGrid_SmallDatasetFullyLoaded",
@@ -878,6 +879,7 @@ internal static class SelfTestFixtureRegistry
         "DataGrid_EditCellColumnPlacement" => new DataGridEditFixtures.EditCellColumnPlacement(harness),
         "DataGrid_RapidSelection" => new DataGridEditFixtures.RapidSelection(harness),
         "DataGrid_ExternalStateUpdate" => new DataGridEditFixtures.ExternalStateUpdate(harness),
+        "DataGrid_CellTypeFlipPreservesTrailingCells" => new DataGridEditFixtures.CellTypeFlipPreservesTrailingCells(harness),
         // DataGrid incremental paging
         "DataGrid_IncrementalLoadVerification" => new DataGridPagingFixtures.IncrementalLoadVerification(harness),
         "DataGrid_SmallDatasetFullyLoaded" => new DataGridPagingFixtures.SmallDatasetFullyLoaded(harness),


### PR DESCRIPTION
## Summary

- Fixes #34 — `DataGrid` cells disappearing from the UIA tree after async-commit state transitions, exposed by the `Interactive_DataGrid_ClickEditTabCommit` E2E test.
- Root cause: `ReconcileImperative` called `UnmountAndPool` on the replaced control, which eagerly detached it from its parent via `ElementPool.Return → DetachFromParent` **before** the caller performed `g.Children[i] = replacement`. The detach shifted sibling indices; `UpdateGrid`'s fast path then overwrote a sibling with the replacement and fell off the end of the loop at `i >= g.Children.Count`, dropping the trailing cell and leaving the retargeted sibling with a stale `AutomationProperties.Name`.
- Fix: switched both `UnmountAndPool` calls in `ReconcileImperative` to plain `Unmount`, mirroring the pattern already used by `ChildReconciler`'s `ReplaceChildWithExitTransition`. WinUI's indexer assignment handles parent bookkeeping cleanly.
- Regression coverage: new `DataGrid_CellTypeFlipPreservesTrailingCells` selfhost fixture that mounts a 4-column Grid, flips its middle child between TextBlock and TextField, and asserts child count + per-cell `AutomationProperties.Name` survive the flip and the flip-back.

## Test plan

- [x] **Build**: library + host test project compile clean (0 warnings, 0 errors).
- [x] **Unit tests** (`dotnet test tests/Reactor.Tests`): **4238/4238 pass**, 0 failures.
- [x] **Unit tests — Reconciler + Grid subset**: 374/374 pass.
- [x] **Selfhost tests** (`Reactor.AppTests.Host.exe --self-test`): **Total failures: 0**. New fixture `DataGrid_CellTypeFlipPreservesTrailingCells` contributes 17 green assertions covering child count preservation and AutomationName integrity across a TextBlock↔TextBox flip cycle.
- [ ] **E2E** (`Interactive_DataGrid_ClickEditTabCommit`): not run locally — WinAppDriver won't stay resident in this shell (requires an interactive desktop session / elevated context). CI or a manual run on a reviewer's machine is required to confirm the previously-failing test now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)