### PR TITLE
Ensure the compiled ReactorApplication.xaml gets embedded in the .PRI

### DIFF
--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -9,6 +9,7 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
     <!-- Override Directory.Build.props (true) — this library should not bundle
          the WinUI runtime; the consuming executable controls self-containedness. -->
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>


### PR DESCRIPTION
## Summary

When doing `dotnet pack` the generated nuget package fails to build with the following build error:
> C:\Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin\arm64\Microsoft.Common.CurrentVersion.targets(5395,5): error MSB3030: Could not copy the file "E:\.nuget\packages\microsoft.ui.reactor\0.0.0-local\lib\net9.0-windows10.0.22621\Reactor\Hosting\ReactorApplication.xbf" because it was not found.

Setting `DisableEmbeddedXbf` to false ensures the .xbf file gets packaged inside the .pri file and the generated nuget package will work.


## Test plan

- [x] Manually ran `dotnet pack --project Reactor\Reactor.csproj` + reference nuget package in a new Reactor app.


## Risk / breaking changes

None