### PR TITLE
ci: fix non-md path filter to actually skip markdown-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           filters: |
             non-md:
-              - '!(**/*.md)'
-              - '!(**/*.md)/**'
+              - '**'
+              - '!**/*.md'
 
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION
## Summary
- `!(**/*.md)` inside `dorny/paths-filter` is a single-segment extglob, not a recursive negation, so markdown-only PRs (e.g. #45) were flagged as having non-md changes and still ran Unit Tests.
- Replace with the idiomatic include-all + negation pattern so the filter output matches intent.

## Test plan
- [ ] Open a markdown-only change and confirm the `Detect changes` job marks `non-md` as `false` and `Unit Tests` is skipped.
- [ ] Open a PR that touches a non-markdown file and confirm `Unit Tests` still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)