### PR TITLE
perf(stress_perf): emit per-second samples CSV alongside report

### DIFF
--- a/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
+++ b/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
@@ -118,5 +118,16 @@ public sealed class PerfTracker
         var report = GetReport(appName, percent);
         var path = Path.Combine(AppContext.BaseDirectory, $"{appName}.report.txt");
         File.WriteAllText(path, report);
+
+        var csv = new StringBuilder();
+        csv.AppendLine("Second,FPS,Memory_MB");
+        int n = Math.Min(_fpsSamples.Count, _memorySamples.Count);
+        for (int i = 0; i < n; i++)
+        {
+            double mb = _memorySamples[i] / (1024.0 * 1024.0);
+            csv.AppendLine($"{i + 1},{_fpsSamples[i]:F2},{mb:F1}");
+        }
+        var csvPath = Path.Combine(AppContext.BaseDirectory, $"{appName}.samples.csv");
+        File.WriteAllText(csvPath, csv.ToString());
     }
 }


### PR DESCRIPTION
## Summary

`PerfTracker` already collects per-second FPS and memory samples, but `WriteReportFile` only emits aggregates. This change additionally writes the raw time series as `<AppName>.samples.csv` next to the existing `<AppName>.report.txt`, so drift over time can be inspected without code changes.

Useful for diagnosing apparent regressions: in this session a "FPS degradation over 2 minutes" turned out to be caused by switching virtual desktops mid-run (DWM stops compositing the window, and Windows applies EcoQoS to the process). The per-second samples made the sharp transition obvious.

## Sweep results — full StressPerf suite, 7s per cell

Reference numbers from running the existing `tests/stress_perf/run_benchmark.sh`-equivalent sweep at 10/50/100% load on this branch:

### FPS by load (higher is better)

| Variant            |   10% |   50% |  100% |
|--------------------|------:|------:|------:|
| WinUI.Direct       |  23.3 |   7.5 |   5.1 |
| WinUI.Bound        |  21.0 |   6.4 |   4.4 |
| WinUI.Reactor      |  19.0 |   8.2 |   6.1 |
| WinUI.ReactorGrid  |  15.2 |  10.0 |   7.9 |
| WinUI.DirectX      |  29.9 |  37.9 |  32.0 |
| WPF.Direct         |  22.2 |   6.6 |   3.7 |

### Update time, ms (lower is better)

| Variant            | 10% avg/max | 50% avg/max | 100% avg/max |
|--------------------|------------:|------------:|-------------:|
| WinUI.Direct       |   2.3 / 3.7 |  9.6 / 14.4 | 16.3 / 21.6  |
| WinUI.Bound        |   6.4 / 8.1 | 27.6 / 51.6 | 44.0 / 65.2  |
| WinUI.Reactor      |   0.1 / 0.6 |   0.3 / 1.6 |   0.4 / 1.7  |
| WinUI.ReactorGrid  |   0.1 / 0.6 |   0.3 / 1.9 |   0.3 / 2.3  |
| WinUI.DirectX      |   0.1 / 0.7 |   0.1 / 2.5 |   0.3 / 2.1  |
| WPF.Direct         |   0.9 / 2.6 |  4.7 / 16.6 |   6.5 / 14.8 |

### Peak memory, MB

| Variant            | 10% | 50% | 100% |
|--------------------|----:|----:|-----:|
| WinUI.Direct       | 463 | 481 |  490 |
| WinUI.Bound        | 548 | 559 |  560 |
| WinUI.Reactor      | 493 | 495 |  509 |
| WinUI.ReactorGrid  | 411 | 413 |  411 |
| WinUI.DirectX      | 138 | 135 |  134 |
| WPF.Direct         | 976 |1085 |  907 |

## Test machine

| | |
|---|---|
| Device       | Microsoft Surface Laptop, 7th Edition |
| CPU          | Snapdragon X Elite X1E80100 (12-core @ 3.40 GHz) |
| Architecture | ARM64 |
| RAM          | 32 GB |
| OS           | Windows 11 Enterprise 26200 |
| Display      | 3072 × 1728 (built-in) |
| Build        | Release / ARM64, `net9.0-windows10.0.22621.0` (WPF: `net9.0-windows`) |
| Mode         | `--headless --percent N --duration 7`, foreground / undisturbed |

Note: results are sensitive to window state. If the bench window is occluded or moved to an inactive virtual desktop, DWM stops compositing it (suppressing the `CompositionTarget.Rendering` callbacks `PerfTracker` uses) and Windows applies process power throttling — both of which inflate apparent regressions. Keep the window foregrounded for the duration of a run.

## Test plan

- [x] `dotnet build tests/stress_perf/StressPerf.Reactor -c Release -p:Platform=ARM64`
- [x] Headless run produces both `StressPerf.Reactor.report.txt` and `StressPerf.Reactor.samples.csv` next to the exe
- [x] CSV has one row per second with `Second,FPS,Memory_MB` columns
- [x] No change to existing report file format

🤖 Generated with [Claude Code](https://claude.com/claude-code)