### PR TITLE
fix(ci-stress): add -p:Platform=x64 to restore/build/test commands

### DIFF
--- a/.github/workflows/ci-stress.yml
+++ b/.github/workflows/ci-stress.yml
@@ -76,10 +76,10 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Restore
-        run: dotnet restore tests/Reactor.Tests/Reactor.Tests.csproj
+        run: dotnet restore tests/Reactor.Tests/Reactor.Tests.csproj -p:Platform=x64
 
       - name: Build (once)
-        run: dotnet build tests/Reactor.Tests/Reactor.Tests.csproj --no-restore --configuration Debug
+        run: dotnet build tests/Reactor.Tests/Reactor.Tests.csproj --no-restore --configuration Debug -p:Platform=x64
 
       - name: Stress loop
         shell: pwsh
@@ -96,7 +96,7 @@ jobs:
           $failures = New-Object System.Collections.Generic.List[int]
           for ($i = 1; $i -le $count; $i++) {
             Write-Host "::group::Unit iteration $i / $count (shard $idx)"
-            dotnet test tests/Reactor.Tests/Reactor.Tests.csproj --no-restore --no-build --logger "console;verbosity=normal"
+            dotnet test tests/Reactor.Tests/Reactor.Tests.csproj --no-restore --no-build -p:Platform=x64 --logger "console;verbosity=normal"
             $code = $LASTEXITCODE
             Write-Host "::endgroup::"
             if ($code -ne 0) {
@@ -129,10 +129,10 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Restore
-        run: dotnet restore tests/Reactor.SelfTests/Reactor.SelfTests.csproj
+        run: dotnet restore tests/Reactor.SelfTests/Reactor.SelfTests.csproj -p:Platform=x64
 
       - name: Build (once)
-        run: dotnet build tests/Reactor.SelfTests/Reactor.SelfTests.csproj --no-restore --configuration Debug
+        run: dotnet build tests/Reactor.SelfTests/Reactor.SelfTests.csproj --no-restore --configuration Debug -p:Platform=x64
 
       - name: Stress loop
         shell: pwsh
@@ -149,7 +149,7 @@ jobs:
           $failures = New-Object System.Collections.Generic.List[int]
           for ($i = 1; $i -le $count; $i++) {
             Write-Host "::group::Selftest iteration $i / $count (shard $idx)"
-            dotnet test tests/Reactor.SelfTests/Reactor.SelfTests.csproj --no-restore --no-build --logger "console;verbosity=normal"
+            dotnet test tests/Reactor.SelfTests/Reactor.SelfTests.csproj --no-restore --no-build -p:Platform=x64 --logger "console;verbosity=normal"
             $code = $LASTEXITCODE
             Write-Host "::endgroup::"
             if ($code -ne 0) {


### PR DESCRIPTION
## Summary

- `ci-stress.yml` was not updated when commit `1aa6e02` added `-p:Platform=x64` to all standalone dotnet commands in `ci.yml`
- All 20 shards in stress run [#25540595850](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/25540595850) failed at **Build (once)** with `WindowsAppSDKSelfContained requires a supported Windows architecture` — no test iterations ran
- Adds `-p:Platform=x64` to `restore`, `build`, and `dotnet test` in both the `unit-tests` and `selftests` jobs, matching what `ci.yml` already does

## Test plan

- [ ] Merge and re-trigger the 500-iteration selftest stress run to confirm shards build and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)