### PR TITLE
fix(selftest): stabilize HostControlMountFunc + Tab/RadioButtons selection flakes

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HostingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HostingCoverageFixtures.cs
@@ -92,9 +92,12 @@ internal static class HostingCoverageFixtures
                 );
             });
 
+            // Standalone ReactorHostControl doesn't register with ReactorApp.ActiveHost,
+            // so Harness.Render() can't wait on its render loop directly — give it
+            // wall-clock time, same as the sibling Component / Factory fixtures.
             var container = new Border { Child = hostControl };
             H.SetContent(container);
-            await Harness.Render();
+            await Harness.Render(200);
 
             var text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Func:") == true);
             H.Check("HostCtrlFunc_Mounted", text is not null);
@@ -107,7 +110,7 @@ internal static class HostingCoverageFixtures
                 ((Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
                     peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)).Invoke();
             }
-            await Harness.Render();
+            await Harness.Render(200);
             text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Func:") == true);
             H.Check("HostCtrlFunc_Updated", text?.Text == "Func:world");
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SelectionEventFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SelectionEventFixtures.cs
@@ -71,6 +71,11 @@ internal static class SelectionEventFixtures
             count = 0; lastIndex = -1;
             if (rbs is not null) rbs.SelectedIndex = 1;
 
+            // RadioButtons can raise SelectionChanged via the dispatcher (unlike
+            // ComboBox/ListView/etc. which fire it synchronously in the setter),
+            // so pump once before asserting on the counter.
+            await Harness.Render();
+
             H.Check("RadioButtonsSel_CallbackFired", count >= 1);
             H.Check("RadioButtonsSel_PayloadIndex", lastIndex == 1);
         }
@@ -198,6 +203,11 @@ internal static class SelectionEventFixtures
 
             count = 0; lastIndex = -1;
             if (tv is not null) tv.SelectedIndex = 2;
+
+            // TabView can raise SelectionChanged via the dispatcher (unlike
+            // ComboBox/ListView/etc. which fire it synchronously in the setter),
+            // so pump once before asserting on the counter.
+            await Harness.Render();
 
             H.Check("TabViewSel_CallbackFired", count >= 1);
             H.Check("TabViewSel_PayloadIndex", lastIndex == 2);


### PR DESCRIPTION
## Summary

- `HostControlMountFunc`: use `Harness.Render(200)` so the standalone `ReactorHostControl` (which doesn't register with `ReactorApp.ActiveHost`) gets enough wall-clock time for its render loop. Matches the sibling `HostControlMountComponent` / `HostControlFactory` fixtures.
- `TabViewSelectionFires` / `RadioButtonsSelectionFires`: pump once with `await Harness.Render()` between the `SelectedIndex` mutation and the callback-counter assertion. Both controls can raise `SelectionChanged` via the dispatcher rather than synchronously in the setter (unlike `ComboBox` / `ListView` / `GridView` / `FlipView` / `Pivot`).
- Both are fixture-side fixes; no SUT changes.

## Repro & validation

Captured 100x runs of `Reactor.AppTests.Host --self-test` before and after.

| Cluster | Before (batch2) | After (batch3) |
|---|---:|---:|
| `HostCtrlFunc_Mounted/Initial/Updated` | 7/100 | **0/100** |
| `TabViewSel_CallbackFired/PayloadIndex` | 7/100 | **0/100** |
| `RadioButtonsSel_CallbackFired/PayloadIndex` | 5/100 | **0/100** |
| Run-failure rate (any test) | 18/100 | 2/100 |

The 2 remaining run-failures are unrelated, out-of-scope flakes (`Resource_FetchedData`, `Mutation_Completed`) — neither was touched here, and neither was in the original failure clusters.

## Test plan

- [x] `dotnet build tests/Reactor.AppTests.Host` — green
- [x] Smoke filtered runs of the affected fixtures (`Hosting_HostControl*`, `SelectionEvt_*`) — all pass
- [x] 100x full-suite sweep — targeted clusters at 0 occurrences

🤖 Generated with [Claude Code](https://claude.com/claude-code)