### PR TITLE
Sample polish + reconciler in-place updates

### DIFF
--- a/samples/CommandingDemo/App.cs
+++ b/samples/CommandingDemo/App.cs
@@ -1,6 +1,7 @@
-// CommandingDemo — Demonstrates Reactor's commanding system.
-// Shows: StandardCommand, Command, UseCommand, CommandHost, parameterized commands,
-// per-site overrides with `with`, context-based command sharing, and ICommand interop.
+// CommandingDemo — Showcases Reactor's commanding system.
+// Shows: StandardCommand, Command, UseCommand, CommandHost, parameterized
+// commands via MenuItem<T>, per-site overrides with `with`, context-based
+// command sharing.
 
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
@@ -8,39 +9,31 @@ using static Microsoft.UI.Reactor.Factories;
 using static Microsoft.UI.Reactor.Core.Theme;
 using Windows.System;
 
-ReactorApp.Run<CommandingDemoApp>("Commanding Demo", width: 900, height: 700);
+ReactorApp.Run<CommandingDemoApp>("Commanding Demo", width: 960, height: 720
+#if DEBUG
+    , devtools: true
+#endif
+);
 
 // ─── Root component ───────────────────────────────────────────────────────────
 
 class CommandingDemoApp : Component
 {
-    public override Element Render()
-    {
-        var (selectedTab, setSelectedTab) = UseState(0);
-
-        var tabs = new[] { "Standard Commands", "Async / UseCommand", "Parameterized", "CommandHost", "Per-Site Override", "Context Sharing" };
-
-        return VStack(
-            TextBlock("Reactor Commanding Demo").FontSize(24).Bold().Margin(16, 16, 16, 8),
-            HStack(8,
-                tabs.Select((tab, i) =>
-                    Button(tab, () => setSelectedTab(i))
-                        .Background(i == selectedTab ? Accent : SubtleFill)
-                        .Margin(0, 0, 0, 8)
-                ).ToArray()
-            ).Margin(16, 0),
-            selectedTab switch
+    public override Element Render() =>
+        Grid(
+            columns: ["*"], rows: ["Auto", "*"],
+            (TitleBar("Commanding Demo") with
             {
-                0 => Component<StandardCommandsDemo>(),
-                1 => Component<AsyncCommandDemo>(),
-                2 => Component<ParameterizedCommandDemo>(),
-                3 => Component<CommandHostDemo>(),
-                4 => Component<PerSiteOverrideDemo>(),
-                5 => Component<ContextSharingDemo>(),
-                _ => Empty(),
-            }
-        );
-    }
+                Subtitle = "StandardCommand · UseCommand · CommandHost",
+            }).Grid(row: 0),
+            TabView(
+                Tab("Standard Commands",  Component<StandardCommandsDemo>())  with { IsClosable = false },
+                Tab("Async / UseCommand", Component<AsyncCommandDemo>())      with { IsClosable = false },
+                Tab("Parameterized",      Component<ParameterizedCommandDemo>()) with { IsClosable = false },
+                Tab("CommandHost",        Component<CommandHostDemo>())       with { IsClosable = false },
+                Tab("Per-Site Override",  Component<PerSiteOverrideDemo>())   with { IsClosable = false },
+                Tab("Context Sharing",    Component<ContextSharingDemo>())    with { IsClosable = false }
+            ).Grid(row: 1));
 }
 
 // ─── 1. Standard Commands Demo ────────────────────────────────────────────────
@@ -52,61 +45,57 @@ class StandardCommandsDemo : Component
         var (text, setText) = UseState("Select some text and use Cut/Copy/Paste from the toolbar or menu.");
         var (clipboard, setClipboard) = UseState("");
         var (selectedText, setSelectedText) = UseState("");
-        var (selStart, setSelStart) = UseState<int?>(null);
-        var (selLength, setSelLength) = UseState<int?>(null);
+
+        // Keep caret/length in refs — OnSelectionChanged fires on every click
+        // inside the TextBox, and if these drove state the re-render would
+        // re-push SelectionStart/Length back through the reconciler, which in
+        // turn refires SelectionChanged. Refs break that feedback loop while
+        // still giving Cut/Paste access to the live caret position.
+        var selStart = UseRef(0);
+        var selLength = UseRef(0);
+
+        // Tracks a one-shot selection we want to apply after a programmatic
+        // text mutation (Cut/Paste/SelectAll). Cleared back to null as soon
+        // as the TextField consumes it, so normal user clicks don't trigger
+        // a programmatic selection write.
+        var (pendingSelection, setPendingSelection) = UseState<(int Start, int Length)?>(null);
 
         var hasSelection = selectedText.Length > 0;
 
-        // Define commands once — use in toolbar, menu, and context menu
+        // Define commands once — use in toolbar, menu, and context menu.
         var cut = StandardCommand.Cut(() =>
         {
-            if (selStart is not null)
+            var start = selStart.Current;
+            var len = selectedText.Length;
+            if (len > 0)
             {
-                var start = selStart.Value;
-                var len = selectedText.Length;
                 setClipboard(selectedText);
                 setText(text.Remove(start, len));
-                setSelStart(start);        // keep caret at cut position
-                setSelLength(0);
                 setSelectedText("");
+                setPendingSelection((start, 0));
             }
         }, canExecute: hasSelection);
 
-        var copy = StandardCommand.Copy(() =>
-        {
-            setClipboard(selectedText);
-        }, canExecute: hasSelection);
+        var copy = StandardCommand.Copy(() => setClipboard(selectedText), canExecute: hasSelection);
 
         var paste = StandardCommand.Paste(() =>
         {
-            if (selStart is not null && selLength is not null)
-            {
-                // Replace selection with clipboard content
-                var start = selStart.Value;
-                var len = selLength.Value;
-                var newText = text.Remove(start, len).Insert(start, clipboard);
-                setText(newText);
-                setSelStart(start + clipboard.Length);
-                setSelLength(0);
-                setSelectedText("");
-            }
-            else
-            {
-                setText(text + clipboard);
-            }
+            var start = selStart.Current;
+            var len = selLength.Current;
+            setText(text.Remove(start, len).Insert(start, clipboard));
+            setSelectedText("");
+            setPendingSelection((start + clipboard.Length, 0));
         }, canExecute: clipboard.Length > 0);
 
         var selectAll = StandardCommand.SelectAll(() =>
         {
-            setSelStart(0);
-            setSelLength(text.Length);
             setSelectedText(text);
+            setPendingSelection((0, text.Length));
         });
 
         return VStack(8,
-            TextBlock("Standard Commands — define once, use everywhere").Bold().Margin(16, 8),
+            SubHeading("Standard Commands — define once, use everywhere").Margin(16, 8),
 
-            // CommandBar with same commands
             CommandBar(primaryCommands: [
                 AppBarButton(cut),
                 AppBarButton(copy),
@@ -115,36 +104,51 @@ class StandardCommandsDemo : Component
                 AppBarButton(selectAll),
             ]),
 
-            // MenuBar with same commands
             MenuBar(
                 Menu("Edit",
                     MenuItem(cut),
                     MenuItem(copy),
                     MenuItem(paste),
                     MenuSeparator(),
-                    MenuItem(selectAll)
-                )
-            ),
+                    MenuItem(selectAll))),
 
-            // Text area — OnSelectionChanged fires with (selectedText, selectionStart, selectionLength)
             (TextField(text, setText, placeholder: "Type here...") with
             {
                 OnSelectionChanged = (sel, start, len) =>
                 {
-                    setSelectedText(sel);
-                    setSelStart(start);
-                    setSelLength(len);
+                    selStart.Current = start;
+                    selLength.Current = len;
+                    // Only update state when the presence-or-absence of a
+                    // selection changes — caret moves without a selection
+                    // shouldn't trigger a re-render (avoids the flash on
+                    // simple clicks inside the text box).
+                    var nowHas = sel.Length > 0;
+                    if (nowHas || selectedText.Length > 0) setSelectedText(sel);
                 },
-                SelectionStart = selStart,
-                SelectionLength = selLength,
+                SelectionStart = pendingSelection?.Start,
+                SelectionLength = pendingSelection?.Length,
             }).Margin(16, 8),
 
-            // Status
-            TextBlock($"Clipboard: \"{clipboard}\"").Margin(16, 4).FontSize(12),
-            TextBlock($"Selected: \"{selectedText}\"").Margin(16, 4).FontSize(12),
-            TextBlock($"Has selection: {hasSelection}").Margin(16, 4).FontSize(12)
-        );
+            // Clear the pending selection once the TextField has had a chance
+            // to apply it. Runs after render; no-op when nothing pending.
+            PendingSelectionConsumer(pendingSelection, setPendingSelection),
+
+            Caption($"Clipboard: \"{clipboard}\"").Foreground(SecondaryText).Margin(16, 4),
+            Caption($"Selected: \"{selectedText}\"").Foreground(SecondaryText).Margin(16, 4),
+            Caption($"Has selection: {hasSelection}").Foreground(SecondaryText).Margin(16, 4));
     }
+
+    static Element PendingSelectionConsumer(
+        (int Start, int Length)? pending,
+        Action<(int Start, int Length)?> setPending) =>
+        Func(ctx =>
+        {
+            ctx.UseEffect(() =>
+            {
+                if (pending.HasValue) setPending(null);
+            }, (object?)pending ?? (object)"null");
+            return Empty();
+        });
 }
 
 // ─── 2. Async Command Demo (UseCommand) ──────────────────────────────────────
@@ -156,30 +160,28 @@ class AsyncCommandDemo : Component
         var (saveCount, setSaveCount) = UseState(0);
         var (lastStatus, setLastStatus) = UseState("Ready");
 
-        // Define async command — UseCommand wraps it with IsExecuting tracking
+        // UseCommand wraps the async command so IsExecuting flips automatically
+        // and click re-entrance is guarded.
         var saveCmd = UseCommand(StandardCommand.Save(async () =>
         {
             setLastStatus("Saving...");
-            await Task.Delay(2000); // Simulate save
+            await Task.Delay(2000);
             setSaveCount(saveCount + 1);
             setLastStatus($"Saved! (total: {saveCount + 1})");
         }));
 
         return VStack(8,
-            TextBlock("Async Commands — UseCommand auto-tracks IsExecuting").Bold().Margin(16, 8),
+            SubHeading("Async Commands — UseCommand auto-tracks IsExecuting").Margin(16, 8),
 
             HStack(8,
                 Button(saveCmd).Margin(16, 0),
-                saveCmd.IsExecuting
-                    ? ProgressRing().Width(20).Height(20)
-                    : Empty()
-            ),
+                saveCmd.IsExecuting ? ProgressRing().Size(20, 20) : Empty()),
 
             TextBlock($"Status: {lastStatus}").Margin(16, 4),
-            TextBlock($"IsExecuting: {saveCmd.IsExecuting}").Margin(16, 4).FontSize(12),
-            TextBlock($"IsEnabled: {saveCmd.IsEnabled}").Margin(16, 4).FontSize(12),
-            TextBlock("Try clicking Save — the button auto-disables during the 2-second operation.").Margin(16, 8).FontSize(12)
-        );
+            Caption($"IsExecuting: {saveCmd.IsExecuting}").Foreground(SecondaryText).Margin(16, 4),
+            Caption($"IsEnabled: {saveCmd.IsEnabled}").Foreground(SecondaryText).Margin(16, 4),
+            Caption("Try clicking Save — the button auto-disables during the 2-second operation.")
+                .Foreground(SecondaryText).Margin(16, 8));
     }
 }
 
@@ -191,13 +193,16 @@ class ParameterizedCommandDemo : Component
 
     public override Element Render()
     {
-        var (items, updateItems) = UseReducer(new Item[]
+        var (items, updateItems) = UseReducer(new[]
         {
-            new("Apple", "1"), new("Banana", "2"), new("Cherry", "3"),
-            new("Date", "4"), new("Elderberry", "5"),
+            new Item("Apple", "1"),
+            new Item("Banana", "2"),
+            new Item("Cherry", "3"),
+            new Item("Date", "4"),
+            new Item("Elderberry", "5"),
         });
 
-        // Single command definition — parameter bound per-item
+        // Single command definition — parameter bound per-item via MenuItem<T>.
         var deleteCmd = new Command<Item>
         {
             Label = "Delete",
@@ -206,17 +211,20 @@ class ParameterizedCommandDemo : Component
         };
 
         return VStack(8,
-            TextBlock("Parameterized Commands — Command<T> with per-item binding").Bold().Margin(16, 8),
+            SubHeading("Parameterized Commands — Command<T> with per-item binding").Margin(16, 8),
+            Caption("Right-click each row to open the context menu — MenuItem<T> binds the item as the command parameter.")
+                .Foreground(SecondaryText).Margin(16, 0, 16, 8),
 
-            ForEach(items, (item, i) =>
+            ForEach(items, item =>
                 HStack(8,
-                    TextBlock($"{item.Name}").Width(120),
-                    Button($"Delete {item.Name}", () => deleteCmd.Execute?.Invoke(item))
+                    TextBlock(item.Name).Width(120),
+                    Button("Delete", () => deleteCmd.Execute?.Invoke(item))
+                        .AutomationName($"Delete {item.Name}")
                 ).Margin(16, 2)
-            ),
+                 .WithContextFlyout(MenuItems(MenuItem(deleteCmd, item)))
+                 .WithKey(item.Id)),
 
-            TextBlock($"Items remaining: {items.Length}").Margin(16, 8).FontSize(12)
-        );
+            Caption($"Items remaining: {items.Length}").Foreground(SecondaryText).Margin(16, 8));
     }
 }
 
@@ -226,34 +234,31 @@ class CommandHostDemo : Component
 {
     public override Element Render()
     {
-        var (log, setLog) = UseState("Press Ctrl+S, Ctrl+Z, or Ctrl+Y within the blue region.");
+        var (log, setLog) = UseState("Press Ctrl+S, Ctrl+Z, or Ctrl+Y within the highlighted region.");
 
         var save = StandardCommand.Save(() => setLog($"[{DateTime.Now:HH:mm:ss}] Save triggered via Ctrl+S"));
         var undo = StandardCommand.Undo(() => setLog($"[{DateTime.Now:HH:mm:ss}] Undo triggered via Ctrl+Z"));
         var redo = StandardCommand.Redo(() => setLog($"[{DateTime.Now:HH:mm:ss}] Redo triggered via Ctrl+Y"));
 
         return VStack(8,
-            TextBlock("CommandHost — keyboard accelerators scoped to a subtree").Bold().Margin(16, 8),
+            SubHeading("CommandHost — keyboard accelerators scoped to a subtree").Margin(16, 8),
 
-            // INSIDE scope — shortcuts should work here
             CommandHost([save, undo, redo],
                 VStack(8,
-                    TextBlock("INSIDE CommandHost scope (blue) — Ctrl+S / Ctrl+Z / Ctrl+Y work here:").Bold(),
+                    TextBlock("INSIDE CommandHost scope — Ctrl+S / Ctrl+Z / Ctrl+Y fire here:")
+                        .Set(tb => tb.FontWeight = Microsoft.UI.Text.FontWeights.SemiBold),
                     TextField("", _ => { }, placeholder: "Click here and press Ctrl+S..."),
-                    TextBlock(log).FontSize(12)
-                ).Padding(16).Background(new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                    global::Windows.UI.Color.FromArgb(30, 100, 149, 237)))
+                    Caption(log).Foreground(SecondaryText))
+                .Padding(16)
+                .Background(SystemAttentionBackground)
                 .CornerRadius(8)
             ).Margin(16, 0),
 
-            // OUTSIDE scope — shortcuts should NOT work here
             VStack(8,
-                TextBlock("OUTSIDE CommandHost scope (red) — Ctrl+S / Ctrl+Z / Ctrl+Y should NOT work here:").Bold(),
+                TextBlock("OUTSIDE CommandHost scope — accelerators do NOT fire here:")
+                    .Set(tb => tb.FontWeight = Microsoft.UI.Text.FontWeights.SemiBold),
                 TextField("", _ => { }, placeholder: "Click here and press Ctrl+S — nothing should happen...")
-            ).Padding(16).Margin(16, 0).Background(new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                global::Windows.UI.Color.FromArgb(30, 237, 100, 100)))
-            .CornerRadius(8)
-        );
+            ).Padding(16).Margin(16, 0).Background(SystemCriticalBackground).CornerRadius(8));
     }
 }
 
@@ -268,28 +273,22 @@ class PerSiteOverrideDemo : Component
         var deleteCmd = StandardCommand.Delete(() => setLastAction("Deleted!"));
 
         return VStack(8,
-            TextBlock("Per-Site Overrides — same command, different presentation with `with`").Bold().Margin(16, 8),
+            SubHeading("Per-Site Overrides — same command, different presentation with `with`").Margin(16, 8),
 
             HStack(16,
                 VStack(4,
-                    TextBlock("Toolbar:").FontSize(12),
-                    CommandBar(primaryCommands: [
-                        AppBarButton(deleteCmd),  // Shows "Delete" with icon
-                    ])
-                ),
+                    Caption("Toolbar:").Foreground(SecondaryText),
+                    CommandBar(primaryCommands: [AppBarButton(deleteCmd)])),
+
                 VStack(4,
-                    TextBlock("Context menu (overridden label):").FontSize(12),
+                    Caption("Context menu (overridden labels):").Foreground(SecondaryText),
                     MenuBar(
                         Menu("Actions",
                             MenuItem(deleteCmd with { Label = "Remove selected item" }),
-                            MenuItem(deleteCmd with { Label = "Erase permanently", Icon = new SymbolIconData("Clear") })
-                        )
-                    )
-                )
+                            MenuItem(deleteCmd with { Label = "Erase permanently", Icon = new SymbolIconData("Clear") }))))
             ).Margin(16, 0),
 
-            TextBlock($"Last action: {lastAction}").Margin(16, 8)
-        );
+            TextBlock($"Last action: {lastAction}").Margin(16, 8));
     }
 }
 
@@ -307,36 +306,16 @@ class ToolbarComponent : Component
     public override Element Render()
     {
         var commands = UseContext(EditorCommandsContext.Instance);
-
         if (commands is null)
-            return TextBlock("No editor commands available").FontSize(12);
+            return Caption("No editor commands available").Foreground(SecondaryText);
 
         return VStack(4,
-            TextBlock("Toolbar (consumes commands via context):").FontSize(12).Bold(),
+            Caption("Toolbar (consumes commands via context):").Foreground(SecondaryText),
             CommandBar(primaryCommands: [
                 AppBarButton(commands.Save),
                 AppBarButton(commands.Undo),
                 AppBarButton(commands.Redo),
-            ])
-        );
-    }
-}
-
-class EditorComponent : Component
-{
-    public override Element Render()
-    {
-        var (content, setContent) = UseState("Edit this text...");
-        var (history, updateHistory) = UseReducer(new string[] { "Edit this text..." });
-
-        return VStack(4,
-            TextBlock("Editor (provides text + history state):").FontSize(12).Bold(),
-            TextField(content, newText =>
-            {
-                setContent(newText);
-                updateHistory(h => [.. h, newText]);
-            })
-        );
+            ]));
     }
 }
 
@@ -344,9 +323,9 @@ class ContextSharingDemo : Component
 {
     public override Element Render()
     {
-        // Command state lives here so context wraps BOTH toolbar and editor
+        // Command state lives here so context wraps both toolbar and editor.
         var (content, setContent) = UseState("Edit this text...");
-        var (history, updateHistory) = UseReducer(new string[] { "Edit this text..." });
+        var (history, updateHistory) = UseReducer(new[] { "Edit this text..." });
         var (saveStatus, setSaveStatus) = UseState("");
 
         var save = UseCommand(StandardCommand.Save(async () =>
@@ -368,25 +347,26 @@ class ContextSharingDemo : Component
 
         var commands = new EditorCommands(save, undo, redo);
 
-        // Provide context so both toolbar and editor can access commands
         return VStack(8,
-            TextBlock("Context Sharing — parent provides, children consume").Bold().Margin(16, 8),
+            SubHeading("Context Sharing — parent provides, children consume").Margin(16, 8),
 
             VStack(8,
                 Component<ToolbarComponent>(),
                 VStack(4,
-                    TextBlock("Editor:").FontSize(12).Bold(),
+                    Caption("Editor:").Foreground(SecondaryText),
                     TextField(content, newText =>
                     {
                         setContent(newText);
                         updateHistory(h => [.. h, newText]);
-                    })
-                ),
-                saveStatus.Length > 0 ? TextBlock(saveStatus).Margin(0, 4).FontSize(12) : Empty()
+                    })),
+                saveStatus.Length > 0
+                    ? Caption(saveStatus).Foreground(SecondaryText).Margin(0, 4)
+                    : Empty()
             ).Margin(16, 0).Provide(EditorCommandsContext.Instance, commands),
 
-            TextBlock("The parent component owns the commands and provides them via Context.").Margin(16, 8).FontSize(12),
-            TextBlock("The toolbar consumes them via UseContext — no prop drilling needed.").Margin(16, 4).FontSize(12)
-        );
+            Caption("The parent component owns the commands and provides them via Context.")
+                .Foreground(SecondaryText).Margin(16, 8),
+            Caption("The toolbar consumes them via UseContext — no prop drilling.")
+                .Foreground(SecondaryText).Margin(16, 4));
     }
 }

--- a/samples/NavigationDemo/App.cs
+++ b/samples/NavigationDemo/App.cs
@@ -37,7 +37,11 @@ if (dlIdx >= 0 && dlIdx + 1 < args.Length)
     }
 }
 
-ReactorApp.Run<AppShell>("Navigation Demo", width: 1200, height: 800);
+ReactorApp.Run<AppShell>("Navigation Demo", width: 1200, height: 800
+#if DEBUG
+    , devtools: true
+#endif
+);
 
 // ─── Deep link state (static, consumed once by AppShell) ──────────────────────
 
@@ -205,23 +209,23 @@ class AppShell : Component
 
     static Element DiagnosticsPanel(List<string> log, NavigationHandle<AppRoute> nav)
     {
+        // Left-side divider. WithBorder applies uniform thickness, and we only
+        // want a 1px edge on the left, so set BorderThickness directly and use
+        // the themed DividerStroke brush for the color.
         return Border(
             VStack(4,
-                TextBlock("Navigation Diagnostics").FontSize(12).SemiBold().Opacity(0.6),
-                TextBlock($"Depth: {nav.Depth} | CanGoBack: {nav.CanGoBack} | Route: {nav.CurrentRoute}")
-                    .FontSize(11).Opacity(0.5),
+                Caption("Navigation Diagnostics").SemiBold().Foreground(SecondaryText),
+                Caption($"Depth: {nav.Depth} | CanGoBack: {nav.CanGoBack} | Route: {nav.CurrentRoute}")
+                    .Foreground(TertiaryText),
                 VStack(0, log.Select(line =>
                     TextBlock(line).FontSize(10).Opacity(line.Contains("BLOCKED") ? 1.0 : 0.7)
                         .Foreground(line.Contains("BLOCKED") ? SystemCritical :
                                     line.Contains("HIT") ? SystemSuccess : SecondaryText)
                 ).ToArray())
             ).Padding(8)
-        ).Width(320).Set(b =>
-        {
-            b.BorderBrush = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                global::Windows.UI.Color.FromArgb(30, 128, 128, 128));
-            b.BorderThickness = new Thickness(1, 0, 0, 0);
-        });
+        ).Width(320)
+         .WithBorder(DividerStroke, 1)
+         .Set(b => b.BorderThickness = new Thickness(1, 0, 0, 0));
     }
 
     static string RouteDescription(AppRoute route) => route switch
@@ -262,8 +266,8 @@ class HomePage : Component
 
         return ScrollView(
             VStack(16,
-                TextBlock("Home").FontSize(28).SemiBold(),
-                TextBlock("Select an item, try deep links, or test the destination guard below.").Opacity(0.7),
+                Heading("Home"),
+                TextBlock("Select an item, try deep links, or test the destination guard below.").Foreground(SecondaryText),
 
                 When(loaded, () =>
                     VStack(8, SampleData.Items.Select(item =>
@@ -274,8 +278,8 @@ class HomePage : Component
                 ),
 
                 // Deep link examples
-                TextBlock("Deep Link Examples").FontSize(18).SemiBold().Margin(0, 24, 0, 0),
-                TextBlock("These simulate URI-based deep links with query strings, optional params, and wildcards.").Opacity(0.6),
+                SubHeading("Deep Link Examples").Margin(0, 24, 0, 0),
+                Caption("These simulate URI-based deep links with query strings, optional params, and wildcards.").Foreground(SecondaryText),
                 HStack(8,
                     Button("/detail/3?tab=related", () =>
                     {
@@ -304,8 +308,8 @@ class HomePage : Component
                 ),
 
                 // Transition distance demo
-                TextBlock("Slide Distance").FontSize(18).SemiBold().Margin(0, 24, 0, 0),
-                TextBlock("Custom slide distance — compare 100px vs 400px.").Opacity(0.6),
+                SubHeading("Slide Distance").Margin(0, 24, 0, 0),
+                Caption("Custom slide distance — compare 100px vs 400px.").Foreground(SecondaryText),
                 HStack(8,
                     Button("Slide 100px to Settings", () =>
                         nav.Navigate(new Settings(),
@@ -316,8 +320,8 @@ class HomePage : Component
                 ),
 
                 // Destination guard demo
-                TextBlock("Destination Guard").FontSize(18).SemiBold().Margin(0, 24, 0, 0),
-                TextBlock("The Admin page has a destination-side guard (onNavigatingTo). Toggle auth, then try to navigate.").Opacity(0.6),
+                SubHeading("Destination Guard").Margin(0, 24, 0, 0),
+                Caption("The Admin page has a destination-side guard (onNavigatingTo). Toggle auth, then try to navigate.").Foreground(SecondaryText),
                 HStack(8,
                     ToggleSwitch(isAuthorized, v => { AuthState.IsAuthorized = v; setIsAuthorized(v); },
                         header: $"Authorized: {(isAuthorized ? "Yes" : "No")}"),
@@ -325,7 +329,7 @@ class HomePage : Component
                 ),
                 When(!isAuthorized, () =>
                     TextBlock("Try clicking 'Go to Admin' — the destination guard will block. Toggle the switch first to allow it.")
-                        .Opacity(0.6).FontSize(12))
+                        .Foreground(SecondaryText))
             ).Padding(24)
         );
     }
@@ -352,12 +356,12 @@ class DetailPage : Component<Detail>
 
         return ScrollView(
             VStack(16,
-                TextBlock(title).FontSize(28).SemiBold(),
-                TextBlock(description).FontSize(16).Opacity(0.8),
-                TextBlock($"Item ID: {id}  |  Tab: {tab}").Opacity(0.5),
+                Heading(title),
+                TextBlock(description).Foreground(SecondaryText),
+                Caption($"Item ID: {id}  |  Tab: {tab}").Foreground(TertiaryText),
 
                 // Tab selection — demonstrates query string deep link result
-                TextBlock("Tabs (from query string)").FontSize(18).SemiBold().Margin(0, 16, 0, 0),
+                SubHeading("Tabs (from query string)").Margin(0, 16, 0, 0),
                 HStack(8,
                     TabButton("Overview", "overview", tab, id, nav),
                     TabButton("Related", "related", tab, id, nav),
@@ -369,7 +373,7 @@ class DetailPage : Component<Detail>
                     tab switch
                     {
                         "related" => VStack(8,
-                            TextBlock("Related Items").FontSize(16).SemiBold(),
+                            TextBlock("Related Items").SemiBold(),
                             When(prevId.HasValue, () =>
                                 Button($"Previous (#{prevId})", () =>
                                     nav.Navigate(new Detail(prevId!.Value),
@@ -380,12 +384,12 @@ class DetailPage : Component<Detail>
                                         new NavigateOptions { Transition = NavigationTransition.DrillIn() })))
                         ),
                         "history" => VStack(8,
-                            TextBlock("History").FontSize(16).SemiBold(),
+                            TextBlock("History").SemiBold(),
                             TextBlock($"Item #{id} was created on day {id} of the project."),
                             TextBlock($"Last modified: {id * 3} days ago.")
                         ),
                         _ => VStack(8,
-                            TextBlock("Overview").FontSize(16).SemiBold(),
+                            TextBlock("Overview").SemiBold(),
                             TextBlock(description),
                             TextBlock($"This is item #{id} of {SampleData.Items.Length} total items.")
                         ),
@@ -393,7 +397,7 @@ class DetailPage : Component<Detail>
                 ).Padding(16).Margin(0, 8, 0, 0),
 
                 // Transition demos
-                TextBlock("Transition Demos").FontSize(18).SemiBold().Margin(0, 16, 0, 0),
+                SubHeading("Transition Demos").Margin(0, 16, 0, 0),
                 HStack(8,
                     Button("Slide to Home", () =>
                         nav.Navigate(new Home(),
@@ -428,15 +432,15 @@ class DocsPageView : Component<string>
 
         return ScrollView(
             VStack(16,
-                TextBlock("Documentation").FontSize(28).SemiBold(),
-                TextBlock($"Path: /docs/{path}").FontSize(14).Opacity(0.6),
+                Heading("Documentation"),
+                Caption($"Path: /docs/{path}").Foreground(SecondaryText),
 
                 // Breadcrumb from wildcard path
-                TextBlock("Breadcrumb").FontSize(18).SemiBold().Margin(0, 16, 0, 0),
+                SubHeading("Breadcrumb").Margin(0, 16, 0, 0),
                 HStack(4,
                     Button("docs", () => nav.Navigate(new DocsPage("index"),
                         new NavigateOptions { PushToBackStack = false })),
-                    TextBlock("/").Opacity(0.3),
+                    TextBlock("/").Foreground(TertiaryText),
                     HStack(4, segments.Select((seg, i) => (Element)HStack(4,
                         Button(seg, () =>
                         {
@@ -444,18 +448,18 @@ class DocsPageView : Component<string>
                             nav.Navigate(new DocsPage(subPath),
                                 new NavigateOptions { PushToBackStack = false });
                         }),
-                        When(i < segments.Length - 1, () => TextBlock("/").Opacity(0.3))
+                        When(i < segments.Length - 1, () => TextBlock("/").Foreground(TertiaryText))
                     )).ToArray())
                 ),
 
                 // Simulated doc content
-                TextBlock("Content").FontSize(18).SemiBold().Margin(0, 16, 0, 0),
+                SubHeading("Content").Margin(0, 16, 0, 0),
                 TextBlock($"This is the documentation page for '{segments[^1]}'."),
                 TextBlock("Wildcard routes (/docs/**) capture the entire remaining path,"),
                 TextBlock("enabling documentation-style hierarchical navigation."),
 
                 // Navigate to child paths
-                TextBlock("Sub-pages").FontSize(18).SemiBold().Margin(0, 16, 0, 0),
+                SubHeading("Sub-pages").Margin(0, 16, 0, 0),
                 HStack(8,
                     Button($"{path}/overview", () =>
                         nav.Navigate(new DocsPage($"{path}/overview"))),
@@ -497,7 +501,7 @@ class AdminPageView : Component
         // This content only shows if authorized (guard allows navigation through)
         return ScrollView(
             VStack(16,
-                TextBlock("Admin Panel").FontSize(28).SemiBold(),
+                Heading("Admin Panel"),
                 TextBlock("You are authorized.").Foreground(SystemSuccess),
                 TextBlock("This page uses a destination-side guard (onNavigatingTo)."),
                 TextBlock("Navigation here was allowed because AuthState.IsAuthorized was true."),
@@ -517,7 +521,7 @@ class SettingsPage : Component
         var nestedNav = UseNavigation<SettingsRoute>(new GeneralSettings());
 
         return VStack(0,
-            TextBlock("Settings").FontSize(28).SemiBold().Margin(24, 24, 24, 8),
+            Heading("Settings").Margin(24, 24, 24, 8),
 
             HStack(8,
                 SettingsTab("General", new GeneralSettings(), nestedNav),
@@ -544,7 +548,7 @@ class SettingsPage : Component
 
     static Element GeneralSettingsContent() =>
         VStack(12,
-            TextBlock("General Settings").FontSize(18).SemiBold(),
+            SubHeading("General Settings"),
             TextBlock("Application Name: Navigation Demo"),
             TextBlock("Version: 2.0.0"),
             TextBlock("Language: English")
@@ -552,7 +556,7 @@ class SettingsPage : Component
 
     static Element DisplaySettingsContent() =>
         VStack(12,
-            TextBlock("Display Settings").FontSize(18).SemiBold(),
+            SubHeading("Display Settings"),
             TextBlock("Theme: System Default"),
             TextBlock("Font Size: Medium"),
             TextBlock("Compact Mode: Off")
@@ -560,7 +564,7 @@ class SettingsPage : Component
 
     static Element AboutSettingsContent() =>
         VStack(12,
-            TextBlock("About").FontSize(18).SemiBold(),
+            SubHeading("About"),
             TextBlock("Navigation Demo App"),
             TextBlock("Built with Reactor — a functional UI framework for WinUI 3."),
             TextBlock("Features: type-safe routes, GPU transitions, lifecycle guards,"),
@@ -600,7 +604,7 @@ class ProfilePage : Component<string>
 
         return ScrollView(
             VStack(16,
-                TextBlock($"Profile: {name}").FontSize(28).SemiBold(),
+                Heading($"Profile: {name}"),
 
                 VStack(8,
                     TextBlock("Display Name"),
@@ -622,7 +626,7 @@ class ProfilePage : Component<string>
                 ),
 
                 // Serialization demo
-                TextBlock("State Serialization").FontSize(18).SemiBold().Margin(0, 24, 0, 0),
+                SubHeading("State Serialization").Margin(0, 24, 0, 0),
                 TextBlock("Save and restore the entire navigation stack as JSON."),
                 HStack(8,
                     Button("Save State", () =>

--- a/samples/ReactorCharting.Gallery/Program.cs
+++ b/samples/ReactorCharting.Gallery/Program.cs
@@ -16,6 +16,9 @@ if (args.Contains("--self-test"))
 else
 {
     ReactorApp.Run<GalleryApp>("Reactor Charting Gallery", width: 1400, height: 900,
+#if DEBUG
+        devtools: true,
+#endif
         configure: host => XamlInterop.Register(host.Reconciler));
 }
 
@@ -100,7 +103,7 @@ class GalleryApp : Component
             )
         )
         .Background(Theme.SolidBackground)
-        .Set(b => b.RequestedTheme = isDark ? ElementTheme.Dark : ElementTheme.Light);
+        .RequestedTheme(isDark ? ElementTheme.Dark : ElementTheme.Light);
     }
 
     static string SubtitleFor(GalleryRoute route) => route switch
@@ -116,16 +119,18 @@ class GalleryApp : Component
     static Element ThemeToggle(bool isDark, Action<bool> setIsDark) =>
         Button(isDark ? "\uE793" : "\uE708", () => setIsDark(!isDark))
             .Foreground(Theme.AccentText)
+            .AutomationName(isDark ? "Switch to Light theme" : "Switch to Dark theme")
+            .ToolTip(isDark ? "Switch to Light" : "Switch to Dark")
+            .Size(36, 36)
+            .Resources(r => r
+                .Set("ButtonBackground", Theme.Ref("SubtleFillColorTransparentBrush"))
+                .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush")))
             .Set(b =>
             {
                 b.FontFamily = new FontFamily("Segoe MDL2 Assets");
-                b.Width = 36;
-                b.Height = 36;
                 b.Padding = new Thickness(0);
                 b.MinWidth = 0;
                 b.MinHeight = 0;
-                b.Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-                b.BorderThickness = new Thickness(0);
             });
 }
 
@@ -149,10 +154,12 @@ class LandingPage : Component
                         Button(
                             VStack(6,
                                 SampleIcon(sample, 36),
-                                TextBlock(sample.Title) with { FontSize = 12 }
+                                Caption(sample.Title)
                             ).MaxWidth(100).HAlign(HorizontalAlignment.Center),
                             () => nav.Navigate(new SampleDetail(sample.Title))
                         ).Width(130).Height(90)
+                         .WithKey(sample.Title)
+                         .AutomationName(sample.Title)
                     ).ToArray()
                 )
                 {
@@ -173,7 +180,7 @@ class LandingPage : Component
         global::System.IO.Path.Combine(AppContext.BaseDirectory, "Icons", $"{sample.IconName}.svg");
 
     static Element SampleIcon(GallerySample sample, double size) =>
-        Image(IconPath(sample)) with { Width = size, Height = size };
+        Image(IconPath(sample)).Size(size, size).AccessibilityHidden();
 
     static int CategoryOrder(string category) => category switch
     {

--- a/samples/ReactorCharting.Sample/Program.cs
+++ b/samples/ReactorCharting.Sample/Program.cs
@@ -7,7 +7,11 @@ using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static Microsoft.UI.Reactor.Charting.ChartDsl;
 
-ReactorApp.Run<ChartGallery>("Reactor Chart Gallery", width: 1200, height: 800);
+ReactorApp.Run<ChartGallery>("Reactor Chart Gallery", width: 1200, height: 800
+#if DEBUG
+    , devtools: true
+#endif
+);
 
 // ── Data types ──────────────────────────────────────────────────────────────
 
@@ -61,11 +65,15 @@ class ChartGallery : Component
 
         string[] tabs = ["Line", "Bar", "Area", "Pie", "Tree", "Force"];
 
-        return VStack(8,
-            Heading("Reactor Charting — D3-Powered Charts"),
-            Caption($"Tick {tick} — data changes every 800 ms"),
-            HStack(8, tabs.Select((name, i) =>
-                Button(tab == i ? $"● {name}" : name, () => setTab(i))).ToArray()),
+        return Grid(
+            columns: ["*"], rows: ["Auto", "*"],
+            (TitleBar("Reactor Chart Gallery") with
+            {
+                Subtitle = $"D3-powered live charts · tick {tick}",
+            }).Grid(row: 0),
+            VStack(8,
+                SelectorBar(tabs.Select(t => SelectorBarItem(t)).ToArray(),
+                    selectedIndex: tab, onSelectionChanged: setTab).Margin(24, 16, 24, 0),
             ScrollView(
                 Border(
                     tab switch
@@ -103,8 +111,8 @@ class ChartGallery : Component
                         _ => TextBlock("Select a tab"),
                     }
                 ).Padding(16)
-            )
-        ).Padding(24);
+            )).Padding(0).Grid(row: 1)
+        );
     }
 
     // ── Data generators — pure functions of tick ─────────────────────────

--- a/samples/ReactorGallery/GalleryShell.cs
+++ b/samples/ReactorGallery/GalleryShell.cs
@@ -131,7 +131,8 @@ class GalleryShell : Component
                     Button(isDark ? "\uE706" : "\uE708", () => setIsDark(!isDark))
                         .Set(b => b.FontFamily = new FontFamily("Segoe MDL2 Assets"))
                         .Width(40).Height(36)
-                        .ToolTip(isDark ? "Switch to Light" : "Switch to Dark"),
+                        .ToolTip(isDark ? "Switch to Light" : "Switch to Dark")
+                        .AutomationName(isDark ? "Switch to Light theme" : "Switch to Dark theme"),
                 IsPaneToggleButtonVisible = true,
                 OnPaneToggleRequested = () => setIsPaneOpen(!isPaneOpen),
                 IsBackButtonVisible = true,
@@ -183,6 +184,6 @@ class GalleryShell : Component
 
         return Border(shell)
             .Background(Theme.SolidBackground)
-            .Set(b => b.RequestedTheme = isDark ? ElementTheme.Dark : ElementTheme.Light);
+            .RequestedTheme(isDark ? ElementTheme.Dark : ElementTheme.Light);
     }
 }

--- a/samples/ReactorHostControlDemo/CounterDemo.cs
+++ b/samples/ReactorHostControlDemo/CounterDemo.cs
@@ -29,20 +29,22 @@ public class CounterDemo : Component
         }, auto, step);
 
         return VStack(12,
-            TextBlock("Counter").FontSize(20).Bold().Margin(16, 16, 16, 0),
+            SubHeading("Counter").Margin(16, 16, 16, 0),
 
             TextBlock($"{count}")
-                .FontSize(48).Bold()
+                .FontSize(48).SemiBold()
                 .HAlign(HorizontalAlignment.Center)
                 .Margin(0, 8),
 
             HStack(8,
-                Button("-", () => setCount(count - (int)step)).Width(60),
+                Button("-", () => setCount(count - (int)step)).Width(60)
+                    .AutomationName("Decrement"),
                 Button("Reset", () => setCount(0)),
                 Button("+", () => setCount(count + (int)step)).Width(60)
+                    .AutomationName("Increment")
             ).HAlign(HorizontalAlignment.Center),
 
-            Slider(step, min: 1, max: 10, onChanged: v => setStep(v))
+            Slider(step, min: 1, max: 10, onChanged: setStep)
                 .Margin(16, 8),
 
             TextBlock($"Step size: {(int)step}").HAlign(HorizontalAlignment.Center),

--- a/samples/StylingGallery/App.cs
+++ b/samples/StylingGallery/App.cs
@@ -5,57 +5,32 @@ using static Microsoft.UI.Reactor.Factories;
 using static StylingHelpers;
 using Microsoft.UI.Xaml;
 
-ReactorApp.Run<StylingGalleryApp>("Styling Gallery", width: 900, height: 750);
+ReactorApp.Run<StylingGalleryApp>("Styling Gallery", width: 960, height: 780
+#if DEBUG
+    , devtools: true
+#endif
+);
 
 // ════════════════════════════════════════════════════════════════════════
-//  Root app — tab-based navigation between styling feature demos
+//  Root app — TabView navigates between styling feature demos
 // ════════════════════════════════════════════════════════════════════════
 
 class StylingGalleryApp : Component
 {
-    public override Element Render()
-    {
-        var (tab, setTab) = UseState(0);
-
-        return VStack(0,
-            // Tab bar
-            HStack(0,
-                TabButton("Theme Tokens", 0, tab, setTab),
-                TabButton("RequestedTheme", 1, tab, setTab),
-                TabButton("UseColorScheme", 2, tab, setTab),
-                TabButton("Lightweight Styling", 3, tab, setTab),
-                TabButton("Style Caching", 4, tab, setTab)
-            ).Background(Theme.SolidBackground)
-             .Padding(8, 8, 8, 0),
-
-            // Content area
-            ScrollView(
-                tab switch
-                {
-                    0 => Component<ThemeTokensDemo>(),
-                    1 => Component<RequestedThemeDemo>(),
-                    2 => Component<ColorSchemeDemo>(),
-                    3 => Component<LightweightStylingDemo>(),
-                    4 => Component<StyleCachingDemo>(),
-                    _ => TextBlock("Unknown tab"),
-                }
-            )
-        );
-    }
-
-    static Element TabButton(string label, int index, int current, Action<int> setTab) =>
-        Button(label, () => setTab(index))
-            .Resources(r =>
+    public override Element Render() =>
+        Grid(
+            columns: ["*"], rows: ["Auto", "*"],
+            (TitleBar("Styling Gallery") with
             {
-                if (index == current)
-                {
-                    r.Set("ButtonBackground", Theme.Accent)
-                     .Set("ButtonBackgroundPointerOver", Theme.AccentSecondary)
-                     .Set("ButtonForeground", "#FFFFFF")
-                     .Set("ButtonForegroundPointerOver", "#FFFFFF");
-                }
-            })
-            .Margin(0, 0, 4, 0);
+                Subtitle = "Theme tokens · RequestedTheme · Lightweight styling",
+            }).Grid(row: 0),
+            TabView(
+                Tab("Theme Tokens",         ScrollView(Component<ThemeTokensDemo>())) with { IsClosable = false },
+                Tab("RequestedTheme",       ScrollView(Component<RequestedThemeDemo>())) with { IsClosable = false },
+                Tab("UseColorScheme",       ScrollView(Component<ColorSchemeDemo>())) with { IsClosable = false },
+                Tab("Lightweight Styling",  ScrollView(Component<LightweightStylingDemo>())) with { IsClosable = false },
+                Tab("Style Caching",        ScrollView(Component<StyleCachingDemo>())) with { IsClosable = false }
+            ).Grid(row: 1));
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -75,7 +50,7 @@ class ThemeTokensDemo : Component
                 TextBlock("SecondaryText").Foreground(Theme.SecondaryText),
                 TextBlock("TertiaryText").Foreground(Theme.TertiaryText),
                 TextBlock("DisabledText").Foreground(Theme.DisabledText),
-                TextBlock("AccentText").Foreground(Theme.AccentText).SemiBold()
+                TextBlock("AccentText").SemiBold().Foreground(Theme.AccentText)
             ),
 
             SubHeading("Accent Colors"),
@@ -114,10 +89,10 @@ class ThemeTokensDemo : Component
 
     static Element ColorSwatch(string label, ThemeRef color) =>
         VStack(4,
-            Border(TextBlock(""))
+            Border(Empty())
                 .Background(color)
                 .Width(80).Height(40)
-                .CornerRadius(6)
+                .CornerRadius(4)
                 .WithBorder(Theme.ControlStroke),
             Caption(label).Foreground(Theme.SecondaryText)
                 .HAlign(HorizontalAlignment.Center)
@@ -143,20 +118,19 @@ class RequestedThemeDemo : Component
             SubHeading("Dark Sidebar + Light Content"),
             HStack(0,
                 // Dark sidebar — native controls get dark styling automatically.
-                // Use a static dark background; text/buttons adopt dark theme natively.
                 VStack(12,
-                    TextBlock("Sidebar").Bold(),
-                    TextBlock("Navigation").Opacity(0.7),
-                    TextBlock("Settings").Opacity(0.7),
-                    TextBlock("Profile").Opacity(0.7)
+                    TextBlock("Sidebar").SemiBold(),
+                    TextBlock("Navigation").Foreground(Theme.SecondaryText),
+                    TextBlock("Settings").Foreground(Theme.SecondaryText),
+                    TextBlock("Profile").Foreground(Theme.SecondaryText)
                 ).Padding(16)
-                 .Background("#1E1E1E")
+                 .Background(Theme.SolidBackground)
                  .RequestedTheme(ElementTheme.Dark)
                  .Width(180),
 
-                // Light content (system theme)
+                // Light content area (system theme)
                 VStack(12,
-                    TextBlock("Main Content").Bold(),
+                    TextBlock("Main Content").SemiBold(),
                     TextBlock("This area uses the system theme."),
                     Button("Action", () => { })
                 ).Padding(16)
@@ -168,41 +142,39 @@ class RequestedThemeDemo : Component
 
             SubHeading("Toggle Theme Override"),
             ToggleSwitch(isDark, setIsDark, onContent: "Dark", offContent: "Light"),
-            // RequestedTheme makes native controls adopt the theme automatically.
-            // Background uses a static color matching the theme variant.
             Border(
                 VStack(12,
                     TextBlock("This panel follows the toggle."),
-                    TextBlock("Native controls adapt automatically."),
+                    TextBlock("Native controls adapt automatically.").Foreground(Theme.SecondaryText),
                     HStack(8,
                         Button("Primary", () => { }),
                         Button("Secondary", () => { }),
                         ToggleSwitch(false, _ => { }, onContent: "On", offContent: "Off")
                     )
                 ).Padding(16)
-            ).Background(isDark ? "#2D2D2D" : "#F3F3F3")
+            ).Background(Theme.SolidBackground)
              .CornerRadius(8)
              .RequestedTheme(isDark ? ElementTheme.Dark : ElementTheme.Light),
 
             SubHeading("ElementTheme.Default (System Inheritance)"),
             TextBlock("Setting RequestedTheme to Default restores the system theme:"),
             HStack(12,
-                ThemeBox("Dark", ElementTheme.Dark, "#2D2D2D"),
-                ThemeBox("Default", ElementTheme.Default, null),
-                ThemeBox("Light", ElementTheme.Light, "#F3F3F3")
+                ThemeBox("Dark", ElementTheme.Dark),
+                ThemeBox("Default", ElementTheme.Default),
+                ThemeBox("Light", ElementTheme.Light)
             )
         ).Padding(24);
     }
 
-    static Element ThemeBox(string label, ElementTheme theme, string? bg) =>
+    static Element ThemeBox(string label, ElementTheme theme) =>
         Border(
             VStack(4,
-                TextBlock(label).Bold(),
-                TextBlock("Sample text"),
+                TextBlock(label).SemiBold(),
+                TextBlock("Sample text").Foreground(Theme.SecondaryText),
                 Button("Button", () => { })
             ).Padding(12)
-        ).Background(bg ?? "#F9F9F9")
-         .CornerRadius(6)
+        ).Background(Theme.CardBackground)
+         .CornerRadius(4)
          .RequestedTheme(theme)
          .Width(150);
 }
@@ -234,10 +206,10 @@ class ColorSchemeDemo : Component
 
             Border(
                 HStack(16,
-                    TextBlock(isDark ? "\U0001F319" : "\u2600\uFE0F").FontSize(48),
+                    TextBlock(isDark ? "\U0001F319" : "☀️").FontSize(48),
                     VStack(4,
                         TextBlock(isDark ? "Dark Mode Active" : "Light Mode Active")
-                            .Bold().Foreground(Theme.PrimaryText),
+                            .SemiBold().Foreground(Theme.PrimaryText),
                         TextBlock(isDark
                                 ? "UI is optimized for low-light viewing"
                                 : "UI is optimized for well-lit environments")
@@ -249,7 +221,8 @@ class ColorSchemeDemo : Component
              .WithBorder(Theme.CardStroke),
 
             SubHeading("Opacity Adjustment"),
-            TextBlock("Decorative elements use lower opacity in light mode to reduce visual noise:")
+            TextBlock("Decorative accent bars use lower opacity in Light mode to reduce visual noise. " +
+                      "For text, prefer themed Secondary/Tertiary foregrounds — opacity breaks in High Contrast.")
                 .Foreground(Theme.SecondaryText),
             HStack(12,
                 DecorativeBox("Normal", 1.0),
@@ -268,19 +241,19 @@ class ColorSchemeDemo : Component
         Border(
             VStack(4,
                 Caption(label).Foreground(Theme.SecondaryText),
-                TextBlock(value).FontSize(20).Bold().Foreground(Theme.AccentText)
+                SubHeading(value).Foreground(Theme.AccentText)
             ).Padding(12)
         ).Background(Theme.CardBackground)
-         .CornerRadius(6)
+         .CornerRadius(4)
          .WithBorder(Theme.CardStroke)
          .Width(160);
 
     static Element DecorativeBox(string label, double opacity) =>
         VStack(4,
-            Border(TextBlock(""))
+            Border(Empty())
                 .Background(Theme.Accent)
                 .Width(80).Height(50)
-                .CornerRadius(6)
+                .CornerRadius(4)
                 .Opacity(opacity),
             Caption(label).Foreground(Theme.SecondaryText)
                 .HAlign(HorizontalAlignment.Center)
@@ -305,7 +278,6 @@ class LightweightStylingDemo : Component
                  "to create branded buttons without custom templates.")
                 .Foreground(Theme.SecondaryText),
             HStack(12,
-                // Blue brand button
                 Button("Primary Action", () => { })
                     .Resources(r => r
                         .Set("ButtonBackground", "#0078D4")
@@ -315,7 +287,6 @@ class LightweightStylingDemo : Component
                         .Set("ButtonForegroundPointerOver", "#FFFFFF")
                         .Set("ButtonForegroundPressed", "#FFFFFF")),
 
-                // Green success button
                 Button("Confirm", () => { })
                     .Resources(r => r
                         .Set("ButtonBackground", "#107C10")
@@ -325,7 +296,6 @@ class LightweightStylingDemo : Component
                         .Set("ButtonForegroundPointerOver", "#FFFFFF")
                         .Set("ButtonForegroundPressed", "#FFFFFF")),
 
-                // Red danger button
                 Button("Delete", () => { })
                     .Resources(r => r
                         .Set("ButtonBackground", "#D13438")
@@ -335,7 +305,6 @@ class LightweightStylingDemo : Component
                         .Set("ButtonForegroundPointerOver", "#FFFFFF")
                         .Set("ButtonForegroundPressed", "#FFFFFF")),
 
-                // Default button for comparison
                 Button("Default", () => { })
             ),
 
@@ -413,20 +382,21 @@ class StyleCachingDemo : Component
 
             HStack(12,
                 Button("-10", () => setCount(Math.Max(10, count - 10))),
-                TextBlock($"{count} items").Foreground(Theme.PrimaryText).VAlign(VerticalAlignment.Center),
+                TextBlock($"{count} items").VAlign(VerticalAlignment.Center),
                 Button("+10", () => setCount(Math.Min(200, count + 10)))
             ),
 
             WrapGrid(
                 Enumerable.Range(0, count).Select(i =>
                     Border(
-                        TextBlock($"#{i + 1}").Foreground(Theme.SecondaryText).FontSize(11)
+                        Caption($"#{i + 1}").Foreground(Theme.SecondaryText)
                             .HAlign(HorizontalAlignment.Center)
                             .VAlign(VerticalAlignment.Center)
                     ).Background(Theme.CardBackground)
                      .WithBorder(Theme.CardStroke)
                      .CornerRadius(4)
                      .Width(55).Height(36)
+                     .WithKey(i.ToString())
                 ).ToArray()
             ),
 
@@ -440,8 +410,7 @@ class StyleCachingDemo : Component
 }
 
 // ════════════════════════════════════════════════════════════════════════
-//  Shared helpers — called as SectionHeader() from components via
-//  'using static StylingHelpers'
+//  Shared helpers
 // ════════════════════════════════════════════════════════════════════════
 
 static class StylingHelpers

--- a/samples/TodoApp/Program.cs
+++ b/samples/TodoApp/Program.cs
@@ -1,21 +1,31 @@
-// TodoApp — A real starter template demonstrating Reactor's component model.
-// Shows: UseReducer for state management, Command for actions, Theme tokens.
+// TodoApp — A starter template that showcases Reactor's component model.
+// Highlights: UseReducer, Command, command-aware Button, FlexColumn/FlexRow
+// layout with grow/shrink, theme tokens, TitleBar integration, and
+// a11y-friendly controls.
 
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Layout;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
 using static Microsoft.UI.Reactor.Factories;
 using static Microsoft.UI.Reactor.Core.Theme;
 
-ReactorApp.Run<TodoApp>("Todo App", width: 700, height: 550);
+ReactorApp.Run<TodoApp>("Todos", width: 900, height: 720
+#if DEBUG
+    , devtools: true
+#endif
+);
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
 record TodoItem(string Id, string Text, bool IsCompleted);
 
-record TodoState(IReadOnlyList<TodoItem> Items, string NewItemText, string Filter)
+enum TodoFilter { All, Active, Completed }
+
+record TodoState(IReadOnlyList<TodoItem> Items, string NewItemText, TodoFilter Filter)
 {
-    public static readonly TodoState Initial = new([], "", "all");
+    public static readonly TodoState Initial = new([], "", TodoFilter.All);
 }
 
 abstract record TodoAction;
@@ -23,7 +33,8 @@ record AddItem : TodoAction;
 record ToggleItem(string Id) : TodoAction;
 record DeleteItem(string Id) : TodoAction;
 record SetNewItemText(string Text) : TodoAction;
-record SetFilter(string Filter) : TodoAction;
+record SetFilter(TodoFilter Filter) : TodoAction;
+record ClearCompleted : TodoAction;
 
 // ─── Reducer ─────────────────────────────────────────────────────────────────
 
@@ -39,15 +50,16 @@ static class TodoReducer
             },
         ToggleItem t => state with
         {
-            Items = state.Items.Select(i =>
-                i.Id == t.Id ? i with { IsCompleted = !i.IsCompleted } : i).ToList()
+            Items = [.. state.Items.Select(i =>
+                i.Id == t.Id ? i with { IsCompleted = !i.IsCompleted } : i)]
         },
         DeleteItem d => state with
         {
-            Items = state.Items.Where(i => i.Id != d.Id).ToList()
+            Items = [.. state.Items.Where(i => i.Id != d.Id)]
         },
         SetNewItemText s => state with { NewItemText = s.Text },
         SetFilter f => state with { Filter = f.Filter },
+        ClearCompleted => state with { Items = [.. state.Items.Where(i => !i.IsCompleted)] },
         _ => state
     };
 }
@@ -60,93 +72,191 @@ class TodoApp : Component
     {
         var (state, dispatch) = UseReducer<TodoState, TodoAction>(TodoReducer.Reduce, TodoState.Initial);
 
-        var filtered = state.Filter switch
+        var filtered = UseMemo(() => state.Filter switch
         {
-            "active" => state.Items.Where(i => !i.IsCompleted).ToArray(),
-            "completed" => state.Items.Where(i => i.IsCompleted).ToArray(),
-            _ => state.Items.ToArray()
-        };
+            TodoFilter.Active    => state.Items.Where(i => !i.IsCompleted).ToArray(),
+            TodoFilter.Completed => state.Items.Where(i => i.IsCompleted).ToArray(),
+            _                    => state.Items.ToArray()
+        }, state.Items, state.Filter);
 
         var remaining = state.Items.Count(i => !i.IsCompleted);
+        var completed = state.Items.Count - remaining;
 
         var addCmd = new Command
         {
             Label = "Add",
             Execute = () => dispatch(new AddItem()),
             CanExecute = !string.IsNullOrWhiteSpace(state.NewItemText),
+            Accelerator = Accelerator(Windows.System.VirtualKey.Enter),
         };
 
-        return VStack(0,
-            // Header
-            TextBlock("todos").FontSize(36)
-                .Set(t => t.FontWeight = Microsoft.UI.Text.FontWeights.Light)
-                .Foreground(AccentText)
-                .HAlign(HorizontalAlignment.Center)
-                .Margin(0, 16, 0, 8),
+        var subtitle = state.Items.Count switch
+        {
+            0 => "No tasks",
+            _ => $"{remaining} remaining of {state.Items.Count}",
+        };
 
-            // Input bar
-            HStack(8,
-                TextField(state.NewItemText, v => dispatch(new SetNewItemText(v)))
-                    .Set(tb => tb.PlaceholderText = "What needs to be done?")
-                    .HAlign(HorizontalAlignment.Stretch),
-                Button(addCmd)
-            ).Padding(16, 8, 16, 8)
-             .Background(CardBackground),
+        return CommandHost([addCmd],
+            FlexColumn(
+                // Real Windows title bar — integrates with caption buttons and
+                // the system drag region instead of painting a custom header.
+                (TitleBar("Todos") with { Subtitle = subtitle }).Flex(shrink: 0),
 
-            // List
-            ScrollView(
-                VStack(0,
-                    filtered.Select(item =>
-                        TodoRow(item, dispatch)
-                    ).ToArray()
-                )
-            ).Flex(grow: 1, basis: 0),
-
-            // Footer
-            HStack(8,
-                TextBlock($"{remaining} item{(remaining == 1 ? "" : "s")} left")
-                    .FontSize(12).Foreground(SecondaryText)
-                    .VAlign(VerticalAlignment.Center),
-                Empty().HAlign(HorizontalAlignment.Stretch),
-                FilterButton("All", "all", state.Filter, dispatch),
-                FilterButton("Active", "active", state.Filter, dispatch),
-                FilterButton("Completed", "completed", state.Filter, dispatch)
-            ).Padding(12, 8, 12, 8)
-             .WithBorder(DividerStroke)
-        ).Background(SolidBackground)
-         .MaxWidth(600)
-         .HAlign(HorizontalAlignment.Center);
+                // Scrollable body — padded off the window edges so the card
+                // has breathing room on every side.
+                // ScrollView fills remaining space. Inside it, a 3-column Grid
+                // centers the card in the available width — the star/auto/star
+                // columns give equal gutters without fighting MaxWidth in the way
+                // HAlign(Center) does on narrow windows.
+                ScrollView(
+                    Grid(
+                        columns: ["*", "Auto", "*"],
+                        rows: ["Auto"],
+                        Card(state, filtered, addCmd, remaining, completed, dispatch)
+                            .MinWidth(320)
+                            .MaxWidth(560)
+                            .Margin(16, 16, 16, 24)
+                            .Grid(row: 0, column: 1)
+                    )
+                ).Flex(grow: 1)
+            )
+            .Background(SolidBackground));
     }
 
+    // ── Card: input row, list, footer — all inside a rounded surface ──
+
+    static Element Card(
+        TodoState state,
+        TodoItem[] filtered,
+        Command addCmd,
+        int remaining,
+        int completed,
+        Action<TodoAction> dispatch) =>
+        Border(
+            FlexColumn(
+                InputRow(state.NewItemText, addCmd, dispatch),
+                Divider(),
+                filtered.Length == 0
+                    ? EmptyState(state.Filter)
+                    : FlexColumn(filtered.Select(item => TodoRow(item, dispatch)).ToArray<Element?>()),
+                Divider(),
+                FooterRow(remaining, completed, state.Filter, dispatch)
+            )
+        )
+        .Background(CardBackground)
+        .WithBorder(CardStroke, 1)
+        .CornerRadius(8);
+
+    // ── Input row ────────────────────────────────────────────────────
+
+    static Element InputRow(string text, Command addCmd, Action<TodoAction> dispatch) =>
+        (FlexRow(
+            TextField(text, v => dispatch(new SetNewItemText(v)),
+                      placeholder: "What needs to be done?")
+                .Flex(grow: 1),
+            Button(addCmd).Flex(shrink: 0)
+        ) with { AlignItems = FlexAlign.Center, ColumnGap = 12 })
+            .Padding(16, 14);
+
+    // ── Todo row ─────────────────────────────────────────────────────
+
     static Element TodoRow(TodoItem item, Action<TodoAction> dispatch) =>
-        HStack(8,
-            CheckBox(item.IsCompleted, _ => dispatch(new ToggleItem(item.Id))),
+        (FlexRow(
+            // CheckBox's default style sets MinWidth=120 (CheckBoxMinWidth theme
+            // resource) to reserve space for a Content label. Collapse it with
+            // a local MinWidth(0) since we render the label separately so that
+            // completed items can get strikethrough styling.
+            CheckBox(item.IsCompleted, _ => dispatch(new ToggleItem(item.Id)))
+                .AutomationName(item.IsCompleted ? "Mark as incomplete" : "Mark as complete")
+                .MinWidth(0)
+                .Flex(shrink: 0),
+
             TextBlock(item.Text)
-                .FontSize(14)
-                .Opacity(item.IsCompleted ? 0.5 : 1)
+                .Foreground(item.IsCompleted ? TertiaryText : PrimaryText)
                 .Set(t =>
                 {
+                    t.TextTrimming = Microsoft.UI.Xaml.TextTrimming.CharacterEllipsis;
                     if (item.IsCompleted)
                         t.TextDecorations = global::Windows.UI.Text.TextDecorations.Strikethrough;
                 })
-                .VAlign(VerticalAlignment.Center),
-            Empty().HAlign(HorizontalAlignment.Stretch),
-            Button("✕", () => dispatch(new DeleteItem(item.Id)))
-                .Set(b =>
-                {
-                    b.Padding = new Thickness(6, 2, 6, 2);
-                    b.MinWidth = 0;
-                    b.MinHeight = 0;
-                })
-        ).Padding(12, 6, 12, 6)
-         .WithKey(item.Id);
+                .ToolTip(item.Text)
+                .Flex(grow: 1, alignSelf: FlexAlign.Center),
 
-    static Element FilterButton(string label, string filter, string active, Action<TodoAction> dispatch) =>
-        Button(label, () => dispatch(new SetFilter(filter)))
-            .Background(filter == active ? Accent : SubtleFill)
-            .Set(b =>
+            // Icon-only delete button — trash-can glyph (E74D) from the
+            // Segoe Fluent icon font. Styled as a subtle "ghost" button so it
+            // recedes visually but still reveals hover + pressed states
+            // through .Resources().
+            Button("", () => dispatch(new DeleteItem(item.Id)))
+                .AutomationName($"Delete '{item.Text}'")
+                .ToolTip("Delete")
+                .FontSize(14)
+                .Size(36, 32)
+                .Set(b => b.FontFamily = (Microsoft.UI.Xaml.Media.FontFamily)
+                    Application.Current.Resources["SymbolThemeFontFamily"])
+                .Resources(r => r
+                    .Set("ButtonBackground", Theme.Ref("SubtleFillColorTransparentBrush"))
+                    .Set("ButtonBorderBrush", Theme.Ref("SubtleFillColorTransparentBrush"))
+                    .Set("ButtonForeground", SecondaryText)
+                    .Set("ButtonForegroundPointerOver", SystemCritical))
+                .Flex(shrink: 0)
+         ) with { AlignItems = FlexAlign.Center, ColumnGap = 12 })
+            .Padding(16, 8)
+            .WithKey(item.Id);
+
+    // ── Empty state — shown when filter returns nothing ───────────────
+
+    static Element EmptyState(TodoFilter filter) =>
+        (FlexColumn(
+                        // Decorative checkbox glyph (E73A) from the Segoe Fluent icon font.
+            // Rendered as a TextBlock since FontIcon returns IconData (used on
+            // commands / menu items), not a free-standing Element.
+            TextBlock("")
+                .FontSize(32)
+                .Foreground(TertiaryText)
+                .Set(tb => tb.FontFamily = (Microsoft.UI.Xaml.Media.FontFamily)
+                    Application.Current.Resources["SymbolThemeFontFamily"]),
+            TextBlock(filter switch
             {
-                b.Padding = new Thickness(10, 4, 10, 4);
-                b.MinHeight = 0;
-            });
+                TodoFilter.Active    => "Nothing active — you're all caught up!",
+                TodoFilter.Completed => "Nothing completed yet.",
+                _                    => "No todos yet. Add one above to get started.",
+            })
+            .Foreground(SecondaryText)
+            .HAlign(HorizontalAlignment.Center)
+        ) with { AlignItems = FlexAlign.Center, RowGap = 12 })
+            .Padding(24, 40);
+
+    // ── Divider ─────────────────────────────────────────────────────
+
+    static Element Divider() =>
+        Border(Empty()).Height(1).Background(DividerStroke);
+
+    // ── Footer — counts, filter toggles, clear-completed ──────────────
+
+    static Element FooterRow(int remaining, int completed, TodoFilter active, Action<TodoAction> dispatch) =>
+        (FlexRow(
+            Caption($"{remaining} item{(remaining == 1 ? "" : "s")} left")
+                .Foreground(SecondaryText)
+                .Flex(shrink: 0, alignSelf: FlexAlign.Center),
+
+            // Spacer
+            Flex().Flex(grow: 1),
+
+            FilterToggle("All", TodoFilter.All, active, dispatch),
+            FilterToggle("Active", TodoFilter.Active, active, dispatch),
+            FilterToggle("Completed", TodoFilter.Completed, active, dispatch),
+
+            When(completed > 0, () =>
+                HyperlinkButton("Clear completed", onClick: () => dispatch(new ClearCompleted()))
+                    .Flex(shrink: 0, alignSelf: FlexAlign.Center))
+         ) with { AlignItems = FlexAlign.Center, ColumnGap = 6 })
+            .Padding(16, 10);
+
+    static Element FilterToggle(string label, TodoFilter filter, TodoFilter active, Action<TodoAction> dispatch) =>
+        // shrink: 0 — the flex spacer would otherwise clip "Active" → "Ac" and
+        // "Completed" → "Comp" in narrower windows.
+        ToggleButton(label,
+            isChecked: filter == active,
+            onToggled: _ => dispatch(new SetFilter(filter)))
+            .Flex(shrink: 0);
 }

--- a/samples/TodoApp/TodoApp.sln
+++ b/samples/TodoApp/TodoApp.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 18.4.11605.240
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoApp", "TodoApp.csproj", "{81119FD0-90EC-4FB0-B5E8-6FB9C5C4ECB5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reactor", "..\..\Reactor\Reactor.csproj", "{DDA8F21F-21A2-4496-9A07-3F9EC517B7C4}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reactor", "..\..\src\Reactor\Reactor.csproj", "{DDA8F21F-21A2-4496-9A07-3F9EC517B7C4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/samples/WinFormsInterop/SampleDuctComponent.cs
+++ b/samples/WinFormsInterop/SampleDuctComponent.cs
@@ -24,22 +24,19 @@ class SampleReactorComponent : Component
         return Grid(["*"], ["*"],
           VStack(
             // ── Header ─────────────────────────────────────
-            TextBlock("Reactor Component (via XAML Island)")
-                .FontSize(22)
-                .FontWeight(Microsoft.UI.Text.FontWeights.Bold)
-                .Margin(0, 0, 0, 4),
+            SubHeading("Reactor Component (via XAML Island)").Margin(0, 0, 0, 4),
 
             TextBlock("This Reactor/WinUI component is rendered inside a XAML Island hosted in a WinForms window.")
-                .Opacity(0.6)
+                .Foreground(SecondaryText)
                 .Margin(0, 0, 0, 20),
 
             // ── Counter ────────────────────────────────────
             HStack(
-                Button("-", () => setCount(count - 1)),
+                Button("-", () => setCount(count - 1)).AutomationName("Decrement"),
                 TextBlock($"  {count}  ")
                     .FontSize(20)
                     .VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center),
-                Button("+", () => setCount(count + 1))
+                Button("+", () => setCount(count + 1)).AutomationName("Increment")
             ).Margin(0, 0, 0, 16),
 
             // ── Text input ─────────────────────────────────
@@ -51,7 +48,6 @@ class SampleReactorComponent : Component
             ).Margin(0, 0, 0, 8),
 
             TextBlock($"Hello, {name}! (count={count})")
-                .FontSize(16)
                 .Margin(0, 0, 0, 16),
 
             // ── Slider ─────────────────────────────────────
@@ -59,34 +55,33 @@ class SampleReactorComponent : Component
                 .Width(300)
                 .Margin(0, 0, 0, 4),
 
-            TextBlock($"Slider: {sliderValue:F0}%")
-                .FontSize(12)
-                .Opacity(0.5)
+            Caption($"Slider: {sliderValue:F0}%")
+                .Foreground(SecondaryText)
                 .Margin(0, 0, 0, 20),
 
             // ── Visual proof of WinUI rendering ────────────
-            TextBlock("WinUI CornerRadius + accent colors:")
-                .FontSize(11)
-                .Opacity(0.4)
+            Caption("WinUI CornerRadius + accent colors:")
+                .Foreground(SecondaryText)
                 .Margin(0, 0, 0, 6),
 
             HStack(
                 Enumerable.Range(0, 5).Select(i =>
                     Border(
                         TextBlock($"{i + 1}")
+                            .Foreground(Theme.Ref("TextOnAccentFillColorPrimaryBrush"))
                             .HAlign(XamlAlignment.Center)
                             .VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center)
                     )
                     .CornerRadius(8)
-                    .Background(i == count % 5 ? "#0078D4" : "#404040")
-                    .Width(50).Height(50)
+                    .Background(i == count % 5 ? Accent : ControlFill)
+                    .Size(50, 50)
                     .Margin(4)
+                    .WithKey(i.ToString())
                 ).ToArray()
             ),
 
-            TextBlock("These rounded boxes use WinUI rendering — not possible in WinForms.")
-                .FontSize(11)
-                .Opacity(0.35)
+            Caption("These rounded boxes use WinUI rendering — not possible in WinForms.")
+                .Foreground(TertiaryText)
                 .Margin(0, 8, 0, 0)
           ).Padding(24)
         ).Background(SolidBackground);

--- a/samples/apps/headtrax/HeadTrax/App.cs
+++ b/samples/apps/headtrax/HeadTrax/App.cs
@@ -56,10 +56,10 @@ internal class App : Component
             ),
 
             RightHeader = HStack(12,
-                TextBlock(ReactorFeatureFlags.UseHookBasedPaging ? "hook paging" : "legacy paging")
-                    .FontSize(11).Opacity(0.45)
+                Caption(ReactorFeatureFlags.UseHookBasedPaging ? "hook paging" : "legacy paging")
+                    .Foreground(Theme.TertiaryText)
                     .Set(t => t.IsHitTestVisible = false),
-                TextBlock($"{rowsLoaded:N0} rows fetched").FontSize(12).Opacity(0.6)
+                Caption($"{rowsLoaded:N0} rows fetched").Foreground(Theme.SecondaryText)
                     .LiveRegion(Microsoft.UI.Xaml.Automation.Peers.AutomationLiveSetting.Polite)
                     .Set(t => t.IsHitTestVisible = false)
             ),

--- a/samples/apps/monaco-editor/App.cs
+++ b/samples/apps/monaco-editor/App.cs
@@ -30,7 +30,11 @@ using Path = System.IO.Path;
 public static class Program
 {
     [STAThread]
-    static void Main() => ReactorApp.Run<EditorApp>("Monaco Editor", width: 1200, height: 800, configure: host =>
+    static void Main() => ReactorApp.Run<EditorApp>("Monaco Editor", width: 1200, height: 800,
+#if DEBUG
+        devtools: true,
+#endif
+        configure: host =>
     {
         host.Window.SystemBackdrop = new Microsoft.UI.Xaml.Media.MicaBackdrop();
         // Register the custom MonacoEditorElement so the reconciler knows how to
@@ -218,9 +222,9 @@ class EditorApp : Component
         .Grid(row: 1, columnSpan: columns.Length);
 
         var statusBar = (FlexRow(
-            TextBlock(title).FontSize(12),
-            TextBlock("").Flex(grow: 1),
-            TextBlock(status).FontSize(12).Opacity(0.7)
+            Caption(title),
+            Flex().Flex(grow: 1),
+            Caption(status).Foreground(SecondaryText)
         ) with { ColumnGap = 12 })
         .Padding(8, 4)
         .Grid(row: 3, columnSpan: columns.Length);

--- a/samples/apps/netpulse/App.cs
+++ b/samples/apps/netpulse/App.cs
@@ -92,15 +92,19 @@ sealed class App : Component
         //  └──────────────────────────────────────────────────────────┘
 
         return VStack(0,
-            // Header bar
-            HStack(12,
-                TextBlock("NetPulse").FontSize(18).Bold().Margin(12, 8, 0, 4),
-                TextBlock($"TCP: {tcpActive} active").FontSize(11).Foreground(Gray(100)).Margin(0, 10, 0, 0),
-                TextBlock($"UDP: {udpEndpoints.Length} endpoints").FontSize(11).Foreground(Gray(100)).Margin(0, 10, 0, 0),
-                TextBlock($"Sparklines: {sparklineData.Length}").FontSize(11).Foreground(Gray(100)).Margin(0, 10, 0, 0),
-                TextBlock($"Renders: {renderCountRef.Current}").FontSize(11).Foreground(Gray(80)).Margin(0, 10, 0, 0),
-                TextBlock($"History: {trafficHistory.Count} samples").FontSize(11).Foreground(Gray(80)).Margin(0, 10, 0, 0)
-            ),
+            // Real Windows title bar — stats live in the RightHeader so the
+            // window caption and in-app chrome share one visual layer.
+            TitleBar("NetPulse") with
+            {
+                Subtitle = "Network Traffic Visualizer",
+                RightHeader = HStack(16,
+                    Caption($"TCP: {tcpActive} active").Foreground(Theme.SecondaryText),
+                    Caption($"UDP: {udpEndpoints.Length} endpoints").Foreground(Theme.SecondaryText),
+                    Caption($"Sparklines: {sparklineData.Length}").Foreground(Theme.SecondaryText),
+                    Caption($"Renders: {renderCountRef.Current}").Foreground(Theme.TertiaryText),
+                    Caption($"History: {trafficHistory.Count}").Foreground(Theme.TertiaryText)
+                ),
+            },
 
             // Row 1: Area chart + Donut
             HStack(0,

--- a/samples/apps/netpulse/Program.cs
+++ b/samples/apps/netpulse/Program.cs
@@ -1,3 +1,7 @@
 using Microsoft.UI.Reactor;
 
-ReactorApp.Run<NetPulse.App>("NetPulse — Network Traffic Visualizer", width: 1400, height: 920);
+ReactorApp.Run<NetPulse.App>("NetPulse — Network Traffic Visualizer", width: 1400, height: 920
+#if DEBUG
+    , devtools: true
+#endif
+);

--- a/samples/apps/validation-showcase/App.cs
+++ b/samples/apps/validation-showcase/App.cs
@@ -193,7 +193,7 @@ class PasswordFormDemo : Component
                     ctx.MarkAllTouched();
                 }),
                 When(submitted && ctx.IsValid(), () =>
-                    TextBlock("Password set!").Foreground("#107c10").FontSize(13)
+                    TextBlock("Password set!").Foreground(Theme.SystemSuccess)
                         .VAlign(VerticalAlignment.Center))
             ).Margin(0, 8, 0, 0)
         ).Padding(24)
@@ -232,47 +232,46 @@ class MaskedInputDemo : Component
             Caption("Input masks enforce structured formats. Formatters transform text live."),
 
             VStack(8,
-                TextBlock("Phone (US) — digits only").FontSize(13).Opacity(0.7),
+                TextBlock("Phone (US) — digits only").Foreground(Theme.SecondaryText),
                 TextField(phone, v => setPhone(new string(v.Where(char.IsDigit).ToArray())),
                     placeholder: "5551234567"),
                 When(phone.Length > 0, () =>
                     HStack(8,
-                        TextBlock($"Formatted: {phoneFormatted}").FontSize(12).Opacity(0.6),
-                        TextBlock($"Raw: {phoneMask.GetRawValue(phoneFormatted)}").FontSize(12).Opacity(0.6),
+                        TextBlock($"Formatted: {phoneFormatted}").Foreground(Theme.SecondaryText),
+                        TextBlock($"Raw: {phoneMask.GetRawValue(phoneFormatted)}").Foreground(Theme.SecondaryText),
                         TextBlock(phoneMask.IsComplete(phoneFormatted) ? "Complete" : "Incomplete")
-                            .FontSize(12)
-                            .Foreground(phoneMask.IsComplete(phoneFormatted) ? "#107c10" : "#d13438")
+                            .Foreground(phoneMask.IsComplete(phoneFormatted) ? Theme.SystemSuccess : Theme.SystemCritical)
                     ))
             ),
 
             VStack(8,
-                TextBlock("SSN — digits only").FontSize(13).Opacity(0.7),
+                TextBlock("SSN — digits only").Foreground(Theme.SecondaryText),
                 TextField(ssn, v => setSsn(new string(v.Where(char.IsDigit).ToArray())),
                     placeholder: "123456789"),
                 When(ssn.Length > 0, () =>
-                    TextBlock($"Formatted: {ssnFormatted}").FontSize(12).Opacity(0.6))
+                    TextBlock($"Formatted: {ssnFormatted}").Foreground(Theme.SecondaryText))
             ),
 
             VStack(8,
-                TextBlock("ZIP Code — digits only").FontSize(13).Opacity(0.7),
+                TextBlock("ZIP Code — digits only").Foreground(Theme.SecondaryText),
                 TextField(zip, v => setZip(new string(v.Where(char.IsDigit).ToArray())),
                     placeholder: "90210"),
                 When(zip.Length > 0, () =>
-                    TextBlock($"Formatted: {zipFormatted}").FontSize(12).Opacity(0.6))
+                    TextBlock($"Formatted: {zipFormatted}").Foreground(Theme.SecondaryText))
             ),
 
             VStack(8,
-                TextBlock("Currency (InputFormatter)").FontSize(13).Opacity(0.7),
+                TextBlock("Currency (InputFormatter)").Foreground(Theme.SecondaryText),
                 TextField(amount,
                     v => setAmount(new string(v.Where(c => char.IsDigit(c) || c == '.').ToArray())),
                     placeholder: "1234.56"),
                 When(amount.Length > 0, () =>
                     TextBlock($"Display: {currencyResult.Output}  |  Raw: {currencyFmt.Parse(currencyResult.Output)}")
-                        .FontSize(12).Opacity(0.6))
+                        .Foreground(Theme.SecondaryText))
             ),
 
             VStack(8,
-                TextBlock("Uppercase Formatter").FontSize(13).Opacity(0.7),
+                TextBlock("Uppercase Formatter").Foreground(Theme.SecondaryText),
                 TextField(shout, v => setShout(v.ToUpperInvariant()),
                     placeholder: "auto uppercased")
                     .Set(tb => tb.CharacterCasing = CharacterCasing.Upper)
@@ -310,25 +309,25 @@ class DirtyResetDemo : Component
             Caption("Tracks whether fields changed from initial values or were interacted with."),
 
             VStack(4,
-                TextBlock("Name").FontSize(13)
+                TextBlock("Name")
                     .Set(t => t.FontWeight = Microsoft.UI.Text.FontWeights.SemiBold),
                 TextField(name, v => { setName(v); ctx.MarkTouched("name"); }),
-                TextBlock("Initial: \"John Doe\"").FontSize(12).Foreground("#888888")
+                TextBlock("Initial: \"John Doe\"").Foreground(Theme.SecondaryText)
             ),
 
             VStack(4,
-                TextBlock("Favorite Color").FontSize(13)
+                TextBlock("Favorite Color")
                     .Set(t => t.FontWeight = Microsoft.UI.Text.FontWeights.SemiBold),
                 ComboBox(colors, color, v => { setColor(v); ctx.MarkTouched("color"); }),
-                TextBlock("Initial: Red").FontSize(12).Foreground("#888888")
+                TextBlock("Initial: Red").Foreground(Theme.SecondaryText)
             ),
 
             VStack(4,
                 TextBlock($"name — touched: {ctx.IsTouched("name")}, dirty: {ctx.IsDirty("name")}")
-                    .FontSize(12).Opacity(0.6),
+                    .Foreground(Theme.SecondaryText),
                 TextBlock($"color — touched: {ctx.IsTouched("color")}, dirty: {ctx.IsDirty("color")}")
-                    .FontSize(12).Opacity(0.6),
-                TextBlock($"Form dirty: {ctx.IsDirty()}").FontSize(12).Opacity(0.6)
+                    .Foreground(Theme.SecondaryText),
+                TextBlock($"Form dirty: {ctx.IsDirty()}").Foreground(Theme.SecondaryText)
             ),
 
             HStack(12,
@@ -384,7 +383,7 @@ class FocusDemo : Component
             ),
 
             When(log.Length > 0, () =>
-                TextBlock(log).FontSize(12).Opacity(0.6).Margin(0, 4, 0, 0))
+                TextBlock(log).Foreground(Theme.SecondaryText).Margin(0, 4, 0, 0))
         ).Padding(24);
     }
 }

--- a/samples/apps/wordpuzzle/App.cs
+++ b/samples/apps/wordpuzzle/App.cs
@@ -7,7 +7,11 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Text;
 using static Microsoft.UI.Reactor.Factories;
 
-ReactorApp.Run<WordPuzzleApp>("Reactor Word Puzzle", width: 520, height: 620);
+ReactorApp.Run<WordPuzzleApp>("Reactor Word Puzzle", width: 520, height: 680
+#if DEBUG
+    , devtools: true
+#endif
+);
 
 // ─── Main game component ───────────────────────────────────────────────────────
 
@@ -173,24 +177,31 @@ class WordPuzzleApp : Component
 
         var randomizeCmd = new Command { Label = "Randomize", Execute = OnRandomize };
 
-        return VStack(12,
-            // Header
-            VStack(8,
-                Button(randomizeCmd)
-                    .HAlign(HorizontalAlignment.Center),
-                TextBlock(timeDisplay).FontSize(26).Bold()
-                    .HAlign(HorizontalAlignment.Center)
-            ).Margin(0, 12, 0, 4),
+        return VStack(0,
+            (TitleBar("Reactor Word Puzzle") with
+            {
+                Subtitle = hasWon ? "Solved!" : (isPlaying ? timeDisplay : "Tap Randomize to begin"),
+            }),
 
-            // Game board
-            Grid(
-                ["*", "*", "*", "*"],
-                ["*", "*", "*", "*"],
-                BuildCells(tiles, showWinText, OnTileClicked)
+            VStack(12,
+                // Header
+                VStack(8,
+                    Button(randomizeCmd)
+                        .HAlign(HorizontalAlignment.Center),
+                    TextBlock(timeDisplay).FontSize(26).SemiBold()
+                        .HAlign(HorizontalAlignment.Center)
+                ).Margin(0, 16, 0, 4),
+
+                // Game board
+                Grid(
+                    ["*", "*", "*", "*"],
+                    ["*", "*", "*", "*"],
+                    BuildCells(tiles, showWinText, OnTileClicked)
+                )
+                .Width(440).Height(440)
+                .Set(g => { g.RowSpacing = 4; g.ColumnSpacing = 4; })
+                .HAlign(HorizontalAlignment.Center)
             )
-            .Width(440).Height(440)
-            .Set(g => { g.RowSpacing = 4; g.ColumnSpacing = 4; })
-            .HAlign(HorizontalAlignment.Center)
         );
     }
 
@@ -209,14 +220,15 @@ class WordPuzzleApp : Component
             int capturedPos = pos;
 
             var tile = Button(label, () => onTileClicked(capturedPos))
-                .FontSize(32).FontWeight(FontWeights.Bold)
+                .FontSize(32).FontWeight(FontWeights.SemiBold)
                 .HAlign(HorizontalAlignment.Stretch)
                 .VAlign(VerticalAlignment.Stretch)
+                .CornerRadius(4)
+                .AutomationName($"Tile {label}")
                 .Set(b =>
                 {
                     b.HorizontalContentAlignment = HorizontalAlignment.Center;
                     b.VerticalContentAlignment = VerticalAlignment.Center;
-                    b.CornerRadius = new CornerRadius(6);
                 })
                 .WithKey($"tile-{tileIndex}")
                 .Grid(row: row, column: col);

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -340,9 +340,9 @@ public sealed partial class Reconciler
     {
         var tb = new WinPrim.ToggleButton { Content = togBtn.Label, IsChecked = togBtn.IsChecked };
         SetElementTag(tb, togBtn);
-        // Use Click (not Checked/Unchecked) so programmatic IsChecked writes from
-        // UpdateToggleButton don't re-fire the callback and start a loop when the
-        // parent's state-driven render flips another toggle in the same group.
+        // Bind to Click — fires only for real user toggles. Checked/Unchecked
+        // would also fire when UpdateToggleButton rewrites IsChecked during a
+        // state-driven rerender, which would re-enter the callback and loop.
         tb.Click += (s, _) =>
         {
             var t = (WinPrim.ToggleButton)s!;
@@ -1047,7 +1047,7 @@ public sealed partial class Reconciler
                 Header = tabItem.Header, IsClosable = tabItem.IsClosable,
                 Content = Mount(tabItem.Content, requestRerender),
             };
-            if (tabItem.Icon is not null) tvi.IconSource = new WinUI.SymbolIconSource { Symbol = ParseSymbol(tabItem.Icon) };
+            if (tabItem.Icon is not null) tvi.IconSource = ResolveIconSource(tabItem.Icon);
             tv.TabItems.Add(tvi);
         }
         SetElementTag(tv, tab);
@@ -1781,6 +1781,22 @@ public sealed partial class Reconciler
             return new WinUI.SymbolIcon(symbol);
         // Treat as a Segoe Fluent / MDL2 glyph codepoint.
         return new WinUI.FontIcon
+        {
+            Glyph = iconSymbol,
+            FontFamily = Microsoft.UI.Xaml.Application.Current?.Resources["SymbolThemeFontFamily"] as Microsoft.UI.Xaml.Media.FontFamily
+                         ?? new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons"),
+        };
+    }
+
+    // IconSource counterpart for controls (TabView, etc.) that take an
+    // IconSource instead of IconElement. Same glyph-fallback semantics as
+    // ResolveIconString.
+    internal static WinUI.IconSource? ResolveIconSource(string? iconSymbol)
+    {
+        if (string.IsNullOrEmpty(iconSymbol)) return null;
+        if (Enum.TryParse<Symbol>(iconSymbol, ignoreCase: true, out var symbol))
+            return new WinUI.SymbolIconSource { Symbol = symbol };
+        return new WinUI.FontIconSource
         {
             Glyph = iconSymbol,
             FontFamily = Microsoft.UI.Xaml.Application.Current?.Resources["SymbolThemeFontFamily"] as Microsoft.UI.Xaml.Media.FontFamily

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -340,8 +340,14 @@ public sealed partial class Reconciler
     {
         var tb = new WinPrim.ToggleButton { Content = togBtn.Label, IsChecked = togBtn.IsChecked };
         SetElementTag(tb, togBtn);
-        tb.Checked += (s, _) => (GetElementTag((UIElement)s!) as ToggleButtonElement)?.OnToggled?.Invoke(true);
-        tb.Unchecked += (s, _) => (GetElementTag((UIElement)s!) as ToggleButtonElement)?.OnToggled?.Invoke(false);
+        // Use Click (not Checked/Unchecked) so programmatic IsChecked writes from
+        // UpdateToggleButton don't re-fire the callback and start a loop when the
+        // parent's state-driven render flips another toggle in the same group.
+        tb.Click += (s, _) =>
+        {
+            var t = (WinPrim.ToggleButton)s!;
+            (GetElementTag(t) as ToggleButtonElement)?.OnToggled?.Invoke(t.IsChecked ?? false);
+        };
         ApplySetters(togBtn.Setters, tb);
         return tb;
     }
@@ -1752,7 +1758,7 @@ public sealed partial class Reconciler
         {
             return iconData switch
             {
-                SymbolIconData sym => new WinUI.SymbolIcon(ParseSymbol(sym.Symbol)),
+                SymbolIconData sym => ResolveIconString(sym.Symbol) ?? new WinUI.SymbolIcon(Symbol.Placeholder),
                 FontIconData fi => CreateFontIcon(fi),
                 BitmapIconData bi => new WinUI.BitmapIcon { UriSource = bi.Source, ShowAsMonochrome = bi.ShowAsMonochrome },
                 PathIconData pi => CreatePathIcon(pi),
@@ -1760,8 +1766,26 @@ public sealed partial class Reconciler
                 _ => null,
             };
         }
-        if (iconSymbol is not null) return new WinUI.SymbolIcon(ParseSymbol(iconSymbol));
+        if (iconSymbol is not null) return ResolveIconString(iconSymbol);
         return null;
+    }
+
+    // Handles both Symbol enum names ("Home", "Edit") and raw Segoe Fluent
+    // glyphs (""). A Symbol enum mismatch used to collapse to
+    // Symbol.Placeholder, which rendered as a diamond — fall through to a
+    // FontIcon with SymbolThemeFontFamily so glyph strings render correctly.
+    private static WinUI.IconElement? ResolveIconString(string iconSymbol)
+    {
+        if (string.IsNullOrEmpty(iconSymbol)) return null;
+        if (Enum.TryParse<Symbol>(iconSymbol, ignoreCase: true, out var symbol))
+            return new WinUI.SymbolIcon(symbol);
+        // Treat as a Segoe Fluent / MDL2 glyph codepoint.
+        return new WinUI.FontIcon
+        {
+            Glyph = iconSymbol,
+            FontFamily = Microsoft.UI.Xaml.Application.Current?.Resources["SymbolThemeFontFamily"] as Microsoft.UI.Xaml.Media.FontFamily
+                         ?? new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons"),
+        };
     }
 
     private static WinUI.FontIcon CreateFontIcon(FontIconData fi)

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -123,10 +123,10 @@ public sealed partial class Reconciler
                 => UpdateCheckBox(n, cb),
             (RadioButtonElement, RadioButtonElement n, WinUI.RadioButton rb)
                 => UpdateRadioButton(n, rb),
-            (RadioButtonsElement, RadioButtonsElement, WinUI.RadioButtons)
-                => Mount(newEl, requestRerender),
-            (ComboBoxElement, ComboBoxElement, WinUI.ComboBox)
-                => Mount(newEl, requestRerender),
+            (RadioButtonsElement o, RadioButtonsElement n, WinUI.RadioButtons rbg)
+                => UpdateRadioButtons(o, n, rbg),
+            (ComboBoxElement o, ComboBoxElement n, WinUI.ComboBox cb)
+                => UpdateComboBox(o, n, cb, requestRerender),
             (SliderElement, SliderElement n, WinUI.Slider s)
                 => UpdateSlider(n, s),
             (ToggleSwitchElement, ToggleSwitchElement n, WinUI.ToggleSwitch ts)
@@ -161,20 +161,20 @@ public sealed partial class Reconciler
                 => UpdateBorder(o, n, b, newEl, requestRerender),
             (ExpanderElement o, ExpanderElement n, WinUI.Expander exp)
                 => UpdateExpander(o, n, exp, requestRerender),
-            (SplitViewElement, SplitViewElement, WinUI.SplitView)
-                => Mount(newEl, requestRerender),
+            (SplitViewElement o, SplitViewElement n, WinUI.SplitView sv)
+                => UpdateSplitView(o, n, sv, requestRerender),
             (NavigationHostElement o, NavigationHostElement n, WinUI.Grid navGrid)
                 => UpdateNavigationHost(o, n, navGrid, requestRerender),
             (NavigationViewElement o, NavigationViewElement n, WinUI.NavigationView nv)
                 => UpdateNavigationView(o, n, nv, requestRerender),
             (TitleBarElement o, TitleBarElement n, WinUI.TitleBar tb)
                 => UpdateTitleBar(o, n, tb, requestRerender),
-            (TabViewElement, TabViewElement, WinUI.TabView)
-                => Mount(newEl, requestRerender),
+            (TabViewElement o, TabViewElement n, WinUI.TabView tabView)
+                => UpdateTabView(o, n, tabView, requestRerender),
             (BreadcrumbBarElement, BreadcrumbBarElement n, WinUI.BreadcrumbBar bcb)
                 => UpdateBreadcrumbBar(n, bcb),
-            (PivotElement, PivotElement, WinUI.Pivot)
-                => Mount(newEl, requestRerender),
+            (PivotElement o, PivotElement n, WinUI.Pivot pivot)
+                => UpdatePivot(o, n, pivot, requestRerender),
             (ListViewElement o, ListViewElement n, WinUI.ListView lv)
                 => UpdateListView(o, n, lv, requestRerender),
             (GridViewElement o, GridViewElement n, WinUI.GridView gv)
@@ -219,36 +219,36 @@ public sealed partial class Reconciler
                 => UpdateLine(n, l),
             (PathElement o, PathElement n, WinShapes.Path p)
                 => UpdatePath(o, n, p),
-            (RelativePanelElement, RelativePanelElement, WinUI.RelativePanel)
-                => Mount(newEl, requestRerender),
+            (RelativePanelElement o, RelativePanelElement n, WinUI.RelativePanel rp)
+                => UpdateRelativePanel(o, n, rp, requestRerender),
             (MediaPlayerElementElement, MediaPlayerElementElement n, WinUI.MediaPlayerElement mpe)
                 => UpdateMediaPlayerElement(n, mpe),
             (AnimatedVisualPlayerElement, AnimatedVisualPlayerElement n, WinUI.AnimatedVisualPlayer avp)
                 => UpdateAnimatedVisualPlayer(n, avp),
-            (SemanticZoomElement, SemanticZoomElement, WinUI.SemanticZoom)
-                => Mount(newEl, requestRerender),
-            (ListBoxElement, ListBoxElement, WinUI.ListBox)
-                => Mount(newEl, requestRerender),
-            (SelectorBarElement, SelectorBarElement, WinUI.SelectorBar)
-                => Mount(newEl, requestRerender),
+            (SemanticZoomElement o, SemanticZoomElement n, WinUI.SemanticZoom sz)
+                => UpdateSemanticZoom(o, n, sz, requestRerender),
+            (ListBoxElement o, ListBoxElement n, WinUI.ListBox lb)
+                => UpdateListBox(o, n, lb),
+            (SelectorBarElement o, SelectorBarElement n, WinUI.SelectorBar sbar)
+                => UpdateSelectorBar(o, n, sbar),
             (PipsPagerElement, PipsPagerElement n, WinUI.PipsPager pp)
                 => UpdatePipsPager(n, pp),
             (AnnotatedScrollBarElement, AnnotatedScrollBarElement n, WinUI.AnnotatedScrollBar asb)
                 => UpdateAnnotatedScrollBar(n, asb),
-            (PopupElement, PopupElement, WinUI.StackPanel)
-                => Mount(newEl, requestRerender),
-            (RefreshContainerElement, RefreshContainerElement, WinUI.RefreshContainer)
-                => Mount(newEl, requestRerender),
-            (CommandBarFlyoutElement, CommandBarFlyoutElement, _)
-                => Mount(newEl, requestRerender),
+            (PopupElement o, PopupElement n, WinUI.StackPanel popupWrap)
+                => UpdatePopup(o, n, popupWrap, requestRerender),
+            (RefreshContainerElement o, RefreshContainerElement n, WinUI.RefreshContainer rc)
+                => UpdateRefreshContainer(o, n, rc, requestRerender),
+            (CommandBarFlyoutElement o, CommandBarFlyoutElement n, UIElement cbfTarget)
+                => UpdateCommandBarFlyout(o, n, cbfTarget, requestRerender),
             (CalendarViewElement, CalendarViewElement n, WinUI.CalendarView cv)
                 => UpdateCalendarView(n, cv),
-            (SwipeControlElement, SwipeControlElement, WinUI.SwipeControl)
-                => Mount(newEl, requestRerender),
+            (SwipeControlElement o, SwipeControlElement n, WinUI.SwipeControl swipe)
+                => UpdateSwipeControl(o, n, swipe, requestRerender),
             (AnimatedIconElement, AnimatedIconElement n, WinUI.AnimatedIcon ai)
                 => UpdateAnimatedIcon(n, ai),
-            (ParallaxViewElement, ParallaxViewElement, WinUI.ParallaxView)
-                => Mount(newEl, requestRerender),
+            (ParallaxViewElement o, ParallaxViewElement n, WinUI.ParallaxView pv)
+                => UpdateParallaxView(o, n, pv, requestRerender),
             (MapControlElement, MapControlElement n, WinUI.MapControl mc)
                 => UpdateMapControl(n, mc),
             (FrameElement, FrameElement n, WinUI.Frame f)
@@ -650,7 +650,12 @@ public sealed partial class Reconciler
 
     private UIElement? UpdateToggleButton(ToggleButtonElement n, WinPrim.ToggleButton tb)
     {
-        tb.Content = n.Label; tb.IsChecked = n.IsChecked; SetElementTag(tb, n);
+        tb.Content = n.Label;
+        // Only write when it actually needs to change. The Mount path binds
+        // OnToggled to Click (not Checked/Unchecked), so programmatic writes
+        // don't re-enter, but skipping equal writes is still cheaper.
+        if ((tb.IsChecked ?? false) != n.IsChecked) tb.IsChecked = n.IsChecked;
+        SetElementTag(tb, n);
         ApplySetters(n.Setters, tb);
         return null;
     }
@@ -1294,6 +1299,519 @@ public sealed partial class Reconciler
             Unmount(stale);
             clearControl();
         }
+    }
+
+    private UIElement? UpdateTabView(TabViewElement o, TabViewElement n, WinUI.TabView tabView, Action requestRerender)
+    {
+        // In-place reconcile so that state changes on descendants don't tear the
+        // TabView down (which would re-animate the tab bar in and steal focus
+        // from any control inside the active tab — see the Commanding Demo
+        // regression where every keystroke blew away the selection).
+        var items = tabView.TabItems;
+        int oldCount = o.Tabs.Length;
+        int newCount = n.Tabs.Length;
+        int common = Math.Min(oldCount, newCount);
+
+        for (int i = 0; i < common; i++)
+        {
+            var oldTab = o.Tabs[i];
+            var newTab = n.Tabs[i];
+            if (items[i] is not WinUI.TabViewItem tvi) continue;
+
+            if (tvi.Header as string != newTab.Header) tvi.Header = newTab.Header;
+            if (tvi.IsClosable != newTab.IsClosable) tvi.IsClosable = newTab.IsClosable;
+            if (newTab.Icon != oldTab.Icon)
+            {
+                tvi.IconSource = newTab.Icon is not null
+                    ? new WinUI.SymbolIconSource { Symbol = ParseSymbol(newTab.Icon) }
+                    : null;
+            }
+
+            if (tvi.Content is UIElement existingContent && CanUpdate(oldTab.Content, newTab.Content))
+            {
+                var replacement = Update(oldTab.Content, newTab.Content, existingContent, requestRerender);
+                if (replacement is not null) tvi.Content = replacement;
+            }
+            else
+            {
+                if (tvi.Content is UIElement stale) Unmount(stale);
+                tvi.Content = Mount(newTab.Content, requestRerender);
+            }
+        }
+
+        // Remove excess tabs
+        for (int i = items.Count - 1; i >= newCount; i--)
+        {
+            if (items[i] is WinUI.TabViewItem stale && stale.Content is UIElement staleContent)
+                Unmount(staleContent);
+            items.RemoveAt(i);
+        }
+
+        // Add new tabs
+        for (int i = oldCount; i < newCount; i++)
+        {
+            var tabItem = n.Tabs[i];
+            var tvi = new WinUI.TabViewItem
+            {
+                Header = tabItem.Header,
+                IsClosable = tabItem.IsClosable,
+                Content = Mount(tabItem.Content, requestRerender),
+            };
+            if (tabItem.Icon is not null)
+                tvi.IconSource = new WinUI.SymbolIconSource { Symbol = ParseSymbol(tabItem.Icon) };
+            items.Add(tvi);
+        }
+
+        if (tabView.SelectedIndex != n.SelectedIndex && n.SelectedIndex >= 0 && n.SelectedIndex < newCount)
+            tabView.SelectedIndex = n.SelectedIndex;
+        if (tabView.IsAddTabButtonVisible != n.IsAddTabButtonVisible)
+            tabView.IsAddTabButtonVisible = n.IsAddTabButtonVisible;
+
+        SetElementTag(tabView, n);
+        ApplySetters(n.Setters, tabView);
+        return null;
+    }
+
+    private UIElement? UpdatePivot(PivotElement o, PivotElement n, WinUI.Pivot pivot, Action requestRerender)
+    {
+        var items = pivot.Items;
+        int common = Math.Min(o.Items.Length, n.Items.Length);
+
+        for (int i = 0; i < common; i++)
+        {
+            if (items[i] is not WinUI.PivotItem pi) continue;
+            var oldItem = o.Items[i];
+            var newItem = n.Items[i];
+
+            if (pi.Header as string != newItem.Header) pi.Header = newItem.Header;
+
+            if (pi.Content is UIElement existing && CanUpdate(oldItem.Content, newItem.Content))
+            {
+                var replacement = Update(oldItem.Content, newItem.Content, existing, requestRerender);
+                if (replacement is not null) pi.Content = replacement;
+            }
+            else
+            {
+                if (pi.Content is UIElement stale) Unmount(stale);
+                pi.Content = Mount(newItem.Content, requestRerender);
+            }
+        }
+
+        for (int i = items.Count - 1; i >= n.Items.Length; i--)
+        {
+            if (items[i] is WinUI.PivotItem stale && stale.Content is UIElement sc) Unmount(sc);
+            items.RemoveAt(i);
+        }
+
+        for (int i = o.Items.Length; i < n.Items.Length; i++)
+        {
+            var newItem = n.Items[i];
+            items.Add(new WinUI.PivotItem { Header = newItem.Header, Content = Mount(newItem.Content, requestRerender) });
+        }
+
+        if (n.Title is not null && pivot.Title as string != n.Title) pivot.Title = n.Title;
+        if (pivot.SelectedIndex != n.SelectedIndex && n.SelectedIndex >= 0 && n.SelectedIndex < items.Count)
+            pivot.SelectedIndex = n.SelectedIndex;
+
+        SetElementTag(pivot, n);
+        ApplySetters(n.Setters, pivot);
+        return null;
+    }
+
+    private UIElement? UpdateRadioButtons(RadioButtonsElement o, RadioButtonsElement n, WinUI.RadioButtons rbg)
+    {
+        // Rebuild items only when the string array actually differs.
+        if (!StringArrayEquals(o.Items, n.Items))
+        {
+            rbg.Items.Clear();
+            foreach (var item in n.Items) rbg.Items.Add(item);
+        }
+        if (n.Header is not null && rbg.Header as string != n.Header) rbg.Header = n.Header;
+        if (rbg.SelectedIndex != n.SelectedIndex) rbg.SelectedIndex = n.SelectedIndex;
+        SetElementTag(rbg, n);
+        ApplySetters(n.Setters, rbg);
+        return null;
+    }
+
+    private UIElement? UpdateComboBox(ComboBoxElement o, ComboBoxElement n, WinUI.ComboBox cb, Action requestRerender)
+    {
+        if (n.ItemElements is { } newEls)
+        {
+            // Element-based items — reconcile each slot so nested components
+            // keep their state across re-renders.
+            var oldEls = o.ItemElements ?? [];
+            int common = Math.Min(oldEls.Length, newEls.Length);
+            for (int i = 0; i < common; i++)
+            {
+                if (cb.Items[i] is UIElement existing && CanUpdate(oldEls[i], newEls[i]))
+                {
+                    var replacement = Update(oldEls[i], newEls[i], existing, requestRerender);
+                    if (replacement is not null) cb.Items[i] = replacement;
+                }
+                else
+                {
+                    if (cb.Items[i] is UIElement stale) Unmount(stale);
+                    cb.Items[i] = Mount(newEls[i], requestRerender);
+                }
+            }
+            for (int i = cb.Items.Count - 1; i >= newEls.Length; i--)
+            {
+                if (cb.Items[i] is UIElement stale) Unmount(stale);
+                cb.Items.RemoveAt(i);
+            }
+            for (int i = oldEls.Length; i < newEls.Length; i++)
+                cb.Items.Add(Mount(newEls[i], requestRerender));
+        }
+        else if (!StringArrayEquals(o.Items, n.Items))
+        {
+            cb.Items.Clear();
+            foreach (var item in n.Items) cb.Items.Add(item);
+        }
+
+        if (cb.SelectedIndex != n.SelectedIndex) cb.SelectedIndex = n.SelectedIndex;
+        cb.PlaceholderText = n.PlaceholderText ?? "";
+        if (cb.IsEditable != n.IsEditable) cb.IsEditable = n.IsEditable;
+        if (n.Header is not null && cb.Header as string != n.Header) cb.Header = n.Header;
+        SetElementTag(cb, n);
+        ApplySetters(n.Setters, cb);
+        return null;
+    }
+
+    private UIElement? UpdateListBox(ListBoxElement o, ListBoxElement n, WinUI.ListBox lb)
+    {
+        if (!StringArrayEquals(o.Items, n.Items))
+        {
+            lb.Items.Clear();
+            foreach (var item in n.Items) lb.Items.Add(item);
+        }
+        if (lb.SelectedIndex != n.SelectedIndex) lb.SelectedIndex = n.SelectedIndex;
+        SetElementTag(lb, n);
+        ApplySetters(n.Setters, lb);
+        return null;
+    }
+
+    private UIElement? UpdateSelectorBar(SelectorBarElement o, SelectorBarElement n, WinUI.SelectorBar bar)
+    {
+        var items = bar.Items;
+        int common = Math.Min(o.Items.Length, n.Items.Length);
+
+        for (int i = 0; i < common; i++)
+        {
+            if (items[i] is not WinUI.SelectorBarItem sbi) continue;
+            var oldItem = o.Items[i];
+            var newItem = n.Items[i];
+
+            if (sbi.Text != newItem.Text) sbi.Text = newItem.Text;
+            if (oldItem.Icon != newItem.Icon)
+            {
+                sbi.Icon = newItem.Icon is not null ? new WinUI.SymbolIcon(ParseSymbol(newItem.Icon)) : null;
+            }
+        }
+
+        for (int i = items.Count - 1; i >= n.Items.Length; i--)
+            items.RemoveAt(i);
+
+        for (int i = o.Items.Length; i < n.Items.Length; i++)
+        {
+            var newItem = n.Items[i];
+            var sbi = new WinUI.SelectorBarItem { Text = newItem.Text };
+            if (newItem.Icon is not null) sbi.Icon = new WinUI.SymbolIcon(ParseSymbol(newItem.Icon));
+            items.Add(sbi);
+        }
+
+        if (n.SelectedIndex >= 0 && n.SelectedIndex < items.Count)
+        {
+            var desired = items[n.SelectedIndex];
+            if (!ReferenceEquals(bar.SelectedItem, desired)) bar.SelectedItem = desired;
+        }
+        SetElementTag(bar, n);
+        ApplySetters(n.Setters, bar);
+        return null;
+    }
+
+    private UIElement? UpdateSplitView(SplitViewElement o, SplitViewElement n, WinUI.SplitView sv, Action requestRerender)
+    {
+        if (sv.IsPaneOpen != n.IsPaneOpen) sv.IsPaneOpen = n.IsPaneOpen;
+        if (sv.OpenPaneLength != n.OpenPaneLength) sv.OpenPaneLength = n.OpenPaneLength;
+        if (sv.CompactPaneLength != n.CompactPaneLength) sv.CompactPaneLength = n.CompactPaneLength;
+        if (sv.DisplayMode != n.DisplayMode) sv.DisplayMode = n.DisplayMode;
+
+        ReconcileChild(o.Pane, n.Pane,
+            () => sv.Pane as UIElement,
+            c => sv.Pane = c,
+            () => sv.Pane = null,
+            requestRerender);
+
+        ReconcileChild(o.Content, n.Content,
+            () => sv.Content as UIElement,
+            c => sv.Content = c,
+            () => sv.Content = null,
+            requestRerender);
+
+        SetElementTag(sv, n);
+        ApplySetters(n.Setters, sv);
+        return null;
+    }
+
+    private UIElement? UpdateSemanticZoom(SemanticZoomElement o, SemanticZoomElement n, WinUI.SemanticZoom sz, Action requestRerender)
+    {
+        // ZoomedInView/ZoomedOutView must be ISemanticZoomInformation — reconcile
+        // in place when possible to keep list state; otherwise swap.
+        if (sz.ZoomedInView is UIElement oldIn && CanUpdate(o.ZoomedInView, n.ZoomedInView))
+        {
+            var replacement = Update(o.ZoomedInView, n.ZoomedInView, oldIn, requestRerender);
+            if (replacement is ISemanticZoomInformation szi) sz.ZoomedInView = szi;
+        }
+        else
+        {
+            if (sz.ZoomedInView is UIElement staleIn) Unmount(staleIn);
+            if (Mount(n.ZoomedInView, requestRerender) is ISemanticZoomInformation szi) sz.ZoomedInView = szi;
+        }
+
+        if (sz.ZoomedOutView is UIElement oldOut && CanUpdate(o.ZoomedOutView, n.ZoomedOutView))
+        {
+            var replacement = Update(o.ZoomedOutView, n.ZoomedOutView, oldOut, requestRerender);
+            if (replacement is ISemanticZoomInformation szo) sz.ZoomedOutView = szo;
+        }
+        else
+        {
+            if (sz.ZoomedOutView is UIElement staleOut) Unmount(staleOut);
+            if (Mount(n.ZoomedOutView, requestRerender) is ISemanticZoomInformation szo) sz.ZoomedOutView = szo;
+        }
+
+        SetElementTag(sz, n);
+        ApplySetters(n.Setters, sz);
+        return null;
+    }
+
+    private UIElement? UpdateRelativePanel(RelativePanelElement o, RelativePanelElement n, WinUI.RelativePanel rp, Action requestRerender)
+    {
+        // RelativePanel's children reference each other by name for layout.
+        // Reconcile in place when the children line up positionally; if the
+        // count differs, fall back to a rebuild since attached-property
+        // references depend on the name map.
+        if (o.Children.Length != n.Children.Length)
+        {
+            foreach (var existing in rp.Children)
+                if (existing is UIElement ue) Unmount(ue);
+            rp.Children.Clear();
+            // Re-run the mount logic so the two-pass attached-property wiring
+            // stays consistent.
+            var remount = Mount(n, requestRerender);
+            return remount;
+        }
+
+        var nameMap = new Dictionary<string, UIElement>();
+        for (int i = 0; i < n.Children.Length; i++)
+        {
+            if (rp.Children[i] is not UIElement existingCtrl) continue;
+            UIElement? updated = existingCtrl;
+            if (CanUpdate(o.Children[i], n.Children[i]))
+            {
+                var replacement = Update(o.Children[i], n.Children[i], existingCtrl, requestRerender);
+                if (replacement is not null)
+                {
+                    rp.Children[i] = replacement;
+                    updated = replacement;
+                }
+            }
+            else
+            {
+                Unmount(existingCtrl);
+                var mounted = Mount(n.Children[i], requestRerender);
+                rp.Children[i] = mounted;
+                updated = mounted;
+            }
+            var rpa = n.Children[i].GetAttached<RelativePanelAttached>();
+            if (rpa is not null && updated is FrameworkElement fe)
+            {
+                fe.Name = rpa.Name;
+                nameMap[rpa.Name] = updated;
+            }
+        }
+
+        // Reapply relative attached properties using the refreshed name map.
+        for (int i = 0; i < n.Children.Length; i++)
+        {
+            var rpa = n.Children[i].GetAttached<RelativePanelAttached>();
+            if (rpa is null) continue;
+            if (!nameMap.TryGetValue(rpa.Name, out var ctrl)) continue;
+            if (rpa.RightOf is not null && nameMap.TryGetValue(rpa.RightOf, out var rightOf))
+                WinUI.RelativePanel.SetRightOf(ctrl, rightOf);
+            if (rpa.Below is not null && nameMap.TryGetValue(rpa.Below, out var below))
+                WinUI.RelativePanel.SetBelow(ctrl, below);
+            if (rpa.LeftOf is not null && nameMap.TryGetValue(rpa.LeftOf, out var leftOf))
+                WinUI.RelativePanel.SetLeftOf(ctrl, leftOf);
+            if (rpa.Above is not null && nameMap.TryGetValue(rpa.Above, out var above))
+                WinUI.RelativePanel.SetAbove(ctrl, above);
+            if (rpa.AlignLeftWith is not null && nameMap.TryGetValue(rpa.AlignLeftWith, out var alw))
+                WinUI.RelativePanel.SetAlignLeftWith(ctrl, alw);
+            if (rpa.AlignRightWith is not null && nameMap.TryGetValue(rpa.AlignRightWith, out var arw))
+                WinUI.RelativePanel.SetAlignRightWith(ctrl, arw);
+            if (rpa.AlignTopWith is not null && nameMap.TryGetValue(rpa.AlignTopWith, out var atw))
+                WinUI.RelativePanel.SetAlignTopWith(ctrl, atw);
+            if (rpa.AlignBottomWith is not null && nameMap.TryGetValue(rpa.AlignBottomWith, out var abw))
+                WinUI.RelativePanel.SetAlignBottomWith(ctrl, abw);
+            if (rpa.AlignHorizontalCenterWith is not null && nameMap.TryGetValue(rpa.AlignHorizontalCenterWith, out var ahcw))
+                WinUI.RelativePanel.SetAlignHorizontalCenterWith(ctrl, ahcw);
+            if (rpa.AlignVerticalCenterWith is not null && nameMap.TryGetValue(rpa.AlignVerticalCenterWith, out var avcw))
+                WinUI.RelativePanel.SetAlignVerticalCenterWith(ctrl, avcw);
+            WinUI.RelativePanel.SetAlignLeftWithPanel(ctrl, rpa.AlignLeftWithPanel);
+            WinUI.RelativePanel.SetAlignRightWithPanel(ctrl, rpa.AlignRightWithPanel);
+            WinUI.RelativePanel.SetAlignTopWithPanel(ctrl, rpa.AlignTopWithPanel);
+            WinUI.RelativePanel.SetAlignBottomWithPanel(ctrl, rpa.AlignBottomWithPanel);
+            WinUI.RelativePanel.SetAlignHorizontalCenterWithPanel(ctrl, rpa.AlignHorizontalCenterWithPanel);
+            WinUI.RelativePanel.SetAlignVerticalCenterWithPanel(ctrl, rpa.AlignVerticalCenterWithPanel);
+        }
+
+        SetElementTag(rp, n);
+        ApplySetters(n.Setters, rp);
+        return null;
+    }
+
+    private UIElement? UpdatePopup(PopupElement o, PopupElement n, WinUI.StackPanel wrapper, Action requestRerender)
+    {
+        // The popup itself is the wrapper's first child. Update its scalar
+        // props and reconcile the hosted Child in place so transient popup
+        // state (focus, scroll) survives parent re-renders.
+        if (wrapper.Children.Count == 0 || wrapper.Children[0] is not WinPrim.Popup popup)
+            return Mount(n, requestRerender);
+
+        if (popup.IsOpen != n.IsOpen) popup.IsOpen = n.IsOpen;
+        if (popup.IsLightDismissEnabled != n.IsLightDismissEnabled) popup.IsLightDismissEnabled = n.IsLightDismissEnabled;
+        if (popup.HorizontalOffset != n.HorizontalOffset) popup.HorizontalOffset = n.HorizontalOffset;
+        if (popup.VerticalOffset != n.VerticalOffset) popup.VerticalOffset = n.VerticalOffset;
+
+        if (popup.Child is UIElement existing && CanUpdate(o.Child, n.Child))
+        {
+            var replacement = Update(o.Child, n.Child, existing, requestRerender);
+            if (replacement is not null) popup.Child = replacement;
+        }
+        else
+        {
+            if (popup.Child is UIElement stale) Unmount(stale);
+            popup.Child = Mount(n.Child, requestRerender) as UIElement;
+        }
+
+        SetElementTag(wrapper, n);
+        ApplySetters(n.Setters, popup);
+        return null;
+    }
+
+    private UIElement? UpdateRefreshContainer(RefreshContainerElement o, RefreshContainerElement n, WinUI.RefreshContainer rc, Action requestRerender)
+    {
+        if (rc.Content is UIElement existing && CanUpdate(o.Content, n.Content))
+        {
+            var replacement = Update(o.Content, n.Content, existing, requestRerender);
+            if (replacement is not null) rc.Content = replacement;
+        }
+        else
+        {
+            if (rc.Content is UIElement stale) Unmount(stale);
+            rc.Content = Mount(n.Content, requestRerender);
+        }
+        SetElementTag(rc, n);
+        ApplySetters(n.Setters, rc);
+        return null;
+    }
+
+    private UIElement? UpdateCommandBarFlyout(CommandBarFlyoutElement o, CommandBarFlyoutElement n, UIElement targetControl, Action requestRerender)
+    {
+        // Reconcile the target in place; rewire the attached flyout with
+        // fresh command lists. The flyout itself is not a tree node — it's
+        // attached via FlyoutBase.SetAttachedFlyout on the target.
+        UIElement? updated = targetControl;
+        if (CanUpdate(o.Target, n.Target))
+        {
+            var replacement = Update(o.Target, n.Target, targetControl, requestRerender);
+            if (replacement is not null) updated = replacement;
+        }
+        else
+        {
+            Unmount(targetControl);
+            updated = Mount(n.Target, requestRerender);
+        }
+
+        if (updated is FrameworkElement targetFe)
+        {
+            var flyout = new WinUI.CommandBarFlyout { Placement = n.Placement };
+            if (n.PrimaryCommands is not null)
+                foreach (var cmd in n.PrimaryCommands) flyout.PrimaryCommands.Add(CreateAppBarItem(cmd));
+            if (n.SecondaryCommands is not null)
+                foreach (var cmd in n.SecondaryCommands) flyout.SecondaryCommands.Add(CreateAppBarItem(cmd));
+            SetElementTag(targetFe, n);
+            WinPrim.FlyoutBase.SetAttachedFlyout(targetFe, flyout);
+            ApplySetters(n.Setters, flyout);
+        }
+        return updated == targetControl ? null : updated;
+    }
+
+    private UIElement? UpdateSwipeControl(SwipeControlElement o, SwipeControlElement n, WinUI.SwipeControl sc, Action requestRerender)
+    {
+        if (sc.Content is UIElement existing && CanUpdate(o.Content, n.Content))
+        {
+            var replacement = Update(o.Content, n.Content, existing, requestRerender);
+            if (replacement is not null) sc.Content = replacement;
+        }
+        else
+        {
+            if (sc.Content is UIElement stale) Unmount(stale);
+            sc.Content = Mount(n.Content, requestRerender);
+        }
+
+        // Swipe items are thin data — rebuild the SwipeItems collections when
+        // the definitions change. Reference-equal arrays skip the rebuild.
+        if (!ReferenceEquals(o.LeftItems, n.LeftItems) || o.LeftItemsMode != n.LeftItemsMode)
+        {
+            if (n.LeftItems is { Length: > 0 })
+            {
+                var items = new SwipeItems { Mode = n.LeftItemsMode };
+                foreach (var it in n.LeftItems) items.Add(CreateSwipeItem(it));
+                sc.LeftItems = items;
+            }
+            else sc.LeftItems = null;
+        }
+        if (!ReferenceEquals(o.RightItems, n.RightItems) || o.RightItemsMode != n.RightItemsMode)
+        {
+            if (n.RightItems is { Length: > 0 })
+            {
+                var items = new SwipeItems { Mode = n.RightItemsMode };
+                foreach (var it in n.RightItems) items.Add(CreateSwipeItem(it));
+                sc.RightItems = items;
+            }
+            else sc.RightItems = null;
+        }
+
+        SetElementTag(sc, n);
+        ApplySetters(n.Setters, sc);
+        return null;
+    }
+
+    private UIElement? UpdateParallaxView(ParallaxViewElement o, ParallaxViewElement n, WinUI.ParallaxView pv, Action requestRerender)
+    {
+        if (pv.VerticalShift != n.VerticalShift) pv.VerticalShift = n.VerticalShift;
+        if (pv.HorizontalShift != n.HorizontalShift) pv.HorizontalShift = n.HorizontalShift;
+        if (pv.Child is UIElement existing && CanUpdate(o.Child, n.Child))
+        {
+            var replacement = Update(o.Child, n.Child, existing, requestRerender);
+            if (replacement is not null) pv.Child = replacement as UIElement;
+        }
+        else
+        {
+            if (pv.Child is UIElement stale) Unmount(stale);
+            pv.Child = Mount(n.Child, requestRerender) as UIElement;
+        }
+        ApplySetters(n.Setters, pv);
+        return null;
+    }
+
+    private static bool StringArrayEquals(string[] a, string[] b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a.Length != b.Length) return false;
+        for (int i = 0; i < a.Length; i++)
+            if (a[i] != b[i]) return false;
+        return true;
     }
 
     private UIElement? UpdateBreadcrumbBar(BreadcrumbBarElement n, WinUI.BreadcrumbBar bcb)

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -651,9 +651,6 @@ public sealed partial class Reconciler
     private UIElement? UpdateToggleButton(ToggleButtonElement n, WinPrim.ToggleButton tb)
     {
         tb.Content = n.Label;
-        // Only write when it actually needs to change. The Mount path binds
-        // OnToggled to Click (not Checked/Unchecked), so programmatic writes
-        // don't re-enter, but skipping equal writes is still cheaper.
         if ((tb.IsChecked ?? false) != n.IsChecked) tb.IsChecked = n.IsChecked;
         SetElementTag(tb, n);
         ApplySetters(n.Setters, tb);
@@ -1307,6 +1304,10 @@ public sealed partial class Reconciler
         // TabView down (which would re-animate the tab bar in and steal focus
         // from any control inside the active tab — see the Commanding Demo
         // regression where every keystroke blew away the selection).
+        // Retag first so any events raised by property writes resolve through
+        // the new element's closures.
+        SetElementTag(tabView, n);
+
         var items = tabView.TabItems;
         int oldCount = o.Tabs.Length;
         int newCount = n.Tabs.Length;
@@ -1321,11 +1322,7 @@ public sealed partial class Reconciler
             if (tvi.Header as string != newTab.Header) tvi.Header = newTab.Header;
             if (tvi.IsClosable != newTab.IsClosable) tvi.IsClosable = newTab.IsClosable;
             if (newTab.Icon != oldTab.Icon)
-            {
-                tvi.IconSource = newTab.Icon is not null
-                    ? new WinUI.SymbolIconSource { Symbol = ParseSymbol(newTab.Icon) }
-                    : null;
-            }
+                tvi.IconSource = ResolveIconSource(newTab.Icon);
 
             if (tvi.Content is UIElement existingContent && CanUpdate(oldTab.Content, newTab.Content))
             {
@@ -1358,22 +1355,29 @@ public sealed partial class Reconciler
                 Content = Mount(tabItem.Content, requestRerender),
             };
             if (tabItem.Icon is not null)
-                tvi.IconSource = new WinUI.SymbolIconSource { Symbol = ParseSymbol(tabItem.Icon) };
+                tvi.IconSource = ResolveIconSource(tabItem.Icon);
             items.Add(tvi);
         }
 
-        if (tabView.SelectedIndex != n.SelectedIndex && n.SelectedIndex >= 0 && n.SelectedIndex < newCount)
+        // Only sync SelectedIndex when the element itself changed it. Writing
+        // on every update would clobber the user's current tab when the element
+        // doesn't control SelectedIndex (common in "uncontrolled" samples).
+        if (o.SelectedIndex != n.SelectedIndex
+            && n.SelectedIndex >= 0 && n.SelectedIndex < newCount
+            && tabView.SelectedIndex != n.SelectedIndex)
             tabView.SelectedIndex = n.SelectedIndex;
+
         if (tabView.IsAddTabButtonVisible != n.IsAddTabButtonVisible)
             tabView.IsAddTabButtonVisible = n.IsAddTabButtonVisible;
 
-        SetElementTag(tabView, n);
         ApplySetters(n.Setters, tabView);
         return null;
     }
 
     private UIElement? UpdatePivot(PivotElement o, PivotElement n, WinUI.Pivot pivot, Action requestRerender)
     {
+        SetElementTag(pivot, n);
+
         var items = pivot.Items;
         int common = Math.Min(o.Items.Length, n.Items.Length);
 
@@ -1410,36 +1414,55 @@ public sealed partial class Reconciler
         }
 
         if (n.Title is not null && pivot.Title as string != n.Title) pivot.Title = n.Title;
-        if (pivot.SelectedIndex != n.SelectedIndex && n.SelectedIndex >= 0 && n.SelectedIndex < items.Count)
+
+        // Only sync SelectedIndex when the element changed it — see UpdateTabView.
+        if (o.SelectedIndex != n.SelectedIndex
+            && n.SelectedIndex >= 0 && n.SelectedIndex < items.Count
+            && pivot.SelectedIndex != n.SelectedIndex)
             pivot.SelectedIndex = n.SelectedIndex;
 
-        SetElementTag(pivot, n);
         ApplySetters(n.Setters, pivot);
         return null;
     }
 
     private UIElement? UpdateRadioButtons(RadioButtonsElement o, RadioButtonsElement n, WinUI.RadioButtons rbg)
     {
-        // Rebuild items only when the string array actually differs.
+        SetElementTag(rbg, n);
         if (!StringArrayEquals(o.Items, n.Items))
         {
             rbg.Items.Clear();
             foreach (var item in n.Items) rbg.Items.Add(item);
         }
         if (n.Header is not null && rbg.Header as string != n.Header) rbg.Header = n.Header;
-        if (rbg.SelectedIndex != n.SelectedIndex) rbg.SelectedIndex = n.SelectedIndex;
-        SetElementTag(rbg, n);
+        // Only sync when the element itself changed SelectedIndex.
+        if (o.SelectedIndex != n.SelectedIndex && rbg.SelectedIndex != n.SelectedIndex)
+            rbg.SelectedIndex = n.SelectedIndex;
         ApplySetters(n.Setters, rbg);
         return null;
     }
 
     private UIElement? UpdateComboBox(ComboBoxElement o, ComboBoxElement n, WinUI.ComboBox cb, Action requestRerender)
     {
-        if (n.ItemElements is { } newEls)
+        SetElementTag(cb, n);
+
+        bool oldIsElements = o.ItemElements is not null;
+        bool newIsElements = n.ItemElements is not null;
+
+        // Mode switch: unmount any UIElement items (strings need no unmount),
+        // then drop the whole list so the following code starts from scratch.
+        if (oldIsElements != newIsElements)
         {
-            // Element-based items — reconcile each slot so nested components
-            // keep their state across re-renders.
-            var oldEls = o.ItemElements ?? [];
+            for (int i = cb.Items.Count - 1; i >= 0; i--)
+                if (cb.Items[i] is UIElement stale) Unmount(stale);
+            cb.Items.Clear();
+        }
+
+        if (newIsElements)
+        {
+            var newEls = n.ItemElements!;
+            // After a mode switch, oldEls is empty so we fall through to pure
+            // append below — that's correct because cb.Items is empty too.
+            var oldEls = oldIsElements ? o.ItemElements! : Array.Empty<Element>();
             int common = Math.Min(oldEls.Length, newEls.Length);
             for (int i = 0; i < common; i++)
             {
@@ -1462,36 +1485,44 @@ public sealed partial class Reconciler
             for (int i = oldEls.Length; i < newEls.Length; i++)
                 cb.Items.Add(Mount(newEls[i], requestRerender));
         }
-        else if (!StringArrayEquals(o.Items, n.Items))
+        else
         {
-            cb.Items.Clear();
-            foreach (var item in n.Items) cb.Items.Add(item);
+            // String items. After a mode switch cb.Items is empty, so fill it;
+            // otherwise only refill when the string array actually differs.
+            if (oldIsElements || !StringArrayEquals(o.Items, n.Items))
+            {
+                cb.Items.Clear();
+                foreach (var item in n.Items) cb.Items.Add(item);
+            }
         }
 
-        if (cb.SelectedIndex != n.SelectedIndex) cb.SelectedIndex = n.SelectedIndex;
+        if (o.SelectedIndex != n.SelectedIndex && cb.SelectedIndex != n.SelectedIndex)
+            cb.SelectedIndex = n.SelectedIndex;
         cb.PlaceholderText = n.PlaceholderText ?? "";
         if (cb.IsEditable != n.IsEditable) cb.IsEditable = n.IsEditable;
         if (n.Header is not null && cb.Header as string != n.Header) cb.Header = n.Header;
-        SetElementTag(cb, n);
         ApplySetters(n.Setters, cb);
         return null;
     }
 
     private UIElement? UpdateListBox(ListBoxElement o, ListBoxElement n, WinUI.ListBox lb)
     {
+        SetElementTag(lb, n);
         if (!StringArrayEquals(o.Items, n.Items))
         {
             lb.Items.Clear();
             foreach (var item in n.Items) lb.Items.Add(item);
         }
-        if (lb.SelectedIndex != n.SelectedIndex) lb.SelectedIndex = n.SelectedIndex;
-        SetElementTag(lb, n);
+        if (o.SelectedIndex != n.SelectedIndex && lb.SelectedIndex != n.SelectedIndex)
+            lb.SelectedIndex = n.SelectedIndex;
         ApplySetters(n.Setters, lb);
         return null;
     }
 
     private UIElement? UpdateSelectorBar(SelectorBarElement o, SelectorBarElement n, WinUI.SelectorBar bar)
     {
+        SetElementTag(bar, n);
+
         var items = bar.Items;
         int common = Math.Min(o.Items.Length, n.Items.Length);
 
@@ -1503,9 +1534,7 @@ public sealed partial class Reconciler
 
             if (sbi.Text != newItem.Text) sbi.Text = newItem.Text;
             if (oldItem.Icon != newItem.Icon)
-            {
-                sbi.Icon = newItem.Icon is not null ? new WinUI.SymbolIcon(ParseSymbol(newItem.Icon)) : null;
-            }
+                sbi.Icon = ResolveIconString(newItem.Icon ?? "");
         }
 
         for (int i = items.Count - 1; i >= n.Items.Length; i--)
@@ -1515,16 +1544,17 @@ public sealed partial class Reconciler
         {
             var newItem = n.Items[i];
             var sbi = new WinUI.SelectorBarItem { Text = newItem.Text };
-            if (newItem.Icon is not null) sbi.Icon = new WinUI.SymbolIcon(ParseSymbol(newItem.Icon));
+            if (newItem.Icon is not null) sbi.Icon = ResolveIconString(newItem.Icon);
             items.Add(sbi);
         }
 
-        if (n.SelectedIndex >= 0 && n.SelectedIndex < items.Count)
+        // Only sync selection when the element moved it.
+        if (o.SelectedIndex != n.SelectedIndex
+            && n.SelectedIndex >= 0 && n.SelectedIndex < items.Count)
         {
             var desired = items[n.SelectedIndex];
             if (!ReferenceEquals(bar.SelectedItem, desired)) bar.SelectedItem = desired;
         }
-        SetElementTag(bar, n);
         ApplySetters(n.Setters, bar);
         return null;
     }
@@ -1677,6 +1707,10 @@ public sealed partial class Reconciler
         if (wrapper.Children.Count == 0 || wrapper.Children[0] is not WinPrim.Popup popup)
             return Mount(n, requestRerender);
 
+        // Retag first so Closed/Opened handlers that resolve callbacks via the
+        // wrapper's Tag see the new element's closures.
+        SetElementTag(wrapper, n);
+
         if (popup.IsOpen != n.IsOpen) popup.IsOpen = n.IsOpen;
         if (popup.IsLightDismissEnabled != n.IsLightDismissEnabled) popup.IsLightDismissEnabled = n.IsLightDismissEnabled;
         if (popup.HorizontalOffset != n.HorizontalOffset) popup.HorizontalOffset = n.HorizontalOffset;
@@ -1693,7 +1727,6 @@ public sealed partial class Reconciler
             popup.Child = Mount(n.Child, requestRerender) as UIElement;
         }
 
-        SetElementTag(wrapper, n);
         ApplySetters(n.Setters, popup);
         return null;
     }
@@ -1717,9 +1750,9 @@ public sealed partial class Reconciler
 
     private UIElement? UpdateCommandBarFlyout(CommandBarFlyoutElement o, CommandBarFlyoutElement n, UIElement targetControl, Action requestRerender)
     {
-        // Reconcile the target in place; rewire the attached flyout with
-        // fresh command lists. The flyout itself is not a tree node — it's
-        // attached via FlyoutBase.SetAttachedFlyout on the target.
+        // Reconcile the target in place and reuse the attached flyout when
+        // possible — re-attaching a brand-new flyout on every update would
+        // close an already-open flyout and discard its transient state.
         UIElement? updated = targetControl;
         if (CanUpdate(o.Target, n.Target))
         {
@@ -1734,14 +1767,36 @@ public sealed partial class Reconciler
 
         if (updated is FrameworkElement targetFe)
         {
-            var flyout = new WinUI.CommandBarFlyout { Placement = n.Placement };
-            if (n.PrimaryCommands is not null)
-                foreach (var cmd in n.PrimaryCommands) flyout.PrimaryCommands.Add(CreateAppBarItem(cmd));
-            if (n.SecondaryCommands is not null)
-                foreach (var cmd in n.SecondaryCommands) flyout.SecondaryCommands.Add(CreateAppBarItem(cmd));
             SetElementTag(targetFe, n);
-            WinPrim.FlyoutBase.SetAttachedFlyout(targetFe, flyout);
-            ApplySetters(n.Setters, flyout);
+            var existing = WinPrim.FlyoutBase.GetAttachedFlyout(targetFe) as WinUI.CommandBarFlyout;
+            var commandsChanged =
+                !ReferenceEquals(o.PrimaryCommands, n.PrimaryCommands) ||
+                !ReferenceEquals(o.SecondaryCommands, n.SecondaryCommands);
+
+            if (existing is null)
+            {
+                var flyout = new WinUI.CommandBarFlyout { Placement = n.Placement };
+                if (n.PrimaryCommands is not null)
+                    foreach (var cmd in n.PrimaryCommands) flyout.PrimaryCommands.Add(CreateAppBarItem(cmd));
+                if (n.SecondaryCommands is not null)
+                    foreach (var cmd in n.SecondaryCommands) flyout.SecondaryCommands.Add(CreateAppBarItem(cmd));
+                WinPrim.FlyoutBase.SetAttachedFlyout(targetFe, flyout);
+                ApplySetters(n.Setters, flyout);
+            }
+            else
+            {
+                if (existing.Placement != n.Placement) existing.Placement = n.Placement;
+                if (commandsChanged)
+                {
+                    existing.PrimaryCommands.Clear();
+                    existing.SecondaryCommands.Clear();
+                    if (n.PrimaryCommands is not null)
+                        foreach (var cmd in n.PrimaryCommands) existing.PrimaryCommands.Add(CreateAppBarItem(cmd));
+                    if (n.SecondaryCommands is not null)
+                        foreach (var cmd in n.SecondaryCommands) existing.SecondaryCommands.Add(CreateAppBarItem(cmd));
+                }
+                ApplySetters(n.Setters, existing);
+            }
         }
         return updated == targetControl ? null : updated;
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -74,9 +74,15 @@ internal static class CommandingCoverageFixtures
             H.Check("ToggleButton_Command_Mounted", tb is not null);
             if (tb is not null)
             {
-                // Simulate toggles by flipping IsChecked — Checked/Unchecked fires on change.
-                tb.IsChecked = true;
-                tb.IsChecked = false;
+                // OnToggled binds to Click, which fires for real user toggles
+                // (mouse, keyboard, and AutomationPeer.Invoke) — programmatic
+                // IsChecked writes don't, by design. Simulate user toggles via
+                // the toggle automation pattern.
+                var peer = Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer.CreatePeerForElement(tb);
+                var toggle = peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Toggle)
+                    as Microsoft.UI.Xaml.Automation.Provider.IToggleProvider;
+                toggle?.Toggle();
+                toggle?.Toggle();
             }
             H.Check("ToggleButton_Command_InvokedOnEachToggle", count == 2);
         }


### PR DESCRIPTION
## Summary
- **Samples polish**: adopt `TitleBar` + `TabView`, `Caption`/`SubHeading` typography, `AutomationName` wiring, and tighter layouts across 14 samples (CommandingDemo, NavigationDemo, StylingGallery, TodoApp, WinFormsInterop, NetPulse, HeadTrax, MonacoEditorApp, ValidationShowcase, WordPuzzle, ReactorGallery, and both ReactorCharting samples).
- **Reconciler in-place updates**: replace remount-on-update with in-place update handlers for `TabView`, `Pivot`, `SplitView`, `RadioButtons`, `ComboBox`, `ListBox`, `SelectorBar`, `SemanticZoom`, `RelativePanel`, `Popup`, `RefreshContainer`, `CommandBarFlyout`, `SwipeControl`, `ParallaxView` — preserves focus and descendant state across state-driven re-renders.
- **ToggleButton**: bind `OnToggled` to `Click` instead of `Checked`/`Unchecked` so programmatic `IsChecked` writes from `UpdateToggleButton` don't re-fire the callback.
- **Icon resolution**: symbol strings fall back to `FontIcon` with `SymbolThemeFontFamily` when `Enum.TryParse<Symbol>` fails, so raw Segoe Fluent glyphs render correctly instead of collapsing to the placeholder diamond.

## Test plan
- [x] `dotnet build` for all 14 touched samples — all succeed (0 warnings, 0 errors)
- [x] Smoke-launch all 14 samples — each stays alive past 8s (no fail-fast)
- [ ] Click through CommandingDemo tabs; verify TextField selection survives re-renders after the `UseRef` + pending-selection refactor
- [ ] Toggle theme in ReactorGallery; confirm `RequestedTheme` fluent call works
- [ ] Exercise TabView-based samples; confirm tab bar does not re-animate when descendants rerender
- [ ] Exercise ComboBox / RadioButtons / ListBox scenarios; confirm selection state persists across parent re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)