### PR TITLE
fix(selftest): stabilize Mutation_Completed and GotFocus_FiresOnA

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoverageBoostFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoverageBoostFixtures.cs
@@ -600,6 +600,10 @@ internal static class CoverageBoostFixtures
 
             H.ClickButton("Mutate");
             await Harness.Render(100);
+            // The mutation's RunAsync resolves during the 100ms wall-clock wait
+            // and schedules a re-render that may not have flushed before
+            // Render(100) returns. Pump once more to drain the queued re-render.
+            await Harness.Render();
             H.Check("Mutation_Completed", H.FindText("Mutation:done:test") is not null);
         }
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PointerModifierFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PointerModifierFixtures.cs
@@ -127,10 +127,15 @@ internal static class PointerModifierFixtures
             H.Check("GotLostFocus_ControlsFound", tbA is not null && tbB is not null);
 
             tbA?.Focus(FocusState.Programmatic);
+            // GotFocus can be raised via the dispatcher rather than synchronously
+            // in Focus() (same shape as the TabView/RadioButtons/PasswordBox flake
+            // fixed in #139/#149). Pump twice so the queued event lands.
+            await Harness.Render();
             await Harness.Render();
             H.Check("GotFocus_FiresOnA", gotA == 1 && lostA == 0);
 
             tbB?.Focus(FocusState.Programmatic);
+            await Harness.Render();
             await Harness.Render();
             H.Check("LostFocus_FiresOnA", lostA == 1);
             H.Check("GotFocus_FiresOnB", gotB == 1);


### PR DESCRIPTION
## Summary

Two flake clusters surfaced in a 100x `Reactor.AppTests.Host --self-test` sweep on top of #149.

- **`Mutation_Completed`** (`CovBoost_ComponentUseMutation`) — the `useMutation` `RunAsync` resolves during the 100 ms wall-clock wait inside `Harness.Render(100)` and schedules a re-render that may not flush before `Render(100)` returns. Pump once more to drain the queued re-render. Same shape as the `Resource_FetchedData` fix in #149.

- **`GotFocus_FiresOnA`** (`PointerMod_GotLostFocusFires`) — `TextBox.Focus()` can raise `GotFocus` via the dispatcher rather than synchronously, like TabView/RadioButtons/PasswordBox before it (#139/#149). Pump twice between `Focus()` and the counter assertion so the queued event lands. Applied to both focus transitions in the fixture.

## Verification

| Sweep | Build | Failures | Notes |
|---|---|---|---|
| `run100` | on top of #149 | **3/100** | `Mutation_Completed` ×2 (runs 020, 081) and `GotFocus_FiresOnA` ×1 (run 076) |
| `run100v2` | this branch | **0/100** | 65 000 fixture executions, all green |

## Test plan

- [x] Local 100x `--self-test` sweep on this branch: 0/100 failures
- [ ] CI Selftests job green on the PR
- [ ] CI Unit Tests job green (or rerun if the unrelated `WaitForState` 5 s-timeout flake recurs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)