### PR TITLE
docs(skill): document .Flex(grow:1) gotcha vs CSS `flex: 1` shorthand

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -238,6 +238,12 @@ ForEach(items, item => TextBlock(item.Name))
 6. **`.WithKey("id")` on dynamic list items.** Without keys, the reconciler
    matches by position and re-mounts everything on insert/reorder.
 7. **Memoize expensive computations.** `UseMemo(() => items.OrderBy(...).ToList(), items)`.
+8. **`.Flex(grow: 1)` is `flex-grow`, not the CSS `flex: 1` shorthand.** Default
+   basis is `auto` (content size), so a growing child with large intrinsic
+   content (e.g. `ListView` with many items) overflows the container and Yoga
+   shrinks every sibling proportionally — heading/buttons/inputs all collapse.
+   Pass `.Flex(grow: 1, basis: 0)` (matches CSS `flex: 1`) or add
+   `.Flex(shrink: 0)` to each fixed-size sibling. See `skills/dsl-reference.md`.
 
 ## Starter template
 

--- a/skills/dsl-reference.md
+++ b/skills/dsl-reference.md
@@ -150,6 +150,30 @@ FlexColumn(
 row/column with defined tracks. `Flex` for grow/shrink, wrapping, or
 space distribution.
 
+**Gotcha — `.Flex(grow: 1)` is `flex-grow: 1`, NOT CSS shorthand `flex: 1`.**
+Reactor's `.Flex(...)` maps each parameter to the matching CSS individual
+property. Default basis is `auto` (content size). When a growing child has
+a large intrinsic size (`ListView`, `ScrollView` with many items, long
+text), its content size makes the flex container overflow, and Yoga
+shrinks **every** sibling proportionally — heading, buttons, and inputs
+all collapse along with the scrollable region. Two ways to fix:
+
+```csharp
+// 1. Pass basis: 0 alongside grow — matches CSS `flex: 1` shorthand.
+//    The grower starts at 0; siblings keep their natural size.
+Border(ListView(items, ...)).Flex(grow: 1, basis: 0)
+
+// 2. Put shrink: 0 on every fixed-size sibling.
+FlexColumn(
+    Heading("Title").Flex(shrink: 0),
+    TextField(name, setName).Flex(shrink: 0),
+    Border(ListView(items, ...)).Flex(grow: 1))
+```
+
+Prefer (1) for a single growing region — one modifier, no per-sibling
+bookkeeping. Use (2) when several children grow and you need basis=auto
+on the growers (e.g., proportional columns sized by content).
+
 Required: `using Microsoft.UI.Reactor.Layout;`
 
 ## Navigation


### PR DESCRIPTION
## Summary

- `.Flex(grow: 1)` maps to CSS `flex-grow: 1`, **not** the `flex: 1` shorthand — basis stays `auto`. With a growing child that has large intrinsic content (e.g. `ListView` with many items), the container overflows and Yoga shrinks every sibling proportionally; headings, buttons, and inputs visibly collapse alongside the scrollable region.
- Add a gotcha entry to `skills/dsl-reference.md` (Flex Layout section) with the two fixes (`basis: 0` vs per-sibling `shrink: 0`) and a one-paragraph summary in the root `SKILL.md` "Critical gotchas" list.

## Test plan

- [ ] Manual: read `skills/dsl-reference.md` and `SKILL.md` — verify the wording is accurate and the example code compiles mentally.
- [ ] Repro the original symptom: `FlexColumn` containing fixed-size children plus a `Border(ListView(items))` with `~100` items and `.Flex(grow: 1)`. Confirm the documented fix (`.Flex(grow: 1, basis: 0)`) restores natural sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)