### PR TITLE
fix(hot-reload): bypass component memo so updated Render() bodies repaint

### DIFF
--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -67,7 +67,8 @@ internal static class ChildReconciler
             // unchanged child (IVector.GetAt + all the property diffing inside Update).
             var oldEl = oldChildren[i];
             var newEl = newChildren[i];
-            if (Element.CanSkipUpdate(oldEl, newEl))
+            if (Element.CanSkipUpdate(oldEl, newEl)
+                && !reconciler.ForceRenderThroughWrapper(newEl))
             {
                 reconciler.DebugElementsSkipped++;
                 // Refresh Tag when the element carries callbacks. The skip short-

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -70,7 +70,8 @@ public sealed partial class Reconciler
         // null→non-null checks (non-poolable) can subscribe.
         if (Element.ShallowEquals(oldEl, newEl)
             && Element.ModifiersEqual(oldModifiers, modifiers)
-            && oldEl.HasCallbacks == newEl.HasCallbacks)
+            && oldEl.HasCallbacks == newEl.HasCallbacks
+            && !ForceRenderThroughWrapper(newEl))
         {
             DebugElementsSkipped++;
             // Refresh Tag so the event trampoline dispatches into the new element's

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -120,6 +120,18 @@ public sealed partial class Reconciler : IDisposable
     public int DebugUIElementsModified;
     private int _debugReconcileDepth;
 
+    // Hot reload signal: when set, the next top-level Reconcile() pass bypasses
+    // Component memo (props/deps equality) so updated method bodies are picked up
+    // even when props are unchanged. Cleared at the start of that pass.
+    internal volatile bool ForceFullRenderPending;
+    private bool _forceFullRenderActive;
+
+    // True only during a force pass and only for the wrapper elements whose
+    // skip would prevent ReconcileComponent from running. Used by Update()
+    // and ChildReconciler to bypass their structural-equality short-circuits.
+    internal bool ForceRenderThroughWrapper(Element el) =>
+        _forceFullRenderActive && el is ComponentElement or MemoElement or FuncElement;
+
     // ── Reconcile-highlight capture (gated by ReactorFeatureFlags.HighlightReconcileChanges) ──
     private List<UIElement>? _highlightMounted;
     private List<UIElement>? _highlightModified;
@@ -541,6 +553,10 @@ public sealed partial class Reconciler : IDisposable
                 (_highlightMounted ??= new()).Clear();
                 (_highlightModified ??= new()).Clear();
             }
+            // Consume the hot-reload signal exactly once per top-level pass so
+            // every component re-runs Render() even when props/deps are unchanged.
+            _forceFullRenderActive = ForceFullRenderPending;
+            ForceFullRenderPending = false;
         }
         try {
         try
@@ -567,7 +583,11 @@ public sealed partial class Reconciler : IDisposable
                     DebugUIElementsCreated, DebugUIElementsModified);
             }
         }
-        } finally { _debugReconcileDepth--; }
+        } finally
+        {
+            if (--_debugReconcileDepth == 0)
+                _forceFullRenderActive = false;
+        }
     }
 
     // Tracks top-level Reconcile() entries so trace start/stop only fires once
@@ -649,6 +669,12 @@ public sealed partial class Reconciler : IDisposable
         // ── Memo check: skip render if props/context unchanged and not self-triggered ──
         bool selfTriggered = node.SelfTriggered;
         node.SelfTriggered = false;
+
+        // Hot reload forces every component to re-run Render(); the new method
+        // body lives only on the type, not in props/deps, so the memo gate
+        // would otherwise skip it.
+        if (_forceFullRenderActive)
+            selfTriggered = true;
 
         if (!selfTriggered)
         {

--- a/src/Reactor/Hosting/HotReloadService.cs
+++ b/src/Reactor/Hosting/HotReloadService.cs
@@ -18,6 +18,9 @@ static class HotReloadService
     /// <summary>Called after the metadata update is applied. Re-renders the UI.</summary>
     public static void UpdateApplication(Type[]? updatedTypes)
     {
-        ReactorApp.ActiveHost?.RequestRender();
+        // force: true bypasses component memo (Props/deps equality) for this
+        // pass — the updated Render() body would otherwise be skipped because
+        // props and hook deps haven't changed.
+        ReactorApp.ActiveHost?.RequestRender(force: true);
     }
 }

--- a/src/Reactor/Hosting/ReactorHost.cs
+++ b/src/Reactor/Hosting/ReactorHost.cs
@@ -354,10 +354,17 @@ public sealed class ReactorHost : IDisposable
     /// During render: setState calls set _needsRerender (no enqueue).
     /// Between renders: first setState CAS-flips _renderPending 0→1 and enqueues.
     /// _renderPending stays 1 throughout the render, blocking duplicate enqueues.
+    ///
+    /// Pass <paramref name="force"/>=true to bypass component memoization
+    /// (Props/deps equality, ShouldUpdate) for the next pass — used by hot
+    /// reload where the updated Render() body lives on the type, not in props.
     /// </summary>
-    internal void RequestRender()
+    internal void RequestRender(bool force = false)
     {
         if (_disposed) return;
+
+        if (force)
+            _reconciler.ForceFullRenderPending = true;
 
         // Capture ambient animation curve so the async render pass can restore it.
         // Multiple state changes may fire before the render — last curve wins.
@@ -420,9 +427,13 @@ public sealed class ReactorHost : IDisposable
             Charting.D3Charts.IsReducedMotion = _isReducedMotion;
             Charting.D3Charts.ForcedColors = _forcedColorsTheme;
 
+            // RequestRender has an optional `force` parameter, so it can't bind
+            // directly to an Action method group — wrap once and reuse.
+            Action rerender = () => RequestRender();
+
             if (_rootComponent is not null)
             {
-                _rootComponent.Context.BeginRender(RequestRender);
+                _rootComponent.Context.BeginRender(rerender);
                 try
                 {
                     newTree = _rootComponent.Render();
@@ -436,7 +447,7 @@ public sealed class ReactorHost : IDisposable
             }
             else if (_rootRenderFunc is not null && _funcContext is not null)
             {
-                _funcContext.BeginRender(RequestRender);
+                _funcContext.BeginRender(rerender);
                 try
                 {
                     newTree = _rootRenderFunc(_funcContext);
@@ -468,7 +479,7 @@ public sealed class ReactorHost : IDisposable
                     _currentTree,
                     newTree,
                     _currentControl,
-                    RequestRender
+                    rerender
                 );
             }
             finally


### PR DESCRIPTION
## Summary

Hot reload edits the IL of a Component's `Render()` body but doesn't change props or hook deps. After the chart-primitive memo work in #161 — combined with the existing wrapper-element `ShallowEquals` carve-outs (`(ComponentElement, ComponentElement) => true`) — the post-edit tree compared equal to the pre-edit tree at every gate the reconciler can short-circuit on, and `ListItem.Render()` never ran again.

Repro: a `PieChart(...).LabelView((item, _) => Component<ListItem, ItemProps>(...))` where editing `ListItem.Render()` triggers the .NET hot reload metadata update but the chart slices keep rendering with the pre-edit body.

## Fix

`RequestRender` now takes an optional `force` bool. When true, the `Reconciler` sets `_forceFullRenderActive` for the next top-level pass:

- `ReconcileComponent` treats every node as self-triggered (skips `Component<TProps>.ShouldUpdate` / `MemoElement` deps).
- `Update()`'s `ShallowEquals` short-circuit and `ChildReconciler.ReconcileUnkeyed`'s `CanSkipUpdate` skip both fall through for `ComponentElement` / `MemoElement` / `FuncElement` so the pass actually descends to `ReconcileComponent`.

`HotReloadService.UpdateApplication` just calls `RequestRender(force: true)`. State survives because `RenderContext` and hook lists are unchanged — only the type's method body has been swapped.

## Test plan

- [x] Solution builds (`dotnet build Reactor.sln`)
- [ ] `Reactor.Tests` passes
- [ ] `Reactor.SelfTests` passes
- [ ] Edit `ListItem.Render()` body in `dryrun.cs` repro app → chart label re-renders on next hot reload tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)