### PR TITLE
test(selftest): add event-wiring fixtures for selection and value-change controls

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/RareControlFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/RareControlFixtures.cs
@@ -321,4 +321,11 @@ internal static class RareControlFixtures
                 H.FindControl<Microsoft.UI.Xaml.Controls.RadioButtons>(_ => true) is not null);
         }
     }
+
+    // MapControl is intentionally not exercised here — mounting it into a real
+    // WinUI window blocks on networking/graphics initialization in the self-test
+    // harness, which causes the whole run to hang. MapControl requires a
+    // MapServiceToken and a realistic host environment (packaged identity,
+    // network access) to initialize cleanly; it is better exercised in a
+    // dedicated interactive sample, not a unit-style selftest.
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SelectionEventFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SelectionEventFixtures.cs
@@ -8,9 +8,9 @@ using static Microsoft.UI.Reactor.Factories;
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
 /// <summary>
-/// Verifies that OnSelectionChanged / OnItemInvoked callbacks wired by the
-/// reconciler actually fire through to user code when the underlying WinUI
-/// control raises its native selection event.
+/// Verifies that OnSelectionChanged callbacks wired by the reconciler
+/// actually fire through to user code when the underlying WinUI control
+/// raises its native selection event.
 ///
 /// Each fixture mounts the control with a counter-incrementing callback,
 /// waits for initial mount to settle, resets the counter (initial selection
@@ -93,8 +93,7 @@ internal static class SelectionEventFixtures
                 {
                     SelectedIndex = -1,
                     OnSelectionChanged = i => { count++; lastIndex = i; },
-                    Setters = [l => l.Name = "lvSel"],
-                }
+                }.Set(l => l.Name = "lvSel")
             ));
             await Harness.Render();
 
@@ -126,8 +125,7 @@ internal static class SelectionEventFixtures
                 {
                     SelectedIndex = -1,
                     OnSelectionChanged = i => { count++; lastIndex = i; },
-                    Setters = [g => g.Name = "gvSel"],
-                }
+                }.Set(g => g.Name = "gvSel")
             ));
             await Harness.Render();
 
@@ -159,8 +157,7 @@ internal static class SelectionEventFixtures
                 {
                     SelectedIndex = 0,
                     OnSelectionChanged = i => { count++; lastIndex = i; },
-                    Setters = [f => f.Name = "fvSel"],
-                }
+                }.Set(f => f.Name = "fvSel")
             ));
             await Harness.Render();
 
@@ -192,8 +189,7 @@ internal static class SelectionEventFixtures
                 {
                     SelectedIndex = 0,
                     OnSelectionChanged = i => { count++; lastIndex = i; },
-                    Setters = [t => t.Name = "tvSel"],
-                }
+                }.Set(t => t.Name = "tvSel")
             ));
             await Harness.Render();
 
@@ -225,8 +221,7 @@ internal static class SelectionEventFixtures
                 {
                     SelectedIndex = 0,
                     OnSelectionChanged = i => { count++; lastIndex = i; },
-                    Setters = [p => p.Name = "pivSel"],
-                }
+                }.Set(p => p.Name = "pivSel")
             ));
             await Harness.Render();
 
@@ -260,8 +255,7 @@ internal static class SelectionEventFixtures
                 {
                     OnSelectionChanged = tag => { count++; lastTag = tag; },
                     IsSettingsVisible = false,
-                    Setters = [n => n.Name = "navSel"],
-                }
+                }.Set(n => n.Name = "navSel")
             ));
             await Harness.Render();
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SelectionEventFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SelectionEventFixtures.cs
@@ -1,0 +1,289 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Verifies that OnSelectionChanged / OnItemInvoked callbacks wired by the
+/// reconciler actually fire through to user code when the underlying WinUI
+/// control raises its native selection event.
+///
+/// Each fixture mounts the control with a counter-incrementing callback,
+/// waits for initial mount to settle, resets the counter (initial selection
+/// wiring can fire once during mount on some controls), then drives the
+/// WinUI control directly and asserts the callback ran with the expected
+/// payload.
+/// </summary>
+internal static class SelectionEventFixtures
+{
+    internal class ComboBoxSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            int lastIndex = -1;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                ComboBox(
+                    ["A", "B", "C"],
+                    selectedIndex: -1,
+                    onSelectionChanged: i => { count++; lastIndex = i; })
+                    .Set(c => c.Name = "comboSel")
+            ));
+            await Harness.Render();
+
+            var cb = H.FindControl<ComboBox>(c => c.Name == "comboSel");
+            H.Check("ComboBoxSel_Mounted", cb is not null);
+
+            count = 0; lastIndex = -1;
+            if (cb is not null) cb.SelectedIndex = 2;
+
+            H.Check("ComboBoxSel_CallbackFired", count >= 1);
+            H.Check("ComboBoxSel_PayloadIndex", lastIndex == 2);
+        }
+    }
+
+    internal class RadioButtonsSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            int lastIndex = -1;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                RadioButtons(
+                    ["R1", "R2", "R3"],
+                    selectedIndex: -1,
+                    onSelectionChanged: i => { count++; lastIndex = i; })
+                    .Set(r => r.Name = "rbsSel")
+            ));
+            await Harness.Render();
+
+            var rbs = H.FindControl<RadioButtons>(r => r.Name == "rbsSel");
+            H.Check("RadioButtonsSel_Mounted", rbs is not null);
+
+            count = 0; lastIndex = -1;
+            if (rbs is not null) rbs.SelectedIndex = 1;
+
+            H.Check("RadioButtonsSel_CallbackFired", count >= 1);
+            H.Check("RadioButtonsSel_PayloadIndex", lastIndex == 1);
+        }
+    }
+
+    internal class ListViewSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            int lastIndex = -1;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                new ListViewElement([
+                    TextBlock("LVA"),
+                    TextBlock("LVB"),
+                    TextBlock("LVC"),
+                ])
+                {
+                    SelectedIndex = -1,
+                    OnSelectionChanged = i => { count++; lastIndex = i; },
+                    Setters = [l => l.Name = "lvSel"],
+                }
+            ));
+            await Harness.Render();
+
+            var lv = H.FindControl<ListView>(l => l.Name == "lvSel");
+            H.Check("ListViewSel_Mounted", lv is not null);
+
+            count = 0; lastIndex = -1;
+            if (lv is not null) lv.SelectedIndex = 1;
+
+            H.Check("ListViewSel_CallbackFired", count >= 1);
+            H.Check("ListViewSel_PayloadIndex", lastIndex == 1);
+        }
+    }
+
+    internal class GridViewSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            int lastIndex = -1;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                new GridViewElement([
+                    TextBlock("GVA"),
+                    TextBlock("GVB"),
+                    TextBlock("GVC"),
+                ])
+                {
+                    SelectedIndex = -1,
+                    OnSelectionChanged = i => { count++; lastIndex = i; },
+                    Setters = [g => g.Name = "gvSel"],
+                }
+            ));
+            await Harness.Render();
+
+            var gv = H.FindControl<GridView>(g => g.Name == "gvSel");
+            H.Check("GridViewSel_Mounted", gv is not null);
+
+            count = 0; lastIndex = -1;
+            if (gv is not null) gv.SelectedIndex = 2;
+
+            H.Check("GridViewSel_CallbackFired", count >= 1);
+            H.Check("GridViewSel_PayloadIndex", lastIndex == 2);
+        }
+    }
+
+    internal class FlipViewSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            int lastIndex = -1;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                new FlipViewElement([
+                    TextBlock("FVA"),
+                    TextBlock("FVB"),
+                    TextBlock("FVC"),
+                ])
+                {
+                    SelectedIndex = 0,
+                    OnSelectionChanged = i => { count++; lastIndex = i; },
+                    Setters = [f => f.Name = "fvSel"],
+                }
+            ));
+            await Harness.Render();
+
+            var fv = H.FindControl<FlipView>(f => f.Name == "fvSel");
+            H.Check("FlipViewSel_Mounted", fv is not null);
+
+            count = 0; lastIndex = -1;
+            if (fv is not null) fv.SelectedIndex = 2;
+
+            H.Check("FlipViewSel_CallbackFired", count >= 1);
+            H.Check("FlipViewSel_PayloadIndex", lastIndex == 2);
+        }
+    }
+
+    internal class TabViewSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            int lastIndex = -1;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                new TabViewElement([
+                    Tab("T1", TextBlock("tab1")),
+                    Tab("T2", TextBlock("tab2")),
+                    Tab("T3", TextBlock("tab3")),
+                ])
+                {
+                    SelectedIndex = 0,
+                    OnSelectionChanged = i => { count++; lastIndex = i; },
+                    Setters = [t => t.Name = "tvSel"],
+                }
+            ));
+            await Harness.Render();
+
+            var tv = H.FindControl<TabView>(t => t.Name == "tvSel");
+            H.Check("TabViewSel_Mounted", tv is not null);
+
+            count = 0; lastIndex = -1;
+            if (tv is not null) tv.SelectedIndex = 2;
+
+            H.Check("TabViewSel_CallbackFired", count >= 1);
+            H.Check("TabViewSel_PayloadIndex", lastIndex == 2);
+        }
+    }
+
+    internal class PivotSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            int lastIndex = -1;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                new PivotElement([
+                    PivotItem("P1", TextBlock("p1")),
+                    PivotItem("P2", TextBlock("p2")),
+                    PivotItem("P3", TextBlock("p3")),
+                ])
+                {
+                    SelectedIndex = 0,
+                    OnSelectionChanged = i => { count++; lastIndex = i; },
+                    Setters = [p => p.Name = "pivSel"],
+                }
+            ));
+            await Harness.Render();
+
+            var piv = H.FindControl<Pivot>(p => p.Name == "pivSel");
+            H.Check("PivotSel_Mounted", piv is not null);
+
+            count = 0; lastIndex = -1;
+            if (piv is not null) piv.SelectedIndex = 2;
+
+            H.Check("PivotSel_CallbackFired", count >= 1);
+            H.Check("PivotSel_PayloadIndex", lastIndex == 2);
+        }
+    }
+
+    internal class NavigationViewSelectionFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            string? lastTag = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                new NavigationViewElement(
+                    [
+                        NavItem("Home", tag: "home"),
+                        NavItem("Settings", tag: "settings"),
+                        NavItem("About", tag: "about"),
+                    ],
+                    TextBlock("nav content"))
+                {
+                    OnSelectionChanged = tag => { count++; lastTag = tag; },
+                    IsSettingsVisible = false,
+                    Setters = [n => n.Name = "navSel"],
+                }
+            ));
+            await Harness.Render();
+
+            var nv = H.FindControl<NavigationView>(n => n.Name == "navSel");
+            H.Check("NavViewSel_Mounted", nv is not null);
+
+            count = 0; lastTag = null;
+
+            // Find the nav item tagged "about" and select it.
+            NavigationViewItem? target = null;
+            if (nv is not null)
+            {
+                foreach (var item in nv.MenuItems.OfType<NavigationViewItem>())
+                    if ((item.Tag as string) == "about") { target = item; break; }
+            }
+            H.Check("NavViewSel_TargetItemFound", target is not null);
+
+            if (nv is not null && target is not null)
+                nv.SelectedItem = target;
+
+            H.Check("NavViewSel_CallbackFired", count >= 1);
+            H.Check("NavViewSel_PayloadTag", lastTag == "about");
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ValueChangeEventFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ValueChangeEventFixtures.cs
@@ -1,0 +1,236 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Verifies that OnChanged / OnValueChanged / OnColorChanged / OnPasswordChanged
+/// callbacks wired by the reconciler actually fire through to user code when
+/// the underlying WinUI control's native change event is raised.
+///
+/// DatePicker, TimePicker, and AutoSuggestBox TextChanged are intentionally not
+/// covered here — those events only fire for user input, not programmatic
+/// property changes, so they require the E2E/UIA tier to exercise.
+/// </summary>
+internal static class ValueChangeEventFixtures
+{
+    internal class CheckBoxToggleFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            bool? lastValue = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                CheckBox(false, onChanged: v => { count++; lastValue = v; }, label: "chkEvt")
+                    .Set(c => c.Name = "chkEvt")
+            ));
+            await Harness.Render();
+
+            var cb = H.FindControl<CheckBox>(c => c.Name == "chkEvt");
+            H.Check("CheckBoxEvt_Mounted", cb is not null);
+
+            count = 0; lastValue = null;
+            if (cb is not null) cb.IsChecked = true;
+            H.Check("CheckBoxEvt_CheckedFired", count == 1 && lastValue == true);
+
+            if (cb is not null) cb.IsChecked = false;
+            H.Check("CheckBoxEvt_UncheckedFired", count == 2 && lastValue == false);
+        }
+    }
+
+    internal class RadioButtonToggleFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            bool? lastValue = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                RadioButton("rbEvt", isChecked: false,
+                    onChecked: v => { count++; lastValue = v; })
+                    .Set(r => r.Name = "rbEvt")
+            ));
+            await Harness.Render();
+
+            var rb = H.FindControl<RadioButton>(r => r.Name == "rbEvt");
+            H.Check("RadioButtonEvt_Mounted", rb is not null);
+
+            count = 0; lastValue = null;
+            if (rb is not null) rb.IsChecked = true;
+            H.Check("RadioButtonEvt_CheckedFired", count == 1 && lastValue == true);
+
+            if (rb is not null) rb.IsChecked = false;
+            H.Check("RadioButtonEvt_UncheckedFired", count == 2 && lastValue == false);
+        }
+    }
+
+    internal class ToggleSwitchToggleFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            bool? lastValue = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                ToggleSwitch(false, onChanged: v => { count++; lastValue = v; },
+                    header: "tsEvtHdr")
+                    .Set(t => t.Name = "tsEvt")
+            ));
+            await Harness.Render();
+
+            var ts = H.FindControl<ToggleSwitch>(t => t.Name == "tsEvt");
+            H.Check("ToggleSwitchEvt_Mounted", ts is not null);
+
+            count = 0; lastValue = null;
+            if (ts is not null) ts.IsOn = true;
+            H.Check("ToggleSwitchEvt_OnFired", count == 1 && lastValue == true);
+
+            if (ts is not null) ts.IsOn = false;
+            H.Check("ToggleSwitchEvt_OffFired", count == 2 && lastValue == false);
+        }
+    }
+
+    internal class SliderValueFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            double lastValue = double.NaN;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                Slider(10, 0, 100, onChanged: v => { count++; lastValue = v; })
+                    .Set(s => s.Name = "slEvt")
+            ));
+            await Harness.Render();
+
+            var sl = H.FindControl<Slider>(s => s.Name == "slEvt");
+            H.Check("SliderEvt_Mounted", sl is not null);
+
+            count = 0; lastValue = double.NaN;
+            if (sl is not null) sl.Value = 75;
+
+            H.Check("SliderEvt_ValueChangedFired", count >= 1);
+            H.Check("SliderEvt_PayloadValue", Math.Abs(lastValue - 75) < 0.01);
+        }
+    }
+
+    internal class NumberBoxValueFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            double lastValue = double.NaN;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                NumberBox(5, onValueChanged: v => { count++; lastValue = v; },
+                    header: "nbEvtHdr")
+                    .Set(n => n.Name = "nbEvt")
+            ));
+            await Harness.Render();
+
+            var nb = H.FindControl<NumberBox>(n => n.Name == "nbEvt");
+            H.Check("NumberBoxEvt_Mounted", nb is not null);
+
+            count = 0; lastValue = double.NaN;
+            if (nb is not null) nb.Value = 42;
+
+            H.Check("NumberBoxEvt_ValueChangedFired", count >= 1);
+            H.Check("NumberBoxEvt_PayloadValue", Math.Abs(lastValue - 42) < 0.01);
+        }
+    }
+
+    // RatingControl.ValueChanged is only raised for user input (tap/keyboard) in
+    // WinUI 3 — programmatic Value assignment updates the property but does not
+    // fire the event. Verifying the wiring end-to-end therefore requires a UIA
+    // interaction and lives in the E2E tier. We still assert the mount + setter
+    // round-trip here to catch regressions in the Reconciler mount path.
+    internal class RatingControlValueFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                RatingControl(1, onValueChanged: _ => { count++; })
+                    .Set(r => r.Name = "rcEvt")
+            ));
+            await Harness.Render();
+
+            var rc = H.FindControl<RatingControl>(r => r.Name == "rcEvt");
+            H.Check("RatingEvt_Mounted", rc is not null);
+            H.Check("RatingEvt_InitialValue", rc is not null && Math.Abs(rc.Value - 1) < 0.01);
+
+            if (rc is not null) rc.Value = 4;
+            await Harness.Render();
+
+            H.Check("RatingEvt_ProgrammaticAssignReflected",
+                rc is not null && Math.Abs(rc.Value - 4) < 0.01);
+        }
+    }
+
+    internal class PasswordBoxChangeFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            string? lastValue = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                PasswordBox("initial", onPasswordChanged: v => { count++; lastValue = v; })
+                    .Set(p => p.Name = "pbEvt")
+            ));
+            await Harness.Render();
+
+            var pb = H.FindControl<PasswordBox>(p => p.Name == "pbEvt");
+            H.Check("PasswordBoxEvt_Mounted", pb is not null);
+
+            count = 0; lastValue = null;
+            if (pb is not null) pb.Password = "changed";
+            await Harness.Render();
+
+            H.Check("PasswordBoxEvt_CallbackFired", count >= 1);
+            H.Check("PasswordBoxEvt_PayloadValue", lastValue == "changed");
+        }
+    }
+
+    internal class ColorPickerChangeFires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            global::Windows.UI.Color lastColor = default;
+
+            var red = global::Windows.UI.Color.FromArgb(255, 255, 0, 0);
+            var blue = global::Windows.UI.Color.FromArgb(255, 0, 0, 255);
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                ColorPicker(red, onColorChanged: c => { count++; lastColor = c; })
+                    .Set(p => p.Name = "cpEvt")
+            ));
+            await Harness.Render();
+
+            var cp = H.FindControl<ColorPicker>(p => p.Name == "cpEvt");
+            H.Check("ColorPickerEvt_Mounted", cp is not null);
+
+            count = 0; lastColor = default;
+            if (cp is not null) cp.Color = blue;
+
+            H.Check("ColorPickerEvt_CallbackFired", count >= 1);
+            H.Check("ColorPickerEvt_PayloadColor",
+                lastColor.R == blue.R && lastColor.G == blue.G && lastColor.B == blue.B);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -619,6 +619,26 @@ internal static class SelfTestFixtureRegistry
         "DevtoolsUx_MenuHiddenWhenDisabled",
         "DevtoolsUx_MenuVisibleWhenEnabled",
         "DevtoolsUx_ObservableToggleRerendersSubscribers",
+
+        // Selection-event wiring (Tier 2 gap closure)
+        "SelectionEvt_ComboBox",
+        "SelectionEvt_RadioButtons",
+        "SelectionEvt_ListView",
+        "SelectionEvt_GridView",
+        "SelectionEvt_FlipView",
+        "SelectionEvt_TabView",
+        "SelectionEvt_Pivot",
+        "SelectionEvt_NavigationView",
+
+        // Value-change / toggle event wiring (Tier 2 gap closure)
+        "ValueEvt_CheckBox",
+        "ValueEvt_RadioButton",
+        "ValueEvt_ToggleSwitch",
+        "ValueEvt_Slider",
+        "ValueEvt_NumberBox",
+        "ValueEvt_RatingControl",
+        "ValueEvt_PasswordBox",
+        "ValueEvt_ColorPicker",
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
@@ -1234,6 +1254,26 @@ internal static class SelfTestFixtureRegistry
         "DevtoolsUx_MenuHiddenWhenDisabled" => new DevtoolsUxTests.MenuHiddenWhenDisabled(harness),
         "DevtoolsUx_MenuVisibleWhenEnabled" => new DevtoolsUxTests.MenuVisibleWhenEnabled(harness),
         "DevtoolsUx_ObservableToggleRerendersSubscribers" => new DevtoolsUxTests.ObservableToggleRerendersSubscribers(harness),
+
+        // Selection-event wiring
+        "SelectionEvt_ComboBox" => new SelectionEventFixtures.ComboBoxSelectionFires(harness),
+        "SelectionEvt_RadioButtons" => new SelectionEventFixtures.RadioButtonsSelectionFires(harness),
+        "SelectionEvt_ListView" => new SelectionEventFixtures.ListViewSelectionFires(harness),
+        "SelectionEvt_GridView" => new SelectionEventFixtures.GridViewSelectionFires(harness),
+        "SelectionEvt_FlipView" => new SelectionEventFixtures.FlipViewSelectionFires(harness),
+        "SelectionEvt_TabView" => new SelectionEventFixtures.TabViewSelectionFires(harness),
+        "SelectionEvt_Pivot" => new SelectionEventFixtures.PivotSelectionFires(harness),
+        "SelectionEvt_NavigationView" => new SelectionEventFixtures.NavigationViewSelectionFires(harness),
+
+        // Value-change / toggle event wiring
+        "ValueEvt_CheckBox" => new ValueChangeEventFixtures.CheckBoxToggleFires(harness),
+        "ValueEvt_RadioButton" => new ValueChangeEventFixtures.RadioButtonToggleFires(harness),
+        "ValueEvt_ToggleSwitch" => new ValueChangeEventFixtures.ToggleSwitchToggleFires(harness),
+        "ValueEvt_Slider" => new ValueChangeEventFixtures.SliderValueFires(harness),
+        "ValueEvt_NumberBox" => new ValueChangeEventFixtures.NumberBoxValueFires(harness),
+        "ValueEvt_RatingControl" => new ValueChangeEventFixtures.RatingControlValueFires(harness),
+        "ValueEvt_PasswordBox" => new ValueChangeEventFixtures.PasswordBoxChangeFires(harness),
+        "ValueEvt_ColorPicker" => new ValueChangeEventFixtures.ColorPickerChangeFires(harness),
 
         _ => null,
     };


### PR DESCRIPTION
## Summary

- Adds 16 selftest fixtures (49 assertions) that verify Reactor user callbacks fire end-to-end when the underlying WinUI control raises its native event. Previously only `Button`, `TextField`, and command-bound buttons had event coverage at the selftest tier.
- `SelectionEventFixtures.cs` covers `ComboBox`, `RadioButtons`, `ListView`, `GridView`, `FlipView`, `TabView`, `Pivot`, `NavigationView` — each drives the WinUI control directly (`SelectedIndex` / `SelectedItem`) and asserts the Reactor callback ran with the correct payload.
- `ValueChangeEventFixtures.cs` covers `CheckBox`, `RadioButton`, `ToggleSwitch`, `Slider`, `NumberBox`, `PasswordBox`, `ColorPicker` with full event verification. `RatingControl` gets a mount + property round-trip test only (its `ValueChanged` only fires for user input).
- `MapControl` was investigated as a Tier-1 gap but hangs the selftest harness on networking/graphics init; documented in `RareControlFixtures.cs` as unsuitable for selftest.

## Gaps still relying on the E2E/UIA tier

These WinUI events only fire for real user input, not programmatic property assignment, so they cannot be covered from a selftest fixture:

- `DatePicker.DateChanged`, `TimePicker.TimeChanged`, `CalendarDatePicker.DateChanged`
- `AutoSuggestBox.TextChanged` (gated on `Reason == UserInput`)
- `RatingControl.ValueChanged`
- `TreeView.ItemInvoked`

## Test plan

- [x] `dotnet build tests/Reactor.AppTests.Host -p:Platform=x64` — clean
- [x] `dotnet run --project tests/Reactor.AppTests.Host -- --self-test --filter "Evt_"` — 16/16 fixtures, 49/49 assertions pass
- [x] `dotnet run --project tests/Reactor.AppTests.Host -- --self-test --filter "ControlCatalog"` — no regression
- [x] `dotnet run --project tests/Reactor.AppTests.Host -- --self-test --filter "RareControl"` — no regression
- [ ] Full `dotnet test tests/Reactor.SelfTests` run on CI
- [ ] Full `dotnet test tests/Reactor.Tests` run on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)