### PR TITLE
fix(cli): correct scaffolder project path and drop stale WindowsSdkPackageVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Or create a `.csproj` manually:
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
-    <ProjectReference Include="..\Reactor\Reactor.csproj" />
+    <ProjectReference Include="..\src\Reactor\Reactor.csproj" />
   </ItemGroup>
 </Project>
 ```

--- a/src/Reactor.Cli/Program.cs
+++ b/src/Reactor.Cli/Program.cs
@@ -137,7 +137,7 @@ int CreateProject(string name)
     Console.WriteLine();
     Console.WriteLine("NOTE: The generated .sln assumes this project is a sibling of the Reactor directory:");
     Console.WriteLine($"    parent/");
-    Console.WriteLine($"      Reactor/Reactor.csproj");
+    Console.WriteLine($"      src/Reactor/Reactor.csproj");
     Console.WriteLine($"      {name}/{name}.csproj");
     Console.WriteLine();
     Console.WriteLine("To build and run:");
@@ -199,7 +199,7 @@ string GenerateCsproj() =>
         <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
       </ItemGroup>
       <ItemGroup>
-        <ProjectReference Include="..\Reactor\Reactor.csproj" />
+        <ProjectReference Include="..\src\Reactor\Reactor.csproj" />
       </ItemGroup>
     </Project>
     """;
@@ -225,7 +225,7 @@ string GenerateSln(string name, string appGuid, string patchGuid)
         "MinimumVisualStudioVersion = 10.0.40219.1",
         $"Project(\"{csharpGuid}\") = \"{name}\", \"{name}.csproj\", \"{ag}\"",
         "EndProject",
-        $"Project(\"{csharpGuid}\") = \"Reactor\", \"..\\Reactor\\Reactor.csproj\", \"{pg}\"",
+        $"Project(\"{csharpGuid}\") = \"Reactor\", \"..\\src\\Reactor\\Reactor.csproj\", \"{pg}\"",
         "EndProject",
         "Global",
         $"{t1}GlobalSection(SolutionConfigurationPlatforms) = preSolution",

--- a/src/Reactor.Cli/Program.cs
+++ b/src/Reactor.Cli/Program.cs
@@ -193,7 +193,6 @@ string GenerateCsproj() =>
         <Nullable>enable</Nullable>
         <UseWinUI>true</UseWinUI>
         <WindowsPackageType>None</WindowsPackageType>
-        <WindowsSdkPackageVersion>10.0.22621.52</WindowsSdkPackageVersion>
       </PropertyGroup>
       <ItemGroup>
         <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />


### PR DESCRIPTION
## Problem

`dotnet run --project src/Reactor.Cli -- --create MyApp` generated a broken app:

1. **Wrong project path** — emitted `..\Reactor\Reactor.csproj` but the actual path is `..\src\Reactor\Reactor.csproj`
2. **Stale WindowsSdkPackageVersion** — pinned `10.0.22621.52` which ships CsWinRT 2.1, conflicting with Windows App SDK 2.0-preview2 (CsWinRT 2.2). The app builds with MSB3277 warnings and crashes at runtime with `FileNotFoundException: WinRT.Runtime 2.2.0.0`

## Fix

- Correct the ProjectReference path in the scaffolder template, generated .sln, and README example
- Remove the hardcoded `WindowsSdkPackageVersion` — let the SDK resolve it automatically (matching what Reactor.csproj already does)

## Verification

Regenerated MyApp, built, and launched successfully with .NET 9 SDK.