### PR TITLE
Fix #230: add docs compile job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,19 @@ jobs:
 
       - name: Build
         run: dotnet build Reactor.slnx --no-restore --configuration Release
+
+  docs-compile:
+    name: Docs compile
+    needs: changes
+    if: needs.changes.outputs.non-md == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Compile docs
+        run: dotnet run --project src/Reactor.Cli -- docs compile --no-screenshots --ci


### PR DESCRIPTION
## Summary

Adds a `docs-compile` job to CI that runs the doc pipeline (`mur docs compile --no-screenshots --ci`) on every PR with non-markdown changes. This catches broken snippet references and doc app build failures before merge.

## Changes

**`.github/workflows/ci.yml`** — new `docs-compile` job:
- Same trigger filter as other jobs (`non-md == true`)
- Runs on `windows-latest` with .NET 10.0.x
- Invokes `dotnet run --project src/Reactor.Cli -- docs compile --no-screenshots --ci`
- `--no-screenshots`: skips GUI-dependent screenshot capture (no display in CI)
- `--ci`: makes snippet/screenshot validation errors fail the build

## How it works

The compile pipeline (phases run in CI):
1. **Validate** — discovers doc apps and templates, resolves snippet/screenshot references
2. **Extract** — pulls code snippets from doc app source files
3. **Build** — `dotnet build` each doc app (catches API breakage)
4. **Assemble** — substitutes snippets into templates, produces final markdown

Closes #230.