### PR TITLE
feat: reduce reactor-dev agent build-attempt fix-loops

### DIFF
--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -115,7 +115,7 @@ NumberBox(double value, Action<double> onValueChanged = null, string header = nu
 Paragraph(RichTextInline[] inlines) → RichTextParagraph
 ParallaxView(Element child, double verticalShift = 0, double horizontalShift = 0) → ParallaxViewElement
 PasswordBox(string password, Action<string> onPasswordChanged = null, string placeholderText = null) → PasswordBoxElement
-Path() → PathElement
+Path2D() → PathElement
 PathIcon(string data) → PathIconData
 PersonPicture() → PersonPictureElement
 PipsPager(int numberOfPages, int selectedPageIndex = 0, Action<int> onSelectedPageIndexChanged = null) → PipsPagerElement
@@ -515,6 +515,7 @@ T.HeadingLevel<T>(AutomationHeadingLevel level) → T
 T.Height<T>(double height) → T
 T.HelpText<T>(string text) → T
 T.HierarchyLevel<T>(int level) → T
+T.HorizontalAlignment<T>(HorizontalAlignment alignment) → T
 T.Immediate<T>() → T
 T.InteractionStates<T>(Func<InteractionStatesBuilder, InteractionStatesBuilder> configure, Curve curve = null) → T
 T.IsTabStop<T>(bool isTabStop = true) → T
@@ -612,6 +613,7 @@ T.Validate<T>(string fieldName, IValidator[] validators) → T
 T.Validate<T>(string fieldName, object value, IValidator[] validators) → T
 T.ValidateAsync<T>(string fieldName, IAsyncValidator[] asyncValidators) → T
 T.ValidateAsync<T>(string fieldName, object value, IAsyncValidator[] asyncValidators) → T
+T.VerticalAlignment<T>(VerticalAlignment alignment) → T
 T.Visible<T>(bool isVisible) → T
 T.Width<T>(double width) → T
 T.WithBorder<T>(Brush brush, double thickness = 1) → T

--- a/plugins/reactor/skills/reactor-recipes/references/index.md
+++ b/plugins/reactor/skills/reactor-recipes/references/index.md
@@ -25,6 +25,7 @@ component.
 | Absolute positioning with Canvas | [`canvas-positioning.cs`](canvas-positioning.cs) | `Canvas`, `.Canvas(left, top)`, `.CenterAt`, shapes |
 | Named-style buttons + InfoBar severity | [`named-styles.cs`](named-styles.cs) | `.AccentButton()`, `.SubtleButton()`, `.TextLink()`, `.Informational()` / `.Success()` / `.Warning()` / `.Error()` |
 | Multi-select calendar | [`calendar-multiselect.cs`](calendar-multiselect.cs) | `CalendarView`, `CalendarViewSelectionMode.Multiple`, `.SelectedDatesChanged` |
+| Factor stateful logic into a custom hook | [`use-custom-hook.cs`](use-custom-hook.cs) | `UseState`, `UseEffect` inside a `Use*` extension on `RenderContext` |
 
 ## How to use a recipe
 

--- a/plugins/reactor/skills/reactor-recipes/references/use-custom-hook.cs
+++ b/plugins/reactor/skills/reactor-recipes/references/use-custom-hook.cs
@@ -1,0 +1,89 @@
+// Recipe: extract stateful logic into a custom hook.
+//
+// Rule: hooks (UseState, UseEffect, UseMemo, …) can only be called from a
+// Render() override or from another method whose name starts with `Use`. If
+// you want to share stateful behavior across components — or just hide it
+// behind a clean name — write a custom hook as an *extension method on
+// RenderContext*. The analyzer (REACTOR_HOOKS_005) enforces the naming
+// convention; a method called `DebouncedValue(...)` that calls UseState
+// internally will fail to compile.
+//
+// Wrong shapes that the analyzer rejects:
+//   * UseState in a field initializer:  `int _x = UseState(0).Item1;`
+//   * UseState in a regular helper:     `int GetCount() { return UseState(0).Item1; }`
+//   * UseState inside an event handler: `Button("X", () => UseState(0))`
+//
+// Right shape: a `Use*` extension on RenderContext that bundles the hooks.
+// Render() calls it like any other hook — order-stable, deps-driven.
+
+#:package Microsoft.UI.Reactor@0.0.0-local
+#:package Microsoft.WindowsAppSDK@2.0.1
+#:property OutputType=WinExe
+#:property TargetFramework=net10.0-windows10.0.22621.0
+#:property UseWinUI=true
+#:property WindowsPackageType=None
+
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+ReactorApp.Run<App>("Custom hook demo", width: 520, height: 320);
+
+// ── The custom hook ────────────────────────────────────────────────────
+// Extension on RenderContext; name starts with `Use`. Inside we are free
+// to call other hooks (UseState, UseEffect). Callers see one return value
+// and never know the hook ran two underlying hooks.
+
+static class DebounceHooks
+{
+    public static T UseDebouncedValue<T>(this RenderContext ctx, T value, int delayMs)
+    {
+        var (debounced, setDebounced) = ctx.UseState(value);
+
+        // Deps array drives re-arming. Pass scalars (value, delayMs) — never
+        // a freshly-allocated array/lambda, or REACTOR_HOOKS_004 fires.
+        ctx.UseEffect(() =>
+        {
+            var cts = new CancellationTokenSource();
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(delayMs, cts.Token);
+                    setDebounced(value);
+                }
+                catch (TaskCanceledException) { /* superseded by next render */ }
+            });
+            return () => cts.Cancel();
+        }, value!, delayMs);
+
+        return debounced;
+    }
+
+    // Optional Component-receiver overload mirrors the built-in hook pattern
+    // (see UseAnnounce / UseFocus in src/Reactor/Hooks). Lets callers write
+    // `this.UseDebouncedValue(...)` from inside a Component subclass without
+    // touching ctx directly.
+    public static T UseDebouncedValue<T>(this Component component, T value, int delayMs)
+        => component.Context.UseDebouncedValue(value, delayMs);
+}
+
+// ── The component that uses it ─────────────────────────────────────────
+
+class App : Component
+{
+    public override Element Render()
+    {
+        var (query, setQuery) = UseState("");
+
+        // One call site, two underlying hooks. Order is stable because the
+        // custom hook always calls the same hooks in the same sequence.
+        var debouncedQuery = this.UseDebouncedValue(query, delayMs: 300);
+
+        return VStack(12,
+            TextField(query, setQuery, placeholder: "Type to search…"),
+            TextBlock($"Live: {query}").Opacity(0.7),
+            TextBlock($"Debounced (300ms): {debouncedQuery}").Bold()
+        ).Padding(24);
+    }
+}

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -115,7 +115,7 @@ NumberBox(double value, Action<double> onValueChanged = null, string header = nu
 Paragraph(RichTextInline[] inlines) → RichTextParagraph
 ParallaxView(Element child, double verticalShift = 0, double horizontalShift = 0) → ParallaxViewElement
 PasswordBox(string password, Action<string> onPasswordChanged = null, string placeholderText = null) → PasswordBoxElement
-Path() → PathElement
+Path2D() → PathElement
 PathIcon(string data) → PathIconData
 PersonPicture() → PersonPictureElement
 PipsPager(int numberOfPages, int selectedPageIndex = 0, Action<int> onSelectedPageIndexChanged = null) → PipsPagerElement
@@ -515,6 +515,7 @@ T.HeadingLevel<T>(AutomationHeadingLevel level) → T
 T.Height<T>(double height) → T
 T.HelpText<T>(string text) → T
 T.HierarchyLevel<T>(int level) → T
+T.HorizontalAlignment<T>(HorizontalAlignment alignment) → T
 T.Immediate<T>() → T
 T.InteractionStates<T>(Func<InteractionStatesBuilder, InteractionStatesBuilder> configure, Curve curve = null) → T
 T.IsTabStop<T>(bool isTabStop = true) → T
@@ -612,6 +613,7 @@ T.Validate<T>(string fieldName, IValidator[] validators) → T
 T.Validate<T>(string fieldName, object value, IValidator[] validators) → T
 T.ValidateAsync<T>(string fieldName, IAsyncValidator[] asyncValidators) → T
 T.ValidateAsync<T>(string fieldName, object value, IAsyncValidator[] asyncValidators) → T
+T.VerticalAlignment<T>(VerticalAlignment alignment) → T
 T.Visible<T>(bool isVisible) → T
 T.Width<T>(double width) → T
 T.WithBorder<T>(Brush brush, double thickness = 1) → T

--- a/src/Reactor.Cli/Check/Rules/ThemeBackgroundSuffixRule.cs
+++ b/src/Reactor.Cli/Check/Rules/ThemeBackgroundSuffixRule.cs
@@ -25,6 +25,17 @@
 // confirmed it. The Class-A → Class-B distinction is about evidence type,
 // not rule shape; the rule itself is unchanged. Cross-agent audit recorded
 // at `docs/specs/tasks/038-tuning-reports/2026-05-11-cross-agent-audit.md`.
+//
+// 2026-05-16 refinement — claude-opus-4.7 run5 (140-trial reactor sweep) cross-
+// analysis at `OneDrive\big-eval\reactor-runs-cross-analysis.md` surfaced one
+// `*Background`-suffixed invented name that is NOT a surface-background and
+// must NOT collapse to SolidBackground:
+//   • LayerBackground — 64 occurrences across 28 distinct trials (the single
+//     highest-frequency invented Theme.* name in the corpus). The agent wants a
+//     layer fill, mapping to `Theme.LayerFill` (`LayerFillColorDefaultBrush`),
+//     not a surface background. The pre-refinement rule was actively wrong
+//     here: it suggested SolidBackground for 28 trials. The override table
+//     below short-circuits before the suffix fallback.
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -34,8 +45,22 @@ namespace Microsoft.UI.Reactor.Cli.Check.Rules;
 internal sealed class ThemeBackgroundSuffixRule : IRulePattern
 {
     const string ThemeFqn = "Microsoft.UI.Reactor.Core.Theme";
-    const string CanonicalTarget = "SolidBackground";
+    const string SuffixFallbackTarget = "SolidBackground";
     const string BackgroundSuffix = "Background";
+
+    // Exact-name overrides for `*Background` invented names that map to a real
+    // Theme member OTHER than SolidBackground. Without these the suffix rule
+    // would emit a confidently-wrong suggestion. Keys are intentional Ordinal:
+    // we only override on exact agent-typed spellings observed in corpus.
+    static readonly IReadOnlyDictionary<string, string> ExactOverrides =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // run5 (opus-4.7, 140 reactor trials): 64 occurrences across 28
+            // distinct trials. The agent wants a layer fill brush — the real
+            // member is Theme.LayerFill (LayerFillColorDefaultBrush). Single
+            // strongest cross-trial signal in the run5 invented-name table.
+            ["LayerBackground"] = "LayerFill",
+        };
 
     public string Name => "ThemeBackgroundSuffixRule";
     public string Provenance => "vocab:WinUI3";
@@ -60,19 +85,32 @@ internal sealed class ThemeBackgroundSuffixRule : IRulePattern
         if (memberName is null) return RuleSuggestion.Silent;
         if (!memberName.EndsWith(BackgroundSuffix, StringComparison.Ordinal))
             return RuleSuggestion.Silent;
+
+        // Pick exact-override target first, else fall through to the
+        // surface-background default. Evidence string distinguishes the two
+        // so reviewers can spot which path fired.
+        var hasOverride = ExactOverrides.TryGetValue(memberName, out var overrideTarget);
+        var target = hasOverride ? overrideTarget! : SuffixFallbackTarget;
+
         // Same name we'd propose? Then the diagnostic must be on a different
         // axis (compiler reordering, multitree edge case). Silent rather than
         // emit a no-op suggestion.
-        if (string.Equals(memberName, CanonicalTarget, StringComparison.Ordinal))
+        if (string.Equals(memberName, target, StringComparison.Ordinal))
             return RuleSuggestion.Silent;
 
-        var solid = ctx.Resolver.ResolveMember(themeType, CanonicalTarget);
-        if (solid is null) return RuleSuggestion.Silent;
+        // The chosen target must still exist on the current Reactor Theme
+        // surface — protects against a rename that hasn't propagated.
+        if (ctx.Resolver.ResolveMember(themeType, target) is null)
+            return RuleSuggestion.Silent;
+
+        var evidence = hasOverride
+            ? $"Theme.{memberName} → Theme.{target} (run5 cross-trial override)"
+            : $"Theme.{memberName} → Theme.{target} (WinUI surface-background token)";
 
         return new RuleSuggestion(
-            Text: $"Theme.{CanonicalTarget}",
+            Text: $"Theme.{target}",
             Confidence: 0.92,
-            Evidence: $"Theme.{memberName} → Theme.{CanonicalTarget} (WinUI surface-background token)");
+            Evidence: evidence);
     }
 
     static string? ExtractMissingName(SyntaxNode node) => node switch

--- a/src/Reactor.Cli/Check/Rules/ThemeRawResourceKeyRule.cs
+++ b/src/Reactor.Cli/Check/Rules/ThemeRawResourceKeyRule.cs
@@ -1,0 +1,106 @@
+// Class A (induced) rule — corpus-justified by the run5 cross-analysis at
+// `OneDrive\big-eval\reactor-runs-cross-analysis.md` (claude-opus-4.7,
+// 140-trial reactor sweep, 2026-05-15).
+//
+// CS0117 on `Microsoft.UI.Reactor.Core.Theme` where the agent typed a name
+// that looks like (or partially mirrors) the underlying WinUI 3 ThemeResource
+// key — `LayerFillColorDefault`, `AccentFillColorDefault`, `SubtleFillColorSecondary`,
+// `TextFillColorSecondary`, `CardBackgroundFillColorDefault`, plus the
+// "Color"-stripped near-variants (`SubtleFillSecondary`, `AccentFill`).
+// None of these exist as members on Reactor's `Theme` static — the canonical
+// surface deliberately renames them to short, intent-named aliases:
+//   • AccentFillColorDefaultBrush      → Theme.Accent
+//   • LayerFillColorDefaultBrush       → Theme.LayerFill
+//   • SubtleFillColorSecondaryBrush    → Theme.SubtleFill
+//   • TextFillColorSecondaryBrush      → Theme.SecondaryText
+//   • CardBackgroundFillColorDefaultBrush → Theme.CardBackground
+//
+// Why this is a SEPARATE rule from ThemeBackgroundSuffixRule rather than a
+// fold-in: the failure shape is different. The suffix rule covers tokens that
+// END IN "Background"; this rule covers tokens that EMBED the WinUI
+// "<X>FillColor<Y>" stem. Composing them via overrides on one rule would
+// require either two suffix checks or a leading regex, and `--disable-rule`
+// granularity is more useful when each pattern family is its own kill switch.
+//
+// Tier-2 fuzzy match also can't bridge these: from `LayerFillColorDefault`
+// JaroWinkler picks `LayerFill` as the closest member with similarity ≈ 0.72,
+// which IS the right answer — but the per-code CS0117 threshold (0.75) is just
+// above the actual similarity, so Tier-2 stays silent and Tier-3 inherits the
+// hand-off. (Holding the Tier-2 threshold at 0.75 keeps wrong-suggestion rate
+// down for the long-tail names; the high-frequency map in this file covers
+// the names that matter without trading away threshold safety.)
+//
+// Cross-agent reproducibility (Validation Gate bar #2): PARTIAL. Authored
+// from the run5 opus-4.7 corpus only — the entries are also justified by
+// the underlying WinUI 3 ThemeResource key documentation (structural Class-B
+// evidence), which is the more durable signal of the two. Re-validate when
+// the next sonnet-4.6 / opus-4.7 sweep lands.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Cli.Check.Rules;
+
+internal sealed class ThemeRawResourceKeyRule : IRulePattern
+{
+    const string ThemeFqn = "Microsoft.UI.Reactor.Core.Theme";
+
+    // Exact-name map. Each entry meets BOTH bars:
+    //   • ≥ 2 distinct trials in run5 (cross-trial signal, not single-trial fluke)
+    //   • Underlying WinUI 3 ThemeResource key maps unambiguously to a real
+    //     member on the current Reactor Theme surface — independent of corpus.
+    static readonly IReadOnlyDictionary<string, string> Mappings =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["LayerFillColorDefault"]          = "LayerFill",          // 6 trials
+            ["SubtleFillColorSecondary"]       = "SubtleFill",         // 6 trials
+            ["SubtleFillSecondary"]            = "SubtleFill",         // 12 trials (Color-stripped)
+            ["AccentFillColorDefault"]         = "Accent",             // 3 trials
+            ["AccentFill"]                     = "Accent",             // 3 trials (Color-stripped)
+            ["CardBackgroundFillColorDefault"] = "CardBackground",     // 2 trials
+            ["TextFillColorSecondary"]         = "SecondaryText",      // 2 trials
+        };
+
+    public string Name => "ThemeRawResourceKeyRule";
+    public string Provenance => "cluster:run5-opus-theme-raw-keys";
+    public IReadOnlyList<string> DiagnosticCodes { get; } = new[] { "CS0117" };
+    public IReadOnlyList<string> DeclaredTargets { get; } = new[] { ThemeFqn };
+
+    public RuleSuggestion TryMatch(in RuleContext ctx)
+    {
+        if (ctx.Diagnostic.Id != "CS0117") return RuleSuggestion.Silent;
+        if (ctx.Receiver is null) return RuleSuggestion.Silent;
+
+        var themeType = ctx.Resolver.ResolveType(ThemeFqn);
+        if (themeType is null) return RuleSuggestion.Silent;
+
+        // Receiver must be Reactor's `Theme` — same defensive symbol check as
+        // ThemeBackgroundSuffixRule, for the same reason (look-alike namespaces).
+        if (!SymbolEqualityComparer.Default.Equals(ctx.Receiver, themeType))
+            return RuleSuggestion.Silent;
+
+        var memberName = ExtractMissingName(ctx.Node);
+        if (memberName is null) return RuleSuggestion.Silent;
+        if (!Mappings.TryGetValue(memberName, out var target)) return RuleSuggestion.Silent;
+
+        // Target must still exist on the current Reactor Theme surface — the
+        // CI rule-target gate doesn't check value-side members, only the
+        // DeclaredTargets type, so do the membership check here. If a future
+        // rename moves `LayerFill` → `LayerSurface`, this rule self-skips
+        // instead of emitting a stale suggestion.
+        if (ctx.Resolver.ResolveMember(themeType, target) is null)
+            return RuleSuggestion.Silent;
+
+        return new RuleSuggestion(
+            Text: $"Theme.{target}",
+            Confidence: 0.92,
+            Evidence: $"Theme.{memberName} → Theme.{target} (WinUI resource-key transliteration)");
+    }
+
+    static string? ExtractMissingName(SyntaxNode node) => node switch
+    {
+        MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        _ => null,
+    };
+}

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -35,6 +35,34 @@ public abstract record Element
     public ElementModifiers? Modifiers { get; init; }
 
     /// <summary>
+    /// Outer margin shim that routes to <see cref="Modifiers"/>. Lets
+    /// <c>el with { Margin = new Thickness(8) }</c> work directly on a record
+    /// initializer (where extension methods are not visible). Identical
+    /// semantics to <c>.Margin(...)</c>.
+    /// </summary>
+    public Thickness? Margin
+    {
+        get => Modifiers?.Margin;
+        init => Modifiers = Modifiers is null
+            ? new ElementModifiers { Margin = value }
+            : Modifiers with { Margin = value };
+    }
+
+    /// <summary>
+    /// Inner padding shim that routes to <see cref="Modifiers"/>. Lets
+    /// <c>el with { Padding = new Thickness(8) }</c> work directly on a record
+    /// initializer (where extension methods are not visible). Identical
+    /// semantics to <c>.Padding(...)</c>.
+    /// </summary>
+    public Thickness? Padding
+    {
+        get => Modifiers?.Padding;
+        init => Modifiers = Modifiers is null
+            ? new ElementModifiers { Padding = value }
+            : Modifiers with { Padding = value };
+    }
+
+    /// <summary>
     /// Attached properties from parent containers (Grid.Row, Canvas.Left, etc.).
     /// Set via fluent extension methods: Text("hi").Grid(row: 1, column: 2)
     /// Stored as a type-keyed dictionary so each provider defines its own data record.
@@ -381,7 +409,6 @@ public abstract record Element
                 BrushesEqual(ba.Background, bb.Background)
                 && BrushesEqual(ba.BorderBrush, bb.BorderBrush)
                 && ba.CornerRadius == bb.CornerRadius
-                && ba.Padding == bb.Padding
                 && ba.BorderThickness == bb.BorderThickness
                 && ReferenceEquals(ba.Child, bb.Child)
                 && ReferenceEquals(ba.Setters, bb.Setters),
@@ -2311,7 +2338,6 @@ public record ScrollViewElement(Element Child) : Element
 public record BorderElement(Element? Child) : Element
 {
     public double? CornerRadius { get; init; }
-    public Thickness? Padding { get; init; }
     public Brush? Background { get; init; }
     public Brush? BorderBrush { get; init; }
     public double? BorderThickness { get; init; }

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -1186,7 +1186,6 @@ public sealed partial class Reconciler
     {
         var bdr = _pool.TryRent(typeof(WinUI.Border)) as WinUI.Border ?? new WinUI.Border();
         if (border.CornerRadius.HasValue) bdr.CornerRadius = new Microsoft.UI.Xaml.CornerRadius(border.CornerRadius.Value);
-        if (border.Padding.HasValue) bdr.Padding = border.Padding.Value;
         if (border.Background is not null) bdr.Background = border.Background;
         if (border.BorderBrush is not null) bdr.BorderBrush = border.BorderBrush;
         if (border.BorderThickness.HasValue) bdr.BorderThickness = new Microsoft.UI.Xaml.Thickness(border.BorderThickness.Value);

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -1383,7 +1383,6 @@ public sealed partial class Reconciler
         else return Mount(newEl, requestRerender);
 
         if (n.CornerRadius.HasValue) b.CornerRadius = new Microsoft.UI.Xaml.CornerRadius(n.CornerRadius.Value);
-        if (n.Padding.HasValue) b.Padding = n.Padding.Value;
         if (n.Background is not null) b.Background = n.Background;
         if (n.BorderBrush is not null) b.BorderBrush = n.BorderBrush;
         if (n.BorderThickness.HasValue) b.BorderThickness = new Microsoft.UI.Xaml.Thickness(n.BorderThickness.Value);

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -998,7 +998,11 @@ public static partial class Factories
     public static LineElement Line(double x1, double y1, double x2, double y2) =>
         new() { X1 = x1, Y1 = y1, X2 = x2, Y2 = y2 };
 
-    public static PathElement Path() => new();
+    // Named `Path2D` (not `Path`) to avoid colliding with `System.IO.Path`.
+    // Models reach for both in the same file and the bare name causes
+    // CS0119 cascades. Borrows the Web Canvas API's `Path2D` spelling for the
+    // vector-geometry primitive — collision-free and familiar from JS/SVG.
+    public static PathElement Path2D() => new();
 
     // ── Additional layout ───────────────────────────────────────────
 

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -115,11 +115,22 @@ public static partial class ElementExtensions
     public static T VAlign<T>(this T el, VerticalAlignment alignment) where T : Element =>
         Modify(el, new ElementModifiers { VerticalAlignment = alignment });
 
+    // Long-form aliases matching the WinUI/WPF FrameworkElement property names.
+    // The agent's first-instinct write is `.HorizontalAlignment(...)`; making
+    // that compile saves a fix-loop without forcing a rename of the short forms.
+    // Parameter types are fully qualified because the method names shadow the
+    // enum names in this scope.
+    public static T HorizontalAlignment<T>(this T el, Microsoft.UI.Xaml.HorizontalAlignment alignment) where T : Element =>
+        Modify(el, new ElementModifiers { HorizontalAlignment = alignment });
+
+    public static T VerticalAlignment<T>(this T el, Microsoft.UI.Xaml.VerticalAlignment alignment) where T : Element =>
+        Modify(el, new ElementModifiers { VerticalAlignment = alignment });
+
     public static T Center<T>(this T el) where T : Element =>
         Modify(el, new ElementModifiers
         {
-            HorizontalAlignment = HorizontalAlignment.Center,
-            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
+            VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Center,
         });
 
     // ── Theme override ───────────────────────────────────────────────

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DslExtensionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DslExtensionFixtures.cs
@@ -333,7 +333,7 @@ internal static class DslExtensionFixtures
                 TextBlock("FontFamilyObj").FontFamily(ff),
                 Button("FontWeightBtn").FontWeight(Microsoft.UI.Text.FontWeights.SemiBold),
                 TextBlock("BoldText").Bold(),
-                Path().StrokeDashArray(2, 4, 1).Stroke(brush).StrokeThickness(1)
+                Path2D().StrokeDashArray(2, 4, 1).Stroke(brush).StrokeThickness(1)
                     .Set(p => p.Data = new Microsoft.UI.Xaml.Media.PathGeometry()),
                 Rectangle().Fill(brush).Set(r => r.Width = 10).Set(r => r.Height = 10),
                 Ellipse().Fill(brush2).Set(e => e.Width = 10).Set(e => e.Height = 10),

--- a/tests/Reactor.Tests/CheckCommandTests/Rules/ThemeBackgroundSuffixRuleTests.cs
+++ b/tests/Reactor.Tests/CheckCommandTests/Rules/ThemeBackgroundSuffixRuleTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.UI.Reactor.Core
     {
         public static object SolidBackground => null!;
         public static object CardBackground => null!;
+        public static object LayerFill => null!;
         public static object Accent => null!;
     }
 }";
@@ -58,6 +59,20 @@ namespace Microsoft.UI.Reactor.Core
         // Source run_id: reactor-skilled-sweep-db7ffb9050df-2026-05-11T04:15:22.011Z
         // (corpus row member="DefaultBackground", code=CS0117).
         AssertFiresOn("DefaultBackground");
+    }
+
+    [Fact]
+    public void LayerBackground_Routes_To_LayerFill_Not_SolidBackground()
+    {
+        // run5 opus-4.7 corpus, 64 occurrences across 28 distinct trials.
+        // The agent wants a layer fill, not a surface background — pre-
+        // refinement, the suffix rule incorrectly suggested SolidBackground.
+        var diag = MakeThemeDiag("LayerBackground", ThemeStub, out var c);
+        var suggestion = RunRule(diag, c);
+        Assert.NotNull(suggestion);
+        Assert.Equal("ThemeBackgroundSuffixRule", suggestion!.SuggesterName);
+        Assert.Equal("Theme.LayerFill", suggestion.Text);
+        Assert.Contains("run5 cross-trial override", suggestion.Evidence);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/CheckCommandTests/Rules/ThemeRawResourceKeyRuleTests.cs
+++ b/tests/Reactor.Tests/CheckCommandTests/Rules/ThemeRawResourceKeyRuleTests.cs
@@ -1,0 +1,140 @@
+// Spec 038 §3.2 Class-A fixture tests for ThemeRawResourceKeyRule.
+//
+// Validation Gate (six bars per spec 038 §"Human Validation Gate"):
+//   #1 Frequency: run5 opus-4.7 corpus — each mapping has ≥ 2 distinct trials
+//      (highest: SubtleFillSecondary at 12 trials, LayerFillColorDefault and
+//      SubtleFillColorSecondary at 6 each).
+//   #2 Cross-agent reproducibility: PARTIAL — single-agent (opus-4.7) at time
+//      of authoring. Structural justification (WinUI 3 ThemeResource key →
+//      Reactor short alias) carries the cross-agent gap.
+//   #3 Positive coverage: ≥ 3 below (one per major mapping family).
+//   #4 Negative coverage: ≥ 2 below.
+//   #5 Independent reviewer signoff: pending (PR review).
+//   #6 Telemetry kill-switch: Name "ThemeRawResourceKeyRule" round-trips
+//      through --disable-rule via RuleRegistry auto-discovery.
+
+using Microsoft.UI.Reactor.Cli.Check;
+using Microsoft.UI.Reactor.Cli.Check.Rules;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.CheckCommandTests.Rules;
+
+public class ThemeRawResourceKeyRuleTests
+{
+    // Stub including all targets the rule maps TO. If any of these are
+    // missing the rule self-skips for that name — which is the correct
+    // behavior under API churn but makes negative tests hard, so we keep
+    // them present here.
+    const string ThemeStub = @"
+namespace Microsoft.UI.Reactor.Core
+{
+    public static class Theme
+    {
+        public static object Accent => null!;
+        public static object LayerFill => null!;
+        public static object SubtleFill => null!;
+        public static object SecondaryText => null!;
+        public static object CardBackground => null!;
+        public static object SolidBackground => null!;
+    }
+}";
+
+    [Fact]
+    public void Maps_LayerFillColorDefault_To_LayerFill()
+        => AssertMapsTo("LayerFillColorDefault", "Theme.LayerFill");
+
+    [Fact]
+    public void Maps_SubtleFillColorSecondary_To_SubtleFill()
+        => AssertMapsTo("SubtleFillColorSecondary", "Theme.SubtleFill");
+
+    [Fact]
+    public void Maps_ColorStripped_SubtleFillSecondary_To_SubtleFill()
+        => AssertMapsTo("SubtleFillSecondary", "Theme.SubtleFill");
+
+    [Fact]
+    public void Maps_AccentFillColorDefault_To_Accent()
+        => AssertMapsTo("AccentFillColorDefault", "Theme.Accent");
+
+    [Fact]
+    public void Maps_TextFillColorSecondary_To_SecondaryText()
+        => AssertMapsTo("TextFillColorSecondary", "Theme.SecondaryText");
+
+    [Fact]
+    public void Does_not_fire_on_unmapped_invented_name()
+    {
+        // Negative #1: an invented name that is NOT in our map. Tier-2 fuzzy
+        // and/or ThemeBackgroundSuffixRule may still respond, but this rule
+        // must stay silent.
+        var diag = MakeThemeDiag("AppFillColorRandom", ThemeStub, out var c);
+        var suggestion = RunRule(diag, c);
+        Assert.True(suggestion is null || suggestion.SuggesterName != "ThemeRawResourceKeyRule",
+            $"Rule should be silent on unmapped names; got {suggestion?.SuggesterName}");
+    }
+
+    [Fact]
+    public void Does_not_fire_when_receiver_is_a_user_type_named_Theme()
+    {
+        // Negative #2: look-alike Theme type in a different namespace. Same
+        // safety as ThemeBackgroundSuffixRule — symbol equality must rule out
+        // a user's domain model that happens to share the type name.
+        const string lookalikeStub = ThemeStub + @"
+namespace Acme.Branding
+{
+    public static class Theme
+    {
+        public static object Accent => null!;
+    }
+}";
+        const string source = @"
+using Acme.Branding;
+class Test { void M() { var x = Theme.LayerFillColorDefault; } }
+";
+        var c = TestCompilation.Create(new[]
+        {
+            (lookalikeStub, "Stub.cs"),
+            (source, "Test.cs"),
+        });
+        var roslynDiag = c.GetDiagnostics().First(d => d.Id == "CS0117");
+        var span = roslynDiag.Location.GetLineSpan();
+        var diag = new CheckCommand.Diag(
+            span.Path, span.StartLinePosition.Line + 1, span.StartLinePosition.Character + 1,
+            "error", "CS0117", roslynDiag.GetMessage());
+
+        var suggestion = RunRule(diag, c);
+        Assert.Null(suggestion);
+    }
+
+    static void AssertMapsTo(string invented, string expectedSuggestion)
+    {
+        var diag = MakeThemeDiag(invented, ThemeStub, out var c);
+        var suggestion = RunRule(diag, c);
+        Assert.NotNull(suggestion);
+        Assert.Equal("ThemeRawResourceKeyRule", suggestion!.SuggesterName);
+        Assert.Equal(expectedSuggestion, suggestion.Text);
+        Assert.Contains("resource-key transliteration", suggestion.Evidence);
+    }
+
+    static CheckCommand.Diag MakeThemeDiag(string missingMember, string themeStub, out Microsoft.CodeAnalysis.CSharp.CSharpCompilation c)
+    {
+        var source = $@"
+using Microsoft.UI.Reactor.Core;
+class Test {{ void M() {{ var x = Theme.{missingMember}; }} }}";
+        c = TestCompilation.Create(new[]
+        {
+            (themeStub, "Stub.cs"),
+            (source, "Test.cs"),
+        });
+        var roslynDiag = c.GetDiagnostics().First(d => d.Id == "CS0117");
+        var span = roslynDiag.Location.GetLineSpan();
+        return new CheckCommand.Diag(
+            span.Path, span.StartLinePosition.Line + 1, span.StartLinePosition.Character + 1,
+            "error", "CS0117", roslynDiag.GetMessage());
+    }
+
+    static Suggestion? RunRule(CheckCommand.Diag diag, Microsoft.CodeAnalysis.CSharp.CSharpCompilation c)
+    {
+        var registry = RuleRegistry.Of(new IRulePattern[] { new ThemeRawResourceKeyRule() });
+        var orch = new SuggesterOrchestrator(rules: registry);
+        return orch.SuggestAgainst(diag, c);
+    }
+}

--- a/tests/Reactor.Tests/ElementExtensionsAdditionalTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsAdditionalTests.cs
@@ -253,6 +253,50 @@ public class ElementExtensionsAdditionalTests
     }
 
     [Fact]
+    public void LongForm_Alignment_Aliases_Match_Short_Forms()
+    {
+        var longForm = TextBlock("hi")
+            .HorizontalAlignment(HorizontalAlignment.Right)
+            .VerticalAlignment(VerticalAlignment.Bottom);
+
+        Assert.IsType<TextBlockElement>(longForm);
+        Assert.Equal(HorizontalAlignment.Right, longForm.Modifiers!.HorizontalAlignment);
+        Assert.Equal(VerticalAlignment.Bottom, longForm.Modifiers!.VerticalAlignment);
+    }
+
+    [Fact]
+    public void With_Initializer_Sets_Padding_And_Margin_On_Modifiers()
+    {
+        var el = TextBlock("hi") with
+        {
+            Padding = new Thickness(8),
+            Margin = new Thickness(4),
+        };
+
+        Assert.IsType<TextBlockElement>(el);
+        Assert.Equal(new Thickness(8), el.Modifiers!.Padding);
+        Assert.Equal(new Thickness(4), el.Modifiers!.Margin);
+    }
+
+    [Fact]
+    public void With_Initializer_Padding_Merges_With_Existing_Modifiers()
+    {
+        var el = TextBlock("hi").Width(100) with { Padding = new Thickness(8) };
+
+        Assert.Equal(100.0, el.Modifiers!.Width);
+        Assert.Equal(new Thickness(8), el.Modifiers!.Padding);
+    }
+
+    [Fact]
+    public void BorderElement_With_Initializer_Routes_Padding_Through_Modifiers()
+    {
+        var b = Border(TextBlock("x")) with { Padding = new Thickness(12) };
+
+        Assert.Equal(new Thickness(12), b.Padding);
+        Assert.Equal(new Thickness(12), b.Modifiers!.Padding);
+    }
+
+    [Fact]
     public void Multiple_Setters_Are_Accumulated()
     {
         var el = TextBlock("x")

--- a/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
@@ -254,7 +254,7 @@ public class ElementExtensionsCoverageTests
     {
         // Brush-typed Fill/Stroke require WinUI activation; the StrokeThickness
         // modifier is independent and exercises the `el with` body.
-        var pa = Path().StrokeThickness(3);
+        var pa = Path2D().StrokeThickness(3);
         Assert.Equal(3.0, pa.StrokeThickness);
         var li = Line(0, 0, 1, 1).StrokeThickness(2);
         Assert.Equal(2.0, li.StrokeThickness);


### PR DESCRIPTION
## Summary

Addresses H3, H4, H5, H6, and H8 from `reactor-build-improvements.md` — the cluster of compile-error fix-loops that drove `reactor-dev`'s 4.9× build-attempt gap vs `winui3-simple-base` in run5.

## Eval signal (run8 n=5 vs run5 mew58 baseline n=10)

| | run5 (n=10) | run8 (n=5) | Δ |
|---|---|---|---|
| Turns | 62.1 (σ≈16, 47–98) | 54.2 (σ=10.0, 45–70) | **−13%, tighter** |
| `dotnet build` invocations | ~5–6 | 0.2 (4/5 trials = 0) | **−96%** |
| Session time | 22m 22s | 13m 39s | **−39%** |
| Input tokens | 6.27m ±21% | 5.88m | inside band |
| Output tokens | 58.0k ±12% | 46.2k | **−20%, outside band** |
| Build / run pass | 100% | 100% / 100% | flat |

## Commits

### `feat(dsl): reduce agent fix-loops in the fluent surface`

- **H3 — long-form alignment aliases.** `.HorizontalAlignment(...)` and `.VerticalAlignment(...)` on `T : Element` alongside the short `HAlign` / `VAlign`. WinUI/WPF-trained models reach for the long names first; both compile now. (`AlignmentShortcutRule` stays as a safety net — self-skips when no CS1061 fires.)
- **H5 — `Factories.Path()` → `Path2D()`.** The `System.IO.Path` collision drove 289 CS0119 occurrences across 36 files in run5. WinUI / WPF / SwiftUI all use `Path` (the source of the conflict), so the rename borrows the Web Canvas API's `Path2D` spelling — collision-free and familiar from JS/SVG.
- **H6 — `Padding` / `Margin` init shims on the `Element` base record.** Routes through `Modifiers` so `el with { Padding = new Thickness(8) }` works on any Element subtype. Unified `BorderElement`'s separate `Padding` slot with the base shim — single source of truth, dropped redundant `MountBorder` / `UpdateBorder` / equality lines.

### `feat(check): theme-suggestion rules from run5 corpus`

- **`ThemeBackgroundSuffixRule` refined.** The rule was confidently wrong on the single highest-frequency invented Theme.* name in run5: `Theme.LayerBackground` (64 occurrences across 28 distinct trials) was being routed to `Theme.SolidBackground` when the agent wanted `Theme.LayerFill`. Exact-name override table added; the suffix-fallback path is unchanged for `AppBackground` / `DefaultBackground` / `WindowBackground` / `PageBackground`.
- **`ThemeRawResourceKeyRule` (new).** Seven mappings where the agent typed (or partially typed) the WinUI 3 raw ThemeResource key — `LayerFillColorDefault → LayerFill`, `SubtleFillColorSecondary → SubtleFill`, `AccentFillColorDefault → Accent`, `CardBackgroundFillColorDefault → CardBackground`, `TextFillColorSecondary → SecondaryText`, plus two Color-stripped variants. Each entry has ≥ 2 distinct trials in run5 plus structural justification from the WinUI doc. Auto-discovered by `RuleRegistry`; granular kill switch via `--disable-rule`.

### `docs(recipes): add custom-hook extraction recipe`

- **H8 — `use-custom-hook.cs`.** A `UseDebouncedValue<T>` extension on `RenderContext` that bundles `UseState + UseEffect`, mirroring the `UseAnnounce` / `UseFocus` shape in `src/Reactor/Hooks/`. Calls out the three wrong shapes the analyzer rejects (field initializer, regular helper, event-handler lambda) so the agent recognizes the failure mode without running into it. Plugs the gap behind 43 of the run5 `REACTOR_HOOKS_005` occurrences.

## Test plan

- [x] `dotnet test tests/Reactor.Tests` — 7264 passed, 0 failed (46 pre-existing skipped)
- [x] `dotnet test tests/Reactor.AppTests` — padding/border/margin runtime tests pass
- [x] 47 Theme-rule tests pass (including new `LayerBackground` override + 5 raw-resource-key cases)
- [x] New DSL tests added for the alignment aliases and `with {}` Padding/Margin shims
- [x] `mur pack-local` builds `Microsoft.UI.Reactor.0.0.0-local.nupkg` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)