### PR TITLE
chore(coverage): clean up coverage config, document unit+selftest merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,15 +158,21 @@ dotnet test tests/Reactor.AppTests --filter "ClassName=Reactor.AppTests.Tests.Ac
 
 ### Code coverage
 
-```bash
-# Unit tests (via coverlet, bundled in Reactor.Tests.csproj)
-dotnet test tests/Reactor.Tests --collect:"XPlat Code Coverage"
+The canonical coverage metric is **unit + selftest merged**. Run both and merge:
 
-# Selftest — covers Reactor.dll while fixtures drive real controls
+```bash
 # (install once: dotnet tool install -g dotnet-coverage)
 
+# --- Unit tests ---
+dotnet build tests/Reactor.Tests -c Debug -p:Optimize=false -p:DebugType=portable
+dotnet-coverage collect -s coverage.settings.xml \
+  --output unit.cobertura.xml --output-format cobertura \
+  -- dotnet test tests/Reactor.Tests --no-build
+
+# --- Selftest ---
 # Step 1: Rebuild with explicit Debug settings (required for instrumentation)
-dotnet build tests/Reactor.AppTests.Host -c Debug -p:Optimize=false -p:DebugType=portable
+dotnet build src/Reactor                      -c Debug -p:Optimize=false -p:DebugType=portable --no-incremental
+dotnet build tests/Reactor.AppTests.Host      -c Debug -p:Optimize=false -p:DebugType=portable --no-incremental
 
 # Step 2: Instrument Reactor.dll statically
 #         (dynamic instrumentation skips referenced assemblies)
@@ -178,9 +184,13 @@ dotnet-coverage instrument \
 dotnet-coverage collect -s coverage.settings.xml \
   --output selftest.cobertura.xml --output-format cobertura \
   -- dotnet run --project tests/Reactor.AppTests.Host --no-build -- --self-test
+
+# --- Merge ---
+dotnet-coverage merge unit.cobertura.xml selftest.cobertura.xml \
+  --output merged.cobertura.xml --output-format cobertura
 ```
 
-Replace `$(RuntimeIdentifier)` with `ARM64` or `x64`, or omit the platform segment if you used the default platform from `Directory.Build.props`. The `coverage.settings.xml` file in the repo root controls which modules are included.
+Replace `$(RuntimeIdentifier)` with `ARM64` or `x64`, or omit the platform segment if you used the default platform from `Directory.Build.props`. The `coverage.settings.xml` file in the repo root controls which modules are included and excludes generated code (`obj/`, `*.g.cs`) and test-host scaffolding exercised only by the Appium/E2E runner.
 
 ---
 

--- a/coverage.settings.xml
+++ b/coverage.settings.xml
@@ -3,8 +3,11 @@
   <CodeCoverage>
     <ModulePaths>
       <Include>
+        <!-- Only the product DLL. Reactor.AppTests.Host.dll is the test harness;
+             measuring how much of the harness its own fixtures exercise is
+             circular and inflates the number without saying anything about
+             product-code quality. -->
         <ModulePath>.*[/\\]Reactor\.dll$</ModulePath>
-        <ModulePath>.*[/\\]Reactor\.AppTests\.Host\.dll$</ModulePath>
       </Include>
     </ModulePaths>
     <Sources>
@@ -14,12 +17,6 @@
              meaningful signal. -->
         <Source>.*[/\\]obj[/\\].*</Source>
         <Source>.*\.g\.cs$</Source>
-        <!-- Test scaffolding in Reactor.AppTests.Host that is exercised by the
-             Appium/E2E test runner rather than by selftest or unit tests. Measuring
-             this in a selftest+unit coverage run just inflates the denominator. -->
-        <Source>.*[/\\]Reactor\.AppTests\.Host[/\\]Fixtures[/\\].*</Source>
-        <Source>.*[/\\]Reactor\.AppTests\.Host[/\\]DevtoolsStress[/\\].*</Source>
-        <Source>.*[/\\]Reactor\.AppTests\.Host[/\\]FixtureRegistry\.cs$</Source>
       </Exclude>
     </Sources>
     <Attributes>

--- a/coverage.settings.xml
+++ b/coverage.settings.xml
@@ -4,9 +4,29 @@
     <ModulePaths>
       <Include>
         <ModulePath>.*[/\\]Reactor\.dll$</ModulePath>
-        <ModulePath>.*[/\\]ReactorD3\.dll$</ModulePath>
         <ModulePath>.*[/\\]Reactor\.AppTests\.Host\.dll$</ModulePath>
       </Include>
     </ModulePaths>
+    <Sources>
+      <Exclude>
+        <!-- WinRT/AOT source-generator output and other build-time generated code
+             live under obj/. These files are not hand-written and provide no
+             meaningful signal. -->
+        <Source>.*[/\\]obj[/\\].*</Source>
+        <Source>.*\.g\.cs$</Source>
+        <!-- Test scaffolding in Reactor.AppTests.Host that is exercised by the
+             Appium/E2E test runner rather than by selftest or unit tests. Measuring
+             this in a selftest+unit coverage run just inflates the denominator. -->
+        <Source>.*[/\\]Reactor\.AppTests\.Host[/\\]Fixtures[/\\].*</Source>
+        <Source>.*[/\\]Reactor\.AppTests\.Host[/\\]DevtoolsStress[/\\].*</Source>
+        <Source>.*[/\\]Reactor\.AppTests\.Host[/\\]FixtureRegistry\.cs$</Source>
+      </Exclude>
+    </Sources>
+    <Attributes>
+      <Exclude>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+        <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
   </CodeCoverage>
 </Configuration>


### PR DESCRIPTION
## Summary

Clean up `coverage.settings.xml` so the combined unit+selftest coverage number reflects product-code quality, not test-harness self-coverage.

**What changed in `coverage.settings.xml`:**
- Drop stale `ReactorD3.dll` include (the D3 project was folded into `Reactor.dll` long ago, leaving the entry as a dangling warning in every coverage run).
- Exclude generated code: `obj/**` paths and `*.g.cs` files (WinRT/AOT source-generator output was ~11k lines of noise in the denominator — un-hand-written, un-testable).
- Exclude attribute-marked code: `[ExcludeFromCodeCoverage]`, `[GeneratedCode]`.
- **Drop `Reactor.AppTests.Host.dll` from `ModulePaths` entirely.** The test harness's own self-coverage is circular — selftest fixtures cover themselves by definition. Including it just juiced the number.

**What changed in `CONTRIBUTING.md`:**
- Document the unit+selftest merge flow (`dotnet-coverage merge unit.cobertura.xml selftest.cobertura.xml ...`) as the canonical coverage command.

## Resulting numbers (merged unit + selftest, Reactor.dll only)

| Before | After |
|---|---|
| 54.0% (Reactor.dll alone, selftest only) | **81.3%** (merged unit + selftest) |

Most of the jump comes from (a) merging in unit-test coverage that was never being counted and (b) no longer drowning the denominator in WinRT source-generator output.

The honest number is **below the 85% target**. Closing that gap via new selftest fixtures for uncovered areas (`SemanticPanel`, `PreviewCaptureServer`, `TransitionEngine`, reconciler edge cases, etc.) is a follow-up change — this PR is config only.

## Test plan

- [x] `dotnet test tests/Reactor.Tests` — 4600 pass, 0 fail
- [x] `dotnet run --project tests/Reactor.AppTests.Host -- --self-test` — 0 failures
- [x] `dotnet-coverage merge unit.cobertura.xml selftest.cobertura.xml …` produces a merged Cobertura report without warnings
- [x] No more "ReactorD3.dll" stale-path warning in coverage output

🤖 Generated with [Claude Code](https://claude.com/claude-code)