### PR TITLE
fix(hot-reload): mirror hook-order recovery into ReactorHost

### DIFF
--- a/src/Reactor/Hosting/ReactorHost.cs
+++ b/src/Reactor/Hosting/ReactorHost.cs
@@ -494,6 +494,20 @@ public sealed class ReactorHost : IDisposable
     private void Render()
     {
         _isRendering = true;
+        // Atomic capture-and-clear gives us at-most-once recovery per
+        // UpdateApplication call — see the matching block in
+        // ReactorHostControl.Render() for the full rationale.
+        bool hotReloadRender = HotReloadService.ConsumeUpdatePending();
+
+        void RecoverFromHookOrder(HookOrderException ex, RenderContext ctx, string mode)
+        {
+            _logger?.LogWarning(ex,
+                "Hot reload: hook order/type changed — resetting {Mode} state and re-rendering",
+                mode);
+            ctx.ResetForHotReload();
+            RequestRender();
+        }
+
         try
         {
             Element? newTree = null;
@@ -523,6 +537,11 @@ public sealed class ReactorHost : IDisposable
                 {
                     newTree = _rootComponent.Render();
                 }
+                catch (HookOrderException ex) when (hotReloadRender)
+                {
+                    RecoverFromHookOrder(ex, _rootComponent.Context, "component");
+                    return;
+                }
                 catch (Exception ex)
                 {
                     _logger?.LogError(ex, "Component Render() threw");
@@ -536,6 +555,11 @@ public sealed class ReactorHost : IDisposable
                 try
                 {
                     newTree = _rootRenderFunc(_funcContext);
+                }
+                catch (HookOrderException ex) when (hotReloadRender)
+                {
+                    RecoverFromHookOrder(ex, _funcContext, "function-component");
+                    return;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary

- #186 wired hot-reload hook-order recovery into `ReactorHostControl` but missed `ReactorHost` — the host that backs `ReactorApp.Run<T>(...)`. Apps launched via the app-builder path (the demo template, samples, every non-XAML-Islands consumer) hit `HookOrderException` on the first hot-reload edit that adds, removes, or reorders a hook, fall through to the generic catch, and stick on the error fallback until restart.
- Mirror the same recovery sequence in `ReactorHost.Render()`: capture `HotReloadService.ConsumeUpdatePending()` once at the top, add a `catch (HookOrderException ex) when (hotReloadRender)` filter ahead of the generic catch on both component-mode and function-component branches, and route into a shared `RecoverFromHookOrder` local that runs cleanups, calls `RenderContext.ResetForHotReload()`, and `RequestRender`s.

Surfaced while iterating on a `ReactorApp.Run<App>` demo — adding a `UseResource` between renders consistently produced the error fallback even though the same edit recovered cleanly under `ReactorHostControl`.

## Test plan

- [ ] Launch a `ReactorApp.Run<App>(...)` demo with `dotnet watch run` and add a `UseResource(...)` line above an existing `UseState`. Expect a `Hot reload: hook order/type changed — resetting component state and re-rendering` warning and a clean re-render (state is lost, app keeps running). Pre-fix: error fallback until restart.
- [ ] Same edit on a function-component host (`ReactorApp.Run(ctx => ...)` if applicable) — expect the `function-component` log message and recovery.
- [ ] Make a *genuinely* broken edit (hooks throw on every render) and confirm the app shows the error fallback after one retry rather than looping — this validates the at-most-once contract carried over from `ConsumeUpdatePending`.
- [ ] Existing `Reactor.Tests.HookStateRefactorTests` hot-reload coverage still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)