### PR TITLE
Change DataChanged from Action to EventHandler (#265)

### DIFF
--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -205,7 +205,7 @@ public class DataGridComponent<T> : Component<DataGridElement<T>>
         {
             if (source is IObservableDataSource<T> observable)
             {
-                void OnDataChanged()
+                void OnDataChanged(object? sender, EventArgs e)
                 {
                     if (state.IsEditing || state.IsRowEditing)
                         state.CancelEdit();

--- a/src/Reactor/Data/IDataSource.cs
+++ b/src/Reactor/Data/IDataSource.cs
@@ -47,7 +47,7 @@ public interface IMutableDataSource<T> : IDataSource<T>
 /// </summary>
 public interface IObservableDataSource<T> : IDataSource<T>
 {
-    event Action? DataChanged;
+    event EventHandler? DataChanged;
 }
 
 /// <summary>

--- a/src/Reactor/Data/Providers/ObservableListDataSource.cs
+++ b/src/Reactor/Data/Providers/ObservableListDataSource.cs
@@ -28,7 +28,7 @@ public class ObservableListDataSource<[DynamicallyAccessedMembers(DynamicallyAcc
             SubscribeItem(item);
     }
 
-    public event Action? DataChanged;
+    public event EventHandler? DataChanged;
 
     private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
@@ -58,7 +58,7 @@ public class ObservableListDataSource<[DynamicallyAccessedMembers(DynamicallyAcc
                 SubscribeItem(item);
         }
 
-        DataChanged?.Invoke();
+        DataChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private void SyncInternalList()
@@ -91,7 +91,7 @@ public class ObservableListDataSource<[DynamicallyAccessedMembers(DynamicallyAcc
 
     private void OnItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        DataChanged?.Invoke();
+        DataChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public void Dispose()

--- a/tests/Reactor.Tests/ObservableListDataSourceTests.cs
+++ b/tests/Reactor.Tests/ObservableListDataSourceTests.cs
@@ -37,7 +37,7 @@ public class ObservableListDataSourceTests
         var collection = new ObservableCollection<InpcItem>();
         var source = new ObservableListDataSource<InpcItem>(collection, x => (RowKey)x.Id);
         var fired = false;
-        source.DataChanged += () => fired = true;
+        source.DataChanged += (_, _) => fired = true;
 
         collection.Add(new InpcItem { Id = 1, Name = "Alice" });
         Assert.True(fired);
@@ -50,7 +50,7 @@ public class ObservableListDataSourceTests
         var collection = new ObservableCollection<InpcItem> { item };
         var source = new ObservableListDataSource<InpcItem>(collection, x => (RowKey)x.Id);
         var fired = false;
-        source.DataChanged += () => fired = true;
+        source.DataChanged += (_, _) => fired = true;
 
         collection.Remove(item);
         Assert.True(fired);
@@ -63,7 +63,7 @@ public class ObservableListDataSourceTests
         var collection = new ObservableCollection<InpcItem> { item };
         var source = new ObservableListDataSource<InpcItem>(collection, x => (RowKey)x.Id);
         var fired = false;
-        source.DataChanged += () => fired = true;
+        source.DataChanged += (_, _) => fired = true;
 
         item.Name = "Alice Updated";
         Assert.True(fired);
@@ -76,7 +76,7 @@ public class ObservableListDataSourceTests
         var collection = new ObservableCollection<InpcItem> { item };
         var source = new ObservableListDataSource<InpcItem>(collection, x => (RowKey)x.Id);
         var count = 0;
-        source.DataChanged += () => count++;
+        source.DataChanged += (_, _) => count++;
 
         source.Dispose();
 
@@ -102,5 +102,30 @@ public class ObservableListDataSourceTests
 
         var page2 = await source.GetPageAsync(new DataRequest());
         Assert.Equal(2, page2.Items.Count);
+    }
+
+    [Fact]
+    public void DataChanged_Provides_Sender()
+    {
+        var collection = new ObservableCollection<InpcItem>();
+        var source = new ObservableListDataSource<InpcItem>(collection, x => (RowKey)x.Id);
+        object? capturedSender = null;
+        source.DataChanged += (s, _) => capturedSender = s;
+
+        collection.Add(new InpcItem { Id = 1, Name = "Alice" });
+        Assert.Same(source, capturedSender);
+    }
+
+    [Fact]
+    public void DataChanged_From_INPC_Provides_Sender()
+    {
+        var item = new InpcItem { Id = 1, Name = "Alice" };
+        var collection = new ObservableCollection<InpcItem> { item };
+        var source = new ObservableListDataSource<InpcItem>(collection, x => (RowKey)x.Id);
+        object? capturedSender = null;
+        source.DataChanged += (s, _) => capturedSender = s;
+
+        item.Name = "Updated";
+        Assert.Same(source, capturedSender);
     }
 }

--- a/tests/stress_perf/StressPerf.ReactorGrid/Program.cs
+++ b/tests/stress_perf/StressPerf.ReactorGrid/Program.cs
@@ -231,7 +231,7 @@ class StockGridSource : IDataSource<StockRow>, IObservableDataSource<StockRow>
         }
     }
 
-    public event Action? DataChanged;
+    public event EventHandler? DataChanged;
 
     public DataSourceCapabilities Capabilities => DataSourceCapabilities.ServerCount;
 
@@ -277,6 +277,6 @@ class StockGridSource : IDataSource<StockRow>, IObservableDataSource<StockRow>
             cells[col] = new StockItem(item.Symbol, item.CurrentPrice, newPrice, newPrice >= item.CurrentPrice);
         }
 
-        DataChanged?.Invoke();
+        DataChanged?.Invoke(this, EventArgs.Empty);
     }
 }


### PR DESCRIPTION
## Summary

Changes `IObservableDataSource<T>.DataChanged` from `event Action?` to `event EventHandler?` to follow .NET event guidelines.

### What changed

- **`IDataSource.cs`** — interface declaration: `event Action?` → `event EventHandler?`
- **`ObservableListDataSource.cs`** — implementation + invocations now pass `(this, EventArgs.Empty)`
- **`DataGridComponent.cs`** — handler signature updated to `(object? sender, EventArgs e)`
- **`StressPerf.ReactorGrid/Program.cs`** — stress-test implementation updated
- **`ObservableListDataSourceTests.cs`** — existing tests updated to `(_, _)` delegate shape; two new tests verify `sender` is the data source instance

### Why

`Action`-shaped events lose `sender` identity and future extensibility (no event-args type to evolve). The rest of the CLR-event surface already uses `EventHandler` / `EventHandler<T>`.

Fixes #265
