### PR TITLE
docs: migrate doc templates + apps to renamed boolean modifiers (#268)

### DIFF
--- a/docs/_pipeline/apps/commanding/App.cs
+++ b/docs/_pipeline/apps/commanding/App.cs
@@ -199,7 +199,7 @@ class ParameterizedCommandExample : Component
                     // Inline button — Command<T> doesn't have a Button(cmd, arg) overload
                     // by design, so call .Execute(arg) directly from the click handler.
                     Button(delete.Label, () => delete.Execute?.Invoke(item))
-                        .Disabled(!delete.IsEnabled)))
+                        .IsEnabled(delete.IsEnabled)))
         ).Padding(24);
     }
 }

--- a/docs/_pipeline/apps/dialogs-and-flyouts/App.cs
+++ b/docs/_pipeline/apps/dialogs-and-flyouts/App.cs
@@ -176,7 +176,7 @@ class PopupDemo : Component
                 () => setOpen(!open)),
             Popup(popupContent, isOpen: open,
                 onClosed: () => setOpen(false))
-                .LightDismiss()
+                .IsLightDismissEnabled()
                 .Offset(120, 0)
         ).Padding(24);
     }

--- a/docs/_pipeline/apps/forms/doc-manifest.yaml
+++ b/docs/_pipeline/apps/forms/doc-manifest.yaml
@@ -21,7 +21,7 @@ screenshots:
     region: client
     format: png
   - id: keep-submit-reachable
-    description: "Form using .Immediate() on NumberBox and .DisabledFocusable() on Submit so keyboard users can always reach the button"
+    description: "Form using .Immediate() on NumberBox and .IsDisabledFocusable() on Submit so keyboard users can always reach the button"
     component: KeepSubmitReachableDemo
     region: client
     format: png

--- a/docs/_pipeline/apps/recipe-login/App.cs
+++ b/docs/_pipeline/apps/recipe-login/App.cs
@@ -58,7 +58,7 @@ class LoginForm : Component
                 ? Empty()
                 : TextBlock(error).Foreground("#C42B1C"),
             Button(submitting ? "Signing in…" : "Sign in", () => _ = Submit())
-                .Disabled(!canSubmit)
+                .IsEnabled(canSubmit)
         ).Padding(20).Width(320);
         // </snippet:render>
     }

--- a/docs/_pipeline/apps/recipe-multi-step-form/App.cs
+++ b/docs/_pipeline/apps/recipe-multi-step-form/App.cs
@@ -87,9 +87,9 @@ class Wizard : Component
             Heading("Create your account"),
             body,
             HStack(8,
-                Button("Back", () => setStep(step - 1)).Disabled(step == 0),
+                Button("Back", () => setStep(step - 1)).IsEnabled(step != 0),
                 Button(step == 2 ? "Submit" : "Next",
-                    () => setStep(step + 1)).Disabled(!canAdvance || step == 2)
+                    () => setStep(step + 1)).IsEnabled(canAdvance && step != 2)
             )
         ).Padding(20).Width(380);
         // </snippet:render>

--- a/docs/_pipeline/apps/recipe-paginated-list/App.cs
+++ b/docs/_pipeline/apps/recipe-paginated-list/App.cs
@@ -110,7 +110,7 @@ class CommitFeed : Component
                 : Button(
                     loadingMore ? "Loading more…" : $"Load more ({commits.EstimatedRemaining} remaining)",
                     () => commits.FetchNext()
-                  ).Disabled(loadingMore).Padding(8);
+                  ).IsEnabled(!loadingMore).Padding(8);
 
         return VStack(0,
             Heading($"Commits ({commits.TotalCount ?? loadedItems.Length})").Padding(20),

--- a/docs/_pipeline/apps/status-and-info/App.cs
+++ b/docs/_pipeline/apps/status-and-info/App.cs
@@ -15,15 +15,15 @@ class InfoBarSeveritiesDemo : Component
     public override Element Render() => VStack(8,
         SubHeading("InfoBar — severity fluents"),
         InfoBar("Saving…", "Your changes are being written.")
-            .Informational().Closable(false),
+            .Informational().IsClosable(false),
         InfoBar("Saved", "Your changes were saved.")
-            .Success().Closable(false),
+            .Success().IsClosable(false),
         InfoBar("Slow connection",
             "Some assets may not load until the network recovers.")
-            .Warning().Closable(false),
+            .Warning().IsClosable(false),
         InfoBar("Save failed",
             "The destination drive is read-only.")
-            .Error().Closable(false)
+            .Error().IsClosable(false)
     ).Padding(24);
 }
 // </snippet:infobar-severities>
@@ -47,7 +47,7 @@ class InfoBarDismissDemo : Component
                 OnClosed = () => setOpen(false),
                 Severity = Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
             },
-            Button("Show again", () => setOpen(true)).Disabled(open)
+            Button("Show again", () => setOpen(true)).IsEnabled(!open)
         ).Padding(24);
     }
 }
@@ -106,7 +106,7 @@ class ProgressRingDemo : Component
         // Determinate ring at 60%.
         ProgressRing(0.6).Width(48).Height(48),
         // Indeterminate spinner.
-        ProgressRing().Active().Width(48).Height(48)
+        ProgressRing().IsActive().Width(48).Height(48)
     ).Padding(24);
 }
 // </snippet:progress-ring>

--- a/docs/_pipeline/apps/text-and-media/App.cs
+++ b/docs/_pipeline/apps/text-and-media/App.cs
@@ -26,7 +26,7 @@ class TextBlockModifiersDemo : Component
 {
     public override Element Render() => VStack(8,
         TextBlock("Bold + sized").Bold().FontSize(18),
-        TextBlock("Selectable so the user can copy.").Selectable(),
+        TextBlock("Selectable so the user can copy.").IsTextSelectionEnabled(),
         TextBlock(
             "A long paragraph that demonstrates wrapping behavior. " +
             "Without TextWrapping, content stays on one line and is " +

--- a/docs/_pipeline/templates/accessibility.md.dt
+++ b/docs/_pipeline/templates/accessibility.md.dt
@@ -177,7 +177,7 @@ matches the stale handle and `args.Cancel = true` wedges focus on a
 neighboring page element. Always flip `isActive` to false in the same
 state batch that unmounts the container, or apply the trap to an
 element that stays in the tree across the open/closed transition
-(an always-mounted overlay with `.Visible(open)` rather than
+(an always-mounted overlay with `.IsVisible(open)` rather than
 `When(open, ...)`).
 <!-- /ai:caveat -->
 
@@ -281,7 +281,7 @@ The standard accessible modal combines three primitives: a controlled
 `isOpen` boolean, a `UseFocusTrap` keyed on it, and a
 `UseAnnounce` that announces "Dialog opened" on first render and
 "Dialog closed" on dismiss. The trap container should stay mounted
-across the open/closed transition (use `.Visible(open)` not
+across the open/closed transition (use `.IsVisible(open)` not
 `When(open, ...)`) so focus is released cleanly when `isActive`
 flips false — see the caveat above. The
 [modal-dialog recipe](recipes/modal-dialog.md) wires all three end
@@ -311,17 +311,17 @@ keeps them keyboard- and pointer-interactive.
 
 ## Common Mistakes
 
-### Disabled Submit with no `.DisabledFocusable()`
+### Disabled Submit with no `.IsDisabledFocusable()`
 
 ```csharp
 // Don't:
-Button("Submit", onSubmit).Disabled(!form.IsValid)
+Button("Submit", onSubmit).IsEnabled(form.IsValid)
 ```
 
 A disabled button is removed from the Tab order. The user fixes the
 last field, presses Tab to reach Submit, focus skips past the still-
 disabled button, and they're stranded with no keyboard route. Use
-`.DisabledFocusable(!form.IsValid)` on the button — it keeps the
+`.IsDisabledFocusable(!form.IsValid)` on the button — it keeps the
 button keyboard-focusable while presenting as disabled. The
 [Forms page](forms.md#keeping-submit-reachable) covers the full
 shape (it composes with `.Immediate()` on commit-on-blur inputs).
@@ -338,7 +338,7 @@ Button("Save", onSave)
 focus and pointer hit-testing still work. The result is a button the
 user can Tab to and click but a screen reader user cannot discover.
 If the control should not be exposed to assistive tech, it should
-not exist for keyboard users either; use `.Disabled(true)` or pull it
+not exist for keyboard users either; use `.IsEnabled(false)` or pull it
 from the tree with `When(...)`. Use `.AccessibilityHidden()` only on
 decorative elements that don't accept focus (icons, ornamental
 borders, redundant labels).

--- a/docs/_pipeline/templates/cheat-sheet.md.dt
+++ b/docs/_pipeline/templates/cheat-sheet.md.dt
@@ -91,7 +91,7 @@ Full coverage on [Controls](controls.md).
 | Text | `.FontSize(n)` `.Bold()` `.SemiBold()` `.Opacity(n)` |
 | Color | `.Background(token)` `.Foreground(token)` `.WithBorder(token, thickness?)` |
 | Shape | `.CornerRadius(n)` |
-| Behavior | `.Disabled(bool)` `.Visible(bool)` `.ToolTip(s)` |
+| Behavior | `.IsEnabled(bool)` `.IsVisible(bool)` `.ToolTip(s)` |
 | Keying | `.WithKey(s)` |
 | Flex | `.Flex(grow?, shrink?, basis?)` |
 | Themed | `.RequestedTheme(ElementTheme)` `.Backdrop(BackdropKind)` |
@@ -149,7 +149,7 @@ so the reconciler can move rows rather than rebuild them.
 the function-component cache holds it across parent re-renders.
 
 **Disable submit during async work.** A single `submitting` bool
-covers both the button's `.Disabled(...)` and the spinner label.
+covers both the button's `.IsEnabled(...)` and the spinner label.
 
 ## Rules
 

--- a/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
+++ b/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
@@ -96,7 +96,7 @@ all three as Cancel.
 
 When the dialog content is itself a form (rename file, set password),
 the primary button should be disabled until the form is valid. Use
-`IsPrimaryButtonEnabled` rather than `.Disabled()` on a custom button
+`IsPrimaryButtonEnabled` rather than `.IsEnabled(false)` on a custom button
 inside the content — the dialog primary keeps the accent color, the
 keyboard binding to Enter, and the focus trap that the WinUI dialog
 provides:
@@ -201,7 +201,7 @@ content that isn't a menu — all of them are popups.
 
 | Fluent | Effect |
 |---|---|
-| `.LightDismiss(bool)` | Close on outside click. Default `true`. |
+| `.IsLightDismissEnabled(bool)` | Close on outside click. Default `true`. |
 | `.Offset(horizontal, vertical)` | Position relative to the popup's anchor point. |
 | `.Opened(Action)` | Fires after the popup is on screen. |
 | `.Closed(Action)` | Fires after the popup leaves the screen. |

--- a/docs/_pipeline/templates/forms.md.dt
+++ b/docs/_pipeline/templates/forms.md.dt
@@ -363,7 +363,7 @@ Tab to reach Submit, focus skips the still-disabled button, and the
 user is stranded. Two fixes compose: `.Immediate()` on the input
 switches it to per-keystroke commit (see
 [Keeping Submit Reachable](#keeping-submit-reachable)), and
-`.DisabledFocusable()` on the Submit button keeps it keyboard-focusable
+`.IsDisabledFocusable()` on the Submit button keeps it keyboard-focusable
 while it's gated.
 <!-- /ai:caveat -->
 

--- a/docs/_pipeline/templates/recipes/login.md.dt
+++ b/docs/_pipeline/templates/recipes/login.md.dt
@@ -22,7 +22,7 @@ no view model, no event handler classes.
 | Concern | API |
 |---|---|
 | Per-field state | `UseState<string>` / `UseState<bool>` |
-| Submit-disabled gating | `.Disabled(!canSubmit)` |
+| Submit-disabled gating | `.IsEnabled(canSubmit)` |
 | Async submit | `async Task` + `Task.Delay` |
 | Error display | Conditional `Empty()` vs `TextBlock` |
 | Password input | [`PasswordBox`](../forms.md) |

--- a/docs/_pipeline/templates/recipes/multi-step-form.md.dt
+++ b/docs/_pipeline/templates/recipes/multi-step-form.md.dt
@@ -26,7 +26,7 @@ visible slot changes.
 | Step index | `UseState<int>` |
 | Per-field state | `UseState<string>` / `UseState<int>` / `UseState<bool>` |
 | Step branching | `switch` on the step index returning `Element` |
-| Advance gating | `.Disabled(!canAdvance)` on the Next button |
+| Advance gating | `.IsEnabled(canAdvance)` on the Next button |
 | Input controls | [`TextField`](../forms.md), [`RadioButtons`](../forms.md), [`CheckBox`](../forms.md) |
 
 ### State
@@ -47,7 +47,7 @@ when they come forward again.
 
 `canAdvance` is a pure function of the current step plus the field
 values. It runs on every render — no debounce, no validation pass —
-and the Next button binds to it directly via `.Disabled(!canAdvance)`.
+and the Next button binds to it directly via `.IsEnabled(canAdvance)`.
 Step 0 wants a name and a plausible email; step 1 wants a role
 selected; step 2 (summary) is always advanceable since the only
 forward action is Submit.

--- a/docs/_pipeline/templates/status-and-info.md.dt
+++ b/docs/_pipeline/templates/status-and-info.md.dt
@@ -49,7 +49,7 @@ icon, color, and accessibility role in one call:
 | Fluent | Effect |
 |---|---|
 | `.Informational()` / `.Success()` / `.Warning()` / `.Error()` | Sets `Severity` + paired icon/color. |
-| `.Closable(bool)` | Toggle the dismiss button. |
+| `.IsClosable(bool)` | Toggle the dismiss button. |
 | `.IconSource(IconData)` | Override the severity icon. |
 | `.Content(Element)` | Render rich content (links, embedded controls) below the message. |
 | `.ActionButtonClick(Action)` | Subscribe to the trailing action button. |
@@ -186,7 +186,7 @@ same controlled-input pattern as `Slider` and `NumberBox` from
 | Fluent | Effect |
 |---|---|
 | `.MaxRating(int)` | Star count. Default 5. |
-| `.ReadOnly(bool)` | Display-only mode for showing an existing rating. |
+| `.IsReadOnly(bool)` | Display-only mode for showing an existing rating. |
 | `.Caption(string)` | Caption shown below the stars. |
 | `.PlaceholderValue(double)` | Greyed-out value before the user rates. |
 | `.InitialSetValue(int)` | Value applied on first interaction. |

--- a/docs/_pipeline/templates/text-and-media.md.dt
+++ b/docs/_pipeline/templates/text-and-media.md.dt
@@ -88,7 +88,7 @@ The fluents you reach for most often:
 | `.TextTrimming(mode)` | `CharacterEllipsis` / `WordEllipsis` / `Clip` / `None`. |
 | `.TextAlignment(alignment)` | `Left` / `Right` / `Center` / `Justify`. |
 | `.LineHeight(double)` | Override the line-box height (useful for dense lists). |
-| `.Selectable()` | Lets the user select and copy the text. |
+| `.IsTextSelectionEnabled()` | Lets the user select and copy the text. |
 | `.CharacterSpacing(int)` | Hundredths of an em — `30` ≈ 0.3em tracking. |
 
 <!-- ai:caveat -->

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -308,7 +308,7 @@ For a complete dialog pattern that combines `UseFocusTrap` with
 > neighboring page element. Always flip `isActive` to false in the same
 > state batch that unmounts the container, or apply the trap to an
 > element that stays in the tree across the open/closed transition
-> (an always-mounted overlay with `.Visible(open)` rather than
+> (an always-mounted overlay with `.IsVisible(open)` rather than
 > `When(open, ...)`).
 
 ## Screen Reader Announcements
@@ -467,7 +467,7 @@ The standard accessible modal combines three primitives: a controlled
 `isOpen` boolean, a `UseFocusTrap` keyed on it, and a
 `UseAnnounce` that announces "Dialog opened" on first render and
 "Dialog closed" on dismiss. The trap container should stay mounted
-across the open/closed transition (use `.Visible(open)` not
+across the open/closed transition (use `.IsVisible(open)` not
 `When(open, ...)`) so focus is released cleanly when `isActive`
 flips false — see the caveat above. The
 [modal-dialog recipe](recipes/modal-dialog.md) wires all three end
@@ -497,17 +497,17 @@ keeps them keyboard- and pointer-interactive.
 
 ## Common Mistakes
 
-### Disabled Submit with no `.DisabledFocusable()`
+### Disabled Submit with no `.IsDisabledFocusable()`
 
 ```csharp
 // Don't:
-Button("Submit", onSubmit).Disabled(!form.IsValid)
+Button("Submit", onSubmit).IsEnabled(form.IsValid)
 ```
 
 A disabled button is removed from the Tab order. The user fixes the
 last field, presses Tab to reach Submit, focus skips past the still-
 disabled button, and they're stranded with no keyboard route. Use
-`.DisabledFocusable(!form.IsValid)` on the button — it keeps the
+`.IsDisabledFocusable(!form.IsValid)` on the button — it keeps the
 button keyboard-focusable while presenting as disabled. The
 [Forms page](forms.md#keeping-submit-reachable) covers the full
 shape (it composes with `.Immediate()` on commit-on-blur inputs).
@@ -524,7 +524,7 @@ Button("Save", onSave)
 focus and pointer hit-testing still work. The result is a button the
 user can Tab to and click but a screen reader user cannot discover.
 If the control should not be exposed to assistive tech, it should
-not exist for keyboard users either; use `.Disabled(true)` or pull it
+not exist for keyboard users either; use `.IsEnabled(false)` or pull it
 from the tree with `When(...)`. Use `.AccessibilityHidden()` only on
 decorative elements that don't accept focus (icons, ornamental
 borders, redundant labels).

--- a/docs/guide/cheat-sheet.md
+++ b/docs/guide/cheat-sheet.md
@@ -110,7 +110,7 @@ Full coverage on [Controls](controls.md).
 | Text | `.FontSize(n)` `.Bold()` `.SemiBold()` `.Opacity(n)` |
 | Color | `.Background(token)` `.Foreground(token)` `.WithBorder(token, thickness?)` |
 | Shape | `.CornerRadius(n)` |
-| Behavior | `.Disabled(bool)` `.Visible(bool)` `.ToolTip(s)` |
+| Behavior | `.IsEnabled(bool)` `.IsVisible(bool)` `.ToolTip(s)` |
 | Keying | `.WithKey(s)` |
 | Flex | `.Flex(grow?, shrink?, basis?)` |
 | Themed | `.RequestedTheme(ElementTheme)` `.Backdrop(BackdropKind)` |
@@ -168,7 +168,7 @@ so the reconciler can move rows rather than rebuild them.
 the function-component cache holds it across parent re-renders.
 
 **Disable submit during async work.** A single `submitting` bool
-covers both the button's `.Disabled(...)` and the spinner label.
+covers both the button's `.IsEnabled(...)` and the spinner label.
 
 ## Rules
 

--- a/docs/guide/commanding.md
+++ b/docs/guide/commanding.md
@@ -292,7 +292,7 @@ class ParameterizedCommandExample : Component
                     // Inline button — Command<T> doesn't have a Button(cmd, arg) overload
                     // by design, so call .Execute(arg) directly from the click handler.
                     Button(delete.Label, () => delete.Execute?.Invoke(item))
-                        .Disabled(!delete.IsEnabled)))
+                        .IsEnabled(delete.IsEnabled)))
         ).Padding(24);
     }
 }

--- a/docs/guide/dialogs-and-flyouts.md
+++ b/docs/guide/dialogs-and-flyouts.md
@@ -133,7 +133,7 @@ all three as Cancel.
 
 When the dialog content is itself a form (rename file, set password),
 the primary button should be disabled until the form is valid. Use
-`IsPrimaryButtonEnabled` rather than `.Disabled()` on a custom button
+`IsPrimaryButtonEnabled` rather than `.IsEnabled(false)` on a custom button
 inside the content — the dialog primary keeps the accent color, the
 keyboard binding to Enter, and the focus trap that the WinUI dialog
 provides:
@@ -324,7 +324,7 @@ class PopupDemo : Component
                 () => setOpen(!open)),
             Popup(popupContent, isOpen: open,
                 onClosed: () => setOpen(false))
-                .LightDismiss()
+                .IsLightDismissEnabled()
                 .Offset(120, 0)
         ).Padding(24);
     }
@@ -340,7 +340,7 @@ content that isn't a menu — all of them are popups.
 
 | Fluent | Effect |
 |---|---|
-| `.LightDismiss(bool)` | Close on outside click. Default `true`. |
+| `.IsLightDismissEnabled(bool)` | Close on outside click. Default `true`. |
 | `.Offset(horizontal, vertical)` | Position relative to the popup's anchor point. |
 | `.Opened(Action)` | Fires after the popup is on screen. |
 | `.Closed(Action)` | Fires after the popup leaves the screen. |

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -702,7 +702,7 @@ WinUI design page: [Color picker](https://learn.microsoft.com/en-us/windows/apps
 > user is stranded. Two fixes compose: `.Immediate()` on the input
 > switches it to per-keystroke commit (see
 > [Keeping Submit Reachable](#keeping-submit-reachable)), and
-> `.DisabledFocusable()` on the Submit button keeps it keyboard-focusable
+> `.IsDisabledFocusable()` on the Submit button keeps it keyboard-focusable
 > while it's gated.
 
 ## Patterns

--- a/docs/guide/recipes/login.md
+++ b/docs/guide/recipes/login.md
@@ -11,7 +11,7 @@ no view model, no event handler classes.
 | Concern | API |
 |---|---|
 | Per-field state | `UseState<string>` / `UseState<bool>` |
-| Submit-disabled gating | `.Disabled(!canSubmit)` |
+| Submit-disabled gating | `.IsEnabled(canSubmit)` |
 | Async submit | `async Task` + `Task.Delay` |
 | Error display | Conditional `Empty()` vs `TextBlock` |
 | Password input | [`PasswordBox`](../forms.md) |
@@ -78,7 +78,7 @@ return VStack(12,
         ? Empty()
         : TextBlock(error).Foreground("#C42B1C"),
     Button(submitting ? "Signing in…" : "Sign in", () => _ = Submit())
-        .Disabled(!canSubmit)
+        .IsEnabled(canSubmit)
 ).Padding(20).Width(320);
 ```
 

--- a/docs/guide/recipes/multi-step-form.md
+++ b/docs/guide/recipes/multi-step-form.md
@@ -14,7 +14,7 @@ visible slot changes.
 | Step index | `UseState<int>` |
 | Per-field state | `UseState<string>` / `UseState<int>` / `UseState<bool>` |
 | Step branching | `switch` on the step index returning `Element` |
-| Advance gating | `.Disabled(!canAdvance)` on the Next button |
+| Advance gating | `.IsEnabled(canAdvance)` on the Next button |
 | Input controls | [`TextField`](../forms.md), [`RadioButtons`](../forms.md), [`CheckBox`](../forms.md) |
 
 ### State
@@ -54,7 +54,7 @@ bool canAdvance = step switch
 
 `canAdvance` is a pure function of the current step plus the field
 values. It runs on every render — no debounce, no validation pass —
-and the Next button binds to it directly via `.Disabled(!canAdvance)`.
+and the Next button binds to it directly via `.IsEnabled(canAdvance)`.
 Step 0 wants a name and a plausible email; step 1 wants a role
 selected; step 2 (summary) is always advanceable since the only
 forward action is Submit.
@@ -107,9 +107,9 @@ return VStack(16,
     Heading("Create your account"),
     body,
     HStack(8,
-        Button("Back", () => setStep(step - 1)).Disabled(step == 0),
+        Button("Back", () => setStep(step - 1)).IsEnabled(step != 0),
         Button(step == 2 ? "Submit" : "Next",
-            () => setStep(step + 1)).Disabled(!canAdvance || step == 2)
+            () => setStep(step + 1)).IsEnabled(canAdvance && step != 2)
     )
 ).Padding(20).Width(380);
 ```

--- a/docs/guide/recipes/paginated-list.md
+++ b/docs/guide/recipes/paginated-list.md
@@ -132,7 +132,7 @@ Element footer = atEnd
         : Button(
             loadingMore ? "Loading more…" : $"Load more ({commits.EstimatedRemaining} remaining)",
             () => commits.FetchNext()
-          ).Disabled(loadingMore).Padding(8);
+          ).IsEnabled(!loadingMore).Padding(8);
 
 return VStack(0,
     Heading($"Commits ({commits.TotalCount ?? loadedItems.Length})").Padding(20),

--- a/docs/guide/status-and-info.md
+++ b/docs/guide/status-and-info.md
@@ -34,15 +34,15 @@ class InfoBarSeveritiesDemo : Component
     public override Element Render() => VStack(8,
         SubHeading("InfoBar — severity fluents"),
         InfoBar("Saving…", "Your changes are being written.")
-            .Informational().Closable(false),
+            .Informational().IsClosable(false),
         InfoBar("Saved", "Your changes were saved.")
-            .Success().Closable(false),
+            .Success().IsClosable(false),
         InfoBar("Slow connection",
             "Some assets may not load until the network recovers.")
-            .Warning().Closable(false),
+            .Warning().IsClosable(false),
         InfoBar("Save failed",
             "The destination drive is read-only.")
-            .Error().Closable(false)
+            .Error().IsClosable(false)
     ).Padding(24);
 }
 ```
@@ -52,7 +52,7 @@ class InfoBarSeveritiesDemo : Component
 | Fluent | Effect |
 |---|---|
 | `.Informational()` / `.Success()` / `.Warning()` / `.Error()` | Sets `Severity` + paired icon/color. |
-| `.Closable(bool)` | Toggle the dismiss button. |
+| `.IsClosable(bool)` | Toggle the dismiss button. |
 | `.IconSource(IconData)` | Override the severity icon. |
 | `.Content(Element)` | Render rich content (links, embedded controls) below the message. |
 | `.ActionButtonClick(Action)` | Subscribe to the trailing action button. |
@@ -82,7 +82,7 @@ class InfoBarDismissDemo : Component
                 OnClosed = () => setOpen(false),
                 Severity = Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
             },
-            Button("Show again", () => setOpen(true)).Disabled(open)
+            Button("Show again", () => setOpen(true)).IsEnabled(!open)
         ).Padding(24);
     }
 }
@@ -168,7 +168,7 @@ class ProgressRingDemo : Component
         // Determinate ring at 60%.
         ProgressRing(0.6).Width(48).Height(48),
         // Indeterminate spinner.
-        ProgressRing().Active().Width(48).Height(48)
+        ProgressRing().IsActive().Width(48).Height(48)
     ).Padding(24);
 }
 ```
@@ -322,7 +322,7 @@ class RatingDemo : Component
 | Fluent | Effect |
 |---|---|
 | `.MaxRating(int)` | Star count. Default 5. |
-| `.ReadOnly(bool)` | Display-only mode for showing an existing rating. |
+| `.IsReadOnly(bool)` | Display-only mode for showing an existing rating. |
 | `.Caption(string)` | Caption shown below the stars. |
 | `.PlaceholderValue(double)` | Greyed-out value before the user rates. |
 | `.InitialSetValue(int)` | Value applied on first interaction. |

--- a/docs/guide/text-and-media.md
+++ b/docs/guide/text-and-media.md
@@ -72,7 +72,7 @@ class TextBlockModifiersDemo : Component
 {
     public override Element Render() => VStack(8,
         TextBlock("Bold + sized").Bold().FontSize(18),
-        TextBlock("Selectable so the user can copy.").Selectable(),
+        TextBlock("Selectable so the user can copy.").IsTextSelectionEnabled(),
         TextBlock(
             "A long paragraph that demonstrates wrapping behavior. " +
             "Without TextWrapping, content stays on one line and is " +
@@ -100,7 +100,7 @@ The fluents you reach for most often:
 | `.TextTrimming(mode)` | `CharacterEllipsis` / `WordEllipsis` / `Clip` / `None`. |
 | `.TextAlignment(alignment)` | `Left` / `Right` / `Center` / `Justify`. |
 | `.LineHeight(double)` | Override the line-box height (useful for dense lists). |
-| `.Selectable()` | Lets the user select and copy the text. |
+| `.IsTextSelectionEnabled()` | Lets the user select and copy the text. |
 | `.CharacterSpacing(int)` | Hundredths of an em — `30` ≈ 0.3em tracking. |
 
 > **Caveat:** `TextBlock` has a fast-path renderer that activates only when you set the


### PR DESCRIPTION
Migrates the remaining doc-pipeline templates, doc apps, and compiled guide pages to the WinUI-aligned boolean modifier names introduced in #296 / #268.

## Rename map

| Old | New | Notes |
|-----|-----|-------|
| .Visible(x) | .IsVisible(x) | |
| .Disabled(x) | .IsEnabled(!x) | **Inverted** — boolean flipped at each call site |
| .Selectable(...) | .IsTextSelectionEnabled(...) | TextBlock |
| .ReadOnly(...) | .IsReadOnly(...) | TextField, RatingControl |
| .Editable(...) | .IsEditable(...) | ComboBox |
| .Closable(...) | .IsClosable(...) | InfoBar |
| .Active(...) | .IsActive(...) | ProgressRing |
| .DisabledFocusable(...) | .IsDisabledFocusable(...) | Button |
| .LightDismiss(...) | .IsLightDismissEnabled(...) | Popup |

## Scope

The original PR (#296) migrated first-party src/, samples, and 5 of the 45 doc apps. This sweep covers the remaining 21 files in `docs/`:

- **8 doc apps**: `commanding`, `dialogs-and-flyouts`, `recipe-login`, `recipe-multi-step-form`, `recipe-paginated-list`, `status-and-info`, `text-and-media`, plus `forms/doc-manifest.yaml` description text
- **8 templates** (`.md.dt`): `accessibility`, `cheat-sheet`, `dialogs-and-flyouts`, `forms`, `recipes/login`, `recipes/multi-step-form`, `status-and-info`, `text-and-media`
- **10 compiled guide pages** (regenerated with `mur docs compile`, recipes patched in place to preserve inlined snippets)

## Verification

- `mur docs compile --validate-only` ΓÇö all references resolve; only pre-existing warnings remain
- `dotnet build` on all 7 modified doc apps ΓÇö all succeed
- Skills (`skills/`, `plugins/reactor/skills/`) audited ΓÇö no stale references; `reactor.api.txt` files already reflect the rename from #296
- Pure rename: 26 files, +61 / -61

## Out of scope

- Old fluent shims remain in place as `[Obsolete]` (per #296)
- `IsTabStop()` was kept as-is in #296 (already matches WinUI naming)