### PR TITLE
build(samples): add per-app SLNX next to each sample csproj

### DIFF
--- a/samples/CommandingDemo/CommandingDemo.slnx
+++ b/samples/CommandingDemo/CommandingDemo.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="CommandingDemo.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/InteropFirst/InteropFirst.slnx
+++ b/samples/InteropFirst/InteropFirst.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="InteropFirst.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/NavigationDemo/NavigationDemo.slnx
+++ b/samples/NavigationDemo/NavigationDemo.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="NavigationDemo.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/Reactor.TestApp/Reactor.TestApp.slnx
+++ b/samples/Reactor.TestApp/Reactor.TestApp.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="Reactor.TestApp.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/ReactorCharting.Gallery/ReactorCharting.Gallery.slnx
+++ b/samples/ReactorCharting.Gallery/ReactorCharting.Gallery.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="ReactorCharting.Gallery.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/ReactorCharting.Sample/ReactorCharting.Sample.slnx
+++ b/samples/ReactorCharting.Sample/ReactorCharting.Sample.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="ReactorCharting.Sample.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/ReactorGallery/ReactorGallery.slnx
+++ b/samples/ReactorGallery/ReactorGallery.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="ReactorGallery.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/ReactorHostControlDemo/ReactorHostControlDemo.slnx
+++ b/samples/ReactorHostControlDemo/ReactorHostControlDemo.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="ReactorHostControlDemo.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/StylingGallery/StylingGallery.slnx
+++ b/samples/StylingGallery/StylingGallery.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="StylingGallery.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/TodoApp/TodoApp.slnx
+++ b/samples/TodoApp/TodoApp.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="TodoApp.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/WinFormsInterop/WinFormsInterop.slnx
+++ b/samples/WinFormsInterop/WinFormsInterop.slnx
@@ -1,0 +1,14 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="WinFormsInterop.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../src/Reactor.Interop.WinForms/Reactor.Interop.WinForms.csproj" />
+  <Project Path="../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/a11y-showcase/A11yShowcase.slnx
+++ b/samples/apps/a11y-showcase/A11yShowcase.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="A11yShowcase.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/chat/App/ChatSample.slnx
+++ b/samples/apps/chat/App/ChatSample.slnx
@@ -1,0 +1,15 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="ChatSample.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../Chat.Model/Chat.Model.csproj" />
+  <Project Path="../Chat.UI/Chat.UI.csproj" />
+  <Project Path="../../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/chat/Chat.Model/Chat.Model.slnx
+++ b/samples/apps/chat/Chat.Model/Chat.Model.slnx
@@ -1,3 +1,0 @@
-<Solution>
-  <Project Path="Chat.Model.csproj" DefaultStartup="true" />
-</Solution>

--- a/samples/apps/chat/Chat.Model/Chat.Model.slnx
+++ b/samples/apps/chat/Chat.Model/Chat.Model.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="Chat.Model.csproj" DefaultStartup="true" />
+</Solution>

--- a/samples/apps/chat/Chat.UI/Chat.UI.slnx
+++ b/samples/apps/chat/Chat.UI/Chat.UI.slnx
@@ -1,7 +1,0 @@
-<Solution>
-  <Project Path="Chat.UI.csproj" DefaultStartup="true" />
-  <Project Path="../Chat.Model/Chat.Model.csproj" />
-  <Project Path="../../../../src/Reactor/Reactor.csproj" />
-  <Project Path="../../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
-  <Project Path="../../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
-</Solution>

--- a/samples/apps/chat/Chat.UI/Chat.UI.slnx
+++ b/samples/apps/chat/Chat.UI/Chat.UI.slnx
@@ -1,0 +1,7 @@
+<Solution>
+  <Project Path="Chat.UI.csproj" DefaultStartup="true" />
+  <Project Path="../Chat.Model/Chat.Model.csproj" />
+  <Project Path="../../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/demo-script-tool/App/DemoScriptTool.slnx
+++ b/samples/apps/demo-script-tool/App/DemoScriptTool.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="DemoScriptTool.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/headtrax/HeadTrax/HeadTrax.slnx
+++ b/samples/apps/headtrax/HeadTrax/HeadTrax.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="HeadTrax.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/minesweeper/Minesweeper.slnx
+++ b/samples/apps/minesweeper/Minesweeper.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="Minesweeper.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/monaco-editor/MonacoEditorApp.slnx
+++ b/samples/apps/monaco-editor/MonacoEditorApp.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="MonacoEditorApp.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/netpulse/NetPulse.slnx
+++ b/samples/apps/netpulse/NetPulse.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="NetPulse.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/regedit/ReactorRegedit.slnx
+++ b/samples/apps/regedit/ReactorRegedit.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="ReactorRegedit.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/validation-showcase/ValidationShowcase.slnx
+++ b/samples/apps/validation-showcase/ValidationShowcase.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="ValidationShowcase.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>

--- a/samples/apps/wordpuzzle/WordPuzzle.slnx
+++ b/samples/apps/wordpuzzle/WordPuzzle.slnx
@@ -1,0 +1,13 @@
+<Solution>
+  <Configurations>
+    <Platform Name="x64" />
+    <Platform Name="ARM64" />
+  </Configurations>
+  <Project Path="WordPuzzle.csproj" DefaultStartup="true">
+    <Platform Solution="*|ARM64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+  </Project>
+  <Project Path="../../../src/Reactor/Reactor.csproj" />
+  <Project Path="../../../src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="../../../src/Reactor.Analyzers/Reactor.Analyzers.csproj" />
+</Solution>


### PR DESCRIPTION
## Summary
- Adds a SLNX file next to every csproj under `samples/` (23 files), so each sample is openable as a standalone solution with the full transitive ProjectReference closure.
- Each sample's own project is marked `DefaultStartup=\"true\"`, so F5 in Visual Studio launches the right app on first open without anyone having to right-click → Set as Startup Project.

Deps captured per SLNX:
- Most samples → `Reactor` + `Reactor.Localization.Generator` + `Reactor.Analyzers`.
- `WinFormsInterop` → also `Reactor.Interop.WinForms`.
- `ChatSample` (chat/App) → also `Chat.Model` + `Chat.UI`.
- `Chat.UI` → also `Chat.Model` (library SLNX).
- `Chat.Model` → standalone library SLNX.

`DefaultStartup` is honored by Visual Studio / `vs-solutionpersistence` on first load only — once a developer has a local `.vs/*.suo` for the solution, that per-user state wins. Matters for fresh clones and CI.

## Test plan
- [x] `dotnet build samples/CommandingDemo/CommandingDemo.slnx -p:Platform=x64` — clean
- [x] `dotnet build samples/apps/chat/App/ChatSample.slnx -p:Platform=x64` — clean (covers the multi-project graph)
- [ ] Open a couple of the SLNX files in Visual Studio and confirm F5 launches the right app on a fresh clone (no `.vs/` present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)