### PR TITLE
fix(selftest): stabilize Resource_FetchedData and PasswordBox UserEditFires

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoverageBoostFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoverageBoostFixtures.cs
@@ -638,6 +638,10 @@ internal static class CoverageBoostFixtures
             var host = H.CreateHost();
             host.Mount(new ResourceComponent());
             await Harness.Render(200);
+            // The fetcher's Task.Delay(10) resolves during the 200ms wall-clock
+            // wait, then schedules a re-render that may not have flushed before
+            // Render(200) returns. Pump once more to drain the queued re-render.
+            await Harness.Render();
 
             var tb = H.FindTextContaining("Data:fetched-data");
             H.Check("Resource_FetchedData", tb is not null);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
@@ -453,6 +453,10 @@ internal static class EchoSuppressionFixtures
             H.Check("EchoSuppress_PasswordBox_NoEchoCall", calls.Count == 0);
 
             if (pb is not null) pb.Password = "typed";
+            // PasswordBox.PasswordChanged can be raised via the dispatcher rather
+            // than synchronously in the setter, so a single render pump is racy.
+            // Pump twice so the queued event lands before the assertion.
+            await Harness.Render();
             await Harness.Render();
             H.Check("EchoSuppress_PasswordBox_UserEditFires",
                 calls.Count >= 1 && calls[^1] == "typed");


### PR DESCRIPTION
## Summary

Two remaining flake clusters surfaced in a 100× `Reactor.AppTests.Host --self-test` sweep on top of #139 (**3/100 run-fail rate before; expected 0/100 after**). Both are async-timing races where a single render pump isn't enough.

- **`Resource_FetchedData`** (CovBoost_ComponentUseResource) — 2/100, runs 49 & 54. `Task.Delay(10)` fetcher resolves *during* the 200 ms wall-clock wait inside `Harness.Render(200)`, then schedules a re-render that may not flush before `Render(200)` returns. Pump once more after the wall-clock wait so the queued re-render drains.
- **`EchoSuppress_PasswordBox_UserEditFires`** — 1/100, run 24. `PasswordBox.PasswordChanged` can be raised via the dispatcher rather than synchronously in the setter (same shape as the TabView/RadioButtons flake fixed in #139). Pump twice between `pb.Password = "typed"` and the counter assertion.

Diff is +8 lines across two fixture files — no production code changed.

## Test plan

- [x] `dotnet build tests/Reactor.AppTests.Host` — clean (0 warnings, 0 errors)
- [ ] 100× selftest sweep on this branch (next PR action — will be run in a fresh context)
- [ ] Targeted clusters report 0/100 run-fail; total fixture count remains 648/run

🤖 Generated with [Claude Code](https://claude.com/claude-code)