### PR TITLE
docs(aot): expand selftest AOT skip list + document AOT test workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,49 @@ dotnet run --project tests/Reactor.AppTests.Host -- --self-test
 dotnet run --project tests/Reactor.AppTests.Host -- --self-test --filter "Flex"
 ```
 
+#### Running selftests under NativeAOT
+
+The Host app supports an AOT-published build so the selftest suite doubles as Reactor's primary AOT regression gate. The framework itself is AOT-clean (see [`docs/aot-support.md`](docs/aot-support.md)) but a meaningful slice of selftest *fixtures* still trip over reflection paths the AOT compiler can't preserve. Those fixtures are pre-skipped via a baked-in pattern list so the run completes and the remaining failures are visible.
+
+**1. Publish the Host with AOT.** The publish step shells out to MSVC's `link.exe`, so it must run inside a Visual Studio Developer environment. From a Developer Command Prompt / Developer PowerShell (or after sourcing `Launch-VsDevShell.ps1`):
+
+```powershell
+dotnet publish tests/Reactor.AppTests.Host `
+    -c Release -p:Platform=x64 -r win-x64 `
+    -p:PublishAotInternal=true --self-contained
+```
+
+`PublishAotInternal=true` is the internal opt-in property that flips `PublishAot` on for the Host (kept opt-in so an ordinary `dotnet build Reactor.slnx` doesn't pay the AOT compile cost). Swap `-r win-x64` / `-p:Platform=x64` for `win-arm64` / `ARM64` on ARM machines.
+
+The published binary lands at:
+
+```
+tests/Reactor.AppTests.Host/bin/x64/Release/net10.0-windows10.0.22621.0/win-x64/publish/Reactor.AppTests.Host.exe
+```
+
+**2. Run the suite.** Same `--self-test` flag as the JIT build:
+
+```bash
+./tests/Reactor.AppTests.Host/bin/x64/Release/net10.0-windows10.0.22621.0/win-x64/publish/Reactor.AppTests.Host.exe --self-test
+```
+
+Output is the same TAP stream as a normal selftest run. The runner detects AOT at startup (`RuntimeFeature.IsDynamicCodeSupported == false`) and emits `# SKIP crashes/hangs under NativeAOT` lines for known-bad fixtures.
+
+**3. Filtering known-bad fixtures.** The skip list lives in `DefaultAotSkipPatterns` in `tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs`. Entries are exact names or `Prefix*` wildcards. When you discover a new AOT crasher, you have two choices:
+
+- **Without rebuilding** (best for iteration): append patterns via the `REACTOR_AOT_SKIP` env var. They merge into the defaults — they do *not* replace them.
+
+  ```bash
+  REACTOR_AOT_SKIP="MyFixture_Crasher,SomeFamily_*" \
+    ./.../Reactor.AppTests.Host.exe --self-test
+  ```
+
+- **Permanent**: add the pattern to `DefaultAotSkipPatterns` and re-publish. Leave a comment naming the family / observed crash mode so a future contributor can verify whether the underlying issue has been fixed and drop the entry.
+
+A native crash terminates the AOT process — the per-fixture managed watchdog can't fire. Iterate by tailing the TAP output for the *last* `# Running: <name>` line before exit, add that name to the skip list, and re-run. Be conservative when wildcarding a family: many `Family_*` fixtures pass even when one member crashes.
+
+**4. Expected pass count.** As of 2026-05-20, an AOT run of the suite produces roughly: 735 fixtures total → 149 skipped, 544 passed, ~42 failed (assertion failures + initialization crashes for fixtures already past the skip filter). The non-AOT run on the same commit is 735/735 pass.
+
 ### 3. E2E tests (`tests/Reactor.AppTests`) — MSTest + WinAppDriver
 
 End-to-end tests that use Appium/WinAppDriver to simulate real user input (clicks, keyboard, tab navigation) through the cross-process UI Automation pipeline. These verify the full input → render → output path and validate that UIA properties are visible to assistive technology.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,26 +146,23 @@ The Host app supports an AOT-published build so the selftest suite doubles as Re
 ```powershell
 dotnet publish tests/Reactor.AppTests.Host `
     -c Release -p:Platform=x64 -r win-x64 `
-    -p:PublishAotInternal=true --self-contained
+    -p:PublishAotInternal=true --self-contained `
+    -o artifacts/aot-host
 ```
 
 `PublishAotInternal=true` is the internal opt-in property that flips `PublishAot` on for the Host (kept opt-in so an ordinary `dotnet build Reactor.slnx` doesn't pay the AOT compile cost). Swap `-r win-x64` / `-p:Platform=x64` for `win-arm64` / `ARM64` on ARM machines.
 
-The published binary lands at:
-
-```
-tests/Reactor.AppTests.Host/bin/x64/Release/net10.0-windows10.0.22621.0/win-x64/publish/Reactor.AppTests.Host.exe
-```
+`-o artifacts/aot-host` pins the publish output to a stable, predictable path. Without it, the binary lands under the default-shape `tests/Reactor.AppTests.Host/bin/<Platform>/<Config>/<TFM>/<RID>/publish/Reactor.AppTests.Host.exe` — fine, but the TFM/RID/SDK-version segments drift over time, so the explicit `-o` is friendlier for scripts and docs.
 
 **2. Run the suite.** Same `--self-test` flag as the JIT build:
 
 ```bash
-./tests/Reactor.AppTests.Host/bin/x64/Release/net10.0-windows10.0.22621.0/win-x64/publish/Reactor.AppTests.Host.exe --self-test
+./artifacts/aot-host/Reactor.AppTests.Host.exe --self-test
 ```
 
 Output is the same TAP stream as a normal selftest run. The runner detects AOT at startup (`RuntimeFeature.IsDynamicCodeSupported == false`) and emits `# SKIP crashes/hangs under NativeAOT` lines for known-bad fixtures.
 
-**3. Filtering known-bad fixtures.** The skip list lives in `DefaultAotSkipPatterns` in `tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs`. Entries are exact names or `Prefix*` wildcards. When you discover a new AOT crasher, you have two choices:
+**3. Filtering known-bad fixtures.** The skip list lives in `DefaultAotSkipPatterns` in `tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs`. Entries are either an exact fixture name or a prefix-wildcard ending in `*` — by convention these match a fixture family, e.g. `MyFamily_*`. When you discover a new AOT crasher, you have two choices:
 
 - **Without rebuilding** (best for iteration): append patterns via the `REACTOR_AOT_SKIP` env var. They merge into the defaults — they do *not* replace them.
 

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -77,6 +77,26 @@ internal static class SelfTestRunner
         "CoreCov2_XamlHostMount",
         "CoreCov2_InfoBadgeMountUpdate",
         "CoreCov2_SelectorBarUpdate",
+        // Iteration round 2 (2026-05-20): crashers observed when re-running
+        // selftests against an AOT-published Host. Same approach — skip the
+        // crasher, then wildcard family members that are likely to share the
+        // shape problem.
+        "ValCov_FormFieldRendering",
+        "EchoSuppress_*",
+        "IdentityPreserve_RadioButtons",
+        "IdentityPreserve_SelectorBar",
+        "DataGrid_RowEditTemplatesAndEmptyState",
+        "CovBoost_ElementPoolExercise",
+        "CovBoost2_TitleBarMountUpdate",
+        "CovBoost2_ReconcileChildPaths",
+        "CovBoost2_NavigationViewExercise",
+        "CovBoost2_ElementPoolInteractiveReset",
+        "Commanding_*",
+        "SelectionEvt_*",
+        "ValueEvt_*",
+        "Immediate_*",
+        "Editors_*",
+        "RBC_*",
     };
 
     private static string[] GetAotSkipPatterns()

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -77,26 +77,58 @@ internal static class SelfTestRunner
         "CoreCov2_XamlHostMount",
         "CoreCov2_InfoBadgeMountUpdate",
         "CoreCov2_SelectorBarUpdate",
-        // Iteration round 2 (2026-05-20): crashers observed when re-running
-        // selftests against an AOT-published Host. Same approach — skip the
-        // crasher, then wildcard family members that are likely to share the
-        // shape problem.
+        // ---- Iteration round 2 (2026-05-20) ----
+        // Crashers observed when re-running selftests against an AOT-published
+        // Host. A native crash terminates the process before the managed
+        // watchdog can fire, so each entry below is the name of the *last*
+        // fixture printed before exit. Wildcards are an inference — when the
+        // crashed fixture is part of an obvious family (e.g. one of N
+        // per-control variants), assume the family shares the shape problem
+        // rather than rebuild+rerun N times. Drop the wildcard back to
+        // explicit names if you have time to verify which members pass.
+
+        // ValCov_FormFieldRendering: single fixture, exercises form-field
+        // editor selection over reflected property metadata.
         "ValCov_FormFieldRendering",
+
+        // EchoSuppress family: ColorPicker crashed; other members unverified.
+        // Suspected shared path through value-change event echo suppression
+        // on the control wrappers.
         "EchoSuppress_*",
+
+        // IdentityPreserve family: two distinct fixtures crashed (RadioButtons,
+        // SelectorBar). Not wildcarding the whole family — other members of
+        // this family passed under AOT and we don't want to lose the coverage.
         "IdentityPreserve_RadioButtons",
         "IdentityPreserve_SelectorBar",
+
+        // DataGrid_RowEditTemplatesAndEmptyState: template-instantiation path
+        // in DataGrid row editing. Other DataGrid fixtures pass.
         "DataGrid_RowEditTemplatesAndEmptyState",
+
+        // CovBoost / CovBoost2 individual crashers — heterogeneous, so listed
+        // individually rather than wildcarded. Each crash was at the named
+        // fixture; rest of CovBoost / CovBoost2 currently runs.
         "CovBoost_ElementPoolExercise",
         "CovBoost2_TitleBarMountUpdate",
         "CovBoost2_ReconcileChildPaths",
         "CovBoost2_NavigationViewExercise",
         "CovBoost2_ElementPoolInteractiveReset",
+
+        // Commanding_* — SplitButtonCommandInvokesExecute crashed. ICommand
+        // dispatch wires up through reflected `CanExecute` / `Execute`; the
+        // whole family likely shares the breakage.
         "Commanding_*",
-        "SelectionEvt_*",
-        "ValueEvt_*",
-        "Immediate_*",
-        "Editors_*",
-        "RBC_*",
+
+        // Event-handler families. In each case the named fixture crashed;
+        // wildcarding the family on the assumption that the breakage is in
+        // shared event-subscription code paths (handler binding /
+        // EventHandler<T> instantiation under AOT) rather than per-control.
+        "SelectionEvt_*",   // RadioButtons crashed; covers ComboBox/ListBox/…
+        "ValueEvt_*",       // NumberBox crashed; covers Slider/ToggleSwitch/…
+        "Immediate_*",      // NumberBoxFiresOnTextChange crashed; "immediate" event variants
+        "Editors_*",        // NumberMounts crashed; PropertyGrid auto-editor mounts
+        "RBC_*",            // HandlerWiringOnSecondRender crashed; recycle-by-component event rewiring
     };
 
     private static string[] GetAotSkipPatterns()


### PR DESCRIPTION
## Summary
- Adds 16 new patterns to `DefaultAotSkipPatterns` in `SelfTestRunner.cs`, discovered by iteratively re-running an AOT-published Host and adding each native crasher (and likely-shared-shape family wildcards) to the skip list until the run reached the end of the suite.
- Adds a **Running selftests under NativeAOT** subsection to `CONTRIBUTING.md` under the existing selftest section, covering: the `dotnet publish -p:PublishAotInternal=true` command (and the Developer-Command-Prompt requirement for MSVC's `link.exe`), where the binary lands, the `REACTOR_AOT_SKIP=` env var for iterating without rebuilding, and the current pass headcount.

## Current pass counts (on this branch)

| Mode | Attempted | Skipped | Passed | Failed / crashed |
|------|-----------|---------|--------|------------------|
| Non-AOT (Debug x64) | 735 | 0 | **735** | 0 |
| AOT (Release x64 publish) | 586 | 149 | **544** | 22 assertion fails + 20 init crashes |

The AOT process now exits cleanly (no native termination mid-run) — remaining failures are surfaceable, attributable, and actionable.

## Test plan
- [x] `dotnet build tests/Reactor.AppTests.Host -c Debug -p:Platform=x64` clean
- [x] `dotnet publish tests/Reactor.AppTests.Host -c Release -p:Platform=x64 -r win-x64 -p:PublishAotInternal=true --self-contained` (inside VS Developer PowerShell) clean
- [x] AOT-published `Reactor.AppTests.Host.exe --self-test` runs to completion (no native crash)
- [x] Non-AOT `dotnet test tests/Reactor.SelfTests` unaffected (skip list is gated on `RuntimeFeature.IsDynamicCodeSupported == false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)