### PR TITLE
fix(reconciler): stop highlight overlay flashing typed ListView/GridView/FlipView/LazyStack on unrelated re-renders

### DIFF
--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -2412,10 +2412,14 @@ public abstract record TemplatedListElementBase : Element
     public abstract void ApplyControlSetters(object control);
     /// <summary>
     /// True when programmatic setter actions (.Set(...)) have been attached.
-    /// OwnPropsEqual / ShallowEquals must return false in that case so the
-    /// reconciler always re-runs ApplyControlSetters.
+    /// Used by <see cref="OwnPropsEqual"/> to suppress the reconcile-highlight
+    /// short-circuit so the overlay correctly tags the control as modified
+    /// (and ApplyControlSetters keeps running on every reconcile pass).
+    /// Virtual + default-false so external types deriving from this public
+    /// abstract record don't break — only Reactor's own derived records that
+    /// expose Setters need to override.
     /// </summary>
-    internal abstract bool HasSetters { get; }
+    internal virtual bool HasSetters => false;
 }
 
 public record TemplatedListViewElement<T>(

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -576,6 +576,30 @@ public abstract record Element
             (BreadcrumbBarElement ba, BreadcrumbBarElement bb) =>
                 ba.Setters.Length == 0 && bb.Setters.Length == 0,
 
+            // Templated (data-driven) collections: own props are the WinUI
+            // properties UpdateTemplatedXxx writes back. Items + ViewBuilder
+            // are not own props — they drive child reconcile but don't write
+            // properties on the parent control. Without this case, the typed
+            // ListView<T>/GridView<T>/FlipView<T> falls through to false and
+            // the highlight overlay flashes the whole list on every parent
+            // re-render (because OwnPropsEqual returning false is the gate
+            // for ReconcileHighlightOverlay's "modified" tag).
+            (TemplatedListElementBase ta, TemplatedListElementBase tb) =>
+                ta.GetSelectedIndex() == tb.GetSelectedIndex()
+                && ta.GetSelectionMode() == tb.GetSelectionMode()
+                && ta.GetHeader() == tb.GetHeader()
+                && ta.GetIsItemClickEnabled() == tb.GetIsItemClickEnabled()
+                && !ta.HasSetters && !tb.HasSetters,
+
+            // Lazy (virtualized) stacks: same rationale — Items/ViewBuilder
+            // are factory inputs, not control properties.
+            (LazyStackElementBase la, LazyStackElementBase lb) =>
+                la.Orientation == lb.Orientation
+                && la.Spacing == lb.Spacing
+                && la.EstimatedItemSize == lb.EstimatedItemSize
+                && la.ScrollViewerSetters.Length == 0 && lb.ScrollViewerSetters.Length == 0
+                && la.RepeaterSetters.Length == 0 && lb.RepeaterSetters.Length == 0,
+
             // Non-container / leaf types: return false → always captured
             _ => false,
         };
@@ -2386,6 +2410,12 @@ public abstract record TemplatedListElementBase : Element
     public abstract void InvokeSelectionChanged(int index);
     public abstract void InvokeItemClick(int index);
     public abstract void ApplyControlSetters(object control);
+    /// <summary>
+    /// True when programmatic setter actions (.Set(...)) have been attached.
+    /// OwnPropsEqual / ShallowEquals must return false in that case so the
+    /// reconciler always re-runs ApplyControlSetters.
+    /// </summary>
+    internal abstract bool HasSetters { get; }
 }
 
 public record TemplatedListViewElement<T>(
@@ -2416,6 +2446,7 @@ public record TemplatedListViewElement<T>(
     public override void ApplyControlSetters(object control) =>
         Reconciler.ApplySetters(Setters, (WinUI.ListView)control);
     internal override bool HasCallbacks => OnSelectionChanged is not null || OnItemClick is not null;
+    internal override bool HasSetters => Setters.Length > 0;
 }
 
 public record TemplatedGridViewElement<T>(
@@ -2446,6 +2477,7 @@ public record TemplatedGridViewElement<T>(
     public override void ApplyControlSetters(object control) =>
         Reconciler.ApplySetters(Setters, (WinUI.GridView)control);
     internal override bool HasCallbacks => OnSelectionChanged is not null || OnItemClick is not null;
+    internal override bool HasSetters => Setters.Length > 0;
 }
 
 public record TemplatedFlipViewElement<T>(
@@ -2472,6 +2504,7 @@ public record TemplatedFlipViewElement<T>(
     public override void ApplyControlSetters(object control) =>
         Reconciler.ApplySetters(Setters, (WinUI.FlipView)control);
     internal override bool HasCallbacks => OnSelectionChanged is not null;
+    internal override bool HasSetters => Setters.Length > 0;
 }
 
 // ════════════════════════════════════════════════════════════════════════

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TemplatedListHighlightTests.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TemplatedListHighlightTests.cs
@@ -1,0 +1,426 @@
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Regression coverage for the templated/lazy collection element types in
+/// <see cref="Element.OwnPropsEqual"/> and <see cref="Element.ShallowEquals"/>.
+///
+/// Without explicit cases for <c>TemplatedListElementBase</c> and
+/// <c>LazyStackElementBase</c>, OwnPropsEqual fell through to <c>_ =&gt; false</c>,
+/// which made <see cref="ReconcileHighlightOverlay"/> mark the entire list/grid/
+/// flip-view (and lazy-stack ScrollViewer) as "modified" on every parent re-render
+/// — even when nothing about the element actually changed. Visually that paints a
+/// yellow stripe over the whole list region, making it look like every item was
+/// reconciled when in fact none were.
+///
+/// These fixtures pin the contract:
+///  - Unrelated parent re-renders MUST NOT add the list/grid/flip control to
+///    LastModifiedElements.
+///  - Property changes (Header, SelectionMode, Setters) MUST still flag the
+///    control as modified.
+///  - Item-level updates (Items reference change) MUST still propagate.
+/// </summary>
+internal static class TemplatedListHighlightTests
+{
+    // ── Typed ListView<T>: stable items + sibling state change → not modified ──
+    internal class TemplatedListView_NoHighlightOnSiblingStateChange(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var prev = ReactorFeatureFlags.HighlightReconcileChanges;
+            try
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = true;
+
+                // Items list is allocated once, outside the render closure, so its
+                // reference is stable across re-renders triggered by `count`.
+                var items = new[] { "a", "b", "c" };
+
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (count, setCount) = ctx.UseState(0);
+                    return VStack(
+                        TextBlock($"count:{count}").AutomationId("tlvCount"),
+                        Button("inc", () => setCount(count + 1)),
+                        ListView<string>(items, s => s, (item, _) => TextBlock(item))
+                    );
+                });
+
+                await Harness.Render();
+
+                // Bump unrelated state — the ListView's own props are unchanged.
+                H.ClickButton("inc");
+                await Harness.Render();
+
+                var modified = host.Reconciler.LastModifiedElements;
+                var listView = H.FindControl<ListView>(_ => true);
+
+                H.Check("TemplatedListHL_ListViewExists", listView is not null);
+                H.Check("TemplatedListHL_ListView_NotModifiedOnSiblingChange",
+                    listView is not null && !modified.Contains(listView));
+
+                // Sanity: the TextBlock that did change should still be flagged.
+                var tb = H.FindControl<TextBlock>(t =>
+                    Microsoft.UI.Xaml.Automation.AutomationProperties.GetAutomationId(t) == "tlvCount");
+                H.Check("TemplatedListHL_SiblingTextBlockModified",
+                    tb is not null && modified.Contains(tb));
+            }
+            finally
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = prev;
+            }
+        }
+    }
+
+    // ── Typed ListView<T>: header change DOES flag the control ──
+    internal class TemplatedListView_HeaderChangeFlagsListView(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var prev = ReactorFeatureFlags.HighlightReconcileChanges;
+            try
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = true;
+
+                var items = new[] { "x", "y" };
+
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (header, setHeader) = ctx.UseState("h1");
+                    return VStack(
+                        Button("rename", () => setHeader("h2")),
+                        ListView<string>(items, s => s, (item, _) => TextBlock(item))
+                            with { Header = header }
+                    );
+                });
+
+                await Harness.Render();
+
+                H.ClickButton("rename");
+                await Harness.Render();
+
+                var modified = host.Reconciler.LastModifiedElements;
+                var listView = H.FindControl<ListView>(_ => true);
+
+                H.Check("TemplatedListHL_HeaderChange_ListViewExists", listView is not null);
+                H.Check("TemplatedListHL_HeaderChange_ListViewModified",
+                    listView is not null && modified.Contains(listView));
+                H.Check("TemplatedListHL_HeaderChange_HeaderApplied",
+                    listView?.Header is string s && s == "h2");
+            }
+            finally
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = prev;
+            }
+        }
+    }
+
+    // ── Typed ListView<T>: items reference change still triggers item updates ──
+    internal class TemplatedListView_ItemsChangeStillUpdates(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var items = phase == 0
+                    ? new[] { "Alpha", "Beta" }
+                    : new[] { "Alpha", "Beta", "Gamma" };
+                return VStack(
+                    Button("grow", () => setPhase(1)),
+                    ListView<string>(items, s => s, (item, _) => TextBlock(item).AutomationId($"tli_{item}"))
+                );
+            });
+
+            await Harness.Render();
+            H.Check("TemplatedListHL_ItemsChange_InitialAlpha",
+                H.FindControl<TextBlock>(t =>
+                    Microsoft.UI.Xaml.Automation.AutomationProperties.GetAutomationId(t) == "tli_Alpha") is not null);
+
+            H.ClickButton("grow");
+            await Harness.Render();
+
+            // Realized containers should reflect the new item count.
+            var listView = H.FindControl<ListView>(_ => true);
+            H.Check("TemplatedListHL_ItemsChange_CountReflected",
+                listView is not null
+                && listView.ItemsSource is global::System.Collections.IList src
+                && src.Count == 3);
+        }
+    }
+
+    // ── Typed ListView<T>: .Set(...) Setters force "modified" tagging ──
+    // HasSetters has to gate the OwnPropsEqual short-circuit — without that
+    // gate, ApplyControlSetters would silently stop running.
+    internal class TemplatedListView_SettersStillFlagged(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var prev = ReactorFeatureFlags.HighlightReconcileChanges;
+            try
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = true;
+
+                var items = new[] { "p", "q" };
+                int setterRuns = 0;
+
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (count, setCount) = ctx.UseState(0);
+                    return VStack(
+                        TextBlock($"c:{count}").AutomationId("setterCount"),
+                        Button("tick", () => setCount(count + 1)),
+                        ListView<string>(items, s => s, (item, _) => TextBlock(item))
+                            .Set(lv => { setterRuns++; })
+                    );
+                });
+
+                await Harness.Render();
+                int afterMount = setterRuns;
+                H.Check("TemplatedListHL_Setters_RanOnMount", afterMount >= 1);
+
+                H.ClickButton("tick");
+                await Harness.Render();
+
+                // Setter must run again on update because HasSetters disables the skip.
+                H.Check("TemplatedListHL_Setters_RanOnUpdate", setterRuns > afterMount);
+
+                // And the ListView should be tagged modified (the gate is HasSetters).
+                var listView = H.FindControl<ListView>(_ => true);
+                var modified = host.Reconciler.LastModifiedElements;
+                H.Check("TemplatedListHL_Setters_ListViewModified",
+                    listView is not null && modified.Contains(listView));
+            }
+            finally
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = prev;
+            }
+        }
+    }
+
+    // ── Typed GridView<T>: stable items + sibling change → not modified ──
+    internal class TemplatedGridView_NoHighlightOnSiblingStateChange(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var prev = ReactorFeatureFlags.HighlightReconcileChanges;
+            try
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = true;
+
+                var items = new[] { "g1", "g2", "g3" };
+
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (count, setCount) = ctx.UseState(0);
+                    return VStack(
+                        TextBlock($"gc:{count}").AutomationId("tgvCount"),
+                        Button("ginc", () => setCount(count + 1)),
+                        GridView<string>(items, s => s, (item, _) => TextBlock(item))
+                    );
+                });
+
+                await Harness.Render();
+                H.ClickButton("ginc");
+                await Harness.Render();
+
+                var modified = host.Reconciler.LastModifiedElements;
+                var gridView = H.FindControl<GridView>(_ => true);
+                H.Check("TemplatedListHL_GridViewExists", gridView is not null);
+                H.Check("TemplatedListHL_GridView_NotModifiedOnSiblingChange",
+                    gridView is not null && !modified.Contains(gridView));
+            }
+            finally
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = prev;
+            }
+        }
+    }
+
+    // ── Typed FlipView<T>: stable items + sibling change → not modified ──
+    internal class TemplatedFlipView_NoHighlightOnSiblingStateChange(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var prev = ReactorFeatureFlags.HighlightReconcileChanges;
+            try
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = true;
+
+                var items = new[] { "f1", "f2" };
+
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (count, setCount) = ctx.UseState(0);
+                    return VStack(
+                        TextBlock($"fc:{count}").AutomationId("tfvCount"),
+                        Button("finc", () => setCount(count + 1)),
+                        FlipView<string>(items, s => s, (item, _) => TextBlock(item))
+                    );
+                });
+
+                await Harness.Render();
+                H.ClickButton("finc");
+                await Harness.Render();
+
+                var modified = host.Reconciler.LastModifiedElements;
+                var flipView = H.FindControl<FlipView>(_ => true);
+                H.Check("TemplatedListHL_FlipViewExists", flipView is not null);
+                H.Check("TemplatedListHL_FlipView_NotModifiedOnSiblingChange",
+                    flipView is not null && !modified.Contains(flipView));
+            }
+            finally
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = prev;
+            }
+        }
+    }
+
+    // ── LazyVStack<T>: stable items + sibling change → ScrollViewer not modified ──
+    // The lazy stack mounts as ScrollViewer + ItemsRepeater; the OwnPropsEqual
+    // gate covers the ScrollViewer (the element control), which is what would
+    // otherwise be added to LastModifiedElements.
+    internal class LazyVStack_NoHighlightOnSiblingStateChange(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var prev = ReactorFeatureFlags.HighlightReconcileChanges;
+            try
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = true;
+
+                var items = Enumerable.Range(1, 10).Select(i => $"L{i}").ToArray();
+
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (count, setCount) = ctx.UseState(0);
+                    return VStack(
+                        TextBlock($"lvc:{count}").AutomationId("lvCount"),
+                        Button("lvinc", () => setCount(count + 1)),
+                        LazyVStack<string>(items, s => s, (item, _) => TextBlock(item))
+                    );
+                });
+
+                await Harness.Render();
+                int modifiedCountBefore = host.Reconciler.LastModifiedElements.Count;
+
+                H.ClickButton("lvinc");
+                await Harness.Render();
+
+                var modified = host.Reconciler.LastModifiedElements;
+                // After the click, the only element that should be marked modified
+                // is the count TextBlock. The lazy ScrollViewer + ItemsRepeater
+                // should NOT appear.
+                var modifiedScrollViewers = modified.OfType<ScrollViewer>().ToList();
+                var modifiedRepeaters = modified.OfType<ItemsRepeater>().ToList();
+
+                H.Check("TemplatedListHL_LazyVStack_ScrollViewerNotModified",
+                    modifiedScrollViewers.Count == 0);
+                H.Check("TemplatedListHL_LazyVStack_RepeaterNotModified",
+                    modifiedRepeaters.Count == 0);
+            }
+            finally
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = prev;
+            }
+        }
+    }
+
+    // ── LazyHStack<T>: same expectation, horizontal orientation ──
+    internal class LazyHStack_NoHighlightOnSiblingStateChange(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var prev = ReactorFeatureFlags.HighlightReconcileChanges;
+            try
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = true;
+
+                var items = Enumerable.Range(1, 10).Select(i => $"H{i}").ToArray();
+
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (count, setCount) = ctx.UseState(0);
+                    return VStack(
+                        TextBlock($"lhc:{count}").AutomationId("lhCount"),
+                        Button("lhinc", () => setCount(count + 1)),
+                        LazyHStack<string>(items, s => s, (item, _) => TextBlock(item))
+                    );
+                });
+
+                await Harness.Render();
+                H.ClickButton("lhinc");
+                await Harness.Render();
+
+                var modified = host.Reconciler.LastModifiedElements;
+                var modifiedScrollViewers = modified.OfType<ScrollViewer>().ToList();
+                var modifiedRepeaters = modified.OfType<ItemsRepeater>().ToList();
+
+                H.Check("TemplatedListHL_LazyHStack_ScrollViewerNotModified",
+                    modifiedScrollViewers.Count == 0);
+                H.Check("TemplatedListHL_LazyHStack_RepeaterNotModified",
+                    modifiedRepeaters.Count == 0);
+            }
+            finally
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = prev;
+            }
+        }
+    }
+
+    // ── LazyVStack<T>: spacing change DOES flag the ScrollViewer ──
+    // Spacing is in OwnPropsEqual, so changing it must mark the control modified.
+    internal class LazyVStack_SpacingChangeFlagsControl(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var prev = ReactorFeatureFlags.HighlightReconcileChanges;
+            try
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = true;
+
+                var items = Enumerable.Range(1, 5).Select(i => $"S{i}").ToArray();
+
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (spacing, setSpacing) = ctx.UseState(8.0);
+                    return VStack(
+                        Button("respace", () => setSpacing(20.0)),
+                        LazyVStack<string>(items, s => s, (item, _) => TextBlock(item))
+                            with { Spacing = spacing }
+                    );
+                });
+
+                await Harness.Render();
+                H.ClickButton("respace");
+                await Harness.Render();
+
+                var modified = host.Reconciler.LastModifiedElements;
+                // At least the ScrollViewer (or the inner ItemsRepeater whose
+                // StackLayout.Spacing is rewritten) should appear in modified.
+                bool anyLazyControlModified =
+                    modified.OfType<ScrollViewer>().Any()
+                    || modified.OfType<ItemsRepeater>().Any();
+                H.Check("TemplatedListHL_LazyVStack_SpacingChangeFlagged",
+                    anyLazyControlModified);
+            }
+            finally
+            {
+                ReactorFeatureFlags.HighlightReconcileChanges = prev;
+            }
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TemplatedListHighlightTests.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TemplatedListHighlightTests.cs
@@ -313,7 +313,6 @@ internal static class TemplatedListHighlightTests
                 });
 
                 await Harness.Render();
-                int modifiedCountBefore = host.Reconciler.LastModifiedElements.Count;
 
                 H.ClickButton("lvinc");
                 await Harness.Render();

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -688,6 +688,15 @@ internal static class SelfTestFixtureRegistry
         "ReconcileHighlight_ContainerNotModifiedWhenOnlyChildrenChange",
         "ReconcileHighlight_UpdatePathNotRemount",
         "ReconcileHighlight_MenuFlyoutUpdatesInPlace",
+        "TemplatedListHL_ListView_NoHighlightOnSiblingStateChange",
+        "TemplatedListHL_ListView_HeaderChangeFlagsListView",
+        "TemplatedListHL_ListView_ItemsChangeStillUpdates",
+        "TemplatedListHL_ListView_SettersStillFlagged",
+        "TemplatedListHL_GridView_NoHighlightOnSiblingStateChange",
+        "TemplatedListHL_FlipView_NoHighlightOnSiblingStateChange",
+        "TemplatedListHL_LazyVStack_NoHighlightOnSiblingStateChange",
+        "TemplatedListHL_LazyHStack_NoHighlightOnSiblingStateChange",
+        "TemplatedListHL_LazyVStack_SpacingChangeFlagsControl",
 
         // Layout-cost overlay (spec 032)
         "LayoutCost_FlagOn_BackFillsExistingComponents",
@@ -1419,6 +1428,15 @@ internal static class SelfTestFixtureRegistry
         "ReconcileHighlight_ContainerNotModifiedWhenOnlyChildrenChange" => new ReconcileHighlightTests.ContainerNotModifiedWhenOnlyChildrenChange(harness),
         "ReconcileHighlight_UpdatePathNotRemount" => new ReconcileHighlightTests.UpdatePathNotRemount(harness),
         "ReconcileHighlight_MenuFlyoutUpdatesInPlace" => new ReconcileHighlightTests.MenuFlyoutUpdatesInPlace(harness),
+        "TemplatedListHL_ListView_NoHighlightOnSiblingStateChange" => new TemplatedListHighlightTests.TemplatedListView_NoHighlightOnSiblingStateChange(harness),
+        "TemplatedListHL_ListView_HeaderChangeFlagsListView" => new TemplatedListHighlightTests.TemplatedListView_HeaderChangeFlagsListView(harness),
+        "TemplatedListHL_ListView_ItemsChangeStillUpdates" => new TemplatedListHighlightTests.TemplatedListView_ItemsChangeStillUpdates(harness),
+        "TemplatedListHL_ListView_SettersStillFlagged" => new TemplatedListHighlightTests.TemplatedListView_SettersStillFlagged(harness),
+        "TemplatedListHL_GridView_NoHighlightOnSiblingStateChange" => new TemplatedListHighlightTests.TemplatedGridView_NoHighlightOnSiblingStateChange(harness),
+        "TemplatedListHL_FlipView_NoHighlightOnSiblingStateChange" => new TemplatedListHighlightTests.TemplatedFlipView_NoHighlightOnSiblingStateChange(harness),
+        "TemplatedListHL_LazyVStack_NoHighlightOnSiblingStateChange" => new TemplatedListHighlightTests.LazyVStack_NoHighlightOnSiblingStateChange(harness),
+        "TemplatedListHL_LazyHStack_NoHighlightOnSiblingStateChange" => new TemplatedListHighlightTests.LazyHStack_NoHighlightOnSiblingStateChange(harness),
+        "TemplatedListHL_LazyVStack_SpacingChangeFlagsControl" => new TemplatedListHighlightTests.LazyVStack_SpacingChangeFlagsControl(harness),
 
         // Layout-cost overlay
         "LayoutCost_FlagOn_BackFillsExistingComponents" => new LayoutCostOverlayTests.FlagOn_BackFillsExistingComponents(harness),


### PR DESCRIPTION
## Summary

- `TemplatedListElementBase` (typed `ListView<T>` / `GridView<T>` / `FlipView<T>`) and `LazyStackElementBase` had no case in `Element.OwnPropsEqual`. They fell through to `_ => false`, which meant any unrelated parent re-render added the list/grid/flip control to `LastModifiedElements` and the dev-mode reconcile highlight overlay painted a yellow stripe over the whole list region — making it look like every row had been reconciled even when no item element had changed.
- Adds an `internal abstract HasSetters` to `TemplatedListElementBase` (implemented on each derived record) so the short-circuit can correctly defer to the existing `.Set(...)` path.
- Adds two cases to `Element.OwnPropsEqual` mirroring the existing non-templated `ListViewElement` / `GridViewElement` cases — comparing `SelectedIndex`, `SelectionMode`, `Header`, `IsItemClickEnabled` (templated) and `Orientation`, `Spacing`, `EstimatedItemSize` (lazy stack).
- `ShallowEquals` deliberately not changed: skipping `Update` on these types would leave a stale `ViewBuilder` closure on the realized factory / ListView Tag, so newly-realized items (via `ContainerContentChanging`) would render with the old closure.

## Test plan

- [x] `dotnet test tests/Reactor.Tests` — 6793 passed, 0 failed, 46 skipped.
- [x] Full `--self-test` suite — 2207 ok, 0 failures.
- [x] 9 new fixtures in `TemplatedListHighlightTests` cover:
  - `ListView<T>` / `GridView<T>` / `FlipView<T>` / `LazyVStack<T>` / `LazyHStack<T>` — sibling state change does **not** flag the control as modified.
  - `ListView<T>` Header change — control **is** flagged and Header is applied.
  - `ListView<T>` items-reference change — `ItemsSource.Count` reflects the new size.
  - `ListView<T>` `.Set(...)` — setter still runs on every update and the control is flagged when setters are present (proves `HasSetters` gate is wired).
  - `LazyVStack<T>` spacing change — control still flagged.
- [x] Repro from the demo (`ReactorDemo/step-05.cs`): clicking +/- with a stable `items` list no longer paints a yellow overlay over the list region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)