### PR TITLE
docs(specs): add 037 (eval trace mining) + 038 (mur check did-you-mean)

### DIFF
--- a/docs/specs/037-eval-trace-mining-design.md
+++ b/docs/specs/037-eval-trace-mining-design.md
@@ -1,0 +1,347 @@
+# Reactor Eval Trace Mining — Design Spec
+
+## Status
+
+**Proposed** — 2026-05-09. No code yet.
+
+This spec describes a **standalone harness** that drives a coding agent to author small Reactor apps from natural-language prompts, captures the full build/fix loop the agent runs through, and emits a structured corpus of `(broken_source, diagnostic, fixed_source)` triples. The corpus seeds the pattern rules in spec [038 — `mur check` Did-You-Mean Engine](./038-mur-check-did-you-mean-design.md).
+
+The harness is deliberately built to run **outside** the `microsoft-ui-reactor` source tree. The agent it drives must not have file-system access to the Reactor source, samples, or internal skills — only what a real downstream consumer would have (the public NuGet feed, the `mur` CLI binary, whatever public docs ship with the package). This is not a packaging accident; it is the **point** of the harness. We want the agent to struggle in the same ways a real first-time Reactor user / agent would, so the failures we capture reflect real prediction needs and not artifacts of source-code peeking.
+
+This spec is written so an external agent — one *without* access to this repo — can implement the harness from this document alone. Do not reference internal Reactor source paths from inside the harness implementation; the package surface, the CLI, and what is documented in this spec are the contract.
+
+---
+
+## Table of Contents
+
+- [§1 Motivation](#1-motivation)
+- [§2 Goals and non-goals](#2-goals-and-non-goals)
+- [§3 What the agent under test sees](#3-what-the-agent-under-test-sees)
+- [§4 Architecture](#4-architecture)
+- [§5 Prompt grid](#5-prompt-grid)
+- [§6 Sandbox layout](#6-sandbox-layout)
+- [§7 Trace capture](#7-trace-capture)
+- [§8 Pair extraction](#8-pair-extraction)
+- [§9 Output schema](#9-output-schema)
+- [§10 Aggregation and rule induction](#10-aggregation-and-rule-induction)
+- [§11 Operational concerns](#11-operational-concerns)
+- [§12 Implementation phases](#12-implementation-phases)
+- [§13 Open questions](#13-open-questions)
+
+---
+
+## §1 Motivation
+
+The `mur check` Roslyn-backed suggestion engine (spec 038) needs a frequency-ranked list of the mistake patterns a real coding agent makes when authoring Reactor apps. Without that list we have to *guess* which pattern rules to write, and a wrong guess wastes engineering effort on a code path that never fires.
+
+Three sources of truth exist in principle:
+
+1. **Production telemetry** from `mur check` invocations. Doesn't exist yet — `mur check` ships only the analyzer-ID hint table today, so we have no signal on CS-prefixed errors against Reactor types.
+2. **Synthetic mutation** of known-good Reactor source: rename methods, fluentize named args, swap overloads, drop `WithKey` calls, etc. Cheap to scale to 100K pairs but distribution is artificial — captures what we *can* corrupt rather than what an LLM agent *does* corrupt.
+3. **Replay of real agent runs.** The closest thing to ground truth: drive an LLM agent to write a Reactor app, capture every build failure and the eventual fix, take the diff. Errors are sampled from the real distribution; fixes are validated by the C# compiler.
+
+This spec implements (3). It is the load-bearing data source for spec 038. (1) takes over once 038 ships and runs at scale; (2) is retained as a validation set, never as training data.
+
+A second, equally important constraint: **the agent under test must not be able to read the Reactor source code or samples.** If it can, the failures we capture stop reflecting a downstream user's experience and start reflecting a uniquely-privileged author's. The harness enforces this isolation; see §3 and §6.
+
+## §2 Goals and non-goals
+
+### Goals
+
+- **Drive a coding agent through a prompt grid** broad enough to surface the long tail of mistake patterns, not just the two scenarios in the existing eval suite.
+- **Sandbox the agent's view** so it cannot read Reactor source, internal skills, or the existing sample apps. It sees only the public NuGet package and `mur` binary.
+- **Capture every build cycle** — the source state at each failed `dotnet build`, the resulting diagnostics, and the source state at the next successful build.
+- **Emit a normalized JSONL corpus** of `(broken, diagnostic, fixed)` triples consumable by spec 038's pair-extraction and rule-induction stages.
+- **Be reproducible.** Same prompt, same model, same package version → roughly the same trace shape. Hermetic working directories. No reliance on user-specific state.
+- **Be cheap to extend.** New prompts, new control combinations, new agents (Claude / GPT / Copilot) plug in by configuration, not code changes.
+
+### Non-goals
+
+- **Not a benchmark of agent quality.** We don't score the agent on whether it eventually succeeded; we keep the trace either way. The data is the product, not the leaderboard.
+- **Not a CI gate.** This is an offline data-generation pipeline run on a cadence (weekly, when Reactor cuts a release, etc.). It is not in the build path.
+- **Not a `mur check` substitute.** This harness produces training data; spec 038 is the runtime feature that uses it.
+- **Not an end-to-end UI tester.** We grade compile, not behavior. UIA-driven runtime verification is out of scope.
+- **Not bound to any one agent.** The harness drives whatever agent supports stdin/stdout tool calls; Claude Code / OpenAI Agents SDK / a custom MCP shim are all targets, but only one is required for v1.
+
+## §3 What the agent under test sees
+
+This is the most important section of the spec. Get it wrong and the corpus is contaminated.
+
+The agent runs in a hermetic working directory provisioned per prompt. Inside that directory it has:
+
+- **A `.NET SDK** of the version Reactor's NuGet declares. Installed system-wide, available on `PATH`.
+- **The public Reactor NuGet packages**, restored from `nuget.org` (or a private feed configured by env var — see §11) the first time it runs `dotnet build`. The agent never sees the source — only compiled assemblies in the local NuGet cache.
+- **The `mur` CLI binary**, installed as a dotnet tool from the same NuGet feed: `dotnet tool install -g mur`. The agent invokes `mur new`, `mur check`, etc., as a black box.
+- **A starter prompt** specifying the app to build (see §5).
+- **No skills, no API index, no cheatsheet, no samples.** The point is to capture what an agent does when it has to *infer* the API shape from compiler errors. If we ship guidance, we are training the rules to handle a populated-skill scenario, not a struggling one.
+
+What the agent does **not** have:
+
+- Read access to `microsoft-ui-reactor` source on disk. The harness is a separate repo / separate working tree; nothing in `$PWD` or any ancestor path is a reactor checkout.
+- Access to the agent-eval skill packs (`reactor-getting-started`, `reactor-dsl`, `reactor-build-and-check`). The harness explicitly does not load them.
+- Access to the existing sample apps under `samples/apps/`. Same reason.
+- Network access to repositories that mirror Reactor source (GitHub web fetch of `microsoft/microsoft-ui-reactor`, etc.). The sandbox blocks egress to those hostnames; allow-list only `nuget.org` and the LLM API.
+
+If the agent's tool surface includes a generic web-fetch or web-search tool, the harness must either disable it or apply a domain allow-list before each run. See §6 for the enforcement mechanism.
+
+We accept that the agent will fail more often than it does in the populated-skill scenario. That is the data we are after.
+
+## §4 Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  reactor-eval-mine (this harness, separate repo)                     │
+│                                                                       │
+│   ┌────────────────┐     ┌─────────────────┐    ┌────────────────┐  │
+│   │ PromptGen      │────▶│ Runner          │───▶│ TraceWriter    │  │
+│   │  - grid        │     │  - sandbox      │    │  - JSONL       │  │
+│   │  - JSONL out   │     │  - spawn agent  │    │  - per-run     │  │
+│   │                │     │  - capture I/O  │    │                │  │
+│   └────────────────┘     └────────┬────────┘    └───────┬────────┘  │
+│                                   │                     │           │
+│                                   ▼                     ▼           │
+│                          ┌─────────────────┐    ┌────────────────┐  │
+│                          │  Sandbox        │    │ PairExtractor  │  │
+│                          │   workdir/      │    │  - replay log  │  │
+│                          │   .nuget cache  │    │  - emit triples│  │
+│                          │   no reactor src│    │  - normalize   │  │
+│                          └─────────────────┘    └───────┬────────┘  │
+│                                                         │           │
+│                                                         ▼           │
+│                                                ┌────────────────┐   │
+│                                                │  fixes.jsonl   │   │
+│                                                │   (the corpus) │   │
+│                                                └────────────────┘   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Five components, each with a single responsibility:
+
+1. **PromptGen** — emits a JSONL of prompts. Combinatorial grid (§5) plus optional LLM-rewriting for natural-language variation. Output: `prompts.jsonl`.
+2. **Runner** — for each prompt, provisions a sandbox, spawns the agent process, pipes the prompt in, captures every tool call and file edit and shell output. Output: one `trace-<run_id>.jsonl` per run.
+3. **Sandbox** — the per-run hermetic working directory plus its enforcement policy (no reactor src on path; egress allow-list).
+4. **PairExtractor** — replays each trace, finds every `dotnet build` invocation, captures the source state immediately before and the source state at the next successful build, computes the diff, classifies the fix kind. Output: `fixes-<run_id>.jsonl`.
+5. **Aggregator** — merges all per-run JSONL into `fixes.jsonl`, deduplicates, ranks by frequency.
+
+Components are pipelinable but each can be invoked standalone for debugging.
+
+## §5 Prompt grid
+
+A prompt is a templated string filled from a Cartesian product of axes. Suggested axes for v1:
+
+| Axis | Values |
+|---|---|
+| App shape | `single page`, `tabbed app`, `master-detail`, `dialog flow` |
+| Primary control | `Button`, `CheckBox`, `ComboBox`, `DataGrid`, `TextBox`, `Slider`, `RadioButton`, `Toggle` |
+| Interaction | `triggers an action`, `binds to state`, `filters a list`, `edits a record`, `submits a form` |
+| State shape | `string`, `int counter`, `enum selection`, `record`, `list of records`, `tree of nodes` |
+| Layout | `Grid`, `HStack`, `VStack`, `Flex`, `Wrap` |
+| Theming | `default`, `dark mode toggle`, `accent color override` |
+
+A v1 grid that takes the cross-product of one value per axis at a time gives ~8K prompts; in practice the harness samples a stratified subset (see §11) to keep cost bounded.
+
+A prompt template:
+
+```
+Build me a {app_shape} that uses a {primary_control} to {interaction} a {state_shape},
+laid out in a {layout}. Theme it with {theming}. Use Microsoft.UI.Reactor (the C#/WinUI
+React-style framework). The app must build cleanly with `dotnet build`. Do not add
+unrelated features.
+```
+
+Optional: an LLM-rewriting pass takes each templated prompt and produces three to five natural-language variants (different word order, different framing, light paraphrase) to keep the agent from pattern-matching on the template itself.
+
+The harness emits each prompt with a stable `prompt_id` (hash of the template-fill) so re-runs are joinable.
+
+## §6 Sandbox layout
+
+For each run, Runner creates:
+
+```
+<harness-root>/
+  runs/
+    <run_id>/
+      workdir/                  ← agent's CWD; ONLY thing the agent sees
+        (initially empty)
+      trace.jsonl               ← Runner writes here (outside agent's view)
+      meta.json                 ← prompt, agent config, package versions
+      .stdout / .stderr         ← agent process logs
+```
+
+Enforcement of "no Reactor source visible":
+
+- `workdir` lives under a path that does **not** contain the substring `microsoft-ui-reactor` or `reactor2`. The harness aborts startup if it does.
+- The agent process is spawned with `CWD=workdir` and a scrubbed `PATH` that includes only the .NET SDK, `mur`, and standard system tools. No editor, no `git` against the reactor remote.
+- Network egress (if controllable in the agent's runtime) is filtered to: the LLM provider, `api.nuget.org`, `*.blob.core.windows.net` (NuGet CDN). Block `github.com/microsoft/microsoft-ui-reactor` and any mirror.
+- If the agent has a web-fetch tool that the harness cannot intercept, the harness logs each fetch URL and post-hoc filters out runs that touched a forbidden domain. Better than nothing, worse than blocking.
+
+The first build the agent runs causes NuGet to populate `~/.nuget/packages` with the public Reactor packages. That cache is shared across runs (it's a public artifact, identical to what any user gets) and survives between runs to keep cold-start cost down.
+
+## §7 Trace capture
+
+For each agent action, Runner appends one JSON object to `trace.jsonl`:
+
+```json
+{
+  "run_id": "...", "turn": 7, "ts": "2026-05-09T12:34:56Z",
+  "kind": "tool_call",
+  "tool": "Bash",
+  "input": "dotnet build .\\App.csproj -p:Platform=ARM64",
+  "output": "...",
+  "exit_code": 1,
+  "files_after": [
+    { "path": "Program.cs", "sha": "...", "content": "..." }
+  ]
+}
+```
+
+Five `kind` values cover the full surface:
+
+| `kind` | When |
+|---|---|
+| `prompt` | turn 0; the initial user message |
+| `assistant_text` | the agent's textual reasoning between tool calls |
+| `tool_call` | every tool invocation; for shell-style tools, includes stdin/stdout/exit_code |
+| `file_snapshot` | a full content dump of every file in `workdir` after each tool call that mutated the tree |
+| `terminal` | end of run; final disposition (`succeeded` / `failed` / `timeout`) |
+
+`file_snapshot` is what makes pair extraction tractable. It is verbose; gzip the trace at end of run.
+
+## §8 Pair extraction
+
+Replay walks `trace.jsonl` and slides a window over `tool_call` entries with `tool == "Bash"` and the command matching `dotnet build` or `mur check`. For each such entry:
+
+- If `exit_code != 0` and the parsed output contains a CS-prefixed diagnostic on a Reactor type, it's a **failed-build event**. Snapshot the file referenced by the diagnostic at the entry's `files_after`. Mark this as `before`.
+- Continue forward through the trace. If a subsequent `dotnet build` / `mur check` exits 0 **and** the same file's content has changed, the snapshot at that entry is `after`.
+- Emit a triple: `(before, diagnostic, after)`. If the same file is modified again before the build succeeds, retain only the *closest* `before` (the one nearest to the success) — that is the state the eventual fix transformed.
+
+Edge cases:
+
+- **No subsequent success.** Run ended in failure. The pair is incomplete; record it under `unresolved.jsonl` for manual triage. Do not feed unresolved pairs into rule induction.
+- **Multiple files changed between fail and success.** The fix is multi-file; emit one triple per file that changed and tag them with a shared `bundle_id` so rule induction can either treat them independently or as a unit.
+- **The diagnostic moves between turns.** If `dotnet build` reports five errors at turn 7 and three different errors at turn 11, treat each `(before, diag)` pair independently against its own `after`.
+
+## §9 Output schema
+
+Each row in `fixes.jsonl`:
+
+```json
+{
+  "run_id": "p001-r03",
+  "prompt_id": "tabbed/Button/triggers/int-counter/Grid/dark",
+  "turn_before": 7, "turn_after": 11,
+  "file": "Program.cs",
+  "diag": {
+    "code": "CS1061",
+    "msg": "'ButtonElement' does not contain a definition for 'OnClick'",
+    "line": 34, "col": 16,
+    "receiver_type": "Microsoft.UI.Reactor.ButtonElement"
+  },
+  "before": { "sha": "...", "text": "...full file..." },
+  "after":  { "sha": "...", "text": "...full file..." },
+  "delta": {
+    "hunks": [ { "before": "Button(\"+\").OnClick(...)", "after": "Button(\"+\", onClick: ...)" } ]
+  },
+  "fix_kind": "fluent_to_named",
+  "bundle_id": null,
+  "agent": "claude-opus-4-7",
+  "package_version": "0.0.0-local"
+}
+```
+
+`fix_kind` is a small enum the extractor assigns heuristically:
+
+- `renamed_member` — receiver type unchanged, member name swapped.
+- `fluent_to_named` — chained call removed, named argument added on the parent factory call.
+- `overload_swap` — same factory, different overload (different positional shape).
+- `factory_swap` — different factory entirely (`Button` → `HyperlinkButton`).
+- `argument_type_fix` — same call shape, argument types adjusted.
+- `missing_with_key` — `.WithKey(...)` appended to elements in a dynamic list.
+- `import_added` — fix was a new `using` statement.
+- `other` — extractor couldn't classify; rule induction treats these as a residual bucket.
+
+## §10 Aggregation and rule induction
+
+Aggregator clusters by `(diag.code, fix_kind, AST-shape-of-before)` and emits `patterns.json`:
+
+```json
+[
+  {
+    "cluster_id": "C0001",
+    "diag_code": "CS1061",
+    "receiver_type": "Microsoft.UI.Reactor.ButtonElement",
+    "fix_kind": "fluent_to_named",
+    "frequency": 0.087,
+    "exemplar_pairs": ["p001-r03", "p014-r02", "p044-r01"],
+    "proposed_rule": "On CS1061 against ButtonElement member 'OnClick', suggest moving to named argument onClick: on the parent Button(...) factory call."
+  },
+  ...
+]
+```
+
+`patterns.json` is the human-reviewed handoff to spec 038's Phase 3 rule authors. The harness does **not** auto-generate runtime rules from this — every cluster gets human review before becoming a Tier 3 rule, because false positives (Phase 1 §risk) cost more than missed suggestions.
+
+The "AST-shape-of-before" is computed from a Roslyn parse of the snippet around the diagnostic span. Since the harness runs outside the reactor repo, it depends on `Microsoft.CodeAnalysis.CSharp` from NuGet — same Roslyn version spec 038 uses — and treats the snippet as standalone text (no full Compilation needed at this stage; rule induction is structural, not semantic).
+
+## §11 Operational concerns
+
+**Cost.** Each run costs roughly $3–5 of LLM tokens at current Claude / GPT prices, by analogy to the existing eval suite. A 500-prompt sweep with 3 LLM-rewritten variants per prompt and 1 run per variant ≈ 1500 runs ≈ $4.5K–$7.5K. Stratify the prompt grid: bias toward axes (`Primary control`, `Interaction`) that are likely to surface novel patterns, downsample axes (`Theming`) that probably don't.
+
+**Agent flakiness.** Agents time out, get rate-limited, refuse to act on prompts they misread. Runner enforces a per-run wall-clock budget (default 15 min) and a max-turn budget (default 30). Runs that exceed either are marked `timeout` and excluded from `fixes.jsonl` aggregation. Their `unresolved.jsonl` rows are still useful for cost estimation.
+
+**Determinism.** Even with `temperature=0` agents are not bit-deterministic. Runs are tagged with the model id, package version, and SDK version so re-runs against a different baseline can be compared like-for-like. Don't treat any single run's pairs as canonical; rely on cluster frequency.
+
+**Privacy and PII.** The agent under test is given a synthetic prompt and an empty workdir. Nothing in the trace should contain user identifiers. The harness still scrubs absolute paths, usernames, and machine names from each trace before writing.
+
+**Storage.** Each run is small (~1–5 MB compressed). 1500 runs ≈ 5 GB. Keep raw traces on local disk for the active sweep; archive to a blob store keyed by `(prompt_id, agent, package_version, run_id)` after rule induction completes.
+
+**Reactor version pinning.** The package version under test is recorded per run. When Reactor cuts a new release, the harness re-runs against the new version — patterns rules induced against an old surface may need refresh.
+
+## §12 Implementation phases
+
+### Phase A — minimal harness, one prompt, one agent
+
+- PromptGen with a single hand-authored prompt.
+- Runner that spawns Claude Code (or whatever LLM agent) against a temp `workdir`, pipes the prompt in, tees stdout/stderr.
+- TraceWriter capturing `tool_call` and `file_snapshot` only.
+- PairExtractor that pulls one (before, diag, after) triple end-to-end.
+
+**Exit:** one row in `fixes.jsonl` from one real run.
+
+### Phase B — grid expansion
+
+- Combinatorial PromptGen (§5).
+- Stratified sampling.
+- Runner parallelism (4–8 concurrent runs).
+- LLM-rewriting pass for prompt variants.
+
+**Exit:** 200-row `fixes.jsonl` from a 100-prompt sweep.
+
+### Phase C — aggregation and review
+
+- Aggregator with AST-shape clustering.
+- `patterns.json` emission.
+- Human-review workflow: a Markdown report per cluster with exemplar diffs, ready to hand off to spec 038 rule authors.
+
+**Exit:** `patterns.json` covering the top 20 clusters by frequency, each with ≥ 3 exemplar pairs.
+
+### Phase D — operationalization
+
+- Sandbox enforcement hardening (egress filter, source-tree assertion).
+- Multi-agent support (rotate Claude, GPT, Copilot).
+- Cost dashboarding.
+- Scheduled re-runs against new Reactor releases.
+
+**Exit:** harness runs unattended on a schedule; outputs feed spec 038's Phase 0 instrumentation.
+
+## §13 Open questions
+
+1. **Which agent for v1?** Claude Code is the closest match for the existing eval setup, but it is not strictly necessary — any LLM agent that exposes a tool-call protocol works. Document the chosen target in `meta.json` per run; don't lock the harness to one.
+2. **How much guidance is too little?** The default is "no skills, no cheatsheet" — pure struggle. We may discover that *zero* guidance produces too-noisy traces (every run flails on the same scaffolding question) and that a *tiny* always-loaded preamble (e.g. "Reactor is a C# WinUI framework; use `mur new` to scaffold") is needed to keep traces focused on the questions we actually care about. Tune empirically in Phase A.
+3. **What fraction of runs must succeed for the corpus to be useful?** Failed-but-illuminating runs (`unresolved.jsonl`) still tell us where the agent gets stuck. The threshold for *training-quality* pairs (`fixes.jsonl`) is probably 30–50 % run success; below that the corpus is dominated by terminal flailing rather than recoverable mistakes.
+4. **How do we keep the prompt grid fresh?** Patterns rules tuned on today's grid may overfit to today's controls. Open: rotate axes quarterly, or seed the grid from public Reactor sample-app *names* (not source) once we stabilize.
+5. **Does the harness need its own license?** It's a separate repo and embeds nothing from `microsoft-ui-reactor` source. Recommend MIT or Apache-2.0; coordinate with the Reactor team on the canonical answer before publishing.
+
+---
+
+This spec is the data-side counterpart of [038 — `mur check` Did-You-Mean Engine](./038-mur-check-did-you-mean-design.md). The corpus emitted here (`fixes.jsonl`, `patterns.json`) is the input to spec 038's Phase 3 rule induction. Spec 038 also adds production telemetry that, once running at scale, supersedes this harness as the dominant signal source.

--- a/docs/specs/037-eval-trace-mining-design.md
+++ b/docs/specs/037-eval-trace-mining-design.md
@@ -42,6 +42,8 @@ Three sources of truth exist in principle:
 
 This spec implements (3). It is the load-bearing data source for spec 038. (1) takes over once 038 ships and runs at scale; (2) is retained as a validation set, never as training data.
 
+The corpus serves a **second** consumer in spec 038: the **pre-emit warning ranker** (spec 038 §8). The same per-turn trace that lets us extract `(broken, diagnostic, fixed)` pairs also tells us, for every diagnostic that fired, whether the agent's eventual fix actually touched the line / file / symbol the diagnostic pointed at. That binary label — *did this diagnostic correlate with a real fix, or did the agent ignore it?* — is the supervised signal for training a learned ranker that decides which warnings to surface mid-iteration vs. defer to a final-pass mode. The harness emits this label alongside the pair triples so the ranker training pipeline does not need to re-walk the trace.
+
 A second, equally important constraint: **the agent under test must not be able to read the Reactor source code or samples.** If it can, the failures we capture stop reflecting a downstream user's experience and start reflecting a uniquely-privileged author's. The harness enforces this isolation; see §3 and §6.
 
 ## §2 Goals and non-goals
@@ -259,6 +261,26 @@ Each row in `fixes.jsonl`:
 - `missing_with_key` — `.WithKey(...)` appended to elements in a dynamic list.
 - `import_added` — fix was a new `using` statement.
 - `other` — extractor couldn't classify; rule induction treats these as a residual bucket.
+
+### Per-diagnostic ranker labels
+
+In addition to the pair triples, the extractor emits one row per diagnostic that fired during the run (whether it became a "blocker" eventually fixed, or was carried over silently across builds, or never resurfaced). This is the supervised signal for spec 038 §8's learned warning ranker. Schema:
+
+```json
+{
+  "run_id": "p001-r03",
+  "turn": 7,
+  "file": "Program.cs",
+  "diag": { "code": "CS1591", "msg": "...", "line": 12, "col": 1 },
+  "severity": "W",
+  "addressed_by_next_fix": false,
+  "addressed_within_run": false,
+  "still_present_at_run_end": true,
+  "agent_ignored": true
+}
+```
+
+Output to `ranker-labels-<run_id>.jsonl`, aggregated alongside `fixes.jsonl`. The label `addressed_by_next_fix` is the primary supervised signal: a diagnostic the agent's *next* edit touched is emit-worthy in iteration mode; one it didn't is a candidate for suppression. `addressed_within_run` (eventually addressed before run end) and `still_present_at_run_end` (carried over silently) are auxiliary labels useful for distinguishing "deferred but real" warnings from "ignored as noise."
 
 ## §10 Aggregation and rule induction
 

--- a/docs/specs/038-mur-check-did-you-mean-design.md
+++ b/docs/specs/038-mur-check-did-you-mean-design.md
@@ -34,13 +34,14 @@ This spec was filed first as design proposal [#227](https://github.com/microsoft
 - [§5 Tier 2 — Roslyn semantic suggester](#5-tier-2--roslyn-semantic-suggester)
 - [§6 Tier 3 — induced pattern rules](#6-tier-3--induced-pattern-rules)
 - [§7 Tier 4 — confidence ranker](#7-tier-4--confidence-ranker)
-- [§8 Output format](#8-output-format)
-- [§9 Telemetry](#9-telemetry)
-- [§10 Risks](#10-risks)
-- [§11 Predicted impact](#11-predicted-impact)
-- [§12 Implementation phases](#12-implementation-phases)
-- [§13 Open questions](#13-open-questions)
-- [§14 Pointers](#14-pointers)
+- [§8 Warning ranking and noise reduction](#8-warning-ranking-and-noise-reduction)
+- [§9 Output format](#9-output-format)
+- [§10 Telemetry](#10-telemetry)
+- [§11 Risks](#11-risks)
+- [§12 Predicted impact](#12-predicted-impact)
+- [§13 Implementation phases](#13-implementation-phases)
+- [§14 Open questions](#14-open-questions)
+- [§15 Pointers](#15-pointers)
 
 ---
 
@@ -59,6 +60,7 @@ The catch: a *wrong* suggestion is worse than no suggestion. The agent will trus
 - For every C# compiler error (CS-prefixed) whose receiver, type, or member references a `Microsoft.UI.Reactor.*` symbol, emit a single-line suggestion with confidence ≥ T.
 - Stay silent below T. Silent is correct. Wrong is not.
 - Compose with the existing `REACTOR_*` analyzer hint table, not replace it.
+- **Suppress noise.** Most MSBuild and analyzer output an agent sees mid-iteration is boilerplate or low-priority hints that distract from the load-bearing fix. Surface only the diagnostics whose resolution is on the critical path to a clean build; defer the rest to a final-pass mode (§8).
 - Keep the diagnostic format machine-parseable: one line per diagnostic, predictable column structure.
 - Be fast: total `mur check` wall time stays within ~1.2× the underlying `dotnet build` it wraps.
 
@@ -100,13 +102,23 @@ mur check <path>
     │             AST-shape similarity).
     │
     ▼ append "-> try: <suggestion>" only when confidence >= T
+    │
+    ▼ Pre-emit ranker (§8) — transversal across all tiers:
+    │   score every diagnostic against an emission policy.
+    │   - errors:     always emit
+    │   - warnings:   emit only if score >= mode threshold
+    │   - hints/info: suppress in iteration mode; emit in --final mode
+    │   default mode is "iteration" — aggressive suppression so the
+    │   agent sees only diagnostics on the critical path to a clean build.
+    │
+    ▼ format and write one line per surviving diagnostic
 ```
 
-The tier structure is deliberate: **most of the value is deterministic.** ML enters only as a tiebreaker, only after measured data shows where Tier 2 + 3 fall short.
+The tier structure is deliberate: **most of the value is deterministic.** ML enters only as a tiebreaker, only after measured data shows where Tier 2 + 3 fall short. The four tiers decide *what suggestion to attach*; the ranker (§8) is orthogonal — it decides *whether to emit the diagnostic at all*.
 
 ## §4 Tier 1 — analyzer-ID hint table
 
-**Status: shipped.** Today `CheckCommand.HintFor(code)` returns a static skill-file pointer for 12 `REACTOR_*` analyzer codes (see §14). This tier is unchanged by this spec. New analyzer codes added by future analyzers slot into the same table.
+**Status: shipped.** Today `CheckCommand.HintFor(code)` returns a static skill-file pointer for 12 `REACTOR_*` analyzer codes (see §15). This tier is unchanged by this spec. New analyzer codes added by future analyzers slot into the same table.
 
 ## §5 Tier 2 — Roslyn semantic suggester
 
@@ -168,7 +180,7 @@ Rules live in `src/Reactor.Cli/Check/Rules/<Name>Rule.cs`, one rule per file, ea
 
 ## §7 Tier 4 — confidence ranker
 
-**Status: future.** Build only if telemetry (§9) shows Tier 2 + 3 leave a meaningful long tail.
+**Status: future.** Build only if telemetry (§10) shows Tier 2 + 3 leave a meaningful long tail.
 
 If built: a gradient-boosted tree over hand-engineered features — Levenshtein distance, parameter-name overlap, factory-popularity-in-samples (counted from `samples/apps/`), AST-shape similarity, prior agent-accept rate per rule. Inputs: the candidate set produced by Tiers 2 + 3. Output: re-ranked list with a calibrated confidence head.
 
@@ -176,7 +188,85 @@ Inference cost is negligible (microseconds). Training cost is one offline pipeli
 
 We deliberately do **not** propose a small LLM here. Small models hallucinate without huge corpora, and Reactor's training set is fundamentally limited; the deterministic system already has access to the things a small model would have to memorize (the api index, the samples).
 
-## §8 Output format
+## §8 Warning ranking and noise reduction
+
+The four suggestion tiers answer *what hint to attach to a diagnostic*. The pre-emit ranker answers a separate question: *should this diagnostic be sent to the agent at all, right now?* This matters because raw MSBuild output is dominated by diagnostics whose resolution is **not** on the critical path to a clean build — and every one of them costs context, distracts the agent, and reduces the chance of a 1-step fix.
+
+### Why ranking matters
+
+A representative kanban-run `dotnet build` emits ~30–80 diagnostic lines. Of those, typically 1–3 are the actual blockers. The rest are some mix of:
+
+- **NuGet restore noise** — `NU1701`, `NU1605`, package-version downgrades, target-framework fallbacks.
+- **MSBuild reference-resolution chatter** — `MSB3245`, `MSB3277`, `MSB3270` lines that resolve at the next build with no source change.
+- **IDE style hints** — `IDE0xxx` series: prefer expression-bodied member, unused using, etc.
+- **CS warnings on auto-generated or template code** — `CS8602` nullable, `CS0168` unused variable, `CS1591` missing XML doc — almost never the right thing to fix mid-iteration.
+- **Reactor analyzer Info-severity warnings** — e.g. `REACTOR_HOOKS_006` (non-idempotent fetcher heuristic) that are *guidance*, not blockers.
+- **Boilerplate** — `Build succeeded with N Warning(s)`, target hits, paths, timing.
+
+If the agent reads all of these every turn, two pathologies follow: (a) it spends turns "fixing" warnings that didn't need fixing this turn, and (b) the *real* blocker scrolls off attention. The ranker exists to flatten this: in iteration mode, only the critical path; in final mode, everything.
+
+### Modes
+
+| Mode | Flag | Behavior |
+|---|---|---|
+| **iteration** *(default)* | `mur check` | Emit errors always; emit warnings only if rank ≥ iteration threshold; suppress info / style hints. |
+| **strict** | `mur check --strict` | Treat warnings as errors. Useful for one-shot CI gates; not recommended for the inner loop. |
+| **final** | `mur check --final` | Emit every diagnostic, no suppression. Run this once before declaring done. |
+| **quiet** | `mur check --quiet` | Errors only. Maximally aggressive suppression for sub-iteration loops. |
+
+The agent-eval prompt for Reactor (#226 §5) directs the agent to use `mur check` (iteration) during the build/fix loop and `mur check --final` once iteration mode is clean. The transition is the explicit "I am done iterating" signal.
+
+### Ranking policy
+
+Each diagnostic gets a score from 0.0 (suppress) to 1.0 (always emit), computed as:
+
+```
+score = base_policy(code) * code_weight
+      + severity_weight(severity)            // E=1.0, W=0.5, I=0.1
+      + location_weight(file, span)          // user-edited > generated
+      + recency_weight(turns_since_touched)  // freshly written > stale
+      + accept_history(code, rule_name)      // telemetry-driven, optional
+```
+
+`base_policy(code)` is a hand-authored table (§8 of this spec, owned by the Reactor team) covering the ~30 highest-frequency diagnostic codes. Sketch:
+
+| Code prefix / id | Iteration score | Final score | Notes |
+|---|---:|---:|---|
+| Any CS error | 1.0 | 1.0 | Always emit. |
+| `REACTOR_*` Warning | 0.9 | 1.0 | Hooks/A11y/Theme are correctness-adjacent. |
+| `REACTOR_*` Info | 0.2 | 1.0 | Heuristic; suppress mid-iteration. |
+| `CS8600`–`CS8625` (nullable) | 0.3 | 1.0 | Mostly noise unless the agent is fixing a null-deref. |
+| `CS0168` (unused var) | 0.0 | 0.7 | Never blocks a build. |
+| `CS1591` (XML doc) | 0.0 | 0.5 | Cosmetic. |
+| `IDE0xxx` | 0.0 | 0.3 | Style. |
+| `NU1701`, `NU1605` | 0.0 | 0.6 | Transient — usually next build. |
+| `MSB3245`, `MSB3270`, `MSB3277` | 0.0 | 0.4 | Resolution flakiness. |
+| Unknown | 0.5 | 1.0 | Conservative; surface unknown codes by default in iteration too — better to over-emit a novel code than to hide a real bug behind silence. |
+
+Iteration threshold: **≥ 0.6**. Final threshold: **≥ 0.0** (everything). Tunable via `mur check --emit-threshold`.
+
+### Learned ranker (Phase D)
+
+The deterministic table is the v1 baseline. Once spec 037's corpus is producing pairs at scale, train a small classifier:
+
+- **Label:** for each diagnostic that fired in a trace, did the agent's eventual fix touch the line/symbol/file the diagnostic pointed at? Yes → emit-worthy; no → noise.
+- **Features:** diagnostic code, severity, file path category (user / generated / nuget cache), turn index, whether prior `mur check` already surfaced this diagnostic and the agent ignored it, whether other higher-priority diagnostics are in the same emission, file churn rate.
+- **Model:** GBDT or logistic regression. Tiny (<100 KB ONNX). Microseconds to score per diagnostic.
+- **Calibration:** isotonic regression on a held-out fold so the score behaves like a probability of "this diagnostic is emit-worthy."
+
+The learned ranker complements rather than replaces the policy table — the table is the floor (always-emit / never-emit anchors), the model fills the gray middle.
+
+### Why not just trust MSBuild's severity?
+
+MSBuild severity is what the *language* / *analyzer* author chose, not what the *agent's-build-loop* needs. `CS1591` is severity Warning by spec; in the inner loop it is suppress-grade noise. `REACTOR_HOOKS_006` is severity Info; in the inner loop it is borderline because a hook misuse can cause runtime corruption. The ranker overlays a *task-shaped* severity on top of the language-shaped one.
+
+### Failure modes the ranker must not introduce
+
+- **Hiding a load-bearing warning the agent needed to see.** Mitigation: telemetry tracks suppressed diagnostics that later became errors in subsequent builds; auto-promote any code that crosses the suppression-then-error threshold > N times.
+- **Suppressing in iteration but never emitting in final.** Mitigation: the harness asserts `mur check --final` is run on the success build of every spec 037 trace; any diagnostic that the user-mode lint would have flagged but `--final` didn't is a CI failure.
+- **Confusing the agent with mode-dependent output.** Mitigation: include the mode in every emission's metadata (`// mode: iteration`) so the agent can reason about why a diagnostic does or doesn't appear.
+
+## §9 Output format
 
 `mur check` emits one line per diagnostic, format:
 
@@ -195,7 +285,7 @@ If multiple suggestions cross threshold for the same diagnostic, emit the highes
 
 Exit code preserves `dotnet build`'s exit code. `mur check` does not invent its own exit semantics.
 
-## §9 Telemetry
+## §10 Telemetry
 
 Each `mur check` invocation logs (locally; opt-in upload):
 
@@ -214,7 +304,7 @@ If running inside an agent harness, the harness can additionally report whether 
 
 Telemetry is local-first, opt-in, scoped to the active project. No source code, no PII, no machine identifiers.
 
-## §10 Risks
+## §11 Risks
 
 | Risk | Mitigation |
 |---|---|
@@ -225,8 +315,10 @@ Telemetry is local-first, opt-in, scoped to the active project. No source code, 
 | Pattern rules become a maintenance treadmill | Auto-generate the `samples/`-derived validation set; CI fails when a Tier 3 rule change regresses a captured pair. |
 | Tier 2 fuzzy-match emits an embarrassingly wrong rename | Whitelist threshold T. Per-code thresholds, not one global T. |
 | The corpus encodes a model's idiosyncrasies | Spec 037 supports multi-agent rotation. Tier 3 rules ship only when a cluster reproduces across ≥ 2 agents. |
+| Ranker hides a load-bearing warning the agent needed to see | Telemetry on suppress→error transitions; auto-promote codes whose suppression precedes a related error > N times. `mur check --final` is mandatory before "done" — captured in eval prompt and CI. |
+| Over-suppression makes the build/fix loop *worse* by hiding novel diagnostics | Default base score for unknown codes is 0.5 (above iteration threshold) — better to over-emit a novel code than to silence a real bug. Threshold tunable per agent via telemetry. |
 
-## §11 Predicted impact
+## §12 Predicted impact
 
 If the per-kanban-run breakdown in #226 (build + fix cycles ≈ 150 K tokens, 2–4 turns) is right, and Tier 2 + 3 remove ~70 % of those turns:
 
@@ -236,9 +328,9 @@ If the per-kanban-run breakdown in #226 (build + fix cycles ≈ 150 K tokens, 2�
 
 Stacking with #226 §1 (richer template) + §2 (inline cheatsheet): kanban tokens 738 K → ~380 K, putting Reactor decisively under WinUI on cost and within ~2× HTML — at the realistic ceiling identified in #226.
 
-These numbers are estimates; the empirical question is settled by Phase 0 instrumentation (§12).
+These numbers are estimates; the empirical question is settled by Phase 0 instrumentation (§13).
 
-## §12 Implementation phases
+## §13 Implementation phases
 
 Phased so each phase is independently shippable.
 
@@ -272,22 +364,34 @@ Phased so each phase is independently shippable.
 
 **Exit:** Tier 3 catches every cluster with frequency ≥ 5 % in the random-app corpus.
 
-### Phase 4 — telemetry-driven Tier 4 (only if needed)
+### Phase 4 — pre-emit ranker, deterministic table
+
+- Land §8's hand-authored `base_policy(code)` table covering the top ~30 highest-frequency diagnostic codes from Phase 0's sweep.
+- Add `--strict`, `--final`, `--quiet`, `--emit-threshold` flags to `mur check`.
+- Update the eval prompt and the `reactor-build-and-check` skill to direct agents to use iteration mode in the inner loop and `--final` once iteration is clean.
+- Add the suppress→error CI guardrail: every `mur check --final` run on a successful build must surface no diagnostic that, by code alone, the table would have flagged in iteration mode but didn't.
+
+**Exit:** the agent sees ≥ 50 % fewer diagnostic lines per turn in iteration mode without missing any blockers (measured against a 50×N replay of Phase 0 traces).
+
+### Phase 5 — telemetry-driven Tier 4 + learned ranker (only if needed)
 
 - Log `(diagnostic, candidates, picked, accepted-by-agent)` from production `mur check` invocations.
-- If Tier 2 + 3 still leave a meaningful tail, train a small GBDT ranker over hand-engineered features. Defer until data justifies it.
+- If Tier 2 + 3 still leave a meaningful tail of suggestion misses, train a small GBDT confidence ranker over hand-engineered features. Defer until data justifies it.
+- In parallel, train the §8 learned ranker against spec 037's pair corpus using the "did the agent's eventual fix touch this diagnostic's location?" label. Calibrate to behave as an emit-worthiness probability; combine with the policy-table floor.
 
-**Exit:** measured improvement on the long-tail clusters or formal decision to not pursue.
+**Exit:** measured improvement on the long-tail or a formal decision to not pursue. For the learned ranker specifically: ≥ 5-point lift in the precision of "diagnostics emitted in iteration mode that the agent's next fix actually touched," vs. the deterministic table baseline.
 
-## §13 Open questions
+## §14 Open questions
 
 1. **Trace format for the random-app generator (spec 037).** Does its trace produce a transcript rich enough to extract before/after source pairs without re-running the build? See spec 037 §7. Coordinate before either lands.
 2. **Confidence threshold T.** Start strict (≥ 0.85 JaroWinkler-equivalent) and loosen with telemetry, or start loose and tighten? Defaulting to strict preserves "silent is OK" — propose strict.
 3. **Should Tier 2 rewrite the surface form?** Today suggestions are text-only ("try: `Button(label, onClick: x)`"). A future variant could emit a unified-diff hunk; that is a separate scope.
 4. **Roslyn workspaces vs. compilations.** Workspaces give project-graph reasoning but cost more to load. Start with `Compilation` only; revisit if rules need cross-project context.
 5. **Per-agent rule profiles?** If different LLM agents make different mistakes, Tier 3 rule sets could be agent-keyed. Likely premature; cross-agent rules are simpler. Reconsider once telemetry shows agent-specific deltas.
+6. **Iteration-mode emit threshold (§8).** Default proposed at 0.6. Tuning lever: too high silences load-bearing warnings; too low restores the noise. Land conservative (0.5–0.55) and tighten as the policy table covers more codes? Or go aggressive (0.7) and accept that novel codes get surfaced via the unknown-code default? Settle empirically once Phase 0 produces the diagnostic-frequency distribution.
+7. **Should the ranker score Tier 1 hints as well?** Today every `REACTOR_*` analyzer warning carries a static skill pointer and is implicitly emit-worthy. The ranker could in principle suppress low-priority `REACTOR_*` Info diagnostics in iteration mode (e.g. `REACTOR_HOOKS_006`, the non-idempotent fetcher heuristic). Recommendation: yes, treat Tier 1 emissions as just another diagnostic for ranking purposes; the policy table is the single source of truth for emit/suppress decisions.
 
-## §14 Pointers
+## §15 Pointers
 
 - Existing `mur check` implementation: `src/Reactor.Cli/Check/CheckCommand.cs`
 - Existing analyzers (12 `REACTOR_*` IDs): `src/Reactor.Analyzers/{HookRulesAnalyzer,UseMemoCellsAnalyzer,UseThemeRefAnalyzer,RequestedThemeSetAnalyzer,UseLightweightStylingAnalyzer,AccessibilityAnalyzers,MissingWithKeyAnalyzer}.cs`

--- a/docs/specs/038-mur-check-did-you-mean-design.md
+++ b/docs/specs/038-mur-check-did-you-mean-design.md
@@ -1,0 +1,304 @@
+# `mur check` Did-You-Mean Engine — Design Spec
+
+## Status
+
+**Proposed** — 2026-05-09. No code yet.
+
+This spec proposes extending the existing `mur check` command (a thin MSBuild wrapper at `src/Reactor.Cli/Check/CheckCommand.cs`) into a **diagnostic-aware coach** that augments C# compiler errors landing on Reactor types with concrete *did-you-mean* suggestions. Today `mur check` parses MSBuild output into one-line diagnostics and looks up skill-file pointers for the 12 known `REACTOR_*` analyzer codes. This spec adds three further tiers — Roslyn semantic suggestions, induced pattern rules, and an optional learned ranker — driven by data the harness in [037 — Reactor Eval Trace Mining](./037-eval-trace-mining-design.md) produces.
+
+The motivating example, from agent-eval traces summarized in [#226](https://github.com/microsoft/microsoft-ui-reactor/issues/226):
+
+```
+Program.cs(34,16): error CS1061: 'ButtonElement' does not contain a definition for 'OnClick'
+```
+
+After this spec:
+
+```
+Program.cs:34:16  E  CS1061  'ButtonElement' has no member 'OnClick'
+                              -> try: Button(label, onClick: x)         [factory has Action onClick parameter]
+```
+
+A 2–4-turn build/fix cycle (~150 K tokens of context per kanban run, per the breakdown in #226) compresses to a 1-turn correction.
+
+This spec was filed first as design proposal [#227](https://github.com/microsoft/microsoft-ui-reactor/issues/227); this document is the canonical, in-tree version and supersedes the issue once landed.
+
+---
+
+## Table of Contents
+
+- [§1 Motivation](#1-motivation)
+- [§2 Goals and non-goals](#2-goals-and-non-goals)
+- [§3 Architecture: four tiers](#3-architecture-four-tiers)
+- [§4 Tier 1 — analyzer-ID hint table](#4-tier-1--analyzer-id-hint-table)
+- [§5 Tier 2 — Roslyn semantic suggester](#5-tier-2--roslyn-semantic-suggester)
+- [§6 Tier 3 — induced pattern rules](#6-tier-3--induced-pattern-rules)
+- [§7 Tier 4 — confidence ranker](#7-tier-4--confidence-ranker)
+- [§8 Output format](#8-output-format)
+- [§9 Telemetry](#9-telemetry)
+- [§10 Risks](#10-risks)
+- [§11 Predicted impact](#11-predicted-impact)
+- [§12 Implementation phases](#12-implementation-phases)
+- [§13 Open questions](#13-open-questions)
+- [§14 Pointers](#14-pointers)
+
+---
+
+## §1 Motivation
+
+The Phase-7 eval results in #226 show Reactor at 1.00× / 1.11× WinUI XAML on tokens but still 3–4× HTML. The remaining gap is **structural overhead** — and the largest single bucket inside it is the **build/fix loop**, ~150 K tokens / 2–4 turns per kanban run. Every cycle, the agent runs `dotnet build`, dumps 1.5–3 K tokens of MSBuild output into context, reads it, infers what to change, and edits.
+
+#226 §5 proposes replacing `dotnet build` with `mur check` as the default verification path; that alone shrinks each diagnostic dump from kilobytes to ~50–150 tokens. This spec goes further: instead of `mur check` only forwarding shorter diagnostics, have it run a Roslyn-backed pass that *answers the agent's likely next question*. When the diagnostic is `'ButtonElement' does not contain a definition for 'OnClick'`, the agent's next move is almost always to inspect the `Button` factory and discover the `Action onClick` parameter. We can save that inspection turn by emitting the answer in the diagnostic itself.
+
+The catch: a *wrong* suggestion is worse than no suggestion. The agent will trust it and burn turns chasing a phantom fix. So the bar to emit a suggestion is high confidence, and the bar to ship a new pattern rule is empirical evidence (from spec 037's corpus) that real agents make the mistake the rule covers.
+
+## §2 Goals and non-goals
+
+### Goals
+
+- For every C# compiler error (CS-prefixed) whose receiver, type, or member references a `Microsoft.UI.Reactor.*` symbol, emit a single-line suggestion with confidence ≥ T.
+- Stay silent below T. Silent is correct. Wrong is not.
+- Compose with the existing `REACTOR_*` analyzer hint table, not replace it.
+- Keep the diagnostic format machine-parseable: one line per diagnostic, predictable column structure.
+- Be fast: total `mur check` wall time stays within ~1.2× the underlying `dotnet build` it wraps.
+
+### Non-goals
+
+- Suggestions for non-Reactor compile errors (NuGet, target framework, generic CS1002 syntax). Out of scope; those go to standard MSBuild output unchanged.
+- Auto-fix / write-back to source. Emit text only; the agent edits.
+- Replacing the existing analyzers. The 12 `REACTOR_*` codes ship as Roslyn analyzers and continue to fire through MSBuild. This spec adds a *parallel* analysis path for CS-codes only.
+- Cross-project / workspace-level reasoning in v1. Single `Compilation` per project, loaded fresh each invocation.
+- Fancy output formats (JSON, SARIF). One-line text only in v1; structured emission is a future scope.
+
+## §3 Architecture: four tiers
+
+```
+mur check <path>
+    │
+    ▼ spawn dotnet build, parse diagnostics  (existing — CheckCommand.cs)
+    │
+    ▼ for each diagnostic that references a Microsoft.UI.Reactor.* symbol:
+    │
+    │   Tier 1 — analyzer-ID hint table              (existing — HintFor() in CheckCommand)
+    │             REACTOR_HOOKS_001 -> SKILL.md §Hooks
+    │             12 IDs covered today.
+    │
+    │   Tier 2 — Roslyn semantic suggester           (NEW)
+    │             Load Compilation, resolve symbol at span,
+    │             fuzzy-match against in-scope members + factory set.
+    │             Handles CS1061, CS0103, CS0117, CS1503, CS7036.
+    │
+    │   Tier 3 — pattern rules (React-ism reductions) (NEW)
+    │             .OnClick(x)        -> onClick: x
+    │             .Style(...)        -> .With(...) modifier chain
+    │             .Children([...])   -> factory(elements[])  positional
+    │             className=         -> not a thing; surface modifier API
+    │
+    │   Tier 4 — confidence ranker / tiebreaker      (FUTURE — only if Tier 2+3 leave gaps)
+    │             GBDT over hand-engineered features (Levenshtein,
+    │             param-name overlap, factory-popularity-in-samples,
+    │             AST-shape similarity).
+    │
+    ▼ append "-> try: <suggestion>" only when confidence >= T
+```
+
+The tier structure is deliberate: **most of the value is deterministic.** ML enters only as a tiebreaker, only after measured data shows where Tier 2 + 3 fall short.
+
+## §4 Tier 1 — analyzer-ID hint table
+
+**Status: shipped.** Today `CheckCommand.HintFor(code)` returns a static skill-file pointer for 12 `REACTOR_*` analyzer codes (see §14). This tier is unchanged by this spec. New analyzer codes added by future analyzers slot into the same table.
+
+## §5 Tier 2 — Roslyn semantic suggester
+
+The new code lives in `src/Reactor.Cli/Check/Suggesters/SymbolSuggester.cs`. Inputs: a `CSharpCompilation`, the parsed `Diagnostic`, the `SyntaxNode` at the diagnostic's `(line, col)`. Output: an ordered list of `(suggestion_text, confidence, evidence)`.
+
+**Diagnostic codes handled:**
+
+| Code | Meaning | Suggester logic |
+|---|---|---|
+| CS1061 | Member missing on type | Walk receiver's `ITypeSymbol` members; rank by JaroWinkler against the missing name. If a top-3 candidate is a *parameter* of an enclosing factory call, prefer "use named arg `name:`". |
+| CS0103 | Name not in scope | Walk static methods of `Microsoft.UI.Reactor.Factories`; rank by JaroWinkler. Filter to factories whose return type is assignable to the expected type at the use site. |
+| CS0117 | No static member | Walk static members of the named type; same fuzzy-match. |
+| CS1503 | Argument type mismatch | If the expected parameter is `Element` and the supplied is a string-typed value, suggest the relevant text factory (`Caption`, `Heading`, `Body`). If expected is `Action` and supplied is `Action<T>`, surface the lambda-shape mismatch. |
+| CS7036 | No overload takes N args | Walk overloads of the called factory; rank by Hamming distance on the parameter-shape vector. Suggest the closest overload's named-argument form. |
+
+**Confidence scoring** is a function of:
+
+- Top candidate's similarity score (JaroWinkler ≥ 0.85 → 1.0; below 0.7 → 0.0).
+- Margin between top-1 and top-2 (close ties → discount).
+- Whether the candidate is in the same `Element` / `Modifier` family as the receiver (boost).
+- Whether the receiver is a confirmed Reactor type (`Microsoft.UI.Reactor.*` namespace; boost).
+
+Default threshold T = 0.75. Tunable via `mur check --suggest-threshold`. Below T the suggester emits nothing for that diagnostic.
+
+**Compilation lifecycle.** The suggester loads a single `CSharpCompilation` per `mur check` invocation, parsing all `.cs` files in the project tree and resolving references against the .NET SDK + Reactor NuGet that `dotnet build` already restored. ~200–500 ms one-time cost; cheaper than the underlying build it wraps. Cache by `(csproj-path, file-set-hash)` for the multi-invocation devloop scenario.
+
+`Microsoft.CodeAnalysis.CSharp` 4.8.0 is already a `PackageReference` in `src/Reactor.Cli/Reactor.Cli.csproj`, so no dependency churn.
+
+## §6 Tier 3 — induced pattern rules
+
+Tier 3 catches mistakes Tier 2 can't reach because they cross the AST-shape boundary, not just the symbol-name boundary. Examples:
+
+- `.OnClick(x)` chained on a `Button(...)` call. Tier 2 sees CS1061 on `OnClick`; the *fix* moves the lambda into the parent factory's argument list as `onClick: x`. That's a tree rewrite, not a rename.
+- `.Style(new { Color = "red" })`. Tier 2 sees CS1061; the fix is a `.With(Modifiers.Foreground(Theme.Critical))` chain — entirely different shape.
+- React-attr-style `className=`, `key=`, `ref=`. Tier 2 sees a syntax error on the `=`; the fix is to use the relevant Reactor modifier or the `WithKey` extension.
+
+Each rule is a small class implementing `IRulePattern`:
+
+```csharp
+interface IRulePattern
+{
+    string Name { get; }          // for telemetry
+    bool TryMatch(in RuleContext ctx, out RuleSuggestion suggestion);
+}
+```
+
+Rules live in `src/Reactor.Cli/Check/Rules/<Name>Rule.cs`, one rule per file, each with a unit test against a captured `(broken, fixed)` pair from the spec 037 corpus.
+
+**Rule induction process** (the seam to spec 037):
+
+1. Spec 037's harness produces `fixes.jsonl` and the aggregated `patterns.json`. Each cluster has `cluster_id`, `diag_code`, `fix_kind`, frequency, and a set of exemplar pairs.
+2. A human reviewer walks `patterns.json` top-down by frequency. For each cluster they decide:
+   - **Yes** — author an `IRulePattern`. Use the exemplars as test fixtures.
+   - **Tier 2 already covers this** — no rule needed.
+   - **No** — false-positive risk too high, frequency too low, or the cluster reflects a flaw in Reactor's API surface that should be fixed at the framework level instead.
+3. Each shipped rule carries a per-rule confidence (default 0.85) and a kill-switch (`mur check --disable-rule <Name>`).
+
+**Why human review and not auto-induction?** Rules are public-facing suggestions to the agent; a bad rule contaminates every downstream session. The cost of one bad rule landing is high; the cost of one cluster waiting another sprint for review is low. The asymmetry justifies the review step.
+
+## §7 Tier 4 — confidence ranker
+
+**Status: future.** Build only if telemetry (§9) shows Tier 2 + 3 leave a meaningful long tail.
+
+If built: a gradient-boosted tree over hand-engineered features — Levenshtein distance, parameter-name overlap, factory-popularity-in-samples (counted from `samples/apps/`), AST-shape similarity, prior agent-accept rate per rule. Inputs: the candidate set produced by Tiers 2 + 3. Output: re-ranked list with a calibrated confidence head.
+
+Inference cost is negligible (microseconds). Training cost is one offline pipeline against `fixes.jsonl`.
+
+We deliberately do **not** propose a small LLM here. Small models hallucinate without huge corpora, and Reactor's training set is fundamentally limited; the deterministic system already has access to the things a small model would have to memorize (the api index, the samples).
+
+## §8 Output format
+
+`mur check` emits one line per diagnostic, format:
+
+```
+<file>:<line>:<col>  <SEV>  <CODE>  <message>[ -> <hint>][ // <evidence>]
+```
+
+Where:
+
+- `<SEV>` is `E` / `W` / `I` (error, warning, info).
+- `<message>` is truncated to ~100 chars.
+- `<hint>` is the Tier 1 hint pointer if present, else the highest-confidence Tier 2 / Tier 3 suggestion above threshold.
+- `<evidence>` (optional, after `//`) is a brief justification — `[factory has Action onClick parameter]`, `[matched rule: FluentToNamed]`, `[skill: SKILL.md §Hooks]`. Always present so the agent can sanity-check.
+
+If multiple suggestions cross threshold for the same diagnostic, emit the highest-confidence one only. Ties broken by Tier 1 > Tier 3 > Tier 2 (analyzer hints are most reliable, hand-authored rules next, fuzzy matches last).
+
+Exit code preserves `dotnet build`'s exit code. `mur check` does not invent its own exit semantics.
+
+## §9 Telemetry
+
+Each `mur check` invocation logs (locally; opt-in upload):
+
+```json
+{
+  "session_id": "...", "ts": "...",
+  "diagnostic": { "code": "CS1061", "receiver_type": "ButtonElement", "member": "OnClick" },
+  "tiers_fired": ["Tier2", "Tier3"],
+  "suggestion_emitted": "Button(label, onClick: x)",
+  "confidence": 0.91,
+  "rule_name": "FluentToNamed"
+}
+```
+
+If running inside an agent harness, the harness can additionally report whether the agent's *next edit* matched the suggestion (proxy for accept rate). Per-rule accept rate is the primary signal for promoting / demoting / killing rules.
+
+Telemetry is local-first, opt-in, scoped to the active project. No source code, no PII, no machine identifiers.
+
+## §10 Risks
+
+| Risk | Mitigation |
+|---|---|
+| Wrong suggestions corrupt the agent's reasoning | Per-rule confidence threshold; emit only above T. Telemetry on agent-accept rate per rule, auto-suppress rules whose accept rate falls below 50 %. |
+| Roslyn `Compilation` load is slow on cold runs | Single load per `mur check` invocation, ~200–500 ms one-time vs. the multi-second `dotnet build` we already pay for. Cache by file-set hash for incremental loops. |
+| `reactor.api.txt` and the live `Reactor.dll` drift apart | Tier 2 reads from the live `Compilation`, not the api index. The api index is a pre-filter only. |
+| Random-app corpus over-represents simple controls | Stratify the prompt grid in spec 037; weight rules by both frequency *and* per-cluster turn-cost (rare patterns that cost 5 turns matter more than common ones that cost 1). |
+| Pattern rules become a maintenance treadmill | Auto-generate the `samples/`-derived validation set; CI fails when a Tier 3 rule change regresses a captured pair. |
+| Tier 2 fuzzy-match emits an embarrassingly wrong rename | Whitelist threshold T. Per-code thresholds, not one global T. |
+| The corpus encodes a model's idiosyncrasies | Spec 037 supports multi-agent rotation. Tier 3 rules ship only when a cluster reproduces across ≥ 2 agents. |
+
+## §11 Predicted impact
+
+If the per-kanban-run breakdown in #226 (build + fix cycles ≈ 150 K tokens, 2–4 turns) is right, and Tier 2 + 3 remove ~70 % of those turns:
+
+- Tokens: ~−100 K per kanban run (~14 % of total).
+- Turns: ~−2 (16.8 → ~14.8).
+- Cost: ~−$0.70 per run.
+
+Stacking with #226 §1 (richer template) + §2 (inline cheatsheet): kanban tokens 738 K → ~380 K, putting Reactor decisively under WinUI on cost and within ~2× HTML — at the realistic ceiling identified in #226.
+
+These numbers are estimates; the empirical question is settled by Phase 0 instrumentation (§12).
+
+## §12 Implementation phases
+
+Phased so each phase is independently shippable.
+
+### Phase 0 — instrumentation (no behavior change)
+
+- Extend `CheckCommand` to emit a structured trace (`mur check --trace <path>`) capturing every CS-diagnostic that resolves to a `Microsoft.UI.Reactor.*` symbol, even when no suggestion fires today.
+- Coordinate with spec 037's pair-extraction so traces are joinable with the harness output.
+- Run a 50×N sweep on the existing calc + kanban prompts. Output: a frequency-ranked list of CS codes + receiver-types that touch Reactor.
+
+**Exit:** ranked list of the top ~20 CS-diagnostic patterns the agent hits.
+
+### Phase 1 — Tier 2 (Roslyn semantic suggester)
+
+- Add `Reactor.Cli.Check.Suggesters.SymbolSuggester` per §5.
+- Cover CS1061, CS0103, CS0117, CS1503, CS7036.
+- Per-code confidence threshold tunable via CLI flag.
+
+**Exit:** for the top ~20 patterns from Phase 0, ≥ 70 % of cases get a correct suggestion at confidence ≥ T, with false-positive rate ≤ 5 % on a held-out validation set (the `samples/apps/` mutations from spec 037 §10).
+
+### Phase 2 — wait for spec 037's corpus
+
+- Spec 037's harness lands and produces `fixes.jsonl` + `patterns.json`.
+- Human-review pass over the top clusters.
+
+**Exit:** a vetted list of pattern rules to author, sized for the next sprint.
+
+### Phase 3 — Tier 3 (pattern rules, induced)
+
+- For each high-frequency cluster, hand-author a rule (`IRulePattern`) matched against the failing AST and the diagnostic code.
+- Rules live in `src/Reactor.Cli/Check/Rules/*.cs`, one per file, each with a unit test against a captured pair.
+
+**Exit:** Tier 3 catches every cluster with frequency ≥ 5 % in the random-app corpus.
+
+### Phase 4 — telemetry-driven Tier 4 (only if needed)
+
+- Log `(diagnostic, candidates, picked, accepted-by-agent)` from production `mur check` invocations.
+- If Tier 2 + 3 still leave a meaningful tail, train a small GBDT ranker over hand-engineered features. Defer until data justifies it.
+
+**Exit:** measured improvement on the long-tail clusters or formal decision to not pursue.
+
+## §13 Open questions
+
+1. **Trace format for the random-app generator (spec 037).** Does its trace produce a transcript rich enough to extract before/after source pairs without re-running the build? See spec 037 §7. Coordinate before either lands.
+2. **Confidence threshold T.** Start strict (≥ 0.85 JaroWinkler-equivalent) and loosen with telemetry, or start loose and tighten? Defaulting to strict preserves "silent is OK" — propose strict.
+3. **Should Tier 2 rewrite the surface form?** Today suggestions are text-only ("try: `Button(label, onClick: x)`"). A future variant could emit a unified-diff hunk; that is a separate scope.
+4. **Roslyn workspaces vs. compilations.** Workspaces give project-graph reasoning but cost more to load. Start with `Compilation` only; revisit if rules need cross-project context.
+5. **Per-agent rule profiles?** If different LLM agents make different mistakes, Tier 3 rule sets could be agent-keyed. Likely premature; cross-agent rules are simpler. Reconsider once telemetry shows agent-specific deltas.
+
+## §14 Pointers
+
+- Existing `mur check` implementation: `src/Reactor.Cli/Check/CheckCommand.cs`
+- Existing analyzers (12 `REACTOR_*` IDs): `src/Reactor.Analyzers/{HookRulesAnalyzer,UseMemoCellsAnalyzer,UseThemeRefAnalyzer,RequestedThemeSetAnalyzer,UseLightweightStylingAnalyzer,AccessibilityAnalyzers,MissingWithKeyAnalyzer}.cs`
+- API surface index generator: `tools/Reactor.SignaturesGen/Program.cs` → writes `skills/reactor.api.txt` and `plugins/reactor/skills/reactor-dsl/references/reactor.api.txt`
+- Build/check skill (cheat table for known IDs): `plugins/reactor/skills/reactor-build-and-check/SKILL.md`
+- Sample apps (validation corpus for Tier 3): `samples/apps/` (13 projects)
+- Roslyn version available today: `Microsoft.CodeAnalysis.CSharp` 4.8.0 in `src/Reactor.Cli/Reactor.Cli.csproj`
+- Originating issue: [#226 — Agent-eval: close the Reactor → HTML gap](https://github.com/microsoft/microsoft-ui-reactor/issues/226) §5
+- Originating proposal issue: [#227 — Roslyn-backed did-you-mean suggestions for `mur check`](https://github.com/microsoft/microsoft-ui-reactor/issues/227)
+- Companion data-generation spec: [037 — Reactor Eval Trace Mining](./037-eval-trace-mining-design.md)
+
+---
+
+This spec extends and depends on **#226 §5**. It is independent of, but complementary to, **#226 §1** and **#226 §2**.


### PR DESCRIPTION
## Summary

- Adds **037 — Reactor Eval Trace Mining**: a standalone harness, intended to live outside this repo, that drives a coding agent to author small Reactor apps from a stratified prompt grid and records every `(broken_source, diagnostic, fixed_source)` triple. The agent under test cannot read Reactor source, samples, or internal skill packs — by design, so the failures we capture reflect a real downstream user's experience and not a privileged author's. Output: `fixes.jsonl` + an aggregated `patterns.json`.
- Adds **038 — `mur check` Did-You-Mean Engine**: the runtime feature that consumes 037's corpus. Four tiers — existing analyzer-ID hint table, new Roslyn semantic suggester (CS1061 / CS0103 / CS0117 / CS1503 / CS7036), human-reviewed pattern rules induced from 037's clusters, and an optional learned ranker only if telemetry shows tiers 2–3 leave a tail. Originated as design proposal #227 against #226 §5.

The two specs are deliberately paired: 037 is the data side, 038 is the runtime side. Phases in 038 explicitly wait on 037's corpus (Phase 2). Phase 0 of 038 (instrumentation) and Phase A of 037 (one-prompt smoke) can land in parallel.

Predicted impact (per #227): if Tier 2+3 remove ~70 % of build/fix turns, kanban runs save ~−100 K tokens / ~−2 turns / ~−$0.70. Stacked with #226 §1 (richer template) + §2 (inline cheatsheet), kanban tokens drop from 738 K → ~380 K — Reactor decisively under WinUI on cost and within ~2× HTML.

Closes nothing yet; tracks #226, #227.

## Test plan

- [ ] Specs render correctly on GitHub (TOC anchors, code blocks).
- [ ] Cross-links between 037 ↔ 038 resolve.
- [ ] References to existing files (`src/Reactor.Cli/Check/CheckCommand.cs`, `src/Reactor.Analyzers/*.cs`, `tools/Reactor.SignaturesGen/Program.cs`, `samples/apps/`) are accurate as of `main`.
- [ ] No new code lands in this PR — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
