### PR TITLE
Polish default template: TitleBar + content padding

### DIFF
--- a/src/Reactor.Cli/Program.cs
+++ b/src/Reactor.Cli/Program.cs
@@ -255,10 +255,13 @@ int CreateProject(string name)
 
 string GenerateProgram(string name) =>
     $$"""
+    using System;
     using Microsoft.UI.Reactor;
     using Microsoft.UI.Reactor.Core;
+    using Microsoft.UI.Reactor.Layout;   // FlexDirection, FlexJustify, FlexAlign
+    using Microsoft.UI.Xaml;             // Thickness, HorizontalAlignment, VerticalAlignment
+    using Microsoft.UI.Xaml.Controls;    // Orientation, InfoBarSeverity, etc.
     using static Microsoft.UI.Reactor.Factories;
-    using Microsoft.UI.Xaml;
 
     ReactorApp.Run<App>("{{name}}", width: 800, height: 600
     #if DEBUG
@@ -273,7 +276,11 @@ string GenerateProgram(string name) =>
     {
         public override Element Render()
         {
-            return TextBlock("Hello, World!").FontSize(24).Margin(20);
+            var titleBar = TitleBar("{{name}}").Flex(shrink: 0);
+            var content = Border(
+                TextBlock("Hello, World!").FontSize(24)
+            ).Padding(24);
+            return FlexColumn(titleBar, content);
         }
     }
     """;


### PR DESCRIPTION
Use the modern Windows TitleBar (drag region, system menu, themed caption) as the top-of-window element and wrap content in a Border with 24px padding. Apply the same polish to the `mur --create` scaffolder so both entry points produce a presentable starter app. Align the scaffolder's emitted usings with the dotnet new template (PR #250) so generated apps have the common WinUI/Reactor namespaces ready to go.

<!--
Thanks for contributing to Reactor! A few notes before you open this PR:

- Link the issue or spec this PR addresses (Fixes #..., Implements docs/specs/0XX-...).
- Keep the change focused. Smaller, well-scoped PRs land faster.
- Include tests. See CONTRIBUTING.md for the unit / selftest / e2e split.
- Run `dotnet build Reactor.slnx` and `dotnet test tests/Reactor.Tests` locally.
- First-time contributors: the Microsoft CLA bot will comment automatically; sign once and you're set.
-->

## Summary

<!-- One or two sentences: what changes, and why. -->

## Linked issue / spec

<!-- Fixes #...  /  Implements docs/specs/0XX-...  /  Part of #... -->

## Test plan

<!-- Bulleted list of how this was verified. Examples:
- [ ] Added unit tests in tests/Reactor.Tests/...
- [ ] Added selftest fixture in tests/Reactor.AppTests.Host/SelfTest/Fixtures/...
- [ ] Ran `dotnet test tests/Reactor.Tests`
- [ ] Manually ran `dotnet run --project samples/Reactor.TestApp`
-->

## Risk / breaking changes

<!-- Any public-API change, behavior shift, or perf-sensitive path? Flag it here. -->
