### PR TITLE
docs(skill): clarify FlexElement property naming (JustifyContent)

### DIFF
--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -165,6 +165,10 @@ FlexColumn(children...)                       FlexRow(children...)
 // Prefer FlexRow/FlexColumn for linear layout — CSS Flexbox semantics
 // (grow/shrink/gap/wrap, justify-content, align-items). VStack/HStack
 // remain for StackPanel's shrink-wrap behavior.
+// FlexElement record properties (use `with { ... }`):
+//   Direction, JustifyContent, AlignItems, AlignContent, Wrap, ColumnGap, RowGap
+//   ⚠️ It's `JustifyContent` — NOT `Justify`
+// Example: FlexRow(a, b, c) with { JustifyContent = FlexJustify.SpaceBetween, ColumnGap = 8 }
 Border(child).CornerRadius(8).Background(Theme.CardBackground).Padding(16)
 ScrollView(VStack(...))
 Grid(columns: [GridSize.Star(), GridSize.Px(200)],


### PR DESCRIPTION
Agents use non-existent `Justify` property instead of `JustifyContent`. Added explicit property list with warning.

**Changes:**
- Listed all FlexElement record properties in the factories section
- Added warning that it's `JustifyContent` not `Justify`
- Added usage example with `with { }` syntax

Fixes #281