### PR TITLE
fix(reconciler): key echo-suppress counter on native DO identity

### DIFF
--- a/src/Reactor/Core/ChangeEchoSuppressor.cs
+++ b/src/Reactor/Core/ChangeEchoSuppressor.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml;
 
 namespace Microsoft.UI.Reactor.Core;
@@ -26,17 +25,17 @@ namespace Microsoft.UI.Reactor.Core;
 ///   - Callers should guard with an equality check (only suppress when the new
 ///     value actually differs) so the token is always consumed by a real event.
 ///
-/// Why <see cref="ConditionalWeakTable{TKey,TValue}"/>: controls returned to the
-/// ElementPool or garbage-collected should not leak an entry. Weak keys keep
-/// the map small without any explicit cleanup.
+/// Storage — why <see cref="Reconciler.ReactorAttached.StateProperty"/> instead
+/// of a <c>ConditionalWeakTable&lt;UIElement, …&gt;</c>: WinRT projection can
+/// produce two managed RCWs over the same underlying <c>DependencyObject</c>.
+/// A CWT keyed by RCW would store the BeginSuppress count on one wrapper while
+/// the queued change-event handler runs against a different wrapper, so
+/// ShouldSuppress would miss the token and the echo would fire (issues #86,
+/// #114). The attached DP lives on the native object, so every wrapper sees
+/// the same counter — the same fix shape used for <c>EventHandlerState</c>.
 /// </summary>
 internal static class ChangeEchoSuppressor
 {
-    // Box the counter so we can increment/decrement without repeatedly re-inserting.
-    private sealed class Counter { public int Value; }
-
-    private static readonly ConditionalWeakTable<UIElement, Counter> _counters = new();
-
     /// <summary>
     /// Increment the suppress counter before a programmatic property write that
     /// will raise a change event. Pair exactly one BeginSuppress with exactly
@@ -44,8 +43,8 @@ internal static class ChangeEchoSuppressor
     /// </summary>
     internal static void BeginSuppress(UIElement control)
     {
-        var c = _counters.GetValue(control, static _ => new Counter());
-        c.Value++;
+        if (control is not FrameworkElement fe) return;
+        Reconciler.GetOrCreateReactorState(fe).EchoSuppressCount++;
     }
 
     /// <summary>
@@ -55,9 +54,11 @@ internal static class ChangeEchoSuppressor
     /// </summary>
     internal static bool ShouldSuppress(UIElement control)
     {
-        if (_counters.TryGetValue(control, out var c) && c.Value > 0)
+        if (control is not FrameworkElement fe) return false;
+        if (fe.GetValue(Reconciler.ReactorAttached.StateProperty) is Reconciler.ReactorState state
+            && state.EchoSuppressCount > 0)
         {
-            c.Value--;
+            state.EchoSuppressCount--;
             return true;
         }
         return false;

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -327,11 +327,17 @@ public sealed partial class Reconciler : IDisposable
     /// underlying control. Call from <see cref="ElementPool.CleanElement"/>
     /// so the next rent doesn't fire the previous component's captured
     /// rerender closure. TASK-060.
+    /// Also resets the echo-suppress counter so a stranded BeginSuppress
+    /// (e.g. a write whose change-event got swallowed) can't suppress a
+    /// real user event after the element is rented to a new owner.
     /// </summary>
     internal static void ClearCurrentEventHandlers(FrameworkElement fe)
     {
         if (fe.GetValue(ReactorAttached.StateProperty) is ReactorState state)
+        {
             state.Events?.ClearCurrentHandlers();
+            state.EchoSuppressCount = 0;
+        }
     }
 
     /// <summary>
@@ -350,6 +356,7 @@ public sealed partial class Reconciler : IDisposable
         state.Element = null;
         state.Events?.ClearCurrentHandlers();
         state.Events = null;
+        state.EchoSuppressCount = 0;
     }
 
     // ════════════════════════════════════════════════════════════════════

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -260,6 +260,11 @@ public sealed partial class Reconciler : IDisposable
     {
         public Element? Element;
         public EventHandlerState? Events;
+        // Per-native-element echo-suppress counter consumed by ChangeEchoSuppressor.
+        // Lives here (not in a CWT-by-RCW) so that BeginSuppress on one managed
+        // wrapper and ShouldSuppress on a different wrapper for the same native
+        // DependencyObject see the same counter. See ChangeEchoSuppressor.cs.
+        public int EchoSuppressCount;
     }
 
     internal static class ReactorAttached


### PR DESCRIPTION
## Summary
- `ChangeEchoSuppressor` stored its per-control suppress counter in a `ConditionalWeakTable<UIElement, Counter>` — the same RCW-keyed pattern that #86 surfaced for `EventHandlerState` and #114 catalogues for `PoolableWireFlags`.
- WinRT projection can hand out two managed RCWs over the same native `DependencyObject`: `BeginSuppress(rcwA)` writes the counter on rcwA's CWT entry, but the queued change-event handler runs against `rcwB` so `ShouldSuppress(rcwB)` misses the token and the echo fires.
- A 500x selftest sweep saw `EchoSuppress_PasswordBox_NoEchoCall` flake at 2/500 (~0.4%); same root cause hits all ~14 controls that go through the suppressor (PasswordBox, NumberBox, Slider, ToggleSwitch, ColorPicker, ComboBox, RadioButton, AutoSuggestBox, Date/TimePicker, ColorDoublePicker, …).
- Move the counter onto the existing `ReactorState` wrapper that hangs off `ReactorAttached.StateProperty`. The attached DP lives on the native DO, so every RCW for the same element observes the same counter — same fix shape #113 used for `ToggleSwitch.Toggled`. Boxing `Counter` class and the CWT go away.

## Relationship to #114
Distinct data structure but identical root cause. #114 only catalogues `PoolableWireFlags` (Button.Click, TextBox.TextChanged/SelectionChanged). `ChangeEchoSuppressor` was a separate CWT-by-RCW store with much wider blast radius — worth fixing directly rather than waiting on the #114 migration.

## Test plan
- [x] `dotnet build src/Reactor -c Release` — clean
- [x] `dotnet test tests/Reactor.SelfTests --filter Name~EchoSuppress` — 14/14 pass
- [ ] Follow-up: re-run the 500x selftest sweep on this branch to confirm `EchoSuppress_PasswordBox_NoEchoCall` no longer flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)