### PR TITLE
fix(reconciler): dedupe ToggleSwitch.Toggled wiring via EventHandlerState

### DIFF
--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -675,23 +675,22 @@ public sealed partial class Reconciler
         return toggle;
     }
 
-    /// <summary>
-    /// Wires ToggleSwitch.Toggled trampoline only when the element has a
-    /// handler AND the control hasn't been wired yet. The CWT flag survives
-    /// pool round-trips (ToggleSwitch is a poolable type).
-    /// </summary>
+    // Dedupe via EventHandlerState (attached on ReactorAttached.StateProperty,
+    // keyed by native DependencyObject identity). A plain CWT keyed by managed
+    // RCW identity is unsafe — two RCWs over the same DO miss the dedupe and
+    // double-subscribe, fanning one Toggled into multiple user-callback invocations.
     internal static void EnsureToggleSwitchWiring(WinUI.ToggleSwitch toggle, ToggleSwitchElement ts)
     {
         if (ts.OnChanged is null) return;
-        var flags = GetPoolableWireFlags(toggle);
-        if (flags.ToggleSwitchToggled) return;
-        flags.ToggleSwitchToggled = true;
-        toggle.Toggled += (s, _) =>
+        var state = GetOrCreateEventState(toggle);
+        if (state.ToggleSwitchToggledTrampoline is not null) return;
+        state.ToggleSwitchToggledTrampoline = (s, _) =>
         {
             var t = (WinUI.ToggleSwitch)s!;
             if (ChangeEchoSuppressor.ShouldSuppress(t)) return;
             (GetElementTag(t) as ToggleSwitchElement)?.OnChanged?.Invoke(t.IsOn);
         };
+        toggle.Toggled += state.ToggleSwitchToggledTrampoline;
     }
 
     private WinUI.RatingControl MountRatingControl(RatingControlElement rc)

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -368,7 +368,6 @@ public sealed partial class Reconciler : IDisposable
         public bool ButtonClick;
         public bool TextBoxTextChanged;
         public bool TextBoxSelectionChanged;
-        public bool ToggleSwitchToggled;
     }
 
     private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<FrameworkElement, PoolableWireFlags> _poolableWireFlags = new();
@@ -2554,6 +2553,7 @@ public sealed partial class Reconciler : IDisposable
         public global::Windows.Foundation.TypedEventHandler<UIElement, Microsoft.UI.Xaml.Input.CharacterReceivedRoutedEventArgs>? CharacterReceivedTrampoline;
         public RoutedEventHandler? GotFocusTrampoline;
         public RoutedEventHandler? LostFocusTrampoline;
+        public RoutedEventHandler? ToggleSwitchToggledTrampoline;
         public global::Windows.Foundation.TypedEventHandler<UIElement, Microsoft.UI.Xaml.Input.AccessKeyDisplayRequestedEventArgs>? AccessKeyDisplayRequestedTrampoline;
 
         /// <summary>

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -360,8 +360,19 @@ public sealed partial class Reconciler : IDisposable
     // ElementPool.CleanElement), but clears Tag. So "Tag is null" on rent does
     // NOT mean "unwired" — the control may already have a trampoline attached.
     // We need a per-control flag that survives pool cycles to avoid double-
-    // subscription. A ConditionalWeakTable gives us that with zero cross-ABI
-    // cost and weak keys so GC isn't blocked.
+    // subscription.
+    //
+    // Two dedupe schemes coexist:
+    //   - Button.Click and TextBox.TextChanged/SelectionChanged use the CWT
+    //     below, keyed by managed FrameworkElement identity. This is fragile
+    //     when WinRT projection produces a second RCW over the same native
+    //     DependencyObject (each RCW gets its own entry, both pass dedupe,
+    //     trampoline subscribed twice). See issue #114 for the migration.
+    //   - ToggleSwitch.Toggled uses EventHandlerState (attached on
+    //     ReactorAttached.StateProperty), which is keyed by native DO identity
+    //     and so is RCW-stable. New poolable wiring should follow this pattern
+    //     — see EnsureToggleSwitchWiring and the EnsureXxxSubscribed helpers
+    //     for the input events.
 
     internal sealed class PoolableWireFlags
     {


### PR DESCRIPTION
## Summary

Fixes a ~8% flake in `EchoSuppress_ToggleSwitch_NoEchoCall` caused by the wire-dedupe flag for `ToggleSwitch.Toggled` living in a `ConditionalWeakTable<FrameworkElement, PoolableWireFlags>` keyed by managed RCW identity. WinRT projection can produce two RCWs over the same underlying `DependencyObject`; each gets its own CWT entry, both pass the dedupe check, and `toggle.Toggled +=` subscribes the trampoline twice. One `IsOn` change then fans into multiple user-callback invocations — the first consumes the `BeginSuppress` token, the second runs unsuppressed and invokes the user's `OnChanged` with the value Reactor just wrote (the exact echo bug `ChangeEchoSuppressor` was built to prevent).

The fix moves the trampoline reference to `EventHandlerState`, which lives on `ReactorAttached.StateProperty` (an attached DP keyed by native DO identity). This is the same pattern already used for `SizeChanged`, `PointerPressed`, `Tapped`, and the other input events — and the comment block on `GetOrCreateEventState` (`Reconciler.cs:2590`) explicitly calls out why this key is safe. ToggleSwitch was the lone holdout still on the unsafe CWT-by-RCW scheme.

## How the flake was traced

1. Ran the selftest suite 50× sequentially; got `EchoSuppress_ToggleSwitch_NoEchoCall` failing in 4/50 runs (8%).
2. Ran it 50× in isolation via `--filter EchoSuppress_ToggleSwitch`: **0 flakes** — confirmed the issue requires inter-fixture state.
3. Added a `Console.Error` trace inside the `Toggled` handler (past `ShouldSuppress`). On the next flake, the diagnostic showed exactly **two** trace lines for one user-edit `IsOn=false` write, proving double subscription on the same physical control.
4. After the fix, **60/60 full-suite runs clean** across two iterations (baseline expected ~4.8 flakes at 8%).

## Diff

- `EnsureToggleSwitchWiring` allocates the trampoline through `GetOrCreateEventState(toggle)` and stores it in `state.ToggleSwitchToggledTrampoline`. Dedupe is a null-check on that field.
- Removed unused `PoolableWireFlags.ToggleSwitchToggled`.

## Test plan

- [x] 60 full-suite selftest runs (635 fixtures each) post-fix: 0 failures.
- [x] All 12 EchoSuppression fixtures still pass.
- [x] No build warnings.

## Follow-up

`PoolableWireFlags.ButtonClick`, `TextBoxTextChanged`, and `TextBoxSelectionChanged` share the same CWT-by-RCW vulnerability. They didn't surface in the 50-run baseline but are theoretically vulnerable to the same double-subscription race. Filed as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)