### PR TITLE
fix(devtools): accept HTTP.SYS-owned ports in PortOwnership check

### DIFF
--- a/src/Reactor.Cli/Devtools/PortOwnership.cs
+++ b/src/Reactor.Cli/Devtools/PortOwnership.cs
@@ -39,6 +39,16 @@ internal static class PortOwnership
     /// <see cref="HttpSysPid"/> (HTTP.SYS) on at least one address family while
     /// no other user-mode process holds a competing listener on the same port.
     /// Returns false when no LISTEN row exists for the port at all.
+    /// <para>
+    /// <b>Failure mode for partial TCP-table enumeration:</b> if either
+    /// <c>AF_INET</c> or <c>AF_INET6</c> enumeration fails (rare; e.g. locked-down
+    /// loopback policy, kernel resource pressure), the HTTP.SYS-only fallback
+    /// is disabled — we'd otherwise accept a session whose only HTTP.SYS row is
+    /// on the visible family while a competing user-mode listener could exist
+    /// on the unseen family. Direct pid match is still honored on whatever
+    /// rows we did get back. This keeps the spoof defense intact under
+    /// degraded enumeration.
+    /// </para>
     /// </summary>
     public static bool IsPortOwnedBy(int port, int pid)
     {
@@ -46,11 +56,14 @@ internal static class PortOwnership
         if (pid <= 0) return false;
 
         var rows = new List<TcpListenerRow>();
-        if (TryGetTcpTable(AF_INET, out var v4)) rows.AddRange(v4);
-        if (TryGetTcpTable(AF_INET6, out var v6)) rows.AddRange(v6);
+        bool v4Ok = TryGetTcpTable(AF_INET, out var v4);
+        if (v4Ok) rows.AddRange(v4);
+        bool v6Ok = TryGetTcpTable(AF_INET6, out var v6);
+        if (v6Ok) rows.AddRange(v6);
         if (rows.Count == 0) return false;
 
-        return MatchListener(rows, port, pid);
+        bool enumerationComplete = v4Ok && v6Ok;
+        return MatchListener(rows, port, pid, enumerationComplete);
     }
 
     /// <summary>
@@ -60,13 +73,22 @@ internal static class PortOwnership
     /// The lockfile pid passes when:
     /// (1) any LISTEN row on <paramref name="port"/> directly attributes to
     /// <paramref name="pid"/>, OR
-    /// (2) every LISTEN row on <paramref name="port"/> attributes to
-    /// <see cref="HttpSysPid"/> (HTTP.SYS holds the socket and no user-mode
-    /// process is competing on the same port). Mixed ownership — HTTP.SYS
-    /// plus a different user-mode pid — is rejected as ambiguous.
+    /// (2) <paramref name="enumerationComplete"/> is true AND every LISTEN
+    /// row on <paramref name="port"/> attributes to <see cref="HttpSysPid"/>
+    /// (HTTP.SYS holds the socket and no user-mode process is competing on
+    /// the same port). Mixed ownership — HTTP.SYS plus a different user-mode
+    /// pid — is rejected as ambiguous.
+    /// </para>
+    /// <para>
+    /// When <paramref name="enumerationComplete"/> is false (a TCP-table
+    /// query for one address family failed), the HTTP.SYS-only fallback is
+    /// disabled to prevent acceptance based on a partial view: a
+    /// competing user-mode listener on the unseen family would be invisible
+    /// to this check. Strict pid attribution still works on the visible
+    /// rows.
     /// </para>
     /// </summary>
-    internal static bool MatchListener(IReadOnlyList<TcpListenerRow> rows, int port, int pid)
+    internal static bool MatchListener(IReadOnlyList<TcpListenerRow> rows, int port, int pid, bool enumerationComplete)
     {
         bool anyForPort = false;
         bool anyHttpSys = false;
@@ -82,6 +104,7 @@ internal static class PortOwnership
         }
 
         if (!anyForPort) return false;
+        if (!enumerationComplete) return false;
         return anyHttpSys && !anyOtherUserMode;
     }
 

--- a/src/Reactor.Cli/Devtools/PortOwnership.cs
+++ b/src/Reactor.Cli/Devtools/PortOwnership.cs
@@ -9,55 +9,113 @@ namespace Microsoft.UI.Reactor.Cli.Devtools;
 /// port. Used to defend against same-user lockfile spoofing — without this
 /// check, an attacker can plant a fake server + matching lockfile and route
 /// CLI traffic through it. TASK-004 / TASK-030.
+///
+/// <para>HTTP.SYS caveat: Reactor's MCP server uses
+/// <see cref="System.Net.HttpListener"/>, which routes through Windows'
+/// kernel-mode HTTP driver. The listening TCP socket is therefore owned by
+/// the System process (pid 4 / kernel) rather than the user-mode app, so a
+/// strict "row.OwningPid == lockfile.pid" check rejects every HTTP.SYS-backed
+/// session. We treat <see cref="HttpSysPid"/> as a kernel-attribution sentinel
+/// and accept it: same-user spoof resistance for HTTP.SYS ports falls back to
+/// the per-launch bearer token enforced by the HTTP probe (spec 025 §5,
+/// TASK-001). Direct <see cref="System.Net.Sockets.TcpListener"/> users still
+/// get strict pid attribution. Spec 025 §11 / spec 035 implementation note.
+/// </para>
 /// </summary>
 [SupportedOSPlatform("windows")]
 internal static class PortOwnership
 {
     /// <summary>
-    /// Returns true iff the local IPv4 listening socket on
-    /// <paramref name="port"/> is owned by <paramref name="pid"/>. Returns
-    /// false if there's no LISTEN row for the port at all.
+    /// Sentinel PID for the Windows System process / kernel. Listening sockets
+    /// registered through HTTP.SYS (e.g. <see cref="System.Net.HttpListener"/>)
+    /// surface in the TCP table under this PID rather than the registering
+    /// user-mode process.
+    /// </summary>
+    public const int HttpSysPid = 4;
+
+    /// <summary>
+    /// Returns true iff the local IPv4 or IPv6 listening socket on
+    /// <paramref name="port"/> is owned by <paramref name="pid"/>, or by
+    /// <see cref="HttpSysPid"/> (HTTP.SYS) on at least one address family while
+    /// no other user-mode process holds a competing listener on the same port.
+    /// Returns false when no LISTEN row exists for the port at all.
     /// </summary>
     public static bool IsPortOwnedBy(int port, int pid)
     {
         if (port <= 0 || port > 65535) return false;
         if (pid <= 0) return false;
-        if (!TryGetTcpTable(out var rows)) return false;
-        foreach (var row in rows)
-        {
-            if (row.State != MIB_TCP_STATE.LISTENING) continue;
-            // Local addr is in network-byte-order; compare port the same way.
-            var localPort = ((row.LocalPort >> 8) & 0xFF) | ((row.LocalPort & 0xFF) << 8);
-            if (localPort != port) continue;
-            return row.OwningPid == (uint)pid;
-        }
-        return false;
+
+        var rows = new List<TcpListenerRow>();
+        if (TryGetTcpTable(AF_INET, out var v4)) rows.AddRange(v4);
+        if (TryGetTcpTable(AF_INET6, out var v6)) rows.AddRange(v6);
+        if (rows.Count == 0) return false;
+
+        return MatchListener(rows, port, pid);
     }
 
-    private static bool TryGetTcpTable(out MIB_TCPROW_OWNER_PID[] rows)
+    /// <summary>
+    /// Pure matching predicate over a pre-collected listener table. Extracted
+    /// so the policy can be unit-tested without poking the live TCP table.
+    /// <para>
+    /// The lockfile pid passes when:
+    /// (1) any LISTEN row on <paramref name="port"/> directly attributes to
+    /// <paramref name="pid"/>, OR
+    /// (2) every LISTEN row on <paramref name="port"/> attributes to
+    /// <see cref="HttpSysPid"/> (HTTP.SYS holds the socket and no user-mode
+    /// process is competing on the same port). Mixed ownership — HTTP.SYS
+    /// plus a different user-mode pid — is rejected as ambiguous.
+    /// </para>
+    /// </summary>
+    internal static bool MatchListener(IReadOnlyList<TcpListenerRow> rows, int port, int pid)
     {
-        rows = Array.Empty<MIB_TCPROW_OWNER_PID>();
+        bool anyForPort = false;
+        bool anyHttpSys = false;
+        bool anyOtherUserMode = false;
+
+        foreach (var row in rows)
+        {
+            if (row.LocalPort != port) continue;
+            anyForPort = true;
+            if (row.OwningPid == (uint)pid) return true;
+            if (row.OwningPid == (uint)HttpSysPid) anyHttpSys = true;
+            else anyOtherUserMode = true;
+        }
+
+        if (!anyForPort) return false;
+        return anyHttpSys && !anyOtherUserMode;
+    }
+
+    /// <summary>
+    /// One LISTEN-state entry from the TCP table, normalised to host byte
+    /// order for the port and stripped of address-family details we don't
+    /// match on.
+    /// </summary>
+    internal readonly record struct TcpListenerRow(int LocalPort, uint OwningPid);
+
+    private const uint AF_INET = 2;
+    private const uint AF_INET6 = 23;
+    // 0x05 == TCP_TABLE_OWNER_PID_LISTENER for IPv4 / IPv6.
+    private const int TCP_TABLE_OWNER_PID_LISTENER = 5;
+
+    private static bool TryGetTcpTable(uint family, out TcpListenerRow[] rows)
+    {
+        rows = Array.Empty<TcpListenerRow>();
         int size = 0;
-        // First call: get required buffer size.
-        const uint AF_INET = 2;
-        // 0x05 == TCP_TABLE_OWNER_PID_LISTENER.
-        var ret = GetExtendedTcpTable(IntPtr.Zero, ref size, sort: false, AF_INET, 5, reserved: 0);
+        var ret = GetExtendedTcpTable(IntPtr.Zero, ref size, sort: false, family, TCP_TABLE_OWNER_PID_LISTENER, reserved: 0);
         if (ret != 0 && ret != 122 /* ERROR_INSUFFICIENT_BUFFER */) return false;
+        if (size <= 0) return true; // empty table
+
         var buffer = Marshal.AllocHGlobal(size);
         try
         {
-            ret = GetExtendedTcpTable(buffer, ref size, sort: false, AF_INET, 5, reserved: 0);
+            ret = GetExtendedTcpTable(buffer, ref size, sort: false, family, TCP_TABLE_OWNER_PID_LISTENER, reserved: 0);
             if (ret != 0) return false;
             int count = Marshal.ReadInt32(buffer);
-            var entrySize = Marshal.SizeOf<MIB_TCPROW_OWNER_PID>();
-            rows = new MIB_TCPROW_OWNER_PID[count];
-            // dwNumEntries (DWORD) is followed by the table entries; alignment
-            // matches a DWORD on x64 because the next field is also DWORD-sized.
-            for (int i = 0; i < count; i++)
-            {
-                var entryPtr = IntPtr.Add(buffer, sizeof(int) + i * entrySize);
-                rows[i] = Marshal.PtrToStructure<MIB_TCPROW_OWNER_PID>(entryPtr);
-            }
+            if (count <= 0) return true;
+
+            rows = family == AF_INET
+                ? ReadIPv4(buffer, count)
+                : ReadIPv6(buffer, count);
             return true;
         }
         finally
@@ -65,6 +123,37 @@ internal static class PortOwnership
             Marshal.FreeHGlobal(buffer);
         }
     }
+
+    private static TcpListenerRow[] ReadIPv4(IntPtr buffer, int count)
+    {
+        var entrySize = Marshal.SizeOf<MIB_TCPROW_OWNER_PID>();
+        var rows = new TcpListenerRow[count];
+        for (int i = 0; i < count; i++)
+        {
+            var entryPtr = IntPtr.Add(buffer, sizeof(int) + i * entrySize);
+            var entry = Marshal.PtrToStructure<MIB_TCPROW_OWNER_PID>(entryPtr);
+            if (entry.State != MIB_TCP_STATE.LISTENING) { rows[i] = default; continue; }
+            rows[i] = new TcpListenerRow(NetworkPortToHost(entry.LocalPort), entry.OwningPid);
+        }
+        return rows;
+    }
+
+    private static TcpListenerRow[] ReadIPv6(IntPtr buffer, int count)
+    {
+        var entrySize = Marshal.SizeOf<MIB_TCP6ROW_OWNER_PID>();
+        var rows = new TcpListenerRow[count];
+        for (int i = 0; i < count; i++)
+        {
+            var entryPtr = IntPtr.Add(buffer, sizeof(int) + i * entrySize);
+            var entry = Marshal.PtrToStructure<MIB_TCP6ROW_OWNER_PID>(entryPtr);
+            if (entry.State != MIB_TCP_STATE.LISTENING) { rows[i] = default; continue; }
+            rows[i] = new TcpListenerRow(NetworkPortToHost(entry.LocalPort), entry.OwningPid);
+        }
+        return rows;
+    }
+
+    private static int NetworkPortToHost(uint nbo) =>
+        (int)(((nbo >> 8) & 0xFF) | ((nbo & 0xFF) << 8));
 
     [DllImport("iphlpapi.dll", SetLastError = false)]
     private static extern uint GetExtendedTcpTable(
@@ -83,6 +172,20 @@ internal static class PortOwnership
         public uint LocalPort; // network byte order, low 16 bits
         public uint RemoteAddr;
         public uint RemotePort;
+        public uint OwningPid;
+    }
+
+    // 16-byte address + 4-byte scope id; struct layout for AF_INET6.
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MIB_TCP6ROW_OWNER_PID
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)] public byte[] LocalAddr;
+        public uint LocalScopeId;
+        public uint LocalPort; // network byte order
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)] public byte[] RemoteAddr;
+        public uint RemoteScopeId;
+        public uint RemotePort;
+        public MIB_TCP_STATE State;
         public uint OwningPid;
     }
 

--- a/tests/Reactor.Tests/Devtools/PortOwnershipTests.cs
+++ b/tests/Reactor.Tests/Devtools/PortOwnershipTests.cs
@@ -21,7 +21,7 @@ public class PortOwnershipTests
     {
         // Direct TcpListener user-mode bind — the legacy happy path.
         var rows = new[] { Row(port: 50001, pid: 12345) };
-        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: true));
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class PortOwnershipTests
     {
         // No row at all for the asked port — port is not bound.
         var rows = new[] { Row(port: 50002, pid: 12345) };
-        Assert.False(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+        Assert.False(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: true));
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public class PortOwnershipTests
     {
         // Some other user-mode pid owns the port — classic spoof signature.
         var rows = new[] { Row(port: 50001, pid: 99999) };
-        Assert.False(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+        Assert.False(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: true));
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class PortOwnershipTests
         // user-mode pid is the request-queue owner that mur authenticates
         // against via the bearer token. Single HTTP.SYS row → accept.
         var rows = new[] { Row(port: 50001, pid: PortOwnership.HttpSysPid) };
-        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: true));
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public class PortOwnershipTests
             Row(port: 50001, pid: PortOwnership.HttpSysPid),
             Row(port: 50001, pid: PortOwnership.HttpSysPid),
         };
-        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: true));
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class PortOwnershipTests
             Row(port: 50001, pid: PortOwnership.HttpSysPid),
             Row(port: 50001, pid: 99999),
         };
-        Assert.False(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+        Assert.False(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: true));
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public class PortOwnershipTests
             Row(port: 50001, pid: PortOwnership.HttpSysPid),
             Row(port: 50001, pid: 12345),
         };
-        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: true));
     }
 
     [Fact]
@@ -102,7 +102,48 @@ public class PortOwnershipTests
             Row(port: 50001, pid: PortOwnership.HttpSysPid),
             Row(port: 50002, pid: 99999),                   // unrelated port
         };
-        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: true));
+    }
+
+    [Fact]
+    public void Match_PartialEnumeration_HttpSysOnly_RejectedAsUnsafe()
+    {
+        // PR #128 review (Copilot): if the AF_INET or AF_INET6 TCP-table
+        // query failed, the rows we have are a partial view. Accepting an
+        // HTTP.SYS-only signature on the visible family would let a
+        // competing user-mode listener on the unseen family go undetected
+        // — a same-user spoof opportunity. Direct match still works on
+        // partial data; HTTP.SYS-only does not.
+        var rows = new[]
+        {
+            Row(port: 50001, pid: PortOwnership.HttpSysPid),
+        };
+        Assert.False(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: false));
+    }
+
+    [Fact]
+    public void Match_PartialEnumeration_DirectMatch_StillAccepted()
+    {
+        // Even if one address-family query failed, a direct row attributing
+        // to the lockfile pid is unambiguous — accept.
+        var rows = new[]
+        {
+            Row(port: 50001, pid: 12345),
+        };
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: false));
+    }
+
+    [Fact]
+    public void Match_PartialEnumeration_DirectMatchAlongsideHttpSys_StillAccepted()
+    {
+        // Mixed but the lockfile pid is among the rows we did get back —
+        // direct match wins regardless of enumeration completeness.
+        var rows = new[]
+        {
+            Row(port: 50001, pid: PortOwnership.HttpSysPid),
+            Row(port: 50001, pid: 12345),
+        };
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345, enumerationComplete: false));
     }
 
     [Fact]

--- a/tests/Reactor.Tests/Devtools/PortOwnershipTests.cs
+++ b/tests/Reactor.Tests/Devtools/PortOwnershipTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.UI.Reactor.Cli.Devtools;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.Devtools;
+
+/// <summary>
+/// Spec 025 §11 / spec 035 implementation note. The original strict
+/// "row.OwningPid == lockfile.pid" check rejected every <c>HttpListener</c>-
+/// backed devtools session because Windows attributes the listening socket
+/// to the System process (pid 4) when HTTP.SYS holds the request queue. The
+/// pure <see cref="PortOwnership.MatchListener"/> predicate is the unit-
+/// testable seam — these tests pin its accept/reject policy without hitting
+/// the live TCP table.
+/// </summary>
+public class PortOwnershipTests
+{
+    static PortOwnership.TcpListenerRow Row(int port, uint pid) => new(port, pid);
+
+    [Fact]
+    public void Match_DirectUserModeOwner_Accepts()
+    {
+        // Direct TcpListener user-mode bind — the legacy happy path.
+        var rows = new[] { Row(port: 50001, pid: 12345) };
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+    }
+
+    [Fact]
+    public void Match_NoListenerForPort_Rejects()
+    {
+        // No row at all for the asked port — port is not bound.
+        var rows = new[] { Row(port: 50002, pid: 12345) };
+        Assert.False(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+    }
+
+    [Fact]
+    public void Match_DifferentUserModePid_Rejects()
+    {
+        // Some other user-mode pid owns the port — classic spoof signature.
+        var rows = new[] { Row(port: 50001, pid: 99999) };
+        Assert.False(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+    }
+
+    [Fact]
+    public void Match_HttpSysOnly_Accepts()
+    {
+        // HttpListener case: HTTP.SYS (pid 4) holds the socket; the legitimate
+        // user-mode pid is the request-queue owner that mur authenticates
+        // against via the bearer token. Single HTTP.SYS row → accept.
+        var rows = new[] { Row(port: 50001, pid: PortOwnership.HttpSysPid) };
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+    }
+
+    [Fact]
+    public void Match_HttpSysOnBothFamilies_Accepts()
+    {
+        // HttpListener typically registers under both AF_INET and AF_INET6;
+        // our enumeration unions the two tables. Both showing as PID 4 is
+        // still a clean HTTP.SYS attribution.
+        var rows = new[]
+        {
+            Row(port: 50001, pid: PortOwnership.HttpSysPid),
+            Row(port: 50001, pid: PortOwnership.HttpSysPid),
+        };
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+    }
+
+    [Fact]
+    public void Match_HttpSysPlusCompetingUserMode_RejectsAsAmbiguous()
+    {
+        // Defense-in-depth: if some OTHER user-mode pid is also listening on
+        // the same port, the lockfile claim is ambiguous. The HTTP.SYS row
+        // alone is no longer a clean attribution — refuse to authenticate.
+        var rows = new[]
+        {
+            Row(port: 50001, pid: PortOwnership.HttpSysPid),
+            Row(port: 50001, pid: 99999),
+        };
+        Assert.False(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+    }
+
+    [Fact]
+    public void Match_DirectUserModeOwnerWinsOverHttpSys()
+    {
+        // Direct match short-circuits even when HTTP.SYS also holds the
+        // socket on a different family.
+        var rows = new[]
+        {
+            Row(port: 50001, pid: PortOwnership.HttpSysPid),
+            Row(port: 50001, pid: 12345),
+        };
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+    }
+
+    [Fact]
+    public void Match_OtherPortsIgnored()
+    {
+        // Rows for other ports never contribute — the predicate only considers
+        // rows where row.LocalPort == port.
+        var rows = new[]
+        {
+            Row(port: 50000, pid: 99999),                   // unrelated port
+            Row(port: 50001, pid: PortOwnership.HttpSysPid),
+            Row(port: 50002, pid: 99999),                   // unrelated port
+        };
+        Assert.True(PortOwnership.MatchListener(rows, port: 50001, pid: 12345));
+    }
+
+    [Fact]
+    public void IsPortOwnedBy_RejectsInvalidArgs()
+    {
+        Assert.False(PortOwnership.IsPortOwnedBy(port: 0, pid: 1));
+        Assert.False(PortOwnership.IsPortOwnedBy(port: 70000, pid: 1));
+        Assert.False(PortOwnership.IsPortOwnedBy(port: 5000, pid: 0));
+        Assert.False(PortOwnership.IsPortOwnedBy(port: 5000, pid: -1));
+    }
+}


### PR DESCRIPTION
## Summary

`mur devtools` was unable to connect to any Reactor app launched with `--devtools run`. Every named verb returned exit 4 ("no live session"), and `session list` silently GC'd the lockfile on the way out. Reproduced cleanly against `samples/apps/chat` on Windows 11.

**Root cause**: `LockfileReader.IsLive` calls `PortOwnership.IsPortOwnedBy(port, lockfile.pid)` to defeat lockfile spoofing. The check enumerates the kernel TCP table and matches `row.OwningPid == lockfile.pid`. But Reactor's MCP server uses `HttpListener`, which routes through the kernel-mode HTTP.SYS driver — Windows attributes the listening socket to **PID 4 (System)**, not the user-mode app:

```
> Get-NetTCPConnection -State Listen -LocalPort 51965
LocalAddress LocalPort OwningProcess AddressFamily
127.0.0.1        51965             4
```

So no row ever matched, `IsLive` returned false, and `EndpointDiscovery.FindLiveHttpSessions` deleted the only valid lockfile.

## Fix

Extracted the policy into a pure `MatchListener(rows, port, pid, enumerationComplete)` predicate. Accepts the lockfile pid when **either**:

1. Any LISTEN row on the port directly attributes to it — preserves strict attribution for raw `TcpListener` users.
2. **Enumeration of both address families succeeded** *and* every LISTEN row on the port attributes to `PortOwnership.HttpSysPid` (PID 4) — HTTP.SYS holds the socket cleanly with no competing user-mode listener.

Mixed ownership (HTTP.SYS + a different user-mode pid on the same port) is rejected as ambiguous. Same-user spoof resistance for HTTP.SYS ports falls back to the per-launch random bearer token already enforced by the HTTP probe (spec 025 §5 / TASK-001) — documented in the class XML doc.

Other improvements rolled in:
- Enumerates **AF_INET6** in addition to AF_INET so `[::1]:<port>` bindings are reachable.
- Iterates **all** matching rows instead of bailing on the first port hit (the original code returned false on the first matching-port row regardless of owner).

## Review feedback addressed

[@copilot-pull-request-reviewer](https://github.com/apps/copilot-pull-request-reviewer) flagged a real spoof gap on partial TCP-table enumeration: if `TryGetTcpTable(AF_INET, …)` failed but `TryGetTcpTable(AF_INET6, …)` succeeded with only HTTP.SYS rows, the original fix would have accepted the lockfile — but a competing user-mode listener could exist on the unseen family.

Fixed in `c88ab25`. `IsPortOwnedBy` now tracks per-family enumeration success and threads it through to `MatchListener` as `enumerationComplete`. The HTTP.SYS-only fallback is gated on full enumeration; **direct pid attribution still works under partial enumeration** so legitimate sessions on rare degraded-enum systems don't break. XML doc updated on both methods to call out the policy.

## Test plan

- [x] **12** unit tests in `tests/Reactor.Tests/Devtools/PortOwnershipTests.cs` covering direct match, no listener, different user-mode pid, HTTP.SYS-only, HTTP.SYS dual-stack (v4+v6), HTTP.SYS + competing user-mode rejected, direct match wins over HTTP.SYS, irrelevant ports ignored, arg validation, **partial-enumeration HTTP.SYS-only rejected, partial-enumeration direct accepted, partial-enumeration direct-alongside-HTTP.SYS accepted**.
- [x] All **326** Devtools tests in `Reactor.Tests` pass (post-fix; was 323 in the original PR before the 3 new partial-enum tests).
- [x] End-to-end against `samples/apps/chat`: `mur devtools session list / version / windows / components / tree / state / screenshot` all return exit 0 with live data after the fix.
- [x] **End-to-end against `samples/Reactor.TestApp`** (validating the post-review fix specifically): launched via `mur devtools samples/Reactor.TestApp/Reactor.TestApp.csproj`, then ran `session list --pretty` → discovered `pid 43348 port 65323 http://127.0.0.1:65323/mcp` (the exact case the fix enables); `version` → reported the c88ab25 build tag back; `windows` → discovered main window; `tree --view summary` → 36 KB visual-tree JSON; `screenshot --out testapp.png --wait-idle` → 16 KB PNG of the Counter demo. Confirms the lockfile-discovery + HTTP-probe round-trip works under both the original fix and the partial-enumeration tightening.
- [ ] Reviewer: spot-check on x64 (only ARM64 hardware was available locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)