### PR TITLE
docs(skill): add NavigationView usage recipe

### DIFF
--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -398,6 +398,42 @@ class ChildView : Component
 
 Nested `.Provide()` overrides the outer for its subtree only. If no provider is present, `UseContext` returns the `Context<T>` default.
 
+### NavigationView (sidebar/top nav with page switching)
+
+```csharp
+var (selectedTag, setSelectedTag) = UseState("home");
+
+var navItems = new[]
+{
+    NavItem("Home",     icon: "Home",     tag: "home"),
+    NavItem("Settings", icon: "Setting",  tag: "settings"),
+    NavItem("About",    icon: "Info",     tag: "about"),
+};
+
+// Content switches based on selectedTag
+Element content = selectedTag switch
+{
+    "home"     => TextBlock("Welcome home"),
+    "settings" => TextBlock("Settings page"),
+    _          => TextBlock("About page"),
+};
+
+return (NavigationView(navItems, content: content) with
+{
+    SelectedTag = selectedTag,
+    OnSelectionChanged = tag => { if (tag != null) setSelectedTag(tag); },
+    PaneTitle = "My App",
+    IsSettingsVisible = false,
+}).Height(400);
+```
+
+**Key points:**
+- `SelectedTag` (string) and `OnSelectionChanged` (Action<string?>) are record properties — use `with { }`.
+- `IsPaneOpen` is also a record property for programmatic pane control.
+- `NavItem(label, icon, tag)` — the `tag` string is what `SelectedTag`/`OnSelectionChanged` traffic in.
+- For settings item: set `IsSettingsVisible = true` and check `args.IsSettingsSelected` (not via tag).
+- Use `.Set(nv => nv.PaneDisplayMode = NavigationViewPaneDisplayMode.Top)` for non-record properties.
+
 ## Bootstrap
 
 `mur pack-local` (selfhost) and `nuget.config` (consumer outside the source clone) — see the top-level `SKILL.md`'s "Which mode are you in?" section. If selfhost restore fails with "package Microsoft.UI.Reactor 0.0.0-local was not found", run `mur pack-local`.

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -398,42 +398,6 @@ class ChildView : Component
 
 Nested `.Provide()` overrides the outer for its subtree only. If no provider is present, `UseContext` returns the `Context<T>` default.
 
-### NavigationView (sidebar/top nav with page switching)
-
-```csharp
-var (selectedTag, setSelectedTag) = UseState("home");
-
-var navItems = new[]
-{
-    NavItem("Home",     icon: "Home",     tag: "home"),
-    NavItem("Settings", icon: "Setting",  tag: "settings"),
-    NavItem("About",    icon: "Info",     tag: "about"),
-};
-
-// Content switches based on selectedTag
-Element content = selectedTag switch
-{
-    "home"     => TextBlock("Welcome home"),
-    "settings" => TextBlock("Settings page"),
-    _          => TextBlock("About page"),
-};
-
-return (NavigationView(navItems, content: content) with
-{
-    SelectedTag = selectedTag,
-    OnSelectionChanged = tag => { if (tag != null) setSelectedTag(tag); },
-    PaneTitle = "My App",
-    IsSettingsVisible = false,
-}).Height(400);
-```
-
-**Key points:**
-- `SelectedTag` (string) and `OnSelectionChanged` (Action<string?>) are record properties — use `with { }`.
-- `IsPaneOpen` is also a record property for programmatic pane control.
-- `NavItem(label, icon, tag)` — the `tag` string is what `SelectedTag`/`OnSelectionChanged` traffic in.
-- For settings item: set `IsSettingsVisible = true` and check `args.IsSettingsSelected` (not via tag).
-- Use `.Set(nv => nv.PaneDisplayMode = NavigationViewPaneDisplayMode.Top)` for non-record properties.
-
 ## Bootstrap
 
 `mur pack-local` (selfhost) and `nuget.config` (consumer outside the source clone) — see the top-level `SKILL.md`'s "Which mode are you in?" section. If selfhost restore fails with "package Microsoft.UI.Reactor 0.0.0-local was not found", run `mur pack-local`.

--- a/plugins/reactor/skills/reactor-navigation/SKILL.md
+++ b/plugins/reactor/skills/reactor-navigation/SKILL.md
@@ -115,6 +115,11 @@ return NavigationView(
 `NavItem(label, icon?, tag?)` creates sidebar items. Icons are Segoe Fluent
 Icons names. The `NavigationView` handles selection state.
 
+**Manual wiring (without `UseNavigation`):**
+`SelectedTag` and `OnSelectionChanged` are record properties — use `with { }`.
+For the settings item: set `IsSettingsVisible = true` and check `args.IsSettingsSelected` (not via tag).
+Use `.Set(nv => nv.PaneDisplayMode = ...)` for non-record properties.
+
 ## 5. TabView (parallel tabs)
 
 Unlike stack navigation, tabs keep all content alive simultaneously:


### PR DESCRIPTION
Agents struggle with `NavigationView` setup, trying incorrect property init patterns. Added complete paste-ready recipe.

**Recipe covers:**
- `NavItem` creation with icon + tag
- `SelectedTag` / `OnSelectionChanged` via record with-expression
- Content switching based on `selectedTag`
- `IsPaneOpen` for programmatic pane control
- `.Set()` escape hatch for non-record properties (`PaneDisplayMode`)
- Settings item handling notes

Fixes #280
