### PR TITLE
Loosen ScrollPerfRelative ratio threshold

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs
@@ -202,7 +202,7 @@ internal static class DataGridScrollFixtures
     /// total wall time for the scroll + ItemsRepeater realization + layout
     /// across several jump positions and compare the median.
     ///
-    /// Asserts DataGrid stays within 20% of VirtualList. This catches
+    /// Asserts DataGrid stays within 2x of VirtualList. This catches
     /// structural per-row regressions (e.g., FlexRow wrapper, extra Yoga
     /// layout pass) that inflate the mount cost of each realized row during
     /// scroll, without depending on absolute timers.
@@ -312,17 +312,15 @@ internal static class DataGridScrollFixtures
             H.Check($"ScrollPerf_DG_Measured (median={dgMedian:F2}ms)",
                 dgTimes.Count > 0);
 
-            // DataGrid scroll-to-position should be within 40% of VirtualList.
+            // DataGrid scroll-to-position should stay within 2x of VirtualList.
             // Both realize ~11 rows per scroll jump with the same Grid structure.
             // The DataGrid adds selection/placeholder/event-handler overhead per
-            // row; this ratio depends heavily on hardware and measurement jitter
-            // at the single-digit-ms range the test operates in (ARM64 dev boxes
-            // land at ~1.3–1.4x, x64 CI closer to 1.1–1.2x). The headroom to
-            // 1.4x absorbs that variance while still catching structural
-            // regressions (FlexRow wrapping, redundant Yoga passes, …) which
-            // the fixture's original comment calls out as 2x+.
+            // row; measured ratios vary by hardware and CI runner load (ARM64 dev
+            // boxes ~1.3x, x64 CI ~1.1–1.5x). The 2.0x ceiling absorbs that
+            // variance while still catching structural regressions (FlexRow
+            // wrapping, redundant Yoga passes, …) that push ratios well above 2x.
             H.Check($"ScrollPerf_Ratio (dg={dgMedian:F2} vl={vlMedian:F2} ratio={ratio:F1}x)",
-                ratio < 1.4);
+                ratio < 2.0);
         }
     }
 }


### PR DESCRIPTION
Loosen the DataGrid-vs-VirtualList scroll perf ratio threshold from 1.4x to 2.0x.

## Problem
CI stress runs showed the ratio hitting ~1.46–1.52x under load, right at the 1.4x threshold. This is measurement jitter, not a product regression — true structural regressions (FlexRow wrapping, redundant Yoga passes) push ratios well above 2x.

## Fix
- Changed assertion from `ratio < 1.4` to `ratio < 2.0`
- Updated comments to reflect the new calibration

## Testing
- Selftest passes 20/20 runs locally
- Full selftest suite (688 fixtures): 0 failures

Fixes #209
