### PR TITLE
docs(skills): fix broken examples; filter obsolete from api.txt

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -327,7 +327,9 @@ VStack(spacing, children...)    HStack(spacing, children...)
 TextBlock("hi")  Heading("Title")    SubHeading("Section")  Caption("note")
 Border(child).CornerRadius(8).Background(Theme.CardBackground).Padding(16)
 ScrollView(VStack(...))
-Grid(columns: ["*", "200"], rows: ["Auto", "*"], cells.Grid(row, column))
+Grid(columns: [GridSize.Star(), GridSize.Px(200)],
+     rows:    [GridSize.Auto,   GridSize.Star()],
+    childA.Grid(row: 0, column: 0), childB.Grid(row: 1, column: 1))
 TitleBar("App") with { Subtitle = "Home", Content = ..., RightHeader = ... }
 
 // Controls
@@ -395,7 +397,8 @@ class App : Component
         var (page, setPage) = UseState("Home");
 
         return Grid(
-            rows: "Auto,*",
+            columns: [GridSize.Star()],
+            rows: [GridSize.Auto, GridSize.Star()],
             Border(
                 HStack(12,
                     Heading("My App").VAlign(VerticalAlignment.Center),

--- a/plugins/reactor/skills/reactor-design/SKILL.md
+++ b/plugins/reactor/skills/reactor-design/SKILL.md
@@ -7,7 +7,7 @@ description: "Windows 11 design rules for Reactor — theme tokens, High Contras
 
 Author, review, and fix Reactor UI code following Windows 11 design system rules.
 
-Reactor is a functional UI framework for WinUI 3 that builds UI entirely in C# — no XAML, no data binding, no ViewModels. UI is described with immutable Element records, composed via factory methods (`UI.Text()`, `UI.VStack()`, etc.), and updated through a React-style reconciler with hooks (`UseState`, `UseEffect`, etc.).
+Reactor is a functional UI framework for WinUI 3 that builds UI entirely in C# — no XAML, no data binding, no ViewModels. UI is described with immutable Element records, composed via bare factory methods imported with `using static Microsoft.UI.Reactor.Factories` (`TextBlock(...)`, `VStack(...)`, etc.), and updated through a React-style reconciler with hooks (`UseState`, `UseEffect`, etc.).
 
 This skill translates the Windows 11 design language into Reactor's C# projection so that apps built with Reactor look, feel, and behave like first-class Windows 11 applications.
 
@@ -789,13 +789,14 @@ Combine validation with accessibility:
 var validation = UseValidationContext();
 var (email, setEmail) = UseState("");
 
-return FormField("Email",
+return FormField(
     TextField(email, setEmail)
-        .Validate(validation, "email", Validators.Required(), Validators.Email())
-        .Required(true)
+        .Validate("email", email, Validate.Required(), Validate.Email())
+        .Required()
         .HelpText("We'll send a confirmation to this address"),
+    label: "Email",
     required: true,
-    showErrorWhen: ShowWhen.Touched)
+    showWhen: ShowWhen.WhenTouched)
 .Landmark(AutomationLandmarkType.Form);
 ```
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -63,9 +63,7 @@ FontIcon(string glyph, string fontFamily = null, double? fontSize = null) → Fo
 ForEach<T>(IEnumerable<T> items, Func<T, Element> render) → Element
 ForEach<T>(IEnumerable<T> items, Func<T, int, Element> render) → Element
 Frame(Type sourcePageType = null, object navigationParameter = null) → FrameElement
-Func(Func<RenderContext, Element> render) → FuncElement
 Grid(GridSize[] columns, GridSize[] rows, Element[] children) → GridElement
-Grid(string[] columns, string[] rows, Element[] children) → GridElement
 GridView(Element[] items) → GridViewElement
 GridView<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → TemplatedGridViewElement<T>
 Group(Element[] children) → Element

--- a/plugins/reactor/skills/reactor-forms/SKILL.md
+++ b/plugins/reactor/skills/reactor-forms/SKILL.md
@@ -17,7 +17,7 @@ declarative `.Validate()` modifiers.
 | `TextField(value, setValue)` | Controlled text input |
 | `UseValidationContext()` | Track validation messages, touched/dirty state |
 | `.Validate(...)` | Attach built-in validators to an input |
-| `FormField(label, input)` | Wraps input with label, error display, required marker |
+| `FormField(input, label: ...)` | Wraps input with label, error display, required marker |
 | `new MaskEngine(...)` | Masked text input (phone, SSN, etc.) |
 | `InputFormatter.Currency(...)` | Format-as-you-type |
 
@@ -33,7 +33,7 @@ var (agreed, setAgreed) = UseState(false);
 return VStack(12,
     TextField(name, setName, placeholder: "Name"),
     NumberBox(age, setAge),
-    CheckBox("I agree", agreed, setAgreed),
+    CheckBox(agreed, setAgreed, label: "I agree"),
     Button("Submit", onSubmit).Disabled(string.IsNullOrEmpty(name) || !agreed)
 );
 ```
@@ -42,19 +42,23 @@ return VStack(12,
 
 | Factory | Value type | Common modifiers |
 |---------|-----------|------------------|
-| `TextField(text, setText)` | `string` | `.Placeholder()`, `.MaxLength()` |
-| `PasswordBox(text, setText)` | `string` | `.Placeholder()`, `.PasswordRevealMode()` |
-| `NumberBox(value, setValue)` | `double` | `.Min()`, `.Max()`, `.SmallChange()` |
-| `Slider(value, min, max, setValue)` | `double` | `.StepFrequency()` |
-| `ToggleSwitch(isOn, setIsOn)` | `bool` | `.OnContent()`, `.OffContent()` |
-| `CheckBox(label, isChecked, setIsChecked)` | `bool` | — |
-| `RadioButtons(items, selected, setSelected)` | `int` | `.Header()` |
-| `ComboBox(items, selected, setSelected)` | `object` | `.Placeholder()` |
-| `DatePicker(date, setDate)` | `DateTimeOffset` | `.MinYear()`, `.MaxYear()` |
-| `TimePicker(time, setTime)` | `TimeSpan` | `.MinuteIncrement()` |
-| `AutoSuggestBox(text, setText)` | `string` | `.ItemsSource()`, `.OnSuggestionChosen()` |
-| `RichEditBox(doc, setDoc)` | `string` | `.IsReadOnly()` |
-| `CalendarDatePicker(date, setDate)` | `DateTimeOffset?` | `.MinDate()`, `.MaxDate()` |
+| `TextField(value, setValue, placeholder, header)` | `string` | `.Header()`, `.ReadOnly()`, `.AcceptsReturn()`, `.TextWrapping()` |
+| `PasswordBox(value, setValue, placeholder, header)` | `string` | `.Set(pb => ...)` |
+| `NumberBox(value, setValue, placeholder, header)` | `double` | `.Range(min, max)`, `.SpinButtons(...)` |
+| `Slider(value, min, max, setValue)` | `double` | `.Header()`, `.StepFrequency()` |
+| `ToggleSwitch(isOn, setIsOn, header, onContent, offContent)` | `bool` | `.Header()` |
+| `CheckBox(isChecked, setIsChecked, label)` | `bool` | — |
+| `RadioButtons(items, selected, setSelected, header)` | `int` | `.Set(rb => ...)` |
+| `ComboBox(items, selected, setSelected, placeholder)` | `object` | `.Header()`, `.Editable()`, `.Placeholder()` |
+| `DatePicker(date, setDate, header)` | `DateTimeOffset` | `.Set(dp => ...)` |
+| `TimePicker(time, setTime, header)` | `TimeSpan` | `.Set(tp => ...)` |
+| `AutoSuggestBox(text, setText, placeholder, header)` | `string` | `.Set(asb => ...)` |
+| `RichEditBox(doc, setDoc, header)` | `string` | `.Set(reb => ...)` |
+| `CalendarDatePicker(date, setDate, placeholder, header)` | `DateTimeOffset?` | `.Set(cdp => ...)` |
+
+For modifiers that aren't in the typed surface (e.g. `PasswordRevealMode`,
+date min/max), use `.Set(native => ...)` to reach the underlying WinUI control.
+The full catalog is in `references/reactor.api.txt`.
 
 ## 2. Simple validation (derived booleans)
 
@@ -84,32 +88,42 @@ var (email, setEmail) = UseState("");
 
 return VStack(12,
     TextField(name, setName, placeholder: "Name")
-        .Validate(validation, "name",
+        .Validate("name", name,
             Validate.Required("Name is required"),
             Validate.MinLength(2, "Name too short")),
 
     TextField(email, setEmail, placeholder: "Email")
-        .Validate(validation, "email",
+        .Validate("email", email,
             Validate.Required("Email is required"),
             Validate.Email("Invalid email")),
 
     Button("Submit", () =>
     {
-        validation.ValidateAll();
-        if (validation.IsValid)
+        validation.MarkAllTouched();
+        if (validation.IsValid())
             Submit(name, email);
     })
 );
 ```
 
+`.Validate(fieldName, value, ...)` resolves the surrounding `ValidationContext`
+through React-style ambient context — you do not pass `validation` explicitly.
+Passing the current value (the second arg) opts in to auto-validation as the
+component re-renders; the validator-only overload `.Validate(fieldName, ...)`
+is for cases where you trigger validation manually.
+
 ### ValidationContext API
 
 | Member | Purpose |
 |--------|---------|
-| `.IsValid` | `true` when no field has errors |
-| `.IsDirty` | `true` when any field differs from initial value |
-| `.ValidateAll()` | Force validation on all registered fields |
-| `.Reset()` | Clear all messages and touched/dirty flags |
+| `.IsValid()` | `true` when no field has Error-severity messages |
+| `.IsDirty()` | `true` when any registered field differs from initial value |
+| `.IsDirty("field")` | Per-field dirty check |
+| `.MarkAllTouched()` | Mark every registered field touched (typical on submit) |
+| `.MarkTouched("field")` | Mark a single field touched |
+| `.Reset("field")` | Reset one field to initial value, returns the initial |
+| `.ResetAll()` | Reset all fields to initial values |
+| `.ClearAll()` | Clear all messages (preserve touched/initial state) |
 | `.GetMessages("field")` | Get error messages for a specific field |
 | `.IsTouched("field")` | Whether the user has interacted with a field |
 
@@ -139,12 +153,13 @@ text, and error display:
 var validation = UseValidationContext();
 var (name, setName) = UseState("");
 
-return FormField("Full Name",
+return FormField(
     TextField(name, setName, placeholder: "Enter your name")
-        .Validate(validation, "name", Validate.Required("Required")),
+        .Validate("name", name, Validate.Required("Required")),
+    label: "Full Name",
     required: true,
     description: "As it appears on your ID",
-    showWhen: ShowWhen.WhenTouched  // or Always, WhenDirty, AfterFirstSubmit
+    showWhen: ShowWhen.WhenTouched  // or Always, WhenDirty, AfterFirstSubmit, Never
 );
 ```
 
@@ -206,9 +221,11 @@ return TextField(amount,
 
 1. **Always use controlled inputs** — `(value, setter)` pair. There is no
    uncontrolled / two-way binding in Reactor.
-2. **Call `validation.ValidateAll()` before submit** — individual fields
-   validate on blur/change, but you must trigger all-field validation
-   before acting on the form.
+2. **Call `validation.MarkAllTouched()` before submit** — when fields use the
+   `.Validate(name, value, ...)` form, validators run automatically every
+   render, but errors stay hidden until each field is touched. Mark all
+   registered fields touched on submit so error messages reveal at once,
+   then gate on `validation.IsValid()`.
 3. **Use `ShowWhen.WhenTouched`** (default) — showing errors immediately on
    page load is hostile UX.
 4. **MaskEngine and InputFormatter are different** — masks restrict what

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -34,7 +34,7 @@ description: "Reactor essentials in one place — React-to-Reactor mental model,
 | `className="..."` (style) | `.Background(...)`, `.Padding(...)`, `.Margin(...)`, etc. |
 | `style={{margin: 10}}` | `.Margin(10)` |
 | `display: flex; flex: 1` | `FlexRow(...)` / `.Flex(grow: 1, basis: 0)` |
-| `gap: 8` | `VStack(8, …)`, `FlexRow(...).Gap(8)` |
+| `gap: 8` | `VStack(8, …)`, `FlexRow(...) with { ColumnGap = 8 }` (FlexColumn → `RowGap`) |
 | React Query `useQuery` / `useMutation` | `UseResource` / `UseMutation` (see `reactor-async`) |
 | JSX | C# method calls + `using static Microsoft.UI.Reactor.Factories` |
 
@@ -209,7 +209,11 @@ FlexColumn(children...)                       FlexRow(children...)
 // remain for StackPanel's shrink-wrap behavior.
 Border(child).CornerRadius(8).Background(Theme.CardBackground).Padding(16)
 ScrollView(VStack(...))
-Grid(columns: ["*", "200"], rows: ["Auto", "*"], cells.Grid(row, column))
+Grid(columns: [GridSize.Star(), GridSize.Px(200)],
+     rows:    [GridSize.Auto,   GridSize.Star()],
+    TextBlock("Header").Grid(row: 0, column: 0, columnSpan: 2),
+    ListView(items, ...).Grid(row: 1, column: 0),
+    Sidebar().Grid(row: 1, column: 1))
 TitleBar("App") with { Subtitle = "Home", Content = ..., RightHeader = ... }
 ContentDialog(string title, Element content, string primaryButtonText = "OK")
 Flyout(Element target, Element content)
@@ -255,7 +259,7 @@ items.Select(i => Component<Card, CardProps>(new CardProps(i)).WithKey(i.Id)).To
 .CornerRadius(8)       .WithBorder(Theme.CardStroke, 1)
 .Flex(grow: 1, basis: 0)        // CSS `flex: 1` equivalent
 .WithKey("id")                  // dynamic list items — see gotcha #6
-.OnClick(() => ...)             // pointer / tap surfaces
+.OnTapped((s, e) => ...)        // pointer / tap surfaces (Buttons take a click handler in their ctor)
 .Set(el => el.AutomationProperties.Name = "...")   // native escape hatch
 ```
 

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -260,7 +260,8 @@ items.Select(i => Component<Card, CardProps>(new CardProps(i)).WithKey(i.Id)).To
 .Flex(grow: 1, basis: 0)        // CSS `flex: 1` equivalent
 .WithKey("id")                  // dynamic list items — see gotcha #6
 .OnTapped((s, e) => ...)        // pointer / tap surfaces (Buttons take a click handler in their ctor)
-.Set(el => el.AutomationProperties.Name = "...")   // native escape hatch
+.AutomationName("Submit")       // a11y — sets AutomationProperties.Name
+.Set(native => native.MaxWidth = 400)   // native escape hatch (lambda receives the WinUI control)
 ```
 
 ## Theme tokens (always)

--- a/plugins/reactor/skills/reactor-input/SKILL.md
+++ b/plugins/reactor/skills/reactor-input/SKILL.md
@@ -226,7 +226,7 @@ Border(TextBlock(item.Name))
 
 // Drop target — typed overload auto-extracts payload
 Border(TextBlock("Drop here"))
-    .OnDrop<Border, Item>(
+    .OnDrop<BorderElement, Item>(
         onDrop: (droppedItem) => HandleDrop(droppedItem))
 ```
 
@@ -238,7 +238,7 @@ For type-safe object transfer within the same app, use the typed
 ```csharp
 // Drag source — typed payload via getPayload factory
 Border(TextBlock(item.Name))
-    .OnDragStart<Border, Item>(
+    .OnDragStart<BorderElement, Item>(
         getPayload: () => item,
         allowedOperations: DragOperations.Move,
         onEnd: (ctx) =>
@@ -249,7 +249,7 @@ Border(TextBlock(item.Name))
 
 // Drop target — typed extraction
 Border(TextBlock("Drop here"))
-    .OnDrop<Border, Item>(
+    .OnDrop<BorderElement, Item>(
         onDrop: (droppedItem) => MoveItem(droppedItem),
         acceptedOps: DragOperations.Move)
 ```

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -63,9 +63,7 @@ FontIcon(string glyph, string fontFamily = null, double? fontSize = null) → Fo
 ForEach<T>(IEnumerable<T> items, Func<T, Element> render) → Element
 ForEach<T>(IEnumerable<T> items, Func<T, int, Element> render) → Element
 Frame(Type sourcePageType = null, object navigationParameter = null) → FrameElement
-Func(Func<RenderContext, Element> render) → FuncElement
 Grid(GridSize[] columns, GridSize[] rows, Element[] children) → GridElement
-Grid(string[] columns, string[] rows, Element[] children) → GridElement
 GridView(Element[] items) → GridViewElement
 GridView<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → TemplatedGridViewElement<T>
 Group(Element[] children) → Element

--- a/tools/Reactor.SignaturesGen/Program.cs
+++ b/tools/Reactor.SignaturesGen/Program.cs
@@ -83,6 +83,7 @@ static void EmitFactories(Assembly asm, StringBuilder sb)
     var methods = factories
         .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
         .Where(m => !m.IsSpecialName)
+        .Where(m => !IsObsolete(m))
         .Select(FormatMethod)
         .Distinct()
         .OrderBy(s => s, StringComparer.Ordinal);
@@ -101,9 +102,11 @@ static void EmitModifiers(Assembly asm, StringBuilder sb)
     var lines = asm
         .GetExportedTypes()
         .Where(t => t.IsClass && t.IsAbstract && t.IsSealed && !t.IsGenericType)  // static class
+        .Where(t => !IsObsolete(t))
         .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
         .Where(m => m.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false))
         .Where(m => IsElementExtension(m))
+        .Where(m => !IsObsolete(m))
         .Select(FormatMethod)
         .Distinct()
         .OrderBy(s => s, StringComparer.Ordinal);
@@ -125,15 +128,18 @@ static void EmitHooks(Assembly asm, StringBuilder sb)
         ? Enumerable.Empty<string>()
         : rc.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
              .Where(m => m.Name.StartsWith("Use", StringComparison.Ordinal))
+             .Where(m => !IsObsolete(m))
              .Select(m => "RenderContext." + FormatMethod(m));
 
     // Extension hooks (UseValidationContext, UseInfiniteResource, UseAnnounce, ...).
     var extHooks = asm
         .GetExportedTypes()
         .Where(t => t.IsClass && t.IsAbstract && t.IsSealed && !t.IsGenericType)
+        .Where(t => !IsObsolete(t))
         .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
         .Where(m => m.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false))
         .Where(IsHookExtension)
+        .Where(m => !IsObsolete(m))
         .Select(FormatMethod);
 
     var lines = instanceHooks.Concat(extHooks)
@@ -157,6 +163,7 @@ static void EmitTheme(Assembly asm, StringBuilder sb)
     var properties = theme
         .GetProperties(BindingFlags.Public | BindingFlags.Static)
         .Where(p => p.PropertyType.Name == "ThemeRef")
+        .Where(p => !IsObsolete(p))
         .OrderBy(p => p.Name, StringComparer.Ordinal);
 
     foreach (var p in properties)
@@ -186,14 +193,30 @@ static void EmitEnums(Assembly asm, StringBuilder sb)
 
     var enums = asm.GetExportedTypes()
         .Where(t => t.IsEnum)
+        .Where(t => !IsObsolete(t))
         .OrderBy(t => t.FullName, StringComparer.Ordinal);
 
     foreach (var t in enums)
     {
-        var values = string.Join(", ", Enum.GetNames(t));
-        sb.AppendLine($"{Short(t)} {{ {values} }}");
+        var values = Enum.GetNames(t)
+            .Where(name => !IsEnumMemberObsolete(t, name));
+        sb.AppendLine($"{Short(t)} {{ {string.Join(", ", values)} }}");
     }
     sb.AppendLine();
+}
+
+// ---------------------------------------------------------------------------
+//  Obsolete filtering — keep deprecated surface out of the index so AI agents
+//  don't paste from it. Mirrors what `using` would surface to a real consumer.
+// ---------------------------------------------------------------------------
+
+static bool IsObsolete(MemberInfo m) =>
+    m.IsDefined(typeof(ObsoleteAttribute), inherit: false);
+
+static bool IsEnumMemberObsolete(Type enumType, string name)
+{
+    var field = enumType.GetField(name, BindingFlags.Public | BindingFlags.Static);
+    return field is not null && IsObsolete(field);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes code examples across the skill files that don't compile (wrong arg order, non-existent overloads, deprecated APIs). All call sites were verified against the actual source in `src/Reactor/` and the canonical recipe (`reactor-recipes/references/form-with-validation.cs`).
- Teaches `Reactor.SignaturesGen` to skip `[Obsolete]` members so `reactor.api.txt` only advertises non-deprecated surface — agents reading the index won't paste from deprecated overloads going forward.

### Skill fixes (most impactful)

- **reactor-forms**: `.Validate(validation, "field", ...)` is not a real overload — context is ambient. Now `.Validate("field", value, ...)`. `FormField("Label", input, ...)` had the wrong positional order; first arg is the content `Element`. `CheckBox("label", checked, set)` had the wrong arg order. `ValidationContext` API table referenced `.IsValid`/`.IsDirty` as properties (they're methods) and `.ValidateAll()`/`.Reset()` (don't exist). Modifier table trimmed to actually-existing modifiers; `.Set(native => ...)` documented for un-wrapped natives.
- **reactor-design**: Same accessible-form errors as forms; plus `Validators.X()` → `Validate.X()`, `.Required(true)` → `.Required()`, `showErrorWhen:` → `showWhen:`, `ShowWhen.Touched` → `ShowWhen.WhenTouched`. Dropped bogus `UI.Text()` / `UI.VStack()` prose (factories are bare imports).
- **reactor-input**: `OnDrop<Border, T>` → `OnDrop<BorderElement, T>` (the generic constraint is `T : Element`; `Border` is the WinUI control type, not the Reactor element).
- **reactor-getting-started + root SKILL.md**: Replaced pseudo `cells.Grid(row, column)` with concrete examples; converted all Grid examples to typed `GridSize.Star()/.Auto/.Px()` (string-form is `[Obsolete]`). `.OnClick` → `.OnTapped`. `FlexRow(...).Gap(8)` → `FlexRow(...) with { ColumnGap = 8 }`.

### SignaturesGen change

Added `IsObsolete(MemberInfo)` and `IsEnumMemberObsolete(...)` helpers. Applied filters in all five emit sections (Factories, Modifiers, Hooks, Theme, Enums). Container static classes also filtered, so an entire deprecated extension class drops out at once.

Regenerated `reactor.api.txt` (both copies) — net 2 lines removed:
- `Grid(string[] columns, string[] rows, Element[] children)` (deprecated string-form)
- `Func(Func<RenderContext, Element>)` (deprecated in favor of `Memo`/`RenderEachTime`)

## Test plan

- [x] `dotnet build tools/Reactor.SignaturesGen` succeeds on x64.
- [x] Running the regenerated tool produces identical output across both `skills/reactor.api.txt` and `plugins/reactor/skills/reactor-dsl/references/reactor.api.txt`.
- [x] `git diff` on `reactor.api.txt` shows exactly the two `[Obsolete]` lines removed.
- [ ] Verify the fixed forms / accessible-form examples compile by running them through `mur check` or pasting into a single-file app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)