### PR TITLE
ci: fix MD-only path filter with shell diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,27 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_SHA: ${{ github.sha }}
         run: |
+          set +e
+          ZERO_SHA="0000000000000000000000000000000000000000"
           if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
-            files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+            # Three-dot mirrors GitHub's PR diff (merge-base..head).
+            files=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+            rc=$?
+          elif [ -n "$PUSH_BEFORE" ] && [ -n "$PUSH_SHA" ] && [ "$PUSH_BEFORE" != "$ZERO_SHA" ]; then
+            files=$(git diff --name-only "$PUSH_BEFORE" "$PUSH_SHA")
+            rc=$?
           else
-            files=$(git diff --name-only HEAD^ HEAD)
+            echo "No valid diff range; defaulting to non-md=true"
+            echo "non-md=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$rc" -ne 0 ]; then
+            echo "git diff failed; defaulting to non-md=true"
+            echo "non-md=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "Changed files:"
           echo "$files"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Filter non-Markdown changes
+      - name: Detect non-Markdown changes
         id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        with:
-          filters: |
-            non-md:
-              - '**'
-              - '!**/*.md'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+            files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          else
+            files=$(git diff --name-only HEAD^ HEAD)
+          fi
+          echo "Changed files:"
+          echo "$files"
+          if [ -z "$files" ] || echo "$files" | grep -qv '\.md$'; then
+            echo "non-md=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "non-md=false" >> "$GITHUB_OUTPUT"
+          fi
 
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION
## Summary
- The `dorny/paths-filter` rule `['**', '!**/*.md']` did not actually skip markdown-only PRs (see #49) — each array entry is compiled as an independent matcher and OR'd, so `**` always matched and the `!`-negation never subtracted.
- Prior fix (fb3bf0d) swapped one broken picomatch pattern for another without addressing the underlying semantics.
- Replaces the filter with a shell-based diff that **defaults to running CI** and only skips when every changed file ends in `.md`. Empty diff, missing SHAs, or any non-md path all fall through to `non-md=true`, so we fail safe toward running the test suite.

## Test plan
- [ ] This PR itself touches `.github/workflows/ci.yml` (non-md) → Unit Tests **should run**.
- [ ] Follow-up: the next markdown-only PR against `main` should have Unit Tests **skipped**, and the `Detect changes` step log should show only `.md` files and `non-md=false`.
- [ ] Non-md changes on `push` to `main` continue to trigger Unit Tests (falls through `HEAD^..HEAD` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)