### PR TITLE
fix(hot-reload,devtools): recover from hook-order edits; default DevtoolsMenu items to null

### DIFF
--- a/src/Reactor/Core/HookOrderException.cs
+++ b/src/Reactor/Core/HookOrderException.cs
@@ -1,0 +1,25 @@
+namespace Microsoft.UI.Reactor.Core;
+
+/// <summary>
+/// Thrown when a component's hook call sequence diverges from the previous
+/// render's sequence — either a hook is called at a different index, or the
+/// hook type at a given index doesn't match what was previously declared.
+///
+/// In normal operation this is a programming bug (hooks must be called in
+/// the same order every render). During Hot Reload, however, an edit that
+/// reorders or changes hook types is the *expected* outcome of the user
+/// editing their code — so the host catches this exception, runs cleanups
+/// on the surviving RenderContext, resets its hook state, and re-renders.
+/// State is lost (we cannot reliably re-key surviving hook values to a
+/// shape that may have changed), but the app keeps running rather than
+/// hard-failing the dev loop.
+///
+/// Derives from <see cref="InvalidOperationException"/> so existing
+/// `catch (InvalidOperationException)` handlers around component render
+/// continue to work; the host's render catch sniffs the more specific
+/// type to gate the hot-reload recovery path.
+/// </summary>
+public sealed class HookOrderException : InvalidOperationException
+{
+    public HookOrderException(string message) : base(message) { }
+}

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -70,7 +70,7 @@ public sealed class RenderContext
         _hookIndex++;
 
         if (_hooks[currentIndex] is not ValueHookState<T> hook)
-            throw new InvalidOperationException(
+            throw new HookOrderException(
                 $"Hook at index {currentIndex} is {_hooks[currentIndex].GetType().Name}, expected ValueHookState<{typeof(T).Name}> (UseState). " +
                 "Hooks must be called in the same order every render.");
 
@@ -129,7 +129,7 @@ public sealed class RenderContext
         _hookIndex++;
 
         if (_hooks[currentIndex] is not ValueHookState<T> hook)
-            throw new InvalidOperationException(
+            throw new HookOrderException(
                 $"Hook at index {currentIndex} is {_hooks[currentIndex].GetType().Name}, expected ValueHookState<{typeof(T).Name}> (UseReducer). " +
                 "Hooks must be called in the same order every render.");
 
@@ -194,7 +194,7 @@ public sealed class RenderContext
         _hookIndex++;
 
         if (_hooks[currentIndex] is not ValueHookState<TState> hook)
-            throw new InvalidOperationException(
+            throw new HookOrderException(
                 $"Hook at index {currentIndex} is {_hooks[currentIndex].GetType().Name}, expected ValueHookState<{typeof(TState).Name}> (UseReducer). " +
                 "Hooks must be called in the same order every render.");
 
@@ -248,7 +248,7 @@ public sealed class RenderContext
         }
 
         if (_hooks[_hookIndex] is not EffectHookState hook)
-            throw new InvalidOperationException(
+            throw new HookOrderException(
                 $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected EffectHookState. " +
                 "Hooks must be called in the same order every render.");
         _hookIndex++;
@@ -274,7 +274,7 @@ public sealed class RenderContext
         }
 
         if (_hooks[_hookIndex] is not EffectHookState hook)
-            throw new InvalidOperationException(
+            throw new HookOrderException(
                 $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected EffectHookState. " +
                 "Hooks must be called in the same order every render.");
         _hookIndex++;
@@ -300,7 +300,7 @@ public sealed class RenderContext
         }
 
         if (_hooks[_hookIndex] is not MemoHookState<T> hook)
-            throw new InvalidOperationException(
+            throw new HookOrderException(
                 $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected MemoHookState<{typeof(T).Name}>. " +
                 "Hooks must be called in the same order every render.");
         _hookIndex++;
@@ -336,7 +336,7 @@ public sealed class RenderContext
         _hookIndex++;
 
         if (_hooks[currentIndex] is not ValueHookState<Ref<T>> hook)
-            throw new InvalidOperationException(
+            throw new HookOrderException(
                 $"Hook at index {currentIndex} expected ValueHookState<Ref<{typeof(T).Name}>>, got {_hooks[currentIndex].GetType().Name}. " +
                 "Hooks must be called in the same order every render.");
         return hook.Value;
@@ -386,7 +386,7 @@ public sealed class RenderContext
         _hookIndex++;
 
         if (_hooks[currentIndex] is not PersistedHookState<T> hook)
-            throw new InvalidOperationException(
+            throw new HookOrderException(
                 $"Hook at index {currentIndex} is {_hooks[currentIndex].GetType().Name}, expected PersistedHookState<{typeof(T).Name}> (UsePersisted). " +
                 "Hooks must be called in the same order every render.");
 
@@ -593,7 +593,7 @@ public sealed class RenderContext
         }
 
         if (_hooks[_hookIndex] is not NavigationLifecycleHookState hook)
-            throw new InvalidOperationException(
+            throw new HookOrderException(
                 $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected NavigationLifecycleHookState. " +
                 "Hooks must be called in the same order every render.");
         _hookIndex++;
@@ -636,7 +636,7 @@ public sealed class RenderContext
         }
 
         if (_hooks[_hookIndex] is not ContextHookState hook)
-            throw new InvalidOperationException(
+            throw new HookOrderException(
                 $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected ContextHookState (UseContext). " +
                 "Hooks must be called in the same order every render.");
         _hookIndex++;
@@ -1031,6 +1031,23 @@ public sealed class RenderContext
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Hot Reload recovery: run effect cleanups and discard the entire hook
+    /// list so the next BeginRender starts with a fresh hook sequence. Used
+    /// by the host when a HookOrderException surfaces during a hot-reload-
+    /// triggered render — an edit that reorders or changes hook types is
+    /// the expected outcome of a developer change, so we trade away state
+    /// (which we cannot reliably re-key onto a new hook shape) to keep the
+    /// dev loop alive instead of leaving the user staring at an error
+    /// fallback.
+    /// </summary>
+    internal void ResetForHotReload()
+    {
+        RunCleanups();
+        _hooks.Clear();
+        _hookIndex = 0;
     }
 
     private static bool DepsEqual(object[] prev, object[] next)

--- a/src/Reactor/Hosting/Devtools/DevtoolsMenuFactory.cs
+++ b/src/Reactor/Hosting/Devtools/DevtoolsMenuFactory.cs
@@ -42,7 +42,7 @@ public static partial class Factories
     /// component via <c>ctx.UseObservable(flag)</c>.
     /// </summary>
     public static Element DevtoolsMenu(
-        Func<IEnumerable<MenuFlyoutItemBase>> items,
+        Func<IEnumerable<MenuFlyoutItemBase>>? items = null,
         string glyph = "⚡",
         string toolTip = "Devtools",
         string? automationId = null)

--- a/src/Reactor/Hosting/HotReloadService.cs
+++ b/src/Reactor/Hosting/HotReloadService.cs
@@ -1,4 +1,5 @@
 using System.Reflection.Metadata;
+using System.Threading;
 
 [assembly: MetadataUpdateHandler(typeof(Microsoft.UI.Reactor.Hosting.HotReloadService))]
 
@@ -12,15 +13,36 @@ namespace Microsoft.UI.Reactor.Hosting;
 /// </summary>
 internal static class HotReloadService
 {
+    // Underlying int storage (0 = false, 1 = true) so we can use
+    // Interlocked.Exchange for atomic capture-and-clear. .NET Hot Reload
+    // calls UpdateApplication from a runtime-controlled thread (typically
+    // the threadpool callback that just delivered the metadata update),
+    // while Render runs on the UI dispatcher. A non-atomic read-then-write
+    // would race: a second UpdateApplication firing between
+    // ReactorHostControl.Render's read and write of the flag could lose
+    // the new pending update. Exchange = single CAS, no window.
+    private static int _updatePending;
+
     /// <summary>
-    /// Set true between <see cref="UpdateApplication"/> firing and the next
-    /// successful render completing. While true, the host treats a
-    /// <see cref="Microsoft.UI.Reactor.Core.HookOrderException"/> as a
-    /// hot-reload recovery trigger (run cleanups, drop hook state,
-    /// re-render) instead of escalating to the error fallback. Cleared by
-    /// the host after the recovery (or normal) render completes.
+    /// True from when <see cref="UpdateApplication"/> sets it until
+    /// <see cref="ConsumeUpdatePending"/> atomically clears it (called by
+    /// the host at the start of each render attempt). When the consuming
+    /// render observes <c>true</c>, the host treats a
+    /// <see cref="Microsoft.UI.Reactor.Core.HookOrderException"/> raised
+    /// during that render as a hot-reload recovery trigger (run cleanups,
+    /// drop hook state, re-render) instead of escalating to the error
+    /// fallback.
     /// </summary>
-    internal static bool UpdatePending;
+    internal static bool UpdatePending => Volatile.Read(ref _updatePending) == 1;
+
+    /// <summary>
+    /// Atomically reads-and-clears <see cref="UpdatePending"/>. Returns
+    /// true exactly once per <see cref="UpdateApplication"/> call, even
+    /// if another <c>UpdateApplication</c> fires concurrently from the
+    /// hot-reload thread.
+    /// </summary>
+    internal static bool ConsumeUpdatePending() =>
+        Interlocked.Exchange(ref _updatePending, 0) == 1;
 
     /// <summary>Called by the runtime to clear any caches of metadata.</summary>
     public static void ClearCache(Type[]? updatedTypes) { }
@@ -28,7 +50,7 @@ internal static class HotReloadService
     /// <summary>Called after the metadata update is applied. Re-renders the UI.</summary>
     public static void UpdateApplication(Type[]? updatedTypes)
     {
-        UpdatePending = true;
+        Volatile.Write(ref _updatePending, 1);
 
         // force: true bypasses component memo (Props/deps equality) for this
         // pass — the updated Render() body would otherwise be skipped because

--- a/src/Reactor/Hosting/HotReloadService.cs
+++ b/src/Reactor/Hosting/HotReloadService.cs
@@ -10,14 +10,26 @@ namespace Microsoft.UI.Reactor.Hosting;
 /// UseState values survive because the RenderContext and its hooks list
 /// remain in memory — only the Render() method body changes.
 /// </summary>
-static class HotReloadService
+internal static class HotReloadService
 {
+    /// <summary>
+    /// Set true between <see cref="UpdateApplication"/> firing and the next
+    /// successful render completing. While true, the host treats a
+    /// <see cref="Microsoft.UI.Reactor.Core.HookOrderException"/> as a
+    /// hot-reload recovery trigger (run cleanups, drop hook state,
+    /// re-render) instead of escalating to the error fallback. Cleared by
+    /// the host after the recovery (or normal) render completes.
+    /// </summary>
+    internal static bool UpdatePending;
+
     /// <summary>Called by the runtime to clear any caches of metadata.</summary>
     public static void ClearCache(Type[]? updatedTypes) { }
 
     /// <summary>Called after the metadata update is applied. Re-renders the UI.</summary>
     public static void UpdateApplication(Type[]? updatedTypes)
     {
+        UpdatePending = true;
+
         // force: true bypasses component memo (Props/deps equality) for this
         // pass — the updated Render() body would otherwise be skipped because
         // props and hook deps haven't changed.

--- a/src/Reactor/Hosting/ReactorHostControl.cs
+++ b/src/Reactor/Hosting/ReactorHostControl.cs
@@ -325,6 +325,28 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
     private void Render()
     {
         _isRendering = true;
+        // Capture-and-clear gives us at-most-once recovery per
+        // UpdateApplication call:
+        //
+        //   UpdateApplication fires:    UpdatePending = true
+        //   Render runs:                hotReloadRender = true,
+        //                               UpdatePending = false  (consumed)
+        //     hooks throw:              recover + RequestRender, return
+        //   Recovery render runs:       hotReloadRender = false  (already consumed)
+        //     hooks throw again:        falls through `when (hotReloadRender)`
+        //                               filter → ShowErrorFallback
+        //
+        // So a developer who has saved genuinely broken code (hooks that
+        // continue to throw after a fresh hook list) sees the error
+        // fallback once, not an infinite reset loop. Each subsequent save
+        // sets UpdatePending again and grants exactly one more retry.
+        //
+        // Coalesced bursts (multiple UpdateApplication calls before any
+        // render dispatches) collapse to one retry — UpdatePending stays
+        // true through the burst and is consumed by the next render. That
+        // matches the dispatcher's RequestRender coalescing behavior.
+        bool hotReloadRender = HotReloadService.UpdatePending;
+        HotReloadService.UpdatePending = false;
         try
         {
             Element? newTree = null;
@@ -337,6 +359,14 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
                 try
                 {
                     newTree = _rootComponent.Render();
+                }
+                catch (HookOrderException ex) when (hotReloadRender)
+                {
+                    _logger.LogWarning(ex,
+                        "Hot reload: hook order/type changed — resetting component state and re-rendering");
+                    _rootComponent.Context.ResetForHotReload();
+                    RequestRender();
+                    return;
                 }
                 catch (Exception ex)
                 {
@@ -351,6 +381,14 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
                 try
                 {
                     newTree = _rootRenderFunc(_funcContext);
+                }
+                catch (HookOrderException ex) when (hotReloadRender)
+                {
+                    _logger.LogWarning(ex,
+                        "Hot reload: hook order/type changed — resetting function-component state and re-rendering");
+                    _funcContext.ResetForHotReload();
+                    RequestRender();
+                    return;
                 }
                 catch (Exception ex)
                 {

--- a/src/Reactor/Hosting/ReactorHostControl.cs
+++ b/src/Reactor/Hosting/ReactorHostControl.cs
@@ -325,28 +325,41 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
     private void Render()
     {
         _isRendering = true;
-        // Capture-and-clear gives us at-most-once recovery per
+        // Atomic capture-and-clear gives us at-most-once recovery per
         // UpdateApplication call:
         //
-        //   UpdateApplication fires:    UpdatePending = true
-        //   Render runs:                hotReloadRender = true,
-        //                               UpdatePending = false  (consumed)
+        //   UpdateApplication fires:    UpdatePending = 1
+        //   Render runs:                ConsumeUpdatePending() → true
+        //                               (atomic Interlocked.Exchange to 0)
         //     hooks throw:              recover + RequestRender, return
-        //   Recovery render runs:       hotReloadRender = false  (already consumed)
+        //   Recovery render runs:       ConsumeUpdatePending() → false
         //     hooks throw again:        falls through `when (hotReloadRender)`
         //                               filter → ShowErrorFallback
         //
-        // So a developer who has saved genuinely broken code (hooks that
+        // A developer who has saved genuinely broken code (hooks that
         // continue to throw after a fresh hook list) sees the error
         // fallback once, not an infinite reset loop. Each subsequent save
-        // sets UpdatePending again and grants exactly one more retry.
+        // raises UpdatePending again and grants exactly one more retry.
         //
-        // Coalesced bursts (multiple UpdateApplication calls before any
-        // render dispatches) collapse to one retry — UpdatePending stays
-        // true through the burst and is consumed by the next render. That
-        // matches the dispatcher's RequestRender coalescing behavior.
-        bool hotReloadRender = HotReloadService.UpdatePending;
-        HotReloadService.UpdatePending = false;
+        // Atomicity matters because UpdateApplication is invoked by the
+        // hot-reload runtime on a non-UI thread; a non-atomic read-then-
+        // write here could miss a pending update if the hot-reload thread
+        // raises the flag in the window between the read and the write.
+        bool hotReloadRender = HotReloadService.ConsumeUpdatePending();
+
+        // Local helper centralizes the recovery sequence (log → reset
+        // RenderContext → request a fresh render). Both component-mode
+        // and function-mode catches share it; future tweaks (telemetry,
+        // additional reset steps, throttling) only need editing here.
+        void RecoverFromHookOrder(HookOrderException ex, RenderContext ctx, string mode)
+        {
+            _logger.LogWarning(ex,
+                "Hot reload: hook order/type changed — resetting {Mode} state and re-rendering",
+                mode);
+            ctx.ResetForHotReload();
+            RequestRender();
+        }
+
         try
         {
             Element? newTree = null;
@@ -362,10 +375,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
                 }
                 catch (HookOrderException ex) when (hotReloadRender)
                 {
-                    _logger.LogWarning(ex,
-                        "Hot reload: hook order/type changed — resetting component state and re-rendering");
-                    _rootComponent.Context.ResetForHotReload();
-                    RequestRender();
+                    RecoverFromHookOrder(ex, _rootComponent.Context, "component");
                     return;
                 }
                 catch (Exception ex)
@@ -384,10 +394,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
                 }
                 catch (HookOrderException ex) when (hotReloadRender)
                 {
-                    _logger.LogWarning(ex,
-                        "Hot reload: hook order/type changed — resetting function-component state and re-rendering");
-                    _funcContext.ResetForHotReload();
-                    RequestRender();
+                    RecoverFromHookOrder(ex, _funcContext, "function-component");
                     return;
                 }
                 catch (Exception ex)

--- a/tests/Reactor.Tests/ContextSystemUnitTests.cs
+++ b/tests/Reactor.Tests/ContextSystemUnitTests.cs
@@ -210,7 +210,7 @@ public class ContextSystemUnitTests
 
         // Second render: try UseContext where UseState was
         ctx.BeginRender(() => { }, scope);
-        var ex = Assert.Throws<InvalidOperationException>(() => ctx.UseContext(TestTheme));
+        var ex = Assert.Throws<HookOrderException>(() => ctx.UseContext(TestTheme));
         Assert.Contains("ContextHookState", ex.Message);
     }
 

--- a/tests/Reactor.Tests/HookStateRefactorTests.cs
+++ b/tests/Reactor.Tests/HookStateRefactorTests.cs
@@ -238,7 +238,7 @@ public class HookStateRefactorTests
 
         // Second render: try to call UseEffect where UseState was — should throw
         ctx.BeginRender(() => { });
-        var ex = Assert.Throws<InvalidOperationException>(() => ctx.UseEffect(() => { }, "dep"));
+        var ex = Assert.Throws<HookOrderException>(() => ctx.UseEffect(() => { }, "dep"));
         Assert.Contains("ValueHookState", ex.Message);
     }
 
@@ -255,9 +255,66 @@ public class HookStateRefactorTests
 
         // Second render: UseState where UseEffect was — should throw
         ctx.BeginRender(() => { });
-        var ex = Assert.Throws<InvalidOperationException>(() => ctx.UseState(0));
+        var ex = Assert.Throws<HookOrderException>(() => ctx.UseState(0));
         Assert.Contains("EffectHookState", ex.Message);
         Assert.Contains("ValueHookState", ex.Message);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Hot Reload recovery: ResetForHotReload clears state + cleanups
+    //  so a render after a hook-order break can succeed
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ResetForHotReload_RunsCleanups_And_ClearsHooks_So_Next_Render_Sees_Fresh_Sequence()
+    {
+        var ctx = new RenderContext();
+        bool cleanupRan = false;
+
+        // Render 1 (pre-edit): UseState + UseEffect with cleanup.
+        ctx.BeginRender(() => { });
+        ctx.UseState(42);
+        ctx.UseEffect(() => () => cleanupRan = true, "dep");
+        ctx.FlushEffects();
+
+        // Render 2 (post-edit): the developer reordered hooks. Calling
+        // UseEffect at index 0 (where UseState lived) throws.
+        ctx.BeginRender(() => { });
+        Assert.Throws<HookOrderException>(() => ctx.UseEffect(() => { }, "dep"));
+
+        // Hot reload recovery: cleanups run, hook list reset.
+        ctx.ResetForHotReload();
+        Assert.True(cleanupRan, "Effect cleanup should run during ResetForHotReload");
+
+        // Render 3 (recovery): the new hook order is accepted as if first
+        // mount — UseEffect-then-UseState now works because the hook list
+        // starts empty. State is lost (the 42 from render 1), which is the
+        // documented trade-off.
+        ctx.BeginRender(() => { });
+        ctx.UseEffect(() => { }, "dep");
+        var (value, _) = ctx.UseState(0);
+        Assert.Equal(0, value);
+    }
+
+    [Fact]
+    public void ResetForHotReload_Allows_Different_Hook_Type_At_Same_Index()
+    {
+        var ctx = new RenderContext();
+
+        // Render 1: UseState<int>.
+        ctx.BeginRender(() => { });
+        ctx.UseState(7);
+
+        // Render 2: developer changed UseState<int> to UseState<string>.
+        // Same hook *kind* but different generic — different ValueHookState<T>.
+        ctx.BeginRender(() => { });
+        Assert.Throws<HookOrderException>(() => ctx.UseState("hello"));
+
+        // After recovery the new shape works.
+        ctx.ResetForHotReload();
+        ctx.BeginRender(() => { });
+        var (s, _) = ctx.UseState("hello");
+        Assert.Equal("hello", s);
     }
 
     // ════════════════════════════════════════════════════════════════

--- a/tests/Reactor.Tests/NavigationLifecycleTests.cs
+++ b/tests/Reactor.Tests/NavigationLifecycleTests.cs
@@ -154,7 +154,7 @@ public class NavigationLifecycleTests
 
         // Second render: try UseNavigationLifecycle at UseState's index
         ctx.BeginRender(() => { });
-        Assert.Throws<InvalidOperationException>(() => ctx.UseNavigationLifecycle());
+        Assert.Throws<HookOrderException>(() => ctx.UseNavigationLifecycle());
     }
 
     // ════════════════════════════════════════════════════════════════

--- a/tests/Reactor.Tests/PersistedStateTests.cs
+++ b/tests/Reactor.Tests/PersistedStateTests.cs
@@ -349,7 +349,7 @@ public class PersistedStateTests : IDisposable
 
         // Second render: try UsePersisted where UseState was
         ctx.BeginRender(() => { });
-        var ex = Assert.Throws<InvalidOperationException>(() => ctx.UsePersisted("key", "hello"));
+        var ex = Assert.Throws<HookOrderException>(() => ctx.UsePersisted("key", "hello"));
         Assert.Contains("PersistedHookState", ex.Message);
     }
 }


### PR DESCRIPTION
## Summary

Two related issues surfaced while putting together a demo app:

1. **Hot Reload now survives hook-order / hook-type edits.** Adding, removing, or reordering hooks (or changing a hook's generic type) used to leave the app stuck on the error fallback after the very next save — the surviving `RenderContext` had the *previous* hook list pinned by index. The dev loop died until the user restarted. New behavior: when a hook mismatch surfaces during a render triggered by .NET Hot Reload, the host runs effect cleanups, drops the hook list, and re-renders from scratch. State is lost (cannot reliably re-key surviving values onto a changed shape), but the app keeps running.

2. **`DevtoolsMenu()` works with no arguments.** Calling it with no args used to require a no-op `() => Array.Empty<MenuFlyoutItemBase>()` to get the built-in toggles. The implementation already null-coalesced internally; only the parameter signature blocked it.

## Why one PR

Both surfaced in the same demo session. Together they're \"things that should just work when you're prototyping.\" Splitting felt like ceremony for two tightly related quality-of-life fixes. Happy to split if reviewers prefer.

## Hot Reload recovery — design

- **New `HookOrderException : InvalidOperationException`** so the host can sniff the specific subtype without changing existing `catch (InvalidOperationException)` semantics for callers.
- **10 hook-order throw sites in `RenderContext.cs`** converted from `InvalidOperationException` to `HookOrderException`. Cross-thread setter and `UseNavigation` lookup throws are intentionally left as plain `InvalidOperationException` — neither is a hot-reload-recoverable failure.
- **`RenderContext.ResetForHotReload()`** (internal): runs cleanups, clears hook list, resets index.
- **`HotReloadService.UpdatePending`**: signals \"the next render is a hot-reload-induced render.\" Set by `UpdateApplication`, consumed (capture-and-clear) by `ReactorHostControl.Render` at the top.
- **`ReactorHostControl.Render()`** picks up the flag and adds `catch (HookOrderException) when (hotReloadRender)` recovery filters on each render branch.

### Infinite-loop guard

The capture-and-clear pattern guarantees **at-most-once recovery per `UpdateApplication` call**:

```
UpdateApplication fires:    UpdatePending = true
Render runs:                hotReloadRender = true,
                            UpdatePending = false  (consumed)
  hooks throw:              recover + RequestRender, return
Recovery render runs:       hotReloadRender = false  (already consumed)
  hooks throw again:        falls through `when (hotReloadRender)`
                            filter → ShowErrorFallback
```

A developer who saved genuinely broken hook code sees the error fallback once, not an infinite reset loop. Each subsequent save grants exactly one more retry.

## Test plan

- [x] `dotnet test tests/Reactor.Tests` — 6821 passed, 0 failed (2 new for the recovery path)
- [ ] `dotnet test tests/Reactor.SelfTests` — pending (running)
- [x] 5 existing `Assert.Throws<InvalidOperationException>` hook-order tests tightened to `Assert.Throws<HookOrderException>`. The looser assertion was incidental — these tests have always been about a specific contract that now has a specific type.
- [x] 2 new tests in `HookStateRefactorTests.cs`: `ResetForHotReload_RunsCleanups_And_ClearsHooks_So_Next_Render_Sees_Fresh_Sequence` and `ResetForHotReload_Allows_Different_Hook_Type_At_Same_Index`.
- [ ] Recommended manual: run `dotnet watch` against a Reactor sample, edit a component to add/remove/reorder a hook, save, confirm the app reloads instead of hard-failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)