### PR TITLE
Add .editorconfig codifying repo C# conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,282 @@
+# EditorConfig — https://editorconfig.org
+# Reverse-engineered from existing code style in src/Reactor and around the repo.
+# Formatting rules (indent, EOL, trailing whitespace) are enforced; C# style
+# preferences are at suggestion level so they document the convention without
+# turning historical drift into build breaks.
+
+root = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Universal defaults
+# ─────────────────────────────────────────────────────────────────────────────
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Web / config formats — 2-space indent is conventional
+# ─────────────────────────────────────────────────────────────────────────────
+[*.{json,json5,yml,yaml,toml,js,jsx,ts,tsx,mjs,cjs,html,htm,css,scss}]
+indent_size = 2
+
+[*.{csproj,vbproj,fsproj,proj,props,targets,xaml,xml,resx,resw,config,nuspec}]
+indent_size = 2
+
+[*.{ps1,psm1,psd1}]
+indent_size = 4
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Markdown — don't strip trailing spaces (two-space line breaks are syntactic)
+# ─────────────────────────────────────────────────────────────────────────────
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C#
+# ─────────────────────────────────────────────────────────────────────────────
+[*.cs]
+
+# ── File layout ──────────────────────────────────────────────────────────────
+# File-scoped namespaces are the project convention (250+ files).
+csharp_style_namespace_declarations = file_scoped:suggestion
+
+# `using` directives are placed outside the namespace declaration in this repo.
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# System.* usings are not specifically grouped first in this project; leave alphabetical.
+dotnet_sort_system_directives_first = false
+dotnet_separate_import_directive_groups = false
+
+# ── Braces & blocks ──────────────────────────────────────────────────────────
+# Allman braces (open brace on new line) — matches existing code.
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Single-line blocks for very short methods (`try { action(); }` pattern seen in AnimationScope.cs).
+csharp_prefer_braces = when_multiline:suggestion
+
+# ── Indentation within C# ────────────────────────────────────────────────────
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+
+# ── Spacing ──────────────────────────────────────────────────────────────────
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# ── Wrapping ─────────────────────────────────────────────────────────────────
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+
+# ── `var` preferences ────────────────────────────────────────────────────────
+# `var` is used freely in this codebase.
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:silent
+
+# ── Expression-bodied members ────────────────────────────────────────────────
+# One-liner factory/accessor pattern is common (see Animation/Curve.cs, Core/Component.cs).
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = when_on_single_line:suggestion
+csharp_style_expression_bodied_properties = when_on_single_line:suggestion
+csharp_style_expression_bodied_indexers = when_on_single_line:suggestion
+csharp_style_expression_bodied_accessors = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = when_on_single_line:silent
+
+# ── Modern C# language preferences ───────────────────────────────────────────
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:silent
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
+csharp_style_prefer_primary_constructors = true:silent
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = false:silent
+
+# Nullable: project enables nullable everywhere via <Nullable>enable</Nullable>.
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+
+# ── Misc dotnet preferences ──────────────────────────────────────────────────
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+dotnet_style_namespace_match_folder = false:silent
+
+# ── Unused / parameter rules ─────────────────────────────────────────────────
+dotnet_code_quality_unused_parameters = non_public:suggestion
+dotnet_remove_unnecessary_suppression_exclusions = none
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+# ── Naming conventions ───────────────────────────────────────────────────────
+# Convention: private instance/static fields use _camelCase (e.g. _current, _hasScope).
+# Public members are PascalCase. Locals/parameters are camelCase. Constants PascalCase.
+
+# Symbol groups
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_fields.required_modifiers =
+
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+dotnet_naming_symbols.constants.applicable_kinds = field
+dotnet_naming_symbols.constants.applicable_accessibilities = *
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_symbols.public_members.applicable_kinds = property,method,event,field,delegate
+dotnet_naming_symbols.public_members.applicable_accessibilities = public,internal,protected,protected_internal,private_protected
+
+dotnet_naming_symbols.parameters.applicable_kinds = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+
+dotnet_naming_symbols.locals.applicable_kinds = local
+dotnet_naming_symbols.locals.applicable_accessibilities = *
+
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = *
+
+dotnet_naming_symbols.type_params.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_params.applicable_accessibilities = *
+
+dotnet_naming_symbols.types.applicable_kinds = class,struct,enum,delegate
+dotnet_naming_symbols.types.applicable_accessibilities = *
+
+# Styles
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.camel_case.capitalization = camel_case
+
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+
+dotnet_naming_style.iprefix_pascal.required_prefix = I
+dotnet_naming_style.iprefix_pascal.capitalization = pascal_case
+
+dotnet_naming_style.tprefix_pascal.required_prefix = T
+dotnet_naming_style.tprefix_pascal.capitalization = pascal_case
+
+# Rules
+dotnet_naming_rule.private_fields_with_underscore.symbols = private_fields
+dotnet_naming_rule.private_fields_with_underscore.style = underscore_camel_case
+dotnet_naming_rule.private_fields_with_underscore.severity = suggestion
+
+dotnet_naming_rule.private_static_fields_with_underscore.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_with_underscore.style = underscore_camel_case
+dotnet_naming_rule.private_static_fields_with_underscore.severity = suggestion
+
+dotnet_naming_rule.constants_pascal.symbols = constants
+dotnet_naming_rule.constants_pascal.style = pascal_case
+dotnet_naming_rule.constants_pascal.severity = suggestion
+
+dotnet_naming_rule.public_members_pascal.symbols = public_members
+dotnet_naming_rule.public_members_pascal.style = pascal_case
+dotnet_naming_rule.public_members_pascal.severity = suggestion
+
+dotnet_naming_rule.parameters_camel.symbols = parameters
+dotnet_naming_rule.parameters_camel.style = camel_case
+dotnet_naming_rule.parameters_camel.severity = suggestion
+
+dotnet_naming_rule.locals_camel.symbols = locals
+dotnet_naming_rule.locals_camel.style = camel_case
+dotnet_naming_rule.locals_camel.severity = suggestion
+
+dotnet_naming_rule.interfaces_iprefix.symbols = interfaces
+dotnet_naming_rule.interfaces_iprefix.style = iprefix_pascal
+dotnet_naming_rule.interfaces_iprefix.severity = suggestion
+
+dotnet_naming_rule.type_params_tprefix.symbols = type_params
+dotnet_naming_rule.type_params_tprefix.style = tprefix_pascal
+dotnet_naming_rule.type_params_tprefix.severity = suggestion
+
+dotnet_naming_rule.types_pascal.symbols = types
+dotnet_naming_rule.types_pascal.style = pascal_case
+dotnet_naming_rule.types_pascal.severity = suggestion
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Vendored / generated trees — leave alone
+# ─────────────────────────────────────────────────────────────────────────────
+[**/node_modules/**]
+charset = unset
+end_of_line = unset
+indent_style = unset
+indent_size = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+
+[**/bin/**]
+charset = unset
+end_of_line = unset
+indent_style = unset
+indent_size = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+
+[**/obj/**]
+charset = unset
+end_of_line = unset
+indent_style = unset
+indent_size = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+
+# Markdown under docs/guide/ is generated — leave formatting flexible.
+[docs/guide/**.md]
+trim_trailing_whitespace = false
+insert_final_newline = unset


### PR DESCRIPTION
## Summary

Adds a root `.editorconfig` reverse-engineered from existing code style in `src/Reactor`. Closes discussion #304 — sonnemaf asked for one so editors stop imposing personal defaults that diverge from the project's actual conventions.

- **Universal formatting (enforced):** UTF-8, LF, 4-space indent, trim trailing whitespace, final newline
- **Per-format overrides:** 2-space for `*.csproj` / `*.xaml` / `*.xml` / `*.json` / `*.yaml` / web files; trailing whitespace preserved in markdown (two-space line breaks are syntactic)
- **C# style rules:** file-scoped namespaces, `using` outside namespace, Allman braces, `var` when type apparent, expression-bodied one-liners, `_camelCase` for private fields, `PascalCase` public, `IPrefix` interfaces, `TPrefix` type params — all at `:suggestion` severity so they document the convention without breaking historical drift
- **Carve-outs:** formatting `unset` under `node_modules/`, `bin/`, `obj/`, and `docs/guide/**` (generated output per repo convention)

## Validation

Built locally before pushing:

```powershell
dotnet build src/Reactor/Reactor.csproj -p:Platform=ARM64
# Build succeeded — 2 Warning(s), 0 Error(s)
```

Both warnings are pre-existing `CS8604` nullable-reference checks at `ReactorHostControl.cs:360`, last touched in commit `bb85642` (May 7). Zero new warnings from this change — every style rule is at `:suggestion` or `:silent`, which surface as IDE hints rather than build warnings.

## Conventions sampled to derive the rules

| Convention | Source |
|---|---|
| File-scoped namespaces | 250+ files vs 2 traditional |
| `_camelCase` private fields | `AnimationScope.cs:12`, `Element.cs`, ~5 files sampled |
| Allman braces | uniform across `src/Reactor/**/*.cs` |
| Expression-bodied one-liners | `Curve.cs:12-21`, `Component.cs:28-76` |
| 2-space csproj indent | `Reactor.csproj` |
| Nullable enabled project-wide | `Reactor.csproj`: `<Nullable>enable</Nullable>` |
| LF git-canonical | `git ls-files --eol` reports `i/lf` |

## Followup (not in this PR)

If the team wants stricter enforcement later, the safest candidates to promote from `:suggestion` to `:warning` are `csharp_style_namespace_declarations` and `csharp_using_directive_placement` — 250+ files already conform. Left as `:suggestion` here to keep this PR purely additive.

## Test plan

- [ ] Open the repo in VS / VS Code / Rider — confirm new files pick up 4-space indent, file-scoped namespace, `_camelCase` field naming hints
- [ ] Open a `.csproj` — confirm 2-space indent
- [ ] Open a `.md` — confirm trailing whitespace isn't auto-stripped on save
- [ ] `dotnet build src/Reactor/Reactor.csproj -p:Platform=ARM64` — no new warnings vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)