### PR TITLE
perf(reconciler): unblock fast-path for Setters; fix CommandHost ambient chord-tooltip leak

### DIFF
--- a/samples/apps/demo-script-tool/App/Components/DemoPromptPanel.cs
+++ b/samples/apps/demo-script-tool/App/Components/DemoPromptPanel.cs
@@ -8,10 +8,15 @@ public sealed record DemoPromptPanelProps(
     System.Action<string> OnPromptChanged,
     System.Action<string> OnTitleChanged)
 {
-    // Manual Equals: callback delegates are excluded from memo equality. Their
-    // identity is fresh each parent render but dispatch always reads the latest
-    // value, so identity isn't load-bearing. Including them here would force a
-    // re-render on every parent render. Framework-level fix tracked at #151.
+    // Manual Equals: callback delegates are excluded from memo equality. They
+    // get a fresh delegate identity each parent render. SAFETY CONTRACT: when
+    // memo decides "skip render", Reactor does NOT refresh Props on the child,
+    // so the child continues to dispatch through the *prior* delegates. That's
+    // only safe when the callbacks' captured state doesn't change between
+    // renders, OR any state they capture is reflected in one of the data
+    // fields below. Both hold today: callbacks close over `model` (UseRef-
+    // stable identity); Model changes flow via reference identity below.
+    // Framework-level fix tracked at #151.
     public bool Equals(DemoPromptPanelProps? other) =>
         other is not null && ReferenceEquals(Model, other.Model);
     public override int GetHashCode() => Model.GetHashCode();

--- a/samples/apps/demo-script-tool/App/Components/DemoPromptPanel.cs
+++ b/samples/apps/demo-script-tool/App/Components/DemoPromptPanel.cs
@@ -6,7 +6,16 @@ namespace DemoScriptTool.App.Components;
 public sealed record DemoPromptPanelProps(
     DemoScriptModel Model,
     System.Action<string> OnPromptChanged,
-    System.Action<string> OnTitleChanged);
+    System.Action<string> OnTitleChanged)
+{
+    // Manual Equals: callback delegates are excluded from memo equality. Their
+    // identity is fresh each parent render but dispatch always reads the latest
+    // value, so identity isn't load-bearing. Including them here would force a
+    // re-render on every parent render. Framework-level fix tracked at #151.
+    public bool Equals(DemoPromptPanelProps? other) =>
+        other is not null && ReferenceEquals(Model, other.Model);
+    public override int GetHashCode() => Model.GetHashCode();
+}
 
 /// <summary>
 /// Top-of-body region binding to <c>## Demo Prompt</c>. The text-area writes

--- a/samples/apps/demo-script-tool/App/Components/StepCard.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepCard.cs
@@ -16,7 +16,21 @@ public sealed record StepCardProps(
     Action<StepModel> OnRun,
     Action<StepModel> OnCopyDelta,
     Action<StepModel> OnDelete,
-    Action<StepModel> OnRegenFromHere);
+    Action<StepModel> OnRegenFromHere)
+{
+    // Manual Equals: callback delegates are excluded from memo equality. Their
+    // identity is fresh each parent render but dispatch always reads the latest
+    // value, so identity isn't load-bearing. Including them here would re-render
+    // every card on every shell render. Framework-level fix tracked at #151.
+    public bool Equals(StepCardProps? other) =>
+        other is not null
+        && ReferenceEquals(Step, other.Step)
+        && ReferenceEquals(PriorStep, other.PriorStep)
+        && TotalSteps == other.TotalSteps
+        && IsGenerating == other.IsGenerating;
+    public override int GetHashCode() =>
+        HashCode.Combine(Step, PriorStep, TotalSteps, IsGenerating);
+}
 
 /// <summary>
 /// One step rendered as a three-column card: prompt | code | actions

--- a/samples/apps/demo-script-tool/App/Components/StepCard.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepCard.cs
@@ -18,10 +18,18 @@ public sealed record StepCardProps(
     Action<StepModel> OnDelete,
     Action<StepModel> OnRegenFromHere)
 {
-    // Manual Equals: callback delegates are excluded from memo equality. Their
-    // identity is fresh each parent render but dispatch always reads the latest
-    // value, so identity isn't load-bearing. Including them here would re-render
-    // every card on every shell render. Framework-level fix tracked at #151.
+    // Manual Equals: callback delegates are excluded from memo equality. They
+    // get a fresh delegate identity each parent render (local functions in
+    // DemoScriptShell.Render), and including them here would re-render every
+    // card on every shell render. SAFETY CONTRACT: when memo decides "skip
+    // render", Reactor does NOT refresh Props on the child, so the child
+    // continues to dispatch through the *prior* delegates. That's only safe
+    // when the callbacks' captured state doesn't change between renders, OR
+    // when any state they capture is also reflected in one of the data
+    // fields below (so a meaningful change forces a refresh). Both hold for
+    // these callbacks today: they close over `model` (UseRef-stable identity)
+    // and per-step actions; per-step state changes show up via Step / PriorStep
+    // identity. Framework-level fix tracked at #151.
     public bool Equals(StepCardProps? other) =>
         other is not null
         && ReferenceEquals(Step, other.Step)

--- a/samples/apps/demo-script-tool/App/Components/StepsPanel.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepsPanel.cs
@@ -15,7 +15,17 @@ public sealed record StepsPanelProps(
     Action<StepModel> OnCopyDelta,
     Action OnAddStep,
     Action<StepModel> OnDeleteStep,
-    Action<StepModel> OnRegenFromStep);
+    Action<StepModel> OnRegenFromStep)
+{
+    // Manual Equals: callback delegates are excluded from memo equality. Their
+    // identity is fresh each parent render but dispatch always reads the latest
+    // value, so identity isn't load-bearing. Framework-level fix tracked at #151.
+    public bool Equals(StepsPanelProps? other) =>
+        other is not null
+        && ReferenceEquals(Model, other.Model)
+        && IsGenerating == other.IsGenerating;
+    public override int GetHashCode() => HashCode.Combine(Model, IsGenerating);
+}
 
 /// <summary>
 /// Vertical scroller of <see cref="StepCard"/> instances keyed by step number.

--- a/samples/apps/demo-script-tool/App/Components/StepsPanel.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepsPanel.cs
@@ -17,9 +17,16 @@ public sealed record StepsPanelProps(
     Action<StepModel> OnDeleteStep,
     Action<StepModel> OnRegenFromStep)
 {
-    // Manual Equals: callback delegates are excluded from memo equality. Their
-    // identity is fresh each parent render but dispatch always reads the latest
-    // value, so identity isn't load-bearing. Framework-level fix tracked at #151.
+    // Manual Equals: callback delegates are excluded from memo equality. They
+    // get a fresh delegate identity each parent render (local functions in
+    // DemoScriptShell.Render). SAFETY CONTRACT: when memo decides "skip render",
+    // Reactor does NOT refresh Props on the child, so the child continues to
+    // dispatch through the *prior* delegates. That's only safe when the
+    // callbacks' captured state doesn't change between renders, OR any state
+    // they capture is reflected in one of the data fields below. Both hold
+    // today: callbacks close over `model` (UseRef-stable identity) and
+    // observable Model changes show up via reference identity. Framework-level
+    // fix tracked at #151.
     public bool Equals(StepsPanelProps? other) =>
         other is not null
         && ReferenceEquals(Model, other.Model)

--- a/src/Reactor/Core/CommandBindings.cs
+++ b/src/Reactor/Core/CommandBindings.cs
@@ -67,6 +67,20 @@ internal static class CommandBindings
         }
         if (cmd.Accelerator is not null)
         {
+            // Set placement mode BEFORE adding the accelerator. WinUI captures the
+            // auto-tooltip-generation decision at the moment the accelerator is
+            // added; setting mode=Hidden afterward didn't reliably clear the
+            // already-generated chord tooltip ("Ctrl+O") on x64-emulated WinUI 3
+            // self-contained — it could persist and stick when the UI thread was
+            // briefly busy. Setting mode first keeps the auto tooltip from ever
+            // being generated. Callers that want the chord visible set
+            // cmd.Description — WinUI shows that as the explicit tooltip and the
+            // chord remains discoverable via the keyboard hint overlay.
+            if (cmd.Description is null)
+                btn.KeyboardAcceleratorPlacementMode = KeyboardAcceleratorPlacementMode.Hidden;
+            else
+                btn.ClearValue(UIElement.KeyboardAcceleratorPlacementModeProperty);
+
             var accel = new KeyboardAccelerator
             {
                 Key = cmd.Accelerator.Key,
@@ -74,19 +88,6 @@ internal static class CommandBindings
             };
             btn.KeyboardAccelerators.Add(accel);
             _commandAccelerators.Add(btn, accel);
-
-            // Suppress WinUI's auto-generated bare-chord tooltip ("Ctrl+O") when
-            // the command has no Description to anchor it. Without a label, the
-            // floating "Ctrl+O" tooltip is uninformative on its own, and has been
-            // observed to stick on screen when the UI thread is briefly busy
-            // (the dismiss animation can't run). Callers that want the chord
-            // visible should set cmd.Description ("Open Folder", say) — WinUI
-            // shows that as the explicit tooltip and the chord remains
-            // discoverable via the keyboard hint overlay.
-            if (cmd.Description is null)
-                btn.KeyboardAcceleratorPlacementMode = KeyboardAcceleratorPlacementMode.Hidden;
-            else
-                btn.ClearValue(UIElement.KeyboardAcceleratorPlacementModeProperty);
         }
         else
         {

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -220,7 +220,7 @@ public abstract record Element
                 && ta.Weight == tb.Weight
                 && ta.FontStyle == tb.FontStyle
                 && ta.HorizontalAlignment == tb.HorizontalAlignment
-                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+                && ReferenceEquals(ta.Setters, tb.Setters),
 
             // Callbacks (OnClick, OnChanged, etc.) are intentionally not compared:
             // dispatch goes through the Tag trampoline, and the Update.cs skip path
@@ -231,23 +231,23 @@ public abstract record Element
                 ba.Label == bb.Label
                 && ba.IsEnabled == bb.IsEnabled
                 && ba.ContentElement is null && bb.ContentElement is null
-                && ba.Setters.Length == 0 && bb.Setters.Length == 0,
+                && ReferenceEquals(ba.Setters, bb.Setters),
 
             (HyperlinkButtonElement ha, HyperlinkButtonElement hb) =>
                 ha.Content == hb.Content
                 && ha.NavigateUri == hb.NavigateUri
-                && ha.Setters.Length == 0 && hb.Setters.Length == 0,
+                && ReferenceEquals(ha.Setters, hb.Setters),
 
             (RepeatButtonElement ra, RepeatButtonElement rb) =>
                 ra.Label == rb.Label
                 && ra.Delay == rb.Delay
                 && ra.Interval == rb.Interval
-                && ra.Setters.Length == 0 && rb.Setters.Length == 0,
+                && ReferenceEquals(ra.Setters, rb.Setters),
 
             (ToggleButtonElement ta, ToggleButtonElement tb) =>
                 ta.Label == tb.Label
                 && ta.IsChecked == tb.IsChecked
-                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+                && ReferenceEquals(ta.Setters, tb.Setters),
 
             (SliderElement sa, SliderElement sb) =>
                 sa.Value == sb.Value
@@ -255,27 +255,27 @@ public abstract record Element
                 && sa.Max == sb.Max
                 && sa.StepFrequency == sb.StepFrequency
                 && sa.Header == sb.Header
-                && sa.Setters.Length == 0 && sb.Setters.Length == 0,
+                && ReferenceEquals(sa.Setters, sb.Setters),
 
             (ToggleSwitchElement ta, ToggleSwitchElement tb) =>
                 ta.IsOn == tb.IsOn
                 && ta.OnContent == tb.OnContent
                 && ta.OffContent == tb.OffContent
                 && ta.Header == tb.Header
-                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+                && ReferenceEquals(ta.Setters, tb.Setters),
 
             (CheckBoxElement ca, CheckBoxElement cb) =>
                 ca.IsChecked == cb.IsChecked
                 && ca.Label == cb.Label
                 && ca.IsThreeState == cb.IsThreeState
                 && ca.CheckedState == cb.CheckedState
-                && ca.Setters.Length == 0 && cb.Setters.Length == 0,
+                && ReferenceEquals(ca.Setters, cb.Setters),
 
             (RadioButtonElement ra, RadioButtonElement rb) =>
                 ra.Label == rb.Label
                 && ra.IsChecked == rb.IsChecked
                 && ra.GroupName == rb.GroupName
-                && ra.Setters.Length == 0 && rb.Setters.Length == 0,
+                && ReferenceEquals(ra.Setters, rb.Setters),
 
             (ComboBoxElement ca, ComboBoxElement cb) =>
                 ReferenceEquals(ca.Items, cb.Items)
@@ -284,7 +284,7 @@ public abstract record Element
                 && ca.Header == cb.Header
                 && ca.IsEditable == cb.IsEditable
                 && ReferenceEquals(ca.ItemElements, cb.ItemElements)
-                && ca.Setters.Length == 0 && cb.Setters.Length == 0,
+                && ReferenceEquals(ca.Setters, cb.Setters),
 
             (TextFieldElement ta, TextFieldElement tb) =>
                 ta.Value == tb.Value
@@ -295,7 +295,7 @@ public abstract record Element
                 && ta.TextWrapping == tb.TextWrapping
                 && ta.SelectionStart == tb.SelectionStart
                 && ta.SelectionLength == tb.SelectionLength
-                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+                && ReferenceEquals(ta.Setters, tb.Setters),
 
             (NumberBoxElement na, NumberBoxElement nb) =>
                 na.Value == nb.Value
@@ -306,12 +306,12 @@ public abstract record Element
                 && na.Header == nb.Header
                 && na.PlaceholderText == nb.PlaceholderText
                 && na.SpinButtonPlacement == nb.SpinButtonPlacement
-                && na.Setters.Length == 0 && nb.Setters.Length == 0,
+                && ReferenceEquals(na.Setters, nb.Setters),
 
             (PasswordBoxElement pa, PasswordBoxElement pb) =>
                 pa.Password == pb.Password
                 && pa.PlaceholderText == pb.PlaceholderText
-                && pa.Setters.Length == 0 && pb.Setters.Length == 0,
+                && ReferenceEquals(pa.Setters, pb.Setters),
 
             (ProgressElement pa, ProgressElement pb) =>
                 pa.Value == pb.Value
@@ -319,24 +319,24 @@ public abstract record Element
                 && pa.Maximum == pb.Maximum
                 && pa.ShowError == pb.ShowError
                 && pa.ShowPaused == pb.ShowPaused
-                && pa.Setters.Length == 0 && pb.Setters.Length == 0,
+                && ReferenceEquals(pa.Setters, pb.Setters),
 
             (ProgressRingElement pa, ProgressRingElement pb) =>
                 pa.Value == pb.Value
                 && pa.Minimum == pb.Minimum
                 && pa.Maximum == pb.Maximum
                 && pa.IsActive == pb.IsActive
-                && pa.Setters.Length == 0 && pb.Setters.Length == 0,
+                && ReferenceEquals(pa.Setters, pb.Setters),
 
             (ImageElement ia, ImageElement ib) =>
                 ia.Source == ib.Source
-                && ia.Setters.Length == 0 && ib.Setters.Length == 0,
+                && ReferenceEquals(ia.Setters, ib.Setters),
 
             (RectangleElement ra, RectangleElement rb) =>
-                ra.Setters.Length == 0 && rb.Setters.Length == 0,
+                ReferenceEquals(ra.Setters, rb.Setters),
 
             (EllipseElement ea, EllipseElement eb) =>
-                ea.Setters.Length == 0 && eb.Setters.Length == 0,
+                ReferenceEquals(ea.Setters, eb.Setters),
 
             (RichTextBlockElement ra, RichTextBlockElement rb) =>
                 ra.Text == rb.Text
@@ -344,7 +344,7 @@ public abstract record Element
                 && ra.IsTextSelectionEnabled == rb.IsTextSelectionEnabled
                 && ra.TextWrapping == rb.TextWrapping
                 && ParagraphsEqual(ra.Paragraphs, rb.Paragraphs)
-                && ra.Setters.Length == 0 && rb.Setters.Length == 0,
+                && ReferenceEquals(ra.Setters, rb.Setters),
 
             // Container elements: compare own props + children by reference.
             // Same children reference = truly unchanged subtree = safe to skip entirely.
@@ -355,7 +355,7 @@ public abstract record Element
                 && sa.HorizontalAlignment == sb.HorizontalAlignment
                 && sa.VerticalAlignment == sb.VerticalAlignment
                 && ReferenceEquals(sa.Children, sb.Children)
-                && sa.Setters.Length == 0 && sb.Setters.Length == 0,
+                && ReferenceEquals(sa.Setters, sb.Setters),
 
             (BorderElement ba, BorderElement bb) =>
                 BrushesEqual(ba.Background, bb.Background)
@@ -364,14 +364,14 @@ public abstract record Element
                 && ba.Padding == bb.Padding
                 && ba.BorderThickness == bb.BorderThickness
                 && ReferenceEquals(ba.Child, bb.Child)
-                && ba.Setters.Length == 0 && bb.Setters.Length == 0,
+                && ReferenceEquals(ba.Setters, bb.Setters),
 
             (GridElement ga, GridElement gb) =>
                 ga.RowSpacing == gb.RowSpacing
                 && ga.ColumnSpacing == gb.ColumnSpacing
                 && ReferenceEquals(ga.Definition, gb.Definition)
                 && ReferenceEquals(ga.Children, gb.Children)
-                && ga.Setters.Length == 0 && gb.Setters.Length == 0,
+                && ReferenceEquals(ga.Setters, gb.Setters),
 
             (ScrollViewElement sva, ScrollViewElement svb) =>
                 sva.Orientation == svb.Orientation
@@ -381,7 +381,7 @@ public abstract record Element
                 && sva.VerticalScrollMode == svb.VerticalScrollMode
                 && sva.ZoomMode == svb.ZoomMode
                 && ReferenceEquals(sva.Child, svb.Child)
-                && sva.Setters.Length == 0 && svb.Setters.Length == 0,
+                && ReferenceEquals(sva.Setters, svb.Setters),
 
             (FlexElement fa, FlexElement fb) =>
                 fa.Direction == fb.Direction
@@ -393,7 +393,7 @@ public abstract record Element
                 && fa.RowGap == fb.RowGap
                 && fa.FlexPadding == fb.FlexPadding
                 && ReferenceEquals(fa.Children, fb.Children)
-                && fa.Setters.Length == 0 && fb.Setters.Length == 0,
+                && ReferenceEquals(fa.Setters, fb.Setters),
 
             (EmptyElement, EmptyElement) => true,
 
@@ -426,13 +426,13 @@ public abstract record Element
                 && sa.Spacing == sb.Spacing
                 && sa.HorizontalAlignment == sb.HorizontalAlignment
                 && sa.VerticalAlignment == sb.VerticalAlignment
-                && sa.Setters.Length == 0 && sb.Setters.Length == 0,
+                && ReferenceEquals(sa.Setters, sb.Setters),
 
             (Core.GridElement ga, Core.GridElement gb) =>
                 ga.RowSpacing == gb.RowSpacing
                 && ga.ColumnSpacing == gb.ColumnSpacing
                 && ReferenceEquals(ga.Definition, gb.Definition)
-                && ga.Setters.Length == 0 && gb.Setters.Length == 0,
+                && ReferenceEquals(ga.Setters, gb.Setters),
 
             (BorderElement ba, BorderElement bb) =>
                 BrushesEqual(ba.Background, bb.Background)
@@ -440,7 +440,7 @@ public abstract record Element
                 && ba.CornerRadius == bb.CornerRadius
                 && ba.Padding == bb.Padding
                 && ba.BorderThickness == bb.BorderThickness
-                && ba.Setters.Length == 0 && bb.Setters.Length == 0,
+                && ReferenceEquals(ba.Setters, bb.Setters),
 
             (ScrollViewElement sva, ScrollViewElement svb) =>
                 sva.Orientation == svb.Orientation
@@ -449,7 +449,7 @@ public abstract record Element
                 && sva.HorizontalScrollMode == svb.HorizontalScrollMode
                 && sva.VerticalScrollMode == svb.VerticalScrollMode
                 && sva.ZoomMode == svb.ZoomMode
-                && sva.Setters.Length == 0 && svb.Setters.Length == 0,
+                && ReferenceEquals(sva.Setters, svb.Setters),
 
             (FlexElement fa, FlexElement fb) =>
                 fa.Direction == fb.Direction
@@ -460,23 +460,23 @@ public abstract record Element
                 && fa.ColumnGap == fb.ColumnGap
                 && fa.RowGap == fb.RowGap
                 && fa.FlexPadding == fb.FlexPadding
-                && fa.Setters.Length == 0 && fb.Setters.Length == 0,
+                && ReferenceEquals(fa.Setters, fb.Setters),
 
             (CanvasElement ca, CanvasElement cb) =>
-                ca.Setters.Length == 0 && cb.Setters.Length == 0,
+                ReferenceEquals(ca.Setters, cb.Setters),
 
             (WrapGridElement wa, WrapGridElement wb) =>
                 wa.Orientation == wb.Orientation
                 && wa.ItemWidth == wb.ItemWidth
                 && wa.ItemHeight == wb.ItemHeight
                 && wa.MaximumRowsOrColumns == wb.MaximumRowsOrColumns
-                && wa.Setters.Length == 0 && wb.Setters.Length == 0,
+                && ReferenceEquals(wa.Setters, wb.Setters),
 
             (RelativePanelElement ra, RelativePanelElement rb) =>
-                ra.Setters.Length == 0 && rb.Setters.Length == 0,
+                ReferenceEquals(ra.Setters, rb.Setters),
 
             (ViewboxElement va, ViewboxElement vb) =>
-                va.Setters.Length == 0 && vb.Setters.Length == 0,
+                ReferenceEquals(va.Setters, vb.Setters),
 
             // Structural wrappers that only contain children
             (NavigationHostElement, NavigationHostElement) => true,
@@ -494,7 +494,7 @@ public abstract record Element
                 && ta.IsBackButtonVisible == tb.IsBackButtonVisible
                 && ta.IsBackButtonEnabled == tb.IsBackButtonEnabled
                 && ta.IsPaneToggleButtonVisible == tb.IsPaneToggleButtonVisible
-                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+                && ReferenceEquals(ta.Setters, tb.Setters),
 
             // Pure composition wrappers — they never write their own WinUI
             // properties; their rendered output is diffed separately. Returning
@@ -525,56 +525,56 @@ public abstract record Element
                 && ca.PlaceholderText == cb.PlaceholderText
                 && ca.Header == cb.Header
                 && ca.IsEditable == cb.IsEditable
-                && ca.Setters.Length == 0 && cb.Setters.Length == 0,
+                && ReferenceEquals(ca.Setters, cb.Setters),
 
             (ListViewElement la, ListViewElement lb) =>
                 la.SelectedIndex == lb.SelectedIndex
                 && la.SelectionMode == lb.SelectionMode
                 && la.Header == lb.Header
-                && la.Setters.Length == 0 && lb.Setters.Length == 0,
+                && ReferenceEquals(la.Setters, lb.Setters),
 
             (GridViewElement ga, GridViewElement gb) =>
                 ga.SelectedIndex == gb.SelectedIndex
                 && ga.SelectionMode == gb.SelectionMode
                 && ga.Header == gb.Header
-                && ga.Setters.Length == 0 && gb.Setters.Length == 0,
+                && ReferenceEquals(ga.Setters, gb.Setters),
 
             (FlipViewElement fa, FlipViewElement fb) =>
                 fa.SelectedIndex == fb.SelectedIndex
-                && fa.Setters.Length == 0 && fb.Setters.Length == 0,
+                && ReferenceEquals(fa.Setters, fb.Setters),
 
             (PivotElement pa, PivotElement pb) =>
                 pa.SelectedIndex == pb.SelectedIndex
                 && pa.Title == pb.Title
-                && pa.Setters.Length == 0 && pb.Setters.Length == 0,
+                && ReferenceEquals(pa.Setters, pb.Setters),
 
             (TabViewElement ta, TabViewElement tb) =>
                 ta.SelectedIndex == tb.SelectedIndex
                 && ta.IsAddTabButtonVisible == tb.IsAddTabButtonVisible
-                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+                && ReferenceEquals(ta.Setters, tb.Setters),
 
             (TreeViewElement ta, TreeViewElement tb) =>
                 ta.SelectionMode == tb.SelectionMode
                 && ta.CanDragItems == tb.CanDragItems
                 && ta.AllowDrop == tb.AllowDrop
                 && ta.CanReorderItems == tb.CanReorderItems
-                && ta.Setters.Length == 0 && tb.Setters.Length == 0,
+                && ReferenceEquals(ta.Setters, tb.Setters),
 
             (SelectorBarElement sa, SelectorBarElement sb) =>
                 sa.SelectedIndex == sb.SelectedIndex
-                && sa.Setters.Length == 0 && sb.Setters.Length == 0,
+                && ReferenceEquals(sa.Setters, sb.Setters),
 
             (ListBoxElement la, ListBoxElement lb) =>
                 la.SelectedIndex == lb.SelectedIndex
-                && la.Setters.Length == 0 && lb.Setters.Length == 0,
+                && ReferenceEquals(la.Setters, lb.Setters),
 
             (RadioButtonsElement ra, RadioButtonsElement rb) =>
                 ra.SelectedIndex == rb.SelectedIndex
                 && ra.Header == rb.Header
-                && ra.Setters.Length == 0 && rb.Setters.Length == 0,
+                && ReferenceEquals(ra.Setters, rb.Setters),
 
             (BreadcrumbBarElement ba, BreadcrumbBarElement bb) =>
-                ba.Setters.Length == 0 && bb.Setters.Length == 0,
+                ReferenceEquals(ba.Setters, bb.Setters),
 
             // Templated (data-driven) collections: own props are the WinUI
             // properties UpdateTemplatedXxx writes back. Items + ViewBuilder
@@ -597,8 +597,8 @@ public abstract record Element
                 la.Orientation == lb.Orientation
                 && la.Spacing == lb.Spacing
                 && la.EstimatedItemSize == lb.EstimatedItemSize
-                && la.ScrollViewerSetters.Length == 0 && lb.ScrollViewerSetters.Length == 0
-                && la.RepeaterSetters.Length == 0 && lb.RepeaterSetters.Length == 0,
+                && ReferenceEquals(la.ScrollViewerSetters, lb.ScrollViewerSetters)
+                && ReferenceEquals(la.RepeaterSetters, lb.RepeaterSetters),
 
             // Non-container / leaf types: return false → always captured
             _ => false,

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -1762,6 +1762,16 @@ public sealed partial class Reconciler
 
     private static void AddCommandHostAccelerators(WinUI.Grid host, Command[] commands)
     {
+        // Suppress WinUI's auto-generated chord tooltip on the host Grid. Without
+        // this, accelerators registered on the host (which wraps the entire app)
+        // propagate as ambient keyboard hints — hovering ANY descendant (a step
+        // prompt textbox, say) flashes the parent's chord ("Ctrl+O") as a tooltip
+        // on the descendant. Setting Hidden on the host stops the auto-generation
+        // at the source and is invisible to users (the chord is still announced
+        // by command-bound buttons that opt back in via their own tooltip).
+        if (commands.Length > 0)
+            host.KeyboardAcceleratorPlacementMode = Microsoft.UI.Xaml.Input.KeyboardAcceleratorPlacementMode.Hidden;
+
         foreach (var cmd in commands)
         {
             if (cmd.Accelerator is null) continue;

--- a/tests/Reactor.Tests/ElementTests.cs
+++ b/tests/Reactor.Tests/ElementTests.cs
@@ -667,6 +667,56 @@ public class ElementTests
     }
 
     // ════════════════════════════════════════════════════════════════
+    //  Setters fast-path: ShallowEquals uses ReferenceEquals on Setters
+    // ════════════════════════════════════════════════════════════════
+    //
+    // Setters arrays are reference-compared rather than length-checked. The
+    // C# 12 collection-expression `[]` default lowers to Array.Empty<T>(),
+    // which is a singleton — so two elements with the default empty Setters
+    // remain reference-equal. Non-empty arrays are *not* deep-compared:
+    // a stable Setters reference held across renders fast-paths; a freshly
+    // allocated array (the typical case) does not. This contract is what
+    // lets future call-sites that cache their Setters opt into skip.
+
+    [Fact]
+    public void ShallowEquals_TextBlock_Default_Empty_Setters_Are_Equal()
+    {
+        // Both use the empty-default Setters → same Array.Empty<T>() singleton.
+        var a = TextBlock("Hello");
+        var b = TextBlock("Hello");
+        Assert.True(Element.ShallowEquals(a, b));
+    }
+
+    [Fact]
+    public void ShallowEquals_TextBlock_Different_NonEmpty_Setters_Are_Not_Equal()
+    {
+        // .Set allocates a fresh Setters array each call — distinct refs → not equal.
+        var a = TextBlock("Hello").Set(tb => tb.FontSize = 14);
+        var b = TextBlock("Hello").Set(tb => tb.FontSize = 14);
+        Assert.False(Element.ShallowEquals(a, b));
+    }
+
+    [Fact]
+    public void ShallowEquals_TextBlock_Same_NonEmpty_Setters_Reference_Are_Equal()
+    {
+        // Authors that cache the Setters array across renders get the fast-path:
+        // identical underlying record + reference-equal Setters → ShallowEquals true.
+        var setters = new Action<TextBlock>[] { tb => tb.FontSize = 14 };
+        var a = TextBlock("Hello") with { Setters = setters };
+        var b = TextBlock("Hello") with { Setters = setters };
+        Assert.True(Element.ShallowEquals(a, b));
+    }
+
+    [Fact]
+    public void ShallowEquals_TextBlock_Empty_Vs_NonEmpty_Setters_Are_Not_Equal()
+    {
+        // Empty default vs non-empty: refs differ → fast-path declines.
+        var a = TextBlock("Hello");
+        var b = TextBlock("Hello").Set(tb => tb.FontSize = 14);
+        Assert.False(Element.ShallowEquals(a, b));
+    }
+
+    // ════════════════════════════════════════════════════════════════
     //  Record immutability
     // ════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Three independent reconciler/UX fixes that came out of profiling typing slowness in `samples/apps/demo-script-tool`. Per top-level reconcile dropped from **107ms to 19ms** (5.5x); per-StepCard re-render rate fell from **4.5/s to 1.1/s** for one-card edits.

## Changes

### 1. `Element.ShallowEquals` / `OwnPropsEqual` — relax Setters check

Across all 47 element-type clauses:

```diff
- && a.Setters.Length == 0 && b.Setters.Length == 0,
+ && ReferenceEquals(a.Setters, b.Setters),
```

The old check was a strict subset of correctness — when both arrays are the empty default `[]`, the C# 12 collection-expression lowering already returns the same `Array.Empty<T>()` singleton, so reference-equality matches and the fast path fires identically. The new check additionally lets callsites that hold a stable non-empty array benefit from the same fast path. Pure win, no behavior change for existing callers.

### 2. `CommandBindings.ApplyButtonBaseCommon` — set placement mode before adding accelerator

WinUI captures the auto-tooltip-generation decision at `KeyboardAccelerators.Add` time; setting `Mode = Hidden` afterward did not reliably suppress the chord on x64-emulated WinUI 3 self-contained — the literal `Ctrl+O` tooltip would persist and stick when the UI thread was briefly busy. Hidden-before-Add prevents the auto tooltip from ever being generated. Conditional on `cmd.Description == null` is unchanged: callers that explicitly want the chord visible set `Description`.

### 3. `Reconciler.Mount.AddCommandHostAccelerators` — Hidden on the host Grid

Without this, the `CommandHost` (which wraps the entire app) became an ambient source of auto chord tooltips: hovering ANY descendant (e.g. a step prompt textbox) flashed `Ctrl+O` on the descendant's tooltip, because WinUI walks up looking for ancestors with accelerators-and-Auto-placement to inherit chord hints from. Setting Hidden on the host stops the ambient propagation; command-bound buttons that want their own tooltip continue to set it explicitly.

### 4. demo-script-tool: manual `Equals`/`GetHashCode` on three props records

`StepCardProps` / `StepsPanelProps` / `DemoPromptPanelProps` each contain `Action<...>` fields. Reactor's default `Component<TProps>.ShouldUpdate` calls record `Equals`, which compares delegates by reference — and `DemoScriptShell`'s local-function callbacks (`OnPromptChanged` etc.) are fresh delegate instances every render, forcing every `StepCard` to re-render on every shell render. The manual override compares only data fields. Workaround scope only; the framework-level fix is tracked at #151.

## Profile data

| Metric | Before | After (v3) |
|--------|--------|------------|
| Per top-level reconcile (`UpdateCommandHost`) | 107ms | 19ms |
| StepCard re-render rate (1-card edit) | 4.5/s | 1.1/s |
| `set_Style` calls/sec | 3.5 | ~1 |

Remaining bottleneck (filed for follow-up): `ChildReconciler` still walks containers whose children arrays are freshly allocated each parent render. Even after `Setters` and props memoization, ~14ms of every 19ms reconcile is in the descent. Tracked alongside #151 / #153.

## Related issues

- #151 — framework-level fix for callback fields defeating component memoization (removes the workaround applied here)
- #153 — lift `Command` to first-class on `ButtonElement` (lets `Button(Command)` skip Setters entirely)

## Test plan

- [ ] `dotnet test tests/Reactor.Tests` (ShallowEquals fast-path coverage)
- [ ] Manual: launch demo-script-tool, type rapidly into a step's title and prompt — should be smooth, no Ctrl+O tooltip on prompt hover, Open Folder tooltip on Open button shows "Open Folder" and dismisses cleanly
- [ ] Manual: confirm Ctrl+O / Ctrl+G / Ctrl+E keyboard shortcuts still fire from anywhere in the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)