### PR TITLE
test(devtools): add stress harnesses for MCP startup/shutdown lifecycle

### DIFF
--- a/tests/Reactor.AppTests.Host/DevtoolsStress/DevtoolsStressE2ERunner.cs
+++ b/tests/Reactor.AppTests.Host/DevtoolsStress/DevtoolsStressE2ERunner.cs
@@ -1,0 +1,414 @@
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.DevtoolsStress;
+
+/// <summary>
+/// End-to-end stress runner: the parent process repeatedly spawns a fresh
+/// child via <c>--stress-child --devtools run</c>, parses the child's
+/// stdout for the <c>devtools-ready</c> JSON sentinel to learn the
+/// child-allocated MCP port, runs a lightweight MCP validation
+/// (<c>initialize</c> + <c>tools/list</c> + <c>tools/call version</c>),
+/// then terminates the child and repeats. Unlike the in-process runner,
+/// this exercises the full process-lifetime paths — WinUI init, devtools
+/// CLI dispatch, render-time <c>AnnounceReady</c>, window close → MCP
+/// dispose — which is where the customer crash in CoreMessagingXP.dll
+/// most likely lives.
+/// </summary>
+internal static class DevtoolsStressE2ERunner
+{
+    private sealed class Options
+    {
+        public int Iterations = 100;
+        public int ReadyTimeoutMs = 10_000;
+        public int GraceMs = 500;
+        public bool HardKill;
+        public bool NoDump;
+        public string? LogPath;
+    }
+
+    public static void Run(string[] args)
+    {
+        var opts = ParseArgs(args);
+        opts.LogPath ??= global::System.IO.Path.Combine(
+            global::System.IO.Path.GetTempPath(),
+            $"reactor-devtools-stress-e2e-{Environment.ProcessId}.log");
+
+        var ownExe = Environment.ProcessPath
+            ?? throw new InvalidOperationException("ProcessPath unavailable");
+
+        using var log = new E2ELog(opts.LogPath);
+        log.Meta("e2e-start", new()
+        {
+            ["parentPid"] = Environment.ProcessId.ToString(),
+            ["iterations"] = opts.Iterations.ToString(),
+            ["readyTimeoutMs"] = opts.ReadyTimeoutMs.ToString(),
+            ["graceMs"] = opts.GraceMs.ToString(),
+            ["hardKill"] = opts.HardKill.ToString(),
+            ["dump"] = (!opts.NoDump).ToString(),
+            ["exe"] = ownExe,
+        });
+        Console.Error.WriteLine($"[stress-e2e] log: {opts.LogPath}");
+        Console.Error.WriteLine($"[stress-e2e] exe: {ownExe}");
+        Console.Error.WriteLine($"[stress-e2e] iterations={opts.Iterations} ready-timeout={opts.ReadyTimeoutMs}ms grace={opts.GraceMs}ms hardKill={opts.HardKill}");
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var totalSw = Stopwatch.StartNew();
+        int suspicious = 0;
+
+        for (int i = 1; i <= opts.Iterations; i++)
+        {
+            try
+            {
+                bool flagged = RunIterationAsync(i, ownExe, opts, http, log).GetAwaiter().GetResult();
+                if (flagged) suspicious++;
+            }
+            catch (Exception ex)
+            {
+                log.Iter(i, -1, $"harness-fail:{ex.GetType().Name}:{ex.Message}", 0);
+            }
+            Console.Error.WriteLine($"[stress-e2e] i={i}/{opts.Iterations} elapsed={totalSw.Elapsed.TotalSeconds:F1}s suspicious={suspicious}");
+        }
+
+        log.Meta("e2e-end", new()
+        {
+            ["iterations"] = opts.Iterations.ToString(),
+            ["elapsedMs"] = totalSw.ElapsedMilliseconds.ToString(),
+            ["suspicious"] = suspicious.ToString(),
+        });
+        Console.Error.WriteLine($"[stress-e2e] DONE {opts.Iterations} iterations in {totalSw.Elapsed.TotalSeconds:F1}s  suspicious-exits={suspicious}");
+        Environment.Exit(suspicious > 0 ? 2 : 0);
+    }
+
+    // -- One iteration ------------------------------------------------------
+
+    private static async Task<bool> RunIterationAsync(int i, string exe, Options opts, HttpClient http, E2ELog log)
+    {
+        var psi = new ProcessStartInfo(exe)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = false, // let the real WinUI window show — matches customer scenario
+        };
+        psi.ArgumentList.Add("--stress-child");
+        psi.ArgumentList.Add("--devtools");
+        psi.ArgumentList.Add("run");
+
+        if (!opts.NoDump)
+        {
+            var dumpDir = global::System.IO.Path.Combine(
+                global::System.IO.Path.GetTempPath(), "reactor-stress-dumps");
+            Directory.CreateDirectory(dumpDir);
+            // %p expands to the child pid — one dump file per crashing child.
+            psi.Environment["COMPlus_DbgEnableMiniDump"] = "1";
+            psi.Environment["COMPlus_DbgMiniDumpType"] = "2"; // full heap
+            psi.Environment["COMPlus_DbgMiniDumpName"] = global::System.IO.Path.Combine(dumpDir, "reactor-stress-%p.dmp");
+            psi.Environment["DOTNET_DbgEnableMiniDump"] = "1";
+            psi.Environment["DOTNET_DbgMiniDumpType"] = "2";
+            psi.Environment["DOTNET_DbgMiniDumpName"] = global::System.IO.Path.Combine(dumpDir, "reactor-stress-%p.dmp");
+        }
+
+        Process child;
+        try { child = Process.Start(psi)!; }
+        catch (Exception ex)
+        {
+            log.Iter(i, -1, $"spawn-fail:{ex.GetType().Name}:{ex.Message}", 0);
+            return true;
+        }
+
+        int pid = child.Id;
+        var iterSw = Stopwatch.StartNew();
+        log.Iter(i, pid, "spawned", 0);
+
+        // Stdout/stderr tails — keep the last N lines in case the child crashes.
+        var stdoutTail = new TailBuffer(capacity: 200);
+        var stderrTail = new TailBuffer(capacity: 200);
+        var readyTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // stdout reader: mirror into tail + sniff for the ready JSON sentinel
+        var stdoutTask = Task.Run(async () =>
+        {
+            try
+            {
+                string? line;
+                while ((line = await child.StandardOutput.ReadLineAsync()) is not null)
+                {
+                    stdoutTail.Add(line);
+                    if (!readyTcs.Task.IsCompleted &&
+                        line.StartsWith("{\"event\":\"devtools-ready\"", StringComparison.Ordinal))
+                    {
+                        try
+                        {
+                            using var doc = JsonDocument.Parse(line);
+                            var port = doc.RootElement.GetProperty("port").GetInt32();
+                            readyTcs.TrySetResult(port);
+                        }
+                        catch (Exception ex) { readyTcs.TrySetException(ex); }
+                    }
+                }
+            }
+            catch { /* pipe closed on child exit */ }
+        });
+        var stderrTask = Task.Run(async () =>
+        {
+            try
+            {
+                string? line;
+                while ((line = await child.StandardError.ReadLineAsync()) is not null)
+                    stderrTail.Add(line);
+            }
+            catch { }
+        });
+
+        // -- Wait for ready ------------------------------------------------
+        int port;
+        using (var readyCts = new CancellationTokenSource(opts.ReadyTimeoutMs))
+        {
+            // Abort the wait if the child exits before emitting the sentinel.
+            var childExited = child.WaitForExitAsync(readyCts.Token);
+            var winner = await Task.WhenAny(readyTcs.Task, childExited, Task.Delay(opts.ReadyTimeoutMs, readyCts.Token));
+            if (winner == readyTcs.Task)
+            {
+                port = await readyTcs.Task;
+                log.Iter(i, pid, $"ready:{port}", iterSw.ElapsedMilliseconds);
+            }
+            else if (child.HasExited)
+            {
+                log.Iter(i, pid, $"child-died-pre-ready:exit=0x{UnsignedHex(child.ExitCode)}", iterSw.ElapsedMilliseconds);
+                await DrainAsync(stdoutTask, stderrTask);
+                LogTails(log, i, pid, stdoutTail, stderrTail);
+                return IsSuspicious(child.ExitCode);
+            }
+            else
+            {
+                log.Iter(i, pid, "ready-timeout", iterSw.ElapsedMilliseconds);
+                KillSafe(child);
+                await child.WaitForExitAsync();
+                await DrainAsync(stdoutTask, stderrTask);
+                LogTails(log, i, pid, stdoutTail, stderrTail);
+                return true;
+            }
+        }
+
+        // -- MCP validation ------------------------------------------------
+        bool mcpOk = true;
+        try
+        {
+            var init = await PostJsonRpcAsync(http, port, new
+            {
+                jsonrpc = "2.0",
+                id = 1,
+                method = "initialize",
+                @params = new
+                {
+                    protocolVersion = "2024-11-05",
+                    capabilities = new { },
+                    clientInfo = new { name = "reactor-stress-e2e", version = "1.0" },
+                },
+            });
+            if (!init.TryGetProperty("result", out _))
+                throw new Exception("initialize returned no result");
+            log.Iter(i, pid, "initialize:ok", iterSw.ElapsedMilliseconds);
+
+            var list = await PostJsonRpcAsync(http, port, new
+            {
+                jsonrpc = "2.0",
+                id = 2,
+                method = "tools/list",
+            });
+            int toolCount = list.GetProperty("result").GetProperty("tools").GetArrayLength();
+            log.Iter(i, pid, $"tools/list:{toolCount}", iterSw.ElapsedMilliseconds);
+
+            var ver = await PostJsonRpcAsync(http, port, new
+            {
+                jsonrpc = "2.0",
+                id = 3,
+                method = "tools/call",
+                @params = new { name = "version", arguments = new { } },
+            });
+            if (!ver.TryGetProperty("result", out _))
+                throw new Exception("tools/call version returned no result");
+            log.Iter(i, pid, "version:ok", iterSw.ElapsedMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            mcpOk = false;
+            log.Iter(i, pid, $"mcp-fail:{ex.GetType().Name}:{ex.Message}", iterSw.ElapsedMilliseconds);
+        }
+
+        // -- Terminate -----------------------------------------------------
+        string termPhase;
+        if (opts.HardKill)
+        {
+            KillSafe(child);
+            termPhase = "hard-killed";
+        }
+        else
+        {
+            bool closed = false;
+            try { closed = child.CloseMainWindow(); } catch { }
+
+            var exit = child.WaitForExitAsync();
+            var winner = await Task.WhenAny(exit, Task.Delay(opts.GraceMs));
+            if (winner != exit)
+            {
+                KillSafe(child);
+                termPhase = closed ? "kill-after-grace" : "kill-no-close-handle";
+            }
+            else termPhase = "graceful";
+        }
+
+        await child.WaitForExitAsync();
+        await DrainAsync(stdoutTask, stderrTask);
+
+        int exitCode = child.ExitCode;
+        bool suspicious = IsSuspicious(exitCode);
+        log.Iter(i, pid, $"exit:0x{UnsignedHex(exitCode)} term={termPhase}{(suspicious ? " SUSPICIOUS" : "")}", iterSw.ElapsedMilliseconds);
+
+        if (suspicious || !mcpOk)
+            LogTails(log, i, pid, stdoutTail, stderrTail);
+
+        return suspicious;
+    }
+
+    // -- Helpers ------------------------------------------------------------
+
+    private static async Task<JsonElement> PostJsonRpcAsync(HttpClient http, int port, object envelope)
+    {
+        var json = JsonSerializer.Serialize(envelope);
+        using var req = new HttpRequestMessage(HttpMethod.Post, $"http://127.0.0.1:{port}/mcp")
+        {
+            Content = new StringContent(json, Encoding.UTF8),
+        };
+        req.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        using var resp = await http.SendAsync(req);
+        var body = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.Clone();
+    }
+
+    private static void KillSafe(Process p)
+    {
+        try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { }
+    }
+
+    private static async Task DrainAsync(params Task[] tasks)
+    {
+        // Reader tasks complete when their pipes hit EOF (child exit). Bound
+        // the wait so a stuck pipe doesn't hang the harness.
+        await Task.WhenAny(Task.WhenAll(tasks), Task.Delay(2000));
+    }
+
+    /// <summary>
+    /// A crash-like exit code from the Windows/CLR surface: NT status codes
+    /// (0xCxxxxxxx), or the SEH/CLR rethrow tag (0xE0434352). Graceful exits
+    /// are 0; <c>Process.Kill</c> produces -1 (0xFFFFFFFF) which is NOT
+    /// flagged here — operator-initiated.
+    /// </summary>
+    private static bool IsSuspicious(int exitCode)
+    {
+        uint u = unchecked((uint)exitCode);
+        if (u == 0) return false;
+        if (u == 0xFFFFFFFF) return false; // our own Kill
+        if (u == 0xE0434352) return true;  // CLR managed exception
+        if (u >= 0xC0000000 && u <= 0xCFFFFFFF) return true; // NT status range
+        return false;
+    }
+
+    private static string UnsignedHex(int exit) => unchecked((uint)exit).ToString("X8");
+
+    private static void LogTails(E2ELog log, int i, int pid, TailBuffer stdoutTail, TailBuffer stderrTail)
+    {
+        foreach (var line in stdoutTail.Snapshot())
+            log.Tail(i, pid, "stdout", line);
+        foreach (var line in stderrTail.Snapshot())
+            log.Tail(i, pid, "stderr", line);
+    }
+
+    private static Options ParseArgs(string[] args)
+    {
+        var o = new Options();
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--iterations" when i + 1 < args.Length && int.TryParse(args[++i], out var n): o.Iterations = n; break;
+                case "--ready-timeout" when i + 1 < args.Length && int.TryParse(args[++i], out var t): o.ReadyTimeoutMs = t; break;
+                case "--grace-ms" when i + 1 < args.Length && int.TryParse(args[++i], out var g): o.GraceMs = g; break;
+                case "--hard-kill": o.HardKill = true; break;
+                case "--no-dump": o.NoDump = true; break;
+                case "--log" when i + 1 < args.Length: o.LogPath = args[++i]; break;
+            }
+        }
+        return o;
+    }
+
+    // -- Ring-buffer tail ---------------------------------------------------
+
+    private sealed class TailBuffer
+    {
+        private readonly int _capacity;
+        private readonly Queue<string> _queue;
+        private readonly object _lock = new();
+        public TailBuffer(int capacity) { _capacity = capacity; _queue = new Queue<string>(capacity); }
+
+        public void Add(string s)
+        {
+            lock (_lock)
+            {
+                if (_queue.Count == _capacity) _queue.Dequeue();
+                _queue.Enqueue(s);
+            }
+        }
+
+        public string[] Snapshot()
+        {
+            lock (_lock) return _queue.ToArray();
+        }
+    }
+
+    // -- Flush-per-write log -----------------------------------------------
+
+    private sealed class E2ELog : IDisposable
+    {
+        private readonly FileStream _fs;
+        private readonly object _lock = new();
+
+        public E2ELog(string path)
+        {
+            Directory.CreateDirectory(global::System.IO.Path.GetDirectoryName(path)!);
+            _fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
+        }
+
+        public void Iter(int i, int pid, string phase, long dtMs)
+            => Write($"{DateTime.UtcNow:O}\titer={i}\tpid={pid}\tphase={phase}\tdt={dtMs}ms\n");
+
+        public void Tail(int i, int pid, string stream, string line)
+            => Write($"{DateTime.UtcNow:O}\titer={i}\tpid={pid}\t{stream}\t{line}\n");
+
+        public void Meta(string kind, Dictionary<string, string> fields)
+        {
+            var sb = new StringBuilder();
+            sb.Append(DateTime.UtcNow.ToString("O")).Append('\t').Append(kind);
+            foreach (var kv in fields) sb.Append('\t').Append(kv.Key).Append('=').Append(kv.Value);
+            sb.Append('\n');
+            Write(sb.ToString());
+        }
+
+        private void Write(string s)
+        {
+            var bytes = Encoding.UTF8.GetBytes(s);
+            lock (_lock)
+            {
+                _fs.Write(bytes, 0, bytes.Length);
+                _fs.Flush(flushToDisk: true);
+            }
+        }
+
+        public void Dispose() { try { _fs.Dispose(); } catch { } }
+    }
+}

--- a/tests/Reactor.AppTests.Host/DevtoolsStress/DevtoolsStressRunner.cs
+++ b/tests/Reactor.AppTests.Host/DevtoolsStress/DevtoolsStressRunner.cs
@@ -1,0 +1,266 @@
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Reactor.Hosting.Devtools;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.DevtoolsStress;
+
+/// <summary>
+/// Reproduction harness for a customer-reported crash in
+/// <c>CoreMessagingXP.dll</c> (0xc000027b — stowed WinRT exception) that
+/// surfaces while using the Reactor devtools surface. The theory under test
+/// is that the devtools HTTP listener interacts badly with the WinUI STA
+/// dispatcher over repeated start/stop cycles. This runner spins up a real
+/// WinUI window, then cycles <see cref="DevtoolsMcpServer"/> Start/Dispose
+/// many times in-process and logs each iteration to disk so that on a native
+/// crash we can see exactly where the process died.
+/// </summary>
+internal static class DevtoolsStressRunner
+{
+    private sealed class Options
+    {
+        public int Iterations = 5000;
+        public int DelayMs = 0;
+        public bool Background;     // cycle on a worker thread instead of the UI dispatcher
+        public bool Ping;           // fire an HTTP GET /mcp between Start and Dispose
+        public bool PinPort;        // reuse the same port each iteration (stresses TIME_WAIT reuse)
+        public string? LogPath;     // flush-per-iteration log; inspect after crash
+    }
+
+    public static void Run(string[] args)
+    {
+        var opts = ParseArgs(args);
+        opts.LogPath ??= global::System.IO.Path.Combine(
+            global::System.IO.Path.GetTempPath(),
+            $"reactor-devtools-stress-{Environment.ProcessId}.log");
+
+        using var log = new IterLog(opts.LogPath);
+        log.Meta("stress-start", new()
+        {
+            ["pid"] = Environment.ProcessId.ToString(),
+            ["iterations"] = opts.Iterations.ToString(),
+            ["delayMs"] = opts.DelayMs.ToString(),
+            ["mode"] = opts.Background ? "bg" : "ui",
+            ["ping"] = opts.Ping.ToString(),
+            ["pinPort"] = opts.PinPort.ToString(),
+        });
+        Console.Error.WriteLine($"[stress] log: {opts.LogPath}");
+        Console.Error.WriteLine($"[stress] iterations={opts.Iterations} delayMs={opts.DelayMs} mode={(opts.Background ? "bg" : "ui")} ping={opts.Ping} pinPort={opts.PinPort}");
+
+        WinRT.ComWrappersSupport.InitializeComWrappers();
+        Application.Start(p =>
+        {
+            var context = new DispatcherQueueSynchronizationContext(DispatcherQueue.GetForCurrentThread());
+            SynchronizationContext.SetSynchronizationContext(context);
+            new ReactorApplication();
+            var dispatcher = DispatcherQueue.GetForCurrentThread();
+
+            var window = new Window { Title = "Devtools Stress — starting…" };
+            window.AppWindow.Resize(new global::Windows.Graphics.SizeInt32(520, 220));
+            var statusText = new Microsoft.UI.Xaml.Controls.TextBlock
+            {
+                Text = "initializing…",
+                FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas"),
+                FontSize = 14,
+                Margin = new Microsoft.UI.Xaml.Thickness(16),
+                TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap,
+            };
+            window.Content = statusText;
+            window.Activate();
+
+            // Suppress the per-iteration banner lines that DevtoolsMcpServer.Start
+            // writes to stdout — otherwise 10k iterations spam 40k lines and the
+            // cycling is hard to see. We still keep stderr (our own progress).
+            Console.SetOut(TextWriter.Null);
+
+            // Pick a stable port up front if pinning — FindFreePort allocates a
+            // fresh loopback socket each call, so without pinning ports differ
+            // every cycle.
+            int? pinnedPort = opts.PinPort ? GrabFreePort() : null;
+
+            if (opts.Background)
+            {
+                _ = Task.Run(() => RunLoop(dispatcher, window, opts, pinnedPort, log, statusText));
+            }
+            else
+            {
+                dispatcher.TryEnqueue(() =>
+                {
+                    _ = RunLoopAsync(dispatcher, window, opts, pinnedPort, log, statusText);
+                });
+            }
+        });
+    }
+
+    // -- Loop bodies --------------------------------------------------------
+
+    private static void RunLoop(DispatcherQueue dispatcher, Window window, Options opts, int? pinnedPort, IterLog log, Microsoft.UI.Xaml.Controls.TextBlock statusText)
+    {
+        RunLoopAsync(dispatcher, window, opts, pinnedPort, log, statusText).GetAwaiter().GetResult();
+    }
+
+    private static async Task RunLoopAsync(DispatcherQueue dispatcher, Window window, Options opts, int? pinnedPort, IterLog log, Microsoft.UI.Xaml.Controls.TextBlock statusText)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var sw = Stopwatch.StartNew();
+
+        for (int i = 1; i <= opts.Iterations; i++)
+        {
+            var iterSw = Stopwatch.StartNew();
+            DevtoolsMcpServer? server = null;
+            try
+            {
+                // Construct on whatever thread we're on — the ctor only captures
+                // the dispatcher/window handles, it does not touch them.
+                server = new DevtoolsMcpServer(
+                    dispatcher,
+                    window,
+                    preferredPort: pinnedPort,
+                    logger: null,
+                    transport: McpTransport.Http);
+
+                server.Start();
+                log.Iter(i, "started", server.Port, iterSw.ElapsedMilliseconds);
+
+                if (opts.Ping)
+                {
+                    // GET /mcp is the self-describing schema endpoint — cheap and
+                    // exercises the listener's accept loop without registering
+                    // any tools.
+                    try
+                    {
+                        var resp = await http.GetAsync($"http://127.0.0.1:{server.Port}/mcp");
+                        log.Iter(i, $"ping:{(int)resp.StatusCode}", server.Port, iterSw.ElapsedMilliseconds);
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Iter(i, $"ping-fail:{ex.GetType().Name}", server.Port, iterSw.ElapsedMilliseconds);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Iter(i, $"start-fail:{ex.GetType().Name}:{ex.Message}", pinnedPort ?? -1, iterSw.ElapsedMilliseconds);
+            }
+            finally
+            {
+                try { server?.Dispose(); }
+                catch (Exception ex) { log.Iter(i, $"dispose-fail:{ex.GetType().Name}:{ex.Message}", server?.Port ?? -1, iterSw.ElapsedMilliseconds); }
+            }
+
+            log.Iter(i, "disposed", server?.Port ?? -1, iterSw.ElapsedMilliseconds);
+
+            // Visible feedback — update window title + status body every cycle so
+            // the user can see the loop ticking. Marshal to the UI thread if we're
+            // running in --bg mode; no-op if we're already on it.
+            int iCap = i;
+            int portCap = server?.Port ?? -1;
+            long dtCap = iterSw.ElapsedMilliseconds;
+            dispatcher.TryEnqueue(() =>
+            {
+                window.Title = $"Devtools Stress — {iCap}/{opts.Iterations}  port {portCap}  ({dtCap} ms)";
+                statusText.Text =
+                    $"iteration: {iCap} / {opts.Iterations}\n" +
+                    $"last port: {portCap}\n" +
+                    $"cycle dt:  {dtCap} ms\n" +
+                    $"elapsed:   {sw.Elapsed.TotalSeconds:F1} s\n" +
+                    $"mode:      {(opts.Background ? "bg" : "ui")}  ping={opts.Ping}  pinPort={opts.PinPort}";
+            });
+
+            // Console line every iteration so `tail -f` shows the cycle — tiny
+            // overhead, and makes "is it actually cycling?" obvious.
+            if (opts.Iterations <= 500 || (i % 25) == 0 || i == opts.Iterations)
+                Console.Error.WriteLine($"[stress] i={iCap}/{opts.Iterations} port={portCap} dt={dtCap}ms elapsed={sw.Elapsed.TotalSeconds:F1}s");
+
+            if (opts.DelayMs > 0)
+                await Task.Delay(opts.DelayMs);
+        }
+
+        log.Meta("stress-end", new()
+        {
+            ["iterations"] = opts.Iterations.ToString(),
+            ["elapsedMs"] = sw.ElapsedMilliseconds.ToString(),
+        });
+        Console.Error.WriteLine($"[stress] DONE {opts.Iterations} iterations in {sw.Elapsed.TotalSeconds:F1}s");
+        Environment.Exit(0);
+    }
+
+    // -- Helpers ------------------------------------------------------------
+
+    private static int GrabFreePort()
+    {
+        var l = new global::System.Net.Sockets.TcpListener(global::System.Net.IPAddress.Loopback, 0);
+        l.Start();
+        int port = ((global::System.Net.IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+
+    private static Options ParseArgs(string[] args)
+    {
+        var o = new Options();
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--iterations" when i + 1 < args.Length && int.TryParse(args[++i], out var n): o.Iterations = n; break;
+                case "--delay" when i + 1 < args.Length && int.TryParse(args[++i], out var d): o.DelayMs = d; break;
+                case "--log" when i + 1 < args.Length: o.LogPath = args[++i]; break;
+                case "--bg": o.Background = true; break;
+                case "--ping": o.Ping = true; break;
+                case "--pin-port": o.PinPort = true; break;
+            }
+        }
+        return o;
+    }
+
+    /// <summary>
+    /// Append-only per-iteration log that flushes every write. Native crashes
+    /// skip managed finalizers, so we can't rely on buffered writers — the
+    /// last persisted line is our post-mortem breadcrumb for when the process
+    /// goes down without a managed stack trace.
+    /// </summary>
+    private sealed class IterLog : IDisposable
+    {
+        private readonly FileStream _fs;
+        private readonly object _lock = new();
+
+        public IterLog(string path)
+        {
+            Directory.CreateDirectory(global::System.IO.Path.GetDirectoryName(path)!);
+            _fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
+        }
+
+        public void Iter(int i, string phase, int port, long elapsedMs)
+        {
+            var line = $"{DateTime.UtcNow:O}\titer={i}\tphase={phase}\tport={port}\tdt={elapsedMs}ms\n";
+            Write(line);
+        }
+
+        public void Meta(string kind, Dictionary<string, string> fields)
+        {
+            var sb = new StringBuilder();
+            sb.Append(DateTime.UtcNow.ToString("O")).Append('\t').Append(kind);
+            foreach (var kv in fields) sb.Append('\t').Append(kv.Key).Append('=').Append(kv.Value);
+            sb.Append('\n');
+            Write(sb.ToString());
+        }
+
+        private void Write(string s)
+        {
+            var bytes = Encoding.UTF8.GetBytes(s);
+            lock (_lock)
+            {
+                _fs.Write(bytes, 0, bytes.Length);
+                _fs.Flush(flushToDisk: true);
+            }
+        }
+
+        public void Dispose()
+        {
+            try { _fs.Dispose(); } catch { }
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/DevtoolsStress/StressChild.cs
+++ b/tests/Reactor.AppTests.Host/DevtoolsStress/StressChild.cs
@@ -1,0 +1,17 @@
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.DevtoolsStress;
+
+/// <summary>
+/// Minimal Reactor component hosted by the E2E stress child process. Kept
+/// deliberately trivial so each iteration's cold start is dominated by
+/// framework/devtools init cost, not render cost.
+/// </summary>
+internal sealed class StressChild : Component
+{
+    public override Element Render() => VStack(
+        TextBlock($"stress child — pid {Environment.ProcessId}"),
+        TextBlock("devtools MCP up; parent will validate and terminate")
+    );
+}

--- a/tests/Reactor.AppTests.Host/Program.cs
+++ b/tests/Reactor.AppTests.Host/Program.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.AppTests.Host;
+using Microsoft.UI.Reactor.AppTests.Host.DevtoolsStress;
 using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
 
 if (args.Contains("--self-test"))
@@ -13,6 +14,24 @@ if (args.Contains("--self-test"))
     if (filterIdx >= 0 && filterIdx + 1 < args.Length)
         SelfTestRunner.Filter = args[filterIdx + 1];
     SelfTestRunner.RunAll();
+}
+else if (args.Contains("--devtools-stress"))
+{
+    DevtoolsStressRunner.Run(args);
+}
+else if (args.Contains("--devtools-stress-e2e"))
+{
+    DevtoolsStressE2ERunner.Run(args);
+}
+else if (args.Contains("--stress-child"))
+{
+    // Child process spawned by the E2E stress parent. Goes through the real
+    // ReactorApp.Run<T>(devtools: true) path so that --devtools run on the
+    // command line triggers TryRunDevtools → RunRunSubverb → full MCP init
+    // (tool registration + AnnounceReady). That is the same code the
+    // customer hits when they launch their app with --devtools.
+    ReactorApp.Run<Microsoft.UI.Reactor.AppTests.Host.DevtoolsStress.StressChild>(
+        "Stress Child", width: 320, height: 160, devtools: true);
 }
 else
     ReactorApp.Run<TestHost>("Reactor Test Host", width: 1200, height: 800);


### PR DESCRIPTION
## Summary

Adds two stress runners under `Reactor.AppTests.Host` to help reproduce a customer-reported crash in `CoreMessagingXP.dll` (0xc000027b stowed WinRT exception) that surfaces while using the devtools MCP surface.

Both are gated on new CLI flags on the existing test host binary — no new project, no new build artifact.

### `--devtools-stress` — in-process cycling
Cycles `DevtoolsMcpServer` Start/Dispose thousands of times inside a single WinUI process. Isolates HTTP listener bind/unbind from the surrounding WinUI lifetime.

```bash
Reactor.AppTests.Host.exe --devtools-stress --iterations 10000 --ping
```

Flags: `--iterations N`, `--delay MS`, `--ping` (GET /mcp each cycle), `--bg` (cycle off the UI thread), `--pin-port` (reuse one port to stress TIME_WAIT), `--log PATH`.

### `--devtools-stress-e2e` — process-level cycling
Parent repeatedly spawns a fresh child via `--stress-child --devtools run`, reads the `devtools-ready` JSON sentinel from stdout to learn the child-allocated MCP port, runs a light MCP validation (`initialize` + `tools/list` + `tools/call version`), then terminates and repeats. Goes through the **real** `ReactorApp.Run<T>(devtools: true)` path — full 19-tool registration, `AnnounceReady` on first render, `Window.Closed → mcp.Dispose` chain.

```bash
Reactor.AppTests.Host.exe --devtools-stress-e2e --iterations 100
Reactor.AppTests.Host.exe --devtools-stress-e2e --iterations 200 --hard-kill
```

Flags: `--iterations N`, `--ready-timeout MS`, `--grace-ms MS`, `--hard-kill` (race listener teardown against `TerminateProcess`), `--no-dump`, `--log PATH`.

### Post-mortem capture
- Flush-per-iteration log at `%TEMP%` so the last persisted line is a breadcrumb after a native crash
- Exit codes flagged as `SUSPICIOUS` when they match the NT status range (0xCxxxxxxx) or the CLR rethrow tag (0xE0434352); our own `Kill` (0xFFFFFFFF) and graceful exit (0) are excluded
- Child stdout/stderr tail dumped on suspicious exit or MCP failure
- `COMPlus/DOTNET_DbgEnableMiniDump` env vars set on each child so a faulting child drops a full-heap `.dmp` under `%TEMP%\reactor-stress-dumps`

### Results on the author's box
| Run | Result |
| --- | --- |
| 10k in-process with `--ping` | clean, 0 failures, avg 29 ms/cycle |
| 100 E2E graceful | clean, all `exit:0x00000000`, avg 466 ms/cycle |
| 50 E2E `--hard-kill` | clean, all `exit:0xFFFFFFFF` (our Kill), avg 428 ms/cycle |

Customer crash not reproduced locally — merging so the customer can run it in their environment where the fault actually fires.

## Test plan

- [x] `dotnet build tests/Reactor.AppTests.Host/Reactor.AppTests.Host.csproj` clean
- [x] `--devtools-stress --iterations 10 --ping` — cycle count + port rotation verified via live window title and log
- [x] `--devtools-stress-e2e --iterations 3` — spawn/ready/initialize/tools-list/version/graceful verified in log
- [x] `--devtools-stress-e2e --iterations 100` — full soak, 0 suspicious exits
- [x] `--devtools-stress-e2e --iterations 50 --hard-kill` — teardown-race soak, 0 suspicious exits, 0 dumps
- [ ] Customer runs the harness against their repro environment