### PR TITLE
Add retry loop for DataGrid external state test

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
@@ -341,13 +341,15 @@ internal static class DataGridEditFixtures
                 );
             });
 
-            await Harness.Render(500);
-
-            // 1. Initial render with fontSize=14
-            H.Check("DataGrid_ExtState_Renders",
-                H.FindTextContaining("Product 0") is not null);
-
-            var initialTb = H.FindControl<TextBlock>(tb => tb.Text == "Product 0");
+            // 1. Initial render with fontSize=14 — retry to absorb VirtualList
+            //    item realization timing on slow CI runners.
+            TextBlock? initialTb = null;
+            for (int attempt = 0; attempt < 5 && initialTb is null; attempt++)
+            {
+                await Harness.Render(200);
+                initialTb = H.FindControl<TextBlock>(tb => tb.Text == "Product 0");
+            }
+            H.Check("DataGrid_ExtState_Renders", initialTb is not null);
             H.Check("DataGrid_ExtState_InitialFontSize",
                 initialTb is not null && Math.Abs(initialTb.FontSize - 14.0) < 0.1);
 


### PR DESCRIPTION
Add a retry loop for the initial item realization check in the DataGrid external state update selftest.

## Problem
`FindTextContaining("Product 0")` could fail if the DataGrid's VirtualList hadn't finished realizing items after a single `Harness.Render(500)` call, especially on slow CI runners.

## Fix
- Replaced single render + assert with a retry loop (up to 5 attempts, `Harness.Render(200)` between each)
- The loop exits as soon as the item is found, so fast machines see no slowdown

## Testing
- Selftest passes 20/20 runs locally
- Full selftest suite (688 fixtures): 0 failures

Fixes #211
