### PR TITLE
Add standalone IconElement for the element tree

### DIFF
--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -81,6 +81,9 @@ HyperlinkButton(Command command) → HyperlinkButtonElement
 HyperlinkButton(string content, Uri navigateUri = null, Action onClick = null) → HyperlinkButtonElement
 If(bool condition, Func<Element> then, Func<Element> otherwise = null) → Element
 Image(string source) → ImageElement
+Icon(IconData data) → IconElement
+Icon(Symbol symbol) → IconElement
+Icon(string symbol) → IconElement
 ImageIcon(Uri source) → ImageIconData
 InfoBadge() → InfoBadgeElement
 InfoBadge(int value) → InfoBadgeElement
@@ -308,6 +311,7 @@ HyperlinkButtonElement.TextLink() → HyperlinkButtonElement
 ImageElement.ImageFailed(Action<string> handler) → ImageElement
 ImageElement.ImageOpened(Action handler) → ImageElement
 ImageElement.NineGrid(Thickness nineGrid) → ImageElement
+IconElement.Set(Action<IconElement> configure) → IconElement
 ImageElement.Set(Action<Image> configure) → ImageElement
 InfoBadgeElement.Set(Action<InfoBadge> configure) → InfoBadgeElement
 InfoBarElement.ActionButtonClick(Action handler) → InfoBarElement

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -81,6 +81,9 @@ HyperlinkButton(Command command) → HyperlinkButtonElement
 HyperlinkButton(string content, Uri navigateUri = null, Action onClick = null) → HyperlinkButtonElement
 If(bool condition, Func<Element> then, Func<Element> otherwise = null) → Element
 Image(string source) → ImageElement
+Icon(IconData data) → IconElement
+Icon(Symbol symbol) → IconElement
+Icon(string symbol) → IconElement
 ImageIcon(Uri source) → ImageIconData
 InfoBadge() → InfoBadgeElement
 InfoBadge(int value) → InfoBadgeElement
@@ -308,6 +311,7 @@ HyperlinkButtonElement.TextLink() → HyperlinkButtonElement
 ImageElement.ImageFailed(Action<string> handler) → ImageElement
 ImageElement.ImageOpened(Action handler) → ImageElement
 ImageElement.NineGrid(Thickness nineGrid) → ImageElement
+IconElement.Set(Action<IconElement> configure) → IconElement
 ImageElement.Set(Action<Image> configure) → ImageElement
 InfoBadgeElement.Set(Action<InfoBadge> configure) → InfoBadgeElement
 InfoBarElement.ActionButtonClick(Action handler) → InfoBarElement

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -1650,6 +1650,16 @@ public record BitmapIconData(global::System.Uri Source, bool ShowAsMonochrome = 
 public record PathIconData(string Data) : IconData;
 public record ImageIconData(global::System.Uri Source) : IconData;
 
+/// <summary>
+/// Standalone icon element that can be placed in the element tree.
+/// Wraps an <see cref="IconData"/> and mounts to the corresponding
+/// native <see cref="WinUI.IconElement"/> subtype.
+/// </summary>
+public record IconElement(IconData Data) : Element
+{
+    internal Action<WinUI.IconElement>[] Setters { get; init; } = [];
+}
+
 public abstract record AppBarItemBase;
 public record AppBarButtonData(string Label, Action? OnClick = null, string? Icon = null) : AppBarItemBase
 {

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -145,6 +145,7 @@ public sealed partial class Reconciler
             CalendarViewElement cv => MountCalendarView(cv),
             SwipeControlElement swipe => MountSwipeControl(swipe, requestRerender),
             AnimatedIconElement ai => MountAnimatedIcon(ai),
+            IconElement ie => MountIcon(ie),
             ParallaxViewElement pv => MountParallaxView(pv, requestRerender),
             MapControlElement mc => MountMapControl(mc),
             FrameElement frame => MountFrame(frame),
@@ -3452,6 +3453,15 @@ public sealed partial class Reconciler
             icon.Source = src;
         if (ai.FallbackIconSource is not null) icon.FallbackIconSource = ai.FallbackIconSource;
         ApplySetters(ai.Setters, icon);
+        return icon;
+    }
+
+    // ── Icon ─────────────────────────────────────────────────────────
+
+    private WinUI.IconElement? MountIcon(IconElement ie)
+    {
+        var icon = ResolveIcon(ie.Data, null);
+        if (icon is not null) ApplySetters(ie.Setters, icon);
         return icon;
     }
 

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -274,6 +274,8 @@ public sealed partial class Reconciler
                 => UpdateSwipeControl(o, n, swipe, requestRerender),
             (AnimatedIconElement, AnimatedIconElement n, WinUI.AnimatedIcon ai)
                 => UpdateAnimatedIcon(n, ai),
+            (IconElement, IconElement n, WinUI.IconElement icon)
+                => UpdateIcon(n, icon),
             (ParallaxViewElement o, ParallaxViewElement n, WinUI.ParallaxView pv)
                 => UpdateParallaxView(o, n, pv, requestRerender),
             (MapControlElement, MapControlElement n, WinUI.MapControl mc)
@@ -3829,6 +3831,49 @@ public sealed partial class Reconciler
             ai.Source = src;
         if (n.FallbackIconSource is not null) ai.FallbackIconSource = n.FallbackIconSource;
         ApplySetters(n.Setters, ai);
+        return null;
+    }
+
+    private UIElement? UpdateIcon(IconElement n, WinUI.IconElement icon)
+    {
+        // If the IconData subtype changed, replace the entire native control.
+        var fresh = Reconciler.ResolveIcon(n.Data, null);
+        if (fresh is null) return null;
+
+        if (fresh.GetType() != icon.GetType())
+        {
+            ApplySetters(n.Setters, fresh);
+            return fresh; // signals reconciler to swap the control
+        }
+
+        // Same native type — patch in place.
+        switch (n.Data)
+        {
+            case SymbolIconData sym when icon is WinUI.SymbolIcon si:
+                if (Enum.TryParse<Symbol>(sym.Symbol, ignoreCase: true, out var s)) si.Symbol = s;
+                break;
+            case FontIconData fi when icon is WinUI.FontIcon fontIcon:
+                fontIcon.Glyph = fi.Glyph;
+                if (fi.FontFamily is not null)
+                    fontIcon.FontFamily = new Microsoft.UI.Xaml.Media.FontFamily(fi.FontFamily);
+                if (fi.FontSize is not null) fontIcon.FontSize = fi.FontSize.Value;
+                break;
+            case BitmapIconData bi when icon is WinUI.BitmapIcon bitmapIcon:
+                bitmapIcon.UriSource = bi.Source;
+                bitmapIcon.ShowAsMonochrome = bi.ShowAsMonochrome;
+                break;
+            case PathIconData pi when icon is WinUI.PathIcon pathIcon:
+                if (Microsoft.UI.Xaml.Markup.XamlReader.Load(
+                    $"<Geometry xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>{pi.Data}</Geometry>")
+                    is Microsoft.UI.Xaml.Media.Geometry geo)
+                    pathIcon.Data = geo;
+                break;
+            case ImageIconData ii when icon is WinUI.ImageIcon imageIcon:
+                imageIcon.Source = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(ii.Source);
+                break;
+        }
+
+        ApplySetters(n.Setters, icon);
         return null;
     }
 

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -1192,6 +1192,12 @@ public static partial class Factories
 
     public static ImageIconData ImageIcon(global::System.Uri source) => new(source);
 
+    /// <summary>Creates a standalone icon element from an <see cref="IconData"/> instance.</summary>
+    public static Core.IconElement Icon(IconData data) => new(data);
+
+    /// <summary>Creates a standalone symbol icon element (e.g. <c>Icon("Home")</c>).</summary>
+    public static Core.IconElement Icon(string symbol) => new(new SymbolIconData(symbol));
+
     // ── Keyboard Accelerators ───────────────────────────────────────
 
     public static KeyboardAcceleratorData Accelerator(global::Windows.System.VirtualKey key, global::Windows.System.VirtualKeyModifiers modifiers = global::Windows.System.VirtualKeyModifiers.None) =>

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -1195,6 +1195,9 @@ public static partial class Factories
     /// <summary>Creates a standalone icon element from an <see cref="IconData"/> instance.</summary>
     public static Core.IconElement Icon(IconData data) => new(data);
 
+    /// <summary>Creates a standalone symbol icon element from a <see cref="Symbol"/> enum value.</summary>
+    public static Core.IconElement Icon(Symbol symbol) => new(new SymbolIconData(symbol.ToString()));
+
     /// <summary>Creates a standalone symbol icon element (e.g. <c>Icon("Home")</c>).</summary>
     public static Core.IconElement Icon(string symbol) => new(new SymbolIconData(symbol));
 

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1730,6 +1730,10 @@ public static partial class ElementExtensions
     public static AnimatedIconElement Set(this AnimatedIconElement el, Action<WinUI.AnimatedIcon> configure) =>
         el with { Setters = [.. el.Setters, configure] };
 
+    // Icon
+    public static Core.IconElement Set(this Core.IconElement el, Action<WinUI.IconElement> configure) =>
+        el with { Setters = [.. el.Setters, configure] };
+
     // ParallaxView
     public static ParallaxViewElement Set(this ParallaxViewElement el, Action<WinUI.ParallaxView> configure) =>
         el with { Setters = [.. el.Setters, configure] };

--- a/tests/Reactor.Tests/ElementRecordCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementRecordCoverageTests.cs
@@ -63,6 +63,14 @@ public class ElementRecordCoverageTests
     }
 
     [Fact]
+    public void Icon_Factory_From_Symbol_Enum_Creates_SymbolIconData()
+    {
+        var el = Factories.Icon(Microsoft.UI.Xaml.Controls.Symbol.Home);
+        Assert.IsType<SymbolIconData>(el.Data);
+        Assert.Equal("Home", ((SymbolIconData)el.Data).Symbol);
+    }
+
+    [Fact]
     public void AppBar_Data_Variants_Construct()
     {
         var btn = new AppBarButtonData("Open", () => { }, "Open");

--- a/tests/Reactor.Tests/ElementRecordCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementRecordCoverageTests.cs
@@ -28,6 +28,41 @@ public class ElementRecordCoverageTests
     }
 
     [Fact]
+    public void IconElement_Wraps_IconData()
+    {
+        var sym = new SymbolIconData("Home");
+        var el = new IconElement(sym);
+        Assert.Same(sym, el.Data);
+        Assert.Empty(el.Setters);
+    }
+
+    [Fact]
+    public void IconElement_With_Expression_Preserves_Data()
+    {
+        var el = new IconElement(new FontIconData("\uE700", "Segoe Fluent Icons", 16));
+        var copy = el with { Setters = [_ => { }] };
+        Assert.Same(el.Data, copy.Data);
+        Assert.Single(copy.Setters);
+    }
+
+    [Fact]
+    public void Icon_Factory_From_IconData()
+    {
+        var data = new PathIconData("M 0,0 L 10,10");
+        var el = Factories.Icon(data);
+        Assert.IsType<PathIconData>(el.Data);
+        Assert.Equal("M 0,0 L 10,10", ((PathIconData)el.Data).Data);
+    }
+
+    [Fact]
+    public void Icon_Factory_From_String_Creates_SymbolIconData()
+    {
+        var el = Factories.Icon("Home");
+        Assert.IsType<SymbolIconData>(el.Data);
+        Assert.Equal("Home", ((SymbolIconData)el.Data).Symbol);
+    }
+
+    [Fact]
     public void AppBar_Data_Variants_Construct()
     {
         var btn = new AppBarButtonData("Open", () => { }, "Open");


### PR DESCRIPTION
## Summary

Adds a new `IconElement(IconData Data)` record that wraps the existing `IconData` hierarchy so icons can be placed as standalone children in any layout container.

**Before:** `IconData` records (`SymbolIconData`, `FontIconData`, etc.) could only be used as data slots on composite controls (NavigationViewItemData, MenuFlyoutItemData, etc.). There was no way to render a standalone icon in the element tree.

**After:**
```csharp
Icon("Home")
Icon(FontIcon("\uE700", "Segoe Fluent Icons"))
Icon(BitmapIcon(new Uri("ms-appx:///icon.png")))
```

## Changes

| File | Change |
|------|--------|
| `Element.cs` | New `IconElement(IconData Data) : Element` record |
| `Dsl.cs` | `Icon(IconData)` and `Icon(string)` factory methods |
| `Reconciler.Mount.cs` | `MountIcon` — delegates to existing `ResolveIcon` |
| `Reconciler.Update.cs` | `UpdateIcon` — patches same-type, replaces on cross-type change |
| `ElementExtensions.cs` | `.Set(Action<IconElement>)` fluent modifier |
| `ElementRecordCoverageTests.cs` | 4 new unit tests |

## Testing

- All 7237 unit tests pass (0 failures)
- Full solution builds cleanly

Closes #257
