### PR TITLE
Sets the minimum supported version to 10.0.17763

### DIFF
--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -12,6 +12,8 @@
     <!-- Override Directory.Build.props (true) — this library should not bundle
          the WinUI runtime; the consuming executable controls self-containedness. -->
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <!-- ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

This ensures the assembly attribute gets sets to the actual lowest version WinUI supports instead of the default pulled from the Target Framework (ie 10.0.22621.0). This can be a problem if you use the default min-version of 17763 and you can get [CA1422](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1422) build warnings. This is because the min-supported version is not specified, matches the version in the target framework. WinUI sets its min-version to 17763, so this matches that.

You can see the assembly attribute generated in for instance dotPeek:

Before fix:
<img width="915" height="92" alt="image" src="https://github.com/user-attachments/assets/b934557d-54d9-4434-a902-a4825a324df9" />

After fix:
<img width="939" height="106" alt="image" src="https://github.com/user-attachments/assets/a1f000ff-cf70-4877-bfcf-3318b779fa68" />

## Test plan

- [x] Manually ran `dotnet run --project samples/Reactor.TestApp -p:Platform=x64`
- [x] Inspected the generated assembly info using dotPeek

## Risk / breaking changes

None.