### PR TITLE
build: update CsWinRT to 2.3.0-prerelease + apply OSClient defaults

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,13 +1,46 @@
 <Project>
 
   <!--
-    Centralize the Windows App SDK version so all projects stay in sync.
+    Centralize the Windows App SDK + CsWinRT versions so all projects stay in sync.
     This uses the public Microsoft.WindowsAppSDK package from NuGet.
     To install: dotnet restore (NuGet will pull the package automatically).
   -->
   <PropertyGroup>
     <WindowsAppSDKVersion>2.0.1</WindowsAppSDKVersion>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <!-- CsWinRT pin. Latest 2.3.x is currently a prerelease; bump to the next
+         stable when it ships. The PackageReference is added in
+         Directory.Build.targets for any project that opts into WinUI. -->
+    <CsWinRTVersion>2.3.0-prerelease.251115.2</CsWinRTVersion>
+  </PropertyGroup>
+
+  <!-- ──────────────────────────────────────────────────────────────────
+       CsWinRT best-practice defaults for WinUI projects.
+
+       Modeled on OSClient's UES.Common.CSharp.SDK.props
+       (microsoft.visualstudio.com/OS — Build/MSBuild/UES.Common.CSharp.SDK.props),
+       trimmed to the settings that make sense for a pure WinAppSDK repo
+       (no UWP, no OS XAML mixing, no AOT-merged WinRT components).
+
+       Gated on UseWinUI=true so analyzers/source-generators/etc that don't
+       reference WinAppSDK keep their default behavior.
+       ────────────────────────────────────────────────────────────────── -->
+  <PropertyGroup Condition="'$(UseWinUI)' == 'true'">
+    <!-- Get verbose CsWinRT diagnostics in the build log — same default OSClient uses. -->
+    <CsWinRTEnableLogging>true</CsWinRTEnableLogging>
+
+    <!-- We don't author WinRT projections in this repo (we only consume them).
+         IID patching adds startup cost for projection authors and is not needed
+         for consumers. -->
+    <CsWinRTIIDOptimizerOptOut>true</CsWinRTIIDOptimizerOptOut>
+
+    <!-- Don't pick up a side-by-side UWP toolset that may exist on a dev box.
+         Keeps local builds matching what the CI/lab build will produce. -->
+    <CsWinRTUseEnvironmentalTools>false</CsWinRTUseEnvironmentalTools>
+
+    <!-- By default CsWinRT loads WinRT components into a separate AssemblyLoadContext,
+         which breaks JIT-only test/sample apps. Production AOT builds aren't affected. -->
+    <CsWinRTLoadComponentsInDefaultALC>true</CsWinRTLoadComponentsInDefaultALC>
   </PropertyGroup>
 
   <!-- Default Platform to the current machine architecture so that

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,4 +28,20 @@
     <PublishAot>false</PublishAot>
   </PropertyGroup>
 
+  <!-- ───────────────────────────────────────────────────────────────────
+       Pin Microsoft.Windows.CsWinRT to the version centralized in
+       $(CsWinRTVersion) (Directory.Build.props). Without this the version
+       floats with whatever WinAppSDK pulls in transitively — currently a
+       very old 2.0.x — and we lose access to newer projection generators
+       and analyzer rules.
+
+       PrivateAssets=all because CsWinRT is a build-time generator; the
+       downstream nupkg should not list it as a dependency.
+       ─────────────────────────────────────────────────────────────────── -->
+  <ItemGroup Condition="'$(UseWinUI)' == 'true'">
+    <PackageReference Include="Microsoft.Windows.CsWinRT"
+                      Version="$(CsWinRTVersion)"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/samples/Reactor.TestApp/Demos/SpecializedEditorsDemo.cs
+++ b/samples/Reactor.TestApp/Demos/SpecializedEditorsDemo.cs
@@ -252,7 +252,7 @@ class SpecializedEditorsDemo : Component
         // Explicit: only offer three of the four enum values here.
         TypedColumns.ComboBoxColumn<Gizmo, GizmoPriority>(
             "Priority", g => g.Priority,
-            choices: [GizmoPriority.Low, GizmoPriority.Medium, GizmoPriority.High],
+            choices: (GizmoPriority[])[GizmoPriority.Low, GizmoPriority.Medium, GizmoPriority.High],
             width: 110),
         TypedColumns.HyperlinkColumn<Gizmo>("Website", g => g.Website, width: 200),
         TypedColumns.ColorColumn<Gizmo>("AccentColor", g => g.AccentColor,

--- a/samples/ReactorCharting.Gallery/Samples/CandlestickChart.cs
+++ b/samples/ReactorCharting.Gallery/Samples/CandlestickChart.cs
@@ -98,7 +98,7 @@ public class CandlestickChart : GallerySample
              .. Enumerable.Range(0, 4).Select(n => n * 5)
                  .Select(i => D3Charts.Text(xs.Map(i) - 12, top + height + 4, $"Day {i + 1}", 10, ChartMutedForeground)),
              D3Charts.Text(2, top - 14, "Price", 11, ChartMutedForeground),
-             .. D3Legend(left + width - 120, top + 5, [("Bullish", bullBrush), ("Bearish", bearBrush)])]
+             .. D3Legend(left + width - 120, top + 5, ((string, Microsoft.UI.Xaml.Media.SolidColorBrush)[])[("Bullish", bullBrush), ("Bearish", bearBrush)])]
         )
             .AutomationName("Stock Price Candlestick Chart")
             .FullDescription("Candlestick chart showing 20 trading days of OHLC price data, with green candles for bullish and red for bearish days.");

--- a/samples/ReactorCharting.Gallery/Samples/CirclePacking.cs
+++ b/samples/ReactorCharting.Gallery/Samples/CirclePacking.cs
@@ -106,7 +106,7 @@ public sealed class CirclePackingSample : GallerySample
                         };
                     }
 
-                    return [circle];
+                    return (Element[])[circle];
                 }
                 else
                 {

--- a/samples/ReactorCharting.Gallery/Samples/DifferenceChart.cs
+++ b/samples/ReactorCharting.Gallery/Samples/DifferenceChart.cs
@@ -85,7 +85,7 @@ D3Canvas(W, H,
                 stroke: greenBrush, strokeWidth: 2, curve: D3Curve.MonotoneX),
             D3LinePath(data, x: d => xScale.Map(d.X), y: d => yScale.Map(d.B),
                 stroke: redBrush, strokeWidth: 2, curve: D3Curve.MonotoneX),
-            .. D3Legend(lx, marginTop + 6, [("Revenue", greenBrush), ("Expenses", redBrush)]),
+            .. D3Legend(lx, marginTop + 6, ((string, Microsoft.UI.Xaml.Media.SolidColorBrush)[])[("Revenue", greenBrush), ("Expenses", redBrush)]),
             Microsoft.UI.Reactor.Charting.D3Charts.Text(marginLeft, 4, "Difference Chart (Revenue vs Expenses)", 14, ChartForeground),
         ])
             .AutomationName("Difference Chart (Revenue vs Expenses)")

--- a/samples/ReactorCharting.Gallery/Samples/DivergingBarChart.cs
+++ b/samples/ReactorCharting.Gallery/Samples/DivergingBarChart.cs
@@ -105,7 +105,7 @@ public class DivergingBarChartSample : GallerySample
                  TextRight(2, top + band.Map(item) + band.Bandwidth / 2 - 7, item, left - 6, 10, ChartMutedForeground)),
 
              // Legend
-             .. D3Legend(left + plotW - 120, top + 2, [("Positive", posBrush), ("Negative", negBrush)]),
+             .. D3Legend(left + plotW - 120, top + 2, ((string, Microsoft.UI.Xaml.Media.SolidColorBrush)[])[("Positive", posBrush), ("Negative", negBrush)]),
 
              D3Charts.Text(left, 4, "Customer Sentiment Scores", 13, ChartForeground),
             ]

--- a/samples/ReactorCharting.Gallery/Samples/SlopeChart.cs
+++ b/samples/ReactorCharting.Gallery/Samples/SlopeChart.cs
@@ -89,7 +89,7 @@ public class SlopeChart : GallerySample
              }),
 
              // Legend
-             .. D3Legend(canvasW / 2 - 80, canvasH - 22, [("Improved", Brush(Palette[2])), ("Declined", Brush(Palette[3]))]),
+             .. D3Legend(canvasW / 2 - 80, canvasH - 22, ((string, Microsoft.UI.Xaml.Media.SolidColorBrush)[])[("Improved", Brush(Palette[2])), ("Declined", Brush(Palette[3]))]),
             ]
         )
             .AutomationName("Department Performance: Before vs After")

--- a/samples/TodoApp/Program.cs
+++ b/samples/TodoApp/Program.cs
@@ -45,21 +45,21 @@ static class TodoReducer
         AddItem when !string.IsNullOrWhiteSpace(state.NewItemText) =>
             state with
             {
-                Items = [.. state.Items, new(Guid.NewGuid().ToString(), state.NewItemText.Trim(), false)],
+                Items = (TodoItem[])[.. state.Items, new(Guid.NewGuid().ToString(), state.NewItemText.Trim(), false)],
                 NewItemText = ""
             },
         ToggleItem t => state with
         {
-            Items = [.. state.Items.Select(i =>
+            Items = (TodoItem[])[.. state.Items.Select(i =>
                 i.Id == t.Id ? i with { IsCompleted = !i.IsCompleted } : i)]
         },
         DeleteItem d => state with
         {
-            Items = [.. state.Items.Where(i => i.Id != d.Id)]
+            Items = (TodoItem[])[.. state.Items.Where(i => i.Id != d.Id)]
         },
         SetNewItemText s => state with { NewItemText = s.Text },
         SetFilter f => state with { Filter = f.Filter },
-        ClearCompleted => state with { Items = [.. state.Items.Where(i => !i.IsCompleted)] },
+        ClearCompleted => state with { Items = (TodoItem[])[.. state.Items.Where(i => !i.IsCompleted)] },
         _ => state
     };
 }

--- a/src/Reactor/Charting/Charts.Tree.cs
+++ b/src/Reactor/Charting/Charts.Tree.cs
@@ -166,7 +166,7 @@ public sealed class TreeChartElement<T> : IChartAccessibilityData
                 return new ChartPointDescriptor(label, node.Depth);
             }).ToArray();
 
-            return [new ChartSeriesDescriptor("Nodes", points)];
+            return (ChartSeriesDescriptor[])[new ChartSeriesDescriptor("Nodes", points)];
         }
     }
 
@@ -390,7 +390,7 @@ public sealed class ForceGraphElement : IChartAccessibilityData
                     $"{sourceName} to {targetName}, weight {link.Strength}");
             }).ToArray();
 
-            return [new ChartSeriesDescriptor("Edges", points)];
+            return (ChartSeriesDescriptor[])[new ChartSeriesDescriptor("Edges", points)];
         }
     }
 

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -394,7 +394,7 @@ public sealed class ChartElement<T> : IChartAccessibilityData
                 return new ChartPointDescriptor(xLabel, yVal, label);
             }).ToArray();
 
-            return [new ChartSeriesDescriptor(seriesName, points)];
+            return (ChartSeriesDescriptor[])[new ChartSeriesDescriptor(seriesName, points)];
         }
     }
 
@@ -407,7 +407,7 @@ public sealed class ChartElement<T> : IChartAccessibilityData
             var (xMin, xMax) = D3Extent.Extent(Data, XAccessor);
             var (yMin, yMax) = D3Extent.Extent(Data, YAccessor);
 
-            return [
+            return (ChartAxisDescriptor[])[
                 new ChartAxisDescriptor(ChartAxisType.X, _xAxisLabel, xMin, xMax, _xUnits),
                 new ChartAxisDescriptor(ChartAxisType.Y, _yAxisLabel, yMin, yMax, _yUnits),
             ];
@@ -672,7 +672,7 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
             }).ToArray();
 
             var seriesName = _seriesNames?.Length > 0 ? _seriesNames[0] : "Slices";
-            return [new ChartSeriesDescriptor(seriesName, points)];
+            return (ChartSeriesDescriptor[])[new ChartSeriesDescriptor(seriesName, points)];
         }
     }
 

--- a/src/Reactor/Hosting/ReactorHostControl.cs
+++ b/src/Reactor/Hosting/ReactorHostControl.cs
@@ -357,7 +357,7 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
         // additional reset steps, throttling) only need editing here.
         void RecoverFromHookOrder(HookOrderException ex, RenderContext ctx, string mode)
         {
-            _logger.LogWarning(ex,
+            _logger?.LogWarning(ex,
                 "Hot reload: hook order/type changed — resetting {Mode} state and re-rendering",
                 mode);
             ctx.ResetForHotReload();

--- a/tests/Reactor.AppTests.Host/Reactor.AppTests.Host.csproj
+++ b/tests/Reactor.AppTests.Host/Reactor.AppTests.Host.csproj
@@ -10,6 +10,14 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- CsWinRT1032 (collection-literal targeting non-mutable interface) and
+         CsWinRT1033 (cast through [ComImport] interface) are AOT/trimming
+         warnings about data flowing across a WinRT ABI boundary. The
+         selftest harness uses ITaskbarList3 via classic COM interop and the
+         fixtures pass collection literals into managed Reactor APIs — neither
+         crosses a WinRT projection boundary, and the host is never AOT-
+         published. Suppress to keep selftest code idiomatic. -->
+    <NoWarn>$(NoWarn);CsWinRT1032;CsWinRT1033</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Reactor.Tests/Reactor.Tests.csproj
+++ b/tests/Reactor.Tests/Reactor.Tests.csproj
@@ -11,6 +11,12 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <OutputType>Library</OutputType>
+    <!-- CsWinRT1032 (collection-literal targeting non-mutable interface) and
+         CsWinRT1033 (cast through [ComImport] interface) are AOT/trimming
+         warnings about data flowing across a WinRT ABI boundary. These tests
+         call managed Reactor APIs directly and are never AOT-published, so
+         neither concern applies. Suppress to keep test code idiomatic. -->
+    <NoWarn>$(NoWarn);CsWinRT1032;CsWinRT1033</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Pin `Microsoft.Windows.CsWinRT` to **`2.3.0-prerelease.251115.2`** (latest 2.3.x; no stable 2.3 released yet) and apply the subset of CsWinRT defaults from OSClient's [`UES.Common.CSharp.SDK.props`](https://microsoft.visualstudio.com/OS/_git/OSClient?path=/Build/MSBuild/UES.Common.CSharp.SDK.props) that make sense for a pure WinAppSDK repo.

Before this change, the repo picked up CsWinRT only transitively from `Microsoft.WindowsAppSDK 2.0.1`, which dragged in an old 2.0.x build and missed two years of generator/analyzer improvements.

## Why

- **Stay current** with the CsWinRT generator — newer projection code, better diagnostics, AOT/trimming improvements that ship in 2.3.
- **Stop floating** on whatever WinAppSDK happens to bundle. Pin once in `Directory.Build.props` and every WinUI project picks it up automatically.
- **Adopt OSClient's vetted defaults** so we benefit from the same CsWinRT settings that ship Windows.

## CsWinRT defaults applied

Centralized in `Directory.Build.props`, gated on `UseWinUI=true`:

| Property | Value | Why |
|---|---|---|
| `CsWinRTEnableLogging` | `true` | Verbose CsWinRT diagnostics in the build log. |
| `CsWinRTIIDOptimizerOptOut` | `true` | We don't author projections — IID patching is overhead for consumers. |
| `CsWinRTUseEnvironmentalTools` | `false` | Don't pick up a side-by-side UWP toolset that may exist on a dev box; matches CI/lab. |
| `CsWinRTLoadComponentsInDefaultALC` | `true` | Avoids ALC-isolation breaking JIT-mode test/sample apps. |

The `Microsoft.Windows.CsWinRT` `PackageReference` lives in `Directory.Build.targets` behind the same `UseWinUI=true` condition, with `PrivateAssets="all"` because it's a build-time generator.

### Defaults intentionally **not** applied (with rationale in `plan.md`)

- `ReportAnalyzer=true` — analyzer-timing reports are noisy/expensive for a smaller repo.
- `CsWinRTGenerateManagedDllGetActivationFactory=true` — only useful for AOT-merged WinRT components; nothing here authors WinRT components.
- The `UseUwp` / `CsWinRTUseWindowsUIXamlProjections=false` / `EnableUnsafeMixedMicrosoftWindowsUIXamlProjections=true` cluster — these turn on UWP/OS-XAML mixing, which is OSClient-specific. We're a pure WinAppSDK repo.
- `DisableRuntimeMarshalling=true` — wide-blast-radius assembly attribute, separate work.

## Cleanup driven by the upgrade

CsWinRT 2.3 introduces `CsWinRT1032` (collection literals targeting non-mutable WinRT-projected interfaces aren't AOT-safe) and `CsWinRT1033` ([ComImport] casts aren't compatible with CsWinRT/AOT). 144 new warnings appeared.

**Product code (5 sites, fixed properly)**
- `src/Reactor/Charting/Charts.cs` (3)
- `src/Reactor/Charting/Charts.Tree.cs` (2)

These implement `IReadOnlyList<ChartSeriesDescriptor>`/`IReadOnlyList<ChartAxisDescriptor>` properties returning collection expressions. Cast to `T[]` so the analyzer knows the concrete type.

**Sample code (~10 sites, fixed properly)**
- `samples/TodoApp/Program.cs`, `samples/Reactor.TestApp`, four `samples/ReactorCharting.Gallery/Samples/*.cs` files.

Same `(T[])[...]` cast pattern at the call sites.

**Test code (`tests/Reactor.Tests`, `tests/Reactor.AppTests.Host`): suppressed `CsWinRT1032`/`CsWinRT1033` with rationale comment**

These tests:
1. Call managed Reactor APIs directly — no WinRT projection ABI in the path.
2. Are never AOT-published.

So the warnings don't apply, and rewriting 100+ test sites with `(T[])[...]` casts is significant churn for zero runtime benefit. The suppression is documented in each `.csproj` next to the `NoWarn` line.

**Pre-existing baseline issue fixed**
- `src/Reactor/Hosting/ReactorHostControl.cs:360` — `_logger.LogWarning(...)` (CS8604) made null-conditional like every other call site in the file.

## Build state

| | Errors | Warnings |
|---|---|---|
| Baseline (`main`) | 0 | 19 |
| After this PR | 0 | 17 |

Remaining 17 warnings are all pre-existing:
- 10× `REACTOR_A11Y_001/002/003` in `samples/apps/a11y-showcase` — intentional analyzer-demo (per code comments)
- 3× `NU1903` Nerdbank.MessagePack 1.0.2 vulnerability — transitive from `GitHub.Copilot.SDK 0.1.32`, out of scope

## Test plan

- [x] `dotnet build Reactor.sln` — 0 errors, 17 warnings (all pre-existing)
- [x] `dotnet test tests/Reactor.Tests` — 6820 pass, 1 fail, 46 skipped
  - The single failure (`IntlAccessorTests.FormatDate_Short_ReturnsShortDate`) is pre-existing on `main`: `.NET 10` ICU returns `"2026-01-15"` for `en-US` short date format, the test still expects `"1/15/2026"`. Same root cause as PR #169. Verified by `git stash` + re-run.
- [x] `dotnet test tests/Reactor.SelfTests` — **671/671 pass**
- [ ] E2E (`tests/Reactor.AppTests`) not run — requires WinAppDriver, not part of the standard PR loop.

## Risk / breaking changes

- All consumers of the framework now get CsWinRT 2.3 generator output instead of 2.0. This is a build-time generator, so no runtime ABI shift; the projections it produces are still WinRT-callable.
- Test/sample projects suppress two CsWinRT analyzer rules. New product code is unaffected because the suppression is scoped to the test `.csproj` files only.
