### PR TITLE
ci: add AOT Selftests job to gate against NativeAOT regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,57 @@ jobs:
       - name: Build
         run: dotnet build Reactor.slnx --no-restore --configuration Release
 
+  aot-selftests:
+    name: AOT Selftests
+    needs: changes
+    if: needs.changes.outputs.non-md == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: 10.0.x
+
+      # Publish the selftest host with NativeAOT. PublishAotInternal=true,
+      # Platform=x64, and rid=win-x64 are the canonical knobs documented in
+      # docs/aot-support.md and used by tests/Reactor.AppTests.Host/probe-aot-skips.ps1.
+      - name: Publish AOT host
+        run: >
+          dotnet publish tests/Reactor.AppTests.Host
+          -p:PublishAotInternal=true
+          -p:Platform=x64
+          -r win-x64
+          -c Release
+          --nologo
+
+      # Run the published exe directly (not via `dotnet test`) so we exercise
+      # the NativeAOT binary. SelfTestRunner.DefaultAotSkipPatterns gates the
+      # known reflection-bound failures (40 fixtures across Devtools/MCP,
+      # PropertyGrid auto-discovery, Issue142 XAML metadata, and two framework
+      # cases); any *new* failure surfaces as exit code 1 and fails the job.
+      # See docs/aot-support.md for the skip-list debugging workflow.
+      - name: Run AOT selftests
+        shell: pwsh
+        run: |
+          $exe = 'tests/Reactor.AppTests.Host/bin/x64/Release/net10.0-windows10.0.22621.0/win-x64/publish/Reactor.AppTests.Host.exe'
+          if (-not (Test-Path $exe)) {
+            Write-Error "AOT-published host not found at $exe"
+            exit 1
+          }
+          & $exe --self-test 2>&1 | Tee-Object -FilePath aot-selftest-output.tap
+          exit $LASTEXITCODE
+
+      - name: Upload TAP output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: aot-selftest-tap
+          path: aot-selftest-output.tap
+          if-no-files-found: ignore
+
   docs-check-tier:
     name: Docs tier-drift
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,8 @@ jobs:
       # Publish the selftest host with NativeAOT. PublishAotInternal=true,
       # Platform=x64, and rid=win-x64 are the canonical knobs documented in
       # docs/aot-support.md and used by tests/Reactor.AppTests.Host/probe-aot-skips.ps1.
+      # `-o` pins the publish folder so the run step doesn't depend on the
+      # default TFM/RID/Platform path layout.
       - name: Publish AOT host
         run: >
           dotnet publish tests/Reactor.AppTests.Host
@@ -167,6 +169,7 @@ jobs:
           -p:Platform=x64
           -r win-x64
           -c Release
+          -o ${{ runner.temp }}/aot-publish
           --nologo
 
       # Run the published exe directly (not via `dotnet test`) so we exercise
@@ -178,7 +181,7 @@ jobs:
       - name: Run AOT selftests
         shell: pwsh
         run: |
-          $exe = 'tests/Reactor.AppTests.Host/bin/x64/Release/net10.0-windows10.0.22621.0/win-x64/publish/Reactor.AppTests.Host.exe'
+          $exe = Join-Path '${{ runner.temp }}/aot-publish' 'Reactor.AppTests.Host.exe'
           if (-not (Test-Path $exe)) {
             Write-Error "AOT-published host not found at $exe"
             exit 1

--- a/docs/aot-support.md
+++ b/docs/aot-support.md
@@ -42,6 +42,7 @@ These subsystems compile cleanly with `IsAotCompatible=true` (the warnings are s
 - **The library compiles AOT-clean.** Builds of `Reactor.csproj` produce zero IL2*/IL3* warnings. New code that reaches for reflection must either be source-generated, annotated with `DynamicallyAccessedMembers`, or — as a last resort — gated behind `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` so consumers see the warning at the call site.
 - **Suppressions are temporary.** Every `[UnconditionalSuppressMessage("Trimming", ...)]` or `("AOT", ...)` in this repo is a TODO. The justification field names the reflection use; tracking is folded into issue #70.
 - **The benchmark canary.** `tests/stress_perf/StressPerf.Reactor` (and the `StressPerf.Direct`/`ReactorGrid` siblings) set `PublishAot=true`. If they stop publishing, an AOT regression has landed in the framework.
+- **The runtime canary.** CI's `AOT Selftests` job (`.github/workflows/ci.yml`) publishes `tests/Reactor.AppTests.Host` with `PublishAotInternal=true` and runs the full selftest suite against the NativeAOT binary on every PR. `SelfTestRunner.DefaultAotSkipPatterns` mutes the known reflection-bound fixtures (Devtools/MCP, PropertyGrid auto-discovery, Issue142 XAML metadata, plus the two framework cases under investigation); any *new* failure fails the job. If you intentionally need to add a skip, document the bucket in the comment above `DefaultAotSkipPatterns` and re-probe with `tests/Reactor.AppTests.Host/probe-aot-skips.ps1`.
 
 ## Required publish-time workarounds
 


### PR DESCRIPTION
## Summary

Adds a new `AOT Selftests` job to `.github/workflows/ci.yml` that runs in parallel with the existing CI jobs. It publishes `tests/Reactor.AppTests.Host` with `PublishAotInternal=true` and executes the published `.exe` with `--self-test` against the NativeAOT binary — locking in today''s "2514 pass / 40 skip / 0 fail" baseline as a PR gate.

## Why

We currently exercise the selftest suite under the JIT only. NativeAOT regressions (a new reflection use, a missing trim annotation, a fixture that quietly starts crashing) ship to `main` undetected — caught only when someone manually re-publishes the Host. This job closes that gap.

## How the gate behaves

- `SelfTestRunner.DefaultAotSkipPatterns` continues to mute the 40 known reflection-bound fixtures (Devtools/MCP, PropertyGrid auto-discovery, Issue142 XAML metadata, plus two framework cases under investigation). They emit `# SKIP` as today.
- Any **new** failure — a fixture that starts failing, or a skip entry that is removed — surfaces as exit 1 and fails the job, blocking the PR.
- Adding a new skip requires editing `DefaultAotSkipPatterns` with a categorised comment and re-running `tests/Reactor.AppTests.Host/probe-aot-skips.ps1` to confirm the bucket. `docs/aot-support.md` now points to this workflow.

## Baseline (verified locally against this branch)

```
Total fixtures : 2554
ok             : 2514
SKIP           : 40   (matches DefaultAotSkipPatterns exactly)
not ok         : 0
Exit code      : 0
```

Probe of all 40 skips: every one is `ASSERT_FAIL` — zero native crashes, zero hangs (the WindowsAppSDK#6394 `.pri` copy workaround from #360 is fully effective). Buckets:

| Count | Bucket | Reason (per docs/aot-support.md) |
|-------|--------|----------------------------------|
| 27 | Devtools / MCP | Reflection-heavy JSON-RPC tool discovery (#70) |
| 9  | PropertyGrid auto-discovery | `TypeRegistry.Resolve` + reflection editor instantiation (#70) |
| 2  | Issue142 XAML metadata | Third-party assemblies without `.xaml` lack `IXamlMetadataProvider` (#142) |
| 2  | Framework — under investigation | `ControlUpdate_Collections`, `CoreCov2_UseObservableTreeHook` (likely `UseObservable`-on-POCO via `ObservableTreeTracker`, #70) |

## Job details

- **Parallel:** `needs: changes` only — runs alongside `unit-tests`, `selftests`, `integration-tests`, `build-solution`, `docs-compile`.
- **Skip on docs-only PRs:** same `non-md` gate as siblings (avoids ~5 min of publish time when irrelevant).
- **Runner:** `windows-latest` (same as `selftests`).
- **Timeout:** `30m`. Local measurements: AOT publish ~3-5 min, selftest run ~10-15 s.
- **Artifact:** TAP output uploaded as `aot-selftest-tap` on every run (success or failure) for triage.

## Files changed

- `.github/workflows/ci.yml` — new `aot-selftests` job (+51 lines)
- `docs/aot-support.md` — "runtime canary" bullet next to the existing "benchmark canary" entry (+1 line)
