### PR TITLE
loc/devtools: minor terminology cleanup

### DIFF
--- a/src/Reactor.Cli/Loc/TranslationPrompt.cs
+++ b/src/Reactor.Cli/Loc/TranslationPrompt.cs
@@ -169,7 +169,7 @@ internal static class TranslationPrompt
             "ko" => "- Use formal polite speech level (합쇼체/해요체).\n- Keep translations concise.",
             "zh" => targetLocale.Contains("TW", StringComparison.OrdinalIgnoreCase)
                 ? "- Use Traditional Chinese characters.\n- Use Taiwan-standard terminology."
-                : "- Use Simplified Chinese characters.\n- Use mainland China terminology.",
+                : "- Use Simplified Chinese characters.\n- Use PRC-standard terminology.",
             "ar" => "- Use Modern Standard Arabic (MSA) for UI text.\n- Note: the UI supports RTL layout.",
             "he" => "- Note: the UI supports RTL layout.",
             "es" => targetLocale.Contains("419", StringComparison.OrdinalIgnoreCase)

--- a/src/Reactor/Hosting/Devtools/DevtoolsMcpServer.cs
+++ b/src/Reactor/Hosting/Devtools/DevtoolsMcpServer.cs
@@ -342,8 +342,8 @@ internal sealed class DevtoolsMcpServer : IDisposable
 
         // GET /mcp — self-describing schema endpoint. Returns the tool inventory,
         // selector grammar, schema version, and protocol version in one payload so
-        // an agent can orient itself with a single curl / browser visit without
-        // crafting a JSON-RPC initialize + tools/list dance first.
+        // an agent can discover the server with a single curl / browser visit
+        // without crafting a JSON-RPC initialize + tools/list dance first.
         if (ctx.Request.HttpMethod == "GET")
         {
             var schemaDoc = BuildSchemaDocument();
@@ -559,7 +559,7 @@ internal sealed class DevtoolsMcpServer : IDisposable
     /// <summary>
     /// Builds the self-describing document emitted by GET /mcp — the tool
     /// inventory, selector grammar, and protocol / schema versions in one
-    /// payload so an agent can orient itself without crafting a JSON-RPC
+    /// payload so an agent can discover the server without crafting a JSON-RPC
     /// initialize + tools/list dance first.
     /// </summary>
     private object BuildSchemaDocument()


### PR DESCRIPTION
## Summary
- `TranslationPrompt.cs`: zh-CN translator guidance now says **"PRC-standard terminology"** instead of "mainland China terminology". Pure prompt-string text change.
- `DevtoolsMcpServer.cs`: rewords two `GET /mcp` doc comments (`"orient itself"` → `"discover the server"`). Comment-only.

No behavior change in either file — strings/comments only.

## Test plan
- [ ] Build passes (`dotnet build Reactor.slnx`).
- [ ] No test changes required; no runtime paths altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)