### PR TITLE
analyzer: REACTOR_POOL_001 — flag .Set writes to pool-reset properties (#346)

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -119,6 +119,7 @@ via `.editorconfig`.
 | `REACTOR_DSL_001` | Warning | Dynamic list item missing .WithKey | `MissingWithKeyAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_DOC_002` | Warning | XML doc cref does not resolve | `XmlDocCrefAnalyzer.cs` |
+| `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -16,3 +16,4 @@ REACTOR_A11Y_003 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityA
 REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list item missing .WithKey
 REACTOR_DOC_001 | Reactor.Documentation | Warning | XmlDocSummaryAnalyzer - Public API missing XML doc summary
 REACTOR_DOC_002 | Reactor.Documentation | Warning | XmlDocCrefAnalyzer - XML doc cref does not resolve
+REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier

--- a/src/Reactor.Analyzers/PoolResetSetAnalyzer.cs
+++ b/src/Reactor.Analyzers/PoolResetSetAnalyzer.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// REACTOR_POOL_001: Detects <c>.Set(fe =&gt; fe.PROP = ...)</c> patterns where
+/// <c>PROP</c> is a FrameworkElement property that <c>ElementPool.CleanElement</c>
+/// resets on pool return (or that the reconciler clears between renders), and a
+/// Reactor modifier exists that survives the reset. Suggests the fluent modifier.
+/// </summary>
+/// <remarks>
+/// The pool reset is intentional — it's how Reactor guarantees a clean rental.
+/// But it makes <c>.Set(...)</c> writes to these properties silently disappear
+/// on re-render. The modifier path (stored on <c>Element.Modifiers</c>) is
+/// re-applied by the reconciler every render and so survives pool reuse.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PoolResetSetAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_POOL_001";
+
+    /// <summary>
+    /// FrameworkElement property → Reactor modifier method name.
+    /// Each entry must be:
+    ///   - a property reset in <c>src/Reactor/Core/ElementPool.cs CleanElement(...)</c>
+    ///     (or otherwise cleared between renders by the reconciler), AND
+    ///   - have a corresponding modifier in <c>ElementExtensions.cs</c> that
+    ///     stores into <c>ElementModifiers</c> and is re-applied each render.
+    /// Keep this list in sync with both files when either changes.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, string> TrappedProperties =
+        new Dictionary<string, string>(System.StringComparer.Ordinal)
+        {
+            { "Margin",              "Margin" },
+            { "Width",               "Width" },
+            { "Height",              "Height" },
+            { "MinWidth",            "MinWidth" },
+            { "MinHeight",           "MinHeight" },
+            { "MaxWidth",            "MaxWidth" },
+            { "MaxHeight",           "MaxHeight" },
+            { "HorizontalAlignment", "HorizontalAlignment" },
+            { "VerticalAlignment",   "VerticalAlignment" },
+            { "Opacity",             "Opacity" },
+            { "AccessKey",           "AccessKey" },
+        };
+
+    private static readonly LocalizableString Title =
+        "Use modifier instead of .Set for pool-reset property";
+
+    private static readonly LocalizableString MessageFormat =
+        "'{0}' is reset on pool return; '.Set(...)' writes to it are lost on re-render. Use '.{1}(...)' modifier instead.";
+
+    private static readonly LocalizableString Description =
+        "The element pool clears these FrameworkElement properties when a control is " +
+        "returned for reuse, and the reconciler re-applies the modifier chain on every " +
+        "render. Imperative '.Set(...)' assignments to these properties survive the " +
+        "first render but disappear on the next reconcile. Use the corresponding " +
+        "fluent modifier (stored on Element.Modifiers) so the value survives pool reuse.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Pool",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+        if (memberAccess.Name.Identifier.Text != "Set")
+            return;
+
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count != 1)
+            return;
+
+        ExpressionSyntax? body = args[0].Expression switch
+        {
+            SimpleLambdaExpressionSyntax simple => simple.ExpressionBody,
+            ParenthesizedLambdaExpressionSyntax paren => paren.ExpressionBody,
+            _ => null,
+        };
+
+        if (body is not AssignmentExpressionSyntax assignment)
+            return;
+        if (assignment.Kind() != SyntaxKind.SimpleAssignmentExpression)
+            return;
+
+        if (assignment.Left is not MemberAccessExpressionSyntax leftAccess)
+            return;
+
+        var propName = leftAccess.Name.Identifier.Text;
+        if (!TrappedProperties.TryGetValue(propName, out var modifierName))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.GetLocation(),
+            propName,
+            modifierName));
+    }
+}

--- a/src/Reactor.Analyzers/PoolResetSetAnalyzer.cs
+++ b/src/Reactor.Analyzers/PoolResetSetAnalyzer.cs
@@ -94,14 +94,8 @@ public sealed class PoolResetSetAnalyzer : DiagnosticAnalyzer
         if (args.Count != 1)
             return;
 
-        ExpressionSyntax? body = args[0].Expression switch
-        {
-            SimpleLambdaExpressionSyntax simple => simple.ExpressionBody,
-            ParenthesizedLambdaExpressionSyntax paren => paren.ExpressionBody,
-            _ => null,
-        };
-
-        if (body is not AssignmentExpressionSyntax assignment)
+        var assignment = TryGetLambdaAssignment(args[0].Expression);
+        if (assignment is null)
             return;
         if (assignment.Kind() != SyntaxKind.SimpleAssignmentExpression)
             return;
@@ -118,5 +112,30 @@ public sealed class PoolResetSetAnalyzer : DiagnosticAnalyzer
             invocation.GetLocation(),
             propName,
             modifierName));
+    }
+
+    /// <summary>
+    /// Extract the single assignment expression from a lambda passed to <c>.Set(...)</c>.
+    /// Supports both expression-body lambdas (<c>fe =&gt; fe.X = v</c>) and block-body
+    /// lambdas with a single assignment statement (<c>fe =&gt; { fe.X = v; }</c>).
+    /// Multi-statement blocks return <c>null</c> — the codefix can't safely rewrite them.
+    /// </summary>
+    internal static AssignmentExpressionSyntax? TryGetLambdaAssignment(ExpressionSyntax lambdaExpr)
+    {
+        SyntaxNode? exprOrBlock = lambdaExpr switch
+        {
+            SimpleLambdaExpressionSyntax simple => (SyntaxNode?)simple.ExpressionBody ?? simple.Block,
+            ParenthesizedLambdaExpressionSyntax paren => (SyntaxNode?)paren.ExpressionBody ?? paren.Block,
+            _ => null,
+        };
+
+        return exprOrBlock switch
+        {
+            AssignmentExpressionSyntax a => a,
+            BlockSyntax block when block.Statements.Count == 1
+                && block.Statements[0] is ExpressionStatementSyntax es
+                && es.Expression is AssignmentExpressionSyntax ba => ba,
+            _ => null,
+        };
     }
 }

--- a/src/Reactor.Analyzers/PoolResetSetCodeFix.cs
+++ b/src/Reactor.Analyzers/PoolResetSetCodeFix.cs
@@ -12,7 +12,15 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// <summary>
 /// Code fix for REACTOR_POOL_001: rewrites <c>x.Set(fe =&gt; fe.PROP = VALUE)</c>
 /// to <c>x.PROP(VALUE)</c> using the corresponding Reactor modifier.
+/// Block-body lambdas with a single assignment statement
+/// (<c>fe =&gt; { fe.PROP = VALUE; }</c>) are also handled.
 /// </summary>
+/// <remarks>
+/// Where the modifier signature differs from the property type, the codefix
+/// translates the RHS into the modifier's expected shape (see <c>Margin</c>
+/// below). When no safe translation exists, the codefix is suppressed —
+/// the analyzer still reports the trap, the developer just has to fix by hand.
+/// </remarks>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PoolResetSetCodeFix))]
 [Shared]
 public sealed class PoolResetSetCodeFix : CodeFixProvider
@@ -37,21 +45,16 @@ public sealed class PoolResetSetCodeFix : CodeFixProvider
             var args = invocation.ArgumentList.Arguments;
             if (args.Count != 1) continue;
 
-            ExpressionSyntax? body = args[0].Expression switch
-            {
-                SimpleLambdaExpressionSyntax simple => simple.ExpressionBody,
-                ParenthesizedLambdaExpressionSyntax paren => paren.ExpressionBody,
-                _ => null,
-            };
-
-            if (body is not AssignmentExpressionSyntax assignment) continue;
+            var assignment = PoolResetSetAnalyzer.TryGetLambdaAssignment(args[0].Expression);
+            if (assignment is null) continue;
             if (assignment.Left is not MemberAccessExpressionSyntax leftAccess) continue;
 
             var propName = leftAccess.Name.Identifier.Text;
             if (!PoolResetSetAnalyzer.TrappedProperties.TryGetValue(propName, out var modifierName))
                 continue;
 
-            var value = assignment.Right;
+            var modifierArgs = TryBuildModifierArguments(propName, assignment.Right);
+            if (modifierArgs is null) continue; // Cannot safely translate RHS; leave the warning unfixed.
 
             context.RegisterCodeFix(
                 CodeAction.Create(
@@ -63,9 +66,7 @@ public sealed class PoolResetSetCodeFix : CodeFixProvider
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 memberAccess.Expression,
                                 SyntaxFactory.IdentifierName(modifierName)),
-                            SyntaxFactory.ArgumentList(
-                                SyntaxFactory.SingletonSeparatedList(
-                                    SyntaxFactory.Argument(value))))
+                            modifierArgs)
                             .WithTriviaFrom(invocation);
 
                         var newRoot = root.ReplaceNode(invocation, newInvocation);
@@ -75,4 +76,48 @@ public sealed class PoolResetSetCodeFix : CodeFixProvider
                 diagnostic);
         }
     }
+
+    /// <summary>
+    /// Build the argument list for the modifier call, translating the RHS when
+    /// the modifier signature differs from the raw FE property type.
+    /// </summary>
+    /// <returns>
+    /// The argument list to pass to the modifier, or <c>null</c> if no safe
+    /// translation is possible (in which case no codefix is registered).
+    /// </returns>
+    private static ArgumentListSyntax? TryBuildModifierArguments(string propName, ExpressionSyntax value)
+    {
+        // The FrameworkElement.Margin property is a Thickness, but Reactor's
+        // .Margin(...) modifier overloads all take doubles. Translate the
+        // common literal shapes:
+        //   new Thickness(uniform)           → .Margin(uniform)
+        //   new Thickness(l, t, r, b)        → .Margin(l, t, r, b)
+        // Other RHS shapes (variables, member access, Thickness without
+        // constructor args, etc.) we can't rewrite safely — skip the fix.
+        if (propName == "Margin")
+        {
+            if (value is not ObjectCreationExpressionSyntax oce) return null;
+            if (!IsThicknessType(oce.Type)) return null;
+            var ctorArgs = oce.ArgumentList?.Arguments;
+            if (ctorArgs is null) return null;
+            // Thickness has constructors for 0, 1, and 4 args. The 0-arg
+            // (default Thickness) is not interesting; 1 and 4 map cleanly to
+            // Margin(double) and Margin(double, double, double, double).
+            if (ctorArgs.Value.Count is 1 or 4)
+                return SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(ctorArgs.Value));
+            return null;
+        }
+
+        // All other tracked properties: the modifier accepts the same type
+        // as the property (double / enum / string), so pass the RHS through.
+        return SyntaxFactory.ArgumentList(
+            SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(value)));
+    }
+
+    private static bool IsThicknessType(TypeSyntax type) => type switch
+    {
+        IdentifierNameSyntax { Identifier.Text: "Thickness" } => true,
+        QualifiedNameSyntax q when q.Right.Identifier.Text == "Thickness" => true,
+        _ => false,
+    };
 }

--- a/src/Reactor.Analyzers/PoolResetSetCodeFix.cs
+++ b/src/Reactor.Analyzers/PoolResetSetCodeFix.cs
@@ -1,0 +1,78 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for REACTOR_POOL_001: rewrites <c>x.Set(fe =&gt; fe.PROP = VALUE)</c>
+/// to <c>x.PROP(VALUE)</c> using the corresponding Reactor modifier.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PoolResetSetCodeFix))]
+[Shared]
+public sealed class PoolResetSetCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(PoolResetSetAnalyzer.DiagnosticId);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var span = diagnostic.Location.SourceSpan;
+            var node = root.FindNode(span);
+            if (node is not InvocationExpressionSyntax invocation) continue;
+            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) continue;
+
+            var args = invocation.ArgumentList.Arguments;
+            if (args.Count != 1) continue;
+
+            ExpressionSyntax? body = args[0].Expression switch
+            {
+                SimpleLambdaExpressionSyntax simple => simple.ExpressionBody,
+                ParenthesizedLambdaExpressionSyntax paren => paren.ExpressionBody,
+                _ => null,
+            };
+
+            if (body is not AssignmentExpressionSyntax assignment) continue;
+            if (assignment.Left is not MemberAccessExpressionSyntax leftAccess) continue;
+
+            var propName = leftAccess.Name.Identifier.Text;
+            if (!PoolResetSetAnalyzer.TrappedProperties.TryGetValue(propName, out var modifierName))
+                continue;
+
+            var value = assignment.Right;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    $"Use .{modifierName}() modifier",
+                    ct =>
+                    {
+                        var newInvocation = SyntaxFactory.InvocationExpression(
+                            SyntaxFactory.MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                memberAccess.Expression,
+                                SyntaxFactory.IdentifierName(modifierName)),
+                            SyntaxFactory.ArgumentList(
+                                SyntaxFactory.SingletonSeparatedList(
+                                    SyntaxFactory.Argument(value))))
+                            .WithTriviaFrom(invocation);
+
+                        var newRoot = root.ReplaceNode(invocation, newInvocation);
+                        return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+                    },
+                    equivalenceKey: PoolResetSetAnalyzer.DiagnosticId + ":" + modifierName),
+                diagnostic);
+        }
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/PoolResetSetAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/PoolResetSetAnalyzerTests.cs
@@ -1,0 +1,222 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="PoolResetSetAnalyzer"/> (<c>REACTOR_POOL_001</c>) and its
+/// <see cref="PoolResetSetCodeFix"/>. Stubs a minimal Reactor-shaped fluent
+/// element so the analyzer's syntactic match against <c>.Set(fe =&gt; fe.PROP = ...)</c>
+/// fires without pulling the framework in.
+/// </summary>
+public class PoolResetSetAnalyzerTests
+{
+    // Mirrors the real Reactor shape: FakeElement carries the raw FE properties
+    // that .Set writes to, and the modifiers (MaxHeight/Margin/HorizontalAlignment/...)
+    // are extension methods — same as ElementExtensions.cs in src/Reactor.
+    private const string Stubs = @"
+using System;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.UI.Xaml
+{
+    public enum HorizontalAlignment { Left, Center, Right, Stretch }
+    public enum VerticalAlignment { Top, Center, Bottom, Stretch }
+    public struct Thickness { public Thickness(double u) {} }
+}
+
+public class FakeElement
+{
+    public double MaxHeight;
+    public double MinHeight;
+    public double MaxWidth;
+    public double MinWidth;
+    public double Width;
+    public double Height;
+    public double Opacity;
+    public Thickness Margin;
+    public HorizontalAlignment HorizontalAlignment;
+    public VerticalAlignment VerticalAlignment;
+
+    // Unrelated property — should never trigger.
+    public string Text = string.Empty;
+
+    public FakeElement Set(Action<FakeElement> configure) { configure(this); return this; }
+    public FakeElement Apply(Action<FakeElement> configure) { configure(this); return this; }
+}
+
+public static class FakeElementExtensions
+{
+    public static FakeElement MaxHeight(this FakeElement el, double v) => el;
+    public static FakeElement MinHeight(this FakeElement el, double v) => el;
+    public static FakeElement MaxWidth(this FakeElement el, double v) => el;
+    public static FakeElement MinWidth(this FakeElement el, double v) => el;
+    public static FakeElement Width(this FakeElement el, double v) => el;
+    public static FakeElement Height(this FakeElement el, double v) => el;
+    public static FakeElement Opacity(this FakeElement el, double v) => el;
+    public static FakeElement Margin(this FakeElement el, double u) => el;
+    public static FakeElement HorizontalAlignment(this FakeElement el, HorizontalAlignment a) => el;
+    public static FakeElement VerticalAlignment(this FakeElement el, VerticalAlignment a) => el;
+}
+";
+
+    [Fact]
+    public async Task Fires_For_MaxHeight()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_POOL_001:el.Set(fe => fe.MaxHeight = 260)|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<PoolResetSetAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task Fires_For_HorizontalAlignment()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_POOL_001:el.Set(fe => fe.HorizontalAlignment = HorizontalAlignment.Center)|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<PoolResetSetAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task Fires_With_Parenthesized_Lambda()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_POOL_001:el.Set((fe) => fe.MinWidth = 100)|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<PoolResetSetAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Untrapped_Property()
+    {
+        // .Text is not in ElementPool.CleanElement's FE-prop reset list and has
+        // no equivalent modifier — .Set is legitimate here.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.Set(fe => fe.Text = ""hi"");
+    }
+}";
+
+        await new CSharpAnalyzerTest<PoolResetSetAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Non_Set_Method()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.Apply(fe => fe.MaxHeight = 260);
+    }
+}";
+
+        await new CSharpAnalyzerTest<PoolResetSetAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_Rewrites_MaxHeight()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_POOL_001:el.Set(fe => fe.MaxHeight = 260)|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.MaxHeight(260);
+    }
+}";
+
+        await new CSharpCodeFixTest<PoolResetSetAnalyzer, PoolResetSetCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_Rewrites_HorizontalAlignment()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_POOL_001:el.Set(fe => fe.HorizontalAlignment = HorizontalAlignment.Center)|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.HorizontalAlignment(HorizontalAlignment.Center);
+    }
+}";
+
+        await new CSharpCodeFixTest<PoolResetSetAnalyzer, PoolResetSetCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync();
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/PoolResetSetAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/PoolResetSetAnalyzerTests.cs
@@ -25,7 +25,11 @@ namespace Microsoft.UI.Xaml
 {
     public enum HorizontalAlignment { Left, Center, Right, Stretch }
     public enum VerticalAlignment { Top, Center, Bottom, Stretch }
-    public struct Thickness { public Thickness(double u) {} }
+    public struct Thickness
+    {
+        public Thickness(double u) {}
+        public Thickness(double l, double t, double r, double b) {}
+    }
 }
 
 public class FakeElement
@@ -58,6 +62,7 @@ public static class FakeElementExtensions
     public static FakeElement Height(this FakeElement el, double v) => el;
     public static FakeElement Opacity(this FakeElement el, double v) => el;
     public static FakeElement Margin(this FakeElement el, double u) => el;
+    public static FakeElement Margin(this FakeElement el, double l, double t, double r, double b) => el;
     public static FakeElement HorizontalAlignment(this FakeElement el, HorizontalAlignment a) => el;
     public static FakeElement VerticalAlignment(this FakeElement el, VerticalAlignment a) => el;
 }
@@ -217,6 +222,167 @@ class C
         {
             TestCode = before,
             FixedCode = after,
+        }.RunAsync();
+    }
+
+    // ── Block-bodied lambdas ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Fires_For_Block_Bodied_Lambda_With_Single_Statement()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_POOL_001:el.Set(fe => { fe.MaxHeight = 260; })|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<PoolResetSetAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Block_Bodied_Lambda_With_Multiple_Statements()
+    {
+        // Multi-statement block bodies are intentionally not detected in v1:
+        // the codefix can't safely rewrite them (it would need to extract the
+        // matched assignment while preserving the rest of the body), and the
+        // analyzer mirrors the codefix scope. If a future PR adds multi-stmt
+        // support, this test should flip to a positive case.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.Set(fe => { fe.MaxHeight = 260; fe.MinHeight = 100; });
+    }
+}";
+
+        await new CSharpAnalyzerTest<PoolResetSetAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_Rewrites_Block_Bodied_Lambda()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_POOL_001:el.Set(fe => { fe.MaxHeight = 260; })|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.MaxHeight(260);
+    }
+}";
+
+        await new CSharpCodeFixTest<PoolResetSetAnalyzer, PoolResetSetCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync();
+    }
+
+    // ── Margin / Thickness translation ──────────────────────────────────
+
+    [Fact]
+    public async Task CodeFix_Rewrites_Margin_Uniform_Thickness()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_POOL_001:el.Set(fe => fe.Margin = new Thickness(8))|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.Margin(8);
+    }
+}";
+
+        await new CSharpCodeFixTest<PoolResetSetAnalyzer, PoolResetSetCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task CodeFix_Rewrites_Margin_FourArg_Thickness()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_POOL_001:el.Set(fe => fe.Margin = new Thickness(1, 2, 3, 4))|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.Margin(1, 2, 3, 4);
+    }
+}";
+
+        await new CSharpCodeFixTest<PoolResetSetAnalyzer, PoolResetSetCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task Analyzer_Fires_But_CodeFix_Suppressed_For_Opaque_Margin_RHS()
+    {
+        // RHS is a variable reference, not a Thickness constructor literal —
+        // we can't safely translate, so the analyzer fires (the trap is real)
+        // but no codefix is offered. The verifier confirms this by leaving
+        // TestCode == FixedCode: the warning persists, and no rewrite occurs.
+        var code = Stubs + @"
+class C
+{
+    void M(Thickness margin)
+    {
+        var el = new FakeElement();
+        {|REACTOR_POOL_001:el.Set(fe => fe.Margin = margin)|};
+    }
+}";
+
+        await new CSharpCodeFixTest<PoolResetSetAnalyzer, PoolResetSetCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
         }.RunAsync();
     }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
@@ -176,24 +176,39 @@ class C
         Assert.True(File.Exists(path), $"ElementPool.cs not found at {path}");
         var source = File.ReadAllText(path);
 
-        var start = source.IndexOf("internal static void CleanElement(FrameworkElement fe)", StringComparison.Ordinal);
-        Assert.True(start >= 0, "Could not locate CleanElement signature in ElementPool.cs — has it been renamed?");
-        var braceStart = source.IndexOf('{', start);
-        Assert.True(braceStart > start, "CleanElement opening brace not found");
-        var switchStart = source.IndexOf("switch (fe)", braceStart, StringComparison.Ordinal);
-        Assert.True(switchStart > braceStart, "CleanElement layout changed — could not find 'switch (fe)' boundary");
+        // Locate `(internal|private|...) static void CleanElement(FrameworkElement <param>)`,
+        // capturing the parameter name. Matching by signature shape — not by the
+        // exact `(FrameworkElement fe)` string — keeps the test robust to harmless
+        // renames or spacing changes.
+        var sigMatch = Regex.Match(source,
+            @"static\s+void\s+CleanElement\s*\(\s*FrameworkElement\s+(\w+)\s*\)");
+        Assert.True(sigMatch.Success,
+            "Could not locate CleanElement(FrameworkElement) signature in ElementPool.cs — has it been removed or had its type changed?");
+        var paramName = sigMatch.Groups[1].Value;
 
-        var commonBlock = source.Substring(braceStart, switchStart - braceStart);
+        var braceStart = source.IndexOf('{', sigMatch.Index + sigMatch.Length);
+        Assert.True(braceStart > sigMatch.Index, "CleanElement opening brace not found");
 
-        // ClearValue() is a method call caught separately by the second
-        // regex; filter it out of the direct-assignment match set.
-        var directAssignments = Regex.Matches(commonBlock, @"\bfe\.(\w+)\s*=")
+        // The FE-common block runs from the opening brace up to the first
+        // `switch (<param>)` that starts the type-specific cleanup.
+        var switchRegex = new Regex($@"\bswitch\s*\(\s*{Regex.Escape(paramName)}\s*\)");
+        var switchMatch = switchRegex.Match(source, braceStart);
+        Assert.True(switchMatch.Success,
+            $"CleanElement layout changed — could not find 'switch ({paramName})' boundary after the opening brace.");
+
+        var commonBlock = source.Substring(braceStart, switchMatch.Index - braceStart);
+
+        // ClearValue() is a method call caught separately by the second regex;
+        // filter it out of the direct-assignment match set. Both regexes use
+        // the captured parameter name so renaming `fe` → `element` keeps working.
+        var escapedParam = Regex.Escape(paramName);
+        var directAssignments = Regex.Matches(commonBlock, $@"\b{escapedParam}\.(\w+)\s*=")
             .Cast<Match>()
             .Select(m => m.Groups[1].Value)
             .Where(name => name != "ClearValue");
 
         var clearValueProps = Regex.Matches(commonBlock,
-                @"\bfe\.ClearValue\(\s*FrameworkElement\.(\w+)Property\s*\)")
+                $@"\b{escapedParam}\.ClearValue\(\s*FrameworkElement\.(\w+)Property\s*\)")
             .Cast<Match>()
             .Select(m => m.Groups[1].Value);
 

--- a/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
@@ -104,14 +104,12 @@ public class PoolResetSetConsistencyTests
         var modifierNames = ReadModifierNames();
         var tracked = PoolResetSetAnalyzer.TrappedProperties.Keys;
 
-        var missing = new List<string>();
-        foreach (var prop in resetProps)
-        {
-            if (IntentionallyExcluded.ContainsKey(prop)) continue;
-            if (!modifierNames.Contains(prop)) continue;
-            if (tracked.Contains(prop)) continue;
-            missing.Add(prop);
-        }
+        var missing = resetProps
+            .Where(prop =>
+                !IntentionallyExcluded.ContainsKey(prop) &&
+                modifierNames.Contains(prop) &&
+                !tracked.Contains(prop))
+            .ToList();
 
         Assert.True(
             missing.Count == 0,
@@ -169,7 +167,12 @@ class C
     {
         var root = RepoRootFinder.FindRepoRoot();
         Assert.NotNull(root);
-        var path = Path.Combine(root!, "src", "Reactor", "Core", "ElementPool.cs");
+        // Path.Join (vs Path.Combine) avoids the "rooted segment silently
+        // discards the base path" behavior flagged by CodeQL cs/path-combine.
+        // All segments here are hardcoded literals, so the warning is a
+        // false positive — but the equivalent Path.Join keeps the analyzer
+        // quiet and is otherwise identical for non-rooted segments.
+        var path = Path.Join(root!, "src", "Reactor", "Core", "ElementPool.cs");
         Assert.True(File.Exists(path), $"ElementPool.cs not found at {path}");
         var source = File.ReadAllText(path);
 
@@ -182,19 +185,19 @@ class C
 
         var commonBlock = source.Substring(braceStart, switchStart - braceStart);
 
-        var props = new HashSet<string>(StringComparer.Ordinal);
-        foreach (Match m in Regex.Matches(commonBlock, @"\bfe\.(\w+)\s*="))
-        {
-            var name = m.Groups[1].Value;
-            // ClearValue() is a method call, not a property reset — caught by the second regex below.
-            if (name != "ClearValue") props.Add(name);
-        }
-        foreach (Match m in Regex.Matches(commonBlock,
-            @"\bfe\.ClearValue\(\s*FrameworkElement\.(\w+)Property\s*\)"))
-        {
-            props.Add(m.Groups[1].Value);
-        }
-        return props;
+        // ClearValue() is a method call caught separately by the second
+        // regex; filter it out of the direct-assignment match set.
+        var directAssignments = Regex.Matches(commonBlock, @"\bfe\.(\w+)\s*=")
+            .Cast<Match>()
+            .Select(m => m.Groups[1].Value)
+            .Where(name => name != "ClearValue");
+
+        var clearValueProps = Regex.Matches(commonBlock,
+                @"\bfe\.ClearValue\(\s*FrameworkElement\.(\w+)Property\s*\)")
+            .Cast<Match>()
+            .Select(m => m.Groups[1].Value);
+
+        return new HashSet<string>(directAssignments.Concat(clearValueProps), StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -205,17 +208,16 @@ class C
     {
         var root = RepoRootFinder.FindRepoRoot();
         Assert.NotNull(root);
-        var path = Path.Combine(root!, "src", "Reactor", "Elements", "ElementExtensions.cs");
+        // Path.Join — see ReadResetProperties for the cs/path-combine rationale.
+        var path = Path.Join(root!, "src", "Reactor", "Elements", "ElementExtensions.cs");
         Assert.True(File.Exists(path), $"ElementExtensions.cs not found at {path}");
         var source = File.ReadAllText(path);
 
-        var names = new HashSet<string>(StringComparer.Ordinal);
-        foreach (Match m in Regex.Matches(source,
-            @"public\s+static\s+T\s+(\w+)\s*<T>\s*\(\s*this\s+T\s+\w+"))
-        {
-            names.Add(m.Groups[1].Value);
-        }
-        return names;
+        var names = Regex.Matches(source, @"public\s+static\s+T\s+(\w+)\s*<T>\s*\(\s*this\s+T\s+\w+")
+            .Cast<Match>()
+            .Select(m => m.Groups[1].Value);
+
+        return new HashSet<string>(names, StringComparer.Ordinal);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.UI.Reactor.Cli.Pack;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Cross-source consistency tests for <see cref="PoolResetSetAnalyzer"/>
+/// (<c>REACTOR_POOL_001</c>). Catches drift between three files:
+///
+///   1. <c>src/Reactor/Core/ElementPool.cs</c> — the FE-prop reset list in
+///      <c>CleanElement(FrameworkElement)</c>.
+///   2. <c>src/Reactor/Elements/ElementExtensions.cs</c> — the modifier methods
+///      that survive pool reset.
+///   3. <c>src/Reactor.Analyzers/PoolResetSetAnalyzer.cs</c> —
+///      the <c>TrappedProperties</c> dictionary.
+///
+/// The bug we're guarding against: someone adds a new property reset to
+/// <c>CleanElement</c> (because pooled controls were leaking that prop into
+/// the next mount), there is already a modifier with the same name, but
+/// nobody updates the analyzer — so <c>.Set(fe => fe.NewProp = ...)</c>
+/// still silently loses values and there's no warning at edit time. The
+/// invariant test below fails in that scenario and tells the developer
+/// exactly what to add.
+/// </summary>
+public class PoolResetSetConsistencyTests
+{
+    /// <summary>
+    /// FE properties that <c>CleanElement</c> resets but that we intentionally
+    /// do NOT include in <see cref="PoolResetSetAnalyzer.TrappedProperties"/>.
+    /// Add a new entry here (with a comment explaining why) only when the
+    /// property genuinely has no clean modifier-based replacement.
+    /// </summary>
+    private static readonly Dictionary<string, string> IntentionallyExcluded =
+        new(StringComparer.Ordinal)
+        {
+            // Modifier is .IsVisible(bool); .Set(...) writes Visibility (enum).
+            // The codefix would need an enum→bool translation, so we exclude
+            // it from the auto-fix set. A future analyzer with a custom
+            // codefix could pick this up.
+            { "Visibility", "different signature (enum vs bool via .IsVisible)" },
+
+            // No exact-name modifier exists, and Reactor uses Tag internally
+            // to attach its element record — user .Set writes here are wrong
+            // for a different reason (TASK-060 / Reconciler.ClearElementTag).
+            { "Tag", "framework-internal — Reactor stores its element record here" },
+
+            // No matching modifier; transform pipeline goes through Animate /
+            // Scale / Rotation / Translation modifiers instead.
+            { "RenderTransform", "no modifier; use Scale/Rotation/Translation modifiers" },
+
+            // No matching modifier; FlowDirection is set on the root via app
+            // configuration, not via a per-element modifier.
+            { "FlowDirection", "no modifier; root-level concern" },
+        };
+
+    [Fact]
+    public void Every_TrappedProperty_Is_Reset_In_CleanElement()
+    {
+        var resetProps = ReadResetProperties();
+
+        foreach (var prop in PoolResetSetAnalyzer.TrappedProperties.Keys)
+        {
+            Assert.True(
+                resetProps.Contains(prop),
+                $"'{prop}' is in PoolResetSetAnalyzer.TrappedProperties but is " +
+                $"NOT reset in ElementPool.CleanElement. Either remove it from " +
+                $"TrappedProperties or add a reset for it in CleanElement.");
+        }
+    }
+
+    [Fact]
+    public void Every_TrappedProperty_Has_A_Matching_Modifier()
+    {
+        var modifierNames = ReadModifierNames();
+
+        foreach (var (prop, modifier) in PoolResetSetAnalyzer.TrappedProperties)
+        {
+            Assert.True(
+                modifierNames.Contains(modifier),
+                $"'{prop}' maps to modifier '.{modifier}(...)' in " +
+                $"PoolResetSetAnalyzer.TrappedProperties, but no such " +
+                $"extension method exists in ElementExtensions.cs. The " +
+                $"codefix would produce code that doesn't compile.");
+        }
+    }
+
+    [Fact]
+    public void Every_Reset_Property_With_Matching_Modifier_Is_Tracked()
+    {
+        // This is the load-bearing invariant: if someone adds a new
+        // property to CleanElement's reset list, and ElementExtensions already
+        // has a same-named modifier, then PoolResetSetAnalyzer MUST flag
+        // .Set writes to that property — otherwise the trap is silent.
+        var resetProps = ReadResetProperties();
+        var modifierNames = ReadModifierNames();
+        var tracked = PoolResetSetAnalyzer.TrappedProperties.Keys;
+
+        var missing = new List<string>();
+        foreach (var prop in resetProps)
+        {
+            if (IntentionallyExcluded.ContainsKey(prop)) continue;
+            if (!modifierNames.Contains(prop)) continue;
+            if (tracked.Contains(prop)) continue;
+            missing.Add(prop);
+        }
+
+        Assert.True(
+            missing.Count == 0,
+            "These properties are reset in ElementPool.CleanElement AND have " +
+            "a matching '.PROP(...)' modifier in ElementExtensions.cs, but " +
+            "are NOT in PoolResetSetAnalyzer.TrappedProperties: " +
+            $"[{string.Join(", ", missing)}]. " +
+            "Either add them to TrappedProperties (so REACTOR_POOL_001 fires " +
+            "on .Set writes to them), or — if intentional — add them to " +
+            "IntentionallyExcluded in this test with a documented reason.");
+    }
+
+    /// <summary>
+    /// Table-driven exercise of every entry in <see cref="PoolResetSetAnalyzer.TrappedProperties"/>:
+    /// for each, prove the analyzer fires on the corresponding <c>.Set</c>
+    /// lambda. This keeps the regular-test count growing automatically as
+    /// new entries land, instead of relying on hand-written per-prop tests.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(AllTrappedProperties))]
+    public async Task Analyzer_Fires_For_Every_TrappedProperty(string propName, string modifierName)
+    {
+        _ = modifierName; // not consumed here; pinned by Every_TrappedProperty_Has_A_Matching_Modifier
+        var stubs = BuildStubs();
+        var source = stubs + $@"
+class C
+{{
+    void M()
+    {{
+        var el = new FakeElement();
+        {{|REACTOR_POOL_001:el.Set(fe => fe.{propName} = default!)|}};
+    }}
+}}";
+
+        await new CSharpAnalyzerTest<PoolResetSetAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    public static IEnumerable<object[]> AllTrappedProperties() =>
+        PoolResetSetAnalyzer.TrappedProperties
+            .Select(kvp => new object[] { kvp.Key, kvp.Value });
+
+    // ── Source-scanning helpers ─────────────────────────────────────────
+
+    /// <summary>
+    /// Extract the set of property names reset in the FE-common block of
+    /// <c>ElementPool.CleanElement</c> — from the method's opening brace up
+    /// to (but not including) the <c>switch (fe)</c> that begins type-specific
+    /// cleanup. Captures both <c>fe.PROP = ...</c> direct sets and
+    /// <c>fe.ClearValue(FrameworkElement.PROPProperty)</c> calls.
+    /// </summary>
+    private static HashSet<string> ReadResetProperties()
+    {
+        var root = RepoRootFinder.FindRepoRoot();
+        Assert.NotNull(root);
+        var path = Path.Combine(root!, "src", "Reactor", "Core", "ElementPool.cs");
+        Assert.True(File.Exists(path), $"ElementPool.cs not found at {path}");
+        var source = File.ReadAllText(path);
+
+        var start = source.IndexOf("internal static void CleanElement(FrameworkElement fe)", StringComparison.Ordinal);
+        Assert.True(start >= 0, "Could not locate CleanElement signature in ElementPool.cs — has it been renamed?");
+        var braceStart = source.IndexOf('{', start);
+        Assert.True(braceStart > start, "CleanElement opening brace not found");
+        var switchStart = source.IndexOf("switch (fe)", braceStart, StringComparison.Ordinal);
+        Assert.True(switchStart > braceStart, "CleanElement layout changed — could not find 'switch (fe)' boundary");
+
+        var commonBlock = source.Substring(braceStart, switchStart - braceStart);
+
+        var props = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match m in Regex.Matches(commonBlock, @"\bfe\.(\w+)\s*="))
+        {
+            var name = m.Groups[1].Value;
+            // ClearValue() is a method call, not a property reset — caught by the second regex below.
+            if (name != "ClearValue") props.Add(name);
+        }
+        foreach (Match m in Regex.Matches(commonBlock,
+            @"\bfe\.ClearValue\(\s*FrameworkElement\.(\w+)Property\s*\)"))
+        {
+            props.Add(m.Groups[1].Value);
+        }
+        return props;
+    }
+
+    /// <summary>
+    /// Extract the set of modifier method names defined in
+    /// <c>ElementExtensions.cs</c> — any <c>public static T Name&lt;T&gt;(this T el, ...)</c>.
+    /// </summary>
+    private static HashSet<string> ReadModifierNames()
+    {
+        var root = RepoRootFinder.FindRepoRoot();
+        Assert.NotNull(root);
+        var path = Path.Combine(root!, "src", "Reactor", "Elements", "ElementExtensions.cs");
+        Assert.True(File.Exists(path), $"ElementExtensions.cs not found at {path}");
+        var source = File.ReadAllText(path);
+
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match m in Regex.Matches(source,
+            @"public\s+static\s+T\s+(\w+)\s*<T>\s*\(\s*this\s+T\s+\w+"))
+        {
+            names.Add(m.Groups[1].Value);
+        }
+        return names;
+    }
+
+    /// <summary>
+    /// Build a stub C# preamble that declares <c>FakeElement</c> with a
+    /// public field for every property in <c>TrappedProperties</c>, so the
+    /// table-driven analyzer test can compile uniformly. Uses <c>object?</c>
+    /// fields with <c>default!</c> assignment — analyzer matches on syntax,
+    /// not types, so this is sufficient.
+    /// </summary>
+    private static string BuildStubs()
+    {
+        var fields = string.Join(
+            "\n    ",
+            PoolResetSetAnalyzer.TrappedProperties.Keys
+                .Select(p => $"public object? {p};"));
+
+        return $@"
+using System;
+
+#nullable enable
+
+public class FakeElement
+{{
+    {fields}
+    public FakeElement Set(Action<FakeElement> configure) {{ configure(this); return this; }}
+}}
+";
+    }
+}


### PR DESCRIPTION
Closes #346.

## Summary

- New analyzer + codefix `REACTOR_POOL_001` (`Reactor.Pool`, Warning). Detects `.Set(fe => fe.PROP = ...)` where `PROP` is a FrameworkElement property that `ElementPool.CleanElement` resets and that has a matching Reactor modifier. The codefix rewrites the `.Set(...)` into the modifier (e.g. `.MaxHeight(260)`), which is stored on `Element.Modifiers` and survives pool reuse.
- Cross-source **consistency tests** that fail loudly if `ElementPool.CleanElement` grows a new property reset that has a matching modifier in `ElementExtensions.cs` but is not in the analyzer's `TrappedProperties`. Verified the test catches the failure mode by simulating it (added `fe.IsTabStop = true;` to `CleanElement` — test failed with an actionable message; then reverted).
- Table-driven `[Theory]` over `TrappedProperties` so per-property coverage scales automatically.

## Covered properties

`Margin`, `Width`, `Height`, `MinWidth`, `MinHeight`, `MaxWidth`, `MaxHeight`, `HorizontalAlignment`, `VerticalAlignment`, `Opacity`, `AccessKey`.

Intentionally excluded (documented in the test): `Visibility` (modifier is `IsVisible(bool)` — different signature), `Tag` (Reactor-internal), `RenderTransform`, `FlowDirection` (no matching modifier).

## What this does *not* include

Part 1 of issue #346 — the `pool-and-set.md` doc page enumerating every trapped property — is out of scope for this PR; the issue notes both parts add value independently.

## Test plan

- [x] `dotnet test tests/Reactor.Tests/Reactor.Tests.csproj --filter FullyQualifiedName~PoolReset` → 22 passed, 0 failed.
- [x] Full `AnalyzerTests` suite still green (85 passed, 0 failed).
- [x] Manually verified the consistency test catches the target regression by injecting `fe.IsTabStop = true;` into `CleanElement` and confirming the failure message names `IsTabStop` and tells the developer what to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)