### PR TITLE
reconciler: skip-path correctness + lazy event wiring + overlay fidelity

### DIFF
--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -70,6 +70,14 @@ internal static class ChildReconciler
             if (Element.CanSkipUpdate(oldEl, newEl))
             {
                 reconciler.DebugElementsSkipped++;
+                // Refresh Tag when the element carries callbacks. The skip short-
+                // circuits Update, so without this the event trampoline keeps
+                // dispatching through the previous render's closure — stale state
+                // (e.g., Counter's `() => setCount(count + 1)` would keep capturing
+                // the initial count). For callback-free elements we still avoid
+                // the children.Get COM call.
+                if (newEl.HasCallbacks && children.Get(i) is FrameworkElement fe)
+                    fe.Tag = newEl;
                 continue;
             }
 

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -164,6 +164,16 @@ public abstract record Element
     // ════════════════════════════════════════════════════════════════════════
 
     /// <summary>
+    /// True if this element exposes any non-null event-handler delegate (OnClick,
+    /// OnChanged, etc.). Dispatch goes through the Tag trampoline, so when the
+    /// reconciler skips Update it must still refresh the control's Tag so clicks
+    /// invoke the current render's closure rather than a stale one. Elements with
+    /// no handlers at all don't need the Tag refresh — their controls never fire
+    /// into Reactor code. Override on each callback-bearing leaf.
+    /// </summary>
+    internal virtual bool HasCallbacks => false;
+
+    /// <summary>
     /// Returns true if two elements are structurally identical AND the child can be
     /// completely skipped during reconciliation (no need to call Update at all).
     /// This is stricter than ShallowEquals: elements with ThemeBindings must still
@@ -198,12 +208,111 @@ public abstract record Element
                 && ta.HorizontalAlignment == tb.HorizontalAlignment
                 && ta.Setters.Length == 0 && tb.Setters.Length == 0,
 
+            // Callbacks (OnClick, OnChanged, etc.) are intentionally not compared:
+            // dispatch goes through the Tag trampoline, and the Update.cs skip path
+            // refreshes Tag when HasCallbacks is true. So identity of the delegate
+            // on the element is irrelevant to dispatch correctness — only presence
+            // mattered historically (and presence is still captured by HasCallbacks).
             (ButtonElement ba, ButtonElement bb) =>
                 ba.Label == bb.Label
                 && ba.IsEnabled == bb.IsEnabled
-                && ReferenceEquals(ba.OnClick, bb.OnClick)
                 && ba.ContentElement is null && bb.ContentElement is null
                 && ba.Setters.Length == 0 && bb.Setters.Length == 0,
+
+            (HyperlinkButtonElement ha, HyperlinkButtonElement hb) =>
+                ha.Content == hb.Content
+                && ha.NavigateUri == hb.NavigateUri
+                && ha.Setters.Length == 0 && hb.Setters.Length == 0,
+
+            (RepeatButtonElement ra, RepeatButtonElement rb) =>
+                ra.Label == rb.Label
+                && ra.Delay == rb.Delay
+                && ra.Interval == rb.Interval
+                && ra.Setters.Length == 0 && rb.Setters.Length == 0,
+
+            (ToggleButtonElement ta, ToggleButtonElement tb) =>
+                ta.Label == tb.Label
+                && ta.IsChecked == tb.IsChecked
+                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+
+            (SliderElement sa, SliderElement sb) =>
+                sa.Value == sb.Value
+                && sa.Min == sb.Min
+                && sa.Max == sb.Max
+                && sa.StepFrequency == sb.StepFrequency
+                && sa.Header == sb.Header
+                && sa.Setters.Length == 0 && sb.Setters.Length == 0,
+
+            (ToggleSwitchElement ta, ToggleSwitchElement tb) =>
+                ta.IsOn == tb.IsOn
+                && ta.OnContent == tb.OnContent
+                && ta.OffContent == tb.OffContent
+                && ta.Header == tb.Header
+                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+
+            (CheckBoxElement ca, CheckBoxElement cb) =>
+                ca.IsChecked == cb.IsChecked
+                && ca.Label == cb.Label
+                && ca.IsThreeState == cb.IsThreeState
+                && ca.CheckedState == cb.CheckedState
+                && ca.Setters.Length == 0 && cb.Setters.Length == 0,
+
+            (RadioButtonElement ra, RadioButtonElement rb) =>
+                ra.Label == rb.Label
+                && ra.IsChecked == rb.IsChecked
+                && ra.GroupName == rb.GroupName
+                && ra.Setters.Length == 0 && rb.Setters.Length == 0,
+
+            (ComboBoxElement ca, ComboBoxElement cb) =>
+                ReferenceEquals(ca.Items, cb.Items)
+                && ca.SelectedIndex == cb.SelectedIndex
+                && ca.PlaceholderText == cb.PlaceholderText
+                && ca.Header == cb.Header
+                && ca.IsEditable == cb.IsEditable
+                && ReferenceEquals(ca.ItemElements, cb.ItemElements)
+                && ca.Setters.Length == 0 && cb.Setters.Length == 0,
+
+            (TextFieldElement ta, TextFieldElement tb) =>
+                ta.Value == tb.Value
+                && ta.Placeholder == tb.Placeholder
+                && ta.Header == tb.Header
+                && ta.IsReadOnly == tb.IsReadOnly
+                && ta.AcceptsReturn == tb.AcceptsReturn
+                && ta.TextWrapping == tb.TextWrapping
+                && ta.SelectionStart == tb.SelectionStart
+                && ta.SelectionLength == tb.SelectionLength
+                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+
+            (NumberBoxElement na, NumberBoxElement nb) =>
+                na.Value == nb.Value
+                && na.Minimum == nb.Minimum
+                && na.Maximum == nb.Maximum
+                && na.SmallChange == nb.SmallChange
+                && na.LargeChange == nb.LargeChange
+                && na.Header == nb.Header
+                && na.PlaceholderText == nb.PlaceholderText
+                && na.SpinButtonPlacement == nb.SpinButtonPlacement
+                && na.Setters.Length == 0 && nb.Setters.Length == 0,
+
+            (PasswordBoxElement pa, PasswordBoxElement pb) =>
+                pa.Password == pb.Password
+                && pa.PlaceholderText == pb.PlaceholderText
+                && pa.Setters.Length == 0 && pb.Setters.Length == 0,
+
+            (ProgressElement pa, ProgressElement pb) =>
+                pa.Value == pb.Value
+                && pa.Minimum == pb.Minimum
+                && pa.Maximum == pb.Maximum
+                && pa.ShowError == pb.ShowError
+                && pa.ShowPaused == pb.ShowPaused
+                && pa.Setters.Length == 0 && pb.Setters.Length == 0,
+
+            (ProgressRingElement pa, ProgressRingElement pb) =>
+                pa.Value == pb.Value
+                && pa.Minimum == pb.Minimum
+                && pa.Maximum == pb.Maximum
+                && pa.IsActive == pb.IsActive
+                && pa.Setters.Length == 0 && pb.Setters.Length == 0,
 
             (ImageElement ia, ImageElement ib) =>
                 ia.Source == ib.Source
@@ -1134,11 +1243,13 @@ public record ButtonElement(string Label, Action? OnClick = null) : Element
     public bool IsEnabled { get; init; } = true;
     public Element? ContentElement { get; init; }
     internal Action<WinUI.Button>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnClick is not null;
 }
 
 public record HyperlinkButtonElement(string Content, Uri? NavigateUri = null, Action? OnClick = null) : Element
 {
     internal Action<WinUI.HyperlinkButton>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnClick is not null;
 }
 
 public record RepeatButtonElement(string Label, Action? OnClick = null) : Element
@@ -1146,11 +1257,13 @@ public record RepeatButtonElement(string Label, Action? OnClick = null) : Elemen
     public int Delay { get; init; } = 250;
     public int Interval { get; init; } = 50;
     internal Action<WinPrim.RepeatButton>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnClick is not null;
 }
 
 public record ToggleButtonElement(string Label, bool IsChecked = false, Action<bool>? OnToggled = null) : Element
 {
     internal Action<WinPrim.ToggleButton>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnToggled is not null;
 }
 
 public record DropDownButtonElement(string Label, Element? Flyout = null) : Element
@@ -1161,11 +1274,13 @@ public record DropDownButtonElement(string Label, Element? Flyout = null) : Elem
 public record SplitButtonElement(string Label, Action? OnClick = null, Element? Flyout = null) : Element
 {
     internal Action<WinUI.SplitButton>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnClick is not null;
 }
 
 public record ToggleSplitButtonElement(string Label, bool IsChecked = false, Action<bool>? OnIsCheckedChanged = null, Element? Flyout = null) : Element
 {
     internal Action<WinUI.ToggleSplitButton>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnIsCheckedChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -1189,6 +1304,7 @@ public record TextFieldElement(
     /// <summary>Selection length. Set alongside SelectionStart to control the selection range.</summary>
     public int? SelectionLength { get; init; }
     internal Action<WinUI.TextBox>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnChanged is not null || OnSelectionChanged is not null;
 }
 
 public record PasswordBoxElement(
@@ -1198,6 +1314,7 @@ public record PasswordBoxElement(
 ) : Element
 {
     internal Action<WinUI.PasswordBox>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnPasswordChanged is not null;
 }
 
 public record NumberBoxElement(
@@ -1213,6 +1330,7 @@ public record NumberBoxElement(
     public double SmallChange { get; init; } = 1;
     public double LargeChange { get; init; } = 10;
     internal Action<WinUI.NumberBox>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnValueChanged is not null;
 }
 
 public record AutoSuggestBoxElement(
@@ -1225,6 +1343,7 @@ public record AutoSuggestBoxElement(
     public string[] Suggestions { get; init; } = [];
     public string? PlaceholderText { get; init; }
     internal Action<WinUI.AutoSuggestBox>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnTextChanged is not null || OnQuerySubmitted is not null || OnSuggestionChosen is not null;
 }
 
 public record CheckBoxElement(
@@ -1237,6 +1356,7 @@ public record CheckBoxElement(
     public bool? CheckedState { get; init; }
     public Action<bool?>? OnCheckedStateChanged { get; init; }
     internal Action<WinUI.CheckBox>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnChanged is not null || OnCheckedStateChanged is not null;
 }
 
 public record RadioButtonElement(
@@ -1247,6 +1367,7 @@ public record RadioButtonElement(
 ) : Element
 {
     internal Action<WinUI.RadioButton>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnChecked is not null;
 }
 
 public record RadioButtonsElement(
@@ -1257,6 +1378,7 @@ public record RadioButtonsElement(
 {
     public string? Header { get; init; }
     internal Action<WinUI.RadioButtons>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectionChanged is not null;
 }
 
 public record ComboBoxElement(
@@ -1270,6 +1392,7 @@ public record ComboBoxElement(
     public bool IsEditable { get; init; }
     public Element[]? ItemElements { get; init; }
     internal Action<WinUI.ComboBox>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectionChanged is not null;
 }
 
 public record SliderElement(
@@ -1282,6 +1405,7 @@ public record SliderElement(
     public double StepFrequency { get; init; } = 1;
     public string? Header { get; init; }
     internal Action<WinUI.Slider>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnChanged is not null;
 }
 
 public record ToggleSwitchElement(
@@ -1293,6 +1417,7 @@ public record ToggleSwitchElement(
 {
     public string? Header { get; init; }
     internal Action<WinUI.ToggleSwitch>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnChanged is not null;
 }
 
 public record RatingControlElement(
@@ -1304,6 +1429,7 @@ public record RatingControlElement(
     public bool IsReadOnly { get; init; }
     public string? Caption { get; init; }
     internal Action<WinUI.RatingControl>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnValueChanged is not null;
 }
 
 public record ColorPickerElement(
@@ -1318,6 +1444,7 @@ public record ColorPickerElement(
     public bool IsColorChannelTextInputVisible { get; init; } = true;
     public bool IsHexInputVisible { get; init; } = true;
     internal Action<WinUI.ColorPicker>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnColorChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -1334,6 +1461,7 @@ public record CalendarDatePickerElement(
     public DateTimeOffset? MinDate { get; init; }
     public DateTimeOffset? MaxDate { get; init; }
     internal Action<WinUI.CalendarDatePicker>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnDateChanged is not null;
 }
 
 public record DatePickerElement(
@@ -1348,6 +1476,7 @@ public record DatePickerElement(
     public bool MonthVisible { get; init; } = true;
     public bool YearVisible { get; init; } = true;
     internal Action<WinUI.DatePicker>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnDateChanged is not null;
 }
 
 public record TimePickerElement(
@@ -1359,6 +1488,7 @@ public record TimePickerElement(
     public int MinuteIncrement { get; init; } = 1;
     public int ClockIdentifier { get; init; } = 12;
     internal Action<WinUI.TimePicker>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnTimeChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -1411,6 +1541,7 @@ public record WebView2Element(Uri? Source = null) : Element
     public Action<Uri>? OnNavigationStarting { get; init; }
     public Action<Uri>? OnNavigationCompleted { get; init; }
     internal Action<WinUI.WebView2>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnNavigationStarting is not null || OnNavigationCompleted is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -1426,6 +1557,7 @@ public record RichEditBoxElement(
     public string? PlaceholderText { get; init; }
     public Action<string>? OnTextChanged { get; init; }
     internal Action<WinUI.RichEditBox>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnTextChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -1507,6 +1639,7 @@ public record ExpanderElement(
 {
     public ExpandDirection ExpandDirection { get; init; } = ExpandDirection.Down;
     internal Action<WinUI.Expander>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnExpandedChanged is not null;
 }
 
 public record SplitViewElement(
@@ -1520,6 +1653,7 @@ public record SplitViewElement(
     public SplitViewDisplayMode DisplayMode { get; init; } = SplitViewDisplayMode.Overlay;
     public Action<bool>? OnPaneOpenChanged { get; init; }
     internal Action<WinUI.SplitView>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnPaneOpenChanged is not null;
 }
 
 public record ViewboxElement(Element Child) : Element
@@ -1611,6 +1745,7 @@ public record NavigationViewElement(
     public bool IsSettingsVisible { get; init; } = true;
     public string? PaneTitle { get; init; }
     internal Action<WinUI.NavigationView>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectionChanged is not null || OnBackRequested is not null;
 }
 
 public record TitleBarElement(
@@ -1626,6 +1761,7 @@ public record TitleBarElement(
     public Element? Content { get; init; }
     public Element? RightHeader { get; init; }
     internal Action<WinUI.TitleBar>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnBackRequested is not null || OnPaneToggleRequested is not null;
 }
 
 public record TabViewElement(
@@ -1638,6 +1774,7 @@ public record TabViewElement(
     public Action? OnAddTabButtonClick { get; init; }
     public bool IsAddTabButtonVisible { get; init; }
     internal Action<WinUI.TabView>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectionChanged is not null || OnTabCloseRequested is not null || OnAddTabButtonClick is not null;
 }
 
 public record BreadcrumbBarElement(
@@ -1646,6 +1783,7 @@ public record BreadcrumbBarElement(
 ) : Element
 {
     internal Action<WinUI.BreadcrumbBar>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnItemClicked is not null;
 }
 
 public record PivotElement(
@@ -1656,6 +1794,7 @@ public record PivotElement(
     public Action<int>? OnSelectionChanged { get; init; }
     public string? Title { get; init; }
     internal Action<WinUI.Pivot>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectionChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -1672,6 +1811,7 @@ public record ListViewElement(
     public ListViewSelectionMode SelectionMode { get; init; } = ListViewSelectionMode.Single;
     public string? Header { get; init; }
     internal Action<WinUI.ListView>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectionChanged is not null || OnItemClick is not null;
 }
 
 public record GridViewElement(
@@ -1684,6 +1824,7 @@ public record GridViewElement(
     public ListViewSelectionMode SelectionMode { get; init; } = ListViewSelectionMode.Single;
     public string? Header { get; init; }
     internal Action<WinUI.GridView>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectionChanged is not null || OnItemClick is not null;
 }
 
 public record TreeViewElement(
@@ -1697,6 +1838,7 @@ public record TreeViewElement(
     public bool AllowDrop { get; init; }
     public bool CanReorderItems { get; init; }
     internal Action<WinUI.TreeView>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnItemInvoked is not null || OnExpanding is not null;
 }
 
 public record FlipViewElement(
@@ -1706,6 +1848,7 @@ public record FlipViewElement(
     public int SelectedIndex { get; init; } = 0;
     public Action<int>? OnSelectionChanged { get; init; }
     internal Action<WinUI.FlipView>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectionChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -1728,6 +1871,7 @@ public record ContentDialogElement(
     public ContentDialogButton DefaultButton { get; init; } = ContentDialogButton.Primary;
     public Action<ContentDialogResult>? OnClosed { get; init; }
     internal Action<WinUI.ContentDialog>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnClosed is not null;
 }
 
 /// <summary>
@@ -1743,6 +1887,7 @@ public record FlyoutElement(
     public Action? OnOpened { get; init; }
     public Action? OnClosed { get; init; }
     internal Action<WinUI.Flyout>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnOpened is not null || OnClosed is not null;
 }
 
 /// <summary>
@@ -1775,6 +1920,7 @@ public record TeachingTipElement(
     public string? CloseButtonContent { get; init; }
     public Action? OnClosed { get; init; }
     internal Action<WinUI.TeachingTip>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnActionButtonClick is not null || OnClosed is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -1792,6 +1938,7 @@ public record InfoBarElement(
     public string? ActionButtonContent { get; init; }
     public Action? OnActionButtonClick { get; init; }
     public Action? OnClosed { get; init; }
+    internal override bool HasCallbacks => OnActionButtonClick is not null || OnClosed is not null;
     internal Action<WinUI.InfoBar>[] Setters { get; init; } = [];
 }
 
@@ -1885,6 +2032,7 @@ public record TemplatedListViewElement<T>(
         OnItemClick?.Invoke(index >= 0 && index < Items.Count ? Items[index] : default!);
     public override void ApplyControlSetters(object control) =>
         Reconciler.ApplySetters(Setters, (WinUI.ListView)control);
+    internal override bool HasCallbacks => OnSelectionChanged is not null || OnItemClick is not null;
 }
 
 public record TemplatedGridViewElement<T>(
@@ -1914,6 +2062,7 @@ public record TemplatedGridViewElement<T>(
         OnItemClick?.Invoke(index >= 0 && index < Items.Count ? Items[index] : default!);
     public override void ApplyControlSetters(object control) =>
         Reconciler.ApplySetters(Setters, (WinUI.GridView)control);
+    internal override bool HasCallbacks => OnSelectionChanged is not null || OnItemClick is not null;
 }
 
 public record TemplatedFlipViewElement<T>(
@@ -1939,6 +2088,7 @@ public record TemplatedFlipViewElement<T>(
     public override void InvokeItemClick(int index) { }
     public override void ApplyControlSetters(object control) =>
         Reconciler.ApplySetters(Setters, (WinUI.FlipView)control);
+    internal override bool HasCallbacks => OnSelectionChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -2120,6 +2270,7 @@ public record ListBoxElement(string[] Items) : Element
     public int SelectedIndex { get; init; } = -1;
     public Action<int>? OnSelectionChanged { get; init; }
     internal Action<WinUI.ListBox>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectionChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -2131,6 +2282,7 @@ public record SelectorBarElement(SelectorBarItemData[] Items) : Element
     public int SelectedIndex { get; init; } = 0;
     public Action<int>? OnSelectionChanged { get; init; }
     internal Action<WinUI.SelectorBar>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectionChanged is not null;
 }
 
 public record SelectorBarItemData(string Text, string? Icon = null);
@@ -2140,6 +2292,7 @@ public record PipsPagerElement(int NumberOfPages) : Element
     public int SelectedPageIndex { get; init; }
     public Action<int>? OnSelectedIndexChanged { get; init; }
     internal Action<WinUI.PipsPager>[] Setters { get; init; } = [];
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
 }
 
 public record AnnotatedScrollBarElement() : Element

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -344,8 +344,8 @@ public abstract record Element
                 && sa.Setters.Length == 0 && sb.Setters.Length == 0,
 
             (BorderElement ba, BorderElement bb) =>
-                ReferenceEquals(ba.Background, bb.Background)
-                && ReferenceEquals(ba.BorderBrush, bb.BorderBrush)
+                BrushesEqual(ba.Background, bb.Background)
+                && BrushesEqual(ba.BorderBrush, bb.BorderBrush)
                 && ba.CornerRadius == bb.CornerRadius
                 && ba.Padding == bb.Padding
                 && ba.BorderThickness == bb.BorderThickness
@@ -421,8 +421,8 @@ public abstract record Element
                 && ga.Setters.Length == 0 && gb.Setters.Length == 0,
 
             (BorderElement ba, BorderElement bb) =>
-                ReferenceEquals(ba.Background, bb.Background)
-                && ReferenceEquals(ba.BorderBrush, bb.BorderBrush)
+                BrushesEqual(ba.Background, bb.Background)
+                && BrushesEqual(ba.BorderBrush, bb.BorderBrush)
                 && ba.CornerRadius == bb.CornerRadius
                 && ba.Padding == bb.Padding
                 && ba.BorderThickness == bb.BorderThickness
@@ -538,8 +538,33 @@ public abstract record Element
     }
 
     /// <summary>
+    /// Structural brush comparison. BrushHelper.Parse caches the parsed Color
+    /// but returns a fresh SolidColorBrush instance on every call (Brushes have
+    /// thread affinity), so ReferenceEquals always fails for ".Background("#x")"
+    /// style fluent chains. Unwrap the underlying Color for the common
+    /// SolidColorBrush case and fall back to ReferenceEquals for everything else.
+    /// </summary>
+    private static bool BrushesEqual(Brush? a, Brush? b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+        if (a is SolidColorBrush sa && b is SolidColorBrush sb)
+            return sa.Color == sb.Color && sa.Opacity == sb.Opacity;
+        return false;
+    }
+
+    private static bool FontFamiliesEqual(Microsoft.UI.Xaml.Media.FontFamily? a, Microsoft.UI.Xaml.Media.FontFamily? b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+        return a.Source == b.Source;
+    }
+
+    /// <summary>
     /// Compare two ElementModifiers for rendering equivalence.
-    /// Uses ReferenceEquals for Brush properties (BrushHelper.Parse caches instances).
+    /// Brushes and FontFamily are compared structurally because fluent helpers
+    /// (<c>.Background("#color")</c>, <c>.FontFamily("Segoe UI")</c>) allocate
+    /// fresh instances on every render even when the underlying values match.
     /// Ignores OnMountAction (only runs at mount time, not during update).
     /// </summary>
     internal static bool ModifiersEqual(ElementModifiers? a, ElementModifiers? b)
@@ -566,12 +591,12 @@ public abstract record Element
             && a.ToolTip == b.ToolTip
             && a.AutomationName == b.AutomationName
             && a.AutomationId == b.AutomationId
-            && ReferenceEquals(a.Background, b.Background)
-            && ReferenceEquals(a.Foreground, b.Foreground)
-            && ReferenceEquals(a.BorderBrush, b.BorderBrush)
+            && BrushesEqual(a.Background, b.Background)
+            && BrushesEqual(a.Foreground, b.Foreground)
+            && BrushesEqual(a.BorderBrush, b.BorderBrush)
             && a.FontSize == b.FontSize
             && a.FontWeight == b.FontWeight
-            && ReferenceEquals(a.FontFamily, b.FontFamily)
+            && FontFamiliesEqual(a.FontFamily, b.FontFamily)
             // Skip OnMountAction — only runs at mount time
             // Skip event handlers — delegate comparison is unreliable, conservative false
             && a.OnSizeChanged is null && b.OnSizeChanged is null

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -165,11 +165,21 @@ public abstract record Element
 
     /// <summary>
     /// True if this element exposes any non-null event-handler delegate (OnClick,
-    /// OnChanged, etc.). Dispatch goes through the Tag trampoline, so when the
-    /// reconciler skips Update it must still refresh the control's Tag so clicks
-    /// invoke the current render's closure rather than a stale one. Elements with
-    /// no handlers at all don't need the Tag refresh — their controls never fire
-    /// into Reactor code. Override on each callback-bearing leaf.
+    /// OnChanged, etc.). Two roles:
+    ///
+    /// 1. When the reconciler takes a skip fast-path, it must still refresh the
+    ///    control's Tag so the event trampoline dispatches into the current
+    ///    render's closure rather than a stale one. Handler-free elements don't
+    ///    need the Tag refresh — their controls never fire into Reactor code.
+    ///
+    /// 2. Callback *presence* is part of the skip invariant: when
+    ///    <c>oldEl.HasCallbacks != newEl.HasCallbacks</c>, skipping is unsafe
+    ///    because <see cref="ShallowEquals"/> intentionally ignores delegate
+    ///    identity — a null→non-null transition wouldn't trigger the lazy-wire
+    ///    path in UpdateXxx, so the WinRT event would never be subscribed.
+    ///    The skip fast-paths therefore guard on this equality.
+    ///
+    /// Override on each callback-bearing leaf.
     /// </summary>
     internal virtual bool HasCallbacks => false;
 
@@ -177,11 +187,15 @@ public abstract record Element
     /// Returns true if two elements are structurally identical AND the child can be
     /// completely skipped during reconciliation (no need to call Update at all).
     /// This is stricter than ShallowEquals: elements with ThemeBindings must still
-    /// go through Update so bindings can be re-evaluated against the current theme.
+    /// go through Update so bindings can be re-evaluated against the current theme,
+    /// and a change in callback *presence* must run Update so the lazy-wire path
+    /// can subscribe to the WinRT event on a null→non-null transition.
     /// IMPORTANT: keep in sync with the ShallowEquals fast-path in Reconciler.Update().
     /// </summary>
     internal static bool CanSkipUpdate(Element oldEl, Element newEl)
-        => ShallowEquals(oldEl, newEl) && newEl.ThemeBindings is null;
+        => ShallowEquals(oldEl, newEl)
+            && newEl.ThemeBindings is null
+            && oldEl.HasCallbacks == newEl.HasCallbacks;
 
     /// <summary>
     /// Fast structural comparison that avoids the pitfalls of record Equals

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -500,6 +500,68 @@ public abstract record Element
             (MenuFlyoutContentElement, MenuFlyoutContentElement) => true,
             (FlyoutElement, FlyoutElement) => true,
 
+            // Collection-style elements: compare own props only (SelectedIndex,
+            // mode flags, header). Item/children arrays are compared separately
+            // in ShallowEquals via ReferenceEquals — a fresh items array does
+            // NOT mean own props changed, so the highlight overlay should not
+            // light up the ComboBox/ListView/etc. when only the authored items
+            // projection allocated a new array.
+            (ComboBoxElement ca, ComboBoxElement cb) =>
+                ca.SelectedIndex == cb.SelectedIndex
+                && ca.PlaceholderText == cb.PlaceholderText
+                && ca.Header == cb.Header
+                && ca.IsEditable == cb.IsEditable
+                && ca.Setters.Length == 0 && cb.Setters.Length == 0,
+
+            (ListViewElement la, ListViewElement lb) =>
+                la.SelectedIndex == lb.SelectedIndex
+                && la.SelectionMode == lb.SelectionMode
+                && la.Header == lb.Header
+                && la.Setters.Length == 0 && lb.Setters.Length == 0,
+
+            (GridViewElement ga, GridViewElement gb) =>
+                ga.SelectedIndex == gb.SelectedIndex
+                && ga.SelectionMode == gb.SelectionMode
+                && ga.Header == gb.Header
+                && ga.Setters.Length == 0 && gb.Setters.Length == 0,
+
+            (FlipViewElement fa, FlipViewElement fb) =>
+                fa.SelectedIndex == fb.SelectedIndex
+                && fa.Setters.Length == 0 && fb.Setters.Length == 0,
+
+            (PivotElement pa, PivotElement pb) =>
+                pa.SelectedIndex == pb.SelectedIndex
+                && pa.Title == pb.Title
+                && pa.Setters.Length == 0 && pb.Setters.Length == 0,
+
+            (TabViewElement ta, TabViewElement tb) =>
+                ta.SelectedIndex == tb.SelectedIndex
+                && ta.IsAddTabButtonVisible == tb.IsAddTabButtonVisible
+                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+
+            (TreeViewElement ta, TreeViewElement tb) =>
+                ta.SelectionMode == tb.SelectionMode
+                && ta.CanDragItems == tb.CanDragItems
+                && ta.AllowDrop == tb.AllowDrop
+                && ta.CanReorderItems == tb.CanReorderItems
+                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+
+            (SelectorBarElement sa, SelectorBarElement sb) =>
+                sa.SelectedIndex == sb.SelectedIndex
+                && sa.Setters.Length == 0 && sb.Setters.Length == 0,
+
+            (ListBoxElement la, ListBoxElement lb) =>
+                la.SelectedIndex == lb.SelectedIndex
+                && la.Setters.Length == 0 && lb.Setters.Length == 0,
+
+            (RadioButtonsElement ra, RadioButtonsElement rb) =>
+                ra.SelectedIndex == rb.SelectedIndex
+                && ra.Header == rb.Header
+                && ra.Setters.Length == 0 && rb.Setters.Length == 0,
+
+            (BreadcrumbBarElement ba, BreadcrumbBarElement bb) =>
+                ba.Setters.Length == 0 && bb.Setters.Length == 0,
+
             // Non-container / leaf types: return false → always captured
             _ => false,
         };

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -471,6 +471,35 @@ public abstract record Element
                 pa.IsOpen == pb.IsOpen
                 && pa.IsLightDismissEnabled == pb.IsLightDismissEnabled,
 
+            // TitleBar: own-props check (ignore Content/RightHeader slots which
+            // recurse as children). Without this, TitleBar flashes yellow on
+            // every reconcile even when only descendants changed.
+            (TitleBarElement ta, TitleBarElement tb) =>
+                ta.Title == tb.Title
+                && ta.Subtitle == tb.Subtitle
+                && ta.IsBackButtonVisible == tb.IsBackButtonVisible
+                && ta.IsBackButtonEnabled == tb.IsBackButtonEnabled
+                && ta.IsPaneToggleButtonVisible == tb.IsPaneToggleButtonVisible
+                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+
+            // Pure composition wrappers — they never write their own WinUI
+            // properties; their rendered output is diffed separately. Returning
+            // true here prevents the overlay from flashing the entire content
+            // block every time the component re-renders.
+            (ComponentElement, ComponentElement) => true,
+            (FuncElement, FuncElement) => true,
+            (MemoElement, MemoElement) => true,
+            (ModifiedElement, ModifiedElement) => true,
+            (GroupElement, GroupElement) => true,
+            (ErrorBoundaryElement, ErrorBoundaryElement) => true,
+
+            // MenuFlyout attaches a flyout to its Target but doesn't have its
+            // own WinUI props that change across renders.
+            (MenuFlyoutElement, MenuFlyoutElement) => true,
+            (ContentFlyoutElement, ContentFlyoutElement) => true,
+            (MenuFlyoutContentElement, MenuFlyoutContentElement) => true,
+            (FlyoutElement, FlyoutElement) => true,
+
             // Non-container / leaf types: return false → always captured
             _ => false,
         };

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -315,10 +315,24 @@ public sealed partial class Reconciler
         else
             button.Content = btn.Label;
         SetElementTag(button, btn);
-        if (rented is null) // Only wire events on fresh controls — pooled controls retain their handler
-            button.Click += (s, _) => (GetElementTag((UIElement)s!) as ButtonElement)?.OnClick?.Invoke();
+        EnsureButtonWiring(button, btn);
         ApplySetters(btn.Setters, button);
         return button;
+    }
+
+    /// <summary>
+    /// Wires Button.Click trampoline only when the element has a handler AND
+    /// the control hasn't been wired yet. The CWT flag survives pool round-
+    /// trips (Button is a poolable type, and ElementPool intentionally retains
+    /// event subscriptions across rent/return cycles).
+    /// </summary>
+    internal static void EnsureButtonWiring(WinUI.Button button, ButtonElement btn)
+    {
+        if (btn.OnClick is null) return;
+        var flags = GetPoolableWireFlags(button);
+        if (flags.ButtonClick) return;
+        flags.ButtonClick = true;
+        button.Click += (s, _) => (GetElementTag((UIElement)s!) as ButtonElement)?.OnClick?.Invoke();
     }
 
     private WinUI.HyperlinkButton MountHyperlinkButton(HyperlinkButtonElement hlBtn)
@@ -326,7 +340,8 @@ public sealed partial class Reconciler
         var hb = new WinUI.HyperlinkButton { Content = hlBtn.Content };
         if (hlBtn.NavigateUri is not null) hb.NavigateUri = hlBtn.NavigateUri;
         SetElementTag(hb, hlBtn);
-        hb.Click += (s, _) => (GetElementTag((UIElement)s!) as HyperlinkButtonElement)?.OnClick?.Invoke();
+        if (hlBtn.OnClick is not null)
+            hb.Click += (s, _) => (GetElementTag((UIElement)s!) as HyperlinkButtonElement)?.OnClick?.Invoke();
         ApplySetters(hlBtn.Setters, hb);
         return hb;
     }
@@ -335,7 +350,8 @@ public sealed partial class Reconciler
     {
         var rb = new WinPrim.RepeatButton { Content = repBtn.Label, Delay = repBtn.Delay, Interval = repBtn.Interval };
         SetElementTag(rb, repBtn);
-        rb.Click += (s, _) => (GetElementTag((UIElement)s!) as RepeatButtonElement)?.OnClick?.Invoke();
+        if (repBtn.OnClick is not null)
+            rb.Click += (s, _) => (GetElementTag((UIElement)s!) as RepeatButtonElement)?.OnClick?.Invoke();
         ApplySetters(repBtn.Setters, rb);
         return rb;
     }
@@ -347,11 +363,12 @@ public sealed partial class Reconciler
         // Bind to Click — fires only for real user toggles. Checked/Unchecked
         // would also fire when UpdateToggleButton rewrites IsChecked during a
         // state-driven rerender, which would re-enter the callback and loop.
-        tb.Click += (s, _) =>
-        {
-            var t = (WinPrim.ToggleButton)s!;
-            (GetElementTag(t) as ToggleButtonElement)?.OnToggled?.Invoke(t.IsChecked ?? false);
-        };
+        if (togBtn.OnToggled is not null)
+            tb.Click += (s, _) =>
+            {
+                var t = (WinPrim.ToggleButton)s!;
+                (GetElementTag(t) as ToggleButtonElement)?.OnToggled?.Invoke(t.IsChecked ?? false);
+            };
         ApplySetters(togBtn.Setters, tb);
         return tb;
     }
@@ -369,7 +386,8 @@ public sealed partial class Reconciler
     {
         var sb = new WinUI.SplitButton { Content = spBtn.Label };
         SetElementTag(sb, spBtn);
-        sb.Click += (s, _) => (GetElementTag((UIElement)s!) as SplitButtonElement)?.OnClick?.Invoke();
+        if (spBtn.OnClick is not null)
+            sb.Click += (s, _) => (GetElementTag((UIElement)s!) as SplitButtonElement)?.OnClick?.Invoke();
         if (spBtn.Flyout is not null)
             sb.Flyout = CreateFlyoutFromElement(spBtn.Flyout, requestRerender);
         ApplySetters(spBtn.Setters, sb);
@@ -380,12 +398,13 @@ public sealed partial class Reconciler
     {
         var tsb = new WinUI.ToggleSplitButton { Content = tspBtn.Label, IsChecked = tspBtn.IsChecked };
         SetElementTag(tsb, tspBtn);
-        tsb.IsCheckedChanged += (s, _) =>
-        {
-            var t = (WinUI.ToggleSplitButton)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(t)) return;
-            (GetElementTag(t) as ToggleSplitButtonElement)?.OnIsCheckedChanged?.Invoke(t.IsChecked);
-        };
+        if (tspBtn.OnIsCheckedChanged is not null)
+            tsb.IsCheckedChanged += (s, _) =>
+            {
+                var t = (WinUI.ToggleSplitButton)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(t)) return;
+                (GetElementTag(t) as ToggleSplitButtonElement)?.OnIsCheckedChanged?.Invoke(t.IsChecked);
+            };
         if (tspBtn.Flyout is not null)
             tsb.Flyout = CreateFlyoutFromElement(tspBtn.Flyout, requestRerender);
         ApplySetters(tspBtn.Setters, tsb);
@@ -412,8 +431,24 @@ public sealed partial class Reconciler
         if (tf.TextWrapping.HasValue) textBox.TextWrapping = tf.TextWrapping.Value;
         if (tf.SelectionStart.HasValue) textBox.SelectionStart = tf.SelectionStart.Value;
         if (tf.SelectionLength.HasValue) textBox.SelectionLength = tf.SelectionLength.Value;
-        if (rented is null) // Only wire events on fresh controls — pooled controls retain their handler
+        EnsureTextFieldWiring(textBox, tf, requestRerender);
+        ApplySetters(tf.Setters, textBox);
+        return textBox;
+    }
+
+    /// <summary>
+    /// Wires TextField's TextChanged/SelectionChanged trampolines only when the
+    /// element has a corresponding handler AND the control hasn't been wired
+    /// yet. Called from both Mount (fresh or pooled) and Update (null→non-null
+    /// transition). The CWT flags survive pool round-trips.
+    /// </summary>
+    internal static void EnsureTextFieldWiring(TextBox textBox, TextFieldElement tf, Action requestRerender)
+    {
+        if (tf.OnChanged is null && tf.OnSelectionChanged is null) return;
+        var flags = GetPoolableWireFlags(textBox);
+        if (tf.OnChanged is not null && !flags.TextBoxTextChanged)
         {
+            flags.TextBoxTextChanged = true;
             textBox.TextChanged += (_, _) =>
             {
                 if (ChangeEchoSuppressor.ShouldSuppress(textBox)) return;
@@ -426,22 +461,25 @@ public sealed partial class Reconciler
                 if (tag?.OnChanged is not null)
                     requestRerender();
             };
+        }
+        if (tf.OnSelectionChanged is not null && !flags.TextBoxSelectionChanged)
+        {
+            flags.TextBoxSelectionChanged = true;
             textBox.SelectionChanged += (_, _) => (GetElementTag(textBox) as TextFieldElement)?.OnSelectionChanged?.Invoke(textBox.SelectedText, textBox.SelectionStart, textBox.SelectionLength);
         }
-        ApplySetters(tf.Setters, textBox);
-        return textBox;
     }
 
     private WinUI.PasswordBox MountPasswordBox(PasswordBoxElement pw)
     {
         var pb = new WinUI.PasswordBox { Password = pw.Password, PlaceholderText = pw.PlaceholderText ?? "" };
         SetElementTag(pb, pw);
-        pb.PasswordChanged += (s, _) =>
-        {
-            var c = (UIElement)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            (GetElementTag(c) as PasswordBoxElement)?.OnPasswordChanged?.Invoke(((WinUI.PasswordBox)c).Password);
-        };
+        if (pw.OnPasswordChanged is not null)
+            pb.PasswordChanged += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as PasswordBoxElement)?.OnPasswordChanged?.Invoke(((WinUI.PasswordBox)c).Password);
+            };
         ApplySetters(pw.Setters, pb);
         return pb;
     }
@@ -457,12 +495,13 @@ public sealed partial class Reconciler
         };
         if (nb.Header is not null) numBox.Header = nb.Header;
         SetElementTag(numBox, nb);
-        numBox.ValueChanged += (s, _) =>
-        {
-            var box = (WinUI.NumberBox)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(box)) return;
-            (GetElementTag(box) as NumberBoxElement)?.OnValueChanged?.Invoke(box.Value);
-        };
+        if (nb.OnValueChanged is not null)
+            numBox.ValueChanged += (s, _) =>
+            {
+                var box = (WinUI.NumberBox)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(box)) return;
+                (GetElementTag(box) as NumberBoxElement)?.OnValueChanged?.Invoke(box.Value);
+            };
         ApplySetters(nb.Setters, numBox);
         return numBox;
     }
@@ -472,15 +511,18 @@ public sealed partial class Reconciler
         var box = new WinUI.AutoSuggestBox { Text = asb.Text, PlaceholderText = asb.PlaceholderText ?? "" };
         if (asb.Suggestions.Length > 0) box.ItemsSource = asb.Suggestions;
         SetElementTag(box, asb);
-        box.TextChanged += (s, args) =>
-        {
-            if (args.Reason == WinUI.AutoSuggestionBoxTextChangeReason.UserInput)
-                (GetElementTag((UIElement)s!) as AutoSuggestBoxElement)?.OnTextChanged?.Invoke(((WinUI.AutoSuggestBox)s!).Text);
-        };
-        box.QuerySubmitted += (s, args) =>
-            (GetElementTag((UIElement)s!) as AutoSuggestBoxElement)?.OnQuerySubmitted?.Invoke(args.QueryText);
-        box.SuggestionChosen += (s, args) =>
-            (GetElementTag((UIElement)s!) as AutoSuggestBoxElement)?.OnSuggestionChosen?.Invoke(args.SelectedItem?.ToString() ?? "");
+        if (asb.OnTextChanged is not null)
+            box.TextChanged += (s, args) =>
+            {
+                if (args.Reason == WinUI.AutoSuggestionBoxTextChangeReason.UserInput)
+                    (GetElementTag((UIElement)s!) as AutoSuggestBoxElement)?.OnTextChanged?.Invoke(((WinUI.AutoSuggestBox)s!).Text);
+            };
+        if (asb.OnQuerySubmitted is not null)
+            box.QuerySubmitted += (s, args) =>
+                (GetElementTag((UIElement)s!) as AutoSuggestBoxElement)?.OnQuerySubmitted?.Invoke(args.QueryText);
+        if (asb.OnSuggestionChosen is not null)
+            box.SuggestionChosen += (s, args) =>
+                (GetElementTag((UIElement)s!) as AutoSuggestBoxElement)?.OnSuggestionChosen?.Invoke(args.SelectedItem?.ToString() ?? "");
         ApplySetters(asb.Setters, box);
         return box;
     }
@@ -498,29 +540,32 @@ public sealed partial class Reconciler
             checkBox.IsChecked = cb.IsChecked;
         }
         SetElementTag(checkBox, cb);
-        checkBox.Checked += (s, _) =>
+        if (cb.OnChanged is not null || cb.OnCheckedStateChanged is not null)
         {
-            var c = (UIElement)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            var el = GetElementTag(c) as CheckBoxElement;
-            el?.OnChanged?.Invoke(true);
-            el?.OnCheckedStateChanged?.Invoke(true);
-        };
-        checkBox.Unchecked += (s, _) =>
-        {
-            var c = (UIElement)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            var el = GetElementTag(c) as CheckBoxElement;
-            el?.OnChanged?.Invoke(false);
-            el?.OnCheckedStateChanged?.Invoke(false);
-        };
-        checkBox.Indeterminate += (s, _) =>
-        {
-            var c = (UIElement)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            var el = GetElementTag(c) as CheckBoxElement;
-            el?.OnCheckedStateChanged?.Invoke(null);
-        };
+            checkBox.Checked += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                var el = GetElementTag(c) as CheckBoxElement;
+                el?.OnChanged?.Invoke(true);
+                el?.OnCheckedStateChanged?.Invoke(true);
+            };
+            checkBox.Unchecked += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                var el = GetElementTag(c) as CheckBoxElement;
+                el?.OnChanged?.Invoke(false);
+                el?.OnCheckedStateChanged?.Invoke(false);
+            };
+            checkBox.Indeterminate += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                var el = GetElementTag(c) as CheckBoxElement;
+                el?.OnCheckedStateChanged?.Invoke(null);
+            };
+        }
         ApplySetters(cb.Setters, checkBox);
         return checkBox;
     }
@@ -530,18 +575,21 @@ public sealed partial class Reconciler
         var radio = new WinUI.RadioButton { Content = rb.Label, IsChecked = rb.IsChecked };
         if (rb.GroupName is not null) radio.GroupName = rb.GroupName;
         SetElementTag(radio, rb);
-        radio.Checked += (s, _) =>
+        if (rb.OnChecked is not null)
         {
-            var c = (UIElement)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(true);
-        };
-        radio.Unchecked += (s, _) =>
-        {
-            var c = (UIElement)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(false);
-        };
+            radio.Checked += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(true);
+            };
+            radio.Unchecked += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(false);
+            };
+        }
         ApplySetters(rb.Setters, radio);
         return radio;
     }
@@ -552,12 +600,13 @@ public sealed partial class Reconciler
         if (rbs.Header is not null) rbGroup.Header = rbs.Header;
         foreach (var item in rbs.Items) rbGroup.Items.Add(item);
         SetElementTag(rbGroup, rbs);
-        rbGroup.SelectionChanged += (s, _) =>
-        {
-            var g = (WinUI.RadioButtons)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(g)) return;
-            (GetElementTag(g) as RadioButtonsElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
-        };
+        if (rbs.OnSelectionChanged is not null)
+            rbGroup.SelectionChanged += (s, _) =>
+            {
+                var g = (WinUI.RadioButtons)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(g)) return;
+                (GetElementTag(g) as RadioButtonsElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
+            };
         ApplySetters(rbs.Setters, rbGroup);
         return rbGroup;
     }
@@ -576,12 +625,13 @@ public sealed partial class Reconciler
         else
             foreach (var item in combo.Items) cb.Items.Add(item);
         SetElementTag(cb, combo);
-        cb.SelectionChanged += (s, _) =>
-        {
-            var c = (WinUI.ComboBox)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            (GetElementTag(c) as ComboBoxElement)?.OnSelectionChanged?.Invoke(c.SelectedIndex);
-        };
+        if (combo.OnSelectionChanged is not null)
+            cb.SelectionChanged += (s, _) =>
+            {
+                var c = (WinUI.ComboBox)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as ComboBoxElement)?.OnSelectionChanged?.Invoke(c.SelectedIndex);
+            };
         ApplySetters(combo.Setters, cb);
         return cb;
     }
@@ -591,11 +641,12 @@ public sealed partial class Reconciler
         var slider = new WinUI.Slider { Value = sl.Value, Minimum = sl.Min, Maximum = sl.Max, StepFrequency = sl.StepFrequency };
         if (sl.Header is not null) slider.Header = sl.Header;
         SetElementTag(slider, sl);
-        slider.ValueChanged += (_, args) =>
-        {
-            if (ChangeEchoSuppressor.ShouldSuppress(slider)) return;
-            (GetElementTag(slider) as SliderElement)?.OnChanged?.Invoke(args.NewValue);
-        };
+        if (sl.OnChanged is not null)
+            slider.ValueChanged += (_, args) =>
+            {
+                if (ChangeEchoSuppressor.ShouldSuppress(slider)) return;
+                (GetElementTag(slider) as SliderElement)?.OnChanged?.Invoke(args.NewValue);
+            };
         ApplySetters(sl.Setters, slider);
         return slider;
     }
@@ -614,27 +665,41 @@ public sealed partial class Reconciler
         toggle.OnContent = ts.OnContent;
         toggle.OffContent = ts.OffContent;
         if (ts.Header is not null) toggle.Header = ts.Header;
-        if (rented is null) // Only wire events on fresh controls — pooled controls retain their handler
-            toggle.Toggled += (s, _) =>
-            {
-                var t = (WinUI.ToggleSwitch)s!;
-                if (ChangeEchoSuppressor.ShouldSuppress(t)) return;
-                (GetElementTag(t) as ToggleSwitchElement)?.OnChanged?.Invoke(t.IsOn);
-            };
+        EnsureToggleSwitchWiring(toggle, ts);
         ApplySetters(ts.Setters, toggle);
         return toggle;
+    }
+
+    /// <summary>
+    /// Wires ToggleSwitch.Toggled trampoline only when the element has a
+    /// handler AND the control hasn't been wired yet. The CWT flag survives
+    /// pool round-trips (ToggleSwitch is a poolable type).
+    /// </summary>
+    internal static void EnsureToggleSwitchWiring(WinUI.ToggleSwitch toggle, ToggleSwitchElement ts)
+    {
+        if (ts.OnChanged is null) return;
+        var flags = GetPoolableWireFlags(toggle);
+        if (flags.ToggleSwitchToggled) return;
+        flags.ToggleSwitchToggled = true;
+        toggle.Toggled += (s, _) =>
+        {
+            var t = (WinUI.ToggleSwitch)s!;
+            if (ChangeEchoSuppressor.ShouldSuppress(t)) return;
+            (GetElementTag(t) as ToggleSwitchElement)?.OnChanged?.Invoke(t.IsOn);
+        };
     }
 
     private WinUI.RatingControl MountRatingControl(RatingControlElement rc)
     {
         var rating = new WinUI.RatingControl { Value = rc.Value, MaxRating = rc.MaxRating, IsReadOnly = rc.IsReadOnly, Caption = rc.Caption ?? "" };
         SetElementTag(rating, rc);
-        rating.ValueChanged += (s, _) =>
-        {
-            var r = (WinUI.RatingControl)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(r)) return;
-            (GetElementTag(r) as RatingControlElement)?.OnValueChanged?.Invoke(r.Value);
-        };
+        if (rc.OnValueChanged is not null)
+            rating.ValueChanged += (s, _) =>
+            {
+                var r = (WinUI.RatingControl)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(r)) return;
+                (GetElementTag(r) as RatingControlElement)?.OnValueChanged?.Invoke(r.Value);
+            };
         ApplySetters(rc.Setters, rating);
         return rating;
     }
@@ -648,12 +713,13 @@ public sealed partial class Reconciler
             IsColorChannelTextInputVisible = cp.IsColorChannelTextInputVisible, IsHexInputVisible = cp.IsHexInputVisible,
         };
         SetElementTag(picker, cp);
-        picker.ColorChanged += (s, args) =>
-        {
-            var c = (UIElement)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            (GetElementTag(c) as ColorPickerElement)?.OnColorChanged?.Invoke(args.NewColor);
-        };
+        if (cp.OnColorChanged is not null)
+            picker.ColorChanged += (s, args) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as ColorPickerElement)?.OnColorChanged?.Invoke(args.NewColor);
+            };
         ApplySetters(cp.Setters, picker);
         return picker;
     }
@@ -665,12 +731,13 @@ public sealed partial class Reconciler
         if (cdp.MinDate.HasValue) cal.MinDate = cdp.MinDate.Value;
         if (cdp.MaxDate.HasValue) cal.MaxDate = cdp.MaxDate.Value;
         SetElementTag(cal, cdp);
-        cal.DateChanged += (s, _) =>
-        {
-            var c = (WinUI.CalendarDatePicker)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            (GetElementTag(c) as CalendarDatePickerElement)?.OnDateChanged?.Invoke(c.Date);
-        };
+        if (cdp.OnDateChanged is not null)
+            cal.DateChanged += (s, _) =>
+            {
+                var c = (WinUI.CalendarDatePicker)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as CalendarDatePickerElement)?.OnDateChanged?.Invoke(c.Date);
+            };
         ApplySetters(cdp.Setters, cal);
         return cal;
     }
@@ -682,12 +749,13 @@ public sealed partial class Reconciler
         if (dp.MinYear.HasValue) picker.MinYear = dp.MinYear.Value;
         if (dp.MaxYear.HasValue) picker.MaxYear = dp.MaxYear.Value;
         SetElementTag(picker, dp);
-        picker.DateChanged += (s, args) =>
-        {
-            var c = (UIElement)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            (GetElementTag(c) as DatePickerElement)?.OnDateChanged?.Invoke(args.NewDate);
-        };
+        if (dp.OnDateChanged is not null)
+            picker.DateChanged += (s, args) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as DatePickerElement)?.OnDateChanged?.Invoke(args.NewDate);
+            };
         ApplySetters(dp.Setters, picker);
         return picker;
     }
@@ -697,12 +765,13 @@ public sealed partial class Reconciler
         var picker = new WinUI.TimePicker { Time = tp.Time, MinuteIncrement = tp.MinuteIncrement };
         if (tp.Header is not null) picker.Header = tp.Header;
         SetElementTag(picker, tp);
-        picker.TimeChanged += (s, args) =>
-        {
-            var c = (UIElement)s!;
-            if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            (GetElementTag(c) as TimePickerElement)?.OnTimeChanged?.Invoke(args.NewTime);
-        };
+        if (tp.OnTimeChanged is not null)
+            picker.TimeChanged += (s, args) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as TimePickerElement)?.OnTimeChanged?.Invoke(args.NewTime);
+            };
         ApplySetters(tp.Setters, picker);
         return picker;
     }
@@ -768,10 +837,12 @@ public sealed partial class Reconciler
         var webView = new WinUI.WebView2();
         if (wv.Source is not null) webView.Source = wv.Source;
         SetElementTag(webView, wv);
-        webView.NavigationStarting += (s, args) =>
-            (GetElementTag((UIElement)s!) as WebView2Element)?.OnNavigationStarting?.Invoke(new Uri(args.Uri));
-        webView.NavigationCompleted += (s, _) =>
-            (GetElementTag((UIElement)s!) as WebView2Element)?.OnNavigationCompleted?.Invoke(((WinUI.WebView2)s!).Source);
+        if (wv.OnNavigationStarting is not null)
+            webView.NavigationStarting += (s, args) =>
+                (GetElementTag((UIElement)s!) as WebView2Element)?.OnNavigationStarting?.Invoke(new Uri(args.Uri));
+        if (wv.OnNavigationCompleted is not null)
+            webView.NavigationCompleted += (s, _) =>
+                (GetElementTag((UIElement)s!) as WebView2Element)?.OnNavigationCompleted?.Invoke(((WinUI.WebView2)s!).Source);
         ApplySetters(wv.Setters, webView);
         return webView;
     }
@@ -784,12 +855,13 @@ public sealed partial class Reconciler
         if (!string.IsNullOrEmpty(reb.Text))
             box.Document.SetText(Microsoft.UI.Text.TextSetOptions.None, reb.Text);
         SetElementTag(box, reb);
-        box.TextChanged += (s, _) =>
-        {
-            var r = (WinUI.RichEditBox)s!;
-            r.Document.GetText(Microsoft.UI.Text.TextGetOptions.None, out var text);
-            (GetElementTag(r) as RichEditBoxElement)?.OnTextChanged?.Invoke(text?.TrimEnd('\r') ?? "");
-        };
+        if (reb.OnTextChanged is not null)
+            box.TextChanged += (s, _) =>
+            {
+                var r = (WinUI.RichEditBox)s!;
+                r.Document.GetText(Microsoft.UI.Text.TextGetOptions.None, out var text);
+                (GetElementTag(r) as RichEditBoxElement)?.OnTextChanged?.Invoke(text?.TrimEnd('\r') ?? "");
+            };
         ApplySetters(reb.Setters, box);
         return box;
     }
@@ -898,8 +970,11 @@ public sealed partial class Reconciler
         };
         expander.Content = Mount(exp.Content, requestRerender);
         SetElementTag(expander, exp);
-        expander.Expanding += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnExpandedChanged?.Invoke(true);
-        expander.Collapsed += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnExpandedChanged?.Invoke(false);
+        if (exp.OnExpandedChanged is not null)
+        {
+            expander.Expanding += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnExpandedChanged?.Invoke(true);
+            expander.Collapsed += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnExpandedChanged?.Invoke(false);
+        }
         ApplySetters(exp.Setters, expander);
         return expander;
     }
@@ -914,8 +989,11 @@ public sealed partial class Reconciler
         if (svEl.Pane is not null) splitView.Pane = Mount(svEl.Pane, requestRerender);
         if (svEl.Content is not null) splitView.Content = Mount(svEl.Content, requestRerender);
         SetElementTag(splitView, svEl);
-        splitView.PaneOpening += (s, _) => (GetElementTag((UIElement)s!) as SplitViewElement)?.OnPaneOpenChanged?.Invoke(true);
-        splitView.PaneClosing += (s, _) => (GetElementTag((UIElement)s!) as SplitViewElement)?.OnPaneOpenChanged?.Invoke(false);
+        if (svEl.OnPaneOpenChanged is not null)
+        {
+            splitView.PaneOpening += (s, _) => (GetElementTag((UIElement)s!) as SplitViewElement)?.OnPaneOpenChanged?.Invoke(true);
+            splitView.PaneClosing += (s, _) => (GetElementTag((UIElement)s!) as SplitViewElement)?.OnPaneOpenChanged?.Invoke(false);
+        }
         ApplySetters(svEl.Setters, splitView);
         return splitView;
     }
@@ -1054,12 +1132,14 @@ public sealed partial class Reconciler
                 if (mi.Tag as string == nav.SelectedTag) { nv.SelectedItem = mi; break; }
         }
         SetElementTag(nv, nav);
-        nv.SelectionChanged += (s, args) =>
-        {
-            var selected = args.SelectedItem as WinUI.NavigationViewItem;
-            (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnSelectionChanged?.Invoke(selected?.Tag as string);
-        };
-        nv.BackRequested += (s, _) => (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnBackRequested?.Invoke();
+        if (nav.OnSelectionChanged is not null)
+            nv.SelectionChanged += (s, args) =>
+            {
+                var selected = args.SelectedItem as WinUI.NavigationViewItem;
+                (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnSelectionChanged?.Invoke(selected?.Tag as string);
+            };
+        if (nav.OnBackRequested is not null)
+            nv.BackRequested += (s, _) => (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnBackRequested?.Invoke();
         ApplySetters(nav.Setters, nv);
         return nv;
     }
@@ -1087,8 +1167,10 @@ public sealed partial class Reconciler
         if (tb.Content is not null) titleBar.Content = Mount(tb.Content, requestRerender);
         if (tb.RightHeader is not null) titleBar.RightHeader = Mount(tb.RightHeader, requestRerender);
         SetElementTag(titleBar, tb);
-        titleBar.BackRequested += (s, _) => (GetElementTag((UIElement)s!) as TitleBarElement)?.OnBackRequested?.Invoke();
-        titleBar.PaneToggleRequested += (s, _) => (GetElementTag((UIElement)s!) as TitleBarElement)?.OnPaneToggleRequested?.Invoke();
+        if (tb.OnBackRequested is not null)
+            titleBar.BackRequested += (s, _) => (GetElementTag((UIElement)s!) as TitleBarElement)?.OnBackRequested?.Invoke();
+        if (tb.OnPaneToggleRequested is not null)
+            titleBar.PaneToggleRequested += (s, _) => (GetElementTag((UIElement)s!) as TitleBarElement)?.OnPaneToggleRequested?.Invoke();
         ApplySetters(tb.Setters, titleBar);
 
         // Register with the window for drag regions and caption buttons
@@ -1115,18 +1197,21 @@ public sealed partial class Reconciler
             tv.TabItems.Add(tvi);
         }
         SetElementTag(tv, tab);
-        tv.SelectionChanged += (s, _) =>
-        {
-            var t = (WinUI.TabView)s!;
-            (GetElementTag(t) as TabViewElement)?.OnSelectionChanged?.Invoke(t.SelectedIndex);
-        };
-        tv.TabCloseRequested += (s, args) =>
-        {
-            var t = (WinUI.TabView)s!;
-            var idx = t.TabItems.IndexOf(args.Tab);
-            (GetElementTag(t) as TabViewElement)?.OnTabCloseRequested?.Invoke(idx);
-        };
-        tv.AddTabButtonClick += (s, _) => (GetElementTag((UIElement)s!) as TabViewElement)?.OnAddTabButtonClick?.Invoke();
+        if (tab.OnSelectionChanged is not null)
+            tv.SelectionChanged += (s, _) =>
+            {
+                var t = (WinUI.TabView)s!;
+                (GetElementTag(t) as TabViewElement)?.OnSelectionChanged?.Invoke(t.SelectedIndex);
+            };
+        if (tab.OnTabCloseRequested is not null)
+            tv.TabCloseRequested += (s, args) =>
+            {
+                var t = (WinUI.TabView)s!;
+                var idx = t.TabItems.IndexOf(args.Tab);
+                (GetElementTag(t) as TabViewElement)?.OnTabCloseRequested?.Invoke(idx);
+            };
+        if (tab.OnAddTabButtonClick is not null)
+            tv.AddTabButtonClick += (s, _) => (GetElementTag((UIElement)s!) as TabViewElement)?.OnAddTabButtonClick?.Invoke();
         ApplySetters(tab.Setters, tv);
         return tv;
     }
@@ -1136,11 +1221,12 @@ public sealed partial class Reconciler
         var bar = new WinUI.BreadcrumbBar();
         bar.ItemsSource = bcb.Items.Select(i => i.Label).ToList();
         SetElementTag(bar, bcb);
-        bar.ItemClicked += (s, args) =>
-        {
-            var el = GetElementTag((UIElement)s!) as BreadcrumbBarElement;
-            if (el is not null && args.Index >= 0 && args.Index < el.Items.Length) el.OnItemClicked?.Invoke(el.Items[args.Index]);
-        };
+        if (bcb.OnItemClicked is not null)
+            bar.ItemClicked += (s, args) =>
+            {
+                var el = GetElementTag((UIElement)s!) as BreadcrumbBarElement;
+                if (el is not null && args.Index >= 0 && args.Index < el.Items.Length) el.OnItemClicked?.Invoke(el.Items[args.Index]);
+            };
         ApplySetters(bcb.Setters, bar);
         return bar;
     }
@@ -1155,11 +1241,12 @@ public sealed partial class Reconciler
             pivot.Items.Add(pi);
         }
         SetElementTag(pivot, pvt);
-        pivot.SelectionChanged += (s, _) =>
-        {
-            var p = (WinUI.Pivot)s!;
-            (GetElementTag(p) as PivotElement)?.OnSelectionChanged?.Invoke(p.SelectedIndex);
-        };
+        if (pvt.OnSelectionChanged is not null)
+            pivot.SelectionChanged += (s, _) =>
+            {
+                var p = (WinUI.Pivot)s!;
+                (GetElementTag(p) as PivotElement)?.OnSelectionChanged?.Invoke(p.SelectedIndex);
+            };
         ApplySetters(pvt.Setters, pivot);
         return pivot;
     }
@@ -1201,17 +1288,19 @@ public sealed partial class Reconciler
             }
         };
 
-        listView.SelectionChanged += (s, _) =>
-        {
-            var l = (WinUI.ListView)s!;
-            (GetElementTag(l) as ListViewElement)?.OnSelectionChanged?.Invoke(l.SelectedIndex);
-        };
-        listView.ItemClick += (s, args) =>
-        {
-            var l = (WinUI.ListView)s!;
-            if (args.ClickedItem is int idx)
-                (GetElementTag(l) as ListViewElement)?.OnItemClick?.Invoke(idx);
-        };
+        if (lv.OnSelectionChanged is not null)
+            listView.SelectionChanged += (s, _) =>
+            {
+                var l = (WinUI.ListView)s!;
+                (GetElementTag(l) as ListViewElement)?.OnSelectionChanged?.Invoke(l.SelectedIndex);
+            };
+        if (lv.OnItemClick is not null)
+            listView.ItemClick += (s, args) =>
+            {
+                var l = (WinUI.ListView)s!;
+                if (args.ClickedItem is int idx)
+                    (GetElementTag(l) as ListViewElement)?.OnItemClick?.Invoke(idx);
+            };
 
         // Set ItemsSource LAST — triggers container creation which needs the handler above
         listView.ItemsSource = Enumerable.Range(0, lv.Items.Length).ToList();
@@ -1257,17 +1346,19 @@ public sealed partial class Reconciler
             }
         };
 
-        gridView.SelectionChanged += (s, _) =>
-        {
-            var g = (WinUI.GridView)s!;
-            (GetElementTag(g) as GridViewElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
-        };
-        gridView.ItemClick += (s, args) =>
-        {
-            var g = (WinUI.GridView)s!;
-            if (args.ClickedItem is int idx)
-                (GetElementTag(g) as GridViewElement)?.OnItemClick?.Invoke(idx);
-        };
+        if (gv.OnSelectionChanged is not null)
+            gridView.SelectionChanged += (s, _) =>
+            {
+                var g = (WinUI.GridView)s!;
+                (GetElementTag(g) as GridViewElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
+            };
+        if (gv.OnItemClick is not null)
+            gridView.ItemClick += (s, args) =>
+            {
+                var g = (WinUI.GridView)s!;
+                if (args.ClickedItem is int idx)
+                    (GetElementTag(g) as GridViewElement)?.OnItemClick?.Invoke(idx);
+            };
 
         gridView.ItemsSource = Enumerable.Range(0, gv.Items.Length).ToList();
 
@@ -1310,22 +1401,24 @@ public sealed partial class Reconciler
 
         SetElementTag(treeView, tv);
 
-        treeView.ItemInvoked += (s, args) =>
-        {
-            var t = (WinUI.TreeView)s!;
-            if (args.InvokedItem is WinUI.TreeViewNode tvn
-                && tvn.Content is TreeViewNodeData nodeData)
+        if (tv.OnItemInvoked is not null)
+            treeView.ItemInvoked += (s, args) =>
             {
-                (GetElementTag(t) as TreeViewElement)?.OnItemInvoked?.Invoke(nodeData);
-            }
-        };
+                var t = (WinUI.TreeView)s!;
+                if (args.InvokedItem is WinUI.TreeViewNode tvn
+                    && tvn.Content is TreeViewNodeData nodeData)
+                {
+                    (GetElementTag(t) as TreeViewElement)?.OnItemInvoked?.Invoke(nodeData);
+                }
+            };
 
-        treeView.Expanding += (s, args) =>
-        {
-            var t = (WinUI.TreeView)s!;
-            if (args.Node.Content is TreeViewNodeData nodeData)
-                (GetElementTag(t) as TreeViewElement)?.OnExpanding?.Invoke(nodeData);
-        };
+        if (tv.OnExpanding is not null)
+            treeView.Expanding += (s, args) =>
+            {
+                var t = (WinUI.TreeView)s!;
+                if (args.Node.Content is TreeViewNodeData nodeData)
+                    (GetElementTag(t) as TreeViewElement)?.OnExpanding?.Invoke(nodeData);
+            };
 
         ApplySetters(tv.Setters, treeView);
         return treeView;
@@ -1381,11 +1474,12 @@ public sealed partial class Reconciler
             if (ctrl is not null) flipView.Items.Add(ctrl);
         }
         SetElementTag(flipView, fv);
-        flipView.SelectionChanged += (s, _) =>
-        {
-            var f = (WinUI.FlipView)s!;
-            (GetElementTag(f) as FlipViewElement)?.OnSelectionChanged?.Invoke(f.SelectedIndex);
-        };
+        if (fv.OnSelectionChanged is not null)
+            flipView.SelectionChanged += (s, _) =>
+            {
+                var f = (WinUI.FlipView)s!;
+                (GetElementTag(f) as FlipViewElement)?.OnSelectionChanged?.Invoke(f.SelectedIndex);
+            };
         ApplySetters(fv.Setters, flipView);
         return flipView;
     }
@@ -1542,11 +1636,13 @@ public sealed partial class Reconciler
         {
             infoBar.ActionButton = new WinUI.Button { Content = ib.ActionButtonContent };
             SetElementTag(infoBar.ActionButton, ib);
-            ((WinUI.Button)infoBar.ActionButton).Click += (s, _) =>
-                (GetElementTag((UIElement)s!) as InfoBarElement)?.OnActionButtonClick?.Invoke();
+            if (ib.OnActionButtonClick is not null)
+                ((WinUI.Button)infoBar.ActionButton).Click += (s, _) =>
+                    (GetElementTag((UIElement)s!) as InfoBarElement)?.OnActionButtonClick?.Invoke();
         }
         SetElementTag(infoBar, ib);
-        infoBar.Closed += (s, _) => (GetElementTag((UIElement)s!) as InfoBarElement)?.OnClosed?.Invoke();
+        if (ib.OnClosed is not null)
+            infoBar.Closed += (s, _) => (GetElementTag((UIElement)s!) as InfoBarElement)?.OnClosed?.Invoke();
         ApplySetters(ib.Setters, infoBar);
         return infoBar;
     }
@@ -1600,8 +1696,10 @@ public sealed partial class Reconciler
             // Route handlers through the target's Tag so Update() refreshing the tag to the
             // new FlyoutElement causes subsequent Opened/Closed to fire the current delegates —
             // capturing flyEl directly would freeze handlers to the mount-time element.
-            flyout.Opened += (_, _) => (GetElementTag(targetFe) as FlyoutElement)?.OnOpened?.Invoke();
-            flyout.Closed += (_, _) => (GetElementTag(targetFe) as FlyoutElement)?.OnClosed?.Invoke();
+            if (flyEl.OnOpened is not null)
+                flyout.Opened += (_, _) => (GetElementTag(targetFe) as FlyoutElement)?.OnOpened?.Invoke();
+            if (flyEl.OnClosed is not null)
+                flyout.Closed += (_, _) => (GetElementTag(targetFe) as FlyoutElement)?.OnClosed?.Invoke();
             // SetFlyoutOnControl wires .Flyout on Button/SplitButton targets so
             // clicking opens the flyout natively; non-button targets fall back
             // to SetAttachedFlyout metadata (opened only via ShowAttachedFlyout).
@@ -1619,11 +1717,13 @@ public sealed partial class Reconciler
         if (ttEl.ActionButtonContent is not null)
         {
             tip.ActionButtonContent = ttEl.ActionButtonContent;
-            tip.ActionButtonClick += (_, _) => ttEl.OnActionButtonClick?.Invoke();
+            if (ttEl.OnActionButtonClick is not null)
+                tip.ActionButtonClick += (_, _) => ttEl.OnActionButtonClick?.Invoke();
         }
         if (ttEl.CloseButtonContent is not null) tip.CloseButtonContent = ttEl.CloseButtonContent;
         SetElementTag(tip, ttEl);
-        tip.Closed += (s, _) => (GetElementTag((UIElement)s!) as TeachingTipElement)?.OnClosed?.Invoke();
+        if (ttEl.OnClosed is not null)
+            tip.Closed += (s, _) => (GetElementTag((UIElement)s!) as TeachingTipElement)?.OnClosed?.Invoke();
         ApplySetters(ttEl.Setters, tip);
         return tip;
     }
@@ -2445,11 +2545,12 @@ public sealed partial class Reconciler
         var listBox = new WinUI.ListBox { SelectedIndex = lb.SelectedIndex };
         foreach (var item in lb.Items) listBox.Items.Add(item);
         SetElementTag(listBox, lb);
-        listBox.SelectionChanged += (s, _) =>
-        {
-            var l = (WinUI.ListBox)s!;
-            (GetElementTag(l) as ListBoxElement)?.OnSelectionChanged?.Invoke(l.SelectedIndex);
-        };
+        if (lb.OnSelectionChanged is not null)
+            listBox.SelectionChanged += (s, _) =>
+            {
+                var l = (WinUI.ListBox)s!;
+                (GetElementTag(l) as ListBoxElement)?.OnSelectionChanged?.Invoke(l.SelectedIndex);
+            };
         ApplySetters(lb.Setters, listBox);
         return listBox;
     }
@@ -2468,12 +2569,13 @@ public sealed partial class Reconciler
         if (sb.SelectedIndex >= 0 && sb.SelectedIndex < selectorBar.Items.Count)
             selectorBar.SelectedItem = selectorBar.Items[sb.SelectedIndex];
         SetElementTag(selectorBar, sb);
-        selectorBar.SelectionChanged += (s, _) =>
-        {
-            var bar = (WinUI.SelectorBar)s!;
-            var idx = bar.Items.IndexOf(bar.SelectedItem);
-            (GetElementTag(bar) as SelectorBarElement)?.OnSelectionChanged?.Invoke(idx);
-        };
+        if (sb.OnSelectionChanged is not null)
+            selectorBar.SelectionChanged += (s, _) =>
+            {
+                var bar = (WinUI.SelectorBar)s!;
+                var idx = bar.Items.IndexOf(bar.SelectedItem);
+                (GetElementTag(bar) as SelectorBarElement)?.OnSelectionChanged?.Invoke(idx);
+            };
         ApplySetters(sb.Setters, selectorBar);
         return selectorBar;
     }
@@ -2488,11 +2590,12 @@ public sealed partial class Reconciler
             SelectedPageIndex = pp.SelectedPageIndex,
         };
         SetElementTag(pager, pp);
-        pager.SelectedIndexChanged += (s, _) =>
-        {
-            var p = (WinUI.PipsPager)s!;
-            (GetElementTag(p) as PipsPagerElement)?.OnSelectedIndexChanged?.Invoke(p.SelectedPageIndex);
-        };
+        if (pp.OnSelectedIndexChanged is not null)
+            pager.SelectedIndexChanged += (s, _) =>
+            {
+                var p = (WinUI.PipsPager)s!;
+                (GetElementTag(p) as PipsPagerElement)?.OnSelectedIndexChanged?.Invoke(p.SelectedPageIndex);
+            };
         ApplySetters(pp.Setters, pager);
         return pager;
     }

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -1632,15 +1632,18 @@ public sealed partial class Reconciler
             Title = ib.Title ?? "", Message = ib.Message ?? "",
             Severity = ib.Severity, IsOpen = ib.IsOpen, IsClosable = ib.IsClosable,
         };
+        // Tag the parent InfoBar first so both the Closed handler (wired on
+        // infoBar) and the ActionButton handler (captures infoBar in its
+        // closure, reads Tag from there) dispatch through a Tag that the
+        // Update/skip paths will keep refreshed.
+        SetElementTag(infoBar, ib);
         if (ib.ActionButtonContent is not null)
         {
             infoBar.ActionButton = new WinUI.Button { Content = ib.ActionButtonContent };
-            SetElementTag(infoBar.ActionButton, ib);
             if (ib.OnActionButtonClick is not null)
-                ((WinUI.Button)infoBar.ActionButton).Click += (s, _) =>
-                    (GetElementTag((UIElement)s!) as InfoBarElement)?.OnActionButtonClick?.Invoke();
+                ((WinUI.Button)infoBar.ActionButton).Click += (_, _) =>
+                    (GetElementTag(infoBar) as InfoBarElement)?.OnActionButtonClick?.Invoke();
         }
-        SetElementTag(infoBar, ib);
         if (ib.OnClosed is not null)
             infoBar.Closed += (s, _) => (GetElementTag((UIElement)s!) as InfoBarElement)?.OnClosed?.Invoke();
         ApplySetters(ib.Setters, infoBar);
@@ -1714,14 +1717,14 @@ public sealed partial class Reconciler
     {
         var tip = new WinUI.TeachingTip { Title = ttEl.Title, Subtitle = ttEl.Subtitle ?? "", IsOpen = ttEl.IsOpen };
         if (ttEl.Content is not null) tip.Content = Mount(ttEl.Content, requestRerender);
-        if (ttEl.ActionButtonContent is not null)
-        {
-            tip.ActionButtonContent = ttEl.ActionButtonContent;
-            if (ttEl.OnActionButtonClick is not null)
-                tip.ActionButtonClick += (_, _) => ttEl.OnActionButtonClick?.Invoke();
-        }
+        if (ttEl.ActionButtonContent is not null) tip.ActionButtonContent = ttEl.ActionButtonContent;
         if (ttEl.CloseButtonContent is not null) tip.CloseButtonContent = ttEl.CloseButtonContent;
+        // Tag BEFORE wires so trampolines see the current element from the first tick.
         SetElementTag(tip, ttEl);
+        // Route through the Tag trampoline (not a captured local) so skip-path
+        // Tag refresh / Update can swap the dispatch target without re-wiring.
+        if (ttEl.OnActionButtonClick is not null)
+            tip.ActionButtonClick += (s, _) => (GetElementTag((UIElement)s!) as TeachingTipElement)?.OnActionButtonClick?.Invoke();
         if (ttEl.OnClosed is not null)
             tip.Closed += (s, _) => (GetElementTag((UIElement)s!) as TeachingTipElement)?.OnClosed?.Invoke();
         ApplySetters(ttEl.Setters, tip);

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -2908,7 +2908,16 @@ public sealed partial class Reconciler
             // g.Children[i] read entirely. ShallowEquals already checks modifiers
             // and attached (GridAttached), so grid placement is also covered.
             if (Element.CanSkipUpdate(oldChild, newChild))
+            {
+                // Must still refresh Tag when the element exposes callbacks,
+                // otherwise the event trampoline dispatches through the previous
+                // render's stale closure. Pays one children.Get COM call only
+                // for callback-bearing elements; handler-free leaves stay free.
+                if (newChild.HasCallbacks && i < g.Children.Count
+                    && g.Children[i] is FrameworkElement fe)
+                    fe.Tag = newChild;
                 continue;
+            }
 
             // Guard: recursive Reconcile may have modified g.Children (e.g., via
             // component re-renders that remove children from this grid).

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -57,7 +57,11 @@ public sealed partial class Reconciler
         // the resolved brush value depends on the control's effective theme,
         // which can change independently of the element tree (e.g., parent
         // RequestedTheme toggle).
-        if (Element.ShallowEquals(oldEl, newEl) && ReferenceEquals(oldModifiers, modifiers))
+        // ReferenceEquals would fail constantly because fluent chains like
+        // .Width(200).Margin(10) produce a fresh ElementModifiers each render —
+        // identical values, new instance. Use structural equality so we skip
+        // when nothing actually changed.
+        if (Element.ShallowEquals(oldEl, newEl) && Element.ModifiersEqual(oldModifiers, modifiers))
         {
             DebugElementsSkipped++;
             // Refresh Tag so the event trampoline dispatches into the new element's
@@ -301,7 +305,7 @@ public sealed partial class Reconciler
         // Containers whose only change is children references are excluded — the
         // individual children will be captured if they change.
         if (result is null && _highlightModified is not null
-            && (!Element.OwnPropsEqual(oldEl, newEl) || !ReferenceEquals(oldModifiers, modifiers)))
+            && (!Element.OwnPropsEqual(oldEl, newEl) || !Element.ModifiersEqual(oldModifiers, modifiers)))
             _highlightModified.Add(control);
         if ((modifiers is not null || oldModifiers is not null) && target is FrameworkElement fe)
             ApplyModifiers(fe, oldModifiers, modifiers ?? new ElementModifiers(), requestRerender);

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -61,7 +61,16 @@ public sealed partial class Reconciler
         // .Width(200).Margin(10) produce a fresh ElementModifiers each render —
         // identical values, new instance. Use structural equality so we skip
         // when nothing actually changed.
-        if (Element.ShallowEquals(oldEl, newEl) && Element.ModifiersEqual(oldModifiers, modifiers))
+        //
+        // Callback-presence (oldEl.HasCallbacks == newEl.HasCallbacks) must
+        // also match: ShallowEquals ignores delegate identity, so a null→non-null
+        // OnClick transition would otherwise be skipped and the lazy-wire path
+        // in UpdateXxx never gets to attach the WinRT event. If presence
+        // changes, force Update so EnsureXxxWiring (poolable) or the diff-based
+        // null→non-null checks (non-poolable) can subscribe.
+        if (Element.ShallowEquals(oldEl, newEl)
+            && Element.ModifiersEqual(oldModifiers, modifiers)
+            && oldEl.HasCallbacks == newEl.HasCallbacks)
         {
             DebugElementsSkipped++;
             // Refresh Tag so the event trampoline dispatches into the new element's
@@ -660,7 +669,8 @@ public sealed partial class Reconciler
     private UIElement? UpdateHyperlinkButton(HyperlinkButtonElement o, HyperlinkButtonElement n, WinUI.HyperlinkButton hb)
     {
         hb.Content = n.Content;
-        if (n.NavigateUri is not null) hb.NavigateUri = n.NavigateUri;
+        // Unconditional: a transition to null must clear the stale navigation target.
+        if (o.NavigateUri != n.NavigateUri) hb.NavigateUri = n.NavigateUri;
         SetElementTag(hb, n);
         if (o.OnClick is null && n.OnClick is not null)
             hb.Click += (s, _) => (GetElementTag((UIElement)s!) as HyperlinkButtonElement)?.OnClick?.Invoke();
@@ -2374,10 +2384,16 @@ public sealed partial class Reconciler
         SetElementTag(ib, n);
         if (o.OnClosed is null && n.OnClosed is not null)
             ib.Closed += (s, _) => (GetElementTag((UIElement)s!) as InfoBarElement)?.OnClosed?.Invoke();
-        // Note: action button wire cannot be added here lazily because the
-        // action button itself only exists when ActionButtonContent is set
-        // at mount time. If you need OnActionButtonClick to appear after mount,
-        // wire it from the mount path by providing the content upfront.
+        // Lazy-wire ActionButton.Click on null→non-null. The ActionButton
+        // control itself only exists when ActionButtonContent was authored,
+        // and Mount handles the case where both content and handler are
+        // present. If the handler appears later without the button, WinUI
+        // still won't render one — that's an author-side constraint.
+        // Dispatch captures infoBar (not the button) so it reads the parent
+        // InfoBar's Tag, which Update keeps fresh via SetElementTag above.
+        if (o.OnActionButtonClick is null && n.OnActionButtonClick is not null
+            && ib.ActionButton is WinUI.Button actionButton)
+            actionButton.Click += (_, _) => (GetElementTag(ib) as InfoBarElement)?.OnActionButtonClick?.Invoke();
         ApplySetters(n.Setters, ib);
         return null;
     }
@@ -2402,7 +2418,13 @@ public sealed partial class Reconciler
         SetElementTag(tip, n);
         if (o.OnClosed is null && n.OnClosed is not null)
             tip.Closed += (s, _) => (GetElementTag((UIElement)s!) as TeachingTipElement)?.OnClosed?.Invoke();
-        // OnActionButtonClick only wired if ActionButtonContent was present at mount.
+        // Lazy-wire ActionButtonClick on null→non-null. The event is on the
+        // TeachingTip itself (not a sub-control), so Tag refresh on the tip
+        // keeps the dispatch target fresh. Note: WinUI only raises this event
+        // when ActionButtonContent is set; callers who bind OnActionButtonClick
+        // after mount also need to provide ActionButtonContent.
+        if (o.OnActionButtonClick is null && n.OnActionButtonClick is not null)
+            tip.ActionButtonClick += (s, _) => (GetElementTag((UIElement)s!) as TeachingTipElement)?.OnActionButtonClick?.Invoke();
         ApplySetters(n.Setters, tip);
         return null;
     }

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -107,50 +107,50 @@ public sealed partial class Reconciler
                 => UpdateRichTextBlock(o, n, rtb),
             (ButtonElement o, ButtonElement n, WinUI.Button b)
                 => UpdateButton(o, n, b, requestRerender),
-            (HyperlinkButtonElement, HyperlinkButtonElement n, WinUI.HyperlinkButton hb)
-                => UpdateHyperlinkButton(n, hb),
-            (RepeatButtonElement, RepeatButtonElement n, WinPrim.RepeatButton rb)
-                => UpdateRepeatButton(n, rb),
-            (ToggleButtonElement, ToggleButtonElement n, WinPrim.ToggleButton tb)
-                => UpdateToggleButton(n, tb),
+            (HyperlinkButtonElement o, HyperlinkButtonElement n, WinUI.HyperlinkButton hb)
+                => UpdateHyperlinkButton(o, n, hb),
+            (RepeatButtonElement o, RepeatButtonElement n, WinPrim.RepeatButton rb)
+                => UpdateRepeatButton(o, n, rb),
+            (ToggleButtonElement o, ToggleButtonElement n, WinPrim.ToggleButton tb)
+                => UpdateToggleButton(o, n, tb),
             (DropDownButtonElement, DropDownButtonElement n, WinUI.DropDownButton ddb)
                 => UpdateDropDownButton(n, ddb),
-            (SplitButtonElement, SplitButtonElement n, WinUI.SplitButton sb)
-                => UpdateSplitButton(n, sb),
-            (ToggleSplitButtonElement, ToggleSplitButtonElement n, WinUI.ToggleSplitButton tsb)
-                => UpdateToggleSplitButton(n, tsb),
-            (RichEditBoxElement, RichEditBoxElement n, WinUI.RichEditBox reb)
-                => UpdateRichEditBox(n, reb),
+            (SplitButtonElement o, SplitButtonElement n, WinUI.SplitButton sb)
+                => UpdateSplitButton(o, n, sb),
+            (ToggleSplitButtonElement o, ToggleSplitButtonElement n, WinUI.ToggleSplitButton tsb)
+                => UpdateToggleSplitButton(o, n, tsb),
+            (RichEditBoxElement o, RichEditBoxElement n, WinUI.RichEditBox reb)
+                => UpdateRichEditBox(o, n, reb),
             (TextFieldElement o, TextFieldElement n, TextBox tb)
-                => UpdateTextField(o, n, tb),
-            (PasswordBoxElement, PasswordBoxElement n, WinUI.PasswordBox pb)
-                => UpdatePasswordBox(n, pb),
-            (NumberBoxElement, NumberBoxElement n, WinUI.NumberBox nb)
-                => UpdateNumberBox(n, nb),
-            (AutoSuggestBoxElement, AutoSuggestBoxElement n, WinUI.AutoSuggestBox asb)
-                => UpdateAutoSuggestBox(n, asb),
-            (CheckBoxElement, CheckBoxElement n, WinUI.CheckBox cb)
-                => UpdateCheckBox(n, cb),
-            (RadioButtonElement, RadioButtonElement n, WinUI.RadioButton rb)
-                => UpdateRadioButton(n, rb),
+                => UpdateTextField(o, n, tb, requestRerender),
+            (PasswordBoxElement o, PasswordBoxElement n, WinUI.PasswordBox pb)
+                => UpdatePasswordBox(o, n, pb),
+            (NumberBoxElement o, NumberBoxElement n, WinUI.NumberBox nb)
+                => UpdateNumberBox(o, n, nb),
+            (AutoSuggestBoxElement o, AutoSuggestBoxElement n, WinUI.AutoSuggestBox asb)
+                => UpdateAutoSuggestBox(o, n, asb),
+            (CheckBoxElement o, CheckBoxElement n, WinUI.CheckBox cb)
+                => UpdateCheckBox(o, n, cb),
+            (RadioButtonElement o, RadioButtonElement n, WinUI.RadioButton rb)
+                => UpdateRadioButton(o, n, rb),
             (RadioButtonsElement o, RadioButtonsElement n, WinUI.RadioButtons rbg)
                 => UpdateRadioButtons(o, n, rbg),
             (ComboBoxElement o, ComboBoxElement n, WinUI.ComboBox cb)
                 => UpdateComboBox(o, n, cb, requestRerender),
-            (SliderElement, SliderElement n, WinUI.Slider s)
-                => UpdateSlider(n, s),
+            (SliderElement o, SliderElement n, WinUI.Slider s)
+                => UpdateSlider(o, n, s),
             (ToggleSwitchElement, ToggleSwitchElement n, WinUI.ToggleSwitch ts)
                 => UpdateToggleSwitch(n, ts),
-            (RatingControlElement, RatingControlElement n, WinUI.RatingControl r)
-                => UpdateRatingControl(n, r),
-            (ColorPickerElement, ColorPickerElement n, WinUI.ColorPicker cp)
-                => UpdateColorPicker(n, cp),
-            (CalendarDatePickerElement, CalendarDatePickerElement n, WinUI.CalendarDatePicker cdp)
-                => UpdateCalendarDatePicker(n, cdp),
-            (DatePickerElement, DatePickerElement n, WinUI.DatePicker dp)
-                => UpdateDatePicker(n, dp),
-            (TimePickerElement, TimePickerElement n, WinUI.TimePicker tp)
-                => UpdateTimePicker(n, tp),
+            (RatingControlElement o, RatingControlElement n, WinUI.RatingControl r)
+                => UpdateRatingControl(o, n, r),
+            (ColorPickerElement o, ColorPickerElement n, WinUI.ColorPicker cp)
+                => UpdateColorPicker(o, n, cp),
+            (CalendarDatePickerElement o, CalendarDatePickerElement n, WinUI.CalendarDatePicker cdp)
+                => UpdateCalendarDatePicker(o, n, cdp),
+            (DatePickerElement o, DatePickerElement n, WinUI.DatePicker dp)
+                => UpdateDatePicker(o, n, dp),
+            (TimePickerElement o, TimePickerElement n, WinUI.TimePicker tp)
+                => UpdateTimePicker(o, n, tp),
             (ProgressElement, ProgressElement n, WinUI.ProgressBar pb)
                 => UpdateProgress(n, pb),
             (ProgressRingElement, ProgressRingElement n, WinUI.ProgressRing pr)
@@ -183,8 +183,8 @@ public sealed partial class Reconciler
                 => UpdateTitleBar(o, n, tb, requestRerender),
             (TabViewElement o, TabViewElement n, WinUI.TabView tabView)
                 => UpdateTabView(o, n, tabView, requestRerender),
-            (BreadcrumbBarElement, BreadcrumbBarElement n, WinUI.BreadcrumbBar bcb)
-                => UpdateBreadcrumbBar(n, bcb),
+            (BreadcrumbBarElement o, BreadcrumbBarElement n, WinUI.BreadcrumbBar bcb)
+                => UpdateBreadcrumbBar(o, n, bcb),
             (PivotElement o, PivotElement n, WinUI.Pivot pivot)
                 => UpdatePivot(o, n, pivot, requestRerender),
             (ListViewElement o, ListViewElement n, WinUI.ListView lv)
@@ -195,14 +195,14 @@ public sealed partial class Reconciler
                 => UpdateTreeView(o, n, tv, requestRerender),
             (FlipViewElement o, FlipViewElement n, WinUI.FlipView fv)
                 => UpdateFlipView(o, n, fv, requestRerender),
-            (InfoBarElement, InfoBarElement n, WinUI.InfoBar ib)
-                => UpdateInfoBar(n, ib),
+            (InfoBarElement o, InfoBarElement n, WinUI.InfoBar ib)
+                => UpdateInfoBar(o, n, ib),
             (InfoBadgeElement, InfoBadgeElement n, WinUI.InfoBadge badge)
                 => UpdateInfoBadge(n, badge),
             (ContentDialogElement o, ContentDialogElement n, FrameworkElement cdFe)
                 => UpdateContentDialog(o, n, cdFe, requestRerender),
-            (TeachingTipElement, TeachingTipElement n, WinUI.TeachingTip tip)
-                => UpdateTeachingTip(n, tip),
+            (TeachingTipElement o, TeachingTipElement n, WinUI.TeachingTip tip)
+                => UpdateTeachingTip(o, n, tip),
             (MenuBarElement o, MenuBarElement n, WinUI.MenuBar mb)
                 => UpdateMenuBar(o, n, mb),
             (CommandHostElement o, CommandHostElement n, WinUI.Grid chGrid)
@@ -243,8 +243,8 @@ public sealed partial class Reconciler
                 => UpdateListBox(o, n, lb),
             (SelectorBarElement o, SelectorBarElement n, WinUI.SelectorBar sbar)
                 => UpdateSelectorBar(o, n, sbar),
-            (PipsPagerElement, PipsPagerElement n, WinUI.PipsPager pp)
-                => UpdatePipsPager(n, pp),
+            (PipsPagerElement o, PipsPagerElement n, WinUI.PipsPager pp)
+                => UpdatePipsPager(o, n, pp),
             (AnnotatedScrollBarElement, AnnotatedScrollBarElement n, WinUI.AnnotatedScrollBar asb)
                 => UpdateAnnotatedScrollBar(n, asb),
             (PopupElement o, PopupElement n, WinUI.StackPanel popupWrap)
@@ -652,31 +652,42 @@ public sealed partial class Reconciler
             b.Content = n.Label;
         }
         SetElementTag(b, n);
+        EnsureButtonWiring(b, n);
         ApplySetters(n.Setters, b);
         return null;
     }
 
-    private UIElement? UpdateHyperlinkButton(HyperlinkButtonElement n, WinUI.HyperlinkButton hb)
+    private UIElement? UpdateHyperlinkButton(HyperlinkButtonElement o, HyperlinkButtonElement n, WinUI.HyperlinkButton hb)
     {
         hb.Content = n.Content;
         if (n.NavigateUri is not null) hb.NavigateUri = n.NavigateUri;
         SetElementTag(hb, n);
+        if (o.OnClick is null && n.OnClick is not null)
+            hb.Click += (s, _) => (GetElementTag((UIElement)s!) as HyperlinkButtonElement)?.OnClick?.Invoke();
         ApplySetters(n.Setters, hb);
         return null;
     }
 
-    private UIElement? UpdateRepeatButton(RepeatButtonElement n, WinPrim.RepeatButton rb)
+    private UIElement? UpdateRepeatButton(RepeatButtonElement o, RepeatButtonElement n, WinPrim.RepeatButton rb)
     {
         rb.Content = n.Label; rb.Delay = n.Delay; rb.Interval = n.Interval; SetElementTag(rb, n);
+        if (o.OnClick is null && n.OnClick is not null)
+            rb.Click += (s, _) => (GetElementTag((UIElement)s!) as RepeatButtonElement)?.OnClick?.Invoke();
         ApplySetters(n.Setters, rb);
         return null;
     }
 
-    private UIElement? UpdateToggleButton(ToggleButtonElement n, WinPrim.ToggleButton tb)
+    private UIElement? UpdateToggleButton(ToggleButtonElement o, ToggleButtonElement n, WinPrim.ToggleButton tb)
     {
         tb.Content = n.Label;
         if ((tb.IsChecked ?? false) != n.IsChecked) tb.IsChecked = n.IsChecked;
         SetElementTag(tb, n);
+        if (o.OnToggled is null && n.OnToggled is not null)
+            tb.Click += (s, _) =>
+            {
+                var t = (WinPrim.ToggleButton)s!;
+                (GetElementTag(t) as ToggleButtonElement)?.OnToggled?.Invoke(t.IsChecked ?? false);
+            };
         ApplySetters(n.Setters, tb);
         return null;
     }
@@ -689,16 +700,25 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateSplitButton(SplitButtonElement n, WinUI.SplitButton sb)
+    private UIElement? UpdateSplitButton(SplitButtonElement o, SplitButtonElement n, WinUI.SplitButton sb)
     {
         sb.Content = n.Label; SetElementTag(sb, n);
+        if (o.OnClick is null && n.OnClick is not null)
+            sb.Click += (s, _) => (GetElementTag((UIElement)s!) as SplitButtonElement)?.OnClick?.Invoke();
         ApplySetters(n.Setters, sb);
         return null;
     }
 
-    private UIElement? UpdateToggleSplitButton(ToggleSplitButtonElement n, WinUI.ToggleSplitButton tsb)
+    private UIElement? UpdateToggleSplitButton(ToggleSplitButtonElement o, ToggleSplitButtonElement n, WinUI.ToggleSplitButton tsb)
     {
         SetElementTag(tsb, n);
+        if (o.OnIsCheckedChanged is null && n.OnIsCheckedChanged is not null)
+            tsb.IsCheckedChanged += (s, _) =>
+            {
+                var t = (WinUI.ToggleSplitButton)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(t)) return;
+                (GetElementTag(t) as ToggleSplitButtonElement)?.OnIsCheckedChanged?.Invoke(t.IsChecked);
+            };
         tsb.Content = n.Label;
         if (tsb.IsChecked != n.IsChecked)
         {
@@ -709,10 +729,11 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateTextField(TextFieldElement o, TextFieldElement n, TextBox tb)
+    private UIElement? UpdateTextField(TextFieldElement o, TextFieldElement n, TextBox tb, Action requestRerender)
     {
         // Tag first so any echoed TextChanged sees this element.
         SetElementTag(tb, n);
+        EnsureTextFieldWiring(tb, n, requestRerender);
         if (o.Value != n.Value)
         {
             // Element value changed — always enforce
@@ -754,9 +775,16 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdatePasswordBox(PasswordBoxElement n, WinUI.PasswordBox pb)
+    private UIElement? UpdatePasswordBox(PasswordBoxElement o, PasswordBoxElement n, WinUI.PasswordBox pb)
     {
         SetElementTag(pb, n);
+        if (o.OnPasswordChanged is null && n.OnPasswordChanged is not null)
+            pb.PasswordChanged += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as PasswordBoxElement)?.OnPasswordChanged?.Invoke(((WinUI.PasswordBox)c).Password);
+            };
         if (pb.Password != n.Password)
         {
             ChangeEchoSuppressor.BeginSuppress(pb);
@@ -767,9 +795,16 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateNumberBox(NumberBoxElement n, WinUI.NumberBox nb)
+    private UIElement? UpdateNumberBox(NumberBoxElement o, NumberBoxElement n, WinUI.NumberBox nb)
     {
         SetElementTag(nb, n);
+        if (o.OnValueChanged is null && n.OnValueChanged is not null)
+            nb.ValueChanged += (s, _) =>
+            {
+                var box = (WinUI.NumberBox)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(box)) return;
+                (GetElementTag(box) as NumberBoxElement)?.OnValueChanged?.Invoke(box.Value);
+            };
         // Set Min/Max before Value so a new, in-range Value doesn't get
         // coerced by a stale range. But Min/Max writes can themselves coerce
         // the existing Value, which raises ValueChanged — suppress those
@@ -796,12 +831,24 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateAutoSuggestBox(AutoSuggestBoxElement n, WinUI.AutoSuggestBox asb)
+    private UIElement? UpdateAutoSuggestBox(AutoSuggestBoxElement o, AutoSuggestBoxElement n, WinUI.AutoSuggestBox asb)
     {
         // AutoSuggestBox already filters TextChanged to UserInput only, so
         // programmatic Text= is already safe. Suppress anyway for consistency
         // with the other editors (covers future handler changes).
         SetElementTag(asb, n);
+        if (o.OnTextChanged is null && n.OnTextChanged is not null)
+            asb.TextChanged += (s, args) =>
+            {
+                if (args.Reason == WinUI.AutoSuggestionBoxTextChangeReason.UserInput)
+                    (GetElementTag((UIElement)s!) as AutoSuggestBoxElement)?.OnTextChanged?.Invoke(((WinUI.AutoSuggestBox)s!).Text);
+            };
+        if (o.OnQuerySubmitted is null && n.OnQuerySubmitted is not null)
+            asb.QuerySubmitted += (s, args) =>
+                (GetElementTag((UIElement)s!) as AutoSuggestBoxElement)?.OnQuerySubmitted?.Invoke(args.QueryText);
+        if (o.OnSuggestionChosen is null && n.OnSuggestionChosen is not null)
+            asb.SuggestionChosen += (s, args) =>
+                (GetElementTag((UIElement)s!) as AutoSuggestBoxElement)?.OnSuggestionChosen?.Invoke(args.SelectedItem?.ToString() ?? "");
         if (asb.Text != n.Text)
         {
             ChangeEchoSuppressor.BeginSuppress(asb);
@@ -813,9 +860,37 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateCheckBox(CheckBoxElement n, WinUI.CheckBox cb)
+    private UIElement? UpdateCheckBox(CheckBoxElement o, CheckBoxElement n, WinUI.CheckBox cb)
     {
         SetElementTag(cb, n);
+        bool oldWired = o.OnChanged is not null || o.OnCheckedStateChanged is not null;
+        bool newWired = n.OnChanged is not null || n.OnCheckedStateChanged is not null;
+        if (!oldWired && newWired)
+        {
+            cb.Checked += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                var el = GetElementTag(c) as CheckBoxElement;
+                el?.OnChanged?.Invoke(true);
+                el?.OnCheckedStateChanged?.Invoke(true);
+            };
+            cb.Unchecked += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                var el = GetElementTag(c) as CheckBoxElement;
+                el?.OnChanged?.Invoke(false);
+                el?.OnCheckedStateChanged?.Invoke(false);
+            };
+            cb.Indeterminate += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                var el = GetElementTag(c) as CheckBoxElement;
+                el?.OnCheckedStateChanged?.Invoke(null);
+            };
+        }
         cb.Content = n.Label;
         cb.IsThreeState = n.IsThreeState;
         var target = n.IsThreeState ? n.CheckedState : n.IsChecked;
@@ -828,9 +903,24 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateRadioButton(RadioButtonElement n, WinUI.RadioButton rb)
+    private UIElement? UpdateRadioButton(RadioButtonElement o, RadioButtonElement n, WinUI.RadioButton rb)
     {
         SetElementTag(rb, n);
+        if (o.OnChecked is null && n.OnChecked is not null)
+        {
+            rb.Checked += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(true);
+            };
+            rb.Unchecked += (s, _) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(false);
+            };
+        }
         rb.Content = n.Label;
         if (rb.IsChecked != n.IsChecked)
         {
@@ -842,9 +932,18 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateSlider(SliderElement n, WinUI.Slider s)
+    private UIElement? UpdateSlider(SliderElement o, SliderElement n, WinUI.Slider s)
     {
         SetElementTag(s, n);
+        if (o.OnChanged is null && n.OnChanged is not null)
+        {
+            var sliderCapture = s;
+            s.ValueChanged += (_, args) =>
+            {
+                if (ChangeEchoSuppressor.ShouldSuppress(sliderCapture)) return;
+                (GetElementTag(sliderCapture) as SliderElement)?.OnChanged?.Invoke(args.NewValue);
+            };
+        }
         // Min/Max before Value so a new, in-range Value doesn't get coerced
         // by a stale range. But Min/Max writes can themselves coerce the
         // existing Value, which raises ValueChanged — suppress those echoes
@@ -873,6 +972,7 @@ public sealed partial class Reconciler
     private UIElement? UpdateToggleSwitch(ToggleSwitchElement n, WinUI.ToggleSwitch ts)
     {
         SetElementTag(ts, n);
+        EnsureToggleSwitchWiring(ts, n);
         if (ts.IsOn != n.IsOn)
         {
             ChangeEchoSuppressor.BeginSuppress(ts);
@@ -884,9 +984,16 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateRatingControl(RatingControlElement n, WinUI.RatingControl r)
+    private UIElement? UpdateRatingControl(RatingControlElement o, RatingControlElement n, WinUI.RatingControl r)
     {
         SetElementTag(r, n);
+        if (o.OnValueChanged is null && n.OnValueChanged is not null)
+            r.ValueChanged += (s, _) =>
+            {
+                var rr = (WinUI.RatingControl)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(rr)) return;
+                (GetElementTag(rr) as RatingControlElement)?.OnValueChanged?.Invoke(rr.Value);
+            };
         r.MaxRating = n.MaxRating;
         if (r.Value != n.Value)
         {
@@ -899,7 +1006,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateColorPicker(ColorPickerElement n, WinUI.ColorPicker cp)
+    private UIElement? UpdateColorPicker(ColorPickerElement o, ColorPickerElement n, WinUI.ColorPicker cp)
     {
         // Tag FIRST so the ColorChanged echo (fired synchronously from the
         // programmatic Color= assignment in some WinAppSDK builds) resolves
@@ -907,6 +1014,13 @@ public sealed partial class Reconciler
         // the echo entirely — preventing the cross-row value-swap observed
         // when a PropertyGrid bound to a selection re-renders.
         SetElementTag(cp, n);
+        if (o.OnColorChanged is null && n.OnColorChanged is not null)
+            cp.ColorChanged += (s, args) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as ColorPickerElement)?.OnColorChanged?.Invoke(args.NewColor);
+            };
         if (cp.Color != n.Color)
         {
             ChangeEchoSuppressor.BeginSuppress(cp);
@@ -917,9 +1031,16 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateCalendarDatePicker(CalendarDatePickerElement n, WinUI.CalendarDatePicker cdp)
+    private UIElement? UpdateCalendarDatePicker(CalendarDatePickerElement o, CalendarDatePickerElement n, WinUI.CalendarDatePicker cdp)
     {
         SetElementTag(cdp, n);
+        if (o.OnDateChanged is null && n.OnDateChanged is not null)
+            cdp.DateChanged += (s, _) =>
+            {
+                var c = (WinUI.CalendarDatePicker)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as CalendarDatePickerElement)?.OnDateChanged?.Invoke(c.Date);
+            };
         if (cdp.Date != n.Date)
         {
             ChangeEchoSuppressor.BeginSuppress(cdp);
@@ -929,9 +1050,16 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateDatePicker(DatePickerElement n, WinUI.DatePicker dp)
+    private UIElement? UpdateDatePicker(DatePickerElement o, DatePickerElement n, WinUI.DatePicker dp)
     {
         SetElementTag(dp, n);
+        if (o.OnDateChanged is null && n.OnDateChanged is not null)
+            dp.DateChanged += (s, args) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as DatePickerElement)?.OnDateChanged?.Invoke(args.NewDate);
+            };
         if (dp.Date != n.Date)
         {
             ChangeEchoSuppressor.BeginSuppress(dp);
@@ -941,9 +1069,16 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateTimePicker(TimePickerElement n, WinUI.TimePicker tp)
+    private UIElement? UpdateTimePicker(TimePickerElement o, TimePickerElement n, WinUI.TimePicker tp)
     {
         SetElementTag(tp, n);
+        if (o.OnTimeChanged is null && n.OnTimeChanged is not null)
+            tp.TimeChanged += (s, args) =>
+            {
+                var c = (UIElement)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as TimePickerElement)?.OnTimeChanged?.Invoke(args.NewTime);
+            };
         if (tp.Time != n.Time)
         {
             ChangeEchoSuppressor.BeginSuppress(tp);
@@ -998,16 +1133,29 @@ public sealed partial class Reconciler
     {
         if (n.Source is not null && n.Source != o.Source) wv.Source = n.Source;
         SetElementTag(wv, n);
+        if (o.OnNavigationStarting is null && n.OnNavigationStarting is not null)
+            wv.NavigationStarting += (s, args) =>
+                (GetElementTag((UIElement)s!) as WebView2Element)?.OnNavigationStarting?.Invoke(new Uri(args.Uri));
+        if (o.OnNavigationCompleted is null && n.OnNavigationCompleted is not null)
+            wv.NavigationCompleted += (s, _) =>
+                (GetElementTag((UIElement)s!) as WebView2Element)?.OnNavigationCompleted?.Invoke(((WinUI.WebView2)s!).Source);
         ApplySetters(n.Setters, wv);
         return null;
     }
 
-    private UIElement? UpdateRichEditBox(RichEditBoxElement n, WinUI.RichEditBox reb)
+    private UIElement? UpdateRichEditBox(RichEditBoxElement o, RichEditBoxElement n, WinUI.RichEditBox reb)
     {
         reb.IsReadOnly = n.IsReadOnly;
         if (n.Header is not null) reb.Header = n.Header;
         if (n.PlaceholderText is not null) reb.PlaceholderText = n.PlaceholderText;
         SetElementTag(reb, n);
+        if (o.OnTextChanged is null && n.OnTextChanged is not null)
+            reb.TextChanged += (s, _) =>
+            {
+                var r = (WinUI.RichEditBox)s!;
+                r.Document.GetText(Microsoft.UI.Text.TextGetOptions.None, out var text);
+                (GetElementTag(r) as RichEditBoxElement)?.OnTextChanged?.Invoke(text?.TrimEnd('\r') ?? "");
+            };
         ApplySetters(n.Setters, reb);
         return null;
     }
@@ -1122,6 +1270,11 @@ public sealed partial class Reconciler
         }
 
         SetElementTag(exp, n);
+        if (o.OnExpandedChanged is null && n.OnExpandedChanged is not null)
+        {
+            exp.Expanding += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnExpandedChanged?.Invoke(true);
+            exp.Collapsed += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnExpandedChanged?.Invoke(false);
+        }
         ApplySetters(n.Setters, exp);
         return null;
     }
@@ -1380,6 +1533,14 @@ public sealed partial class Reconciler
         }
 
         SetElementTag(nv, n);
+        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+            nv.SelectionChanged += (s, args) =>
+            {
+                var selected = args.SelectedItem as WinUI.NavigationViewItem;
+                (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnSelectionChanged?.Invoke(selected?.Tag as string);
+            };
+        if (o.OnBackRequested is null && n.OnBackRequested is not null)
+            nv.BackRequested += (s, _) => (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnBackRequested?.Invoke();
         ApplySetters(n.Setters, nv);
         return null;
     }
@@ -1405,6 +1566,10 @@ public sealed partial class Reconciler
             requestRerender);
 
         SetElementTag(titleBar, n);
+        if (o.OnBackRequested is null && n.OnBackRequested is not null)
+            titleBar.BackRequested += (s, _) => (GetElementTag((UIElement)s!) as TitleBarElement)?.OnBackRequested?.Invoke();
+        if (o.OnPaneToggleRequested is null && n.OnPaneToggleRequested is not null)
+            titleBar.PaneToggleRequested += (s, _) => (GetElementTag((UIElement)s!) as TitleBarElement)?.OnPaneToggleRequested?.Invoke();
         ApplySetters(n.Setters, titleBar);
         return null;
     }
@@ -1441,6 +1606,22 @@ public sealed partial class Reconciler
         // Retag first so any events raised by property writes resolve through
         // the new element's closures.
         SetElementTag(tabView, n);
+
+        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+            tabView.SelectionChanged += (s, _) =>
+            {
+                var t = (WinUI.TabView)s!;
+                (GetElementTag(t) as TabViewElement)?.OnSelectionChanged?.Invoke(t.SelectedIndex);
+            };
+        if (o.OnTabCloseRequested is null && n.OnTabCloseRequested is not null)
+            tabView.TabCloseRequested += (s, args) =>
+            {
+                var t = (WinUI.TabView)s!;
+                var idx = t.TabItems.IndexOf(args.Tab);
+                (GetElementTag(t) as TabViewElement)?.OnTabCloseRequested?.Invoke(idx);
+            };
+        if (o.OnAddTabButtonClick is null && n.OnAddTabButtonClick is not null)
+            tabView.AddTabButtonClick += (s, _) => (GetElementTag((UIElement)s!) as TabViewElement)?.OnAddTabButtonClick?.Invoke();
 
         var items = tabView.TabItems;
         int oldCount = o.Tabs.Length;
@@ -1512,6 +1693,13 @@ public sealed partial class Reconciler
     {
         SetElementTag(pivot, n);
 
+        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+            pivot.SelectionChanged += (s, _) =>
+            {
+                var p = (WinUI.Pivot)s!;
+                (GetElementTag(p) as PivotElement)?.OnSelectionChanged?.Invoke(p.SelectedIndex);
+            };
+
         var items = pivot.Items;
         int common = Math.Min(o.Items.Length, n.Items.Length);
 
@@ -1562,6 +1750,13 @@ public sealed partial class Reconciler
     private UIElement? UpdateRadioButtons(RadioButtonsElement o, RadioButtonsElement n, WinUI.RadioButtons rbg)
     {
         SetElementTag(rbg, n);
+        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+            rbg.SelectionChanged += (s, _) =>
+            {
+                var g = (WinUI.RadioButtons)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(g)) return;
+                (GetElementTag(g) as RadioButtonsElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
+            };
         if (!StringArrayEquals(o.Items, n.Items))
         {
             rbg.Items.Clear();
@@ -1578,6 +1773,14 @@ public sealed partial class Reconciler
     private UIElement? UpdateComboBox(ComboBoxElement o, ComboBoxElement n, WinUI.ComboBox cb, Action requestRerender)
     {
         SetElementTag(cb, n);
+
+        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+            cb.SelectionChanged += (s, _) =>
+            {
+                var c = (WinUI.ComboBox)s!;
+                if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
+                (GetElementTag(c) as ComboBoxElement)?.OnSelectionChanged?.Invoke(c.SelectedIndex);
+            };
 
         bool oldIsElements = o.ItemElements is not null;
         bool newIsElements = n.ItemElements is not null;
@@ -1642,6 +1845,12 @@ public sealed partial class Reconciler
     private UIElement? UpdateListBox(ListBoxElement o, ListBoxElement n, WinUI.ListBox lb)
     {
         SetElementTag(lb, n);
+        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+            lb.SelectionChanged += (s, _) =>
+            {
+                var l = (WinUI.ListBox)s!;
+                (GetElementTag(l) as ListBoxElement)?.OnSelectionChanged?.Invoke(l.SelectedIndex);
+            };
         if (!StringArrayEquals(o.Items, n.Items))
         {
             lb.Items.Clear();
@@ -1656,6 +1865,14 @@ public sealed partial class Reconciler
     private UIElement? UpdateSelectorBar(SelectorBarElement o, SelectorBarElement n, WinUI.SelectorBar bar)
     {
         SetElementTag(bar, n);
+
+        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+            bar.SelectionChanged += (s, _) =>
+            {
+                var b = (WinUI.SelectorBar)s!;
+                var idx = b.Items.IndexOf(b.SelectedItem);
+                (GetElementTag(b) as SelectorBarElement)?.OnSelectionChanged?.Invoke(idx);
+            };
 
         var items = bar.Items;
         int common = Math.Min(o.Items.Length, n.Items.Length);
@@ -1713,6 +1930,11 @@ public sealed partial class Reconciler
             requestRerender);
 
         SetElementTag(sv, n);
+        if (o.OnPaneOpenChanged is null && n.OnPaneOpenChanged is not null)
+        {
+            sv.PaneOpening += (s, _) => (GetElementTag((UIElement)s!) as SplitViewElement)?.OnPaneOpenChanged?.Invoke(true);
+            sv.PaneClosing += (s, _) => (GetElementTag((UIElement)s!) as SplitViewElement)?.OnPaneOpenChanged?.Invoke(false);
+        }
         ApplySetters(n.Setters, sv);
         return null;
     }
@@ -2013,6 +2235,16 @@ public sealed partial class Reconciler
                     flyout.Content = Mount(n.FlyoutContent, requestRerender);
                 }
                 flyout.Placement = n.Placement;
+                if (o.OnOpened is null && n.OnOpened is not null)
+                {
+                    var openedTarget = targetFe;
+                    flyout.Opened += (_, _) => (GetElementTag(openedTarget) as FlyoutElement)?.OnOpened?.Invoke();
+                }
+                if (o.OnClosed is null && n.OnClosed is not null)
+                {
+                    var closedTarget = targetFe;
+                    flyout.Closed += (_, _) => (GetElementTag(closedTarget) as FlyoutElement)?.OnClosed?.Invoke();
+                }
                 ApplySetters(n.Setters, flyout);
             }
             else
@@ -2121,19 +2353,31 @@ public sealed partial class Reconciler
         return true;
     }
 
-    private UIElement? UpdateBreadcrumbBar(BreadcrumbBarElement n, WinUI.BreadcrumbBar bcb)
+    private UIElement? UpdateBreadcrumbBar(BreadcrumbBarElement o, BreadcrumbBarElement n, WinUI.BreadcrumbBar bcb)
     {
         bcb.ItemsSource = n.Items.Select(i => i.Label).ToList();
         SetElementTag(bcb, n);
+        if (o.OnItemClicked is null && n.OnItemClicked is not null)
+            bcb.ItemClicked += (s, args) =>
+            {
+                var el = GetElementTag((UIElement)s!) as BreadcrumbBarElement;
+                if (el is not null && args.Index >= 0 && args.Index < el.Items.Length) el.OnItemClicked?.Invoke(el.Items[args.Index]);
+            };
         ApplySetters(n.Setters, bcb);
         return null;
     }
 
-    private UIElement? UpdateInfoBar(InfoBarElement n, WinUI.InfoBar ib)
+    private UIElement? UpdateInfoBar(InfoBarElement o, InfoBarElement n, WinUI.InfoBar ib)
     {
         ib.Title = n.Title ?? ""; ib.Message = n.Message ?? "";
         ib.Severity = n.Severity; ib.IsOpen = n.IsOpen; ib.IsClosable = n.IsClosable;
         SetElementTag(ib, n);
+        if (o.OnClosed is null && n.OnClosed is not null)
+            ib.Closed += (s, _) => (GetElementTag((UIElement)s!) as InfoBarElement)?.OnClosed?.Invoke();
+        // Note: action button wire cannot be added here lazily because the
+        // action button itself only exists when ActionButtonContent is set
+        // at mount time. If you need OnActionButtonClick to appear after mount,
+        // wire it from the mount path by providing the content upfront.
         ApplySetters(n.Setters, ib);
         return null;
     }
@@ -2152,10 +2396,13 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateTeachingTip(TeachingTipElement n, WinUI.TeachingTip tip)
+    private UIElement? UpdateTeachingTip(TeachingTipElement o, TeachingTipElement n, WinUI.TeachingTip tip)
     {
         tip.Title = n.Title; tip.Subtitle = n.Subtitle ?? ""; tip.IsOpen = n.IsOpen;
         SetElementTag(tip, n);
+        if (o.OnClosed is null && n.OnClosed is not null)
+            tip.Closed += (s, _) => (GetElementTag((UIElement)s!) as TeachingTipElement)?.OnClosed?.Invoke();
+        // OnActionButtonClick only wired if ActionButtonContent was present at mount.
         ApplySetters(n.Setters, tip);
         return null;
     }
@@ -2173,6 +2420,20 @@ public sealed partial class Reconciler
 
         SetElementTag(lv, n);
 
+        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+            lv.SelectionChanged += (s, _) =>
+            {
+                var l = (WinUI.ListView)s!;
+                (GetElementTag(l) as ListViewElement)?.OnSelectionChanged?.Invoke(l.SelectedIndex);
+            };
+        if (o.OnItemClick is null && n.OnItemClick is not null)
+            lv.ItemClick += (s, args) =>
+            {
+                var l = (WinUI.ListView)s!;
+                if (args.ClickedItem is int idx)
+                    (GetElementTag(l) as ListViewElement)?.OnItemClick?.Invoke(idx);
+            };
+
         if (n.SelectedIndex >= 0) lv.SelectedIndex = n.SelectedIndex;
         ApplySetters(n.Setters, lv);
         return null;
@@ -2189,6 +2450,20 @@ public sealed partial class Reconciler
 
         SetElementTag(gv, n);
 
+        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+            gv.SelectionChanged += (s, _) =>
+            {
+                var g = (WinUI.GridView)s!;
+                (GetElementTag(g) as GridViewElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
+            };
+        if (o.OnItemClick is null && n.OnItemClick is not null)
+            gv.ItemClick += (s, args) =>
+            {
+                var g = (WinUI.GridView)s!;
+                if (args.ClickedItem is int idx)
+                    (GetElementTag(g) as GridViewElement)?.OnItemClick?.Invoke(idx);
+            };
+
         if (n.SelectedIndex >= 0) gv.SelectedIndex = n.SelectedIndex;
         ApplySetters(n.Setters, gv);
         return null;
@@ -2199,6 +2474,12 @@ public sealed partial class Reconciler
         ReconcileItemsChildren(o.Items, n.Items, fv, requestRerender);
         fv.SelectedIndex = n.SelectedIndex;
         SetElementTag(fv, n);
+        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+            fv.SelectionChanged += (s, _) =>
+            {
+                var f = (WinUI.FlipView)s!;
+                (GetElementTag(f) as FlipViewElement)?.OnSelectionChanged?.Invoke(f.SelectedIndex);
+            };
         ApplySetters(n.Setters, fv);
         return null;
     }
@@ -2717,6 +2998,23 @@ public sealed partial class Reconciler
         if (ReferenceEquals(o.Nodes, n.Nodes))
         {
             SetElementTag(tv, n);
+            if (o.OnItemInvoked is null && n.OnItemInvoked is not null)
+                tv.ItemInvoked += (s, args) =>
+                {
+                    var t = (WinUI.TreeView)s!;
+                    if (args.InvokedItem is WinUI.TreeViewNode tvn
+                        && tvn.Content is TreeViewNodeData nodeData)
+                    {
+                        (GetElementTag(t) as TreeViewElement)?.OnItemInvoked?.Invoke(nodeData);
+                    }
+                };
+            if (o.OnExpanding is null && n.OnExpanding is not null)
+                tv.Expanding += (s, args) =>
+                {
+                    var t = (WinUI.TreeView)s!;
+                    if (args.Node.Content is TreeViewNodeData nodeData)
+                        (GetElementTag(t) as TreeViewElement)?.OnExpanding?.Invoke(nodeData);
+                };
             return null;
         }
 
@@ -2725,6 +3023,23 @@ public sealed partial class Reconciler
 
         tv.SelectionMode = n.SelectionMode;
         SetElementTag(tv, n);
+        if (o.OnItemInvoked is null && n.OnItemInvoked is not null)
+            tv.ItemInvoked += (s, args) =>
+            {
+                var t = (WinUI.TreeView)s!;
+                if (args.InvokedItem is WinUI.TreeViewNode tvn
+                    && tvn.Content is TreeViewNodeData nodeData)
+                {
+                    (GetElementTag(t) as TreeViewElement)?.OnItemInvoked?.Invoke(nodeData);
+                }
+            };
+        if (o.OnExpanding is null && n.OnExpanding is not null)
+            tv.Expanding += (s, args) =>
+            {
+                var t = (WinUI.TreeView)s!;
+                if (args.Node.Content is TreeViewNodeData nodeData)
+                    (GetElementTag(t) as TreeViewElement)?.OnExpanding?.Invoke(nodeData);
+            };
         ApplySetters(n.Setters, tv);
         return null;
     }
@@ -2901,11 +3216,17 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdatePipsPager(PipsPagerElement n, WinUI.PipsPager pp)
+    private UIElement? UpdatePipsPager(PipsPagerElement o, PipsPagerElement n, WinUI.PipsPager pp)
     {
         pp.NumberOfPages = n.NumberOfPages;
         pp.SelectedPageIndex = n.SelectedPageIndex;
         SetElementTag(pp, n);
+        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
+            pp.SelectedIndexChanged += (s, _) =>
+            {
+                var p = (WinUI.PipsPager)s!;
+                (GetElementTag(p) as PipsPagerElement)?.OnSelectedIndexChanged?.Invoke(p.SelectedPageIndex);
+            };
         ApplySetters(n.Setters, pp);
         return null;
     }

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -60,6 +60,12 @@ public sealed partial class Reconciler
         if (Element.ShallowEquals(oldEl, newEl) && ReferenceEquals(oldModifiers, modifiers))
         {
             DebugElementsSkipped++;
+            // Refresh Tag so the event trampoline dispatches into the new element's
+            // closure on next click/value-change. Gated on HasCallbacks so we skip
+            // the DependencyProperty write entirely for leaves with no handlers
+            // (TextBlock, Image, Border, etc.) — which is most of them.
+            if (newEl.HasCallbacks && control is FrameworkElement tagFeSE)
+                tagFeSE.Tag = newEl;
             if (newEl.ThemeBindings is not null && control is FrameworkElement thFeSE)
                 ApplyThemeBindings(thFeSE, newEl.ThemeBindings);
             // Re-resolve ThemeRef-based resource overrides on theme change

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -182,6 +182,35 @@ public sealed partial class Reconciler : IDisposable
         control is FrameworkElement fe ? fe.Tag as Element : null;
 
     // ════════════════════════════════════════════════════════════════════
+    //  Lazy event wiring for poolable types
+    // ════════════════════════════════════════════════════════════════════
+    //
+    // Non-poolable controls are created fresh on every Mount, so lazy wiring
+    // works off the (oldEl, newEl) diff alone — wire at Mount when the handler
+    // is non-null, wire at Update when it transitions null → non-null.
+    //
+    // Poolable controls (Button, TextBox, ToggleSwitch) are different: the pool
+    // intentionally retains WinRT event subscriptions across rent/return (see
+    // ElementPool.CleanElement), but clears Tag. So "Tag is null" on rent does
+    // NOT mean "unwired" — the control may already have a trampoline attached.
+    // We need a per-control flag that survives pool cycles to avoid double-
+    // subscription. A ConditionalWeakTable gives us that with zero cross-ABI
+    // cost and weak keys so GC isn't blocked.
+
+    internal sealed class PoolableWireFlags
+    {
+        public bool ButtonClick;
+        public bool TextBoxTextChanged;
+        public bool TextBoxSelectionChanged;
+        public bool ToggleSwitchToggled;
+    }
+
+    private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<FrameworkElement, PoolableWireFlags> _poolableWireFlags = new();
+
+    internal static PoolableWireFlags GetPoolableWireFlags(FrameworkElement fe) =>
+        _poolableWireFlags.GetValue(fe, static _ => new PoolableWireFlags());
+
+    // ════════════════════════════════════════════════════════════════════
     //  Extensible type registry (Feature 1: RegisterType API)
     // ════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Started as a single fix for "moving a slider flashes every control yellow" on the Counter demo, ended up as a coherent series that lands the full skip-path design described in `reconciler-excessive-invalidation-investigation.md` plus a lazy WinRT event-wiring story. Seven commits, each independently reviewable.

## What was wrong

1. **Skip path was unreachable for callback-bearing leaves.** `ShallowEquals` had a `ReferenceEquals(ba.OnClick, bb.OnClick)` guard that always failed for lambda-allocating render functions, forcing Update on every Button.
2. **Skip path couldn't tolerate fluent modifier chains.** The outer guard used `ReferenceEquals(oldModifiers, modifiers)`, but `.Width(200)` / `.Margin(10)` produce a fresh `ElementModifiers` instance each render — identical values, new reference — so skip never triggered.
3. **Brush/FontFamily were compared by reference.** `BrushHelper.Parse` returns a fresh `SolidColorBrush` per call (DependencyObject thread affinity blocks caching), so `.Background("#color")` chains also defeated skip.
4. **Highlight overlay flagged composition wrappers.** `OwnPropsEqual` returned `false` for `ComponentElement`, `FuncElement`, `MemoElement`, `MenuFlyoutElement`, `TitleBarElement`, and every collection element (ComboBox/ListView/GridView/Pivot/Tab/Tree/FlipView/SelectorBar/ListBox/RadioButtons/BreadcrumbBar). The overlay lit them up even though they never write their own WinUI properties.
5. **Child-reconciler fast-paths skipped Tag refresh.** `ChildReconciler.cs`'s `CanSkipUpdate` shortcut and `UpdateGrid`'s same-count loop bypassed `Update`'s Tag refresh. Once `ShallowEquals` actually accepted Button (from fix #1), Counter-style components silently stuck on their first click — stale trampoline closure.
6. **Every WinRT event was wired at Mount regardless of handler presence.** ~47 sites did `control.Event += ...` unconditionally — hundreds of COM `add_Event` calls for buttons/inputs that carry no handler.

## What changed

### Correctness (commits 1, 2, 5, 6, 7)

- `Element.HasCallbacks` virtual (44 overrides) + gated `Tag` refresh on `Update`'s skip path so the event trampoline dispatches into the current render's closure even when the full Update is elided.
- Dropped the `ReferenceEquals(OnClick)` guard in `ButtonElement.ShallowEquals` — now redundant.
- Added 13 missing `ShallowEquals` cases (HyperlinkButton, RepeatButton, ToggleButton, Slider, ToggleSwitch, CheckBox, RadioButton, ComboBox, TextField, NumberBox, PasswordBox, Progress, ProgressRing).
- Outer skip uses `Element.ModifiersEqual` (structural) instead of `ReferenceEquals`.
- `BrushesEqual` helper unwraps `SolidColorBrush.Color/Opacity`; `FontFamiliesEqual` compares `Source` string; routed `Background`/`Foreground`/`BorderBrush`/`FontFamily` through them in both `ModifiersEqual` and `BorderElement`'s equality cases.
- `ChildReconciler` positional skip + `UpdateGrid` same-count loop now refresh `fe.Tag` when `newEl.HasCallbacks` is true — pays one `children.Get` COM call only for callback-bearing children; handler-free leaves stay free.
- Collection-style elements now have explicit `OwnPropsEqual` cases.

### Performance (commit 3)

- Lazy WinRT event wiring. Poolable types (`Button`, `TextBox`, `ToggleSwitch`) use a new `PoolableWireFlags` CWT keyed on `FrameworkElement` (weak keys, zero cross-ABI cost) to survive the pool's "retain handlers, clear Tag" semantics across rent/return. Non-poolable types (~40) wire at Mount only when the handler is non-null and catch null→non-null transitions at Update — mechanical signature change for the ~20 `UpdateXxx` methods that previously discarded `o`.
- Phase A's TagRefresh gate means handler-free leaves (TextBlock, Image, Border, etc.) avoid the `Tag` DP write on the skip path entirely.

### Overlay fidelity (commit 4)

- Added `ComponentElement`, `FuncElement`, `MemoElement`, `ModifiedElement`, `GroupElement`, `ErrorBoundaryElement`, `MenuFlyoutElement`, `ContentFlyoutElement`, `MenuFlyoutContentElement`, `FlyoutElement`, and `TitleBarElement` to `OwnPropsEqual`. None of these write their own WinUI properties — their rendered output is diffed separately.

## Test plan

- [x] Build clean (0 errors, 15 unrelated warnings).
- [x] Unit tests: 6562 passed (one pre-existing timing flake in `UseResourceTests.Retry_Exhausted_Surfaces_Final_Error`, passes in isolation).
- [x] Selftests: 590/590 passed. Bisected during development — the ChildReconciler Tag-refresh hole regressed ~17 fixtures until fixed; full suite clean at HEAD.
- [x] Manual: Counter demo slider, Transitions demo slider, PerfStress running, AsyncValueSamples scenario selector — all flash only the controls whose own props actually changed. Handler dispatch across multi-click sequences works (fixed the stale-closure trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)