### PR TITLE
ci(stress): escape $idx in pwsh string to fix parse error

### DIFF
--- a/.github/workflows/ci-stress.yml
+++ b/.github/workflows/ci-stress.yml
@@ -108,7 +108,7 @@ jobs:
             Write-Host "::error::Shard $idx had $($failures.Count) failed iteration(s): $($failures -join ', ')"
             exit 1
           }
-          Write-Host "Shard $idx: $count iterations passed."
+          Write-Host "Shard ${idx}: $count iterations passed."
 
   selftests:
     name: Selftests (shard ${{ matrix.shard }})
@@ -161,7 +161,7 @@ jobs:
             Write-Host "::error::Shard $idx had $($failures.Count) failed iteration(s): $($failures -join ', ')"
             exit 1
           }
-          Write-Host "Shard $idx: $count iterations passed."
+          Write-Host "Shard ${idx}: $count iterations passed."
 
   summary:
     name: Stress summary


### PR DESCRIPTION
## Summary
- Fixes the stress-loop step that failed on every shard of the first dispatched run ([run 25503010105](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/25503010105)) before any `dotnet test` iteration could execute.
- PowerShell parses `"$idx:"` inside a double-quoted string as a drive/scope-qualified variable reference (the same syntax as `$env:FOO` or `$global:bar`) and rejects it with `Variable reference is not valid. ':' was not followed by a valid variable name character.`
- Switches both the unit and selftest closing lines to `"Shard ${idx}: $count iterations passed."` so the variable boundary is explicit. No other behavior change.

## Test plan
- [ ] Re-dispatch CI Stress on `main` after merge with defaults (100 iters, both, 20 shards) and confirm shards reach the actual `dotnet test` loop.
- [ ] Confirm the green-path final line `Shard N: M iterations passed.` renders correctly in shard logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)