### PR TITLE
docs(skill): list all Theme tokens, warn about hallucinated ones

### DIFF
--- a/plugins/reactor/skills/reactor-design/SKILL.md
+++ b/plugins/reactor/skills/reactor-design/SKILL.md
@@ -54,6 +54,9 @@ Hardcoded colors are acceptable only for:
 
 #### Theme Token Reference
 
+> ⚠️ **`Theme.Error`, `Theme.Success`, `Theme.Warning`, `Theme.ErrorText` do NOT exist.**
+> Use `Theme.SystemCritical` (red/error), `Theme.SystemSuccess` (green), `Theme.SystemCaution` (yellow).
+
 **Text:**
 
 | Token | WinUI Resource | Purpose |

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -230,33 +230,10 @@ items.Select(i => Component<Card, CardProps>(new CardProps(i)).WithKey(i.Id)).To
 
 ## Theme tokens (always)
 
-Use `Theme.*` for all themed colors — never hardcoded hex on themed surfaces.
+Use `Theme.*` for all themed colors — never hardcoded hex on themed surfaces. The full token list with WinUI keys is in the `reactor-design` skill.
 
 > ⚠️ **`Theme.Error`, `Theme.Success`, `Theme.Warning`, `Theme.ErrorText` do NOT exist.**
 > Use `Theme.SystemCritical` (red/error), `Theme.SystemSuccess` (green), `Theme.SystemCaution` (yellow).
-
-**Available tokens:**
-
-| Category | Token | Use for |
-|---|---|---|
-| Accent | `Theme.Accent` | Primary action buttons, links |
-| Accent | `Theme.AccentSecondary`, `.AccentTertiary` | Hover/pressed states |
-| Text | `Theme.PrimaryText` | Body text |
-| Text | `Theme.SecondaryText`, `.TertiaryText` | Subtitles, captions |
-| Text | `Theme.AccentText` | Colored/linked text |
-| Surface | `Theme.SolidBackground` | Page/window background |
-| Surface | `Theme.CardBackground` | Card/panel fill |
-| Surface | `Theme.SubtleFill`, `.LayerFill` | Hover/surface layers |
-| Stroke | `Theme.CardStroke`, `.SurfaceStroke` | Card/panel borders |
-| Stroke | `Theme.DividerStroke` | Separators |
-| Signal | `Theme.SystemCritical` | Error/danger (red) |
-| Signal | `Theme.SystemSuccess` | Success (green) |
-| Signal | `Theme.SystemCaution` | Warning (yellow/orange) |
-| Signal | `Theme.SystemAttention` | Info/attention (blue) |
-| Signal | `Theme.SystemCriticalBackground` | Error background |
-| Signal | `Theme.SystemSuccessBackground` | Success background |
-
-For any WinUI resource not listed: `Theme.Ref("YourResourceKeyBrush")`
 
 ```csharp
 TextBlock("Hi").Foreground(Theme.PrimaryText)

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -230,12 +230,40 @@ items.Select(i => Component<Card, CardProps>(new CardProps(i)).WithKey(i.Id)).To
 
 ## Theme tokens (always)
 
-Use `Theme.*` for all themed colors — never hardcoded hex on themed surfaces. The full token list with WinUI keys is in the api index.
+Use `Theme.*` for all themed colors — never hardcoded hex on themed surfaces.
+
+> ⚠️ **`Theme.Error`, `Theme.Success`, `Theme.Warning`, `Theme.ErrorText` do NOT exist.**
+> Use `Theme.SystemCritical` (red/error), `Theme.SystemSuccess` (green), `Theme.SystemCaution` (yellow).
+
+**Available tokens:**
+
+| Category | Token | Use for |
+|---|---|---|
+| Accent | `Theme.Accent` | Primary action buttons, links |
+| Accent | `Theme.AccentSecondary`, `.AccentTertiary` | Hover/pressed states |
+| Text | `Theme.PrimaryText` | Body text |
+| Text | `Theme.SecondaryText`, `.TertiaryText` | Subtitles, captions |
+| Text | `Theme.AccentText` | Colored/linked text |
+| Surface | `Theme.SolidBackground` | Page/window background |
+| Surface | `Theme.CardBackground` | Card/panel fill |
+| Surface | `Theme.SubtleFill`, `.LayerFill` | Hover/surface layers |
+| Stroke | `Theme.CardStroke`, `.SurfaceStroke` | Card/panel borders |
+| Stroke | `Theme.DividerStroke` | Separators |
+| Signal | `Theme.SystemCritical` | Error/danger (red) |
+| Signal | `Theme.SystemSuccess` | Success (green) |
+| Signal | `Theme.SystemCaution` | Warning (yellow/orange) |
+| Signal | `Theme.SystemAttention` | Info/attention (blue) |
+| Signal | `Theme.SystemCriticalBackground` | Error background |
+| Signal | `Theme.SystemSuccessBackground` | Success background |
+
+For any WinUI resource not listed: `Theme.Ref("YourResourceKeyBrush")`
 
 ```csharp
 TextBlock("Hi").Foreground(Theme.PrimaryText)
 Border(child).Background(Theme.CardBackground).WithBorder(Theme.CardStroke, 1)
 Button("Action").Background(Theme.Accent)
+TextBlock("Error!").Foreground(Theme.SystemCritical)       // NOT Theme.Error
+TextBlock("Saved").Foreground(Theme.SystemSuccess)         // NOT Theme.Success
 ```
 
 ## Critical gotchas


### PR DESCRIPTION
Agents hallucinate `Theme.Error`, `Theme.Success`, `Theme.ErrorText` in 3/7 benchmark runs. These don't exist.

**Changes:**
- Removed redundant condensed token table from getting-started (`reactor-design` already has the full reference with WinUI resource keys)
- Added the nonexistent-token warning (`Theme.Error` etc.) to `reactor-design`'s token reference section
- Kept the warning + corrected examples in getting-started as a critical gotcha
- Updated getting-started intro to point at `reactor-design` for the full token list

Fixes #277
