### PR TITLE
FlexPanel: address PR #366 review feedback (rename attached DPs)

### DIFF
--- a/docs/_pipeline/templates/flex-layout.md.dt
+++ b/docs/_pipeline/templates/flex-layout.md.dt
@@ -47,7 +47,7 @@ enum types.
 | `ColumnGap` / `RowGap` | container (`with { ... }`) | Spacing between children — applies between wrapped lines too |
 | `FlexPadding` | container (`with { ... }`) | Inside-container padding measured by Yoga (distinct from the `.Padding(...)` modifier) |
 | `.Flex(grow:, shrink:, basis:)` | child | Main-axis sizing |
-| `.Flex(minWidth:, minHeight:)` | child | Override CSS §4.5 auto-min on the main axis (`null` = `min-content` floor; `0` = no floor) |
+| `.Flex(minWidth:, minHeight:)` | child | Override CSS §4.5 auto-min on the main axis (`null` = CSS `auto`; `0` = no floor; positive = hard floor). See the [Min sizing](#min-sizing-css-45) table for how `auto` resolves. |
 | `.Flex(alignSelf:)` | child | Override the container's `AlignItems` for one child |
 
 ## Direction

--- a/src/Reactor/Core/ElementPool.cs
+++ b/src/Reactor/Core/ElementPool.cs
@@ -244,8 +244,8 @@ public sealed class ElementPool : IDisposable
         fe.ClearValue(Layout.FlexPanel.GrowProperty);
         fe.ClearValue(Layout.FlexPanel.ShrinkProperty);
         fe.ClearValue(Layout.FlexPanel.BasisProperty);
-        fe.ClearValue(Layout.FlexPanel.MinWidthProperty);
-        fe.ClearValue(Layout.FlexPanel.MinHeightProperty);
+        fe.ClearValue(Layout.FlexPanel.FlexMinWidthProperty);
+        fe.ClearValue(Layout.FlexPanel.FlexMinHeightProperty);
         fe.ClearValue(Layout.FlexPanel.AlignSelfProperty);
         fe.ClearValue(Layout.FlexPanel.PositionProperty);
         fe.ClearValue(Layout.FlexPanel.LeftProperty);

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -3528,9 +3528,9 @@ public sealed partial class Reconciler
         if (fa is { Basis: { } basis }) Layout.FlexPanel.SetBasis(ctrl, basis);
         else ctrl.ClearValue(Layout.FlexPanel.BasisProperty);
         if (fa is { MinWidth: { } minWidth }) Layout.FlexPanel.SetMinWidth(ctrl, minWidth);
-        else ctrl.ClearValue(Layout.FlexPanel.MinWidthProperty);
+        else ctrl.ClearValue(Layout.FlexPanel.FlexMinWidthProperty);
         if (fa is { MinHeight: { } minHeight }) Layout.FlexPanel.SetMinHeight(ctrl, minHeight);
-        else ctrl.ClearValue(Layout.FlexPanel.MinHeightProperty);
+        else ctrl.ClearValue(Layout.FlexPanel.FlexMinHeightProperty);
         if (fa is { AlignSelf: { } alignSelf }) Layout.FlexPanel.SetAlignSelf(ctrl, alignSelf);
         else ctrl.ClearValue(Layout.FlexPanel.AlignSelfProperty);
         Layout.FlexPanel.SetPosition(ctrl, fa?.Position ?? Layout.FlexPositionType.Relative);

--- a/src/Reactor/Yoga/FlexPanel.cs
+++ b/src/Reactor/Yoga/FlexPanel.cs
@@ -181,16 +181,19 @@ public partial class FlexPanel : Panel
     // (including 0) is treated as an explicit point min that suppresses the
     // auto/min-content heuristic.
     //
-    // The `new` modifier intentionally shadows FrameworkElement.MinWidthProperty.
-    // These are attached DPs that drive Yoga's flex distribution; the inherited
-    // properties drive WinUI's own Measure. They coexist on the same control:
-    // FrameworkElement.MinWidth = X forces Measure to return ≥X; this attached
-    // property tells Yoga to clamp the flex-resolved slot to ≥X.
-    public static new readonly DependencyProperty MinWidthProperty =
+    // These are named `FlexMinWidthProperty`/`FlexMinHeightProperty` rather
+    // than `MinWidthProperty`/`MinHeightProperty` to avoid shadowing
+    // `FrameworkElement.MinWidthProperty`/`MinHeightProperty` on this public
+    // type. The inherited WinUI DPs and these attached Yoga DPs coexist on
+    // the same control with different semantics: `FrameworkElement.MinWidth`
+    // forces Measure to return ≥X; this attached property tells Yoga to
+    // clamp the flex-resolved slot to ≥X. Setting one does not affect the
+    // other (see `CssWinUI_NativeMinWidthSeparateFromFlexMinWidth` selftest).
+    public static readonly DependencyProperty FlexMinWidthProperty =
         DependencyProperty.RegisterAttached("FlexMinWidth", typeof(double), typeof(FlexPanel),
             new PropertyMetadata(double.NaN, OnChildPropertyChanged));
 
-    public static new readonly DependencyProperty MinHeightProperty =
+    public static readonly DependencyProperty FlexMinHeightProperty =
         DependencyProperty.RegisterAttached("FlexMinHeight", typeof(double), typeof(FlexPanel),
             new PropertyMetadata(double.NaN, OnChildPropertyChanged));
 
@@ -228,11 +231,11 @@ public partial class FlexPanel : Panel
     public static void SetBasis(UIElement el, double value) => el.SetValue(BasisProperty, value);
     public static double GetBasis(UIElement el) => (double)el.GetValue(BasisProperty);
 
-    public static void SetMinWidth(UIElement el, double value) => el.SetValue(MinWidthProperty, value);
-    public static double GetMinWidth(UIElement el) => (double)el.GetValue(MinWidthProperty);
+    public static void SetMinWidth(UIElement el, double value) => el.SetValue(FlexMinWidthProperty, value);
+    public static double GetMinWidth(UIElement el) => (double)el.GetValue(FlexMinWidthProperty);
 
-    public static void SetMinHeight(UIElement el, double value) => el.SetValue(MinHeightProperty, value);
-    public static double GetMinHeight(UIElement el) => (double)el.GetValue(MinHeightProperty);
+    public static void SetMinHeight(UIElement el, double value) => el.SetValue(FlexMinHeightProperty, value);
+    public static double GetMinHeight(UIElement el) => (double)el.GetValue(FlexMinHeightProperty);
 
     public static void SetAlignSelf(UIElement el, FlexAlign value) => el.SetValue(AlignSelfProperty, value);
     public static FlexAlign GetAlignSelf(UIElement el) => (FlexAlign)el.GetValue(AlignSelfProperty);
@@ -703,8 +706,9 @@ public partial class FlexPanel : Panel
                     // panel itself, defeating flex-grow distribution.
                     //
                     // CSS Flexbox §4.5 min-content floor is enforced separately
-                    // via node.Style.MinDimensions in ApplyAttachedProperties —
-                    // see the auto-min computation there.
+                    // by writing `node.MinWidth` / `node.MinHeight` in
+                    // ApplyAttachedProperties — see ResolveMinDimension and
+                    // ComputeMinContent there.
                     var outW = (float)(capturedChild.DesiredSize.Width - mH);
                     var outH = (float)(capturedChild.DesiredSize.Height - mV);
                     if (wMode == YogaMeasureMode.Exactly) outW = (float)w;

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlexPanelCssBehaviorFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlexPanelCssBehaviorFixtures.cs
@@ -976,7 +976,7 @@ internal static class FlexPanelCssBehaviorFixtures
             // Simulate prior layout that set MinWidth=200.
             Microsoft.UI.Reactor.Layout.FlexPanel.SetMinWidth(paneA, 200);
             // Then a "release to pool" cycle: ClearValue mirrors ElementPool.
-            paneA.ClearValue(Microsoft.UI.Reactor.Layout.FlexPanel.MinWidthProperty);
+            paneA.ClearValue(Microsoft.UI.Reactor.Layout.FlexPanel.FlexMinWidthProperty);
 
             Microsoft.UI.Reactor.Layout.FlexPanel.SetGrow(paneA, 1);
             Microsoft.UI.Reactor.Layout.FlexPanel.SetShrink(paneA, 1);
@@ -1072,7 +1072,7 @@ internal static class FlexPanelCssBehaviorFixtures
 
     /// <summary>
     /// **WinUI divergence**: `FrameworkElement.MinWidth` (inherited DP) and
-    /// `FlexPanel.MinWidth` (our attached DP) are TWO different properties.
+    /// `FlexPanel.FlexMinWidth` (our attached DP) are TWO different properties.
     /// The inherited one applies during WinUI Measure; the attached one is
     /// what Yoga reads as the flex auto-min floor. Setting one does not
     /// affect the other.


### PR DESCRIPTION
Follow-up to #366 addressing the three review findings from Copilot's review.

## What changed

### 1. Rename `FlexPanel.MinWidthProperty` / `MinHeightProperty` → `FlexMinWidthProperty` / `FlexMinHeightProperty`

The original PR used `public static new readonly DependencyProperty MinWidthProperty` / `MinHeightProperty` to shadow the inherited `FrameworkElement` DPs of the same names. The `new` keyword silently changed what `FlexPanel.MinWidthProperty` refers to — any caller using that expression to reach the inherited native DP would have been redirected to the new attached DP, with different semantics. This is the source-level behavior change the reviewer flagged.

After this PR, `FlexPanel.MinWidthProperty` resolves to the inherited `FrameworkElement.MinWidthProperty` again (as it did before #366). The attached DPs are reached via the explicit `FlexMinWidthProperty` / `FlexMinHeightProperty` names. The accessor methods `Set/GetMinWidth` / `Set/GetMinHeight` keep their existing names (they were never shadowing anything — `FrameworkElement` has no static `SetMinWidth` method).

Updated all references:
- `Reconciler.Update.cs` — `ApplyFlexAttached`
- `ElementPool.cs` — recycle clear
- `CssMin_StaleMinWidthCleared` selftest fixture (also updated its inline comment)

### 2. Fix stale comment in `FlexPanel.cs`

The MeasureFunc clamp comment referenced `node.Style.MinDimensions`, but `ApplyAttachedProperties` actually writes `node.MinWidth` / `node.MinHeight`. Updated the comment to point at the real mechanism (`ResolveMinDimension` / `ComputeMinContent`).

### 3. Fix docs at-a-glance row

The at-a-glance reference in `flex-layout.md.dt` said `null` means a `min-content` floor, contradicting the Min sizing table later on the same page where `null` is CSS `auto` (which can resolve to `0` when `basis: 0` short-circuits, or `min(basis, min-content)` when `basis > 0`). Reworded to `null = CSS auto` with a link to the §4.5 table.

## Verification

- **Build**: clean, 0 errors.
- **CssMin_* selftests**: 10/10 pass — including `CssMin_StaleMinWidthCleared` which directly references the renamed `FlexMinWidthProperty`.
- **AttachedExtensionsCoverageTests**: 17/17 pass.

## Notes

This is a tiny surgical PR — 5 files, +24 / -20. No behavior change for any caller using the public `.Flex(minWidth:, minHeight:)` DSL or the `SetMinWidth` / `GetMinWidth` accessors. The only consumers affected are any that referenced `FlexPanel.MinWidthProperty` / `MinHeightProperty` directly — and those callers now get the inherited DP (as they did pre-#366) rather than the new attached DP.
