### PR TITLE
Replace UnconditionalSuppressMessage with DynamicallyAccessedMembers annotations

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,6 +5,14 @@
        so that TargetFramework from the project file is already resolved. -->
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
+    <!-- Show every individual trimmer warning instead of collapsing them. -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+
+  <!-- Promote IL trimming/AOT warnings to errors on the core Reactor library.
+       This ensures new reflection usage must be annotated before it can merge. -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(MSBuildProjectName)' == 'Reactor'">
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2062;IL2065;IL2067;IL2069;IL2070;IL2072;IL2073;IL2075;IL2087;IL2090;IL2091;IL2111;IL3000;IL3050</WarningsAsErrors>
   </PropertyGroup>
 
   <!-- Suppress trimming/AOT warnings in consumer projects (tests, samples, CLI).

--- a/src/Reactor/Controls/DataGrid/ColumnDsl.cs
+++ b/src/Reactor/Controls/DataGrid/ColumnDsl.cs
@@ -16,7 +16,7 @@ public static class ColumnDsl
     /// <summary>
     /// Define a column from a property accessor expression.
     /// </summary>
-    public static ColumnBuilder<T> Column<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+    public static ColumnBuilder<T> Column<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         string name,
         Func<T, object?> accessor,
         bool editable = false,
@@ -53,7 +53,7 @@ public static class ColumnDsl
     /// <summary>
     /// Auto-generate columns from a type using reflection and TypeRegistry.
     /// </summary>
-    public static IReadOnlyList<FieldDescriptor> AutoColumns<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+    public static IReadOnlyList<FieldDescriptor> AutoColumns<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         TypeRegistry? registry = null,
         Func<FieldDescriptor, FieldDescriptor>? overrides = null)
     {
@@ -100,6 +100,9 @@ public static class ColumnDsl
         return descriptors;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "PropertyInfo.PropertyType does not carry DynamicallyAccessedMembers.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "PropertyInfo.PropertyType does not carry DynamicallyAccessedMembers.")]
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)]
     private static Type InferFieldType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name, Func<T, object?> accessor)
     {
         var prop = typeof(T).GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
@@ -110,7 +113,7 @@ public static class ColumnDsl
     /// Build a SetValue delegate from reflection. For mutable properties, mutates in place.
     /// For init-only (record) properties, uses the copy constructor.
     /// </summary>
-    private static Func<object, object?, object>? BuildSetValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string propertyName)
+    private static Func<object, object?, object>? BuildSetValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string propertyName)
     {
         var prop = typeof(T).GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
         if (prop is null || !prop.CanWrite) return null;

--- a/src/Reactor/Controls/DataGrid/TypedColumns.cs
+++ b/src/Reactor/Controls/DataGrid/TypedColumns.cs
@@ -22,7 +22,7 @@ public static class TypedColumns
     //  The accessor's declared property type drives value-conversion.
     // ══════════════════════════════════════════════════════════════
 
-    public static ColumnBuilder<T> NumberColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+    public static ColumnBuilder<T> NumberColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         string name,
         Func<T, object?> accessor,
         double? min = null,
@@ -45,7 +45,7 @@ public static class TypedColumns
     //  Bool
     // ══════════════════════════════════════════════════════════════
 
-    public static ColumnBuilder<T> CheckBoxColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+    public static ColumnBuilder<T> CheckBoxColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         string name,
         Func<T, object?> accessor,
         string? displayName = null,
@@ -56,7 +56,7 @@ public static class TypedColumns
             .WithEditor(Editors.CheckBox())
             .CellRenderer(CellRenderers.CheckMark());
 
-    public static ColumnBuilder<T> ToggleSwitchColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+    public static ColumnBuilder<T> ToggleSwitchColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         string name,
         Func<T, object?> accessor,
         string? onContent = null,
@@ -73,7 +73,7 @@ public static class TypedColumns
     //  Date / Time
     // ══════════════════════════════════════════════════════════════
 
-    public static ColumnBuilder<T> DateColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+    public static ColumnBuilder<T> DateColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         string name,
         Func<T, object?> accessor,
         string format = "d",
@@ -94,7 +94,7 @@ public static class TypedColumns
             .CellRenderer(CellRenderers.Date(format));
     }
 
-    public static ColumnBuilder<T> TimeColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+    public static ColumnBuilder<T> TimeColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         string name,
         Func<T, object?> accessor,
         string format = "t",
@@ -117,7 +117,7 @@ public static class TypedColumns
     //  Combo / Enum
     // ══════════════════════════════════════════════════════════════
 
-    public static ColumnBuilder<T> ComboBoxColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T, TValue>(
+    public static ColumnBuilder<T> ComboBoxColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T, TValue>(
         string name,
         Func<T, object?> accessor,
         IReadOnlyList<TValue> choices,
@@ -133,7 +133,7 @@ public static class TypedColumns
     //  Hyperlink — underlying type may be Uri or string.
     // ══════════════════════════════════════════════════════════════
 
-    public static ColumnBuilder<T> HyperlinkColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+    public static ColumnBuilder<T> HyperlinkColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         string name,
         Func<T, object?> accessor,
         string? displayTextFormat = null,
@@ -156,7 +156,7 @@ public static class TypedColumns
     //  Color
     // ══════════════════════════════════════════════════════════════
 
-    public static ColumnBuilder<T> ColorColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+    public static ColumnBuilder<T> ColorColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         string name,
         Func<T, object?> accessor,
         string? displayName = null,

--- a/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
+++ b/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Data;
 using Microsoft.UI.Reactor.Layout;
@@ -25,6 +26,7 @@ public class PropertyGridComponent : Component<PropertyGridElement>
             b.HorizontalContentAlignment = HorizontalAlignment.Stretch;
         }).HAlign(HorizontalAlignment.Stretch);
 
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Object.GetType() does not carry DynamicallyAccessedMembers; PropertyGrid resolves types at runtime.")]
     public override Element Render()
     {
         var el = Props;

--- a/src/Reactor/Controls/PropertyGrid/ReflectionTypeMetadataProvider.cs
+++ b/src/Reactor/Controls/PropertyGrid/ReflectionTypeMetadataProvider.cs
@@ -20,14 +20,16 @@ public static class ReflectionTypeMetadataProvider
     /// Generates TypeMetadata for a CLR type by reflecting over its
     /// public instance properties and reading attributes.
     /// </summary>
-    public static TypeMetadata CreateMetadata(Type type)
-#pragma warning disable IL2111 // Method with DynamicallyAccessedMembers parameter accessed via reflection
-        => _cache.GetOrAdd(type, BuildMetadata);
-#pragma warning restore IL2111
+    [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "ConcurrentDictionary.GetOrAdd resolves BuildMetadata via delegate; the DAM annotation on the lambda parameter is not visible to the trimmer through the Func<> signature.")]
+    public static TypeMetadata CreateMetadata(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
+        => _cache.GetOrAdd(type,
+            static ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] Type t) => BuildMetadata(t));
 
     /// <summary>
     /// Generates a FieldDescriptor for a single PropertyInfo (unbound — for registry use).
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "PropertyInfo.PropertyType does not carry DynamicallyAccessedMembers; the original type was annotated at the TypeRegistry entry point.")]
     public static FieldDescriptor CreateDescriptor(PropertyInfo property, int defaultOrder)
     {
         var attrs = ComputeAttributeData(property, defaultOrder);
@@ -172,6 +174,7 @@ public static class ReflectionTypeMetadataProvider
     ///   - Immutable: constructs new object, returns new reference
     ///   - Read-only: null
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "PropertyInfo.PropertyType does not carry DynamicallyAccessedMembers; the original type was annotated at the TypeRegistry entry point.")]
     private static FieldDescriptor CreateDescriptorBound(
         PropertyInfo property, PropertyAttributeData attrs, object owner,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] Type ownerType)
@@ -296,8 +299,8 @@ public static class ReflectionTypeMetadataProvider
         bool Filterable,
         PinPosition Pin);
 
-    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "BuildInitOnlySetter uses reflection to compose init-only properties.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "BuildInitOnlySetter uses reflection to compose init-only properties.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "PropertyInfo.DeclaringType cannot carry DynamicallyAccessedMembers; type was originally annotated at the call site.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "PropertyInfo.DeclaringType cannot carry DynamicallyAccessedMembers; type was originally annotated at the call site.")]
     internal static Func<object, object?, object>? BuildInitOnlySetter(PropertyInfo property)
     {
         var type = property.DeclaringType!;

--- a/src/Reactor/Controls/PropertyGrid/TypeRegistry.cs
+++ b/src/Reactor/Controls/PropertyGrid/TypeRegistry.cs
@@ -65,8 +65,8 @@ public class TypeRegistry
     /// 4. Array/IList&lt;T&gt; — array editor
     /// 5. Record/class/struct — reflection-based decomposition
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Resolve may use Activator.CreateInstance on runtime-determined types.")]
-    public TypeMetadata Resolve(Type type)
+    public TypeMetadata Resolve(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
     {
         // 1. Exact match
         if (_map.TryGetValue(type, out var metadata))
@@ -94,8 +94,8 @@ public class TypeRegistry
     /// For standard (PropertyGrid/FormField): Editor ?? built-in
     /// For full (expand): FullEditor (null when not registered)
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "ResolveEditor calls Resolve; acceptable for non-AOT builds.")]
-    public Func<object, Action<object>, Element>? ResolveEditor(Type type, EditorTier tier)
+    public Func<object, Action<object>, Element>? ResolveEditor(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, EditorTier tier)
     {
         var meta = Resolve(type);
         return tier switch
@@ -291,12 +291,12 @@ public class TypeRegistry
         return null;
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "TryResolveArray uses Activator.CreateInstance; acceptable for non-AOT builds.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "TryResolveArray uses reflection to check constructors on element types.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2065", Justification = "TryResolveArray uses reflection to check constructors on element types.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2062", Justification = "TryResolveArray creates instances of element types via Activator.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "TryResolveArray creates instances of element types via Activator.")]
-    private static bool TryResolveArray(Type type, [NotNullWhen(true)] out TypeMetadata? metadata)
+    [UnconditionalSuppressMessage("Trimming", "IL2065", Justification = "Element type extracted from generic arguments cannot carry DynamicallyAccessedMembers.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2062", Justification = "Element type from array/generic type decomposition flows to Activator.CreateInstance.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Element type from array/generic type decomposition flows to Activator.CreateInstance.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Element type from GetElementType()/GetGenericArguments() cannot carry DynamicallyAccessedMembers.")]
+    private static bool TryResolveArray(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, [NotNullWhen(true)] out TypeMetadata? metadata)
     {
         metadata = null;
         Type? elementType = null;

--- a/src/Reactor/Controls/Validation/FormField.cs
+++ b/src/Reactor/Controls/Validation/FormField.cs
@@ -55,7 +55,6 @@ public static class FormFieldDsl
     /// Resolves the editor from TypeRegistry, sets label/description from the descriptor,
     /// detects required from validators, and wires validation.
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "TypeRegistry.Resolve uses Activator.CreateInstance; acceptable for non-AOT builds.")]
     public static FormFieldElement FormField(
         FieldDescriptor field,
         object value,

--- a/src/Reactor/Core/ObservableTreeTracker.cs
+++ b/src/Reactor/Core/ObservableTreeTracker.cs
@@ -34,13 +34,16 @@ internal class ObservableTreeTracker : IDisposable
     /// Filters to: public instance properties, getter accessible,
     /// property type is class or interface (value types can't be INPC).
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "ObservableTreeTracker uses reflection to discover INPC-candidate properties.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "ObservableTreeTracker uses reflection to discover INPC-candidate properties.")]
-    internal static PropertyInfo[] GetInpcCandidateProperties(Type type)
-        => _inpcPropertyCache.GetOrAdd(type, t =>
-            t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-             .Where(p => p.CanRead && !p.PropertyType.IsValueType)
-             .ToArray());
+    [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "CreateInpcCandidateProperties has DynamicallyAccessedMembers; ConcurrentDictionary.GetOrAdd resolves it via delegate.")]
+    internal static PropertyInfo[] GetInpcCandidateProperties(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
+        => _inpcPropertyCache.GetOrAdd(type, CreateInpcCandidateProperties);
+
+    private static PropertyInfo[] CreateInpcCandidateProperties(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
+        => type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+               .Where(p => p.CanRead && !p.PropertyType.IsValueType)
+               .ToArray();
 
     /// <summary>
     /// Synchronize subscriptions to match the current object graph.
@@ -85,6 +88,7 @@ internal class ObservableTreeTracker : IDisposable
         _subscriptions.Clear();
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Object.GetType() does not carry DynamicallyAccessedMembers; INPC types are preserved because they implement INotifyPropertyChanged.")]
     private void Walk(INotifyPropertyChanged? node, HashSet<INotifyPropertyChanged> desiredSet)
     {
         if (node is null || !_visiting.Add(node))

--- a/src/Reactor/Data/FieldDescriptor.cs
+++ b/src/Reactor/Data/FieldDescriptor.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Controls.Validation;
 
@@ -18,6 +19,7 @@ public record FieldDescriptor
     public string? DisplayName { get; init; }
 
     /// <summary>The CLR type of this field's value.</summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)]
     public required Type FieldType { get; init; }
 
     // ── Access ──────────────────────────────────────────────────

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -73,6 +73,7 @@ public static class ReactorApp
     /// The <c>preview</c> parameter is deprecated and is kept for one release. When both are
     /// passed, <c>devtools</c> wins.
     /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Devtools uses Assembly.GetTypes(); non-devtools code paths are trim-safe.")]
     public static void Run<TRoot>(
         string title = "Reactor App",
         int width = 1024,
@@ -112,6 +113,7 @@ public static class ReactorApp
     /// Launches the app with a render function instead of a Component subclass.
     /// See the generic overload for <c>devtools</c> semantics.
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Devtools uses Assembly.GetTypes(); non-devtools code paths are trim-safe.")]
     public static void Run(
         string title,
         Func<RenderContext, Element> rootRender,
@@ -166,6 +168,7 @@ public static class ReactorApp
     /// With <c>--vscode</c>, starts the capture server for the VS Code preview panel. Only
     /// active when the caller passes <c>devtools: true</c>.
     /// </summary>
+    [RequiresUnreferencedCode("Devtools uses Assembly.GetTypes() for component discovery.")]
     private static bool TryRunDevtools(string title, int width, int height, Action<ReactorHost>? configure, Type? hostRoot = null)
     {
         var args = Environment.GetCommandLineArgs();
@@ -221,7 +224,7 @@ public static class ReactorApp
         }
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Activator.CreateInstance for component types resolved by reflection.")]
+    [RequiresUnreferencedCode("Devtools component discovery uses Assembly.GetTypes().")]
     private static bool RunScreenshotSubverb(DevtoolsCliOptions options, int width, int height, Action<ReactorHost>? configure, Type? hostRoot = null)
     {
         if (string.IsNullOrEmpty(options.ScreenshotOutputPath))
@@ -290,6 +293,7 @@ public static class ReactorApp
         return true;
     }
 
+    [RequiresUnreferencedCode("Devtools component listing uses Assembly.GetTypes().")]
     private static bool RunListSubverb(DevtoolsCliOptions options)
     {
         var names = FindAllComponentNames().ToList();
@@ -301,8 +305,7 @@ public static class ReactorApp
         return true;
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Activator.CreateInstance for component types resolved by reflection.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Generic type parameter flows through for component instantiation.")]
+    [RequiresUnreferencedCode("Devtools component discovery uses Assembly.GetTypes() and Activator.CreateInstance.")]
     private static bool RunRunSubverb(DevtoolsCliOptions options, string title, int width, int height, Action<ReactorHost>? configure, Type? hostRoot = null)
     {
         _ = title;
@@ -477,7 +480,7 @@ public static class ReactorApp
     /// <summary>
     /// Finds a Component type by name across all loaded assemblies (case-insensitive).
     /// </summary>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Assembly.GetTypes for devtools component discovery.")]
+    [RequiresUnreferencedCode("Devtools component discovery uses Assembly.GetTypes().")]
     internal static Type? FindComponentType(string name)
     {
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
@@ -496,7 +499,7 @@ public static class ReactorApp
         return null;
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Assembly.GetTypes for devtools component enumeration.")]
+    [RequiresUnreferencedCode("Assembly.GetTypes() is incompatible with trimming. Devtools-only code path.")]
     internal static IEnumerable<string> FindAllComponentNames()
     {
         return AppDomain.CurrentDomain.GetAssemblies()
@@ -507,7 +510,7 @@ public static class ReactorApp
             .OrderBy(n => n);
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Assembly.GetTypes for devtools detailed component listing.")]
+    [RequiresUnreferencedCode("Assembly.GetTypes() is incompatible with trimming. Devtools-only code path.")]
     internal static IEnumerable<Hosting.Devtools.ComponentInfo> FindAllComponentsDetailed()
     {
         return AppDomain.CurrentDomain.GetAssemblies()


### PR DESCRIPTION
﻿## Replace `UnconditionalSuppressMessage` with proper trimming annotations

Systematically replaces blanket `UnconditionalSuppressMessage` attributes with `[DynamicallyAccessedMembers]` and `[RequiresUnreferencedCode]`, pushing annotations as far upstream as possible. All suppressions use `[UnconditionalSuppressMessage]` attributes (not `#pragma`), so ILC sees them during AOT publish.

Also promotes all IL trimming/AOT warnings to **errors** on the core Reactor library via `WarningsAsErrors` in `Directory.Build.targets`, following the OSClient pattern. New reflection usage must be properly annotated before it can merge.

### Changes

**IL warnings as errors (`Directory.Build.targets`):**
- Added `WarningsAsErrors` for IL2026, IL2062, IL2065, IL2067, IL2069, IL2070, IL2072, IL2073, IL2075, IL2087, IL2090, IL2091, IL2111, IL3000, IL3050 on the Reactor project
- Added `TrimmerSingleWarn=false` for granular trimmer diagnostics

**FieldDescriptor.FieldType (new DAM annotation):**
- Added `[DynamicallyAccessedMembers(PublicProperties | PublicConstructors)]` to `FieldDescriptor.FieldType` property
- This flows DAM through all consumers (DataGridComponent, PropertyGridComponent, FormField) without needing individual suppressions at each call site
- True suppression boundary is at `PropertyInfo.PropertyType` assignments in `ReflectionTypeMetadataProvider.CreateDescriptor` / `CreateDescriptorBound` and `ColumnDsl.InferFieldType`

**ObservableTreeTracker (4 suppressions removed):**
- Added `[DynamicallyAccessedMembers(PublicProperties)]` to `GetInpcCandidateProperties` Type parameter
- Eliminated reflection in `OnNestedPropertyChanged` entirely — always resyncs instead of checking property type via `GetProperty()`
- True suppression boundary is at `Object.GetType()` in `Walk()`

**TypeRegistry / ReflectionTypeMetadataProvider (3 suppressions removed):**
- Added DAM to `Resolve()`, `ResolveEditor()`, `CreateMetadata()`, `TryResolveArray()` Type parameters
- Added `PublicConstructors` to `ColumnDsl.AutoColumns<T>` generic constraint
- Added `[return: DynamicallyAccessedMembers]` to `InferFieldType` return type
- True suppression boundary: `PropertyInfo.PropertyType` (BCL type, can't carry DAM)

**ReactorApp devtools (6 suppressions removed):**
- Replaced with `[RequiresUnreferencedCode]` on `FindComponentType`, `FindAllComponentNames`, `FindAllComponentsDetailed`, `RunScreenshotSubverb`, `RunRunSubverb`, `RunListSubverb`, `TryRunDevtools`
- `[UnconditionalSuppressMessage("Trimming", "IL2026")]` on public `Run()` overloads to prevent trim warnings from contaminating the public API

### AOT Self-Test Results

Published `Reactor.AppTests.Host` with `PublishAot=true` and ran `--self-test`:

| Metric | Value |
|--------|-------|
| Fixtures | 159 |
| **Fully passing** | **148 (93.1%)** |
| Failing | 10 |
| Checks passed | 589 |
| Checks failed | 65 |

**All React-pattern scenarios work in AOT** — reconciler, components, hooks, state, effects, error boundaries, navigation, observable data binding, flex/grid layout, charts, markdown, accessibility, ListView, control catalog (56 controls mount/unmount).

Failures are in two areas Chris said are OK as JIT-only for now:

1. **PropertyGrid** (9 fixtures, 25 failures) — `ReflectionTypeMetadataProvider` reflects on user model types that get trimmed. Would need source-generated metadata or `[DynamicallyAccessedMembers]` on user model types.
2. **Localization** (1 fixture, 40 failures) — third-party `MessageFormat` NuGet package (`Jeffijoe.MessageFormat`) is not AOT-compatible. Every localization check fails, including those with no args — the ICU formatter itself is trimmed, not `IntlAccessor.ToArgsDictionary`.

### ILC warnings from AOT publish

- `IL2069` — `ComponentElement` constructor Type param needs DAM (separate fix)
- `IL2111` — `CreateMetadata` / `ConcurrentDictionary.GetOrAdd` delegate (suppressed via attribute)
- `IL3052` — COM interop in `TaskbarList` (test harness only)