### PR TITLE
Fix #267: rename terse charting parameter names

### DIFF
--- a/src/Reactor/Charting/Charts.Tree.cs
+++ b/src/Reactor/Charting/Charts.Tree.cs
@@ -63,11 +63,11 @@ public sealed class TreeChartElement<T> : IChartAccessibilityData
     private string? _description;
     private Element? _alternateView;
 
-    public TreeChartElement<T> Width(double w) { _width = w; return this; }
-    public TreeChartElement<T> Height(double h) { _height = h; return this; }
-    public TreeChartElement<T> LinkColor(string c) { _linkColor = c; return this; }
-    public TreeChartElement<T> NodeColor(string c) { _nodeColor = c; return this; }
-    public TreeChartElement<T> NodeRadius(double r) { _nodeRadius = r; return this; }
+    public TreeChartElement<T> Width(double width) { _width = width; return this; }
+    public TreeChartElement<T> Height(double height) { _height = height; return this; }
+    public TreeChartElement<T> LinkColor(string color) { _linkColor = color; return this; }
+    public TreeChartElement<T> NodeColor(string color) { _nodeColor = color; return this; }
+    public TreeChartElement<T> NodeRadius(double radius) { _nodeRadius = radius; return this; }
     public TreeChartElement<T> OnReady(Action<TreeChartHandle> callback) { _onReady = callback; return this; }
 
     /// <summary>Sets visible title + accessible name for the chart.</summary>
@@ -216,13 +216,13 @@ public sealed class ForceGraphElement : IChartAccessibilityData
     private string? _description;
     private Element? _alternateView;
 
-    public ForceGraphElement Width(double w) { _width = w; return this; }
-    public ForceGraphElement Height(double h) { _height = h; return this; }
-    public ForceGraphElement LinkColor(string c) { _linkColor = c; return this; }
-    public ForceGraphElement NodeColor(string c) { _nodeColor = c; return this; }
+    public ForceGraphElement Width(double width) { _width = width; return this; }
+    public ForceGraphElement Height(double height) { _height = height; return this; }
+    public ForceGraphElement LinkColor(string color) { _linkColor = color; return this; }
+    public ForceGraphElement NodeColor(string color) { _nodeColor = color; return this; }
     public ForceGraphElement Charge(double strength) { _chargeStrength = strength; return this; }
-    public ForceGraphElement Distance(double d) { _linkDistance = d; return this; }
-    public ForceGraphElement Iterations(int n) { _iterations = n; return this; }
+    public ForceGraphElement Distance(double distance) { _linkDistance = distance; return this; }
+    public ForceGraphElement Iterations(int count) { _iterations = count; return this; }
 
     /// <summary>Sets visible title + accessible name for the graph.</summary>
     public ForceGraphElement Title(string title) { _title = title; return this; }

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -100,13 +100,13 @@ public sealed class ChartElement<T> : IChartAccessibilityData
     private global::Windows.UI.Color? _customFocusColor;
     private bool _announceEveryFrame;
 
-    public ChartElement<T> Width(double w) { _width = w; return this; }
-    public ChartElement<T> Height(double h) { _height = h; return this; }
+    public ChartElement<T> Width(double width) { _width = width; return this; }
+    public ChartElement<T> Height(double height) { _height = height; return this; }
     public ChartElement<T> Margin(double left, double top, double right, double bottom) { _marginLeft = left; _marginTop = top; _marginRight = right; _marginBottom = bottom; return this; }
     public ChartElement<T> Stroke(string color) { _stroke = color; return this; }
     public ChartElement<T> Fill(string color) { _fill = color; return this; }
-    public ChartElement<T> StrokeWidth(double w) { _strokeWidth = w; return this; }
-    public ChartElement<T> FillOpacity(double o) { _fillOpacity = o; return this; }
+    public ChartElement<T> StrokeWidth(double width) { _strokeWidth = width; return this; }
+    public ChartElement<T> FillOpacity(double opacity) { _fillOpacity = opacity; return this; }
     public ChartElement<T> ShowAxes(bool show) { _showAxes = show; return this; }
     public ChartElement<T> ShowGrid(bool show) { _showGrid = show; return this; }
 
@@ -465,10 +465,10 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     // for accessibility (slice descriptors), so screen-reader summaries keep working.
     private Func<T, PieSliceLayout, Element>? _labelView;
 
-    public PieChartElement<T> Width(double w) { _width = w; return this; }
-    public PieChartElement<T> Height(double h) { _height = h; return this; }
-    public PieChartElement<T> InnerRadius(double r) { _innerRadius = r; return this; }
-    public PieChartElement<T> PadAngle(double a) { _padAngle = a; return this; }
+    public PieChartElement<T> Width(double width) { _width = width; return this; }
+    public PieChartElement<T> Height(double height) { _height = height; return this; }
+    public PieChartElement<T> InnerRadius(double radius) { _innerRadius = radius; return this; }
+    public PieChartElement<T> PadAngle(double angle) { _padAngle = angle; return this; }
 
     /// <summary>
     /// Shifts auto-positioned labels along the radial axis from the slice centroid.


### PR DESCRIPTION
## Summary

Renames single-letter parameters to descriptive names across the public charting builder API, improving readability at named-argument call sites.

### `Charts.cs`

| Method | Before | After |
|--------|--------|-------|
| `ChartElement<T>.Width` | `double w` | `double width` |
| `ChartElement<T>.Height` | `double h` | `double height` |
| `ChartElement<T>.StrokeWidth` | `double w` | `double width` |
| `ChartElement<T>.FillOpacity` | `double o` | `double opacity` |
| `PieChartElement<T>.Width` | `double w` | `double width` |
| `PieChartElement<T>.Height` | `double h` | `double height` |
| `PieChartElement<T>.InnerRadius` | `double r` | `double radius` |
| `PieChartElement<T>.PadAngle` | `double a` | `double angle` |

### `Charts.Tree.cs`

| Method | Before | After |
|--------|--------|-------|
| `TreeChartElement<T>.Width` | `double w` | `double width` |
| `TreeChartElement<T>.Height` | `double h` | `double height` |
| `TreeChartElement<T>.LinkColor` | `string c` | `string color` |
| `TreeChartElement<T>.NodeColor` | `string c` | `string color` |
| `TreeChartElement<T>.NodeRadius` | `double r` | `double radius` |
| `ForceGraphElement.Width` | `double w` | `double width` |
| `ForceGraphElement.Height` | `double h` | `double height` |
| `ForceGraphElement.LinkColor` | `string c` | `string color` |
| `ForceGraphElement.NodeColor` | `string c` | `string color` |
| `ForceGraphElement.Distance` | `double d` | `double distance` |
| `ForceGraphElement.Iterations` | `int n` | `int count` |

## Compatibility

- **Source-compatible** for positional callers (all existing callers verified)
- **Binary-compatible** (parameter names are not part of the binary signature)
- D3 internals left as-is (idiomatic short names from the d3.js port)

## Tests

All 404 charting tests pass.

Closes #267.