### PR TITLE
Typed editors catalog + fix programmatic-write change-event echo

### DIFF
--- a/docs/research/investigations/change-event-echo.md
+++ b/docs/research/investigations/change-event-echo.md
@@ -1,0 +1,109 @@
+# Change-event echo — incident report and framework-level mitigations
+
+**Date:** 2026-04-23
+**Area:** `Reconciler.Update*` / `Reconciler.Mount*` for value-bearing WinUI controls.
+**Severity:** Silent cross-component state corruption.
+
+## What happened
+
+The DataGrid's `Specialized Editors` demo exhibited an "exact value swap" bug: clicking Row A's Accent cell and then Row B's Accent cell caused Row A's `AccentColor` to be overwritten with Row B's color byte-for-byte. The bug reproduced every time.
+
+Root cause was *not* in the DataGrid edit pipeline. It was in the **`PropertyGrid` bound to the selected row**, which renders an `Editors.Color()` (a full WinUI `ColorPicker`). When the selection shifted from Row A to Row B:
+
+1. `UpdatePropertyGrid` → `UpdateColorPicker` ran with `n.Color = rowB.AccentColor`.
+2. `UpdateColorPicker` wrote `cp.Color = n.Color` **before** calling `SetElementTag(cp, n)`. The ColorPicker's tag at that moment was still `rowAColorPickerElement` (the previous render).
+3. `ColorPicker.ColorChanged` fired synchronously (in WinAppSDK 2.0-preview for this property). The handler read the stale tag, invoked *Row A's* `OnColorChanged` with `rowB.AccentColor`, and the PropertyGrid wrote `rowB.AccentColor` into `rowA.AccentColor`.
+
+Because the echo fires on every programmatic write where the tag hasn't been swapped yet, the same issue silently corrupted `Quantity`, `UnitPrice`, `OrderDate`, and `Duration` on row A too — we only noticed the color because it was visually obvious.
+
+## The class of bug
+
+Every Reactor updater for a WinUI control whose change event fires from a programmatic property write is vulnerable:
+
+| Control | Change event fired by programmatic set |
+|---|---|
+| `ColorPicker.Color`     | `ColorChanged` — confirmed sync (or near-sync) |
+| `NumberBox.Value`       | `ValueChanged` — confirmed |
+| `ToggleSwitch.IsOn`     | `Toggled` — confirmed |
+| `Slider.Value`          | `ValueChanged` — confirmed |
+| `DatePicker.Date`       | `DateChanged` — confirmed |
+| `CalendarDatePicker.Date` | `DateChanged` — confirmed |
+| `TimePicker.Time`       | `TimeChanged` — confirmed |
+| `CheckBox.IsChecked`    | `Checked` / `Unchecked` / `Indeterminate` — confirmed |
+| `RadioButton.IsChecked` | `Checked` / `Unchecked` — confirmed |
+| `ToggleSplitButton.IsChecked` | `IsCheckedChanged` — confirmed |
+| `TextBox.Text`          | `TextChanged` — dispatched async, still observable |
+| `PasswordBox.Password`  | `PasswordChanged` — confirmed |
+| `AutoSuggestBox.Text`   | `TextChanged` — but filtered to `UserInput`, effectively safe |
+| `RatingControl.Value`   | `ValueChanged` — does NOT fire from programmatic write in preview2 |
+| `ComboBox.SelectedIndex` | `SelectionChanged` — ComboBox re-mounts on update, no echo path |
+
+Anything that mounts a WinUI control and wires a `SomethingChanged` handler is a candidate — even adding a new control later without realizing the pattern reintroduces the bug.
+
+## The fix that shipped
+
+1. A small helper — `src/Reactor/Core/ChangeEchoSuppressor.cs` — backed by a `ConditionalWeakTable<UIElement, Counter>`. `BeginSuppress(control)` increments; the handler calls `ShouldSuppress(control)` as its first line and returns early if it decremented a token.
+2. Every `Update<Control>` method now: (a) calls `SetElementTag` *first* (defense-in-depth even if the handler is delayed), (b) guards the value write with an equality check, and (c) calls `BeginSuppress` immediately before the assignment.
+3. Every `Mount<Control>` handler wraps the user-callback dispatch behind `ShouldSuppress`. Pooled controls (`TextField`, `ToggleSwitch`) also get `BeginSuppress` + `SetElementTag`-first on re-rent so the retained handler sees the new element.
+4. Regression coverage: `tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs` (12 fixtures, 48 assertions) exercises mount → update → simulated-user-edit for every affected control.
+
+## How we should have caught this sooner
+
+### 1. A selftest fixture per new control is non-negotiable — and it must cover the echo path
+
+The existing `SpecializedEditorsTests` only asserted that the control *mounted*. That's a shallow test: it never toggled state, never re-rendered, never watched whether onChange fired spuriously. The mitigation is to make the echo invariant part of the per-control fixture template:
+
+> Every fixture for a control that exposes an `onChange`-style parameter must assert, at minimum:
+>   - mount does not invoke `onChange`,
+>   - an internal state change that re-renders the control with a new value does not invoke `onChange`,
+>   - direct property write simulating user input *does* invoke `onChange`.
+
+Add this to the "How to add a new element type" checklist in `CONTRIBUTING.md` (§6) so the requirement is visible when new controls land.
+
+### 2. Make the safe pattern the default: a `SetSuppressed<T>` helper the updaters opt into by calling
+
+Right now every updater hand-rolls the `SetElementTag` + equality-check + `BeginSuppress` + assignment pattern. It's easy to add a new updater and forget one of the four steps. Extracting a helper like:
+
+```csharp
+// In Reconciler.cs
+private static void SetSuppressed<TVal>(UIElement control, TVal current, TVal target,
+    Action<TVal> assign)
+    where TVal : IEquatable<TVal>
+{
+    if (current.Equals(target)) return;
+    ChangeEchoSuppressor.BeginSuppress(control);
+    assign(target);
+}
+
+// Usage
+SetSuppressed(cp, cp.Color, n.Color, v => cp.Color = v);
+```
+
+makes the updater code one line per property and eliminates the class of mistake where someone adds a new property and forgets to guard it. The three-line body today *is* the pattern — but by not having a name it's also invisible to the next contributor.
+
+### 3. A unit-level "echo-check" scaffold
+
+The selftests live in-process with real WinUI, which is the right home for event semantics. But there's a unit-level check we can run in `Reactor.Tests` that catches the *static* mistake: for every `Update<X>` method, verify it calls `SetElementTag` **before** any non-const property assignment on the control. That's a Roslyn-based lint we could run in CI:
+
+- Parse `Reconciler.Update.cs` into a syntax tree.
+- For every method named `Update*`, find the first statement that's either `SetElementTag(...)` or a member assignment on the control parameter.
+- Fail if the member assignment comes first.
+
+That catches the specific shape of the bug (tag-set-after-value-write) without any runtime instrumentation, costs essentially nothing in CI time, and scales as new updaters are added. It's weaker than the selftest (won't catch cases where suppression is needed but absent), but it's faster feedback and complementary.
+
+### 4. Documentation: name the pattern in the reconciler comment header
+
+`Reconciler.cs` opens with a summary of how mount / update / children are split across partial files. That's the place to add a short "every value-bearing updater obeys this contract" paragraph pointing at `ChangeEchoSuppressor`. Contributors reaching for the pattern should find it the moment they're looking for where to put a new updater.
+
+### 5. Consider: sentinel mode for the DEBUG build
+
+`ChangeEchoSuppressor.BeginSuppress` could, in `#if DEBUG`, also record the call site (`[CallerMemberName]`). If the handler never consumes the token within one dispatcher tick, log a warning — "suspicious: `UpdateX` suppressed a change event that never fired." That would surface the opposite failure mode (over-suppression from a write that doesn't actually trigger an event) early rather than as a mysterious lost-user-input bug.
+
+## Secondary findings from the investigation
+
+Two unrelated issues surfaced in the trace logs and deserve tracking:
+
+- **Stacked `OnPointerPressed` / `OnTapped` handlers on DataGrid rows.** A single click on a row fired the enqueued handler 4–10 times (once per previous render). The handler is idempotent so it's not visibly broken today, but it's wasted work and masks real ordering issues. Investigate how `.OnPointerPressed` binds on re-render — it should replace the handler, not accumulate.
+- **`ObservableListDataSource.OnItemPropertyChanged` triggers `DataChanged` on every INPC event.** Combined with the echo bug this was cascading: one real edit fired 5+ `DataChanged` events, each causing a full grid re-render. With echo-suppression in place the cascade quiets down, but coalescing INPC bursts (e.g. within a single dispatcher tick) is still worth doing.
+
+Both are separate from this fix; filing as follow-up work.

--- a/samples/Reactor.TestApp/App.cs
+++ b/samples/Reactor.TestApp/App.cs
@@ -31,7 +31,7 @@ static class AppFlags
 
 // ─── Root application component ────────────────────────────────────────────────
 
-enum Tab { Counter, TodoList, ConditionalUI, Form, DynamicList, PerfStress, Virtualization, Flyout, DataTemplate, FlexPanel, Transitions, PropertyGrid, DataSystem, DataGrid, IntegratedData, AsyncValueSamples, Context, Memo, Persisted, Slots, Navigation, Commanding, InputGestures }
+enum Tab { Counter, TodoList, ConditionalUI, Form, DynamicList, PerfStress, Virtualization, Flyout, DataTemplate, FlexPanel, Transitions, PropertyGrid, DataSystem, DataGrid, IntegratedData, AsyncValueSamples, Context, Memo, Persisted, Slots, Navigation, Commanding, InputGestures, SpecializedEditors }
 
 class DemoApp : Component
 {
@@ -66,6 +66,7 @@ class DemoApp : Component
             Tab.Navigation => ("Navigation", "navigation"),
             Tab.Commanding => ("Commanding", "commanding"),
             Tab.InputGestures => ("Input & Gestures", "counter"),
+            Tab.SpecializedEditors => ("Specialized Editors", "propertygrid"),
             _ => (tab.ToString(), "counter")
         }).ToArray();
 
@@ -134,6 +135,7 @@ class DemoApp : Component
                     Tab.Navigation => Component<NavigationDemo>(),
                     Tab.Commanding => Component<CommandingTestDemo>(),
                     Tab.InputGestures => Component<InputGesturesDemo>(),
+                    Tab.SpecializedEditors => Component<SpecializedEditorsDemo>(),
                     _ => TextBlock("Select a tab")
                 }
             )

--- a/samples/Reactor.TestApp/Demos/SpecializedEditorsDemo.cs
+++ b/samples/Reactor.TestApp/Demos/SpecializedEditorsDemo.cs
@@ -1,0 +1,271 @@
+using System.Collections.ObjectModel;
+using INotifyPropertyChanged = System.ComponentModel.INotifyPropertyChanged;
+using PropertyChangedEventArgs = System.ComponentModel.PropertyChangedEventArgs;
+using PropertyChangedEventHandler = System.ComponentModel.PropertyChangedEventHandler;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Data;
+using Microsoft.UI.Reactor.Data.Providers;
+using Microsoft.UI.Reactor.Controls;
+using Microsoft.UI.Reactor.Layout;
+using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
+using WinUIColor = global::Windows.UI.Color;
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Specialized Editors Demo — shows every type-specific editor in DataGrid
+//  and PropertyGrid. Three sections demonstrate the two discovery paths
+//  and how PropertyGrid reads the same metadata.
+//
+//  Data flow: Gizmo is INotifyPropertyChanged, hosted in an
+//  ObservableCollection wrapped by ObservableListDataSource. Edits made in
+//  any of the three sections fire PropertyChanged, which the data source
+//  forwards as DataChanged, which refreshes every grid bound to it — so
+//  editing InStock in the PropertyGrid immediately flips the pill in both
+//  DataGrids above it.
+// ═══════════════════════════════════════════════════════════════════════
+
+enum GizmoPriority { Low, Medium, High, Critical }
+
+abstract class NotifyBase : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected bool Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        return true;
+    }
+}
+
+/// <summary>
+/// Covers one property per specialized editor type. INPC-aware so edits
+/// from any surface (DataGrid cells or PropertyGrid fields) propagate back
+/// to every other surface through ObservableListDataSource.
+/// </summary>
+class Gizmo : NotifyBase
+{
+    // A stable per-instance key decoupled from user-editable fields. Even if
+    // a user changed Id or Name, row identity in the DataGrid stays anchored
+    // to this Guid — selection and edit state never alias across rows.
+    internal readonly global::System.Guid _key = global::System.Guid.NewGuid();
+
+    int _id;
+    string _name = "";
+    int _quantity;
+    decimal _unitPrice;
+    global::System.DateTime _orderDate;
+    global::System.TimeSpan _duration;
+    bool _inStock;
+    GizmoPriority _priority;
+    string _docsUrl = "";
+    global::System.Uri _website = new("https://microsoft.com");
+    WinUIColor _accentColor;
+
+    [PropertyReadOnly]
+    public int Id { get => _id; set => Set(ref _id, value); }
+    public string Name { get => _name; set => Set(ref _name, value); }
+
+    [Range(0, 10_000)]
+    public int Quantity { get => _quantity; set => Set(ref _quantity, value); }
+
+    public decimal UnitPrice { get => _unitPrice; set => Set(ref _unitPrice, value); }
+    public global::System.DateTime OrderDate { get => _orderDate; set => Set(ref _orderDate, value); }
+    public global::System.TimeSpan Duration { get => _duration; set => Set(ref _duration, value); }
+    public bool InStock { get => _inStock; set => Set(ref _inStock, value); }
+    public GizmoPriority Priority { get => _priority; set => Set(ref _priority, value); }
+
+    [DataType(DataType.Url)]
+    public string DocsUrl { get => _docsUrl; set => Set(ref _docsUrl, value); }
+
+    public global::System.Uri Website { get => _website; set => Set(ref _website, value); }
+    public WinUIColor AccentColor { get => _accentColor; set => Set(ref _accentColor, value); }
+}
+
+static class GizmoSeed
+{
+    public static ObservableCollection<Gizmo> MakeItems() => new([
+        new Gizmo
+        {
+            Id = 1, Name = "Resonator", Quantity = 42, UnitPrice = 19.99m,
+            OrderDate = new(2026, 3, 15),
+            Duration = global::System.TimeSpan.FromHours(2.5),
+            InStock = true, Priority = GizmoPriority.High,
+            DocsUrl = "https://example.com/docs/resonator",
+            Website = new("https://example.com"),
+            AccentColor = global::Microsoft.UI.Colors.SteelBlue,
+        },
+        new Gizmo
+        {
+            Id = 2, Name = "Modulator", Quantity = 8, UnitPrice = 125.00m,
+            OrderDate = new(2026, 4, 1),
+            Duration = global::System.TimeSpan.FromMinutes(45),
+            InStock = false, Priority = GizmoPriority.Critical,
+            DocsUrl = "https://example.com/docs/modulator",
+            Website = new("https://example.org"),
+            AccentColor = global::Microsoft.UI.Colors.Crimson,
+        },
+        new Gizmo
+        {
+            Id = 3, Name = "Transducer", Quantity = 1000, UnitPrice = 0.79m,
+            OrderDate = new(2026, 2, 28),
+            Duration = global::System.TimeSpan.FromMinutes(5),
+            InStock = true, Priority = GizmoPriority.Low,
+            DocsUrl = "https://example.com/docs/transducer",
+            Website = new("https://github.com"),
+            AccentColor = global::Microsoft.UI.Colors.MediumSeaGreen,
+        },
+        new Gizmo
+        {
+            Id = 4, Name = "Flux Capacitor", Quantity = 1, UnitPrice = 1_210_000m,
+            OrderDate = new(2026, 1, 1),
+            Duration = global::System.TimeSpan.FromHours(24),
+            InStock = false, Priority = GizmoPriority.Medium,
+            DocsUrl = "https://example.com/docs/flux",
+            Website = new("https://bttf.com"),
+            AccentColor = global::Microsoft.UI.Colors.MediumPurple,
+        },
+    ]);
+}
+
+class SpecializedEditorsDemo : Component
+{
+    public override Element Render()
+    {
+        // Shared data across all three sections. Using ObservableCollection +
+        // ObservableListDataSource means INPC mutations on any Gizmo (from any
+        // surface) fire DataChanged, and every grid bound to this source
+        // refreshes — that's how the PropertyGrid edit propagates to the grid.
+        var items = UseMemo(() => GizmoSeed.MakeItems());
+        var source = UseMemo(() =>
+            new ObservableListDataSource<Gizmo>(items, g => (RowKey)g._key.ToString()));
+        var registry = UseMemo(() => new TypeRegistry());
+        var (selectedKey, setSelectedKey) = UseState<string?>(items[0]._key.ToString());
+
+        Gizmo? selected = selectedKey is null
+            ? null
+            : items.FirstOrDefault(g => g._key.ToString() == selectedKey);
+
+        Action<IReadOnlySet<RowKey>> onSelect = keys =>
+        {
+            if (keys.Count == 0) { setSelectedKey(null); return; }
+            setSelectedKey(keys.First().Value);
+        };
+
+        return FlexColumn(
+            Heading("Specialized Editors").Flex(shrink: 0),
+            TextBlock(
+                "Same data, three renderings. Compare how auto-discovery picks the " +
+                "right editor from each property's type (and attributes), vs how an " +
+                "explicit typed column can intentionally pick something different. " +
+                "Edits in any surface propagate to the others via INPC."
+            ).Foreground(SecondaryText).Flex(shrink: 0),
+
+            ScrollView(
+                VStack(16,
+                    // ──────────────────────────────────────────────────
+                    // Section 1 — read-only display via AutoColumns.
+                    // Editable=false keeps this section purely about how
+                    // auto-discovery picks renderers; edits happen in the
+                    // PropertyGrid and flow back through INPC.
+                    // ──────────────────────────────────────────────────
+                    SectionCard(
+                        "1.  DataGrid — metadata-driven (display)",
+                        "AutoColumns resolves each property's type through TypeRegistry. " +
+                            "bool → CheckMark. DateTime → short date. TimeSpan → short time. " +
+                            "Uri → hyperlink. Color → swatch. enum → plain text. " +
+                            "DocsUrl renders as a hyperlink because of [DataType(DataType.Url)]. " +
+                            "This section is non-editable — click a row to select, edit below.",
+                        DataGridDsl.DataGrid(
+                            source: source,
+                            registry: registry,
+                            selectionMode: SelectionMode.Single,
+                            onSelectionChanged: onSelect,
+                            editable: false,
+                            rowHeight: 40
+                        ).Height(260)
+                    ),
+
+                    // ──────────────────────────────────────────────────
+                    // Section 2 — explicit typed columns, editable.
+                    // ──────────────────────────────────────────────────
+                    SectionCard(
+                        "2.  DataGrid — explicit typed columns (edit in grid)",
+                        "Same data, columns set explicitly via NumberColumn / DateColumn / " +
+                            "ToggleSwitchColumn / ComboBoxColumn / HyperlinkColumn / ColorColumn. " +
+                            "InStock is intentionally rendered as a toggle pill + ToggleSwitch " +
+                            "editor here (vs the CheckMark in section 1). Priority uses a " +
+                            "ComboBox seeded with only three of the four enum values.",
+                        DataGridDsl.DataGrid(
+                            source: source,
+                            columns: BuildExplicitColumns(),
+                            selectionMode: SelectionMode.Single,
+                            onSelectionChanged: onSelect,
+                            editable: true,
+                            rowHeight: 40
+                        ).Height(260)
+                    ),
+
+                    // ──────────────────────────────────────────────────
+                    // Section 3 — PropertyGrid bound to selected row
+                    // ──────────────────────────────────────────────────
+                    SectionCard(
+                        "3.  PropertyGrid — metadata-driven",
+                        selected is null
+                            ? "Select a row above to edit its properties here."
+                            : $"Editing Gizmo #{selected.Id}. PropertyGrid uses the Standard " +
+                                "tier, so bool renders as ToggleSwitch (vs CheckMark/pill above). " +
+                                "All other editors come from the same TypeRegistry resolution " +
+                                "path. Toggling InStock here updates both grids above.",
+                        selected is null
+                            ? (Element)TextBlock("(nothing selected)").Foreground(SecondaryText).Padding(12)
+                            : PropertyGridDsl.PropertyGrid(target: selected, registry: registry)
+                    )
+                )
+            ).Flex(grow: 1)
+        ) with { RowGap = 8 };
+    }
+
+    /// <summary>
+    /// Section 2's explicit columns. Uses TypedColumns factories so the editor
+    /// and cell renderer are wired at the call site — no registry lookup at
+    /// render time. Two rows (InStock, Priority) deliberately pick a different
+    /// editor than the auto-discovered one to make the override visible.
+    /// </summary>
+    static FieldDescriptor[] BuildExplicitColumns() =>
+    [
+        ColumnDsl.Column<Gizmo>("Id", g => g.Id, width: 40),
+        ColumnDsl.Column<Gizmo>("Name", g => g.Name, editable: true, width: 140),
+        TypedColumns.NumberColumn<Gizmo>("Quantity", g => g.Quantity,
+            min: 0, max: 10_000, width: 100),
+        TypedColumns.NumberColumn<Gizmo>("UnitPrice", g => g.UnitPrice,
+            displayName: "Unit Price", format: "C2", width: 110),
+        TypedColumns.DateColumn<Gizmo>("OrderDate", g => g.OrderDate,
+            displayName: "Date", format: "d", width: 130),
+        TypedColumns.TimeColumn<Gizmo>("Duration", g => g.Duration, width: 110),
+        // Explicit: render bool as a ToggleSwitch pill even in DataGrid's compact tier.
+        TypedColumns.ToggleSwitchColumn<Gizmo>("InStock", g => g.InStock,
+            displayName: "Stock", width: 100),
+        // Explicit: only offer three of the four enum values here.
+        TypedColumns.ComboBoxColumn<Gizmo, GizmoPriority>(
+            "Priority", g => g.Priority,
+            choices: [GizmoPriority.Low, GizmoPriority.Medium, GizmoPriority.High],
+            width: 110),
+        TypedColumns.HyperlinkColumn<Gizmo>("Website", g => g.Website, width: 200),
+        TypedColumns.ColorColumn<Gizmo>("AccentColor", g => g.AccentColor,
+            displayName: "Accent", width: 130),
+    ];
+
+    static Element SectionCard(string title, string description, Element content) =>
+        Border(
+            VStack(8,
+                SubHeading(title),
+                TextBlock(description).Foreground(SecondaryText).TextWrapping(
+                    Microsoft.UI.Xaml.TextWrapping.Wrap),
+                Border(content).Padding(0)
+            )
+        ).Padding(16).WithBorder("#30000000", 1).CornerRadius(8);
+}

--- a/samples/Reactor.TestApp/Properties/launchSettings.json
+++ b/samples/Reactor.TestApp/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Patch.TestApp": {
       "commandName": "Project",
+      "commandLineArgs": "--devtools",
       "nativeDebugging": false
     }
   }

--- a/src/Reactor/Controls/DataGrid/ColumnDsl.cs
+++ b/src/Reactor/Controls/DataGrid/ColumnDsl.cs
@@ -184,6 +184,30 @@ public class ColumnBuilder<T>
         return this;
     }
 
+    /// <summary>
+    /// Set a custom inline editor for this column. The delegate receives the
+    /// current value and an onChange callback and returns the editor Element.
+    /// See <see cref="Editors"/> for pre-built factories.
+    /// </summary>
+    public ColumnBuilder<T> WithEditor(Func<object, Action<object>, Element> editor)
+    {
+        _descriptor = _descriptor with { Editor = editor };
+        return this;
+    }
+
+    /// <summary>Width / min / max / flex for the column.</summary>
+    public ColumnBuilder<T> Width(double? width = null, double? min = null, double? max = null, double? flex = null)
+    {
+        _descriptor = _descriptor with
+        {
+            Width = width ?? _descriptor.Width,
+            MinWidth = min ?? _descriptor.MinWidth,
+            MaxWidth = max ?? _descriptor.MaxWidth,
+            Flex = flex ?? _descriptor.Flex,
+        };
+        return this;
+    }
+
     /// <summary>Set sortable state.</summary>
     public ColumnBuilder<T> NotSortable()
     {

--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -618,6 +618,19 @@ public class DataGridComponent<T> : Component<DataGridElement<T>>
                 {
                     Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
                     {
+                        // Commit any in-flight edit BEFORE starting a new one.
+                        // BeginEdit unconditionally overwrites _editingValue with the
+                        // new cell's current value, which would destroy the in-flight
+                        // edit's pending value if we didn't commit first.
+                        if (state.IsEditing)
+                        {
+                            var editKey = state.EditingRowKey;
+                            var origItem = editKey is not null
+                                ? GetOriginalItem(state, editKey.Value) : default;
+                            var result = state.CommitEdit();
+                            if (result is not null && el.OnRowChanged is not null)
+                                HandleAsyncCommit(state, el, result.Value.Key, result.Value.NewItem, origItem!);
+                        }
                         state.SetFocus(capturedRow, capturedCol);
                         state.BeginEdit(capturedRow, capturedCol);
                     });
@@ -784,33 +797,39 @@ public class DataGridComponent<T> : Component<DataGridElement<T>>
 
     // ── Cell rendering ──────────────────────────────────────────────
 
+    // Shared cell padding: left, top, right, bottom. The extra right padding
+    // creates a forced gutter between adjacent columns so content — including
+    // right-aligned numbers and colored pills — can't visually merge into the
+    // neighbor cell.
+    private const double CellPadLeft = 8, CellPadTop = 4, CellPadRight = 12, CellPadBottom = 4;
+
     private static Element RenderCell(
         FieldDescriptor col, object? value, TypeRegistry registry)
     {
         if (col.CellRenderer is not null && value is not null)
-            return col.CellRenderer(value).Padding(8, 4);
+            return col.CellRenderer(value).Padding(CellPadLeft, CellPadTop, CellPadRight, CellPadBottom);
 
         if (col.FormatValue is not null)
-            return TextBlock(col.FormatValue(value)).Padding(8, 4);
+            return TextBlock(col.FormatValue(value)).Padding(CellPadLeft, CellPadTop, CellPadRight, CellPadBottom);
 
         var registryRenderer = registry.GetCellRenderer(col.FieldType);
         if (registryRenderer is not null && value is not null)
-            return registryRenderer(value).Padding(8, 4);
+            return registryRenderer(value).Padding(CellPadLeft, CellPadTop, CellPadRight, CellPadBottom);
 
         var registryFormatter = registry.GetFormatter(col.FieldType);
         if (registryFormatter is not null)
-            return TextBlock(registryFormatter(value)).Padding(8, 4);
+            return TextBlock(registryFormatter(value)).Padding(CellPadLeft, CellPadTop, CellPadRight, CellPadBottom);
 
         if (value is bool boolVal)
-            return TextBlock(boolVal ? "\u2713" : "").Padding(8, 4);
+            return TextBlock(boolVal ? "\u2713" : "").Padding(CellPadLeft, CellPadTop, CellPadRight, CellPadBottom);
 
         if (value is double d)
-            return TextBlock(d.ToString("G")).Padding(8, 4);
+            return TextBlock(d.ToString("G")).Padding(CellPadLeft, CellPadTop, CellPadRight, CellPadBottom);
 
         if (value is float f)
-            return TextBlock(f.ToString("G")).Padding(8, 4);
+            return TextBlock(f.ToString("G")).Padding(CellPadLeft, CellPadTop, CellPadRight, CellPadBottom);
 
-        return TextBlock(value?.ToString() ?? "").Padding(8, 4);
+        return TextBlock(value?.ToString() ?? "").Padding(CellPadLeft, CellPadTop, CellPadRight, CellPadBottom);
     }
 
     private static Element RenderEditingCell(
@@ -1264,7 +1283,7 @@ public class DataGridComponent<T> : Component<DataGridElement<T>>
     {
         // Vary the bar width per column so it looks organic, not uniform
         var barText = new string('\u2003', Math.Max(1, (int)(colWidth / 24)));
-        return TextBlock(barText).Padding(8, 4)
+        return TextBlock(barText).Padding(CellPadLeft, CellPadTop, CellPadRight, CellPadBottom)
             .Background("#e0e0e0").Opacity(0.5);
     }
 

--- a/src/Reactor/Controls/DataGrid/TypedColumns.cs
+++ b/src/Reactor/Controls/DataGrid/TypedColumns.cs
@@ -1,0 +1,172 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Data;
+using WinUIColor = global::Windows.UI.Color;
+
+namespace Microsoft.UI.Reactor.Controls;
+
+/// <summary>
+/// Typed column factories that ship specialized editors + cell renderers out of
+/// the box. Thin wrappers over <see cref="ColumnDsl.Column{T}"/> that pre-wire
+/// the matching pair from <see cref="Editors"/> and <see cref="CellRenderers"/>.
+///
+/// Use when the column type is known at the call site and you want HitTable-style
+/// "batteries included" ergonomics. For discovery-driven columns, use
+/// <see cref="ColumnDsl.AutoColumns{T}"/> with a <see cref="TypeRegistry"/>
+/// populated via <see cref="TypeRegistry.WithDefaultEditors"/>.
+/// </summary>
+public static class TypedColumns
+{
+    // ══════════════════════════════════════════════════════════════
+    //  Number — one factory covering int/long/short/byte/float/double/decimal.
+    //  The accessor's declared property type drives value-conversion.
+    // ══════════════════════════════════════════════════════════════
+
+    public static ColumnBuilder<T> NumberColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+        string name,
+        Func<T, object?> accessor,
+        double? min = null,
+        double? max = null,
+        double smallChange = 1,
+        string? displayName = null,
+        string? format = null,
+        double? width = null,
+        PinPosition pin = PinPosition.None)
+    {
+        var builder = ColumnDsl.Column(name, accessor,
+            editable: true, displayName: displayName, format: format, width: width, pin: pin);
+        var fieldType = ((FieldDescriptor)builder).FieldType;
+        return builder
+            .WithEditor(Editors.Number(fieldType, min, max, smallChange))
+            .CellRenderer(CellRenderers.Number(format));
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  Bool
+    // ══════════════════════════════════════════════════════════════
+
+    public static ColumnBuilder<T> CheckBoxColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+        string name,
+        Func<T, object?> accessor,
+        string? displayName = null,
+        double? width = null,
+        PinPosition pin = PinPosition.None)
+        => ColumnDsl.Column(name, accessor,
+                editable: true, displayName: displayName, width: width, pin: pin)
+            .WithEditor(Editors.CheckBox())
+            .CellRenderer(CellRenderers.CheckMark());
+
+    public static ColumnBuilder<T> ToggleSwitchColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+        string name,
+        Func<T, object?> accessor,
+        string? onContent = null,
+        string? offContent = null,
+        string? displayName = null,
+        double? width = null,
+        PinPosition pin = PinPosition.None)
+        => ColumnDsl.Column(name, accessor,
+                editable: true, displayName: displayName, width: width, pin: pin)
+            .WithEditor(Editors.Toggle(onContent, offContent))
+            .CellRenderer(CellRenderers.ToggleIndicator());
+
+    // ══════════════════════════════════════════════════════════════
+    //  Date / Time
+    // ══════════════════════════════════════════════════════════════
+
+    public static ColumnBuilder<T> DateColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+        string name,
+        Func<T, object?> accessor,
+        string format = "d",
+        string? displayName = null,
+        double? width = null,
+        PinPosition pin = PinPosition.None)
+    {
+        var builder = ColumnDsl.Column(name, accessor,
+            editable: true, displayName: displayName, format: format, width: width, pin: pin);
+        var fieldType = ((FieldDescriptor)builder).FieldType;
+        var editor = fieldType == typeof(global::System.DateTimeOffset)
+            ? Editors.DateOffset()
+            : fieldType == typeof(global::System.DateOnly)
+                ? Editors.DateOnly()
+                : Editors.Date();
+        return builder
+            .WithEditor(editor)
+            .CellRenderer(CellRenderers.Date(format));
+    }
+
+    public static ColumnBuilder<T> TimeColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+        string name,
+        Func<T, object?> accessor,
+        string format = "t",
+        string? displayName = null,
+        double? width = null,
+        PinPosition pin = PinPosition.None)
+    {
+        var builder = ColumnDsl.Column(name, accessor,
+            editable: true, displayName: displayName, format: format, width: width, pin: pin);
+        var fieldType = ((FieldDescriptor)builder).FieldType;
+        var editor = fieldType == typeof(global::System.TimeOnly)
+            ? Editors.TimeOnlyEditor()
+            : Editors.TimeSpanEditor();
+        return builder
+            .WithEditor(editor)
+            .CellRenderer(CellRenderers.Time(format));
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  Combo / Enum
+    // ══════════════════════════════════════════════════════════════
+
+    public static ColumnBuilder<T> ComboBoxColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T, TValue>(
+        string name,
+        Func<T, object?> accessor,
+        IReadOnlyList<TValue> choices,
+        string? displayName = null,
+        double? width = null,
+        PinPosition pin = PinPosition.None)
+        => ColumnDsl.Column(name, accessor,
+                editable: true, displayName: displayName, width: width, pin: pin)
+            .WithEditor(Editors.Combo(choices))
+            .CellRenderer(CellRenderers.Enum());
+
+    // ══════════════════════════════════════════════════════════════
+    //  Hyperlink — underlying type may be Uri or string.
+    // ══════════════════════════════════════════════════════════════
+
+    public static ColumnBuilder<T> HyperlinkColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+        string name,
+        Func<T, object?> accessor,
+        string? displayTextFormat = null,
+        string? displayName = null,
+        double? width = null,
+        PinPosition pin = PinPosition.None)
+    {
+        var builder = ColumnDsl.Column(name, accessor,
+            editable: true, displayName: displayName, width: width, pin: pin);
+        var fieldType = ((FieldDescriptor)builder).FieldType;
+        var editor = fieldType == typeof(global::System.Uri)
+            ? Editors.Uri()
+            : Editors.Text(placeholder: "https://...");
+        return builder
+            .WithEditor(editor)
+            .CellRenderer(CellRenderers.Hyperlink(displayTextFormat));
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  Color
+    // ══════════════════════════════════════════════════════════════
+
+    public static ColumnBuilder<T> ColorColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+        string name,
+        Func<T, object?> accessor,
+        string? displayName = null,
+        double? width = null,
+        PinPosition pin = PinPosition.None)
+        // Editors.ColorCompact (not .Color) — grid cells are ~40px tall, the
+        // full inline ColorPicker would overflow ~300px and obscure adjacent
+        // rows. Compact = swatch + hex text box; stays inside the row.
+        => ColumnDsl.Column(name, accessor,
+                editable: true, displayName: displayName, width: width, pin: pin)
+            .WithEditor(Editors.ColorCompact())
+            .CellRenderer(CellRenderers.ColorSwatch());
+}

--- a/src/Reactor/Controls/Editors/CellRenderers.cs
+++ b/src/Reactor/Controls/Editors/CellRenderers.cs
@@ -1,0 +1,131 @@
+using System.Globalization;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+using WinUIColor = global::Windows.UI.Color;
+
+namespace Microsoft.UI.Reactor.Controls;
+
+/// <summary>
+/// Catalog of read-mode cell renderers for DataGrid (and anywhere else
+/// that needs a "display this value" factory). Each method returns a
+/// <c>Func&lt;object, Element&gt;</c> matching <see cref="Data.FieldDescriptor.CellRenderer"/>.
+///
+/// Paired with <see cref="Editors"/> — the convention is that a specialized
+/// column uses the matching pair (e.g. <c>CellRenderers.Date</c> + <c>Editors.DateTime</c>).
+/// </summary>
+public static class CellRenderers
+{
+    // ══════════════════════════════════════════════════════════════
+    //  Text — default fallback, honors an optional .NET format spec.
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Element> Text(string? format = null)
+        => value => TextBlock(FormatValue(value, format));
+
+    // ══════════════════════════════════════════════════════════════
+    //  Bool
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Element> CheckMark()
+        => value =>
+        {
+            var on = (bool)(value ?? false);
+            return TextBlock(on ? "✓" : string.Empty)
+                .Foreground(on ? "#2e7d32" : "#9e9e9e")
+                .FontSize(16);
+        };
+
+    public static Func<object, Element> ToggleIndicator()
+        => value =>
+        {
+            var on = (bool)(value ?? false);
+            // Read-mode stylized toggle: a small pill. HAlign.Left keeps the
+            // pill at its natural content width — without this, Border stretches
+            // to the cell's full width and visually bleeds into the next column.
+            return Border(TextBlock(on ? "ON" : "OFF")
+                    .Foreground(on ? "#FFFFFF" : "#555555")
+                    .FontSize(10))
+                .Background(on ? "#2e7d32" : "#e0e0e0")
+                .CornerRadius(8)
+                .Padding(6, 2)
+                .HAlign(Microsoft.UI.Xaml.HorizontalAlignment.Left)
+                .VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center);
+        };
+
+    // ══════════════════════════════════════════════════════════════
+    //  Numeric
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Element> Number(string? format = null)
+        => value => TextBlock(FormatValue(value, format))
+            .TextAlignment(Microsoft.UI.Xaml.TextAlignment.Right)
+            // Stretch the text block so TextAlignment.Right actually takes effect —
+            // otherwise the TextBlock sizes to its content and sits at the left.
+            .HAlign(Microsoft.UI.Xaml.HorizontalAlignment.Stretch);
+
+    // ══════════════════════════════════════════════════════════════
+    //  Date / Time
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Element> Date(string format = "d")
+        => value => TextBlock(FormatValue(value, format));
+
+    public static Func<object, Element> Time(string format = "t")
+        => value => TextBlock(FormatValue(value, format));
+
+    // ══════════════════════════════════════════════════════════════
+    //  Hyperlink
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Element> Hyperlink(string? displayTextFormat = null)
+        => value =>
+        {
+            if (value is global::System.Uri uri)
+                return HyperlinkButton(
+                    displayTextFormat is null ? uri.ToString() : string.Format(displayTextFormat, uri),
+                    navigateUri: uri);
+
+            var text = value?.ToString() ?? string.Empty;
+            if (global::System.Uri.TryCreate(text, UriKind.Absolute, out var parsed))
+                return HyperlinkButton(text, navigateUri: parsed);
+
+            return TextBlock(text);
+        };
+
+    // ══════════════════════════════════════════════════════════════
+    //  Color — a small color swatch with the hex as a label next to it.
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Element> ColorSwatch()
+        => value =>
+        {
+            var color = (WinUIColor)(value ?? global::Microsoft.UI.Colors.Transparent);
+            return HStack(6,
+                Border(Empty())
+                    .Background($"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}")
+                    .Width(16).Height(16)
+                    .CornerRadius(3)
+                    .WithBorder("#80000000", 1),
+                TextBlock(color.ToHexString()).FontSize(11).Foreground("#555555")
+            );
+        };
+
+    // ══════════════════════════════════════════════════════════════
+    //  Combo / Enum — just the string form of the value.
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Element> Enum()
+        => value => TextBlock(value?.ToString() ?? string.Empty);
+
+    // ══════════════════════════════════════════════════════════════
+    //  Helpers
+    // ══════════════════════════════════════════════════════════════
+
+    private static string FormatValue(object? value, string? format)
+    {
+        if (value is null) return string.Empty;
+        if (format is not null && value is IFormattable f)
+            return f.ToString(format, CultureInfo.CurrentCulture);
+        return value.ToString() ?? string.Empty;
+    }
+}

--- a/src/Reactor/Controls/Editors/Editors.cs
+++ b/src/Reactor/Controls/Editors/Editors.cs
@@ -1,0 +1,327 @@
+using System.Globalization;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+using WinUIColor = global::Windows.UI.Color;
+
+namespace Microsoft.UI.Reactor.Controls;
+
+/// <summary>
+/// Catalog of inline editor factories for DataGrid and PropertyGrid. Each method
+/// returns a <c>Func&lt;object, Action&lt;object&gt;, Element&gt;</c> matching the
+/// <see cref="Data.FieldDescriptor.Editor"/> contract: takes the current cell
+/// value and an onChange callback, returns the editor Element.
+///
+/// Use these via:
+/// <list type="bullet">
+///   <item><c>FieldDescriptor</c>'s <c>Editor</c> slot directly, or</item>
+///   <item>A typed column factory like <c>NumberColumn&lt;T&gt;</c> (thin wrappers over this catalog), or</item>
+///   <item><c>TypeRegistry</c> registration for metadata-driven discovery.</item>
+/// </list>
+/// </summary>
+public static class Editors
+{
+    // ══════════════════════════════════════════════════════════════
+    //  Text
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Action<object>, Element> Text(
+        string? placeholder = null,
+        int? maxLength = null)
+        => (value, onChange) =>
+        {
+            var el = TextField((string?)value ?? string.Empty, s => onChange(s), placeholder: placeholder);
+            return maxLength is { } max
+                ? el.Set(tb => tb.MaxLength = max)
+                : el;
+        };
+
+    // ══════════════════════════════════════════════════════════════
+    //  Bool
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Action<object>, Element> CheckBox()
+        => (value, onChange) =>
+            Factories.CheckBox((bool)(value ?? false), b => onChange(b));
+
+    public static Func<object, Action<object>, Element> Toggle(
+        string? onContent = null,
+        string? offContent = null)
+        => (value, onChange) =>
+            ToggleSwitch(
+                (bool)(value ?? false),
+                b => onChange(b),
+                onContent: onContent,
+                offContent: offContent);
+
+    // ══════════════════════════════════════════════════════════════
+    //  Numeric
+    //  NumberBox operates in double; we bounce to/from the declared
+    //  CLR type so the onChange callback hands the property setter a
+    //  value it can cast without InvalidCastException.
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Action<object>, Element> Number(
+        Type numberType,
+        double? min = null,
+        double? max = null,
+        double smallChange = 1)
+        => (value, onChange) =>
+        {
+            var current = ToDouble(value);
+            var el = NumberBox(current, v => onChange(FromDouble(numberType, v)));
+            return el.Set(nb =>
+            {
+                if (min is { } mn) nb.Minimum = mn;
+                if (max is { } mx) nb.Maximum = mx;
+                nb.SmallChange = smallChange;
+            });
+        };
+
+    public static Func<object, Action<object>, Element> Int(int? min = null, int? max = null)
+        => Number(typeof(int), min, max);
+
+    public static Func<object, Action<object>, Element> Long(long? min = null, long? max = null)
+        => Number(typeof(long), min, max);
+
+    public static Func<object, Action<object>, Element> Double(
+        double? min = null, double? max = null)
+        => Number(typeof(double), min, max);
+
+    public static Func<object, Action<object>, Element> Decimal(
+        decimal? min = null, decimal? max = null)
+        => Number(typeof(decimal), (double?)min, (double?)max);
+
+    public static Func<object, Action<object>, Element> Float(float? min = null, float? max = null)
+        => Number(typeof(float), min, max);
+
+    // ══════════════════════════════════════════════════════════════
+    //  Date / Time
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Action<object>, Element> Date()
+        => (value, onChange) =>
+        {
+            global::System.DateTimeOffset dto;
+            if (value is global::System.DateTime dt)
+            {
+                var kind = dt.Kind == DateTimeKind.Unspecified
+                    ? global::System.DateTime.SpecifyKind(dt, DateTimeKind.Local)
+                    : dt;
+                dto = new global::System.DateTimeOffset(kind);
+            }
+            else if (value is global::System.DateTimeOffset off)
+            {
+                dto = off;
+            }
+            else
+            {
+                dto = global::System.DateTimeOffset.Now;
+            }
+            return DatePicker(dto, d => onChange(d.DateTime));
+        };
+
+    public static Func<object, Action<object>, Element> DateOffset()
+        => (value, onChange) =>
+        {
+            var dto = (global::System.DateTimeOffset)(value ?? global::System.DateTimeOffset.Now);
+            return DatePicker(dto, d => onChange(d));
+        };
+
+    public static Func<object, Action<object>, Element> DateOnly()
+        => (value, onChange) =>
+        {
+            var d = (global::System.DateOnly)(value ?? global::System.DateOnly.FromDateTime(global::System.DateTime.Today));
+            var dto = new DateTimeOffset(d.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+            return DatePicker(dto, picked =>
+                onChange(global::System.DateOnly.FromDateTime(picked.DateTime)));
+        };
+
+    public static Func<object, Action<object>, Element> TimeOfDay()
+        => (value, onChange) =>
+        {
+            var ts = value switch
+            {
+                global::System.TimeSpan t => t,
+                global::System.TimeOnly to => to.ToTimeSpan(),
+                null => global::System.TimeSpan.Zero,
+                _ => global::System.TimeSpan.Zero,
+            };
+            return TimePicker(ts, t => onChange(value is TimeOnly ? TimeOnly.FromTimeSpan(t) : (object)t));
+        };
+
+    public static Func<object, Action<object>, Element> TimeSpanEditor()
+        => (value, onChange) =>
+        {
+            var ts = (global::System.TimeSpan)(value ?? global::System.TimeSpan.Zero);
+            return TimePicker(ts, t => onChange(t));
+        };
+
+    public static Func<object, Action<object>, Element> TimeOnlyEditor()
+        => (value, onChange) =>
+        {
+            var to = (global::System.TimeOnly)(value ?? global::System.TimeOnly.MinValue);
+            return TimePicker(to.ToTimeSpan(), t => onChange(global::System.TimeOnly.FromTimeSpan(t)));
+        };
+
+    // ══════════════════════════════════════════════════════════════
+    //  Uri / Hyperlink (edit mode = TextBox over the URL string).
+    //  The display renderer is where the hyperlink rendering lives.
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Action<object>, Element> Uri()
+        => (value, onChange) =>
+        {
+            var text = value switch
+            {
+                global::System.Uri u => u.ToString(),
+                null => string.Empty,
+                _ => value.ToString() ?? string.Empty,
+            };
+            return TextField(text, s =>
+            {
+                // Only commit valid Uris; leave the field alone for partial input.
+                if (global::System.Uri.TryCreate(s, UriKind.RelativeOrAbsolute, out var uri))
+                    onChange(uri);
+            }, placeholder: "https://...");
+        };
+
+    // ══════════════════════════════════════════════════════════════
+    //  Choice / Combo
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Action<object>, Element> Combo<TValue>(IReadOnlyList<TValue> choices)
+        => (value, onChange) =>
+        {
+            var names = choices.Select(c => c?.ToString() ?? string.Empty).ToArray();
+            var idx = 0;
+            for (int i = 0; i < choices.Count; i++)
+            {
+                if (Equals(choices[i], value)) { idx = i; break; }
+            }
+            return ComboBox(names, idx, i => onChange(choices[i]!));
+        };
+
+    public static Func<object, Action<object>, Element> EnumCombo(Type enumType)
+    {
+        var names = Enum.GetNames(enumType);
+        return (value, onChange) =>
+        {
+            var current = value?.ToString();
+            var idx = Array.IndexOf(names, current);
+            if (idx < 0) idx = 0;
+            return ComboBox(names, idx, i => onChange(Enum.Parse(enumType, names[i])));
+        };
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  Color — two variants.
+    //    • Compact (DataGrid cell): swatch + hex text box. Typing a
+    //      valid #RRGGBB / #AARRGGBB hex commits the color. No flyout —
+    //      avoids a WinAppSDK 2.0-preview ColorPicker-in-Flyout crash.
+    //    • Full (PropertyGrid / expanded): inline WinUI ColorPicker.
+    // ══════════════════════════════════════════════════════════════
+
+    public static Func<object, Action<object>, Element> ColorCompact()
+        => (value, onChange) =>
+        {
+            var color = (WinUIColor)(value ?? global::Microsoft.UI.Colors.Transparent);
+            var hex = color.ToHexString();
+            return HStack(6,
+                Border(Empty())
+                    .Background($"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}")
+                    .Width(20).Height(20)
+                    .CornerRadius(3)
+                    .WithBorder("#80000000", 1),
+                TextField(hex, s =>
+                {
+                    if (TryParseHexColor(s, out var parsed))
+                        onChange(parsed);
+                }).Width(110)
+            ).VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center);
+        };
+
+    public static Func<object, Action<object>, Element> Color()
+        => (value, onChange) =>
+        {
+            var color = (WinUIColor)(value ?? global::Microsoft.UI.Colors.Transparent);
+            return ColorPicker(color, c => onChange(c));
+        };
+
+    private static bool TryParseHexColor(string text, out WinUIColor color)
+    {
+        color = global::Microsoft.UI.Colors.Transparent;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        var s = text.Trim().TrimStart('#');
+        byte a = 0xFF, r, g, b;
+        try
+        {
+            if (s.Length == 6)
+            {
+                r = Convert.ToByte(s.Substring(0, 2), 16);
+                g = Convert.ToByte(s.Substring(2, 2), 16);
+                b = Convert.ToByte(s.Substring(4, 2), 16);
+            }
+            else if (s.Length == 8)
+            {
+                a = Convert.ToByte(s.Substring(0, 2), 16);
+                r = Convert.ToByte(s.Substring(2, 2), 16);
+                g = Convert.ToByte(s.Substring(4, 2), 16);
+                b = Convert.ToByte(s.Substring(6, 2), 16);
+            }
+            else return false;
+        }
+        catch { return false; }
+        color = global::Windows.UI.Color.FromArgb(a, r, g, b);
+        return true;
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  Helpers
+    // ══════════════════════════════════════════════════════════════
+
+    private static double ToDouble(object? value) => value switch
+    {
+        null => 0d,
+        double d => d,
+        float f => f,
+        decimal m => (double)m,
+        int i => i,
+        long l => l,
+        short s => s,
+        byte b => b,
+        sbyte sb => sb,
+        ushort us => us,
+        uint ui => ui,
+        ulong ul => ul,
+        _ => Convert.ToDouble(value, CultureInfo.InvariantCulture),
+    };
+
+    private static object FromDouble(Type targetType, double value)
+    {
+        if (targetType == typeof(double)) return value;
+        if (targetType == typeof(float)) return (float)value;
+        if (targetType == typeof(decimal)) return (decimal)value;
+        if (targetType == typeof(int)) return (int)value;
+        if (targetType == typeof(long)) return (long)value;
+        if (targetType == typeof(short)) return (short)value;
+        if (targetType == typeof(byte)) return (byte)value;
+        if (targetType == typeof(sbyte)) return (sbyte)value;
+        if (targetType == typeof(ushort)) return (ushort)value;
+        if (targetType == typeof(uint)) return (uint)value;
+        if (targetType == typeof(ulong)) return (ulong)value;
+        return Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
+    }
+
+    internal static string ToHexString(this WinUIColor c)
+        => $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+
+    private static string ToBrushHex(WinUIColor c)
+        => $"#{c.A:X2}{c.R:X2}{c.G:X2}{c.B:X2}";
+
+    private static string ContrastForeground(WinUIColor c)
+    {
+        // Simple luminance threshold — white text on dark, black on light.
+        var l = (0.299 * c.R + 0.587 * c.G + 0.114 * c.B) / 255.0;
+        return l > 0.55 ? "#000000" : "#FFFFFF";
+    }
+}

--- a/src/Reactor/Controls/Editors/Editors.cs
+++ b/src/Reactor/Controls/Editors/Editors.cs
@@ -314,14 +314,4 @@ public static class Editors
 
     internal static string ToHexString(this WinUIColor c)
         => $"#{c.R:X2}{c.G:X2}{c.B:X2}";
-
-    private static string ToBrushHex(WinUIColor c)
-        => $"#{c.A:X2}{c.R:X2}{c.G:X2}{c.B:X2}";
-
-    private static string ContrastForeground(WinUIColor c)
-    {
-        // Simple luminance threshold — white text on dark, black on light.
-        var l = (0.299 * c.R + 0.587 * c.G + 0.114 * c.B) / 255.0;
-        return l > 0.55 ? "#000000" : "#FFFFFF";
-    }
 }

--- a/src/Reactor/Controls/PropertyGrid/ReflectionTypeMetadataProvider.cs
+++ b/src/Reactor/Controls/PropertyGrid/ReflectionTypeMetadataProvider.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Data;
 
 namespace Microsoft.UI.Reactor.Controls;
@@ -45,6 +47,8 @@ public static class ReflectionTypeMetadataProvider
             setter = BuildInitOnlySetter(property);
         }
 
+        var (editorFromAttrs, rendererFromAttrs) = ResolveEditorFromDataAnnotations(property);
+
         return new FieldDescriptor
         {
             Name = property.Name,
@@ -62,8 +66,62 @@ public static class ReflectionTypeMetadataProvider
             Sortable = attrs.Sortable,
             Filterable = attrs.Filterable,
             Pin = attrs.Pin,
+            Editor = editorFromAttrs,
+            CellRenderer = rendererFromAttrs,
         };
     }
+
+    /// <summary>
+    /// Maps a small set of <see cref="System.ComponentModel.DataAnnotations"/>
+    /// attributes onto Reactor editors/renderers:
+    /// <list type="bullet">
+    ///   <item><c>[DataType(DataType.Url)]</c> on string → Hyperlink display + URL text input</item>
+    ///   <item><c>[DataType(DataType.MultilineText)]</c> on string → multi-line text (renderer only, editor left to TypeRegistry)</item>
+    ///   <item><c>[Range(min, max)]</c> on a numeric type → NumberBox with min/max bounds</item>
+    /// </list>
+    /// Returns null for either slot when no attribute dictates that slot, so
+    /// TypeRegistry-driven defaults still apply.
+    /// </summary>
+    private static (Func<object, Action<object>, Element>? Editor, Func<object, Element>? CellRenderer)
+        ResolveEditorFromDataAnnotations(PropertyInfo property)
+    {
+        Func<object, Action<object>, Element>? editor = null;
+        Func<object, Element>? renderer = null;
+
+        var dataType = property.GetCustomAttribute<DataTypeAttribute>();
+        if (dataType is not null)
+        {
+            if (dataType.DataType == DataType.Url && property.PropertyType == typeof(string))
+            {
+                editor = Editors.Text(placeholder: "https://...");
+                renderer = CellRenderers.Hyperlink();
+            }
+            else if (dataType.DataType == DataType.Url && property.PropertyType == typeof(global::System.Uri))
+            {
+                editor = Editors.Uri();
+                renderer = CellRenderers.Hyperlink();
+            }
+        }
+
+        var range = property.GetCustomAttribute<RangeAttribute>();
+        if (range is not null && IsNumericType(property.PropertyType))
+        {
+            double? min = range.Minimum is IConvertible minC
+                ? minC.ToDouble(global::System.Globalization.CultureInfo.InvariantCulture)
+                : null;
+            double? max = range.Maximum is IConvertible maxC
+                ? maxC.ToDouble(global::System.Globalization.CultureInfo.InvariantCulture)
+                : null;
+            editor = Editors.Number(property.PropertyType, min, max);
+        }
+
+        return (editor, renderer);
+    }
+
+    private static bool IsNumericType(Type t) =>
+        t == typeof(int) || t == typeof(long) || t == typeof(short) || t == typeof(byte) ||
+        t == typeof(sbyte) || t == typeof(ushort) || t == typeof(uint) || t == typeof(ulong) ||
+        t == typeof(float) || t == typeof(double) || t == typeof(decimal);
 
     private static TypeMetadata BuildMetadata([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {

--- a/src/Reactor/Controls/PropertyGrid/ReflectionTypeMetadataProvider.cs
+++ b/src/Reactor/Controls/PropertyGrid/ReflectionTypeMetadataProvider.cs
@@ -75,8 +75,8 @@ public static class ReflectionTypeMetadataProvider
     /// Maps a small set of <see cref="System.ComponentModel.DataAnnotations"/>
     /// attributes onto Reactor editors/renderers:
     /// <list type="bullet">
-    ///   <item><c>[DataType(DataType.Url)]</c> on string → Hyperlink display + URL text input</item>
-    ///   <item><c>[DataType(DataType.MultilineText)]</c> on string → multi-line text (renderer only, editor left to TypeRegistry)</item>
+    ///   <item><c>[DataType(DataType.Url)]</c> on string → URL text input + Hyperlink display</item>
+    ///   <item><c>[DataType(DataType.Url)]</c> on <see cref="System.Uri"/> → Uri editor + Hyperlink display</item>
     ///   <item><c>[Range(min, max)]</c> on a numeric type → NumberBox with min/max bounds</item>
     /// </list>
     /// Returns null for either slot when no attribute dictates that slot, so

--- a/src/Reactor/Controls/PropertyGrid/TypeRegistry.cs
+++ b/src/Reactor/Controls/PropertyGrid/TypeRegistry.cs
@@ -44,7 +44,13 @@ public class TypeRegistry
     {
         if (_cellRenderers.TryGetValue(type, out var renderer))
             return renderer;
-        return TryResolveCellRendererFallback(type);
+        // TryResolveCellRendererFallback constructs a fresh delegate each call
+        // (CellRenderers.* factory methods return lambdas). Cache the first
+        // resolution so DataGrid's per-cell render path doesn't re-allocate.
+        renderer = TryResolveCellRendererFallback(type);
+        if (renderer is not null)
+            _cellRenderers[type] = renderer;
+        return renderer;
     }
 
     /// <summary>Try to get a registered formatter for a type.</summary>

--- a/src/Reactor/Controls/PropertyGrid/TypeRegistry.cs
+++ b/src/Reactor/Controls/PropertyGrid/TypeRegistry.cs
@@ -35,9 +35,17 @@ public class TypeRegistry
         return this;
     }
 
-    /// <summary>Try to get a registered cell renderer for a type.</summary>
+    /// <summary>
+    /// Try to get a cell renderer for a type. Falls back to built-in defaults
+    /// for common primitive/date/uri/color types so <c>AutoColumns</c> picks
+    /// up sensible display renderers without requiring explicit registration.
+    /// </summary>
     public Func<object, Element>? GetCellRenderer(Type type)
-        => _cellRenderers.TryGetValue(type, out var renderer) ? renderer : null;
+    {
+        if (_cellRenderers.TryGetValue(type, out var renderer))
+            return renderer;
+        return TryResolveCellRendererFallback(type);
+    }
 
     /// <summary>Try to get a registered formatter for a type.</summary>
     public Func<object?, string>? GetFormatter(Type type)
@@ -122,10 +130,64 @@ public class TypeRegistry
 
         if (type == typeof(bool))
         {
+            // Density-aware: PropertyGrid (Standard) renders a ToggleSwitch — it's
+            // roomier and reads better as a standalone field. DataGrid (Compact)
+            // renders a CheckBox so the cell stays dense. Both are wired via the
+            // shared Editors catalog so behavior stays consistent with any typed
+            // column factory a caller uses explicitly.
             metadata = new TypeMetadata
             {
-                Editor = (value, onChange) =>
-                    ToggleSwitch((bool)(value ?? false), v => onChange(v))
+                Editor = Editors.Toggle(),
+                CompactEditor = Editors.CheckBox(),
+            };
+            return true;
+        }
+
+        if (type == typeof(global::System.DateTime))
+        {
+            metadata = new TypeMetadata { Editor = Editors.Date() };
+            return true;
+        }
+
+        if (type == typeof(global::System.DateTimeOffset))
+        {
+            metadata = new TypeMetadata { Editor = Editors.DateOffset() };
+            return true;
+        }
+
+        if (type == typeof(global::System.DateOnly))
+        {
+            metadata = new TypeMetadata { Editor = Editors.DateOnly() };
+            return true;
+        }
+
+        if (type == typeof(global::System.TimeSpan))
+        {
+            metadata = new TypeMetadata { Editor = Editors.TimeSpanEditor() };
+            return true;
+        }
+
+        if (type == typeof(global::System.TimeOnly))
+        {
+            metadata = new TypeMetadata { Editor = Editors.TimeOnlyEditor() };
+            return true;
+        }
+
+        if (type == typeof(global::System.Uri))
+        {
+            metadata = new TypeMetadata { Editor = Editors.Uri() };
+            return true;
+        }
+
+        if (type == typeof(global::Windows.UI.Color))
+        {
+            // Standard tier (PropertyGrid) gets the full ColorPicker inline;
+            // Compact tier (DataGrid cells) gets swatch + hex text input so a
+            // cell doesn't blow up into a huge picker at row height.
+            metadata = new TypeMetadata
+            {
+                Editor = Editors.Color(),
+                CompactEditor = Editors.ColorCompact(),
             };
             return true;
         }
@@ -201,6 +263,26 @@ public class TypeRegistry
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Default cell renderers for common display types. Mirrors the fallback
+    /// pattern of <see cref="TryResolvePrimitive"/> for editors — so a
+    /// <c>AutoColumns&lt;T&gt;()</c> call on a type with a Uri or Color
+    /// property gets a hyperlink / color swatch display without any explicit
+    /// registration step.
+    /// </summary>
+    private static Func<object, Element>? TryResolveCellRendererFallback(Type type)
+    {
+        if (type == typeof(bool)) return CellRenderers.CheckMark();
+        if (type == typeof(global::System.DateTime)) return CellRenderers.Date();
+        if (type == typeof(global::System.DateTimeOffset)) return CellRenderers.Date();
+        if (type == typeof(global::System.DateOnly)) return CellRenderers.Date();
+        if (type == typeof(global::System.TimeSpan)) return CellRenderers.Time();
+        if (type == typeof(global::System.TimeOnly)) return CellRenderers.Time();
+        if (type == typeof(global::System.Uri)) return CellRenderers.Hyperlink();
+        if (type == typeof(global::Windows.UI.Color)) return CellRenderers.ColorSwatch();
+        return null;
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "TryResolveArray uses Activator.CreateInstance; acceptable for non-AOT builds.")]

--- a/src/Reactor/Core/ChangeEchoSuppressor.cs
+++ b/src/Reactor/Core/ChangeEchoSuppressor.cs
@@ -1,0 +1,65 @@
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.UI.Reactor.Core;
+
+/// <summary>
+/// Per-control "suppress next change event" counter used by the reconciler.
+///
+/// Background — why this exists:
+///   A Reactor Update handler that writes a value-bearing DP (<c>cp.Color = ...</c>,
+///   <c>nb.Value = ...</c>, <c>ts.IsOn = ...</c>) synthesizes a ValueChanged /
+///   ColorChanged / Toggled / etc. event. If the user wired an OnChanged callback
+///   (via <c>ColorPicker(..., onChanged: ...)</c> and friends), that callback
+///   gets invoked with the value WE just wrote — which is indistinguishable from
+///   a real user interaction. If the owning component's state derives from
+///   another source (e.g. a PropertyGrid bound to the selected row), the echo
+///   writes the new value back into the PREVIOUS state — a silent cross-row
+///   value swap. See spec-030 investigation notes.
+///
+/// Contract:
+///   - Before a programmatic write that will raise the control's change event,
+///     call <see cref="BeginSuppress(UIElement)"/>. Pair it 1:1 with the write.
+///   - The registered event handler must call <see cref="ShouldSuppress(UIElement)"/>
+///     as its first line and return early if it returns true. That consumes
+///     one suppression token.
+///   - Callers should guard with an equality check (only suppress when the new
+///     value actually differs) so the token is always consumed by a real event.
+///
+/// Why <see cref="ConditionalWeakTable{TKey,TValue}"/>: controls returned to the
+/// ElementPool or garbage-collected should not leak an entry. Weak keys keep
+/// the map small without any explicit cleanup.
+/// </summary>
+internal static class ChangeEchoSuppressor
+{
+    // Box the counter so we can increment/decrement without repeatedly re-inserting.
+    private sealed class Counter { public int Value; }
+
+    private static readonly ConditionalWeakTable<UIElement, Counter> _counters = new();
+
+    /// <summary>
+    /// Increment the suppress counter before a programmatic property write that
+    /// will raise a change event. Pair exactly one BeginSuppress with exactly
+    /// one expected event.
+    /// </summary>
+    internal static void BeginSuppress(UIElement control)
+    {
+        var c = _counters.GetValue(control, static _ => new Counter());
+        c.Value++;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the current event fire should be suppressed (and
+    /// decrements the counter). Returns <c>false</c> otherwise. Call at the top
+    /// of a change-event handler before invoking the user's OnChanged.
+    /// </summary>
+    internal static bool ShouldSuppress(UIElement control)
+    {
+        if (_counters.TryGetValue(control, out var c) && c.Value > 0)
+        {
+            c.Value--;
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -373,6 +373,7 @@ public sealed partial class Reconciler
         tsb.IsCheckedChanged += (s, _) =>
         {
             var t = (WinUI.ToggleSplitButton)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(t)) return;
             (GetElementTag(t) as ToggleSplitButtonElement)?.OnIsCheckedChanged?.Invoke(t.IsChecked);
         };
         if (tspBtn.Flyout is not null)
@@ -385,6 +386,14 @@ public sealed partial class Reconciler
     {
         var rented = _pool.TryRent(typeof(TextBox));
         var textBox = rented as TextBox ?? new TextBox();
+        // SetElementTag BEFORE writing Text: pooled controls retain their
+        // previous tag, and programmatic Text= fires TextChanged on the pooled
+        // event handler. Setting the new tag first ensures the handler reads
+        // this mount's element, not the pool's last owner. The BeginSuppress
+        // guard below is additional belt-and-suspenders against echo.
+        SetElementTag(textBox, tf);
+        if (rented is not null && textBox.Text != tf.Value)
+            ChangeEchoSuppressor.BeginSuppress(textBox);
         textBox.Text = tf.Value;
         textBox.PlaceholderText = tf.Placeholder ?? "";
         if (tf.Header is not null) textBox.Header = tf.Header;
@@ -393,11 +402,11 @@ public sealed partial class Reconciler
         if (tf.TextWrapping.HasValue) textBox.TextWrapping = tf.TextWrapping.Value;
         if (tf.SelectionStart.HasValue) textBox.SelectionStart = tf.SelectionStart.Value;
         if (tf.SelectionLength.HasValue) textBox.SelectionLength = tf.SelectionLength.Value;
-        SetElementTag(textBox, tf);
         if (rented is null) // Only wire events on fresh controls — pooled controls retain their handler
         {
             textBox.TextChanged += (_, _) =>
             {
+                if (ChangeEchoSuppressor.ShouldSuppress(textBox)) return;
                 var tag = GetElementTag(textBox) as TextFieldElement;
                 tag?.OnChanged?.Invoke(textBox.Text);
                 // Controlled input: when onChange is wired, always request a
@@ -417,7 +426,12 @@ public sealed partial class Reconciler
     {
         var pb = new WinUI.PasswordBox { Password = pw.Password, PlaceholderText = pw.PlaceholderText ?? "" };
         SetElementTag(pb, pw);
-        pb.PasswordChanged += (s, _) => (GetElementTag((UIElement)s!) as PasswordBoxElement)?.OnPasswordChanged?.Invoke(((WinUI.PasswordBox)s!).Password);
+        pb.PasswordChanged += (s, _) =>
+        {
+            var c = (UIElement)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+            (GetElementTag(c) as PasswordBoxElement)?.OnPasswordChanged?.Invoke(((WinUI.PasswordBox)c).Password);
+        };
         ApplySetters(pw.Setters, pb);
         return pb;
     }
@@ -436,6 +450,7 @@ public sealed partial class Reconciler
         numBox.ValueChanged += (s, _) =>
         {
             var box = (WinUI.NumberBox)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(box)) return;
             (GetElementTag(box) as NumberBoxElement)?.OnValueChanged?.Invoke(box.Value);
         };
         ApplySetters(nb.Setters, numBox);
@@ -475,19 +490,25 @@ public sealed partial class Reconciler
         SetElementTag(checkBox, cb);
         checkBox.Checked += (s, _) =>
         {
-            var el = GetElementTag((UIElement)s!) as CheckBoxElement;
+            var c = (UIElement)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+            var el = GetElementTag(c) as CheckBoxElement;
             el?.OnChanged?.Invoke(true);
             el?.OnCheckedStateChanged?.Invoke(true);
         };
         checkBox.Unchecked += (s, _) =>
         {
-            var el = GetElementTag((UIElement)s!) as CheckBoxElement;
+            var c = (UIElement)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+            var el = GetElementTag(c) as CheckBoxElement;
             el?.OnChanged?.Invoke(false);
             el?.OnCheckedStateChanged?.Invoke(false);
         };
         checkBox.Indeterminate += (s, _) =>
         {
-            var el = GetElementTag((UIElement)s!) as CheckBoxElement;
+            var c = (UIElement)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+            var el = GetElementTag(c) as CheckBoxElement;
             el?.OnCheckedStateChanged?.Invoke(null);
         };
         ApplySetters(cb.Setters, checkBox);
@@ -499,8 +520,18 @@ public sealed partial class Reconciler
         var radio = new WinUI.RadioButton { Content = rb.Label, IsChecked = rb.IsChecked };
         if (rb.GroupName is not null) radio.GroupName = rb.GroupName;
         SetElementTag(radio, rb);
-        radio.Checked += (s, _) => (GetElementTag((UIElement)s!) as RadioButtonElement)?.OnChecked?.Invoke(true);
-        radio.Unchecked += (s, _) => (GetElementTag((UIElement)s!) as RadioButtonElement)?.OnChecked?.Invoke(false);
+        radio.Checked += (s, _) =>
+        {
+            var c = (UIElement)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+            (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(true);
+        };
+        radio.Unchecked += (s, _) =>
+        {
+            var c = (UIElement)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+            (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(false);
+        };
         ApplySetters(rb.Setters, radio);
         return radio;
     }
@@ -514,6 +545,7 @@ public sealed partial class Reconciler
         rbGroup.SelectionChanged += (s, _) =>
         {
             var g = (WinUI.RadioButtons)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(g)) return;
             (GetElementTag(g) as RadioButtonsElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
         };
         ApplySetters(rbs.Setters, rbGroup);
@@ -537,6 +569,7 @@ public sealed partial class Reconciler
         cb.SelectionChanged += (s, _) =>
         {
             var c = (WinUI.ComboBox)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
             (GetElementTag(c) as ComboBoxElement)?.OnSelectionChanged?.Invoke(c.SelectedIndex);
         };
         ApplySetters(combo.Setters, cb);
@@ -548,7 +581,11 @@ public sealed partial class Reconciler
         var slider = new WinUI.Slider { Value = sl.Value, Minimum = sl.Min, Maximum = sl.Max, StepFrequency = sl.StepFrequency };
         if (sl.Header is not null) slider.Header = sl.Header;
         SetElementTag(slider, sl);
-        slider.ValueChanged += (_, args) => (GetElementTag(slider) as SliderElement)?.OnChanged?.Invoke(args.NewValue);
+        slider.ValueChanged += (_, args) =>
+        {
+            if (ChangeEchoSuppressor.ShouldSuppress(slider)) return;
+            (GetElementTag(slider) as SliderElement)?.OnChanged?.Invoke(args.NewValue);
+        };
         ApplySetters(sl.Setters, slider);
         return slider;
     }
@@ -557,15 +594,21 @@ public sealed partial class Reconciler
     {
         var rented = _pool.TryRent(typeof(WinUI.ToggleSwitch));
         var toggle = rented as WinUI.ToggleSwitch ?? new WinUI.ToggleSwitch();
+        // SetElementTag BEFORE IsOn= so a pooled control's retained handler
+        // sees this mount's element, not the pool's last owner. Suppress the
+        // echo fired by the programmatic IsOn write when it actually changes.
+        SetElementTag(toggle, ts);
+        if (rented is not null && toggle.IsOn != ts.IsOn)
+            ChangeEchoSuppressor.BeginSuppress(toggle);
         toggle.IsOn = ts.IsOn;
         toggle.OnContent = ts.OnContent;
         toggle.OffContent = ts.OffContent;
         if (ts.Header is not null) toggle.Header = ts.Header;
-        SetElementTag(toggle, ts);
         if (rented is null) // Only wire events on fresh controls — pooled controls retain their handler
             toggle.Toggled += (s, _) =>
             {
                 var t = (WinUI.ToggleSwitch)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(t)) return;
                 (GetElementTag(t) as ToggleSwitchElement)?.OnChanged?.Invoke(t.IsOn);
             };
         ApplySetters(ts.Setters, toggle);
@@ -579,6 +622,7 @@ public sealed partial class Reconciler
         rating.ValueChanged += (s, _) =>
         {
             var r = (WinUI.RatingControl)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(r)) return;
             (GetElementTag(r) as RatingControlElement)?.OnValueChanged?.Invoke(r.Value);
         };
         ApplySetters(rc.Setters, rating);
@@ -594,7 +638,12 @@ public sealed partial class Reconciler
             IsColorChannelTextInputVisible = cp.IsColorChannelTextInputVisible, IsHexInputVisible = cp.IsHexInputVisible,
         };
         SetElementTag(picker, cp);
-        picker.ColorChanged += (s, args) => (GetElementTag((UIElement)s!) as ColorPickerElement)?.OnColorChanged?.Invoke(args.NewColor);
+        picker.ColorChanged += (s, args) =>
+        {
+            var c = (UIElement)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+            (GetElementTag(c) as ColorPickerElement)?.OnColorChanged?.Invoke(args.NewColor);
+        };
         ApplySetters(cp.Setters, picker);
         return picker;
     }
@@ -609,6 +658,7 @@ public sealed partial class Reconciler
         cal.DateChanged += (s, _) =>
         {
             var c = (WinUI.CalendarDatePicker)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
             (GetElementTag(c) as CalendarDatePickerElement)?.OnDateChanged?.Invoke(c.Date);
         };
         ApplySetters(cdp.Setters, cal);
@@ -622,7 +672,12 @@ public sealed partial class Reconciler
         if (dp.MinYear.HasValue) picker.MinYear = dp.MinYear.Value;
         if (dp.MaxYear.HasValue) picker.MaxYear = dp.MaxYear.Value;
         SetElementTag(picker, dp);
-        picker.DateChanged += (s, args) => (GetElementTag((UIElement)s!) as DatePickerElement)?.OnDateChanged?.Invoke(args.NewDate);
+        picker.DateChanged += (s, args) =>
+        {
+            var c = (UIElement)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+            (GetElementTag(c) as DatePickerElement)?.OnDateChanged?.Invoke(args.NewDate);
+        };
         ApplySetters(dp.Setters, picker);
         return picker;
     }
@@ -632,7 +687,12 @@ public sealed partial class Reconciler
         var picker = new WinUI.TimePicker { Time = tp.Time, MinuteIncrement = tp.MinuteIncrement };
         if (tp.Header is not null) picker.Header = tp.Header;
         SetElementTag(picker, tp);
-        picker.TimeChanged += (s, args) => (GetElementTag((UIElement)s!) as TimePickerElement)?.OnTimeChanged?.Invoke(args.NewTime);
+        picker.TimeChanged += (s, args) =>
+        {
+            var c = (UIElement)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+            (GetElementTag(c) as TimePickerElement)?.OnTimeChanged?.Invoke(args.NewTime);
+        };
         ApplySetters(tp.Setters, picker);
         return picker;
     }
@@ -1529,7 +1589,10 @@ public sealed partial class Reconciler
             flyout.Opened += (_, _) => flyEl.OnOpened?.Invoke();
             flyout.Closed += (_, _) => flyEl.OnClosed?.Invoke();
             SetElementTag(targetFe, flyEl);
-            WinPrim.FlyoutBase.SetAttachedFlyout(targetFe, flyout);
+            // SetFlyoutOnControl wires .Flyout on Button/SplitButton targets so
+            // clicking opens the flyout natively; non-button targets fall back
+            // to SetAttachedFlyout metadata (opened only via ShowAttachedFlyout).
+            SetFlyoutOnControl(targetFe, flyout);
             ApplySetters(flyEl.Setters, flyout);
             if (flyEl.IsOpen) WinPrim.FlyoutBase.ShowAttachedFlyout(targetFe);
         }

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -672,17 +672,29 @@ public sealed partial class Reconciler
 
     private UIElement? UpdateToggleSplitButton(ToggleSplitButtonElement n, WinUI.ToggleSplitButton tsb)
     {
-        tsb.Content = n.Label; tsb.IsChecked = n.IsChecked; SetElementTag(tsb, n);
+        SetElementTag(tsb, n);
+        tsb.Content = n.Label;
+        if (tsb.IsChecked != n.IsChecked)
+        {
+            ChangeEchoSuppressor.BeginSuppress(tsb);
+            tsb.IsChecked = n.IsChecked;
+        }
         ApplySetters(n.Setters, tsb);
         return null;
     }
 
     private UIElement? UpdateTextField(TextFieldElement o, TextFieldElement n, TextBox tb)
     {
+        // Tag first so any echoed TextChanged sees this element.
+        SetElementTag(tb, n);
         if (o.Value != n.Value)
         {
             // Element value changed — always enforce
-            tb.Text = n.Value;
+            if (tb.Text != n.Value)
+            {
+                ChangeEchoSuppressor.BeginSuppress(tb);
+                tb.Text = n.Value;
+            }
         }
         else if (n.OnChanged is not null && tb.Text != n.Value)
         {
@@ -690,6 +702,7 @@ public sealed partial class Reconciler
             // The TextBox text diverges from the controlled value because the
             // callback filtered it to the same state (e.g. digits-only rejecting alpha).
             var caret = tb.SelectionStart;
+            ChangeEchoSuppressor.BeginSuppress(tb);
             tb.Text = n.Value;
             tb.SelectionStart = Math.Min(caret, tb.Text.Length);
         }
@@ -711,108 +724,183 @@ public sealed partial class Reconciler
         // Apply selection position after text — must come after Text is set so the range is valid
         if (n.SelectionStart.HasValue) tb.SelectionStart = Math.Min(n.SelectionStart.Value, tb.Text.Length);
         if (n.SelectionLength.HasValue) tb.SelectionLength = Math.Min(n.SelectionLength.Value, tb.Text.Length - tb.SelectionStart);
-        SetElementTag(tb, n);
         ApplySetters(n.Setters, tb);
         return null;
     }
 
     private UIElement? UpdatePasswordBox(PasswordBoxElement n, WinUI.PasswordBox pb)
     {
-        pb.Password = n.Password; pb.PlaceholderText = n.PlaceholderText ?? ""; SetElementTag(pb, n);
+        SetElementTag(pb, n);
+        if (pb.Password != n.Password)
+        {
+            ChangeEchoSuppressor.BeginSuppress(pb);
+            pb.Password = n.Password;
+        }
+        pb.PlaceholderText = n.PlaceholderText ?? "";
         ApplySetters(n.Setters, pb);
         return null;
     }
 
     private UIElement? UpdateNumberBox(NumberBoxElement n, WinUI.NumberBox nb)
     {
-        nb.Value = n.Value; nb.Minimum = n.Minimum; nb.Maximum = n.Maximum;
+        SetElementTag(nb, n);
+        // Set Min/Max first so coerced Value stays inside range.
+        nb.Minimum = n.Minimum;
+        nb.Maximum = n.Maximum;
+        if (nb.Value != n.Value)
+        {
+            ChangeEchoSuppressor.BeginSuppress(nb);
+            nb.Value = n.Value;
+        }
         nb.SmallChange = n.SmallChange; nb.LargeChange = n.LargeChange;
         nb.SpinButtonPlacementMode = n.SpinButtonPlacement;
         if (n.Header is not null) nb.Header = n.Header;
-        SetElementTag(nb, n);
         ApplySetters(n.Setters, nb);
         return null;
     }
 
     private UIElement? UpdateAutoSuggestBox(AutoSuggestBoxElement n, WinUI.AutoSuggestBox asb)
     {
-        asb.Text = n.Text; asb.PlaceholderText = n.PlaceholderText ?? "";
-        if (n.Suggestions.Length > 0) asb.ItemsSource = n.Suggestions;
+        // AutoSuggestBox already filters TextChanged to UserInput only, so
+        // programmatic Text= is already safe. Suppress anyway for consistency
+        // with the other editors (covers future handler changes).
         SetElementTag(asb, n);
+        if (asb.Text != n.Text)
+        {
+            ChangeEchoSuppressor.BeginSuppress(asb);
+            asb.Text = n.Text;
+        }
+        asb.PlaceholderText = n.PlaceholderText ?? "";
+        if (n.Suggestions.Length > 0) asb.ItemsSource = n.Suggestions;
         ApplySetters(n.Setters, asb);
         return null;
     }
 
     private UIElement? UpdateCheckBox(CheckBoxElement n, WinUI.CheckBox cb)
     {
+        SetElementTag(cb, n);
         cb.Content = n.Label;
         cb.IsThreeState = n.IsThreeState;
-        cb.IsChecked = n.IsThreeState ? n.CheckedState : n.IsChecked;
-        SetElementTag(cb, n);
+        var target = n.IsThreeState ? n.CheckedState : n.IsChecked;
+        if (cb.IsChecked != target)
+        {
+            ChangeEchoSuppressor.BeginSuppress(cb);
+            cb.IsChecked = target;
+        }
         ApplySetters(n.Setters, cb);
         return null;
     }
 
     private UIElement? UpdateRadioButton(RadioButtonElement n, WinUI.RadioButton rb)
     {
-        rb.Content = n.Label; rb.IsChecked = n.IsChecked;
-        if (n.GroupName is not null) rb.GroupName = n.GroupName;
         SetElementTag(rb, n);
+        rb.Content = n.Label;
+        if (rb.IsChecked != n.IsChecked)
+        {
+            ChangeEchoSuppressor.BeginSuppress(rb);
+            rb.IsChecked = n.IsChecked;
+        }
+        if (n.GroupName is not null) rb.GroupName = n.GroupName;
         ApplySetters(n.Setters, rb);
         return null;
     }
 
     private UIElement? UpdateSlider(SliderElement n, WinUI.Slider s)
     {
-        s.Minimum = n.Min; s.Maximum = n.Max; s.Value = n.Value;
+        SetElementTag(s, n);
+        // Min/Max first so coerced Value stays inside range.
+        s.Minimum = n.Min;
+        s.Maximum = n.Max;
+        if (s.Value != n.Value)
+        {
+            ChangeEchoSuppressor.BeginSuppress(s);
+            s.Value = n.Value;
+        }
         s.StepFrequency = n.StepFrequency;
         if (n.Header is not null) s.Header = n.Header;
-        SetElementTag(s, n);
         ApplySetters(n.Setters, s);
         return null;
     }
 
     private UIElement? UpdateToggleSwitch(ToggleSwitchElement n, WinUI.ToggleSwitch ts)
     {
-        ts.IsOn = n.IsOn; ts.OnContent = n.OnContent; ts.OffContent = n.OffContent;
-        if (n.Header is not null) ts.Header = n.Header;
         SetElementTag(ts, n);
+        if (ts.IsOn != n.IsOn)
+        {
+            ChangeEchoSuppressor.BeginSuppress(ts);
+            ts.IsOn = n.IsOn;
+        }
+        ts.OnContent = n.OnContent; ts.OffContent = n.OffContent;
+        if (n.Header is not null) ts.Header = n.Header;
         ApplySetters(n.Setters, ts);
         return null;
     }
 
     private UIElement? UpdateRatingControl(RatingControlElement n, WinUI.RatingControl r)
     {
-        r.Value = n.Value; r.MaxRating = n.MaxRating; r.IsReadOnly = n.IsReadOnly;
-        r.Caption = n.Caption ?? ""; SetElementTag(r, n);
+        SetElementTag(r, n);
+        r.MaxRating = n.MaxRating;
+        if (r.Value != n.Value)
+        {
+            ChangeEchoSuppressor.BeginSuppress(r);
+            r.Value = n.Value;
+        }
+        r.IsReadOnly = n.IsReadOnly;
+        r.Caption = n.Caption ?? "";
         ApplySetters(n.Setters, r);
         return null;
     }
 
     private UIElement? UpdateColorPicker(ColorPickerElement n, WinUI.ColorPicker cp)
     {
-        cp.Color = n.Color; cp.IsAlphaEnabled = n.IsAlphaEnabled; SetElementTag(cp, n);
+        // Tag FIRST so the ColorChanged echo (fired synchronously from the
+        // programmatic Color= assignment in some WinAppSDK builds) resolves
+        // against this element, not the previous one. Suppressor then drops
+        // the echo entirely — preventing the cross-row value-swap observed
+        // when a PropertyGrid bound to a selection re-renders.
+        SetElementTag(cp, n);
+        if (cp.Color != n.Color)
+        {
+            ChangeEchoSuppressor.BeginSuppress(cp);
+            cp.Color = n.Color;
+        }
+        cp.IsAlphaEnabled = n.IsAlphaEnabled;
         ApplySetters(n.Setters, cp);
         return null;
     }
 
     private UIElement? UpdateCalendarDatePicker(CalendarDatePickerElement n, WinUI.CalendarDatePicker cdp)
     {
-        cdp.Date = n.Date; SetElementTag(cdp, n);
+        SetElementTag(cdp, n);
+        if (cdp.Date != n.Date)
+        {
+            ChangeEchoSuppressor.BeginSuppress(cdp);
+            cdp.Date = n.Date;
+        }
         ApplySetters(n.Setters, cdp);
         return null;
     }
 
     private UIElement? UpdateDatePicker(DatePickerElement n, WinUI.DatePicker dp)
     {
-        dp.Date = n.Date; SetElementTag(dp, n);
+        SetElementTag(dp, n);
+        if (dp.Date != n.Date)
+        {
+            ChangeEchoSuppressor.BeginSuppress(dp);
+            dp.Date = n.Date;
+        }
         ApplySetters(n.Setters, dp);
         return null;
     }
 
     private UIElement? UpdateTimePicker(TimePickerElement n, WinUI.TimePicker tp)
     {
-        tp.Time = n.Time; SetElementTag(tp, n);
+        SetElementTag(tp, n);
+        if (tp.Time != n.Time)
+        {
+            ChangeEchoSuppressor.BeginSuppress(tp);
+            tp.Time = n.Time;
+        }
         ApplySetters(n.Setters, tp);
         return null;
     }

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -744,9 +744,20 @@ public sealed partial class Reconciler
     private UIElement? UpdateNumberBox(NumberBoxElement n, WinUI.NumberBox nb)
     {
         SetElementTag(nb, n);
-        // Set Min/Max first so coerced Value stays inside range.
-        nb.Minimum = n.Minimum;
-        nb.Maximum = n.Maximum;
+        // Set Min/Max before Value so a new, in-range Value doesn't get
+        // coerced by a stale range. But Min/Max writes can themselves coerce
+        // the existing Value, which raises ValueChanged — suppress those
+        // echoes too, one token per write that might fire.
+        if (nb.Minimum != n.Minimum)
+        {
+            if (nb.Value < n.Minimum) ChangeEchoSuppressor.BeginSuppress(nb);
+            nb.Minimum = n.Minimum;
+        }
+        if (nb.Maximum != n.Maximum)
+        {
+            if (nb.Value > n.Maximum) ChangeEchoSuppressor.BeginSuppress(nb);
+            nb.Maximum = n.Maximum;
+        }
         if (nb.Value != n.Value)
         {
             ChangeEchoSuppressor.BeginSuppress(nb);
@@ -808,9 +819,20 @@ public sealed partial class Reconciler
     private UIElement? UpdateSlider(SliderElement n, WinUI.Slider s)
     {
         SetElementTag(s, n);
-        // Min/Max first so coerced Value stays inside range.
-        s.Minimum = n.Min;
-        s.Maximum = n.Max;
+        // Min/Max before Value so a new, in-range Value doesn't get coerced
+        // by a stale range. But Min/Max writes can themselves coerce the
+        // existing Value, which raises ValueChanged — suppress those echoes
+        // too, one token per write that might fire.
+        if (s.Minimum != n.Min)
+        {
+            if (s.Value < n.Min) ChangeEchoSuppressor.BeginSuppress(s);
+            s.Minimum = n.Min;
+        }
+        if (s.Maximum != n.Max)
+        {
+            if (s.Value > n.Max) ChangeEchoSuppressor.BeginSuppress(s);
+            s.Maximum = n.Max;
+        }
         if (s.Value != n.Value)
         {
             ChangeEchoSuppressor.BeginSuppress(s);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
@@ -204,6 +204,78 @@ internal static class EchoSuppressionFixtures
         }
     }
 
+    /// <summary>
+    /// Min/Max coercion can itself raise ValueChanged before we reach the
+    /// explicit Value= write. Verifies that when the range shifts such that
+    /// the current Value is forced in-range, the user's onChange is still
+    /// not called. This is the regression coverage for the gap Copilot
+    /// flagged on the initial PR review.
+    /// </summary>
+    internal class SliderMinMaxCoercionNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<double>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                // Phase 0: Value=25 inside [0,100]. Phase 1: Min=50 shifts the
+                // range so Value=25 is out of range. If Min= coerces Value
+                // without suppression, the echo fires. Also note the explicit
+                // Value jumps to 75 to exercise the Value= path on the same
+                // reconcile as the Min= coercion.
+                var (min, max, v) = phase == 0 ? (0.0, 100.0, 25.0) : (50.0, 100.0, 75.0);
+                return VStack(
+                    Button("Go_SL_MM", () => setPhase(1)),
+                    Slider(v, min, max, d => calls.Add(d))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_SliderMinMax_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_SL_MM");
+            await Harness.Render();
+
+            var sl = H.FindControl<Slider>(_ => true);
+            H.Check("EchoSuppress_SliderMinMax_UpdateApplied",
+                sl is not null && sl.Minimum == 50.0 && sl.Value == 75.0);
+            H.Check("EchoSuppress_SliderMinMax_NoEchoCall", calls.Count == 0);
+        }
+    }
+
+    /// <summary>
+    /// Same coercion scenario for NumberBox. Min shift forces the existing
+    /// Value out of range; we must suppress that echo too.
+    /// </summary>
+    internal class NumberBoxMinMaxCoercionNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<double>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var (min, max, v) = phase == 0 ? (0.0, 100.0, 25.0) : (50.0, 100.0, 75.0);
+                return VStack(
+                    Button("Go_NB_MM", () => setPhase(1)),
+                    NumberBox(v, d => calls.Add(d)) with { Minimum = min, Maximum = max }
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_NumberBoxMinMax_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_NB_MM");
+            await Harness.Render();
+
+            var nb = H.FindControl<NumberBox>(_ => true);
+            H.Check("EchoSuppress_NumberBoxMinMax_UpdateApplied",
+                nb is not null && nb.Minimum == 50.0 && nb.Value == 75.0);
+            H.Check("EchoSuppress_NumberBoxMinMax_NoEchoCall", calls.Count == 0);
+        }
+    }
+
     // ── RatingControl ─────────────────────────────────────────────────
 
     internal class RatingControlNoEcho(Harness h) : SelfTestFixtureBase(h)

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
@@ -1,0 +1,463 @@
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using WinUIColor = global::Windows.UI.Color;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Regression coverage for the "programmatic-write echo" class of bug.
+///
+/// When a Reactor Update handler writes a value-bearing DP (ColorPicker.Color,
+/// NumberBox.Value, ToggleSwitch.IsOn, Slider.Value, …), the control raises its
+/// change event. If that event re-enters the user's onChange callback, the
+/// owning component's state gets overwritten with the value Reactor just wrote —
+/// which, for components bound to an external selection (PropertyGrid, tabbed
+/// forms), corrupts the PREVIOUS selection's state with the NEW selection's
+/// value.
+///
+/// Each fixture below:
+///   1. mounts the editor with value A and a call-recording onChange.
+///   2. verifies the mount itself did NOT invoke onChange.
+///   3. re-renders with value B via setState and verifies:
+///        - the control reflects value B (basic update works),
+///        - onChange was NOT invoked (no echo).
+///   4. directly pokes the control to simulate real user input, and verifies
+///      onChange DID fire (continuous-value editing is NOT broken by the fix).
+///
+/// All three invariants together distinguish a correct suppressor from either
+/// an over-eager (kills real input) or under-eager (regression) implementation.
+/// </summary>
+internal static class EchoSuppressionFixtures
+{
+    // ── ColorPicker ───────────────────────────────────────────────────
+
+    internal class ColorPickerNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<WinUIColor>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var color = phase == 0
+                    ? global::Microsoft.UI.Colors.Red
+                    : global::Microsoft.UI.Colors.Green;
+                return VStack(
+                    Button("Go_CP", () => setPhase(1)),
+                    ColorPicker(color, c => calls.Add(c))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_ColorPicker_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_CP");
+            await Harness.Render();
+
+            var cp = H.FindControl<ColorPicker>(_ => true);
+            H.Check("EchoSuppress_ColorPicker_UpdateAppliedValue",
+                cp is not null && cp.Color == global::Microsoft.UI.Colors.Green);
+            H.Check("EchoSuppress_ColorPicker_NoEchoCall", calls.Count == 0);
+
+            if (cp is not null) cp.Color = global::Microsoft.UI.Colors.Blue;
+            await Harness.Render();
+            H.Check("EchoSuppress_ColorPicker_UserEditFires",
+                calls.Count >= 1 && calls[^1] == global::Microsoft.UI.Colors.Blue);
+        }
+    }
+
+    // ── NumberBox ─────────────────────────────────────────────────────
+
+    internal class NumberBoxNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<double>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var value = phase == 0 ? 10.0 : 42.0;
+                return VStack(
+                    Button("Go_NB", () => setPhase(1)),
+                    NumberBox(value, v => calls.Add(v))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_NumberBox_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_NB");
+            await Harness.Render();
+
+            var nb = H.FindControl<NumberBox>(_ => true);
+            H.Check("EchoSuppress_NumberBox_UpdateAppliedValue", nb?.Value == 42.0);
+            H.Check("EchoSuppress_NumberBox_NoEchoCall", calls.Count == 0);
+
+            if (nb is not null) nb.Value = 77.0;
+            await Harness.Render();
+            H.Check("EchoSuppress_NumberBox_UserEditFires",
+                calls.Count >= 1 && calls[^1] == 77.0);
+        }
+    }
+
+    // ── ToggleSwitch ──────────────────────────────────────────────────
+
+    internal class ToggleSwitchNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<bool>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var on = phase == 1;
+                return VStack(
+                    Button("Go_TS", () => setPhase(1)),
+                    ToggleSwitch(on, v => calls.Add(v))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_ToggleSwitch_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_TS");
+            await Harness.Render();
+
+            var ts = H.FindControl<ToggleSwitch>(_ => true);
+            H.Check("EchoSuppress_ToggleSwitch_UpdateAppliedValue", ts?.IsOn == true);
+            H.Check("EchoSuppress_ToggleSwitch_NoEchoCall", calls.Count == 0);
+
+            if (ts is not null) ts.IsOn = false;
+            await Harness.Render();
+            H.Check("EchoSuppress_ToggleSwitch_UserEditFires",
+                calls.Count >= 1 && calls[^1] == false);
+        }
+    }
+
+    // ── CheckBox ──────────────────────────────────────────────────────
+
+    internal class CheckBoxNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<bool>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var chk = phase == 1;
+                return VStack(
+                    Button("Go_CB", () => setPhase(1)),
+                    CheckBox(chk, v => calls.Add(v), label: "CB")
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_CheckBox_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_CB");
+            await Harness.Render();
+
+            var cb = H.FindControl<CheckBox>(c => c.Content is string s && s == "CB");
+            H.Check("EchoSuppress_CheckBox_UpdateAppliedValue", cb?.IsChecked == true);
+            H.Check("EchoSuppress_CheckBox_NoEchoCall", calls.Count == 0);
+
+            if (cb is not null) cb.IsChecked = false;
+            await Harness.Render();
+            H.Check("EchoSuppress_CheckBox_UserEditFires",
+                calls.Count >= 1 && calls[^1] == false);
+        }
+    }
+
+    // ── Slider ────────────────────────────────────────────────────────
+
+    internal class SliderNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<double>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var v = phase == 0 ? 25.0 : 75.0;
+                return VStack(
+                    Button("Go_SL", () => setPhase(1)),
+                    Slider(v, 0, 100, d => calls.Add(d))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_Slider_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_SL");
+            await Harness.Render();
+
+            var sl = H.FindControl<Slider>(_ => true);
+            H.Check("EchoSuppress_Slider_UpdateAppliedValue", sl?.Value == 75.0);
+            H.Check("EchoSuppress_Slider_NoEchoCall", calls.Count == 0);
+
+            if (sl is not null) sl.Value = 50.0;
+            await Harness.Render();
+            H.Check("EchoSuppress_Slider_UserEditFires",
+                calls.Count >= 1 && calls[^1] == 50.0);
+        }
+    }
+
+    // ── RatingControl ─────────────────────────────────────────────────
+
+    internal class RatingControlNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<double>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var v = phase == 0 ? 2.0 : 4.0;
+                return VStack(
+                    Button("Go_RC", () => setPhase(1)),
+                    RatingControl(v, d => calls.Add(d))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_Rating_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_RC");
+            await Harness.Render();
+
+            var rc = H.FindControl<RatingControl>(_ => true);
+            H.Check("EchoSuppress_Rating_UpdateAppliedValue", rc?.Value == 4.0);
+            H.Check("EchoSuppress_Rating_NoEchoCall", calls.Count == 0);
+
+            // RatingControl in WinAppSDK 2.0-preview does not raise
+            // ValueChanged from a programmatic Value= assignment (by contrast
+            // with NumberBox/Slider/ColorPicker). That means there is no echo
+            // to suppress in the first place for this control — the
+            // "no echo during Update" invariant holds trivially. We keep the
+            // fixture for mount + update-applies-value coverage and skip the
+            // user-edit assertion that would need real input to exercise.
+            if (rc is not null) rc.Value = 3.0;
+            await Harness.Render();
+            H.Check("EchoSuppress_Rating_ProgrammaticAppliesValue", rc?.Value == 3.0);
+        }
+    }
+
+    // ── DatePicker ────────────────────────────────────────────────────
+
+    internal class DatePickerNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<DateTimeOffset>();
+            var host = H.CreateHost();
+            var d0 = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var d1 = new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero);
+            var d2 = new DateTimeOffset(2026, 3, 3, 0, 0, 0, TimeSpan.Zero);
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var d = phase == 0 ? d0 : d1;
+                return VStack(
+                    Button("Go_DP", () => setPhase(1)),
+                    DatePicker(d, v => calls.Add(v))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_DatePicker_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_DP");
+            await Harness.Render();
+
+            var dp = H.FindControl<DatePicker>(_ => true);
+            H.Check("EchoSuppress_DatePicker_UpdateAppliedValue", dp?.Date == d1);
+            H.Check("EchoSuppress_DatePicker_NoEchoCall", calls.Count == 0);
+
+            if (dp is not null) dp.Date = d2;
+            await Harness.Render();
+            H.Check("EchoSuppress_DatePicker_UserEditFires",
+                calls.Count >= 1 && calls[^1] == d2);
+        }
+    }
+
+    // ── CalendarDatePicker ────────────────────────────────────────────
+
+    internal class CalendarDatePickerNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<DateTimeOffset?>();
+            var host = H.CreateHost();
+            var d0 = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var d1 = new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero);
+            var d2 = new DateTimeOffset(2026, 3, 3, 0, 0, 0, TimeSpan.Zero);
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                DateTimeOffset? d = phase == 0 ? d0 : d1;
+                return VStack(
+                    Button("Go_CDP", () => setPhase(1)),
+                    CalendarDatePicker(d, v => calls.Add(v))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_CalDatePicker_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_CDP");
+            await Harness.Render();
+
+            var cdp = H.FindControl<CalendarDatePicker>(_ => true);
+            H.Check("EchoSuppress_CalDatePicker_UpdateAppliedValue", cdp?.Date == d1);
+            H.Check("EchoSuppress_CalDatePicker_NoEchoCall", calls.Count == 0);
+
+            if (cdp is not null) cdp.Date = d2;
+            await Harness.Render();
+            H.Check("EchoSuppress_CalDatePicker_UserEditFires",
+                calls.Count >= 1 && calls[^1] == d2);
+        }
+    }
+
+    // ── TimePicker ────────────────────────────────────────────────────
+
+    internal class TimePickerNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<TimeSpan>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var t = phase == 0 ? TimeSpan.FromHours(9) : TimeSpan.FromHours(17);
+                return VStack(
+                    Button("Go_TP", () => setPhase(1)),
+                    TimePicker(t, v => calls.Add(v))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_TimePicker_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_TP");
+            await Harness.Render();
+
+            var tp = H.FindControl<TimePicker>(_ => true);
+            H.Check("EchoSuppress_TimePicker_UpdateAppliedValue",
+                tp?.Time == TimeSpan.FromHours(17));
+            H.Check("EchoSuppress_TimePicker_NoEchoCall", calls.Count == 0);
+
+            if (tp is not null) tp.Time = TimeSpan.FromHours(12);
+            await Harness.Render();
+            H.Check("EchoSuppress_TimePicker_UserEditFires",
+                calls.Count >= 1 && calls[^1] == TimeSpan.FromHours(12));
+        }
+    }
+
+    // ── PasswordBox ───────────────────────────────────────────────────
+
+    internal class PasswordBoxNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<string>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var p = phase == 0 ? "initial" : "next";
+                return VStack(
+                    Button("Go_PW", () => setPhase(1)),
+                    PasswordBox(p, s => calls.Add(s))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_PasswordBox_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_PW");
+            await Harness.Render();
+
+            var pb = H.FindControl<PasswordBox>(_ => true);
+            H.Check("EchoSuppress_PasswordBox_UpdateAppliedValue", pb?.Password == "next");
+            H.Check("EchoSuppress_PasswordBox_NoEchoCall", calls.Count == 0);
+
+            if (pb is not null) pb.Password = "typed";
+            await Harness.Render();
+            H.Check("EchoSuppress_PasswordBox_UserEditFires",
+                calls.Count >= 1 && calls[^1] == "typed");
+        }
+    }
+
+    // ── TextField ─────────────────────────────────────────────────────
+
+    internal class TextFieldNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<string>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var t = phase == 0 ? "initial" : "next";
+                return VStack(
+                    Button("Go_TF", () => setPhase(1)),
+                    TextField(t, s => calls.Add(s), placeholder: "test")
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_TextField_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_TF");
+            await Harness.Render();
+
+            var tb = H.FindControl<TextBox>(t => t.PlaceholderText == "test");
+            H.Check("EchoSuppress_TextField_UpdateAppliedValue", tb?.Text == "next");
+            // Note: after a setState-driven change to "next", the controlled
+            // TextField's onChange MAY receive a trailing call from the
+            // re-render snap-back path. We allow at most one non-echo call
+            // that equals the current value (not a cross-value echo).
+            bool onlyCurrentOrEmpty = calls.All(s => s == "next");
+            H.Check("EchoSuppress_TextField_NoEchoCallCrossValue", onlyCurrentOrEmpty);
+
+            var precedingCount = calls.Count;
+            if (tb is not null) tb.Text = "typed";
+            await Harness.Render();
+            H.Check("EchoSuppress_TextField_UserEditFires",
+                calls.Count > precedingCount && calls[^1] == "typed");
+        }
+    }
+
+    // ── ToggleSplitButton ─────────────────────────────────────────────
+
+    internal class ToggleSplitButtonNoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<bool>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var chk = phase == 1;
+                return VStack(
+                    Button("Go_TSB", () => setPhase(1)),
+                    ToggleSplitButton("Label", isChecked: chk, onIsCheckedChanged: v => calls.Add(v))
+                );
+            });
+            await Harness.Render();
+            H.Check("EchoSuppress_TSB_MountNoFire", calls.Count == 0);
+
+            H.ClickButton("Go_TSB");
+            await Harness.Render();
+
+            var tsb = H.FindControl<ToggleSplitButton>(_ => true);
+            H.Check("EchoSuppress_TSB_UpdateAppliedValue", tsb?.IsChecked == true);
+            H.Check("EchoSuppress_TSB_NoEchoCall", calls.Count == 0);
+
+            if (tsb is not null) tsb.IsChecked = false;
+            await Harness.Render();
+            H.Check("EchoSuppress_TSB_UserEditFires",
+                calls.Count >= 1 && calls[^1] == false);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SpecializedEditorsTests.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SpecializedEditorsTests.cs
@@ -125,8 +125,11 @@ internal static class SpecializedEditorsTests
             });
             await Harness.Render();
 
-            // Find the hex TextBox — proves swatch+hex layout rendered.
-            var tb = H.FindControl<TextBox>(_ => true);
+            // Find the hex TextBox by its expected initial Crimson hex value —
+            // proves the compact swatch+hex layout rendered and avoids matching
+            // an unrelated TextBox elsewhere in the host window.
+            var tb = H.FindControl<TextBox>(textBox =>
+                textBox.Text is string s && s.Equals("#DC143C", StringComparison.OrdinalIgnoreCase));
             H.Check("Editors_ColorCompact_HexField", tb is not null);
         }
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SpecializedEditorsTests.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SpecializedEditorsTests.cs
@@ -1,0 +1,173 @@
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Reactor.Controls;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Data;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Selftest coverage for the specialized editor stack: mounts the editor
+/// factories directly (outside a DataGrid) to confirm each one produces a
+/// valid visual tree under real WinUI. Catches the "eager brush allocation"
+/// class of bugs that unit tests can't see.
+/// </summary>
+internal static class SpecializedEditorsTests
+{
+    internal class CheckBoxEditorMounts(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var factory = Editors.CheckBox();
+                return factory(true, _ => { }).AutomationId("cb");
+            });
+            await Harness.Render();
+
+            var control = H.FindControl<CheckBox>(c =>
+                Microsoft.UI.Xaml.Automation.AutomationProperties.GetAutomationId(c) == "cb");
+            H.Check("Editors_CheckBox_Mounts", control is not null);
+            H.Check("Editors_CheckBox_InitialValue", control?.IsChecked == true);
+        }
+    }
+
+    internal class ToggleEditorMounts(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var factory = Editors.Toggle();
+                return factory(true, _ => { }).AutomationId("ts");
+            });
+            await Harness.Render();
+
+            var control = H.FindControl<ToggleSwitch>(c =>
+                Microsoft.UI.Xaml.Automation.AutomationProperties.GetAutomationId(c) == "ts");
+            H.Check("Editors_Toggle_Mounts", control is not null);
+            H.Check("Editors_Toggle_InitialValue", control?.IsOn == true);
+        }
+    }
+
+    internal class NumberEditorMounts(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var factory = Editors.Number(typeof(int), min: 0, max: 100);
+                return factory(42, _ => { }).AutomationId("nb");
+            });
+            await Harness.Render();
+
+            var control = H.FindControl<NumberBox>(c =>
+                Microsoft.UI.Xaml.Automation.AutomationProperties.GetAutomationId(c) == "nb");
+            H.Check("Editors_Number_Mounts", control is not null);
+            H.Check("Editors_Number_InitialValue", control?.Value == 42);
+            H.Check("Editors_Number_MinApplied", control?.Minimum == 0);
+            H.Check("Editors_Number_MaxApplied", control?.Maximum == 100);
+        }
+    }
+
+    internal class DateEditorMounts(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var factory = Editors.Date();
+                return factory(new DateTime(2026, 1, 15), _ => { }).AutomationId("dp");
+            });
+            await Harness.Render();
+
+            var control = H.FindControl<DatePicker>(c =>
+                Microsoft.UI.Xaml.Automation.AutomationProperties.GetAutomationId(c) == "dp");
+            H.Check("Editors_Date_Mounts", control is not null);
+        }
+    }
+
+    internal class ColorEditorMounts(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                // Standard tier now inlines a ColorPicker directly (avoids the
+                // preview2 WinAppSDK crash with ColorPicker-in-Flyout).
+                var factory = Editors.Color();
+                return factory(global::Microsoft.UI.Colors.Crimson, _ => { }).AutomationId("cp");
+            });
+            await Harness.Render();
+
+            var picker = H.FindControl<ColorPicker>(c =>
+                Microsoft.UI.Xaml.Automation.AutomationProperties.GetAutomationId(c) == "cp");
+            H.Check("Editors_Color_PickerMounts", picker is not null);
+        }
+    }
+
+    internal class ColorCompactEditorMounts(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                // Compact tier (DataGrid cells): swatch + hex text box.
+                var factory = Editors.ColorCompact();
+                return factory(global::Microsoft.UI.Colors.Crimson, _ => { }).AutomationId("cc");
+            });
+            await Harness.Render();
+
+            // Find the hex TextBox — proves swatch+hex layout rendered.
+            var tb = H.FindControl<TextBox>(_ => true);
+            H.Check("Editors_ColorCompact_HexField", tb is not null);
+        }
+    }
+
+    internal class HyperlinkRendererMounts(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var renderer = CellRenderers.Hyperlink();
+                return renderer(new Uri("https://example.com")).AutomationId("hl");
+            });
+            await Harness.Render();
+
+            var link = H.FindControl<HyperlinkButton>(b =>
+                Microsoft.UI.Xaml.Automation.AutomationProperties.GetAutomationId(b) == "hl");
+            H.Check("Renderers_Hyperlink_Mounts", link is not null);
+            H.Check("Renderers_Hyperlink_Href",
+                link?.NavigateUri?.ToString() == "https://example.com/");
+        }
+    }
+
+    internal class ColorSwatchRendererMounts(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var renderer = CellRenderers.ColorSwatch();
+                return renderer(global::Microsoft.UI.Colors.DodgerBlue).AutomationId("sw");
+            });
+            await Harness.Render();
+
+            // ColorSwatch returns HStack(Border, TextBlock). We'd find a TextBlock
+            // holding "#FF1E90FF" (ARGB) or "#1E90FF" (RGB) — our helper emits RGB.
+            var text = H.FindControl<TextBlock>(tb =>
+                tb.Text is string s && s.Equals("#1E90FF", StringComparison.OrdinalIgnoreCase));
+            H.Check("Renderers_ColorSwatch_HexLabel", text is not null);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -453,9 +453,11 @@ internal static class SelfTestFixtureRegistry
         // Echo-suppression — programmatic Update* writes must not re-enter onChange
         "EchoSuppress_ColorPicker",
         "EchoSuppress_NumberBox",
+        "EchoSuppress_NumberBoxMinMaxCoercion",
         "EchoSuppress_ToggleSwitch",
         "EchoSuppress_CheckBox",
         "EchoSuppress_Slider",
+        "EchoSuppress_SliderMinMaxCoercion",
         "EchoSuppress_RatingControl",
         "EchoSuppress_DatePicker",
         "EchoSuppress_CalendarDatePicker",
@@ -1109,9 +1111,11 @@ internal static class SelfTestFixtureRegistry
         // Echo-suppression regression coverage
         "EchoSuppress_ColorPicker" => new EchoSuppressionFixtures.ColorPickerNoEcho(harness),
         "EchoSuppress_NumberBox" => new EchoSuppressionFixtures.NumberBoxNoEcho(harness),
+        "EchoSuppress_NumberBoxMinMaxCoercion" => new EchoSuppressionFixtures.NumberBoxMinMaxCoercionNoEcho(harness),
         "EchoSuppress_ToggleSwitch" => new EchoSuppressionFixtures.ToggleSwitchNoEcho(harness),
         "EchoSuppress_CheckBox" => new EchoSuppressionFixtures.CheckBoxNoEcho(harness),
         "EchoSuppress_Slider" => new EchoSuppressionFixtures.SliderNoEcho(harness),
+        "EchoSuppress_SliderMinMaxCoercion" => new EchoSuppressionFixtures.SliderMinMaxCoercionNoEcho(harness),
         "EchoSuppress_RatingControl" => new EchoSuppressionFixtures.RatingControlNoEcho(harness),
         "EchoSuppress_DatePicker" => new EchoSuppressionFixtures.DatePickerNoEcho(harness),
         "EchoSuppress_CalendarDatePicker" => new EchoSuppressionFixtures.CalendarDatePickerNoEcho(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -450,6 +450,19 @@ internal static class SelfTestFixtureRegistry
         "ControlsCov_FormatterPipeline",
         "ControlsCov_AutoSuggestElement",
         "ControlsCov_SearchManager",
+        // Echo-suppression — programmatic Update* writes must not re-enter onChange
+        "EchoSuppress_ColorPicker",
+        "EchoSuppress_NumberBox",
+        "EchoSuppress_ToggleSwitch",
+        "EchoSuppress_CheckBox",
+        "EchoSuppress_Slider",
+        "EchoSuppress_RatingControl",
+        "EchoSuppress_DatePicker",
+        "EchoSuppress_CalendarDatePicker",
+        "EchoSuppress_TimePicker",
+        "EchoSuppress_PasswordBox",
+        "EchoSuppress_TextField",
+        "EchoSuppress_ToggleSplitButton",
         // Hooks coverage — FocusManager, UseFocus
         "HooksCov_FocusManagerRegistration",
         "HooksCov_FocusManagerNavigation",
@@ -639,6 +652,16 @@ internal static class SelfTestFixtureRegistry
         "ValueEvt_RatingControl",
         "ValueEvt_PasswordBox",
         "ValueEvt_ColorPicker",
+
+        // Specialized editors — HitTable-style typed editors
+        "Editors_CheckBoxMounts",
+        "Editors_ToggleMounts",
+        "Editors_NumberMounts",
+        "Editors_DateMounts",
+        "Editors_ColorMounts",
+        "Editors_ColorCompactMounts",
+        "Renderers_HyperlinkMounts",
+        "Renderers_ColorSwatchMounts",
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
@@ -1083,6 +1106,19 @@ internal static class SelfTestFixtureRegistry
         "ControlsCov_InputFormattersFiltering" => new ControlsCoverageFixtures.InputFormattersFiltering(harness),
         "ControlsCov_FormatterPipeline" => new ControlsCoverageFixtures.FormatterPipelineExercise(harness),
         "ControlsCov_AutoSuggestElement" => new ControlsCoverageFixtures.AutoSuggestElementCreation(harness),
+        // Echo-suppression regression coverage
+        "EchoSuppress_ColorPicker" => new EchoSuppressionFixtures.ColorPickerNoEcho(harness),
+        "EchoSuppress_NumberBox" => new EchoSuppressionFixtures.NumberBoxNoEcho(harness),
+        "EchoSuppress_ToggleSwitch" => new EchoSuppressionFixtures.ToggleSwitchNoEcho(harness),
+        "EchoSuppress_CheckBox" => new EchoSuppressionFixtures.CheckBoxNoEcho(harness),
+        "EchoSuppress_Slider" => new EchoSuppressionFixtures.SliderNoEcho(harness),
+        "EchoSuppress_RatingControl" => new EchoSuppressionFixtures.RatingControlNoEcho(harness),
+        "EchoSuppress_DatePicker" => new EchoSuppressionFixtures.DatePickerNoEcho(harness),
+        "EchoSuppress_CalendarDatePicker" => new EchoSuppressionFixtures.CalendarDatePickerNoEcho(harness),
+        "EchoSuppress_TimePicker" => new EchoSuppressionFixtures.TimePickerNoEcho(harness),
+        "EchoSuppress_PasswordBox" => new EchoSuppressionFixtures.PasswordBoxNoEcho(harness),
+        "EchoSuppress_TextField" => new EchoSuppressionFixtures.TextFieldNoEcho(harness),
+        "EchoSuppress_ToggleSplitButton" => new EchoSuppressionFixtures.ToggleSplitButtonNoEcho(harness),
         "ControlsCov_SearchManager" => new ControlsCoverageFixtures.SearchManagerExercise(harness),
         // Hooks coverage
         "HooksCov_FocusManagerRegistration" => new HooksCoverageFixtures.FocusManagerRegistration(harness),
@@ -1274,6 +1310,16 @@ internal static class SelfTestFixtureRegistry
         "ValueEvt_RatingControl" => new ValueChangeEventFixtures.RatingControlValueFires(harness),
         "ValueEvt_PasswordBox" => new ValueChangeEventFixtures.PasswordBoxChangeFires(harness),
         "ValueEvt_ColorPicker" => new ValueChangeEventFixtures.ColorPickerChangeFires(harness),
+
+        // Specialized editors — mount each editor standalone under real WinUI.
+        "Editors_CheckBoxMounts" => new SpecializedEditorsTests.CheckBoxEditorMounts(harness),
+        "Editors_ToggleMounts" => new SpecializedEditorsTests.ToggleEditorMounts(harness),
+        "Editors_NumberMounts" => new SpecializedEditorsTests.NumberEditorMounts(harness),
+        "Editors_DateMounts" => new SpecializedEditorsTests.DateEditorMounts(harness),
+        "Editors_ColorMounts" => new SpecializedEditorsTests.ColorEditorMounts(harness),
+        "Editors_ColorCompactMounts" => new SpecializedEditorsTests.ColorCompactEditorMounts(harness),
+        "Renderers_HyperlinkMounts" => new SpecializedEditorsTests.HyperlinkRendererMounts(harness),
+        "Renderers_ColorSwatchMounts" => new SpecializedEditorsTests.ColorSwatchRendererMounts(harness),
 
         _ => null,
     };

--- a/tests/Reactor.Tests/Controls/TypedEditorsTests.cs
+++ b/tests/Reactor.Tests/Controls/TypedEditorsTests.cs
@@ -124,16 +124,14 @@ public class TypedEditorsTests
     // ══════════════════════════════════════════════════════════════
 
     [Fact]
-    public void Number_Editor_For_Int_Hands_Int_To_Callback()
+    public void Number_Editor_For_Int_Returns_Factory()
     {
+        // Unit tests run without a WinUI window, so we can't exercise the
+        // onChange path end-to-end here. The invariant we can assert is
+        // that resolving the numeric editor for int type succeeds and
+        // returns a usable factory delegate.
         var factory = Editors.Number(typeof(int));
-        object? captured = null;
-        // We don't construct the Element here (no WinUI host in unit tests);
-        // instead we reach the onChange callback by directly invoking the
-        // editor factory — but since the factory returns an Element, we just
-        // assert the factory doesn't blow up at type-resolution time.
         Assert.NotNull(factory);
-        _ = captured;
     }
 
     [Fact]
@@ -197,9 +195,12 @@ public class TypedEditorsTests
     }
 
     [Fact]
-    public void DateColumn_Picks_DateOnly_Editor_For_DateOnly_Property()
+    public void DateColumn_Wires_Editor_For_DateTime_Property()
     {
-        // Uses the DateColumn factory's type-inference branch.
+        // Target.When is DateTime — exercises the default branch of DateColumn's
+        // type dispatch (falls through to Editors.Date()). The DateOnly /
+        // DateTimeOffset branches are covered by selftest fixtures mounting
+        // against real WinUI controls.
         FieldDescriptor col = TypedColumns.DateColumn<Target>(
             nameof(Target.When), t => t.When);
         Assert.NotNull(col.Editor);

--- a/tests/Reactor.Tests/Controls/TypedEditorsTests.cs
+++ b/tests/Reactor.Tests/Controls/TypedEditorsTests.cs
@@ -1,0 +1,216 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.UI.Reactor.Controls;
+using Microsoft.UI.Reactor.Data;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.Controls;
+
+/// <summary>
+/// Unit tests for the HitTable-style typed editor stack (spec-030 direction):
+/// TypeRegistry density-aware resolution, attribute-based discovery via
+/// DataAnnotations, and the typed column factories.
+/// </summary>
+public class TypedEditorsTests
+{
+    // ══════════════════════════════════════════════════════════════
+    //  TypeRegistry — density-aware bool resolution
+    // ══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Bool_Standard_Editor_Is_Distinct_From_Compact()
+    {
+        var r = new TypeRegistry();
+        var standard = r.ResolveEditor(typeof(bool), EditorTier.Standard);
+        var compact = r.ResolveEditor(typeof(bool), EditorTier.Compact);
+
+        Assert.NotNull(standard);
+        Assert.NotNull(compact);
+        // Different delegate instances — PropertyGrid gets ToggleSwitch, DataGrid gets CheckBox.
+        Assert.NotSame(standard, compact);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  TypeRegistry — date/time/uri/color wired as primitives
+    // ══════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(typeof(global::System.DateTime))]
+    [InlineData(typeof(global::System.DateTimeOffset))]
+    [InlineData(typeof(global::System.DateOnly))]
+    [InlineData(typeof(global::System.TimeSpan))]
+    [InlineData(typeof(global::System.TimeOnly))]
+    [InlineData(typeof(global::System.Uri))]
+    [InlineData(typeof(global::Windows.UI.Color))]
+    public void Registry_Resolves_Editor_For_Primitive(Type type)
+    {
+        var r = new TypeRegistry();
+        Assert.NotNull(r.ResolveEditor(type, EditorTier.Standard));
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  TypeRegistry — cell renderer fallbacks
+    // ══════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(typeof(bool))]
+    [InlineData(typeof(global::System.DateTime))]
+    [InlineData(typeof(global::System.DateTimeOffset))]
+    [InlineData(typeof(global::System.DateOnly))]
+    [InlineData(typeof(global::System.TimeSpan))]
+    [InlineData(typeof(global::System.TimeOnly))]
+    [InlineData(typeof(global::System.Uri))]
+    [InlineData(typeof(global::Windows.UI.Color))]
+    public void Registry_Falls_Back_To_Builtin_CellRenderer(Type type)
+    {
+        var r = new TypeRegistry();
+        Assert.NotNull(r.GetCellRenderer(type));
+    }
+
+    [Fact]
+    public void Explicit_CellRenderer_Registration_Wins_Over_Fallback()
+    {
+        var r = new TypeRegistry();
+        Func<object, Microsoft.UI.Reactor.Core.Element> custom = _ => null!;
+        r.RegisterCellRenderer<bool>(custom);
+        Assert.Same(custom, r.GetCellRenderer(typeof(bool)));
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  Attribute-based discovery via ReflectionTypeMetadataProvider
+    // ══════════════════════════════════════════════════════════════
+
+    private sealed class Annotated
+    {
+        [DataType(DataType.Url)]
+        public string Website { get; set; } = "";
+
+        [Range(1, 100)]
+        public int Count { get; set; }
+
+        public string Plain { get; set; } = "";
+    }
+
+    [Fact]
+    public void DataType_Url_On_String_Sets_Hyperlink_Renderer()
+    {
+        var prop = typeof(Annotated).GetProperty(nameof(Annotated.Website))!;
+        var desc = ReflectionTypeMetadataProvider.CreateDescriptor(prop, 0);
+        Assert.NotNull(desc.CellRenderer);
+        Assert.NotNull(desc.Editor);
+    }
+
+    [Fact]
+    public void Range_On_Numeric_Sets_Editor()
+    {
+        var prop = typeof(Annotated).GetProperty(nameof(Annotated.Count))!;
+        var desc = ReflectionTypeMetadataProvider.CreateDescriptor(prop, 0);
+        Assert.NotNull(desc.Editor);
+    }
+
+    [Fact]
+    public void Plain_String_Has_No_Attribute_Editor()
+    {
+        var prop = typeof(Annotated).GetProperty(nameof(Annotated.Plain))!;
+        var desc = ReflectionTypeMetadataProvider.CreateDescriptor(prop, 0);
+        // No attribute on this property — attribute-path leaves Editor null so
+        // TypeRegistry resolution takes over at render time.
+        Assert.Null(desc.Editor);
+        Assert.Null(desc.CellRenderer);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  Editors value-conversion round-trips — verify FromDouble maps
+    //  the NumberBox's double back to the declared numeric type.
+    // ══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Number_Editor_For_Int_Hands_Int_To_Callback()
+    {
+        var factory = Editors.Number(typeof(int));
+        object? captured = null;
+        // We don't construct the Element here (no WinUI host in unit tests);
+        // instead we reach the onChange callback by directly invoking the
+        // editor factory — but since the factory returns an Element, we just
+        // assert the factory doesn't blow up at type-resolution time.
+        Assert.NotNull(factory);
+        _ = captured;
+    }
+
+    [Fact]
+    public void Number_Editor_Decimal_Min_Max_Accept_Decimal_Literals()
+    {
+        var factory = Editors.Decimal(min: 0m, max: 9999m);
+        Assert.NotNull(factory);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    //  Typed column factories
+    // ══════════════════════════════════════════════════════════════
+
+    private sealed class Target
+    {
+        public int N { get; set; }
+        public bool On { get; set; }
+        public global::System.DateTime When { get; set; }
+        public global::System.TimeSpan How { get; set; }
+        public global::System.Uri Where { get; set; } = new("https://x");
+        public global::Windows.UI.Color C { get; set; }
+        public Priority P { get; set; }
+    }
+    private enum Priority { Low, Med, High }
+
+    [Fact]
+    public void NumberColumn_Wires_Editor_And_CellRenderer()
+    {
+        FieldDescriptor col = TypedColumns.NumberColumn<Target>(
+            nameof(Target.N), t => t.N, min: 0, max: 99);
+        Assert.NotNull(col.Editor);
+        Assert.NotNull(col.CellRenderer);
+    }
+
+    [Fact]
+    public void ToggleSwitchColumn_Overrides_Default_Bool_Editor()
+    {
+        FieldDescriptor col = TypedColumns.ToggleSwitchColumn<Target>(
+            nameof(Target.On), t => t.On);
+        // Explicit typed column sets Editor on the descriptor; DataGrid
+        // renders this instead of the Compact (CheckBox) registry default.
+        Assert.NotNull(col.Editor);
+    }
+
+    [Fact]
+    public void ColorColumn_Wires_Swatch_Renderer()
+    {
+        FieldDescriptor col = TypedColumns.ColorColumn<Target>(
+            nameof(Target.C), t => t.C);
+        Assert.NotNull(col.Editor);
+        Assert.NotNull(col.CellRenderer);
+    }
+
+    [Fact]
+    public void ComboBoxColumn_Accepts_Explicit_Choices()
+    {
+        FieldDescriptor col = TypedColumns.ComboBoxColumn<Target, Priority>(
+            nameof(Target.P), t => t.P,
+            choices: [Priority.Low, Priority.Med]);
+        Assert.NotNull(col.Editor);
+    }
+
+    [Fact]
+    public void DateColumn_Picks_DateOnly_Editor_For_DateOnly_Property()
+    {
+        // Uses the DateColumn factory's type-inference branch.
+        FieldDescriptor col = TypedColumns.DateColumn<Target>(
+            nameof(Target.When), t => t.When);
+        Assert.NotNull(col.Editor);
+    }
+
+    [Fact]
+    public void HyperlinkColumn_Picks_Uri_Editor_For_Uri_Property()
+    {
+        FieldDescriptor col = TypedColumns.HyperlinkColumn<Target>(
+            nameof(Target.Where), t => t.Where);
+        Assert.NotNull(col.Editor);
+        Assert.NotNull(col.CellRenderer);
+    }
+}


### PR DESCRIPTION
## Summary

Two related landings in one PR. The second was discovered while building the first.

### 1. Typed editor catalog + specialized editors demo (commit `c4c6a43`)
- `Editors` catalog of editor factories (Text, CheckBox/Toggle, Number, Date/Time, Uri, Combo/EnumCombo, Color/ColorCompact) and matching `CellRenderers`.
- `TypedColumns` batteries-included column factories that pair editor + renderer (NumberColumn, ToggleSwitchColumn, DateColumn, HyperlinkColumn, ColorColumn, etc.).
- `SpecializedEditorsDemo` sample — three sections (auto-discovery DataGrid, explicit-typed-columns DataGrid, PropertyGrid) over one shared INPC-aware Gizmo source; edits in any surface propagate via INPC.
- DataGrid cell `OnTapped` gets a commit-before-begin guard so an in-flight edit is not clobbered when the user clicks a new cell.
- Selftest: `SpecializedEditorsTests` mount coverage for every editor factory against real WinUI controls.
- Unit test: `TypedEditorsTests`.

### 2. Fix: suppress programmatic-write change-event echo (commit `b6d155b`)

**Bug.** When a Reactor `Update<Control>` handler wrote a value-bearing DP (`cp.Color = n.Color`, `nb.Value = n.Value`, `ts.IsOn = n.IsOn`, …), the control raised its change event. If the user had wired an `onChange` callback, that callback got invoked with the value Reactor just wrote — indistinguishable from a real user edit. For components bound to an external selection (e.g. a `PropertyGrid` watching the currently-selected DataGrid row), the echo silently wrote the *new* selection's value back into the *previous* selection's state: a cross-row byte-for-byte value swap on selection change. Every scalar property of the previous selection was overwritten, not just the one that was visible. See [`docs/research/investigations/change-event-echo.md`](./docs/research/investigations/change-event-echo.md) for the full incident report.

**Fix.** A `ChangeEchoSuppressor` (per-control `ConditionalWeakTable`-backed counter):
- `BeginSuppress(control)` increments before a programmatic write that will raise a change event.
- Every change-event handler calls `ShouldSuppress(control)` as its first line and returns early if it consumed a token.

Every `Update<Control>` now: (a) calls `SetElementTag` first (defense-in-depth), (b) equality-guards the write, (c) `BeginSuppress`es before the assign. Every `Mount<Control>` gates its user-callback dispatch behind `ShouldSuppress`. Pooled controls (`TextField`, `ToggleSwitch`) also re-tag before re-rent so the retained handler sees the new element.

Covers `ColorPicker`, `NumberBox`, `ToggleSwitch`, `CheckBox`, `RadioButton`, `RadioButtons`, `ComboBox`, `Slider`, `RatingControl`, `DatePicker`, `CalendarDatePicker`, `TimePicker`, `ToggleSplitButton`, `PasswordBox`, `TextField`, `AutoSuggestBox`.

**Regression coverage.** `EchoSuppressionFixtures` — 12 fixtures × 48 TAP assertions. Each editor asserts the three invariants: mount does not fire `onChange`, programmatic re-render does not echo, simulated user edit still fires `onChange`.

## Follow-ups (noted in the investigation doc, out of scope here)
- `.OnPointerPressed` / `.OnTapped` stack handlers across re-renders — a single click fires the enqueued handler 4–10 times. Idempotent today so not visibly broken, but wasted work.
- `ObservableListDataSource.OnItemPropertyChanged` emits a `DataChanged` per INPC event with no coalescing. One real edit currently triggers 5+ grid re-renders.
- Consider extracting a `SetSuppressed(control, current, target, assign)` helper to name the pattern, plus a Roslyn-based unit lint that fails any `Update<X>` assigning a control property before `SetElementTag`.

## Test plan
- [x] `dotnet test tests/Reactor.Tests` — 6562 pass, 0 fail
- [x] `dotnet run --project tests/Reactor.AppTests.Host -- --self-test` — 1996 pass, 0 fail (including 48 new echo-suppression asserts and the existing `ControlUpdate_InputControls`, `ControlUpdate_DateTimePicker`, DataGrid edit fixtures that exercise continuous-value update paths)
- [x] Manual: reproduce the original Row 0 → Row 2 AccentColor swap in the Specialized Editors tab — confirmed fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)