### PR TITLE
samples(demo-script-tool): generate/re-gen fixes + session logging

### DIFF
--- a/samples/apps/demo-script-tool/App/Components/StepCard.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepCard.cs
@@ -16,7 +16,7 @@ public sealed record StepCardProps(
     Action<StepModel> OnRun,
     Action<StepModel> OnCopyDelta,
     Action<StepModel> OnDelete,
-    Action<StepModel> OnRerunFromHere);
+    Action<StepModel> OnRegenFromHere);
 
 /// <summary>
 /// One step rendered as a three-column card: prompt | code | actions
@@ -205,13 +205,13 @@ public sealed class StepCard : Component<StepCardProps>
             },
         });
 
-        var rerunCmd = UseCommand(new Command
+        var regenCmd = UseCommand(new Command
         {
             Label = "Re-gen",
             CanExecute = !Props.IsGenerating,
             ExecuteAsync = async () =>
             {
-                Props.OnRerunFromHere(step);
+                Props.OnRegenFromHere(step);
                 await Task.Delay(250).ConfigureAwait(false);
             },
         });
@@ -240,8 +240,8 @@ public sealed class StepCard : Component<StepCardProps>
             ActionButton(IconAsset("run"), runCmd, $"Run step {step.Number}"),
             ActionButton(IconAsset(showCode ? "notes" : "code"), toggleCmd, $"Toggle code/notes view for step {step.Number}"),
             ActionButton(IconAsset("copy"), copyCmd, $"Copy speaker notes for step {step.Number}"),
-            // Re-run-from-here regenerates this step + every step that follows.
-            ActionButton(IconAsset("rerun"), rerunCmd, $"Re-run step {step.Number} and every following step"),
+            // Re-gen regenerates this step + every step that follows.
+            ActionButton(IconAsset("rerun"), regenCmd, $"Re-gen step {step.Number} and every following step"),
             ActionButton(IconAsset("delete"), deleteCmd, $"Delete step {step.Number}"));
 
         var failureOutput = (step.BuildState == BuildState.Failed && !string.IsNullOrEmpty(step.BuildOutput))

--- a/samples/apps/demo-script-tool/App/Components/StepCard.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepCard.cs
@@ -205,16 +205,20 @@ public sealed class StepCard : Component<StepCardProps>
             },
         });
 
-        var regenCmd = UseCommand(new Command
+        // Plain sync Command (no UseCommand). UseCommand's Task.Run wrapper
+        // would put OnRegenFromHere on a threadpool thread, which made the
+        // shell's announce.Announce throw RPC_E_WRONG_THREAD on the
+        // FrameworkElementAutomationPeer call (the exact issue tracked by
+        // framework #130). The 250 ms IsExecuting bridge is no longer needed
+        // either — the shell's lastRegenClickRef debounce (200 ms) covers
+        // the same multi-fire window without crossing threads, and
+        // Props.IsGenerating disables the button on the next render.
+        var regenCmd = new Command
         {
             Label = "Re-gen",
             CanExecute = !Props.IsGenerating,
-            ExecuteAsync = async () =>
-            {
-                Props.OnRegenFromHere(step);
-                await Task.Delay(250).ConfigureAwait(false);
-            },
-        });
+            Execute = () => Props.OnRegenFromHere(step),
+        };
 
         var toggleCmd = new Command
         {

--- a/samples/apps/demo-script-tool/App/Components/StepsPanel.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepsPanel.cs
@@ -15,7 +15,7 @@ public sealed record StepsPanelProps(
     Action<StepModel> OnCopyDelta,
     Action OnAddStep,
     Action<StepModel> OnDeleteStep,
-    Action<StepModel> OnRerunFromStep);
+    Action<StepModel> OnRegenFromStep);
 
 /// <summary>
 /// Vertical scroller of <see cref="StepCard"/> instances keyed by step number.
@@ -79,7 +79,7 @@ public sealed class StepsPanel : Component<StepsPanelProps>
                 steps.Count,
                 Props.IsGenerating,
                 Props.OnPromptChanged, Props.OnTitleChanged, Props.OnRun, Props.OnCopyDelta, Props.OnDeleteStep,
-                Props.OnRerunFromStep)))
+                Props.OnRegenFromStep)))
             .Append(addButton)
             .ToArray();
 

--- a/samples/apps/demo-script-tool/App/DemoScriptShell.cs
+++ b/samples/apps/demo-script-tool/App/DemoScriptShell.cs
@@ -289,7 +289,26 @@ public sealed class DemoScriptShell : Component
             }
         }
 
-        void OnGenerateAll()
+        // Wraps a click handler so any exception (e.g. UseAnnounce hitting an
+        // unattached automation peer, a stale UseRef, an SDK call surfacing
+        // mid-handler) is logged and surfaced as a banner instead of being
+        // swallowed by the WinUI Click event chain. The repro that motivated
+        // this: OnRegenFromStep entered (entry log fired), exited the click
+        // event with no further log, no Task.Run, no toast — a silent throw
+        // somewhere between the entry log and the kickoff log was the most
+        // likely cause but invisible without this scaffolding.
+        void SafeClickHandler(string name, Action body)
+        {
+            try { body(); }
+            catch (Exception ex)
+            {
+                SessionLog.Write($"[Shell] {name} threw: {ex}");
+                _status.SetBanner($"{name} crashed: {ex.GetType().Name} — {ex.Message}");
+            }
+        }
+
+        void OnGenerateAll() => SafeClickHandler("OnGenerateAll", OnGenerateAllCore);
+        void OnGenerateAllCore()
         {
             var now = Environment.TickCount64;
             var delta = now - lastGenerateClickRef.Current;
@@ -382,7 +401,8 @@ public sealed class DemoScriptShell : Component
             });
         }
 
-        void OnRegenFromStep(StepModel step)
+        void OnRegenFromStep(StepModel step) => SafeClickHandler($"OnRegenFromStep(step={step.Number})", () => OnRegenFromStepCore(step));
+        void OnRegenFromStepCore(StepModel step)
         {
             var now = Environment.TickCount64;
             var delta = now - lastRegenClickRef.Current;

--- a/samples/apps/demo-script-tool/App/DemoScriptShell.cs
+++ b/samples/apps/demo-script-tool/App/DemoScriptShell.cs
@@ -62,6 +62,17 @@ public sealed class DemoScriptShell : Component
         var watcherRef = UseRef<DemoScriptWatcher?>(null);
         var generationCtsRef = UseRef<CancellationTokenSource?>(null);
         var saveDebounceRef = UseRef<CancellationTokenSource?>(null);
+        // Last-click-fired timestamp guards against Generate / Re-gen / etc.
+        // entry handlers running multiple times per user click. We've observed
+        // (logged at SessionLog) the OnGenerateAll handler firing 3+ times
+        // within 1 ms of a single click — which previously kicked off a run
+        // and then immediately cancelled it. Until the framework-level cause
+        // is found (suspected leaky button click subscription across
+        // re-renders, see PoolableWireFlags + EnsureButtonWiring) a cheap
+        // 200 ms debounce stops the immediate-cancel symptom without changing
+        // the user's perceived behavior on legitimate clicks.
+        var lastGenerateClickRef = UseRef<long>(0);
+        var lastRegenClickRef = UseRef<long>(0);
         // SHA-256 of the bytes of our most recent save (or load). When the
         // file watcher fires for a write WE just made, the disk hash equals
         // this value and we suppress the reload — otherwise our own debounced
@@ -280,7 +291,15 @@ public sealed class DemoScriptShell : Component
 
         void OnGenerateAll()
         {
-            SessionLog.Write($"[Shell] OnGenerateAll projectRoot='{projectRoot ?? "(null)"}' ctsCurrent={(generationCtsRef.Current is null ? "null" : "non-null")} isGenerating={isGenerating} steps={model.Steps.Count}");
+            var now = Environment.TickCount64;
+            var delta = now - lastGenerateClickRef.Current;
+            SessionLog.Write($"[Shell] OnGenerateAll projectRoot='{projectRoot ?? "(null)"}' ctsCurrent={(generationCtsRef.Current is null ? "null" : "non-null")} isGenerating={isGenerating} steps={model.Steps.Count} sinceLastClick={delta}ms");
+            if (lastGenerateClickRef.Current != 0 && delta < 200)
+            {
+                SessionLog.Write($"[Shell] OnGenerateAll → debounce drop ({delta}ms since last invocation)");
+                return;
+            }
+            lastGenerateClickRef.Current = now;
             if (projectRoot is null)
             {
                 _status.ShowToast("Open a folder first (Ctrl+O).", StatusSeverity.Warning);
@@ -365,7 +384,15 @@ public sealed class DemoScriptShell : Component
 
         void OnRegenFromStep(StepModel step)
         {
-            SessionLog.Write($"[Shell] OnRegenFromStep step={step.Number} '{step.Title}' projectRoot='{projectRoot ?? "(null)"}' ctsCurrent={(generationCtsRef.Current is null ? "null" : "non-null")} isGenerating={isGenerating}");
+            var now = Environment.TickCount64;
+            var delta = now - lastRegenClickRef.Current;
+            SessionLog.Write($"[Shell] OnRegenFromStep step={step.Number} '{step.Title}' projectRoot='{projectRoot ?? "(null)"}' ctsCurrent={(generationCtsRef.Current is null ? "null" : "non-null")} isGenerating={isGenerating} sinceLastClick={delta}ms");
+            if (lastRegenClickRef.Current != 0 && delta < 200)
+            {
+                SessionLog.Write($"[Shell] OnRegenFromStep → debounce drop ({delta}ms since last invocation)");
+                return;
+            }
+            lastRegenClickRef.Current = now;
             if (projectRoot is null)
             {
                 _status.ShowToast("Open a folder first.", StatusSeverity.Warning);

--- a/samples/apps/demo-script-tool/App/DemoScriptShell.cs
+++ b/samples/apps/demo-script-tool/App/DemoScriptShell.cs
@@ -84,6 +84,7 @@ public sealed class DemoScriptShell : Component
             }
             void OnGenerating(string? msg)
             {
+                SessionLog.Write($"[Shell] OnGenerating '{msg ?? "(null)"}'");
                 setGenerationStatus(msg);
                 if (msg is not null)
                 {
@@ -105,7 +106,7 @@ public sealed class DemoScriptShell : Component
 
             if (InitialFolder is not null && projectRoot is null)
             {
-                System.Diagnostics.Debug.WriteLine($"[demo-script] auto-loading CLI folder: {InitialFolder}");
+                SessionLog.Write($"[demo-script] auto-loading CLI folder: {InitialFolder}");
                 _ = LoadFolderAsync(InitialFolder);
             }
 
@@ -279,6 +280,7 @@ public sealed class DemoScriptShell : Component
 
         void OnGenerateAll()
         {
+            SessionLog.Write($"[Shell] OnGenerateAll projectRoot='{projectRoot ?? "(null)"}' ctsCurrent={(generationCtsRef.Current is null ? "null" : "non-null")} isGenerating={isGenerating} steps={model.Steps.Count}");
             if (projectRoot is null)
             {
                 _status.ShowToast("Open a folder first (Ctrl+O).", StatusSeverity.Warning);
@@ -294,6 +296,7 @@ public sealed class DemoScriptShell : Component
             // cancel a run regardless of any UseState-vs-render drift.
             if (generationCtsRef.Current is not null)
             {
+                SessionLog.Write("[Shell] OnGenerateAll → cancelling in-flight gen");
                 generationCtsRef.Current.Cancel();
                 return;
             }
@@ -306,21 +309,24 @@ public sealed class DemoScriptShell : Component
             generationCtsRef.Current = cts;
             setIsGenerating(true);
             announce.Announce($"Generating {model.Steps.Count} steps…", assertive: false);
+            SessionLog.Write("[Shell] Generate-All kicking off Task.Run");
 
             _ = Task.Run(async () =>
             {
+                SessionLog.Write("[Shell] Generate-All Task.Run entered");
                 try
                 {
                     await _pipeline.GenerateAllAsync(model, projectRoot, cts.Token).ConfigureAwait(false);
+                    SessionLog.Write("[Shell] Generate-All Task.Run pipeline returned normally");
                 }
                 catch (Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[Shell] Generate task crashed: {ex}");
+                    SessionLog.Write($"[Shell] Generate task crashed: {ex}");
                     _status.SetBanner($"Generation crashed: {ex.GetType().Name} — {ex.Message}");
                 }
                 finally
                 {
-                    System.Diagnostics.Debug.WriteLine("[Shell] Generate finally — clearing isGenerating + cts");
+                    SessionLog.Write("[Shell] Generate finally — clearing isGenerating + cts");
                     setIsGenerating(false);
                     generationCtsRef.Current?.Dispose();
                     generationCtsRef.Current = null;
@@ -359,6 +365,7 @@ public sealed class DemoScriptShell : Component
 
         void OnRegenFromStep(StepModel step)
         {
+            SessionLog.Write($"[Shell] OnRegenFromStep step={step.Number} '{step.Title}' projectRoot='{projectRoot ?? "(null)"}' ctsCurrent={(generationCtsRef.Current is null ? "null" : "non-null")} isGenerating={isGenerating}");
             if (projectRoot is null)
             {
                 _status.ShowToast("Open a folder first.", StatusSeverity.Warning);
@@ -387,21 +394,24 @@ public sealed class DemoScriptShell : Component
             generationCtsRef.Current = cts;
             setIsGenerating(true);
             announce.Announce($"Re-generating from step {step.Number}…", assertive: false);
+            SessionLog.Write($"[Shell] Re-gen kicking off Task.Run startIndex={idx}");
 
             _ = Task.Run(async () =>
             {
+                SessionLog.Write($"[Shell] Re-gen Task.Run entered startIndex={idx}");
                 try
                 {
                     await _pipeline.GenerateFromAsync(model, projectRoot, idx, cts.Token).ConfigureAwait(false);
+                    SessionLog.Write("[Shell] Re-gen Task.Run pipeline returned normally");
                 }
                 catch (Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[Shell] Re-gen task crashed: {ex}");
+                    SessionLog.Write($"[Shell] Re-gen task crashed: {ex}");
                     _status.SetBanner($"Re-gen crashed: {ex.GetType().Name} — {ex.Message}");
                 }
                 finally
                 {
-                    System.Diagnostics.Debug.WriteLine("[Shell] Re-gen finally — clearing isGenerating + cts");
+                    SessionLog.Write("[Shell] Re-gen finally — clearing isGenerating + cts");
                     setIsGenerating(false);
                     generationCtsRef.Current?.Dispose();
                     generationCtsRef.Current = null;
@@ -510,13 +520,28 @@ public sealed class DemoScriptShell : Component
                     }
                     catch (Exception ex) { _status.ShowToast($"Reveal failed: {ex.Message}", StatusSeverity.Error); }
                 }),
+            MenuItem("Reveal log folder…",
+                () =>
+                {
+                    try
+                    {
+                        // Prefer selecting the current session's file (highlights it
+                        // in Explorer); fall back to opening the folder if Init
+                        // hasn't run or the file is gone.
+                        var arg = SessionLog.CurrentPath is { } p && System.IO.File.Exists(p)
+                            ? $"/select,\"{p}\""
+                            : $"\"{SessionLog.LogDirectory}\"";
+                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("explorer.exe", arg) { UseShellExecute = true });
+                    }
+                    catch (Exception ex) { _status.ShowToast($"Reveal log failed: {ex.Message}", StatusSeverity.Error); }
+                }),
             MenuItem("Log model snapshot",
-                () => System.Diagnostics.Debug.WriteLine($"[demo-script] title='{model.Title}' steps={model.Steps.Count} multiFile={model.IsMultiFile}")),
+                () => SessionLog.Write($"[demo-script] title='{model.Title}' steps={model.Steps.Count} multiFile={model.IsMultiFile}")),
             MenuItem("Log available Copilot models…",
                 () => _ = Task.Run(async () =>
                 {
                     var s = await _client.DescribeAvailableModelsAsync(CancellationToken.None);
-                    System.Diagnostics.Debug.WriteLine("[demo-script] available models:\n" + s);
+                    SessionLog.Write("[demo-script] available models:\n" + s);
                     _status.ShowToast("Available Copilot models written to debug log.", StatusSeverity.Info);
                 })),
             MenuItem("Force banner: dummy auth error",

--- a/samples/apps/demo-script-tool/App/DemoScriptShell.cs
+++ b/samples/apps/demo-script-tool/App/DemoScriptShell.cs
@@ -284,11 +284,23 @@ public sealed class DemoScriptShell : Component
                 _status.ShowToast("Open a folder first (Ctrl+O).", StatusSeverity.Warning);
                 return;
             }
-            if (isGenerating)
+
+            // The CTS ref is the source of truth for "actually in flight" — it's
+            // mutated synchronously and never lags behind a UseState dispatch.
+            // We previously gated on the isGenerating UseState, which ended up
+            // stuck true on at least one repro after a normal completion (the
+            // Cancel button never reverted to Generate All), blocking subsequent
+            // runs. Falling back to the ref means the user can always start /
+            // cancel a run regardless of any UseState-vs-render drift.
+            if (generationCtsRef.Current is not null)
             {
-                generationCtsRef.Current?.Cancel();
+                generationCtsRef.Current.Cancel();
                 return;
             }
+
+            // Defensively reset the UI flag in case it's stuck out of sync with
+            // the ref. setIsGenerating(true) below schedules a render either way.
+            if (isGenerating) setIsGenerating(false);
 
             var cts = new CancellationTokenSource();
             generationCtsRef.Current = cts;
@@ -308,6 +320,7 @@ public sealed class DemoScriptShell : Component
                 }
                 finally
                 {
+                    System.Diagnostics.Debug.WriteLine("[Shell] Generate finally — clearing isGenerating + cts");
                     setIsGenerating(false);
                     generationCtsRef.Current?.Dispose();
                     generationCtsRef.Current = null;
@@ -344,18 +357,22 @@ public sealed class DemoScriptShell : Component
             });
         }
 
-        void OnRerunFromStep(StepModel step)
+        void OnRegenFromStep(StepModel step)
         {
             if (projectRoot is null)
             {
                 _status.ShowToast("Open a folder first.", StatusSeverity.Warning);
                 return;
             }
-            if (isGenerating)
+            // CTS-ref-as-truth (see OnGenerateAll). Gating on UseState's
+            // isGenerating directly used to leave Re-gen permanently disabled
+            // when the flag got stuck after a normal completion.
+            if (generationCtsRef.Current is not null)
             {
                 _status.ShowToast("Generation already running — cancel it first.", StatusSeverity.Warning);
                 return;
             }
+            if (isGenerating) setIsGenerating(false);
 
             // Locate this step's index in the live steps list. Comparing by
             // reference is robust to renumbering after Add/Delete.
@@ -369,7 +386,7 @@ public sealed class DemoScriptShell : Component
             var cts = new CancellationTokenSource();
             generationCtsRef.Current = cts;
             setIsGenerating(true);
-            announce.Announce($"Re-running from step {step.Number}…", assertive: false);
+            announce.Announce($"Re-generating from step {step.Number}…", assertive: false);
 
             _ = Task.Run(async () =>
             {
@@ -379,11 +396,12 @@ public sealed class DemoScriptShell : Component
                 }
                 catch (Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[Shell] Re-run task crashed: {ex}");
-                    _status.SetBanner($"Re-run crashed: {ex.GetType().Name} — {ex.Message}");
+                    System.Diagnostics.Debug.WriteLine($"[Shell] Re-gen task crashed: {ex}");
+                    _status.SetBanner($"Re-gen crashed: {ex.GetType().Name} — {ex.Message}");
                 }
                 finally
                 {
+                    System.Diagnostics.Debug.WriteLine("[Shell] Re-gen finally — clearing isGenerating + cts");
                     setIsGenerating(false);
                     generationCtsRef.Current?.Dispose();
                     generationCtsRef.Current = null;
@@ -546,7 +564,7 @@ public sealed class DemoScriptShell : Component
                 .Margin(0, banner is null && parseError is null ? 0 : 12, 0, 0),
             (parseError is null
                 ? (Element)Component<StepsPanel, StepsPanelProps>(
-                    new StepsPanelProps(model, isGenerating, OnPromptChanged, OnTitleChanged, OnRunStep, OnCopyDelta, OnAddStep, OnDeleteStep, OnRerunFromStep))
+                    new StepsPanelProps(model, isGenerating, OnPromptChanged, OnTitleChanged, OnRunStep, OnCopyDelta, OnAddStep, OnDeleteStep, OnRegenFromStep))
                     .Flex(grow: 1, basis: 0)
                 : Empty()))
             with { RowGap = 0 })

--- a/samples/apps/demo-script-tool/App/DemoScriptShell.cs
+++ b/samples/apps/demo-script-tool/App/DemoScriptShell.cs
@@ -97,17 +97,7 @@ public sealed class DemoScriptShell : Component
             {
                 SessionLog.Write($"[Shell] OnGenerating '{msg ?? "(null)"}'");
                 setGenerationStatus(msg);
-                if (msg is not null)
-                {
-                    // announce.Announce hits WinUI's automation peer which is
-                    // UI-thread-only — marshal explicitly since the pipeline
-                    // raises this event from Task.Run.
-                    var dq = ReactorApp.ActiveHost?.Window?.DispatcherQueue;
-                    if (dq is null || dq.HasThreadAccess)
-                        announce.Announce(msg, assertive: false);
-                    else
-                        dq.TryEnqueue(() => announce.Announce(msg, assertive: false));
-                }
+                if (msg is not null) SafeAnnounce(msg);
             }
             void OnBanner(string? msg) => setBanner(msg);
 
@@ -307,6 +297,34 @@ public sealed class DemoScriptShell : Component
             }
         }
 
+        // SafeAnnounce — never throws. UseAnnounce.Announce ultimately calls
+        // FrameworkElementAutomationPeer.FromElement, which is UI-thread-only
+        // and surfaces RPC_E_WRONG_THREAD (COMException 0x8001010E) when
+        // invoked from a threadpool thread (we hit this from
+        // UseCommand-wrapped click handlers — see framework #130). Marshals
+        // to the UI dispatcher when needed and swallows any other automation
+        // peer flake — losing one screen-reader announcement is fine, leaving
+        // the caller mid-state-setup is not.
+        void SafeAnnounce(string message, bool assertive = false)
+        {
+            try
+            {
+                var dq = ReactorApp.ActiveHost?.Window?.DispatcherQueue;
+                if (dq is null || dq.HasThreadAccess)
+                    announce.Announce(message, assertive);
+                else
+                    dq.TryEnqueue(() =>
+                    {
+                        try { announce.Announce(message, assertive); }
+                        catch (Exception ex) { SessionLog.Write($"[Shell] SafeAnnounce (dispatched) swallowed: {ex.Message}"); }
+                    });
+            }
+            catch (Exception ex)
+            {
+                SessionLog.Write($"[Shell] SafeAnnounce swallowed: {ex.Message}");
+            }
+        }
+
         void OnGenerateAll() => SafeClickHandler("OnGenerateAll", OnGenerateAllCore);
         void OnGenerateAllCore()
         {
@@ -346,7 +364,7 @@ public sealed class DemoScriptShell : Component
             var cts = new CancellationTokenSource();
             generationCtsRef.Current = cts;
             setIsGenerating(true);
-            announce.Announce($"Generating {model.Steps.Count} steps…", assertive: false);
+            SafeAnnounce($"Generating {model.Steps.Count} steps…");
             SessionLog.Write("[Shell] Generate-All kicking off Task.Run");
 
             _ = Task.Run(async () =>
@@ -440,7 +458,7 @@ public sealed class DemoScriptShell : Component
             var cts = new CancellationTokenSource();
             generationCtsRef.Current = cts;
             setIsGenerating(true);
-            announce.Announce($"Re-generating from step {step.Number}…", assertive: false);
+            SafeAnnounce($"Re-generating from step {step.Number}…");
             SessionLog.Write($"[Shell] Re-gen kicking off Task.Run startIndex={idx}");
 
             _ = Task.Run(async () =>
@@ -475,7 +493,7 @@ public sealed class DemoScriptShell : Component
                 dp.SetText(step.Delta);
                 global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dp);
                 _status.ShowToast($"Step {step.Number} delta copied to clipboard.", StatusSeverity.Success);
-                announce.Announce($"Step {step.Number} delta copied.", assertive: false);
+                SafeAnnounce($"Step {step.Number} delta copied.");
             }
             catch (Exception ex)
             {
@@ -504,7 +522,7 @@ public sealed class DemoScriptShell : Component
         {
             var added = model.AddStep(title: "", prompt: "");
             ScheduleSave();
-            announce.Announce($"Added step {added.Number}.", assertive: false);
+            SafeAnnounce($"Added step {added.Number}.");
         }
 
         void OnDeleteStep(StepModel step)

--- a/samples/apps/demo-script-tool/App/Models/StepModel.cs
+++ b/samples/apps/demo-script-tool/App/Models/StepModel.cs
@@ -253,7 +253,7 @@ public sealed class StepModel
             try { Changed?.Invoke(); }
             catch (System.Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"[StepModel] Changed handler threw: {ex}");
+                SessionLog.Write($"[StepModel] Changed handler threw: {ex}");
             }
         });
     }

--- a/samples/apps/demo-script-tool/App/Program.cs
+++ b/samples/apps/demo-script-tool/App/Program.cs
@@ -27,6 +27,11 @@ foreach (var raw in System.Environment.GetCommandLineArgs().Skip(1))
     break;
 }
 
+// Persistent session log — opens before anything else can call Write so
+// even early-startup failures land in the file, not just the debugger.
+DemoScriptTool.App.Services.SessionLog.Init();
+DemoScriptTool.App.Services.SessionLog.Write($"[Program] launched initialFolder='{initialFolder ?? "(none)"}' args={string.Join(' ', System.Environment.GetCommandLineArgs())}");
+
 DemoScriptShell.InitialFolder = initialFolder;
 
 ReactorApp.Run<DemoScriptShell>(

--- a/samples/apps/demo-script-tool/App/Resources/SystemPrompt.txt
+++ b/samples/apps/demo-script-tool/App/Resources/SystemPrompt.txt
@@ -41,6 +41,14 @@ file-based app is a top-level-statements program — no `class App :
 Application`, no `Main`, no namespace, no XAML. The entry point is the
 top-level statements themselves.
 
+Order matters: `#:` directives FIRST, then `using` statements, then
+top-level statements (like `ReactorApp.Run<App>(...);`), THEN any
+`class`, `record`, `struct` declarations. C# enforces this
+("`error CS8803: Top-level statements must precede namespace and type
+declarations`"). When you define a `class App : Component` and call
+`ReactorApp.Run<App>(...)`, the `Run<App>(...)` call must appear ABOVE
+the `class App` declaration in the file.
+
 # Reactor (default for desktop / WinUI / GUI demos)
 
 If the demo prompt mentions Reactor, WinUI 3, XAML, or building a

--- a/samples/apps/demo-script-tool/App/Services/CopilotSdkClient.cs
+++ b/samples/apps/demo-script-tool/App/Services/CopilotSdkClient.cs
@@ -71,9 +71,9 @@ public sealed class CopilotSdkClient : IModelClient, IAsyncDisposable
                 GitHubToken = _explicitToken,
             };
             var client = new CopilotClient(options);
-            System.Diagnostics.Debug.WriteLine($"[CopilotSdk] starting CLI server (model={_model}, explicitToken={(_explicitToken is null ? "no" : "yes")})");
+            SessionLog.Write($"[CopilotSdk] starting CLI server (model={_model}, explicitToken={(_explicitToken is null ? "no" : "yes")})");
             await client.StartAsync().ConfigureAwait(false);
-            System.Diagnostics.Debug.WriteLine("[CopilotSdk] CLI server ready");
+            SessionLog.Write("[CopilotSdk] CLI server ready");
             _client = client;
             return _client;
         }
@@ -88,7 +88,7 @@ public sealed class CopilotSdkClient : IModelClient, IAsyncDisposable
         string userPrompt,
         [EnumeratorCancellation] CancellationToken ct)
     {
-        System.Diagnostics.Debug.WriteLine($"[CopilotSdk] StreamAsync model={_model} userPromptBytes={userPrompt.Length}");
+        SessionLog.Write($"[CopilotSdk] StreamAsync model={_model} userPromptBytes={userPrompt.Length}");
         var client = await GetClientAsync(ct).ConfigureAwait(false);
 
         // Channel bridges the SDK's event-based delivery to our IAsyncEnumerable
@@ -119,7 +119,7 @@ public sealed class CopilotSdkClient : IModelClient, IAsyncDisposable
         };
 
         await using var session = await client.CreateSessionAsync(sessionConfig, ct).ConfigureAwait(false);
-        System.Diagnostics.Debug.WriteLine($"[CopilotSdk] session created id={session.SessionId}");
+        SessionLog.Write($"[CopilotSdk] session created id={session.SessionId}");
 
         Exception? terminalError = null;
         bool sawDeltas = false;
@@ -131,7 +131,7 @@ public sealed class CopilotSdkClient : IModelClient, IAsyncDisposable
             // is visible during debugging. The line is kept short so it doesn't
             // dominate the devtools log; payload is only read for the events
             // we care about below.
-            System.Diagnostics.Debug.WriteLine($"[CopilotSdk] evt: {evt.GetType().Name}");
+            SessionLog.Write($"[CopilotSdk] evt: {evt.GetType().Name}");
 
             switch (evt)
             {
@@ -173,7 +173,7 @@ public sealed class CopilotSdkClient : IModelClient, IAsyncDisposable
 
                 case SessionErrorEvent err:
                     var msg = $"Copilot {err.Data.ErrorType}: {err.Data.Message}";
-                    System.Diagnostics.Debug.WriteLine($"[CopilotSdk] {msg}");
+                    SessionLog.Write($"[CopilotSdk] {msg}");
                     terminalError = err.Data.ErrorType switch
                     {
                         "authentication" or "authorization" => new AuthExpiredException(msg),
@@ -246,16 +246,16 @@ public sealed class CopilotSdkClient : IModelClient, IAsyncDisposable
         {
             if (_client is { } client)
             {
-                System.Diagnostics.Debug.WriteLine("[CopilotSdk] resetting CLI client (auth refresh)");
+                SessionLog.Write("[CopilotSdk] resetting CLI client (auth refresh)");
                 try { await client.StopAsync().ConfigureAwait(false); }
                 catch (System.Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[CopilotSdk] StopAsync during reset threw: {ex.Message}");
+                    SessionLog.Write($"[CopilotSdk] StopAsync during reset threw: {ex.Message}");
                 }
                 try { await client.DisposeAsync().ConfigureAwait(false); }
                 catch (System.Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[CopilotSdk] DisposeAsync during reset threw: {ex.Message}");
+                    SessionLog.Write($"[CopilotSdk] DisposeAsync during reset threw: {ex.Message}");
                 }
                 _client = null;
             }

--- a/samples/apps/demo-script-tool/App/Services/DotnetRunner.cs
+++ b/samples/apps/demo-script-tool/App/Services/DotnetRunner.cs
@@ -122,7 +122,7 @@ public sealed class DotnetRunner
 
     static async Task<BuildResult> RunCapturedAsync(string fileName, string args, string workdir, CancellationToken ct)
     {
-        System.Diagnostics.Debug.WriteLine($"[DotnetRunner] spawn '{fileName} {args}' cwd='{workdir}'");
+        SessionLog.Write($"[DotnetRunner] spawn '{fileName} {args}' cwd='{workdir}'");
         var psi = new ProcessStartInfo(fileName, args)
         {
             WorkingDirectory = workdir,

--- a/samples/apps/demo-script-tool/App/Services/GenerationPipeline.cs
+++ b/samples/apps/demo-script-tool/App/Services/GenerationPipeline.cs
@@ -65,10 +65,10 @@ public sealed class GenerationPipeline
 
     /// <summary>
     /// Generate from <paramref name="startIndex"/> through the end of the
-    /// script. The "Re-run from here" affordance on each step card calls this
-    /// with the chosen step's index — regenerating one step inevitably changes
-    /// the baseline code that downstream steps were built on, so we always
-    /// re-run the chain from the chosen point onward.
+    /// script. The "Re-gen" affordance on each step card calls this with the
+    /// chosen step's index — regenerating one step inevitably changes the
+    /// baseline code that downstream steps were built on, so we always
+    /// re-generate the chain from the chosen point onward.
     /// </summary>
     public async Task GenerateFromAsync(DemoScriptModel model, string projectRoot, int startIndex, CancellationToken ct)
     {
@@ -101,10 +101,10 @@ public sealed class GenerationPipeline
                     // Halt: continuing would feed the next step a poisoned (empty
                     // or stale) baseline, which we observed cascading into a
                     // chain of "No code produced" failures. The user can fix
-                    // the prompt and click Re-run from here.
+                    // the prompt and click Re-gen.
                     System.Diagnostics.Debug.WriteLine($"[Pipeline] step {step.Number}: no code produced; halting");
                     step.SetBuildState(BuildState.Failed, "No code produced.");
-                    _status.SetBanner($"Step {step.Number} produced no code — generation halted. Edit the prompt or earlier steps and use “Re-run from here.”");
+                    _status.SetBanner($"Step {step.Number} produced no code — generation halted. Edit the prompt or earlier steps and click Re-gen.");
                     return;
                 }
 
@@ -116,11 +116,11 @@ public sealed class GenerationPipeline
                 // attempts; passing its broken code to step N+1 produced
                 // cascade-failure runs in practice, so halt here. The user can
                 // tweak the failing step's prompt or an earlier step's code
-                // and Re-run from here to pick up where we stopped.
+                // and click Re-gen to pick up where we stopped.
                 if (step.BuildState == BuildState.Failed)
                 {
                     System.Diagnostics.Debug.WriteLine($"[Pipeline] step {step.Number}: build failed after {MaxFixAttempts} fix attempts; halting");
-                    _status.SetBanner($"Step {step.Number} failed to build after {MaxFixAttempts} fix attempts — generation halted. Use “Re-run from here” after editing the step.");
+                    _status.SetBanner($"Step {step.Number} failed to build after {MaxFixAttempts} fix attempts — generation halted. Click Re-gen after editing the step.");
                     return;
                 }
             }

--- a/samples/apps/demo-script-tool/App/Services/GenerationPipeline.cs
+++ b/samples/apps/demo-script-tool/App/Services/GenerationPipeline.cs
@@ -72,7 +72,7 @@ public sealed class GenerationPipeline
     /// </summary>
     public async Task GenerateFromAsync(DemoScriptModel model, string projectRoot, int startIndex, CancellationToken ct)
     {
-        System.Diagnostics.Debug.WriteLine($"[Pipeline] GenerateFrom start root='{projectRoot}' steps={model.Steps.Count} startIndex={startIndex} multiFile={model.IsMultiFile}");
+        SessionLog.Write($"[Pipeline] GenerateFrom start root='{projectRoot}' steps={model.Steps.Count} startIndex={startIndex} multiFile={model.IsMultiFile}");
         if (model.Steps.Count == 0)
         {
             _status.ShowToast("Add at least one step to your demo script before generating.", StatusSeverity.Warning);
@@ -80,7 +80,7 @@ public sealed class GenerationPipeline
         }
         if (startIndex < 0 || startIndex >= model.Steps.Count)
         {
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] GenerateFrom: invalid startIndex {startIndex}, falling back to 0");
+            SessionLog.Write($"[Pipeline] GenerateFrom: invalid startIndex {startIndex}, falling back to 0");
             startIndex = 0;
         }
 
@@ -93,7 +93,7 @@ public sealed class GenerationPipeline
                 var prior = i > 0 ? model.Steps[i - 1] : null;
 
                 _status.SetGeneratingStatus($"Generating step {step.Number} of {model.Steps.Count}…");
-                System.Diagnostics.Debug.WriteLine($"[Pipeline] streaming step {step.Number} (prior={(prior?.Number.ToString() ?? "<none>")})");
+                SessionLog.Write($"[Pipeline] streaming step {step.Number} (prior={(prior?.Number.ToString() ?? "<none>")})");
 
                 if (!await StreamSingleStepWithAuthRetryAsync(model, projectRoot, step, prior, ct).ConfigureAwait(false))
                 {
@@ -102,7 +102,7 @@ public sealed class GenerationPipeline
                     // or stale) baseline, which we observed cascading into a
                     // chain of "No code produced" failures. The user can fix
                     // the prompt and click Re-gen.
-                    System.Diagnostics.Debug.WriteLine($"[Pipeline] step {step.Number}: no code produced; halting");
+                    SessionLog.Write($"[Pipeline] step {step.Number}: no code produced; halting");
                     step.SetBuildState(BuildState.Failed, "No code produced.");
                     _status.SetBanner($"Step {step.Number} produced no code — generation halted. Edit the prompt or earlier steps and click Re-gen.");
                     return;
@@ -119,26 +119,26 @@ public sealed class GenerationPipeline
                 // and click Re-gen to pick up where we stopped.
                 if (step.BuildState == BuildState.Failed)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[Pipeline] step {step.Number}: build failed after {MaxFixAttempts} fix attempts; halting");
+                    SessionLog.Write($"[Pipeline] step {step.Number}: build failed after {MaxFixAttempts} fix attempts; halting");
                     _status.SetBanner($"Step {step.Number} failed to build after {MaxFixAttempts} fix attempts — generation halted. Click Re-gen after editing the step.");
                     return;
                 }
             }
-            System.Diagnostics.Debug.WriteLine("[Pipeline] GenerateFrom completed normally");
+            SessionLog.Write("[Pipeline] GenerateFrom completed normally");
         }
         catch (OperationCanceledException)
         {
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] Cancelled with {CompletedCount(model)} of {model.Steps.Count} done");
+            SessionLog.Write($"[Pipeline] Cancelled with {CompletedCount(model)} of {model.Steps.Count} done");
             _status.ShowToast($"Cancelled — {CompletedCount(model)} of {model.Steps.Count} steps generated.", StatusSeverity.Info);
         }
         catch (AuthUnavailableException ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] AuthUnavailable: {ex.Message}");
+            SessionLog.Write($"[Pipeline] AuthUnavailable: {ex.Message}");
             _status.SetBanner(ex.Message);
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] Generation failed: {ex}");
+            SessionLog.Write($"[Pipeline] Generation failed: {ex}");
             _status.SetBanner($"Generation failed: {ex.Message}");
         }
         finally
@@ -168,7 +168,7 @@ public sealed class GenerationPipeline
         }
         catch (AuthExpiredException ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] AuthExpired on step {step.Number}, retrying after re-auth: {ex.Message}");
+            SessionLog.Write($"[Pipeline] AuthExpired on step {step.Number}, retrying after re-auth: {ex.Message}");
             _status.SetGeneratingStatus("Re-authenticating with GitHub…");
             await _auth.EnsureAuthenticatedAsync(ct).ConfigureAwait(false);
             // Drop any cached client state (e.g. CopilotSdkClient's long-lived
@@ -194,7 +194,7 @@ public sealed class GenerationPipeline
         step.ResetForRegeneration();
 
         var perStepPrompt = BuildSingleStepUserPrompt(model, projectRoot, step, prior);
-        System.Diagnostics.Debug.WriteLine($"[Pipeline] step {step.Number} per-step user prompt ({perStepPrompt.Length} bytes)");
+        SessionLog.Write($"[Pipeline] step {step.Number} per-step user prompt ({perStepPrompt.Length} bytes)");
 
         var parser = new GeneratedOutputParser();
         var buffer = new StepFileBuffer();
@@ -203,12 +203,12 @@ public sealed class GenerationPipeline
         parser.StepStarted += n =>
         {
             if (n != step.Number)
-                System.Diagnostics.Debug.WriteLine($"[Parser] step number mismatch: expected {step.Number}, model emitted {n}");
+                SessionLog.Write($"[Parser] step number mismatch: expected {step.Number}, model emitted {n}");
         };
 
         parser.CodeBlockStarted += (_, path) =>
         {
-            System.Diagnostics.Debug.WriteLine($"[Parser] step {step.Number} CodeBlockStarted path='{path}'");
+            SessionLog.Write($"[Parser] step {step.Number} CodeBlockStarted path='{path}'");
             buffer.OpenFile(path);
         };
 
@@ -223,12 +223,12 @@ public sealed class GenerationPipeline
 
         parser.StepCompleted += n =>
         {
-            System.Diagnostics.Debug.WriteLine($"[Parser] step {step.Number} StepCompleted (model emitted n={n})");
+            SessionLog.Write($"[Parser] step {step.Number} StepCompleted (model emitted n={n})");
         };
 
         parser.Warning += msg =>
         {
-            System.Diagnostics.Debug.WriteLine($"[Parser] Warning: {msg}");
+            SessionLog.Write($"[Parser] Warning: {msg}");
             _status.ShowToast(msg, StatusSeverity.Warning);
         };
 
@@ -241,19 +241,19 @@ public sealed class GenerationPipeline
 
         if (!sawCode)
         {
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] step {step.Number}: no CodeChunk seen");
+            SessionLog.Write($"[Pipeline] step {step.Number}: no CodeChunk seen");
             return false;
         }
 
         var snapshot = buffer.Snapshot();
         if (snapshot.Count == 0)
         {
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] step {step.Number}: empty file snapshot");
+            SessionLog.Write($"[Pipeline] step {step.Number}: empty file snapshot");
             return false;
         }
 
         var primary = _writer.Write(step.Number, snapshot, projectRoot, model.IsMultiFile);
-        System.Diagnostics.Debug.WriteLine($"[Pipeline] step {step.Number}: wrote primary='{primary}'");
+        SessionLog.Write($"[Pipeline] step {step.Number}: wrote primary='{primary}'");
         step.SetOutputPath(primary);
 
         // Replace the streamed buffer with the canonical file body. The streamed
@@ -267,7 +267,7 @@ public sealed class GenerationPipeline
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] step {step.Number}: ReplaceCode read failed: {ex.Message}");
+            SessionLog.Write($"[Pipeline] step {step.Number}: ReplaceCode read failed: {ex.Message}");
         }
 
         // Stamp model id + timestamp so the per-card provenance footer survives
@@ -283,7 +283,7 @@ public sealed class GenerationPipeline
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] step {step.Number}: ComputeFileHash failed: {ex.Message}");
+            SessionLog.Write($"[Pipeline] step {step.Number}: ComputeFileHash failed: {ex.Message}");
         }
 
         WriteDeltaSidecar(step, projectRoot);
@@ -295,12 +295,12 @@ public sealed class GenerationPipeline
         try
         {
             step.SetBuildState(BuildState.Building);
-            System.Diagnostics.Debug.WriteLine($"[BuildFix] step {step.Number}: starting initial build");
+            SessionLog.Write($"[BuildFix] step {step.Number}: starting initial build");
             var result = await _runner.BuildAsync(step, projectRoot, model.IsMultiFile, ct).ConfigureAwait(false);
-            System.Diagnostics.Debug.WriteLine($"[BuildFix] step {step.Number}: initial build exit={result.ExitCode} succeeded={result.Succeeded} outputBytes={result.CombinedOutput.Length}");
+            SessionLog.Write($"[BuildFix] step {step.Number}: initial build exit={result.ExitCode} succeeded={result.Succeeded} outputBytes={result.CombinedOutput.Length}");
             if (!result.Succeeded)
             {
-                System.Diagnostics.Debug.WriteLine($"[BuildFix] step {step.Number} build output (last 500 chars): {result.CombinedOutput[Math.Max(0, result.CombinedOutput.Length - 500)..]}");
+                SessionLog.Write($"[BuildFix] step {step.Number} build output (last 500 chars): {result.CombinedOutput[Math.Max(0, result.CombinedOutput.Length - 500)..]}");
             }
             if (result.Succeeded)
             {
@@ -315,14 +315,14 @@ public sealed class GenerationPipeline
             {
                 ct.ThrowIfCancellationRequested();
                 _status.SetGeneratingStatus($"Fixing step {step.Number} of {model.Steps.Count} (attempt {attempt})…");
-                System.Diagnostics.Debug.WriteLine($"[BuildFix] step {step.Number}: fix attempt {attempt}");
+                SessionLog.Write($"[BuildFix] step {step.Number}: fix attempt {attempt}");
                 if (!await ApplyFixAttemptAsync(step, model, projectRoot, lastOutput, ct).ConfigureAwait(false))
                     break;
 
                 step.IncrementFixAttempts();
                 _status.SetGeneratingStatus($"Building step {step.Number} of {model.Steps.Count} (re-build {attempt})…");
                 var rebuild = await _runner.BuildAsync(step, projectRoot, model.IsMultiFile, ct).ConfigureAwait(false);
-                System.Diagnostics.Debug.WriteLine($"[BuildFix] step {step.Number}: fix-attempt {attempt} build exit={rebuild.ExitCode} succeeded={rebuild.Succeeded}");
+                SessionLog.Write($"[BuildFix] step {step.Number}: fix-attempt {attempt} build exit={rebuild.ExitCode} succeeded={rebuild.Succeeded}");
                 if (rebuild.Succeeded)
                 {
                     step.SetBuildState(BuildState.Succeeded);
@@ -404,7 +404,7 @@ public sealed class GenerationPipeline
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[BuildFix] ReplaceCode read failed: {ex.Message}");
+            SessionLog.Write($"[BuildFix] ReplaceCode read failed: {ex.Message}");
         }
         return true;
     }
@@ -479,7 +479,7 @@ public sealed class GenerationPipeline
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[Pipeline] WriteDeltaSidecar failed: {ex.Message}");
+            SessionLog.Write($"[Pipeline] WriteDeltaSidecar failed: {ex.Message}");
         }
     }
 
@@ -627,7 +627,7 @@ public sealed class GenerationPipeline
             try { return System.IO.File.ReadAllText(prior.OutputPath); }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"[Pipeline] read prior step file failed: {ex.Message}");
+                SessionLog.Write($"[Pipeline] read prior step file failed: {ex.Message}");
             }
         }
         // Fallback paths for the standard layout — same shape the writer uses.
@@ -639,7 +639,7 @@ public sealed class GenerationPipeline
             try { return System.IO.File.ReadAllText(fallback); }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"[Pipeline] read prior step fallback failed: {ex.Message}");
+                SessionLog.Write($"[Pipeline] read prior step fallback failed: {ex.Message}");
             }
         }
         var inMem = prior.Code;

--- a/samples/apps/demo-script-tool/App/Services/GenerationPipeline.cs
+++ b/samples/apps/demo-script-tool/App/Services/GenerationPipeline.cs
@@ -300,7 +300,10 @@ public sealed class GenerationPipeline
             SessionLog.Write($"[BuildFix] step {step.Number}: initial build exit={result.ExitCode} succeeded={result.Succeeded} outputBytes={result.CombinedOutput.Length}");
             if (!result.Succeeded)
             {
-                SessionLog.Write($"[BuildFix] step {step.Number} build output (last 500 chars): {result.CombinedOutput[Math.Max(0, result.CombinedOutput.Length - 500)..]}");
+                // 800 chars: 500 was clipping the leading lines of compiler
+                // output (the success-cascade from upstream project builds
+                // pushes the actual CSC error past 500 chars from the tail).
+                SessionLog.Write($"[BuildFix] step {step.Number} build output (last 800 chars): {result.CombinedOutput[Math.Max(0, result.CombinedOutput.Length - 800)..]}");
             }
             if (result.Succeeded)
             {
@@ -322,7 +325,17 @@ public sealed class GenerationPipeline
                 step.IncrementFixAttempts();
                 _status.SetGeneratingStatus($"Building step {step.Number} of {model.Steps.Count} (re-build {attempt})…");
                 var rebuild = await _runner.BuildAsync(step, projectRoot, model.IsMultiFile, ct).ConfigureAwait(false);
-                SessionLog.Write($"[BuildFix] step {step.Number}: fix-attempt {attempt} build exit={rebuild.ExitCode} succeeded={rebuild.Succeeded}");
+                SessionLog.Write($"[BuildFix] step {step.Number}: fix-attempt {attempt} build exit={rebuild.ExitCode} succeeded={rebuild.Succeeded} outputBytes={rebuild.CombinedOutput.Length}");
+                if (!rebuild.Succeeded)
+                {
+                    // Mirror the initial-build logging so we can see what each
+                    // fix actually broke or left broken. The model's own diff
+                    // is one big LLM blob; the COMPILER tells us whether it
+                    // converged. Without this we can't tell "AI made it worse"
+                    // from "AI made same mistake" from "different error each
+                    // attempt" — they all just show "exit=1" otherwise.
+                    SessionLog.Write($"[BuildFix] step {step.Number} fix-attempt {attempt} build output (last 800 chars): {rebuild.CombinedOutput[Math.Max(0, rebuild.CombinedOutput.Length - 800)..]}");
+                }
                 if (rebuild.Succeeded)
                 {
                     step.SetBuildState(BuildState.Succeeded);
@@ -400,7 +413,16 @@ public sealed class GenerationPipeline
         try
         {
             if (System.IO.File.Exists(fixedPrimary))
-                step.ReplaceCode(System.IO.File.ReadAllText(fixedPrimary));
+            {
+                var fixedBody = System.IO.File.ReadAllText(fixedPrimary);
+                step.ReplaceCode(fixedBody);
+                // Log the first 600 chars of what the AI emitted as its fix.
+                // Without this we couldn't tell whether a 3rd-attempt failure
+                // was the model repeating the same broken code or making a
+                // new mistake — the fix prompt and the SDK events are opaque.
+                var preview = fixedBody.Length > 600 ? fixedBody[..600] + "…[truncated]" : fixedBody;
+                SessionLog.Write($"[BuildFix] step {step.Number} fix-attempt produced ({fixedBody.Length} bytes):\n{preview}");
+            }
         }
         catch (Exception ex)
         {

--- a/samples/apps/demo-script-tool/App/Services/GithubModelsClient.cs
+++ b/samples/apps/demo-script-tool/App/Services/GithubModelsClient.cs
@@ -46,10 +46,10 @@ public sealed class GithubModelsClient : IModelClient, IDisposable
         string userPrompt,
         [EnumeratorCancellation] CancellationToken ct)
     {
-        System.Diagnostics.Debug.WriteLine($"[GithubModels] StreamAsync model={_model} endpoint={_endpoint} userPromptBytes={userPrompt.Length}");
+        SessionLog.Write($"[GithubModels] StreamAsync model={_model} endpoint={_endpoint} userPromptBytes={userPrompt.Length}");
         var token = await _auth.GetTokenAsync(ct).ConfigureAwait(false)
             ?? throw new AuthExpiredException("No GitHub token available. Sign in via the Open Folder flow.");
-        System.Diagnostics.Debug.WriteLine($"[GithubModels] token acquired (len={token.Length})");
+        SessionLog.Write($"[GithubModels] token acquired (len={token.Length})");
 
         var payload = new
         {
@@ -79,17 +79,17 @@ public sealed class GithubModelsClient : IModelClient, IDisposable
         req.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
 
         using var response = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
-        System.Diagnostics.Debug.WriteLine($"[GithubModels] HTTP {(int)response.StatusCode} {response.ReasonPhrase}");
+        SessionLog.Write($"[GithubModels] HTTP {(int)response.StatusCode} {response.ReasonPhrase}");
         if (response.StatusCode is System.Net.HttpStatusCode.Unauthorized or System.Net.HttpStatusCode.Forbidden)
         {
             var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            System.Diagnostics.Debug.WriteLine($"[GithubModels] auth rejected body={body}");
+            SessionLog.Write($"[GithubModels] auth rejected body={body}");
             throw new AuthExpiredException($"GitHub Models rejected the request ({(int)response.StatusCode} {response.ReasonPhrase}). Likely missing the `models:read` scope on your GitHub token — re-run `gh auth login --scopes models:read`.");
         }
         if (!response.IsSuccessStatusCode)
         {
             var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            System.Diagnostics.Debug.WriteLine($"[GithubModels] error body={body}");
+            SessionLog.Write($"[GithubModels] error body={body}");
             throw new HttpRequestException($"GitHub Models returned {(int)response.StatusCode} {response.ReasonPhrase}: {body}");
         }
 

--- a/samples/apps/demo-script-tool/App/Services/SessionLog.cs
+++ b/samples/apps/demo-script-tool/App/Services/SessionLog.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace DemoScriptTool.App.Services;
+
+/// <summary>
+/// File-backed log for diagnosing the app after the fact. Each app launch
+/// opens a fresh <c>session-YYYYMMDD-HHMMSS.log</c> file under
+/// <c>%LOCALAPPDATA%\DemoScriptTool\logs\</c>; the last 10 sessions are kept
+/// and older files are pruned. Lines are timestamped and flushed on every
+/// write so a crash leaves no buffered tail behind.
+///
+/// <para>
+/// All writes ALSO mirror to <see cref="System.Diagnostics.Debug.WriteLine(string)"/>
+/// so the existing dev-time inner loop (debugger Output / mur devtools logs)
+/// keeps working unchanged. Use <see cref="Write"/> instead of bare
+/// <c>Debug.WriteLine</c> in this app so events survive across runs without
+/// requiring an attached debugger.
+/// </para>
+///
+/// <para>
+/// Logs are intentionally outside the project root — accidental commits of
+/// debug spew aren't a risk, and the "Reveal log folder" devtools menu item
+/// gives a one-click route to share a session log when something goes wrong.
+/// </para>
+/// </summary>
+public static class SessionLog
+{
+    const int MaxRetainedSessions = 10;
+
+    static readonly object _gate = new();
+    static StreamWriter? _writer;
+
+    /// <summary>Path of the current session's log file once <see cref="Init"/> has run.</summary>
+    public static string? CurrentPath { get; private set; }
+
+    /// <summary>Directory that holds rotated session logs.</summary>
+    public static string LogDirectory { get; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "DemoScriptTool", "logs");
+
+    /// <summary>
+    /// Open the session log file. Safe to call multiple times — second and
+    /// later calls are no-ops. Failures (read-only volume, permission issues,
+    /// concurrent locking) fall back to debugger-only logging via the mirror
+    /// in <see cref="Write"/>; the app keeps running.
+    /// </summary>
+    public static void Init()
+    {
+        if (_writer is not null) return;
+
+        try
+        {
+            Directory.CreateDirectory(LogDirectory);
+
+            // Prune older sessions BEFORE opening the new one so the directory
+            // doesn't grow unbounded across many launches.
+            try
+            {
+                var stale = Directory.GetFiles(LogDirectory, "session-*.log")
+                    .OrderByDescending(p => p)
+                    .Skip(MaxRetainedSessions - 1)
+                    .ToArray();
+                foreach (var path in stale)
+                {
+                    try { File.Delete(path); }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"[SessionLog] prune skip '{path}': {ex.Message}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[SessionLog] prune failed: {ex.Message}");
+            }
+
+            var name = $"session-{DateTime.Now:yyyyMMdd-HHmmss}.log";
+            CurrentPath = Path.Combine(LogDirectory, name);
+            // FileShare.Read so an external tail / editor can read the live
+            // file while we're still writing.
+            var stream = new FileStream(CurrentPath, FileMode.Create, FileAccess.Write, FileShare.Read);
+            _writer = new StreamWriter(stream) { AutoFlush = true };
+
+            var os = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
+            var arch = System.Runtime.InteropServices.RuntimeInformation.OSArchitecture;
+            var clr = Environment.Version;
+            WriteInternal($"=== Session started {DateTime.Now:yyyy-MM-dd HH:mm:ss zzz} ===");
+            WriteInternal($"=== OS={os} arch={arch} CLR={clr} pid={Environment.ProcessId} ===");
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[SessionLog] init failed: {ex.Message}");
+            _writer = null;
+            CurrentPath = null;
+        }
+    }
+
+    /// <summary>
+    /// Append <paramref name="line"/> to the session log with a timestamp
+    /// and mirror to the debugger. Thread-safe; never throws (failures are
+    /// swallowed so logging itself doesn't bring down a release build).
+    /// </summary>
+    public static void Write(string line)
+    {
+        var stamped = $"{DateTime.Now:HH:mm:ss.fff} t{Environment.CurrentManagedThreadId,3} {line}";
+        WriteInternal(stamped);
+    }
+
+    static void WriteInternal(string stamped)
+    {
+        // Mirror to debugger so existing dev-loop tooling keeps observing the
+        // same line stream.
+        System.Diagnostics.Debug.WriteLine(stamped);
+
+        var w = _writer;
+        if (w is null) return;
+        lock (_gate)
+        {
+            try
+            {
+                w.WriteLine(stamped);
+            }
+            catch (Exception ex)
+            {
+                // Last-resort: drop the file writer so subsequent calls
+                // don't keep throwing. Debugger mirror still works.
+                System.Diagnostics.Debug.WriteLine($"[SessionLog] write failed, disabling file sink: {ex.Message}");
+                try { _writer?.Dispose(); } catch { }
+                _writer = null;
+            }
+        }
+    }
+}

--- a/samples/apps/demo-script-tool/App/Services/StepFileWriter.cs
+++ b/samples/apps/demo-script-tool/App/Services/StepFileWriter.cs
@@ -68,7 +68,7 @@ public sealed class StepFileWriter
             // path that, once resolved, doesn't sit strictly inside stepDir.
             if (!TryResolveContainedPath(stepDirCanonical, rel, out var target))
             {
-                System.Diagnostics.Debug.WriteLine($"[StepFileWriter] rejecting unsafe path '{kv.Key}' → outside step dir");
+                SessionLog.Write($"[StepFileWriter] rejecting unsafe path '{kv.Key}' → outside step dir");
                 continue;
             }
 
@@ -125,7 +125,7 @@ public sealed class StepFileWriter
         }
         catch (System.Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[StepFileWriter] path resolve failed for '{rel}': {ex.Message}");
+            SessionLog.Write($"[StepFileWriter] path resolve failed for '{rel}': {ex.Message}");
             return false;
         }
     }


### PR DESCRIPTION
## Summary

Five-commit follow-up sweep on the demo-script-tool sample, driven by repros captured in the new persistent session log:

- **Persistent `SessionLog`** (`bac2972`) — file-backed log under `%LOCALAPPDATA%\DemoScriptTool\logs\`, mirroring every existing `Debug.WriteLine`, plus a "Reveal log folder…" devtools entry. Repros now leave a paper trail without an attached debugger.
- **Re-run → Re-gen rename + stuck `isGenerating` fix** (`09a1285`) — rename avoids collision with the per-step Run button. In-flight gate now reads `generationCtsRef.Current` (synchronous) instead of the `isGenerating` UseState, so render-state hiccups can't wedge the shell.
- **Generate/Re-gen click debounce** (`f15ee32`) — 200 ms gate per handler. Repro showed each click firing 3–6 times; the duplicates self-cancelled, leaving "Cancelled" with nothing actually running. Band-aid; root-cause investigation tracked separately.
- **Logging gaps for failed fix attempts** (`347d9aa`) — fix-attempt builds now log compiler output (last 800 chars), AI-emitted code is logged (first 600 chars), and Generate/Re-gen click handlers are wrapped in a `SafeClickHandler` that catches + surfaces silent throws.
- **Re-gen COMException + stuck-state fix** (`2641625`) — `regenCmd` no longer wraps in `UseCommand` (which marshalled onto a thread-pool thread, then `announce.Announce` hit `FromElement` off-thread → `RPC_E_WRONG_THREAD`). Added `SafeAnnounce` helper used at every announce site so future surprises can't leave in-flight state behind. System prompt updated to call out CS8803 (declarations before top-level statements).

## Test plan

- [ ] Generate All from empty state — single run kicks off, Cancel button appears, log shows one kickoff line per click
- [ ] Re-gen from a mid-pipeline step — runs without `Generation already running` toast, status announcements appear
- [ ] Cancel during a generation — stops cleanly, Cancel button reverts to Generate All
- [ ] Trigger a build failure (e.g. force a syntax error in a step) — fix-attempt CSC output appears in session log; AI's emitted code preview appears alongside
- [ ] Spam-click Generate All — only one run kicks off, debounced clicks logged
- [ ] Reveal log folder devtools item opens Explorer to the active session file

🤖 Generated with [Claude Code](https://claude.com/claude-code)