### PR TITLE
Bump WindowsAppSDK to 2.0.0-preview2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,11 @@ When filing an issue, include the platform (`x64` / `ARM64`), .NET SDK version, 
 ## Prerequisites
 
 - [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
-- Windows App SDK 2.0 (experimental) — restored automatically from NuGet, no manual install required
+- Windows App SDK 2.0 (preview) — restored automatically from NuGet, no manual install required
 - Visual Studio 2022 (17.8+) or VS Code with C# Dev Kit
 - (Optional) [Rust toolchain](https://rustup.rs/) via rustup — only needed for the native differ
 
-> **Package version:** All projects reference `Microsoft.WindowsAppSDK` **2.0.0-experimental6** (public NuGet). The version is centralized in `Directory.Build.props` — update it there to change the version for every project at once.
+> **Package version:** All projects reference `Microsoft.WindowsAppSDK` **2.0.0-preview2** (public NuGet). The version is centralized in `Directory.Build.props` — update it there to change the version for every project at once.
 
 ---
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     To install: dotnet restore (NuGet will pull the package automatically).
   -->
   <PropertyGroup>
-    <WindowsAppSDKVersion>2.0.0-experimental6</WindowsAppSDKVersion>
+    <WindowsAppSDKVersion>2.0.0-preview2</WindowsAppSDKVersion>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ If you're building line-of-business applications:
 ### Prerequisites
 
 - [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
-- Windows App SDK 2.0 (experimental) — pulled automatically on `dotnet restore`
+- Windows App SDK 2.0 (preview) — pulled automatically on `dotnet restore`
 - Visual Studio 2022 (17.8+) or just the .NET 8 CLI
 
-> This project uses the **experimental** Windows App SDK 2.0 (`Microsoft.WindowsAppSDK` 2.0.0-experimental6). The package comes from NuGet — no manual SDK installer is needed.
+> This project uses the **preview** Windows App SDK 2.0 (`Microsoft.WindowsAppSDK` 2.0.0-preview2). The package comes from NuGet — no manual SDK installer is needed.
 
 ### Create a new app
 
@@ -147,7 +147,7 @@ Or create a `.csproj` manually:
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental6" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-preview2" />
     <ProjectReference Include="..\Reactor\Reactor.csproj" />
   </ItemGroup>
 </Project>

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,7 +40,7 @@ re-renders automatically. No XAML. No data binding. No ViewModels.
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental6" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-preview2" />
     <ProjectReference Include="..\Reactor\Reactor.csproj" />
   </ItemGroup>
 </Project>
@@ -300,7 +300,7 @@ For lightweight demos, skip the `.csproj` entirely. Add a file-level header:
 
 ```csharp
 #:project C:\Users\andersonch\Code\reactor1\src\Reactor
-#:package Microsoft.WindowsAppSDK@2.0.0-experimental6
+#:package Microsoft.WindowsAppSDK@2.0.0-preview2
 #:property OutputType=WinExe
 #:property TargetFramework=net9.0-windows10.0.22621.0
 #:property UseWinUI=true

--- a/docs/specs/022-packaging-and-distribution.md
+++ b/docs/specs/022-packaging-and-distribution.md
@@ -354,7 +354,7 @@ Consumer gets: framework, analyzers, source generator, and WinUI SDK (transitive
 - **Internal feed ownership.** Which Azure Artifacts organization hosts the P1 feed? Creating one takes ~a day plus approvals.
 - **Signing prerequisite for P1.** Does the chosen internal feed enforce signed packages? If yes, P1 needs ESRP too, not just P2.
 - **Package ID.** `Microsoft.UI.Reactor` assumes we stay in the `Microsoft.UI.*` namespace (see spec 018 for the namespace rename). If that namespace decision changes, the package ID follows.
-- **WinUI SDK version.** We currently pin `Microsoft.WindowsAppSDK` 2.0.0-experimental6. Consumers who want a different WinUI version will conflict. Decide: float this transitively, or lock it and force consumers to match.
+- **WinUI SDK version.** We currently pin `Microsoft.WindowsAppSDK` 2.0.0-preview2. Consumers who want a different WinUI version will conflict. Decide: float this transitively, or lock it and force consumers to match.
 - **`mur` install-script trust boundary.** `iwr | iex` from GitHub Releases works for P1 but will concern P3 users. Document the signed-binary fallback (direct download + verify signature) before public launch.
 
 ## 14. Implementation Phases

--- a/samples/ReactorGallery/ReactorGallery.csproj
+++ b/samples/ReactorGallery/ReactorGallery.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>ReactorGallery</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental6" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(WindowsAppSDKVersion)" />
     <ProjectReference Include="..\..\src\Reactor\Reactor.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/WinFormsInterop/README.md
+++ b/samples/WinFormsInterop/README.md
@@ -40,7 +40,7 @@ static class Program
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
 
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental6" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-preview2" />
     <ProjectReference Include="path\to\Reactor.Interop.WinForms.csproj" />
     <ProjectReference Include="path\to\Reactor.csproj" />
 ```

--- a/src/Reactor.Cli/Program.cs
+++ b/src/Reactor.Cli/Program.cs
@@ -196,7 +196,7 @@ string GenerateCsproj() =>
         <WindowsSdkPackageVersion>10.0.22621.52</WindowsSdkPackageVersion>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental6" />
+        <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-preview2" />
       </ItemGroup>
       <ItemGroup>
         <ProjectReference Include="..\Reactor\Reactor.csproj" />

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -1870,19 +1870,17 @@ public abstract record LazyStackElementBase : Element
     public abstract double Spacing { get; init; }
     public abstract double EstimatedItemSize { get; init; }
     public abstract object GetItemsSource();
-#pragma warning disable CS8305 // ElementFactory is experimental; we coordinate with WinUI team
-    public abstract ElementFactory CreateFactory(Reconciler reconciler, Action requestRerender, ElementPool? pool);
+    public abstract IElementFactory CreateFactory(Reconciler reconciler, Action requestRerender, ElementPool? pool);
     /// <summary>
     /// Update an existing factory's items and viewBuilder in place, avoiding
     /// ItemsRepeater re-realization. Returns true if the factory was updated.
     /// </summary>
-    public abstract bool TryUpdateFactory(ElementFactory existingFactory);
+    public abstract bool TryUpdateFactory(IElementFactory existingFactory);
     /// <summary>
     /// After updating the factory in place, reconcile all realized items
     /// with the new viewBuilder output (property diffs only, no collection changes).
     /// </summary>
-    public abstract void RefreshRealizedItems(ElementFactory factory, WinUI.ItemsRepeater repeater);
-#pragma warning restore CS8305
+    public abstract void RefreshRealizedItems(IElementFactory factory, WinUI.ItemsRepeater repeater);
     internal Action<WinUI.ScrollViewer>[] ScrollViewerSetters { get; init; } = [];
     internal Action<WinUI.ItemsRepeater>[] RepeaterSetters { get; init; } = [];
 }
@@ -1900,21 +1898,19 @@ public record LazyVStackElement<T>(
     public override object GetItemsSource() =>
         Enumerable.Range(0, Items.Count).ToList();
 
-#pragma warning disable CS8305
-    public override ElementFactory CreateFactory(Reconciler reconciler, Action requestRerender, ElementPool? pool) =>
+    public override IElementFactory CreateFactory(Reconciler reconciler, Action requestRerender, ElementPool? pool) =>
         new ElementFactory<T>(Items, ViewBuilder, reconciler, requestRerender, pool);
 
-    public override bool TryUpdateFactory(ElementFactory existingFactory)
+    public override bool TryUpdateFactory(IElementFactory existingFactory)
     {
         if (existingFactory is ElementFactory<T> f) { f.UpdateInPlace(Items, ViewBuilder); return true; }
         return false;
     }
 
-    public override void RefreshRealizedItems(ElementFactory factory, WinUI.ItemsRepeater repeater)
+    public override void RefreshRealizedItems(IElementFactory factory, WinUI.ItemsRepeater repeater)
     {
         if (factory is ElementFactory<T> f) f.RefreshRealizedItems(repeater);
     }
-#pragma warning restore CS8305
 }
 
 public record LazyHStackElement<T>(
@@ -1930,21 +1926,19 @@ public record LazyHStackElement<T>(
     public override object GetItemsSource() =>
         Enumerable.Range(0, Items.Count).ToList();
 
-#pragma warning disable CS8305
-    public override ElementFactory CreateFactory(Reconciler reconciler, Action requestRerender, ElementPool? pool) =>
+    public override IElementFactory CreateFactory(Reconciler reconciler, Action requestRerender, ElementPool? pool) =>
         new ElementFactory<T>(Items, ViewBuilder, reconciler, requestRerender, pool);
 
-    public override bool TryUpdateFactory(ElementFactory existingFactory)
+    public override bool TryUpdateFactory(IElementFactory existingFactory)
     {
         if (existingFactory is ElementFactory<T> f) { f.UpdateInPlace(Items, ViewBuilder); return true; }
         return false;
     }
 
-    public override void RefreshRealizedItems(ElementFactory factory, WinUI.ItemsRepeater repeater)
+    public override void RefreshRealizedItems(IElementFactory factory, WinUI.ItemsRepeater repeater)
     {
         if (factory is ElementFactory<T> f) f.RefreshRealizedItems(repeater);
     }
-#pragma warning restore CS8305
 }
 
 // ════════════════════════════════════════════════════════════════════════

--- a/src/Reactor/Core/ElementFactory.cs
+++ b/src/Reactor/Core/ElementFactory.cs
@@ -4,12 +4,10 @@ using Microsoft.UI.Xaml.Controls;
 namespace Microsoft.UI.Reactor.Core;
 
 /// <summary>
-/// Bridges WinUI's ItemsRepeater/ElementFactory to Reactor's Reconciler.
-/// GetElementCore calls the view builder then mounts; RecycleElementCore unmounts.
+/// Bridges WinUI's ItemsRepeater/IElementFactory to Reactor's Reconciler.
+/// GetElement calls the view builder then mounts; RecycleElement unmounts.
 /// </summary>
-#pragma warning disable CS8305 // ElementFactory is experimental; we coordinate with WinUI team
-public sealed partial class ElementFactory<T> : ElementFactory
-#pragma warning restore CS8305
+public sealed partial class ElementFactory<T> : IElementFactory
 {
     private IReadOnlyList<T> _items;
     private Func<T, int, Element> _viewBuilder;
@@ -85,7 +83,7 @@ public sealed partial class ElementFactory<T> : ElementFactory
         }
     }
 
-    protected override UIElement GetElementCore(ElementFactoryGetArgs args)
+    public UIElement GetElement(ElementFactoryGetArgs args)
     {
         var index = args.Data is int i ? i : 0;
         if (index < 0 || index >= _items.Count)
@@ -98,7 +96,7 @@ public sealed partial class ElementFactory<T> : ElementFactory
         return control ?? new TextBlock { Text = "" };
     }
 
-    protected override void RecycleElementCore(ElementFactoryRecycleArgs args)
+    public void RecycleElement(ElementFactoryRecycleArgs args)
     {
         if (args.Element is null) return;
 

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -1505,9 +1505,7 @@ public sealed partial class Reconciler
             // The factory keeps its identity; existing realized items
             // stay mounted. On next scroll or layout, GetElementCore
             // uses the updated viewBuilder to produce new content.
-#pragma warning disable CS8305 // ElementFactory is evaluation-only; we control WinUI versions and rely on this API.
-            if (repeater.ItemTemplate is ElementFactory existingFactory && n.TryUpdateFactory(existingFactory))
-#pragma warning restore CS8305
+            if (repeater.ItemTemplate is IElementFactory existingFactory && n.TryUpdateFactory(existingFactory))
             {
                 // Item count may have changed — update the source
                 var newSource = n.GetItemsSource();

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -1503,7 +1503,7 @@ public sealed partial class Reconciler
             // re-realize all items (modifying Children during layout →
             // "Cannot run layout in the middle of a collection change").
             // The factory keeps its identity; existing realized items
-            // stay mounted. On next scroll or layout, GetElementCore
+            // stay mounted. On next scroll or layout, IElementFactory.GetElement
             // uses the updated viewBuilder to produce new content.
             if (repeater.ItemTemplate is IElementFactory existingFactory && n.TryUpdateFactory(existingFactory))
             {

--- a/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Bound/MainWindow.cs
+++ b/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Bound/MainWindow.cs
@@ -101,14 +101,13 @@ public sealed class MainWindow : Window
     }
 }
 
-#pragma warning disable CS8305 // ElementFactory is experimental
-internal sealed class BoundElementFactory : ElementFactory
+internal sealed class BoundElementFactory : IElementFactory
 {
     private readonly InteractiveItemViewModel[] _vms;
 
     public BoundElementFactory(InteractiveItemViewModel[] vms) => _vms = vms;
 
-    protected override UIElement GetElementCore(ElementFactoryGetArgs args)
+    public UIElement GetElement(ElementFactoryGetArgs args)
     {
         var i = args.Data is int idx ? idx : 0;
         var vm = _vms[i];
@@ -145,6 +144,5 @@ internal sealed class BoundElementFactory : ElementFactory
         return row;
     }
 
-    protected override void RecycleElementCore(ElementFactoryRecycleArgs args) { }
+    public void RecycleElement(ElementFactoryRecycleArgs args) { }
 }
-#pragma warning restore CS8305

--- a/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Direct/MainWindow.cs
+++ b/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Direct/MainWindow.cs
@@ -89,10 +89,9 @@ public sealed class MainWindow : Window
     }
 }
 
-#pragma warning disable CS8305 // ElementFactory is experimental
-internal sealed class DirectElementFactory : ElementFactory
+internal sealed class DirectElementFactory : IElementFactory
 {
-    protected override UIElement GetElementCore(ElementFactoryGetArgs args)
+    public UIElement GetElement(ElementFactoryGetArgs args)
     {
         var i = args.Data is int idx ? idx : 0;
         var row = new StackPanel { Orientation = Orientation.Horizontal, Padding = new Thickness(2), Spacing = 8 };
@@ -102,6 +101,5 @@ internal sealed class DirectElementFactory : ElementFactory
         return row;
     }
 
-    protected override void RecycleElementCore(ElementFactoryRecycleArgs args) { }
+    public void RecycleElement(ElementFactoryRecycleArgs args) { }
 }
-#pragma warning restore CS8305


### PR DESCRIPTION
## Summary

- Bump `WindowsAppSDK` pin from `2.0.0-experimental6` to `2.0.0-preview2` in `Directory.Build.props` (the single source of truth).
- Migrate to preview2's new `IElementFactory` interface — preview2 replaces the experimental abstract `ElementFactory` base with an interface, so the library's `ItemsRepeater` bridge in `ElementFactory<T>`, the `LazyStackElement` virtual shape in `Element.cs`, the pattern match in `Reconciler.Update.cs`, and the two InteractivePool perf benches all switch to `IElementFactory` with public `GetElement`/`RecycleElement` methods. All `#pragma warning disable CS8305` suppressions drop.
- Refresh version strings in docs/samples that pinned the version inline: `README.md`, `CONTRIBUTING.md`, `SKILL.md`, `docs/specs/022-packaging-and-distribution.md`, `samples/WinFormsInterop/README.md`, the CLI scaffold template in `src/Reactor.Cli/Program.cs`, and `samples/ReactorGallery/ReactorGallery.csproj` (which was hard-coding the version — now uses `$(WindowsAppSDKVersion)`).

## Test plan

- [x] `dotnet build Reactor.sln -p:Platform=ARM64` — 0 errors
- [x] `dotnet test tests/Reactor.Tests` — 6518 passed / 0 failed / 46 skipped
- [x] `dotnet test tests/Reactor.SelfTests` — 535 passed / 0 failed
- [x] `dotnet test tests/Reactor.AppTests` — 53 passed + 1 flaky (`DragDrop_TypedReorder_MovesCard` Selenium 6s timeout, passes on retry — pre-existing flake, not a regression)
- [x] Manual launch of `samples/Reactor.TestApp` — window visible, interactive

> Note for reviewers: if you're hitting a `0xc0000602` fast-fail in `new Window()` after pulling this branch, blow away `obj/` and `bin/` across the solution first. Incremental builds from an experimental6 tree can leave stale artifacts that surface as a Window activation fast-fail under preview2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)