### PR TITLE
test: deflake 12 unit tests across 4 test classes

### DIFF
--- a/tests/Reactor.Tests/Core/UseResourceTests.cs
+++ b/tests/Reactor.Tests/Core/UseResourceTests.cs
@@ -279,19 +279,28 @@ public class UseResourceTests
 
         var ctx = new RenderContext();
         ctx.BeginRender(() => { });
-        var v = ctx.UseResource(fetcher, cache, Array.Empty<object>(),
+        ctx.UseResource(fetcher, cache, Array.Empty<object>(),
             new ResourceOptions(RetryCount: 3), dispatcher);
         ctx.FlushEffects();
 
-        // First fetch is sync-faulted. Without retry logic we'd see Error immediately.
-        // Retry schedules on a Timer with ~100ms backoff; wait generously.
-        for (int i = 0; i < 40 && calls < 3; i++) await Task.Delay(50);
+        // The retry chain runs on Timer/threadpool callbacks. `calls++` increments
+        // ahead of the dispatcher.Post that publishes state, so polling on `calls`
+        // alone races the state transition. Poll the rendered AsyncValue instead —
+        // re-rendering with identical deps just reads the current hook state and
+        // does not re-invoke the fetcher.
+        AsyncValue<int>? probe = null;
+        var sw = global::System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            ctx.BeginRender(() => { });
+            probe = ctx.UseResource(fetcher, cache, Array.Empty<object>(),
+                new ResourceOptions(RetryCount: 3), dispatcher);
+            if (probe is AsyncValue<int>.Data) break;
+            await Task.Delay(25);
+        }
 
         Assert.Equal(3, calls);
-        ctx.BeginRender(() => { });
-        var v2 = ctx.UseResource(fetcher, cache, Array.Empty<object>(),
-            new ResourceOptions(RetryCount: 3), dispatcher);
-        Assert.Equal(new AsyncValue<int>.Data(42), v2);
+        Assert.Equal(new AsyncValue<int>.Data(42), probe);
     }
 
     [Fact]
@@ -312,14 +321,20 @@ public class UseResourceTests
             new ResourceOptions(RetryCount: 2), dispatcher);
         ctx.FlushEffects();
 
-        // With 2 retries we expect up to 3 calls total.
-        for (int i = 0; i < 40 && calls < 3; i++) await Task.Delay(50);
-        Assert.Equal(3, calls);
+        // See sibling test: poll the rendered state, not the call counter.
+        AsyncValue<int>? probe = null;
+        var sw = global::System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            ctx.BeginRender(() => { });
+            probe = ctx.UseResource(fetcher, cache, Array.Empty<object>(),
+                new ResourceOptions(RetryCount: 2), dispatcher);
+            if (probe is AsyncValue<int>.Error) break;
+            await Task.Delay(25);
+        }
 
-        ctx.BeginRender(() => { });
-        var v = ctx.UseResource(fetcher, cache, Array.Empty<object>(),
-            new ResourceOptions(RetryCount: 2), dispatcher);
-        var err = Assert.IsType<AsyncValue<int>.Error>(v);
+        Assert.Equal(3, calls);
+        var err = Assert.IsType<AsyncValue<int>.Error>(probe);
         Assert.Contains("attempt", err.Exception.Message);
     }
 
@@ -375,24 +390,24 @@ public class UseResourceTests
     {
         var cache = NewCache();
         var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        // The continuation runs on the threadpool, so the polling loop on the test
-        // thread needs an explicit memory barrier to observe the write — Volatile.Write
-        // on the producer side, Volatile.Read on the consumer side.
-        var rerendered = 0;
+        // The rerender callback runs on the threadpool when the fetch task completes.
+        // Under heavy parallel test load the threadpool can be starved long enough that
+        // a fixed-budget poll loop misses it, so signal a TCS from the callback and
+        // await that instead. The Volatile read after the await observes the final count.
+        int rerendered = 0;
+        var rerenderedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var ctx = new RenderContext();
-        ctx.BeginRender(() => Volatile.Write(ref rerendered, 1));
+        ctx.BeginRender(() =>
+        {
+            Volatile.Write(ref rerendered, 1);
+            rerenderedTcs.TrySetResult();
+        });
         ctx.UseResource(_ => tcs.Task, cache, Array.Empty<object>(), null, dispatcher: null);
 
         tcs.SetResult(7);
 
-        // Continuation hops to the threadpool (RunContinuationsAsynchronously). Under
-        // heavy parallel test load the threadpool can take longer than a single 10ms
-        // tick, causing this assertion to flake. Poll up to 1s for the rerender flag.
-        var sw = global::System.Diagnostics.Stopwatch.StartNew();
-        while (Volatile.Read(ref rerendered) == 0 && sw.Elapsed < TimeSpan.FromSeconds(1))
-            await Task.Delay(10);
-
+        await rerenderedTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
         Assert.Equal(1, Volatile.Read(ref rerendered));
     }
 

--- a/tests/Reactor.Tests/Core/UseResourceTests.cs
+++ b/tests/Reactor.Tests/Core/UseResourceTests.cs
@@ -270,11 +270,13 @@ public class UseResourceTests
     {
         var cache = NewCache();
         var dispatcher = new InlineDispatcher();
+        // The fetcher runs on Timer/threadpool callbacks, so all access to `calls`
+        // must be synchronized — Interlocked on the increment, Volatile on reads.
         int calls = 0;
         Func<CancellationToken, Task<int>> fetcher = _ =>
         {
-            calls++;
-            return calls < 3 ? Task.FromException<int>(new InvalidOperationException("transient")) : Task.FromResult(42);
+            int n = Interlocked.Increment(ref calls);
+            return n < 3 ? Task.FromException<int>(new InvalidOperationException("transient")) : Task.FromResult(42);
         };
 
         var ctx = new RenderContext();
@@ -283,11 +285,10 @@ public class UseResourceTests
             new ResourceOptions(RetryCount: 3), dispatcher);
         ctx.FlushEffects();
 
-        // The retry chain runs on Timer/threadpool callbacks. `calls++` increments
-        // ahead of the dispatcher.Post that publishes state, so polling on `calls`
-        // alone races the state transition. Poll the rendered AsyncValue instead —
-        // re-rendering with identical deps just reads the current hook state and
-        // does not re-invoke the fetcher.
+        // `calls` increments ahead of the dispatcher.Post that publishes state, so
+        // polling on `calls` alone races the state transition. Poll the rendered
+        // AsyncValue instead — re-rendering with identical deps just reads the
+        // current hook state and does not re-invoke the fetcher.
         AsyncValue<int>? probe = null;
         var sw = global::System.Diagnostics.Stopwatch.StartNew();
         while (sw.Elapsed < TimeSpan.FromSeconds(5))
@@ -299,7 +300,7 @@ public class UseResourceTests
             await Task.Delay(25);
         }
 
-        Assert.Equal(3, calls);
+        Assert.Equal(3, Volatile.Read(ref calls));
         Assert.Equal(new AsyncValue<int>.Data(42), probe);
     }
 
@@ -308,11 +309,13 @@ public class UseResourceTests
     {
         var cache = NewCache();
         var dispatcher = new InlineDispatcher();
+        // See sibling test: synchronized access required because the fetcher runs
+        // on Timer/threadpool callbacks during retry.
         int calls = 0;
         Func<CancellationToken, Task<int>> fetcher = _ =>
         {
-            calls++;
-            return Task.FromException<int>(new InvalidOperationException($"attempt{calls}"));
+            int n = Interlocked.Increment(ref calls);
+            return Task.FromException<int>(new InvalidOperationException($"attempt{n}"));
         };
 
         var ctx = new RenderContext();
@@ -321,7 +324,7 @@ public class UseResourceTests
             new ResourceOptions(RetryCount: 2), dispatcher);
         ctx.FlushEffects();
 
-        // See sibling test: poll the rendered state, not the call counter.
+        // Poll the rendered state, not the call counter.
         AsyncValue<int>? probe = null;
         var sw = global::System.Diagnostics.Stopwatch.StartNew();
         while (sw.Elapsed < TimeSpan.FromSeconds(5))
@@ -333,7 +336,7 @@ public class UseResourceTests
             await Task.Delay(25);
         }
 
-        Assert.Equal(3, calls);
+        Assert.Equal(3, Volatile.Read(ref calls));
         var err = Assert.IsType<AsyncValue<int>.Error>(probe);
         Assert.Contains("attempt", err.Exception.Message);
     }

--- a/tests/Reactor.Tests/Devtools/DevtoolsParamCompatTests.cs
+++ b/tests/Reactor.Tests/Devtools/DevtoolsParamCompatTests.cs
@@ -2,6 +2,10 @@ using Xunit;
 
 namespace Microsoft.UI.Reactor.Tests.Devtools;
 
+// Joins the Localization tests' collection: every test here mutates Console.Error,
+// and racing those mutations against ValidateCommandTests / PruneCommandTests etc.
+// causes one test's stderr to land in another's StringWriter.
+[Collection("ConsoleTests")]
 public class DevtoolsParamCompatTests
 {
     [Fact]

--- a/tests/Reactor.Tests/NavigationDiagnosticsCoverageTests.cs
+++ b/tests/Reactor.Tests/NavigationDiagnosticsCoverageTests.cs
@@ -27,7 +27,8 @@ public class NavigationDiagnosticsCoverageTests
         NavigationDiagnosticEvent? captured = null;
         Action<NavigationDiagnosticEvent> handler = e =>
         {
-            if (e.From == from && e.To == to) captured = e;
+            // From/To are typed `object`; compare via Equals to avoid CS0252.
+            if (Equals(e.From, from) && Equals(e.To, to)) captured = e;
         };
         NavigationDiagnostics.NavigationRequested += handler;
         try
@@ -51,7 +52,8 @@ public class NavigationDiagnosticsCoverageTests
         NavigationDiagnosticEvent? captured = null;
         Action<NavigationDiagnosticEvent> handler = e =>
         {
-            if (e.From == from && e.To == to) captured = e;
+            // From/To are typed `object`; compare via Equals to avoid CS0252.
+            if (Equals(e.From, from) && Equals(e.To, to)) captured = e;
         };
         NavigationDiagnostics.NavigationCompleted += handler;
         try
@@ -73,7 +75,8 @@ public class NavigationDiagnosticsCoverageTests
         NavigationDiagnosticEvent? captured = null;
         Action<NavigationDiagnosticEvent> handler = e =>
         {
-            if (e.From == from && e.To == to) captured = e;
+            // From/To are typed `object`; compare via Equals to avoid CS0252.
+            if (Equals(e.From, from) && Equals(e.To, to)) captured = e;
         };
         NavigationDiagnostics.NavigationCancelled += handler;
         try
@@ -98,9 +101,11 @@ public class NavigationDiagnosticsCoverageTests
         var hits = new List<CacheDiagnosticEvent>();
         var misses = new List<CacheDiagnosticEvent>();
         var evicts = new List<CacheDiagnosticEvent>();
-        Action<CacheDiagnosticEvent> hh = e => { if (e.Route == rHit) hits.Add(e); };
-        Action<CacheDiagnosticEvent> mh = e => { if (e.Route == rMiss) misses.Add(e); };
-        Action<CacheDiagnosticEvent> eh = e => { if (e.Route == rEvict) evicts.Add(e); };
+        // CacheDiagnosticEvent.Route is typed as object; compare via Equals to
+        // avoid the reference-comparison footgun (CS0252).
+        Action<CacheDiagnosticEvent> hh = e => { if (Equals(e.Route, rHit)) hits.Add(e); };
+        Action<CacheDiagnosticEvent> mh = e => { if (Equals(e.Route, rMiss)) misses.Add(e); };
+        Action<CacheDiagnosticEvent> eh = e => { if (Equals(e.Route, rEvict)) evicts.Add(e); };
 
         NavigationDiagnostics.CacheHit += hh;
         NavigationDiagnostics.CacheMiss += mh;

--- a/tests/Reactor.Tests/NavigationDiagnosticsCoverageTests.cs
+++ b/tests/Reactor.Tests/NavigationDiagnosticsCoverageTests.cs
@@ -10,35 +10,53 @@ namespace Microsoft.UI.Reactor.Tests;
 /// </summary>
 public class NavigationDiagnosticsCoverageTests
 {
+    // NavigationDiagnostics events are process-wide static delegates. Real navigation
+    // tests running in parallel fire these same events, so handlers must filter to
+    // their own payload (unique From/To keys per test) or risk capturing a sibling
+    // test's event.
+    private static (string From, string To) UniqueKeys()
+    {
+        var g = Guid.NewGuid().ToString("N");
+        return ($"From-{g}", $"To-{g}");
+    }
+
     [Fact]
     public void OnNavigationRequested_Fires_Event_With_Payload()
     {
+        var (from, to) = UniqueKeys();
         NavigationDiagnosticEvent? captured = null;
-        Action<NavigationDiagnosticEvent> handler = e => captured = e;
+        Action<NavigationDiagnosticEvent> handler = e =>
+        {
+            if (e.From == from && e.To == to) captured = e;
+        };
         NavigationDiagnostics.NavigationRequested += handler;
         try
         {
-            NavigationDiagnostics.OnNavigationRequested("Home", "Detail", NavigationMode.Push);
+            NavigationDiagnostics.OnNavigationRequested(from, to, NavigationMode.Push);
         }
         finally
         {
             NavigationDiagnostics.NavigationRequested -= handler;
         }
         Assert.NotNull(captured);
-        Assert.Equal("Home", captured!.From);
-        Assert.Equal("Detail", captured.To);
+        Assert.Equal(from, captured!.From);
+        Assert.Equal(to, captured.To);
         Assert.Equal(NavigationMode.Push, captured.Mode);
     }
 
     [Fact]
     public void OnNavigationCompleted_Fires_Event()
     {
+        var (from, to) = UniqueKeys();
         NavigationDiagnosticEvent? captured = null;
-        Action<NavigationDiagnosticEvent> handler = e => captured = e;
+        Action<NavigationDiagnosticEvent> handler = e =>
+        {
+            if (e.From == from && e.To == to) captured = e;
+        };
         NavigationDiagnostics.NavigationCompleted += handler;
         try
         {
-            NavigationDiagnostics.OnNavigationCompleted("A", "B", NavigationMode.Pop);
+            NavigationDiagnostics.OnNavigationCompleted(from, to, NavigationMode.Pop);
         }
         finally
         {
@@ -51,12 +69,16 @@ public class NavigationDiagnosticsCoverageTests
     [Fact]
     public void OnNavigationCancelled_Captures_Reason()
     {
+        var (from, to) = UniqueKeys();
         NavigationDiagnosticEvent? captured = null;
-        Action<NavigationDiagnosticEvent> handler = e => captured = e;
+        Action<NavigationDiagnosticEvent> handler = e =>
+        {
+            if (e.From == from && e.To == to) captured = e;
+        };
         NavigationDiagnostics.NavigationCancelled += handler;
         try
         {
-            NavigationDiagnostics.OnNavigationCancelled("A", "B", NavigationMode.Push, "guard");
+            NavigationDiagnostics.OnNavigationCancelled(from, to, NavigationMode.Push, "guard");
         }
         finally
         {
@@ -69,21 +91,25 @@ public class NavigationDiagnosticsCoverageTests
     [Fact]
     public void OnCacheHit_OnCacheMiss_OnCacheEviction_Fire()
     {
+        var g = Guid.NewGuid().ToString("N");
+        var rHit = $"Hit-{g}";
+        var rMiss = $"Miss-{g}";
+        var rEvict = $"Evict-{g}";
         var hits = new List<CacheDiagnosticEvent>();
         var misses = new List<CacheDiagnosticEvent>();
         var evicts = new List<CacheDiagnosticEvent>();
-        Action<CacheDiagnosticEvent> hh = e => hits.Add(e);
-        Action<CacheDiagnosticEvent> mh = e => misses.Add(e);
-        Action<CacheDiagnosticEvent> eh = e => evicts.Add(e);
+        Action<CacheDiagnosticEvent> hh = e => { if (e.Route == rHit) hits.Add(e); };
+        Action<CacheDiagnosticEvent> mh = e => { if (e.Route == rMiss) misses.Add(e); };
+        Action<CacheDiagnosticEvent> eh = e => { if (e.Route == rEvict) evicts.Add(e); };
 
         NavigationDiagnostics.CacheHit += hh;
         NavigationDiagnostics.CacheMiss += mh;
         NavigationDiagnostics.CacheEviction += eh;
         try
         {
-            NavigationDiagnostics.OnCacheHit("R1");
-            NavigationDiagnostics.OnCacheMiss("R2");
-            NavigationDiagnostics.OnCacheEviction("R3");
+            NavigationDiagnostics.OnCacheHit(rHit);
+            NavigationDiagnostics.OnCacheMiss(rMiss);
+            NavigationDiagnostics.OnCacheEviction(rEvict);
         }
         finally
         {
@@ -91,23 +117,25 @@ public class NavigationDiagnosticsCoverageTests
             NavigationDiagnostics.CacheMiss -= mh;
             NavigationDiagnostics.CacheEviction -= eh;
         }
-        Assert.Equal("R1", Assert.Single(hits).Route);
-        Assert.Equal("R2", Assert.Single(misses).Route);
-        Assert.Equal("R3", Assert.Single(evicts).Route);
+        Assert.Equal(rHit, Assert.Single(hits).Route);
+        Assert.Equal(rMiss, Assert.Single(misses).Route);
+        Assert.Equal(rEvict, Assert.Single(evicts).Route);
     }
 
     [Fact]
     public void OnTransitionStarted_OnTransitionCompleted_Fire()
     {
+        // Filter by transition instance identity — concurrent navigation tests fire
+        // their own transitions through the same global event.
+        var transition = new SlideTransition();
         TransitionDiagnosticEvent? start = null;
         TransitionDiagnosticEvent? end = null;
-        Action<TransitionDiagnosticEvent> sh = e => start = e;
-        Action<TransitionDiagnosticEvent> eh = e => end = e;
+        Action<TransitionDiagnosticEvent> sh = e => { if (ReferenceEquals(e.Transition, transition)) start = e; };
+        Action<TransitionDiagnosticEvent> eh = e => { if (ReferenceEquals(e.Transition, transition)) end = e; };
         NavigationDiagnostics.TransitionStarted += sh;
         NavigationDiagnostics.TransitionCompleted += eh;
         try
         {
-            var transition = new SlideTransition();
             NavigationDiagnostics.OnTransitionStarted(transition, NavigationMode.Push);
             NavigationDiagnostics.OnTransitionCompleted(transition, NavigationMode.Pop);
         }
@@ -125,29 +153,31 @@ public class NavigationDiagnosticsCoverageTests
     [Fact]
     public void OnDeepLinkResolved_Fires_With_Match_And_Miss()
     {
+        var pathHit = $"/home-{Guid.NewGuid():N}";
         DeepLinkDiagnosticEvent? captured = null;
-        Action<DeepLinkDiagnosticEvent> handler = e => captured = e;
+        Action<DeepLinkDiagnosticEvent> handler = e => { if (e.Path == pathHit) captured = e; };
         NavigationDiagnostics.DeepLinkResolved += handler;
         try
         {
-            NavigationDiagnostics.OnDeepLinkResolved("/home", true, 2);
+            NavigationDiagnostics.OnDeepLinkResolved(pathHit, true, 2);
         }
         finally
         {
             NavigationDiagnostics.DeepLinkResolved -= handler;
         }
         Assert.NotNull(captured);
-        Assert.Equal("/home", captured!.Path);
+        Assert.Equal(pathHit, captured!.Path);
         Assert.True(captured.Matched);
         Assert.Equal(2, captured.RouteCount);
 
         // Re-fire for the miss branch (matched=false formats differently)
+        var pathMiss = $"/missing-{Guid.NewGuid():N}";
         DeepLinkDiagnosticEvent? miss = null;
-        Action<DeepLinkDiagnosticEvent> handler2 = e => miss = e;
+        Action<DeepLinkDiagnosticEvent> handler2 = e => { if (e.Path == pathMiss) miss = e; };
         NavigationDiagnostics.DeepLinkResolved += handler2;
         try
         {
-            NavigationDiagnostics.OnDeepLinkResolved("/missing", false, 0);
+            NavigationDiagnostics.OnDeepLinkResolved(pathMiss, false, 0);
         }
         finally
         {

--- a/tests/Reactor.Tests/ReactorEventSourceCoverageTests.cs
+++ b/tests/Reactor.Tests/ReactorEventSourceCoverageTests.cs
@@ -13,10 +13,17 @@ public class ReactorEventSourceCoverageTests : IDisposable
 {
     private sealed class CapturingListener : EventListener
     {
-        public readonly List<EventWrittenEventArgs> Events = new();
+        // ReactorEventSource.Log is process-wide. Other tests running in parallel
+        // can fire events into this listener while a test enumerates Events, so
+        // both writes and snapshot reads must be guarded.
+        private readonly List<EventWrittenEventArgs> _events = new();
+        public IReadOnlyList<EventWrittenEventArgs> Events
+        {
+            get { lock (_events) return _events.ToArray(); }
+        }
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            Events.Add(eventData);
+            lock (_events) _events.Add(eventData);
         }
     }
 


### PR DESCRIPTION
## Summary

A 50x rerun of `Reactor.Tests` surfaced **8 flaky tests** with a 24% run-level flake rate (12/50 runs failing). After fixing three independent root-cause clusters and 200 cumulative reruns across three iterations, the suite now passes **50/50 clean at 6,647 tests/run**.

## Root-cause clusters

**A. Global static event sources captured without payload filtering**
- `ReactorEventSourceCoverageTests.CapturingListener` (5 tests fixed): lock-guard the event list and return a snapshot from the `Events` property. `ReactorEventSource.Log` is process-wide, and concurrent callbacks from sibling test classes were mutating the list during `Assert.Contains` enumeration.
- `NavigationDiagnosticsCoverageTests` (5 tests fixed): each handler now filters by a unique-per-test `From`/`To`/`Route`/`Path` key (or transition instance identity). Real navigation flows in other test classes fire the same global events.

**B. Threadpool-continuation race in async hook tests**
- `Core.UseResourceTests.Retry_Exhausted_Surfaces_Final_Error` and `Retry_Invokes_Fetcher_Multiple_Times_And_Settles_On_Success`: poll the rendered `AsyncValue<T>` state instead of the call counter. The original loop exited when `calls == N` before `dispatcher.Post` had published the Error/Data state, so the assertion read a stale Loading/Reloading.
- `Core.UseResourceTests.Null_Dispatcher_Runs_Continuation_Inline`: signal a `TaskCompletionSource` from inside the rerender callback and await it with `WaitAsync(10s)` instead of a 1s budgeted poll loop.

**C. Global `Console.Out`/`Console.Error` mutation racing across parallel test classes**
- `Devtools.DevtoolsParamCompatTests`: joins the existing `[Collection("ConsoleTests")]` xunit collection so it serializes with `ValidateCommandTests` / `PruneCommandTests` / `StatusCommandTests`. Without this, `Console.SetError(...)` calls were interleaving and one test's stderr landed in another test's `StringWriter`.

## Coverage preservation

Every original assertion is preserved. The fixes target test/test interference and timing budgets — not the behavior under test. Per-test review:

| Test | Original assertion | Status after fix |
|---|---|---|
| `ReactorEventSourceCoverageTests.*` | `Events` contains entry with given EventName | unchanged (lock wraps the list, not the assertion) |
| `Retry_Invokes_Fetcher_Multiple_Times_And_Settles_On_Success` | `calls == 3` AND state is `Data(42)` | both preserved |
| `Retry_Exhausted_Surfaces_Final_Error` | `calls == 3` AND state is `Error` AND message contains `"attempt"` | all three preserved |
| `Null_Dispatcher_Runs_Continuation_Inline` | `rerendered == 1` after threadpool continuation | unchanged; await is deterministic instead of timed |
| `NavigationDiagnosticsCoverageTests.*` | captured event has expected mode/route/path/reason | unchanged; handler now filters its own event |
| `DevtoolsParamCompatTests.*` | stderr captures expected substring | unchanged; only added `[Collection]` annotation |

## Verification

| Pass | Failed runs | Distinct flaky tests |
|---|---|---|
| Baseline | 12 / 50 (24%) | 8 |
| After fix pass 1 | 1 / 50 | 1 (`Null_Dispatcher`) |
| After fix pass 2 | 1 / 50 | 1 (`Validate_BrokenIcu`) |
| After fix pass 3 | 0 / 50 | 0 |

## Test plan

- [ ] CI runs `Reactor.Tests` 50x and reports zero failures
- [ ] Verify the new `[Collection("ConsoleTests")]` annotation on `DevtoolsParamCompatTests` doesn't measurably slow the suite (4 small classes joining a serial collection)
- [ ] Spot-check that the unique-Guid filtering in `NavigationDiagnosticsCoverageTests` still reaches the `Debug.WriteLine` + event-invoke bodies on the diagnostic source

🤖 Generated with [Claude Code](https://claude.com/claude-code)