### PR TITLE
fix(docs,analyzers): clear XML doc and analyzer SDK warnings

### DIFF
--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -10,3 +10,6 @@ REACTOR_HOOKS_004 | Reactor.Hooks | Warning | HookRulesAnalyzer - Hook deps cont
 REACTOR_HOOKS_005 | Reactor.Hooks | Warning | HookRulesAnalyzer - Hook called outside Render or custom-hook method
 REACTOR_HOOKS_006 | Reactor.Hooks | Info | HookRulesAnalyzer - UseResource fetcher looks non-idempotent (use UseMutation for writes)
 REACTOR_HOOKS_007 | Reactor.Hooks | Warning | UseMemoCellsAnalyzer - Builder closure capture missing from dependencies
+REACTOR_A11Y_001 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Icon-only button needs an accessible name
+REACTOR_A11Y_002 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Image needs alt text or AccessibilityHidden
+REACTOR_A11Y_003 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Form field needs a label

--- a/src/Reactor.Analyzers/HookRulesAnalyzer.cs
+++ b/src/Reactor.Analyzers/HookRulesAnalyzer.cs
@@ -64,7 +64,7 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor HookOutsideRenderRule = new(
         HookOutsideRenderId,
         "Hook called outside Render or a custom-hook method",
-        "Hook '{0}' must be called inside a Component.Render override or a custom-hook method (by convention, a method whose name starts with 'Use').",
+        "Hook '{0}' must be called inside a Component.Render override or a custom-hook method (by convention, a method whose name starts with 'Use')",
         "Reactor.Hooks",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/src/Reactor/Charting/D3/Array/Ticks.cs
+++ b/src/Reactor/Charting/D3/Array/Ticks.cs
@@ -44,6 +44,9 @@ public static class D3Ticks
         return (i1, i2, inc);
     }
 
+    /// <summary>Hard cap on emitted tick count. TASK-086.</summary>
+    public const int MaxTicks = 10_000;
+
     /// <summary>
     /// Returns an array of approximately <paramref name="count"/> representative values
     /// from the given numeric interval [<paramref name="start"/>, <paramref name="stop"/>].
@@ -51,9 +54,6 @@ public static class D3Ticks
     /// (such as multiples of powers of 10), and are guaranteed to be within the extent
     /// of the given interval.
     /// </summary>
-    /// <summary>Hard cap on emitted tick count. TASK-086.</summary>
-    public const int MaxTicks = 10_000;
-
     public static double[] Ticks(double start, double stop, int count)
     {
         // SECURITY (TASK-086): reject non-finite endpoints and bound the

--- a/src/Reactor/Controls/DataGrid/DataGridState.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridState.cs
@@ -405,6 +405,9 @@ public class DataGridState<T>
     public int LastVisibleFirst;
     public int LastVisibleLast;
 
+    /// <param name="source">Data source feeding rows into the grid.</param>
+    /// <param name="columns">Column descriptors defining accessor + editor + renderer per column.</param>
+    /// <param name="selectionMode">Single-row, multi-row, or no selection.</param>
     /// <param name="blockSize">
     /// Page cache block size. When 0 (default), the cache uses its built-in default (50).
     /// Pass a viewport-derived value to ensure the first block fills the screen.

--- a/src/Reactor/Controls/DataGrid/TypedColumns.cs
+++ b/src/Reactor/Controls/DataGrid/TypedColumns.cs
@@ -13,7 +13,7 @@ namespace Microsoft.UI.Reactor.Controls;
 /// Use when the column type is known at the call site and you want HitTable-style
 /// "batteries included" ergonomics. For discovery-driven columns, use
 /// <see cref="Factories.AutoColumns{T}"/> with a <see cref="TypeRegistry"/>
-/// populated via <see cref="TypeRegistry.WithDefaultEditors"/>.
+/// populated with built-in editors and renderers.
 /// </summary>
 public static class TypedColumns
 {

--- a/src/Reactor/Controls/Formatting/InputFormatter.cs
+++ b/src/Reactor/Controls/Formatting/InputFormatter.cs
@@ -4,7 +4,8 @@ using System.Text.RegularExpressions;
 namespace Microsoft.UI.Reactor.Controls;
 
 /// <summary>
-/// Transforms input text and cursor position. Used in formatter pipelines.
+/// Result returned by an <see cref="InputFormatter"/>: the transformed output text
+/// paired with the adjusted cursor position.
 /// </summary>
 /// <param name="Output">The transformed output text.</param>
 /// <param name="CursorPos">The cursor position in the output.</param>

--- a/src/Reactor/Controls/Formatting/InputFormatter.cs
+++ b/src/Reactor/Controls/Formatting/InputFormatter.cs
@@ -6,8 +6,8 @@ namespace Microsoft.UI.Reactor.Controls;
 /// <summary>
 /// Transforms input text and cursor position. Used in formatter pipelines.
 /// </summary>
-/// <param name="Input">The input text.</param>
-/// <param name="CursorPos">The cursor position in the input.</param>
+/// <param name="Output">The transformed output text.</param>
+/// <param name="CursorPos">The cursor position in the output.</param>
 public readonly record struct FormatResult(string Output, int CursorPos);
 
 /// <summary>

--- a/src/Reactor/Controls/PropertyGrid/ReflectionTypeMetadataProvider.cs
+++ b/src/Reactor/Controls/PropertyGrid/ReflectionTypeMetadataProvider.cs
@@ -74,11 +74,11 @@ public static class ReflectionTypeMetadataProvider
     }
 
     /// <summary>
-    /// Maps a small set of <see cref="System.ComponentModel.DataAnnotations"/>
+    /// Maps a small set of <c>System.ComponentModel.DataAnnotations</c>
     /// attributes onto Reactor editors/renderers:
     /// <list type="bullet">
     ///   <item><c>[DataType(DataType.Url)]</c> on string → URL text input + Hyperlink display</item>
-    ///   <item><c>[DataType(DataType.Url)]</c> on <see cref="System.Uri"/> → Uri editor + Hyperlink display</item>
+    ///   <item><c>[DataType(DataType.Url)]</c> on <c>System.Uri</c> → Uri editor + Hyperlink display</item>
     ///   <item><c>[Range(min, max)]</c> on a numeric type → NumberBox with min/max bounds</item>
     /// </list>
     /// Returns null for either slot when no attribute dictates that slot, so

--- a/src/Reactor/Controls/Validation/Validators/BuiltInValidators.cs
+++ b/src/Reactor/Controls/Validation/Validators/BuiltInValidators.cs
@@ -20,7 +20,7 @@ public static class Validate
         new MinLengthValidator(n, message ?? $"Must be at least {n} characters.");
 
     /// <summary>
-    /// String length must be <= n.
+    /// String length must be &lt;= n.
     /// </summary>
     public static IValidator MaxLength(int n, string? message = null) =>
         new MaxLengthValidator(n, message ?? $"Must be at most {n} characters.");

--- a/src/Reactor/Core/AccessibilityScanner.cs
+++ b/src/Reactor/Core/AccessibilityScanner.cs
@@ -102,7 +102,7 @@ public record A11yContext
 /// <summary>
 /// Post-reconciliation accessibility scanner that walks the Reactor virtual
 /// element tree and produces structured diagnostics. Intended for DEBUG
-/// builds only — call via <see cref="ReactorHostControl.EnableAccessibilityDiagnostics"/>.
+/// builds only — call via <c>ReactorHostControl.EnableAccessibilityDiagnostics</c>.
 ///
 /// The scanner produces AI-agent-friendly JSON output: each diagnostic
 /// includes rich contextual clues (sibling texts, parent names, child

--- a/src/Reactor/Core/CommandBindings.cs
+++ b/src/Reactor/Core/CommandBindings.cs
@@ -18,7 +18,7 @@ internal static class CommandBindings
 {
     /// <summary>
     /// Applies command metadata that is common to every command-capable WinUI control:
-    /// <see cref="Control.IsEnabled"/>, <see cref="ToolTipService.ToolTipProperty"/>,
+    /// <see cref="Control.IsEnabled"/>, the <c>ToolTipService.ToolTip</c> attached property,
     /// <see cref="UIElement.AccessKey"/>, and <see cref="UIElement.KeyboardAccelerators"/>.
     /// Accepts <see cref="Control"/> so it can target both <see cref="ButtonBase"/>
     /// derivatives and WinUI controls that don't derive from ButtonBase

--- a/src/Reactor/Core/CommandBindings.cs
+++ b/src/Reactor/Core/CommandBindings.cs
@@ -18,7 +18,7 @@ internal static class CommandBindings
 {
     /// <summary>
     /// Applies command metadata that is common to every command-capable WinUI control:
-    /// <see cref="Control.IsEnabled"/>, <see cref="ToolTipService.ToolTip"/>,
+    /// <see cref="Control.IsEnabled"/>, <see cref="ToolTipService.ToolTipProperty"/>,
     /// <see cref="UIElement.AccessKey"/>, and <see cref="UIElement.KeyboardAccelerators"/>.
     /// Accepts <see cref="Control"/> so it can target both <see cref="ButtonBase"/>
     /// derivatives and WinUI controls that don't derive from ButtonBase

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -1412,10 +1412,10 @@ public record GridDefinition(string[] Columns, string[] Rows)
     /// <summary>
     /// Construct a <see cref="GridDefinition"/> from the strongly-typed
     /// <see cref="GridSize"/> form. Track strings are produced via
-    /// <see cref="GridSize.ToString"/> using <see cref="System.Globalization.CultureInfo.InvariantCulture"/>.
+    /// <see cref="GridSize.ToString"/> using <c>CultureInfo.InvariantCulture</c>.
     /// Spec 033 §1.
     /// </summary>
-    /// <exception cref="System.ArgumentNullException">Thrown when either array is null.</exception>
+    /// <exception cref="global::System.ArgumentNullException">Thrown when either array is null.</exception>
     public GridDefinition(GridSize[] columns, GridSize[] rows)
         : this(ToStrings(columns), ToStrings(rows))
     {
@@ -2412,7 +2412,7 @@ public abstract record TemplatedListElementBase : Element
     public abstract void ApplyControlSetters(object control);
     /// <summary>
     /// True when programmatic setter actions (.Set(...)) have been attached.
-    /// Used by <see cref="OwnPropsEqual"/> to suppress the reconcile-highlight
+    /// Used by <see cref="Element.OwnPropsEqual"/> to suppress the reconcile-highlight
     /// short-circuit so the overlay correctly tags the control as modified
     /// (and ApplyControlSetters keeps running on every reconcile pass).
     /// Virtual + default-false so external types deriving from this public

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -2841,7 +2841,7 @@ public sealed partial class Reconciler
     /// <summary>
     /// Mounts a zero-size hidden TextBlock for screen reader live-region announcements.
     /// The TextBlock is connected to the <see cref="AnnounceHandle"/> so that
-    /// <see cref="AnnounceHandle.Announce"/> can raise UIA notifications through it.
+    /// <see cref="AnnounceHandle.Announce(string)"/> can raise UIA notifications through it.
     /// </summary>
     private static UIElement MountAnnounceRegion(AnnounceRegionElement ann)
     {

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -3130,7 +3130,7 @@ public sealed partial class Reconciler : IDisposable
     /// Applies per-control resource overrides (lightweight styling) to a
     /// <see cref="FrameworkElement"/>. Literal values are set directly;
     /// <see cref="ThemeRef"/>-based values are resolved from
-    /// <see cref="Application.Current.Resources"/>.
+    /// <c>Application.Current.Resources</c>.
     /// </summary>
     private static void ApplyResourceOverrides(
         FrameworkElement fe,

--- a/src/Reactor/Core/WindowPersistedScope.cs
+++ b/src/Reactor/Core/WindowPersistedScope.cs
@@ -13,7 +13,7 @@ namespace Microsoft.UI.Reactor.Core;
 /// </summary>
 /// <remarks>
 /// Spec 033 §2. Bounded LRU (default capacity 1024). Window-scoped state is
-/// the recommended default for new <see cref="RenderContext.UsePersisted{T}"/>
+/// the recommended default for new <see cref="RenderContext.UsePersisted{T}(string, T)"/>
 /// calls because most apps want "preserved across an unmount/remount within
 /// this window" rather than "preserved across every window in the process."
 /// Memory-pressure registration is deliberately omitted — the lifetime is

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -239,7 +239,7 @@ public static class ElementExtensions
 
     /// <summary>
     /// Attaches a pan (single-finger translation) gesture recognizer. The reconciler
-    /// wires <see cref="FrameworkElement.ManipulationDelta"/> and computes
+    /// wires <see cref="UIElement.ManipulationDelta"/> and computes
     /// <see cref="UIElement.ManipulationMode"/> based on the chosen <paramref name="axis"/>
     /// and <paramref name="withInertia"/> flag. <paramref name="minimumDistance"/> gates
     /// callbacks until the cumulative translation exceeds that distance — on first

--- a/src/Reactor/Elements/GridSize.cs
+++ b/src/Reactor/Elements/GridSize.cs
@@ -7,7 +7,7 @@ namespace Microsoft.UI.Reactor;
 
 /// <summary>
 /// Strongly-typed grid track size, used by the typed
-/// <see cref="Microsoft.UI.Reactor.Factories.Grid(GridSize[], GridSize[], Element?[])"/>
+/// <c>Microsoft.UI.Reactor.Factories.Grid(GridSize[], GridSize[], Element?[])</c>
 /// factory in place of the legacy string-form (<c>"Auto"</c>, <c>"*"</c>,
 /// <c>"200"</c>, <c>"1.5*"</c>) tracks.
 /// </summary>

--- a/src/Reactor/Hooks/UseAnnounce.cs
+++ b/src/Reactor/Hooks/UseAnnounce.cs
@@ -6,8 +6,8 @@ using Microsoft.UI.Xaml.Controls;
 namespace Microsoft.UI.Reactor.Hooks;
 
 /// <summary>
-/// Handle returned by <see cref="UseAnnounceExtensions.UseAnnounce"/>.
-/// Provides an imperative <see cref="Announce"/> method for screen reader
+/// Handle returned by <see cref="UseAnnounceExtensions.UseAnnounce(Microsoft.UI.Reactor.Core.RenderContext)"/>.
+/// Provides an imperative <see cref="Announce(string)"/> method for screen reader
 /// live-region announcements plus a zero-size <see cref="Region"/> element
 /// that must be included somewhere in the component's rendered tree.
 /// </summary>

--- a/src/Reactor/Hooks/UseDevtools.cs
+++ b/src/Reactor/Hooks/UseDevtools.cs
@@ -8,7 +8,7 @@ public static class UseDevtoolsExtensions
     /// Returns <c>true</c> when the current process is running with the in-app
     /// devtools UI enabled. This is the AND of two independent signals:
     /// <list type="number">
-    ///   <item><see cref="ReactorApp.Run{TRoot}(string,int,int,bool,bool,bool,System.Action{ReactorHost}?)"/>
+    ///   <item><c>ReactorApp.Run&lt;TRoot&gt;</c>
     ///   was called with <c>devtools: true</c> (build-time capability gate).</item>
     ///   <item>The process was launched with <c>--devtools app</c> or
     ///   <c>--devtools run</c> (session-scoped opt-in by the user running the app).</item>

--- a/src/Reactor/Hooks/UseElementFocus.cs
+++ b/src/Reactor/Hooks/UseElementFocus.cs
@@ -7,7 +7,7 @@ namespace Microsoft.UI.Reactor.Hooks;
 /// <summary>
 /// Hook for imperative element focus (spec 027 Tier 5). Returns a stable
 /// <see cref="ElementRef"/> (survives re-renders) plus a <c>RequestFocus</c> action
-/// that schedules <see cref="FocusManager.Focus"/> on the UI dispatcher. Scheduling
+/// that schedules <see cref="Microsoft.UI.Reactor.Input.FocusManager.Focus"/> on the UI dispatcher. Scheduling
 /// defers focus past the current reconcile pass so callers can safely request focus
 /// from effects or event handlers without racing against layout.
 /// </summary>
@@ -16,7 +16,7 @@ public static class UseElementFocusExtensions
     /// <summary>
     /// Creates (or retrieves) a component-scoped <see cref="ElementRef"/> and pairs it
     /// with a <c>RequestFocus</c> action. Bind the ref to an element via <c>.Ref(ref)</c>.
-    /// Calling <c>RequestFocus</c> schedules <see cref="FocusManager.Focus"/> on the UI
+    /// Calling <c>RequestFocus</c> schedules <see cref="Microsoft.UI.Reactor.Input.FocusManager.Focus"/> on the UI
     /// dispatcher; if the ref's target has not mounted yet the call is a no-op.
     /// </summary>
     /// <example>

--- a/src/Reactor/Hooks/UseElementRef.cs
+++ b/src/Reactor/Hooks/UseElementRef.cs
@@ -13,7 +13,7 @@ namespace Microsoft.UI.Reactor.Hooks;
 /// <remarks>
 /// Spec 033 §3. The same <see cref="ElementRef{T}"/> instance is returned across
 /// re-renders (identity stable), so storing the ref in a deps array or comparing
-/// with <see cref="ReferenceEquals"/> is safe.
+/// with <see cref="object.ReferenceEquals"/> is safe.
 /// </remarks>
 /// <example>
 /// <code>

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -25,7 +25,7 @@ namespace Microsoft.UI.Reactor.Hooks;
 /// <para>
 /// <b>When to use:</b> tickers, log tables, observability dashboards, file
 /// lists, and other large readonly grids whose cell content is a pure
-/// function of <typeparamref name="T"/> plus a small set of declared
+/// function of the item type plus a small set of declared
 /// deps. <b>When not to use:</b> rows whose chrome depends on focus /
 /// drag / selection / hover state that you aren't capturing in deps.
 /// </para>

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -25,7 +25,7 @@ namespace Microsoft.UI.Reactor.Hooks;
 /// <para>
 /// <b>When to use:</b> tickers, log tables, observability dashboards, file
 /// lists, and other large readonly grids whose cell content is a pure
-/// function of the item type plus a small set of declared
+/// function of each item value plus a small set of declared
 /// deps. <b>When not to use:</b> rows whose chrome depends on focus /
 /// drag / selection / hover state that you aren't capturing in deps.
 /// </para>

--- a/src/Reactor/Hooks/UseMutation.cs
+++ b/src/Reactor/Hooks/UseMutation.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Reactor.Core;
 namespace Microsoft.UI.Reactor.Hooks;
 
 /// <summary>
-/// Callbacks and side-effects for <see cref="UseMutationExtensions.UseMutation{TInput,TResult}"/>.
+/// Callbacks and side-effects for the <c>UseMutation</c> hook.
 /// All callbacks are optional; all run on the dispatcher thread except <see cref="OnOptimistic"/>
 /// which runs synchronously on the caller of <see cref="Mutation{TInput,TResult}.RunAsync"/>
 /// — the typical case is a render-thread click handler, so the optimistic update lands in the
@@ -23,7 +23,7 @@ public sealed record MutationOptions<TInput, TResult>(
     string[]? InvalidateKeys = null);
 
 /// <summary>
-/// Handle returned by <see cref="UseMutationExtensions.UseMutation{TInput,TResult}"/>. Carries
+/// Handle returned by the <c>UseMutation</c> hook. Carries
 /// the pending/error/last-result state and the <see cref="RunAsync"/> entry point.
 /// </summary>
 /// <remarks>
@@ -87,6 +87,7 @@ public static class UseMutationExtensions
     /// Registers a <see cref="Mutation{TInput,TResult}"/> for this hook slot. The handle
     /// is stable across renders (pass it to buttons, context menus, etc.).
     /// </summary>
+    /// <param name="ctx">The render context (extension target).</param>
     /// <param name="mutator">The async write. Receives the caller's input and a token that
     /// fires on unmount. Rethrow <see cref="OperationCanceledException"/> to honour it.</param>
     /// <param name="cache">The cache whose keys to invalidate on success, or null to skip

--- a/src/Reactor/Hooks/UseResource.cs
+++ b/src/Reactor/Hooks/UseResource.cs
@@ -4,7 +4,7 @@ using Microsoft.UI.Reactor.Core;
 namespace Microsoft.UI.Reactor.Hooks;
 
 /// <summary>
-/// Tuning for <see cref="UseResourceExtensions.UseResource{T}"/>. Defaults mirror
+/// Tuning for the <c>UseResource</c> hook. Defaults mirror
 /// TanStack Query — zero <see cref="StaleTime"/> (always refetch-on-mount but dedup
 /// concurrent requests), five-minute <see cref="CacheTime"/>.
 /// </summary>

--- a/src/Reactor/Hosting/Devtools/SelectorResolver.cs
+++ b/src/Reactor/Hosting/Devtools/SelectorResolver.cs
@@ -243,7 +243,7 @@ internal sealed class SelectorResolver
     /// same visible-text surface that <c>tree</c> reports so the selector is
     /// consistent with what an agent reads from the tree — a Reactor
     /// <c>Button("Save", …)</c> can be selected by <c>[name='Save']</c> even
-    /// though WinUI doesn't auto-fill <see cref="AutomationProperties.NameProperty"/>.
+    /// though WinUI doesn't auto-fill the <c>AutomationProperties.Name</c> attached property.
     /// </summary>
     private static bool NameMatches(UIElement el, string value)
     {

--- a/src/Reactor/Hosting/Devtools/SelectorResolver.cs
+++ b/src/Reactor/Hosting/Devtools/SelectorResolver.cs
@@ -243,7 +243,7 @@ internal sealed class SelectorResolver
     /// same visible-text surface that <c>tree</c> reports so the selector is
     /// consistent with what an agent reads from the tree — a Reactor
     /// <c>Button("Save", …)</c> can be selected by <c>[name='Save']</c> even
-    /// though WinUI doesn't auto-fill <see cref="AutomationProperties.Name"/>.
+    /// though WinUI doesn't auto-fill <see cref="AutomationProperties.NameProperty"/>.
     /// </summary>
     private static bool NameMatches(UIElement el, string value)
     {

--- a/src/Reactor/Hosting/LayoutCost/ComponentSnapshot.cs
+++ b/src/Reactor/Hosting/LayoutCost/ComponentSnapshot.cs
@@ -17,24 +17,29 @@ internal readonly record struct ComponentIdentity(long Value)
 /// Handed to the overlay renderer and to <see cref="ILayoutCostReporter"/>
 /// consumers.
 /// </summary>
+/// <param name="Id">Identity of the Component.</param>
+/// <param name="DisplayName">Display name shown in the overlay and reporters.</param>
+/// <param name="AuthoredElementCount">Authored UIElement count (what the Component declared). -1 for the chrome bucket.</param>
+/// <param name="RenderedElementCount">Rendered UIElement count this frame (what WinUI actually materialized under the subtree).</param>
+/// <param name="Depth">Depth of this Component in the Component tree — used by spatial attribution for innermost-match.</param>
+/// <param name="EmaLayoutMs">Exponentially-moving-average of inclusive measure + arrange time in milliseconds.</param>
+/// <param name="LastFrameMs">Most recent frame's raw (un-smoothed) measure+arrange time in ms. Sparkline source.</param>
+/// <param name="FrameMeasureTicks">Most recent frame's inclusive measure time in ticks (100 ns).</param>
+/// <param name="FrameArrangeTicks">Most recent frame's inclusive arrange time in ticks (100 ns).</param>
+/// <param name="SubtreeX">Root-relative X of the Component's subtree bounding rect.</param>
+/// <param name="SubtreeY">Root-relative Y of the Component's subtree bounding rect.</param>
+/// <param name="SubtreeW">Width of the Component's subtree bounding rect.</param>
+/// <param name="SubtreeH">Height of the Component's subtree bounding rect.</param>
 internal readonly record struct ComponentSnapshot(
     ComponentIdentity Id,
     string DisplayName,
-    /// <summary>Authored UIElement count (what the Component declared). -1 for the chrome bucket.</summary>
     int AuthoredElementCount,
-    /// <summary>Rendered UIElement count this frame (what WinUI actually materialized under the subtree).</summary>
     int RenderedElementCount,
-    /// <summary>Depth of this Component in the Component tree — used by spatial attribution for innermost-match.</summary>
     int Depth,
-    /// <summary>Exponentially-moving-average of inclusive measure + arrange time in milliseconds.</summary>
     double EmaLayoutMs,
-    /// <summary>Most recent frame's raw (un-smoothed) measure+arrange time in ms. Sparkline source.</summary>
     double LastFrameMs,
-    /// <summary>Most recent frame's inclusive measure time in ticks (100 ns).</summary>
     long FrameMeasureTicks,
-    /// <summary>Most recent frame's inclusive arrange time in ticks (100 ns).</summary>
     long FrameArrangeTicks,
-    /// <summary>Root-relative bounding rect of the Component's subtree.</summary>
     float SubtreeX,
     float SubtreeY,
     float SubtreeW,

--- a/src/Reactor/Input/DragOperations.cs
+++ b/src/Reactor/Input/DragOperations.cs
@@ -2,7 +2,7 @@ namespace Microsoft.UI.Reactor.Input;
 
 /// <summary>
 /// Drag-and-drop operation flags. Source declares what it allows via
-/// <see cref="ElementExtensions.OnDragStart"/>; target negotiates the final
+/// <c>ElementExtensions.OnDragStart</c>; target negotiates the final
 /// operation by setting <see cref="DragTargetArgs.AcceptedOperation"/>.
 /// </summary>
 [Flags]

--- a/src/Reactor/Input/DragTargetArgs.cs
+++ b/src/Reactor/Input/DragTargetArgs.cs
@@ -7,7 +7,7 @@ namespace Microsoft.UI.Reactor.Input;
 /// <summary>
 /// Mutable hooks on <see cref="DragTargetArgs.UIOverride"/> that let drag-over handlers
 /// tweak the drop indicator (caption, glyph, preview). Values written here are applied
-/// by the reconciler onto the underlying WinUI <see cref="DragUIOverride"/> after the
+/// by the reconciler onto the underlying WinUI <c>Windows.ApplicationModel.DataTransfer.DragDrop.DragUIOverride</c> after the
 /// user callback returns.
 /// </summary>
 public sealed class DragUIOverrideHandle

--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -33,6 +33,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Suppress missing-XML-doc warnings on public API. The .xml doc file
+         still ships whatever comments do exist; we just don't gate the
+         build on documenting every public member. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Fixes 47 unique XML doc bugs across `src/Reactor` (~25 files): broken crefs, ambiguous overload references, invalid cref nullable syntax, malformed XML, mismatched `param`/`typeparamref` tags, and misplaced doc comments on positional record parameters.
- Registers `REACTOR_A11Y_001/002/003` in `AnalyzerReleases.Unshipped.md` (RS2000) and drops a trailing period from a `HookRulesAnalyzer` diagnostic message (RS1032).
- Suppresses CS1591 (missing-XML-doc) at the Reactor project level. `GenerateDocumentationFile=true` was added in #131 so the NuGet package ships an `.xml` doc sidecar; that flipped on CS1591 across the entire public surface (~4650 warnings) without an explicit decision to document every member. The earlier draft of the same packaging work (`nm/nuget-packaging`, unmerged) had `<NoWarn>$(NoWarn);CS1591</NoWarn>` paired with the doc-file enablement for exactly this reason — restoring that pairing here.
- Build: **4761 → 11** warnings, **0 errors**. The 11 remaining warnings are all `REACTOR_A11Y_xxx` from `samples/apps/a11y-showcase/`, which are intentional (the sample exists to demonstrate the analyzer firing — its source explicitly says "DO NOT FIX THE ACCESSIBILITY ISSUES IN THIS FILE").

## Warning codes resolved
| Code | Count | What |
|---|---|---|
| CS1591 | 4650 | missing XML doc on public member (suppressed at project level) |
| CS1574 | 34 | broken `cref` (unresolved type/member) |
| CS0419 | 16 | ambiguous `cref` (multiple matching overloads) |
| CS1587 | 16 | doc comment on positional record param |
| CS1573 | 10 | parameter has no matching `<param>` tag |
| CS1734 | 6 | `<paramref>` with no matching parameter |
| CS1580 | 4 | invalid type for parameter in `cref` |
| CS1570 | 4 | malformed XML |
| CS1735 | 2 | invalid `<typeparamref>` |
| CS1572 | 2 | `<param>` with no matching parameter |
| RS2000 | 6 | analyzer rule not in release-tracking file |
| RS1032 | 2 | diagnostic message format |

## Test plan
- [ ] `dotnet build Reactor.sln` — confirm 0 errors and 11 warnings (all `REACTOR_A11Y_xxx` from the showcase sample)
- [ ] `dotnet test tests/Reactor.Tests` — unit tests still green
- [ ] `dotnet test tests/Reactor.SelfTests` — selftests still green
- [ ] Spot-check `dotnet pack src/Reactor/Reactor.csproj` — `.nupkg` still includes `Reactor.xml` (suppressing CS1591 doesn't disable doc-file generation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)