### PR TITLE
docs(skill): correct selftest command in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -291,8 +291,8 @@ Reactor has three test suites. Run the one that matches what you changed.
 # Unit tests — fast, no UI window (~3s)
 dotnet test tests/Reactor.Tests
 
-# Selfhost tests — real WinUI controls, in-process (~15s)
-dotnet test tests/Reactor.AppTests --filter "ClassName=Reactor.AppTests.Tests.SelfTestBatch"
+# Selfhost tests — real WinUI controls, in-process (~2 min)
+dotnet test tests/Reactor.SelfTests
 
 # Appium / E2E — cross-process UI Automation (~30s, needs WinAppDriver)
 dotnet test tests/Reactor.AppTests --filter "ClassName=Reactor.AppTests.Tests.InteractiveTests"


### PR DESCRIPTION
## Summary
- The selftest filter in SKILL.md (`ClassName=Reactor.AppTests.Tests.SelfTestBatch`) no longer matches any tests — the suite now lives in `tests/Reactor.SelfTests`.
- Replace with `dotnet test tests/Reactor.SelfTests` and update the runtime estimate (~15s → ~2 min) to reflect the current 648-test suite.

## Test plan
- [x] `dotnet test tests/Reactor.SelfTests` runs and passes (648/648, ~1m 52s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)