### PR TITLE
fix(hooks): auto-marshal UseState/UseReducer setters to UI thread (#212)

### DIFF
--- a/docs/_pipeline/templates/effects.md.dt
+++ b/docs/_pipeline/templates/effects.md.dt
@@ -56,13 +56,17 @@ the cleanup disposes the timer, preventing leaks when the component unmounts
 or when `isRunning` changes.
 
 The timer body runs on a background thread (it's inside `Task.Run`) and calls
-the `updateSeconds` reducer from there. That works out of the box — every
-`UseState` / `UseReducer` setter automatically marshals onto the UI dispatcher
-when called from a non-UI thread, so timers, `PeriodicTimer`, network
-callbacks, and code after `await ... ConfigureAwait(false)` can all call the
-returned setter without any extra opt-in. Pass `threadSafe: true` to the hook
-only when you need many concurrent setters to apply in-place (locked) instead
-of being queued one-by-one onto the UI thread.
+the `updateSeconds` reducer from there. Once the host is bootstrapped, that
+works out of the box — every `UseState` / `UseReducer` setter automatically
+marshals onto the captured UI dispatcher when called from a non-UI thread, so
+timers, `PeriodicTimer`, network callbacks, and code after
+`await ... ConfigureAwait(false)` can all call the returned setter without any
+extra opt-in. Pass `threadSafe: true` to the hook only when you need many
+concurrent setters to apply in-place (locked) instead of being queued one-by-one
+onto the UI thread. The setter throws `InvalidOperationException` if it's
+called cross-thread before any host has bootstrapped (no UI dispatcher
+captured) or after the dispatcher has begun shutting down — make sure the
+effect cleanup cancels the background producer so it stops with the component.
 
 ## Async Data Loading
 

--- a/docs/_pipeline/templates/effects.md.dt
+++ b/docs/_pipeline/templates/effects.md.dt
@@ -55,6 +55,15 @@ The `Func<Action>` overload of `UseEffect` returns a cleanup function. Here
 the cleanup disposes the timer, preventing leaks when the component unmounts
 or when `isRunning` changes.
 
+The timer body runs on a background thread (it's inside `Task.Run`) and calls
+the `updateSeconds` reducer from there. That works out of the box — every
+`UseState` / `UseReducer` setter automatically marshals onto the UI dispatcher
+when called from a non-UI thread, so timers, `PeriodicTimer`, network
+callbacks, and code after `await ... ConfigureAwait(false)` can all call the
+returned setter without any extra opt-in. Pass `threadSafe: true` to the hook
+only when you need many concurrent setters to apply in-place (locked) instead
+of being queued one-by-one onto the UI thread.
+
 ## Async Data Loading
 
 Use `UseEffect` with [`UseState`](hooks.md) to load data asynchronously:

--- a/docs/_pipeline/templates/hooks.md.dt
+++ b/docs/_pipeline/templates/hooks.md.dt
@@ -120,6 +120,57 @@ object every render. `UseCallback` returns the same delegate instance as long
 as the dependencies haven't changed. This matters when passing callbacks to
 memoized [child components](components.md).
 
+## Updating State From Background Work
+
+`UseState` and `UseReducer` setters are safe to call from any thread. When you
+invoke a setter from a background task — inside `Task.Run`, from a
+`PeriodicTimer` loop, from a network callback, or after
+`await ... ConfigureAwait(false)` — the setter automatically marshals the write
+and the resulting re-render onto the UI dispatcher. You write the same code
+you'd write on the UI thread:
+
+<!-- ai:lock -->
+```csharp
+public override Element Render()
+{
+    var (seconds, setSeconds) = UseState(0);
+
+    UseEffect(() =>
+    {
+        var cts = new CancellationTokenSource();
+        _ = Task.Run(async () =>
+        {
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+            while (await timer.WaitForNextTickAsync(cts.Token))
+                setSeconds(s => s + 1);   // auto-marshals to the UI thread
+        });
+        return () => cts.Cancel();
+    });
+
+    return TextBlock($"Elapsed: {seconds}s");
+}
+```
+<!-- /ai:lock -->
+
+Each cross-thread setter call costs one `DispatcherQueue.TryEnqueue` —
+microseconds, not free, but vastly cheaper than the bugs you'd hit writing the
+field directly from a worker. If you need many concurrent setters to apply
+in-place rather than serialize through the UI thread (typical for ingest loops
+that hammer the same hook from multiple producers), pass `threadSafe: true` to
+the hook:
+
+<!-- ai:lock -->
+```csharp
+var (count, setCount) = UseState(0, threadSafe: true);
+var (sum, addToSum) = UseReducer(0, threadSafe: true);
+```
+<!-- /ai:lock -->
+
+`threadSafe: true` switches the hook to a per-cell lock: concurrent writers
+serialize on the lock instead of queuing through the UI dispatcher, and reads
+inside the setter (the `prev` argument of a reducer) see the latest committed
+write rather than a snapshot from the last UI tick.
+
 ## Hook Rules
 
 Hooks must be called **in the same order** every render. Reactor tracks hooks by

--- a/docs/_pipeline/templates/hooks.md.dt
+++ b/docs/_pipeline/templates/hooks.md.dt
@@ -122,9 +122,9 @@ memoized [child components](components.md).
 
 ## Updating State From Background Work
 
-`UseState` and `UseReducer` setters are safe to call from any thread. When you
-invoke a setter from a background task — inside `Task.Run`, from a
-`PeriodicTimer` loop, from a network callback, or after
+Once the host is bootstrapped, `UseState` and `UseReducer` setters are safe to
+call from any thread. When you invoke a setter from a background task — inside
+`Task.Run`, from a `PeriodicTimer` loop, from a network callback, or after
 `await ... ConfigureAwait(false)` — the setter automatically marshals the write
 and the resulting re-render onto the UI dispatcher. You write the same code
 you'd write on the UI thread:
@@ -170,6 +170,14 @@ var (sum, addToSum) = UseReducer(0, threadSafe: true);
 serialize on the lock instead of queuing through the UI dispatcher, and reads
 inside the setter (the `prev` argument of a reducer) see the latest committed
 write rather than a snapshot from the last UI tick.
+
+> **When auto-marshal can't help.** The setter needs a captured
+> `ReactorApp.UIDispatcher` to marshal onto. In unit-test / headless contexts
+> that drive `RenderContext` directly, or before the first host has been
+> bootstrapped, a cross-thread setter call throws `InvalidOperationException`
+> instead of silently racing. The setter also throws if the dispatcher refuses
+> the marshaled call (e.g., during shutdown). Cancel background producers in
+> your effect cleanup so they stop before the window closes.
 
 ## Hook Rules
 

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -113,6 +113,15 @@ The `Func<Action>` overload of `UseEffect` returns a cleanup function. Here
 the cleanup disposes the timer, preventing leaks when the component unmounts
 or when `isRunning` changes.
 
+The timer body runs on a background thread (it's inside `Task.Run`) and calls
+the `updateSeconds` reducer from there. That works out of the box — every
+`UseState` / `UseReducer` setter automatically marshals onto the UI dispatcher
+when called from a non-UI thread, so timers, `PeriodicTimer`, network
+callbacks, and code after `await ... ConfigureAwait(false)` can all call the
+returned setter without any extra opt-in. Pass `threadSafe: true` to the hook
+only when you need many concurrent setters to apply in-place (locked) instead
+of being queued one-by-one onto the UI thread.
+
 ## Async Data Loading
 
 Use `UseEffect` with [`UseState`](hooks.md) to load data asynchronously:

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -114,13 +114,17 @@ the cleanup disposes the timer, preventing leaks when the component unmounts
 or when `isRunning` changes.
 
 The timer body runs on a background thread (it's inside `Task.Run`) and calls
-the `updateSeconds` reducer from there. That works out of the box — every
-`UseState` / `UseReducer` setter automatically marshals onto the UI dispatcher
-when called from a non-UI thread, so timers, `PeriodicTimer`, network
-callbacks, and code after `await ... ConfigureAwait(false)` can all call the
-returned setter without any extra opt-in. Pass `threadSafe: true` to the hook
-only when you need many concurrent setters to apply in-place (locked) instead
-of being queued one-by-one onto the UI thread.
+the `updateSeconds` reducer from there. Once the host is bootstrapped, that
+works out of the box — every `UseState` / `UseReducer` setter automatically
+marshals onto the captured UI dispatcher when called from a non-UI thread, so
+timers, `PeriodicTimer`, network callbacks, and code after
+`await ... ConfigureAwait(false)` can all call the returned setter without any
+extra opt-in. Pass `threadSafe: true` to the hook only when you need many
+concurrent setters to apply in-place (locked) instead of being queued one-by-one
+onto the UI thread. The setter throws `InvalidOperationException` if it's
+called cross-thread before any host has bootstrapped (no UI dispatcher
+captured) or after the dispatcher has begun shutting down — make sure the
+effect cleanup cancels the background producer so it stops with the component.
 
 ## Async Data Loading
 

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -275,9 +275,9 @@ memoized [child components](components.md).
 
 ## Updating State From Background Work
 
-`UseState` and `UseReducer` setters are safe to call from any thread. When you
-invoke a setter from a background task — inside `Task.Run`, from a
-`PeriodicTimer` loop, from a network callback, or after
+Once the host is bootstrapped, `UseState` and `UseReducer` setters are safe to
+call from any thread. When you invoke a setter from a background task — inside
+`Task.Run`, from a `PeriodicTimer` loop, from a network callback, or after
 `await ... ConfigureAwait(false)` — the setter automatically marshals the write
 and the resulting re-render onto the UI dispatcher. You write the same code
 you'd write on the UI thread:
@@ -323,6 +323,14 @@ var (sum, addToSum) = UseReducer(0, threadSafe: true);
 serialize on the lock instead of queuing through the UI dispatcher, and reads
 inside the setter (the `prev` argument of a reducer) see the latest committed
 write rather than a snapshot from the last UI tick.
+
+> **When auto-marshal can't help.** The setter needs a captured
+> `ReactorApp.UIDispatcher` to marshal onto. In unit-test / headless contexts
+> that drive `RenderContext` directly, or before the first host has been
+> bootstrapped, a cross-thread setter call throws `InvalidOperationException`
+> instead of silently racing. The setter also throws if the dispatcher refuses
+> the marshaled call (e.g., during shutdown). Cancel background producers in
+> your effect cleanup so they stop before the window closes.
 
 ## Hook Rules
 

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -273,6 +273,57 @@ object every render. `UseCallback` returns the same delegate instance as long
 as the dependencies haven't changed. This matters when passing callbacks to
 memoized [child components](components.md).
 
+## Updating State From Background Work
+
+`UseState` and `UseReducer` setters are safe to call from any thread. When you
+invoke a setter from a background task — inside `Task.Run`, from a
+`PeriodicTimer` loop, from a network callback, or after
+`await ... ConfigureAwait(false)` — the setter automatically marshals the write
+and the resulting re-render onto the UI dispatcher. You write the same code
+you'd write on the UI thread:
+
+<!-- ai:lock -->
+```csharp
+public override Element Render()
+{
+    var (seconds, setSeconds) = UseState(0);
+
+    UseEffect(() =>
+    {
+        var cts = new CancellationTokenSource();
+        _ = Task.Run(async () =>
+        {
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+            while (await timer.WaitForNextTickAsync(cts.Token))
+                setSeconds(s => s + 1);   // auto-marshals to the UI thread
+        });
+        return () => cts.Cancel();
+    });
+
+    return TextBlock($"Elapsed: {seconds}s");
+}
+```
+<!-- /ai:lock -->
+
+Each cross-thread setter call costs one `DispatcherQueue.TryEnqueue` —
+microseconds, not free, but vastly cheaper than the bugs you'd hit writing the
+field directly from a worker. If you need many concurrent setters to apply
+in-place rather than serialize through the UI thread (typical for ingest loops
+that hammer the same hook from multiple producers), pass `threadSafe: true` to
+the hook:
+
+<!-- ai:lock -->
+```csharp
+var (count, setCount) = UseState(0, threadSafe: true);
+var (sum, addToSum) = UseReducer(0, threadSafe: true);
+```
+<!-- /ai:lock -->
+
+`threadSafe: true` switches the hook to a per-cell lock: concurrent writers
+serialize on the lock instead of queuing through the UI dispatcher, and reads
+inside the setter (the `prev` argument of a reducer) see the latest committed
+write rather than a snapshot from the last UI tick.
+
 ## Hook Rules
 
 Hooks must be called **in the same order** every render. Reactor tracks hooks by

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -37,9 +37,13 @@ public sealed class RenderContext
     /// Returns <c>false</c> when the caller is already on the UI thread (hot path).
     /// <para>
     /// When no <see cref="Microsoft.UI.Reactor.ReactorApp.UIDispatcher"/> has been
-    /// captured (unit-test / headless render contexts), a cross-thread call throws
-    /// instead of silently racing: there is no UI dispatcher to marshal onto.
-    /// Production hosts always capture a dispatcher in <c>OnLaunched</c>.
+    /// captured (unit-test / headless render contexts) or when the dispatcher has
+    /// already begun shutting down, a cross-thread call throws instead of silently
+    /// racing or dropping the update. The dispatcher is captured during host
+    /// bootstrap (<c>ReactorApp</c>'s <c>OnLaunched</c> for packaged apps, or
+    /// <c>ReactorHost</c>/<c>ReactorHostControl</c> initialization for embedded /
+    /// test scenarios), so production code reaches this method only after at
+    /// least one render has happened.
     /// </para>
     /// </summary>
     private bool MarshalIfOffUIThread(string hookName, Action work)
@@ -59,7 +63,19 @@ public sealed class RenderContext
                 $"available to marshal the call. Run the setter on the UI thread, " +
                 $"or pass threadSafe: true to the hook.");
         }
-        dq.TryEnqueue(() => work());
+        // TryEnqueue returns false when the dispatcher has begun shutting down
+        // (queue closed, owning thread exiting). Silently swallowing that case
+        // would lose the state update with no diagnostic; throw so the caller
+        // sees the same loud failure mode as the no-dispatcher path.
+        if (!dq.TryEnqueue(() => work()))
+        {
+            throw new InvalidOperationException(
+                $"{hookName} setter was called from thread {Environment.CurrentManagedThreadId}, " +
+                $"but the UI dispatcher refused the marshaled call (TryEnqueue returned " +
+                $"false — typically because the dispatcher is shutting down). The state " +
+                $"update was dropped. Stop scheduling background setters past window/app " +
+                $"shutdown (cancel the producing task in the effect cleanup).");
+        }
         return true;
     }
 

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -30,13 +30,37 @@ public sealed class RenderContext
         _uiThreadId = Environment.CurrentManagedThreadId;
     }
 
-    [global::System.Diagnostics.Conditional("DEBUG")]
-    private void AssertUIThread(string hookName)
+    /// <summary>
+    /// Auto-marshals <paramref name="work"/> to the captured UI dispatcher when the
+    /// caller is not on the UI thread. Returns <c>true</c> if the work was
+    /// scheduled cross-thread (caller should return without executing inline).
+    /// Returns <c>false</c> when the caller is already on the UI thread (hot path).
+    /// <para>
+    /// When no <see cref="Microsoft.UI.Reactor.ReactorApp.UIDispatcher"/> has been
+    /// captured (unit-test / headless render contexts), a cross-thread call throws
+    /// instead of silently racing: there is no UI dispatcher to marshal onto.
+    /// Production hosts always capture a dispatcher in <c>OnLaunched</c>.
+    /// </para>
+    /// </summary>
+    private bool MarshalIfOffUIThread(string hookName, Action work)
     {
-        if (Environment.CurrentManagedThreadId != _uiThreadId)
+        // Hot path — same thread that ran BeginRender. ~1ns TLS read + cmp + branch.
+        if (Environment.CurrentManagedThreadId == _uiThreadId) return false;
+
+        var dq = Microsoft.UI.Reactor.ReactorApp.UIDispatcher;
+        if (dq is null)
+        {
+            // Test/headless context with no captured UI dispatcher AND off-thread.
+            // The legacy [Conditional("DEBUG")] assert at this spot swallowed silently
+            // in RELEASE; surface loudly in both flavors so the call is visible.
             throw new InvalidOperationException(
                 $"{hookName} setter was called from thread {Environment.CurrentManagedThreadId}, " +
-                $"but the UI thread is {_uiThreadId}. Use threadSafe: true to allow cross-thread calls.");
+                $"but the captured UI thread is {_uiThreadId}, and no UI dispatcher is " +
+                $"available to marshal the call. Run the setter on the UI thread, " +
+                $"or pass threadSafe: true to the hook.");
+        }
+        dq.TryEnqueue(() => work());
+        return true;
     }
 
     /// <summary>
@@ -55,9 +79,18 @@ public sealed class RenderContext
     /// <summary>
     /// Declares a piece of state. Returns (currentValue, setter).
     /// Must be called in the same order every render (just like React hooks).
-    /// When <paramref name="threadSafe"/> is true, the setter can be called from any thread
-    /// and reads/writes are synchronized. When false (default), the setter must be called
-    /// from the UI thread — in DEBUG builds, a cross-thread call throws.
+    /// <para>
+    /// When <paramref name="threadSafe"/> is true, reads and writes are synchronized
+    /// with a per-hook lock so concurrent setter calls from many threads serialize.
+    /// When false (default), cross-thread setter calls are auto-marshaled onto the
+    /// captured UI dispatcher — the write and the rerender both run on the UI thread,
+    /// so background-thread setters from <c>Task.Run</c>, <c>PeriodicTimer</c>, or
+    /// callbacks after <c>await … ConfigureAwait(false)</c> work correctly without
+    /// any extra opt-in. Use <paramref name="threadSafe"/>: <c>true</c> when you need
+    /// many concurrent setters to apply in-place (i.e., without an intervening UI
+    /// thread hop) or when the setter result must be visible to its caller before
+    /// the next UI tick.
+    /// </para>
     /// </summary>
     public (T Value, Action<T> Set) UseState<T>(T initialValue, bool threadSafe = false)
     {
@@ -99,7 +132,7 @@ public sealed class RenderContext
             }
             else
             {
-                AssertUIThread("UseState");
+                if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
                 changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
                 if (changed) h.Value = newValue;
                 if (Diagnostics.ReactorEventSource.Log.IsEnabled(
@@ -116,7 +149,10 @@ public sealed class RenderContext
     /// <summary>
     /// Declares a piece of state with a functional updater variant.
     /// The updater receives the previous value and returns the next.
-    /// When <paramref name="threadSafe"/> is true, the updater can be called from any thread.
+    /// Cross-thread updater calls are auto-marshaled onto the captured UI dispatcher
+    /// (same semantics as <see cref="UseState{T}(T, bool)"/>); pass
+    /// <paramref name="threadSafe"/>: <c>true</c> for locked in-place updates that
+    /// serialize many concurrent writers without an intervening UI tick.
     /// </summary>
     public (T Value, Action<Func<T, T>> Update) UseReducer<T>(T initialValue, bool threadSafe = false)
     {
@@ -160,7 +196,7 @@ public sealed class RenderContext
             }
             else
             {
-                AssertUIThread("UseReducer");
+                if (MarshalIfOffUIThread("UseReducer", () => Updater(reducer))) return;
                 var prev = h.Value;
                 var next = reducer(prev);
                 changed = !EqualityComparer<T>.Default.Equals(prev, next);
@@ -180,7 +216,10 @@ public sealed class RenderContext
     /// Declares a piece of state managed by a reducer function (like Redux).
     /// The reducer takes (currentState, action) and returns the next state.
     /// Returns (currentState, dispatch) where dispatch sends an action through the reducer.
-    /// When <paramref name="threadSafe"/> is true, dispatch can be called from any thread.
+    /// Cross-thread dispatch calls are auto-marshaled onto the captured UI dispatcher
+    /// (same semantics as <see cref="UseState{T}(T, bool)"/>); pass
+    /// <paramref name="threadSafe"/>: <c>true</c> for locked in-place dispatch that
+    /// serializes concurrent writers without an intervening UI tick.
     /// </summary>
     public (TState Value, Action<TAction> Dispatch) UseReducer<TState, TAction>(
         Func<TState, TAction, TState> reducer, TState initialValue, bool threadSafe = false)
@@ -221,7 +260,7 @@ public sealed class RenderContext
             }
             else
             {
-                AssertUIThread("UseReducer");
+                if (MarshalIfOffUIThread("UseReducer", () => Dispatch(action))) return;
                 var prev = h.Value;
                 var next = reducer(prev, action);
                 if (!EqualityComparer<TState>.Default.Equals(prev, next))
@@ -399,6 +438,7 @@ public sealed class RenderContext
 
         void Setter(T newValue)
         {
+            if (MarshalIfOffUIThread("UsePersisted", () => Setter(newValue))) return;
             var h = (PersistedHookState<T>)_hooks[currentIndex];
             if (!EqualityComparer<T>.Default.Equals(h.Value, newValue))
             {

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeHookFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeHookFixtures.cs
@@ -359,21 +359,35 @@ internal static class ThreadSafeHookFixtures
 
             // Fire from background tasks — the failure mode the issue documents.
             // The discard `_ = Task.Run(...)` is intentional: it's the exact shape
-            // that swallows the legacy AssertUIThread throw.
+            // that swallows the legacy AssertUIThread throw. Wrap the body in
+            // try/catch + TrySetException so a regression that throws from the
+            // setter doesn't hang `await done.Task` forever; the outer
+            // Task.WhenAny + Task.Delay is the belt-and-suspenders timeout in
+            // case TrySetException is itself bypassed.
             const int iterations = 25;
             var done = new TaskCompletionSource();
             _ = Task.Run(async () =>
             {
-                for (int i = 1; i <= iterations; i++)
+                try
                 {
-                    setValue!(i);
-                    bumpValue!(prev => prev + 1);
-                    await Task.Delay(1);
+                    for (int i = 1; i <= iterations; i++)
+                    {
+                        setValue!(i);
+                        bumpValue!(prev => prev + 1);
+                        await Task.Delay(1);
+                    }
+                    done.TrySetResult();
                 }
-                done.SetResult();
+                catch (Exception ex)
+                {
+                    done.TrySetException(ex);
+                }
             });
 
-            await done.Task;
+            var timeout = Task.Delay(TimeSpan.FromSeconds(10));
+            var winner = await Task.WhenAny(done.Task, timeout);
+            H.Check("AutoMarshal_LoopCompleted", winner == done.Task);
+            if (winner == done.Task) await done.Task; // surface any captured exception
             // Let the marshaled writes drain and render
             for (int i = 0; i < 4; i++) await Harness.Render();
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeHookFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeHookFixtures.cs
@@ -320,6 +320,69 @@ internal static class ThreadSafeHookFixtures
     }
 
     // ════════════════════════════════════════════════════════════════════
+    //  Issue #212 — non-thread-safe setter from a background task auto-marshals
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Reproduces the Pomodoro / PeriodicTimer scenario from microsoft-ui-reactor#212:
+    /// a default <c>UseState</c> + <c>UseReducer</c> hook (no <c>threadSafe: true</c>)
+    /// whose setters are invoked from inside <c>Task.Run</c>. Before the fix this
+    /// either silently failed (RELEASE) or threw an unobserved
+    /// <see cref="InvalidOperationException"/> inside <c>_ = Task.Run(...)</c> (DEBUG).
+    /// After the fix the setter auto-marshals onto the UI dispatcher and the
+    /// rendered text reflects the writes.
+    /// </summary>
+    internal class NonThreadSafeAutoMarshal(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            Action<int>? setValue = null;
+            Action<Func<int, int>>? bumpValue = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (value, set) = ctx.UseState(0); // threadSafe: false (default)
+                var (sum, bump) = ctx.UseReducer(0); // threadSafe: false (default)
+                setValue = set;
+                bumpValue = bump;
+                return VStack(
+                    TextBlock($"Value: {value}"),
+                    TextBlock($"Sum: {sum}")
+                );
+            });
+
+            await Harness.Render();
+            H.Check("AutoMarshal_Initial",
+                H.FindText("Value: 0") is not null &&
+                H.FindText("Sum: 0") is not null);
+
+            // Fire from background tasks — the failure mode the issue documents.
+            // The discard `_ = Task.Run(...)` is intentional: it's the exact shape
+            // that swallows the legacy AssertUIThread throw.
+            const int iterations = 25;
+            var done = new TaskCompletionSource();
+            _ = Task.Run(async () =>
+            {
+                for (int i = 1; i <= iterations; i++)
+                {
+                    setValue!(i);
+                    bumpValue!(prev => prev + 1);
+                    await Task.Delay(1);
+                }
+                done.SetResult();
+            });
+
+            await done.Task;
+            // Let the marshaled writes drain and render
+            for (int i = 0; i < 4; i++) await Harness.Render();
+
+            H.Check("AutoMarshal_ValueFinal", H.FindText($"Value: {iterations}") is not null);
+            H.Check("AutoMarshal_SumFinal", H.FindText($"Sum: {iterations}") is not null);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
     //  Strict render coalescing: setStates inside one dispatcher block
     // ════════════════════════════════════════════════════════════════════
 

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -274,6 +274,7 @@ internal static class SelfTestFixtureRegistry
         "ThreadSafe_HighFrequencyLargeTree",
         "ThreadSafe_RenderCoalescing",
         "ThreadSafe_RenderCoalescingDispatcherBatch",
+        "ThreadSafe_NonThreadSafeAutoMarshal",
         // Animation system — Curve & Easing
         "Curve_RecordEquality",
         "Curve_PresetValues",
@@ -1055,6 +1056,7 @@ internal static class SelfTestFixtureRegistry
         "ThreadSafe_HighFrequencyLargeTree" => new ThreadSafeHookFixtures.HighFrequencyLargeTree(harness),
         "ThreadSafe_RenderCoalescing" => new ThreadSafeHookFixtures.RenderCoalescing(harness),
         "ThreadSafe_RenderCoalescingDispatcherBatch" => new ThreadSafeHookFixtures.RenderCoalescingDispatcherBatch(harness),
+        "ThreadSafe_NonThreadSafeAutoMarshal" => new ThreadSafeHookFixtures.NonThreadSafeAutoMarshal(harness),
         // Animation system — Curve & Easing
         "Curve_RecordEquality" => new CurveTests.RecordEquality(harness),
         "Curve_PresetValues" => new CurveTests.PresetValues(harness),

--- a/tests/Reactor.Tests/ThreadSafeHookTests.cs
+++ b/tests/Reactor.Tests/ThreadSafeHookTests.cs
@@ -413,12 +413,16 @@ public class ThreadSafeHookTests
     }
 
     // ════════════════════════════════════════════════════════════════
-    //  Non-threadsafe hook: DEBUG assertion
+    //  Non-threadsafe hook: cross-thread setter without a captured UI
+    //  dispatcher throws a loud InvalidOperationException. (Issue #212 —
+    //  previously [Conditional("DEBUG")] so the throw was silently
+    //  compiled out in RELEASE.) In production the same call path
+    //  auto-marshals via ReactorApp.UIDispatcher instead — covered by the
+    //  AppTests host fixtures, which actually capture a UI dispatcher.
     // ════════════════════════════════════════════════════════════════
 
-#if DEBUG
     [Fact]
-    public void UseState_NonThreadSafe_Throws_On_Background_Thread_In_Debug()
+    public void UseState_NonThreadSafe_OffThread_NoDispatcher_Throws()
     {
         var ctx = new RenderContext();
         ctx.BeginRender(() => { });
@@ -433,7 +437,7 @@ public class ThreadSafeHookTests
     }
 
     [Fact]
-    public void UseReducer_NonThreadSafe_Throws_On_Background_Thread_In_Debug()
+    public void UseReducer_NonThreadSafe_OffThread_NoDispatcher_Throws()
     {
         var ctx = new RenderContext();
         ctx.BeginRender(() => { });
@@ -448,7 +452,7 @@ public class ThreadSafeHookTests
     }
 
     [Fact]
-    public void UseReducer_Redux_NonThreadSafe_Throws_On_Background_Thread_In_Debug()
+    public void UseReducer_Redux_NonThreadSafe_OffThread_NoDispatcher_Throws()
     {
         var ctx = new RenderContext();
         ctx.BeginRender(() => { });
@@ -463,7 +467,6 @@ public class ThreadSafeHookTests
 
         Assert.Contains("threadSafe: true", ex.Message);
     }
-#endif
 
     // ════════════════════════════════════════════════════════════════
     //  Non-threadsafe hook: UI-thread setter works normally


### PR DESCRIPTION
## Summary

- Replace the DEBUG-only `AssertUIThread` in `UseState`/`UseReducer`/`UsePersisted` setters with an always-on UI-thread check that auto-marshals the write and rerender via `ReactorApp.UIDispatcher.TryEnqueue` when called off-thread.
- Hot path adds ~1-2 ns (one TLS read + int compare); marshal closure allocation is only paid on the off-thread path. Strictly cheaper than flipping the default to `threadSafe: true` (which would force `Monitor.Enter/Exit` on every UI-thread setter).
- When no UI dispatcher has been captured (test/headless contexts), off-thread calls now throw `InvalidOperationException` loudly in both DEBUG and RELEASE — closes the previous silent-RELEASE-failure gap.
- Documents the auto-marshal contract and the still-useful `threadSafe: true` opt-in in `hooks.md` (first mention in the guide) and `effects.md` (explains why the `TimerCleanupExample` snippet works as-written).

Fixes #212.

## Test plan

- [x] Full unit-test suite: 6954/6954 pass (46 pre-existing skipped).
- [x] `ThreadSafeHookTests` (17 tests): pass. The previously `#if DEBUG`-gated "throws on background thread" tests run unconditionally and verify the loud-throw path when no dispatcher is captured.
- [x] New `ThreadSafe_NonThreadSafeAutoMarshal` selftest fixture mounts a real WinUI host and reproduces the issue's `Task.Run` + `PeriodicTimer` pattern using **default** (non-thread-safe) hooks: pass.
- [x] All 7 `ThreadSafe_*` selftest fixtures pass in the WinUI host (no regression in the existing thread-safe stress tests).
- [ ] Repro from the issue (Pomodoro `PeriodicTimer` with default `UseState`) — covered structurally by the selftest fixture; the manual repro is the same code shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)