### PR TITLE
build: migrate from .NET 9 to .NET 10 (LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore
         run: dotnet restore tests/Reactor.Tests/Reactor.Tests.csproj
@@ -84,7 +84,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore
         run: dotnet restore tests/Reactor.SelfTests/Reactor.SelfTests.csproj
@@ -103,7 +103,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore
         run: dotnet restore Reactor.sln

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Install dotnet-coverage
         run: dotnet tool install -g dotnet-coverage
@@ -81,7 +81,7 @@ jobs:
         shell: pwsh
         run: |
           dotnet-coverage instrument `
-            "tests/Reactor.AppTests.Host/bin/x64/Debug/net9.0-windows10.0.22621.0/Reactor.dll" `
+            "tests/Reactor.AppTests.Host/bin/x64/Debug/net10.0-windows10.0.22621.0/Reactor.dll" `
             -s coverage.settings.xml
 
       - name: Collect selftest coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Install minver-cli
         run: dotnet tool install --global minver-cli --version 5.0.0
@@ -104,7 +104,7 @@ jobs:
           -p:Platform=x64
           -o artifacts/nupkg
 
-      # Framework-dependent: the consumer's machine supplies the .NET 9
+      # Framework-dependent: the consumer's machine supplies the .NET 10
       # runtime — saves ~70 MB per RID. install-skill-kit.ps1 checks for it
       # and errors out with an install hint if it's missing. See spec 022 §6.
       - name: Publish mur (win-x64)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ dotnet build tests/Reactor.AppTests.Host      -c Debug -p:Optimize=false -p:Debu
 # Step 2: Instrument Reactor.dll statically
 #         (dynamic instrumentation skips referenced assemblies)
 dotnet-coverage instrument \
-  "tests/Reactor.AppTests.Host/bin/$(RuntimeIdentifier)/Debug/net9.0-windows10.0.22621.0/Reactor.dll" \
+  "tests/Reactor.AppTests.Host/bin/$(RuntimeIdentifier)/Debug/net10.0-windows10.0.22621.0/Reactor.dll" \
   -s coverage.settings.xml
 
 # Step 3: Collect

--- a/SKILL.md
+++ b/SKILL.md
@@ -44,7 +44,7 @@ re-renders automatically. No XAML. No data binding. No ViewModels.
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
-    <ProjectReference Include="..\Reactor\Reactor.csproj" />
+    <ProjectReference Include="..\src\Reactor\Reactor.csproj" />
   </ItemGroup>
 </Project>
 ```
@@ -311,7 +311,7 @@ For lightweight demos, skip the `.csproj` entirely. Add a file-level header:
 #:project ./src/Reactor
 #:package Microsoft.WindowsAppSDK@2.0.1
 #:property OutputType=WinExe
-#:property TargetFramework=net9.0-windows10.0.22621.0
+#:property TargetFramework=net10.0-windows10.0.22621.0
 #:property UseWinUI=true
 #:property WindowsPackageType=None
 #:property WindowsAppSDKSelfContained=true

--- a/docs/_pipeline/ai-author-skill.md
+++ b/docs/_pipeline/ai-author-skill.md
@@ -63,7 +63,7 @@ The pipeline replaces `screenshot://` with a relative path like
 
 ```markdown
 <!-- ai:lock -->
-> **Prerequisites:** .NET 9+ and the Windows App SDK.
+> **Prerequisites:** .NET 10+ and the Windows App SDK.
 <!-- /ai:lock -->
 ```
 
@@ -90,7 +90,7 @@ docs/_pipeline/apps/my-topic/
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/accessibility/accessibility.csproj
+++ b/docs/_pipeline/apps/accessibility/accessibility.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/advanced/advanced.csproj
+++ b/docs/_pipeline/apps/advanced/advanced.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/animation/animation.csproj
+++ b/docs/_pipeline/apps/animation/animation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/async-resources-cookbook/async-resources-cookbook.csproj
+++ b/docs/_pipeline/apps/async-resources-cookbook/async-resources-cookbook.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/calculator/calculator.csproj
+++ b/docs/_pipeline/apps/calculator/calculator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/charting/charting.csproj
+++ b/docs/_pipeline/apps/charting/charting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/collections/collections.csproj
+++ b/docs/_pipeline/apps/collections/collections.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/commanding/commanding.csproj
+++ b/docs/_pipeline/apps/commanding/commanding.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/components/components.csproj
+++ b/docs/_pipeline/apps/components/components.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/context/context.csproj
+++ b/docs/_pipeline/apps/context/context.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/data-system/data-system.csproj
+++ b/docs/_pipeline/apps/data-system/data-system.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/dev-tooling/dev-tooling.csproj
+++ b/docs/_pipeline/apps/dev-tooling/dev-tooling.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/effects/effects.csproj
+++ b/docs/_pipeline/apps/effects/effects.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/flex-layout/flex-layout.csproj
+++ b/docs/_pipeline/apps/flex-layout/flex-layout.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/forms/forms.csproj
+++ b/docs/_pipeline/apps/forms/forms.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/getting-started/getting-started.csproj
+++ b/docs/_pipeline/apps/getting-started/getting-started.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/hooks/hooks.csproj
+++ b/docs/_pipeline/apps/hooks/hooks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/input-and-gestures/input-and-gestures.csproj
+++ b/docs/_pipeline/apps/input-and-gestures/input-and-gestures.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/layout/layout.csproj
+++ b/docs/_pipeline/apps/layout/layout.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/localization/localization.csproj
+++ b/docs/_pipeline/apps/localization/localization.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/navigation/navigation.csproj
+++ b/docs/_pipeline/apps/navigation/navigation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/readme/readme.csproj
+++ b/docs/_pipeline/apps/readme/readme.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/styling/styling.csproj
+++ b/docs/_pipeline/apps/styling/styling.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/todo-app/todo-app.csproj
+++ b/docs/_pipeline/apps/todo-app/todo-app.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/apps/winforms-interop/winforms-interop.csproj
+++ b/docs/_pipeline/apps/winforms-interop/winforms-interop.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/_pipeline/templates/getting-started.md.dt
+++ b/docs/_pipeline/templates/getting-started.md.dt
@@ -13,7 +13,7 @@ goal: |
 # Getting Started with Reactor
 
 <!-- ai:lock -->
-> **Prerequisites:** .NET 9+ and the Windows App SDK.
+> **Prerequisites:** .NET 10+ and the Windows App SDK.
 <!-- /ai:lock -->
 
 Reactor is a declarative UI framework for building native Windows apps in pure C#.
@@ -36,7 +36,7 @@ Edit your `.csproj` to target WinUI:
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>

--- a/docs/_pipeline/templates/readme.md.dt
+++ b/docs/_pipeline/templates/readme.md.dt
@@ -107,7 +107,7 @@ Create a console project, then edit the `.csproj`:
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 # Getting Started with Reactor
 
 <!-- ai:lock -->
-> **Prerequisites:** .NET 9+ and the Windows App SDK.
+> **Prerequisites:** .NET 10+ and the Windows App SDK.
 <!-- /ai:lock -->
 
 Reactor is a declarative UI framework for building native Windows apps in pure C#.
@@ -25,7 +25,7 @@ Edit your `.csproj` to target WinUI:
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>

--- a/docs/guide/readme.md
+++ b/docs/guide/readme.md
@@ -135,7 +135,7 @@ Create a console project, then edit the `.csproj`:
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>

--- a/docs/specs/013-doc-system-design.md
+++ b/docs/specs/013-doc-system-design.md
@@ -521,7 +521,7 @@ goal: |
 ---
 
 <!-- ai:lock -->
-> **Prerequisites:** .NET 9+ and the Windows App SDK. See the [setup guide](setup.md).
+> **Prerequisites:** .NET 10+ and the Windows App SDK. See the [setup guide](setup.md).
 <!-- /ai:lock -->
 ~~~
 
@@ -534,7 +534,7 @@ The AI generates the full document, using available snippets and screenshots:
 ~~~markdown
 # Getting Started with Reactor
 
-> **Prerequisites:** .NET 9+ and the Windows App SDK. See the [setup guide](setup.md).
+> **Prerequisites:** .NET 10+ and the Windows App SDK. See the [setup guide](setup.md).
 
 Reactor is a declarative UI framework for building native Windows apps.
 No XAML, no data binding — you describe your UI in plain C# and Reactor

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/samples/CommandingDemo/CommandingDemo.csproj
+++ b/samples/CommandingDemo/CommandingDemo.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>CommandingDemo</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/InteropFirst/InteropFirst.csproj
+++ b/samples/InteropFirst/InteropFirst.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>InteropFirst</RootNamespace>
     <AssemblyName>InteropFirst</AssemblyName>

--- a/samples/NavigationDemo/NavigationDemo.csproj
+++ b/samples/NavigationDemo/NavigationDemo.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>NavigationDemo</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/Reactor.TestApp/Reactor.TestApp.csproj
+++ b/samples/Reactor.TestApp/Reactor.TestApp.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>Reactor.TestApp</RootNamespace>
     <AssemblyName>Reactor.TestApp</AssemblyName>

--- a/samples/ReactorCharting.Gallery/ReactorCharting.Gallery.csproj
+++ b/samples/ReactorCharting.Gallery/ReactorCharting.Gallery.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/ReactorCharting.Sample/ReactorCharting.Sample.csproj
+++ b/samples/ReactorCharting.Sample/ReactorCharting.Sample.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/ReactorHostControlDemo/ReactorHostControlDemo.csproj
+++ b/samples/ReactorHostControlDemo/ReactorHostControlDemo.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>ReactorHostControlDemo</RootNamespace>
     <AssemblyName>ReactorHostControlDemo</AssemblyName>

--- a/samples/StylingGallery/StylingGallery.csproj
+++ b/samples/StylingGallery/StylingGallery.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/TodoApp/TodoApp.csproj
+++ b/samples/TodoApp/TodoApp.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/WinFormsInterop/WinFormsInterop.csproj
+++ b/samples/WinFormsInterop/WinFormsInterop.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>WinFormsInterop.Sample</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/apps/a11y-showcase/A11yShowcase.csproj
+++ b/samples/apps/a11y-showcase/A11yShowcase.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>A11yShowcase</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/apps/headtrax/HeadTrax/HeadTrax.csproj
+++ b/samples/apps/headtrax/HeadTrax/HeadTrax.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>HeadTrax</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/apps/monaco-editor/MonacoEditorApp.csproj
+++ b/samples/apps/monaco-editor/MonacoEditorApp.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>MonacoEditorApp</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/apps/netpulse/NetPulse.csproj
+++ b/samples/apps/netpulse/NetPulse.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>NetPulse</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/apps/regedit/ReactorRegedit.csproj
+++ b/samples/apps/regedit/ReactorRegedit.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>ReactorRegedit</RootNamespace>
     <AssemblyName>ReactorRegedit</AssemblyName>

--- a/samples/apps/validation-showcase/ValidationShowcase.csproj
+++ b/samples/apps/validation-showcase/ValidationShowcase.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/apps/wordpuzzle/WordPuzzle.csproj
+++ b/samples/apps/wordpuzzle/WordPuzzle.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>WordPuzzle</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Reactor.Cli/Program.cs
+++ b/src/Reactor.Cli/Program.cs
@@ -187,7 +187,7 @@ string GenerateCsproj() =>
     <Project Sdk="Microsoft.NET.Sdk">
       <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+        <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
         <Platforms>x64;ARM64</Platforms>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Reactor.Cli/Reactor.Cli.csproj
+++ b/src/Reactor.Cli/Reactor.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <AssemblyName>mur</AssemblyName>
     <RootNamespace>Microsoft.UI.Reactor.Cli</RootNamespace>

--- a/src/Reactor.Interop.WinForms/Reactor.Interop.WinForms.csproj
+++ b/src/Reactor.Interop.WinForms/Reactor.Interop.WinForms.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>Microsoft.UI.Reactor.Interop.WinForms</RootNamespace>
     <AssemblyName>Reactor.Interop.WinForms</AssemblyName>

--- a/src/Reactor/Controls/Validation/ValidationContext.cs
+++ b/src/Reactor/Controls/Validation/ValidationContext.cs
@@ -265,14 +265,14 @@ public sealed class ValidationContext
             lock (_lock)
             {
                 var fields = new HashSet<string>();
-                foreach (var (field, list) in _messages)
+                foreach (var (fieldName, list) in _messages)
                     foreach (var msg in list)
                         if (msg.Severity == Severity.Error)
-                        { fields.Add(field); break; }
-                foreach (var (field, list) in _externalMessages)
+                        { fields.Add(fieldName); break; }
+                foreach (var (fieldName, list) in _externalMessages)
                     foreach (var msg in list)
                         if (msg.Severity == Severity.Error)
-                        { fields.Add(field); break; }
+                        { fields.Add(fieldName); break; }
                 return fields.ToList();
             }
         }

--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>Microsoft.UI.Reactor</RootNamespace>
     <AssemblyName>Reactor</AssemblyName>

--- a/tests/Reactor.AppTests.Host/Reactor.AppTests.Host.csproj
+++ b/tests/Reactor.AppTests.Host/Reactor.AppTests.Host.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>Microsoft.UI.Reactor.AppTests.Host</RootNamespace>
     <AssemblyName>Reactor.AppTests.Host</AssemblyName>

--- a/tests/Reactor.AppTests.ThirdPartyControls/Reactor.AppTests.ThirdPartyControls.csproj
+++ b/tests/Reactor.AppTests.ThirdPartyControls/Reactor.AppTests.ThirdPartyControls.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>Reactor.AppTests.ThirdPartyControls</RootNamespace>
     <AssemblyName>Reactor.AppTests.ThirdPartyControls</AssemblyName>

--- a/tests/Reactor.AppTests/Infrastructure/TestSession.cs
+++ b/tests/Reactor.AppTests/Infrastructure/TestSession.cs
@@ -191,7 +191,7 @@ public class TestSession
         };
 
         var exe = Path.Combine(dir, "tests", "Reactor.AppTests.Host", "bin", platform,
-            "Debug", "net9.0-windows10.0.22621.0", "Reactor.AppTests.Host.exe");
+            "Debug", "net10.0-windows10.0.22621.0", "Reactor.AppTests.Host.exe");
 
         if (!File.Exists(exe))
             throw new FileNotFoundException($"Build the Host app first. Expected: {exe}");

--- a/tests/Reactor.AppTests/Infrastructure/WinFormsTestSession.cs
+++ b/tests/Reactor.AppTests/Infrastructure/WinFormsTestSession.cs
@@ -170,7 +170,7 @@ public class WinFormsTestSession
         };
 
         var exe = Path.Combine(dir, "tests", "Reactor.WinFormsTests.Host", "bin", platform,
-            "Debug", "net9.0-windows10.0.22621.0", ProcessName + ".exe");
+            "Debug", "net10.0-windows10.0.22621.0", ProcessName + ".exe");
 
         if (!File.Exists(exe))
             throw new FileNotFoundException($"Build the WinForms host first. Expected: {exe}");

--- a/tests/Reactor.AppTests/Reactor.AppTests.csproj
+++ b/tests/Reactor.AppTests/Reactor.AppTests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <RootNamespace>Microsoft.UI.Reactor.AppTests</RootNamespace>
     <AssemblyName>Reactor.AppTests</AssemblyName>
     <IsTestProject>true</IsTestProject>

--- a/tests/Reactor.SelfTests/Reactor.SelfTests.csproj
+++ b/tests/Reactor.SelfTests/Reactor.SelfTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <RootNamespace>Microsoft.UI.Reactor.SelfTests</RootNamespace>
     <AssemblyName>Reactor.SelfTests</AssemblyName>
     <IsTestProject>true</IsTestProject>

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -246,7 +246,7 @@ public class SelfTestBatch
         };
 
         var exe = Path.Combine(dir, "tests", "Reactor.AppTests.Host", "bin", platform,
-            "Debug", "net9.0-windows10.0.22621.0", "Reactor.AppTests.Host.exe");
+            "Debug", "net10.0-windows10.0.22621.0", "Reactor.AppTests.Host.exe");
 
         if (!File.Exists(exe))
             throw new FileNotFoundException($"Host app not built. Expected: {exe}");

--- a/tests/Reactor.Tests/Reactor.Tests.csproj
+++ b/tests/Reactor.Tests/Reactor.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <AssemblyName>Reactor.Tests</AssemblyName>
     <RootNamespace>Microsoft.UI.Reactor.Tests</RootNamespace>

--- a/tests/Reactor.WinFormsTests.Host/Reactor.WinFormsTests.Host.csproj
+++ b/tests/Reactor.WinFormsTests.Host/Reactor.WinFormsTests.Host.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>Microsoft.UI.Reactor.WinFormsTests.Host</RootNamespace>
     <AssemblyName>Reactor.WinFormsTests.Host</AssemblyName>

--- a/tests/cmd_perf/CmdPerf.Reactor/CmdPerf.Reactor.csproj
+++ b/tests/cmd_perf/CmdPerf.Reactor/CmdPerf.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>CmdPerf.Reactor</RootNamespace>
     <AssemblyName>CmdPerf.Reactor</AssemblyName>

--- a/tests/cmd_perf/CmdPerf.Shared/CmdPerf.Shared.csproj
+++ b/tests/cmd_perf/CmdPerf.Shared/CmdPerf.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>CmdPerf.Shared</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/cmd_perf/CmdPerf.Wpf/CmdPerf.Wpf.csproj
+++ b/tests/cmd_perf/CmdPerf.Wpf/CmdPerf.Wpf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>CmdPerf.Wpf</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/cmd_perf/CmdPerf.XamlCmd/CmdPerf.XamlCmd.csproj
+++ b/tests/cmd_perf/CmdPerf.XamlCmd/CmdPerf.XamlCmd.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>CmdPerf.XamlCmd</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/cmd_perf/run_cmd_benchmark.sh
+++ b/tests/cmd_perf/run_cmd_benchmark.sh
@@ -36,8 +36,8 @@ echo ""
 # Clear previous results
 > "$RESULTS_FILE"
 
-TFM_WINUI="net9.0-windows10.0.22621.0"
-TFM_WPF="net9.0-windows"
+TFM_WINUI="net10.0-windows10.0.22621.0"
+TFM_WPF="net10.0-windows"
 
 REACTOR_EXE="$BASE/CmdPerf.Reactor/bin/$PLATFORM/$CONFIG/$TFM_WINUI/CmdPerf.Reactor.exe"
 XAML_EXE="$BASE/CmdPerf.XamlCmd/bin/$PLATFORM/$CONFIG/$TFM_WINUI/CmdPerf.XamlCmd.exe"

--- a/tests/perf_bench/PerfBench.Allocation/Allocation.Bound/Allocation.Bound.csproj
+++ b/tests/perf_bench/PerfBench.Allocation/Allocation.Bound/Allocation.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.Allocation.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.Allocation/Allocation.Direct/Allocation.Direct.csproj
+++ b/tests/perf_bench/PerfBench.Allocation/Allocation.Direct/Allocation.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.Allocation.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.Allocation/Allocation.Reactor/Allocation.Reactor.csproj
+++ b/tests/perf_bench/PerfBench.Allocation/Allocation.Reactor/Allocation.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.Allocation.Reactor</RootNamespace>
     <AssemblyName>Allocation.Reactor</AssemblyName>

--- a/tests/perf_bench/PerfBench.DeferredMount/DeferredMount.Bound/DeferredMount.Bound.csproj
+++ b/tests/perf_bench/PerfBench.DeferredMount/DeferredMount.Bound/DeferredMount.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.DeferredMount.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.DeferredMount/DeferredMount.Direct/DeferredMount.Direct.csproj
+++ b/tests/perf_bench/PerfBench.DeferredMount/DeferredMount.Direct/DeferredMount.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.DeferredMount.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.DeferredMount/DeferredMount.Reactor/DeferredMount.Reactor.csproj
+++ b/tests/perf_bench/PerfBench.DeferredMount/DeferredMount.Reactor/DeferredMount.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.DeferredMount.Reactor</RootNamespace>
     <AssemblyName>DeferredMount.Reactor</AssemblyName>

--- a/tests/perf_bench/PerfBench.DirtyTracking/DirtyTracking.Bound/DirtyTracking.Bound.csproj
+++ b/tests/perf_bench/PerfBench.DirtyTracking/DirtyTracking.Bound/DirtyTracking.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.DirtyTracking.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.DirtyTracking/DirtyTracking.Direct/DirtyTracking.Direct.csproj
+++ b/tests/perf_bench/PerfBench.DirtyTracking/DirtyTracking.Direct/DirtyTracking.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.DirtyTracking.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.DirtyTracking/DirtyTracking.Reactor/DirtyTracking.Reactor.csproj
+++ b/tests/perf_bench/PerfBench.DirtyTracking/DirtyTracking.Reactor/DirtyTracking.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.DirtyTracking.Reactor</RootNamespace>
     <AssemblyName>DirtyTracking.Reactor</AssemblyName>

--- a/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Bound/InteractivePool.Bound.csproj
+++ b/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Bound/InteractivePool.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.InteractivePool.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Direct/InteractivePool.Direct.csproj
+++ b/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Direct/InteractivePool.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.InteractivePool.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Reactor/InteractivePool.Reactor.csproj
+++ b/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Reactor/InteractivePool.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.InteractivePool.Reactor</RootNamespace>
     <AssemblyName>InteractivePool.Reactor</AssemblyName>

--- a/tests/perf_bench/PerfBench.Journal/Journal.Bound/Journal.Bound.csproj
+++ b/tests/perf_bench/PerfBench.Journal/Journal.Bound/Journal.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.Journal.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.Journal/Journal.Direct/Journal.Direct.csproj
+++ b/tests/perf_bench/PerfBench.Journal/Journal.Direct/Journal.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.Journal.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.Journal/Journal.Reactor/Journal.Reactor.csproj
+++ b/tests/perf_bench/PerfBench.Journal/Journal.Reactor/Journal.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.Journal.Reactor</RootNamespace>
     <AssemblyName>Journal.Reactor</AssemblyName>

--- a/tests/perf_bench/PerfBench.OffThread/OffThread.Bound/OffThread.Bound.csproj
+++ b/tests/perf_bench/PerfBench.OffThread/OffThread.Bound/OffThread.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.OffThread.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.OffThread/OffThread.Direct/OffThread.Direct.csproj
+++ b/tests/perf_bench/PerfBench.OffThread/OffThread.Direct/OffThread.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.OffThread.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.OffThread/OffThread.Reactor/OffThread.Reactor.csproj
+++ b/tests/perf_bench/PerfBench.OffThread/OffThread.Reactor/OffThread.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.OffThread.Reactor</RootNamespace>
     <AssemblyName>OffThread.Reactor</AssemblyName>

--- a/tests/perf_bench/PerfBench.Priorities/Priorities.Bound/Priorities.Bound.csproj
+++ b/tests/perf_bench/PerfBench.Priorities/Priorities.Bound/Priorities.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.Priorities.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.Priorities/Priorities.Direct/Priorities.Direct.csproj
+++ b/tests/perf_bench/PerfBench.Priorities/Priorities.Direct/Priorities.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.Priorities.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.Priorities/Priorities.Reactor/Priorities.Reactor.csproj
+++ b/tests/perf_bench/PerfBench.Priorities/Priorities.Reactor/Priorities.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.Priorities.Reactor</RootNamespace>
     <AssemblyName>Priorities.Reactor</AssemblyName>

--- a/tests/perf_bench/PerfBench.PropertyDiff/PropertyDiff.Bound/PropertyDiff.Bound.csproj
+++ b/tests/perf_bench/PerfBench.PropertyDiff/PropertyDiff.Bound/PropertyDiff.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.PropertyDiff.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.PropertyDiff/PropertyDiff.Direct/PropertyDiff.Direct.csproj
+++ b/tests/perf_bench/PerfBench.PropertyDiff/PropertyDiff.Direct/PropertyDiff.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.PropertyDiff.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.PropertyDiff/PropertyDiff.Reactor/PropertyDiff.Reactor.csproj
+++ b/tests/perf_bench/PerfBench.PropertyDiff/PropertyDiff.Reactor/PropertyDiff.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.PropertyDiff.Reactor</RootNamespace>
     <AssemblyName>PropertyDiff.Reactor</AssemblyName>

--- a/tests/perf_bench/PerfBench.Shared/PerfBench.Shared.csproj
+++ b/tests/perf_bench/PerfBench.Shared/PerfBench.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.Shared</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.StructuralSharing/StructuralSharing.Bound/StructuralSharing.Bound.csproj
+++ b/tests/perf_bench/PerfBench.StructuralSharing/StructuralSharing.Bound/StructuralSharing.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.StructuralSharing.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.StructuralSharing/StructuralSharing.Direct/StructuralSharing.Direct.csproj
+++ b/tests/perf_bench/PerfBench.StructuralSharing/StructuralSharing.Direct/StructuralSharing.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.StructuralSharing.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.StructuralSharing/StructuralSharing.Reactor/StructuralSharing.Reactor.csproj
+++ b/tests/perf_bench/PerfBench.StructuralSharing/StructuralSharing.Reactor/StructuralSharing.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.StructuralSharing.Reactor</RootNamespace>
     <AssemblyName>StructuralSharing.Reactor</AssemblyName>

--- a/tests/perf_bench/PerfBench.TimeSlice/TimeSlice.Bound/TimeSlice.Bound.csproj
+++ b/tests/perf_bench/PerfBench.TimeSlice/TimeSlice.Bound/TimeSlice.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.TimeSlice.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.TimeSlice/TimeSlice.Direct/TimeSlice.Direct.csproj
+++ b/tests/perf_bench/PerfBench.TimeSlice/TimeSlice.Direct/TimeSlice.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.TimeSlice.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/perf_bench/PerfBench.TimeSlice/TimeSlice.Reactor/TimeSlice.Reactor.csproj
+++ b/tests/perf_bench/PerfBench.TimeSlice/TimeSlice.Reactor/TimeSlice.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PerfBench.TimeSlice.Reactor</RootNamespace>
     <AssemblyName>TimeSlice.Reactor</AssemblyName>

--- a/tests/stress_perf/PresentTracer/PresentTracer.csproj
+++ b/tests/stress_perf/PresentTracer/PresentTracer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/stress_perf/StressPerf.Bound/StressPerf.Bound.csproj
+++ b/tests/stress_perf/StressPerf.Bound/StressPerf.Bound.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>StressPerf.Bound</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/stress_perf/StressPerf.Direct/StressPerf.Direct.csproj
+++ b/tests/stress_perf/StressPerf.Direct/StressPerf.Direct.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>StressPerf.Direct</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/stress_perf/StressPerf.DirectX/StressPerf.DirectX.csproj
+++ b/tests/stress_perf/StressPerf.DirectX/StressPerf.DirectX.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>StressPerf.DirectX</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/stress_perf/StressPerf.Reactor/StressPerf.Reactor.csproj
+++ b/tests/stress_perf/StressPerf.Reactor/StressPerf.Reactor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>StressPerf.Reactor</RootNamespace>
     <AssemblyName>StressPerf.Reactor</AssemblyName>

--- a/tests/stress_perf/StressPerf.ReactorGrid/StressPerf.ReactorGrid.csproj
+++ b/tests/stress_perf/StressPerf.ReactorGrid/StressPerf.ReactorGrid.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>StressPerf.ReactorGrid</RootNamespace>
     <AssemblyName>StressPerf.ReactorGrid</AssemblyName>

--- a/tests/stress_perf/StressPerf.ReactorOptimized/StressPerf.ReactorOptimized.csproj
+++ b/tests/stress_perf/StressPerf.ReactorOptimized/StressPerf.ReactorOptimized.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>StressPerf.ReactorOptimized</RootNamespace>
     <AssemblyName>StressPerf.ReactorOptimized</AssemblyName>

--- a/tests/stress_perf/StressPerf.Shared/StressPerf.Shared.csproj
+++ b/tests/stress_perf/StressPerf.Shared/StressPerf.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>StressPerf.Shared</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/stress_perf/StressPerf.VirtualList.Reactor/StressPerf.VirtualList.Reactor.csproj
+++ b/tests/stress_perf/StressPerf.VirtualList.Reactor/StressPerf.VirtualList.Reactor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>StressPerf.VirtualList.Reactor</RootNamespace>
     <AssemblyName>StressPerf.VirtualList.Reactor</AssemblyName>

--- a/tests/stress_perf/StressPerf.Wpf/StressPerf.Wpf.csproj
+++ b/tests/stress_perf/StressPerf.Wpf/StressPerf.Wpf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>StressPerf.Wpf</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/stress_perf/run_bench_aot_publish.sh
+++ b/tests/stress_perf/run_bench_aot_publish.sh
@@ -9,8 +9,8 @@ DURATION=7
 OUTFILE="$SCRIPT_DIR/benchmark_results_aot_publish.csv"
 
 CONFIG="Release"
-TFM_WINUI="net9.0-windows10.0.22621.0"
-TFM_WPF="net9.0-windows"
+TFM_WINUI="net10.0-windows10.0.22621.0"
+TFM_WPF="net10.0-windows"
 PLATFORM="ARM64"
 RID="win-arm64"
 

--- a/tests/stress_perf/run_bench_reactor_arm64.ps1
+++ b/tests/stress_perf/run_bench_reactor_arm64.ps1
@@ -1,6 +1,6 @@
-$exe = Join-Path $PSScriptRoot 'StressPerf.Reactor\bin\arm64\Release\net9.0-windows10.0.22621.0\StressPerf.Reactor.exe'
+$exe = Join-Path $PSScriptRoot 'StressPerf.Reactor\bin\arm64\Release\net10.0-windows10.0.22621.0\StressPerf.Reactor.exe'
 if (-not (Test-Path $exe -PathType Leaf)) {
-    Write-Error "Benchmark executable not found at expected path:`n  $exe`nBuild StressPerf.Reactor for arm64 Release (TFM net9.0-windows10.0.22621.0) first, e.g. `n  dotnet build tests/stress_perf/StressPerf.Reactor/StressPerf.Reactor.csproj -c Release -p:Platform=arm64"
+    Write-Error "Benchmark executable not found at expected path:`n  $exe`nBuild StressPerf.Reactor for arm64 Release (TFM net10.0-windows10.0.22621.0) first, e.g. `n  dotnet build tests/stress_perf/StressPerf.Reactor/StressPerf.Reactor.csproj -c Release -p:Platform=arm64"
     exit 1
 }
 $reportPath = Join-Path (Split-Path $exe) 'StressPerf.Reactor.report.txt'

--- a/tests/stress_perf/run_benchmark.sh
+++ b/tests/stress_perf/run_benchmark.sh
@@ -25,8 +25,8 @@ detect_platform() {
 
 # Build configuration
 CONFIG="Release"
-TFM_WINUI="net9.0-windows10.0.22621.0"
-TFM_WPF="net9.0-windows"
+TFM_WINUI="net10.0-windows10.0.22621.0"
+TFM_WPF="net10.0-windows"
 
 STRESS_DIR="$REPO_ROOT/tests/stress_perf"
 

--- a/tests/stress_perf/run_dwm_attribution_test.ps1
+++ b/tests/stress_perf/run_dwm_attribution_test.ps1
@@ -27,9 +27,9 @@ param(
 $ErrorActionPreference = 'Continue'
 
 $repo    = 'C:\Users\andersonch\Code\reactor3'
-$tracer  = "$repo\tests\stress_perf\PresentTracer\bin\ARM64\Release\net9.0\PresentTracer.exe"
-$wpf     = "$repo\tests\stress_perf\StressPerf.Wpf\bin\ARM64\Release\net9.0-windows\StressPerf.Wpf.exe"
-$dx      = "$repo\tests\stress_perf\StressPerf.DirectX\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.DirectX.exe"
+$tracer  = "$repo\tests\stress_perf\PresentTracer\bin\ARM64\Release\net10.0\PresentTracer.exe"
+$wpf     = "$repo\tests\stress_perf\StressPerf.Wpf\bin\ARM64\Release\net10.0-windows\StressPerf.Wpf.exe"
+$dx      = "$repo\tests\stress_perf\StressPerf.DirectX\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.DirectX.exe"
 
 if (-not (Test-Path $tracer)) { throw "Missing tracer: $tracer" }
 if (-not (Test-Path $wpf))    { throw "Missing wpf: $wpf" }

--- a/tests/stress_perf/run_full_matrix.ps1
+++ b/tests/stress_perf/run_full_matrix.ps1
@@ -33,9 +33,9 @@ Add-Type -AssemblyName UIAutomationClient,UIAutomationTypes -ErrorAction Stop
 # ── Paths ──────────────────────────────────────────────────────────────────
 $repoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $stressDir  = Join-Path $repoRoot 'tests\stress_perf'
-$tfmWinUI   = 'net9.0-windows10.0.22621.0'
-$tfmWpf     = 'net9.0-windows'
-$tfmTracer  = 'net9.0'
+$tfmWinUI   = 'net10.0-windows10.0.22621.0'
+$tfmWpf     = 'net10.0-windows'
+$tfmTracer  = 'net10.0'
 
 $tracerExe  = Join-Path $stressDir "PresentTracer\bin\$Platform\$Configuration\$tfmTracer\PresentTracer.exe"
 

--- a/tests/stress_perf/run_present_trace.ps1
+++ b/tests/stress_perf/run_present_trace.ps1
@@ -12,8 +12,8 @@ param(
 
 $ErrorActionPreference = 'Continue'
 
-$tracer  = 'C:\Users\andersonch\Code\reactor3\tests\stress_perf\PresentTracer\bin\ARM64\Release\net9.0\PresentTracer.exe'
-$reactor = 'C:\Users\andersonch\Code\reactor3\tests\stress_perf\StressPerf.Reactor\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.Reactor.exe'
+$tracer  = 'C:\Users\andersonch\Code\reactor3\tests\stress_perf\PresentTracer\bin\ARM64\Release\net10.0\PresentTracer.exe'
+$reactor = 'C:\Users\andersonch\Code\reactor3\tests\stress_perf\StressPerf.Reactor\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.Reactor.exe'
 $rn      = 'C:\Users\andersonch\Code\reactor3\tests\stress_perf_rn\StocksGrid\windows\ARM64\Release\StocksGrid.exe'
 
 if (-not (Test-Path $tracer))  { throw "PresentTracer.exe not found at $tracer" }

--- a/tests/stress_perf/run_spec034_bench.ps1
+++ b/tests/stress_perf/run_spec034_bench.ps1
@@ -12,7 +12,7 @@ param(
 $ErrorActionPreference = 'Continue'
 
 $repo = Resolve-Path (Join-Path $PSScriptRoot '..\..')
-$tfm = 'net9.0-windows10.0.22621.0'
+$tfm = 'net10.0-windows10.0.22621.0'
 $plat = 'ARM64'
 $cfg = 'Release'
 

--- a/tests/stress_perf/run_spec034_reactor_before.ps1
+++ b/tests/stress_perf/run_spec034_reactor_before.ps1
@@ -13,7 +13,7 @@ param(
 
 $ErrorActionPreference = 'Continue'
 
-$tfm = 'net9.0-windows10.0.22621.0'
+$tfm = 'net10.0-windows10.0.22621.0'
 $plat = 'ARM64'
 $cfg = 'Release'
 $exe = Join-Path $PrespecRoot "tests\stress_perf\StressPerf.Reactor\bin\$plat\$cfg\$tfm\StressPerf.Reactor.exe"

--- a/tests/stress_perf/run_stocks_grid_baseline.ps1
+++ b/tests/stress_perf/run_stocks_grid_baseline.ps1
@@ -28,15 +28,15 @@ Add-Type -AssemblyName UIAutomationClient,UIAutomationTypes -ErrorAction Stop
 # ── Variant table ──────────────────────────────────────────────────────────
 $repo = 'C:\Users\andersonch\Code\reactor3'
 $variants = @(
-  [pscustomobject]@{ Name='Direct';    Exe="$repo\tests\stress_perf\StressPerf.Direct\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.Direct.exe";   IsRN=$false; ReportName='StressPerf.Direct' }
-  [pscustomobject]@{ Name='Bound';     Exe="$repo\tests\stress_perf\StressPerf.Bound\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.Bound.exe";     IsRN=$false; ReportName='StressPerf.Bound' }
-  [pscustomobject]@{ Name='Wpf';       Exe="$repo\tests\stress_perf\StressPerf.Wpf\bin\ARM64\Release\net9.0-windows\StressPerf.Wpf.exe";                     IsRN=$false; ReportName='StressPerf.Wpf' }
-  [pscustomobject]@{ Name='DirectX';   Exe="$repo\tests\stress_perf\StressPerf.DirectX\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.DirectX.exe"; IsRN=$false; ReportName='StressPerf.DirectX' }
-  [pscustomobject]@{ Name='Reactor';   Exe="$repo\tests\stress_perf\StressPerf.Reactor\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.Reactor.exe"; IsRN=$false; ReportName='StressPerf.Reactor' }
-  [pscustomobject]@{ Name='ReactorOptimized'; Exe="$repo\tests\stress_perf\StressPerf.ReactorOptimized\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.ReactorOptimized.exe"; IsRN=$false; ReportName='StressPerf.ReactorOptimized' }
+  [pscustomobject]@{ Name='Direct';    Exe="$repo\tests\stress_perf\StressPerf.Direct\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.Direct.exe";   IsRN=$false; ReportName='StressPerf.Direct' }
+  [pscustomobject]@{ Name='Bound';     Exe="$repo\tests\stress_perf\StressPerf.Bound\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.Bound.exe";     IsRN=$false; ReportName='StressPerf.Bound' }
+  [pscustomobject]@{ Name='Wpf';       Exe="$repo\tests\stress_perf\StressPerf.Wpf\bin\ARM64\Release\net10.0-windows\StressPerf.Wpf.exe";                     IsRN=$false; ReportName='StressPerf.Wpf' }
+  [pscustomobject]@{ Name='DirectX';   Exe="$repo\tests\stress_perf\StressPerf.DirectX\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.DirectX.exe"; IsRN=$false; ReportName='StressPerf.DirectX' }
+  [pscustomobject]@{ Name='Reactor';   Exe="$repo\tests\stress_perf\StressPerf.Reactor\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.Reactor.exe"; IsRN=$false; ReportName='StressPerf.Reactor' }
+  [pscustomobject]@{ Name='ReactorOptimized'; Exe="$repo\tests\stress_perf\StressPerf.ReactorOptimized\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.ReactorOptimized.exe"; IsRN=$false; ReportName='StressPerf.ReactorOptimized' }
   [pscustomobject]@{ Name='RN-Fabric'; Exe="$repo\tests\stress_perf_rn\StocksGrid\windows\ARM64\Release\StocksGrid.exe";                                     IsRN=$true;  ReportName='StressPerf.RN.StocksGrid' }
 )
-$tracer = "$repo\tests\stress_perf\PresentTracer\bin\ARM64\Release\net9.0\PresentTracer.exe"
+$tracer = "$repo\tests\stress_perf\PresentTracer\bin\ARM64\Release\net10.0\PresentTracer.exe"
 
 foreach ($v in $variants) {
   if (-not (Test-Path $v.Exe))   { throw "Missing exe: $($v.Exe)" }

--- a/tests/stress_perf/run_sweep_arm64.ps1
+++ b/tests/stress_perf/run_sweep_arm64.ps1
@@ -9,13 +9,13 @@ $resultsDir = Join-Path $stressDir 'sweep-results'
 New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
 
 $variants = @(
-    @{ Name = 'WinUI.Direct';      Exe = "$stressDir\StressPerf.Direct\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.Direct.exe" },
-    @{ Name = 'WinUI.Bound';       Exe = "$stressDir\StressPerf.Bound\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.Bound.exe" },
-    @{ Name = 'WinUI.Reactor';     Exe = "$stressDir\StressPerf.Reactor\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.Reactor.exe" },
-    @{ Name = 'WinUI.ReactorOptimized'; Exe = "$stressDir\StressPerf.ReactorOptimized\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.ReactorOptimized.exe" },
-    @{ Name = 'WinUI.ReactorGrid'; Exe = "$stressDir\StressPerf.ReactorGrid\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.ReactorGrid.exe" },
-    @{ Name = 'WinUI.DirectX';     Exe = "$stressDir\StressPerf.DirectX\bin\ARM64\Release\net9.0-windows10.0.22621.0\StressPerf.DirectX.exe" },
-    @{ Name = 'WPF.Direct';        Exe = "$stressDir\StressPerf.Wpf\bin\ARM64\Release\net9.0-windows\StressPerf.Wpf.exe" }
+    @{ Name = 'WinUI.Direct';      Exe = "$stressDir\StressPerf.Direct\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.Direct.exe" },
+    @{ Name = 'WinUI.Bound';       Exe = "$stressDir\StressPerf.Bound\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.Bound.exe" },
+    @{ Name = 'WinUI.Reactor';     Exe = "$stressDir\StressPerf.Reactor\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.Reactor.exe" },
+    @{ Name = 'WinUI.ReactorOptimized'; Exe = "$stressDir\StressPerf.ReactorOptimized\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.ReactorOptimized.exe" },
+    @{ Name = 'WinUI.ReactorGrid'; Exe = "$stressDir\StressPerf.ReactorGrid\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.ReactorGrid.exe" },
+    @{ Name = 'WinUI.DirectX';     Exe = "$stressDir\StressPerf.DirectX\bin\ARM64\Release\net10.0-windows10.0.22621.0\StressPerf.DirectX.exe" },
+    @{ Name = 'WPF.Direct';        Exe = "$stressDir\StressPerf.Wpf\bin\ARM64\Release\net10.0-windows\StressPerf.Wpf.exe" }
 )
 
 $rows = @()


### PR DESCRIPTION
## What

Migrate the entire repo from .NET 9 to **.NET 10 (LTS)** as [suggested by @codemonkeychris](https://github.com/microsoft/microsoft-ui-reactor/pull/147#issuecomment-2841987413) — rolling forward to the current LTS release rather than staying on .NET 9 (STS, EOL May 2026).

## Why .NET 10 instead of .NET 9?

- **.NET 9 is STS** — standard support ends May 2026; we'd be shipping on an end-of-life runtime almost immediately.
- **.NET 10 is LTS** — long-term support until November 2028; aligns with production stability expectations.
- **CI runners already have .NET 10** — `windows-latest` ships with 10.0 SDK pre-installed; without a global.json pin, builds were already silently picking it up.
- **Windows App SDK 2.0.1 supports .NET 10** — no blocking compatibility issues.

## Changes

### SDK & TFM (101 projects)
- All `csproj` files: `net9.0-windows10.0.22621.0` → `net10.0-windows10.0.22621.0` (5 samples were already on net10.0)
- Added `global.json` pinning SDK to `10.0.100` with `latestFeature` roll-forward

### CI Workflows
- `ci.yml`, `coverage.yml`, `release.yml`: `dotnet-version: 9.0.x` → `10.0.x`
- Coverage and release artifact paths updated for `net10.0` TFM

### C# 14 Compatibility
- `ValidationContext.cs`: renamed `field` → `fieldName` in tuple deconstructions inside a property getter (`field` is a keyword in C# 14)

### Documentation & Templates
- README, CONTRIBUTING, SKILL.md: prerequisites and examples updated to .NET 10
- Doc pipeline templates (`getting-started.md.dt`, `readme.md.dt`) and compiled guides updated
- `ai-author-skill.md`, `013-doc-system-design.md`: prerequisite references updated

### Test Infrastructure & Benchmarks
- `TestSession.cs`, `WinFormsTestSession.cs`, `SelfTestBatch.cs`: hardcoded TFM paths updated
- CLI scaffolder template TFM updated
- All benchmark/perf scripts updated

### Bug Fix (drive-by)
- `SKILL.md`: corrected `ProjectReference` path (`..\Reactor\` → `..\src\Reactor\`)

## Verification

- **Build**: 0 errors ✅
- **Unit tests**: 6790 passed, 3 locale-specific failures (pre-existing on `main`, locale PR forthcoming)
- **Selftests**: ~650 passed, 1 `FlexInBorder_MainAxisDistributed` (pre-existing on `main`)
