### PR TITLE
fix(nuget): clear inherited sources so restore is deterministic (#214)

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -6,11 +6,18 @@
        scaffolded apps under this repo use #:package Microsoft.UI.Reactor and
        resolve through this feed.
 
-       nuget.org remains the source for everything else (Microsoft.WindowsAppSDK
-       and friends). It's added explicitly here so this file is self-contained
-       — global sources still apply additively. -->
+       nuget.org is the only public source we need (Microsoft.WindowsAppSDK and
+       friends resolve from there). We <clear /> first so user-level sources
+       from %APPDATA%\NuGet\NuGet.Config (often authenticated enterprise feeds)
+       don't get merged in. Without this, `dotnet restore` on a fresh clone
+       fans every package out against every inherited feed and can hang for
+       minutes on auth failures — see issue #214. -->
   <packageSources>
+    <clear />
     <add key="reactor-local" value="local-nupkgs" />
     <add key="nuget.org"     value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
## Summary
- Adds `<clear />` to the root `nuget.config` so user-level `%APPDATA%\NuGet\NuGet.Config` entries (often authenticated enterprise feeds) are no longer merged in additively
- Also clears `<disabledPackageSources>` so a user-level disabled entry can't silently turn off `reactor-local` or `nuget.org`
- Matches the convention already used by the repo's own fixture configs under `tests/startup_perf/BlankRNW/` and `tests/stress_perf_rn/*/`

Fixes #214. The reporter's framing is slightly off — the repo *does* ship a root `nuget.config` — but the diagnosis is correct: without `<clear />`, `dotnet restore` on a fresh clone fans every package out against every inherited feed, fails auth, retries, and can hang 14+ minutes producing hundreds of NU1301 errors. The file's prior comment even acknowledged this as intentional ("global sources still apply additively"), which is the bug.

## Test plan
- [x] `dotnet nuget list source` from repo root shows only `reactor-local` + `nuget.org`
- [x] `dotnet restore src/Reactor.Cli/Reactor.Cli.csproj` completes cleanly
- [ ] CI restore is green
- [ ] (Optional) Verify on a machine with authenticated user-level feeds that restore no longer hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)