### PR TITLE
Normalize state-change callback names (#261)

### DIFF
--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -15,7 +15,7 @@ AnnotatedScrollBar() → AnnotatedScrollBarElement
 AppBarButton(Command command) → AppBarButtonData
 AppBarButton(string label, Action onClick = null, string icon = null) → AppBarButtonData
 AppBarSeparator() → AppBarSeparatorData
-AppBarToggleButton(string label, bool isChecked = false, Action<bool> onToggled = null, string icon = null) → AppBarToggleButtonData
+AppBarToggleButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null, string icon = null) → AppBarToggleButtonData
 AutoColumns<T>(TypeRegistry registry = null, Func<FieldDescriptor, FieldDescriptor> overrides = null) → IReadOnlyList<FieldDescriptor>
 AutoSuggestBox(string text, Action<string> onTextChanged = null, Action<string> onQuerySubmitted = null) → AutoSuggestBoxElement
 BitmapIcon(Uri source, bool showAsMonochrome = true) → BitmapIconData
@@ -29,11 +29,11 @@ CalendarDatePicker(DateTimeOffset? date = null, Action<DateTimeOffset?> onDateCh
 CalendarView() → CalendarViewElement
 Canvas(Element[] children) → CanvasElement
 Caption(string content) → TextBlockElement
-CheckBox(bool isChecked, Action<bool> onChanged = null, string label = null) → CheckBoxElement
+CheckBox(bool isChecked, Action<bool> onIsCheckedChanged = null, string label = null) → CheckBoxElement
 ColorPicker(Color color, Action<Color> onColorChanged = null) → ColorPickerElement
 Column<T>(string name, Func<T, object> accessor, bool editable = false, string displayName = null, string format = null, double? width = null, PinPosition pin = PinPosition.None) → ColumnBuilder<T>
-ComboBox(Element[] itemElements, int selectedIndex, Action<int> onSelectionChanged) → ComboBoxElement
-ComboBox(string[] items, int selectedIndex = -1, Action<int> onSelectionChanged = null) → ComboBoxElement
+ComboBox(Element[] itemElements, int selectedIndex, Action<int> onSelectedIndexChanged) → ComboBoxElement
+ComboBox(string[] items, int selectedIndex = -1, Action<int> onSelectedIndexChanged = null) → ComboBoxElement
 CommandBar(AppBarItemBase[] primaryCommands = null, AppBarItemBase[] secondaryCommands = null) → CommandBarElement
 CommandBarFlyout(Element target, AppBarItemBase[] primaryCommands = null, AppBarItemBase[] secondaryCommands = null) → CommandBarFlyoutElement
 CommandHost(Command[] commands, Element child) → CommandHostElement
@@ -50,7 +50,7 @@ Ellipse() → EllipseElement
 Empty() → Element
 ErrorBoundary(Element child, Element fallback) → ErrorBoundaryElement
 ErrorBoundary(Element child, Func<Exception, Element> fallback) → ErrorBoundaryElement
-Expander(string header, Element content, bool isExpanded = false, Action<bool> onExpandedChanged = null) → ExpanderElement
+Expander(string header, Element content, bool isExpanded = false, Action<bool> onIsExpandedChanged = null) → ExpanderElement
 Expr(Func<Element> render) → Element
 Flex(Element[] children) → FlexElement
 Flex(FlexDirection direction, Element[] children) → FlexElement
@@ -84,7 +84,7 @@ ItemsView<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, E
 LazyHStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → LazyHStackElement<T>
 LazyVStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → LazyVStackElement<T>
 Line(double x1, double y1, double x2, double y2) → LineElement
-ListBox(string[] items, int selectedIndex = -1, Action<int> onSelectionChanged = null) → ListBoxElement
+ListBox(string[] items, int selectedIndex = -1, Action<int> onSelectedIndexChanged = null) → ListBoxElement
 ListView(Element[] items) → ListViewElement
 ListView<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → TemplatedListViewElement<T>
 LocaleProvider(string locale, Element child, IStringResourceProvider resourceProvider = null, string defaultLocale = "en-US", bool pseudoLocalize = false) → Element
@@ -114,7 +114,7 @@ PasswordBox(string password, Action<string> onPasswordChanged = null, string pla
 Path() → PathElement
 PathIcon(string data) → PathIconData
 PersonPicture() → PersonPictureElement
-PipsPager(int numberOfPages, int selectedPageIndex = 0, Action<int> onSelectedIndexChanged = null) → PipsPagerElement
+PipsPager(int numberOfPages, int selectedPageIndex = 0, Action<int> onSelectedPageIndexChanged = null) → PipsPagerElement
 Pivot(PivotItemData[] items) → PivotElement
 PivotItem(string header, Element content) → PivotItemData
 Popup(Element child, bool isOpen = false, Action onClosed = null) → PopupElement
@@ -123,8 +123,8 @@ ProgressIndeterminate() → ProgressElement
 ProgressRing() → ProgressRingElement
 ProgressRing(double value) → ProgressRingElement
 PropertyGrid(object target, TypeRegistry registry, Action<object> onRootChanged = null) → Element
-RadioButton(string label, bool isChecked = false, Action<bool> onChecked = null, string groupName = null) → RadioButtonElement
-RadioButtons(string[] items, int selectedIndex = -1, Action<int> onSelectionChanged = null) → RadioButtonsElement
+RadioButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null, string groupName = null) → RadioButtonElement
+RadioButtons(string[] items, int selectedIndex = -1, Action<int> onSelectedIndexChanged = null) → RadioButtonsElement
 RadioMenuItem(string text, string groupName, bool isChecked = false, Action onClick = null, string icon = null) → RadioMenuFlyoutItemData
 RatingControl(double value = 0, Action<double> onValueChanged = null) → RatingControlElement
 Rectangle() → RectangleElement
@@ -138,10 +138,10 @@ RichText(RichTextParagraph[] paragraphs) → RichTextBlockElement
 RichText(string text) → RichTextBlockElement
 Run(string text) → RichTextRun
 ScrollView(Element child) → ScrollViewElement
-SelectorBar(SelectorBarItemData[] items, int selectedIndex = 0, Action<int> onSelectionChanged = null) → SelectorBarElement
+SelectorBar(SelectorBarItemData[] items, int selectedIndex = 0, Action<int> onSelectedIndexChanged = null) → SelectorBarElement
 SelectorBarItem(string text, string icon = null) → SelectorBarItemData
 SemanticZoom(Element zoomedInView, Element zoomedOutView) → SemanticZoomElement
-Slider(double value, double min = 0, double max = 100, Action<double> onChanged = null) → SliderElement
+Slider(double value, double min = 0, double max = 100, Action<double> onValueChanged = null) → SliderElement
 SplitButton(Command command, Element flyout = null) → SplitButtonElement
 SplitButton(string label, Action onClick = null, Element flyout = null) → SplitButtonElement
 SplitView(Element pane = null, Element content = null) → SplitViewElement
@@ -160,11 +160,11 @@ ThreeStateCheckBox(bool? checkedState, Action<bool?> onCheckedStateChanged = nul
 TimePicker(TimeSpan time, Action<TimeSpan> onTimeChanged = null) → TimePickerElement
 TitleBar(string title) → TitleBarElement
 ToggleButton(Command command, bool isChecked = false) → ToggleButtonElement
-ToggleButton(string label, bool isChecked = false, Action<bool> onToggled = null) → ToggleButtonElement
-ToggleMenuItem(string text, bool isChecked = false, Action<bool> onToggled = null, string icon = null) → ToggleMenuFlyoutItemData
+ToggleButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null) → ToggleButtonElement
+ToggleMenuItem(string text, bool isChecked = false, Action<bool> onIsCheckedChanged = null, string icon = null) → ToggleMenuFlyoutItemData
 ToggleSplitButton(Command command, bool isChecked = false, Element flyout = null) → ToggleSplitButtonElement
 ToggleSplitButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null, Element flyout = null) → ToggleSplitButtonElement
-ToggleSwitch(bool isOn, Action<bool> onChanged = null, string onContent = null, string offContent = null, string header = null) → ToggleSwitchElement
+ToggleSwitch(bool isOn, Action<bool> onIsOnChanged = null, string onContent = null, string offContent = null, string header = null) → ToggleSwitchElement
 TreeNode(string content, TreeViewNodeData[] children) → TreeViewNodeData
 TreeView(TreeViewNodeData[] nodes) → TreeViewElement
 UniformGrid(Orientation orientation, Element[] items) → GridElement

--- a/samples/Reactor.TestApp/Demos/DataTemplateDemo.cs
+++ b/samples/Reactor.TestApp/Demos/DataTemplateDemo.cs
@@ -88,7 +88,7 @@ class DataTemplateDemo : Component
                 ) with
                 {
                     SelectedIndex = selectedListIndex,
-                    OnSelectionChanged = setSelectedListIndex,
+                    OnSelectedIndexChanged = setSelectedListIndex,
                     OnItemClick = a => setSelectedListIndex(filtered.IndexOf(a)),
                     Header = "Animals"
                 }
@@ -126,7 +126,7 @@ class DataTemplateDemo : Component
                 ) with
                 {
                     SelectedIndex = selectedGridIndex,
-                    OnSelectionChanged = setSelectedGridIndex,
+                    OnSelectedIndexChanged = setSelectedGridIndex,
                     Header = "Gallery"
                 }
             ).CornerRadius(8).Height(300),
@@ -148,7 +148,7 @@ class DataTemplateDemo : Component
                 ) with
                 {
                     SelectedIndex = flipIndex,
-                    OnSelectionChanged = setFlipIndex,
+                    OnSelectedIndexChanged = setFlipIndex,
                 }
             ).CornerRadius(8).Height(250).Width(400),
 

--- a/samples/ReactorCharting.Sample/Program.cs
+++ b/samples/ReactorCharting.Sample/Program.cs
@@ -73,7 +73,7 @@ class ChartGallery : Component
             }).Grid(row: 0),
             VStack(8,
                 SelectorBar(tabs.Select(t => SelectorBarItem(t)).ToArray(),
-                    selectedIndex: tab, onSelectionChanged: setTab).Margin(24, 16, 24, 0),
+                    selectedIndex: tab, onSelectedIndexChanged: setTab).Margin(24, 16, 24, 0),
             ScrollView(
                 Border(
                     tab switch

--- a/samples/ReactorGallery/ControlPages/MenusAndToolbars/SelectorBarPage.cs
+++ b/samples/ReactorGallery/ControlPages/MenusAndToolbars/SelectorBarPage.cs
@@ -39,7 +39,7 @@ class SelectorBarPage : Component
         SelectorBarItem(""Favorites"", icon: ""Favorite""),
     },
     selectedIndex: idx,
-    onSelectionChanged: i => setIdx(i))"),
+    onSelectedIndexChanged: i => setIdx(i))"),
 
                 SampleCard("SelectorBar without Icons",
                     SelectorBar(

--- a/samples/ReactorGallery/ControlPages/Navigation/NavigationViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Navigation/NavigationViewPage.cs
@@ -41,14 +41,14 @@ class NavigationViewPage : Component
                     with
                     {
                         SelectedTag = selectedTag,
-                        OnSelectionChanged = tag => { if (tag != null) setSelectedTag(tag); },
+                        OnSelectedTagChanged = tag => { if (tag != null) setSelectedTag(tag); },
                         PaneTitle = "Nav Demo",
                         IsSettingsVisible = false,
                     }).Height(300),
                     @"NavigationView(items, content: TextBlock(""Selected: ...""))
 with {
     SelectedTag = tag,
-    OnSelectionChanged = t => setTag(t),
+    OnSelectedTagChanged = t => setTag(t),
     PaneTitle = ""Nav Demo"",
 }",
                     options: OptionPanel(
@@ -62,7 +62,7 @@ with {
                     with
                     {
                         SelectedTag = selectedTag,
-                        OnSelectionChanged = tag => { if (tag != null) setSelectedTag(tag); },
+                        OnSelectedTagChanged = tag => { if (tag != null) setSelectedTag(tag); },
                         PaneDisplayMode = NavigationViewPaneDisplayMode.Top,
                         IsSettingsVisible = false,
                     }).Height(200),

--- a/samples/ReactorGallery/ControlPages/Navigation/TabViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Navigation/TabViewPage.cs
@@ -31,20 +31,20 @@ class TabViewPage : Component
                     ) with
                     {
                         SelectedIndex = selectedIdx,
-                        OnSelectionChanged = i => setSelectedIdx(i),
+                        OnSelectedIndexChanged = i => setSelectedIdx(i),
                     }).Height(200),
                     @"TabView(
     Tab(""Home"", TextBlock(""Home content"")),
     Tab(""Document"", TextBlock(""Document content"")),
     Tab(""Settings"", TextBlock(""Settings content""))
-) with { SelectedIndex = idx, OnSelectionChanged = i => setIdx(i) }"),
+) with { SelectedIndex = idx, OnSelectedIndexChanged = i => setIdx(i) }"),
 
                 SampleCard("Dynamic Tabs",
                     VStack(8,
                         (TabView(tabs) with
                         {
                             SelectedIndex = Math.Min(selectedIdx, tabCount - 1),
-                            OnSelectionChanged = i => setSelectedIdx(i),
+                            OnSelectedIndexChanged = i => setSelectedIdx(i),
                         }).Height(180),
                         HStack(8,
                             Button("Add Tab", () => setTabCount(tabCount + 1)),

--- a/samples/ReactorGallery/GalleryShell.cs
+++ b/samples/ReactorGallery/GalleryShell.cs
@@ -153,7 +153,7 @@ class GalleryShell : Component
             {
                 SelectedTag = selectedTag,
                 IsPaneOpen = isPaneOpen,
-                OnSelectionChanged = tag =>
+                OnSelectedTagChanged = tag =>
                 {
                     setSearchQuery("");
                     if (tag != null)

--- a/samples/ReactorGallery/UserControls/GalleryControls.cs
+++ b/samples/ReactorGallery/UserControls/GalleryControls.cs
@@ -158,7 +158,7 @@ public static class GalleryControls
                 .Height(200)
                 .Background(Theme.SubtleFill),
                 isExpanded: false,
-                onExpandedChanged: null
+                onIsExpandedChanged: null
             )
             .OnMount(el =>
             {

--- a/samples/ReactorHostControlDemo/CounterDemo.cs
+++ b/samples/ReactorHostControlDemo/CounterDemo.cs
@@ -44,12 +44,12 @@ public class CounterDemo : Component
                     .AutomationName("Increment")
             ).HAlign(HorizontalAlignment.Center),
 
-            Slider(step, min: 1, max: 10, onChanged: setStep)
+            Slider(step, min: 1, max: 10, onValueChanged: setStep)
                 .Margin(horizontal: 16, vertical: 8),
 
             TextBlock($"Step size: {(int)step}").HAlign(HorizontalAlignment.Center),
 
-            ToggleSwitch(auto, onChanged: setAuto,
+            ToggleSwitch(auto, onIsOnChanged: setAuto,
                 onContent: "Auto ON", offContent: "Auto OFF",
                 header: "Auto-increment")
                 .Margin(16, 8, 16, 16)

--- a/samples/TodoApp/Program.cs
+++ b/samples/TodoApp/Program.cs
@@ -258,6 +258,6 @@ class TodoApp : Component
         // "Completed" → "Comp" in narrower windows.
         ToggleButton(label,
             isChecked: filter == active,
-            onToggled: _ => dispatch(new SetFilter(filter)))
+            onIsCheckedChanged: _ => dispatch(new SetFilter(filter)))
             .Flex(shrink: 0);
 }

--- a/samples/WinFormsInterop/SampleDuctComponent.cs
+++ b/samples/WinFormsInterop/SampleDuctComponent.cs
@@ -51,7 +51,7 @@ class SampleReactorComponent : Component
                 .Margin(0, 0, 0, 16),
 
             // ── Slider ─────────────────────────────────────
-            Slider(sliderValue, onChanged: setSliderValue)
+            Slider(sliderValue, onValueChanged: setSliderValue)
                 .Width(300)
                 .Margin(0, 0, 0, 4),
 

--- a/samples/apps/headtrax/HeadTrax/App.cs
+++ b/samples/apps/headtrax/HeadTrax/App.cs
@@ -48,10 +48,10 @@ internal class App : Component
         {
             Content = HStack(6,
                 ToggleButton("SQLite Direct", isChecked: mode == "sqlite",
-                    onToggled: on => { if (on) setMode("sqlite"); })
+                    onIsCheckedChanged: on => { if (on) setMode("sqlite"); })
                     .AutomationName("SQLite Direct data source"),
                 ToggleButton("GraphQL API", isChecked: mode == "graphql",
-                    onToggled: on => { if (on) setMode("graphql"); })
+                    onIsCheckedChanged: on => { if (on) setMode("graphql"); })
                     .AutomationName("GraphQL API data source")
             ),
 

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -15,7 +15,7 @@ AnnotatedScrollBar() → AnnotatedScrollBarElement
 AppBarButton(Command command) → AppBarButtonData
 AppBarButton(string label, Action onClick = null, string icon = null) → AppBarButtonData
 AppBarSeparator() → AppBarSeparatorData
-AppBarToggleButton(string label, bool isChecked = false, Action<bool> onToggled = null, string icon = null) → AppBarToggleButtonData
+AppBarToggleButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null, string icon = null) → AppBarToggleButtonData
 AutoColumns<T>(TypeRegistry registry = null, Func<FieldDescriptor, FieldDescriptor> overrides = null) → IReadOnlyList<FieldDescriptor>
 AutoSuggestBox(string text, Action<string> onTextChanged = null, Action<string> onQuerySubmitted = null) → AutoSuggestBoxElement
 BitmapIcon(Uri source, bool showAsMonochrome = true) → BitmapIconData
@@ -29,11 +29,11 @@ CalendarDatePicker(DateTimeOffset? date = null, Action<DateTimeOffset?> onDateCh
 CalendarView() → CalendarViewElement
 Canvas(Element[] children) → CanvasElement
 Caption(string content) → TextBlockElement
-CheckBox(bool isChecked, Action<bool> onChanged = null, string label = null) → CheckBoxElement
+CheckBox(bool isChecked, Action<bool> onIsCheckedChanged = null, string label = null) → CheckBoxElement
 ColorPicker(Color color, Action<Color> onColorChanged = null) → ColorPickerElement
 Column<T>(string name, Func<T, object> accessor, bool editable = false, string displayName = null, string format = null, double? width = null, PinPosition pin = PinPosition.None) → ColumnBuilder<T>
-ComboBox(Element[] itemElements, int selectedIndex, Action<int> onSelectionChanged) → ComboBoxElement
-ComboBox(string[] items, int selectedIndex = -1, Action<int> onSelectionChanged = null) → ComboBoxElement
+ComboBox(Element[] itemElements, int selectedIndex, Action<int> onSelectedIndexChanged) → ComboBoxElement
+ComboBox(string[] items, int selectedIndex = -1, Action<int> onSelectedIndexChanged = null) → ComboBoxElement
 CommandBar(AppBarItemBase[] primaryCommands = null, AppBarItemBase[] secondaryCommands = null) → CommandBarElement
 CommandBarFlyout(Element target, AppBarItemBase[] primaryCommands = null, AppBarItemBase[] secondaryCommands = null) → CommandBarFlyoutElement
 CommandHost(Command[] commands, Element child) → CommandHostElement
@@ -50,7 +50,7 @@ Ellipse() → EllipseElement
 Empty() → Element
 ErrorBoundary(Element child, Element fallback) → ErrorBoundaryElement
 ErrorBoundary(Element child, Func<Exception, Element> fallback) → ErrorBoundaryElement
-Expander(string header, Element content, bool isExpanded = false, Action<bool> onExpandedChanged = null) → ExpanderElement
+Expander(string header, Element content, bool isExpanded = false, Action<bool> onIsExpandedChanged = null) → ExpanderElement
 Expr(Func<Element> render) → Element
 Flex(Element[] children) → FlexElement
 Flex(FlexDirection direction, Element[] children) → FlexElement
@@ -84,7 +84,7 @@ ItemsView<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, E
 LazyHStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → LazyHStackElement<T>
 LazyVStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → LazyVStackElement<T>
 Line(double x1, double y1, double x2, double y2) → LineElement
-ListBox(string[] items, int selectedIndex = -1, Action<int> onSelectionChanged = null) → ListBoxElement
+ListBox(string[] items, int selectedIndex = -1, Action<int> onSelectedIndexChanged = null) → ListBoxElement
 ListView(Element[] items) → ListViewElement
 ListView<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → TemplatedListViewElement<T>
 LocaleProvider(string locale, Element child, IStringResourceProvider resourceProvider = null, string defaultLocale = "en-US", bool pseudoLocalize = false) → Element
@@ -114,7 +114,7 @@ PasswordBox(string password, Action<string> onPasswordChanged = null, string pla
 Path() → PathElement
 PathIcon(string data) → PathIconData
 PersonPicture() → PersonPictureElement
-PipsPager(int numberOfPages, int selectedPageIndex = 0, Action<int> onSelectedIndexChanged = null) → PipsPagerElement
+PipsPager(int numberOfPages, int selectedPageIndex = 0, Action<int> onSelectedPageIndexChanged = null) → PipsPagerElement
 Pivot(PivotItemData[] items) → PivotElement
 PivotItem(string header, Element content) → PivotItemData
 Popup(Element child, bool isOpen = false, Action onClosed = null) → PopupElement
@@ -123,8 +123,8 @@ ProgressIndeterminate() → ProgressElement
 ProgressRing() → ProgressRingElement
 ProgressRing(double value) → ProgressRingElement
 PropertyGrid(object target, TypeRegistry registry, Action<object> onRootChanged = null) → Element
-RadioButton(string label, bool isChecked = false, Action<bool> onChecked = null, string groupName = null) → RadioButtonElement
-RadioButtons(string[] items, int selectedIndex = -1, Action<int> onSelectionChanged = null) → RadioButtonsElement
+RadioButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null, string groupName = null) → RadioButtonElement
+RadioButtons(string[] items, int selectedIndex = -1, Action<int> onSelectedIndexChanged = null) → RadioButtonsElement
 RadioMenuItem(string text, string groupName, bool isChecked = false, Action onClick = null, string icon = null) → RadioMenuFlyoutItemData
 RatingControl(double value = 0, Action<double> onValueChanged = null) → RatingControlElement
 Rectangle() → RectangleElement
@@ -138,10 +138,10 @@ RichText(RichTextParagraph[] paragraphs) → RichTextBlockElement
 RichText(string text) → RichTextBlockElement
 Run(string text) → RichTextRun
 ScrollView(Element child) → ScrollViewElement
-SelectorBar(SelectorBarItemData[] items, int selectedIndex = 0, Action<int> onSelectionChanged = null) → SelectorBarElement
+SelectorBar(SelectorBarItemData[] items, int selectedIndex = 0, Action<int> onSelectedIndexChanged = null) → SelectorBarElement
 SelectorBarItem(string text, string icon = null) → SelectorBarItemData
 SemanticZoom(Element zoomedInView, Element zoomedOutView) → SemanticZoomElement
-Slider(double value, double min = 0, double max = 100, Action<double> onChanged = null) → SliderElement
+Slider(double value, double min = 0, double max = 100, Action<double> onValueChanged = null) → SliderElement
 SplitButton(Command command, Element flyout = null) → SplitButtonElement
 SplitButton(string label, Action onClick = null, Element flyout = null) → SplitButtonElement
 SplitView(Element pane = null, Element content = null) → SplitViewElement
@@ -160,11 +160,11 @@ ThreeStateCheckBox(bool? checkedState, Action<bool?> onCheckedStateChanged = nul
 TimePicker(TimeSpan time, Action<TimeSpan> onTimeChanged = null) → TimePickerElement
 TitleBar(string title) → TitleBarElement
 ToggleButton(Command command, bool isChecked = false) → ToggleButtonElement
-ToggleButton(string label, bool isChecked = false, Action<bool> onToggled = null) → ToggleButtonElement
-ToggleMenuItem(string text, bool isChecked = false, Action<bool> onToggled = null, string icon = null) → ToggleMenuFlyoutItemData
+ToggleButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null) → ToggleButtonElement
+ToggleMenuItem(string text, bool isChecked = false, Action<bool> onIsCheckedChanged = null, string icon = null) → ToggleMenuFlyoutItemData
 ToggleSplitButton(Command command, bool isChecked = false, Element flyout = null) → ToggleSplitButtonElement
 ToggleSplitButton(string label, bool isChecked = false, Action<bool> onIsCheckedChanged = null, Element flyout = null) → ToggleSplitButtonElement
-ToggleSwitch(bool isOn, Action<bool> onChanged = null, string onContent = null, string offContent = null, string header = null) → ToggleSwitchElement
+ToggleSwitch(bool isOn, Action<bool> onIsOnChanged = null, string onContent = null, string offContent = null, string header = null) → ToggleSwitchElement
 TreeNode(string content, TreeViewNodeData[] children) → TreeViewNodeData
 TreeView(TreeViewNodeData[] nodes) → TreeViewElement
 UniformGrid(Orientation orientation, Element[] items) → GridElement

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -1595,7 +1595,7 @@ public record MenuFlyoutSubItemData(string Text, MenuFlyoutItemBase[] Items, str
 {
     public IconData? IconElement { get; init; }
 }
-public record ToggleMenuFlyoutItemData(string Text, bool IsChecked = false, Action<bool>? OnToggled = null, string? Icon = null) : MenuFlyoutItemBase
+public record ToggleMenuFlyoutItemData(string Text, bool IsChecked = false, Action<bool>? OnIsCheckedChanged = null, string? Icon = null) : MenuFlyoutItemBase
 {
     public IconData? IconElement { get; init; }
 }
@@ -1624,7 +1624,7 @@ public record AppBarButtonData(string Label, Action? OnClick = null, string? Ico
     public string? AccessKey { get; init; }
     public string? Description { get; init; }
 }
-public record AppBarToggleButtonData(string Label, bool IsChecked = false, Action<bool>? OnToggled = null, string? Icon = null) : AppBarItemBase
+public record AppBarToggleButtonData(string Label, bool IsChecked = false, Action<bool>? OnIsCheckedChanged = null, string? Icon = null) : AppBarItemBase
 {
     public IconData? IconElement { get; init; }
 }
@@ -1759,10 +1759,10 @@ public record RepeatButtonElement(string Label, Action? OnClick = null) : Elemen
     internal override bool HasCallbacks => OnClick is not null;
 }
 
-public record ToggleButtonElement(string Label, bool IsChecked = false, Action<bool>? OnToggled = null) : Element
+public record ToggleButtonElement(string Label, bool IsChecked = false, Action<bool>? OnIsCheckedChanged = null) : Element
 {
     internal Action<WinPrim.ToggleButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnToggled is not null;
+    internal override bool HasCallbacks => OnIsCheckedChanged is not null;
 }
 
 public record DropDownButtonElement(string Label, Element? Flyout = null) : Element
@@ -1847,7 +1847,7 @@ public record AutoSuggestBoxElement(
 
 public record CheckBoxElement(
     bool IsChecked,
-    Action<bool>? OnChanged = null,
+    Action<bool>? OnIsCheckedChanged = null,
     string? Label = null
 ) : Element
 {
@@ -1855,35 +1855,35 @@ public record CheckBoxElement(
     public bool? CheckedState { get; init; }
     public Action<bool?>? OnCheckedStateChanged { get; init; }
     internal Action<WinUI.CheckBox>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnChanged is not null || OnCheckedStateChanged is not null;
+    internal override bool HasCallbacks => OnIsCheckedChanged is not null || OnCheckedStateChanged is not null;
 }
 
 public record RadioButtonElement(
     string Label,
     bool IsChecked = false,
-    Action<bool>? OnChecked = null,
+    Action<bool>? OnIsCheckedChanged = null,
     string? GroupName = null
 ) : Element
 {
     internal Action<WinUI.RadioButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnChecked is not null;
+    internal override bool HasCallbacks => OnIsCheckedChanged is not null;
 }
 
 public record RadioButtonsElement(
     string[] Items,
     int SelectedIndex = -1,
-    Action<int>? OnSelectionChanged = null
+    Action<int>? OnSelectedIndexChanged = null
 ) : Element
 {
     public string? Header { get; init; }
     internal Action<WinUI.RadioButtons>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectionChanged is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
 }
 
 public record ComboBoxElement(
     string[] Items,
     int SelectedIndex = -1,
-    Action<int>? OnSelectionChanged = null
+    Action<int>? OnSelectedIndexChanged = null
 ) : Element
 {
     public string? PlaceholderText { get; init; }
@@ -1891,32 +1891,32 @@ public record ComboBoxElement(
     public bool IsEditable { get; init; }
     public Element[]? ItemElements { get; init; }
     internal Action<WinUI.ComboBox>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectionChanged is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
 }
 
 public record SliderElement(
     double Value,
     double Min = 0,
     double Max = 100,
-    Action<double>? OnChanged = null
+    Action<double>? OnValueChanged = null
 ) : Element
 {
     public double StepFrequency { get; init; } = 1;
     public string? Header { get; init; }
     internal Action<WinUI.Slider>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnChanged is not null;
+    internal override bool HasCallbacks => OnValueChanged is not null;
 }
 
 public record ToggleSwitchElement(
     bool IsOn,
-    Action<bool>? OnChanged = null,
+    Action<bool>? OnIsOnChanged = null,
     string? OnContent = null,
     string? OffContent = null
 ) : Element
 {
     public string? Header { get; init; }
     internal Action<WinUI.ToggleSwitch>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnChanged is not null;
+    internal override bool HasCallbacks => OnIsOnChanged is not null;
 }
 
 public record RatingControlElement(
@@ -2133,12 +2133,12 @@ public record ExpanderElement(
     string Header,
     Element Content,
     bool IsExpanded = false,
-    Action<bool>? OnExpandedChanged = null
+    Action<bool>? OnIsExpandedChanged = null
 ) : Element
 {
     public ExpandDirection ExpandDirection { get; init; } = ExpandDirection.Down;
     internal Action<WinUI.Expander>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnExpandedChanged is not null;
+    internal override bool HasCallbacks => OnIsExpandedChanged is not null;
 }
 
 public record SplitViewElement(
@@ -2235,7 +2235,7 @@ public record NavigationViewElement(
 ) : Element
 {
     public string? SelectedTag { get; init; }
-    public Action<string?>? OnSelectionChanged { get; init; }
+    public Action<string?>? OnSelectedTagChanged { get; init; }
     public bool IsPaneOpen { get; init; } = true;
     public NavigationViewPaneDisplayMode PaneDisplayMode { get; init; } = NavigationViewPaneDisplayMode.Auto;
     public bool IsBackEnabled { get; init; }
@@ -2244,7 +2244,7 @@ public record NavigationViewElement(
     public bool IsSettingsVisible { get; init; } = true;
     public string? PaneTitle { get; init; }
     internal Action<WinUI.NavigationView>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectionChanged is not null || OnBackRequested is not null;
+    internal override bool HasCallbacks => OnSelectedTagChanged is not null || OnBackRequested is not null;
 }
 
 public record TitleBarElement(
@@ -2277,12 +2277,12 @@ public record TabViewElement(
 ) : Element
 {
     public int SelectedIndex { get; init; } = 0;
-    public Action<int>? OnSelectionChanged { get; init; }
+    public Action<int>? OnSelectedIndexChanged { get; init; }
     public Action<int>? OnTabCloseRequested { get; init; }
     public Action? OnAddTabButtonClick { get; init; }
     public bool IsAddTabButtonVisible { get; init; }
     internal Action<WinUI.TabView>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectionChanged is not null || OnTabCloseRequested is not null || OnAddTabButtonClick is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null || OnTabCloseRequested is not null || OnAddTabButtonClick is not null;
 }
 
 public record BreadcrumbBarElement(
@@ -2299,10 +2299,10 @@ public record PivotElement(
 ) : Element
 {
     public int SelectedIndex { get; init; } = 0;
-    public Action<int>? OnSelectionChanged { get; init; }
+    public Action<int>? OnSelectedIndexChanged { get; init; }
     public string? Title { get; init; }
     internal Action<WinUI.Pivot>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectionChanged is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -2314,12 +2314,12 @@ public record ListViewElement(
 ) : Element
 {
     public int SelectedIndex { get; init; } = -1;
-    public Action<int>? OnSelectionChanged { get; init; }
+    public Action<int>? OnSelectedIndexChanged { get; init; }
     public Action<int>? OnItemClick { get; init; }
     public ListViewSelectionMode SelectionMode { get; init; } = ListViewSelectionMode.Single;
     public string? Header { get; init; }
     internal Action<WinUI.ListView>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectionChanged is not null || OnItemClick is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null || OnItemClick is not null;
 }
 
 public record GridViewElement(
@@ -2327,12 +2327,12 @@ public record GridViewElement(
 ) : Element
 {
     public int SelectedIndex { get; init; } = -1;
-    public Action<int>? OnSelectionChanged { get; init; }
+    public Action<int>? OnSelectedIndexChanged { get; init; }
     public Action<int>? OnItemClick { get; init; }
     public ListViewSelectionMode SelectionMode { get; init; } = ListViewSelectionMode.Single;
     public string? Header { get; init; }
     internal Action<WinUI.GridView>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectionChanged is not null || OnItemClick is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null || OnItemClick is not null;
 }
 
 public record TreeViewElement(
@@ -2354,9 +2354,9 @@ public record FlipViewElement(
 ) : Element
 {
     public int SelectedIndex { get; init; } = 0;
-    public Action<int>? OnSelectionChanged { get; init; }
+    public Action<int>? OnSelectedIndexChanged { get; init; }
     internal Action<WinUI.FlipView>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectionChanged is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -2529,7 +2529,7 @@ public record TemplatedListViewElement<T>(
 ) : TemplatedListElementBase
 {
     public int SelectedIndex { get; init; } = -1;
-    public Action<int>? OnSelectionChanged { get; init; }
+    public Action<int>? OnSelectedIndexChanged { get; init; }
     public Action<T>? OnItemClick { get; init; }
     public ListViewSelectionMode SelectionMode { get; init; } = ListViewSelectionMode.Single;
     public string? Header { get; init; }
@@ -2542,12 +2542,12 @@ public record TemplatedListViewElement<T>(
     public override string? GetHeader() => Header;
     public override bool GetIsItemClickEnabled() => OnItemClick is not null;
     public override Element BuildItemView(int index) => ViewBuilder(Items[index], index);
-    public override void InvokeSelectionChanged(int index) => OnSelectionChanged?.Invoke(index);
+    public override void InvokeSelectionChanged(int index) => OnSelectedIndexChanged?.Invoke(index);
     public override void InvokeItemClick(int index) =>
         OnItemClick?.Invoke(index >= 0 && index < Items.Count ? Items[index] : default!);
     public override void ApplyControlSetters(object control) =>
         Reconciler.ApplySetters(Setters, (WinUI.ListView)control);
-    internal override bool HasCallbacks => OnSelectionChanged is not null || OnItemClick is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null || OnItemClick is not null;
     internal override bool HasSetters => Setters.Length > 0;
 }
 
@@ -2558,7 +2558,7 @@ public record TemplatedGridViewElement<T>(
 ) : TemplatedListElementBase
 {
     public int SelectedIndex { get; init; } = -1;
-    public Action<int>? OnSelectionChanged { get; init; }
+    public Action<int>? OnSelectedIndexChanged { get; init; }
     public Action<T>? OnItemClick { get; init; }
     public ListViewSelectionMode SelectionMode { get; init; } = ListViewSelectionMode.Single;
     public string? Header { get; init; }
@@ -2571,12 +2571,12 @@ public record TemplatedGridViewElement<T>(
     public override string? GetHeader() => Header;
     public override bool GetIsItemClickEnabled() => OnItemClick is not null;
     public override Element BuildItemView(int index) => ViewBuilder(Items[index], index);
-    public override void InvokeSelectionChanged(int index) => OnSelectionChanged?.Invoke(index);
+    public override void InvokeSelectionChanged(int index) => OnSelectedIndexChanged?.Invoke(index);
     public override void InvokeItemClick(int index) =>
         OnItemClick?.Invoke(index >= 0 && index < Items.Count ? Items[index] : default!);
     public override void ApplyControlSetters(object control) =>
         Reconciler.ApplySetters(Setters, (WinUI.GridView)control);
-    internal override bool HasCallbacks => OnSelectionChanged is not null || OnItemClick is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null || OnItemClick is not null;
     internal override bool HasSetters => Setters.Length > 0;
 }
 
@@ -2587,7 +2587,7 @@ public record TemplatedFlipViewElement<T>(
 ) : TemplatedListElementBase
 {
     public int SelectedIndex { get; init; } = 0;
-    public Action<int>? OnSelectionChanged { get; init; }
+    public Action<int>? OnSelectedIndexChanged { get; init; }
     internal Action<WinUI.FlipView>[] Setters { get; init; } = [];
 
     public override TemplatedControlKind ControlKind => TemplatedControlKind.FlipView;
@@ -2597,11 +2597,11 @@ public record TemplatedFlipViewElement<T>(
     public override string? GetHeader() => null;
     public override bool GetIsItemClickEnabled() => false;
     public override Element BuildItemView(int index) => ViewBuilder(Items[index], index);
-    public override void InvokeSelectionChanged(int index) => OnSelectionChanged?.Invoke(index);
+    public override void InvokeSelectionChanged(int index) => OnSelectedIndexChanged?.Invoke(index);
     public override void InvokeItemClick(int index) { }
     public override void ApplyControlSetters(object control) =>
         Reconciler.ApplySetters(Setters, (WinUI.FlipView)control);
-    internal override bool HasCallbacks => OnSelectionChanged is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
     internal override bool HasSetters => Setters.Length > 0;
 }
 
@@ -2782,9 +2782,9 @@ public record SemanticZoomElement(Element ZoomedInView, Element ZoomedOutView) :
 public record ListBoxElement(string[] Items) : Element
 {
     public int SelectedIndex { get; init; } = -1;
-    public Action<int>? OnSelectionChanged { get; init; }
+    public Action<int>? OnSelectedIndexChanged { get; init; }
     internal Action<WinUI.ListBox>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectionChanged is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -2794,9 +2794,9 @@ public record ListBoxElement(string[] Items) : Element
 public record SelectorBarElement(SelectorBarItemData[] Items) : Element
 {
     public int SelectedIndex { get; init; } = 0;
-    public Action<int>? OnSelectionChanged { get; init; }
+    public Action<int>? OnSelectedIndexChanged { get; init; }
     internal Action<WinUI.SelectorBar>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectionChanged is not null;
+    internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
 }
 
 public record SelectorBarItemData(string Text, string? Icon = null);
@@ -2804,9 +2804,9 @@ public record SelectorBarItemData(string Text, string? Icon = null);
 public record PipsPagerElement(int NumberOfPages) : Element
 {
     public int SelectedPageIndex { get; init; }
-    public Action<int>? OnSelectedIndexChanged { get; init; }
+    public Action<int>? OnSelectedPageIndexChanged { get; init; }
     internal Action<WinUI.PipsPager>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
+    internal override bool HasCallbacks => OnSelectedPageIndexChanged is not null;
 }
 
 public record AnnotatedScrollBarElement() : Element

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -407,11 +407,11 @@ public sealed partial class Reconciler
         // Bind to Click — fires only for real user toggles. Checked/Unchecked
         // would also fire when UpdateToggleButton rewrites IsChecked during a
         // state-driven rerender, which would re-enter the callback and loop.
-        if (togBtn.OnToggled is not null)
+        if (togBtn.OnIsCheckedChanged is not null)
             tb.Click += (s, _) =>
             {
                 var t = (WinPrim.ToggleButton)s!;
-                (GetElementTag(t) as ToggleButtonElement)?.OnToggled?.Invoke(t.IsChecked ?? false);
+                (GetElementTag(t) as ToggleButtonElement)?.OnIsCheckedChanged?.Invoke(t.IsChecked ?? false);
             };
         ApplySetters(togBtn.Setters, tb);
         return tb;
@@ -613,14 +613,14 @@ public sealed partial class Reconciler
             checkBox.IsChecked = cb.IsChecked;
         }
         SetElementTag(checkBox, cb);
-        if (cb.OnChanged is not null || cb.OnCheckedStateChanged is not null)
+        if (cb.OnIsCheckedChanged is not null || cb.OnCheckedStateChanged is not null)
         {
             checkBox.Checked += (s, _) =>
             {
                 var c = (UIElement)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
                 var el = GetElementTag(c) as CheckBoxElement;
-                el?.OnChanged?.Invoke(true);
+                el?.OnIsCheckedChanged?.Invoke(true);
                 el?.OnCheckedStateChanged?.Invoke(true);
             };
             checkBox.Unchecked += (s, _) =>
@@ -628,7 +628,7 @@ public sealed partial class Reconciler
                 var c = (UIElement)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
                 var el = GetElementTag(c) as CheckBoxElement;
-                el?.OnChanged?.Invoke(false);
+                el?.OnIsCheckedChanged?.Invoke(false);
                 el?.OnCheckedStateChanged?.Invoke(false);
             };
             checkBox.Indeterminate += (s, _) =>
@@ -648,19 +648,19 @@ public sealed partial class Reconciler
         var radio = new WinUI.RadioButton { Content = rb.Label, IsChecked = rb.IsChecked };
         if (rb.GroupName is not null) radio.GroupName = rb.GroupName;
         SetElementTag(radio, rb);
-        if (rb.OnChecked is not null)
+        if (rb.OnIsCheckedChanged is not null)
         {
             radio.Checked += (s, _) =>
             {
                 var c = (UIElement)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-                (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(true);
+                (GetElementTag(c) as RadioButtonElement)?.OnIsCheckedChanged?.Invoke(true);
             };
             radio.Unchecked += (s, _) =>
             {
                 var c = (UIElement)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-                (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(false);
+                (GetElementTag(c) as RadioButtonElement)?.OnIsCheckedChanged?.Invoke(false);
             };
         }
         ApplySetters(rb.Setters, radio);
@@ -673,12 +673,12 @@ public sealed partial class Reconciler
         if (rbs.Header is not null) rbGroup.Header = rbs.Header;
         foreach (var item in rbs.Items) rbGroup.Items.Add(item);
         SetElementTag(rbGroup, rbs);
-        if (rbs.OnSelectionChanged is not null)
+        if (rbs.OnSelectedIndexChanged is not null)
             rbGroup.SelectionChanged += (s, _) =>
             {
                 var g = (WinUI.RadioButtons)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(g)) return;
-                (GetElementTag(g) as RadioButtonsElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
+                (GetElementTag(g) as RadioButtonsElement)?.OnSelectedIndexChanged?.Invoke(g.SelectedIndex);
             };
         ApplySetters(rbs.Setters, rbGroup);
         return rbGroup;
@@ -698,12 +698,12 @@ public sealed partial class Reconciler
         else
             foreach (var item in combo.Items) cb.Items.Add(item);
         SetElementTag(cb, combo);
-        if (combo.OnSelectionChanged is not null)
+        if (combo.OnSelectedIndexChanged is not null)
             cb.SelectionChanged += (s, _) =>
             {
                 var c = (WinUI.ComboBox)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-                (GetElementTag(c) as ComboBoxElement)?.OnSelectionChanged?.Invoke(c.SelectedIndex);
+                (GetElementTag(c) as ComboBoxElement)?.OnSelectedIndexChanged?.Invoke(c.SelectedIndex);
             };
         ApplySetters(combo.Setters, cb);
         return cb;
@@ -714,11 +714,11 @@ public sealed partial class Reconciler
         var slider = new WinUI.Slider { Value = sl.Value, Minimum = sl.Min, Maximum = sl.Max, StepFrequency = sl.StepFrequency };
         if (sl.Header is not null) slider.Header = sl.Header;
         SetElementTag(slider, sl);
-        if (sl.OnChanged is not null)
+        if (sl.OnValueChanged is not null)
             slider.ValueChanged += (_, args) =>
             {
                 if (ChangeEchoSuppressor.ShouldSuppress(slider)) return;
-                (GetElementTag(slider) as SliderElement)?.OnChanged?.Invoke(args.NewValue);
+                (GetElementTag(slider) as SliderElement)?.OnValueChanged?.Invoke(args.NewValue);
             };
         ApplySetters(sl.Setters, slider);
         return slider;
@@ -749,14 +749,14 @@ public sealed partial class Reconciler
     // double-subscribe, fanning one Toggled into multiple user-callback invocations.
     internal static void EnsureToggleSwitchWiring(WinUI.ToggleSwitch toggle, ToggleSwitchElement ts)
     {
-        if (ts.OnChanged is null) return;
+        if (ts.OnIsOnChanged is null) return;
         var state = GetOrCreateEventState(toggle);
         if (state.ToggleSwitchToggledTrampoline is not null) return;
         state.ToggleSwitchToggledTrampoline = (s, _) =>
         {
             var t = (WinUI.ToggleSwitch)s!;
             if (ChangeEchoSuppressor.ShouldSuppress(t)) return;
-            (GetElementTag(t) as ToggleSwitchElement)?.OnChanged?.Invoke(t.IsOn);
+            (GetElementTag(t) as ToggleSwitchElement)?.OnIsOnChanged?.Invoke(t.IsOn);
         };
         toggle.Toggled += state.ToggleSwitchToggledTrampoline;
     }
@@ -1042,10 +1042,10 @@ public sealed partial class Reconciler
         };
         expander.Content = Mount(exp.Content, requestRerender);
         SetElementTag(expander, exp);
-        if (exp.OnExpandedChanged is not null)
+        if (exp.OnIsExpandedChanged is not null)
         {
-            expander.Expanding += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnExpandedChanged?.Invoke(true);
-            expander.Collapsed += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnExpandedChanged?.Invoke(false);
+            expander.Expanding += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnIsExpandedChanged?.Invoke(true);
+            expander.Collapsed += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnIsExpandedChanged?.Invoke(false);
         }
         ApplySetters(exp.Setters, expander);
         return expander;
@@ -1201,11 +1201,11 @@ public sealed partial class Reconciler
                 if (mi.Tag as string == nav.SelectedTag) { nv.SelectedItem = mi; break; }
         }
         SetElementTag(nv, nav);
-        if (nav.OnSelectionChanged is not null)
+        if (nav.OnSelectedTagChanged is not null)
             nv.SelectionChanged += (s, args) =>
             {
                 var selected = args.SelectedItem as WinUI.NavigationViewItem;
-                (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnSelectionChanged?.Invoke(selected?.Tag as string);
+                (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnSelectedTagChanged?.Invoke(selected?.Tag as string);
             };
         if (nav.OnBackRequested is not null)
             nv.BackRequested += (s, _) => (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnBackRequested?.Invoke();
@@ -1267,11 +1267,11 @@ public sealed partial class Reconciler
             tv.TabItems.Add(tvi);
         }
         SetElementTag(tv, tab);
-        if (tab.OnSelectionChanged is not null)
+        if (tab.OnSelectedIndexChanged is not null)
             tv.SelectionChanged += (s, _) =>
             {
                 var t = (WinUI.TabView)s!;
-                (GetElementTag(t) as TabViewElement)?.OnSelectionChanged?.Invoke(t.SelectedIndex);
+                (GetElementTag(t) as TabViewElement)?.OnSelectedIndexChanged?.Invoke(t.SelectedIndex);
             };
         if (tab.OnTabCloseRequested is not null)
             tv.TabCloseRequested += (s, args) =>
@@ -1311,11 +1311,11 @@ public sealed partial class Reconciler
             pivot.Items.Add(pi);
         }
         SetElementTag(pivot, pvt);
-        if (pvt.OnSelectionChanged is not null)
+        if (pvt.OnSelectedIndexChanged is not null)
             pivot.SelectionChanged += (s, _) =>
             {
                 var p = (WinUI.Pivot)s!;
-                (GetElementTag(p) as PivotElement)?.OnSelectionChanged?.Invoke(p.SelectedIndex);
+                (GetElementTag(p) as PivotElement)?.OnSelectedIndexChanged?.Invoke(p.SelectedIndex);
             };
         ApplySetters(pvt.Setters, pivot);
         return pivot;
@@ -1358,11 +1358,11 @@ public sealed partial class Reconciler
             }
         };
 
-        if (lv.OnSelectionChanged is not null)
+        if (lv.OnSelectedIndexChanged is not null)
             listView.SelectionChanged += (s, _) =>
             {
                 var l = (WinUI.ListView)s!;
-                (GetElementTag(l) as ListViewElement)?.OnSelectionChanged?.Invoke(l.SelectedIndex);
+                (GetElementTag(l) as ListViewElement)?.OnSelectedIndexChanged?.Invoke(l.SelectedIndex);
             };
         if (lv.OnItemClick is not null)
             listView.ItemClick += (s, args) =>
@@ -1416,11 +1416,11 @@ public sealed partial class Reconciler
             }
         };
 
-        if (gv.OnSelectionChanged is not null)
+        if (gv.OnSelectedIndexChanged is not null)
             gridView.SelectionChanged += (s, _) =>
             {
                 var g = (WinUI.GridView)s!;
-                (GetElementTag(g) as GridViewElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
+                (GetElementTag(g) as GridViewElement)?.OnSelectedIndexChanged?.Invoke(g.SelectedIndex);
             };
         if (gv.OnItemClick is not null)
             gridView.ItemClick += (s, args) =>
@@ -1544,11 +1544,11 @@ public sealed partial class Reconciler
             if (ctrl is not null) flipView.Items.Add(ctrl);
         }
         SetElementTag(flipView, fv);
-        if (fv.OnSelectionChanged is not null)
+        if (fv.OnSelectedIndexChanged is not null)
             flipView.SelectionChanged += (s, _) =>
             {
                 var f = (WinUI.FlipView)s!;
-                (GetElementTag(f) as FlipViewElement)?.OnSelectionChanged?.Invoke(f.SelectedIndex);
+                (GetElementTag(f) as FlipViewElement)?.OnSelectedIndexChanged?.Invoke(f.SelectedIndex);
             };
         ApplySetters(fv.Setters, flipView);
         return flipView;
@@ -1952,8 +1952,8 @@ public sealed partial class Reconciler
                 var atb = new WinUI.AppBarToggleButton { Label = toggle.Label, IsChecked = toggle.IsChecked };
                 atb.Icon = ResolveIcon(toggle.IconElement, toggle.Icon);
                 atb.Tag = toggle;
-                atb.Checked += (s, _) => ((AppBarToggleButtonData)((WinUI.AppBarToggleButton)s!).Tag!).OnToggled?.Invoke(true);
-                atb.Unchecked += (s, _) => ((AppBarToggleButtonData)((WinUI.AppBarToggleButton)s!).Tag!).OnToggled?.Invoke(false);
+                atb.Checked += (s, _) => ((AppBarToggleButtonData)((WinUI.AppBarToggleButton)s!).Tag!).OnIsCheckedChanged?.Invoke(true);
+                atb.Unchecked += (s, _) => ((AppBarToggleButtonData)((WinUI.AppBarToggleButton)s!).Tag!).OnIsCheckedChanged?.Invoke(false);
                 return atb;
             }
             case AppBarSeparatorData:
@@ -2010,7 +2010,7 @@ public sealed partial class Reconciler
                 toggleItem.Click += (s, _) =>
                 {
                     var ti = (WinUI.ToggleMenuFlyoutItem)s!;
-                    ((ToggleMenuFlyoutItemData)ti.Tag!).OnToggled?.Invoke(ti.IsChecked);
+                    ((ToggleMenuFlyoutItemData)ti.Tag!).OnIsCheckedChanged?.Invoke(ti.IsChecked);
                 };
                 return toggleItem;
             }
@@ -2799,11 +2799,11 @@ public sealed partial class Reconciler
         var listBox = new WinUI.ListBox { SelectedIndex = lb.SelectedIndex };
         foreach (var item in lb.Items) listBox.Items.Add(item);
         SetElementTag(listBox, lb);
-        if (lb.OnSelectionChanged is not null)
+        if (lb.OnSelectedIndexChanged is not null)
             listBox.SelectionChanged += (s, _) =>
             {
                 var l = (WinUI.ListBox)s!;
-                (GetElementTag(l) as ListBoxElement)?.OnSelectionChanged?.Invoke(l.SelectedIndex);
+                (GetElementTag(l) as ListBoxElement)?.OnSelectedIndexChanged?.Invoke(l.SelectedIndex);
             };
         ApplySetters(lb.Setters, listBox);
         return listBox;
@@ -2823,12 +2823,12 @@ public sealed partial class Reconciler
         if (sb.SelectedIndex >= 0 && sb.SelectedIndex < selectorBar.Items.Count)
             selectorBar.SelectedItem = selectorBar.Items[sb.SelectedIndex];
         SetElementTag(selectorBar, sb);
-        if (sb.OnSelectionChanged is not null)
+        if (sb.OnSelectedIndexChanged is not null)
             selectorBar.SelectionChanged += (s, _) =>
             {
                 var bar = (WinUI.SelectorBar)s!;
                 var idx = bar.Items.IndexOf(bar.SelectedItem);
-                (GetElementTag(bar) as SelectorBarElement)?.OnSelectionChanged?.Invoke(idx);
+                (GetElementTag(bar) as SelectorBarElement)?.OnSelectedIndexChanged?.Invoke(idx);
             };
         ApplySetters(sb.Setters, selectorBar);
         return selectorBar;
@@ -2844,11 +2844,11 @@ public sealed partial class Reconciler
             SelectedPageIndex = pp.SelectedPageIndex,
         };
         SetElementTag(pager, pp);
-        if (pp.OnSelectedIndexChanged is not null)
+        if (pp.OnSelectedPageIndexChanged is not null)
             pager.SelectedIndexChanged += (s, _) =>
             {
                 var p = (WinUI.PipsPager)s!;
-                (GetElementTag(p) as PipsPagerElement)?.OnSelectedIndexChanged?.Invoke(p.SelectedPageIndex);
+                (GetElementTag(p) as PipsPagerElement)?.OnSelectedPageIndexChanged?.Invoke(p.SelectedPageIndex);
             };
         ApplySetters(pp.Setters, pager);
         return pager;

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -694,11 +694,11 @@ public sealed partial class Reconciler
         tb.Content = n.Label;
         if ((tb.IsChecked ?? false) != n.IsChecked) tb.IsChecked = n.IsChecked;
         SetElementTag(tb, n);
-        if (o.OnToggled is null && n.OnToggled is not null)
+        if (o.OnIsCheckedChanged is null && n.OnIsCheckedChanged is not null)
             tb.Click += (s, _) =>
             {
                 var t = (WinPrim.ToggleButton)s!;
-                (GetElementTag(t) as ToggleButtonElement)?.OnToggled?.Invoke(t.IsChecked ?? false);
+                (GetElementTag(t) as ToggleButtonElement)?.OnIsCheckedChanged?.Invoke(t.IsChecked ?? false);
             };
         ApplySetters(n.Setters, tb);
         return null;
@@ -888,8 +888,8 @@ public sealed partial class Reconciler
     private UIElement? UpdateCheckBox(CheckBoxElement o, CheckBoxElement n, WinUI.CheckBox cb)
     {
         SetElementTag(cb, n);
-        bool oldWired = o.OnChanged is not null || o.OnCheckedStateChanged is not null;
-        bool newWired = n.OnChanged is not null || n.OnCheckedStateChanged is not null;
+        bool oldWired = o.OnIsCheckedChanged is not null || o.OnCheckedStateChanged is not null;
+        bool newWired = n.OnIsCheckedChanged is not null || n.OnCheckedStateChanged is not null;
         if (!oldWired && newWired)
         {
             cb.Checked += (s, _) =>
@@ -897,7 +897,7 @@ public sealed partial class Reconciler
                 var c = (UIElement)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
                 var el = GetElementTag(c) as CheckBoxElement;
-                el?.OnChanged?.Invoke(true);
+                el?.OnIsCheckedChanged?.Invoke(true);
                 el?.OnCheckedStateChanged?.Invoke(true);
             };
             cb.Unchecked += (s, _) =>
@@ -905,7 +905,7 @@ public sealed partial class Reconciler
                 var c = (UIElement)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
                 var el = GetElementTag(c) as CheckBoxElement;
-                el?.OnChanged?.Invoke(false);
+                el?.OnIsCheckedChanged?.Invoke(false);
                 el?.OnCheckedStateChanged?.Invoke(false);
             };
             cb.Indeterminate += (s, _) =>
@@ -931,19 +931,19 @@ public sealed partial class Reconciler
     private UIElement? UpdateRadioButton(RadioButtonElement o, RadioButtonElement n, WinUI.RadioButton rb)
     {
         SetElementTag(rb, n);
-        if (o.OnChecked is null && n.OnChecked is not null)
+        if (o.OnIsCheckedChanged is null && n.OnIsCheckedChanged is not null)
         {
             rb.Checked += (s, _) =>
             {
                 var c = (UIElement)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-                (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(true);
+                (GetElementTag(c) as RadioButtonElement)?.OnIsCheckedChanged?.Invoke(true);
             };
             rb.Unchecked += (s, _) =>
             {
                 var c = (UIElement)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-                (GetElementTag(c) as RadioButtonElement)?.OnChecked?.Invoke(false);
+                (GetElementTag(c) as RadioButtonElement)?.OnIsCheckedChanged?.Invoke(false);
             };
         }
         rb.Content = n.Label;
@@ -960,13 +960,13 @@ public sealed partial class Reconciler
     private UIElement? UpdateSlider(SliderElement o, SliderElement n, WinUI.Slider s)
     {
         SetElementTag(s, n);
-        if (o.OnChanged is null && n.OnChanged is not null)
+        if (o.OnValueChanged is null && n.OnValueChanged is not null)
         {
             var sliderCapture = s;
             s.ValueChanged += (_, args) =>
             {
                 if (ChangeEchoSuppressor.ShouldSuppress(sliderCapture)) return;
-                (GetElementTag(sliderCapture) as SliderElement)?.OnChanged?.Invoke(args.NewValue);
+                (GetElementTag(sliderCapture) as SliderElement)?.OnValueChanged?.Invoke(args.NewValue);
             };
         }
         // Min/Max before Value so a new, in-range Value doesn't get coerced
@@ -1307,10 +1307,10 @@ public sealed partial class Reconciler
         }
 
         SetElementTag(exp, n);
-        if (o.OnExpandedChanged is null && n.OnExpandedChanged is not null)
+        if (o.OnIsExpandedChanged is null && n.OnIsExpandedChanged is not null)
         {
-            exp.Expanding += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnExpandedChanged?.Invoke(true);
-            exp.Collapsed += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnExpandedChanged?.Invoke(false);
+            exp.Expanding += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnIsExpandedChanged?.Invoke(true);
+            exp.Collapsed += (s, _) => (GetElementTag((UIElement)s!) as ExpanderElement)?.OnIsExpandedChanged?.Invoke(false);
         }
         ApplySetters(n.Setters, exp);
         return null;
@@ -1570,11 +1570,11 @@ public sealed partial class Reconciler
         }
 
         SetElementTag(nv, n);
-        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+        if (o.OnSelectedTagChanged is null && n.OnSelectedTagChanged is not null)
             nv.SelectionChanged += (s, args) =>
             {
                 var selected = args.SelectedItem as WinUI.NavigationViewItem;
-                (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnSelectionChanged?.Invoke(selected?.Tag as string);
+                (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnSelectedTagChanged?.Invoke(selected?.Tag as string);
             };
         if (o.OnBackRequested is null && n.OnBackRequested is not null)
             nv.BackRequested += (s, _) => (GetElementTag((UIElement)s!) as NavigationViewElement)?.OnBackRequested?.Invoke();
@@ -1651,11 +1651,11 @@ public sealed partial class Reconciler
         // the new element's closures.
         SetElementTag(tabView, n);
 
-        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
             tabView.SelectionChanged += (s, _) =>
             {
                 var t = (WinUI.TabView)s!;
-                (GetElementTag(t) as TabViewElement)?.OnSelectionChanged?.Invoke(t.SelectedIndex);
+                (GetElementTag(t) as TabViewElement)?.OnSelectedIndexChanged?.Invoke(t.SelectedIndex);
             };
         if (o.OnTabCloseRequested is null && n.OnTabCloseRequested is not null)
             tabView.TabCloseRequested += (s, args) =>
@@ -1737,11 +1737,11 @@ public sealed partial class Reconciler
     {
         SetElementTag(pivot, n);
 
-        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
             pivot.SelectionChanged += (s, _) =>
             {
                 var p = (WinUI.Pivot)s!;
-                (GetElementTag(p) as PivotElement)?.OnSelectionChanged?.Invoke(p.SelectedIndex);
+                (GetElementTag(p) as PivotElement)?.OnSelectedIndexChanged?.Invoke(p.SelectedIndex);
             };
 
         var items = pivot.Items;
@@ -1794,12 +1794,12 @@ public sealed partial class Reconciler
     private UIElement? UpdateRadioButtons(RadioButtonsElement o, RadioButtonsElement n, WinUI.RadioButtons rbg)
     {
         SetElementTag(rbg, n);
-        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
             rbg.SelectionChanged += (s, _) =>
             {
                 var g = (WinUI.RadioButtons)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(g)) return;
-                (GetElementTag(g) as RadioButtonsElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
+                (GetElementTag(g) as RadioButtonsElement)?.OnSelectedIndexChanged?.Invoke(g.SelectedIndex);
             };
         if (!StringArrayEquals(o.Items, n.Items))
         {
@@ -1818,12 +1818,12 @@ public sealed partial class Reconciler
     {
         SetElementTag(cb, n);
 
-        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
             cb.SelectionChanged += (s, _) =>
             {
                 var c = (WinUI.ComboBox)s!;
                 if (ChangeEchoSuppressor.ShouldSuppress(c)) return;
-                (GetElementTag(c) as ComboBoxElement)?.OnSelectionChanged?.Invoke(c.SelectedIndex);
+                (GetElementTag(c) as ComboBoxElement)?.OnSelectedIndexChanged?.Invoke(c.SelectedIndex);
             };
 
         bool oldIsElements = o.ItemElements is not null;
@@ -1889,11 +1889,11 @@ public sealed partial class Reconciler
     private UIElement? UpdateListBox(ListBoxElement o, ListBoxElement n, WinUI.ListBox lb)
     {
         SetElementTag(lb, n);
-        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
             lb.SelectionChanged += (s, _) =>
             {
                 var l = (WinUI.ListBox)s!;
-                (GetElementTag(l) as ListBoxElement)?.OnSelectionChanged?.Invoke(l.SelectedIndex);
+                (GetElementTag(l) as ListBoxElement)?.OnSelectedIndexChanged?.Invoke(l.SelectedIndex);
             };
         if (!StringArrayEquals(o.Items, n.Items))
         {
@@ -1910,12 +1910,12 @@ public sealed partial class Reconciler
     {
         SetElementTag(bar, n);
 
-        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
             bar.SelectionChanged += (s, _) =>
             {
                 var b = (WinUI.SelectorBar)s!;
                 var idx = b.Items.IndexOf(b.SelectedItem);
-                (GetElementTag(b) as SelectorBarElement)?.OnSelectionChanged?.Invoke(idx);
+                (GetElementTag(b) as SelectorBarElement)?.OnSelectedIndexChanged?.Invoke(idx);
             };
 
         var items = bar.Items;
@@ -2476,11 +2476,11 @@ public sealed partial class Reconciler
 
         SetElementTag(lv, n);
 
-        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
             lv.SelectionChanged += (s, _) =>
             {
                 var l = (WinUI.ListView)s!;
-                (GetElementTag(l) as ListViewElement)?.OnSelectionChanged?.Invoke(l.SelectedIndex);
+                (GetElementTag(l) as ListViewElement)?.OnSelectedIndexChanged?.Invoke(l.SelectedIndex);
             };
         if (o.OnItemClick is null && n.OnItemClick is not null)
             lv.ItemClick += (s, args) =>
@@ -2506,11 +2506,11 @@ public sealed partial class Reconciler
 
         SetElementTag(gv, n);
 
-        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
             gv.SelectionChanged += (s, _) =>
             {
                 var g = (WinUI.GridView)s!;
-                (GetElementTag(g) as GridViewElement)?.OnSelectionChanged?.Invoke(g.SelectedIndex);
+                (GetElementTag(g) as GridViewElement)?.OnSelectedIndexChanged?.Invoke(g.SelectedIndex);
             };
         if (o.OnItemClick is null && n.OnItemClick is not null)
             gv.ItemClick += (s, args) =>
@@ -2530,11 +2530,11 @@ public sealed partial class Reconciler
         ReconcileItemsChildren(o.Items, n.Items, fv, requestRerender);
         fv.SelectedIndex = n.SelectedIndex;
         SetElementTag(fv, n);
-        if (o.OnSelectionChanged is null && n.OnSelectionChanged is not null)
+        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
             fv.SelectionChanged += (s, _) =>
             {
                 var f = (WinUI.FlipView)s!;
-                (GetElementTag(f) as FlipViewElement)?.OnSelectionChanged?.Invoke(f.SelectedIndex);
+                (GetElementTag(f) as FlipViewElement)?.OnSelectedIndexChanged?.Invoke(f.SelectedIndex);
             };
         ApplySetters(n.Setters, fv);
         return null;
@@ -3313,11 +3313,11 @@ public sealed partial class Reconciler
         pp.NumberOfPages = n.NumberOfPages;
         pp.SelectedPageIndex = n.SelectedPageIndex;
         SetElementTag(pp, n);
-        if (o.OnSelectedIndexChanged is null && n.OnSelectedIndexChanged is not null)
+        if (o.OnSelectedPageIndexChanged is null && n.OnSelectedPageIndexChanged is not null)
             pp.SelectedIndexChanged += (s, _) =>
             {
                 var p = (WinUI.PipsPager)s!;
-                (GetElementTag(p) as PipsPagerElement)?.OnSelectedIndexChanged?.Invoke(p.SelectedPageIndex);
+                (GetElementTag(p) as PipsPagerElement)?.OnSelectedPageIndexChanged?.Invoke(p.SelectedPageIndex);
             };
         ApplySetters(n.Setters, pp);
         return null;

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -109,8 +109,8 @@ public static partial class Factories
             Setters = [b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
         };
 
-    public static ToggleButtonElement ToggleButton(string label, bool isChecked = false, Action<bool>? onToggled = null) =>
-        new(label, isChecked, onToggled);
+    public static ToggleButtonElement ToggleButton(string label, bool isChecked = false, Action<bool>? onIsCheckedChanged = null) =>
+        new(label, isChecked, onIsCheckedChanged);
 
     /// <summary>
     /// Creates a ToggleButton driven by a Command. The command fires on each toggle
@@ -163,29 +163,29 @@ public static partial class Factories
     public static AutoSuggestBoxElement AutoSuggestBox(string text, Action<string>? onTextChanged = null, Action<string>? onQuerySubmitted = null) =>
         new(text, onTextChanged, onQuerySubmitted);
 
-    public static CheckBoxElement CheckBox(bool isChecked, Action<bool>? onChanged = null, string? label = null) =>
-        new(isChecked, onChanged, label);
+    public static CheckBoxElement CheckBox(bool isChecked, Action<bool>? onIsCheckedChanged = null, string? label = null) =>
+        new(isChecked, onIsCheckedChanged, label);
 
     public static CheckBoxElement ThreeStateCheckBox(bool? checkedState, Action<bool?>? onCheckedStateChanged = null, string? label = null) =>
         new(checkedState == true, Label: label) { IsThreeState = true, CheckedState = checkedState, OnCheckedStateChanged = onCheckedStateChanged };
 
-    public static RadioButtonElement RadioButton(string label, bool isChecked = false, Action<bool>? onChecked = null, string? groupName = null) =>
-        new(label, isChecked, onChecked, groupName);
+    public static RadioButtonElement RadioButton(string label, bool isChecked = false, Action<bool>? onIsCheckedChanged = null, string? groupName = null) =>
+        new(label, isChecked, onIsCheckedChanged, groupName);
 
-    public static RadioButtonsElement RadioButtons(string[] items, int selectedIndex = -1, Action<int>? onSelectionChanged = null) =>
-        new(items, selectedIndex, onSelectionChanged);
+    public static RadioButtonsElement RadioButtons(string[] items, int selectedIndex = -1, Action<int>? onSelectedIndexChanged = null) =>
+        new(items, selectedIndex, onSelectedIndexChanged);
 
-    public static ComboBoxElement ComboBox(string[] items, int selectedIndex = -1, Action<int>? onSelectionChanged = null) =>
-        new(items, selectedIndex, onSelectionChanged);
+    public static ComboBoxElement ComboBox(string[] items, int selectedIndex = -1, Action<int>? onSelectedIndexChanged = null) =>
+        new(items, selectedIndex, onSelectedIndexChanged);
 
-    public static ComboBoxElement ComboBox(Element[] itemElements, int selectedIndex, Action<int>? onSelectionChanged) =>
-        new([], selectedIndex, onSelectionChanged) { ItemElements = itemElements };
+    public static ComboBoxElement ComboBox(Element[] itemElements, int selectedIndex, Action<int>? onSelectedIndexChanged) =>
+        new([], selectedIndex, onSelectedIndexChanged) { ItemElements = itemElements };
 
-    public static SliderElement Slider(double value, double min = 0, double max = 100, Action<double>? onChanged = null) =>
-        new(value, min, max, onChanged);
+    public static SliderElement Slider(double value, double min = 0, double max = 100, Action<double>? onValueChanged = null) =>
+        new(value, min, max, onValueChanged);
 
-    public static ToggleSwitchElement ToggleSwitch(bool isOn, Action<bool>? onChanged = null, string? onContent = null, string? offContent = null, string? header = null) =>
-        new(isOn, onChanged, onContent, offContent) { Header = header };
+    public static ToggleSwitchElement ToggleSwitch(bool isOn, Action<bool>? onIsOnChanged = null, string? onContent = null, string? offContent = null, string? header = null) =>
+        new(isOn, onIsOnChanged, onContent, offContent) { Header = header };
 
     public static RatingControlElement RatingControl(double value = 0, Action<double>? onValueChanged = null) =>
         new(value, onValueChanged);
@@ -243,8 +243,8 @@ public static partial class Factories
 
     public static BorderElement Border(Element? child) => new(child!);
 
-    public static ExpanderElement Expander(string header, Element content, bool isExpanded = false, Action<bool>? onExpandedChanged = null) =>
-        new(header, content, isExpanded, onExpandedChanged);
+    public static ExpanderElement Expander(string header, Element content, bool isExpanded = false, Action<bool>? onIsExpandedChanged = null) =>
+        new(header, content, isExpanded, onIsExpandedChanged);
 
     public static SplitViewElement SplitView(Element? pane = null, Element? content = null) =>
         new(pane, content);
@@ -493,7 +493,7 @@ public static partial class Factories
             Description = command.Description,
         };
 
-    public static ToggleMenuFlyoutItemData ToggleMenuItem(string text, bool isChecked = false, Action<bool>? onToggled = null, string? icon = null) => new(text, isChecked, onToggled, icon);
+    public static ToggleMenuFlyoutItemData ToggleMenuItem(string text, bool isChecked = false, Action<bool>? onIsCheckedChanged = null, string? icon = null) => new(text, isChecked, onIsCheckedChanged, icon);
 
     public static RadioMenuFlyoutItemData RadioMenuItem(string text, string groupName, bool isChecked = false, Action? onClick = null, string? icon = null) => new(text, groupName, isChecked, onClick, icon);
 
@@ -522,8 +522,8 @@ public static partial class Factories
             Description = command.Description,
         };
 
-    public static AppBarToggleButtonData AppBarToggleButton(string label, bool isChecked = false, Action<bool>? onToggled = null, string? icon = null) =>
-        new(label, isChecked, onToggled, icon);
+    public static AppBarToggleButtonData AppBarToggleButton(string label, bool isChecked = false, Action<bool>? onIsCheckedChanged = null, string? icon = null) =>
+        new(label, isChecked, onIsCheckedChanged, icon);
 
     public static AppBarSeparatorData AppBarSeparator() => new();
 
@@ -770,18 +770,18 @@ public static partial class Factories
     public static SemanticZoomElement SemanticZoom(Element zoomedInView, Element zoomedOutView) =>
         new(zoomedInView, zoomedOutView);
 
-    public static ListBoxElement ListBox(string[] items, int selectedIndex = -1, Action<int>? onSelectionChanged = null) =>
-        new(items) { SelectedIndex = selectedIndex, OnSelectionChanged = onSelectionChanged };
+    public static ListBoxElement ListBox(string[] items, int selectedIndex = -1, Action<int>? onSelectedIndexChanged = null) =>
+        new(items) { SelectedIndex = selectedIndex, OnSelectedIndexChanged = onSelectedIndexChanged };
 
     // ── Additional navigation ───────────────────────────────────────
 
-    public static SelectorBarElement SelectorBar(SelectorBarItemData[] items, int selectedIndex = 0, Action<int>? onSelectionChanged = null) =>
-        new(items) { SelectedIndex = selectedIndex, OnSelectionChanged = onSelectionChanged };
+    public static SelectorBarElement SelectorBar(SelectorBarItemData[] items, int selectedIndex = 0, Action<int>? onSelectedIndexChanged = null) =>
+        new(items) { SelectedIndex = selectedIndex, OnSelectedIndexChanged = onSelectedIndexChanged };
 
     public static SelectorBarItemData SelectorBarItem(string text, string? icon = null) => new(text, icon);
 
-    public static PipsPagerElement PipsPager(int numberOfPages, int selectedPageIndex = 0, Action<int>? onSelectedIndexChanged = null) =>
-        new(numberOfPages) { SelectedPageIndex = selectedPageIndex, OnSelectedIndexChanged = onSelectedIndexChanged };
+    public static PipsPagerElement PipsPager(int numberOfPages, int selectedPageIndex = 0, Action<int>? onSelectedPageIndexChanged = null) =>
+        new(numberOfPages) { SelectedPageIndex = selectedPageIndex, OnSelectedPageIndexChanged = onSelectedPageIndexChanged };
 
     public static AnnotatedScrollBarElement AnnotatedScrollBar() => new();
 

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -776,13 +776,13 @@ public static class ElementExtensions
 
     /// <summary>
     /// Auto-syncs this NavigationView with a NavigationHandle: sets <c>SelectedTag</c>
-    /// from the current route, wires <c>OnSelectionChanged</c> to navigate,
+    /// from the current route, wires <c>OnSelectedTagChanged</c> to navigate,
     /// <c>OnBackRequested</c> to <c>GoBack</c>, and <c>IsBackEnabled</c> to <c>CanGoBack</c>.
     /// </summary>
     /// <param name="el">The NavigationView element to configure.</param>
     /// <param name="nav">The navigation handle obtained from <c>UseNavigation</c>.</param>
     /// <param name="routeToTag">Maps a route to its NavigationViewItem tag. Return null for routes without a corresponding menu item.</param>
-    /// <param name="tagToRoute">Maps a NavigationViewItem tag back to a route for <c>OnSelectionChanged</c>.</param>
+    /// <param name="tagToRoute">Maps a NavigationViewItem tag back to a route for <c>OnSelectedTagChanged</c>.</param>
     public static NavigationViewElement WithNavigation<TRoute>(
         this NavigationViewElement el,
         Navigation.NavigationHandle<TRoute> nav,
@@ -792,7 +792,7 @@ public static class ElementExtensions
     {
         SelectedTag = routeToTag(nav.CurrentRoute),
         IsBackEnabled = nav.CanGoBack,
-        OnSelectionChanged = tag =>
+        OnSelectedTagChanged = tag =>
         {
             if (tag is not null)
             {

--- a/tests/Reactor.AppTests.Host/Fixtures/DevtoolsUxFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/DevtoolsUxFixtures.cs
@@ -52,7 +52,7 @@ internal static class DevtoolsUxFixtures
                         {
                             ToggleMenuItem("Debug UI",
                                 isChecked: debugUI,
-                                onToggled: v => DebugUI.Value = v),
+                                onIsCheckedChanged: v => DebugUI.Value = v),
                         },
                         automationId: "DevtoolsTrigger")
                 ),

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlUpdateFixtures2.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlUpdateFixtures2.cs
@@ -273,7 +273,7 @@ internal static class ControlUpdateFixtures2
                         phase == 0 ? "ExpanderHdr1" : "ExpanderHdr2",
                         phase == 0 ? TextBlock("ExpContent1") : VStack(TextBlock("ExpContent2a"), TextBlock("ExpContent2b")),
                         isExpanded: true,
-                        onExpandedChanged: _ => { })
+                        onIsExpandedChanged: _ => { })
                 );
             });
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoverageBoostFixtures2.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoverageBoostFixtures2.cs
@@ -496,7 +496,7 @@ internal static class CoverageBoostFixtures2
                         TextField("text1", _ => { }),
                         ToggleSwitch(true, _ => { }, header: "Toggle1"),
                         CheckBox(true, _ => { }, label: "Check1"),
-                        Slider(50, onChanged: _ => { }),
+                        Slider(50, onValueChanged: _ => { }),
                         NumberBox(42, onValueChanged: _ => { }),
                         Button("PoolCycle", () => set(1))
                     ),
@@ -509,7 +509,7 @@ internal static class CoverageBoostFixtures2
                         TextField("text2", _ => { }),
                         ToggleSwitch(false, _ => { }),
                         CheckBox(false, _ => { }, label: "Check2"),
-                        Slider(75, onChanged: _ => { }),
+                        Slider(75, onValueChanged: _ => { }),
                         NumberBox(99, onValueChanged: _ => { }),
                         TextBlock("PoolInteractive_Restored")
                     ),

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -128,16 +128,16 @@ internal static class ReconcilerBigCoverageFixtures
                 var (phase, set) = ctx.UseState(0);
                 Element cb = phase == 0
                     ? CheckBox(false, label: "wire-cb")
-                    : CheckBox(false, onChanged: v => cbHits++, label: "wire-cb");
+                    : CheckBox(false, onIsCheckedChanged: v => cbHits++, label: "wire-cb");
                 Element rb = phase == 0
                     ? RadioButton("wire-rb", isChecked: false)
-                    : RadioButton("wire-rb", isChecked: false, onChecked: v => rbHits++);
+                    : RadioButton("wire-rb", isChecked: false, onIsCheckedChanged: v => rbHits++);
                 Element sl = phase == 0
                     ? Slider(20, 0, 100)
-                    : Slider(20, 0, 100, onChanged: v => sliderHits++);
+                    : Slider(20, 0, 100, onValueChanged: v => sliderHits++);
                 Element ts = phase == 0
                     ? ToggleSwitch(false, header: "wire-ts")
-                    : ToggleSwitch(false, onChanged: v => tsHits++, header: "wire-ts");
+                    : ToggleSwitch(false, onIsOnChanged: v => tsHits++, header: "wire-ts");
                 Element nb = phase == 0
                     ? NumberBox(5, header: "wire-nb")
                     : NumberBox(5, onValueChanged: v => nbHits++, header: "wire-nb");
@@ -343,7 +343,7 @@ internal static class ReconcilerBigCoverageFixtures
                     Button("NVPhase", () => set((phase + 1) % 3)),
                     new NavigationViewElement([NavItem("Home", icon: "Home")], content)
                     {
-                        OnSelectionChanged = _ => { },
+                        OnSelectedTagChanged = _ => { },
                         OnBackRequested = () => { },
                         IsPaneOpen = phase != 0,
                         IsBackEnabled = phase == 1,
@@ -1168,12 +1168,12 @@ internal static class ReconcilerBigCoverageFixtures
 
             var host = H.CreateHost();
             host.Mount(ctx => VStack(
-                CheckBox(false, onChanged: v => cb1Hits++, label: "fire-cb"),
+                CheckBox(false, onIsCheckedChanged: v => cb1Hits++, label: "fire-cb"),
                 new CheckBoxElement(false, Label: "fire-tri")
                     { IsThreeState = true, OnCheckedStateChanged = _ => cb3Hits++ },
-                RadioButton("fire-rb", isChecked: false, onChecked: _ => rbHits++),
-                Slider(20, 0, 100, onChanged: _ => sliderHits++),
-                ToggleSwitch(false, onChanged: _ => tsHits++, header: "fire-ts"),
+                RadioButton("fire-rb", isChecked: false, onIsCheckedChanged: _ => rbHits++),
+                Slider(20, 0, 100, onValueChanged: _ => sliderHits++),
+                ToggleSwitch(false, onIsOnChanged: _ => tsHits++, header: "fire-ts"),
                 NumberBox(5, onValueChanged: _ => nbHits++, header: "fire-nb")
             ));
 
@@ -1210,7 +1210,7 @@ internal static class ReconcilerBigCoverageFixtures
     // ════════════════════════════════════════════════════════════════════
     //  25i. Many controls receive handlers on second render via a state
     //       flip. Exercises Update.cs handler-wiring blocks for a wider
-    //       set of controls (TabView OnSelectionChanged, Pivot, ListView,
+    //       set of controls (TabView OnSelectedIndexChanged, Pivot, ListView,
     //       NumberBox, SearchBox, AutoSuggestBox, ComboBox, etc).
     // ════════════════════════════════════════════════════════════════════
     internal class ManyControlsHandlerWiring(Harness h) : SelfTestFixtureBase(h)
@@ -1225,7 +1225,7 @@ internal static class ReconcilerBigCoverageFixtures
                     ? new TabViewElement([Tab("T1", TextBlock("t1"))])
                     : new TabViewElement([Tab("T1", TextBlock("t1")), Tab("T2", TextBlock("t2"))])
                       {
-                          OnSelectionChanged = _ => { },
+                          OnSelectedIndexChanged = _ => { },
                           OnTabCloseRequested = _ => { },
                           OnAddTabButtonClick = () => { },
                           IsAddTabButtonVisible = true,
@@ -1234,7 +1234,7 @@ internal static class ReconcilerBigCoverageFixtures
                     ? new PivotElement([new PivotItemData("P1", TextBlock("p1"))])
                     : new PivotElement([new PivotItemData("P1", TextBlock("p1")),
                                          new PivotItemData("P2", TextBlock("p2"))])
-                      { OnSelectionChanged = _ => { } };
+                      { OnSelectedIndexChanged = _ => { } };
                 Element bb = phase == 0
                     ? new BreadcrumbBarElement(
                         [new BreadcrumbBarItemData("crumb1")])
@@ -1374,11 +1374,11 @@ internal static class ReconcilerBigCoverageFixtures
                 Element cb = phase == 0
                     ? ComboBox(["x", "y"], selectedIndex: 0)
                     : new ComboBoxElement(["x", "y", "z"], 0)
-                      { OnSelectionChanged = _ => { } };
+                      { OnSelectedIndexChanged = _ => { } };
                 Element lv = phase == 0
                     ? ListView(TextBlock("li-1"), TextBlock("li-2"))
                     : new ListViewElement([TextBlock("li-1"), TextBlock("li-2"), TextBlock("li-3")])
-                      { OnItemClick = _ => { }, OnSelectionChanged = _ => { },
+                      { OnItemClick = _ => { }, OnSelectedIndexChanged = _ => { },
                         SelectionMode = ListViewSelectionMode.Single };
                 return VStack(
                     Button("CollWire", () => set(1)),

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SelectionEventFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SelectionEventFixtures.cs
@@ -8,7 +8,7 @@ using static Microsoft.UI.Reactor.Factories;
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
 /// <summary>
-/// Verifies that OnSelectionChanged callbacks wired by the reconciler
+/// Verifies that OnSelectedIndexChanged / OnSelectedTagChanged callbacks wired by the reconciler
 /// actually fire through to user code when the underlying WinUI control
 /// raises its native selection event.
 ///
@@ -32,7 +32,7 @@ internal static class SelectionEventFixtures
                 ComboBox(
                     ["A", "B", "C"],
                     selectedIndex: -1,
-                    onSelectionChanged: i => { count++; lastIndex = i; })
+                    onSelectedIndexChanged: i => { count++; lastIndex = i; })
                     .Set(c => c.Name = "comboSel")
             ));
             await Harness.Render();
@@ -60,7 +60,7 @@ internal static class SelectionEventFixtures
                 RadioButtons(
                     ["R1", "R2", "R3"],
                     selectedIndex: -1,
-                    onSelectionChanged: i => { count++; lastIndex = i; })
+                    onSelectedIndexChanged: i => { count++; lastIndex = i; })
                     .Set(r => r.Name = "rbsSel")
             ));
             await Harness.Render();
@@ -97,7 +97,7 @@ internal static class SelectionEventFixtures
                 ])
                 {
                     SelectedIndex = -1,
-                    OnSelectionChanged = i => { count++; lastIndex = i; },
+                    OnSelectedIndexChanged = i => { count++; lastIndex = i; },
                 }.Set(l => l.Name = "lvSel")
             ));
             await Harness.Render();
@@ -129,7 +129,7 @@ internal static class SelectionEventFixtures
                 ])
                 {
                     SelectedIndex = -1,
-                    OnSelectionChanged = i => { count++; lastIndex = i; },
+                    OnSelectedIndexChanged = i => { count++; lastIndex = i; },
                 }.Set(g => g.Name = "gvSel")
             ));
             await Harness.Render();
@@ -161,7 +161,7 @@ internal static class SelectionEventFixtures
                 ])
                 {
                     SelectedIndex = 0,
-                    OnSelectionChanged = i => { count++; lastIndex = i; },
+                    OnSelectedIndexChanged = i => { count++; lastIndex = i; },
                 }.Set(f => f.Name = "fvSel")
             ));
             await Harness.Render();
@@ -193,7 +193,7 @@ internal static class SelectionEventFixtures
                 ])
                 {
                     SelectedIndex = 0,
-                    OnSelectionChanged = i => { count++; lastIndex = i; },
+                    OnSelectedIndexChanged = i => { count++; lastIndex = i; },
                 }.Set(t => t.Name = "tvSel")
             ));
             await Harness.Render();
@@ -230,7 +230,7 @@ internal static class SelectionEventFixtures
                 ])
                 {
                     SelectedIndex = 0,
-                    OnSelectionChanged = i => { count++; lastIndex = i; },
+                    OnSelectedIndexChanged = i => { count++; lastIndex = i; },
                 }.Set(p => p.Name = "pivSel")
             ));
             await Harness.Render();
@@ -263,7 +263,7 @@ internal static class SelectionEventFixtures
                     ],
                     TextBlock("nav content"))
                 {
-                    OnSelectionChanged = tag => { count++; lastTag = tag; },
+                    OnSelectedTagChanged = tag => { count++; lastTag = tag; },
                     IsSettingsVisible = false,
                 }.Set(n => n.Name = "navSel")
             ));

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ValueChangeEventFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ValueChangeEventFixtures.cs
@@ -27,7 +27,7 @@ internal static class ValueChangeEventFixtures
 
             var host = H.CreateHost();
             host.Mount(ctx => VStack(
-                CheckBox(false, onChanged: v => { count++; lastValue = v; }, label: "chkEvt")
+                CheckBox(false, onIsCheckedChanged: v => { count++; lastValue = v; }, label: "chkEvt")
                     .Set(c => c.Name = "chkEvt")
             ));
             await Harness.Render();
@@ -54,7 +54,7 @@ internal static class ValueChangeEventFixtures
             var host = H.CreateHost();
             host.Mount(ctx => VStack(
                 RadioButton("rbEvt", isChecked: false,
-                    onChecked: v => { count++; lastValue = v; })
+                    onIsCheckedChanged: v => { count++; lastValue = v; })
                     .Set(r => r.Name = "rbEvt")
             ));
             await Harness.Render();
@@ -80,7 +80,7 @@ internal static class ValueChangeEventFixtures
 
             var host = H.CreateHost();
             host.Mount(ctx => VStack(
-                ToggleSwitch(false, onChanged: v => { count++; lastValue = v; },
+                ToggleSwitch(false, onIsOnChanged: v => { count++; lastValue = v; },
                     header: "tsEvtHdr")
                     .Set(t => t.Name = "tsEvt")
             ));
@@ -107,7 +107,7 @@ internal static class ValueChangeEventFixtures
 
             var host = H.CreateHost();
             host.Mount(ctx => VStack(
-                Slider(10, 0, 100, onChanged: v => { count++; lastValue = v; })
+                Slider(10, 0, 100, onValueChanged: v => { count++; lastValue = v; })
                     .Set(s => s.Name = "slEvt")
             ));
             await Harness.Render();

--- a/tests/Reactor.Tests/CommandingCoverageTests.cs
+++ b/tests/Reactor.Tests/CommandingCoverageTests.cs
@@ -88,8 +88,8 @@ public class CommandingCoverageTests
         var cmd = MakeCmd(() => count++);
         var el = ToggleButton(cmd);
 
-        el.OnToggled!(true);
-        el.OnToggled!(false);
+        el.OnIsCheckedChanged!(true);
+        el.OnIsCheckedChanged!(false);
         Assert.Equal(2, count);
     }
 

--- a/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
@@ -295,7 +295,7 @@ public class ElementExtensionsCoverageTests
     [Fact]
     public void Slider_Sugar()
     {
-        var el = Slider(0, onChanged: _ => { }).StepFrequency(0.5).Header("Vol");
+        var el = Slider(0, onValueChanged: _ => { }).StepFrequency(0.5).Header("Vol");
         Assert.Equal(0.5, el.StepFrequency);
         Assert.Equal("Vol", el.Header);
     }

--- a/tests/Reactor.Tests/ElementTests.cs
+++ b/tests/Reactor.Tests/ElementTests.cs
@@ -110,7 +110,7 @@ public class ElementTests
         var el = ToggleButton("Toggle");
         Assert.Equal("Toggle", el.Label);
         Assert.False(el.IsChecked);
-        Assert.Null(el.OnToggled);
+        Assert.Null(el.OnIsCheckedChanged);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/MoreCoverageTests2.cs
+++ b/tests/Reactor.Tests/MoreCoverageTests2.cs
@@ -821,7 +821,7 @@ public class MoreCoverageTests2
         var withHandlers = el with
         {
             Header = "H",
-            OnSelectionChanged = idx => seen = idx,
+            OnSelectedIndexChanged = idx => seen = idx,
             OnItemClick = v => seen = v,
         };
         Assert.Equal("H", withHandlers.GetHeader());

--- a/tests/Reactor.Tests/NavigationViewSyncTests.cs
+++ b/tests/Reactor.Tests/NavigationViewSyncTests.cs
@@ -102,11 +102,11 @@ public class NavigationViewSyncTests
     }
 
     // ════════════════════════════════════════════════════════════════
-    //  NavigationView.WithNavigation — OnSelectionChanged
+    //  NavigationView.WithNavigation — OnSelectedTagChanged
     // ════════════════════════════════════════════════════════════════
 
     [Fact]
-    public void WithNavigation_OnSelectionChanged_Navigates_To_Route()
+    public void WithNavigation_OnSelectedTagChanged_Navigates_To_Route()
     {
         var stack = new NavigationStack<Route>(new Home());
         var nav = new NavigationHandle<Route>(stack);
@@ -114,14 +114,14 @@ public class NavigationViewSyncTests
         var el = NavigationView([NavItem("Home", tag: "home"), NavItem("Settings", tag: "settings")])
             .WithNavigation(nav, RouteToTag, TagToRoute);
 
-        el.OnSelectionChanged!("settings");
+        el.OnSelectedTagChanged!("settings");
 
         Assert.IsType<Settings>(nav.CurrentRoute);
         Assert.True(nav.CanGoBack);
     }
 
     [Fact]
-    public void WithNavigation_OnSelectionChanged_Ignores_Null_Tag()
+    public void WithNavigation_OnSelectedTagChanged_Ignores_Null_Tag()
     {
         var stack = new NavigationStack<Route>(new Home());
         var nav = new NavigationHandle<Route>(stack);
@@ -129,14 +129,14 @@ public class NavigationViewSyncTests
         var el = NavigationView([NavItem("Home", tag: "home")])
             .WithNavigation(nav, RouteToTag, TagToRoute);
 
-        el.OnSelectionChanged!(null);
+        el.OnSelectedTagChanged!(null);
 
         Assert.IsType<Home>(nav.CurrentRoute);
         Assert.False(nav.CanGoBack);
     }
 
     [Fact]
-    public void WithNavigation_OnSelectionChanged_Skips_Navigation_When_Route_Unchanged()
+    public void WithNavigation_OnSelectedTagChanged_Skips_Navigation_When_Route_Unchanged()
     {
         var stack = new NavigationStack<Route>(new Home());
         var nav = new NavigationHandle<Route>(stack);
@@ -148,7 +148,7 @@ public class NavigationViewSyncTests
             .WithNavigation(nav, RouteToTag, TagToRoute);
 
         // Selecting the already-active route should not trigger navigation
-        el.OnSelectionChanged!("home");
+        el.OnSelectedTagChanged!("home");
 
         Assert.Equal(0, navigatedCount);
         Assert.IsType<Home>(nav.CurrentRoute);

--- a/tests/Reactor.Tests/ThreeStateCheckBoxTests.cs
+++ b/tests/Reactor.Tests/ThreeStateCheckBoxTests.cs
@@ -24,11 +24,11 @@ public class ThreeStateCheckBoxTests
     }
 
     [Fact]
-    public void CheckBox_TwoState_OnChanged_Fires()
+    public void CheckBox_TwoState_OnIsCheckedChanged_Fires()
     {
         bool? result = null;
         var el = CheckBox(false, v => result = v);
-        el.OnChanged!.Invoke(true);
+        el.OnIsCheckedChanged!.Invoke(true);
         Assert.True(result);
     }
 


### PR DESCRIPTION
## Summary

Normalizes state-change callback names across all controls to follow the `On<Property>Changed` pattern for property-change notifications.

### Rename map

| Old name | New name | Controls |
|----------|----------|----------|
| `OnToggled` | `OnIsCheckedChanged` | ToggleButton, ToggleMenuFlyoutItem, AppBarToggleButton |
| `OnChanged` | `OnIsCheckedChanged` | CheckBox |
| `OnChecked` | `OnIsCheckedChanged` | RadioButton |
| `OnChanged` | `OnValueChanged` | Slider |
| `OnChanged` | `OnIsOnChanged` | ToggleSwitch |
| `OnExpandedChanged` | `OnIsExpandedChanged` | Expander |
| `OnSelectionChanged` | `OnSelectedIndexChanged` | ComboBox, RadioButtons, ListView, GridView, FlipView, TabView, Pivot, ListBox, SelectorBar |
| `OnSelectionChanged` | `OnSelectedTagChanged` | NavigationView |
| `OnSelectedIndexChanged` | `OnSelectedPageIndexChanged` | PipsPager |

**Not renamed:** `TextFieldElement.OnSelectionChanged` (text selection) and `TextFieldElement.OnChanged` (text value change) — these are distinct concepts.

### Touch points per rename

- Element record parameter (`Element.cs`)
- Factory method parameter (`Dsl.cs`)
- Reconciler mount handler (`Reconciler.Mount.cs`)
- Reconciler update handler (`Reconciler.Update.cs`)
- Extension methods (`ElementExtensions.cs`)
- `reactor.api.txt` (both copies)
- Tests and samples

### Backward compatibility

Record constructor parameters can't have `[Obsolete]` shims (same positional types = same overload). This is a pre-1.0 clean rename.

Fixes #261
