### PR TITLE
Fix #264: enforce init-only contract on immutable records

### DIFF
--- a/src/Reactor/Core/Command.cs
+++ b/src/Reactor/Core/Command.cs
@@ -1,7 +1,7 @@
 namespace Microsoft.UI.Reactor.Core;
 
 /// <summary>
-/// Immutable command descriptor that bundles an action with its metadata (label, icon,
+/// Immutable (init-only) command descriptor that bundles an action with its metadata (label, icon,
 /// keyboard accelerator, enabled state). Define once, use in any surface:
 ///   var save = new Command { Label = "Save", Execute = () => Save(), Icon = SymbolIcon("Save") };
 ///   AppBarButton(save)   // toolbar
@@ -44,7 +44,7 @@ public sealed record Command
 }
 
 /// <summary>
-/// Parameterized command descriptor. The action receives an argument of type <typeparamref name="T"/>,
+/// Immutable (init-only) parameterized command descriptor. The action receives an argument of type <typeparamref name="T"/>,
 /// enabling a single command definition to operate on different targets:
 ///   var delete = new Command&lt;Item&gt; { Label = "Delete", Execute = item => Remove(item) };
 ///   MenuItem(delete, selectedItem)

--- a/src/Reactor/Hosting/Shell/TrayIconSpec.cs
+++ b/src/Reactor/Hosting/Shell/TrayIconSpec.cs
@@ -1,7 +1,7 @@
 namespace Microsoft.UI.Reactor;
 
 /// <summary>
-/// Immutable, declarative description of a system-tray icon. Hand to
+/// Immutable (init-only) declarative description of a system-tray icon. Hand to
 /// <see cref="ReactorApp.OpenTrayIcon"/> to register; hand to
 /// <see cref="ReactorTrayIcon.Update"/> to diff and re-apply only changed
 /// fields. (spec 036 §11.4)

--- a/src/Reactor/Hosting/WindowSpec.cs
+++ b/src/Reactor/Hosting/WindowSpec.cs
@@ -3,7 +3,7 @@ using Microsoft.UI.Reactor.Core;
 namespace Microsoft.UI.Reactor;
 
 /// <summary>
-/// Immutable, declarative description of a top-level Reactor window. Hand to
+/// Immutable (init-only) declarative description of a top-level Reactor window. Hand to
 /// <see cref="ReactorApp.OpenWindow(WindowSpec, Func{Component}, Action{Microsoft.UI.Reactor.Hosting.ReactorHost})"/>
 /// to open a window; hand to <see cref="ReactorWindow.Update"/> to diff
 /// against the current spec and apply only changed fields.

--- a/tests/Reactor.Tests/ImmutableRecordContractTests.cs
+++ b/tests/Reactor.Tests/ImmutableRecordContractTests.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Reactor.Tests;
+
+/// <summary>
+/// Regression test for issue #264: ensures public record types documented as
+/// "immutable" truly have init-only setters (not plain set).
+/// </summary>
+public class ImmutableRecordContractTests
+{
+    /// <summary>
+    /// At the IL level, an <c>init</c> setter is a <c>set</c> method whose
+    /// return type carries <c>modreq(IsExternalInit)</c>. This helper detects that.
+    /// </summary>
+    private static bool IsInitOnly(PropertyInfo property)
+    {
+        var setter = property.GetSetMethod(nonPublic: true);
+        if (setter is null)
+            return false; // read-only (no setter at all) — still immutable
+
+        var returnParam = setter.ReturnParameter;
+        return returnParam.GetRequiredCustomModifiers()
+            .Any(t => t.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+    }
+
+    public static TheoryData<Type> ImmutableRecordTypes => new()
+    {
+        { typeof(TrayIconSpec) },
+        { typeof(WindowSpec) },
+        { typeof(Command) },
+        { typeof(Command<>) },
+    };
+
+    [Theory]
+    [MemberData(nameof(ImmutableRecordTypes))]
+    public void All_Public_Properties_Are_InitOnly(Type type)
+    {
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetSetMethod(nonPublic: true) is not null);
+
+        foreach (var prop in properties)
+        {
+            Assert.True(
+                IsInitOnly(prop),
+                $"{type.Name}.{prop.Name} has a plain 'set' accessor — " +
+                $"expected 'init' to preserve immutability contract.");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ImmutableRecordTypes))]
+    public void Has_At_Least_One_Public_Property(Type type)
+    {
+        // Sanity check: ensure the test is actually verifying something.
+        var props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotEmpty(props);
+    }
+}


### PR DESCRIPTION
## Summary

The source code was already correct — `TrayIconSpec`, `WindowSpec`, `Command`, and `Command<T>` all use `init`-only properties. The external API review tool likely rendered `init` as `set` because at the IL level `init` is a `set` method with `modreq(IsExternalInit)`.

## Changes

1. **New test:** `tests/Reactor.Tests/ImmutableRecordContractTests.cs` — reflection-based regression test that verifies all public settable properties on the four record types carry the `IsExternalInit` modifier (i.e., are truly `init`-only). Prevents future regressions.

2. **Doc comment updates:** Changed "Immutable" to "Immutable (init-only)" in XML summary tags on all four types, making the contract unambiguous even to tools that cannot distinguish `init` from `set`.

## Test results

All 8 new theory cases pass (4 types × 2 assertions each).

Closes #264.