### PR TITLE
fix: handle Border(null) gracefully

### DIFF
--- a/src/Reactor/Core/AccessibilityScanner.cs
+++ b/src/Reactor/Core/AccessibilityScanner.cs
@@ -203,7 +203,8 @@ public static partial class AccessibilityScanner
 
         // Single-child containers
         ScrollViewElement sc => Single(sc.Child),
-        BorderElement b => Single(b.Child),
+        BorderElement b when b.Child is not null => Single(b.Child),
+        BorderElement => [],
         ViewboxElement vb => Single(vb.Child),
         ErrorBoundaryElement eb => Single(eb.Child),
         CommandHostElement ch => Single(ch.Child),

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -2119,7 +2119,7 @@ public record ScrollViewElement(Element Child) : Element
     internal Action<WinUI.ScrollViewer>[] Setters { get; init; } = [];
 }
 
-public record BorderElement(Element Child) : Element
+public record BorderElement(Element? Child) : Element
 {
     public double? CornerRadius { get; init; }
     public Thickness? Padding { get; init; }

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -1027,7 +1027,7 @@ public sealed partial class Reconciler
         if (border.BorderThickness.HasValue) bdr.BorderThickness = new Microsoft.UI.Xaml.Thickness(border.BorderThickness.Value);
         // Apply RequestedTheme before mounting children so that child ThemeRef
         // bindings resolve against the correct theme variant from the start.
-        bdr.Child = Mount(border.Child, requestRerender);
+        bdr.Child = border.Child is not null ? Mount(border.Child, requestRerender) : null;
         SetElementTag(bdr, border);
         ApplySetters(border.Setters, bdr);
         return bdr;

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -1252,7 +1252,22 @@ public sealed partial class Reconciler
 
     private UIElement? UpdateBorder(BorderElement o, BorderElement n, WinUI.Border b, Element newEl, Action requestRerender)
     {
-        if (CanUpdate(o.Child, n.Child))
+        if (o.Child is null && n.Child is null)
+        {
+            // Both null — nothing to reconcile for child
+        }
+        else if (n.Child is null)
+        {
+            // Child removed
+            if (b.Child is not null) UnmountRecursive(b.Child);
+            b.Child = null;
+        }
+        else if (o.Child is null)
+        {
+            // Child added
+            b.Child = Mount(n.Child, requestRerender);
+        }
+        else if (CanUpdate(o.Child, n.Child))
         {
             if (b.Child is not null)
             {

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -241,7 +241,7 @@ public static partial class Factories
 
     public static ScrollViewElement ScrollView(Element child) => new(child);
 
-    public static BorderElement Border(Element child) => new(child);
+    public static BorderElement Border(Element? child) => new(child!);
 
     public static ExpanderElement Expander(string header, Element content, bool isExpanded = false, Action<bool>? onExpandedChanged = null) =>
         new(header, content, isExpanded, onExpandedChanged);


### PR DESCRIPTION
`Border(null)` previously threw NullReferenceException. Agents use this pattern for conditional rendering: `Border(condition ? content : null)`.

**Changes:**
- `BorderElement.Child` is now `Element?` (nullable)
- `Border()` factory accepts `Element?`
- `MountBorder` skips child mount when null
- `UpdateBorder` handles null↔child transitions (add/remove)
- `AccessibilityScanner` handles null child

**Tests:** All 7242 unit tests pass.

Fixes #283