### PR TITLE
docs: align all .NET version references to .NET 10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ dotnet test tests/Reactor.AppTests
 dotnet test tests/Reactor.AppTests --filter "ClassName=Reactor.AppTests.Tests.AccessibilityTests"
 ```
 
-CI runs unit tests + selftests + full solution build on every PR. .NET 9 SDK, `windows-latest` runner.
+CI runs unit tests + selftests + full solution build on every PR. .NET 10 SDK, `windows-latest` runner.
 
 ## Architecture
 
@@ -121,7 +121,7 @@ Tests that write to `Console.Out`/`Console.Error` must be grouped with `[Collect
 
 ### AOT compatibility
 
-`IsAotCompatible=true` is set for all net8.0+ projects. The core Reactor library promotes IL trimming/AOT warnings to errors — new reflection usage must be annotated before merging. Non-Reactor projects (tests, samples) suppress these warnings.
+`IsAotCompatible=true` is set for all net10.0+ projects. The core Reactor library promotes IL trimming/AOT warnings to errors — new reflection usage must be annotated before merging. Non-Reactor projects (tests, samples) suppress these warnings.
 
 ### WinUI library projects
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 ## Prerequisites
 
-- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 - Windows App SDK 2.0 — restored automatically from NuGet, no manual install required
 - Visual Studio 2022 (17.8+) or VS Code with C# Dev Kit
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,7 +3,7 @@
   <!-- Enable AOT compatibility analysis on all projects except Roslyn
        analyzers / source-generators (netstandard2.0). Placed in .targets
        so that TargetFramework from the project file is already resolved. -->
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
     <!-- Show every individual trimmer warning instead of collapsing them. -->
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
@@ -11,20 +11,20 @@
 
   <!-- Promote IL trimming/AOT warnings to errors on the core Reactor library.
        This ensures new reflection usage must be annotated before it can merge. -->
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(MSBuildProjectName)' == 'Reactor'">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0')) And '$(MSBuildProjectName)' == 'Reactor'">
     <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2062;IL2065;IL2067;IL2069;IL2070;IL2072;IL2073;IL2075;IL2087;IL2090;IL2091;IL2111;IL3000;IL3050</WarningsAsErrors>
   </PropertyGroup>
 
   <!-- Suppress trimming/AOT warnings in consumer projects (tests, samples, CLI).
        The core Reactor library is already warning-free; these projects intentionally
        call reflection-based APIs and will not be AOT-published. -->
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(MSBuildProjectName)' != 'Reactor'">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0')) And '$(MSBuildProjectName)' != 'Reactor'">
     <NoWarn>$(NoWarn);IL2026;IL2062;IL2065;IL2067;IL2070;IL2072;IL2075;IL2090;IL2091;IL3000;IL3050</NoWarn>
   </PropertyGroup>
 
   <!-- Prevent PublishAot from leaking into netstandard projects (e.g. Roslyn
        analyzers/generators) when passed as a global property. -->
-  <PropertyGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+  <PropertyGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <PublishAot>false</PublishAot>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ If you're building line-of-business applications:
 
 ### Prerequisites
 
-- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 - Windows App SDK 2.0 — pulled automatically on `dotnet restore`
-- Visual Studio 2022 (17.8+) or just the .NET 8 CLI
+- Visual Studio 2022 (17.8+) or just the .NET 10 CLI
 
 > This project uses Windows App SDK 2.0 (`Microsoft.WindowsAppSDK` 2.0.1). The package comes from NuGet — no manual SDK installer is needed.
 
@@ -151,7 +151,7 @@ Or create a `.csproj` manually:
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>

--- a/docs/specs/022-packaging-and-distribution.md
+++ b/docs/specs/022-packaging-and-distribution.md
@@ -138,7 +138,7 @@ The `<EmbeddedResource Include="..\..\SKILL.md">` line stays — `mur --skill` s
 
 ```
 Microsoft.UI.Reactor.1.0.0-preview.42.nupkg
-├── lib/net9.0-windows10.0.22621.0/
+├── lib/net10.0-windows10.0.22621.0/
 │   ├── Reactor.dll
 │   └── Reactor.xml                        # XML doc comments
 ├── analyzers/dotnet/cs/
@@ -195,7 +195,7 @@ Add `Microsoft.SourceLink.GitHub` so consumers can step into Reactor source duri
 
 `mur` is short-lived (will fold into the framework once the dev loop stabilizes) but in the meantime it's a real tool consumers need. It cannot ship cleanly as a `dotnet tool` because:
 
-- `src/Reactor.Cli/Reactor.Cli.csproj:4-5` targets `net9.0-windows10.0.22621.0` with `Platforms>x64;ARM64`.
+- `src/Reactor.Cli/Reactor.Cli.csproj:4-5` targets `net10.0-windows10.0.22621.0` with `Platforms>x64;ARM64`.
 - .NET global tools must be AnyCPU and don't cleanly handle Windows-only TFMs.
 - Even if we got it working, Copilot SDK native dependencies (`GitHub.Copilot.SDK`) and WinUI runtime expectations make a self-contained exe the more reliable path.
 
@@ -206,10 +206,10 @@ On every CI run, publish:
 - `bin/x64/mur.exe` and `bin/arm64/mur.exe` (plus their managed/native dependencies) inside `reactor-skill-kit-<version>.zip`
 - Per RID — `--runtime win-x64` and `--runtime win-arm64` — to pick up the right native bits (Copilot SDK natives, etc.)
 
-**Framework-dependent (`--self-contained false`)** — the consumer's machine supplies the .NET 9 desktop runtime. This saves ~70 MB per RID over self-contained. Tradeoffs:
+**Framework-dependent (`--self-contained false`)** — the consumer's machine supplies the .NET 10 desktop runtime. This saves ~70 MB per RID over self-contained. Tradeoffs:
 
-- Requires `winget install Microsoft.DotNet.Runtime.9` on the consumer's machine. Acceptable for the P0 audience (Microsoft engineers) and for P2/P3 consumers willing to install a runtime.
-- `install-skill-kit.ps1` checks for .NET 9 and warns clearly if it's missing.
+- Requires `winget install Microsoft.DotNet.Runtime.10` on the consumer's machine. Acceptable for the P0 audience (Microsoft engineers) and for P2/P3 consumers willing to install a runtime.
+- `install-skill-kit.ps1` checks for .NET 10 and warns clearly if it's missing.
 
 **Sample apps stay self-contained.** Reactor's sample apps and bench/perf projects continue to use `WindowsAppSDKSelfContained=true` (the Directory.Build.props default). Sample apps are sensitive to the WinUI runtime version — bundling makes it trivial to test against different SDK versions during dev. Tools (`mur`) are not.
 
@@ -402,7 +402,7 @@ Target experience after P1 ships:
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
@@ -454,7 +454,7 @@ Verified locally:
 - `dotnet build Reactor.sln -c Release` → 0 errors.
 - `dotnet test tests/Reactor.Tests` → 6836 passed.
 - `dotnet test tests/Reactor.SelfTests` → 639 passed.
-- `dotnet pack src/Reactor -c Release -p:Platform=x64 -p:Version=0.0.1-smoke` → produces `.nupkg` containing `lib/net9.0-windows10.0.22621/Reactor.dll`, `analyzers/dotnet/cs/Reactor.Analyzers.dll`, `analyzers/dotnet/cs/Reactor.Localization.Generator.dll`, `LICENSE`, `Reactor.xml`.
+- `dotnet pack src/Reactor -c Release -p:Platform=x64 -p:Version=0.0.1-smoke` → produces `.nupkg` containing `lib/net10.0-windows10.0.22621/Reactor.dll`, `analyzers/dotnet/cs/Reactor.Analyzers.dll`, `analyzers/dotnet/cs/Reactor.Localization.Generator.dll`, `LICENSE`, `Reactor.xml`.
 
 Still TODO under P0:
 - **Bootstrap MinVer**: `git tag v0.1.0-experimental.0 && git push --tags` so the first CI run produces `0.1.0-experimental.0.<height>` rather than the pre-bootstrap default.

--- a/docs/specs/022-packaging-and-distribution.md
+++ b/docs/specs/022-packaging-and-distribution.md
@@ -454,7 +454,7 @@ Verified locally:
 - `dotnet build Reactor.sln -c Release` → 0 errors.
 - `dotnet test tests/Reactor.Tests` → 6836 passed.
 - `dotnet test tests/Reactor.SelfTests` → 639 passed.
-- `dotnet pack src/Reactor -c Release -p:Platform=x64 -p:Version=0.0.1-smoke` → produces `.nupkg` containing `lib/net10.0-windows10.0.22621/Reactor.dll`, `analyzers/dotnet/cs/Reactor.Analyzers.dll`, `analyzers/dotnet/cs/Reactor.Localization.Generator.dll`, `LICENSE`, `Reactor.xml`.
+- `dotnet pack src/Reactor -c Release -p:Platform=x64 -p:Version=0.0.1-smoke` → produces `.nupkg` containing `lib/net10.0-windows10.0.22621.0/Reactor.dll`, `analyzers/dotnet/cs/Reactor.Analyzers.dll`, `analyzers/dotnet/cs/Reactor.Localization.Generator.dll`, `LICENSE`, `Reactor.xml`.
 
 Still TODO under P0:
 - **Bootstrap MinVer**: `git tag v0.1.0-experimental.0 && git push --tags` so the first CI run produces `0.1.0-experimental.0.<height>` rather than the pre-bootstrap default.

--- a/docs/specs/030-reactor-gallery-design.md
+++ b/docs/specs/030-reactor-gallery-design.md
@@ -483,7 +483,7 @@ No per-feature or per-sample csproj. The head app globs sample content directly 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <RootNamespace>Reactor.Gallery</RootNamespace>
     <UseWindowsAppSDK>true</UseWindowsAppSDK>
   </PropertyGroup>

--- a/docs/specs/035-demo-script-tool-design.md
+++ b/docs/specs/035-demo-script-tool-design.md
@@ -95,7 +95,7 @@ The tool reads and writes this file. It is human-editable outside the tool.
 
 ## Demo Prompt
 
-This demo shows how to build a real-time chat UI using .NET 9 top-level
+This demo shows how to build a real-time chat UI using .NET 10 top-level
 statements and the Spectre.Console library. Single-file mode. Each step
 should compile and run standalone with `dotnet run`. Use NuGet inline
 references where needed.

--- a/tests/startup_perf/diag.ps1
+++ b/tests/startup_perf/diag.ps1
@@ -5,7 +5,7 @@
 $ErrorActionPreference = "Continue"
 $root = $PSScriptRoot
 $arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "ARM64" } else { "x64" }
-$tfm = "net9.0-windows10.0.22621.0"
+$tfm = "net10.0-windows10.0.22621.0"
 $rid = if ($arch -eq "ARM64") { "win-arm64" } else { "win-x64" }
 $ProviderGuid = [guid]'FD80D616-E92B-4B2B-9BED-131ADA36A8FD'
 

--- a/tests/stress_perf/SPEC.md
+++ b/tests/stress_perf/SPEC.md
@@ -138,10 +138,10 @@ Shared library consumed by all three apps:
 
 WinUI variants (`Direct`, `Bound`, `DirectX`, `Reactor`,
 `ReactorOptimized`, `ReactorGrid`, `VirtualList.Reactor`) target
-`net9.0-windows10.0.22621.0` and pick up the repo-wide
+`net10.0-windows10.0.22621.0` and pick up the repo-wide
 `WindowsAppSDKVersion` from `Directory.Build.props`. The WPF variant
-targets `net9.0-windows`; `PresentTracer` is plain `net9.0`. The
-shared scaffold (`StressPerf.Shared`) is `net9.0-windows`.
+targets `net10.0-windows`; `PresentTracer` is plain `net10.0`. The
+shared scaffold (`StressPerf.Shared`) is `net10.0-windows`.
 
 ```bash
 # Build all


### PR DESCRIPTION
## Summary

- The repo targets `net10.0` everywhere (every `.csproj`, `global.json` SDK `10.0.100`, CI `dotnet-version: 10.0.x`), but several setup docs, design specs, and one bench script still pointed at `.NET 8`/`.NET 9` — confusing for new contributors trying to set up.
- Updates `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `selfhost`-facing spec snippets, and `tests/startup_perf/diag.ps1` so every reference matches the actual build.
- Bumps the AOT-compat gate in `Directory.Build.targets` from `net8.0` to `net10.0`. Semantically identical for the current project set (all projects are either `net10.0*` or `netstandard2.0`), but the baseline now reflects reality.

Files touched: `AGENTS.md`, `CONTRIBUTING.md`, `Directory.Build.targets`, `README.md`, `docs/specs/022-packaging-and-distribution.md`, `docs/specs/030-reactor-gallery-design.md`, `docs/specs/035-demo-script-tool-design.md`, `tests/startup_perf/diag.ps1`, `tests/stress_perf/SPEC.md`.

Intentionally left untouched: `tools/reviewer/skills/cs-*.md` (generic C# review knowledge base; `net8.0` appears in illustrative examples, not Reactor's target), historical fix reports / perf baselines, and `selfhost/mur.deps.json` (a build artifact that regenerates).

## Test plan

- [x] `dotnet restore Reactor.slnx` — clean
- [x] `dotnet build Reactor.slnx --no-restore --no-incremental -c Release` — 0 errors, 24 pre-existing warnings (NU1903, sample-only A11Y analyzers, `ReactorApp.ActiveHost` obsolete usage in samples)
- [x] `dotnet test tests/Reactor.Tests -p:Platform=ARM64 -c Release` — **6951 passed, 46 skipped, 0 failed**
- [x] `dotnet test tests/Reactor.SelfTests -c Release` — **671 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)