### PR TITLE
fix: make OnTapped elements keyboard/UIA accessible

### DIFF
--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -224,6 +224,7 @@ items.Select(i => Component<Card, CardProps>(new CardProps(i)).WithKey(i.Id)).To
 .WithKey("id")                  // dynamic list items — see gotcha #6
 .OnTapped((s, e) => ...)        // tap on non-Button surfaces — Border, Image, ScrollView, …
                                 // (Button click → ctor arg, see Controls section)
+                                // ⚠️ For UIA/automation: always pair with .AutomationName("...")
 .AutomationName("Submit")       // a11y — sets AutomationProperties.Name
 .Set(native => native.MaxWidth = 400)   // native escape hatch (lambda receives the WinUI control)
 ```

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -2947,8 +2947,17 @@ public sealed partial class Reconciler : IDisposable
             fe.Tapped += state.TappedTrampoline;
             Diagnostics.ReactorEventSource.Log.EventTrampolineAttached("Tapped", fe.GetType().Name);
         }
-        if (handler is not null) fe.IsTapEnabled = true;
-        else if (oldHandler is not null) fe.IsTapEnabled = false;
+        if (handler is not null)
+        {
+            fe.IsTapEnabled = true;
+            // Make tappable elements keyboard-accessible and visible in UIA tree
+            if (fe is Microsoft.UI.Xaml.Controls.Control ctrl && !ctrl.IsTabStop)
+                ctrl.IsTabStop = true;
+        }
+        else if (oldHandler is not null)
+        {
+            fe.IsTapEnabled = false;
+        }
     }
 
     private static void EnsureDoubleTappedSubscribed(FrameworkElement fe, EventHandlerState state, Action<object, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs>? handler, Action<object, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs>? oldHandler)


### PR DESCRIPTION
Elements with OnTapped handlers were invisible to UI Automation - WinAppDriver couldn't click contact list items in benchmark validation.

**Changes:**
- When OnTapped is wired on a Control-based element, sets `IsTabStop = true` for keyboard/UIA accessibility
- Skill updated: OnTapped modifier docs now warn to pair with `.AutomationName(...)` for non-Control elements (Border etc.)

**Build:** 0 errors, pre-existing warnings only.

Fixes #284