### PR TITLE
Normalize event/callback naming conventions (#260)

### DIFF
--- a/docs/_pipeline/apps/navigation/App.cs
+++ b/docs/_pipeline/apps/navigation/App.cs
@@ -269,10 +269,10 @@ class DiagnosticsDemo : Component
 
         UseEffect(() =>
         {
-            Action<NavigationDiagnosticEvent> onRequested =
-                e => updateLog(l => [.. l, $"Requested: {e.From} → {e.To}"]);
-            Action<NavigationDiagnosticEvent> onCompleted =
-                e => updateLog(l => [.. l, $"Completed: {e.To}"]);
+            EventHandler<NavigationDiagnosticEvent> onRequested =
+                (_, e) => updateLog(l => [.. l, $"Requested: {e.From} → {e.To}"]);
+            EventHandler<NavigationDiagnosticEvent> onCompleted =
+                (_, e) => updateLog(l => [.. l, $"Completed: {e.To}"]);
 
             NavigationDiagnostics.NavigationRequested += onRequested;
             NavigationDiagnostics.NavigationCompleted += onCompleted;

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -295,8 +295,6 @@ StackElement.Set(Action<StackPanel> configure) → StackElement
 StackElement.Spacing(double spacing) → StackElement
 SwipeControlElement.Set(Action<SwipeControl> configure) → SwipeControlElement
 T.AccessKey<T>(string key) → T
-T.AccessKeyDisplayRequested<T>(Action handler) → T
-T.AccessKeyDisplayRequested<T>(Action<UIElement, AccessKeyDisplayRequestedEventArgs> handler) → T
 T.AccessibilityHidden<T>() → T
 T.AccessibilityView<T>(AccessibilityView view) → T
 T.Animate<T>(Curve curve, AnimateProperty properties = AnimateProperty.All) → T
@@ -359,6 +357,8 @@ T.MaxHeight<T>(double h) → T
 T.MaxWidth<T>(double w) → T
 T.MinHeight<T>(double h) → T
 T.MinWidth<T>(double w) → T
+T.OnAccessKeyDisplayRequested<T>(Action handler) → T
+T.OnAccessKeyDisplayRequested<T>(Action<UIElement, AccessKeyDisplayRequestedEventArgs> handler) → T
 T.OnCharacterReceived<T>(Action<UIElement, CharacterReceivedRoutedEventArgs> handler) → T
 T.OnDoubleTap<T>(Action handler) → T
 T.OnDoubleTap<T>(Action<Point> handler) → T

--- a/samples/NavigationDemo/App.cs
+++ b/samples/NavigationDemo/App.cs
@@ -141,13 +141,13 @@ class AppShell : Component
         // Subscribe to navigation diagnostics for the log panel
         UseEffect(() =>
         {
-            void onCompleted(NavigationDiagnosticEvent e) =>
+            void onCompleted(object? sender, NavigationDiagnosticEvent e) =>
                 updateDiagLog(log => [.. log.TakeLast(19), $"[{DateTime.Now:HH:mm:ss}] {e.Mode}: {e.From} -> {e.To}"]);
-            void onCancelled(NavigationDiagnosticEvent e) =>
+            void onCancelled(object? sender, NavigationDiagnosticEvent e) =>
                 updateDiagLog(log => [.. log.TakeLast(19), $"[{DateTime.Now:HH:mm:ss}] BLOCKED: {e.Mode} {e.From} -> {e.To} ({e.Reason})"]);
-            void onCacheHit(CacheDiagnosticEvent e) =>
+            void onCacheHit(object? sender, CacheDiagnosticEvent e) =>
                 updateDiagLog(log => [.. log.TakeLast(19), $"[{DateTime.Now:HH:mm:ss}] Cache HIT: {e.Route}"]);
-            void onCacheMiss(CacheDiagnosticEvent e) =>
+            void onCacheMiss(object? sender, CacheDiagnosticEvent e) =>
                 updateDiagLog(log => [.. log.TakeLast(19), $"[{DateTime.Now:HH:mm:ss}] Cache MISS: {e.Route}"]);
 
             NavigationDiagnostics.NavigationCompleted += onCompleted;

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -295,8 +295,6 @@ StackElement.Set(Action<StackPanel> configure) → StackElement
 StackElement.Spacing(double spacing) → StackElement
 SwipeControlElement.Set(Action<SwipeControl> configure) → SwipeControlElement
 T.AccessKey<T>(string key) → T
-T.AccessKeyDisplayRequested<T>(Action handler) → T
-T.AccessKeyDisplayRequested<T>(Action<UIElement, AccessKeyDisplayRequestedEventArgs> handler) → T
 T.AccessibilityHidden<T>() → T
 T.AccessibilityView<T>(AccessibilityView view) → T
 T.Animate<T>(Curve curve, AnimateProperty properties = AnimateProperty.All) → T
@@ -359,6 +357,8 @@ T.MaxHeight<T>(double h) → T
 T.MaxWidth<T>(double w) → T
 T.MinHeight<T>(double h) → T
 T.MinWidth<T>(double w) → T
+T.OnAccessKeyDisplayRequested<T>(Action handler) → T
+T.OnAccessKeyDisplayRequested<T>(Action<UIElement, AccessKeyDisplayRequestedEventArgs> handler) → T
 T.OnCharacterReceived<T>(Action<UIElement, CharacterReceivedRoutedEventArgs> handler) → T
 T.OnDoubleTap<T>(Action handler) → T
 T.OnDoubleTap<T>(Action<Point> handler) → T

--- a/src/Reactor/Core/Navigation/NavigationDiagnostics.cs
+++ b/src/Reactor/Core/Navigation/NavigationDiagnostics.cs
@@ -10,84 +10,84 @@ namespace Microsoft.UI.Reactor.Navigation;
 public static class NavigationDiagnostics
 {
     /// <summary>Fires when a navigation is attempted (before guards run).</summary>
-    public static event Action<NavigationDiagnosticEvent>? NavigationRequested;
+    public static event EventHandler<NavigationDiagnosticEvent>? NavigationRequested;
 
     /// <summary>Fires when a navigation completes successfully.</summary>
-    public static event Action<NavigationDiagnosticEvent>? NavigationCompleted;
+    public static event EventHandler<NavigationDiagnosticEvent>? NavigationCompleted;
 
     /// <summary>Fires when a navigation guard cancels a navigation.</summary>
-    public static event Action<NavigationDiagnosticEvent>? NavigationCancelled;
+    public static event EventHandler<NavigationDiagnosticEvent>? NavigationCancelled;
 
     /// <summary>Fires on a cache hit during navigation.</summary>
-    public static event Action<CacheDiagnosticEvent>? CacheHit;
+    public static event EventHandler<CacheDiagnosticEvent>? CacheHit;
 
     /// <summary>Fires on a cache miss during navigation.</summary>
-    public static event Action<CacheDiagnosticEvent>? CacheMiss;
+    public static event EventHandler<CacheDiagnosticEvent>? CacheMiss;
 
     /// <summary>Fires when a page is evicted from the cache.</summary>
-    public static event Action<CacheDiagnosticEvent>? CacheEviction;
+    public static event EventHandler<CacheDiagnosticEvent>? CacheEviction;
 
     /// <summary>Fires when a transition animation starts.</summary>
-    public static event Action<TransitionDiagnosticEvent>? TransitionStarted;
+    public static event EventHandler<TransitionDiagnosticEvent>? TransitionStarted;
 
     /// <summary>Fires when a transition animation completes.</summary>
-    public static event Action<TransitionDiagnosticEvent>? TransitionCompleted;
+    public static event EventHandler<TransitionDiagnosticEvent>? TransitionCompleted;
 
     /// <summary>Fires when a deep link resolves (match or miss).</summary>
-    public static event Action<DeepLinkDiagnosticEvent>? DeepLinkResolved;
+    public static event EventHandler<DeepLinkDiagnosticEvent>? DeepLinkResolved;
 
     internal static void OnNavigationRequested(object from, object to, NavigationMode mode)
     {
         Debug.WriteLine($"[Reactor.Nav] Requested: {mode} from {from} → {to}");
-        NavigationRequested?.Invoke(new(from, to, mode));
+        NavigationRequested?.Invoke(null, new(from, to, mode));
     }
 
     internal static void OnNavigationCompleted(object from, object to, NavigationMode mode)
     {
         Debug.WriteLine($"[Reactor.Nav] Completed: {mode} from {from} → {to}");
-        NavigationCompleted?.Invoke(new(from, to, mode));
+        NavigationCompleted?.Invoke(null, new(from, to, mode));
     }
 
     internal static void OnNavigationCancelled(object from, object to, NavigationMode mode, string reason)
     {
         Debug.WriteLine($"[Reactor.Nav] Cancelled: {mode} from {from} → {to} ({reason})");
-        NavigationCancelled?.Invoke(new(from, to, mode) { Reason = reason });
+        NavigationCancelled?.Invoke(null, new(from, to, mode) { Reason = reason });
     }
 
     internal static void OnCacheHit(object route)
     {
         Debug.WriteLine($"[Reactor.Nav] Cache HIT: {route}");
-        CacheHit?.Invoke(new(route));
+        CacheHit?.Invoke(null, new(route));
     }
 
     internal static void OnCacheMiss(object route)
     {
         Debug.WriteLine($"[Reactor.Nav] Cache MISS: {route}");
-        CacheMiss?.Invoke(new(route));
+        CacheMiss?.Invoke(null, new(route));
     }
 
     internal static void OnCacheEviction(object route)
     {
         Debug.WriteLine($"[Reactor.Nav] Cache EVICT: {route}");
-        CacheEviction?.Invoke(new(route));
+        CacheEviction?.Invoke(null, new(route));
     }
 
     internal static void OnTransitionStarted(NavigationTransition transition, NavigationMode mode)
     {
         Debug.WriteLine($"[Reactor.Nav] Transition START: {transition.GetType().Name} ({mode})");
-        TransitionStarted?.Invoke(new(transition, mode));
+        TransitionStarted?.Invoke(null, new(transition, mode));
     }
 
     internal static void OnTransitionCompleted(NavigationTransition transition, NavigationMode mode)
     {
         Debug.WriteLine($"[Reactor.Nav] Transition END: {transition.GetType().Name} ({mode})");
-        TransitionCompleted?.Invoke(new(transition, mode));
+        TransitionCompleted?.Invoke(null, new(transition, mode));
     }
 
     internal static void OnDeepLinkResolved(string path, bool matched, int routeCount)
     {
         Debug.WriteLine($"[Reactor.Nav] DeepLink: '{path}' → {(matched ? $"matched ({routeCount} routes)" : "no match")}");
-        DeepLinkResolved?.Invoke(new(path, matched, routeCount));
+        DeepLinkResolved?.Invoke(null, new(path, matched, routeCount));
     }
 }
 

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1436,14 +1436,24 @@ public static class ElementExtensions
     /// Handler for UIElement.AccessKeyDisplayRequested — fires when the access-key
     /// bubble should appear (e.g., user pressed Alt). Use to customize the visual.
     /// </summary>
-    public static T AccessKeyDisplayRequested<T>(this T el, Action handler) where T : Element =>
+    public static T OnAccessKeyDisplayRequested<T>(this T el, Action handler) where T : Element =>
         Modify(el, new ElementModifiers { OnAccessKeyDisplayRequested = (_, _) => handler() });
 
     /// <summary>
     /// Handler for UIElement.AccessKeyDisplayRequested with full event args.
     /// </summary>
-    public static T AccessKeyDisplayRequested<T>(this T el, Action<UIElement, Microsoft.UI.Xaml.Input.AccessKeyDisplayRequestedEventArgs> handler) where T : Element =>
+    public static T OnAccessKeyDisplayRequested<T>(this T el, Action<UIElement, Microsoft.UI.Xaml.Input.AccessKeyDisplayRequestedEventArgs> handler) where T : Element =>
         Modify(el, new ElementModifiers { OnAccessKeyDisplayRequested = handler });
+
+    /// <inheritdoc cref="OnAccessKeyDisplayRequested{T}(T, Action)"/>
+    [Obsolete("Use OnAccessKeyDisplayRequested. See #260.")]
+    public static T AccessKeyDisplayRequested<T>(this T el, Action handler) where T : Element =>
+        OnAccessKeyDisplayRequested(el, handler);
+
+    /// <inheritdoc cref="OnAccessKeyDisplayRequested{T}(T, Action{UIElement, Microsoft.UI.Xaml.Input.AccessKeyDisplayRequestedEventArgs})"/>
+    [Obsolete("Use OnAccessKeyDisplayRequested. See #260.")]
+    public static T AccessKeyDisplayRequested<T>(this T el, Action<UIElement, Microsoft.UI.Xaml.Input.AccessKeyDisplayRequestedEventArgs> handler) where T : Element =>
+        OnAccessKeyDisplayRequested(el, handler);
 
     /// <summary>
     /// Binds this element to an imperative <see cref="Microsoft.UI.Reactor.Input.ElementRef"/>.

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NavigationCoverageFixtures.cs
@@ -523,7 +523,7 @@ internal static class NavigationCoverageFixtures
         public override async Task RunAsync()
         {
             var completedEvents = new List<NavigationDiagnosticEvent>();
-            void handler(NavigationDiagnosticEvent e) => completedEvents.Add(e);
+            void handler(object? sender, NavigationDiagnosticEvent e) => completedEvents.Add(e);
             NavigationDiagnostics.NavigationCompleted += handler;
 
             try

--- a/tests/Reactor.Tests/NavigationDiagnosticsCoverageTests.cs
+++ b/tests/Reactor.Tests/NavigationDiagnosticsCoverageTests.cs
@@ -25,9 +25,8 @@ public class NavigationDiagnosticsCoverageTests
     {
         var (from, to) = UniqueKeys();
         NavigationDiagnosticEvent? captured = null;
-        Action<NavigationDiagnosticEvent> handler = e =>
+        EventHandler<NavigationDiagnosticEvent> handler = (_, e) =>
         {
-            // From/To are typed `object`; compare via Equals to avoid CS0252.
             if (Equals(e.From, from) && Equals(e.To, to)) captured = e;
         };
         NavigationDiagnostics.NavigationRequested += handler;
@@ -50,9 +49,8 @@ public class NavigationDiagnosticsCoverageTests
     {
         var (from, to) = UniqueKeys();
         NavigationDiagnosticEvent? captured = null;
-        Action<NavigationDiagnosticEvent> handler = e =>
+        EventHandler<NavigationDiagnosticEvent> handler = (_, e) =>
         {
-            // From/To are typed `object`; compare via Equals to avoid CS0252.
             if (Equals(e.From, from) && Equals(e.To, to)) captured = e;
         };
         NavigationDiagnostics.NavigationCompleted += handler;
@@ -73,9 +71,8 @@ public class NavigationDiagnosticsCoverageTests
     {
         var (from, to) = UniqueKeys();
         NavigationDiagnosticEvent? captured = null;
-        Action<NavigationDiagnosticEvent> handler = e =>
+        EventHandler<NavigationDiagnosticEvent> handler = (_, e) =>
         {
-            // From/To are typed `object`; compare via Equals to avoid CS0252.
             if (Equals(e.From, from) && Equals(e.To, to)) captured = e;
         };
         NavigationDiagnostics.NavigationCancelled += handler;
@@ -101,11 +98,9 @@ public class NavigationDiagnosticsCoverageTests
         var hits = new List<CacheDiagnosticEvent>();
         var misses = new List<CacheDiagnosticEvent>();
         var evicts = new List<CacheDiagnosticEvent>();
-        // CacheDiagnosticEvent.Route is typed as object; compare via Equals to
-        // avoid the reference-comparison footgun (CS0252).
-        Action<CacheDiagnosticEvent> hh = e => { if (Equals(e.Route, rHit)) hits.Add(e); };
-        Action<CacheDiagnosticEvent> mh = e => { if (Equals(e.Route, rMiss)) misses.Add(e); };
-        Action<CacheDiagnosticEvent> eh = e => { if (Equals(e.Route, rEvict)) evicts.Add(e); };
+        EventHandler<CacheDiagnosticEvent> hh = (_, e) => { if (Equals(e.Route, rHit)) hits.Add(e); };
+        EventHandler<CacheDiagnosticEvent> mh = (_, e) => { if (Equals(e.Route, rMiss)) misses.Add(e); };
+        EventHandler<CacheDiagnosticEvent> eh = (_, e) => { if (Equals(e.Route, rEvict)) evicts.Add(e); };
 
         NavigationDiagnostics.CacheHit += hh;
         NavigationDiagnostics.CacheMiss += mh;
@@ -130,13 +125,11 @@ public class NavigationDiagnosticsCoverageTests
     [Fact]
     public void OnTransitionStarted_OnTransitionCompleted_Fire()
     {
-        // Filter by transition instance identity — concurrent navigation tests fire
-        // their own transitions through the same global event.
         var transition = new SlideTransition();
         TransitionDiagnosticEvent? start = null;
         TransitionDiagnosticEvent? end = null;
-        Action<TransitionDiagnosticEvent> sh = e => { if (ReferenceEquals(e.Transition, transition)) start = e; };
-        Action<TransitionDiagnosticEvent> eh = e => { if (ReferenceEquals(e.Transition, transition)) end = e; };
+        EventHandler<TransitionDiagnosticEvent> sh = (_, e) => { if (ReferenceEquals(e.Transition, transition)) start = e; };
+        EventHandler<TransitionDiagnosticEvent> eh = (_, e) => { if (ReferenceEquals(e.Transition, transition)) end = e; };
         NavigationDiagnostics.TransitionStarted += sh;
         NavigationDiagnostics.TransitionCompleted += eh;
         try
@@ -160,7 +153,7 @@ public class NavigationDiagnosticsCoverageTests
     {
         var pathHit = $"/home-{Guid.NewGuid():N}";
         DeepLinkDiagnosticEvent? captured = null;
-        Action<DeepLinkDiagnosticEvent> handler = e => { if (e.Path == pathHit) captured = e; };
+        EventHandler<DeepLinkDiagnosticEvent> handler = (_, e) => { if (e.Path == pathHit) captured = e; };
         NavigationDiagnostics.DeepLinkResolved += handler;
         try
         {
@@ -175,10 +168,9 @@ public class NavigationDiagnosticsCoverageTests
         Assert.True(captured.Matched);
         Assert.Equal(2, captured.RouteCount);
 
-        // Re-fire for the miss branch (matched=false formats differently)
         var pathMiss = $"/missing-{Guid.NewGuid():N}";
         DeepLinkDiagnosticEvent? miss = null;
-        Action<DeepLinkDiagnosticEvent> handler2 = e => { if (e.Path == pathMiss) miss = e; };
+        EventHandler<DeepLinkDiagnosticEvent> handler2 = (_, e) => { if (e.Path == pathMiss) miss = e; };
         NavigationDiagnostics.DeepLinkResolved += handler2;
         try
         {


### PR DESCRIPTION
## Summary

Two changes to normalize event/callback naming conventions:

### Part A: DSL callback prefix

Renamed `AccessKeyDisplayRequested` extension methods to `OnAccessKeyDisplayRequested` to match the `OnX` convention used by all other DSL callbacks. Old names kept as `[Obsolete]` shims forwarding to the new methods.

### Part B: NavigationDiagnostics event types

Changed all 9 `NavigationDiagnostics` events from `Action<T>` to `EventHandler<T>` to follow .NET event guidelines. The event-args classes (`NavigationDiagnosticEvent`, `CacheDiagnosticEvent`, `TransitionDiagnosticEvent`, `DeepLinkDiagnosticEvent`) are unchanged — only the delegate shape changes.

### Changed files

| File | Change |
|---|---|
| `ElementExtensions.cs` | New `OnAccessKeyDisplayRequested` + `[Obsolete]` shim |
| `NavigationDiagnostics.cs` | 9 events: `Action<T>` → `EventHandler<T>` |
| `NavigationDiagnosticsCoverageTests.cs` | Handler types updated |
| `reactor.api.txt` (×2) | New `OnAccessKeyDisplayRequested` entries |

Fixes #260
