### PR TITLE
fix(reconciler): reconcile Content for CommandBar + TeachingTip (#343)

### DIFF
--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -215,7 +215,7 @@ public sealed partial class Reconciler
             (ContentDialogElement o, ContentDialogElement n, FrameworkElement cdFe)
                 => UpdateContentDialog(o, n, cdFe, requestRerender),
             (TeachingTipElement o, TeachingTipElement n, WinUI.TeachingTip tip)
-                => UpdateTeachingTip(o, n, tip),
+                => UpdateTeachingTip(o, n, tip, requestRerender),
             (MenuBarElement o, MenuBarElement n, WinUI.MenuBar mb)
                 => UpdateMenuBar(o, n, mb),
             (CommandHostElement o, CommandHostElement n, WinUI.Grid chGrid)
@@ -2665,19 +2665,24 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateTeachingTip(TeachingTipElement o, TeachingTipElement n, WinUI.TeachingTip tip)
+    private UIElement? UpdateTeachingTip(TeachingTipElement o, TeachingTipElement n, WinUI.TeachingTip tip, Action requestRerender)
     {
         tip.Title = n.Title; tip.Subtitle = n.Subtitle ?? ""; tip.IsOpen = n.IsOpen;
         if (tip.PlacementMargin != n.PlacementMargin) tip.PlacementMargin = n.PlacementMargin;
         if (tip.PreferredPlacement != n.PreferredPlacement) tip.PreferredPlacement = n.PreferredPlacement;
         if (!ReferenceEquals(o.IconSource, n.IconSource) && n.IconSource is not null)
             tip.IconSource = ResolveIconSource(n.IconSource);
+        ReconcileChild(o.Content, n.Content,
+            () => tip.Content as UIElement,
+            c => tip.Content = c,
+            () => tip.Content = null,
+            requestRerender);
         // HeroContent is reconciled with a full re-mount on swap — TeachingTip
         // hero content isn't part of a typical hot path, so simple is better.
         if (!ReferenceEquals(o.HeroContent, n.HeroContent))
         {
             if (tip.HeroContent is UIElement stale) Unmount(stale);
-            tip.HeroContent = n.HeroContent is not null ? Mount(n.HeroContent, () => { }) : null;
+            tip.HeroContent = n.HeroContent is not null ? Mount(n.HeroContent, requestRerender) : null;
         }
         SetElementTag(tip, n);
         if (o.OnClosed is null && n.OnClosed is not null)
@@ -3314,6 +3319,12 @@ public sealed partial class Reconciler
         // Update primary commands in-place
         UpdateAppBarItems(cb.PrimaryCommands, n.PrimaryCommands);
         UpdateAppBarItems(cb.SecondaryCommands, n.SecondaryCommands);
+
+        ReconcileChild(o.Content, n.Content,
+            () => cb.Content as UIElement,
+            c => cb.Content = c,
+            () => cb.Content = null,
+            requestRerender);
 
         SetElementTag(cb, n);
         ApplySetters(n.Setters, cb);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue343Fixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue343Fixtures.cs
@@ -1,0 +1,116 @@
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Repro for https://github.com/microsoft/microsoft-ui-reactor/issues/343
+///
+/// CommandBar.Content (and the matching TeachingTip.Content) were assigned by
+/// Mount but never reconciled by Update, so data-driven content (e.g. a
+/// subtitle that reflects a state value) stayed frozen at its mount-time
+/// value across re-renders.
+///
+/// Each fixture mounts a control whose Content is a TextBlock bound to a
+/// useState counter, bumps the counter, and asserts the rendered text reflects
+/// the updated value. Before the fix the post-update text equals the
+/// mount-time text; after the fix it tracks the new state.
+/// </summary>
+internal static class Issue343Fixtures
+{
+    // ── CommandBar.Content is reconciled across re-renders ────────────────
+
+    internal class CommandBarContentUpdates(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (tick, setTick) = ctx.UseState(0);
+                var bar = CommandBar(primaryCommands: [AppBarButton("Save")])
+                    with { Content = TextBlock($"tick = {tick}").Set(t => t.Name = "Issue343_CmdContent") };
+                return VStack(
+                    Button("Issue343_BumpCmd", () => setTick(tick + 1)),
+                    bar
+                );
+            });
+
+            await Harness.Render();
+
+            var cb = H.FindControl<CommandBar>(_ => true);
+            H.Check("Issue343_CmdBar_Mounted", cb is not null);
+
+            var initial = H.FindControl<TextBlock>(t => t.Name == "Issue343_CmdContent");
+            H.Check("Issue343_CmdBar_InitialContent",
+                initial is not null && initial.Text == "tick = 0");
+
+            H.ClickButton("Issue343_BumpCmd");
+            await Harness.Render();
+            H.ClickButton("Issue343_BumpCmd");
+            await Harness.Render();
+            H.ClickButton("Issue343_BumpCmd");
+            await Harness.Render();
+
+            var afterBump = H.FindControl<TextBlock>(t => t.Name == "Issue343_CmdContent");
+            H.Check("Issue343_CmdBar_ContentReconciled",
+                afterBump is not null && afterBump.Text == "tick = 3");
+
+            // Identity is preserved: same TextBlock instance, just with updated Text.
+            H.Check("Issue343_CmdBar_ContentSameInstance",
+                initial is not null && ReferenceEquals(initial, afterBump));
+
+            // CommandBar itself should not be torn down either.
+            var cb2 = H.FindControl<CommandBar>(_ => true);
+            H.Check("Issue343_CmdBar_SameInstance",
+                cb is not null && ReferenceEquals(cb, cb2));
+        }
+    }
+
+    // ── TeachingTip.Content is reconciled across re-renders ───────────────
+
+    internal class TeachingTipContentUpdates(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (tick, setTick) = ctx.UseState(0);
+                // IsOpen=false keeps the content TextBlock in the tip's
+                // Content slot rather than pushed into a Popup, so we can
+                // read it directly off the TeachingTip control.
+                var tip = new TeachingTipElement("Hint")
+                {
+                    Content = TextBlock($"tip-tick = {tick}"),
+                };
+                return VStack(
+                    Button("Issue343_BumpTip", () => setTick(tick + 1)),
+                    tip
+                );
+            });
+
+            await Harness.Render();
+
+            var ttControl = H.FindControl<Microsoft.UI.Xaml.Controls.TeachingTip>(_ => true);
+            H.Check("Issue343_Tip_Mounted", ttControl is not null);
+            var initialContent = ttControl?.Content as TextBlock;
+            H.Check("Issue343_Tip_InitialContent",
+                initialContent is not null && initialContent.Text == "tip-tick = 0");
+
+            H.ClickButton("Issue343_BumpTip");
+            await Harness.Render();
+            H.ClickButton("Issue343_BumpTip");
+            await Harness.Render();
+
+            var ttControlAfter = H.FindControl<Microsoft.UI.Xaml.Controls.TeachingTip>(_ => true);
+            var afterContent = ttControlAfter?.Content as TextBlock;
+            H.Check("Issue343_Tip_ContentReconciled",
+                afterContent is not null && afterContent.Text == "tip-tick = 2");
+            H.Check("Issue343_Tip_ContentSameInstance",
+                initialContent is not null && ReferenceEquals(initialContent, afterContent));
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -560,6 +560,9 @@ internal static class SelfTestFixtureRegistry
         "IdentityPreserve_ListBox",
         "IdentityPreserve_SelectorBar",
         "IdentityPreserve_SplitView",
+        // Issue 343 — CommandBar/TeachingTip Content reconciliation
+        "Issue343_CommandBarContentUpdates",
+        "Issue343_TeachingTipContentUpdates",
         // Hooks coverage — FocusManager, UseFocus
         "HooksCov_FocusManagerRegistration",
         "HooksCov_FocusManagerNavigation",
@@ -1422,6 +1425,9 @@ internal static class SelfTestFixtureRegistry
         "IdentityPreserve_ListBox" => new IdentityPreservationFixtures.ListBoxSurvivesSiblingUpdate(harness),
         "IdentityPreserve_SelectorBar" => new IdentityPreservationFixtures.SelectorBarSurvivesSiblingUpdate(harness),
         "IdentityPreserve_SplitView" => new IdentityPreservationFixtures.SplitViewSurvivesSiblingUpdate(harness),
+        // Issue 343 — CommandBar/TeachingTip Content reconciliation
+        "Issue343_CommandBarContentUpdates" => new Issue343Fixtures.CommandBarContentUpdates(harness),
+        "Issue343_TeachingTipContentUpdates" => new Issue343Fixtures.TeachingTipContentUpdates(harness),
         "ControlsCov_SearchManager" => new ControlsCoverageFixtures.SearchManagerExercise(harness),
         // Hooks coverage
         "HooksCov_FocusManagerRegistration" => new HooksCoverageFixtures.FocusManagerRegistration(harness),


### PR DESCRIPTION
## Summary

- Fixes #343 — `CommandBar.Content` was assigned on mount but never reconciled, so data-driven content (e.g. a subtitle bound to a state value) stayed frozen at mount-time across re-renders.
- Audit of every control with a single `.Content` slot turned up the same bug in `TeachingTip` — same Mount-writes / Update-ignores shape. Fixed alongside.
- `UpdateCommandBar` and `UpdateTeachingTip` now call `ReconcileChild` for `Content`, mirroring the pattern already used by `InfoBar` / `Expander` / `NavigationView` / `TitleBar` / `SplitView`.
- `UpdateTeachingTip` now takes `requestRerender` so the existing `HeroContent` re-mount path (previously wired with `() => { }`) is also correct.

## Test plan

- [x] New `Issue343Fixtures` selftest with two fixtures — `Issue343_CommandBarContentUpdates`, `Issue343_TeachingTipContentUpdates` — that mount each control with `Content = TextBlock("tick = {state}")`, bump a `useState` counter, and assert the rendered content reflects the new state. Also asserts the underlying `TextBlock` and the parent `CommandBar` instances are preserved across the re-render (in-place reconcile, not a teardown).
- [x] Confirmed the new tests fail without the fix (`Issue343_CmdBar_ContentReconciled` and `Issue343_Tip_ContentReconciled` both report `not ok`) and pass with it.
- [x] Full selftest suite: **763/763 passing** (`dotnet test tests/Reactor.SelfTests -p:Platform=x64`).
- [x] Existing CommandBar / TeachingTip coverage (`CoreCov_CommandBarMountUpdate`, `RBC_CommandBarUpdate`, `RBC_CommandBarFlyoutPlacementSwap`, `RareControl_TeachingTip`, `RBC_TeachingTipMount`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)