### PR TITLE
Convert JSON source-gen paths off reflection fallback

### DIFF
--- a/src/Reactor/Hosting/Devtools/DevtoolsJsonContext.cs
+++ b/src/Reactor/Hosting/Devtools/DevtoolsJsonContext.cs
@@ -13,7 +13,6 @@ namespace Microsoft.UI.Reactor.Hosting.Devtools;
 [JsonSerializable(typeof(JsonRpcRequest))]
 [JsonSerializable(typeof(JsonRpcResponse))]
 [JsonSerializable(typeof(JsonRpcError))]
-[JsonSerializable(typeof(LockfileEntry))]
 internal partial class DevtoolsJsonContext : JsonSerializerContext
 {
 }

--- a/src/Reactor/Hosting/Devtools/DevtoolsMcpServer.cs
+++ b/src/Reactor/Hosting/Devtools/DevtoolsMcpServer.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 
@@ -127,8 +128,6 @@ internal sealed class DevtoolsMcpServer : IDisposable
     /// Emits the one-time <c>[devtools] ready</c> line after the first render
     /// completes. Callers invoke this from the reconciler's first-commit hook.
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "JSON serialization for devtools ready announcement.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JSON serialization for devtools ready announcement.")]
     public void AnnounceReady()
     {
         BannerWriter.WriteLine($"[devtools] ready (build {_buildTag})");
@@ -140,8 +139,16 @@ internal sealed class DevtoolsMcpServer : IDisposable
             ? $"http://127.0.0.1:{Port}/mcp"
             : "stdio";
         var pid = global::System.Diagnostics.Process.GetCurrentProcess().Id;
-        var readyJson = $"{{\"event\":\"devtools-ready\",\"endpoint\":{JsonSerializer.Serialize(endpoint, JsonOpts)},\"transport\":\"{transportStr}\",\"port\":{Port},\"pid\":{pid},\"buildTag\":{JsonSerializer.Serialize(_buildTag, JsonOpts)}}}";
-        BannerWriter.WriteLine(readyJson);
+        var readyNode = new JsonObject
+        {
+            ["event"] = "devtools-ready",
+            ["endpoint"] = endpoint,
+            ["transport"] = transportStr,
+            ["port"] = Port,
+            ["pid"] = pid,
+            ["buildTag"] = _buildTag,
+        };
+        BannerWriter.WriteLine(readyNode.ToJsonString());
         BannerWriter.Flush();
 
         WriteLockfile();

--- a/src/Reactor/Hosting/Devtools/LockfileRegistry.cs
+++ b/src/Reactor/Hosting/Devtools/LockfileRegistry.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
@@ -27,6 +26,17 @@ internal sealed class LockfileEntry
     [JsonPropertyName("startedAt")] public string StartedAt { get; set; } = "";
 }
 
+// Dedicated context with WriteIndented so humans `cat`-ing the lockfile see
+// pretty-printed JSON. DevtoolsJsonContext is shared for wire traffic and
+// stays compact.
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(LockfileEntry))]
+internal partial class LockfileJsonContext : JsonSerializerContext
+{
+}
+
 /// <summary>
 /// Reads, writes, and liveness-probes devtools session lockfiles under
 /// <c>%TEMP%/reactor-devtools/</c>. Owned by the server so the producer controls
@@ -37,15 +47,6 @@ internal static class LockfileRegistry
 {
     public const string SchemaTag = "reactor-devtools-lockfile/1";
     public const string McpSchemaTag = "reactor-devtools-mcp/1";
-
-    private static readonly JsonSerializerOptions JsonOpts = new()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-#pragma warning disable IL2026, IL3050 // DefaultJsonTypeInfoResolver is intentional fallback for non-AOT builds
-        TypeInfoResolverChain = { DevtoolsJsonContext.Default, new global::System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver() },
-#pragma warning restore IL2026, IL3050
-    };
 
     /// <summary>
     /// <c>%TEMP%/reactor-devtools/</c> on Windows. On non-Windows hosts this
@@ -93,14 +94,12 @@ internal static class LockfileRegistry
     /// on-disk content already matches so a reload loop doesn't thrash
     /// filesystem watchers.
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "JSON serialization for lockfile write.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JSON serialization for lockfile write.")]
     public static void Write(string path, LockfileEntry entry)
     {
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir)) global::System.IO.Directory.CreateDirectory(dir);
 
-        var json = JsonSerializer.Serialize(entry, JsonOpts);
+        var json = JsonSerializer.Serialize(entry, LockfileJsonContext.Default.LockfileEntry);
 
         if (File.Exists(path))
         {
@@ -134,8 +133,6 @@ internal static class LockfileRegistry
         try { if (File.Exists(path)) File.Delete(path); } catch { }
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "JSON deserialization for lockfile read.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JSON deserialization for lockfile read.")]
     public static bool TryRead(string path, out LockfileEntry? entry)
     {
         entry = null;
@@ -143,7 +140,7 @@ internal static class LockfileRegistry
         try
         {
             var json = File.ReadAllText(path);
-            entry = JsonSerializer.Deserialize<LockfileEntry>(json, JsonOpts);
+            entry = JsonSerializer.Deserialize(json, LockfileJsonContext.Default.LockfileEntry);
             return entry is not null;
         }
         catch

--- a/src/Reactor/Hosting/Devtools/McpDispatcher.cs
+++ b/src/Reactor/Hosting/Devtools/McpDispatcher.cs
@@ -23,14 +23,12 @@ internal sealed class McpDispatcher
         _logger = logger;
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "JSON deserialization for MCP JSON-RPC dispatch.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JSON deserialization for MCP JSON-RPC dispatch.")]
     public JsonRpcResponse Dispatch(string body)
     {
         JsonRpcRequest? request;
         try
         {
-            request = JsonSerializer.Deserialize<JsonRpcRequest>(body, DevtoolsMcpServer.JsonOpts);
+            request = JsonSerializer.Deserialize(body, DevtoolsJsonContext.Default.JsonRpcRequest);
         }
         catch (JsonException ex)
         {

--- a/src/Reactor/Hosting/PreviewCaptureServer.cs
+++ b/src/Reactor/Hosting/PreviewCaptureServer.cs
@@ -298,8 +298,8 @@ internal sealed class PreviewCaptureServer : IDisposable
         }
 
         var success = SwitchComponent(componentName);
-        var resultNode = success
-            ? (JsonNode)new JsonObject { ["ok"] = true, ["component"] = componentName }
+        JsonObject resultNode = success
+            ? new JsonObject { ["ok"] = true, ["component"] = componentName }
             : new JsonObject { ["ok"] = false, ["error"] = $"Component '{componentName}' not found" };
         var resultBytes = Encoding.UTF8.GetBytes(resultNode.ToJsonString());
 

--- a/src/Reactor/Hosting/PreviewCaptureServer.cs
+++ b/src/Reactor/Hosting/PreviewCaptureServer.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Net;
@@ -6,6 +5,7 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 
@@ -265,8 +265,6 @@ internal sealed class PreviewCaptureServer : IDisposable
         response.Close();
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "JSON serialization for preview capture switch-component response.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JSON serialization for preview capture switch-component response.")]
     private void HandleSwitchComponent(HttpListenerRequest request, HttpListenerResponse response)
     {
         if (request.HttpMethod != "POST")
@@ -300,10 +298,10 @@ internal sealed class PreviewCaptureServer : IDisposable
         }
 
         var success = SwitchComponent(componentName);
-        var result = success
-            ? $"{{\"ok\":true,\"component\":{JsonSerializer.Serialize(componentName)}}}"
-            : $"{{\"ok\":false,\"error\":{JsonSerializer.Serialize($"Component '{componentName}' not found")}}}";
-        var resultBytes = Encoding.UTF8.GetBytes(result);
+        var resultNode = success
+            ? (JsonNode)new JsonObject { ["ok"] = true, ["component"] = componentName }
+            : new JsonObject { ["ok"] = false, ["error"] = $"Component '{componentName}' not found" };
+        var resultBytes = Encoding.UTF8.GetBytes(resultNode.ToJsonString());
 
         response.StatusCode = success ? 200 : 404;
         response.ContentType = "application/json";


### PR DESCRIPTION
## Summary

Eliminates 11 `IL2026`/`IL3050` suppressions left over from #69 by routing concrete-typed JSON serialization through the source-gen context directly, and rebuilding small fixed-shape payloads via `JsonObject` instead of interpolating `JsonSerializer.Serialize<string>` into format strings. Addresses part of #70.

#69 wired up `DevtoolsJsonContext` / `PreviewJsonContext` but the call sites kept using `JsonSerializer.Serialize<T>(T, JsonSerializerOptions)` — the overload is annotated `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]`, so every call site needed a suppression pair, and the options had to carry a `TypeInfoResolverChain` with `DefaultJsonTypeInfoResolver` as a reflection fallback.

## Changes

- **`LockfileRegistry.cs`** — new `LockfileJsonContext` (`WriteIndented=true`, `WhenWritingNull`) so `Write`/`TryRead` use the typed `JsonTypeInfo<LockfileEntry>` overload. Deleted the `JsonOpts` field with its reflection fallback. Moved the `LockfileEntry` registration out of `DevtoolsJsonContext` (pretty-print and compact wire traffic shouldn't share a context).
- **`DevtoolsMcpServer.AnnounceReady`** — rebuilt the `devtools-ready` sentinel via `JsonObject.ToJsonString()`. Identical wire format, no reflection.
- **`PreviewCaptureServer.HandleSwitchComponent`** — same `JsonObject` pattern for the `{ok,component}` / `{ok,error}` response.
- **`McpDispatcher.Dispatch`** — typed `Deserialize(body, DevtoolsJsonContext.Default.JsonRpcRequest)`.

## What stays suppressed (and why)

- `DevtoolsMcpServer.HandleRequest` / `StdioMcpLoop.ProcessLine` / `DevtoolsUiaTools.IsUnknownSelector` — all serialize `JsonRpcResponse` whose `Result` is `object?` carrying anonymous tool-return shapes. A typed source-gen overload would `NotSupportedException` at runtime here; the reflection fallback is intentional behavior. Converting these requires refactoring every MCP tool handler to return a source-gen-able type (e.g. `JsonNode`) — separate effort.
- `McpDispatcher.HasOkFalse` — reflection on arbitrary objects, not JSON.
- `NavigationHandle.GetState/SetState` — open generic `T`; needs `RequiresUnreferencedCode` propagation (issue #70 Phase 3), not source-gen.

## Test plan

- [x] `dotnet build src/Reactor` — 0 warnings, 0 errors
- [x] `dotnet test tests/Reactor.Tests` — 6533 passed, 1 pre-existing flaky timing test (`UseResourceTests.Retry_...`, unrelated), 46 skipped
- [x] `dotnet test tests/Reactor.SelfTests` — 538 / 538 passed
- [x] `LockfileRegistryTests` round-trip still green (indented format + null-skip preserved via the new context attribute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)