### PR TITLE
fix(e2e): DevtoolsUx toggle tests — one-shot fixture reset

### DIFF
--- a/tests/Reactor.AppTests.Host/Fixtures/DevtoolsUxFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/DevtoolsUxFixtures.cs
@@ -22,6 +22,23 @@ internal static class DevtoolsUxFixtures
     {
         public override Element Render()
         {
+            // One-shot reset on first render. Done synchronously *before* reading the
+            // observable, not in a UseEffect, for two reasons:
+            //   (1) Reactor re-renders from the root, so putting the reset in the
+            //       factory above would clobber every toggle the moment its
+            //       notification loops back around.
+            //   (2) UseEffect runs *after* Render completes, so a reset there would
+            //       not influence the already-captured `debugUI` value on the first
+            //       mount — the initial UI would still reflect stale state from a
+            //       prior test, and no further re-render would be triggered because
+            //       the new value matches the subscribed one.
+            var hasReset = UseRef(false);
+            if (!hasReset.Current)
+            {
+                DebugUI.Value = false;
+                hasReset.Current = true;
+            }
+
             // Subscribe so the enclosing component re-renders when the flag flips,
             // which rebuilds the DevtoolsMenu flyout with fresh IsChecked state and
             // toggles the mirrored TextBlock below.
@@ -62,9 +79,6 @@ internal static class DevtoolsUxFixtures
         // would only be reached when both Run(devtools:true) AND `--devtools app`
         // CLI were present.
         ReactorApp.DevtoolsEnabled = true;
-        // Reset the backing Observable so the fixture always starts in "off" state
-        // even if a prior navigation toggled it on.
-        DebugUI.Value = false;
         return Component<DevtoolsUxTestComponent>();
     }
 }

--- a/tests/Reactor.AppTests/Infrastructure/AppTestBase.cs
+++ b/tests/Reactor.AppTests/Infrastructure/AppTestBase.cs
@@ -117,11 +117,22 @@ public class AppTestBase
         };
         wait.IgnoreExceptionTypes(typeof(WebDriverException));
 
-        wait.Until(driver =>
+        string lastSeen = "<not found>";
+        try
         {
-            var element = driver.FindElement(MobileBy.AccessibilityId(automationId));
-            return element.Text == expectedText ? element : null;
-        });
+            wait.Until(driver =>
+            {
+                var element = driver.FindElement(MobileBy.AccessibilityId(automationId));
+                lastSeen = element.Text ?? "<null>";
+                return lastSeen == expectedText ? element : null;
+            });
+        }
+        catch (WebDriverTimeoutException)
+        {
+            throw new WebDriverTimeoutException(
+                $"Timed out after {timeoutMs}ms waiting for AutomationId='{automationId}' " +
+                $"to have text '{expectedText}'. Last-seen text: '{lastSeen}'.");
+        }
     }
 
     /// <summary>

--- a/tests/Reactor.AppTests/Tests/DevtoolsUxTests.cs
+++ b/tests/Reactor.AppTests/Tests/DevtoolsUxTests.cs
@@ -53,7 +53,11 @@ public class DevtoolsUxTests : AppTestBase
     [TestMethod]
     public void Devtools_Menu_Toggle_Flows_Through_To_Subscribers()
     {
-        NavigateToFixture("DevtoolsUx_MenuAndToggle");
+        // Fresh navigation re-mounts the fixture component, which runs the
+        // one-shot DebugUI reset inside DevtoolsUxTestComponent.Render. A plain
+        // NavigateToFixture is a no-op when the fixture is already loaded,
+        // leaving prior-test toggle state in place.
+        NavigateToFixtureFresh("DevtoolsUx_MenuAndToggle");
         WaitForText("DebugUiState", "debug-off");
 
         // Open the flyout.
@@ -78,7 +82,8 @@ public class DevtoolsUxTests : AppTestBase
     [TestMethod]
     public void Devtools_Menu_Toggle_Is_Reversible()
     {
-        NavigateToFixture("DevtoolsUx_MenuAndToggle");
+        // See Flows_Through_To_Subscribers for why Fresh is required.
+        NavigateToFixtureFresh("DevtoolsUx_MenuAndToggle");
         WaitForText("DebugUiState", "debug-off");
 
         // Toggle on.


### PR DESCRIPTION
## Summary

- Fixture factory `DevtoolsUxFixtures.DevtoolsUxTest` set `DebugUI.Value = false` on every call. Because Reactor re-renders from the root, each observable notification re-ran the factory and clobbered the toggle before the component could render the new value — so `Devtools_Menu_Toggle_Flows_Through_To_Subscribers` and `Devtools_Menu_Toggle_Is_Reversible` both timed out waiting for `debug-on` / `debug-off`.
- Moved the reset inside `DevtoolsUxTestComponent.Render`, gated by `UseRef` so it fires once per mount, synchronously **before** `UseObservable` reads the value. `UseEffect` isn't sufficient here: effects flush after `Render` has already captured `debugUI`, so the initial remount would still reflect stale state from the previous test and the subsequent TextBlock update never propagates.
- Toggle tests now call `NavigateToFixtureFresh` — `NavigateToFixture` is a no-op when `_currentFixture` already matches, which skips the Component remount and leaves the prior test's toggle state in place.
- Keeps a small ergonomic improvement to `AppTestBase.WaitForText` that includes the last-seen text in the timeout message. This was what made the root cause legible during investigation and is generally useful.

## Test plan

- [x] `dotnet test tests/Reactor.AppTests -p:Platform=x64 --filter ClassName=Microsoft.UI.Reactor.AppTests.Tests.DevtoolsUxTests` — 3/3 pass
- [x] Individual tests also pass in isolation
- [ ] Full `dotnet test tests/Reactor.AppTests -p:Platform=x64` — verified going from 53/57 → 54/57; unrelated failures remain (`Interactive_DataGrid_ClickEditTabCommit` has a known duplicate-handler bug in the reconciler, and a newly observed flake in `GestureTests.Interactive_OnPan_Drag_ReportsTranslationAndPhase` is ordering-sensitive — both are separate investigations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)