### PR TITLE
refactor: move Flex naming note to reactor-dsl skill

### DIFF
--- a/plugins/reactor/skills/reactor-dsl/SKILL.md
+++ b/plugins/reactor/skills/reactor-dsl/SKILL.md
@@ -28,3 +28,10 @@ Load this skill **only** when:
 Read the file **once**, scan for what you need, then keep working from memory. **Do not re-page through it** — the file is large and re-reading injects ~12K tokens per call. Per-pattern lookups are far cheaper than full re-reads.
 
 If you only need to confirm whether a single name exists, use a `grep` for the symbol against the file rather than viewing it whole.
+
+## Common naming gotchas
+
+- **`FlexElement` record properties** (set via `with { ... }`):
+  `Direction`, `JustifyContent`, `AlignItems`, `AlignContent`, `Wrap`, `ColumnGap`, `RowGap`
+  ⚠️ It's `JustifyContent` — NOT `Justify`.
+  Example: `FlexRow(a, b, c) with { JustifyContent = FlexJustify.SpaceBetween, ColumnGap = 8 }`

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -170,10 +170,6 @@ FlexColumn(children...)                       FlexRow(children...)
 // Prefer FlexRow/FlexColumn for linear layout — CSS Flexbox semantics
 // (grow/shrink/gap/wrap, justify-content, align-items). VStack/HStack
 // remain for StackPanel's shrink-wrap behavior.
-// FlexElement record properties (use `with { ... }`):
-//   Direction, JustifyContent, AlignItems, AlignContent, Wrap, ColumnGap, RowGap
-//   ⚠️ It's `JustifyContent` — NOT `Justify`
-// Example: FlexRow(a, b, c) with { JustifyContent = FlexJustify.SpaceBetween, ColumnGap = 8 }
 Border(child).CornerRadius(8).Background(Theme.CardBackground).Padding(16)
 ScrollView(VStack(...))
 Grid(columns: [GridSize.Star(), GridSize.Px(200)],


### PR DESCRIPTION
Follow-up to PR #291 (merged): move `FlexElement` property naming gotcha (`JustifyContent`, not `Justify`) from `reactor-getting-started` to `reactor-dsl` skill where DSL reference details belong.

Addresses feedback about keeping `getting-started` focused on essentials.
