### PR TITLE
perf(startup): defer a11y, charting, and logger init off the cold path

### DIFF
--- a/src/Reactor/Charting/Charts.Tree.cs
+++ b/src/Reactor/Charting/Charts.Tree.cs
@@ -86,7 +86,11 @@ public sealed class TreeChartElement<T> : IChartAccessibilityData
             chart = Accessibility.ChartAlternateViewWrapper.Wrap(chart, alt);
         return chart;
     }
-    public static implicit operator Element(TreeChartElement<T> chart) => chart.ToElement();
+    public static implicit operator Element(TreeChartElement<T> chart)
+    {
+        Hosting.ChartingActivation.RequestActivation();
+        return chart.ToElement();
+    }
 
     private Element BuildElement(T rootData)
     {
@@ -243,7 +247,11 @@ public sealed class ForceGraphElement : IChartAccessibilityData
             chart = Accessibility.ChartAlternateViewWrapper.Wrap(chart, alt);
         return chart;
     }
-    public static implicit operator Element(ForceGraphElement chart) => chart.ToElement();
+    public static implicit operator Element(ForceGraphElement chart)
+    {
+        Hosting.ChartingActivation.RequestActivation();
+        return chart.ToElement();
+    }
 
     private ForceSimulation? _sim;
 

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -255,7 +255,11 @@ public sealed class ChartElement<T> : IChartAccessibilityData
 
         return chart;
     }
-    public static implicit operator Element(ChartElement<T> chart) => chart.ToElement();
+    public static implicit operator Element(ChartElement<T> chart)
+    {
+        Hosting.ChartingActivation.RequestActivation();
+        return chart.ToElement();
+    }
 
     private Element BuildElement(IReadOnlyList<T> data)
     {
@@ -526,7 +530,11 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
             chart = Accessibility.ChartAlternateViewWrapper.Wrap(chart, alt);
         return chart;
     }
-    public static implicit operator Element(PieChartElement<T> chart) => chart.ToElement();
+    public static implicit operator Element(PieChartElement<T> chart)
+    {
+        Hosting.ChartingActivation.RequestActivation();
+        return chart.ToElement();
+    }
 
     private Element BuildElement(IReadOnlyList<T> data)
     {

--- a/src/Reactor/Charting/D3Charts.cs
+++ b/src/Reactor/Charting/D3Charts.cs
@@ -19,6 +19,15 @@ namespace Microsoft.UI.Reactor.Charting;
 /// </summary>
 public static class D3Charts
 {
+    // Cctor — runs the first time anything in this class is touched. Tells
+    // the active host to lazy-init forced-colors / reduced-motion watchers
+    // and push their values into our thread-statics, before chart code
+    // reads them. See Hosting.ChartingActivation for details.
+    static D3Charts()
+    {
+        Hosting.ChartingActivation.RequestActivation();
+    }
+
     // ── Color helpers ───────────────────────────────────────────────────
 
     public static readonly IReadOnlyList<D3Color> Palette = D3Color.Category10;

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -2250,7 +2250,7 @@ public sealed partial class Reconciler
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "ErrorBoundary caught render error");
+            _logger?.LogWarning(ex, "ErrorBoundary caught render error");
             caughtEx = ex;
             renderedElement = eb.Fallback(ex);
             wrapper.Child = Mount(renderedElement, requestRerender);
@@ -2313,7 +2313,7 @@ public sealed partial class Reconciler
         }
         catch (Exception ex) when (_errorBoundaryDepth == 0 && ex is not OutOfMemoryException and not StackOverflowException)
         {
-            _logger.LogError(ex, "Component Render() threw during mount: {ComponentName}", compElement.GetType().Name);
+            _logger?.LogError(ex, "Component Render() threw during mount: {ComponentName}", compElement.GetType().Name);
             childElement = ErrorFallback.BuildElement(ex);
         }
         UIElement? childControl;
@@ -2358,7 +2358,7 @@ public sealed partial class Reconciler
         }
         catch (Exception ex) when (_errorBoundaryDepth == 0 && ex is not OutOfMemoryException and not StackOverflowException)
         {
-            _logger.LogError(ex, "FuncComponent Render() threw during mount");
+            _logger?.LogError(ex, "FuncComponent Render() threw during mount");
             childElement = ErrorFallback.BuildElement(ex);
         }
         UIElement? childControl;
@@ -2404,7 +2404,7 @@ public sealed partial class Reconciler
         }
         catch (Exception ex) when (_errorBoundaryDepth == 0 && ex is not OutOfMemoryException and not StackOverflowException)
         {
-            _logger.LogError(ex, "MemoComponent Render() threw during mount");
+            _logger?.LogError(ex, "MemoComponent Render() threw during mount");
             childElement = ErrorFallback.BuildElement(ex);
         }
         UIElement? childControl;

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -769,7 +769,7 @@ public sealed partial class Reconciler
         {
             // Uncontrolled divergence: value is set but no onChange to reconcile.
             // Log once per field to help developers catch mismatched bindings.
-            _logger.LogWarning(
+            _logger?.LogWarning(
                 "TextField value diverged from controlled value with no OnChanged handler. " +
                 "Controlled: \"{ControlledValue}\", Actual: \"{ActualValue}\". " +
                 "Wire up OnChanged to keep state in sync, or this field won't reflect user edits after re-renders.",
@@ -3445,7 +3445,7 @@ public sealed partial class Reconciler
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "ErrorBoundary caught render error during update");
+            _logger?.LogWarning(ex, "ErrorBoundary caught render error during update");
             caughtEx = ex;
             if (existingChild is not null)
                 Unmount(existingChild);

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -30,7 +30,10 @@ public sealed partial class Reconciler : IDisposable
     private readonly Dictionary<UIElement, NavigationHostNode> _navigationHostNodes = new();
     private readonly ElementPool _pool = new();
     private readonly Dictionary<Type, ITypeRegistration> _typeRegistry = new();
-    private readonly ILogger _logger;
+    // Null when no caller-supplied logger and no devtools logger is published.
+    // All call sites use null-conditional access so the M.E.Logging code path
+    // doesn't run (and stays JIT-cold) for default apps.
+    private readonly ILogger? _logger;
     private readonly List<(ConnectedAnimation Animation, UIElement Target)> _pendingConnectedAnimationStarts = new();
     private readonly ContextScope _contextScope = new();
     private int _errorBoundaryDepth;
@@ -220,11 +223,11 @@ public sealed partial class Reconciler : IDisposable
         set => _enableBitmaskDiff = value;
     }
 
-    public Reconciler() : this(NullLogger.Instance) { }
+    public Reconciler() : this(null) { }
 
-    public Reconciler(ILogger logger)
+    public Reconciler(ILogger? logger)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger;
     }
 
     /// <summary>
@@ -662,7 +665,7 @@ public sealed partial class Reconciler : IDisposable
     {
         if (!_componentNodes.TryGetValue(control, out var node))
         {
-            _logger.LogWarning("ReconcileComponent: component node not found for control — component will not update");
+            _logger?.LogWarning("ReconcileComponent: component node not found for control — component will not update");
             return;
         }
 
@@ -778,7 +781,7 @@ public sealed partial class Reconciler : IDisposable
         }
         catch (Exception ex) when (_errorBoundaryDepth == 0 && ex is not OutOfMemoryException and not StackOverflowException)
         {
-            _logger.LogError(ex, "Component Render() threw: {ComponentName}", newEl.GetType().Name);
+            _logger?.LogError(ex, "Component Render() threw: {ComponentName}", newEl.GetType().Name);
             if (Diagnostics.ReactorEventSource.Log.IsEnabled(
                     global::System.Diagnostics.Tracing.EventLevel.Error,
                     Diagnostics.ReactorEventSource.Keywords.Errors))

--- a/src/Reactor/Hosting/ChartingActivation.cs
+++ b/src/Reactor/Hosting/ChartingActivation.cs
@@ -1,0 +1,19 @@
+namespace Microsoft.UI.Reactor.Hosting;
+
+/// <summary>
+/// One-line indirection used by chart elements / D3 primitives to tell the
+/// active <see cref="ReactorHost"/> that charting is in use. The host then
+/// lazy-initializes <c>AccessibilitySettings</c> + <c>UISettings</c> and
+/// pushes their values into <c>Charting.D3Charts</c>'s thread-statics.
+///
+/// Apps with no charts never call this, never load the WinRT a11y settings,
+/// and never trigger the <c>D3Charts</c> static cctor cascade — saving
+/// 15–30 ms on cold start.
+/// </summary>
+internal static class ChartingActivation
+{
+    public static void RequestActivation()
+    {
+        ReactorApp.ActiveHost?.EnsureChartingActive();
+    }
+}

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -42,6 +42,19 @@ public static class ReactorApp
         internal set => Volatile.Write(ref _activeHost, value);
     }
 
+    // Process-wide ILogger picked up by ReactorHost / ReactorHostControl when
+    // the caller doesn't pass one explicitly. Null by default; populated by
+    // the devtools subverbs and by app code that wants a unified fallback.
+    // Reads on the ReactorHost ctor hot path stay AOT/JIT-cheap because the
+    // field is just a reference — no Microsoft.Extensions.Logging machinery
+    // loads unless the field is actually non-null.
+    private static ILogger? _appLogger;
+    public static ILogger? AppLogger
+    {
+        get => Volatile.Read(ref _appLogger);
+        set => Volatile.Write(ref _appLogger, value);
+    }
+
     private static int _previewParamDeprecationWarned;
 
     // ── XAML control-assembly registration ─────────────────────────────────
@@ -812,8 +825,6 @@ public partial class ReactorApplication : Application, IXamlMetadataProvider
     /// </summary>
     public static Func<Exception, bool>? OnUnhandledException { get; set; }
 
-    private readonly ILogger _logger = NullLogger.Instance;
-
     public ReactorApplication()
     {
         // Loads ReactorApplication.xaml (which references XamlControlsResources) via the
@@ -825,7 +836,7 @@ public partial class ReactorApplication : Application, IXamlMetadataProvider
 
         UnhandledException += (_, e) =>
         {
-            _logger.LogError(e.Exception, "UnhandledException: {ExceptionType}: {ExceptionMessage}", e.Exception.GetType().Name, e.Exception.Message);
+            ReactorApp.AppLogger?.LogError(e.Exception, "UnhandledException: {ExceptionType}: {ExceptionMessage}", e.Exception.GetType().Name, e.Exception.Message);
             if (OnUnhandledException is not null)
                 e.Handled = OnUnhandledException(e.Exception);
             // Don't set e.Handled = true for unknown exceptions — let the app crash

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -43,11 +43,15 @@ public static class ReactorApp
     }
 
     // Process-wide ILogger picked up by ReactorHost / ReactorHostControl when
-    // the caller doesn't pass one explicitly. Null by default; populated by
-    // the devtools subverbs and by app code that wants a unified fallback.
-    // Reads on the ReactorHost ctor hot path stay AOT/JIT-cheap because the
-    // field is just a reference — no Microsoft.Extensions.Logging machinery
-    // loads unless the field is actually non-null.
+    // the caller doesn't pass one explicitly. Null by default. Apps that want
+    // a unified fallback should set this BEFORE creating the first host —
+    // hosts snapshot the value at construction, so a later set won't retro-
+    // actively wire up already-running hosts. Also routes ReactorApplication's
+    // unhandled-exception handler when devtools is off.
+    //
+    // Cold-path note: leaving this null keeps Microsoft.Extensions.Logging
+    // resolution off the JIT critical path entirely — none of the LoggerExtensions
+    // call sites get walked when the field is null.
     private static ILogger? _appLogger;
     public static ILogger? AppLogger
     {

--- a/src/Reactor/Hosting/ReactorHost.cs
+++ b/src/Reactor/Hosting/ReactorHost.cs
@@ -33,7 +33,11 @@ public sealed class ReactorHost : IDisposable
     private readonly Window _window;
     private readonly Reconciler _reconciler;
     private readonly DispatcherQueue _dispatcherQueue;
-    private readonly ILogger _logger;
+    // Null by default. Populated only when the caller passes an ILogger
+    // (or devtools is enabled and assigns one via ReactorApp.AppLogger).
+    // Apps that don't pass a logger never JIT a real Microsoft.Extensions.Logging
+    // call path — saves ~3-5 ms of cold-start JIT + assembly resolve.
+    private readonly ILogger? _logger;
 
     private Component? _rootComponent;
     private Func<RenderContext, Element>? _rootRenderFunc;
@@ -53,12 +57,16 @@ public sealed class ReactorHost : IDisposable
     private readonly BackdropApplier _backdropApplier;
     private readonly global::Windows.Foundation.TypedEventHandler<object, WindowEventArgs> _closedHandler;
 
-    // Accessibility: forced-colors and reduced-motion auto-propagation
+    // Accessibility: forced-colors and reduced-motion auto-propagation.
+    // Allocation is deferred until the first chart element is created (see
+    // EnsureChartingActive). Apps without charts skip the WinRT activation
+    // cost (15–30 ms each) and the Charting.D3Charts cctor cascade.
     private global::Windows.UI.ViewManagement.AccessibilitySettings? _accessibilitySettings;
     private global::Windows.UI.ViewManagement.UISettings? _uiSettings;
     private volatile bool _isForcedColors;
     private volatile bool _isReducedMotion;
     private Charting.ForcedColorsTheme? _forcedColorsTheme;
+    private bool _chartingActive;
 
     // Captured AnimationScope curve — when a state setter is called inside
     // WithAnimation, the scope is synchronous but the render is async.
@@ -136,7 +144,11 @@ public sealed class ReactorHost : IDisposable
 
     public ReactorHost(Window window, ILogger? logger = null)
     {
-        _logger = logger ?? NullLogger.Instance;
+        // Pick up an AppLogger published by the devtools subverb if the
+        // caller didn't pass an explicit logger — keeps Render-loop diagnostics
+        // visible whenever devtools is live, without forcing every app to wire
+        // up Microsoft.Extensions.Logging on the cold path.
+        _logger = logger ?? ReactorApp.AppLogger;
         _reconciler = new Reconciler(_logger);
         _window = window;
         _backdropApplier = new BackdropApplier(window);
@@ -178,25 +190,10 @@ public sealed class ReactorHost : IDisposable
             catch { /* windowless / headless host — no activation hook */ }
         }
 
-        // ── Accessibility: auto-detect forced-colors and reduced-motion ──
-        // D3Charts.IsForcedColors is set each render; listeners trigger re-render.
-        try
-        {
-            _accessibilitySettings = new global::Windows.UI.ViewManagement.AccessibilitySettings();
-            _isForcedColors = _accessibilitySettings.HighContrast;
-            if (_isForcedColors)
-                _forcedColorsTheme = Charting.ForcedColorsTheme.FromSystem();
-            _accessibilitySettings.HighContrastChanged += OnHighContrastChanged;
-        }
-        catch { /* headless / unit-test host — no accessibility settings */ }
-
-        try
-        {
-            _uiSettings = new global::Windows.UI.ViewManagement.UISettings();
-            _isReducedMotion = !_uiSettings.AnimationsEnabled;
-            _uiSettings.ColorValuesChanged += OnColorValuesChanged;
-        }
-        catch { /* headless / unit-test host — no UI settings */ }
+        // ── Accessibility: forced-colors / reduced-motion ──
+        // Deferred to EnsureChartingActive(), called the first time a chart
+        // element is constructed (Charting.ChartingActivation.RequestActivation).
+        // Apps without charts pay zero cost here.
 
         // Register built-in custom element types
         Controls.ResizeGripRegistration.Register(_reconciler);
@@ -334,6 +331,52 @@ public sealed class ReactorHost : IDisposable
     /// <summary>Internal debug hook — paired-event ring buffer (or null when flag was off).</summary>
     internal LayoutEventRing? EventRing => _eventRing;
 
+    /// <summary>
+    /// Called by chart elements (via <see cref="ChartingActivation.RequestActivation"/>)
+    /// the first time a chart appears in the tree. Lazily allocates the WinRT
+    /// accessibility settings, reads their initial values, subscribes for change
+    /// notifications, and pushes the values into <see cref="Charting.D3Charts"/>'s
+    /// thread-statics so the about-to-mount chart sees correct forced-colors /
+    /// reduced-motion state.
+    /// Idempotent — subsequent chart elements are zero-cost.
+    /// </summary>
+    internal void EnsureChartingActive()
+    {
+        if (_chartingActive) return;
+        _chartingActive = true;
+
+        try
+        {
+            _accessibilitySettings = new global::Windows.UI.ViewManagement.AccessibilitySettings();
+            _isForcedColors = _accessibilitySettings.HighContrast;
+            if (_isForcedColors)
+                _forcedColorsTheme = Charting.ForcedColorsTheme.FromSystem();
+            _accessibilitySettings.HighContrastChanged += OnHighContrastChanged;
+        }
+        catch { /* headless / unit-test host — no accessibility settings */ }
+
+        try
+        {
+            _uiSettings = new global::Windows.UI.ViewManagement.UISettings();
+            _isReducedMotion = !_uiSettings.AnimationsEnabled;
+            _uiSettings.ColorValuesChanged += OnColorValuesChanged;
+        }
+        catch { /* headless / unit-test host — no UI settings */ }
+
+        PushChartingState();
+    }
+
+    // Kept in a separate method so the JIT doesn't resolve Charting.D3Charts
+    // when Render() is compiled — D3Charts only loads (and runs its cctor)
+    // the first time PushChartingState is actually invoked, which only
+    // happens for apps that use charts.
+    private void PushChartingState()
+    {
+        Charting.D3Charts.IsForcedColors = _isForcedColors;
+        Charting.D3Charts.IsReducedMotion = _isReducedMotion;
+        Charting.D3Charts.ForcedColors = _forcedColorsTheme;
+    }
+
     public void Mount(Component component)
     {
         _rootComponent = component;
@@ -385,6 +428,20 @@ public sealed class ReactorHost : IDisposable
             return;
         }
 
+        // First render synchronous-on-UI-thread: the very first render
+        // fires from Mount() inside OnLaunched, which is already on the
+        // dispatcher. Skipping the queue saves one tick (~2-5 ms on cold
+        // start) and lets content attach before window.Activate() returns,
+        // matching what an imperative WinUI3 app does. Only the very first
+        // render takes this path — subsequent setStates keep the existing
+        // batch-via-dispatcher behavior so multiple synchronous setState
+        // calls still coalesce into one render.
+        if (_currentControl is null && _dispatcherQueue.HasThreadAccess)
+        {
+            RenderLoop();
+            return;
+        }
+
         _dispatcherQueue.TryEnqueue(RenderLoop);
     }
 
@@ -421,11 +478,13 @@ public sealed class ReactorHost : IDisposable
 
             _phaseSw.Restart();
 
-            // Propagate accessibility state to D3Charts thread-statics so all chart
-            // rendering picks up forced-colors / reduced-motion automatically.
-            Charting.D3Charts.IsForcedColors = _isForcedColors;
-            Charting.D3Charts.IsReducedMotion = _isReducedMotion;
-            Charting.D3Charts.ForcedColors = _forcedColorsTheme;
+            // Propagate accessibility state to D3Charts thread-statics so all
+            // chart rendering picks up forced-colors / reduced-motion. Skipped
+            // entirely (no D3Charts type touch, no cctor cascade) when no
+            // chart has ever been mounted in this host. PushChartingState is
+            // a separate method so the JIT doesn't load Charting.D3Charts
+            // when Render() is compiled.
+            if (_chartingActive) PushChartingState();
 
             // RequestRender has an optional `force` parameter, so it can't bind
             // directly to an Action method group — wrap once and reuse.
@@ -440,7 +499,7 @@ public sealed class ReactorHost : IDisposable
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Component Render() threw");
+                    _logger?.LogError(ex, "Component Render() threw");
                     ShowErrorFallback(ex);
                     return;
                 }
@@ -454,7 +513,7 @@ public sealed class ReactorHost : IDisposable
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Function component threw");
+                    _logger?.LogError(ex, "Function component threw");
                     ShowErrorFallback(ex);
                     return;
                 }
@@ -584,7 +643,7 @@ public sealed class ReactorHost : IDisposable
             OnRenderComplete?.Invoke(treeBuildMs, reconcileMs, effectsMs);
 
 #if DEBUG
-            _logger.LogDebug(
+            _logger?.LogDebug(
                 "RECONCILE: tree={TreeBuildMs:F2}ms  reconcile={ReconcileMs:F2}ms  effects={EffectsMs:F2}ms  total={TotalMs:F2}ms  |  diffed={Diffed}  skipped={Skipped}  created={Created}  modified={Modified}",
                 treeBuildMs, reconcileMs, effectsMs, treeBuildMs + reconcileMs + effectsMs,
                 _reconciler.DebugElementsDiffed, _reconciler.DebugElementsSkipped,
@@ -620,7 +679,7 @@ public sealed class ReactorHost : IDisposable
                     LastModified = _reconciler.DebugUIElementsModified,
                 };
 
-                _logger.LogDebug(
+                _logger?.LogDebug(
                     "PERF [{RenderCount} renders]: tree={TreeMs:F2}ms  reconcile={ReconcileMs:F2}ms  effects={EffectsMs:F2}ms  total={TotalMs:F2}ms",
                     _renderCount, avgTree, avgReconcile, avgEffects, avgTotal);
                 _treeBuildSum = 0;
@@ -632,7 +691,7 @@ public sealed class ReactorHost : IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Render FAILED");
+            _logger?.LogError(ex, "Render FAILED");
             ShowErrorFallback(ex);
         }
         finally
@@ -665,7 +724,7 @@ public sealed class ReactorHost : IDisposable
 
     private void OnActualThemeChanged(FrameworkElement sender, object args)
     {
-        _logger.LogDebug("Theme changed to {Theme} — re-rendering", sender.ActualTheme);
+        _logger?.LogDebug("Theme changed to {Theme} — re-rendering", sender.ActualTheme);
         Microsoft.UI.Reactor.Core.Reconciler.ClearStyleCache();
         RequestRender();
     }
@@ -675,7 +734,7 @@ public sealed class ReactorHost : IDisposable
     {
         _isForcedColors = sender.HighContrast;
         _forcedColorsTheme = _isForcedColors ? Charting.ForcedColorsTheme.FromSystem() : null;
-        _logger.LogDebug("High-contrast changed to {IsHighContrast} — re-rendering", _isForcedColors);
+        _logger?.LogDebug("High-contrast changed to {IsHighContrast} — re-rendering", _isForcedColors);
         RequestRender();
     }
 

--- a/src/Reactor/Hosting/ReactorHost.cs
+++ b/src/Reactor/Hosting/ReactorHost.cs
@@ -33,10 +33,10 @@ public sealed class ReactorHost : IDisposable
     private readonly Window _window;
     private readonly Reconciler _reconciler;
     private readonly DispatcherQueue _dispatcherQueue;
-    // Null by default. Populated only when the caller passes an ILogger
-    // (or devtools is enabled and assigns one via ReactorApp.AppLogger).
-    // Apps that don't pass a logger never JIT a real Microsoft.Extensions.Logging
-    // call path — saves ~3-5 ms of cold-start JIT + assembly resolve.
+    // Null when the caller passes no logger and ReactorApp.AppLogger is unset.
+    // Snapshotted at ctor; later AppLogger writes don't retro-wire this host.
+    // Leaving null keeps the Microsoft.Extensions.Logging call paths off the
+    // JIT critical path — saves ~3-5 ms of cold-start JIT + assembly resolve.
     private readonly ILogger? _logger;
 
     private Component? _rootComponent;
@@ -66,7 +66,10 @@ public sealed class ReactorHost : IDisposable
     private volatile bool _isForcedColors;
     private volatile bool _isReducedMotion;
     private Charting.ForcedColorsTheme? _forcedColorsTheme;
-    private bool _chartingActive;
+    // 0 = inactive, 1 = activation in flight or done. Flipped atomically
+    // via Interlocked.CompareExchange so concurrent chart-element creation
+    // from background threads can't double-subscribe HighContrastChanged.
+    private int _chartingActiveFlag;
 
     // Captured AnimationScope curve — when a state setter is called inside
     // WithAnimation, the scope is synchronous but the render is async.
@@ -144,10 +147,12 @@ public sealed class ReactorHost : IDisposable
 
     public ReactorHost(Window window, ILogger? logger = null)
     {
-        // Pick up an AppLogger published by the devtools subverb if the
-        // caller didn't pass an explicit logger — keeps Render-loop diagnostics
-        // visible whenever devtools is live, without forcing every app to wire
-        // up Microsoft.Extensions.Logging on the cold path.
+        // Fall back to <see cref="ReactorApp.AppLogger"/> when the caller
+        // didn't pass one — apps that want unified host diagnostics set
+        // AppLogger once before constructing their first host. Snapshotted
+        // at ctor time; later AppLogger writes don't propagate to existing
+        // hosts. Apps that don't set either pay zero JIT cost for the
+        // Microsoft.Extensions.Logging call paths.
         _logger = logger ?? ReactorApp.AppLogger;
         _reconciler = new Reconciler(_logger);
         _window = window;
@@ -338,13 +343,30 @@ public sealed class ReactorHost : IDisposable
     /// notifications, and pushes the values into <see cref="Charting.D3Charts"/>'s
     /// thread-statics so the about-to-mount chart sees correct forced-colors /
     /// reduced-motion state.
-    /// Idempotent — subsequent chart elements are zero-cost.
+    /// <para>
+    /// Idempotent and thread-safe. The 0→1 transition is gated by an
+    /// <see cref="Interlocked.CompareExchange(ref int, int, int)"/> so concurrent
+    /// callers can't double-subscribe the change handlers. The init body runs
+    /// on the dispatcher thread regardless of the caller's thread —
+    /// <c>AccessibilitySettings</c> / <c>UISettings</c> are WinRT projections
+    /// that prefer the UI thread, and <c>D3Charts</c>'s <c>[ThreadStatic]</c>
+    /// flags must be written on the thread that will read them (the UI thread,
+    /// where reconciliation runs).
+    /// </para>
     /// </summary>
     internal void EnsureChartingActive()
     {
-        if (_chartingActive) return;
-        _chartingActive = true;
+        if (Interlocked.CompareExchange(ref _chartingActiveFlag, 1, 0) != 0)
+            return;
 
+        if (_dispatcherQueue.HasThreadAccess)
+            InitChartingState();
+        else
+            _dispatcherQueue.TryEnqueue(InitChartingState);
+    }
+
+    private void InitChartingState()
+    {
         try
         {
             _accessibilitySettings = new global::Windows.UI.ViewManagement.AccessibilitySettings();
@@ -484,7 +506,11 @@ public sealed class ReactorHost : IDisposable
             // chart has ever been mounted in this host. PushChartingState is
             // a separate method so the JIT doesn't load Charting.D3Charts
             // when Render() is compiled.
-            if (_chartingActive) PushChartingState();
+            // Volatile read so a chart-element create on a background thread
+            // that flipped _chartingActiveFlag is observed by this UI-thread
+            // render. Plain reads can hoist past the Interlocked write under
+            // sufficiently aggressive JITs.
+            if (Volatile.Read(ref _chartingActiveFlag) != 0) PushChartingState();
 
             // RequestRender has an optional `force` parameter, so it can't bind
             // directly to an Action method group — wrap once and reuse.

--- a/src/Reactor/Hosting/ReactorHostControl.cs
+++ b/src/Reactor/Hosting/ReactorHostControl.cs
@@ -48,7 +48,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
 
     private readonly Reconciler _reconciler;
     private readonly DispatcherQueue _dispatcherQueue;
-    private readonly ILogger _logger;
+    private readonly ILogger? _logger;
 
     private Component? _rootComponent;
     private Func<RenderContext, Element>? _rootRenderFunc;
@@ -124,7 +124,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
 
     public ReactorHostControl(Component? component = null, ILogger? logger = null)
     {
-        _logger = logger ?? NullLogger.Instance;
+        _logger = logger ?? ReactorApp.AppLogger;
         _reconciler = new Reconciler(_logger);
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         HorizontalContentAlignment = HorizontalAlignment.Stretch;
@@ -340,7 +340,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Component Render() threw");
+                    _logger?.LogError(ex, "Component Render() threw");
                     ShowErrorFallback(ex);
                     return;
                 }
@@ -354,7 +354,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Function component threw");
+                    _logger?.LogError(ex, "Function component threw");
                     ShowErrorFallback(ex);
                     return;
                 }
@@ -463,7 +463,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
             OnRenderComplete?.Invoke(treeBuildMs, reconcileMs, effectsMs);
 
 #if DEBUG
-            _logger.LogDebug(
+            _logger?.LogDebug(
                 "RECONCILE: tree={TreeBuildMs:F2}ms  reconcile={ReconcileMs:F2}ms  effects={EffectsMs:F2}ms  total={TotalMs:F2}ms  |  diffed={Diffed}  skipped={Skipped}  created={Created}  modified={Modified}",
                 treeBuildMs, reconcileMs, effectsMs, treeBuildMs + reconcileMs + effectsMs,
                 _reconciler.DebugElementsDiffed, _reconciler.DebugElementsSkipped,
@@ -499,7 +499,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
                     LastModified = _reconciler.DebugUIElementsModified,
                 };
 
-                _logger.LogDebug(
+                _logger?.LogDebug(
                     "PERF [{RenderCount} renders]: tree={TreeMs:F2}ms  reconcile={ReconcileMs:F2}ms  effects={EffectsMs:F2}ms  total={TotalMs:F2}ms",
                     _renderCount, avgTree, avgReconcile, avgEffects, avgTotal);
                 _treeBuildSum = 0;
@@ -511,7 +511,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Render FAILED");
+            _logger?.LogError(ex, "Render FAILED");
             ShowErrorFallback(ex);
         }
         finally
@@ -534,7 +534,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
 
         fe.ActualThemeChanged += (_, _) =>
         {
-            _logger.LogDebug("Theme changed to {Theme} — re-rendering", fe.ActualTheme);
+            _logger?.LogDebug("Theme changed to {Theme} — re-rendering", fe.ActualTheme);
             RequestRender();
         };
     }

--- a/src/Reactor/Hosting/ReactorHostControl.cs
+++ b/src/Reactor/Hosting/ReactorHostControl.cs
@@ -124,6 +124,10 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
 
     public ReactorHostControl(Component? component = null, ILogger? logger = null)
     {
+        // Fall back to ReactorApp.AppLogger so an app that sets the process-wide
+        // logger before constructing controls gets unified diagnostics. Snapshot
+        // at ctor time; later AppLogger writes don't retroactively wire up
+        // already-constructed controls.
         _logger = logger ?? ReactorApp.AppLogger;
         _reconciler = new Reconciler(_logger);
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();

--- a/tests/startup_perf/BlankReactor/BlankReactor.csproj
+++ b/tests/startup_perf/BlankReactor/BlankReactor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>BlankReactor</RootNamespace>
     <AssemblyName>BlankReactor</AssemblyName>

--- a/tests/startup_perf/BlankWinUI3/BlankWinUI3.csproj
+++ b/tests/startup_perf/BlankWinUI3/BlankWinUI3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>BlankWinUI3</RootNamespace>
     <AssemblyName>BlankWinUI3</AssemblyName>

--- a/tests/startup_perf/run_startup_bench.ps1
+++ b/tests/startup_perf/run_startup_bench.ps1
@@ -53,7 +53,7 @@ if (-not (Test-Path $OutputDir)) { New-Item -ItemType Directory -Path $OutputDir
 # ---- Variant table ---------------------------------------------------------
 $arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "ARM64" } else { "x64" }
 $rid = if ($arch -eq "ARM64") { "win-arm64" } else { "win-x64" }
-$tfm = "net9.0-windows10.0.22621.0"
+$tfm = "net10.0-windows10.0.22621.0"
 
 # C# variants are non-AOT (PublishAot=false in csproj — NativeAOT trims the
 # EventSource subclass and emits zero ETW events). Build path therefore has


### PR DESCRIPTION
## Summary

Reactor's empty-window startup overhead vs a vanilla WinUI3 baseline drops from ~163 ms to ~89 ms on ARM64 — about 74 ms (~45%) of the structural gap closed by deferring four pieces of work that the typical app never uses.

| | WinUI3 | Reactor (before) | Reactor (after) | Δ |
|---|---:|---:|---:|---:|
| `XamlAppLoaded` (median, ms) | 71.9 | 234.8 | **161.2** | **−73.6** |
| `WindowLoaded` (median, ms) | 124.6 | 257.8 | **183.1** | −74.7 |
| TTFP (median, ms) | 171.1 | 294.8 | **223.1** | −71.7 |

Numbers are medians of 5 runs of `tests/startup_perf/run_startup_bench.ps1`, run-1 cache-cold runs excluded per the methodology in `tests/startup_perf/README.md`.

## What changed

- **Lazy a11y / UISettings** — `ReactorHost` no longer constructs `AccessibilitySettings` + `UISettings` in its ctor. Both move to a new internal `EnsureChartingActive()` called the first time a chart element is created (wired via `ChartingActivation` from `D3Charts`'s cctor and the chart implicit-conversion operators). Apps without charts skip the WinRT activations entirely.
- **Lazy `D3Charts` thread-static push** — `Render()` no longer references `Charting.D3Charts`. The three thread-static writes live in a separate `PushChartingState` method that stays JIT-cold until the first chart mounts, eliminating the `D3Charts` static-cctor cascade for chart-free apps.
- **Sync first render** — `RequestRender` skips the dispatcher hop on the very first render when called on the UI thread (the `Mount()`-from-`OnLaunched` path). Saves one dispatcher tick and matches what an imperative WinUI3 app does. Subsequent setStates keep the existing dispatcher-batch behavior so coalescing still works.
- **Lazy logging** — `_logger` fields are nullable and default to null; all `_logger.LogXxx` calls are now null-conditional in `ReactorHost`, `ReactorHostControl`, and the three `Reconciler` partials. New `ReactorApp.AppLogger` static lets devtools (or any caller) populate a process-wide fallback so every host picks it up automatically without forcing apps to wire up `Microsoft.Extensions.Logging`.

## Notes

- `tests/startup_perf/Blank{Reactor,WinUI3}.csproj` bumped to `net10.0-windows10.0.22621.0` to restore against the current Reactor TFM (Reactor moved to net10 in 76d0075). `run_startup_bench.ps1` updated to look in the matching output dir.
- The remaining ~89 ms gap to BlankWinUI3 is structural: `ReactorApplication.xaml` loads `<XamlControlsResources/>` unconditionally; `BlankWinUI3` has no `App.xaml`. That's a separate, larger discussion.

## Test plan

- [x] `dotnet build tests/startup_perf/BlankReactor/BlankReactor.csproj -c Release` succeeds.
- [x] `tests/startup_perf/run_startup_bench.ps1 -Runs 5 -Skip RNW` produces medians in line with the table above.
- [ ] CI: existing unit + selftest suites pass (no behavior changes for chart-using apps; lazy paths exercised by any chart selftest).
- [ ] Spot-check: a chart-using sample (e.g. `samples/Charting`) still picks up forced-colors / reduced-motion correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)