### PR TITLE
Break on user-unhandled exceptions

### DIFF
--- a/src/Reactor/Hosting/ReactorHost.cs
+++ b/src/Reactor/Hosting/ReactorHost.cs
@@ -570,6 +570,7 @@ public sealed class ReactorHost : IDisposable
                 }
                 catch (Exception ex)
                 {
+                    Debugger.BreakForUserUnhandledException(ex);
                     _logger?.LogError(ex, "Component Render() threw");
                     ShowErrorFallback(ex);
                     return;


### PR DESCRIPTION
## Summary

When user-code causes an exception during rendering, you're met with a window that shows the exception information:
<img width="1814" height="666" alt="image" src="https://github.com/user-attachments/assets/e28399bb-973a-4d7d-bc53-6e75181d96ec" />
You then need to manually look through that stack trace and find the user-code that caused it.
It is much better for the inner dev loop if the debugger would break on the line that caused the exception.
This PR does just that, by breaking on user-unhandled exceptions if the debugger is attached. This relies on [Debugger.BreakForUserUnhandledException](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.debugger.breakforuserunhandledexception?view=net-10.0) to do that.
<img width="1102" height="302" alt="image" src="https://github.com/user-attachments/assets/4bc380b2-2b65-4448-9ead-532c99f32f05" />
