### PR TITLE
refactor: normalize ShowAddButton to IsAddButtonVisible

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -476,7 +476,7 @@ class App : Component
     }
 
     static Element NavBtn(string label, string current, Action<string> set) =>
-        Button(label, () => set(label)).Disabled(label == current);
+        Button(label, () => set(label)).IsEnabled(!(label == current));
 }
 ```
 

--- a/docs/_pipeline/ai-author-skill.md
+++ b/docs/_pipeline/ai-author-skill.md
@@ -702,7 +702,7 @@ case (no deps); `Memo(ctx => …, deps)` to also re-render when any dep changes;
 `.Background(color|ThemeRef)`, `.Foreground(color|ThemeRef)`,
 `.CornerRadius(n)`, `.WithBorder(color|ThemeRef, thickness?)`,
 `.HAlign(alignment)`, `.VAlign(alignment)`,
-`.Disabled(bool)`, `.Visible(bool)`, `.WithKey(string)`,
+`.IsEnabled(!bool)`, `.IsVisible(bool)`, `.WithKey(string)`,
 `.Flex(grow?, shrink?, basis?)`, `.ToolTip(string)`,
 `.FocusTrap(FocusTrapHandle)`,
 `.Set(control => { /* raw WinUI access */ })`

--- a/docs/_pipeline/apps/accessibility/App.cs
+++ b/docs/_pipeline/apps/accessibility/App.cs
@@ -83,7 +83,7 @@ class AccessibleFormDemo : Component
             CheckBox(agree, setAgree, label: "I accept the terms")
                 .TabIndex(3),
             Button("Register", () => { })
-                .Disabled(!valid).TabIndex(4).AccessKey("R")
+                .IsEnabled(valid).TabIndex(4).AccessKey("R")
         ).Landmark(AutomationLandmarkType.Form).Padding(24);
     }
 }

--- a/docs/_pipeline/apps/forms/App.cs
+++ b/docs/_pipeline/apps/forms/App.cs
@@ -119,11 +119,11 @@ class KeepSubmitReachableDemo : Component
             // commit-on-keystroke, so validation reacts as the user types.
             NumberBox(age, setAge, header: "Age").Immediate(),
 
-            // .DisabledFocusable() keeps the button tab-reachable and
+            // .IsDisabledFocusable() keeps the button tab-reachable and
             // visually dimmed while preventing invocation. Pattern mirrors
             // Fluent UI's `disabledFocusable` and ARIA `aria-disabled`.
             Button("Submit", () => { /* submit */ })
-                .DisabledFocusable(!formValid)
+                .IsDisabledFocusable(!formValid)
                 .Margin(0, 8, 0, 0)
         ).Padding(24);
     }
@@ -162,7 +162,7 @@ class ValidationContextDemo : Component
             {
                 ctx.MarkAllTouched();
                 if (ctx.IsValid()) setSubmitted(true);
-            }).Disabled(submitted),
+            }).IsEnabled(!submitted),
             When(submitted, () =>
                 TextBlock("Registration successful!")
                     .Foreground(Theme.SystemSuccess).SemiBold())

--- a/docs/_pipeline/apps/navigation/App.cs
+++ b/docs/_pipeline/apps/navigation/App.cs
@@ -38,7 +38,7 @@ class BasicNavDemo : Component
                 Button("Settings", () => nav.Navigate(Route.Settings)),
                 Button("Profile", () => nav.Navigate(Route.Profile)),
                 Button("Back", () => nav.GoBack())
-                    .Disabled(!nav.CanGoBack)
+                    .IsEnabled(nav.CanGoBack)
             ),
             NavigationHost(nav, route => route switch
             {
@@ -101,9 +101,9 @@ class StackOperationsDemo : Component
                 Button("Reset", () =>
                     nav.Reset(Route.Home)),
                 Button("Back", () => nav.GoBack())
-                    .Disabled(!nav.CanGoBack),
+                    .IsEnabled(nav.CanGoBack),
                 Button("Forward", () => nav.GoForward())
-                    .Disabled(!nav.CanGoForward)
+                    .IsEnabled(nav.CanGoForward)
             ),
             NavigationHost(nav, route =>
                 TextBlock($"Page: {route}")
@@ -158,7 +158,7 @@ class PageTransitionsDemo : Component
                 Button("Settings", () => nav.Navigate(Route.Settings)),
                 Button("Profile", () => nav.Navigate(Route.Profile)),
                 Button("Back", () => nav.GoBack())
-                    .Disabled(!nav.CanGoBack)
+                    .IsEnabled(nav.CanGoBack)
             ),
             NavigationHost(nav, route => route switch
             {
@@ -256,7 +256,7 @@ class StateSerializationDemo : Component
                 {
                     if (savedState is not null)
                         nav.SetState(savedState);
-                }).Disabled(savedState is null)
+                }).IsEnabled(!(savedState is null))
             ),
             TextBlock($"Current: {nav.CurrentRoute}"),
             TextBlock($"Saved: {savedState?[..Math.Min(50, savedState?.Length ?? 0)] ?? "(none)"}")
@@ -322,7 +322,7 @@ class PageCachingDemo : Component
                 Button("Home", () => nav.Navigate(Route.Home)),
                 Button("Settings", () => nav.Navigate(Route.Settings)),
                 Button("Back", () => nav.GoBack())
-                    .Disabled(!nav.CanGoBack)
+                    .IsEnabled(nav.CanGoBack)
             ),
             NavigationHost(nav, route => route switch
             {

--- a/docs/_pipeline/apps/todo-app/App.cs
+++ b/docs/_pipeline/apps/todo-app/App.cs
@@ -35,7 +35,7 @@ class TodoApp : Component
                         updateItems(list => [.. list, new TodoItem(newText.Trim(), false)]);
                         setNewText("");
                     }
-                }).Disabled(string.IsNullOrWhiteSpace(newText))
+                }).IsEnabled(!(string.IsNullOrWhiteSpace(newText)))
             ),
 
             // Item list

--- a/docs/_pipeline/apps/xaml-developers/App.cs
+++ b/docs/_pipeline/apps/xaml-developers/App.cs
@@ -49,7 +49,7 @@ class TutorialFormPage : Component
             TextField(email, setEmail, header: "Email"),
             CheckBox(wantsUpdates, setWantsUpdates, label: "Email me updates"),
             HStack(8,
-                Button("Save", () => { }).Disabled(!canSave),
+                Button("Save", () => { }).IsEnabled(canSave),
                 TextBlock(canSave ? "Ready to save" : "Complete all required fields")
                     .Opacity(0.7)
             )

--- a/docs/_pipeline/templates/forms.md.dt
+++ b/docs/_pipeline/templates/forms.md.dt
@@ -138,7 +138,7 @@ Reactor offers two opt-in fixes for this. They compose:
 
 ![Keep submit reachable](screenshot://forms/keep-submit-reachable)
 
-**`.DisabledFocusable(bool)` on Button** keeps the button keyboard-focusable
+**`.IsDisabledFocusable(bool)` on Button** keeps the button keyboard-focusable
 and tab-reachable while presenting it as disabled (dimmed; the click is
 suppressed). Mirrors Fluent UI React's `disabledFocusable` and ARIA's
 `aria-disabled`. Use it for any Submit gated on validation, busy state, or
@@ -152,14 +152,14 @@ the right choice when an intermediate value would be expensive or surprising
 (snapping `2.50` to `2.5` mid-edit). Apply when validation gates UI state
 and you want it to feel live.
 
-Use `.DisabledFocusable()` whenever a button is conditionally disabled in a
+Use `.IsDisabledFocusable()` whenever a button is conditionally disabled in a
 form — even if you've also applied `.Immediate()` to every commit-on-blur
 input. The two cover different failure modes: `.Immediate()` keeps validity
-in sync with typing; `.DisabledFocusable()` keeps the button discoverable
+in sync with typing; `.IsDisabledFocusable()` keeps the button discoverable
 when validity is gated on async checks, required-but-untouched fields,
 cross-field rules, or any derived condition that can't be made instantaneous.
 
-> **Where not to use `.DisabledFocusable()`:** only buttons. For data-entry
+> **Where not to use `.IsDisabledFocusable()`:** only buttons. For data-entry
 > controls (`TextField`, `NumberBox`, `CheckBox`, etc.), `IsEnabled=false`
 > usually means "this field isn't part of your current task" (cascading
 > from another input), and tab-skipping is the correct UX. Use

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -156,7 +156,7 @@ class AccessibleFormDemo : Component
             CheckBox(agree, setAgree, label: "I accept the terms")
                 .TabIndex(3),
             Button("Register", () => { })
-                .Disabled(!valid).TabIndex(4).AccessKey("R")
+                .IsEnabled(valid).TabIndex(4).AccessKey("R")
         ).Landmark(AutomationLandmarkType.Form).Padding(24);
     }
 }

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -246,11 +246,11 @@ class KeepSubmitReachableDemo : Component
             // commit-on-keystroke, so validation reacts as the user types.
             NumberBox(age, setAge, header: "Age").Immediate(),
 
-            // .DisabledFocusable() keeps the button tab-reachable and
+            // .IsDisabledFocusable() keeps the button tab-reachable and
             // visually dimmed while preventing invocation. Pattern mirrors
             // Fluent UI's `disabledFocusable` and ARIA `aria-disabled`.
             Button("Submit", () => { /* submit */ })
-                .DisabledFocusable(!formValid)
+                .IsDisabledFocusable(!formValid)
                 .Margin(0, 8, 0, 0)
         ).Padding(24);
     }
@@ -259,7 +259,7 @@ class KeepSubmitReachableDemo : Component
 
 ![Keep submit reachable](images/forms/keep-submit-reachable.png)
 
-**`.DisabledFocusable(bool)` on Button** keeps the button keyboard-focusable
+**`.IsDisabledFocusable(bool)` on Button** keeps the button keyboard-focusable
 and tab-reachable while presenting it as disabled (dimmed; the click is
 suppressed). Mirrors Fluent UI React's `disabledFocusable` and ARIA's
 `aria-disabled`. Use it for any Submit gated on validation, busy state, or
@@ -273,14 +273,14 @@ the right choice when an intermediate value would be expensive or surprising
 (snapping `2.50` to `2.5` mid-edit). Apply when validation gates UI state
 and you want it to feel live.
 
-Use `.DisabledFocusable()` whenever a button is conditionally disabled in a
+Use `.IsDisabledFocusable()` whenever a button is conditionally disabled in a
 form — even if you've also applied `.Immediate()` to every commit-on-blur
 input. The two cover different failure modes: `.Immediate()` keeps validity
-in sync with typing; `.DisabledFocusable()` keeps the button discoverable
+in sync with typing; `.IsDisabledFocusable()` keeps the button discoverable
 when validity is gated on async checks, required-but-untouched fields,
 cross-field rules, or any derived condition that can't be made instantaneous.
 
-> **Where not to use `.DisabledFocusable()`:** only buttons. For data-entry
+> **Where not to use `.IsDisabledFocusable()`:** only buttons. For data-entry
 > controls (`TextField`, `NumberBox`, `CheckBox`, etc.), `IsEnabled=false`
 > usually means "this field isn't part of your current task" (cascading
 > from another input), and tab-skipping is the correct UX. Use
@@ -324,7 +324,7 @@ class ValidationContextDemo : Component
             {
                 ctx.MarkAllTouched();
                 if (ctx.IsValid()) setSubmitted(true);
-            }).Disabled(submitted),
+            }).IsEnabled(!submitted),
             When(submitted, () =>
                 TextBlock("Registration successful!")
                     .Foreground(Theme.SystemSuccess).SemiBold())

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -347,7 +347,7 @@ class TodoApp : Component
                         updateItems(list => [.. list, new TodoItem(newText.Trim(), false)]);
                         setNewText("");
                     }
-                }).Disabled(string.IsNullOrWhiteSpace(newText))
+                }).IsEnabled(!(string.IsNullOrWhiteSpace(newText)))
             ),
 
             // Item list

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -57,7 +57,7 @@ class BasicNavDemo : Component
                 Button("Settings", () => nav.Navigate(Route.Settings)),
                 Button("Profile", () => nav.Navigate(Route.Profile)),
                 Button("Back", () => nav.GoBack())
-                    .Disabled(!nav.CanGoBack)
+                    .IsEnabled(nav.CanGoBack)
             ),
             NavigationHost(nav, route => route switch
             {
@@ -163,9 +163,9 @@ class StackOperationsDemo : Component
                 Button("Reset", () =>
                     nav.Reset(Route.Home)),
                 Button("Back", () => nav.GoBack())
-                    .Disabled(!nav.CanGoBack),
+                    .IsEnabled(nav.CanGoBack),
                 Button("Forward", () => nav.GoForward())
-                    .Disabled(!nav.CanGoForward)
+                    .IsEnabled(nav.CanGoForward)
             ),
             NavigationHost(nav, route =>
                 TextBlock($"Page: {route}")
@@ -272,7 +272,7 @@ class PageTransitionsDemo : Component
                 Button("Settings", () => nav.Navigate(Route.Settings)),
                 Button("Profile", () => nav.Navigate(Route.Profile)),
                 Button("Back", () => nav.GoBack())
-                    .Disabled(!nav.CanGoBack)
+                    .IsEnabled(nav.CanGoBack)
             ),
             NavigationHost(nav, route => route switch
             {
@@ -411,7 +411,7 @@ class PageCachingDemo : Component
                 Button("Home", () => nav.Navigate(Route.Home)),
                 Button("Settings", () => nav.Navigate(Route.Settings)),
                 Button("Back", () => nav.GoBack())
-                    .Disabled(!nav.CanGoBack)
+                    .IsEnabled(nav.CanGoBack)
             ),
             NavigationHost(nav, route => route switch
             {
@@ -514,7 +514,7 @@ class StateSerializationDemo : Component
                 {
                     if (savedState is not null)
                         nav.SetState(savedState);
-                }).Disabled(savedState is null)
+                }).IsEnabled(!(savedState is null))
             ),
             TextBlock($"Current: {nav.CurrentRoute}"),
             TextBlock($"Saved: {savedState?[..Math.Min(50, savedState?.Length ?? 0)] ?? "(none)"}")

--- a/docs/guide/xaml-developers.md
+++ b/docs/guide/xaml-developers.md
@@ -83,7 +83,7 @@ class TutorialFormPage : Component
             TextField(email, setEmail, header: "Email"),
             CheckBox(wantsUpdates, setWantsUpdates, label: "Email me updates"),
             HStack(8,
-                Button("Save", () => { }).Disabled(!canSave),
+                Button("Save", () => { }).IsEnabled(canSave),
                 TextBlock(canSave ? "Ready to save" : "Complete all required fields")
                     .Opacity(0.7)
             )

--- a/docs/reference/async-system.md
+++ b/docs/reference/async-system.md
@@ -765,7 +765,7 @@ cause a flicker on the next render.
 Overlapping `RunAsync` calls each get their own `callCts`; both complete in
 completion order. There is no built-in serialization — if the caller wants
 "only one in flight at a time," they gate the `RunAsync` invocation
-themselves (e.g., `Button.Disabled(mut.IsPending)`).
+themselves (e.g., `Button.IsEnabled(!mut.IsPending)`).
 
 ### 6.3 Unmount
 

--- a/docs/specs/002-winui3-gap-analysis.md
+++ b/docs/specs/002-winui3-gap-analysis.md
@@ -691,7 +691,7 @@ XY focus, and drag-drop are all missing as first-class modifiers.**
 | **XamlUICommand** | Missing | Label+Icon+Accelerator+Description bundling not replicated |
 | **StandardUICommand** | Missing | No pre-built Cut/Copy/Paste/Undo command objects |
 | **Command property on controls** | Missing | Controls only have OnClick/OnChanged callbacks, not a Command binding point |
-| **CanExecute / auto-disable** | Missing | No automatic disable-when-unavailable; `.Disabled(condition)` is manual and must be wired separately per control |
+| **CanExecute / auto-disable** | Missing | No automatic disable-when-unavailable; `.IsEnabled(!condition)` is manual and must be wired separately per control |
 
 **Verdict: Missing.** Reactor has no command abstraction. Action callbacks cover the simplest
 case (click → do thing) but do not replicate what ICommand provides: a named, queryable,

--- a/docs/specs/008-csharp-language-improvements.md
+++ b/docs/specs/008-csharp-language-improvements.md
@@ -905,7 +905,7 @@ return VStack(16) {
         Text("Name"),
         TextField(name, setName, placeholder: "Enter your name").Width(300)
     },
-    Button("Submit", () => setSubmitted(true)).Disabled(!isValid)
+    Button("Submit", () => setSubmitted(true)).IsEnabled(isValid)
 };
 ```
 
@@ -1879,7 +1879,7 @@ class FormDemo : Component
             CheckBox(agreeToTerms, setAgree, label: "I agree to the terms"),
             When(!isValid, () =>
                 Text("Please fill all fields and agree to terms").Opacity(0.6)),
-            Button("Submit", () => setSubmitted(true)).Disabled(!isValid)
+            Button("Submit", () => setSubmitted(true)).IsEnabled(isValid)
         );
     }
 }

--- a/docs/specs/020-async-resources-design.md
+++ b/docs/specs/020-async-resources-design.md
@@ -552,7 +552,7 @@ var save = UseMutation<Employee, Employee>(
         OnError: (ex, e) => cache.Revert(e.Key),
         InvalidateKeys: ["employees.list"]));
 
-Button("Save", () => save.RunAsync(edited)).Disabled(save.IsPending);
+Button("Save", () => save.RunAsync(edited)).IsEnabled(!save.IsPending);
 ```
 
 ### 8.3 Why a separate hook, not "write support on UseResource"

--- a/docs/specs/026-charting-accessibility-design.md
+++ b/docs/specs/026-charting-accessibility-design.md
@@ -361,7 +361,7 @@ LineChart(...)
 ```
 
 `.Interactive()` is implicit when any of `.Pan()`, `.Zoom()`, `.Brush()`, `.OnPointInvoke()`,
-or `.Selectable()` is used.
+or `.IsTextSelectionEnabled()` is used.
 
 ---
 

--- a/docs/specs/archived/cpp-native-reconciler.md
+++ b/docs/specs/archived/cpp-native-reconciler.md
@@ -812,7 +812,7 @@ class CounterDemo : Component
             Text($"Current count: {count}").FontSize(24).SemiBold(),
             HStack(8,
                 Button($"- {step}", () => setCount(count - step)),
-                Button("Reset", () => setCount(0)).Disabled(count == 0),
+                Button("Reset", () => setCount(0)).IsEnabled(!(count == 0)),
                 Button($"+ {step}", () => setCount(count + step))
             ),
             HStack(8,

--- a/docs/specs/proposals/forms-data-entry-ideas.md
+++ b/docs/specs/proposals/forms-data-entry-ideas.md
@@ -351,7 +351,7 @@ ValidationVisualizer(VisualizerStyle.InfoBar,
         ),
 
         Button("Submit", HandleSubmit)
-            .Disabled(!UseValidationContext().IsValid())
+            .IsEnabled(UseValidationContext().IsValid())
     )
 )
 ```
@@ -637,9 +637,9 @@ return VStack(16,
     HStack(12,
         When(wizard.CanGoBack, () => Button("Back", wizard.GoBack)),
         When(!wizard.IsLastStep, () =>
-            Button("Next", wizard.GoNext).Disabled(!wizard.IsCurrentStepValid)),
+            Button("Next", wizard.GoNext).IsEnabled(wizard.IsCurrentStepValid)),
         When(wizard.IsLastStep, () =>
-            Button("Submit", HandleSubmit).Disabled(!wizard.IsValid))
+            Button("Submit", HandleSubmit).IsEnabled(wizard.IsValid))
     )
 );
 ```
@@ -841,7 +841,7 @@ class RegistrationForm : Component
                         if (result.Errors is { } errors)
                             foreach (var e in errors)
                                 ctx.Add(e.Field, e.Message);
-                    }).Disabled(!ctx.IsValid()),
+                    }).IsEnabled(ctx.IsValid()),
 
                     When(ctx.IsDirty(), () =>
                         Button("Reset", () => ctx.Reset())

--- a/docs/specs/tasks/charting-accessibility-implementation.md
+++ b/docs/specs/tasks/charting-accessibility-implementation.md
@@ -415,7 +415,7 @@ values, series headers, and axis labels without any visible table.
 
 - [x] Add `.Interactive()` modifier — turns on navigator (default off for static)
 - [x] `.Interactive()` is implicit when `.Pan()`, `.Zoom()`, `.Brush()`,
-      `.OnPointInvoke()`, or `.Selectable()` is used
+      `.OnPointInvoke()`, or `.IsTextSelectionEnabled()` is used
 - [x] Add `.OnPointInvoke(Action<T, int>)` for Enter/Space + click
 - [x] Add `.OnBrushChanged(Action<ChartRange>)` for brush selection
 

--- a/plugins/reactor/skills/reactor-async/SKILL.md
+++ b/plugins/reactor/skills/reactor-async/SKILL.md
@@ -103,7 +103,7 @@ var addTodo = UseMutation<TodoInput, Todo>(
 
 return VStack(
     Button("Add", () => _ = addTodo.RunAsync(new TodoInput("New")))
-        .Disabled(addTodo.IsPending));
+        .IsEnabled(!addTodo.IsPending));
 ```
 
 - `OnOptimistic` runs synchronously on the caller. If it throws, the mutator

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -209,7 +209,7 @@ BreadcrumbBarElement.ItemClicked(Action<BreadcrumbBarItemData> handler) → Brea
 BreadcrumbBarElement.Set(Action<BreadcrumbBar> configure) → BreadcrumbBarElement
 ButtonElement.AccentButton() → ButtonElement
 ButtonElement.Click(Action handler) → ButtonElement
-ButtonElement.DisabledFocusable(bool disabled = true) → ButtonElement
+ButtonElement.IsDisabledFocusable(bool disabled = true) → ButtonElement
 ButtonElement.Set(Action<Button> configure) → ButtonElement
 ButtonElement.SubtleButton() → ButtonElement
 ButtonElement.TextLink() → ButtonElement
@@ -246,7 +246,7 @@ ColorPickerElement.ValueRange(int minValue, int maxValue) → ColorPickerElement
 ComboBoxElement.Description(string description) → ComboBoxElement
 ComboBoxElement.DropDownClosed(Action handler) → ComboBoxElement
 ComboBoxElement.DropDownOpened(Action handler) → ComboBoxElement
-ComboBoxElement.Editable(bool editable = true) → ComboBoxElement
+ComboBoxElement.IsEditable(bool editable = true) → ComboBoxElement
 ComboBoxElement.Header(string header) → ComboBoxElement
 ComboBoxElement.MaxDropDownHeight(double height) → ComboBoxElement
 ComboBoxElement.Placeholder(string text) → ComboBoxElement
@@ -311,7 +311,7 @@ ImageElement.NineGrid(Thickness nineGrid) → ImageElement
 ImageElement.Set(Action<Image> configure) → ImageElement
 InfoBadgeElement.Set(Action<InfoBadge> configure) → InfoBadgeElement
 InfoBarElement.ActionButtonClick(Action handler) → InfoBarElement
-InfoBarElement.Closable(bool closable = true) → InfoBarElement
+InfoBarElement.IsClosable(bool closable = true) → InfoBarElement
 InfoBarElement.Closed(Action handler) → InfoBarElement
 InfoBarElement.Content(Element content) → InfoBarElement
 InfoBarElement.Error() → InfoBarElement
@@ -404,12 +404,12 @@ PipsPagerElement.WrapMode(PipsPagerWrapMode mode) → PipsPagerElement
 PivotElement.SelectedIndexChanged(Action<int> handler) → PivotElement
 PivotElement.Set(Action<Pivot> configure) → PivotElement
 PopupElement.Closed(Action handler) → PopupElement
-PopupElement.LightDismiss(bool enabled = true) → PopupElement
+PopupElement.IsLightDismissEnabled(bool enabled = true) → PopupElement
 PopupElement.Offset(double horizontal, double vertical) → PopupElement
 PopupElement.Opened(Action handler) → PopupElement
 PopupElement.Set(Action<Popup> configure) → PopupElement
 ProgressElement.Set(Action<ProgressBar> configure) → ProgressElement
-ProgressRingElement.Active(bool active = true) → ProgressRingElement
+ProgressRingElement.IsActive(bool active = true) → ProgressRingElement
 ProgressRingElement.Set(Action<ProgressRing> configure) → ProgressRingElement
 PropertyGridElement.RootChanged(Action<object> handler) → PropertyGridElement
 RadioButtonElement.IsCheckedChanged(Action<bool> handler) → RadioButtonElement
@@ -420,7 +420,7 @@ RatingControlElement.Caption(string caption) → RatingControlElement
 RatingControlElement.InitialSetValue(int value) → RatingControlElement
 RatingControlElement.MaxRating(int max) → RatingControlElement
 RatingControlElement.PlaceholderValue(double value) → RatingControlElement
-RatingControlElement.ReadOnly(bool readOnly = true) → RatingControlElement
+RatingControlElement.IsReadOnly(bool readOnly = true) → RatingControlElement
 RatingControlElement.Set(Action<RatingControl> configure) → RatingControlElement
 RatingControlElement.ValueChanged(Action<double> handler) → RatingControlElement
 RectangleElement.Fill(Brush brush) → RectangleElement
@@ -499,7 +499,7 @@ T.CenterPoint<T>(Vector3 center) → T
 T.ConnectedAnimation<T>(string key) → T
 T.CornerRadius<T>(double radius) → T
 T.CornerRadius<T>(double topLeft, double topRight, double bottomRight, double bottomLeft) → T
-T.Disabled<T>(bool disabled = true) → T
+T.IsEnabled<T>(bool enabled = true) → T
 T.DraggableWhen<T>(Func<bool> canDrag) → T
 T.Flex<T>(double grow = 0, double shrink = 1, double? basis = null, FlexAlign? alignSelf = null, FlexPositionType position = FlexPositionType.Relative, double? left = null, double? top = null, double? right = null, double? bottom = null) → T
 T.FocusMeta<T>(FocusManager fm, string fieldName, bool autoFocus = false) → T
@@ -619,7 +619,7 @@ T.Validate<T>(string fieldName, object value, IValidator[] validators) → T
 T.ValidateAsync<T>(string fieldName, IAsyncValidator[] asyncValidators) → T
 T.ValidateAsync<T>(string fieldName, object value, IAsyncValidator[] asyncValidators) → T
 T.VerticalAlignment<T>(VerticalAlignment alignment) → T
-T.Visible<T>(bool isVisible) → T
+T.IsVisible<T>(bool isVisible) → T
 T.Width<T>(double width) → T
 T.WithBorder<T>(Brush brush, double thickness = 1) → T
 T.WithBorder<T>(ThemeRef theme, double thickness = 1) → T
@@ -641,7 +641,7 @@ TabViewElement.CanReorderTabs(bool canReorder = true) → TabViewElement
 TabViewElement.CloseButtonOverlayMode(TabViewCloseButtonOverlayMode mode) → TabViewElement
 TabViewElement.SelectedIndexChanged(Action<int> handler) → TabViewElement
 TabViewElement.Set(Action<TabView> configure) → TabViewElement
-TabViewElement.ShowAddButton(bool visible = true) → TabViewElement
+TabViewElement.IsAddTabButtonVisible(bool visible = true) → TabViewElement
 TabViewElement.TabCloseRequested(Action<int> handler) → TabViewElement
 TabViewElement.TabStripFooter(Element footer) → TabViewElement
 TabViewElement.TabStripHeader(Element header) → TabViewElement
@@ -671,7 +671,7 @@ TextBlockElement.FontSize(double size) → TextBlockElement
 TextBlockElement.FontStyle(FontStyle style) → TextBlockElement
 TextBlockElement.LineHeight(double height) → TextBlockElement
 TextBlockElement.MaxLines(int maxLines) → TextBlockElement
-TextBlockElement.Selectable(bool selectable = true) → TextBlockElement
+TextBlockElement.IsTextSelectionEnabled(bool enabled = true) → TextBlockElement
 TextBlockElement.SemiBold() → TextBlockElement
 TextBlockElement.Set(Action<TextBlock> configure) → TextBlockElement
 TextBlockElement.TextAlignment(TextAlignment alignment) → TextBlockElement
@@ -690,7 +690,7 @@ TextFieldElement.IsSpellCheckEnabled(bool enabled = true) → TextFieldElement
 TextFieldElement.MaxLength(int maxLength) → TextFieldElement
 TextFieldElement.NumericInput() → TextFieldElement
 TextFieldElement.PhoneInput() → TextFieldElement
-TextFieldElement.ReadOnly(bool readOnly = true) → TextFieldElement
+TextFieldElement.IsReadOnly(bool readOnly = true) → TextFieldElement
 TextFieldElement.SearchInput() → TextFieldElement
 TextFieldElement.SelectionChanged(Action<string, int, int> handler) → TextFieldElement
 TextFieldElement.Set(Action<TextBox> configure) → TextFieldElement

--- a/plugins/reactor/skills/reactor-forms/SKILL.md
+++ b/plugins/reactor/skills/reactor-forms/SKILL.md
@@ -34,7 +34,7 @@ return VStack(12,
     TextField(name, setName, placeholder: "Name"),
     NumberBox(age, setAge),
     CheckBox(agreed, setAgreed, label: "I agree"),
-    Button("Submit", onSubmit).Disabled(string.IsNullOrEmpty(name) || !agreed)
+    Button("Submit", onSubmit).IsEnabled(!(string.IsNullOrEmpty(name) || !agreed))
 );
 ```
 
@@ -42,14 +42,14 @@ return VStack(12,
 
 | Factory | Value type | Common modifiers |
 |---------|-----------|------------------|
-| `TextField(value, setValue, placeholder, header)` | `string` | `.Header()`, `.ReadOnly()`, `.AcceptsReturn()`, `.TextWrapping()`, `.MaxLength(n)`, `.NumericInput()`, `.EmailInput()`, `.Changed(handler)` |
+| `TextField(value, setValue, placeholder, header)` | `string` | `.Header()`, `.IsReadOnly()`, `.AcceptsReturn()`, `.TextWrapping()`, `.MaxLength(n)`, `.NumericInput()`, `.EmailInput()`, `.Changed(handler)` |
 | `PasswordBox(password, setPassword, placeholder)` | `string` | `.Header(text)`, `.MaxLength(n)`, `.PasswordChanged(handler)` |
 | `NumberBox(value, setValue, placeholder, header)` | `double` | `.Range(min, max)`, `.SpinButtons(...)` |
 | `Slider(value, min, max, setValue)` | `double` | `.Header()`, `.StepFrequency()` |
 | `ToggleSwitch(isOn, setIsOn, header, onContent, offContent)` | `bool` | `.Header()` |
 | `CheckBox(isChecked, setIsChecked, label)` | `bool` | — |
 | `RadioButtons(items, selected, setSelected, header)` | `int` | `.Set(rb => ...)` |
-| `ComboBox(items, selected, setSelected, placeholder)` | `object` | `.Header()`, `.Editable()`, `.Placeholder()` |
+| `ComboBox(items, selected, setSelected, placeholder)` | `object` | `.Header()`, `.IsEditable()`, `.Placeholder()` |
 | `DatePicker(date, setDate, header)` | `DateTimeOffset` | `.Set(dp => ...)` |
 | `TimePicker(time, setTime, header)` | `TimeSpan` | `.Set(tp => ...)` |
 | `AutoSuggestBox(text, setText, placeholder, header)` | `string` | `.Set(asb => ...)` |
@@ -81,7 +81,7 @@ var isValid = email.Contains('@') && email.Length > 3;
 
 return VStack(12,
     TextField(email, setEmail, placeholder: "Email"),
-    Button("Submit", onSubmit).Disabled(!isValid)
+    Button("Submit", onSubmit).IsEnabled(isValid)
 );
 ```
 

--- a/plugins/reactor/skills/reactor-navigation/SKILL.md
+++ b/plugins/reactor/skills/reactor-navigation/SKILL.md
@@ -55,7 +55,7 @@ class App : Component
             HStack(8,
                 Button("Home", () => nav.Navigate(Route.Home)),
                 Button("Settings", () => nav.Navigate(Route.Settings)),
-                Button("Back", () => nav.GoBack()).Disabled(!nav.CanGoBack)
+                Button("Back", () => nav.GoBack()).IsEnabled(nav.CanGoBack)
             ),
             NavigationHost(nav, route => route switch
             {

--- a/samples/NavigationDemo/App.cs
+++ b/samples/NavigationDemo/App.cs
@@ -419,7 +419,7 @@ class DetailPage : Component<Detail>
         NavigationHandle<AppRoute> nav) =>
         Button(label, () => nav.Navigate(new Detail(id, tab),
             new NavigateOptions { PushToBackStack = false }))
-            .Disabled(tab == activeTab);
+            .IsEnabled(!(tab == activeTab));
 }
 
 // ─── Docs page (wildcard route target) ──────────────────────────────────────
@@ -546,7 +546,7 @@ class SettingsPage : Component
         {
             if (!Equals(route, nav.CurrentRoute))
                 nav.Navigate(route, new NavigateOptions { PushToBackStack = false });
-        }).Disabled(Equals(route, nav.CurrentRoute));
+        }).IsEnabled(!(Equals(route, nav.CurrentRoute)));
 
     static Element GeneralSettingsContent() =>
         VStack(12,
@@ -623,7 +623,7 @@ class ProfilePage : Component<string>
                             setDisplayName(name);
                             setBio("");
                             setSaved(true);
-                        }).Disabled(saved)
+                        }).IsEnabled(!saved)
                     )
                 ),
 

--- a/samples/Reactor.TestApp/Demos/CommandingDemo.cs
+++ b/samples/Reactor.TestApp/Demos/CommandingDemo.cs
@@ -79,7 +79,7 @@ class CommandingTestDemo : Component
                 HStack(8,
                     Button(asyncCmd),
                     When(asyncCmd.IsExecuting, () =>
-                        ProgressRing().Width(20).Height(20).Active(true))
+                        ProgressRing().Width(20).Height(20).IsActive(true))
                 ),
 
                 // Parameterized command

--- a/samples/Reactor.TestApp/Demos/ConditionalDemo.cs
+++ b/samples/Reactor.TestApp/Demos/ConditionalDemo.cs
@@ -67,11 +67,11 @@ class ConditionalDemo : Component
             SubHeading("2. Switch expression picks a sub-tree"),
             HStack(8,
                 Button("Simple", () => setViewMode(_ => ViewMode.Simple))
-                    .Disabled(viewMode == ViewMode.Simple),
+                    .IsEnabled(!(viewMode == ViewMode.Simple)),
                 Button("Detailed", () => setViewMode(_ => ViewMode.Detailed))
-                    .Disabled(viewMode == ViewMode.Detailed),
+                    .IsEnabled(!(viewMode == ViewMode.Detailed)),
                 Button("Custom", () => setViewMode(_ => ViewMode.Custom))
-                    .Disabled(viewMode == ViewMode.Custom)
+                    .IsEnabled(!(viewMode == ViewMode.Custom))
             ),
 
             // Each branch renders a COMPLETELY different control tree

--- a/samples/Reactor.TestApp/Demos/ContextDemo.cs
+++ b/samples/Reactor.TestApp/Demos/ContextDemo.cs
@@ -28,9 +28,9 @@ class ContextDemo : Component
             SubHeading("1. Provide context values"),
             HStack(8,
                 TextBlock("Accent color:"),
-                Button("Blue", () => setAccent("#0078D4")).Disabled(accent == "#0078D4"),
-                Button("Red", () => setAccent("#E74C3C")).Disabled(accent == "#E74C3C"),
-                Button("Green", () => setAccent("#50C878")).Disabled(accent == "#50C878"),
+                Button("Blue", () => setAccent("#0078D4")).IsEnabled(!(accent == "#0078D4")),
+                Button("Red", () => setAccent("#E74C3C")).IsEnabled(!(accent == "#E74C3C")),
+                Button("Green", () => setAccent("#50C878")).IsEnabled(!(accent == "#50C878")),
                 Border(Empty()).Background(accent).CornerRadius(4).Size(24, 24)
             ),
             HStack(8,

--- a/samples/Reactor.TestApp/Demos/CounterDemo.cs
+++ b/samples/Reactor.TestApp/Demos/CounterDemo.cs
@@ -23,7 +23,7 @@ class CounterDemo : Component
 
             HStack(8,
                 Button($"- {step}", () => setCount(count - step)),
-                Button("Reset", () => setCount(0)).Disabled(count == 0),
+                Button("Reset", () => setCount(0)).IsEnabled(!(count == 0)),
                 Button($"+ {step}", () => setCount(count + step))
             ),
 

--- a/samples/Reactor.TestApp/Demos/DataSystemDemo.cs
+++ b/samples/Reactor.TestApp/Demos/DataSystemDemo.cs
@@ -417,10 +417,10 @@ class DataSourceDemo : Microsoft.UI.Reactor.Core.Component
 
                         FlexRow(
                             Button("\u25C0 Previous", () => setToken(null))
-                                .Disabled(token is null),
+                                .IsEnabled(!(token is null)),
                             TextBlock($"Page size: {pageSize}"),
                             Button("Next \u25B6", () => setToken(page.ContinuationToken))
-                                .Disabled(page.ContinuationToken is null)
+                                .IsEnabled(!(page.ContinuationToken is null))
                         ) with { ColumnGap = 8, AlignItems = FlexAlign.Center }
                       ) with { RowGap = 4 }
                     : TextBlock("No data")

--- a/samples/Reactor.TestApp/Demos/DataTemplateDemo.cs
+++ b/samples/Reactor.TestApp/Demos/DataTemplateDemo.cs
@@ -60,7 +60,7 @@ class DataTemplateDemo : Component
                 })),
                 Button("Remove Last", () => updateAnimals(list =>
                     list.Count > 0 ? list.Take(list.Count - 1).ToList() : list
-                )).Disabled(animals.Count == 0)
+                )).IsEnabled(!(animals.Count == 0))
             ),
 
             TextBlock($"{filtered.Count} animals shown").Foreground(SecondaryText),

--- a/samples/Reactor.TestApp/Demos/DynamicListDemo.cs
+++ b/samples/Reactor.TestApp/Demos/DynamicListDemo.cs
@@ -22,7 +22,7 @@ class DynamicListDemo : Component
             TextBlock("Demonstrates conditional and list rendering"),
 
             HStack(8,
-                Button("Remove", () => setCount(Math.Max(0, count - 1))).Disabled(count == 0),
+                Button("Remove", () => setCount(Math.Max(0, count - 1))).IsEnabled(!(count == 0)),
                 TextBlock($"{count} items"),
                 Button("Add", () => setCount(count + 1))
             ),

--- a/samples/Reactor.TestApp/Demos/FlexPanelDemo.cs
+++ b/samples/Reactor.TestApp/Demos/FlexPanelDemo.cs
@@ -28,40 +28,40 @@ class FlexPanelDemo : Component
                 VStack(4,
                     TextBlock("Direction").SemiBold(),
                     Button("Row", () => setDirection(FlexDirection.Row))
-                        .Disabled(direction == FlexDirection.Row),
+                        .IsEnabled(!(direction == FlexDirection.Row)),
                     Button("Column", () => setDirection(FlexDirection.Column))
-                        .Disabled(direction == FlexDirection.Column),
+                        .IsEnabled(!(direction == FlexDirection.Column)),
                     Button("Row Reverse", () => setDirection(FlexDirection.RowReverse))
-                        .Disabled(direction == FlexDirection.RowReverse)
+                        .IsEnabled(!(direction == FlexDirection.RowReverse))
                 ),
                 VStack(4,
                     TextBlock("Wrap").SemiBold(),
                     Button("No Wrap", () => setWrap(FlexWrap.NoWrap))
-                        .Disabled(wrap == FlexWrap.NoWrap),
+                        .IsEnabled(!(wrap == FlexWrap.NoWrap)),
                     Button("Wrap", () => setWrap(FlexWrap.Wrap))
-                        .Disabled(wrap == FlexWrap.Wrap)
+                        .IsEnabled(!(wrap == FlexWrap.Wrap))
                 ),
                 VStack(4,
                     TextBlock("Justify Content").SemiBold(),
                     Button("Start", () => setJustify(FlexJustify.FlexStart))
-                        .Disabled(justify == FlexJustify.FlexStart),
+                        .IsEnabled(!(justify == FlexJustify.FlexStart)),
                     Button("Center", () => setJustify(FlexJustify.Center))
-                        .Disabled(justify == FlexJustify.Center),
+                        .IsEnabled(!(justify == FlexJustify.Center)),
                     Button("Space Between", () => setJustify(FlexJustify.SpaceBetween))
-                        .Disabled(justify == FlexJustify.SpaceBetween),
+                        .IsEnabled(!(justify == FlexJustify.SpaceBetween)),
                     Button("Space Evenly", () => setJustify(FlexJustify.SpaceEvenly))
-                        .Disabled(justify == FlexJustify.SpaceEvenly)
+                        .IsEnabled(!(justify == FlexJustify.SpaceEvenly))
                 ),
                 VStack(4,
                     TextBlock("Align Items").SemiBold(),
                     Button("Stretch", () => setAlignItems(FlexAlign.Stretch))
-                        .Disabled(alignItems == FlexAlign.Stretch),
+                        .IsEnabled(!(alignItems == FlexAlign.Stretch)),
                     Button("Center", () => setAlignItems(FlexAlign.Center))
-                        .Disabled(alignItems == FlexAlign.Center),
+                        .IsEnabled(!(alignItems == FlexAlign.Center)),
                     Button("Start", () => setAlignItems(FlexAlign.FlexStart))
-                        .Disabled(alignItems == FlexAlign.FlexStart),
+                        .IsEnabled(!(alignItems == FlexAlign.FlexStart)),
                     Button("End", () => setAlignItems(FlexAlign.FlexEnd))
-                        .Disabled(alignItems == FlexAlign.FlexEnd)
+                        .IsEnabled(!(alignItems == FlexAlign.FlexEnd))
                 )
             ),
 

--- a/samples/Reactor.TestApp/Demos/FormDemo.cs
+++ b/samples/Reactor.TestApp/Demos/FormDemo.cs
@@ -63,7 +63,7 @@ class FormDemo : Component
             When(!isValid, () =>
                 TextBlock("Please fill all fields and agree to terms").Foreground(TertiaryText)),
 
-            Button("Submit", () => setSubmitted(true)).DisabledFocusable(!isValid)
+            Button("Submit", () => setSubmitted(true)).IsDisabledFocusable(!isValid)
         );
     }
 }

--- a/samples/Reactor.TestApp/Demos/NavigationDemo.cs
+++ b/samples/Reactor.TestApp/Demos/NavigationDemo.cs
@@ -36,9 +36,9 @@ class NavigationDemo : Component
             TextBlock($"Route: {nav.CurrentRoute}  |  Depth: {nav.Depth}  |  Back stack: {nav.BackStack.Count}"),
 
             HStack(8,
-                Button("Back", () => nav.GoBack()).Disabled(!nav.CanGoBack),
-                Button("Forward", () => nav.GoForward()).Disabled(!nav.CanGoForward),
-                Button("Reset", () => nav.Reset(new NavHome())).Disabled(nav.CurrentRoute is NavHome && nav.Depth == 1)
+                Button("Back", () => nav.GoBack()).IsEnabled(nav.CanGoBack),
+                Button("Forward", () => nav.GoForward()).IsEnabled(nav.CanGoForward),
+                Button("Reset", () => nav.Reset(new NavHome())).IsEnabled(!(nav.CurrentRoute is NavHome && nav.Depth == 1))
             ),
 
             // Transition selector (persisted across tab switches)

--- a/samples/Reactor.TestApp/Demos/PerfStressDemo.cs
+++ b/samples/Reactor.TestApp/Demos/PerfStressDemo.cs
@@ -197,12 +197,12 @@ class PerfStressDemo : Component
                 VStack(4,
                     TextBlock("Elements:"),
                     HStack(8,
-                        Button("10", () => { if (!running) setElementCount(10); }).Disabled(running || elementCount == 10),
-                        Button("50", () => { if (!running) setElementCount(50); }).Disabled(running || elementCount == 50),
-                        Button("100", () => { if (!running) setElementCount(100); }).Disabled(running || elementCount == 100),
-                        Button("250", () => { if (!running) setElementCount(250); }).Disabled(running || elementCount == 250),
-                        Button("500", () => { if (!running) setElementCount(500); }).Disabled(running || elementCount == 500),
-                        Button("1000", () => { if (!running) setElementCount(1000); }).Disabled(running || elementCount == 1000)
+                        Button("10", () => { if (!running) setElementCount(10); }).IsEnabled(!(running || elementCount == 10)),
+                        Button("50", () => { if (!running) setElementCount(50); }).IsEnabled(!(running || elementCount == 50)),
+                        Button("100", () => { if (!running) setElementCount(100); }).IsEnabled(!(running || elementCount == 100)),
+                        Button("250", () => { if (!running) setElementCount(250); }).IsEnabled(!(running || elementCount == 250)),
+                        Button("500", () => { if (!running) setElementCount(500); }).IsEnabled(!(running || elementCount == 500)),
+                        Button("1000", () => { if (!running) setElementCount(1000); }).IsEnabled(!(running || elementCount == 1000))
                     )
                 ),
                 VStack(4,
@@ -220,14 +220,14 @@ class PerfStressDemo : Component
             ),
 
             HStack(8,
-                Button("Start Sort", StartSort).Disabled(running),
+                Button("Start Sort", StartSort).IsEnabled(!running),
                 Button("Reset", () =>
                 {
                     setSortState(_ => null);
                     setRenderTimes(_ => new List<double>());
                     setTotalSwaps(0);
                     setStepCount(0);
-                }).Disabled(running)
+                }).IsEnabled(!running)
             ),
 
             // Status

--- a/samples/Reactor.TestApp/Demos/PersistedDemo.cs
+++ b/samples/Reactor.TestApp/Demos/PersistedDemo.cs
@@ -39,7 +39,7 @@ class PersistedDemo : Component
                 VStack(4,
                     TextBlock("Color"),
                     HStack(4, colors.Select(c =>
-                        Button(c, () => setColor(c)).Disabled(color == c)
+                        Button(c, () => setColor(c)).IsEnabled(!(color == c))
                     ).ToArray())
                 ),
                 Border(VStack(4,

--- a/samples/Reactor.TestApp/Demos/TodoDemo.cs
+++ b/samples/Reactor.TestApp/Demos/TodoDemo.cs
@@ -41,7 +41,7 @@ class TodoDemo : Component
                         updateItems(list => [.. list, new TodoItem(newText.Trim(), false)]);
                         setNewText("");
                     }
-                }).Disabled(string.IsNullOrWhiteSpace(newText))
+                }).IsEnabled(!(string.IsNullOrWhiteSpace(newText)))
             ),
 
             // List of items

--- a/samples/Reactor.TestApp/Demos/VirtualizationDemo.cs
+++ b/samples/Reactor.TestApp/Demos/VirtualizationDemo.cs
@@ -71,18 +71,18 @@ class VirtualizationDemo : Component
                     TextBlock("Mode:"),
                     HStack(8,
                         Button("LazyVStack", () => setMode("LazyVStack"))
-                            .Disabled(mode == "LazyVStack"),
+                            .IsEnabled(!(mode == "LazyVStack")),
                         Button("ListView", () => setMode("ListView"))
-                            .Disabled(mode == "ListView")
+                            .IsEnabled(!(mode == "ListView"))
                     )
                 ),
                 VStack(4,
                     TextBlock("Items:"),
                     HStack(8,
-                        Button("100", () => setItemCount(100)).Disabled(itemCount == 100),
-                        Button("1000", () => setItemCount(1000)).Disabled(itemCount == 1000),
-                        Button("5000", () => setItemCount(5000)).Disabled(itemCount == 5000),
-                        Button("10000", () => setItemCount(10000)).Disabled(itemCount == 10000)
+                        Button("100", () => setItemCount(100)).IsEnabled(!(itemCount == 100)),
+                        Button("1000", () => setItemCount(1000)).IsEnabled(!(itemCount == 1000)),
+                        Button("5000", () => setItemCount(5000)).IsEnabled(!(itemCount == 5000)),
+                        Button("10000", () => setItemCount(10000)).IsEnabled(!(itemCount == 10000))
                     )
                 )
             ),

--- a/samples/Reactor.TestApp/Demos/WindowsDemo.cs
+++ b/samples/Reactor.TestApp/Demos/WindowsDemo.cs
@@ -179,7 +179,7 @@ class WindowsDemo : Component
                         }
                         foreach (var w in toClose) w.Close();
                         setChildCount(0);
-                    }).Disabled(ReactorApp.Windows.Count <= 1)
+                    }).IsEnabled(!(ReactorApp.Windows.Count <= 1))
                 ),
                 TextBlock($"Total open windows: {ReactorApp.Windows.Count}")
                     .Foreground(TertiaryText)

--- a/samples/ReactorCharting.Gallery/Samples/CurveExplorer.cs
+++ b/samples/ReactorCharting.Gallery/Samples/CurveExplorer.cs
@@ -111,7 +111,7 @@ public sealed class CurveExplorerSample : GallerySample
                         Slider(tension, 0, 1, setTension)
                             .StepFrequency(0.05)
                             .Width(160)
-                            .Disabled(!hasTension),
+                            .IsEnabled(hasTension),
                         (TextBlock($"{tension:F2}") with { FontSize = 11 }).Opacity(hasTension ? 1 : 0.4)
                     ).VAlign(VerticalAlignment.Center)
                 ).Padding(8, 0, 8, 0),

--- a/samples/ReactorGallery/ControlPages/BasicInput/ButtonPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/ButtonPage.cs
@@ -27,8 +27,8 @@ class ButtonPage: Component
                 sourceCode: @"Button(""Save"").Click(() => setOutput(""Saved!""))"),
 
             SampleCard("Disabled Button",
-                Button("Can't Click").Disabled(),
-                sourceCode: @"Button(""Can't Click"").Disabled()"),
+                Button("Can't Click").IsEnabled(false),
+                sourceCode: @"Button(""Can't Click"").IsEnabled(false)"),
 
             // Phase 8.1 — .AccentButton() named-style fluent (spec 039 §17.1).
             SampleCard("Accent style — .AccentButton()",

--- a/samples/ReactorGallery/ControlPages/BasicInput/ComboBoxPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/ComboBoxPage.cs
@@ -33,9 +33,9 @@ ComboBox(colors).Placeholder(""Pick a color"")
 "),
 
             SampleCard("Editable ComboBox",
-                ComboBox(colors, editableIndex, i => setEditableIndex(i)).Editable(),
+                ComboBox(colors, editableIndex, i => setEditableIndex(i)).IsEditable(),
                 sourceCode: @"
-ComboBox(colors, editableIndex, i => setEditableIndex(i)).Editable()
+ComboBox(colors, editableIndex, i => setEditableIndex(i)).IsEditable()
 ")
         ).Margin(36, 24, 36, 36));
     }

--- a/samples/ReactorGallery/ControlPages/BasicInput/RatingControlPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/RatingControlPage.cs
@@ -25,9 +25,9 @@ RatingControl(rating, v => setRating(v))
 "),
 
             SampleCard("Read-Only Rating",
-                RatingControl(4.0).ReadOnly(),
+                RatingControl(4.0).IsReadOnly(),
                 sourceCode: @"
-RatingControl(4.0).ReadOnly()
+RatingControl(4.0).IsReadOnly()
 "),
 
             SampleCard("Custom Max Rating",

--- a/samples/ReactorGallery/ControlPages/StatusAndInfo/InfoBarPage.cs
+++ b/samples/ReactorGallery/ControlPages/StatusAndInfo/InfoBarPage.cs
@@ -42,11 +42,11 @@ InfoBar(""Info"",    ""FYI…""     ).Informational().Closable(false)"),
                 SampleCard("Closable InfoBar",
                     VStack(8,
                         showClosable
-                            ? InfoBar("Closable", "Click the close button to dismiss.").Closable()
+                            ? InfoBar("Closable", "Click the close button to dismiss.").IsClosable()
                             : TextBlock("InfoBar was closed.").Foreground(Theme.SecondaryText),
                         Button("Reset", () => setShowClosable(true))
                     ),
-                    @"InfoBar(""Closable"", ""Click close to dismiss."").Closable()")
+                    @"InfoBar(""Closable"", ""Click close to dismiss."").IsClosable()")
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/StatusAndInfo/ProgressRingPage.cs
+++ b/samples/ReactorGallery/ControlPages/StatusAndInfo/ProgressRingPage.cs
@@ -32,11 +32,11 @@ class ProgressRingPage : Component
 
                 SampleCard("Indeterminate ProgressRing",
                     VStack(8,
-                        ProgressRing().Active(isActive).Width(60).Height(60),
+                        ProgressRing().IsActive(isActive).Width(60).Height(60),
                         ToggleSwitch(isActive, b => setIsActive(b),
                             onContent: "Active", offContent: "Inactive")
                     ),
-                    @"ProgressRing().Active(true)")
+                    @"ProgressRing().IsActive(true)")
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/apps/chat/App/ChatSampleApp.cs
+++ b/samples/apps/chat/App/ChatSampleApp.cs
@@ -223,7 +223,7 @@ class ChatSampleApp : Component
             : Component<ChatTimeline, ChatTimelineProps>(new(SelectedId, entries, false, null));
 
         Element notificationBar = _notification is { } n
-            ? InfoBar(n.Message).Severity(n.Severity).Closable()
+            ? InfoBar(n.Message).Severity(n.Severity).IsClosable()
                 .Set(ib => { ib.IsOpen = true; ib.Closed += (_, _) => _setNotification(null); })
             : Empty();
 

--- a/samples/apps/demo-script-tool/App/Components/StepCard.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepCard.cs
@@ -416,7 +416,7 @@ public sealed class StepCard : Component<StepCardProps>
                 if (command.Execute is not null) command.Execute();
                 else if (command.ExecuteAsync is not null) _ = command.ExecuteAsync();
             })
-        .Disabled(!command.IsEnabled)
+        .IsEnabled(command.IsEnabled)
         .HAlign(HorizontalAlignment.Stretch)
         .AutomationName(automationName);
 

--- a/samples/apps/regedit/App.cs
+++ b/samples/apps/regedit/App.cs
@@ -648,7 +648,7 @@ class RegeditApp : Component
                         tb.TextTrimming = Microsoft.UI.Xaml.TextTrimming.CharacterEllipsis;
                         tb.TextWrapping = Microsoft.UI.Xaml.TextWrapping.NoWrap;
                     }),
-                When(isLoading, () => ProgressRing().Width(16).Height(16).Active(true))
+                When(isLoading, () => ProgressRing().Width(16).Height(16).IsActive(true))
             )
             .Padding(8, 4, 8, 4)
             .WithBorder(DividerStroke)

--- a/samples/apps/regedit/Components/Dialogs/EditBinaryDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/EditBinaryDialog.cs
@@ -25,7 +25,7 @@ internal sealed class EditBinaryDialog : Component<EditBinaryDialogProps>
                 VStack(4,
                     TextBlock(Strings.ValueName),
                     TextField(Props.ValueName, _ => { })
-                        .ReadOnly()
+                        .IsReadOnly()
                 ),
                 VStack(4,
                     TextBlock(Strings.ValueData),

--- a/samples/apps/regedit/Components/Dialogs/EditDwordDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/EditDwordDialog.cs
@@ -27,7 +27,7 @@ internal sealed class EditDwordDialog : Component<EditDwordDialogProps>
                 VStack(4,
                     TextBlock(Strings.ValueName),
                     TextField(Props.ValueName, _ => { })
-                        .ReadOnly()
+                        .IsReadOnly()
                 ),
                 VStack(4,
                     TextBlock(Strings.ValueData),

--- a/samples/apps/regedit/Components/Dialogs/EditMultiStringDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/EditMultiStringDialog.cs
@@ -25,7 +25,7 @@ internal sealed class EditMultiStringDialog : Component<EditMultiStringDialogPro
                 VStack(4,
                     TextBlock(Strings.ValueName),
                     TextField(Props.ValueName, _ => { })
-                        .ReadOnly()
+                        .IsReadOnly()
                 ),
                 VStack(4,
                     TextBlock(Strings.ValueData),

--- a/samples/apps/regedit/Components/Dialogs/EditQwordDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/EditQwordDialog.cs
@@ -27,7 +27,7 @@ internal sealed class EditQwordDialog : Component<EditQwordDialogProps>
                 VStack(4,
                     TextBlock(Strings.ValueName),
                     TextField(Props.ValueName, _ => { })
-                        .ReadOnly()
+                        .IsReadOnly()
                 ),
                 VStack(4,
                     TextBlock(Strings.ValueData),

--- a/samples/apps/regedit/Components/Dialogs/EditStringDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/EditStringDialog.cs
@@ -25,7 +25,7 @@ internal sealed class EditStringDialog : Component<EditStringDialogProps>
                 VStack(4,
                     TextBlock(Strings.ValueName),
                     TextField(Props.ValueName, _ => { })
-                        .ReadOnly()
+                        .IsReadOnly()
                 ),
                 VStack(4,
                     TextBlock(Strings.ValueData),

--- a/samples/apps/regedit/Components/Dialogs/ExportDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/ExportDialog.cs
@@ -34,7 +34,7 @@ internal sealed class ExportDialog : Component<ExportDialogProps>
                 ),
                 When(!Props.ExportAll, () =>
                     TextField(Props.SelectedBranch, _ => { })
-                        .ReadOnly()
+                        .IsReadOnly()
                 )
             ).Width(400),
             Strings.Export

--- a/samples/apps/validation-showcase/App.cs
+++ b/samples/apps/validation-showcase/App.cs
@@ -338,7 +338,7 @@ class DirtyResetDemo : Component
                     if (restored.TryGetValue("name", out var n)) setName((string)(n ?? ""));
                     if (restored.TryGetValue("color", out var c)) setColor((int)(c ?? 0));
                     setTick(tick + 1);
-                }).Disabled(!ctx.IsDirty()),
+                }).IsEnabled(ctx.IsDirty()),
                 Button("Mark All Touched", () =>
                 {
                     ctx.MarkAllTouched();

--- a/skills/async.md
+++ b/skills/async.md
@@ -107,7 +107,7 @@ var addTodo = UseMutation<TodoInput, Todo>(
 
 return VStack(
     Button("Add", () => _ = addTodo.RunAsync(new TodoInput("New")))
-        .Disabled(addTodo.IsPending));
+        .IsEnabled(!addTodo.IsPending));
 ```
 
 - `OnOptimistic` runs synchronously on the caller. If it throws, the mutator

--- a/skills/dsl-reference.md
+++ b/skills/dsl-reference.md
@@ -341,7 +341,7 @@ Modifiers return `Element`, so type-specific sugar (`.Bold()`,
 .MinWidth(...) / .MinHeight(...) / .MaxWidth(...) / .MaxHeight(...)
 .HAlign(HorizontalAlignment.Center) / .VAlign(VerticalAlignment.Top)
 .Center()               // both H and V
-.Visible(bool)          // Collapsed when false
+.IsVisible(bool)          // Collapsed when false
 .Opacity(0.6)
 .ToolTip("text") / .WithToolTip(element)
 .WithFlyout(flyout) / .WithContextFlyout(flyout)
@@ -367,24 +367,24 @@ Modifiers return `Element`, so type-specific sugar (`.Bold()`,
 
 ```csharp
 TextBlock("Hello").Bold() / .SemiBold() / .FontSize(24) / .FontStyle(style)
-Button("Click").Disabled() / .Disabled(condition)
+Button("Click").IsEnabled(false) / .IsEnabled(!condition)
 Border(child).CornerRadius(8).Background("#f5f5f5").WithBorder("#ccc", 1)
 VStack(...).Spacing(16)
-ComboBox(items).Placeholder("...").Editable()
+ComboBox(items).Placeholder("...").IsEditable()
 NumberBox(v).Range(0, 100).SpinButtons()
 Slider(v, 0, 100).StepFrequency(5)
-RatingControl(3).MaxRating(10).ReadOnly()
-InfoBar("T", "M").Severity(InfoBarSeverity.Warning).Closable(false)
+RatingControl(3).MaxRating(10).IsReadOnly()
+InfoBar("T", "M").Severity(InfoBarSeverity.Warning).IsClosable(false)
 NavigationView(items, c).PaneDisplayMode(...).PaneTitle("...")
 TitleBar("App").Subtitle("Home")
 Expander("Hdr", body).Direction(ExpandDirection.Up)
 PersonPicture().DisplayName("John Doe").Initials("JD")
 ListView(items).SelectionMode(ListViewSelectionMode.Multiple)
-TabView(tabs).ShowAddButton()
-ProgressRing().Active(active)
+TabView(tabs).IsAddTabButtonVisible()
+ProgressRing().IsActive(active)
 RepeatButton("Go", fn).Delay(d).Interval(i)
 Rectangle().Fill(brush) / Ellipse().Fill(brush)
-Popup(c, open).LightDismiss(true).Offset(h, v)
+Popup(c, open).IsLightDismissEnabled(true).Offset(h, v)
 ScrollView(c).ZoomMode(...).HorizontalScrollMode(...).VerticalScrollMode(...)
 TextField(v, setV).Header("...")
 element.WithKey("stable-id")  // always last

--- a/skills/forms.md
+++ b/skills/forms.md
@@ -37,7 +37,7 @@ return VStack(12,
     TextField(name, setName, placeholder: "Name"),
     NumberBox(age, setAge),
     CheckBox("I agree", agreed, setAgreed),
-    Button("Submit", onSubmit).Disabled(string.IsNullOrEmpty(name) || !agreed)
+    Button("Submit", onSubmit).IsEnabled(!(string.IsNullOrEmpty(name) || !agreed))
 );
 ```
 
@@ -69,7 +69,7 @@ var isValid = email.Contains('@') && email.Length > 3;
 
 return VStack(12,
     TextField(email, setEmail, placeholder: "Email"),
-    Button("Submit", onSubmit).Disabled(!isValid)
+    Button("Submit", onSubmit).IsEnabled(isValid)
 );
 ```
 

--- a/skills/navigation.md
+++ b/skills/navigation.md
@@ -60,7 +60,7 @@ class App : Component
             HStack(8,
                 Button("Home", () => nav.Navigate(Route.Home)),
                 Button("Settings", () => nav.Navigate(Route.Settings)),
-                Button("Back", () => nav.GoBack()).Disabled(!nav.CanGoBack)
+                Button("Back", () => nav.GoBack()).IsEnabled(nav.CanGoBack)
             ),
             NavigationHost(nav, route => route switch
             {

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -209,7 +209,7 @@ BreadcrumbBarElement.ItemClicked(Action<BreadcrumbBarItemData> handler) → Brea
 BreadcrumbBarElement.Set(Action<BreadcrumbBar> configure) → BreadcrumbBarElement
 ButtonElement.AccentButton() → ButtonElement
 ButtonElement.Click(Action handler) → ButtonElement
-ButtonElement.DisabledFocusable(bool disabled = true) → ButtonElement
+ButtonElement.IsDisabledFocusable(bool disabled = true) → ButtonElement
 ButtonElement.Set(Action<Button> configure) → ButtonElement
 ButtonElement.SubtleButton() → ButtonElement
 ButtonElement.TextLink() → ButtonElement
@@ -246,7 +246,7 @@ ColorPickerElement.ValueRange(int minValue, int maxValue) → ColorPickerElement
 ComboBoxElement.Description(string description) → ComboBoxElement
 ComboBoxElement.DropDownClosed(Action handler) → ComboBoxElement
 ComboBoxElement.DropDownOpened(Action handler) → ComboBoxElement
-ComboBoxElement.Editable(bool editable = true) → ComboBoxElement
+ComboBoxElement.IsEditable(bool editable = true) → ComboBoxElement
 ComboBoxElement.Header(string header) → ComboBoxElement
 ComboBoxElement.MaxDropDownHeight(double height) → ComboBoxElement
 ComboBoxElement.Placeholder(string text) → ComboBoxElement
@@ -311,7 +311,7 @@ ImageElement.NineGrid(Thickness nineGrid) → ImageElement
 ImageElement.Set(Action<Image> configure) → ImageElement
 InfoBadgeElement.Set(Action<InfoBadge> configure) → InfoBadgeElement
 InfoBarElement.ActionButtonClick(Action handler) → InfoBarElement
-InfoBarElement.Closable(bool closable = true) → InfoBarElement
+InfoBarElement.IsClosable(bool closable = true) → InfoBarElement
 InfoBarElement.Closed(Action handler) → InfoBarElement
 InfoBarElement.Content(Element content) → InfoBarElement
 InfoBarElement.Error() → InfoBarElement
@@ -404,12 +404,12 @@ PipsPagerElement.WrapMode(PipsPagerWrapMode mode) → PipsPagerElement
 PivotElement.SelectedIndexChanged(Action<int> handler) → PivotElement
 PivotElement.Set(Action<Pivot> configure) → PivotElement
 PopupElement.Closed(Action handler) → PopupElement
-PopupElement.LightDismiss(bool enabled = true) → PopupElement
+PopupElement.IsLightDismissEnabled(bool enabled = true) → PopupElement
 PopupElement.Offset(double horizontal, double vertical) → PopupElement
 PopupElement.Opened(Action handler) → PopupElement
 PopupElement.Set(Action<Popup> configure) → PopupElement
 ProgressElement.Set(Action<ProgressBar> configure) → ProgressElement
-ProgressRingElement.Active(bool active = true) → ProgressRingElement
+ProgressRingElement.IsActive(bool active = true) → ProgressRingElement
 ProgressRingElement.Set(Action<ProgressRing> configure) → ProgressRingElement
 PropertyGridElement.RootChanged(Action<object> handler) → PropertyGridElement
 RadioButtonElement.IsCheckedChanged(Action<bool> handler) → RadioButtonElement
@@ -420,7 +420,7 @@ RatingControlElement.Caption(string caption) → RatingControlElement
 RatingControlElement.InitialSetValue(int value) → RatingControlElement
 RatingControlElement.MaxRating(int max) → RatingControlElement
 RatingControlElement.PlaceholderValue(double value) → RatingControlElement
-RatingControlElement.ReadOnly(bool readOnly = true) → RatingControlElement
+RatingControlElement.IsReadOnly(bool readOnly = true) → RatingControlElement
 RatingControlElement.Set(Action<RatingControl> configure) → RatingControlElement
 RatingControlElement.ValueChanged(Action<double> handler) → RatingControlElement
 RectangleElement.Fill(Brush brush) → RectangleElement
@@ -499,7 +499,7 @@ T.CenterPoint<T>(Vector3 center) → T
 T.ConnectedAnimation<T>(string key) → T
 T.CornerRadius<T>(double radius) → T
 T.CornerRadius<T>(double topLeft, double topRight, double bottomRight, double bottomLeft) → T
-T.Disabled<T>(bool disabled = true) → T
+T.IsEnabled<T>(bool enabled = true) → T
 T.DraggableWhen<T>(Func<bool> canDrag) → T
 T.Flex<T>(double grow = 0, double shrink = 1, double? basis = null, FlexAlign? alignSelf = null, FlexPositionType position = FlexPositionType.Relative, double? left = null, double? top = null, double? right = null, double? bottom = null) → T
 T.FocusMeta<T>(FocusManager fm, string fieldName, bool autoFocus = false) → T
@@ -619,7 +619,7 @@ T.Validate<T>(string fieldName, object value, IValidator[] validators) → T
 T.ValidateAsync<T>(string fieldName, IAsyncValidator[] asyncValidators) → T
 T.ValidateAsync<T>(string fieldName, object value, IAsyncValidator[] asyncValidators) → T
 T.VerticalAlignment<T>(VerticalAlignment alignment) → T
-T.Visible<T>(bool isVisible) → T
+T.IsVisible<T>(bool isVisible) → T
 T.Width<T>(double width) → T
 T.WithBorder<T>(Brush brush, double thickness = 1) → T
 T.WithBorder<T>(ThemeRef theme, double thickness = 1) → T
@@ -641,7 +641,7 @@ TabViewElement.CanReorderTabs(bool canReorder = true) → TabViewElement
 TabViewElement.CloseButtonOverlayMode(TabViewCloseButtonOverlayMode mode) → TabViewElement
 TabViewElement.SelectedIndexChanged(Action<int> handler) → TabViewElement
 TabViewElement.Set(Action<TabView> configure) → TabViewElement
-TabViewElement.ShowAddButton(bool visible = true) → TabViewElement
+TabViewElement.IsAddTabButtonVisible(bool visible = true) → TabViewElement
 TabViewElement.TabCloseRequested(Action<int> handler) → TabViewElement
 TabViewElement.TabStripFooter(Element footer) → TabViewElement
 TabViewElement.TabStripHeader(Element header) → TabViewElement
@@ -671,7 +671,7 @@ TextBlockElement.FontSize(double size) → TextBlockElement
 TextBlockElement.FontStyle(FontStyle style) → TextBlockElement
 TextBlockElement.LineHeight(double height) → TextBlockElement
 TextBlockElement.MaxLines(int maxLines) → TextBlockElement
-TextBlockElement.Selectable(bool selectable = true) → TextBlockElement
+TextBlockElement.IsTextSelectionEnabled(bool enabled = true) → TextBlockElement
 TextBlockElement.SemiBold() → TextBlockElement
 TextBlockElement.Set(Action<TextBlock> configure) → TextBlockElement
 TextBlockElement.TextAlignment(TextAlignment alignment) → TextBlockElement
@@ -690,7 +690,7 @@ TextFieldElement.IsSpellCheckEnabled(bool enabled = true) → TextFieldElement
 TextFieldElement.MaxLength(int maxLength) → TextFieldElement
 TextFieldElement.NumericInput() → TextFieldElement
 TextFieldElement.PhoneInput() → TextFieldElement
-TextFieldElement.ReadOnly(bool readOnly = true) → TextFieldElement
+TextFieldElement.IsReadOnly(bool readOnly = true) → TextFieldElement
 TextFieldElement.SearchInput() → TextFieldElement
 TextFieldElement.SelectionChanged(Action<string, int, int> handler) → TextFieldElement
 TextFieldElement.Set(Action<TextBox> configure) → TextFieldElement

--- a/src/Reactor/Charting/Accessibility/ChartAlternateViewWrapper.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAlternateViewWrapper.cs
@@ -62,8 +62,8 @@ internal static class ChartAlternateViewWrapper
                 : "Showing chart";
 
             return Factories.VStack(
-                chart.Visible(!isShowingAlternate),
-                alternate.Visible(isShowingAlternate),
+                chart.IsVisible(!isShowingAlternate),
+                alternate.IsVisible(isShowingAlternate),
                 // Visually hidden text block for live-region announcement.
                 // Uses 1×1 size at far offscreen position instead of zero-size,
                 // because some screen readers skip zero-dimension elements.

--- a/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
+++ b/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
@@ -269,9 +269,9 @@ public class PropertyGridComponent : Component<PropertyGridElement>
     private static Element RenderReadOnlyValue(object? value, Type type)
     {
         if (type == typeof(bool))
-            return ToggleSwitch((bool)(value ?? false), null).Disabled();
+            return ToggleSwitch((bool)(value ?? false), null).IsEnabled(false);
         if (type == typeof(string))
-            return TextField((string)(value ?? ""), null).Disabled();
+            return TextField((string)(value ?? ""), null).IsEnabled(false);
         return TextBlock(value?.ToString() ?? "(null)");
     }
 

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1417,7 +1417,10 @@ public static partial class ElementExtensions
 
     // ── TabView sugar ───────────────────────────────────────────────
 
-    public static TabViewElement ShowAddButton(this TabViewElement el, bool visible = true) =>
+    /// <summary>
+    /// Controls visibility of the "add tab" button in a TabView.
+    /// </summary>
+    public static TabViewElement IsAddButtonVisible(this TabViewElement el, bool visible = true) =>
         el with { IsAddTabButtonVisible = visible };
 
     /// <summary>Controls how tab widths are sized (Equal, SizeToContent, Compact).</summary>
@@ -1448,6 +1451,10 @@ public static partial class ElementExtensions
     public static TabViewElement TabStripFooter(this TabViewElement el, Element footer) =>
         el with { TabStripFooter = footer };
 
+    /// <inheritdoc cref="IsAddButtonVisible"/>
+    [Obsolete("Use IsAddButtonVisible() — imperative 'Show*' naming is deprecated (see #268).")]
+    public static TabViewElement ShowAddButton(this TabViewElement el, bool visible = true) =>
+        el.IsAddButtonVisible(visible);
     // ── Key ─────────────────────────────────────────────────────────
 
     public static T WithKey<T>(this T el, string key) where T : Element =>

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -150,8 +150,14 @@ public static partial class ElementExtensions
 
     // ── Visibility ──────────────────────────────────────────────────
 
-    public static T Visible<T>(this T el, bool isVisible) where T : Element =>
+    /// <summary>Sets whether the element is visible or collapsed.</summary>
+    public static T IsVisible<T>(this T el, bool isVisible) where T : Element =>
         Modify(el, new ElementModifiers { IsVisible = isVisible });
+
+    /// <inheritdoc cref="IsVisible{T}(T, bool)"/>
+    [Obsolete("Use IsVisible() — aligns with WinUI boolean modifier naming (see #268).")]
+    public static T Visible<T>(this T el, bool isVisible) where T : Element =>
+        el.IsVisible(isVisible);
 
     public static T Opacity<T>(this T el, double opacity) where T : Element =>
         Modify(el, new ElementModifiers { Opacity = opacity });
@@ -560,8 +566,14 @@ public static partial class ElementExtensions
     public static TextBlockElement TextTrimming(this TextBlockElement el, TextTrimming trimming) =>
         el with { TextTrimming = trimming };
 
+    /// <summary>Controls whether text can be selected in a TextBlock.</summary>
+    public static TextBlockElement IsTextSelectionEnabled(this TextBlockElement el, bool enabled = true) =>
+        el with { IsTextSelectionEnabled = enabled };
+
+    /// <inheritdoc cref="IsTextSelectionEnabled"/>
+    [Obsolete("Use IsTextSelectionEnabled() — aligns with WinUI naming (see #268).")]
     public static TextBlockElement Selectable(this TextBlockElement el, bool selectable = true) =>
-        el with { IsTextSelectionEnabled = selectable };
+        el.IsTextSelectionEnabled(selectable);
 
     public static TextBlockElement FontFamily(this TextBlockElement el, string family) =>
         el with { FontFamily = WinRTCache.GetFontFamily(family) };
@@ -631,8 +643,14 @@ public static partial class ElementExtensions
 
     // ── TextField sugar ────────────────────────────────────────────────
 
-    public static TextFieldElement ReadOnly(this TextFieldElement el, bool readOnly = true) =>
+    /// <summary>Sets whether the text field is read-only.</summary>
+    public static TextFieldElement IsReadOnly(this TextFieldElement el, bool readOnly = true) =>
         el with { IsReadOnly = readOnly };
+
+    /// <inheritdoc cref="IsReadOnly(TextFieldElement, bool)"/>
+    [Obsolete("Use IsReadOnly() — aligns with WinUI naming (see #268).")]
+    public static TextFieldElement ReadOnly(this TextFieldElement el, bool readOnly = true) =>
+        el.IsReadOnly(readOnly);
 
     public static TextFieldElement AcceptsReturn(this TextFieldElement el, bool accepts = true) =>
         el with { AcceptsReturn = accepts };
@@ -743,13 +761,19 @@ public static partial class ElementExtensions
 
     // ── IsEnabled (on Control — works on buttons, inputs, etc.) ────
 
+    /// <summary>Sets Control.IsEnabled.</summary>
+    public static T IsEnabled<T>(this T el, bool enabled = true) where T : Element =>
+        Modify(el, new ElementModifiers { IsEnabled = enabled });
+
+    /// <inheritdoc cref="IsEnabled{T}(T, bool)"/>
+    [Obsolete("Use IsEnabled(false) — aligns with WinUI naming (see #268).")]
     public static T Disabled<T>(this T el, bool disabled = true) where T : Element =>
-        Modify(el, new ElementModifiers { IsEnabled = !disabled });
+        el.IsEnabled(!disabled);
 
     /// <summary>
     /// Keeps the button keyboard-focusable while presenting it as disabled
     /// (visually dimmed, click suppressed). Use for submit buttons gated on
-    /// validation: a true <c>.Disabled(true)</c> removes the button from tab
+    /// validation: a true <c>.IsEnabled(false)</c> removes the button from tab
     /// order, which combined with commit-on-blur inputs like NumberBox/
     /// DatePicker produces a focus trap where Tab skips a Submit that is
     /// *about* to become valid. Conceptually the Fluent UI React
@@ -757,8 +781,13 @@ public static partial class ElementExtensions
     /// sees the button as enabled (a custom AutomationPeer override for full
     /// AT "unavailable" reporting is a tracked follow-up).
     /// </summary>
-    public static ButtonElement DisabledFocusable(this ButtonElement el, bool disabled = true) =>
+    public static ButtonElement IsDisabledFocusable(this ButtonElement el, bool disabled = true) =>
         el with { IsDisabledFocusable = disabled };
+
+    /// <inheritdoc cref="IsDisabledFocusable"/>
+    [Obsolete("Use IsDisabledFocusable() — aligns with WinUI naming (see #268).")]
+    public static ButtonElement DisabledFocusable(this ButtonElement el, bool disabled = true) =>
+        el.IsDisabledFocusable(disabled);
 
     // ── Background (Panel, Control, Border) ────────────────────────
 
@@ -896,8 +925,14 @@ public static partial class ElementExtensions
     public static ComboBoxElement Placeholder(this ComboBoxElement el, string text) =>
         el with { PlaceholderText = text };
 
-    public static ComboBoxElement Editable(this ComboBoxElement el, bool editable = true) =>
+    /// <summary>Sets whether the ComboBox is editable.</summary>
+    public static ComboBoxElement IsEditable(this ComboBoxElement el, bool editable = true) =>
         el with { IsEditable = editable };
+
+    /// <inheritdoc cref="IsEditable"/>
+    [Obsolete("Use IsEditable() — aligns with WinUI naming (see #268).")]
+    public static ComboBoxElement Editable(this ComboBoxElement el, bool editable = true) =>
+        el.IsEditable(editable);
 
     public static ComboBoxElement Header(this ComboBoxElement el, string header) =>
         el with { Header = header };
@@ -1042,7 +1077,8 @@ public static partial class ElementExtensions
     public static RatingControlElement MaxRating(this RatingControlElement el, int max) =>
         el with { MaxRating = max };
 
-    public static RatingControlElement ReadOnly(this RatingControlElement el, bool readOnly = true) =>
+    /// <summary>Sets whether the RatingControl is read-only.</summary>
+    public static RatingControlElement IsReadOnly(this RatingControlElement el, bool readOnly = true) =>
         el with { IsReadOnly = readOnly };
 
     /// <summary>Promotes the existing <c>Caption</c> init property to a fluent.</summary>
@@ -1133,12 +1169,17 @@ public static partial class ElementExtensions
     public static ColorPickerElement ValueRange(this ColorPickerElement el, int minValue, int maxValue) =>
         el with { MinValue = minValue, MaxValue = maxValue };
 
+    /// <inheritdoc cref="IsReadOnly(RatingControlElement, bool)"/>
+    [Obsolete("Use IsReadOnly() — aligns with WinUI naming (see #268).")]
+    public static RatingControlElement ReadOnly(this RatingControlElement el, bool readOnly = true) =>
+        el.IsReadOnly(readOnly);
     // ── InfoBar sugar ───────────────────────────────────────────────
 
     public static InfoBarElement Severity(this InfoBarElement el, InfoBarSeverity severity) =>
         el with { Severity = severity };
 
-    public static InfoBarElement Closable(this InfoBarElement el, bool closable = true) =>
+    /// <summary>Sets whether the InfoBar can be closed by the user.</summary>
+    public static InfoBarElement IsClosable(this InfoBarElement el, bool closable = true) =>
         el with { IsClosable = closable };
 
     /// <summary>Custom icon source (overrides the severity-default icon).</summary>
@@ -1266,6 +1307,10 @@ public static partial class ElementExtensions
             ColumnSpan: existing?.ColumnSpan ?? 1));
     }
 
+    /// <inheritdoc cref="IsClosable"/>
+    [Obsolete("Use IsClosable() — aligns with WinUI naming (see #268).")]
+    public static InfoBarElement Closable(this InfoBarElement el, bool closable = true) =>
+        el.IsClosable(closable);
     // ── NavigationView sugar ────────────────────────────────────────
 
     public static NavigationViewElement PaneDisplayMode(this NavigationViewElement el, NavigationViewPaneDisplayMode mode) =>
@@ -1396,8 +1441,14 @@ public static partial class ElementExtensions
 
     // ── ProgressRing sugar ──────────────────────────────────────────
 
-    public static ProgressRingElement Active(this ProgressRingElement el, bool active = true) =>
+    /// <summary>Sets whether the ProgressRing is active (spinning).</summary>
+    public static ProgressRingElement IsActive(this ProgressRingElement el, bool active = true) =>
         el with { IsActive = active };
+
+    /// <inheritdoc cref="IsActive"/>
+    [Obsolete("Use IsActive() — aligns with WinUI naming (see #268).")]
+    public static ProgressRingElement Active(this ProgressRingElement el, bool active = true) =>
+        el.IsActive(active);
 
     // ── PersonPicture sugar ─────────────────────────────────────────
 
@@ -1420,7 +1471,7 @@ public static partial class ElementExtensions
     /// <summary>
     /// Controls visibility of the "add tab" button in a TabView.
     /// </summary>
-    public static TabViewElement IsAddButtonVisible(this TabViewElement el, bool visible = true) =>
+    public static TabViewElement IsAddTabButtonVisible(this TabViewElement el, bool visible = true) =>
         el with { IsAddTabButtonVisible = visible };
 
     /// <summary>Controls how tab widths are sized (Equal, SizeToContent, Compact).</summary>
@@ -1451,10 +1502,15 @@ public static partial class ElementExtensions
     public static TabViewElement TabStripFooter(this TabViewElement el, Element footer) =>
         el with { TabStripFooter = footer };
 
-    /// <inheritdoc cref="IsAddButtonVisible"/>
-    [Obsolete("Use IsAddButtonVisible() — imperative 'Show*' naming is deprecated (see #268).")]
+    /// <inheritdoc cref="IsAddTabButtonVisible"/>
+    [Obsolete("Use IsAddTabButtonVisible() — aligns with WinUI naming (see #268).")]
+    public static TabViewElement IsAddButtonVisible(this TabViewElement el, bool visible = true) =>
+        el.IsAddTabButtonVisible(visible);
+
+    /// <inheritdoc cref="IsAddTabButtonVisible"/>
+    [Obsolete("Use IsAddTabButtonVisible() — aligns with WinUI naming (see #268).")]
     public static TabViewElement ShowAddButton(this TabViewElement el, bool visible = true) =>
-        el.IsAddButtonVisible(visible);
+        el.IsAddTabButtonVisible(visible);
     // ── Key ─────────────────────────────────────────────────────────
 
     public static T WithKey<T>(this T el, string key) where T : Element =>
@@ -1788,8 +1844,14 @@ public static partial class ElementExtensions
 
     // ── Popup convenience modifiers ─────────────────────────────────
 
-    public static PopupElement LightDismiss(this PopupElement el, bool enabled = true) =>
+    /// <summary>Sets whether the Popup closes on outside interaction.</summary>
+    public static PopupElement IsLightDismissEnabled(this PopupElement el, bool enabled = true) =>
         el with { IsLightDismissEnabled = enabled };
+
+    /// <inheritdoc cref="IsLightDismissEnabled"/>
+    [Obsolete("Use IsLightDismissEnabled() — aligns with WinUI naming (see #268).")]
+    public static PopupElement LightDismiss(this PopupElement el, bool enabled = true) =>
+        el.IsLightDismissEnabled(enabled);
 
     public static PopupElement Offset(this PopupElement el, double horizontal, double vertical) =>
         el with { HorizontalOffset = horizontal, VerticalOffset = vertical };

--- a/src/Reactor/Hooks/Pending.cs
+++ b/src/Reactor/Hooks/Pending.cs
@@ -67,8 +67,8 @@ public sealed class PendingComponent : Component<PendingProps>
         return Microsoft.UI.Reactor.Factories.Grid(
             columns: new[] { Microsoft.UI.Reactor.GridSize.Star() },
             rows: new[] { Microsoft.UI.Reactor.GridSize.Star() },
-            Props.Child.Visible(!showFallback),
-            Props.Fallback.Visible(showFallback))
+            Props.Child.IsVisible(!showFallback),
+            Props.Fallback.IsVisible(showFallback))
             .Provide(AppContexts.PendingScope, (PendingScope?)scope);
     }
 

--- a/tests/Reactor.AppTests.Host/Fixtures/DemoFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/DemoFixtures.cs
@@ -22,7 +22,7 @@ internal static class DemoFixtures
                 HStack(8,
                     Button("-1", () => setCount(count - 1)).AutomationId("DecrementBtn"),
                     Button("Reset", () => setCount(0))
-                        .Disabled(count == 0)
+                        .IsEnabled(!(count == 0))
                         .AutomationId("ResetBtn"),
                     Button("+1", () => setCount(count + 1)).AutomationId("IncrementBtn")
                 ),
@@ -80,11 +80,11 @@ internal static class DemoFixtures
             return VStack(12,
                 HStack(8,
                     Button("Home", () => setTab("Home"))
-                        .Disabled(tab == "Home").AutomationId("DemoHomeTab"),
+                        .IsEnabled(!(tab == "Home")).AutomationId("DemoHomeTab"),
                     Button("Settings", () => setTab("Settings"))
-                        .Disabled(tab == "Settings").AutomationId("DemoSettingsTab"),
+                        .IsEnabled(!(tab == "Settings")).AutomationId("DemoSettingsTab"),
                     Button("About", () => setTab("About"))
-                        .Disabled(tab == "About").AutomationId("DemoAboutTab")
+                        .IsEnabled(!(tab == "About")).AutomationId("DemoAboutTab")
                 ),
                 Border(
                     tab switch

--- a/tests/Reactor.AppTests.Host/Fixtures/ImmediateAndDisabledFocusableFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/ImmediateAndDisabledFocusableFixtures.cs
@@ -7,7 +7,7 @@ namespace Microsoft.UI.Reactor.AppTests.Host.Fixtures;
 
 /// <summary>
 /// TestHost fixture for the validation pit-of-success APIs (NumberBox
-/// .Immediate() and Button .DisabledFocusable()). Drives the Appium tier in
+/// .Immediate() and Button .IsDisabledFocusable()). Drives the Appium tier in
 /// <c>Reactor.AppTests.Tests.ImmediateAndDisabledFocusableTests</c> with real
 /// keystroke input so we cover the real-typing path that the in-process self-
 /// tests cannot reach (programmatic <c>NumberBox.Text =</c> also commits Value,
@@ -56,7 +56,7 @@ internal static class ImmediateAndDisabledFocusableFixtures
                     .AutomationId("ValImmediate_FireCount"),
 
                 Button("Submit", () => setSubmitCount(submitCount + 1))
-                    .DisabledFocusable(!formValid)
+                    .IsDisabledFocusable(!formValid)
                     .AutomationId("ValImmediate_Submit"),
 
                 TextBlock($"Submits: {submitCount}")

--- a/tests/Reactor.AppTests.Host/Fixtures/LocalizationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/LocalizationFixtures.cs
@@ -127,7 +127,7 @@ internal static class LocalizationFixtures
                 HStack(4,
                     languages.Select(lang =>
                         Button(lang, () => setLocale(lang))
-                            .Disabled(locale == lang)
+                            .IsEnabled(!(locale == lang))
                             .AutomationId($"Lang_{lang}")
                     ).ToArray()
                 ),

--- a/tests/Reactor.AppTests.Host/Fixtures/NavigationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/NavigationFixtures.cs
@@ -18,11 +18,11 @@ internal static class NavigationFixtures
             return VStack(
                 HStack(
                     Button("Home", () => setTab("Home"))
-                        .Disabled(tab == "Home").AutomationId("HomeTab"),
+                        .IsEnabled(!(tab == "Home")).AutomationId("HomeTab"),
                     Button("Settings", () => setTab("Settings"))
-                        .Disabled(tab == "Settings").AutomationId("SettingsTab"),
+                        .IsEnabled(!(tab == "Settings")).AutomationId("SettingsTab"),
                     Button("About", () => setTab("About"))
-                        .Disabled(tab == "About").AutomationId("AboutTab")
+                        .IsEnabled(!(tab == "About")).AutomationId("AboutTab")
                 ),
                 Border(
                     tab switch
@@ -63,7 +63,7 @@ internal static class NavigationFixtures
             return VStack(
                 HStack(8,
                     Button("Back", () => nav.GoBack())
-                        .Disabled(!nav.CanGoBack)
+                        .IsEnabled(nav.CanGoBack)
                         .AutomationId("BackBtn"),
                     TextBlock($"Depth: {nav.Depth}").AutomationId("NavDepth")
                 ),

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ImmediateAndDisabledFocusableFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ImmediateAndDisabledFocusableFixtures.cs
@@ -16,7 +16,7 @@ namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 ///    level behavior under real input is verified in the Appium tier
 ///    (Reactor.AppTests); this fixture only validates wiring and marker
 ///    propagation.
-///  • Button .DisabledFocusable() — keeps the button keyboard-focusable
+///  • Button .IsDisabledFocusable() — keeps the button keyboard-focusable
 ///    while visually dimmed and dropping invokes via the Click trampoline.
 ///    UIA still reports the button as enabled (a full assistive-tech
 ///    "unavailable" signal would require a custom AutomationPeer override
@@ -72,7 +72,7 @@ internal static class ImmediateAndDisabledFocusableFixtures
 
 
     // ════════════════════════════════════════════════════════════════════════
-    //  Button.DisabledFocusable()
+    //  Button.IsDisabledFocusable()
     // ════════════════════════════════════════════════════════════════════════
 
     internal class ButtonDisabledFocusableState(Harness h) : SelfTestFixtureBase(h)
@@ -84,7 +84,7 @@ internal static class ImmediateAndDisabledFocusableFixtures
             var host = H.CreateHost();
             host.Mount(_ => VStack(
                 Button("Submit", () => clicks++)
-                    .DisabledFocusable()
+                    .IsDisabledFocusable()
                     .Set(b => b.Name = "btnDF")
             ));
             await Harness.Render();
@@ -119,7 +119,7 @@ internal static class ImmediateAndDisabledFocusableFixtures
             var host = H.CreateHost();
             host.Mount(_ => VStack(
                 Button("Submit", () => clicks++)
-                    .DisabledFocusable(disabledFocusable)
+                    .IsDisabledFocusable(disabledFocusable)
                     .Set(b => b.Name = "btnDFT")
             ));
             await Harness.Render();
@@ -134,7 +134,7 @@ internal static class ImmediateAndDisabledFocusableFixtures
             disabledFocusable = false;
             host.Mount(_ => VStack(
                 Button("Submit", () => clicks++)
-                    .DisabledFocusable(disabledFocusable)
+                    .IsDisabledFocusable(disabledFocusable)
                     .Set(b => b.Name = "btnDFT")
             ));
             await Harness.Render();

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/LocalizationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/LocalizationFixtures.cs
@@ -133,7 +133,7 @@ internal static class LocalizationFixtures
                     HStack(4,
                         languages.Select(lang =>
                             Button(lang, () => setLocale(lang))
-                                .Disabled(locale == lang)).ToArray()
+                                .IsEnabled(!(locale == lang))).ToArray()
                     ),
 
                     VStack(8,

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationFixtures.cs
@@ -23,11 +23,11 @@ internal static class NavigationFixtures
                 return VStack(
                     HStack(
                         Button("Home", () => setTab("Home"))
-                            .Disabled(tab == "Home"),
+                            .IsEnabled(!(tab == "Home")),
                         Button("Settings", () => setTab("Settings"))
-                            .Disabled(tab == "Settings"),
+                            .IsEnabled(!(tab == "Settings")),
                         Button("About", () => setTab("About"))
-                            .Disabled(tab == "About")
+                            .IsEnabled(!(tab == "About"))
                     ),
                     Border(
                         tab switch

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -733,7 +733,7 @@ internal static class SelfTestFixtureRegistry
         "ValueEvt_PasswordBox",
         "ValueEvt_ColorPicker",
 
-        // Validation pit-of-success: NumberBox.Immediate() + Button.DisabledFocusable()
+        // Validation pit-of-success: NumberBox.Immediate() + Button.IsDisabledFocusable()
         // Keystroke-level coverage lives in Reactor.AppTests (Appium tier).
         "Immediate_NumberBoxFiresOnTextChange",
         "DisabledFocusable_ButtonState",

--- a/tests/Reactor.AppTests/Tests/ImmediateAndDisabledFocusableTests.cs
+++ b/tests/Reactor.AppTests/Tests/ImmediateAndDisabledFocusableTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.UI.Reactor.AppTests.Tests;
 /// E2E coverage for the validation pit-of-success APIs:
 ///  • <c>NumberBox.Immediate()</c> — fires <c>OnValueChanged</c> on every
 ///    parseable keystroke instead of waiting for blur/Enter/spin.
-///  • <c>Button.DisabledFocusable()</c> — keeps Submit in the keyboard tab
+///  • <c>Button.IsDisabledFocusable()</c> — keeps Submit in the keyboard tab
 ///    order while dimmed, and drops the user <c>OnClick</c> when active so
 ///    invalid submits are suppressed.
 ///
@@ -125,7 +125,7 @@ public class ImmediateAndDisabledFocusableTests : AppTestBase
 
         // Clicking the dimmed Submit should NOT increment the counter —
         // the trampoline drops the invoke. (Without DisabledFocusable,
-        // .Disabled(true) would make the click target unreachable; with
+        // .IsEnabled(false) would make the click target unreachable; with
         // it, the click reaches the trampoline but is suppressed there.)
         var submit = FindById("ValImmediate_Submit");
         submit.Click();

--- a/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
@@ -378,7 +378,15 @@ public class ElementExtensionsCoverageTests
     }
 
     [Fact]
-    public void TabView_ShowAddButton_Sugar()
+    public void TabView_IsAddButtonVisible_Sugar()
+    {
+        var el = TabView([]).IsAddButtonVisible(false);
+        Assert.False(el.IsAddTabButtonVisible);
+    }
+
+    [Fact]
+    [Obsolete("Tests the deprecated ShowAddButton shim")]
+    public void TabView_ShowAddButton_Sugar_Obsolete_Shim()
     {
         var el = TabView([]).ShowAddButton(false);
         Assert.False(el.IsAddTabButtonVisible);

--- a/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
@@ -110,7 +110,7 @@ public class ElementExtensionsCoverageTests
     {
         var v3 = new global::System.Numerics.Vector3(2, 3, 4);
         var el = TextBlock("x")
-            .Visible(false)
+            .IsVisible(false)
             .Opacity(0.5)
             .Scale(2.0f)
             .Scale(v3)
@@ -181,7 +181,7 @@ public class ElementExtensionsCoverageTests
     }
 
     // ────────────────────────────────────────────────────────────────
-    //  CornerRadius / Disabled
+    //  CornerRadius / IsEnabled
     // ────────────────────────────────────────────────────────────────
 
     [Fact]
@@ -194,7 +194,17 @@ public class ElementExtensionsCoverageTests
     }
 
     [Fact]
-    public void Disabled_Inverts_To_IsEnabled()
+    public void IsEnabled_Sets_Modifier()
+    {
+        var el = Button("Y").IsEnabled(false);
+        Assert.False(el.Modifiers!.IsEnabled);
+        var enabled = Button("Y").IsEnabled();
+        Assert.True(enabled.Modifiers!.IsEnabled);
+    }
+
+    [Fact]
+    [Obsolete("Tests the deprecated Disabled shim")]
+    public void Disabled_Shim_Inverts_To_IsEnabled()
     {
         var el = Button("Y").Disabled();
         Assert.False(el.Modifiers!.IsEnabled);
@@ -216,7 +226,7 @@ public class ElementExtensionsCoverageTests
             .TextWrapping()
             .TextAlignment(TextAlignment.Center)
             .TextTrimming(TextTrimming.CharacterEllipsis)
-            .Selectable();
+            .IsTextSelectionEnabled();
         Assert.Equal(14.0, el.FontSize);
         Assert.Equal(global::Microsoft.UI.Xaml.TextWrapping.Wrap, el.TextWrapping);
         Assert.Equal(TextAlignment.Center, el.TextAlignment);
@@ -225,10 +235,18 @@ public class ElementExtensionsCoverageTests
     }
 
     [Fact]
+    [Obsolete("Tests the deprecated Selectable shim")]
+    public void TextBlock_Selectable_Shim()
+    {
+        var el = TextBlock("x").Selectable();
+        Assert.True(el.IsTextSelectionEnabled);
+    }
+
+    [Fact]
     public void TextField_Sugar()
     {
         var el = TextField("x", _ => { })
-            .ReadOnly()
+            .IsReadOnly()
             .AcceptsReturn()
             .TextWrapping()
             .Header("Label");
@@ -241,9 +259,17 @@ public class ElementExtensionsCoverageTests
     // Path.StrokeDashArray uses DoubleCollection (WinUI), tested in selftest.
 
     [Fact]
-    public void Popup_Sugar_LightDismiss_And_Offset()
+    [Obsolete("Tests the deprecated ReadOnly shim for TextField")]
+    public void TextField_ReadOnly_Shim()
     {
-        var el = Popup(TextBlock("x")).LightDismiss().Offset(10, 20);
+        var el = TextField("x", _ => { }).ReadOnly();
+        Assert.True(el.IsReadOnly);
+    }
+
+    [Fact]
+    public void Popup_Sugar_IsLightDismissEnabled_And_Offset()
+    {
+        var el = Popup(TextBlock("x")).IsLightDismissEnabled().Offset(10, 20);
         Assert.True(el.IsLightDismissEnabled);
         Assert.Equal(10, el.HorizontalOffset);
         Assert.Equal(20, el.VerticalOffset);
@@ -276,11 +302,19 @@ public class ElementExtensionsCoverageTests
     {
         var el = ComboBox(new string[] { "a", "b" }, 0, _ => { })
             .Placeholder("Pick…")
-            .Editable()
+            .IsEditable()
             .Header("Lbl");
         Assert.Equal("Pick…", el.PlaceholderText);
         Assert.True(el.IsEditable);
         Assert.Equal("Lbl", el.Header);
+    }
+
+    [Fact]
+    [Obsolete("Tests the deprecated Editable shim")]
+    public void ComboBox_Editable_Shim()
+    {
+        var el = ComboBox(new string[] { "a" }, 0, _ => { }).Editable();
+        Assert.True(el.IsEditable);
     }
 
     [Fact]
@@ -308,18 +342,34 @@ public class ElementExtensionsCoverageTests
     }
 
     [Fact]
-    public void RatingControl_MaxRating_And_ReadOnly()
+    public void RatingControl_MaxRating_And_IsReadOnly()
     {
-        var el = RatingControl(0, _ => { }).MaxRating(10).ReadOnly();
+        var el = RatingControl(0, _ => { }).MaxRating(10).IsReadOnly();
         Assert.Equal(10, el.MaxRating);
         Assert.True(el.IsReadOnly);
     }
 
     [Fact]
-    public void InfoBar_Severity_And_Closable()
+    [Obsolete("Tests the deprecated ReadOnly shim for RatingControl")]
+    public void RatingControl_ReadOnly_Shim()
     {
-        var el = InfoBar("Title", "Msg").Severity(InfoBarSeverity.Warning).Closable(false);
+        var el = RatingControl(0, _ => { }).ReadOnly();
+        Assert.True(el.IsReadOnly);
+    }
+
+    [Fact]
+    public void InfoBar_Severity_And_IsClosable()
+    {
+        var el = InfoBar("Title", "Msg").Severity(InfoBarSeverity.Warning).IsClosable(false);
         Assert.Equal(InfoBarSeverity.Warning, el.Severity);
+        Assert.False(el.IsClosable);
+    }
+
+    [Fact]
+    [Obsolete("Tests the deprecated Closable shim")]
+    public void InfoBar_Closable_Shim()
+    {
+        var el = InfoBar("Title", "Msg").Closable(false);
         Assert.False(el.IsClosable);
     }
 
@@ -354,7 +404,15 @@ public class ElementExtensionsCoverageTests
     }
 
     [Fact]
-    public void ProgressRing_Active_Sugar()
+    public void ProgressRing_IsActive_Sugar()
+    {
+        var el = ProgressRing().IsActive(false);
+        Assert.False(el.IsActive);
+    }
+
+    [Fact]
+    [Obsolete("Tests the deprecated Active shim")]
+    public void ProgressRing_Active_Shim()
     {
         var el = ProgressRing().Active(false);
         Assert.False(el.IsActive);
@@ -378,7 +436,15 @@ public class ElementExtensionsCoverageTests
     }
 
     [Fact]
-    public void TabView_IsAddButtonVisible_Sugar()
+    public void TabView_IsAddTabButtonVisible_Sugar()
+    {
+        var el = TabView([]).IsAddTabButtonVisible(false);
+        Assert.False(el.IsAddTabButtonVisible);
+    }
+
+    [Fact]
+    [Obsolete("Tests the deprecated IsAddButtonVisible shim")]
+    public void TabView_IsAddButtonVisible_Shim()
     {
         var el = TabView([]).IsAddButtonVisible(false);
         Assert.False(el.IsAddTabButtonVisible);
@@ -386,7 +452,7 @@ public class ElementExtensionsCoverageTests
 
     [Fact]
     [Obsolete("Tests the deprecated ShowAddButton shim")]
-    public void TabView_ShowAddButton_Sugar_Obsolete_Shim()
+    public void TabView_ShowAddButton_Shim()
     {
         var el = TabView([]).ShowAddButton(false);
         Assert.False(el.IsAddTabButtonVisible);

--- a/tests/Reactor.Tests/ElementModifiersCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementModifiersCoverageTests.cs
@@ -158,7 +158,16 @@ public class ElementModifiersCoverageTests
     // ════════════════════════════════════════════════════════════════
 
     [Fact]
-    public void Popup_LightDismiss()
+    public void Popup_IsLightDismissEnabled()
+    {
+        var el = new PopupElement(TextBlock("popup content"))
+            .IsLightDismissEnabled(true);
+        Assert.True(el.IsLightDismissEnabled);
+    }
+
+    [Fact]
+    [Obsolete("Tests the deprecated LightDismiss shim")]
+    public void Popup_LightDismiss_Shim()
     {
         var el = new PopupElement(TextBlock("popup content"))
             .LightDismiss(true);

--- a/tests/Reactor.Tests/ElementTests.cs
+++ b/tests/Reactor.Tests/ElementTests.cs
@@ -88,10 +88,10 @@ public class ElementTests
     [Fact]
     public void Button_Disabled_Extension_Toggles_IsEnabled()
     {
-        var el = Button("Go").Disabled();
+        var el = Button("Go").IsEnabled(false);
         Assert.False(el.Modifiers!.IsEnabled);
 
-        var el2 = Button("Go").Disabled(false);
+        var el2 = Button("Go").IsEnabled(true);
         Assert.True(el2.Modifiers!.IsEnabled);
     }
 
@@ -548,7 +548,7 @@ public class ElementTests
     [Fact]
     public void Visible_False_Sets_IsVisible()
     {
-        var el = TextBlock("Hi").Visible(false);
+        var el = TextBlock("Hi").IsVisible(false);
         Assert.IsType<TextBlockElement>(el);
         Assert.NotNull(el.Modifiers);
         Assert.False(el.Modifiers!.IsVisible);
@@ -587,7 +587,7 @@ public class ElementTests
     public void Set_Chains_Multiple_Setters()
     {
         var el = TextBlock("Hi")
-            .Selectable()
+            .IsTextSelectionEnabled()
             .TextWrapping();
         // Fluent methods create new record instances with the properties set
         Assert.NotEqual(TextBlock("Hi"), el);

--- a/tests/stress_perf/StressPerf.VirtualList.Reactor/Program.cs
+++ b/tests/stress_perf/StressPerf.VirtualList.Reactor/Program.cs
@@ -289,9 +289,9 @@ class VirtualListApp : Component
 
         return VStack(
             HStack(8,
-                Button("1k", () => setCount(1000)).Disabled(count == 1000),
-                Button("5k", () => setCount(5000)).Disabled(count == 5000),
-                Button("10k", () => setCount(10000)).Disabled(count == 10000),
+                Button("1k", () => setCount(1000)).IsEnabled(count != 1000),
+                Button("5k", () => setCount(5000)).IsEnabled(count != 5000),
+                Button("10k", () => setCount(10000)).IsEnabled(count != 10000),
                 Button(Cli.WithEdits ? "Edits: on" : "Edits: off",
                     () => { Cli.WithEdits = !Cli.WithEdits; }),
                 Button("Run benchmark", StartBenchmark),


### PR DESCRIPTION
Rename `ShowAddButton()` → `IsAddButtonVisible()` to align with WinUI's `Is*` naming convention for boolean properties (`Control.IsTabStop`, `TabView.IsAddTabButtonVisible`, etc.).

- **`IsTabStop`** — kept as-is (already matches WinUI naming per review feedback)
- **`ShowAddButton`** → **`IsAddButtonVisible`** (imperative verb → `Is*` boolean)
- Old `ShowAddButton` kept as `[Obsolete]` shim for backward compatibility
- `reactor.api.txt` updated in both locations

Fixes #268