### PR TITLE
reconciler: fix duplicate event subscriptions from aliased RCWs (#86)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,6 @@ samples/apps/reactorfiles/Native/reactorfs/target/
 # Cobertura reports are regenerated on demand and should never be committed.
 coverage/
 *.cobertura.xml
+
+# Stress-perf benchmark run artifacts (local measurement data).
+tests/stress_perf/bench-results/

--- a/src/Reactor/Animation/AnimationHelper.cs
+++ b/src/Reactor/Animation/AnimationHelper.cs
@@ -22,7 +22,7 @@ internal static class AnimationHelper
         // Resolve animation curve: prefer ambient WithAnimation scope,
         // fall back to element's .Animate() config curve.
         var curve = AnimationScope.HasScope ? AnimationScope.Current : null;
-        curve ??= (element is FrameworkElement fe && fe.Tag is Element tagEl)
+        curve ??= (element is FrameworkElement fe && Reconciler.GetElementTag(fe) is Element tagEl)
             ? tagEl.AnimationConfig?.Curve : null;
 
         if (curve is null)
@@ -240,7 +240,7 @@ internal static class AnimationHelper
     internal static void SetOrAnimateVector3(UIElement element, string property, Vector3 value)
     {
         var curve = AnimationScope.HasScope ? AnimationScope.Current : null;
-        curve ??= (element is FrameworkElement fe && fe.Tag is Element tagEl)
+        curve ??= (element is FrameworkElement fe && Reconciler.GetElementTag(fe) is Element tagEl)
             ? tagEl.AnimationConfig?.Curve : null;
 
         if (curve is null)

--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -614,25 +614,10 @@ public class DataGridComponent<T> : Component<DataGridElement<T>>
             {
                 var capturedRow = index;
                 var capturedCol = c;
-                var capturedRowKey = rowKey;
-                var capturedColName = col.Name;
                 cell = cell.OnTapped((sender, e) =>
                 {
                     Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
                     {
-                        // Idempotency guard: if we're already editing exactly this cell,
-                        // skip commit+begin. The underlying native element may have
-                        // accumulated multiple Tapped subscriptions across re-renders
-                        // (multiple C# wrappers of the same native control), causing one
-                        // click to invoke this handler more than once; without this guard
-                        // the second invocation would commit the freshly-begun edit with
-                        // the unchanged value, clobbering the previous row's commit.
-                        if (state.IsEditing
-                            && state.EditingRowKey?.Equals(capturedRowKey) == true
-                            && state.EditingColumnName == capturedColName)
-                        {
-                            return;
-                        }
                         // Commit any in-flight edit BEFORE starting a new one.
                         // BeginEdit unconditionally overwrites _editingValue with the
                         // new cell's current value, which would destroy the in-flight

--- a/src/Reactor/Controls/DataGrid/ResizeGrip.cs
+++ b/src/Reactor/Controls/DataGrid/ResizeGrip.cs
@@ -55,7 +55,7 @@ internal static class ResizeGripRegistration
                     var child = r.Mount(el.Child, rerender);
                     if (child is not null) panel.Children.Add(child);
                 }
-                panel.Tag = el;
+                Reconciler.SetElementTag(panel, el);
                 return panel;
             },
             update: (r, oldEl, newEl, panel, rerender) =>
@@ -83,7 +83,7 @@ internal static class ResizeGripRegistration
                     panel.Children.Clear();
                 }
 
-                panel.Tag = newEl;
+                Reconciler.SetElementTag(panel, newEl);
                 return null;
             });
     }

--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -77,7 +77,7 @@ internal static class ChildReconciler
                 // the initial count). For callback-free elements we still avoid
                 // the children.Get COM call.
                 if (newEl.HasCallbacks && children.Get(i) is FrameworkElement fe)
-                    fe.Tag = newEl;
+                    Reconciler.SetElementTag(fe, newEl);
                 continue;
             }
 
@@ -280,7 +280,7 @@ internal static class ChildReconciler
         for (int i = prefixLen; i < searchEnd && i < children.Count; i++)
         {
             var child = children.Get(i);
-            if (child is FrameworkElement fe && fe.Tag is Element tagElement)
+            if (child is FrameworkElement fe && Reconciler.GetElementTag(fe) is Element tagElement)
             {
                 var key = GetKey(tagElement, i);
                 keyToIndex.TryAdd(key, i);
@@ -358,7 +358,7 @@ internal static class ChildReconciler
         for (int i = searchStart; i < searchEnd && i < children.Count; i++)
         {
             var child = children.Get(i);
-            if (child is FrameworkElement fe && fe.Tag is Element tagElement)
+            if (child is FrameworkElement fe && Reconciler.GetElementTag(fe) is Element tagElement)
             {
                 if (oldIndex < oldElements.Length &&
                     GetKey(tagElement, -1) == GetKey(oldElements[oldIndex], oldIndex))

--- a/src/Reactor/Core/ElementPool.cs
+++ b/src/Reactor/Core/ElementPool.cs
@@ -195,6 +195,7 @@ public sealed class ElementPool : IDisposable
     internal static void CleanElement(FrameworkElement fe)
     {
         // Common properties
+        Reconciler.ClearElementTag(fe);
         fe.Tag = null;
         fe.Margin = new Thickness(0);
         fe.Width = double.NaN;

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -15,9 +15,9 @@ namespace Microsoft.UI.Reactor.Core;
 // AI-HINT: Reconciler.Mount.cs — creates real WinUI controls from Element descriptions.
 // Mount() is a big switch over all Element subtypes → MountXxx() methods.
 // Each MountXxx allocates (or rents from pool) a WinUI control, sets properties,
-// wires event handlers via Tag pattern, and recurses for children.
-// The Tag pattern: event handlers read the current Element from control.Tag to
-// dispatch callbacks, so handlers are wired once and survive element recycling.
+// wires event handlers that look up the current Element via the ReactorAttached
+// DP (see Reconciler.SetElementTag), so handlers are wired once and survive
+// element recycling — the trampoline re-reads the current Element on each fire.
 // Context values are pushed/popped around child processing.
 
 public sealed partial class Reconciler
@@ -1509,7 +1509,7 @@ public sealed partial class Reconciler
                 if (oldCc.Content is UIElement oldCtrl)
                     UnmountChild(oldCtrl);
                 oldCc.Content = null;
-                oldCc.Tag = null;
+                ClearElementTag(oldCc);
             }
             return;
         }
@@ -1522,7 +1522,7 @@ public sealed partial class Reconciler
             var itemElement = currentEl.BuildItemView(args.ItemIndex);
             var ctrl = Mount(itemElement, requestRerender);
             cc.Content = ctrl;
-            cc.Tag = itemElement; // Store for later reconciliation
+            SetElementTag(cc, itemElement); // Store for later reconciliation
         }
     }
 

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -78,7 +78,7 @@ public sealed partial class Reconciler
             // the DependencyProperty write entirely for leaves with no handlers
             // (TextBlock, Image, Border, etc.) — which is most of them.
             if (newEl.HasCallbacks && control is FrameworkElement tagFeSE)
-                tagFeSE.Tag = newEl;
+                SetElementTag(tagFeSE, newEl);
             if (newEl.ThemeBindings is not null && control is FrameworkElement thFeSE)
                 ApplyThemeBindings(thFeSE, newEl.ThemeBindings);
             // Re-resolve ThemeRef-based resource overrides on theme change
@@ -2508,7 +2508,7 @@ public sealed partial class Reconciler
 
     /// <summary>
     /// Walks visible (realized) containers and reconciles each item's Element
-    /// using the stored ContentControl.Tag as the old element.
+    /// using the stored reactor element (attached DP) as the old element.
     /// Null containers (virtualized out) are skipped — ContainerContentChanging handles them on scroll.
     /// </summary>
     private void RefreshRealizedContainers(WinUI.ListViewBase listViewBase, TemplatedListElementBase newEl, Action requestRerender)
@@ -2518,7 +2518,7 @@ public sealed partial class Reconciler
             var container = listViewBase.ContainerFromIndex(i) as WinUI.ListViewItem;
             if (container?.ContentTemplateRoot is not ContentControl cc) continue;
 
-            var oldItemElement = cc.Tag as Element;
+            var oldItemElement = GetElementTag(cc);
             var newItemElement = newEl.BuildItemView(i);
 
             if (oldItemElement is not null && cc.Content is UIElement existingCtrl && CanUpdate(oldItemElement, newItemElement))
@@ -2533,7 +2533,7 @@ public sealed partial class Reconciler
                     Unmount(oldCtrl);
                 cc.Content = Mount(newItemElement, requestRerender);
             }
-            cc.Tag = newItemElement;
+            SetElementTag(cc, newItemElement);
         }
     }
 
@@ -2937,7 +2937,7 @@ public sealed partial class Reconciler
                 // for callback-bearing elements; handler-free leaves stay free.
                 if (newChild.HasCallbacks && i < g.Children.Count
                     && g.Children[i] is FrameworkElement fe)
-                    fe.Tag = newChild;
+                    SetElementTag(fe, newChild);
                 continue;
             }
 

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -188,16 +188,16 @@ public sealed partial class Reconciler : IDisposable
     // per-RCW would return a different EventHandlerState for each wrapper
     // and attach duplicate trampolines on the native event source.
     //
-    // Lifecycle notes:
-    //   - SetElementTag/GetElementTag/ClearElementTag operate on the Element
-    //     field only. On pool return we *preserve* the EventHandlerState so
-    //     that already-attached trampolines survive recycling; the trampoline
-    //     dispatches through state.Current*, which Ensure*Subscribed refreshes
-    //     on next mount/update. Re-attaching subscriptions on every rent would
-    //     re-introduce the duplicate-subscription bug.
-    //   - For controls that are truly being discarded (XamlHostElement unmount,
-    //     ListView item recycle), callers don't need to worry about the state —
-    //     the DP dies with the native DO.
+    // Lifecycle:
+    //   - Pool return / ListView recycle: ClearElementTag nulls state.Element
+    //     only, preserving state.Events. Attached trampolines survive; next
+    //     rent/realize flows through Ensure*Subscribed which refreshes
+    //     state.Current* rather than attaching duplicates. Re-attaching on
+    //     every rent would re-introduce the bug this module exists to fix.
+    //   - Permanent unmount (XamlHost/XamlPage — not pooled, may stay rooted
+    //     by app code): DetachReactorState nulls Element, clears Current*,
+    //     drops state.Events. Any orphan trampoline still on the native event
+    //     source becomes a no-op if it fires.
     internal sealed class ReactorState
     {
         public Element? Element;
@@ -248,13 +248,32 @@ public sealed partial class Reconciler : IDisposable
 
     /// <summary>
     /// Clears the Element pointer while preserving EventHandlerState. Call on
-    /// pool return / XamlHost unmount — attached trampolines stay valid so
-    /// that rent/re-mount reuses the same subscriptions.
+    /// pool return — attached trampolines stay valid so that rent/re-mount
+    /// reuses the same subscriptions (re-attaching would re-introduce the
+    /// duplicate-subscription bug).
     /// </summary>
     internal static void ClearElementTag(FrameworkElement fe)
     {
         if (fe.GetValue(ReactorAttached.StateProperty) is ReactorState state)
             state.Element = null;
+    }
+
+    /// <summary>
+    /// Fully detaches reactor state from a control: nulls the Element and
+    /// clears the EventHandlerState's Current* delegates so any already-
+    /// attached trampoline on the native event source becomes a no-op if it
+    /// fires. Use when the control leaves reactor's ownership for good
+    /// (XamlHost / XamlPage unmount) but may remain alive because the app
+    /// holds a reference — without this, captured closures stay reachable
+    /// and stale reactor callbacks can still fire.
+    /// </summary>
+    internal static void DetachReactorState(FrameworkElement fe)
+    {
+        if (fe.GetValue(ReactorAttached.StateProperty) is not ReactorState state)
+            return;
+        state.Element = null;
+        state.Events?.ClearCurrentHandlers();
+        state.Events = null;
     }
 
     // ════════════════════════════════════════════════════════════════════
@@ -801,10 +820,12 @@ public sealed partial class Reconciler : IDisposable
 
         // XamlHostElement children were created outside Reactor's tree —
         // do NOT recurse into them (they may have stale parent references
-        // or be types Reactor doesn't know how to clean).
+        // or be types Reactor doesn't know how to clean). Fully detach
+        // reactor state so retained-by-app references can't fire stale
+        // callbacks through orphaned trampolines.
         if (control is FrameworkElement hostFe && GetElementTag(hostFe) is XamlHostElement)
         {
-            ClearElementTag(hostFe);
+            DetachReactorState(hostFe);
             return;
         }
 
@@ -812,7 +833,7 @@ public sealed partial class Reconciler : IDisposable
         if (control is WinUI.Frame pageFrame && GetElementTag(pageFrame) is XamlPageElement)
         {
             pageFrame.Content = null;
-            ClearElementTag(pageFrame);
+            DetachReactorState(pageFrame);
             return;
         }
 
@@ -2416,6 +2437,37 @@ public sealed partial class Reconciler : IDisposable
         public RoutedEventHandler? GotFocusTrampoline;
         public RoutedEventHandler? LostFocusTrampoline;
         public global::Windows.Foundation.TypedEventHandler<UIElement, Microsoft.UI.Xaml.Input.AccessKeyDisplayRequestedEventArgs>? AccessKeyDisplayRequestedTrampoline;
+
+        /// <summary>
+        /// Null out every Current* user delegate so trampolines already attached
+        /// on the native event source become no-ops. Trampoline delegate fields
+        /// are left intact — they're rooted by WinUI's subscription list and
+        /// can't be detached here without access to the native element.
+        /// </summary>
+        public void ClearCurrentHandlers()
+        {
+            CurrentSizeChanged = null;
+            CurrentPointerPressed = null;
+            CurrentPointerMoved = null;
+            CurrentPointerReleased = null;
+            CurrentPointerEntered = null;
+            CurrentPointerExited = null;
+            CurrentPointerCanceled = null;
+            CurrentPointerCaptureLost = null;
+            CurrentPointerWheelChanged = null;
+            CurrentTapped = null;
+            CurrentDoubleTapped = null;
+            CurrentRightTapped = null;
+            CurrentHolding = null;
+            CurrentKeyDown = null;
+            CurrentKeyUp = null;
+            CurrentPreviewKeyDown = null;
+            CurrentPreviewKeyUp = null;
+            CurrentCharacterReceived = null;
+            CurrentGotFocus = null;
+            CurrentLostFocus = null;
+            CurrentAccessKeyDisplayRequested = null;
+        }
     }
 
     // EventHandlerState lives on the ReactorState wrapper attached to the

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -173,13 +173,89 @@ public sealed partial class Reconciler : IDisposable
             "<ContentControl HorizontalContentAlignment='Stretch' VerticalContentAlignment='Stretch'/>" +
             "</DataTemplate>"));
 
-    internal static void SetElementTag(FrameworkElement control, Element element) => control.Tag = element;
+    // ════════════════════════════════════════════════════════════════════
+    //  ReactorAttached.StateProperty  (ReactorState)
+    // ════════════════════════════════════════════════════════════════════
+    //
+    // A single attached DP carrying a ReactorState wrapper that bundles
+    //   (a) the current Reactor Element for this native element, and
+    //   (b) the per-element EventHandlerState (current user handlers +
+    //       stable trampoline delegates).
+    //
+    // The DP lives on the native DependencyObject, so every C# RCW pointing
+    // at the same native element observes the same ReactorState — fixing the
+    // duplicate-RCW event-subscription bug where ConditionalWeakTable keyed
+    // per-RCW would return a different EventHandlerState for each wrapper
+    // and attach duplicate trampolines on the native event source.
+    //
+    // Lifecycle notes:
+    //   - SetElementTag/GetElementTag/ClearElementTag operate on the Element
+    //     field only. On pool return we *preserve* the EventHandlerState so
+    //     that already-attached trampolines survive recycling; the trampoline
+    //     dispatches through state.Current*, which Ensure*Subscribed refreshes
+    //     on next mount/update. Re-attaching subscriptions on every rent would
+    //     re-introduce the duplicate-subscription bug.
+    //   - For controls that are truly being discarded (XamlHostElement unmount,
+    //     ListView item recycle), callers don't need to worry about the state —
+    //     the DP dies with the native DO.
+    internal sealed class ReactorState
+    {
+        public Element? Element;
+        public EventHandlerState? Events;
+    }
+
+    internal static class ReactorAttached
+    {
+        public static readonly DependencyProperty StateProperty =
+            DependencyProperty.RegisterAttached(
+                "ReactorState",
+                typeof(ReactorState),
+                typeof(ReactorAttached),
+                new PropertyMetadata(null));
+    }
+
+    internal static ReactorState GetOrCreateReactorState(FrameworkElement fe)
+    {
+        if (fe.GetValue(ReactorAttached.StateProperty) is ReactorState state)
+            return state;
+        state = new ReactorState();
+        fe.SetValue(ReactorAttached.StateProperty, state);
+        return state;
+    }
+
+    internal static void SetElementTag(FrameworkElement control, Element? element)
+    {
+        if (control.GetValue(ReactorAttached.StateProperty) is ReactorState state)
+        {
+            state.Element = element;
+            return;
+        }
+        if (element is null) return; // nothing to store
+        state = new ReactorState { Element = element };
+        control.SetValue(ReactorAttached.StateProperty, state);
+    }
 
     /// <summary>
-    /// Retrieves the element associated with a control via Tag, or null.
+    /// Retrieves the element associated with a control, or null.
     /// </summary>
     internal static Element? GetElementTag(UIElement control) =>
-        control is FrameworkElement fe ? fe.Tag as Element : null;
+        control is FrameworkElement fe
+            ? (fe.GetValue(ReactorAttached.StateProperty) as ReactorState)?.Element
+            : null;
+
+    internal static Element? GetElementTag(FrameworkElement fe) =>
+        (fe.GetValue(ReactorAttached.StateProperty) as ReactorState)?.Element;
+
+    /// <summary>
+    /// Clears the Element pointer while preserving EventHandlerState. Call on
+    /// pool return / XamlHost unmount — attached trampolines stay valid so
+    /// that rent/re-mount reuses the same subscriptions.
+    /// </summary>
+    internal static void ClearElementTag(FrameworkElement fe)
+    {
+        if (fe.GetValue(ReactorAttached.StateProperty) is ReactorState state)
+            state.Element = null;
+    }
 
     // ════════════════════════════════════════════════════════════════════
     //  Lazy event wiring for poolable types
@@ -669,7 +745,7 @@ public sealed partial class Reconciler : IDisposable
     private void UnmountRecursive(UIElement control)
     {
         // Capture connected animation snapshot while element is still in the visual tree
-        if (control is FrameworkElement caFe && caFe.Tag is Element caEl
+        if (control is FrameworkElement caFe && GetElementTag(caFe) is Element caEl
             && caEl.ConnectedAnimationKey is not null)
         {
             try
@@ -682,7 +758,7 @@ public sealed partial class Reconciler : IDisposable
         }
 
         // Clean up animation state (mirrors UnmountAndCollect)
-        if (control is FrameworkElement animFe && animFe.Tag is Element animEl)
+        if (control is FrameworkElement animFe && GetElementTag(animFe) is Element animEl)
         {
             if (animEl.InteractionStates is not null)
                 ClearInteractionStates(control);
@@ -715,8 +791,8 @@ public sealed partial class Reconciler : IDisposable
             return; // Children already handled above; don't recurse into Grid children again
         }
 
-        // Check registered type unmount handlers via Tag
-        if (control is FrameworkElement fe && fe.Tag is Element tagEl
+        // Check registered type unmount handlers via the attached element
+        if (control is FrameworkElement fe && GetElementTag(fe) is Element tagEl
             && _typeRegistry.TryGetValue(tagEl.GetType(), out var reg) && reg.HasUnmount)
         {
             reg.Unmount(control, this);
@@ -726,17 +802,17 @@ public sealed partial class Reconciler : IDisposable
         // XamlHostElement children were created outside Reactor's tree —
         // do NOT recurse into them (they may have stale parent references
         // or be types Reactor doesn't know how to clean).
-        if (control is FrameworkElement hostFe && hostFe.Tag is XamlHostElement)
+        if (control is FrameworkElement hostFe && GetElementTag(hostFe) is XamlHostElement)
         {
-            hostFe.Tag = null;
+            ClearElementTag(hostFe);
             return;
         }
 
         // XamlPageElement — clear content to trigger Page.OnNavigatedFrom cleanup
-        if (control is WinUI.Frame pageFrame && pageFrame.Tag is XamlPageElement)
+        if (control is WinUI.Frame pageFrame && GetElementTag(pageFrame) is XamlPageElement)
         {
             pageFrame.Content = null;
-            pageFrame.Tag = null;
+            ClearElementTag(pageFrame);
             return;
         }
 
@@ -777,7 +853,7 @@ public sealed partial class Reconciler : IDisposable
     internal void RemoveChildWithExitTransition(IChildCollection children, int index)
     {
         var control = children.Get(index);
-        var transition = (control is FrameworkElement fe && fe.Tag is Element el)
+        var transition = (control is FrameworkElement fe && GetElementTag(fe) is Element el)
             ? el.ElementTransition : null;
 
         if (transition?.GetExitTransition() is not null)
@@ -812,7 +888,7 @@ public sealed partial class Reconciler : IDisposable
     internal void ReplaceChildWithExitTransition(IChildCollection children, int index, UIElement newControl)
     {
         var oldControl = children.Get(index);
-        var transition = (oldControl is FrameworkElement fe && fe.Tag is Element el)
+        var transition = (oldControl is FrameworkElement fe && GetElementTag(fe) is Element el)
             ? el.ElementTransition : null;
 
         if (transition?.GetExitTransition() is not null)
@@ -857,7 +933,7 @@ public sealed partial class Reconciler : IDisposable
     private void UnmountAndCollect(UIElement control, List<FrameworkElement> toPool)
     {
         // Capture connected animation snapshot while element is still in the visual tree
-        if (control is FrameworkElement caFe && caFe.Tag is Element caEl
+        if (control is FrameworkElement caFe && GetElementTag(caFe) is Element caEl
             && caEl.ConnectedAnimationKey is not null)
         {
             try
@@ -870,7 +946,7 @@ public sealed partial class Reconciler : IDisposable
         }
 
         // Clean up animation state
-        if (control is FrameworkElement animFe && animFe.Tag is Element animEl)
+        if (control is FrameworkElement animFe && GetElementTag(animFe) is Element animEl)
         {
             if (animEl.InteractionStates is not null)
                 ClearInteractionStates(control);
@@ -890,7 +966,7 @@ public sealed partial class Reconciler : IDisposable
             _componentNodes.Remove(control);
         }
 
-        if (control is FrameworkElement fe && fe.Tag is Element tagEl
+        if (control is FrameworkElement fe && GetElementTag(fe) is Element tagEl
             && _typeRegistry.TryGetValue(tagEl.GetType(), out var reg) && reg.HasUnmount)
         {
             reg.Unmount(control, this);
@@ -1418,8 +1494,7 @@ public sealed partial class Reconciler : IDisposable
 
     /// <summary>
     /// State tracking for elements with InteractionStates — stores current state and cached animations.
-    /// Stored on FrameworkElement.Tag cannot be used (already used for Element reference),
-    /// so we use a static dictionary keyed by UIElement.
+    /// Uses a static dictionary keyed by UIElement.
     /// </summary>
     private static readonly Dictionary<UIElement, InteractionStateTracker> _interactionTrackers = new();
 
@@ -2343,19 +2418,14 @@ public sealed partial class Reconciler : IDisposable
         public global::Windows.Foundation.TypedEventHandler<UIElement, Microsoft.UI.Xaml.Input.AccessKeyDisplayRequestedEventArgs>? AccessKeyDisplayRequestedTrampoline;
     }
 
-    // Key for storing EventHandlerState in a dictionary attached to the element.
-    // We use FrameworkElement's Tag only when no setter has claimed it.
-    // To avoid conflicts, we use an attached-property-like pattern via a ConditionalWeakTable.
-    private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<FrameworkElement, EventHandlerState> _eventStates = new();
-
+    // EventHandlerState lives on the ReactorState wrapper attached to the
+    // native DependencyObject via ReactorAttached.StateProperty. That keys
+    // on native identity, so two RCWs pointing at the same element share one
+    // EventHandlerState and one set of trampolines — fixing issue #86.
     private static EventHandlerState GetOrCreateEventState(FrameworkElement fe)
     {
-        if (!_eventStates.TryGetValue(fe, out var state))
-        {
-            state = new EventHandlerState();
-            _eventStates.AddOrUpdate(fe, state);
-        }
-        return state;
+        var state = GetOrCreateReactorState(fe);
+        return state.Events ??= new EventHandlerState();
     }
 
     private static bool HasAnyEventHandler(ElementModifiers? m)

--- a/src/Reactor/Hosting/XamlInterop.cs
+++ b/src/Reactor/Hosting/XamlInterop.cs
@@ -91,7 +91,11 @@ public static class XamlInterop
                 // Do NOT recurse into children — they were never managed by Reactor
                 // and must not be pooled (they may have stale parent references
                 // or be types Reactor doesn't know how to clean).
-                Reconciler.ClearElementTag(control);
+                //
+                // Fully detach reactor state: the host control may outlive this
+                // unmount (app may retain a reference and reuse it). Clearing
+                // Current* handlers ensures stale reactor callbacks can't fire.
+                Reconciler.DetachReactorState(control);
             });
     }
 }

--- a/src/Reactor/Hosting/XamlInterop.cs
+++ b/src/Reactor/Hosting/XamlInterop.cs
@@ -53,14 +53,14 @@ public static class XamlInterop
             {
                 var frame = new Frame();
                 frame.Navigate(el.PageType, el.Parameter);
-                frame.Tag = el;
+                Reconciler.SetElementTag(frame, el);
                 return frame;
             },
             update: (r, oldEl, newEl, frame, rerender) =>
             {
                 if (oldEl.PageType != newEl.PageType || !Equals(oldEl.Parameter, newEl.Parameter))
                     frame.Navigate(newEl.PageType, newEl.Parameter);
-                frame.Tag = newEl;
+                Reconciler.SetElementTag(frame, newEl);
                 return null; // updated in place
             },
             unmount: (r, frame) =>
@@ -76,13 +76,13 @@ public static class XamlInterop
             {
                 var control = el.Factory();
                 el.Updater?.Invoke(control);
-                control.Tag = el;
+                Reconciler.SetElementTag(control, el);
                 return control;
             },
             update: (r, oldEl, newEl, control, rerender) =>
             {
                 newEl.Updater?.Invoke(control);
-                control.Tag = newEl;
+                Reconciler.SetElementTag(control, newEl);
                 return null; // updated in place
             },
             unmount: (r, control) =>
@@ -91,7 +91,7 @@ public static class XamlInterop
                 // Do NOT recurse into children — they were never managed by Reactor
                 // and must not be pooled (they may have stale parent references
                 // or be types Reactor doesn't know how to clean).
-                control.Tag = null;
+                Reconciler.ClearElementTag(control);
             });
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TypeRegistrationMismatchFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TypeRegistrationMismatchFixtures.cs
@@ -96,11 +96,11 @@ internal static class TypeRegistrationMismatchFixtures
                 update: (r, oldEl, newEl, ctrl, rerender) => null,
                 unmount: (r, ctrl) => { unmountHandlerCalled = true; });
 
-            // Create a TextBlock and stamp it with a WidgetElement Tag,
-            // as the reconciler does during mount. This mimics a control
-            // that ended up in the wrong slot after a dynamic reorder.
+            // Create a TextBlock and stamp it with a WidgetElement via the
+            // reactor attached DP, as the reconciler does during mount. This
+            // mimics a control that ended up in the wrong slot after a dynamic reorder.
             var mismatchedControl = new TextBlock();
-            mismatchedControl.Tag = new WidgetElement("Stale");
+            Reconciler.SetElementTag(mismatchedControl, new WidgetElement("Stale"));
 
             // Unmount should silently skip — not throw InvalidCastException
             bool didNotThrow = true;

--- a/tests/stress_perf/run_bench_reactor_arm64.ps1
+++ b/tests/stress_perf/run_bench_reactor_arm64.ps1
@@ -1,0 +1,21 @@
+$exe = Join-Path $PSScriptRoot 'StressPerf.Reactor\bin\arm64\Release\net9.0-windows10.0.22621.0\StressPerf.Reactor.exe'
+$reportPath = Join-Path (Split-Path $exe) 'StressPerf.Reactor.report.txt'
+$resultsDir = Join-Path $PSScriptRoot 'bench-results'
+New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+
+$runs = if ($args[0]) { [int]$args[0] } else { 10 }
+$percent = if ($args[1]) { $args[1] } else { '50' }
+$duration = if ($args[2]) { $args[2] } else { '7' }
+
+for ($i = 1; $i -le $runs; $i++) {
+    Write-Host "=== run $i / $runs ==="
+    if (Test-Path $reportPath) { Remove-Item $reportPath -Force }
+    $p = Start-Process -FilePath $exe -ArgumentList "--headless --percent $percent --duration $duration" -PassThru -Wait
+    Write-Host "  exit=$($p.ExitCode)"
+    if (-not (Test-Path $reportPath)) {
+        Write-Warning "  no report produced"
+        continue
+    }
+    Copy-Item $reportPath (Join-Path $resultsDir "run-$i.txt")
+}
+Write-Host "Done. Reports at $resultsDir"

--- a/tests/stress_perf/run_bench_reactor_arm64.ps1
+++ b/tests/stress_perf/run_bench_reactor_arm64.ps1
@@ -1,4 +1,8 @@
 $exe = Join-Path $PSScriptRoot 'StressPerf.Reactor\bin\arm64\Release\net9.0-windows10.0.22621.0\StressPerf.Reactor.exe'
+if (-not (Test-Path $exe -PathType Leaf)) {
+    Write-Error "Benchmark executable not found at expected path:`n  $exe`nBuild StressPerf.Reactor for arm64 Release (TFM net9.0-windows10.0.22621.0) first, e.g. `n  dotnet build tests/stress_perf/StressPerf.Reactor/StressPerf.Reactor.csproj -c Release -p:Platform=arm64"
+    exit 1
+}
 $reportPath = Join-Path (Split-Path $exe) 'StressPerf.Reactor.report.txt'
 $resultsDir = Join-Path $PSScriptRoot 'bench-results'
 New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null


### PR DESCRIPTION
## Summary

- Fixes #86. Root cause was that per-FE `EventHandlerState` was keyed by C# reference in a `ConditionalWeakTable`. When WinUI handed the reconciler a fresh RCW for the same native element (re-read via `Panel.Children[i]`, `VisualTreeHelper`, etc.), the table treated it as a new key, allocated a new state, and attached another trampoline via `fe.Tapped += ...`. The native element accumulated N trampolines — one per RCW — and a single click fired the user handler N times.
- Moves per-element reactor state onto the native `DependencyObject` via an attached DP (`ReactorAttached.StateProperty`). DP values live on the native DO, so every RCW observes the same `ReactorState` — one `EventHandlerState`, one trampoline set, no accumulation.
- Same DP carries both the reactor `Element` pointer (replacing the `fe.Tag` squat) and the `EventHandlerState`. `Tag` is returned to application code. `ConditionalWeakTable` removed.
- Reverts the symptom-level idempotency guard from #87 on `DataGridComponent.OnTapped`; the DataGrid no longer needs it.

## Why two patterns were consolidated

Both the `Element`-pointer tracking (previously on `Tag`) and the event-state tracking (previously in a weak table) had the same underlying hazard — identity keyed on C# reference rather than on the native DO. Bundling them in a single `ReactorState` on one DP fixes both aliasing paths at once and drops a data structure. `Tag` becomes available to app code.

## Pool lifecycle

`ClearElementTag` nulls out `state.Element` but preserves `state.Events` so already-attached trampolines survive pool return/rent. The trampoline dispatches through `state.Current*`, which `Ensure*Subscribed` refreshes on the next mount/update. Re-attaching subscriptions on every rent would re-introduce the accumulation bug.

## Perf (10 arm64 Release runs, `--percent 50 --duration 7`)

| Metric | Baseline (main) | This PR | Verdict |
|---|---|---|---|
| Avg FPS | 8.71 ± 0.11 | 8.63 ± 0.12 | within CI |
| Avg Working Set (MB) | 483.4 ± 1.5 | 478.7 ± 4.0 | marginal improvement (removing CWT) |
| Peak Working Set (MB) | 505.0 ± 1.9 | 503.1 ± 4.4 | within CI |

No regression. The small memory delta is consistent with removing one `ConditionalWeakTable` entry per callback-bearing FE.

## Validated

- [x] 6562/6562 unit tests pass (`Reactor.Tests`)
- [x] 590/590 self-tests pass (`Reactor.SelfTests`, in-process WinUI harness)
- [x] `Interactive_DataGrid_ClickEditTabCommit` passes **with the #87 idempotency workaround reverted** — root cause is fixed, symptom guard no longer needed
- [x] Build clean across the solution (x64 Debug, arm64 Release)

## Out of scope

The remaining `Tag` squats in `Reconciler.Mount.cs` (~1836–1911) and `Reconciler.Update.cs` (~2723–2836) where `AppBarButton.Tag = cmd` / `MenuFlyoutItem.Tag = data` stash reactor data structs consumed by native event closures. Different pattern from `Element` tracking; can move in a follow-up if we want `Tag` fully returned to the app.

## Test plan

- [ ] Run `dotnet test tests/Reactor.Tests` on CI
- [ ] Run `dotnet test tests/Reactor.SelfTests` on CI
- [ ] Run `dotnet test tests/Reactor.AppTests --filter "FullyQualifiedName~Interactive_DataGrid_ClickEditTabCommit"` on CI
- [ ] Spot-check other event-heavy surfaces: Counter samples, DataGrid row-edit mode, MenuFlyout click paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)