### PR TITLE
ReactorHostControl: survive transient reparent (#344)

### DIFF
--- a/src/Reactor/Hosting/ReactorHostControl.cs
+++ b/src/Reactor/Hosting/ReactorHostControl.cs
@@ -279,7 +279,17 @@ public sealed partial class ReactorHostControl : ContentControl, IDisposable
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
-        Dispose();
+        // WinUI fires Unloaded on *any* reparent — transient (drag between
+        // TabView pivots, WinUI.Dock document moves, NavigationView header
+        // swap, ContentPresenter content swap, theme reload) as well as
+        // terminal teardown. There is no signal at this moment to tell the
+        // two cases apart, and disposing here makes a transient reparent
+        // permanently destroy the Reactor tree (issue #344).
+        //
+        // Treat Dispose() as consumer-driven (the IDisposable contract):
+        // the hosting app calls Dispose when it's truly done with the
+        // control. Until then we keep _rootComponent / _reconciler /
+        // Content alive so the tree survives reparenting.
     }
 
     /// <summary>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HostingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HostingCoverageFixtures.cs
@@ -357,7 +357,106 @@ internal static class HostingCoverageFixtures
     }
 
     // ════════════════════════════════════════════════════════════════════════
-    //  9. PreviewCaptureServer — HTTP/auth/CORS/component endpoints
+    //  9. ReactorHostControl — reparent (issue #344)
+    //     A raw-WinUI reparent (slotA.Child = null; slotB.Child = host) fires
+    //     Unloaded on the host. Before the fix, OnUnloaded called Dispose(),
+    //     blanking the tree permanently. After the fix, the Reactor tree
+    //     survives the reparent and remains interactive in its new slot.
+    // ════════════════════════════════════════════════════════════════════════
+
+    private class ReparentCounter : Microsoft.UI.Reactor.Core.Component
+    {
+        public override Element Render()
+        {
+            var (count, setCount) = UseState(0);
+            return VStack(
+                TextBlock($"Reparent:{count}"),
+                Button("ReparentBump", () => setCount(count + 1))
+            );
+        }
+    }
+
+    internal class HostControlReparentSurvives(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var hostControl = new ReactorHostControl();
+            hostControl.Mount(new ReparentCounter());
+
+            var slotA = new Border();
+            var slotB = new Border();
+            var root = new StackPanel();
+            root.Children.Add(slotA);
+            root.Children.Add(slotB);
+            slotA.Child = hostControl;
+            H.SetContent(root);
+            await Harness.Render(200);
+
+            // Initial mount in slot A renders + reacts to clicks.
+            var text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true);
+            H.Check("HostCtrlReparent_InitialMount", text?.Text == "Reparent:0");
+
+            var btn = FindInContainer<Button>(hostControl, b => b.Content is string s && s == "ReparentBump");
+            if (btn is not null)
+            {
+                var peer = new Microsoft.UI.Xaml.Automation.Peers.ButtonAutomationPeer(btn);
+                ((Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
+                    peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)).Invoke();
+            }
+            await Harness.Render(200);
+            text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true);
+            H.Check("HostCtrlReparent_PreReparentInteractive", text?.Text == "Reparent:1");
+
+            // Raw-WinUI reparent A -> B (drag between dock groups, TabView pivot, etc.)
+            slotA.Child = null;
+            slotB.Child = hostControl;
+            await Harness.Render(200);
+
+            // Tree must still be present and reflect the prior state (count == 1).
+            text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true);
+            H.Check("HostCtrlReparent_SurvivesReparent", text is not null);
+            H.Check("HostCtrlReparent_StatePreserved", text?.Text == "Reparent:1");
+
+            // And still interactive in the new slot.
+            btn = FindInContainer<Button>(hostControl, b => b.Content is string s && s == "ReparentBump");
+            if (btn is not null)
+            {
+                var peer = new Microsoft.UI.Xaml.Automation.Peers.ButtonAutomationPeer(btn);
+                ((Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
+                    peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)).Invoke();
+            }
+            await Harness.Render(200);
+            text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true);
+            H.Check("HostCtrlReparent_InteractiveAfterReparent", text?.Text == "Reparent:2");
+
+            // Reparent back B -> A: state persists, still interactive.
+            slotB.Child = null;
+            slotA.Child = hostControl;
+            await Harness.Render(200);
+
+            text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true);
+            H.Check("HostCtrlReparent_StatePreservedRoundTrip", text?.Text == "Reparent:2");
+
+            btn = FindInContainer<Button>(hostControl, b => b.Content is string s && s == "ReparentBump");
+            if (btn is not null)
+            {
+                var peer = new Microsoft.UI.Xaml.Automation.Peers.ButtonAutomationPeer(btn);
+                ((Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
+                    peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)).Invoke();
+            }
+            await Harness.Render(200);
+            text = FindInContainer<TextBlock>(hostControl, tb => tb.Text?.StartsWith("Reparent:") == true);
+            H.Check("HostCtrlReparent_InteractiveRoundTrip", text?.Text == "Reparent:3");
+
+            // Consumer-driven Dispose still works after a reparent cycle.
+            hostControl.Dispose();
+            H.Check("HostCtrlReparent_DisposeAfterReparent", true);
+            H.SetContent(null);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  10. PreviewCaptureServer — HTTP/auth/CORS/component endpoints
     //     Targets: PreviewCaptureServer request handling without external tools.
     // ════════════════════════════════════════════════════════════════════════
 

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -498,6 +498,7 @@ internal static class SelfTestFixtureRegistry
         "Hosting_HostDispose",
         "Hosting_PageHelperExercise",
         "Hosting_XamlInteropRegister",
+        "Hosting_HostControlReparentSurvives",
         "Hosting_PreviewCaptureServerEndpoints",
         // Navigation coverage — advanced handle ops, serialization, deep links, transitions
         "NavCov_HandleAdvancedOps",
@@ -1364,6 +1365,7 @@ internal static class SelfTestFixtureRegistry
         "Hosting_HostDispose" => new HostingCoverageFixtures.HostDispose(harness),
         "Hosting_PageHelperExercise" => new HostingCoverageFixtures.PageHelperExercise(harness),
         "Hosting_XamlInteropRegister" => new HostingCoverageFixtures.XamlInteropRegister(harness),
+        "Hosting_HostControlReparentSurvives" => new HostingCoverageFixtures.HostControlReparentSurvives(harness),
         "Hosting_PreviewCaptureServerEndpoints" => new HostingCoverageFixtures.PreviewCaptureServerEndpoints(harness),
         // Navigation coverage
         "NavCov_HandleAdvancedOps" => new NavigationCoverageFixtures.NavHandleAdvancedOps(harness),


### PR DESCRIPTION
## Summary

Fixes #344 — `ReactorHostControl.OnUnloaded` called `Dispose()` unconditionally. WinUI fires `Unloaded` on *any* reparent (TabView pivot, ContentPresenter swap, dock drag, theme reload), so a transient reparent permanently destroyed the Reactor tree: even moving back to the original parent left the host blank.

- Make `OnUnloaded` a no-op. `Dispose()` is now purely consumer-driven via `IDisposable`, matching how `ReactorHost` binds its terminal lifecycle to `Window.Closed` (a genuinely terminal signal).
- `OnLoaded` already early-returns when `_rootComponent`/`_rootRenderFunc` is set, so a second `Loaded` after reparent is a safe no-op.
- Added `Hosting_HostControlReparentSurvives` selftest that mounts a counter, reparents the host between two `Border` slots, and verifies the tree + hook state survive each move.

## Test plan

- [x] Selftest fails on `main` (5/8 assertions) and passes with the fix (8/8).
- [x] `dotnet test tests/Reactor.SelfTests --filter Name~Hosting_` — all 10 Hosting fixtures pass.
- [x] `dotnet test tests/Reactor.Tests` — 8397/8397 unit tests pass.

## Related patterns worth flagging (not fixed here)

- `src/Reactor/Yoga/FlexPanel.cs:59` — `OnUnloaded` clears the entire `YogaNode` cache. Not destructive (next measure rebuilds), but a perf cliff on any transient FlexPanel reparent; worth revisiting whether the clear still earns its keep now that `SyncYogaTree` handles per-child removal during normal layout.
- General lesson: `Loaded`/`Unloaded` aren't lifecycle terminals in WinUI — they fire on every reparent. Terminal work belongs on `Window.Closed`, explicit `Dispose()`, or a finalizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)