### PR TITLE
Avoid adding the temporary tools path to global path environment

### DIFF
--- a/tests/Reactor.IntegrationTests/Packaging/CreateTemplateTests.cs
+++ b/tests/Reactor.IntegrationTests/Packaging/CreateTemplateTests.cs
@@ -283,6 +283,7 @@ public sealed class TemplatePackageTestFixture : IDisposable
     {
         return new(StringComparer.OrdinalIgnoreCase)
         {
+            ["DOTNET_ADD_GLOBAL_TOOLS_TO_PATH"] = "false",
             ["DOTNET_CLI_HOME"] = dotnetCliHomeDir,
             ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1",
             ["DOTNET_NOLOGO"] = "1",


### PR DESCRIPTION
## Summary
The integration-test fixture no longer lets dotnet mutate the user-scoped PATH.

I updated tests\Reactor.IntegrationTests\Packaging\CreateTemplateTests.cs to set `DOTNET_ADD_GLOBAL_TOOLS_TO_PATH=false` in the test command environment, which keeps the CLI’s temp `dotnet-home\.dotnet\tools` path process-local instead of appending it to your global PATH. 
## Linked issue / spec

<!-- Fixes #...  /  Implements docs/specs/0XX-...  /  Part of #... -->

## Test plan
- [x] Manually ran `dotnet run --project tests\Reactor.IntegrationTests\Reactor.IntegrationTests.csproj` and verified global environment paths no longer gets modifed.

