### PR TITLE
test(selftest): fix ReconcileHighlight_MenuFlyoutUpdatesInPlace click

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcileHighlightTests.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcileHighlightTests.cs
@@ -228,16 +228,17 @@ internal static class ReconcileHighlightTests
                 var (label, setLabel) = ctx.UseState("Item1");
                 return VStack(
                     MenuFlyout(
-                        Button("mfTarget", () => setLabel("Item2")),
+                        Button("mfTarget"),
                         MenuItem(label)
-                    )
+                    ),
+                    Button("mfTrigger", () => setLabel("Item2"))
                 );
             });
 
             await Harness.Render();
 
             // Trigger update — the menu flyout item label changes.
-            H.ClickButton("mfTarget");
+            H.ClickButton("mfTrigger");
             await Harness.Render();
 
             // No new elements should be created (Update path, not Mount).


### PR DESCRIPTION
## Summary

- The `ReconcileHighlight_MenuFlyoutUpdatesInPlace` fixture wired `setLabel` to the Button serving as the MenuFlyout target. Invoking that Button via automation opens the attached flyout instead of firing Click, so `setLabel` never ran and no update reconcile was triggered.
- `DebugUIElementsCreated` was still showing the initial mount count (3: the target Button is double-counted in `MountMenuFlyout` + the `StackPanel` wrapper), so the assertion failed.
- Fix: move the state change onto a separate sibling `Button("mfTrigger", …)` so the click reliably fires.
- The reconciler's MenuFlyout update path is correct and unchanged.

## Test plan

- [x] `Reactor.AppTests.Host --self-test` — full suite passes (0 failures), including `ReconcileHighlight_MenuFlyoutUpdatesInPlace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)