### PR TITLE
chore(deps): bump Microsoft.WindowsAppSDK 2.0.0-preview2 → 2.0.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,10 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 ## Prerequisites
 
 - [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
-- Windows App SDK 2.0 (preview) — restored automatically from NuGet, no manual install required
+- Windows App SDK 2.0 — restored automatically from NuGet, no manual install required
 - Visual Studio 2022 (17.8+) or VS Code with C# Dev Kit
 
-> **Package version:** All projects reference `Microsoft.WindowsAppSDK` **2.0.0-preview2** (public NuGet). The version is centralized in `Directory.Build.props` — update it there to change the version for every project at once.
+> **Package version:** All projects reference `Microsoft.WindowsAppSDK` **2.0.1** (public NuGet). The version is centralized in `Directory.Build.props` — update it there to change the version for every project at once.
 
 ---
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!--
     Centralize the Windows App SDK version so all projects stay in sync.
-    This uses the public WinUI 3 package from NuGet.
+    This uses the public Microsoft.WindowsAppSDK package from NuGet.
     To install: dotnet restore (NuGet will pull the package automatically).
   -->
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,11 +2,11 @@
 
   <!--
     Centralize the Windows App SDK version so all projects stay in sync.
-    This uses the public experimental WinUI 3 package from NuGet.
+    This uses the public WinUI 3 package from NuGet.
     To install: dotnet restore (NuGet will pull the package automatically).
   -->
   <PropertyGroup>
-    <WindowsAppSDKVersion>2.0.0-preview2</WindowsAppSDKVersion>
+    <WindowsAppSDKVersion>2.0.1</WindowsAppSDKVersion>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ If you're building line-of-business applications:
 ### Prerequisites
 
 - [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
-- Windows App SDK 2.0 (preview) — pulled automatically on `dotnet restore`
+- Windows App SDK 2.0 — pulled automatically on `dotnet restore`
 - Visual Studio 2022 (17.8+) or just the .NET 8 CLI
 
-> This project uses the **preview** Windows App SDK 2.0 (`Microsoft.WindowsAppSDK` 2.0.0-preview2). The package comes from NuGet — no manual SDK installer is needed.
+> This project uses Windows App SDK 2.0 (`Microsoft.WindowsAppSDK` 2.0.1). The package comes from NuGet — no manual SDK installer is needed.
 
 ### Create a new app
 
@@ -157,7 +157,7 @@ Or create a `.csproj` manually:
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-preview2" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
     <ProjectReference Include="..\Reactor\Reactor.csproj" />
   </ItemGroup>
 </Project>

--- a/SKILL.md
+++ b/SKILL.md
@@ -43,7 +43,7 @@ re-renders automatically. No XAML. No data binding. No ViewModels.
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-preview2" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
     <ProjectReference Include="..\Reactor\Reactor.csproj" />
   </ItemGroup>
 </Project>
@@ -309,7 +309,7 @@ For lightweight demos, skip the `.csproj` entirely. Add a file-level header:
 
 ```csharp
 #:project ./src/Reactor
-#:package Microsoft.WindowsAppSDK@2.0.0-preview2
+#:package Microsoft.WindowsAppSDK@2.0.1
 #:property OutputType=WinExe
 #:property TargetFramework=net9.0-windows10.0.22621.0
 #:property UseWinUI=true

--- a/docs/specs/022-packaging-and-distribution.md
+++ b/docs/specs/022-packaging-and-distribution.md
@@ -431,7 +431,7 @@ Consumer gets: framework, analyzers, source generator, and WinUI SDK (transitive
 - **Internal feed ownership.** Which Azure Artifacts organization hosts the P1 feed? Creating one takes ~a day plus approvals.
 - **Signing prerequisite for P1.** Does the chosen internal feed enforce signed packages? If yes, P1 needs ESRP too, not just P2.
 - **Package ID.** `Microsoft.UI.Reactor` assumes we stay in the `Microsoft.UI.*` namespace (see spec 018 for the namespace rename). If that namespace decision changes, the package ID follows.
-- **WinUI SDK version.** We currently pin `Microsoft.WindowsAppSDK` 2.0.0-preview2. Consumers who want a different WinUI version will conflict. Decide: float this transitively, or lock it and force consumers to match.
+- **WinUI SDK version.** We currently pin `Microsoft.WindowsAppSDK` 2.0.1. Consumers who want a different WinUI version will conflict. Decide: float this transitively, or lock it and force consumers to match.
 - **`mur` install-script trust boundary.** `iwr | iex` from GitHub Releases works for P1 but will concern P3 users. Document the signed-binary fallback (direct download + verify signature) before public launch.
 
 ## 14. Implementation Phases

--- a/samples/WinFormsInterop/README.md
+++ b/samples/WinFormsInterop/README.md
@@ -40,7 +40,7 @@ static class Program
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
 
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-preview2" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
     <ProjectReference Include="path\to\Reactor.Interop.WinForms.csproj" />
     <ProjectReference Include="path\to\Reactor.csproj" />
 ```

--- a/samples/apps/demo-script-tool/App/Resources/SystemPrompt.txt
+++ b/samples/apps/demo-script-tool/App/Resources/SystemPrompt.txt
@@ -20,7 +20,7 @@ properties. Examples:
 
 ```csharp
 #:project ../../src/Reactor
-#:package Microsoft.WindowsAppSDK@2.0.0-preview2
+#:package Microsoft.WindowsAppSDK@2.0.1
 #:property OutputType=WinExe
 #:property TargetFramework=net10.0-windows10.0.22621.0
 #:property UseWinUI=true
@@ -53,7 +53,7 @@ Minimum Reactor file-based-app shape:
 
 ```csharp
 #:project <relative-path-to>/src/Reactor
-#:package Microsoft.WindowsAppSDK@2.0.0-preview2
+#:package Microsoft.WindowsAppSDK@2.0.1
 #:property OutputType=WinExe
 #:property TargetFramework=net10.0-windows10.0.22621.0
 #:property UseWinUI=true
@@ -185,7 +185,7 @@ Common fixes:
   ===CODE step-01.cs===
   ```csharp
   #:project ./src/Reactor
-  #:package Microsoft.WindowsAppSDK@2.0.0-preview2
+  #:package Microsoft.WindowsAppSDK@2.0.1
   #:property OutputType=WinExe
   #:property TargetFramework=net10.0-windows10.0.22621.0
   #:property UseWinUI=true

--- a/src/Reactor.Cli/Program.cs
+++ b/src/Reactor.Cli/Program.cs
@@ -196,7 +196,7 @@ string GenerateCsproj() =>
         <WindowsSdkPackageVersion>10.0.22621.52</WindowsSdkPackageVersion>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-preview2" />
+        <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
       </ItemGroup>
       <ItemGroup>
         <ProjectReference Include="..\Reactor\Reactor.csproj" />


### PR DESCRIPTION
## Summary
- Windows App SDK 2.0 went stable on 2026-02-13; latest patch is **2.0.1** (2026-04-29). Move off `2.0.0-preview2`.
- Bump the centralized `WindowsAppSDKVersion` in `Directory.Build.props` (drives every `.csproj` via `$(WindowsAppSDKVersion)`).
- Update remaining literal `2.0.0-preview2` strings in docs and code samples, and drop the "preview" hedging from the prose.

## Files touched (literal-version strings)
- `Directory.Build.props` — central version property
- `CONTRIBUTING.md`, `README.md`, `SKILL.md`, `docs/specs/022-packaging-and-distribution.md`
- `samples/WinFormsInterop/README.md`
- `samples/apps/demo-script-tool/App/Resources/SystemPrompt.txt` (LLM system prompt examples)
- `src/Reactor.Cli/Program.cs` (csproj template emitted by `--create`)

Pipeline `.csproj`s already used `$(WindowsAppSDKVersion)`, and the two `.dt` templates already float on `2.0.*`, so they didn't need to change.

## Test plan
- [x] `dotnet restore src/Reactor` resolves 2.0.1
- [x] `dotnet test tests/Reactor.Tests` — **6793 passed**, 46 skipped, 0 failed (5s)
- [x] `dotnet test tests/Reactor.SelfTests` — **648 passed**, 0 failed (1m54s)
- [ ] E2E (`Reactor.AppTests`) not run — requires WinAppDriver

🤖 Generated with [Claude Code](https://claude.com/claude-code)