### PR TITLE
docs(skills): prefer FlexPanel and TitleBar in design guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -182,12 +182,17 @@ For the complete catalog (every factory, modifier, enum) see
 [`skills/dsl-reference.md`](skills/dsl-reference.md). The 90% cases:
 
 ```csharp
-// Text + layout
+// Text + layout — prefer FlexRow/FlexColumn for linear layout; they use CSS Flexbox
+// semantics (grow/shrink/gap/wrap, justify-content, align-items) so the model matches
+// the web. VStack/HStack remain available when you specifically want StackPanel's
+// shrink-wrap behavior.
+FlexColumn(children...)         FlexRow(children...)
 VStack(spacing, children...)    HStack(spacing, children...)
 TextBlock("hi")  Heading("Title")    SubHeading("Section")  Caption("note")
 Border(child).CornerRadius(8).Background(Theme.CardBackground).Padding(16)
 ScrollView(VStack(...))
 Grid(columns: ["*", "200"], rows: ["Auto", "*"], cells.Grid(row, column))
+TitleBar("App") with { Subtitle = "Home", Content = ..., RightHeader = ... }
 
 // Controls
 Button("Click", () => ...)      TextField(value, setValue, placeholder)
@@ -329,7 +334,7 @@ with `dotnet --info`.
 | `useReducer` | `UseReducer(initial)` — updater is `Func<T,T>` |
 | `useEffect(() => {}, [dep])` | `UseEffect(() => {}, dep)` |
 | `useMemo(() => val, [dep])` | `UseMemo(() => val, dep)` |
-| `<div>` | `VStack() / HStack() / Border() / Flex()` |
+| `<div>` | `FlexColumn() / FlexRow() / Border()` (prefer over `VStack`/`HStack`) |
 | `<span>text</span>` | `TextBlock("text")` |
 | `<button onClick={fn}>` | `Button("label", fn)` |
 | `<input value={v} onChange={fn}>` | `TextField(v, fn)` |

--- a/skills/design-docs/layout-and-scaling.md
+++ b/skills/design-docs/layout-and-scaling.md
@@ -49,9 +49,33 @@ Border(child).CornerRadius(6)   // Not in the design system
 
 ## Layout Containers
 
-### VStack / HStack (Stack-Based)
+**Default for linear layout:** `FlexColumn` / `FlexRow`. They implement CSS
+Flexbox semantics via Yoga, so `grow`, `shrink`, `basis`, `gap`, `wrap`,
+`justify-content`, and `align-items` all behave the way web-trained engineers
+and designers expect. `VStack` / `HStack` (StackPanel) remain appropriate when
+you specifically want StackPanel's shrink-wrap cross-axis behavior, are
+porting existing StackPanel code, or prefer its terser single-arg spacing.
 
-Linear vertical or horizontal layout with optional spacing.
+### FlexColumn / FlexRow (CSS Flexbox — preferred for linear layout)
+
+```csharp
+FlexColumn(
+    Heading("Title"),
+    TextBlock("Description"),
+    Button("Action", onClick)
+) with { RowGap = 8 }
+
+FlexRow(
+    Image(icon).Size(24, 24),
+    TextBlock("Label"),
+    TextBlock("Value").Foreground(Theme.SecondaryText)
+) with { ColumnGap = 12, AlignItems = FlexAlign.Center }
+```
+
+### VStack / HStack (StackPanel)
+
+Linear vertical or horizontal layout with optional spacing. Good fit when
+StackPanel's shrink-wrap cross-axis is what you want.
 
 ```csharp
 VStack(8,
@@ -274,7 +298,7 @@ Border(content)
 
 ## Text Trimming
 
-`HStack` (StackPanel) gives children unbounded width, so `TextTrimming` never activates. Use a `Grid` with a `"*"` column:
+`HStack` (StackPanel) and `FlexRow` both give children unbounded main-axis width, so `TextTrimming` never activates inside them. Use a `Grid` with a `"*"` column:
 
 ```csharp
 // Correct: Grid constrains width
@@ -287,7 +311,7 @@ Grid(
         .ToolTip(title)  // Show full text on hover when trimmed
         .Grid(column: 1))
 
-// Wrong: TextTrimming never fires in HStack
+// Wrong: TextTrimming never fires in HStack or FlexRow
 HStack(8,
     Image(avatar).Size(32, 32),
     TextBlock(title).TextTrimming(TextTrimming.CharacterEllipsis))

--- a/skills/design.md
+++ b/skills/design.md
@@ -278,20 +278,25 @@ TextField(text, setText).Height(30)
 
 #### Container Choice
 
-Pick the right container:
+Pick the right container. **Prefer `FlexRow` / `FlexColumn` as the default for
+linear layout** — they follow CSS Flexbox semantics (grow, shrink, basis, gap,
+wrap, `justify-content`, `align-items`), which matches the mental model web-
+trained engineers and designers already have. `VStack` / `HStack` remain a good
+choice when you specifically want StackPanel's shrink-wrap cross-axis behavior
+or are porting from existing StackPanel code.
 
 | Need | Use | Not |
 |------|-----|-----|
-| Single child with background/border | `Border(child)` | `Grid` or `VStack` with one child |
-| Linear vertical layout | `VStack(children)` | Nested `Grid` |
-| Linear horizontal layout | `HStack(children)` | Nested `Grid` |
-| Flexible proportional layout | `Flex(children)` | Complex nested stacks |
+| Single child with background/border | `Border(child)` | `Grid` or `FlexColumn` with one child |
+| Linear vertical layout | `FlexColumn(children)` (preferred), or `VStack(children)` | Nested `Grid` |
+| Linear horizontal layout | `FlexRow(children)` (preferred), or `HStack(children)` | Nested `Grid` |
+| Grow/shrink, wrapping, or `justify-content` distribution | `Flex(children)` with `.Flex(grow/shrink/basis)` on children | Complex nested stacks |
 | Positional row/column layout | `Grid(columns, rows, children)` | Canvas or absolute positioning |
-| Text that needs trimming | `Grid` with `"*"` column | `HStack` (prevents trimming) |
+| Text that needs trimming | `Grid` with `"*"` column | `HStack` / `FlexRow` (children get unbounded main-axis width) |
 
-Remove wrapper containers (`Border`, `Grid`, `VStack`) that exist only for nesting without contributing layout, styling, or semantic purpose.
+Remove wrapper containers (`Border`, `Grid`, `FlexColumn`, `VStack`) that exist only for nesting without contributing layout, styling, or semantic purpose.
 
-**Text trimming caveat:** `HStack` (StackPanel) gives children unbounded width, so `TextTrimming` never activates. Use a `Grid` with a `"*"` column. Note: `Grid` column `"Auto"` also sizes to content and prevents trimming — always use `"*"` for the column that contains trimmable text.
+**Text trimming caveat:** `HStack` (StackPanel) and `FlexRow` both give children unbounded width on the main axis, so `TextTrimming` never activates inside them. Use a `Grid` with a `"*"` column. Note: `Grid` column `"Auto"` also sizes to content and prevents trimming — always use `"*"` for the column that contains trimmable text.
 
 ```csharp
 // Correct: Grid constrains width so trimming works
@@ -322,9 +327,35 @@ VStack(
     ).Set(sv => sv.HorizontalContentAlignment = HorizontalAlignment.Stretch))
 ```
 
+#### Window Title Bar
+
+Prefer `TitleBar(...)` as the top-of-window element for Reactor desktop apps
+where a title makes sense (most main windows, document shells, settings
+windows). It integrates with the Windows caption (drag region, system menu,
+min/max/close) and themes with the rest of the app, and it accepts inline
+`Content` and `RightHeader` for branding, document context, or small inline
+controls — which avoids the common mistake of stacking a custom header row
+below the system chrome and ending up with two visual title zones.
+
+```csharp
+// Preferred: real Windows title bar with app title + subtitle + inline content
+var titleBar = (TitleBar("MyApp") with
+{
+    Subtitle = currentDoc,
+    Content = ModeSwitcher(mode, setMode),
+    RightHeader = TextBlock($"{rowsLoaded:N0} rows").FontSize(12).Opacity(0.6),
+}).Flex(shrink: 0);
+
+return FlexColumn(titleBar, MainContent());
+```
+
+Small dialogs, embedded pop-outs, and tool windows that already have a
+distinct visual header don't need `TitleBar` — use it where you'd otherwise
+reach for a custom header row across the full window width.
+
 #### Spacing
 
-Use `VStack(spacing, ...)` / `HStack(spacing, ...)` or Grid `RowSpacing`/`ColumnSpacing` — not spacer elements.
+Use `FlexColumn(...) with { RowGap = n }` / `FlexRow(...) with { ColumnGap = n }` (or `VStack(spacing, ...)` / `HStack(spacing, ...)`) or Grid `RowSpacing`/`ColumnSpacing` — not spacer elements.
 
 ```csharp
 // Correct


### PR DESCRIPTION
## Summary
- Present `FlexRow` / `FlexColumn` as the default for linear layout in `SKILL.md` and `skills/design.md`; rationale is CSS Flexbox semantics match the web mental model (grow/shrink/gap/wrap, justify-content, align-items). `VStack` / `HStack` remain listed as valid options for StackPanel shrink-wrap behavior — framed as a preference, not a ban.
- Add a Window Title Bar subsection to `skills/design.md` recommending `TitleBar(...)` as the top-of-window element for Reactor desktop apps, with a usage example (`Subtitle`, `Content`, `RightHeader`) mirroring the HeadTrax sample.
- Reorder `skills/design-docs/layout-and-scaling.md` so FlexColumn/FlexRow are documented first; update the TextTrimming note to mention FlexRow shares StackPanel's unbounded main-axis behavior.

## Test plan
- [ ] Skim `SKILL.md` and `skills/design.md` to confirm the preference reads as guidance, not a prohibition.
- [ ] Verify `TitleBar` example compiles against current DSL (`Subtitle` / `Content` / `RightHeader` init-only props).
- [ ] Confirm Flex gap example uses `with { RowGap / ColumnGap }` (no fictional `.Spacing()` on FlexPanel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)