### PR TITLE
Add off-dispatcher AOT hang watchdog and clean up stale selftest skips

### DIFF
--- a/docs/aot-support.md
+++ b/docs/aot-support.md
@@ -48,7 +48,7 @@ These subsystems compile cleanly with `IsAotCompatible=true` (the warnings are s
 
 ### Failure mode at a glance
 
-Probing each `DefaultAotSkipPatterns` entry in isolation (via the `.aot_runs/probe_skips.ps1` helper) reveals three buckets. Pick the matching workflow:
+Probing each `DefaultAotSkipPatterns` entry in isolation (via the `tests/Reactor.AppTests.Host/probe-aot-skips.ps1` helper) reveals three buckets. Pick the matching workflow:
 
 | Bucket | Symptom | Debug step |
 |---|---|---|

--- a/docs/aot-support.md
+++ b/docs/aot-support.md
@@ -42,6 +42,69 @@ These subsystems compile cleanly with `IsAotCompatible=true` (the warnings are s
 - **Suppressions are temporary.** Every `[UnconditionalSuppressMessage("Trimming", ...)]` or `("AOT", ...)` in this repo is a TODO. The justification field names the reflection use; tracking is folded into issue #70.
 - **The benchmark canary.** `tests/stress_perf/StressPerf.Reactor` (and the `StressPerf.Direct`/`ReactorGrid` siblings) set `PublishAot=true`. If they stop publishing, an AOT regression has landed in the framework.
 
+## Debugging an AOT selftest hang
+
+`tests/Reactor.AppTests.Host` maintains an explicit allow-list of fixtures that hang, crash, or assert-fail under NativeAOT (`SelfTestRunner.DefaultAotSkipPatterns`). When you remove an entry from that list and the published Host hangs, crashes, or asserts instead of producing output, use the following workflow.
+
+### Failure mode at a glance
+
+Probing each `DefaultAotSkipPatterns` entry in isolation (via the `.aot_runs/probe_skips.ps1` helper) reveals three buckets. Pick the matching workflow:
+
+| Bucket | Symptom | Debug step |
+|---|---|---|
+| **Hang** (dispatcher starvation) | Fixture's `RunAsync()` synchronously blocks the UI thread; the in-band 15 s `Task.Delay` watchdog cannot fire because the dispatcher isn't pumping. | Off-dispatcher hang watchdog (60 s default, configurable via `REACTOR_SELFTEST_HANG_TIMEOUT_SECONDS`) writes `Bail out! HANG_DETECTED: <fixture> …` to stdout + stderr, flushes, then `Environment.FailFast`. With `DOTNET_DbgEnableMiniDump=1` set, this produces a Watson minidump. |
+| **Native crash** | Process exits with `0xC0000409` (`STATUS_STACK_BUFFER_OVERRUN`) — the AOT runtime's `FailFast` for unhandled managed exceptions. No `# Total failures:` line because the process terminated abruptly. | Set `DOTNET_DbgEnableMiniDump=1` (and `COMPlus_DbgEnableMiniDump=1` — both, matching `DevtoolsStressE2ERunner`) before launching. Open the resulting `.dmp` with `dotnet-dump analyze` or WinDbg; look at the dispatcher (UI) thread's stack for the throwing call. |
+| **Assertion failure** | TAP output already shows `not ok <name> - <reason>`; process exits 1 cleanly. | No special tooling needed — read the TAP failure line. The fixture and check name are in the message. |
+
+### Parent attribution
+
+The MSTest harness (`Reactor.SelfTests.SelfTestBatch`) parses the `HANG_DETECTED` signal from both stdout and stderr, and on process timeout falls back to the last `# Running:` line. Either way, the failure surfaces against the named fixture in the failing test's detail with a copy-pasteable repro command. It does *not* cascade through `_initError` (which would mark every unrelated fixture failed).
+
+### Capturing a dump
+
+Set these env vars before launching the Host:
+
+```text
+DOTNET_DbgEnableMiniDump=1
+DOTNET_DbgMiniDumpType=2
+DOTNET_DbgMiniDumpName=%TEMP%\reactor-selftest-%p.dmp
+COMPlus_DbgEnableMiniDump=1
+COMPlus_DbgMiniDumpType=2
+COMPlus_DbgMiniDumpName=%TEMP%\reactor-selftest-%p.dmp
+```
+
+Both `Environment.FailFast` (hang path) and the AOT runtime's unhandled-exception fast-fail (crash path) honour these vars.
+
+### Isolated repro
+
+Once you have the offending fixture name, repro it standalone against the AOT-published binary:
+
+```powershell
+dotnet publish tests/Reactor.AppTests.Host -p:PublishAotInternal=true -p:Platform=x64 -r win-x64 -c Release
+$env:DOTNET_DbgEnableMiniDump=1
+$env:DOTNET_DbgMiniDumpName="$env:TEMP\reactor-hang-%p.dmp"
+& "<publish-dir>\Reactor.AppTests.Host.exe" --self-test --no-aot-skip --filter <FixtureName>
+```
+
+`--no-aot-skip` bypasses the entire skip list so the targeted fixture actually runs. To drive the MSTest harness against the AOT-published binary, point it at the publish output:
+
+```powershell
+$env:REACTOR_SELFTEST_HOST_EXE="<publish-dir>\Reactor.AppTests.Host.exe"
+dotnet test tests/Reactor.SelfTests
+```
+
+### Disabling the watchdog while debugging
+
+When stepping through a fixture in a debugger, set `REACTOR_SELFTEST_HANG_TIMEOUT_SECONDS=0` to suppress the hang watchdog entirely. (It also auto-disables whenever `Debugger.IsAttached` returns true at poll time.)
+
+### Categorising the skip list (`tests/Reactor.AppTests.Host/probe-aot-skips.ps1`)
+
+The repo includes a probe script that runs every `DefaultAotSkipPatterns` entry in isolation under `--no-aot-skip` and writes a CSV summarising whether each one passes, hangs, crashes natively, or assert-fails. Use it after AOT framework changes to find stale skips that have started passing, and to triage what's still broken.
+
+```powershell
+pwsh -NoProfile -File tests\Reactor.AppTests.Host\probe-aot-skips.ps1
+```
+
 ## When in doubt
 
 If you need a feature listed in the "does not work" table and you're publishing AOT, file an issue against #70 with your scenario. The fix in most cases is a source generator pass; what gets prioritized is driven by who's hitting the wall.

--- a/tests/Reactor.AppTests.Host/Program.cs
+++ b/tests/Reactor.AppTests.Host/Program.cs
@@ -22,6 +22,8 @@ if (args.Contains("--self-test"))
     var filterIdx = Array.IndexOf(args, "--filter");
     if (filterIdx >= 0 && filterIdx + 1 < args.Length)
         SelfTestRunner.Filter = args[filterIdx + 1];
+    if (args.Contains("--no-aot-skip"))
+        SelfTestRunner.SkipAotPatterns = false;
     SelfTestRunner.RunAll();
 }
 else if (args.Contains("--devtools-stress"))

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -15,10 +15,12 @@ internal static class SelfTestRunner
     public static string? Filter { get; set; }
 
     /// <summary>
-    /// When true, the AOT skip list is ignored — every fixture runs even under
-    /// NativeAOT. Use for targeted repro of a hanging/crashing fixture together
-    /// with <c>--filter &lt;name&gt;</c>. Off-dispatcher watchdog (see
-    /// <see cref="HangTimeout"/>) still fires for dispatcher-starvation hangs.
+    /// When true (the default), <see cref="DefaultAotSkipPatterns"/> is honoured
+    /// under NativeAOT — matching fixtures are skipped. Set to false (via
+    /// <c>--no-aot-skip</c>) to run every fixture even under NativeAOT, for
+    /// targeted repro of a hanging/crashing fixture together with
+    /// <c>--filter &lt;name&gt;</c>. The off-dispatcher watchdog (see
+    /// <see cref="HangTimeout"/>) still fires regardless.
     /// </summary>
     public static bool SkipAotPatterns { get; set; } = true;
 
@@ -55,7 +57,8 @@ internal static class SelfTestRunner
     private static FixtureProgress? _currentFixture;
 
     // Fixtures known to crash or assert-fail under NativeAOT, captured by
-    // running .aot_runs/probe_skips.ps1 against the AOT-published Host.
+    // running tests/Reactor.AppTests.Host/probe-aot-skips.ps1 against the
+    // AOT-published Host.
     // Each name was verified to fail in isolation; wildcards from earlier
     // skip-list iterations have been replaced with explicit names so that
     // newly-passing siblings re-enter the run automatically.

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Dispatching;
@@ -13,6 +14,14 @@ internal static class SelfTestRunner
 {
     public static string? Filter { get; set; }
 
+    /// <summary>
+    /// When true, the AOT skip list is ignored — every fixture runs even under
+    /// NativeAOT. Use for targeted repro of a hanging/crashing fixture together
+    /// with <c>--filter &lt;name&gt;</c>. Off-dispatcher watchdog (see
+    /// <see cref="HangTimeout"/>) still fires for dispatcher-starvation hangs.
+    /// </summary>
+    public static bool SkipAotPatterns { get; set; } = true;
+
     // Per-fixture watchdog. A managed hang used to lock up the whole run; now
     // we time out, mark it failed, and continue. (Note: native crashes under
     // AOT terminate the process before this can fire — use AotSkip patterns
@@ -20,213 +29,158 @@ internal static class SelfTestRunner
     // in milliseconds — 15s is generous.
     private static readonly TimeSpan FixtureTimeout = TimeSpan.FromSeconds(15);
 
-    // Fixtures known to crash/hang under NativeAOT. Skipped with a TAP SKIP
-    // directive so the run completes and the remaining failure surface is
-    // visible. Patterns are exact-match or "Prefix*" wildcard. Override via
-    // REACTOR_AOT_SKIP=Pat1,Pat2 (no rebuild needed). Remove an entry once
-    // its underlying issue is fixed.
+    // Off-dispatcher hang watchdog. The in-band FixtureTimeout above relies on
+    // the dispatcher processing a Task.Delay continuation, so it cannot fire
+    // when a fixture synchronously blocks the UI thread. This second watchdog
+    // runs on a background Thread (immune to dispatcher starvation) and
+    // declares a hang after HangTimeout of no progress in the fixture loop.
+    // Threshold is well past FixtureTimeout so it only catches the
+    // dispatcher-starvation case. Override via REACTOR_SELFTEST_HANG_TIMEOUT_SECONDS;
+    // set to 0 or a negative value to disable entirely (useful when attaching
+    // a debugger). Also auto-disabled when Debugger.IsAttached.
+    private static readonly TimeSpan HangTimeout = ResolveHangTimeout();
+
+    private static TimeSpan ResolveHangTimeout()
+    {
+        var env = Environment.GetEnvironmentVariable("REACTOR_SELFTEST_HANG_TIMEOUT_SECONDS");
+        if (!string.IsNullOrWhiteSpace(env) && int.TryParse(env, out var s))
+            return s <= 0 ? TimeSpan.Zero : TimeSpan.FromSeconds(s);
+        return TimeSpan.FromSeconds(60);
+    }
+
+    // Single immutable progress record — published atomically via
+    // Volatile.Read/Write so the watchdog can never read a mixed
+    // (new-name, old-timestamp) state.
+    private sealed record FixtureProgress(string Name, long StartTimestamp);
+    private static FixtureProgress? _currentFixture;
+
+    // Fixtures known to crash or assert-fail under NativeAOT, captured by
+    // running .aot_runs/probe_skips.ps1 against the AOT-published Host.
+    // Each name was verified to fail in isolation; wildcards from earlier
+    // skip-list iterations have been replaced with explicit names so that
+    // newly-passing siblings re-enter the run automatically.
+    //
+    // Override via REACTOR_AOT_SKIP=Pat1,Pat2 (no rebuild needed). Patterns
+    // are exact-match or Prefix* wildcard. Re-run the probe after framework
+    // changes to find new stale skips. See docs/aot-support.md for the full
+    // debugging workflow.
     private static readonly string[] DefaultAotSkipPatterns =
     {
-        // ControlUpdate_TextProperty and _ButtonProperty are the only two in
-        // this family known to pass under AOT; the rest crash silently.
-        "ControlUpdate_InputControls",
-        "ControlUpdate_DateTimePicker",
-        "ControlUpdate_Containers",
+        // -- Native crashes (process exits 0xC0000409 / STATUS_STACK_BUFFER_OVERRUN).
+        // Capture a dump with DOTNET_DbgEnableMiniDump=1 to diagnose. --
+        "Commanding_DisabledCommandDisablesControl",
+        "Commanding_SplitButtonCommandInvokesExecute",
         "ControlUpdate_Collections",
+        "ControlUpdate_Containers",
+        "ControlUpdate_InputControls",
         "ControlUpdate_Navigation",
-        "ControlUpdate_Modifiers",
-        "ControlUpdate_PaddingModifiers",
-        "ControlUpdate_Shapes",
         "ControlUpdate_StatusControls",
-        "ControlUpdate_Grid",
-        "ControlUpdate_ModifiedElementUnwrap",
-        "ControlUpdate_HyperlinkButton",
-        // First ControlUpdate2_* fixture crashes; rest unverified but assumed
-        // to share the same shape problem. Remove this wildcard to test each.
-        "ControlUpdate2_*",
-        // RareControl_ColorPicker crashed — uncommon-control family, assume
-        // shared risk.
-        "RareControl_*",
-        // DslExt_FactoryMethods crashed mid-family; FluentModifierChain and
-        // TransitionExtensions passed. Skip the rest from FactoryMethods on.
-        "DslExt_FactoryMethods",
-        "DslExt_ShapeExtensions",
-        "DslExt_GridBuilders",
-        "DslExt_MenuDslMethods",
-        "DslExt_AttachedProperties",
-        "DslExt_ErrorBoundaryElement",
-        "DslExt_GroupElement",
-        "DslExt_BrushAndFontModifiers",
-        // CoreCov_* crashers observed iteratively. Many control-specific
-        // CoreCov_* fixtures crash silently under AOT.
-        "CoreCov_MenuBarMountUpdate",
-        "CoreCov_MediaPlayerMount",
-        "CoreCov_SwipeControlMount",
-        "CoreCov_SelectorBarPipsPagerMount",
-        "CoreCov_PopupRefreshContainerMount",
+        "ControlUpdate2_AdditionalControls",
+        "ControlUpdate2_ButtonVariants",
+        "ControlUpdate2_ExpanderContent",
+        "ControlUpdate2_NavigationView",
         "CoreCov_AnnotatedScrollBarMount",
-        "CoreCov_TreeViewUpdateExercise",
         "CoreCov_ExpanderChildUpdateDeep",
-        // CoreCov2_* — InfoBarActionButton crashed; pre-skip the other
-        // control-specific ones (named after specific WinUI controls) which
-        // are likely to share the same shape problem.
-        "CoreCov2_InfoBarActionButton",
+        "CoreCov_MediaPlayerMount",
+        "CoreCov_MenuBarMountUpdate",
+        "CoreCov_PopupRefreshContainerMount",
+        "CoreCov_SelectorBarPipsPagerMount",
+        "CoreCov_SwipeControlMount",
+        "CoreCov_TreeViewUpdateExercise",
         "CoreCov2_CalendarPipsPagerUpdate",
-        "CoreCov2_FrameAnimatedIconUpdate",
-        "CoreCov2_ParallaxViewMount",
-        "CoreCov2_XamlHostMount",
         "CoreCov2_InfoBadgeMountUpdate",
+        "CoreCov2_InfoBarActionButton",
         "CoreCov2_SelectorBarUpdate",
-        // ---- Iteration round 2 (2026-05-20) ----
-        // Crashers observed when re-running selftests against an AOT-published
-        // Host. A native crash terminates the process before the managed
-        // watchdog can fire, so each entry below is the name of the *last*
-        // fixture printed before exit. Wildcards are an inference — when the
-        // crashed fixture is part of an obvious family (e.g. one of N
-        // per-control variants), assume the family shares the shape problem
-        // rather than rebuild+rerun N times. Drop the wildcard back to
-        // explicit names if you have time to verify which members pass.
-
-        // ValCov_FormFieldRendering: single fixture, exercises form-field
-        // editor selection over reflected property metadata.
-        "ValCov_FormFieldRendering",
-
-        // EchoSuppress family: ColorPicker crashed; other members unverified.
-        // Suspected shared path through value-change event echo suppression
-        // on the control wrappers.
-        "EchoSuppress_*",
-
-        // IdentityPreserve family: two distinct fixtures crashed (RadioButtons,
-        // SelectorBar). Not wildcarding the whole family — other members of
-        // this family passed under AOT and we don't want to lose the coverage.
+        "CovBoost_ElementPoolExercise",
+        "CovBoost2_ElementPoolInteractiveReset",
+        "CovBoost2_NavigationViewExercise",
+        "CovBoost2_ReconcileChildPaths",
+        "CovBoost2_TitleBarMountUpdate",
+        "DataGrid_RowEditTemplatesAndEmptyState",
+        "DslExt_FactoryMethods",
+        "DslExt_MenuDslMethods",
+        "EchoSuppress_ColorPicker",
+        "EchoSuppress_NumberBox",
+        "EchoSuppress_NumberBoxMinMaxCoercion",
+        "EchoSuppress_RatingControl",
+        "EchoSuppress_ToggleSplitButton",
+        "Editors_ColorMounts",
+        "Editors_NumberMounts",
         "IdentityPreserve_RadioButtons",
         "IdentityPreserve_SelectorBar",
+        "Immediate_NumberBoxFiresOnTextChange",
+        "RareControl_ColorPicker",
+        "RareControl_ComboBoxRadioButtons",
+        "RareControl_PersonPicture",
+        "RareControl_TeachingTip",
+        "RBC_ExpanderTemplateTransitionEvents",
+        "RBC_HandlerWiringOnSecondRender",
+        "RBC_InputControlsFireEvents",
+        "RBC_SecondRenderCallbackInvocation",
+        "RBC_SwipeControlItemsSwap",
+        "RBC_TeachingTipMount",
+        "RBC_TreeViewHandlerWiring",
+        "RBC_TreeViewHandlerWiringFastPath",
+        "RBC_TreeViewProgrammaticInvoke",
+        "RBC_ValidationVisualizerStyles",
+        "SelectionEvt_NavigationView",
+        "SelectionEvt_RadioButtons",
+        "ValCov_FormFieldRendering",
+        "ValueEvt_ColorPicker",
+        "ValueEvt_NumberBox",
+        "ValueEvt_RatingControl",
 
-        // DataGrid_RowEditTemplatesAndEmptyState: template-instantiation path
-        // in DataGrid row editing. Other DataGrid fixtures pass.
-        "DataGrid_RowEditTemplatesAndEmptyState",
-
-        // CovBoost / CovBoost2 individual crashers — heterogeneous, so listed
-        // individually rather than wildcarded. Each crash was at the named
-        // fixture; rest of CovBoost / CovBoost2 currently runs.
-        "CovBoost_ElementPoolExercise",
-        "CovBoost2_TitleBarMountUpdate",
-        "CovBoost2_ReconcileChildPaths",
-        "CovBoost2_NavigationViewExercise",
-        "CovBoost2_ElementPoolInteractiveReset",
-
-        // Commanding_* — SplitButtonCommandInvokesExecute crashed. ICommand
-        // dispatch wires up through reflected `CanExecute` / `Execute`; the
-        // whole family likely shares the breakage.
-        "Commanding_*",
-
-        // Event-handler families. In each case the named fixture crashed;
-        // wildcarding the family on the assumption that the breakage is in
-        // shared event-subscription code paths (handler binding /
-        // EventHandler<T> instantiation under AOT) rather than per-control.
-        "SelectionEvt_*",   // RadioButtons crashed; covers ComboBox/ListBox/…
-        "ValueEvt_*",       // NumberBox crashed; covers Slider/ToggleSwitch/…
-        "Immediate_*",      // NumberBoxFiresOnTextChange crashed; "immediate" event variants
-        "Editors_*",        // NumberMounts crashed; PropertyGrid auto-editor mounts
-        "RBC_*",            // HandlerWiringOnSecondRender crashed; recycle-by-component event rewiring
-
-        // ---- Iteration round 3 (2026-05-20) ----
-        // After the round-2 skips above eliminated all native crashers, an AOT
-        // run completed end-to-end with 22 assertion failures + 20 fixture
-        // init crashes. Investigating each cluster against
-        // `docs/aot-support.md` showed every remaining failure is a fixture
-        // that exercises a subsystem already documented as not-yet-AOT-clean:
-        // PropertyGrid auto-discovery, devtools/MCP reflection, UseObservable
-        // on POCOs, theme resource lookup, and XAML-metadata-dependent control
-        // hosting. Skipping them gives a 0-failure AOT run that maps cleanly
-        // to the documented surface, so a future fix for any one subsystem
-        // (e.g. source-generated PropertyGrid metadata) translates directly
-        // into selftests being re-enabled here.
-
-        // PropertyGrid auto-discovery: ReflectionTypeMetadataProvider walks
-        // public properties + builds init-only setters. AOT trims members of
-        // the user-supplied target type before the reflection runs. Per
-        // aot-support.md (PropertyGrid auto-discovery row), manually-built
-        // TypeMetadata works; auto-discovery does not. INPC_ExternalMutation
-        // is the only PropertyGrid fixture that passes (it stays inside the
-        // mutation pipeline that's already AOT-clean), so we skip explicitly
-        // rather than wildcard PropertyGrid_*.
-        "PropertyGrid_Reflection_MutableObject",
-        "PropertyGrid_Reflection_Categorized",
-        "PropertyGrid_Reflection_EnumEditor",
-        "PropertyGrid_Target_Switching",
-        "PropertyGrid_Nested_ImmutableRecord",
-        "PropertyGrid_Category_ExpandCollapse",
-        "PropertyGrid_DeepNesting_RecordInRecord",
-        "PropertyGrid_Immutable_Root",
-        "PropertyGrid_Custom_Editor",
-
-        // UseObservable on POCO: ObservableTreeTracker walks public properties
-        // via reflection to subscribe to INPC (aot-support.md). The DeepMutation
-        // assertion is the one that exercises the per-property subscribe path.
+        // -- Assertion failures (fixture runs but "not ok" checks fail).
+        // Most map to documented not-yet-AOT-clean subsystems (PropertyGrid
+        // auto-discovery, devtools/MCP reflection, ThemeRef.Resolve, XAML
+        // metadata for NavigationView/TabView/TemplateBinding). --
+        "CoreCov_NavigationViewContentUpdate",
         "CoreCov2_UseObservableTreeHook",
-
-        // ThemeRef.Resolve walks Application.Current.Resources merged + theme
-        // dictionaries; under AOT the XamlControlsResources entries that
-        // ReactorApplication.xaml loads aren't populated the way the JIT
-        // build sees them, so Resolve returns null for keys that exist at
-        // JIT time. Token *construction* passes; only the Resolve path fails.
         "CovBoost_ThemeRefExplicitResolution",
         "CovBoost_ThemeTokenResolution",
-
-        // NavigationView + TabView don't mount under AOT in this host —
-        // the very first FindControl<…> returns null. WinUI's lifted XAML
-        // metadata provider for these controls appears to lose entries
-        // through trimming; the existing skip list already pre-skipped the
-        // ControlUpdate_Navigation family for the same reason.
-        "CoreCov_NavigationViewContentUpdate",
-        "IdentityPreserve_TabView",
-
-        // Issue142 reproduces TemplateBinding-from-Generic.xaml against a
-        // custom control with a private DP. Under AOT the template/DP
-        // resolution path can't see the metadata it needs (the third-party
-        // variant fails earlier, complaining that no IXamlMetadataProvider
-        // is reachable in the satellite assembly). Both variants depend on
-        // XAML metadata that AOT trimming removes.
-        "Issue142_CustomControlPrivateDp_Renders",
-        "Issue142_ThirdPartyControlPrivateDp_Renders",
-
-        // Devtools / MCP server: JSON-RPC requests come back as
-        // "Invalid JSON-RPC request" or with empty `result` payloads because
-        // System.Text.Json + Assembly.GetTypes + reflection-based property
-        // enumeration + DP enumeration all live behind unconditional
-        // suppressions today (aot-support.md, Devtools/MCP row). Most of
-        // the family is broken; the few fixtures that touch only the
-        // edges (PropertyToolsReflectionExercise, ScreenshotReturnsPng,
-        // and large portions of McpServerProtocolEdges) still pass, so we
-        // skip individually rather than wildcard Devtools_*.
-        "Devtools_VersionTool",
-        "Devtools_ComponentsTool",
-        "Devtools_WindowsTool",
-        "Devtools_TreeSummary",
-        "Devtools_TreeFullView",
-        "Devtools_TreeSelectorScope",
         "Devtools_ClickInvokesButton",
-        "Devtools_TypeSetsTextBox",
+        "Devtools_ComponentsTool",
+        "Devtools_FireInvokesNamedHandler",
+        "Devtools_FireRejectsLifecycleMethods",
         "Devtools_FocusElement",
+        "Devtools_InitializeHandshake",
+        "Devtools_InvokeDirectPattern",
+        "Devtools_LoggerWritesOneLinePerCall",
+        "Devtools_McpServerProtocolEdges",
+        "Devtools_NameSelectorMatchesButtonContent",
+        "Devtools_PropertyToolsExercise",
+        "Devtools_ScrollByAndInto",
+        "Devtools_SelectListItem",
+        "Devtools_StateReadsHooks",
+        "Devtools_SwitchComponentInvalidatesIds",
+        "Devtools_ToggleFlipsCheckBox",
+        "Devtools_TreeFullView",
+        "Devtools_TreeIdsUniqueAcrossSiblingsWithDifferentParents",
+        "Devtools_TreeSelectorScope",
+        "Devtools_TreeSummary",
+        "Devtools_TypeSetsTextBox",
+        "Devtools_UnknownSelectorStructuredError",
+        "Devtools_VersionTool",
         "Devtools_WaitForTextChange",
         "Devtools_WaitForTimeout",
-        "Devtools_ToggleFlipsCheckBox",
-        "Devtools_InvokeDirectPattern",
-        "Devtools_StateReadsHooks",
-        "Devtools_SelectListItem",
-        "Devtools_ScrollByAndInto",
-        "Devtools_LoggerWritesOneLinePerCall",
-        "Devtools_UnknownSelectorStructuredError",
-        "Devtools_NameSelectorMatchesButtonContent",
-        "Devtools_TreeIdsUniqueAcrossSiblingsWithDifferentParents",
-        "Devtools_FireRejectsLifecycleMethods",
-        "Devtools_FireInvokesNamedHandler",
         "Devtools_WaitForTimeoutLoggedAsErr",
-        "Devtools_InitializeHandshake",
-        "Devtools_SwitchComponentInvalidatesIds",
-        "Devtools_PropertyToolsExercise",
-        "Devtools_McpServerProtocolEdges",
+        "Devtools_WindowsTool",
+        "IdentityPreserve_TabView",
+        "Issue142_CustomControlPrivateDp_Renders",
+        "Issue142_ThirdPartyControlPrivateDp_Renders",
+        "PropertyGrid_Category_ExpandCollapse",
+        "PropertyGrid_Custom_Editor",
+        "PropertyGrid_DeepNesting_RecordInRecord",
+        "PropertyGrid_Immutable_Root",
+        "PropertyGrid_Nested_ImmutableRecord",
+        "PropertyGrid_Reflection_Categorized",
+        "PropertyGrid_Reflection_EnumEditor",
+        "PropertyGrid_Reflection_MutableObject",
+        "PropertyGrid_Target_Switching",
+        "RBC_ManyControlsHandlerWiring",
+        "RBC_NavViewContentNullSwap",
+        "RBC_TabViewGrowAndShrink",
+        "SelectionEvt_TabView",
     };
 
     private static string[] GetAotSkipPatterns()
@@ -272,6 +226,7 @@ internal static class SelfTestRunner
 
     public static void RunAll()
     {
+        StartHangWatchdog();
         WinRT.ComWrappersSupport.InitializeComWrappers();
         Application.Start(_ =>
         {
@@ -314,10 +269,13 @@ internal static class SelfTestRunner
                         // looks like a hang on the prior fixture.
                         await YieldLowPriorityAsync(dispatcher);
 
-                        if (isAot && MatchesAnyPattern(fixtureName, aotSkipPatterns))
+                        if (isAot && SkipAotPatterns && MatchesAnyPattern(fixtureName, aotSkipPatterns))
                         {
                             Console.WriteLine($"ok {testIndex} {fixtureName} # SKIP crashes/hangs under NativeAOT");
                             harness.MarkFixtureSkipped(testIndex - 1);
+                            // Clear progress so the hang watchdog doesn't trip
+                            // while we yield between skips.
+                            Volatile.Write(ref _currentFixture, null);
                             // Yield at Low priority so WinUI layout / render
                             // / compositor work can actually run before the
                             // next iteration — Task.Yield runs at Normal,
@@ -326,6 +284,12 @@ internal static class SelfTestRunner
                             await YieldLowPriorityAsync(dispatcher);
                             continue;
                         }
+
+                        // Publish progress to the off-dispatcher watchdog so
+                        // it can identify the in-flight fixture if the
+                        // dispatcher gets blocked.
+                        Volatile.Write(ref _currentFixture,
+                            new FixtureProgress(fixtureName, Stopwatch.GetTimestamp()));
 
                         int failuresBefore = harness.Failures;
                         bool crashed = false;
@@ -341,6 +305,10 @@ internal static class SelfTestRunner
                             else
                             {
                                 Console.WriteLine($"# Running: {fixtureName}");
+                                // Flush so the parent harness can attribute a
+                                // hang to this fixture by name even if the
+                                // child terminates abruptly afterward.
+                                Console.Out.Flush();
                                 var runTask = fixture.RunAsync();
                                 var timeoutTask = Task.Delay(FixtureTimeout);
                                 var completed = await Task.WhenAny(runTask, timeoutTask);
@@ -363,6 +331,10 @@ internal static class SelfTestRunner
                             Console.Error.WriteLine(ex.ToString());
                             harness.RecordFailure();
                         }
+                        // Clear progress now that the fixture finished (or
+                        // its dispatcher-bound timeout fired) so the watchdog
+                        // doesn't blame this fixture for an inter-fixture gap.
+                        Volatile.Write(ref _currentFixture, null);
                         harness.MarkFixtureResult(testIndex - 1,
                             !crashed && harness.Failures == failuresBefore);
                     }
@@ -383,5 +355,60 @@ internal static class SelfTestRunner
                 }
             });
         });
+    }
+
+    private static void StartHangWatchdog()
+    {
+        if (HangTimeout <= TimeSpan.Zero) return;
+        var thread = new Thread(HangWatchdogLoop)
+        {
+            IsBackground = true,
+            Name = "Reactor.SelfTest.HangWatchdog",
+        };
+        thread.Start();
+    }
+
+    private static void HangWatchdogLoop()
+    {
+        // Sleep small slices so disabling-via-debugger-attach takes effect
+        // quickly. Polling 1Hz is plenty: HangTimeout is measured in seconds.
+        var pollMs = 1000;
+        while (true)
+        {
+            try { Thread.Sleep(pollMs); }
+            catch (ThreadInterruptedException) { return; }
+
+            // Auto-disable when a debugger is attached: developers stepping
+            // through a fixture would otherwise trip the watchdog.
+            if (Debugger.IsAttached) continue;
+
+            var progress = Volatile.Read(ref _currentFixture);
+            if (progress is null) continue;
+
+            var elapsed = Stopwatch.GetElapsedTime(progress.StartTimestamp);
+            if (elapsed < HangTimeout) continue;
+
+            // We are >= HangTimeout into a fixture and the dispatcher hasn't
+            // moved on. Emit a structured signal, flush, and FailFast so a
+            // Watson/.NET minidump is produced (when DOTNET_DbgEnableMiniDump=1).
+            var elapsedSec = (int)elapsed.TotalSeconds;
+            var message =
+                $"Bail out! HANG_DETECTED: {progress.Name} ran {elapsedSec}s " +
+                $"without progress — UI dispatcher unresponsive. " +
+                $"Rerun with --no-aot-skip --filter {progress.Name} and " +
+                $"DOTNET_DbgEnableMiniDump=1 to capture a dump for analysis.";
+            try
+            {
+                Console.WriteLine(message);
+                Console.Out.Flush();
+                Console.Error.WriteLine(message);
+                Console.Error.Flush();
+            }
+            catch { /* swallow IO errors — we're about to FailFast anyway */ }
+
+            // FailFast: synchronous, dumpable termination. Preferred over
+            // Environment.Exit (no dump) and Process.Kill (no chance to flush).
+            Environment.FailFast(message);
+        }
     }
 }

--- a/tests/Reactor.AppTests.Host/probe-aot-skips.ps1
+++ b/tests/Reactor.AppTests.Host/probe-aot-skips.ps1
@@ -1,0 +1,133 @@
+#!/usr/bin/env pwsh
+# Probe each AOT-skipped fixture in isolation under --no-aot-skip and categorize
+# behavior: PASS, ASSERT_FAIL, NATIVE_CRASH, HANG, TIMEOUT_NO_SIGNAL.
+#
+# Use this after AOT framework changes to find stale entries in
+# DefaultAotSkipPatterns that have started passing, and to triage what's still
+# broken. Requires the AOT-published Host at
+#   tests/Reactor.AppTests.Host/bin/x64/Release/net10.0-windows10.0.22621.0/win-x64/publish/Reactor.AppTests.Host.exe
+# Publish first with:
+#   dotnet publish tests/Reactor.AppTests.Host -p:PublishAotInternal=true -p:Platform=x64 -r win-x64 -c Release
+# See docs/aot-support.md for the full workflow.
+
+param(
+    [int]$HangTimeoutSec = 10,
+    [int]$ProcessTimeoutSec = 30,
+    [string]$OutputCsv,
+    [string[]]$Only
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Repo root is two levels up: tests/Reactor.AppTests.Host/probe-aot-skips.ps1 → repo root.
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$exe = Join-Path $repoRoot 'tests\Reactor.AppTests.Host\bin\x64\Release\net10.0-windows10.0.22621.0\win-x64\publish\Reactor.AppTests.Host.exe'
+if (-not (Test-Path $exe)) {
+    throw "AOT-published host not found at: $exe`nPublish first with: dotnet publish tests/Reactor.AppTests.Host -p:PublishAotInternal=true -p:Platform=x64 -r win-x64 -c Release"
+}
+
+if (-not $OutputCsv) {
+    $outDir = Join-Path $repoRoot '.aot_runs'
+    if (-not (Test-Path $outDir)) { [void](New-Item -ItemType Directory $outDir) }
+    $OutputCsv = Join-Path $outDir 'probe_results.csv'
+}
+
+# Extract DefaultAotSkipPatterns string literals from SelfTestRunner.cs.
+$runnerCs = Get-Content (Join-Path $repoRoot 'tests\Reactor.AppTests.Host\SelfTest\SelfTestRunner.cs') -Raw
+$skipBlockMatch = [regex]::Match($runnerCs, '(?s)private static readonly string\[\] DefaultAotSkipPatterns\s*=\s*\{(.*?)\};')
+if (-not $skipBlockMatch.Success) { throw 'Could not locate DefaultAotSkipPatterns block in SelfTestRunner.cs' }
+$patterns = [regex]::Matches($skipBlockMatch.Groups[1].Value, '"([^"]+)"') | ForEach-Object { $_.Groups[1].Value }
+$exactPatterns = $patterns | Where-Object { -not $_.EndsWith('*') }
+$wildcardPatterns = $patterns | Where-Object { $_.EndsWith('*') }
+
+# Get full fixture list once.
+$allFixtures = & $exe --list-fixtures | Where-Object { $_ -match '\S' }
+
+# Expand wildcards against the fixture registry.
+$fixturesToTest = New-Object System.Collections.Generic.HashSet[string]
+foreach ($p in $exactPatterns) { if ($allFixtures -contains $p) { [void]$fixturesToTest.Add($p) } }
+foreach ($wp in $wildcardPatterns) {
+    $prefix = $wp.TrimEnd('*')
+    foreach ($f in $allFixtures) { if ($f.StartsWith($prefix)) { [void]$fixturesToTest.Add($f) } }
+}
+
+if ($Only) { $fixturesToTest = [System.Collections.Generic.HashSet[string]]::new([string[]]$Only) }
+
+Write-Host "Probing $($fixturesToTest.Count) skipped fixtures (hang_timeout=${HangTimeoutSec}s, proc_timeout=${ProcessTimeoutSec}s)" -ForegroundColor Cyan
+
+$results = New-Object System.Collections.Generic.List[object]
+$i = 0
+foreach ($fixture in ($fixturesToTest | Sort-Object)) {
+    $i++
+    Write-Host -NoNewline "[$i/$($fixturesToTest.Count)] $fixture ... "
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $exe
+    $psi.Arguments = "--self-test --no-aot-skip --filter $fixture"
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.EnvironmentVariables["REACTOR_SELFTEST_HANG_TIMEOUT_SECONDS"] = "$HangTimeoutSec"
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $p = [System.Diagnostics.Process]::Start($psi)
+    $soutTask = $p.StandardOutput.ReadToEndAsync()
+    $serrTask = $p.StandardError.ReadToEndAsync()
+    $exited = $p.WaitForExit($ProcessTimeoutSec * 1000)
+    if (-not $exited) {
+        try { $p.Kill($true) } catch {}
+        $p.WaitForExit()
+    }
+    $sw.Stop()
+
+    $sout = $soutTask.Result
+    $serr = $serrTask.Result
+    $exitCode = $p.ExitCode
+
+    # Categorize based on exit code + watchdog signal.
+    $category = 'UNKNOWN'
+    $detail = ''
+    if (-not $exited) {
+        $category = 'TIMEOUT_NO_SIGNAL'
+        $detail = "process timeout (${ProcessTimeoutSec}s) without hang signal"
+    } elseif (($sout + $serr) -match 'HANG_DETECTED:\s*(\S+)') {
+        $category = 'HANG'
+        $detail = "watchdog fired: $($Matches[1])"
+    } elseif ($exitCode -eq -1073741189 -or $exitCode -eq 0xC0000409) {
+        $category = 'NATIVE_CRASH'
+        $detail = "STATUS_STACK_BUFFER_OVERRUN ($exitCode)"
+    } elseif ($exitCode -lt 0) {
+        $category = 'NATIVE_CRASH'
+        $detail = "exit=$exitCode (native fault)"
+    } elseif ($exitCode -eq 0) {
+        $category = 'PASS'
+        $detail = 'exit=0'
+    } else {
+        $category = 'ASSERT_FAIL'
+        $detail = "exit=$exitCode"
+        $notOk = ($sout -split "`n") | Where-Object { $_ -match '^not ok' } | Select-Object -First 1
+        if ($notOk) { $detail += " | $($notOk.Trim())" }
+    }
+
+    $color = switch ($category) {
+        'PASS' { 'Green' }
+        'HANG' { 'Yellow' }
+        'NATIVE_CRASH' { 'Red' }
+        'ASSERT_FAIL' { 'Magenta' }
+        default { 'Gray' }
+    }
+    Write-Host -ForegroundColor $color "$category ($([math]::Round($sw.Elapsed.TotalSeconds,1))s) $detail"
+
+    $results.Add([pscustomobject]@{
+        Fixture = $fixture
+        Category = $category
+        ExitCode = $exitCode
+        ElapsedSec = [math]::Round($sw.Elapsed.TotalSeconds, 2)
+        Detail = $detail
+    })
+}
+
+$results | Export-Csv -Path $OutputCsv -NoTypeInformation
+Write-Host "`nWritten: $OutputCsv" -ForegroundColor Cyan
+$results | Group-Object Category | Sort-Object Count -Descending | Format-Table Count, Name -AutoSize
+

--- a/tests/Reactor.AppTests.Host/probe-aot-skips.ps1
+++ b/tests/Reactor.AppTests.Host/probe-aot-skips.ps1
@@ -93,9 +93,12 @@ foreach ($fixture in ($fixturesToTest | Sort-Object)) {
     } elseif (($sout + $serr) -match 'HANG_DETECTED:\s*(\S+)') {
         $category = 'HANG'
         $detail = "watchdog fired: $($Matches[1])"
-    } elseif ($exitCode -eq -1073741189 -or $exitCode -eq 0xC0000409) {
+    } elseif ($exitCode -eq -1073740791) {
+        # 0xC0000409 as a signed 32-bit Win32 exit code. PowerShell hex literals
+        # widen to Int64 so a direct `-eq 0xC0000409` would never match a
+        # negative Process.ExitCode — compare the normalized signed form.
         $category = 'NATIVE_CRASH'
-        $detail = "STATUS_STACK_BUFFER_OVERRUN ($exitCode)"
+        $detail = "STATUS_STACK_BUFFER_OVERRUN (0xC0000409)"
     } elseif ($exitCode -lt 0) {
         $category = 'NATIVE_CRASH'
         $detail = "exit=$exitCode (native fault)"

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -26,6 +26,13 @@ public class SelfTestBatch
     private static string _fullOutput = "";
     private static bool _initialized;
     private static string? _initError;
+    // When the Host run aborts (hang/timeout) we attribute the failure to a
+    // single fixture, but every later fixture still has no entry in
+    // _byFixture. _abortedReason marks the run as not-fully-executed so the
+    // Fixture test method can report missing entries as Inconclusive rather
+    // than cascading "was not reported by the Host" failures across every
+    // fixture downstream of the hang.
+    private static string? _abortedReason;
 
     [ClassInitialize]
     public static void RunSelfTests(TestContext context)
@@ -62,6 +69,7 @@ public class SelfTestBatch
                     $"`Reactor.AppTests.Host.exe --self-test --no-aot-skip --filter {attributed}`. " +
                     $"Set DOTNET_DbgEnableMiniDump=1 (and COMPlus_DbgEnableMiniDump=1) to capture a dump.\n" +
                     $"--- tail of full output ---\n{Tail(_fullOutput, 4000)}");
+                _abortedReason = $"Run aborted by timeout on fixture '{attributed}'";
             }
             else
             {
@@ -78,6 +86,7 @@ public class SelfTestBatch
                 $"Repro: `Reactor.AppTests.Host.exe --self-test --no-aot-skip --filter {hangFixture}`. " +
                 $"Set DOTNET_DbgEnableMiniDump=1 (and COMPlus_DbgEnableMiniDump=1) for a dump.\n" +
                 $"--- tail of full output ---\n{Tail(_fullOutput, 4000)}");
+            _abortedReason = $"Run aborted by hang on fixture '{hangFixture}'";
         }
 
         _initialized = true;
@@ -226,7 +235,13 @@ public class SelfTestBatch
             Assert.Fail(_initError);
 
         if (!_byFixture.TryGetValue(name, out var result))
+        {
+            if (_abortedReason is not null)
+                Assert.Inconclusive(
+                    $"{_abortedReason}; fixture '{name}' was not executed. " +
+                    $"Re-run after the offending fixture is fixed or added to DefaultAotSkipPatterns.");
             Assert.Fail($"Fixture '{name}' was not reported by the Host. Full output:\n{_fullOutput}");
+        }
 
         if (!result.Passed)
             Assert.Fail(result.Detail);

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -37,18 +37,89 @@ public class SelfTestBatch
         if (!string.IsNullOrEmpty(stderr))
             _fullOutput += "\n--- stderr ---\n" + stderr;
 
+        ParseTap(stdout);
+
+        // Off-dispatcher watchdog in the Host emits a structured signal on
+        // dispatcher-starvation hangs. Parse it from stdout *and* stderr (the
+        // Host writes to both before FailFast so the signal survives buffered
+        // pipes), then attribute the failure to the named fixture so the dev
+        // sees a clear pointer to the offender instead of an opaque "process
+        // timed out" affecting every fixture.
+        var hangFixture = ExtractHangSignal(stdout) ?? ExtractHangSignal(stderr);
+
         if (timedOut)
         {
-            _initError = $"Self-test process timed out after {SelfTestTimeoutMs}ms.\n{_fullOutput}";
+            // Process didn't exit on its own. If the Host emitted a hang
+            // signal, attribute the timeout to that fixture. Otherwise fall
+            // back to the last "# Running:" line — that's the fixture that
+            // was in flight when the timeout fired.
+            var attributed = hangFixture ?? ExtractLastRunningFixture(stdout);
+            if (attributed is not null)
+            {
+                _byFixture[attributed] = (false,
+                    $"Selftest process timed out after {SelfTestTimeoutMs}ms with this fixture in flight. " +
+                    $"Repro: build the Host (AOT publish if needed) and run " +
+                    $"`Reactor.AppTests.Host.exe --self-test --no-aot-skip --filter {attributed}`. " +
+                    $"Set DOTNET_DbgEnableMiniDump=1 (and COMPlus_DbgEnableMiniDump=1) to capture a dump.\n" +
+                    $"--- tail of full output ---\n{Tail(_fullOutput, 4000)}");
+            }
+            else
+            {
+                _initError = $"Self-test process timed out after {SelfTestTimeoutMs}ms with no fixture attribution.\n{_fullOutput}";
+            }
             _initialized = true;
             return;
         }
 
-        ParseTap(stdout);
+        if (hangFixture is not null)
+        {
+            _byFixture[hangFixture] = (false,
+                $"Selftest Host detected a dispatcher-starvation hang. " +
+                $"Repro: `Reactor.AppTests.Host.exe --self-test --no-aot-skip --filter {hangFixture}`. " +
+                $"Set DOTNET_DbgEnableMiniDump=1 (and COMPlus_DbgEnableMiniDump=1) for a dump.\n" +
+                $"--- tail of full output ---\n{Tail(_fullOutput, 4000)}");
+        }
+
         _initialized = true;
 
         if (exitCode != 0 && _byFixture.IsEmpty)
             _initError = $"Self-test process exited with code {exitCode} but produced no parsable TAP output.\n{_fullOutput}";
+    }
+
+    private static string? ExtractHangSignal(string output)
+    {
+        if (string.IsNullOrEmpty(output)) return null;
+        const string marker = "HANG_DETECTED: ";
+        foreach (var raw in output.Split('\n'))
+        {
+            var idx = raw.IndexOf(marker, StringComparison.Ordinal);
+            if (idx < 0) continue;
+            var rest = raw[(idx + marker.Length)..].TrimStart();
+            var space = rest.IndexOf(' ');
+            var name = (space > 0 ? rest[..space] : rest).Trim();
+            if (name.Length > 0) return name;
+        }
+        return null;
+    }
+
+    private static string? ExtractLastRunningFixture(string stdout)
+    {
+        if (string.IsNullOrEmpty(stdout)) return null;
+        string? last = null;
+        const string marker = "# Running: ";
+        foreach (var raw in stdout.Split('\n'))
+        {
+            var line = raw.Trim();
+            if (line.StartsWith(marker, StringComparison.Ordinal))
+                last = line[marker.Length..].Trim();
+        }
+        return string.IsNullOrEmpty(last) ? null : last;
+    }
+
+    private static string Tail(string s, int maxChars)
+    {
+        if (string.IsNullOrEmpty(s) || s.Length <= maxChars) return s;
+        return "..." + s[^maxChars..];
     }
 
     private static void ParseTap(string stdout)
@@ -231,6 +302,19 @@ public class SelfTestBatch
 
     private static string FindHostExe()
     {
+        // Allow callers to point the harness at an AOT-published Host (which
+        // lives under a `publish` directory, not the standard build output)
+        // or any other custom build. This lets the same MSTest harness validate
+        // the AOT binary that the developer is actually trying to ship.
+        var overrideExe = Environment.GetEnvironmentVariable("REACTOR_SELFTEST_HOST_EXE");
+        if (!string.IsNullOrWhiteSpace(overrideExe))
+        {
+            if (!File.Exists(overrideExe))
+                throw new FileNotFoundException(
+                    $"REACTOR_SELFTEST_HOST_EXE points at a path that does not exist: {overrideExe}");
+            return overrideExe;
+        }
+
         var dir = AppContext.BaseDirectory;
         while (dir != null && !File.Exists(Path.Combine(dir, "Reactor.slnx")))
             dir = Path.GetDirectoryName(dir);


### PR DESCRIPTION
## Summary

Adds a debugging story for AOT selftests that hang the host, and uses it to clean up the existing skip list. Result: 84 stale skips removed, restoring test coverage, and a clean baseline (627 ran / 1 pre-existing flake / 0 hangs) for tackling the remaining 108 AOT failures.

## What this PR adds

### Off-dispatcher hang watchdog (`SelfTestRunner.cs`)
- Background `Thread` started before `Application.Start`; tracks current fixture as an immutable `FixtureProgress` record published via `Volatile.Read/Write` -- no multi-field consistency race when the publisher and watcher overlap.
- Polls every 1s; fires after `HangTimeout` (default **60s**, configurable via `REACTOR_SELFTEST_HANG_TIMEOUT_SECONDS`; **0 disables**; auto-disabled when `Debugger.IsAttached`).
- On hang, writes `Bail out! HANG_DETECTED: <name> ran <s>s ...` to both stdout and stderr **before** `Environment.FailFast` so a Watson minidump is produced when `DOTNET_DbgEnableMiniDump=1`.

### CLI / environment for AOT debugging
- `--no-aot-skip` on the Host (`Program.cs`) lets a dev run a single `DefaultAotSkipPatterns` entry against the AOT-published binary.
- `REACTOR_SELFTEST_HOST_EXE` on the MSTest harness overrides the auto-discovered Host so the same harness validates the AOT-published `.exe` from a `publish/` directory.

### Parent attribution (`SelfTestBatch.cs`)
- Parses `HANG_DETECTED: <name>` from stdout+stderr; on process timeout or hang signal, attributes the failure to the named fixture with a repro command + dump-env instructions, instead of cascading through `_initError` (which would fail every unrelated fixture).
- Falls back to the last `# Running:` line when the watchdog did not have time to fire.

### Skip-list cleanup (`SelfTestRunner.cs`)
- **Removes 84 stale entries** that pass under AOT today.
- Replaces the prior mix of explicit names and `Prefix*` wildcards with **108 explicit fixture names** grouped by failure mode (`NATIVE_CRASH` vs `ASSERT_FAIL`) so the list documents what is actually broken.

### Empirical probe (`tests/Reactor.AppTests.Host/probe-aot-skips.ps1`)
- Expands `DefaultAotSkipPatterns` (via `--list-fixtures`) and runs each entry in isolation under `--no-aot-skip`, categorising by exit code + watchdog signal, writing a CSV.
- Categories on this baseline:

| Bucket | Count | Symptom |
|---|---|---|
| PASS | 84 | Skip is stale -- removed |
| NATIVE_CRASH | 61 | `0xC0000409` / `STATUS_STACK_BUFFER_OVERRUN` (managed FailFast) |
| ASSERT_FAIL | 47 | Fixture runs to completion but a `not ok` check fails |
| HANG | **0** | No fixture in the current list dispatcher-starves |

The hang watchdog stays as a CI safety net even though no current entry actually hangs -- validated synthetically by injecting `Thread.Sleep(int.MaxValue)` into a fixture and confirming the watchdog fires in 3s with `REACTOR_SELFTEST_HANG_TIMEOUT_SECONDS=3`, exits `0xE0434F4D` (`COR_E_FAILFAST`), and the stack points at `HangWatchdogLoop`.

### Docs (`docs/aot-support.md`)
- New "Debugging an AOT selftest hang" section: three-bucket failure-mode table, minidump env-var setup (`DOTNET_DbgEnableMiniDump=1` + `COMPlus_DbgEnableMiniDump=1`), isolated-repro workflow with `--no-aot-skip --filter <name>`, watchdog tuning, probe-script reference.

## Validation

- JIT selftests: **735/735 passing**, no false positives from the watchdog.
- Synthetic hang test: watchdog fired correctly, dump-ready exit.
- Full cleaned AOT selftest run: **627 fixtures, 2358 ok checks, 108 skipped, 1 known pre-existing flaky assertion (`GotFocus_FiresOnA`), 0 hangs, ~104s**.

## Follow-up

After this PR merges we have a clean baseline for diagnosing the remaining **61 native crashes + 47 assertion failures** -- the documented workflow + probe script make that triage tractable.
