### PR TITLE
fix(selftest): stabilize InfiniteBasic_TotalKnown

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/AsyncInfiniteResourceFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/AsyncInfiniteResourceFixtures.cs
@@ -70,7 +70,11 @@ internal static class AsyncInfiniteResourceFixtures
                 return TextBlock($"count: {r.Items.Count} total: {r.TotalCount?.ToString() ?? "?"}");
             });
 
-            // Let the first page resolve.
+            // Let the first page resolve. The fetcher's 10ms Task.Delay can resolve
+            // during a Render()'s 16ms wall-clock breathing-room, queueing the Apply
+            // continuation (which sets TotalCount) on the dispatcher just after
+            // WaitForIdleAsync returned. Pump a third time to drain it.
+            await Harness.Render();
             await Harness.Render();
             await Harness.Render();
 


### PR DESCRIPTION
## Summary

- Flake surfaced in CI: [run 25404199901](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/25404199901/job/74511213037) on #154 — `not ok InfiniteBasic_TotalKnown () - assertion failed`.
- Same shape as the fixes in #149 (Resource_FetchedData) and #152 (Mutation_Completed): the fetcher's `Task.Delay(10)` resolves during a `Render()`'s 16 ms wall-clock breathing-room delay, then schedules an `Apply` continuation on the dispatcher (which sets `TotalCount` inside `ApplyPageResult`) just after `WaitForIdleAsync` returned. The sibling `Page1Loaded` check still passes because `pageFetches` is incremented inside `FetchPageAsync` before it returns, and `Items.Count >= 25` is satisfied via `_highestInflightEnd` from the in-flight slot — neither requires the `Apply` continuation to have run.
- Adds one more `await Harness.Render()` so a second `WaitForIdleAsync` can drain the queued re-render before the assertion.

## Test plan

- [ ] 100× `Reactor.AppTests.Host --self-test` sweep locally (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)