### PR TITLE
Make the analyzer a project reference

### DIFF
--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -66,10 +66,11 @@
     <ProjectReference Include="..\Reactor.Localization.Generator\Reactor.Localization.Generator.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
-    <!-- Reactor.Analyzers is NOT a ProjectReference here — we don't want its
-         rules running on the framework itself, only on consumer code. The
-         release workflow builds Reactor.sln first, so the analyzer DLL exists
-         before pack runs (see <None Include> below). -->
+    <ProjectReference Include="..\Reactor.Analyzers\Reactor.Analyzers.csproj"
+                      ReferenceOutputAssembly="false" />
+    <!-- Reactor.Analyzers is not referenced as an analyzer here — we don't want its
+         rules running on the framework itself, only on consumer code, but it's a dependency 
+         in order to pack the analyzer's output -->
   </ItemGroup>
 
   <!-- Bundle the analyzer + source-generator DLLs into the framework package
@@ -85,17 +86,6 @@
           Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
-
-  <Target Name="AssertAnalyzerDllsExist" BeforeTargets="Pack">
-    <PropertyGroup>
-      <_ReactorAnalyzersDll>..\Reactor.Analyzers\bin\$(Configuration)\netstandard2.0\Reactor.Analyzers.dll</_ReactorAnalyzersDll>
-      <_ReactorLocGenDll>..\Reactor.Localization.Generator\bin\$(Configuration)\netstandard2.0\Reactor.Localization.Generator.dll</_ReactorLocGenDll>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(_ReactorAnalyzersDll)')"
-           Text="Reactor.Analyzers.dll not found at $(_ReactorAnalyzersDll). Run 'dotnet build Reactor.sln -c $(Configuration)' before 'dotnet pack' so the analyzer assemblies exist for bundling." />
-    <Error Condition="!Exists('$(_ReactorLocGenDll)')"
-           Text="Reactor.Localization.Generator.dll not found at $(_ReactorLocGenDll). Run 'dotnet build Reactor.sln -c $(Configuration)' before 'dotnet pack'." />
-  </Target>
 
   <!-- ═══════════════════════════════════════════════════════════════════
        Localization — .resw files fed to the source generator


### PR DESCRIPTION
## Summary

This solves the issue with the first-build experience in Visual Studio. Since we don't set the ProjectReference's OutputItemType to analyzer, it won't run the analyzer on the project itself. This also means all the msbuild code to ensure the analyzer is present is longer necessary.

## Test plan

- [x] Manually ran `dotnet pack --project Reactor/Reactor.csproj -p:Platform=AnyCPU`* on a clean clone.
- [x] Open solution in Visual Studio, switch to x64 config*, set TestApp as startup and run on a clean clone.

*setting config or Platform won't be needed once Reactor compiles for AnyCPU by default

## Risk / breaking changes

None