### PR TITLE
fix(datagrid): make cell OnTapped idempotent to survive duplicate fires

### DIFF
--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -614,10 +614,25 @@ public class DataGridComponent<T> : Component<DataGridElement<T>>
             {
                 var capturedRow = index;
                 var capturedCol = c;
+                var capturedRowKey = rowKey;
+                var capturedColName = col.Name;
                 cell = cell.OnTapped((sender, e) =>
                 {
                     Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
                     {
+                        // Idempotency guard: if we're already editing exactly this cell,
+                        // skip commit+begin. The underlying native element may have
+                        // accumulated multiple Tapped subscriptions across re-renders
+                        // (multiple C# wrappers of the same native control), causing one
+                        // click to invoke this handler more than once; without this guard
+                        // the second invocation would commit the freshly-begun edit with
+                        // the unchanged value, clobbering the previous row's commit.
+                        if (state.IsEditing
+                            && state.EditingRowKey?.Equals(capturedRowKey) == true
+                            && state.EditingColumnName == capturedColName)
+                        {
+                            return;
+                        }
                         // Commit any in-flight edit BEFORE starting a new one.
                         // BeginEdit unconditionally overwrites _editingValue with the
                         // new cell's current value, which would destroy the in-flight


### PR DESCRIPTION
## Summary
- DataGrid cell `OnTapped` can fire more than once per physical click (root cause in reconciler, tracked in #86). The second fire sees `IsEditing=true` and commits the just-begun edit with the target cell's unchanged value, clobbering the previous row's correct commit.
- Guard the handler: if already editing exactly this cell, no-op. Makes duplicate fires harmless without touching the reconciler.
- Fixes `Interactive_DataGrid_ClickEditTabCommit` E2E failure (the fourth entry in the failure set identified during E2E triage).

## Diagnosis (abridged — full trace in #86)
Instrumented `EnsureTappedSubscribed` with `Marshal.GetIUnknownForObject(fe)`. Two trampolines with different `EventHandlerState` objects fire on the same click, both with `sender_iunk=0x1C184E8FD18` — i.e., they're attached to the same native element via two different C# RCWs. `EventHandlerState` is keyed by C# reference, so the guard `if (state.TappedTrampoline is null)` doesn't catch the cross-RCW aliasing. `ElementPool` is not involved in this path (verified).

## Test plan
- [x] `dotnet test tests/Reactor.AppTests -p:Platform=x64 --filter \"FullyQualifiedName~Interactive_DataGrid_ClickEditTabCommit\"` — passes (was failing)
- [x] `dotnet test tests/Reactor.Tests -p:Platform=x64` — 6562 pass / 46 skipped (pre-existing Yoga skips)
- [x] `dotnet test tests/Reactor.SelfTests -p:Platform=x64` — 590 pass
- [x] `DevtoolsUxTests` 3/3 pass, no regression
- [ ] `DragDropTests.DragDrop_TypedReorder_MovesCard` still fails in-suite (pre-existing ordering flake, unrelated to this change — passes in isolation)

## Follow-up
Reconciler-level fix tracked in #86. Preferred approach: store a sentinel on the native element via `DependencyProperty.RegisterAttached` (shared across RCWs) to detect already-attached Reactor handlers before re-attaching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)