### PR TITLE
test: stabilize four flakes surfaced by CI Stress workflow

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeHookFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeHookFixtures.cs
@@ -46,10 +46,13 @@ internal static class ThreadSafeHookFixtures
             await Harness.Render();
             H.Check("RapidBG_InitialRender", H.FindText("Counter: 0") is not null);
 
-            // Hammer from 4 threads for 2 seconds
-            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            // Hammer from 4 threads for 2 seconds. Use Barrier(5) so the main
+            // thread waits for all workers to be inside the loop before starting
+            // the 2-second budget — otherwise a starved CI threadpool can let
+            // CancelAfter elapse before Task.Run actually schedules the workers.
             int writeCount = 0;
-            var barrier = new Barrier(4);
+            var barrier = new Barrier(5);
+            var cts = new CancellationTokenSource();
             var tasks = Enumerable.Range(0, 4).Select(t =>
                 Task.Run(() =>
                 {
@@ -63,6 +66,8 @@ internal static class ThreadSafeHookFixtures
                 })
             ).ToArray();
 
+            barrier.SignalAndWait();
+            cts.CancelAfter(TimeSpan.FromSeconds(2));
             await Task.WhenAll(tasks);
 
             // Let the render loop settle — low-priority enqueue means a few frames
@@ -71,14 +76,14 @@ internal static class ThreadSafeHookFixtures
             var final = lastWritten;
             var text = H.FindControl<TextBlock>(tb => tb.Text?.StartsWith("Counter:") == true);
             H.Check("RapidBG_TextPresent", text is not null);
-            H.Check("RapidBG_WritesHappened", writeCount > 100);
+            H.Check($"RapidBG_WritesHappened (writes={writeCount})", writeCount > 100);
 
             // The rendered value should be the last value set (or very close to it,
             // since a render might have been in flight when the last write landed)
             if (text is not null)
             {
                 var rendered = int.Parse(text.Text.Replace("Counter: ", ""));
-                H.Check("RapidBG_FinalValueReasonable",
+                H.Check($"RapidBG_FinalValueReasonable (rendered={rendered}, writes={writeCount})",
                     rendered > 0 && rendered <= writeCount);
             }
         }
@@ -292,13 +297,17 @@ internal static class ThreadSafeHookFixtures
 
             H.Check("Coalesce_FinalValue", H.FindText("Value: 1000") is not null);
 
-            // Render count should be far less than 1000 due to coalescing
+            // Render count should be far less than 1000 due to coalescing.
+            // Threshold is loose (1/5 of writes) to tolerate scheduler interleaving
+            // on CI runners where the UI thread can sneak in renders between
+            // background-thread setState calls; full coalescing on a quiet machine
+            // produces ~2 renders.
             var renderText = H.FindControl<TextBlock>(tb =>
                 tb.Text?.StartsWith("Renders:") == true);
             if (renderText is not null)
             {
                 var renders = int.Parse(renderText.Text.Replace("Renders: ", ""));
-                H.Check("Coalesce_FarFewerRenders", renders < 100);
+                H.Check($"Coalesce_FarFewerRenders (renders={renders})", renders < 200);
             }
         }
     }

--- a/tests/Reactor.Tests/AutoSuggestTests.cs
+++ b/tests/Reactor.Tests/AutoSuggestTests.cs
@@ -21,7 +21,10 @@ public class AutoSuggestTests
         // Check after subscribing to avoid TOCTOU race
         if (manager.State == target)
             tcs.TrySetResult();
-        return tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        // Generous budget: under thread-pool starvation on a contended CI runner
+        // a 5s ceiling races debounce+continuation scheduling. 30s still surfaces
+        // a genuine "state never reached" bug with a clear TimeoutException.
+        return tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
     }
     // ════════════════════════════════════════════════════════════════
     //  Element creation

--- a/tests/Reactor.Tests/Core/UseResourceTests.cs
+++ b/tests/Reactor.Tests/Core/UseResourceTests.cs
@@ -291,7 +291,9 @@ public class UseResourceTests
         // current hook state and does not re-invoke the fetcher.
         AsyncValue<int>? probe = null;
         var sw = global::System.Diagnostics.Stopwatch.StartNew();
-        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        // Budget covers retry backoff (100ms + 200ms = 300ms minimum) plus
+        // threadpool/timer scheduling slack on a loaded CI runner.
+        while (sw.Elapsed < TimeSpan.FromSeconds(30))
         {
             ctx.BeginRender(() => { });
             probe = ctx.UseResource(fetcher, cache, Array.Empty<object>(),
@@ -324,10 +326,11 @@ public class UseResourceTests
             new ResourceOptions(RetryCount: 2), dispatcher);
         ctx.FlushEffects();
 
-        // Poll the rendered state, not the call counter.
+        // Poll the rendered state, not the call counter. Budget covers retry
+        // backoff plus threadpool/timer scheduling slack on a loaded CI runner.
         AsyncValue<int>? probe = null;
         var sw = global::System.Diagnostics.Stopwatch.StartNew();
-        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        while (sw.Elapsed < TimeSpan.FromSeconds(30))
         {
             ctx.BeginRender(() => { });
             probe = ctx.UseResource(fetcher, cache, Array.Empty<object>(),

--- a/tests/Reactor.Tests/Devtools/LogCaptureBufferTests.cs
+++ b/tests/Reactor.Tests/Devtools/LogCaptureBufferTests.cs
@@ -132,7 +132,9 @@ public class LogCaptureBufferTests
         await buf.WaitForNewAsync(1, 150);
         sw.Stop();
         Assert.True(sw.ElapsedMilliseconds >= 100, $"WaitForNewAsync returned after only {sw.ElapsedMilliseconds}ms (expected ≥ ~150ms)");
-        Assert.True(sw.ElapsedMilliseconds < 2_000, $"WaitForNewAsync blocked for {sw.ElapsedMilliseconds}ms");
+        // Upper bound is a "didn't get stuck forever" sanity check — generous so
+        // thread-pool starvation on a contended CI runner doesn't fail it.
+        Assert.True(sw.ElapsedMilliseconds < 30_000, $"WaitForNewAsync blocked for {sw.ElapsedMilliseconds}ms");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Addresses all six tests that flaked during the [first real CI Stress run](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/25504721012) (17 iteration failures across 200 iterations).

| Test | Iter failures | Class of fix |
|---|---:|---|
| `UseResourceTests.Retry_Invokes_Fetcher_Multiple_Times_And_Settles_On_Success` | 3 | Poll budget 5s → 30s |
| `UseResourceTests.Retry_Exhausted_Surfaces_Final_Error` | 0 (preventive) | Poll budget 5s → 30s (same shape) |
| `LogCaptureBufferTests.WaitForNewAsync_RespectsTimeout` | 2 | Upper-bound assertion 2s → 30s |
| `AutoSuggestTests.SearchManager_Error_State_On_Exception` | 1 | `WaitForState` budget 5s → 30s |
| `AutoSuggestTests.SearchManager_Empty_State_On_No_Results` | 1 | (same helper) |
| `selftest ThreadSafe_RapidBackgroundSetState` | 2 | **Real race** — start CTS after barrier |
| `selftest ThreadSafe_RenderCoalescing` | 8 | Threshold 100 → 200 + diagnostic message |

## Notable: the one real race
`ThreadSafe_RapidBackgroundSetState` was creating its 2-second `CancellationTokenSource` *before* `Task.Run` actually scheduled the four worker threads. On a starved CI threadpool the 2s budget could elapse before any worker entered the hammer loop, leaving `writeCount = 0` and the rendered counter never updating. Both `RapidBG_WritesHappened` and `RapidBG_FinalValueReasonable` then failed identically. Fix: `Barrier(5)` so the main thread waits for all four workers to be inside the loop, then `cts.CancelAfter(2s)`.

## Diagnostics
`H.Check` only emits `not ok <name> - assertion failed` with no values, which made selftest failures hard to triage from the log. This PR threads the actual numbers into the check name (`RapidBG_WritesHappened (writes=87)`, `Coalesce_FarFewerRenders (renders=137)`) so any future regression is diagnosable from the workflow log without local repro.

## Why bump budgets to 30s rather than something tighter
The `Retry_Invokes_Fetcher_*` tests use 100ms/200ms backoff between retries (~300ms minimum + dispatcher cost). On a quiet machine they settle in ~50ms. The 5s ceiling in the original tests was already a 100x safety factor that turned out not to be enough under threadpool starvation. 30s preserves the genuine "the test never settles" failure mode (now surfacing as `TimeoutException` with a clean stack) while not flaking on scheduling jitter.

## Test plan
- [ ] All five formerly-flaky unit tests pass locally after the change (verified — `Test Run Successful. Total tests: 5, Passed: 5`).
- [ ] After merge, re-run **CI Stress** with `iterations=100, target=both, shards=20` and verify the failure tally drops from 17 to 0 (or close to it — `RenderCoalescing` is a probabilistic probe and the new threshold is a judgment call).
- [ ] If `RenderCoalescing` still flakes, the new diagnostic message will show the actual render count, and we can tune the threshold or investigate whether the production coalescing has degraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)