### PR TITLE
docs(charting): document D3Pie params to silence CS1573

### DIFF
--- a/src/Reactor/Charting/D3Charts.cs
+++ b/src/Reactor/Charting/D3Charts.cs
@@ -309,6 +309,16 @@ public static class D3Charts
     }
 
     /// <summary>Creates pie/donut slice elements directly from data, collapsing PieGenerator + ArcGenerator + iteration into one expression.</summary>
+    /// <param name="data">Source data items, one per slice.</param>
+    /// <param name="value">Selector returning the magnitude for each item.</param>
+    /// <param name="cx">Center X coordinate (slices are translated into place).</param>
+    /// <param name="cy">Center Y coordinate.</param>
+    /// <param name="outerRadius">Outer radius of the pie/donut.</param>
+    /// <param name="innerRadius">Inner radius — non-zero produces a donut.</param>
+    /// <param name="padAngle">Angular padding between slices, in radians.</param>
+    /// <param name="sort">When true, slices are sorted by descending value.</param>
+    /// <param name="stroke">Optional stroke brush for slice borders.</param>
+    /// <param name="strokeWidth">Stroke thickness.</param>
     /// <param name="palette">
     /// Optional color palette. When null or empty, falls back to <see cref="Palette"/>
     /// (D3 Category10). Callers that want slice colors to match an external label


### PR DESCRIPTION
## Summary
- Adds `<param>` tags for the 10 undocumented parameters of `D3Charts.D3Pie<T>` so the existing `palette` doc no longer triggers CS1573 for the rest.
- Solution build is now warning-free (the 11 REACTOR_A11Y_* warnings in `samples/apps/a11y-showcase` are intentional analyzer demonstrations and are left as-is per the file's banner).

## Test plan
- [x] `dotnet build Reactor.sln` — 0 warnings, 0 errors
- [x] Force-rebuild a11y-showcase to confirm its 11 demo warnings still fire
- [ ] `dotnet test tests/Reactor.Tests`
- [ ] `dotnet test tests/Reactor.SelfTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)