### PR TITLE
ci: add managed-mode BinSkim scan to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,18 @@ jobs:
         run: dotnet tool install --global minver-cli --version 5.0.0
 
       - name: Install BinSkim
-        run: dotnet tool install --global Microsoft.CodeAnalysis.BinSkim
+        # BinSkim ships as a regular NuGet package containing BinSkim.exe,
+        # not as a dotnet global tool. Download the package and resolve the
+        # exe path into an env var for the analyze step.
+        shell: pwsh
+        run: |
+          nuget install Microsoft.CodeAnalysis.BinSkim -OutputDirectory binskim-pkg -ExcludeVersion
+          $exe = Get-ChildItem binskim-pkg -Filter BinSkim.exe -Recurse |
+            Where-Object { $_.FullName -like '*win-x64*' } |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $exe) { throw 'BinSkim.exe not found in package' }
+          "BINSKIM_EXE=$exe" >> $env:GITHUB_ENV
+          Write-Host "BinSkim: $exe"
 
       - name: Resolve version
         id: version
@@ -146,7 +157,7 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path artifacts/binskim | Out-Null
-          binskim analyze `
+          & $env:BINSKIM_EXE analyze `
             "artifacts/nupkg/*.nupkg" `
             "artifacts/mur/x64/*.dll" `
             "artifacts/mur/x64/*.exe" `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Install minver-cli
         run: dotnet tool install --global minver-cli --version 5.0.0
 
+      - name: Install BinSkim
+        run: dotnet tool install --global Microsoft.CodeAnalysis.BinSkim
+
       - name: Resolve version
         id: version
         shell: pwsh
@@ -131,6 +134,34 @@ jobs:
           --self-contained false
           -p:Version=${{ steps.version.outputs.version }}
           -o artifacts/mur/arm64
+
+      # Managed-only repo: most native PE-hardening rules no-op against MSIL
+      # assemblies. The run produces a SARIF for SDL compliance attestation
+      # (ADO 62373198). Initial rollout is informational — `continue-on-error`
+      # keeps the release pipeline green while findings are triaged. The
+      # SARIF artifact is uploaded unconditionally so reviewers can attach it
+      # to the work item.
+      - name: Run BinSkim
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path artifacts/binskim | Out-Null
+          binskim analyze `
+            "artifacts/nupkg/*.nupkg" `
+            "artifacts/mur/x64/*.dll" `
+            "artifacts/mur/x64/*.exe" `
+            "artifacts/mur/arm64/*.dll" `
+            "artifacts/mur/arm64/*.exe" `
+            --output artifacts/binskim/binskim.sarif `
+            --recurse
+
+      - name: Upload BinSkim SARIF
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binskim-${{ steps.version.outputs.version }}
+          path: artifacts/binskim/binskim.sarif
+          retention-days: 30
 
       - name: Assemble skill kit
         shell: pwsh


### PR DESCRIPTION
## Summary

- Adds `Install BinSkim`, `Run BinSkim`, and `Upload BinSkim SARIF` steps to `.github/workflows/release.yml`
- Scans `artifacts/nupkg/*.nupkg` plus the `mur` x64 + arm64 publish outputs (`*.dll`, `*.exe`)
- Uploads `binskim.sarif` as workflow artifact `binskim-<version>` (30-day retention, `if: always()`)
- Initial rollout is informational (`continue-on-error: true`) so first-run findings can be triaged before the gate becomes blocking

Satisfies SDL Applications Security policy 270 — tracked as ADO [62373198](https://dev.azure.com/microsoft/OS/_workitems/edit/62373198). Reactor ships only managed .NET assemblies and a framework-dependent `mur.exe`, so most native PE-hardening rules will no-op; the run still produces the SARIF needed for compliance attestation.

## Test plan

- [ ] `Package` workflow completes successfully on this PR
- [ ] `Run BinSkim` step appears in workflow log, runs to completion (with or without findings)
- [ ] `binskim-<version>` artifact uploaded and downloadable from the workflow run
- [ ] SARIF file parses (open in VS Code or `sarif-tools`)
- [ ] If findings exist: triage list captured before flipping `continue-on-error` to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)