### PR TITLE
Remove unnecessary try/catch(Exception) from JumpList code

### DIFF
--- a/src/Reactor/Hosting/Shell/JumpList.cs
+++ b/src/Reactor/Hosting/Shell/JumpList.cs
@@ -263,9 +263,9 @@ public static class JumpList
     /// <remarks>
     /// Clears any previously-set entries first; the OS-managed Recent and
     /// Frequent categories are unaffected (toggle them via
-    /// <see cref="ShowRecent"/> / <see cref="ShowFrequent"/>). Best-effort —
-    /// platform failures (downlevel, group-policy lockdown) log to
-    /// <c>Debug.WriteLine</c> and do not throw.
+    /// <see cref="ShowRecent"/> / <see cref="ShowFrequent"/>). Platform
+    /// failures (downlevel, group-policy lockdown, COM errors) propagate
+    /// as exceptions — callers may catch if fire-and-forget is desired.
     /// </remarks>
     public static async Task UpdateAsync(IEnumerable<JumpListItem> items)
     {
@@ -287,28 +287,20 @@ public static class JumpList
 
         if (TryUpdatePackaged(snapshot, out var task))
         {
-            try { await task!.ConfigureAwait(false); }
-            catch (Exception ex) { Debug.WriteLine($"[Reactor] JumpList packaged update failed: {ex.GetType().Name}: {ex.Message}"); }
+            await task!.ConfigureAwait(false);
             return;
         }
 
         // Unpackaged path — caller-error gates run synchronously (before we
         // hand off to the threadpool) so configuration mistakes surface as
-        // exceptions instead of disappearing into Debug.WriteLine. Platform-
-        // best-effort failures (missing COM, group policy, downlevel shell)
-        // still get swallowed.
+        // exceptions. Platform failures (missing COM, group policy, downlevel
+        // shell) also propagate — callers should catch if fire-and-forget
+        // semantics are desired.
         if (string.IsNullOrEmpty(AppUserModelId))
             throw new InvalidOperationException(
                 "JumpList.AppUserModelId must be set before UpdateAsync on unpackaged apps. (spec 036 §11.3)");
 
-        try
-        {
-            await Task.Run(() => UpdateUnpackaged(snapshot)).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            Debug.WriteLine($"[Reactor] JumpList unpackaged update failed: {ex.GetType().Name}: {ex.Message}");
-        }
+        await Task.Run(() => UpdateUnpackaged(snapshot)).ConfigureAwait(false);
     }
 
     /// <summary>Clear all user-defined jump-list entries. UI-thread only.</summary>
@@ -342,15 +334,7 @@ public static class JumpList
         // Methods on it are async; await on a UI thread completes via the captured
         // SynchronizationContext.
         global::Windows.UI.StartScreen.JumpList list;
-        try
-        {
-            list = await global::Windows.UI.StartScreen.JumpList.LoadCurrentAsync();
-        }
-        catch (Exception ex)
-        {
-            Debug.WriteLine($"[Reactor] JumpList.LoadCurrentAsync failed: {ex.GetType().Name}: {ex.Message}");
-            return;
-        }
+        list = await global::Windows.UI.StartScreen.JumpList.LoadCurrentAsync();
 
         list.Items.Clear();
         list.SystemGroupKind = ResolveSystemGroupKind();
@@ -358,39 +342,25 @@ public static class JumpList
         for (int i = 0; i < items.Count; i++)
         {
             var item = items[i];
-            try
+            if (item.Kind == JumpListItemKind.Separator)
             {
-                if (item.Kind == JumpListItemKind.Separator)
-                {
-                    list.Items.Add(global::Windows.UI.StartScreen.JumpListItem.CreateSeparator());
-                    continue;
-                }
+                list.Items.Add(global::Windows.UI.StartScreen.JumpListItem.CreateSeparator());
+                continue;
+            }
 
-                var native = global::Windows.UI.StartScreen.JumpListItem.CreateWithArguments(
-                    item.Arguments ?? string.Empty,
-                    item.Title);
-                if (!string.IsNullOrEmpty(item.Description))
-                    native.Description = item.Description;
-                if (item.Icon is { IsResource: true, Source: var src } && !string.IsNullOrEmpty(src))
-                    native.Logo = new Uri(src);
-                if (item.Kind == JumpListItemKind.Custom && !string.IsNullOrEmpty(item.GroupCategory))
-                    native.GroupName = item.GroupCategory;
-                list.Items.Add(native);
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"[Reactor] JumpList item add failed for '{item.Title}': {ex.GetType().Name}: {ex.Message}");
-            }
+            var native = global::Windows.UI.StartScreen.JumpListItem.CreateWithArguments(
+                item.Arguments ?? string.Empty,
+                item.Title);
+            if (!string.IsNullOrEmpty(item.Description))
+                native.Description = item.Description;
+            if (item.Icon is { IsResource: true, Source: var src } && !string.IsNullOrEmpty(src))
+                native.Logo = new Uri(src);
+            if (item.Kind == JumpListItemKind.Custom && !string.IsNullOrEmpty(item.GroupCategory))
+                native.GroupName = item.GroupCategory;
+            list.Items.Add(native);
         }
 
-        try
-        {
-            await list.SaveAsync();
-        }
-        catch (Exception ex)
-        {
-            Debug.WriteLine($"[Reactor] JumpList.SaveAsync failed: {ex.GetType().Name}: {ex.Message}");
-        }
+        await list.SaveAsync();
     }
 
     private static global::Windows.UI.StartScreen.JumpListSystemGroupKind ResolveSystemGroupKind()

--- a/src/Reactor/Hosting/Shell/JumpList.cs
+++ b/src/Reactor/Hosting/Shell/JumpList.cs
@@ -263,9 +263,11 @@ public static class JumpList
     /// <remarks>
     /// Clears any previously-set entries first; the OS-managed Recent and
     /// Frequent categories are unaffected (toggle them via
-    /// <see cref="ShowRecent"/> / <see cref="ShowFrequent"/>). Platform
-    /// failures (downlevel, group-policy lockdown, COM errors) propagate
-    /// as exceptions — callers may catch if fire-and-forget is desired.
+    /// <see cref="ShowRecent"/> / <see cref="ShowFrequent"/>). COM activation
+    /// and marshaling failures propagate as exceptions — callers may catch if
+    /// fire-and-forget is desired. Individual HRESULT failures from shell APIs
+    /// (e.g., <c>BeginList</c>, <c>CommitList</c>) are logged via
+    /// <see cref="Core.Diagnostics.DiagnosticLog"/> but do not throw.
     /// </remarks>
     public static async Task UpdateAsync(IEnumerable<JumpListItem> items)
     {

--- a/src/Reactor/Hosting/Shell/JumpListComInterop.cs
+++ b/src/Reactor/Hosting/Shell/JumpListComInterop.cs
@@ -45,8 +45,7 @@ internal static class JumpListComInterop
         try
         {
             cdl = (ICustomDestinationList)new DestinationList();
-            try { cdl.SetAppID(appUserModelId); }
-            catch (Exception ex) { Debug.WriteLine($"[Reactor] JumpList SetAppID failed: {ex.Message}"); }
+            cdl.SetAppID(appUserModelId);
 
             uint slotCount;
             var iidObjArray = typeof(IObjectArray).GUID;
@@ -80,23 +79,19 @@ internal static class JumpListComInterop
             if (taskItems.Count > 0)
             {
                 var coll = BuildShellLinkArray(taskItems);
-                if (coll is not null)
+                try
                 {
-                    try
-                    {
-                        var asArray = (IObjectArray)coll;
-                        int taskHr = cdl.AddUserTasks(asArray);
-                        if (taskHr < 0) DiagnosticLog.HResultFailed(LogCategory.Shell, "JumpList.AddUserTasks", taskHr);
-                    }
-                    finally { Marshal.ReleaseComObject(coll); }
+                    var asArray = (IObjectArray)coll;
+                    int taskHr = cdl.AddUserTasks(asArray);
+                    if (taskHr < 0) DiagnosticLog.HResultFailed(LogCategory.Shell, "JumpList.AddUserTasks", taskHr);
                 }
+                finally { Marshal.ReleaseComObject(coll); }
             }
 
             // Custom groups.
             foreach (var (category, list) in customGroups)
             {
                 var coll = BuildShellLinkArray(list);
-                if (coll is null) continue;
                 try
                 {
                     var asArray = (IObjectArray)coll;
@@ -121,20 +116,12 @@ internal static class JumpListComInterop
             if (commitHr < 0)
                 DiagnosticLog.HResultFailed(LogCategory.Shell, "JumpList.CommitList", commitHr);
         }
-        catch (Exception ex)
-        {
-            Debug.WriteLine($"[Reactor] JumpList unpackaged update threw: {ex.GetType().Name}: {ex.Message}");
-        }
         finally
         {
             if (removed is not null)
-            {
-                try { Marshal.ReleaseComObject(removed); } catch { }
-            }
+                Marshal.ReleaseComObject(removed);
             if (cdl is not null)
-            {
-                try { Marshal.ReleaseComObject(cdl); } catch { }
-            }
+                Marshal.ReleaseComObject(cdl);
         }
     }
 
@@ -160,61 +147,44 @@ internal static class JumpListComInterop
         }
     }
 
-    private static IObjectCollection? BuildShellLinkArray(IReadOnlyList<JumpListItem> items)
+    private static IObjectCollection BuildShellLinkArray(IReadOnlyList<JumpListItem> items)
     {
-        IObjectCollection? coll;
-        try { coll = (IObjectCollection)new EnumerableObjectCollection(); }
-        catch (Exception ex)
-        {
-            Debug.WriteLine($"[Reactor] EnumerableObjectCollection alloc failed: {ex.Message}");
-            return null;
-        }
+        var coll = (IObjectCollection)new EnumerableObjectCollection();
 
         // Path to the current executable. Jump-list shell links re-launch
         // the same exe with the supplied arguments.
-        string exePath;
-        try { exePath = Environment.ProcessPath ?? string.Empty; }
-        catch { exePath = string.Empty; }
+        string exePath = Environment.ProcessPath ?? string.Empty;
 
         for (int i = 0; i < items.Count; i++)
         {
             var item = items[i];
+            var link = (IShellLinkW)new CShellLink();
             try
             {
-                var link = (IShellLinkW)new CShellLink();
-                try
+                if (item.Kind == JumpListItemKind.Separator)
                 {
-                    if (item.Kind == JumpListItemKind.Separator)
-                    {
-                        ApplySeparator(link);
-                    }
-                    else
-                    {
-                        if (!string.IsNullOrEmpty(exePath))
-                            link.SetPath(exePath);
-                        link.SetArguments(item.Arguments ?? string.Empty);
-                        if (!string.IsNullOrEmpty(item.Description))
-                            link.SetDescription(item.Description);
-                        // Icon: WindowIcon.FromPath maps to filesystem; resource
-                        // URIs aren't honoured by ICustomDestinationList without
-                        // additional resource-extraction work that the unpackaged
-                        // path doesn't carry today (silently skipped).
-                        if (item.Icon is { IsResource: false, Source: var iconPath } && !string.IsNullOrEmpty(iconPath))
-                        {
-                            try { link.SetIconLocation(iconPath, 0); } catch { }
-                        }
-
-                        ApplyTitle(link, item.Title);
-                    }
-
-                    coll.AddObject(link);
+                    ApplySeparator(link);
                 }
-                finally { Marshal.ReleaseComObject(link); }
+                else
+                {
+                    if (!string.IsNullOrEmpty(exePath))
+                        link.SetPath(exePath);
+                    link.SetArguments(item.Arguments ?? string.Empty);
+                    if (!string.IsNullOrEmpty(item.Description))
+                        link.SetDescription(item.Description);
+                    // Icon: WindowIcon.FromPath maps to filesystem; resource
+                    // URIs aren't honoured by ICustomDestinationList without
+                    // additional resource-extraction work that the unpackaged
+                    // path doesn't carry today (silently skipped).
+                    if (item.Icon is { IsResource: false, Source: var iconPath } && !string.IsNullOrEmpty(iconPath))
+                        link.SetIconLocation(iconPath, 0);
+
+                    ApplyTitle(link, item.Title);
+                }
+
+                coll.AddObject(link);
             }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"[Reactor] BuildShellLinkArray item '{item.Title}' failed: {ex.Message}");
-            }
+            finally { Marshal.ReleaseComObject(link); }
         }
         return coll;
     }
@@ -232,7 +202,7 @@ internal static class JumpListComInterop
         }
         finally
         {
-            try { PropVariantClear(ref pv); } catch { }
+            PropVariantClear(ref pv);
         }
     }
 
@@ -249,7 +219,7 @@ internal static class JumpListComInterop
         }
         finally
         {
-            try { PropVariantClear(ref pv); } catch { }
+            PropVariantClear(ref pv);
         }
     }
 

--- a/tests/Reactor.Tests/JumpListUpdateValidationTests.cs
+++ b/tests/Reactor.Tests/JumpListUpdateValidationTests.cs
@@ -138,8 +138,7 @@ public class JumpListUpdateValidationTests : IDisposable
 
     // ══════════════════════════════════════════════════════════════
     //  UpdateAsync happy(-ish) path — items pass validation, the
-    //  COM call inside Task.Run fails, the catch swallows. The
-    //  outer Task completes without throwing.
+    //  COM call inside Task.Run fails, the exception propagates.
     // ══════════════════════════════════════════════════════════════
 
     [Fact]
@@ -155,8 +154,11 @@ public class JumpListUpdateValidationTests : IDisposable
             new JumpListItem("Open", "open --doc /path"),
             new JumpListItem("Help", "help"),
         };
-        // In unit test context, the platform call fails — exception must propagate.
-        await Assert.ThrowsAnyAsync<Exception>(
+        // In unit test context, the platform call fails — must be a platform
+        // exception (COM/EntryPoint/DllNotFound), NOT a validation exception.
+        var ex = await Assert.ThrowsAnyAsync<Exception>(
             async () => await JumpList.UpdateAsync(items));
+        Assert.False(ex is ArgumentException or InvalidOperationException,
+            $"Expected a platform failure, not a validation exception: {ex.GetType().Name}: {ex.Message}");
     }
 }

--- a/tests/Reactor.Tests/JumpListUpdateValidationTests.cs
+++ b/tests/Reactor.Tests/JumpListUpdateValidationTests.cs
@@ -82,11 +82,12 @@ public class JumpListUpdateValidationTests : IDisposable
         // Pin: separators bypass the empty-title check (they have no
         // text to render). Setting AppUserModelId so the unpackaged path
         // is reachable, then expecting NO exception from the validation
-        // loop. The downstream COM call will fail silently — its catch
-        // arms are tested elsewhere.
+        // loop. The downstream COM call will fail (no shell context in
+        // unit tests) — that's fine; we only care that validation passed.
         JumpList.AppUserModelId = "Test.App";
         var sep = new JumpListItem(Title: "", Arguments: "", Kind: JumpListItemKind.Separator);
-        // Should not throw from the validation loop.
+        // Should not throw ArgumentException or InvalidOperationException from
+        // the validation loop. COM exceptions are expected and acceptable.
         try
         {
             await JumpList.UpdateAsync(new[] { sep });
@@ -99,8 +100,14 @@ public class JumpListUpdateValidationTests : IDisposable
         {
             Assert.Fail("Separator-with-empty-title must not raise an ArgumentException.");
         }
-        // Other exceptions (COM-related) are expected and caught by
-        // UpdateAsync's catch arms — they don't bubble.
+        catch (global::System.Runtime.InteropServices.COMException)
+        {
+            // Expected — no shell context in unit tests.
+        }
+        catch (global::System.EntryPointNotFoundException)
+        {
+            // Expected — propsys.dll entry points may be unavailable in test context.
+        }
     }
 
     [Fact]
@@ -136,21 +143,20 @@ public class JumpListUpdateValidationTests : IDisposable
     // ══════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task UpdateAsync_With_Valid_Items_And_AumiD_Does_Not_Throw_Even_When_COM_Fails()
+    public async Task UpdateAsync_With_Valid_Items_And_AumiD_Throws_When_COM_Unavailable()
     {
-        // The catch arm around `Task.Run(() => UpdateUnpackaged(...))`
-        // protects callers from COM init failures (test context,
-        // remote-desktop sessions without taskbar, group-policy-locked
-        // shells). Bug shape: a regression that propagated the COM
-        // exception would crash every host launch path that updates
-        // the jump list at startup.
+        // With exceptions no longer swallowed, COM/platform failures (test
+        // context, remote-desktop sessions without taskbar, group-policy-
+        // locked shells) propagate to callers. Callers who want fire-and-
+        // forget semantics should catch at their call site.
         JumpList.AppUserModelId = "Test.App";
         var items = new[]
         {
             new JumpListItem("Open", "open --doc /path"),
             new JumpListItem("Help", "help"),
         };
-        // Must not throw.
-        await JumpList.UpdateAsync(items);
+        // In unit test context, the platform call fails — exception must propagate.
+        await Assert.ThrowsAnyAsync<Exception>(
+            async () => await JumpList.UpdateAsync(items));
     }
 }


### PR DESCRIPTION
Remove defensive try/catch blocks that swallowed exceptions silently. Platform failures (COM errors, missing DLLs, group policy) now propagate to callers, letting them decide on error handling strategy.

**Kept only:**
- \TryUpdatePackaged\ feature-detection catch (logic, not error suppression)
- \DeleteListForTests\ best-effort catch (test helper)

**Removed 12 try/catch blocks** that were either:
- Catching exceptions that can't actually be thrown (\[PreserveSig]\ methods, \PropVariantClear\ returning int, \Marshal.ReleaseComObject\ on known COM objects)
- Redundantly double-catching (JumpListComInterop catch + JumpList.cs catch)
- Silently swallowing platform errors that callers should be able to handle

Updated doc comments to reflect the new contract and adjusted tests to verify exceptions propagate correctly.

**Test results:** 8388 unit tests passed, 735 selftests passed.