### PR TITLE
Add mur clean-local and uninstall-skill-kit

### DIFF
--- a/src/Reactor.Cli/Pack/CleanLocalCommand.cs
+++ b/src/Reactor.Cli/Pack/CleanLocalCommand.cs
@@ -1,0 +1,174 @@
+// `mur clean-local` — removes local NuGet packages produced by `mur pack-local`,
+// clears the matching entries from the NuGet global packages cache, and uninstalls
+// any `dotnet new` project templates that were installed from the local feed.
+//
+// This is the inverse of `mur pack-local` and addresses the "need uninstall"
+// half of https://github.com/microsoft/microsoft-ui-reactor/issues/238.
+
+using System.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Cli.Pack;
+
+public static class CleanLocalCommand
+{
+    // Package IDs that `pack-local` produces — lowercase to match the NuGet
+    // global-packages folder convention.
+    internal static readonly string[] PackageIds =
+    [
+        "microsoft.ui.reactor",
+        "microsoft.ui.reactor.projecttemplates",
+    ];
+
+    // Template package ID used by `dotnet new install`.
+    internal const string TemplatePackageId = "Microsoft.UI.Reactor.ProjectTemplates";
+
+    public static int Run(string[] args)
+    {
+        var repoRoot = RepoRootFinder.FindRepoRoot(Directory.GetCurrentDirectory())
+                    ?? RepoRootFinder.FindRepoRoot();
+
+        if (repoRoot is null)
+        {
+            Console.Error.WriteLine("mur clean-local: must be run from a Reactor source checkout (could not locate src/Reactor).");
+            return 1;
+        }
+
+        var feed = Path.Combine(repoRoot, "local-nupkgs");
+        var removed = 0;
+
+        // 1. Delete .nupkg / .snupkg files from the local feed.
+        if (Directory.Exists(feed))
+        {
+            foreach (var file in Directory.EnumerateFiles(feed, "*.nupkg")
+                        .Concat(Directory.EnumerateFiles(feed, "*.snupkg")))
+            {
+                try
+                {
+                    File.Delete(file);
+                    Console.WriteLine($"  Deleted {Path.GetFileName(file)}");
+                    removed++;
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"  Could not delete {Path.GetFileName(file)}: {ex.Message}");
+                }
+            }
+        }
+
+        if (removed == 0)
+            Console.WriteLine("  No local packages found — nothing to remove.");
+
+        // 2. Remove cached copies from the NuGet global-packages folder so that
+        //    subsequent restores don't silently resolve a stale local version.
+        var globalPackages = GetGlobalPackagesPath();
+        if (globalPackages is not null)
+        {
+            foreach (var id in PackageIds)
+            {
+                var pkgDir = Path.Combine(globalPackages, id);
+                if (!Directory.Exists(pkgDir)) continue;
+
+                // Only delete versions that look like local builds.
+                foreach (var versionDir in Directory.EnumerateDirectories(pkgDir))
+                {
+                    var versionName = Path.GetFileName(versionDir);
+                    if (IsLocalVersion(versionName))
+                    {
+                        try
+                        {
+                            Directory.Delete(versionDir, recursive: true);
+                            Console.WriteLine($"  Removed cached {id}/{versionName}");
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.Error.WriteLine($"  Could not remove cached {id}/{versionName}: {ex.Message}");
+                        }
+                    }
+                }
+            }
+        }
+
+        // 3. Clear the NuGet HTTP cache so stale metadata doesn't linger.
+        RunDotnet(repoRoot, "nuget", "locals", "http-cache", "--clear");
+
+        // 4. Uninstall project templates (non-fatal).
+        UninstallTemplates(repoRoot);
+
+        Console.WriteLine();
+        Console.WriteLine("Done.");
+        return 0;
+    }
+
+    internal static string? GetGlobalPackagesPath()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList = { "nuget", "locals", "global-packages", "--list" },
+            };
+            using var proc = Process.Start(psi);
+            if (proc is null) return null;
+            var output = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
+
+            // Output is: "global-packages: C:\Users\...\.nuget\packages\"
+            var idx = output.IndexOf(':');
+            return idx >= 0 ? output[(idx + 1)..].Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static bool IsLocalVersion(string version)
+    {
+        // Match PackLocalCommand.DefaultLocalVersion ("0.0.0-local") and any
+        // user-supplied version containing "local" (e.g. "1.0.0-local.42").
+        return version.Contains("local", StringComparison.OrdinalIgnoreCase);
+    }
+
+    static void UninstallTemplates(string repoRoot)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                UseShellExecute = false,
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList = { "new", "uninstall", TemplatePackageId },
+            };
+            using var proc = Process.Start(psi);
+            if (proc is null) return;
+            proc.WaitForExit();
+            if (proc.ExitCode == 0)
+                Console.WriteLine($"  Uninstalled dotnet new template: {TemplatePackageId}");
+            // Exit code != 0 means the template wasn't installed — that's fine.
+        }
+        catch { /* non-fatal */ }
+    }
+
+    static void RunDotnet(string workingDirectory, params string[] arguments)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            foreach (var a in arguments) psi.ArgumentList.Add(a);
+            using var proc = Process.Start(psi);
+            proc?.WaitForExit();
+        }
+        catch { /* non-fatal */ }
+    }
+}

--- a/src/Reactor.Cli/Pack/PackLocalCommand.cs
+++ b/src/Reactor.Cli/Pack/PackLocalCommand.cs
@@ -135,16 +135,5 @@ public static class PackLocalCommand
         return null;
     }
 
-    static string? FindRepoRoot()
-    {
-        for (var d = new DirectoryInfo(AppContext.BaseDirectory); d is not null; d = d.Parent)
-        {
-            if (Directory.Exists(Path.Combine(d.FullName, "src", "Reactor"))
-                && File.Exists(Path.Combine(d.FullName, "src", "Reactor", "Reactor.csproj")))
-            {
-                return d.FullName;
-            }
-        }
-        return null;
-    }
+    static string? FindRepoRoot() => RepoRootFinder.FindRepoRoot();
 }

--- a/src/Reactor.Cli/Pack/RepoRootFinder.cs
+++ b/src/Reactor.Cli/Pack/RepoRootFinder.cs
@@ -1,0 +1,24 @@
+namespace Microsoft.UI.Reactor.Cli.Pack;
+
+internal static class RepoRootFinder
+{
+    /// <summary>
+    /// Walks up from <paramref name="startDirectory"/> looking for a directory
+    /// that contains <c>src/Reactor/Reactor.csproj</c>.  Falls back to
+    /// <see cref="AppContext.BaseDirectory"/> when <paramref name="startDirectory"/>
+    /// is <c>null</c>.
+    /// </summary>
+    public static string? FindRepoRoot(string? startDirectory = null)
+    {
+        var start = startDirectory ?? AppContext.BaseDirectory;
+        for (var d = new DirectoryInfo(start); d is not null; d = d.Parent)
+        {
+            if (Directory.Exists(Path.Combine(d.FullName, "src", "Reactor"))
+                && File.Exists(Path.Combine(d.FullName, "src", "Reactor", "Reactor.csproj")))
+            {
+                return d.FullName;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Reactor.Cli/Program.cs
+++ b/src/Reactor.Cli/Program.cs
@@ -79,6 +79,11 @@ if (arg == "pack-local")
     return Microsoft.UI.Reactor.Cli.Pack.PackLocalCommand.Run(args.Skip(1).ToArray());
 }
 
+if (arg == "clean-local")
+{
+    return Microsoft.UI.Reactor.Cli.Pack.CleanLocalCommand.Run(args.Skip(1).ToArray());
+}
+
 Console.Error.WriteLine($"Unknown option: {args[0]}");
 Console.Error.WriteLine();
 ShowHelp();
@@ -112,6 +117,7 @@ void ShowHelp()
     Console.WriteLine("  devtools         Launch project with --devtools run and supervise reloads");
     Console.WriteLine("  check [path]     Build and emit one-line diagnostics with skill-file pointers");
     Console.WriteLine("  pack-local       Pack the in-source framework to <repo>/local-nupkgs/ as 0.0.0-local");
+    Console.WriteLine("  clean-local      Remove local packages, NuGet cache entries, and templates");
 }
 
 int ShowSkill()

--- a/tests/Reactor.Tests/CleanLocalCommandTests.cs
+++ b/tests/Reactor.Tests/CleanLocalCommandTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.UI.Reactor.Cli.Pack;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+public class CleanLocalCommandTests
+{
+    [Theory]
+    [InlineData("0.0.0-local", true)]
+    [InlineData("1.0.0-local.42", true)]
+    [InlineData("2.0.0-LOCAL", true)]
+    [InlineData("3.0.0-preview.1", false)]
+    [InlineData("1.0.0", false)]
+    public void IsLocalVersion_ClassifiesCorrectly(string version, bool expected)
+    {
+        Assert.Equal(expected, CleanLocalCommand.IsLocalVersion(version));
+    }
+
+    [Fact]
+    public void PackageIds_ContainsExpectedEntries()
+    {
+        Assert.Contains("microsoft.ui.reactor", CleanLocalCommand.PackageIds);
+        Assert.Contains("microsoft.ui.reactor.projecttemplates", CleanLocalCommand.PackageIds);
+    }
+}

--- a/tests/Reactor.Tests/RepoRootFinderTests.cs
+++ b/tests/Reactor.Tests/RepoRootFinderTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.UI.Reactor.Cli.Pack;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+public class RepoRootFinderTests
+{
+    [Fact]
+    public void FindRepoRoot_FromRepoDirectory_ReturnsRoot()
+    {
+        // We're running inside the repo, so starting from the test assembly
+        // base directory should find the root.
+        var root = RepoRootFinder.FindRepoRoot();
+        Assert.NotNull(root);
+        Assert.True(File.Exists(Path.Combine(root, "src", "Reactor", "Reactor.csproj")));
+    }
+
+    [Fact]
+    public void FindRepoRoot_FromExplicitRepoPath_ReturnsRoot()
+    {
+        // Start from a known subdirectory within the repo.
+        var root = RepoRootFinder.FindRepoRoot();
+        Assert.NotNull(root);
+
+        var subDir = Path.Combine(root, "src", "Reactor");
+        var found = RepoRootFinder.FindRepoRoot(subDir);
+        Assert.Equal(root, found);
+    }
+
+    [Fact]
+    public void FindRepoRoot_FromUnrelatedPath_ReturnsNull()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        try
+        {
+            Assert.Null(RepoRootFinder.FindRepoRoot(temp));
+        }
+        finally
+        {
+            Directory.Delete(temp);
+        }
+    }
+}

--- a/tools/uninstall-skill-kit.ps1
+++ b/tools/uninstall-skill-kit.ps1
@@ -1,0 +1,84 @@
+# Uninstall the Reactor skill kit.
+#
+# Removes the installed kit directory and cleans the user PATH entries that
+# install-skill-kit.ps1 added.  This is the inverse of install-skill-kit.ps1
+# and addresses https://github.com/microsoft/microsoft-ui-reactor/issues/238.
+#
+# Usage:
+#   .\uninstall-skill-kit.ps1                 # default: ~/.claude/skills/reactor
+#   .\uninstall-skill-kit.ps1 -Path C:\foo    # custom location
+
+[CmdletBinding()]
+param(
+    [string] $Path = (Join-Path $env:USERPROFILE '.claude\skills\reactor')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$absPath = [System.IO.Path]::GetFullPath($Path)
+
+# Safety: refuse to delete drive roots, profile root, system dirs, etc.
+$forbidden = @(
+    [System.IO.Path]::GetPathRoot($absPath).TrimEnd('\'),
+    $env:USERPROFILE,
+    $env:SystemRoot,
+    "$env:SystemRoot\System32",
+    $env:ProgramFiles,
+    "${env:ProgramFiles(x86)}",
+    "$env:USERPROFILE\Desktop",
+    "$env:USERPROFILE\Documents",
+    "$env:USERPROFILE\Downloads"
+) | Where-Object { $_ }
+foreach ($f in $forbidden) {
+    if ($absPath -ieq $f.TrimEnd('\')) {
+        throw "Refusing to delete '$absPath' — that's a system or user-data root."
+    }
+}
+if ($absPath.Length -lt 12) {
+    throw "Refusing to delete '$absPath' — path is suspiciously short."
+}
+
+# 1. Remove PATH entries for both architectures so we don't leave stale
+#    entries behind (e.g. installed on x64, uninstalling from ARM64).
+$userPathRaw = [Environment]::GetEnvironmentVariable('Path', 'User')
+$entries = ($userPathRaw -split ';') | Where-Object { $_ -ne '' }
+$archDirs = @(
+    [System.IO.Path]::GetFullPath((Join-Path $absPath 'bin\x64')),
+    [System.IO.Path]::GetFullPath((Join-Path $absPath 'bin\arm64'))
+)
+
+$cleaned = @()
+$removedEntries = @()
+foreach ($e in $entries) {
+    $eNorm = [System.IO.Path]::GetFullPath($e).TrimEnd('\')
+    $match = $false
+    foreach ($a in $archDirs) {
+        if ($eNorm -ieq $a.TrimEnd('\')) {
+            $match = $true
+            $removedEntries += $e
+            break
+        }
+    }
+    if (-not $match) { $cleaned += $e }
+}
+
+if ($removedEntries.Count -gt 0) {
+    $newPath = $cleaned -join ';'
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    foreach ($r in $removedEntries) {
+        Write-Host "  Removed from user PATH: $r"
+    }
+} else {
+    Write-Host "  No skill-kit PATH entries found."
+}
+
+# 2. Delete the installed directory.
+if (Test-Path $absPath) {
+    Remove-Item -Recurse -Force $absPath
+    Write-Host "  Removed install directory: $absPath"
+} else {
+    Write-Host "  Install directory not found: $absPath (already removed?)"
+}
+
+Write-Host ""
+Write-Host "Done. Reactor skill kit has been uninstalled."


### PR DESCRIPTION
## Summary

Adds uninstall/cleanup commands for local NuGet packages and skill-kit installs.

### Changes

- **\mur clean-local\** — new CLI command (inverse of \mur pack-local\):
  - Deletes \.nupkg\/\.snupkg\ files from \<repo>/local-nupkgs/\
  - Removes matching versions from the NuGet global-packages cache
  - Clears the NuGet HTTP cache
  - Uninstalls \dotnet new\ project templates installed from the local feed
  
- **\	ools/uninstall-skill-kit.ps1\** — inverse of \install-skill-kit.ps1\:
  - Removes the installed skill-kit directory
  - Cleans both x64 and arm64 PATH entries (handles cross-arch uninstall)
  - Has the same safety guards as the install script

- **\RepoRootFinder\** — extracted shared helper from \PackLocalCommand\ for reuse

- **Tests** — unit tests for \CleanLocalCommand.IsLocalVersion\, \PackageIds\, and \RepoRootFinder\

Closes #238