### PR TITLE
Create parameter consistency for margins and paddings

### DIFF
--- a/plugins/reactor/skills/reactor-design/SKILL.md
+++ b/plugins/reactor/skills/reactor-design/SKILL.md
@@ -368,7 +368,7 @@ element.Margin(16)
 element.Margin(horizontal: 24, vertical: 8)
 
 // Per-side: left, top, right, bottom
-element.Margin(4, 8, 16, 24)
+element.Margin(left: 4, top: 8, right: 16, bottom: 24)
 ```
 
 #### Corner Radius

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -350,9 +350,9 @@ T.LayoutAnimation<T>() → T
 T.LayoutAnimation<T>(LayoutAnimationConfig config) → T
 T.LayoutAnimation<T>(TimeSpan duration) → T
 T.LiveRegion<T>(AutomationLiveSetting mode = AutomationLiveSetting.Polite) → T
+T.Margin<T>(double horizontal, double vertical) → T
 T.Margin<T>(double left = 0, double top = 0, double right = 0, double bottom = 0) → T
 T.Margin<T>(double uniform) → T
-T.Margin<T>(double vertical, double horizontal) → T
 T.MarginInlineEnd<T>(double value) → T
 T.MarginInlineStart<T>(double value) → T
 T.MaxHeight<T>(double h) → T
@@ -399,9 +399,9 @@ T.OnTapped<T>(Action<object, TappedRoutedEventArgs> handler) → T
 T.OnWarning<T>(Func<T, T> configure) → T
 T.Opacity<T>(double opacity) → T
 T.OpacityTransition<T>(TimeSpan? duration = null) → T
+T.Padding<T>(double horizontal, double vertical) → T
 T.Padding<T>(double left = 0, double top = 0, double right = 0, double bottom = 0) → T
 T.Padding<T>(double uniform) → T
-T.Padding<T>(double vertical, double horizontal) → T
 T.PaddingInlineEnd<T>(double value) → T
 T.PaddingInlineStart<T>(double value) → T
 T.PositionInSet<T>(int position, int size) → T

--- a/skills/design.md
+++ b/skills/design.md
@@ -473,7 +473,7 @@ element.Margin(16)
 element.Margin(horizontal: 24, vertical: 8)
 
 // Per-side: left, top, right, bottom
-element.Margin(4, 8, 16, 24)
+element.Margin(left: 4, top: 8, right: 16, bottom: 24)
 ```
 
 #### Corner Radius

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -350,9 +350,9 @@ T.LayoutAnimation<T>() → T
 T.LayoutAnimation<T>(LayoutAnimationConfig config) → T
 T.LayoutAnimation<T>(TimeSpan duration) → T
 T.LiveRegion<T>(AutomationLiveSetting mode = AutomationLiveSetting.Polite) → T
+T.Margin<T>(double horizontal, double vertical) → T
 T.Margin<T>(double left = 0, double top = 0, double right = 0, double bottom = 0) → T
 T.Margin<T>(double uniform) → T
-T.Margin<T>(double vertical, double horizontal) → T
 T.MarginInlineEnd<T>(double value) → T
 T.MarginInlineStart<T>(double value) → T
 T.MaxHeight<T>(double h) → T
@@ -399,9 +399,9 @@ T.OnTapped<T>(Action<object, TappedRoutedEventArgs> handler) → T
 T.OnWarning<T>(Func<T, T> configure) → T
 T.Opacity<T>(double opacity) → T
 T.OpacityTransition<T>(TimeSpan? duration = null) → T
+T.Padding<T>(double horizontal, double vertical) → T
 T.Padding<T>(double left = 0, double top = 0, double right = 0, double bottom = 0) → T
 T.Padding<T>(double uniform) → T
-T.Padding<T>(double vertical, double horizontal) → T
 T.PaddingInlineEnd<T>(double value) → T
 T.PaddingInlineStart<T>(double value) → T
 T.PositionInSet<T>(int position, int size) → T

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -102,7 +102,7 @@ public sealed class ChartElement<T> : IChartAccessibilityData
 
     public ChartElement<T> Width(double w) { _width = w; return this; }
     public ChartElement<T> Height(double h) { _height = h; return this; }
-    public ChartElement<T> Margin(double top, double right, double bottom, double left) { _marginTop = top; _marginRight = right; _marginBottom = bottom; _marginLeft = left; return this; }
+    public ChartElement<T> Margin(double left, double top, double right, double bottom) { _marginLeft = left; _marginTop = top; _marginRight = right; _marginBottom = bottom; return this; }
     public ChartElement<T> Stroke(string color) { _stroke = color; return this; }
     public ChartElement<T> Fill(string color) { _fill = color; return this; }
     public ChartElement<T> StrokeWidth(double w) { _strokeWidth = w; return this; }

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -37,12 +37,11 @@ public static class ElementExtensions
     public static T Margin<T>(this T el, double uniform) where T : Element =>
         Modify(el, new ElementModifiers { Margin = new Thickness(uniform) });
 
-    // Parameter order matches CSS shorthand: `padding: 16px 14px;` is
-    // top/bottom=16, left/right=14 — vertical FIRST. Reactor's 2-arg form
-    // mirrors that: `.Margin(16, 14)` → Thickness(14, 16, 14, 16). Use named
-    // args (`.Margin(horizontal: 14, vertical: 16)`) when the call site needs
-    // to be unambiguous to a reader unfamiliar with the convention.
-    public static T Margin<T>(this T el, double vertical, double horizontal) where T : Element =>
+    // Two-argument spacing follows the same order everywhere in Reactor:
+    // horizontal FIRST, then vertical. This keeps `.Margin(...)`,
+    // `.Padding(...)`, and `.FlexPadding(...)` aligned and matches the mental
+    // model of Thickness(left/right, top/bottom).
+    public static T Margin<T>(this T el, double horizontal, double vertical) where T : Element =>
         Modify(el, new ElementModifiers { Margin = new Thickness(horizontal, vertical, horizontal, vertical) });
 
     // Default values on the per-side overload let callers name only the sides
@@ -58,8 +57,8 @@ public static class ElementExtensions
     public static T Padding<T>(this T el, double uniform) where T : Element =>
         Modify(el, new ElementModifiers { Padding = new Thickness(uniform) });
 
-    // Same CSS-shorthand ordering as Margin above — vertical first.
-    public static T Padding<T>(this T el, double vertical, double horizontal) where T : Element =>
+    // Same ordering as Margin above — horizontal first, then vertical.
+    public static T Padding<T>(this T el, double horizontal, double vertical) where T : Element =>
         Modify(el, new ElementModifiers { Padding = new Thickness(horizontal, vertical, horizontal, vertical) });
 
     // Same defaulting story as Margin above — `.Padding(top: 8)` etc. are

--- a/tests/Reactor.Tests/ElementExtensionsAdditionalTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsAdditionalTests.cs
@@ -26,6 +26,27 @@ public class ElementExtensionsAdditionalTests
     }
 
     [Fact]
+    public void Margin_TwoArgument_Positional_Order_Is_Horizontal_Then_Vertical()
+    {
+        var el = TextBlock("x").Margin(10.0, 20.0);
+        Assert.Equal(new Thickness(10, 20, 10, 20), el.Modifiers!.Margin);
+    }
+
+    [Fact]
+    public void Padding_TwoArgument_Positional_Order_Is_Horizontal_Then_Vertical()
+    {
+        var el = TextBlock("x").Padding(10.0, 20.0);
+        Assert.Equal(new Thickness(10, 20, 10, 20), el.Modifiers!.Padding);
+    }
+
+    [Fact]
+    public void FlexPadding_TwoArgument_Positional_Order_Is_Horizontal_Then_Vertical()
+    {
+        var el = FlexRow().FlexPadding(10.0, 20.0);
+        Assert.Equal(new Thickness(10, 20, 10, 20), el.FlexPadding);
+    }
+
+    [Fact]
     public void Center_Sets_Both_Alignments()
     {
         var el = TextBlock("x").Center();

--- a/tests/Reactor.Tests/ElementTests.cs
+++ b/tests/Reactor.Tests/ElementTests.cs
@@ -494,16 +494,11 @@ public class ElementTests
     [Fact]
     public void Margin_Two_Arg_Positional_Follows_CSS_Vertical_First()
     {
-        // CSS shorthand `margin: 16px 14px;` means top/bottom = 16,
-        // left/right = 14 — vertical first. Reactor's 2-arg overload now
-        // mirrors that: `.Margin(16, 14)` → Thickness(14, 16, 14, 16).
-        // Pre-2026-05-11 the order was inverted (horizontal first); see
-        // CHANGELOG "Changed (breaking)" for the migration story.
         var el = TextBlock("x").Margin(16, 14);
-        Assert.Equal(new Thickness(14, 16, 14, 16), el.Modifiers!.Margin);
+        Assert.Equal(new Thickness(16, 14, 16, 14), el.Modifiers!.Margin);
 
         var pad = TextBlock("x").Padding(16, 14);
-        Assert.Equal(new Thickness(14, 16, 14, 16), pad.Modifiers!.Padding);
+        Assert.Equal(new Thickness(16, 14, 16, 14), pad.Modifiers!.Padding);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Ensures Padding and Margins are using consistent parameter order across the API surface, matching the order of WinUI's Thickness constructors.

## Linked issue / spec

Fixes #262

## Test plan

- [x] Added unit tests in tests/Reactor.Tests/...

## Risk / breaking changes

Yes - Order of `Padding(vertical,horizontal)` parameters is swapped, and `Chart.Margin` changed from `(top, right, bottom, left)` to `(left, top, right, bottom)`
