### PR TITLE
fix(selftest): stabilize 3 flakes from stress run #25535961443

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlsCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlsCoverageFixtures.cs
@@ -335,11 +335,19 @@ internal static class ControlsCoverageFixtures
 
             // Trigger a real search
             var stateChanges = new List<SearchState>();
-            mgr.StateChanged += () => stateChanges.Add(mgr.State);
+            var searchSettled = new TaskCompletionSource();
+            mgr.StateChanged += () =>
+            {
+                stateChanges.Add(mgr.State);
+                // Signal once search leaves the transient Loading state
+                if (mgr.State != SearchState.Loading && mgr.State != SearchState.Idle)
+                    searchSettled.TrySetResult();
+            };
             mgr.Search("Ap");
 
-            // Wait for debounce + search to complete
-            await Task.Delay(300);
+            // Wait for the StateChanged signal rather than a fixed wall-clock delay;
+            // System.Threading.Timer debounce is imprecise under CI load.
+            await Task.WhenAny(searchSettled.Task, Task.Delay(5_000));
             H.Check("SM_SearchCalled", searchCalled);
             H.Check("SM_HasResults", mgr.Results.Count == 2); // Apple, Apricot
             H.Check("SM_ResultsState", mgr.State == SearchState.Results);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlsCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlsCoverageFixtures.cs
@@ -335,7 +335,10 @@ internal static class ControlsCoverageFixtures
 
             // Trigger a real search
             var stateChanges = new List<SearchState>();
-            var searchSettled = new TaskCompletionSource();
+            // RunContinuationsAsynchronously: TrySetResult returns immediately
+            // rather than running the awaiter's continuation inline on whatever
+            // thread StateChanged fires on (threadpool or UI thread).
+            var searchSettled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             mgr.StateChanged += () =>
             {
                 stateChanges.Add(mgr.State);
@@ -347,7 +350,13 @@ internal static class ControlsCoverageFixtures
 
             // Wait for the StateChanged signal rather than a fixed wall-clock delay;
             // System.Threading.Timer debounce is imprecise under CI load.
-            await Task.WhenAny(searchSettled.Task, Task.Delay(5_000));
+            var settled = await Task.WhenAny(searchSettled.Task, Task.Delay(5_000));
+            if (settled != searchSettled.Task)
+            {
+                H.Check("SM_SearchTimeout", false);
+                mgr.Dispose();
+                return;
+            }
             H.Check("SM_SearchCalled", searchCalled);
             H.Check("SM_HasResults", mgr.Results.Count == 2); // Apple, Apricot
             H.Check("SM_ResultsState", mgr.State == SearchState.Results);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs
@@ -165,7 +165,14 @@ internal static class DataGridScrollFixtures
 
             await Harness.Render(500);
 
-            // Verify initial data
+            // WaitForIdleAsync returns once the first render pass is idle, but the
+            // DataGrid's async block fetch fires after that pass and isn't tracked
+            // by _renderPending. Poll until data appears rather than betting on a
+            // fixed delay.
+            var deadline = Environment.TickCount64 + 5_000;
+            while (H.FindTextContaining("Emp-000000") is null && Environment.TickCount64 < deadline)
+                await Harness.Render(200);
+
             H.Check("ScrollBack_InitialData",
                 H.FindTextContaining("Emp-000000") is not null);
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcileHighlightOverlayLifecycleTests.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcileHighlightOverlayLifecycleTests.cs
@@ -102,26 +102,27 @@ internal static class ReconcileHighlightOverlayLifecycleTests
     {
         public override async Task RunAsync()
         {
-            // Tight 200ms window; refresh at 120ms (< 200) should keep alive
-            // through 280ms total wall time; let it expire after.
-            var (canvas, targets, _, overlay) = await SetupAsync(H, holdMs: 200);
+            // 600ms hold window with 200ms delays gives ~400ms margin on each
+            // side — enough to absorb CI timer jitter without losing test intent.
+            // Original 200ms/120ms had only 80ms margin and flaked under load.
+            var (canvas, targets, _, overlay) = await SetupAsync(H, holdMs: 600);
             try
             {
                 overlay.Show(canvas, targets, Array.Empty<UIElement>());
-                await Task.Delay(120);
+                await Task.Delay(200);
                 H.Check("OverlayLifecycle_Refresh_AliveBeforeRefresh",
                     overlay.LiveSpriteCount == 1);
 
                 // Refresh — timer should restart from 0
                 overlay.Show(canvas, targets, Array.Empty<UIElement>());
-                await Task.Delay(120);
-                // Now ~240ms since first Show, ~120ms since refresh — would
+                await Task.Delay(200);
+                // Now ~400ms since first Show, ~200ms since refresh — would
                 // be expired without the timer reset; should still be alive.
                 H.Check("OverlayLifecycle_Refresh_AliveAfterRefresh",
                     overlay.LiveSpriteCount == 1);
 
                 // Wait past the new window — should expire.
-                await Task.Delay(160);
+                await Task.Delay(500);
                 H.Check("OverlayLifecycle_Refresh_ExpiresAfterFinalWindow",
                     overlay.LiveSpriteCount == 0 && overlay.ActiveTargetCount == 0);
             }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcileHighlightOverlayLifecycleTests.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcileHighlightOverlayLifecycleTests.cs
@@ -102,27 +102,30 @@ internal static class ReconcileHighlightOverlayLifecycleTests
     {
         public override async Task RunAsync()
         {
-            // 600ms hold window with 200ms delays gives ~400ms margin on each
-            // side — enough to absorb CI timer jitter without losing test intent.
+            // holdMs=500, firstDelay=350, secondDelay=250:
+            //   350 < 500            → alive before refresh (150ms margin)
+            //   350+250=600 > 500    → would have expired without timer reset
+            //   250 < 500            → still alive after refresh (250ms margin)
             // Original 200ms/120ms had only 80ms margin and flaked under load.
-            var (canvas, targets, _, overlay) = await SetupAsync(H, holdMs: 600);
+            var (canvas, targets, _, overlay) = await SetupAsync(H, holdMs: 500);
             try
             {
                 overlay.Show(canvas, targets, Array.Empty<UIElement>());
-                await Task.Delay(200);
+                await Task.Delay(350);
                 H.Check("OverlayLifecycle_Refresh_AliveBeforeRefresh",
                     overlay.LiveSpriteCount == 1);
 
                 // Refresh — timer should restart from 0
                 overlay.Show(canvas, targets, Array.Empty<UIElement>());
-                await Task.Delay(200);
-                // Now ~400ms since first Show, ~200ms since refresh — would
-                // be expired without the timer reset; should still be alive.
+                await Task.Delay(250);
+                // ~600ms since first Show, ~250ms since refresh.
+                // Without the timer reset the sprite would have expired at 500ms;
+                // with the reset it should still be alive.
                 H.Check("OverlayLifecycle_Refresh_AliveAfterRefresh",
                     overlay.LiveSpriteCount == 1);
 
                 // Wait past the new window — should expire.
-                await Task.Delay(500);
+                await Task.Delay(350);
                 H.Check("OverlayLifecycle_Refresh_ExpiresAfterFinalWindow",
                     overlay.LiveSpriteCount == 0 && overlay.ActiveTargetCount == 0);
             }


### PR DESCRIPTION
## Summary

- **`ControlsCov_SearchManager`**: replaced `await Task.Delay(300)` with a `TaskCompletionSource` signaled from the already-wired `StateChanged` handler. `RaiseStateChanged` marshals onto the UI thread via `TryEnqueue`; under CI load the `System.Threading.Timer` debounce could overshoot the 300ms budget, leaving all three post-search assertions reading stale state.
- **`OverlayLifecycle_Show_RefreshExtendsLifetime`**: widened `holdMs` 200→600 and delays 120→200ms, giving ~400ms margin vs the previous 80ms. Both `DispatcherQueueTimer` and `Task.Delay` queue continuations on the same dispatcher; 80ms wasn't enough on loaded CI runners.
- **`DataGrid_ScrollBackPopulatesData`**: added a 5s polling loop after `Render(500)`. `WaitForIdleAsync` returns after the first render pass, but the DataGrid's async `EnsureRangeLoaded` block fetch fires after that pass and isn't tracked by `_renderPending` — `Task.Delay(516)` was the only buffer and sometimes wasn't enough.

## Flake evidence

CI Stress run [#25535961443](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/25535961443) — 300 iterations, 20 shards:

| Shard | Test | Failure |
|-------|------|---------|
| 8 | `ControlsCov_SearchManager` | `SM_SearchCalled`, `SM_HasResults`, `SM_ResultsState` |
| 10 | `OverlayLifecycle_Show_RefreshExtendsLifetime` | `OverlayLifecycle_Refresh_AliveAfterRefresh` |
| 20 | `DataGrid_ScrollBackPopulatesData` | `ScrollBack_InitialData`, `ScrollBack_SVFound` |

## Test plan

- [ ] CI stress run (selftests, ×2) passes clean on this branch
- [ ] No regressions in regular CI