### PR TITLE
docs(research): sync overview comparison with latest critical review

### DIFF
--- a/docs/research/compare/overview.md
+++ b/docs/research/compare/overview.md
@@ -109,10 +109,10 @@ to understand the gap, not to declare winners.
 | **Layout** | D+ | A- | A- | B+ | B+ |
 | **Styling & Theming** | D | A- | A | B | B- |
 | **Navigation** | F | C | C+ | B | B+ |
-| **Animation** | F | B+ | A | C | C+ |
+| **Animation** | F | B+ | A | C | B- |
 | **Accessibility** | D+ | A- | A | B | B |
-| **Input & Gestures** | C | B+ | B+ | B+ | C |
-| **Developer Experience** | B | B- | B- | B | C+ |
+| **Input & Gestures** | C | B+ | B+ | B+ | B |
+| **Developer Experience** | B | B- | B- | B | B |
 | **Platform Reach** | D | D | D | B+ | D |
 | **Testing** | D+ | B | B- | A- | B- |
 | **Error Handling** | C | C | C | B+ | B |
@@ -215,9 +215,28 @@ libraries. Flutter provides only `setState()`.
   store — ecosystem uses Fluxor, Blazor-State, observable libraries. **No
   automatic reactivity tracking** — Blazor's biggest ergonomic weakness
 - **Reactor (B+):** React-style hooks (UseState, UseReducer, UseEffect, UseMemo,
-  UseContext). Context for shared state. UseObservable bridges to MVVM.
-  No fine-grained property tracking (unlike SwiftUI's @Observable), but the
-  hook model is proven and well-understood
+  UseRef, UseContext, UsePersisted). Hook state is now generic (no boxing for
+  value types via `ValueHookState<T>`). Effect cleanup is post-render, not
+  synchronous — matching React's behavior. Default-on memoization: propless
+  components skip re-renders unless self-triggered or context-changed;
+  `Component<TProps>` with record props gets structural equality comparison
+  for free. Context system (`Context<T>` + `.Provide()` + `UseContext`)
+  provides tree-scoped ambient state — `LocaleProvider` was migrated from a
+  thread-static hack to Context, validating the primitive with a real use
+  case. `UsePersisted<T>(key, initial)` survives unmount/remount (in-process
+  static cache — unbounded, no eviction, string keys with no collision
+  protection). `UseObservable` family (tree, property, collection) bridges
+  MVVM. Async resources ship as a separate subsystem (see Data Loading &
+  Async). **Implementation concerns:** `ShouldUpdateWithProps` uses reflection
+  on every memo check with no `MethodInfo` caching — 50 components in a tree
+  = 50 reflection calls per parent re-render. Context scope stores values as
+  `object?` so value-typed context values (`Context<int>`) box on every
+  provide. `UseCallback` is literally `UseMemo(() => callback, deps)` — the
+  lambda captures callback, so reference stability is only as fresh as the
+  deps (correct behavior, undocumented nuance). No `startTransition`
+  equivalent for priority-scheduled updates. Dependency arrays still box
+  into `object[]` and compare with `Equals`, and there's no
+  `exhaustive-deps` analyzer (deferred as control-flow-analysis work)
 
 **Gap:** No Microsoft framework has automatic fine-grained state tracking.
 WPF/WinUI3's INotifyPropertyChanged is functionally equivalent to Flutter's
@@ -288,13 +307,21 @@ system). Flutter's constraint model is powerful but has a steep learning curve.
   system available
 - **Reactor (B+):** FlexPanel (full Flexbox implementation) is ambitious and
   useful — provides layout capabilities WinUI itself doesn't have. Grid is
-  stringly-typed (`["*", "Auto", "200"]`). No custom layout protocol
+  stringly-typed (`["*", "Auto", "200"]`). No custom layout protocol. A
+  silent correctness gap was just closed: FlexPanel's measure pass was not
+  CSS-equivalent until commit `397f274` (April 2026), paired with a 526-line
+  fixture suite that pins behavior against a real WebView-rendered layout.
+  The fix is the right shape; the fact that there was no parity harness from
+  day one is a process gap — any app built against the earlier FlexPanel may
+  have subtly wrong layouts
 
 **Gap:** WPF and WinUI 3 have **no gap** in layout — they're competitive with
 or ahead of most declarative frameworks. Reactor's FlexPanel is a genuine
 addition. The only missing piece is WPF/WinUI3's lack of a single-line
 responsive layout primitive (SwiftUI's ViewThatFits, Compose's
-adaptive Scenes).
+adaptive Scenes). Responsive hooks (`UseWindowSize`, `UseBreakpoint`) in
+Reactor force a full component re-render on resize — SwiftUI's
+`@Environment(\.horizontalSizeClass)` only invalidates views that read it.
 
 ---
 
@@ -324,24 +351,37 @@ Material-centric.
   component. Limitation: third-party components don't participate (open issue
   dotnet/aspnetcore#63091). No built-in design system — ecosystem relies on
   Fluent UI Blazor, MudBlazor, Telerik, Syncfusion, DevExpress
-- **Reactor (B-):** 37 semantic theme tokens (accent, text, surface, control,
-  stroke, signal colors) with `Theme.Ref(key)` for custom resources.
-  ResourceBuilder supports 5 resource types (color string, Brush, ThemeRef,
-  double, CornerRadius) with full WinUI visual state support (hover, pressed,
-  disabled via lightweight styling). Style caching with deterministic sorted
-  keys in a ConcurrentDictionary avoids repeated XamlReader.Load() calls.
-  Three Roslyn analyzers (DUCT001-003) guide developers toward theme tokens
-  and lightweight styling with code fix providers. Sophisticated theme
-  resolution respects per-element RequestedTheme overrides. Still limited to
-  what WinUI lightweight styling exposes — no control template redefinition,
-  no global stylesheets, no style inheritance or composition
+- **Reactor (B-):** ~40 semantic theme tokens with `Theme.Ref(key)` for
+  custom resources. `ResourceBuilder` lightweight styling is Reactor's first
+  genuinely unique styling feature — no other C# declarative framework
+  surfaces WinUI's per-control resource key overrides. Style caching with
+  deterministic sorted keys in a `ConcurrentDictionary` eliminates the
+  XamlReader.Load-per-element perf concern that was the previous review's
+  biggest theming critique. `.RequestedTheme()` modifier and `UseColorScheme`
+  hook shipped. Three Roslyn analyzers (still carrying the old `DUCT001-003`
+  IDs — the `REACTOR_*` rename is partial; `DUCT_LOC001` and `DUCT_A11Y_*`
+  were migrated, the theming IDs were not). **Two headline features don't
+  compose correctly with each other:** `UseColorScheme` reads
+  `Application.Current.RequestedTheme` (app-level), not the element's
+  effective theme — so a component inside `.RequestedTheme(ElementTheme.Dark)`
+  sees `ColorScheme.Light` in a light-mode app. `{ThemeResource}` bindings in
+  dynamically-loaded styles also resolve against the app theme, not
+  per-element `RequestedTheme`. The "dark sidebar in a light app" scenario —
+  exactly what both features were designed for — is broken. **Custom branded
+  theme resources still don't exist** after multiple iterations; `Theme.Ref`
+  only references existing WinUI resources. Only 3 properties support
+  ThemeRef bindings (Background, Foreground, BorderBrush). Lightweight
+  styling resource keys are stringly-typed with no validation or IntelliSense
 
 **Gap:** WPF's styling power exceeds every competitor. WinUI 3's Fluent Design
 with lightweight styling is competitive with SwiftUI/Compose. Reactor's theming
-has improved substantially (from C+ to B-) with 37 theme tokens, resource
-overrides, caching, and analyzers, but remains behind its own platform —
-resource key overrides cannot match WinUI 3's ControlTemplate power for
-deep visual customization.
+has improved (from C+ to B-) — style caching fixed the major perf concern,
+lightweight styling is a genuine differentiator, analyzers provide static
+guidance — but the grade stays at B- because the composition bug between
+`UseColorScheme` and `.RequestedTheme()` defeats the scenario they were built
+for, custom theme resources remain missing, and the pieces don't compose.
+Resource key overrides cannot match WinUI 3's ControlTemplate power for deep
+visual customization.
 
 ---
 
@@ -367,22 +407,34 @@ notoriously complex.
   native deep linking. **No type-safe navigation** — `NavigateTo(string)` is
   not compile-checked against route templates
 - **Reactor (B+):** Type-safe routes via C# records, developer-owned back stack,
-  GPU-powered composition-layer transitions, lifecycle guards, LRU caching,
-  serialization, deep linking with `DeepLinkMap<TRoute>` supporting URI
-  pattern matching (typed parameters `{id:int}`, optional segments `{name?}`,
-  wildcards `/**`, query string extraction, synthetic back stacks).
-  **NavigationDiagnostics** provides a static event system for observing
-  navigation operations (requests, completions, cancellations, cache hits/
-  misses, transitions, deep link resolutions). 29 stress tests covering
-  concurrent cache access, rapid forward/back cycles, serialization round-trips,
-  and deep link edge cases. Architecturally competitive with Compose Nav 3.
-  ConnectedTransition is stub, no adaptive multi-pane
+  GPU-powered composition-layer transitions, lifecycle guards on both source
+  AND destination sides (`NavigatingToContext.Cancel()` lets destinations
+  reject navigation for authorization), LRU caching, JSON state serialization,
+  deep linking with `DeepLinkMap<TRoute>` supporting typed parameters
+  `{id:int}`, optional segments `{name?}`, wildcards `/**`, and query string
+  extraction. `NavigationDiagnostics` emits observability events. A test
+  infrastructure bug was just discovered and fixed: 44 of 46 E2E tests were
+  invisible behind a broken `ClassName=InteractiveTests` filter (should have
+  been `ClassName!=SelfTestBatch`); 43 Appium tests now run across 6 classes.
+  The fix is real, but the fact that 44 tests went unexecuted for the entire
+  dev cycle is a CI process gap. Architecturally on par with Compose Nav 3.
+  **Remaining gaps:** `ConnectedTransition` is a documented API that falls
+  back to a slide animation with only a debug-log message — a shipped name
+  that doesn't do what it says. No adaptive multi-pane layout (Compose Nav 3
+  has `Scene`/`SceneStrategy`). Deep link patterns are stringly-typed at the
+  URI→route boundary — `"/detail/{id:int}"` is a string, `RouteArgs.Get<T>("id")`
+  is a string-keyed lookup, so the type safety stops at the edge. Destination
+  guards are synchronous — React Router's async loaders have no equivalent.
+  `UseSystemBackButton` is opt-in rather than default. **The showcase apps
+  (Outlook clone, file manager) still use `UseState<string>` for navigation**
+  and haven't adopted the system that was built to solve their problem
 
-**Gap:** Reactor's navigation is its strongest competitive position — architecturally
-on par with Compose Nav 3 and ahead of SwiftUI's type-erased NavigationPath.
-The deep linking system is now comprehensive (typed params, optionals, wildcards,
-query strings) and competitive with web-grade routers. WPF and WinUI 3's
-navigation is a full generation behind.
+**Gap:** Reactor's navigation is architecturally competitive with Compose Nav 3
+and ahead of SwiftUI's type-erased NavigationPath. Deep linking covers the
+common patterns but loses type safety at the URI boundary. WPF and WinUI 3's
+navigation is a full generation behind. The trajectory is right; the last
+15% (adaptive layouts, working connected transitions, async guards, showcase
+adoption) separates "competitive" from "best-in-class."
 
 ---
 
@@ -408,24 +460,43 @@ has no built-in animation.
   the floor. Small fragmented ecosystem (Blazor.Animate, blazor-transition-
   group, Toolbelt.ViewTransition). Exit animations are awkward because Blazor
   removes DOM nodes synchronously on state change
-- **Reactor (C+):** Spring, ease, and linear curves on compositor properties
-  (Opacity, Offset, Scale, Rotation, CenterPoint). Enter **and exit**
-  transitions now work — the ChildReconciler defers removal until exit
-  animations complete, with proper index tracking. KeyframeBuilder provides
-  multi-keyframe animations with per-keyframe easing and looping.
-  ScrollAnimation enables scroll-linked expression animations (parallax,
-  fade, scale). InteractionStates handle hover/pressed/focused with
-  compositor animations. WithAnimation scope provides ambient animation
-  context. Still limited to 5 compositor visual properties — no layout/size
-  animations. Pressed state merges with PointerOver rather than being fully
-  independent. Connected animation support remains stub-level
+- **Reactor (B-):** The previous review graded this C+ with four integration
+  bugs. All four are now fixed (commit `d38c6ef`), plus three additional
+  runtime issues (async scope persistence across the DispatcherQueue render
+  boundary, Opacity routing for `.Animate()`, pool crash with
+  compositor-tainted elements). The animation system now delivers what its
+  API promises. Curves (spring, bezier, linear, 7 easing presets) feed an
+  eight-tier system: implicit property transitions, theme transitions, the
+  `Curve` DSL, `.Animate()` modifier, layout animations, enter/exit
+  transitions with `+` (parallel) and `|` (asymmetric) composition operators,
+  interaction states (pointer/pressed/focused all wired), keyframes with
+  per-step easing and looping, staggered children integrated with enter
+  transitions, scroll-linked expression animations, and `AnimationScope.WithAnimation`
+  / `WithAnimationAsync` for ambient curve propagation. 47 regression tests
+  guard the bug fixes. **The ceiling is structural, not fixable:** the system
+  can only animate what the WinUI compositor exposes on the `Visual` —
+  Opacity, Scale, Rotation, Translation, CenterPoint, plus 3 brush swaps
+  in InteractionStates. Width, Height, CornerRadius, Margin, Padding,
+  FontSize, and arbitrary colors cannot animate. SwiftUI animates any state
+  change that produces a different view body; Compose's `animateAsState`
+  works for any type with a `TwoWayConverter`; Flutter's `Tween` works for
+  anything with `lerp`. Reactor has an increasingly sophisticated control
+  model over the same narrow set of properties. There is also no per-frame
+  hook (`UseAnimation`/`UseSpring` equivalents) — compositor runs the
+  animation, component code can't observe intermediate values. Connected
+  animations still use string-key coordination (typos fail silently).
+  Keyframes can only target the same compositor properties. No cross-element
+  orchestration beyond stagger
 
-**Gap:** WinUI 3's Composition API is genuinely world-class — competitive with
-SwiftUI's animation ergonomics while offering more low-level control. WPF is
-solid. Reactor's animation has improved (exit transitions fixed, keyframes and
-scroll animations added) but remains its weakest category relative to its
-own platform — most real UI animations (height changes, layout transitions)
-can't be expressed in 5 compositor properties.
+**Gap:** WinUI 3's Composition API is world-class. WPF is solid. Reactor's
+animation moved from C+ to B- because all four integration bugs are fixed
+and the API is now faithful to what it advertises. The remaining gap is the
+compositor-property ceiling — a WinUI platform constraint, not a Reactor
+design failure, but real. A developer who wants a button's CornerRadius to
+animate on hover, or a sidebar's Width to animate on expand, still has no
+declarative path and must fall back to `.Set()` and WinUI's `DoubleAnimation`.
+Per-frame hooks, typed connected-animation keys, and cross-element orchestration
+are design omissions rather than broken promises.
 
 ---
 
@@ -452,39 +523,57 @@ gaps on web.
   Quality depends entirely on component library choice: Fluent UI Blazor,
   Telerik (WCAG 2.2), Syncfusion (WCAG 2.2 / Section 508 / ADA) all provide
   comprehensive a11y
-- **Reactor (B):** 16+ accessibility modifiers covering automation name, help
-  text, landmarks, heading levels, live regions (Polite/Assertive), required
-  fields, position-in-set, hierarchy level, tab navigation, and accessibility
-  view. Smart lazy allocation (tier 1 inline, tier 2/3 on-demand). 12 E2E
-  Appium tests with explicit WCAG 2.1 criterion mapping (1.1.1, 1.3.1,
-  2.1.1, 3.3.2, 4.1.2, 4.1.3) testing the real UIA pipeline. Full RTL/BiDi
-  support with CLDR-based locale detection and logical layout modifiers
-  (MarginInlineStart/End, PaddingInlineStart/End). **SemanticPanel** wraps
-  composite components in a Panel with a custom AutomationPeer exposing UIA
-  roles (17 mappings including slider, progressbar, list, menu), IValueProvider,
-  and IRangeValueProvider — partially addresses the "no custom automation
-  peers" gap. **UseAnnounce** hook provides imperative screen reader
-  announcements via RaiseNotificationEvent with live-region fallback.
-  **UseFocusTrap** hook traps keyboard focus within a container (modal dialog
-  pattern), though focus cycling is not yet implemented. **AccessibilityScanner**
-  performs 8 WCAG-mapped runtime diagnostics (icon-only buttons, missing alt
-  text, unlabeled form fields, headings without HeadingLevel, concrete brushes
-  on interactive controls, missing Main landmark, non-sequential TabIndex gaps,
-  unresolved LabeledBy references) with structured JSON export. Three **Roslyn
-  analyzers** (REACTOR_A11Y_001–003) catch accessibility issues at compile time
-  with code fix providers. Still limited: SemanticPanel is a workaround (not
-  true per-component AutomationPeer), `LabeledBy()` is still a no-op,
-  UseFocusTrap doesn't cycle focus, and AccessibilityScanner only runs in
-  DEBUG builds
+- **Reactor (B):** 16 first-class accessibility modifiers across two storage
+  tiers (tier 1 inline on `ElementModifiers`, tier 2 lazy sub-record) —
+  common case pays zero cost. 12-13 E2E Appium tests through the real UIA
+  pipeline with explicit WCAG 2.1 criterion mapping (1.1.1, 1.3.1, 2.1.1,
+  3.3.2, 4.1.2, 4.1.3). `SemanticPanel` + `.Semantics()` modifier wraps
+  composite components in a real WinUI `Panel` subclass with a custom
+  `SemanticPanelAutomationPeer` that exposes role, value, and range through
+  `IValueProvider` and `IRangeValueProvider` — this closes the previously
+  "architecturally blocked" composite-automation gap. `LabeledBy` is now
+  wired with deferred resolution (targets not yet in the tree at mount time
+  resolve on `Loaded`). `ElementPool` clears 14 UIA properties on return.
+  `Heading()` and `SubHeading()` factories auto-set `HeadingLevel.Level1`/
+  `Level2`. `UseFocusTrap` hook handles modal focus containment via the
+  `LosingFocus` event. `AccessibilityScanner` runs post-reconciliation WCAG
+  diagnostics with rich context (parent names, nearest heading, WCAG
+  criterion, code-snippet fix suggestions) designed for AI-agent consumption.
+  Three Roslyn analyzers (`REACTOR_A11Y_001/002/003`) cover icon-button,
+  image, and interactive-element missing-AutomationName at edit time.
+  **Remaining gaps:** `SemanticPanel` only implements 2 of ~20 UIA patterns
+  (Value, RangeValue) — no `IToggleProvider`, `IExpandCollapseProvider`,
+  `ISelectionProvider`. Semantic role is a bare string with no enum
+  (`"slidre"` silently maps to `Custom`). `UseFocusTrap` traps but doesn't
+  cycle — tabbing past the last focusable element stays put rather than
+  wrapping, which is the WAI-ARIA Dialog Pattern expectation. `UseFocusTrap`
+  requires `.Set(el => trap.SetContainer(el))` to wire the container, a
+  reach-through-the-declarative-model pattern. `UseAnnounce`,
+  `UseReducedMotion`, and `UseScreenReaderActive` are still unbuilt.
+  `AccessibilityScanner` is DEBUG-only and runtime-only (requires a
+  rendered UI). Analyzer coverage is narrow — `REACTOR_A11Y_001` matches
+  `Button` by identifier name, missing `AppBarButton`, `ToggleButton`,
+  `SplitButton`, `RepeatButton`; `REACTOR_A11Y_003` misses `RadioButton`,
+  `TextBox`, `PasswordBox`, `AutoSuggestBox`. Programmatic focus control
+  (`FocusRequester` / `@FocusState` equivalent), XYFocus directional
+  navigation, and focus restoration on back-navigation are all still
+  missing. SemanticPanel adds a fourth invisible wrapper to the visual
+  tree (after component Border, NavigationHost Grid, CommandHost Grid).
+  **The showcase apps still don't use any accessibility modifiers** —
+  a11y-showcase is an isolated demo; Outlook clone, file manager,
+  registry editor, and word puzzle game still have no headings, landmarks,
+  or live regions
 
 **Gap:** WPF and WinUI 3 have **no gap** in accessibility — UIA is the most
-comprehensive accessibility API on any platform. Reactor has improved (from B-
-to B) with SemanticPanel for custom UIA semantics, UseAnnounce/UseFocusTrap
-hooks, and compile-time + runtime a11y scanning. The AccessibilityScanner
-with WCAG-mapped diagnostics is developer tooling that no competitor provides
-built-in. The remaining gaps are `LabeledBy()` no-op (correctness bug) and
-SemanticPanel being a wrapper approach rather than true custom AutomationPeer
-support per component.
+comprehensive accessibility API on any platform. Reactor moved from B- to B
+in the last cycle on the strength of SemanticPanel (solves the hardest
+architectural problem), a three-layer diagnostic approach (compile-time +
+runtime + E2E) that no other C# UI framework has, and auto-HeadingLevel as
+pit-of-success design. The layered accessibility *system* is real; the
+layers are thin. SwiftUI's `.accessibilityRepresentation {}` and Compose's
+`Modifier.semantics {}` are open — SemanticPanel is closed to two patterns.
+The trajectory is right; the last imperative hooks (announce, reduced motion)
+and the focus-cycling correctness bug are concrete, specific gaps.
 
 ---
 
@@ -510,14 +599,62 @@ capable. React has no built-in gesture system.
   Declarative `@onclick:stopPropagation="true"` / `:preventDefault="true"`.
   Typed form inputs (`<InputText>`, `<InputNumber>`, `<InputDate>`) with
   two-way binding and validation integration. No gesture system
-- **Reactor (C):** Semantic events (OnClick, OnToggle) are good. Commanding
-  system provides focus-scoped keyboard accelerators. But no gesture system,
-  no pointer enter/exit, no right-click/double-click without `.Set()`. Most
-  input still requires the escape hatch
+- **Reactor (B):** Spec 027 (commit `76d0f51`, 73 files, +7.2k LoC) closed the
+  longest-standing "Reactor is a thin WinUI wrapper" critique in one PR.
+  What shipped: the full pointer modifier surface (`.OnPointerPressed`,
+  `Moved`, `Released`, `Entered`, `Exited`, `Canceled`, `CaptureLost`,
+  `WheelChanged`); tap family (`.OnTapped`, `.OnDoubleTapped`, `.OnRightTapped`,
+  `.OnHolding`) with `IsTapEnabled`-family flags auto-toggled by the
+  reconciler; keyboard (`.OnKeyDown`, `.OnKeyUp`, `.OnPreviewKeyDown`,
+  `.OnPreviewKeyUp`, `.OnCharacterReceived`); focus (`.OnGotFocus`,
+  `.OnLostFocus`, plus a `UseElementFocus()` hook with typed `ElementRef`
+  and `.Ref(target)` modifier, and a `FocusManager` helper — the first
+  imperative focus primitive the framework has had); typed pan/pinch/rotate
+  gestures (`.OnPan`, `.OnPinch`, `.OnRotate`) with `PanGesture`/`PinchGesture`/
+  `RotateGesture` records carrying phase, translation/delta/velocity, scale/anchor,
+  angle, and an `IsInertial` flag; drag-and-drop with eager/sync-provider/
+  async-provider format overloads (text, URI, HTML, RTF, files, bitmap, custom)
+  wired through `DataPackage.SetDataProvider` so expensive formats only
+  render if a drop target asks. The event dispatch model also changed: a
+  stable trampoline is attached once per event per element lifetime, replacing
+  the previous "detach + attach on every render" COM churn on hot input
+  paths. ETW events (`EventTrampolineAttached`, `EventTrampolineDispatch`,
+  keyword 0x40) let the one-time-attach invariant be verified from a trace.
+  Commanding remains a real differentiator: define-once `Command` records
+  bundle execute + canExecute + label + icon + accelerator + description;
+  16 standard commands (Cut/Copy/Paste/Undo/Redo/etc.); focus-scoped
+  accelerators via `CommandHost`; ICommand interop. **Remaining gaps:**
+  gesture composition (SwiftUI's `.simultaneously`/`.sequenced`/`.exclusively`)
+  doesn't exist. Long-press is a raw event, not a typed
+  `LongPressGesture(minimumDuration:)`, so "long-press to begin drag" must
+  be hand-rolled across `.OnHolding` and `.OnPan`. Inertia deceleration isn't
+  tunable — `withInertia` is on/off. Pan inherits WinUI's manipulation
+  constraints (screen-axis-aligned translation only). Pointer capture
+  (`CapturePointer`/`ReleasePointerCapture`) still requires `.Set()`. Wheel
+  handling has no typed delta record and no mouse-vs-trackpad momentum
+  classification. StandardCommand labels are English-only (surprising given
+  Reactor has a full ICU localization system). Command routing to the focused
+  view is still missing — Cut/Copy/Paste in multi-panel apps continues to
+  require manual wiring. Accelerators rebuild on every render (O(commands)
+  COM calls per CommandHost per render). **Zero field evidence for the
+  trampoline perf claim** — all 6,390 unit tests pass, but the suite is
+  WinUI-free and doesn't exercise the COM interop path. No before/after
+  render-cycle benchmark exists; the architectural argument is right, the
+  measurement isn't there. **Zero field evidence for drag-and-drop** — 370
+  lines of new `DragData` shipped with no showcase consumer. Typed format
+  ids use `typeof(T).FullName`, unversioned, so renames break round-trips
 
-**Gap:** WPF and WinUI 3 are competitive. Reactor's commanding system is a genuine
-differentiator (no competitor has it built-in), but the lack of a gesture
-system is a significant gap.
+**Gap:** WPF and WinUI 3 are competitive. Reactor moved from C to B in a
+single PR — pointer/gesture/focus/drag-drop are no longer passthrough, and
+commanding remains a unique industry-first (no competitor ships define-once
+commands with metadata bundling). The remaining gaps are composition
+primitives (simultaneous/sequenced gesture chains, typed long-press), command
+routing to focus, typed pointer-capture and wheel-momentum APIs, and the
+uncomfortable fact that Reactor's own showcase apps don't use any of these
+new modifiers. The Outlook clone has no `.OnRightTapped` for message
+context menus, no `.OnDrop<EmailMessage>` for folder drop, no
+`UseElementFocus` for "focus the reading pane after selection." The feature
+exists; the integration evidence doesn't.
 
 ---
 
@@ -546,13 +683,52 @@ and Preview are excellent.
   end-to-end. **No component DevTools** — no render tree inspector, no
   parameter inspector, no render-count profiler. WebAssembly debugging has
   debug-proxy handshake fragility
-- **Reactor (C+):** Hot reload works (via WinUI 3 XAML Hot Reload). Preview is
-  screenshot-only. No DevTools for component inspection. No recomposition
-  count tracking. No profiling tools
+- **Reactor (B):** Hot reload works via .NET's `MetadataUpdateHandler` —
+  UI updates on code change while hook state survives (`UseState` values
+  persist because `RenderContext` stays in memory). Works with both VS and
+  `dotnet watch`. Limited by .NET hot reload's inherent restrictions: adding
+  fields, changing type hierarchies, and lambda shape changes still require
+  a restart. Spec 024+025 shipped an MCP (Model Context Protocol) devtools
+  server — `mur devtools ./App.csproj` spawns a supervisor that exposes
+  ~12 tools over HTTP JSON-RPC and stdio: `reactor.tree`, `reactor.click`,
+  `reactor.type`, `reactor.state`, `reactor.screenshot`, `reactor.logs`,
+  `reactor.windows`, `reactor.waitFor`, `reactor.fire`, `reactor.reload`.
+  Stable window-scoped node ids (`r:main/Counter.btn-inc`) survive re-renders.
+  UIA-based automation means any test an agent can write is also a test that
+  Narrator can see. **No C# declarative framework has an MCP server** — this
+  is genuinely unique, but it's a bet: agents-first debugging. The
+  traditional-developer equivalent (React DevTools panel, Compose Layout
+  Inspector) still doesn't exist; "preview" was renamed to "devtools" and
+  replaced rather than augmented. ETW tracing via `Microsoft-UI-Reactor`
+  EventSource (commit `310a299`) emits reconcile/render/state/MCP/lifecycle/
+  event-dispatch events to classic ETW and EventPipe. Consumers use PerfView
+  or dotnet-trace. Four hook-rule Roslyn analyzers (`REACTOR_HOOKS_001/004/
+  005/006`) catch conditional hooks, unstable deps, hooks-outside-render,
+  and UseResource-on-mutation at edit time — the `eslint-plugin-react-hooks`
+  equivalent that was previously absent. The most valuable ESLint rule
+  (`exhaustive-deps`) is still deferred as control-flow-analysis work.
+  ~5,600 lines of new coverage tests pushed selftest coverage past 85%.
+  **Remaining gaps:** state is read-only in MCP (no `reactor.setState`);
+  tree diffing is deferred (agents must cache client-side); source mapping
+  from tree nodes to authored C# lines is v1.1; no cache inspection
+  surface (`QueryCache` is invisible to devtools — contrast with TanStack
+  Query Devtools); ETW has no per-component render timing or per-hook
+  execution breakdown, only aggregate boundaries; PerfView's learning curve
+  is real; the DEBUG-gated devtools surface has a risk of Release-build leak
+  if environment flags misconfigure. The VS Code extension's interactive
+  preview has regressed relative to the old `--preview` flag — screenshots
+  are now a sub-capability of devtools rather than a first-class command
 
-**Gap:** All Microsoft options lag significantly in developer experience. No
-equivalent to React DevTools, Flutter Widget Inspector, or Compose Layout
-Inspector. Reactor's lack of tooling is its most significant DX gap.
+**Gap:** All Microsoft options lag in developer experience. Reactor moved
+from C+ to B on the strength of MCP devtools (unique industry-wide), ETW
+tracing, and the hook-rule analyzers — but "unique" is not the same as
+"better for humans." There is still no equivalent to React DevTools'
+component tree inspector, Compose Layout Inspector's per-composable
+recomposition counts, or SwiftUI Xcode Previews' inline interactive
+rendering. Reactor's bet is that AI agents are a primary UI-debugging
+audience; if that bet doesn't play out, the traditional-developer story
+is still behind. Per-component render timing is the largest concrete
+profiling gap.
 
 ---
 
@@ -690,15 +866,45 @@ runtime. Flutter's `FutureBuilder` is built-in but considered low-level.
   interactive double-fetch gap. Auto-`StateHasChanged` after `OnInitializedAsync`
   removes boilerplate. No Suspense equivalent in Interactive mode — manual
   loading-state booleans. No built-in caching/retry (no TanStack Query peer)
-- **Reactor (B+):** `UseEffect` provides lifecycle-scoped side effects matching
-  React's model. `UseState` for loading/error management. `UseObservable`
-  bridges async ViewModel patterns. No built-in Suspense equivalent, but
-  ErrorBoundary can catch render errors
+- **Reactor (B+):** Spec 020 (PR #29, `3814def..9f2f5de`, ~40 sub-commits)
+  shipped a full async data subsystem in 72 hours. `UseResource<T>` for
+  single-fetch; `UseInfiniteResource<T>` for cursor pagination;
+  `UseMutation<TIn,TOut>` for writes with pattern-based cache invalidation.
+  The return type is an `AsyncValue<T>` sealed record ADT —
+  `Loading` / `Data` / `Error` / `Reloading` — which expresses
+  stale-while-revalidate as a type-level concept (Reloading carries the
+  old value while the new fetch runs). `Pending` / `PendingScope` provide
+  Suspense-style fallback regions. Hook-owned `CancellationToken` means
+  unmount cancels in-flight requests automatically. `QueryCache.Default`
+  has per-key `SemaphoreSlim` locks preventing duplicate concurrent
+  fetches, ref-counted subscriptions, TTL + pattern invalidation
+  (`Invalidate("employees.*")`), focus revalidation, and an `EntryChanged`
+  event for mutation-driven invalidation. `DataGrid` row-commit was
+  migrated to `UseMutation` and hook-based paging is on by default —
+  a real production-sized control consuming the new API, not just a demo.
+  Four `REACTOR_HOOKS_*` analyzers back it up. **Remaining concerns:**
+  Cache is in-process-only — lost on app exit. No automatic retry;
+  transient network errors throw straight into `AsyncValue.Error<T>`.
+  `StaleTime` defaults to zero (refetch on every mount). `InvalidateKeys`
+  is `string[]` — no partial-match arrays like TanStack Query's
+  `queryKey`. Cache keys derive from `CallerHookId + DepsHash` by default,
+  which differs from TanStack Query where cache sharing is by named
+  key by default — two sibling components calling the same fetcher get
+  different cache entries unless they specify `CacheKey`. **No devtools
+  for the cache** — `reactor.state` exposes hook shape but not
+  `QueryCache` state. Diagnosing "why is this query stale" requires
+  reading source. **No stress tests** — 15 self-host fixtures cover
+  correctness but nothing profiles eviction (O(n) per tick) or per-key
+  lock contention under thousands of live queries. Zero field evidence
 
 **Gap:** Declarative frameworks have lifecycle-scoped async (`.task`,
-`LaunchedEffect`, Suspense). Microsoft frameworks use imperative MVVM async
-patterns. Reactor's `UseEffect` matches React's model but lacks Suspense-style
-declarative loading boundaries.
+`LaunchedEffect`, Suspense + TanStack Query). Reactor now competes on the
+primitives — ADT-based state, hook-owned cancellation, shared cache, typed
+analyzers — but TanStack Query has persistence adapters, devtools, retry,
+prefetching, and a multi-year production track record that Reactor's
+brand-new subsystem lacks. The gap to React's ecosystem is smaller than in
+any other category (this is the closest competitive position), but it
+hasn't been battle-tested.
 
 ---
 
@@ -917,6 +1123,124 @@ and binding-level validation integration.
 
 ---
 
+### 20. Charting & Chart Accessibility (Reactor-specific)
+
+**What this measures:** Built-in charting, chart accessibility for screen
+readers, keyboard navigation of charts, color-blindness accommodation. No
+competitor scorecard slot because only Reactor and Apple Charts ship this
+as a framework concern.
+
+**Competitor standard:** Apple Charts (iOS 16+, 50+ chart types, audio
+graphs/sonification via VoiceOver) is the benchmark. Compose has Vico and
+community libraries. React has D3 and countless charting libs (not
+framework-integrated). WinUI ships no chart library — enterprise WinUI
+apps use LiveCharts, OxyPlot, or Telerik/DevExpress/Syncfusion.
+
+**Reactor:** Spec 026 + 9 implementation phases shipped a full charting
+sub-framework in 72 hours: 43 D3-ported samples, plus an 8-layer
+accessibility infrastructure:
+
+1. **Automation peer infrastructure.** `ChartAutomationPeer` implements
+   `IGridProvider` (series × points) and `ITableProvider`; `ChartPointProvider`
+   exposes per-point `IValueProvider`; `IScrollProvider` for large datasets
+2. **Per-point labels + auto-summarization** via `ChartSummarizer` —
+   "Line chart, 5 series, 120 points. Revenue trending upward by 12%"
+3. **Alternate-view convention.** `.AlternateView(Element)` attaches a
+   developer-supplied DataGrid; T-key toggle, focus save/restore, live
+   announcement handled by the framework
+4. **Keyboard navigation.** Arrow keys walk points/series, Home/End jump
+   to edges, Ctrl+arrow steps by series/axis, +/- zoom, Shift+arrow brush,
+   L focuses legend. Highcharts/Power BI model translated to WinUI
+5. **Focus context** preserves focused point across view transitions
+6. **Live announcements** via debounced (400ms trailing) `ChartLiveAnnouncer`
+7. **Forced colors, reduced motion, double encoding.** `ChartPalette.ForcedColors`
+   swaps to `[CanvasText, Highlight, LinkText, GrayText]` under high
+   contrast. `ChartPalette.Harden` runs deterministic LCH-space lightness
+   adjustment to meet WCAG AA contrast — no other C# declarative framework
+   ships this. `ColorblindSimulate` uses Brettel matrices. Series are
+   double-encoded (color + shape + dash) by default; `.ColorOnly()` warns
+   via the scanner. `ReactorHost` honors `WindowsThemeSettings.HighContrast`
+   and `UISettings.AnimationsEnabled`
+8. **Scanner rules.** 12 chart-specific rules (`A11Y_CHART_001..012`):
+   missing title, missing axis labels, missing point labels, color-only
+   encoding, insufficient contrast, tiny hit targets, etc. Fix suggestions
+   include CLI commands (`reactor charts harden`) for AI-agent consumption
+
+The 43-sample gallery got retrofitted to use all of this in one pass
+(commit `229e41b`) — a real counter-example to the "features exist in
+isolation" pattern that dominates the rest of the review.
+
+**Remaining gaps:** No sonification / audio graphs — Apple Charts and
+Highcharts both ship this. Spec explicitly lists it as "A+ ceiling deferred."
+ForceGraph a11y is explicitly decorative-only — screen reader users get the
+node/edge list but no interactive exploration of dense graphs. Hit-target
+expansion (24×24px minimum for WCAG 2.5.8) requires `.Interactive()` opt-in;
+static analytics charts don't get it. Forced-colors palette clips to 4
+series — beyond that, colors collide under high contrast. `ChartPointProvider`
+peer allocation is unbounded — 10,000-point scatterplot creates 10,000 peer
+instances on each UIA walk, unprofiled. "Alternate view" depends entirely
+on app-supplied DataGrid content — no canonical fully-integrated sample
+that syncs sort/filter state between chart and table. Live-region debounce
+is hard-coded at 400ms. Chart scanner rules don't merge with general a11y
+scanner rules, so `A11Y_001` + `A11Y_CHART_001` both fire on a titleless
+chart. E2E Appium coverage for charts is thin (~153 lines). No third-party
+dashboard has adopted this — zero field evidence, no 10k-point stress
+testing, no screen-reader-user survey.
+
+**Gap:** Reactor's chart accessibility is arguably the most comprehensive
+*system* in any C# declarative framework and ahead of everything except
+Apple Charts on most dimensions. Only sonification and ForceGraph
+interaction remain as clear competitive gaps. Grade: **B+** as a new
+category; would be **A-** with sonification and always-on hit-target
+expansion.
+
+---
+
+### 21. Devtools & Tracing Infrastructure (Reactor-specific)
+
+**What this measures:** Framework-integrated debugging, tree inspection,
+automation, tracing.
+
+**Competitor standard:** React DevTools (component tree, props, hook
+inspection, Profiler flame graphs). Compose Layout Inspector (per-composable
+recomposition counts). SwiftUI Xcode Previews (interactive preview). Apple
+Instruments (sophisticated profiling). None ship an MCP server.
+
+**Reactor:** An unusual position. Spec 024+025 shipped a Model Context
+Protocol devtools server — `reactor.tree`, `reactor.click`, `reactor.type`,
+`reactor.state`, `reactor.screenshot`, `reactor.logs`, `reactor.reload`,
+`reactor.waitFor`, `reactor.fire`, `reactor.switchComponent` — over HTTP
+JSON-RPC and stdio. `mur devtools` is a supervisor; `mur devtools call`
+provides CLI parity for humans. Stable window-scoped node ids
+(`r:<window>/<local>`) survive re-renders. UIA-based automation means
+tests authored against the devtools surface also validate accessibility.
+Single-instance lockfile with pid probe + HTTP liveness check. ETW
+tracing via `Microsoft-UI-Reactor` EventSource emits 6 keyword categories
+to classic ETW and EventPipe; consumers use PerfView or dotnet-trace.
+
+**What's missing:** `reactor.state` is read-only — no `reactor.setState`.
+Tree diffing deferred to a later phase (agents must cache client-side).
+Source mapping (tree node → C# file/line) is v1.1. No cache inspection
+for `QueryCache`. No performance profiling via MCP. ETW has no
+per-component render timing or per-hook execution breakdown — only
+aggregate boundaries. DEBUG-gated with risk of Release-build leak if
+env vars misconfigure. The previous `--preview` flag was replaced
+(renamed to `--devtools`), so non-agent developers have a regression
+in mental model — screenshots are now a devtools sub-capability rather
+than a first-class command. Traditional-developer tooling (live component
+tree in an IDE panel, per-component Profiler) still doesn't exist.
+
+**Gap:** No other C# UI framework — and for that matter, no other
+declarative UI framework on any platform — ships an MCP server. The
+architectural choices (UIA as the bus, MCP as the protocol, stable
+node ids, CLI parity, single-instance lockfile) are correct. The bet
+is that AI agents are a primary UI-debugging audience. If that bet
+pays off, Reactor is uniquely positioned; if developers still prefer
+React DevTools-style GUI devtools, Reactor shipped the supplement
+before the primary. Grade: **B** as a new category.
+
+---
+
 ## Gap Analysis: Microsoft vs Competitor Median
 
 | Category | Competitor Median | Best MS | MS Grade | Gap |
@@ -930,8 +1254,8 @@ and binding-level validation integration.
 | Navigation | B+ | Reactor (B+) | B+ | **Matched** |
 | Animation | B+ | WinUI 3 (A) | A | **Ahead** |
 | Accessibility | B+ | WinUI 3 (A) | A | **Ahead** |
-| Input & Gestures | B+ | WPF/WinUI 3/Blazor (B+) | B+ | **Matched** |
-| Developer Experience | A- | WinForms/Blazor (B) | B | **1 grade behind** |
+| Input & Gestures | B+ | WPF/WinUI 3/Blazor/Reactor (B+/B) | B+ | **Matched** |
+| Developer Experience | A- | WinForms/Blazor/Reactor (B) | B | **1 grade behind** |
 | Platform Reach | A- | Blazor (B+) | B+ | **Half grade behind** |
 | Testing | B+ | Blazor (A-) | A- | **Ahead** |
 | Error Handling | C+ | Blazor (B+) | B+ | **Ahead** |
@@ -940,6 +1264,8 @@ and binding-level validation integration.
 | Internationalization | B+ | Blazor/Reactor/WinUI 3 (B+) | B+ | **Matched** |
 | Interop & Adoption | A- | Blazor/Reactor (A-) | A- | **Matched** |
 | Forms & Data Entry | B | WPF (A) | A | **Ahead** |
+| Charting + Chart A11y | C (Compose/median) | Reactor (B+) | B+ | **Ahead** |
+| Devtools & Tracing (MCP) | — (unique) | Reactor (B) | B | **Unique industry position** |
 
 ### Where Microsoft leads or matches:
 1. **Forms & Data Entry** (WPF) — The richest validation system of any
@@ -1096,42 +1422,114 @@ type safety and no XAML.
 
 **Profile:** The only Microsoft-ecosystem option with a modern declarative
 component model: function components, hooks, reconciler, context, navigation,
-commanding. 94% of WinUI controls wrapped. Navigation is architecturally
-competitive with comprehensive deep linking (typed params, wildcards, query
-strings) and runtime diagnostics. Commanding is a genuine industry-first.
-ErrorBoundary exists (rare). Interop with existing WinUI/MVVM code is
-excellent (`ReactorHostControl`, `UseObservable`, `XamlHostElement`) and now
-extends to WinForms via `XamlIslandControl` with designer support and focus
-bridging. ICU localization closes WinUI 3's plural/gender gap. Form
-validation system with automatic validation pipeline, 10+ built-in
-validators, FormField component, and ValidationVisualizer. **DataGrid** with
-paged LRU caching, server-side sort/filter, inline cell/row editing with
-validation, async commit with optimistic updates, multi-selection, and full
-keyboard navigation. 37 theme tokens with ResourceBuilder lightweight
-styling, style caching, and Roslyn analyzers. Accessibility: 16+ modifiers
-with WCAG-mapped E2E tests, full RTL/BiDi support, SemanticPanel for custom
-UIA roles/values on composite components, UseAnnounce hook for screen reader
-announcements, UseFocusTrap for modal focus management, AccessibilityScanner
-with 8 WCAG-mapped runtime diagnostics, and 3 compile-time Roslyn analyzers.
-Enter/exit transitions, keyframe animations, and scroll-linked animations.
-But: pre-release, animation limited to 5 compositor properties, `LabeledBy()`
-is a no-op, SemanticPanel is a workaround not true per-component
-AutomationPeer, `.Set()` escape hatch is still load-bearing for many
-scenarios, no DevTools or component inspector.
+commanding. 94% of WinUI controls wrapped. Solid component foundation
+(context system, default-on memoization via record prop equality, generic
+hook state without boxing, persisted state, post-render effect cleanup).
+Navigation is architecturally competitive with comprehensive deep linking
+(typed params, wildcards, query strings) and runtime diagnostics.
+Commanding is a genuine industry-first (define-once commands bundling
+execute + canExecute + label + icon + accelerator + description, 16 standard
+commands, async lifecycle, focus-scoped accelerators). ErrorBoundary exists
+(rare). Interop with existing WinUI/MVVM code is excellent (`ReactorHostControl`,
+`UseObservable`, `XamlHostElement`) and extends to WinForms via
+`XamlIslandControl`. ICU localization closes WinUI 3's plural/gender gap.
+Form validation (FormField + 10+ validators + ValidationVisualizer).
+`DataGrid` with paged LRU caching, server-side sort/filter, inline editing,
+async commit with optimistic updates. ~40 theme tokens with `ResourceBuilder`
+lightweight styling (a genuinely unique feature — no other C# declarative
+framework wraps WinUI's per-control resource key overrides), style caching
+that eliminates the XamlReader.Load-per-element perf concern, and Roslyn
+analyzers. Accessibility has crossed a threshold: `SemanticPanel` solves the
+hardest architectural problem (custom automation peers for composites),
+`AccessibilityScanner` runtime WCAG diagnostics + 3 Roslyn analyzers
+(`REACTOR_A11Y_001–003`) = a three-layer diagnostic system (compile-time +
+runtime + E2E) no other C# UI framework has. **Async data is now a full
+framework subsystem** — `UseResource`, `UseInfiniteResource`, `UseMutation`,
+`Pending`/`PendingScope`, `AsyncValue<T>` ADT, `QueryCache` with per-key
+locks, ref-counted subscriptions, TTL + pattern invalidation, focus
+revalidation; `DataGrid` migrated to `UseMutation` as a real integration
+test. Four `REACTOR_HOOKS_*` analyzers cover the most common hook mistakes.
+**Spec 027 made input declarative**: pointer/tap/keyboard/focus modifiers,
+typed pan/pinch/rotate gestures with phase+delta+velocity+inertia metadata,
+drag-and-drop with eager/sync/async provider overloads; stable trampoline
+dispatch replaces per-render COM detach/attach. **Charting + chart a11y**
+is an 8-layer sub-framework (43 samples, 12 scanner rules, WCAG-hardening
+palette, forced-colors remap, keyboard navigation, debounced live
+announcements) — arguably the most comprehensive chart accessibility on
+any platform except Apple Charts' sonification. **Animation** is now
+operational (all 4 previously-identified integration bugs fixed), though
+compositor-property-bound (Opacity, Scale, Rotation, Translation, CenterPoint
++ 3 brush swaps). **MCP devtools** is unique industry-wide (`reactor.tree`,
+`reactor.click`, `reactor.state`, etc. over HTTP + stdio). **ETW tracing**
+closes part of the profiling gap. ~5,600 lines of new coverage tests pushed
+selftest past 85%. **WinForms interop** via `XamlIslandControl` opens
+brownfield adoption.
 
-**Competitive position:** Reactor is the most interesting Microsoft option from
-a declarative-framework perspective. It's the only one that competes on
-the same playing field as SwiftUI, Compose, and React. Its component model,
-navigation, commanding, and interop are competitive. Accessibility now
-includes both compile-time and runtime scanning — developer tooling that no
-competitor provides built-in. The DataGrid with paged caching and inline
-editing is a genuine LOB capability. Theming and forms have improved
-substantially but remain behind the platform (WinUI 3/WPF) in depth.
-Animation and developer tooling are the largest remaining gaps. The
-trajectory is right — six categories improved in the latest development
-cycle (accessibility, lists/virtualization, navigation deep linking,
-interop/WinForms, developer diagnostics, DataGrid) — but significant work
-remains before production-readiness.
+**But — and it's a growing list:** `UseColorScheme` reads app-level theme,
+not element effective theme, so the headline RequestedTheme + UseColorScheme
+scenario doesn't compose. Custom branded theme resources still don't exist
+(multiple review cycles). Only 3 properties support ThemeRef bindings.
+`SemanticPanel` covers 2 of ~20 UIA patterns. `UseFocusTrap` doesn't cycle —
+the WAI-ARIA Dialog Pattern expectation isn't met. `UseAnnounce`,
+`UseReducedMotion`, and `UseScreenReaderActive` are still unbuilt. Animation
+ceiling is structural: Width, CornerRadius, Margin, FontSize, arbitrary
+colors can't animate. `StandardCommand` labels are English-only (ironic —
+Reactor has a full ICU localization system the commands don't use). No
+command routing to the focused view. Accelerators rebuild on every render.
+Delegate equality on `Command` records defeats the memoization system.
+The reconciler is a giant type-based switch — no open/closed extensibility
+for built-in types. Tag-based event dispatch is a fragile workaround.
+Every component adds an invisible `Border` wrapper; NavigationHost adds
+a `Grid`; CommandHost adds a `Grid`; SemanticPanel is a fourth wrapper —
+a well-structured Reactor component can accumulate 4+ framework wrappers
+between a component and its content. `ConnectedTransition` is a shipped
+API that silently falls back to a slide animation. Async `QueryCache` has
+no persistence, no automatic retry, no devtools surface, no stress tests,
+zero field evidence. Drag-and-drop has 370 lines of new code with zero
+showcase consumer. Typed drag format ids are unversioned — rename a model,
+round-trip breaks. Trampoline dispatch is unvalidated at the thing it
+promises (no before/after render benchmark; 6,390 unit tests that don't
+exercise COM interop don't measure COM interop). The `REACTOR_*` analyzer
+rename is partial (`DUCT001-003` still carry the old product name).
+E2E tests were just discovered to be 95% invisible behind a broken filter
+(now fixed, but the blind spot for the entire dev period is telling).
+Three to four invisible wrapper element types, and a running theme of
+string-typed APIs at boundaries (deep link patterns, semantic roles,
+lightweight styling keys, connected-animation keys, drag-format ids).
+`.Set()` surface is materially thinner than a quarter ago but still carries
+composition-layer effects, materials, windowing, pointer-capture, custom
+geometry, and ink. And the single most damning critique that's been
+constant for three review cycles: **the showcase apps don't use the
+framework's own features.** Outlook clone still uses `UseState<string>`
+for navigation. File manager still needs `SynchronizationContext` capture
+for off-thread state updates. None of the four flagship apps use context,
+memoization, persisted state, commanding, navigation, SemanticPanel,
+async resources, UseFocusTrap, or any of the spec 027 input modifiers.
+The charting gallery is the one bright exception — all 43 samples were
+retrofitted in one pass, which proves the work is possible; it just isn't
+being prioritized for the general-purpose flagship apps.
+
+**Competitive position:** Reactor now has *five* features where it's ahead
+of the entire industry: commanding (no competitor has define-once commands
+with metadata bundling), lightweight styling (no competitor wraps WinUI's
+per-control resource overrides), the AccessibilityScanner + chart a11y
+system (no C# UI framework ships framework-integrated runtime WCAG
+diagnostics, and no declarative framework ships an 8-layer chart
+accessibility system), MCP devtools (no framework ships an MCP server —
+whether this bet pays off depends on adoption patterns that don't exist
+yet), and ErrorBoundary (shared with React). These are real differentiators,
+not catch-up. But "features exist in isolated demos" and "features compose
+correctly in real apps under production load" are different claims.
+Reactor's velocity is impressive; the integration debt is accumulating
+at a rate that's also impressive in a less comforting way. Each review
+cycle, new capability arrives faster than the previous cycle's features
+get integrated into the flagship apps. Navigation and commanding moved
+Reactor from "component library with hooks" to "framework with application
+architecture." Accessibility moved it from "annotations on primitives" to
+"a layered system." Async resources closed the largest remaining capability
+gap. Spec 027 closed the largest remaining "this is just a wrapper" gap.
+But the Outlook clone still uses `UseState<string>` for navigation.
+Production-readiness is where that gap closes or the framework stalls.
 
 ---
 
@@ -1192,22 +1590,37 @@ Reactor already does better. **Reactor's native-rendering, native-UIA,
 native-look positioning is its structural advantage over Blazor Hybrid on
 Windows desktop** — positioning that's worth stating explicitly in marketing.
 
-### 4. Reactor addresses the right gaps
+### 4. Reactor addresses the right gaps — but feature velocity is outpacing integration
 
 Reactor's declarative model, navigation, and commanding are not random feature
 additions — they directly address the areas where WPF/WinUI 3 are weakest
 relative to competitors (declarative syntax, component model, navigation
 type safety). The commanding system is genuinely novel. Recent work has
-deepened coverage in theming (37 tokens, ResourceBuilder, analyzers),
-forms (automatic validation pipeline, FormField, ValidationVisualizer),
-accessibility (SemanticPanel for custom UIA semantics, UseAnnounce/
-UseFocusTrap hooks, 8-rule WCAG scanner, 3 compile-time analyzers),
-animation (exit transitions, keyframes, scroll-linked), data grids (paged
-caching, inline editing, server-side sort/filter), navigation (typed deep
-linking with wildcards and query strings, diagnostics), and interop
-(WinForms adoption via XamlIslandControl with designer support). The key
-remaining gaps are animation depth (5 compositor properties), developer
-tooling (no inspector or profiler), and `LabeledBy()` no-op.
+deepened coverage across the board: theming (style caching + lightweight
+styling + analyzers), forms (automatic validation + FormField), accessibility
+(SemanticPanel + AccessibilityScanner + 3 analyzers + UseFocusTrap), animation
+(all 4 integration bugs fixed, API now faithful), DataGrid (paged caching +
+inline editing + server-side sort/filter), navigation (destination guards,
+wildcards, diagnostics), interop (WinForms via XamlIslandControl), **async
+data (full subsystem — UseResource/UseInfiniteResource/UseMutation with
+AsyncValue ADT and QueryCache)**, **charting + chart a11y (8-layer system
+with WCAG-hardening palette + scanner rules)**, **MCP devtools (unique
+industry-wide)**, **ETW tracing**, and **spec 027 declarative input
+(pointer/gesture/focus/drag-drop modifiers + trampoline dispatch)**. The key
+remaining gaps are structural (animation compositor-property ceiling, no
+custom theme resources, SemanticPanel covering 2 of ~20 UIA patterns),
+compositional (UseColorScheme/RequestedTheme don't compose correctly,
+StandardCommand labels aren't localized despite Reactor having a full ICU
+system, no command routing to focused view), and — most uncomfortably —
+integrative. The showcase apps (Outlook clone, file manager, registry
+editor, word puzzle game) don't use navigation, commanding, context,
+memoization, persisted state, SemanticPanel, UseFocusTrap, async resources,
+or any of the spec 027 input modifiers. Every new feature ships with an
+isolated demo; the flagship apps freeze in time. The charting gallery is
+the one bright exception (43 samples retrofitted in one pass, proving the
+team *can* do integration work). Production-readiness doesn't live in
+"features exist" — it lives in "features compose in real apps under real
+load." That gap is widening, not closing.
 
 ### 5. Error handling is an industry-wide gap — but Microsoft has two answers
 
@@ -1299,10 +1712,32 @@ Every framework has embarrassing gaps:
   DevTools, hefty WebAssembly payload, Server-mode latency sensitivity,
   CSS isolation doesn't cover third-party components, no type-safe routing,
   Hybrid renders in a WebView (not native), no built-in animation system
-- **Reactor:** Animation limited to 5 compositor properties, no DevTools or
-  component inspector, `LabeledBy()` no-op, SemanticPanel is a workaround
-  not true per-component AutomationPeer, `.Set()` escape hatch still
-  load-bearing for many scenarios, DataGrid has no grouping
+- **Reactor:** Animation capped at 5 compositor properties + 3 brush swaps
+  (Width/CornerRadius/Margin/FontSize/colors can't animate).
+  `UseColorScheme` reads app theme, not element effective theme — so
+  RequestedTheme + UseColorScheme don't compose in the exact "dark sidebar
+  in light app" scenario they were built for. Custom branded theme
+  resources still don't exist. SemanticPanel covers 2 of ~20 UIA patterns.
+  `UseFocusTrap` doesn't cycle (WAI-ARIA Dialog Pattern expects wrapping).
+  `UseAnnounce`/`UseReducedMotion`/`UseScreenReaderActive` are still
+  unbuilt. `StandardCommand` labels are hard-coded English. No command
+  routing to focused view. Accelerators rebuild on every render. Delegate
+  equality on Command records defeats memoization. 4+ invisible wrapper
+  element types accumulate in the visual tree. `.Set()` still needed for
+  composition layer, materials, windowing, pointer capture, custom
+  geometry, ink. `ConnectedTransition` is shipped but silently falls back
+  to slide. Trampoline dispatch has no render-cycle benchmark proving the
+  perf claim it makes. Async `QueryCache` has no persistence, no auto-retry,
+  no devtools surface, no stress tests. Drag-and-drop has zero consumer
+  apps and unversioned typed format ids that break on model renames.
+  Stringly-typed APIs at every platform boundary (deep link patterns,
+  semantic roles, resource keys, connected-animation keys, drag formats).
+  Analyzer IDs half-renamed (DUCT001-003 still carry the old product name).
+  And the constant-across-three-review-cycles critique: **showcase apps
+  don't use the framework's own features** — Outlook clone still uses
+  `UseState<string>` for navigation; nothing uses SemanticPanel, commanding,
+  context, UseFocusTrap, async resources, or spec 027 input modifiers
+  except isolated demos
 
 The "perfect framework" doesn't exist. The question is which gaps matter
 most for your specific application.

--- a/docs/research/critical-review.md
+++ b/docs/research/critical-review.md
@@ -12,13 +12,17 @@ rather than a principled declarative UI framework.
 Reactor is an ambitious attempt to bring React-style declarative UI to WinUI 3.
 It has impressive breadth of control coverage (94% of WinUI controls wrapped),
 a now-solid component model foundation, and a faithful hooks system. The last
-72 hours alone landed four substantial systems: async resources (a React
+four days alone landed five substantial systems: async resources (a React
 Query-equivalent), a full charting accessibility layer (8 layers across 18
-commits), an MCP devtools surface for AI-agent-driven automation, and ETW
-tracing. The framework is no longer short on features — it is now short on
-the integration and polish to make those features compose reliably in real
-apps. Significant problems remain, and several of the new shipments have
-implementation concerns that temper the enthusiasm:
+commits), an MCP devtools surface for AI-agent-driven automation, ETW
+tracing, and — shipped in the last 24 hours — spec 027's declarative input
+system (73 files, +7.2k LoC) that closes the long-standing pointer /
+gesture / drag-drop / focus gaps and replaces per-render COM event churn
+with a trampoline-dispatch model. The framework is no longer short on
+features — it is now short on the integration and polish to make those
+features compose reliably in real apps. Significant problems remain, and
+several of the new shipments have implementation concerns that temper the
+enthusiasm:
 
 1. **The component model is now a real framework foundation** — context system,
    memoization, generic hook state, persisted state, and post-render effect
@@ -70,9 +74,11 @@ implementation concerns that temper the enthusiasm:
    (Reactor hosts WinForms), with E2E tests for Tab navigation, rendering, and
    accessibility across boundaries. One direction is blocked (Reactor-primary
    hosting WinForms) due to WinUI's compositor-only rendering
-9. **The `.Set()` escape hatch is still load-bearing** — navigation and commanding
-   reduce its surface area, but the majority of input handling, gestures, advanced
-   styling, and composition-layer access still require it
+9. **The `.Set()` escape hatch is load-bearing, but meaningfully narrower** — spec 027
+   pulled pointer / tap / keyboard / focus events, pan/pinch/rotate gestures, and
+   drag-and-drop out of `.Set()` and into first-class modifiers. What remains:
+   composition-layer effects, materials, windowing, ink input, shape geometry,
+   and pointer-capture ergonomics
 10. **Async data is now a framework feature, not a developer chore** — `UseResource`,
     `UseInfiniteResource`, `UseMutation`, and a shared `QueryCache` cover the
     React Query / SWR territory in-framework, with a `Pending` element for
@@ -103,6 +109,26 @@ implementation concerns that temper the enthusiasm:
     from Section 13, but it's coarse-grained (no per-component render
     timing) and requires external tooling (PerfView, dotnet-trace) to
     consume
+14. **Declarative input shipped (spec 027)** — pointer enter/exit/wheel/
+    capture-lost, tap / double-tap / right-tap / holding, key-up /
+    preview-key / character-received, focus modifiers + `UseElementFocus`
+    hook, typed pan/pinch/rotate gestures, and drag-and-drop with
+    eager + sync-provider + async-provider format overloads wired to
+    `DataPackage.SetDataProvider`. Event dispatch now uses a stable
+    trampoline per event per element lifetime, eliminating the previous
+    per-render COM detach/attach cost on hot input paths. But gesture
+    composition (`.simultaneously`/`.sequenced`) is absent, long-press is
+    an event rather than a typed gesture, the trampoline refactor has
+    zero benchmark evidence (just "all 6,390 unit tests pass"), and
+    drag-drop's 370-line `DragData` has no showcase consumer
+15. **Selftest coverage crossed 85%** — commits `e85f4d8` (1,264 new
+    unit tests, 4,222 LoC) and `1870868` (30 new selftest fixtures,
+    1,426 LoC) bring coverage materially higher. Real reliability
+    investment, but whether the new tests catch actual regressions or
+    just inflate the percentage is a later question
+16. **Two XAML-based samples were removed** (`FlexPanelGallery`,
+    `regedit-winui`) to stop teaching anti-patterns, trimming confusion
+    for newcomers without adding new proof points
 
 **Verdict:** Reactor has crossed a third important threshold. The first was the
 component model foundation (context, memoization, hooks). The second was the
@@ -126,16 +152,21 @@ and whether it pays off depends on adoption patterns nobody can predict
 yet. The critical path now runs through: (1) stress-testing async resources
 and QueryCache under realistic load — this is a brand-new subsystem with
 no production miles; (2) the showcase apps still not using the framework's
-own features (Outlook clone still uses `UseState<string>` for navigation);
-(3) fixing the UseColorScheme/RequestedTheme composition bug; (4) custom
-branded theme resources (still missing after multiple iterations); (5)
-remaining imperative accessibility hooks (UseAnnounce, UseReducedMotion);
-(6) chart sonification and hit-target-always-on; (7) devtools state
-mutation and source mapping; (8) reducing the `.Set()` surface area. The
-framework is no longer blocked on any single P0 gap, but the sum of its
-P1/P2 gaps has grown slightly larger as new features arrive faster than
-integration testing. "Features exist" now outpaces "features compose
-correctly in real apps" by a wider margin than a quarter ago.
+own features (Outlook clone still uses `UseState<string>` for navigation,
+and now also doesn't use `.OnPan`, `.OnDrop`, or `UseElementFocus`); (3)
+benchmarking the spec 027 trampoline claim — ETW events prove the
+"one-time attach" invariant held after the refactor, but no one has
+measured a render-cycle before/after delta on a real app; (4) fixing the
+UseColorScheme/RequestedTheme composition bug; (5) custom branded theme
+resources (still missing after multiple iterations); (6) remaining
+imperative accessibility hooks (UseAnnounce, UseReducedMotion); (7) chart
+sonification and hit-target-always-on; (8) devtools state mutation and
+source mapping; (9) gesture composition and a typed long-press primitive;
+(10) composition-layer / materials / windowing — the remaining fat `.Set()`
+surface. The framework is no longer blocked on any single P0 gap, but the
+sum of its P1/P2 gaps has grown slightly larger as new features arrive
+faster than integration testing. "Features exist" now outpaces "features
+compose correctly in real apps" by a wider margin than a quarter ago.
 
 ---
 
@@ -3156,49 +3187,178 @@ summarizer output. The foundation is strong; the field evidence is zero.
 
 ## 12. Input Handling and Events
 
-### What Reactor has
+### What Reactor has — after spec 027
+
+This section was largely rewritten by commit `76d0f51` (spec 027 —
+"declarative pointer, gesture, focus, and drag-drop modifiers," 73 files,
++7,249 / −2,137). Four previous critiques are closed, and a fifth (event
+handler re-attachment churn) is addressed by a new trampoline dispatch
+model. What now exists:
 
 - **Semantic events on controls:** `OnClick`, `OnChanged`, `OnSelectionChanged`
-  — well-covered for all wrapped controls
-- **Declarative event modifiers:** `.OnPointerPressed()`, `.OnPointerMoved()`,
-  `.OnPointerReleased()`, `.OnTapped()`, `.OnKeyDown()`, `.OnSizeChanged()`
-- **Keyboard accelerators:** `Accelerator(key, modifiers)` data records
-- **Everything else:** `.Set()` passthrough
+  — unchanged, well-covered for all wrapped controls.
+- **Pointer modifiers (full surface):** `.OnPointerPressed`, `.OnPointerMoved`,
+  `.OnPointerReleased`, `.OnPointerEntered`, `.OnPointerExited`,
+  `.OnPointerCanceled`, `.OnPointerCaptureLost`, `.OnPointerWheelChanged`.
+  Eleven previously-absent handlers shipped as first-class modifiers.
+- **Tap-family modifiers:** `.OnTapped`, `.OnDoubleTapped`, `.OnRightTapped`,
+  `.OnHolding` — with the corresponding `Is{Tap,DoubleTap,RightTap,Holding}Enabled`
+  flags auto-toggled by the reconciler when a handler is attached/detached.
+- **Keyboard modifiers:** `.OnKeyDown`, `.OnKeyUp`, `.OnPreviewKeyDown`,
+  `.OnPreviewKeyUp`, `.OnCharacterReceived`.
+- **Focus modifiers + hook:** `.OnGotFocus`, `.OnLostFocus`, plus a
+  `UseElementFocus()` hook and a `FocusManager` helper for programmatic
+  focus — the first imperative focus primitive the framework has had.
+- **Gesture recognizers (Tier 3):** `.OnPan(minimumDistance, axis, withInertia)`,
+  `.OnPinch(withInertia)`, `.OnRotate(withInertia)` with typed
+  `PanGesture`/`PinchGesture`/`RotateGesture` records carrying phase,
+  translation/delta/velocity (pan), scale/anchor (pinch), angle (rotate),
+  and an `IsInertial` flag. Backed by a single
+  `ManipulationStarted/Delta/Completed` subscription per element,
+  `ManipulationMode` auto-computed from attached configs.
+- **Drag-and-drop:** `.OnDragStart<TPayload>` + `.OnDrop<TPayload>` for typed
+  round-trip (same-process), plus untyped overloads for cross-process, plus
+  `.OnDragEnter` / `.OnDragOver` / `.OnDragLeave`. `DragData` supports typed
+  payloads, standard formats (text / URI / HTML / RTF / files / bitmap), and
+  custom format ids; each format has eager / sync-provider / async-provider
+  overloads wired to `DataPackage.SetDataProvider` so rendering HTML or
+  rasterizing a bitmap only happens if a drop target actually asks for it.
+  `CanDrag` / `AllowDrop` auto-set. `DragOperationNegotiation` picks an
+  operation when source and target disagree.
+- **Event dispatch model (Tier 2 trampolines):** `EventHandlerState` now
+  attaches a stable trampoline delegate to each WinUI event once per
+  element lifetime; updating the user handler is a single field write, not
+  a detach/attach round-trip. ETW (keyword `EventDispatch`, 0x40) emits
+  `EventTrampolineAttached` (first attach) and `EventTrampolineDispatch`
+  (per fire) so the one-time-attach invariant is observable.
+- **Keyboard accelerators:** unchanged — `Accelerator(key, modifiers)` data
+  records (Section 8).
+- **Escape hatch:** `.Set()` is still available for truly exotic events
+  (`UIElement.ProcessKeyboardAccelerators`, `CharacterReceived` on
+  non-FrameworkElements, ink input, etc.).
 
 ### Critiques
 
-**1. No gesture system.** SwiftUI has `.gesture()` with `DragGesture`,
-`TapGesture`, `LongPressGesture`, and gesture composition (`.simultaneously`,
-`.sequenced`). Compose has `Modifier.pointerInput { detectDragGestures {} }`.
-Reactor has individual pointer events with no abstraction — you're back to manual
-hit testing and state tracking for any gesture more complex than a tap.
+**1. Gesture composition is missing.** SwiftUI's gesture API provides
+`.simultaneously(with:)`, `.sequenced(before:)`, and `.exclusively(before:)`
+so you can declare "pinch and pan at the same time" or "long-press then
+drag." Reactor has three discrete gesture primitives, but they don't
+compose declaratively — if you want simultaneous pan+pinch on the same
+element you can just attach both (the single ManipulationStarted/Delta/
+Completed subscription handles it), but conditional sequencing or priority
+ordering has no API. Compose's `pointerInput { detectTransformGestures { }
+}` handles pan+pinch+rotate in one callback with a shared event loop;
+Reactor's three separate callbacks get separate delta events and have to
+reconcile across them if a component wants unified transform state.
 
-**2. Event handler re-attachment is wasteful.** Declarative event handlers
-(`.OnPointerPressed()` etc.) "re-attach on every update" per the documentation.
-The reconciler detaches the previous handler and attaches the new one on every
-render cycle. This is O(n) COM interop calls per render per element with event
-handlers. React avoids this with event delegation (one handler on the document).
-SwiftUI and Compose handle it at the framework level.
+**2. LongPressGesture is an event, not a typed gesture.** SwiftUI has
+`LongPressGesture(minimumDuration:)` that fires with phase and passes the
+recognized duration. Reactor has `.OnHolding` which surfaces the raw
+`HoldingRoutedEventArgs` — no phase-typed record, no min-duration
+configuration on the modifier (the caller filters inside the handler by
+reading `HoldingState`), and no unification with `.OnPan` for the common
+"long-press to begin drag" interaction. Android and iOS both treat this as
+a single composable gesture.
 
-**3. Commanding exists but doesn't cover all input surfaces.** The new
-commanding system (Section 8) closes the P0 gap — `Command` bundles
-execute + canExecute + metadata, and `UseCommand` handles async lifecycle. But
-the commanding system only integrates with `Button`, `AppBarButton`, and
-`MenuItem`. Other command-capable controls (`SplitButton`, `SwipeItem`,
-`ContentDialog` actions) still use bare `Action` callbacks. And the absence of
-command routing to the focused view (Section 8, critique #3) means Cut/Copy/
-Paste in multi-panel apps still requires manual wiring.
+**3. Gesture recognizers rely on WinUI manipulations and inherit its
+constraints.** `.OnPan/.OnPinch/.OnRotate` wrap
+`UIElement.ManipulationStarted/Delta/Completed`. This means: pan only
+reports translation in screen-axis-aligned space (no rotated-container
+coordinate math), rail behavior is WinUI-native (can't be disabled on
+inertia), `ManipulationCompleted` fires once for all gestures that
+completed together, and inertia deceleration rate isn't exposed — the
+`withInertia` bool toggles inertia on/off but you can't tune the decay.
+Compose and SwiftUI both expose per-axis deceleration parameters.
 
-**4. Six pointer events but no PointerEntered/Exited modifiers.** The
-declarative event handlers include pressed/moved/released but not entered/exited.
-Hover effects — one of the most common interaction patterns — require `.Set()`
-to wire `PointerEntered`/`PointerExited`. This is an odd omission given that
-hover is more common than pointer-move tracking.
+**4. Drag-and-drop has 370 lines of new `DragData` with no field
+evidence.** The API is thoughtfully designed (eager + sync-provider +
+async-provider per format, typed round-trip via
+`reactor/typed/<typeof(T).FullName>` format ids, per-drag GUID in
+`DataPackage.Properties` for same-process transfer). But:
 
-**5. No RightTapped, DoubleTapped, or Holding modifiers.** These common
-interactions are passthrough only, requiring `.Set()`. Context menus need
-right-tap. Double-click is common in desktop apps. Long-press is common in
-touch apps.
+- The typed-format-id is `typeof(T).FullName` — if a class is renamed or
+  moved to a different namespace between the drag source and drop target
+  (during a hot-reload session, or across two differently-versioned
+  assemblies in a multi-process app), the payload won't round-trip. There's
+  no typed-format-id versioning story.
+- The format dictionary uses `StringComparer.Ordinal` over string keys.
+  Reactor's theme throughout this review — "stringly-typed APIs at
+  boundaries" — applies here too.
+- No DnD-specific devtools: you can't inspect what formats a drag is
+  advertising, trace which provider was invoked, or see negotiation
+  outcomes. For a subsystem this large, the observability gap is
+  conspicuous.
+- Zero field evidence. The feature is in spec 027 phase 6-8 plus the E2E
+  fixtures landed the same day; no showcase app consumes it. This is the
+  "feature velocity outpaces integration velocity" pattern from the
+  conclusion, landing again.
+
+**5. Trampoline dispatch is unverified at scale.** Phase 2's claim is
+that attaching a stable trampoline once per event per element lifetime
+eliminates per-render COM churn on the hot `.OnPointer*`/`.OnKey*`
+path. This is architecturally correct and the ETW instrumentation lets
+you confirm the invariant after the fact. But:
+
+- It introduces a new category of bugs: the trampoline is attached
+  permanently, so if the `EventHandlerState` isn't cleaned up on unmount
+  or element-pool return, handlers leak. The PR adds
+  `TrampolineFixtures` covering "latest-handler-wins across 100
+  re-renders" but not "trampoline detached on unmount" explicitly.
+- There's no benchmark yet showing the hot-path delta. "N × events ×
+  subscribe/unsubscribe COM calls per update" was the previous
+  observed cost; the new model claims a single field write, but
+  nobody has measured a real app render cycle before/after. The
+  ETW events exist; running a trace isn't the same as running a
+  benchmark.
+- All 6,390 unit tests still pass, and the Phase 2 commit message
+  calls that out, but the unit suite is largely WinUI-free and
+  doesn't exercise the COM interop path the claim depends on.
+
+**6. Auto-enable / auto-fill is convenient but silently mutates control
+state.** When you attach `.OnTapped`, the reconciler sets
+`IsTapEnabled = true`; when you attach any pointer-family handler on a
+`Shape`, it auto-fills a null `Shape.Fill` with a transparent brush so
+hit-testing works. Both are right defaults — but they mean a developer
+inspecting the live visual tree will see properties they didn't set,
+without any breadcrumb pointing at the modifier that set them. The
+reverse path (detach the last handler → clear the auto-flag) is
+implemented, but conflicts with user-set values (what if the user set
+`IsTapEnabled = true` via `.Set()`?) aren't handled explicitly.
+
+**7. Commanding still doesn't cover all input surfaces.** Unchanged from
+the previous review. `Command` bundles execute + canExecute + metadata,
+but only `Button`, `AppBarButton`, and `MenuItem` integrate. `SplitButton`,
+`SwipeItem`, `ContentDialog` actions still take bare `Action` callbacks.
+And command routing to the focused view is still missing, so Cut/Copy/
+Paste in multi-panel apps continues to require manual wiring.
+
+**8. Focus hook ships but stops short of `@FocusState`.** `UseElementFocus`
+returns `(ElementRef, Action RequestFocus)`, and the new `.Ref(target)`
+modifier binds the ref fluently — that's the right ergonomic shape and
+closes the "wire it via `.Set()`" concern cleanly. What it doesn't give
+you is a *scoped* focus state: SwiftUI's `@FocusState var field: Field?`
+models "which of these N fields is focused" as a single binding;
+Compose's `FocusRequester` composes into `Modifier.focusRequester()`.
+Reactor's pattern is one `ElementRef` per element you might want to
+focus, each with its own `RequestFocus` closure — fine for "focus the
+first input on mount," awkward for "the last-edited row of a datagrid."
+Focus restoration after navigation or dialog dismissal (Section 11
+critique #8) is still unaddressed.
+
+**9. No pointer-capture ergonomics.** `.OnPointerCaptureLost` fires on
+loss, but there's no declarative `.CapturePointer(when:)` modifier.
+Implementing a drag-to-draw surface still requires calling
+`CapturePointer` / `ReleasePointerCapture` manually inside the handler —
+a `.Set()` pattern. Compose's `awaitPointerEventScope` and SwiftUI's
+`DragGesture` hide capture semantics entirely.
+
+**10. Wheel and touchpad gestures are still second-class.**
+`.OnPointerWheelChanged` exists, but there's no typed wheel delta
+record, no momentum-vs-discrete classification (trackpad glide vs. mouse
+scroll), and no horizontal-wheel shortcut. Scroll is handled by
+`ScrollView` via virtualization; anything custom (zoomable canvases,
+custom scrollable surfaces) has to parse `PointerPointProperties` by
+hand.
 
 ---
 
@@ -3565,19 +3725,25 @@ about).
 unless you manually track and remove them. The framework provides no lifecycle
 hook for this — no "cleanup on unmount" for Set-based side effects.
 
-**3. A huge fraction of WinUI is .Set()-only.** From the gap analysis:
-- All pointer events (entered, exited, pressed, released, moved)
-- All gesture events (tapped, double-tapped, right-tapped, holding)
-- All manipulation events
-- All keyboard events (except OnKeyDown modifier)
-- Drag and drop
-- Custom storyboard animations
-- Composition layer access
-- Materials and effects
-- Most windowing APIs
+**3. A meaningful fraction of WinUI is still .Set()-only.** Spec 027 pulled a
+significant chunk out of the escape-hatch list — pointer/tap/keyboard/focus
+events, manipulation gestures, and drag-and-drop all shipped as first-class
+modifiers in commit `76d0f51`. What's left:
+- `ProcessKeyboardAccelerators`, ink input, and a few other specialty event
+  surfaces
+- Custom storyboard animations (outside the compositor-property set
+  covered by `.Animate()` / interaction states)
+- Composition layer access beyond `.Shadow()` / `.Animate()`
+- Materials and effects (`AcrylicBrush` customization, `Compositor.CreateSpriteVisual`)
+- Pointer capture (`CapturePointer` / `ReleasePointerCapture`)
+- Most windowing APIs (`AppWindow`, `OverlappedPresenter`, backdrop configuration)
+- Shape-specific drawing APIs (`Path` data, `Geometry`, stroke dash arrays)
 
-When this much of the platform requires the escape hatch, the abstraction is
-too thin.
+The abstraction is meaningfully thicker than a quarter ago — the input
+critique that dominated this section for three review cycles is mostly
+resolved. But composition, materials, and windowing remain flat-out
+absent, and those are the surfaces customers notice in "polished desktop
+app" territory.
 
 **4. .Set() runs on every render.** The documentation for `OnMount` says it runs
 once at mount time, but `.Set()` Setters are `Action<TControl>[]` arrays stored
@@ -3604,7 +3770,7 @@ SwiftUI, Compose).
 | **Local State** | A- | A | A | A | Generic hooks, post-render cleanup, persisted state; dep arrays still box |
 | **Global State** | B+ | A | A | A | Context + UseContext + .Provide(); boxing in scope stack, no selector |
 | **Async Data** | B+ | A (TanStack) | B+ | C | **NEW section 3a.** UseResource/UseInfiniteResource/UseMutation/Pending, AsyncValue ADT, QueryCache with TTL+pattern invalidation, focus revalidation, DataGrid hook-paging. In-process cache only, no retry default, zero field evidence |
-| **Reconciler** | B- | A | A- | A | Works but monolithic, no concurrent mode; Grid-children-on-type-flip fix (e86ff69) closes a real bug |
+| **Reconciler** | B- | A | A- | A | Works but monolithic, no concurrent mode; Grid-children-on-type-flip fix (e86ff69) closes a real bug; spec 027 Phase 2 trampoline dispatch removes per-render COM detach/attach on pointer/key/focus events — architecturally right, unmeasured in the field |
 | **Layout** | B+ | B+ | A | A | Flex is good; Grid is stringly-typed; FlexPanel CSS semantics just got corrected (commit 397f274) — previous behavior was drift-prone |
 | **Theming** | B- | B+ | A | A | Style caching fixes XamlReader.Load perf; RequestedTheme modifier; UseColorScheme hook (reads app theme, not element effective); 3 ThemeRef props; no custom resources |
 | **Navigation** | B+ | A | A | A | Type-safe routes, dev-owned stack, GPU transitions, source+destination guards, caching, serialization, enhanced deep linking, diagnostics; ConnectedTransition still a stub, no adaptive multi-pane |
@@ -3613,9 +3779,9 @@ SwiftUI, Compose).
 | **Animation** | B- | B | A | A | Curve DSL, enter+exit, interaction states, keyframes, stagger, WithAnimation; compositor-property-bound ceiling; no per-frame hooks |
 | **Accessibility** | B | B | A | A | 16 modifiers + SemanticPanel, UseFocusTrap, 3 Roslyn a11y analyzers, runtime WCAG scanner; SemanticPanel limited to 2 patterns, focus trap doesn't cycle, remaining hooks unbuilt. **Grade rose from B- to B** mostly because of charting a11y (below) — the general surface is unchanged |
 | **Charting + Chart A11y** | B+ | N/A | A (Apple Charts) | C (Vico/ad-hoc) | **NEW section 11a.** 43 samples + 8-layer a11y (ChartAutomationPeer, ChartPalette.Harden/ColorblindSimulate, keyboard nav, live announcer, alternate view, forced-colors, 12 scanner rules). No sonification, ForceGraph a11y decorative-only, hit-target expansion opt-in |
-| **Input/Events** | C | B | A | A | Semantic events good; no gesture system, no pointer enter/exit, rest is .Set() |
+| **Input/Events** | B | B | A | A | **Rose from C to B.** Spec 027 shipped: full pointer modifier surface (entered/exited/canceled/wheel), tap/double/right/holding, key-up/preview/character, focus modifiers + `UseElementFocus`, typed `.OnPan`/`.OnPinch`/`.OnRotate` gestures, drag-and-drop with eager+lazy format providers. Trampoline dispatch eliminates per-render COM churn. Still missing: gesture composition (.simultaneously/.sequenced), typed long-press, pointer capture ergonomics, tuned inertia, wheel momentum classification |
 | **Styling** | B- | B+ | A | A | Lightweight styling is a genuine differentiator; ResourceBuilder fluent API; 3 Roslyn analyzers; stringly-typed resource keys; analyzer coverage shallow; DUCT_/REACTOR_ ID inconsistency |
-| **Developer Experience** | B | A | B+ | B+ | **Rose from C+ to B.** Hot reload works; MCP devtools + ETW + 4 hook analyzers + 4,222 lines of new coverage tests close real gaps. Still no GUI devtools, preview is screenshot-only, no per-component render timing, no cache inspector |
+| **Developer Experience** | B | A | B+ | B+ | **Rose from C+ to B.** Hot reload works; MCP devtools + ETW + 4 hook analyzers + ~5,600 lines of new coverage tests (4,222 unit + 1,426 selftest wave 1+2) pushed selftest coverage past 85%. Still no GUI devtools, preview is screenshot-only, no per-component render timing, no cache inspector |
 | **Devtools + Tracing** | B | B+ (DevTools) | A (Instruments) | B+ (LI) | **NEW section 13a.** MCP server (HTTP+stdio), 12+ MCP tools, stable node ids, supervisor, CLI parity, ETW provider with 6 keywords. State is read-only, no diff in v1, no source map in v1, no cache inspection, ETW has no per-component timing |
 | **Control Coverage** | A | N/A | A | A | 94% of WinUI wrapped |
 | **Error Handling** | B | B+ | D | D | ErrorBoundary exists (rare feature) |
@@ -3775,6 +3941,17 @@ This is a red flag for a framework that wants to be production-ready.
     the first real performance-profiling infrastructure the framework has
     had, closing part of Section 13's "no performance profiling" critique.
 
+19. **Declarative input is a real system now.** Spec 027 closed the
+    single longest-standing "Reactor is a thin WinUI wrapper" critique:
+    pointer / tap / keyboard / focus modifiers are no longer `.Set()`
+    territory, pan/pinch/rotate ship as typed gesture records with
+    phase/delta/velocity/inertia metadata, drag-and-drop supports
+    typed + standard + custom formats with eager / sync / async provider
+    overloads, and the reconciler's event-dispatch model changed from
+    "detach + attach on every render" to a stable-trampoline model that
+    only rewrites a field. No other C# declarative framework ships this
+    breadth of input on top of a Retained UI platform.
+
 ### What prevents Reactor from being production-ready
 
 1. **The showcase apps don't use the framework's own features.** This is the
@@ -3816,14 +3993,17 @@ This is a red flag for a framework that wants to be production-ready.
    means Width, CornerRadius, Margin, FontSize, and arbitrary colors can't
    animate. This is a WinUI platform constraint, not a Reactor design failure.
 
-5. **.Set() still carries too much weight.** Navigation, commanding, and styling
-   have all reclaimed meaningful surface area — `.RequestedTheme()` eliminates
-   another `.Set()` workaround, and lightweight styling eliminates `.Set()`
-   for per-control resource overrides. But gestures, pointer enter/exit,
-   right-tap, double-tap, drag-and-drop, composition-layer effects, materials,
-   and most windowing APIs still require `.Set()`. The abstraction is thicker
-   than before but still not thick enough for a "you don't need to know WinUI"
-   claim.
+5. **.Set() still carries too much weight, but less of it.** Navigation,
+   commanding, and styling reclaimed application-architecture surface; spec 027
+   just reclaimed most of the input surface (pointer enter/exit/wheel,
+   right-tap, double-tap, holding, key-up/preview/character, focus, pan/pinch/
+   rotate gestures, and drag-and-drop). What still requires `.Set()`: composition-
+   layer effects, materials (`AcrylicBrush` internals, sprite visuals), most
+   windowing APIs (`AppWindow`, presenters, backdrop config), custom
+   `Path`/`Geometry` drawing, ink input, and pointer-capture ergonomics. The
+   abstraction is materially thicker than a quarter ago, but "you don't need
+   to know WinUI" is still overclaimed for anything that touches composition
+   or the window chrome.
 
 6. **Performance concerns accumulate (but one is fixed).** Style caching
    eliminates the XamlReader.Load-per-themed-element concern. But reflection-
@@ -3861,22 +4041,52 @@ This is a red flag for a framework that wants to be production-ready.
    for the cache — TanStack Query Devtools is a major productivity feature
    that Reactor has no equivalent of.
 
-10. **The velocity is creating an integration deficit.** In three days the
+10. **The velocity is creating an integration deficit.** In four days the
     framework shipped: async resources (full subsystem, ~40 commits), charting
     accessibility (8 layers, ~18 commits, 3,000+ lines of src), devtools MCP
     (24 tools, HTTP + stdio, ~25 commits), ETW tracing, FlexPanel CSS
-    compliance fix, 4,222 lines of new coverage tests, and a partial
+    compliance fix, spec 027 declarative input (73 files, ~7,200 LoC in a
+    single PR), ~5,600 lines of new coverage tests, and a partial
     analyzer rename. Each feature is individually well-engineered. But the
     showcase apps (Outlook clone, file manager, registry editor, word
     puzzle game) — the only proof that features compose in a real UI — still
     don't use any of this. The charting gallery was retrofitted (a real
     proof point); the apps that were supposed to prove navigation,
-    commanding, context, and memoization compose together still don't use
-    any of them. The pipeline of "ship feature + isolated demo + move on to
-    next feature" accelerates each iteration while the integration debt
-    quietly compounds.
+    commanding, context, memoization, *and now input* compose together
+    still don't use any of them. The pipeline of "ship feature + isolated
+    demo + move on to next feature" accelerates each iteration while the
+    integration debt quietly compounds.
 
-11. **Naming and conceptual churn.** Spec 018 renamed Duct → Reactor;
+11. **The spec 027 trampoline refactor is unvalidated where it matters
+    most.** Phase 2 rewrote event dispatch from "detach + attach on every
+    render" to a stable-trampoline-per-event model. The architectural
+    argument is right, and the ETW telemetry lets you verify the
+    one-time-attach invariant after the fact. What's missing is a
+    render-cycle benchmark — the original critique was "O(n) COM interop
+    calls per render per element with event handlers." The fix claims to
+    eliminate those. But "all 6,390 unit tests pass" doesn't measure
+    the thing being claimed: unit tests don't exercise the COM interop
+    path, and no real app has been profiled before/after. The
+    `TrampolineFixtures` added to selftest cover "latest-handler-wins
+    across 100 re-renders" — useful for correctness, not for the
+    performance claim. Performance refactors that ship without a
+    before/after number are always a risk: they can regress in
+    unexpected dimensions (memory, first-render latency, teardown cost)
+    while nominally delivering on the headline metric.
+
+12. **Drag-and-drop ships with 370 lines of new `DragData` and zero
+    consumers.** `DragData` is genuinely thoughtful — eager / sync /
+    async provider overloads per format, `DataPackage.SetDataProvider`
+    for cross-process laziness, typed round-trip via
+    `reactor/typed/<typeof(T).FullName>` keys, origin-process-id tagging
+    so same-process transfers can stash the live object pointer. But no
+    sample app uses drag-and-drop today, the typed-format-id is unversioned
+    (rename `Models.EmailMessage` and the round-trip breaks), and there's
+    no devtools surface for watching DnD negotiation. This is the
+    integration-deficit critique in miniature: a carefully-designed
+    subsystem landing with no production exercise.
+
+13. **Naming and conceptual churn.** Spec 018 renamed Duct → Reactor;
     commit 55dc53f renamed half the analyzer ids (A11Y + Loc) while
     leaving the theming ids (DUCT001-003) alone; `Factories.Text` →
     `TextBlock`; `--preview` → `--devtools`; Monaco moved out of core into
@@ -3925,22 +4135,29 @@ SemanticPanel solves the hardest architectural problem, the three-layer
 diagnostic approach (compile-time + runtime + E2E) is now more comprehensive
 than any other C# UI framework, and UseFocusTrap is the first behavioral hook.
 But the layers are still thin — SemanticPanel covers 2 of ~20 automation
-patterns, and the remaining imperative hooks are unbuilt. WinForms interop
-opens a migration path that didn't exist before. The `.Set()` surface area is
-smaller but still too large.
+patterns, and the remaining imperative hooks are unbuilt. Input took its own
+threshold-crossing step in the last 24 hours (spec 027) — pointer / tap /
+keyboard / focus / gesture / drag-drop are no longer passthrough, event
+dispatch is now trampoline-based, and the hot-path COM churn the previous
+review called out has been architecturally addressed (though not yet
+benchmarked). WinForms interop opens a migration path that didn't exist
+before. The `.Set()` surface area is meaningfully smaller but still too
+large in the composition / materials / windowing region.
 
 ### To become production-ready, Reactor needs to:
 
 1. **Adopt its own features in the showcase apps.** This has been the
    dominant critique for three review cycles now. The Outlook clone should
    use `UseNavigation`, `Context`, `StandardCommand`, `SemanticPanel`,
-   `UsePersisted`, *and now* `UseResource`. The charting gallery getting
-   fully retrofitted with accessibility in one pass (commit 229e41b) proves
-   the team can do this work — they just haven't prioritized it for the
-   flagship apps. The gap between "ReactorCharting.Gallery uses all the
-   new chart a11y features" and "the Outlook clone still uses
-   `UseState<string>` for navigation" is where production confidence lives
-   or dies.
+   `UsePersisted`, `UseResource`, *and now* the spec 027 input modifiers
+   (`.OnRightTapped` for message context menus, `.OnDrop<EmailMessage>` for
+   folder drag-drop, `UseElementFocus` for "focus the reading pane after
+   message selection"). The charting gallery getting fully retrofitted with
+   accessibility in one pass (commit 229e41b) proves the team can do this
+   work — they just haven't prioritized it for the flagship apps. The gap
+   between "ReactorCharting.Gallery uses all the new chart a11y features"
+   and "the Outlook clone still uses `UseState<string>` for navigation" is
+   where production confidence lives or dies.
 2. **Stress-test async resources before claiming production-ready.** Large
    caches, concurrent fetches, long-running sessions, memory growth under
    churn, per-key lock contention, subscription ref-count correctness under
@@ -3949,16 +4166,19 @@ smaller but still too large.
    equivalent for `QueryCache` would also materially improve debugging.
 3. **Audit and harden the CI pipeline.** The E2E test filter bug (44 invisible
    tests) was a process failure. What other test configurations are silently
-   broken? Commit `a0ea276` added 4,222 lines of coverage tests, which is
-   real investment, but a CI health check that validates test counts and
-   alerts on regression in test discovery would prevent recurrence.
-4. **Do a performance pass using the new ETW infrastructure.** ETW tracing
-   now exists — use it. Profile a real render cycle. Measure: reflection-
-   based ShouldUpdate, XamlReader.Load theming, accelerator rebuild, wrapper
-   elements (now 5 types: Border, Grid×2, SemanticPanel, potentially
-   ChartAlternateViewWrapper), AccessibilityScanner overhead, ChartPointProvider
-   allocation rate on large charts, QueryCache eviction cost. Per-component
-   render timing is missing from ETW; add it.
+   broken? Commits `e85f4d8` + `1870868` added ~5,600 lines of coverage
+   tests, which is real investment, but a CI health check that validates
+   test counts and alerts on regression in test discovery would prevent
+   recurrence.
+4. **Do a performance pass using the new ETW infrastructure — starting
+   with the trampoline refactor.** ETW tracing exists — use it. The spec
+   027 Phase 2 claim is that event dispatch no longer detaches/reattaches
+   per render; that's verifiable with a trace but nobody has run one.
+   Also measure: reflection-based ShouldUpdate, XamlReader.Load theming,
+   accelerator rebuild, wrapper elements (now 5 types: Border, Grid×2,
+   SemanticPanel, potentially ChartAlternateViewWrapper), AccessibilityScanner
+   overhead, ChartPointProvider allocation rate on large charts, QueryCache
+   eviction cost. Per-component render timing is missing from ETW; add it.
 5. **Localize StandardCommand labels.** Still unfixed. The framework's own
    commanding system should use the framework's own localization system.
 6. **Fix UseColorScheme to read element effective theme, not app theme.**
@@ -3985,14 +4205,25 @@ smaller but still too large.
 14. **Finish exhaustive-deps analyzer.** `REACTOR_HOOKS_002/003` are deferred
     pending control-flow analysis. This is the single most valuable ESLint
     rule React developers rely on.
+15. **Add gesture composition.** Spec 027 shipped three discrete gesture
+    primitives but no `.simultaneously` / `.sequenced` / `.exclusively`
+    combinators and no typed `LongPressGesture(minimumDuration:)`. A common
+    "long-press to begin drag" interaction still has to be hand-rolled
+    across `.OnHolding` and `.OnPan`.
+16. **Version typed drag formats.** `DragData`'s
+    `reactor/typed/<typeof(T).FullName>` format id breaks when models are
+    renamed or moved. Add either an explicit version arg or surface-level
+    opt-in versioning before the API is used in shipping apps.
 
 The trajectory is right, and the velocity is notable — probably *too*
-notable. In the last 72 hours: async resources (full subsystem, closing
+notable. In the last 96 hours: async resources (full subsystem, closing
 the biggest remaining capability gap), charting accessibility (8-layer
 system, uniquely comprehensive), devtools MCP (unconventional but
 correctly built), ETW tracing (infrastructure for profiling), FlexPanel
-CSS compliance fix (closes a silent behavioral drift), and 4,222 lines of
-coverage tests.
+CSS compliance fix (closes a silent behavioral drift), spec 027
+declarative input (pointer/gesture/focus/drag-drop modifier surface plus
+a trampoline-dispatch refactor — 73 files in one PR), and ~5,600 lines of
+coverage tests pushing selftest past 85%.
 
 Navigation and commanding moved Reactor from "component library with hooks"
 to "framework with application architecture." The accessibility diff moved
@@ -4003,8 +4234,10 @@ resources now moves the data story from "do it yourself" to "first-class
 subsystem." Charting accessibility moves chart a11y from "WinUI has no
 charts anyway" to "Reactor's charts are more accessible than most native
 iOS/Android chart libraries." Devtools MCP moves the testing story from
-"write Appium tests" to "AI agents can drive your app." These are real
-capability expansions, not just polish.
+"write Appium tests" to "AI agents can drive your app." Spec 027 moves
+the input story from "everything non-trivial is `.Set()`-passthrough" to
+"pointer, gesture, focus, and drag-drop are first-class declarative
+modifiers." These are real capability expansions, not just polish.
 
 But the velocity is outpacing the integration. Three review cycles in a
 row have flagged the same critique: the showcase apps don't use the
@@ -4038,18 +4271,21 @@ But three themes keep recurring across every feature area:
    Outlook clone, file manager, registry editor, and word puzzle game — the
    framework's most complex and most public *general-purpose* apps — still
    don't use navigation, commanding, context, memoization, persisted state,
-   async resources, SemanticPanel, or UseFocusTrap. Until they do, "these
-   features compose in real apps" is a claim supported by demos, not proof.
+   async resources, SemanticPanel, UseFocusTrap, *or* any of the new spec
+   027 input modifiers. Until they do, "these features compose in real
+   apps" is a claim supported by demos, not proof.
 
 4. **New theme: feature velocity now outpaces integration velocity by a
-   widening margin.** In 72 hours: one new subsystem (async resources), one
+   widening margin.** In 96 hours: one new subsystem (async resources), one
    new sub-framework (charting + chart a11y), one new paradigm (MCP
-   devtools), one new profiling story (ETW). None of these are small. And
-   they land before the previous cycle's features (SemanticPanel,
-   UseFocusTrap, NavigationDemo, StandardCommand) have been integrated into
-   the flagship apps. The ratio of feature-land-time to feature-integration-
-   time is getting worse, not better. Sustainable framework development
-   requires the second to keep up with the first.
+   devtools), one new profiling story (ETW), and one major input rewrite
+   (spec 027 — pointer / gesture / focus / drag-drop modifiers +
+   trampoline dispatch). None of these are small. And they land before
+   the previous cycle's features (SemanticPanel, UseFocusTrap,
+   NavigationDemo, StandardCommand) have been integrated into the flagship
+   apps. The ratio of feature-land-time to feature-integration-time is
+   getting worse, not better. Sustainable framework development requires
+   the second to keep up with the first.
 
 Reactor now has *five* features where it's genuinely ahead of the
 competition:
@@ -4071,11 +4307,12 @@ matter if customers can reach them. The gap between "features exist" and
 "features compose correctly in real apps, under production load, in a
 maintained showcase" is where the remaining work lives. That gap has
 narrowed on charting (one gallery fully retrofitted), but widened on
-everything else (async resources, devtools, ETW, accessibility
-improvements to the general surface all sit behind isolated demos). Net
-direction: the framework is more capable than it was a week ago *and*
-further from "production-ready" because the new capability hasn't been
-integration-tested.
+everything else (async resources, devtools, ETW, spec 027 input
+modifiers, accessibility improvements to the general surface all sit
+behind isolated demos or selftest fixtures). Net direction: the
+framework is more capable than it was a week ago *and* further from
+"production-ready" because the new capability hasn't been integration-
+tested.
 
 The honest final grade for this review: **Reactor is a remarkable
 framework being developed at a pace that is both impressive and


### PR DESCRIPTION
## Summary
- Updates `critical-review.md` with the past few days of shipped work: spec 027 declarative input, async resources subsystem, charting + chart accessibility, MCP devtools, ETW tracing, FlexPanel CSS parity fix, and the animation integration bug fixes.
- Re-syncs `compare/overview.md` against the refreshed critical review. Reactor scorecard moves: Animation C+ → B-, Input & Gestures C → B, Developer Experience C+ → B.
- Adds two new comparison sections for capabilities with no direct competitor scorecard slot:
  - §20 Charting & Chart Accessibility (B+) — 8-layer system, only sonification missing vs Apple Charts
  - §21 Devtools & Tracing Infrastructure (B) — MCP server is unique industry-wide

The overview is candid rather than promotional — it names the growing integration deficit (showcase apps still don't use navigation/commanding/context/SemanticPanel/async resources/spec 027 input), the UseColorScheme/RequestedTheme composition bug, the unbenchmarked trampoline perf claim, the drag-drop-with-zero-consumers situation, unversioned typed format IDs, stringly-typed API boundaries, and the 4+ invisible wrapper elements accumulating in the visual tree.

## Test plan
- [ ] Render the two updated docs and skim for broken cross-references or dangling section numbers
- [ ] Verify the scorecard tables render correctly in GitHub markdown
- [ ] Confirm the new §20 / §21 additions don't break any external links into `overview.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)