### PR TITLE
Fix NumberBox immediate typing updates

### DIFF
--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -657,9 +657,9 @@ public sealed partial class Reconciler
         // so the sync-guard below would let them through.
         if (!double.IsFinite(parsed)) return;
         if (parsed < el.Minimum || parsed > el.Maximum) return;
-        if (parsed == el.Value) return; // already in sync; suppresses post-programmatic-write callback
+        if (AreNumberBoxValuesEquivalent(parsed, el.Value)) return; // already in sync; suppresses post-programmatic-write callback
         if (CanSynchronizeNumberBoxImmediateValueWithoutReformat(el, text, parsed)
-            && box.Value != parsed)
+            && !AreNumberBoxValuesEquivalent(box.Value, parsed))
         {
             ChangeEchoSuppressor.BeginSuppress(box);
             box.Value = parsed;

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -646,25 +646,25 @@ public sealed partial class Reconciler
 
     private static void HandleNumberBoxImmediateTextChanged(WinUI.NumberBox box, string text)
     {
-            if (GetElementTag(box) is not NumberBoxElement el) return;
-            if (el.OnValueChanged is null) return;
-            if (el.GetAttached<Microsoft.UI.Reactor.Controls.Validation.ImmediateValueAttached>() is null) return;
-            if (!double.TryParse(text,
-                global::System.Globalization.NumberStyles.Float,
-                global::System.Globalization.CultureInfo.CurrentCulture, out var parsed)) return;
-            // Reject NaN/±Infinity — double.TryParse accepts the literal strings
-            // "NaN"/"Infinity" by default, and NaN comparisons are never equal,
-            // so the sync-guard below would let them through.
-            if (!double.IsFinite(parsed)) return;
-            if (parsed < el.Minimum || parsed > el.Maximum) return;
-            if (parsed == el.Value) return; // already in sync; suppresses post-programmatic-write callback
-            if (CanSynchronizeNumberBoxImmediateValueWithoutReformat(el, text, parsed)
-                && box.Value != parsed)
-            {
-                ChangeEchoSuppressor.BeginSuppress(box);
-                box.Value = parsed;
-            }
-            el.OnValueChanged.Invoke(parsed);
+        if (GetElementTag(box) is not NumberBoxElement el) return;
+        if (el.OnValueChanged is null) return;
+        if (el.GetAttached<Microsoft.UI.Reactor.Controls.Validation.ImmediateValueAttached>() is null) return;
+        if (!double.TryParse(text,
+            global::System.Globalization.NumberStyles.Float,
+            global::System.Globalization.CultureInfo.CurrentCulture, out var parsed)) return;
+        // Reject NaN/±Infinity — double.TryParse accepts the literal strings
+        // "NaN"/"Infinity" by default, and NaN comparisons are never equal,
+        // so the sync-guard below would let them through.
+        if (!double.IsFinite(parsed)) return;
+        if (parsed < el.Minimum || parsed > el.Maximum) return;
+        if (parsed == el.Value) return; // already in sync; suppresses post-programmatic-write callback
+        if (CanSynchronizeNumberBoxImmediateValueWithoutReformat(el, text, parsed)
+            && box.Value != parsed)
+        {
+            ChangeEchoSuppressor.BeginSuppress(box);
+            box.Value = parsed;
+        }
+        el.OnValueChanged.Invoke(parsed);
     }
 
     private WinUI.AutoSuggestBox MountAutoSuggestBox(AutoSuggestBoxElement asb)

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -598,6 +598,7 @@ public sealed partial class Reconciler
         // without re-mounting — the handler re-checks the marker each fire.
         numBox.RegisterPropertyChangedCallback(WinUI.NumberBox.TextProperty,
             NumberBoxImmediateTextChanged);
+        numBox.Loaded += NumberBoxLoadedEnsureImmediateTextBox;
         ApplySetters(nb.Setters, numBox);
         return numBox;
     }
@@ -606,10 +607,49 @@ public sealed partial class Reconciler
         (sender, _) =>
         {
             if (sender is not WinUI.NumberBox box) return;
+            HandleNumberBoxImmediateTextChanged(box, box.Text);
+        };
+
+    private static void NumberBoxLoadedEnsureImmediateTextBox(object sender, RoutedEventArgs _)
+    {
+        if (sender is not WinUI.NumberBox box) return;
+        if (EnsureNumberBoxImmediateTextBoxWiring(box))
+            box.Loaded -= NumberBoxLoadedEnsureImmediateTextBox;
+    }
+
+    private static bool EnsureNumberBoxImmediateTextBoxWiring(WinUI.NumberBox box)
+    {
+        var events = GetOrCreateEventState(box);
+        if (events.NumberBoxInnerTextChanged) return true;
+
+        box.ApplyTemplate();
+        var input = FindDescendant<TextBox>(box);
+        if (input is null) return false;
+
+        events.NumberBoxInnerTextChanged = true;
+        input.TextChanged += (_, _) => HandleNumberBoxImmediateTextChanged(box, input.Text);
+        return true;
+    }
+
+    private static T? FindDescendant<T>(DependencyObject root) where T : DependencyObject
+    {
+        int count = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var child = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is T match) return match;
+            var nested = FindDescendant<T>(child);
+            if (nested is not null) return nested;
+        }
+        return null;
+    }
+
+    private static void HandleNumberBoxImmediateTextChanged(WinUI.NumberBox box, string text)
+    {
             if (GetElementTag(box) is not NumberBoxElement el) return;
             if (el.OnValueChanged is null) return;
             if (el.GetAttached<Microsoft.UI.Reactor.Controls.Validation.ImmediateValueAttached>() is null) return;
-            if (!double.TryParse(box.Text,
+            if (!double.TryParse(text,
                 global::System.Globalization.NumberStyles.Float,
                 global::System.Globalization.CultureInfo.CurrentCulture, out var parsed)) return;
             // Reject NaN/±Infinity — double.TryParse accepts the literal strings
@@ -618,8 +658,14 @@ public sealed partial class Reconciler
             if (!double.IsFinite(parsed)) return;
             if (parsed < el.Minimum || parsed > el.Maximum) return;
             if (parsed == el.Value) return; // already in sync; suppresses post-programmatic-write callback
+            if (CanSynchronizeNumberBoxImmediateValueWithoutReformat(el, text, parsed)
+                && box.Value != parsed)
+            {
+                ChangeEchoSuppressor.BeginSuppress(box);
+                box.Value = parsed;
+            }
             el.OnValueChanged.Invoke(parsed);
-        };
+    }
 
     private WinUI.AutoSuggestBox MountAutoSuggestBox(AutoSuggestBoxElement asb)
     {

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -883,7 +883,7 @@ public sealed partial class Reconciler
                     global::System.Globalization.NumberStyles.Float,
                     global::System.Globalization.CultureInfo.CurrentCulture, out var typed)
                 && double.IsFinite(typed)   // NaN/Infinity must never defeat the skip and slip through
-                && typed == n.Value
+                && AreNumberBoxValuesEquivalent(typed, n.Value)
                 && !CanSynchronizeNumberBoxImmediateValueWithoutReformat(n, nb.Text, typed);
             if (!skipValueWrite)
             {
@@ -911,6 +911,14 @@ public sealed partial class Reconciler
         if (el.NumberFormatter is not null) return false;
         var canonical = value.ToString("G", global::System.Globalization.CultureInfo.CurrentCulture);
         return string.Equals(text, canonical, StringComparison.Ordinal);
+    }
+
+    private static bool AreNumberBoxValuesEquivalent(double left, double right)
+    {
+        var tolerance = 1e-12 * global::System.Math.Max(
+            1.0,
+            global::System.Math.Max(global::System.Math.Abs(left), global::System.Math.Abs(right)));
+        return global::System.Math.Abs(left - right) <= tolerance;
     }
 
     private UIElement? UpdateAutoSuggestBox(AutoSuggestBoxElement o, AutoSuggestBoxElement n, WinUI.AutoSuggestBox asb)

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -875,16 +875,16 @@ public sealed partial class Reconciler
         }
         if (nb.Value != n.Value)
         {
-            // Immediate mode: if the user's current text already represents
-            // n.Value, leave the text alone — writing Value mid-edit would
-            // reformat the text and clobber the caret / trailing zeros /
-            // partial decimals while the user is still typing.
+            // Immediate mode: preserve non-canonical in-progress text such as
+            // "1." or "2.0", but keep WinUI's Value in sync for canonical text
+            // so subsequent real keystrokes keep flowing through NumberBox.
             var skipValueWrite = n.GetAttached<Microsoft.UI.Reactor.Controls.Validation.ImmediateValueAttached>() is not null
                 && double.TryParse(nb.Text,
                     global::System.Globalization.NumberStyles.Float,
                     global::System.Globalization.CultureInfo.CurrentCulture, out var typed)
                 && double.IsFinite(typed)   // NaN/Infinity must never defeat the skip and slip through
-                && typed == n.Value;
+                && typed == n.Value
+                && !CanSynchronizeNumberBoxImmediateValueWithoutReformat(n, nb.Text, typed);
             if (!skipValueWrite)
             {
                 ChangeEchoSuppressor.BeginSuppress(nb);
@@ -904,6 +904,13 @@ public sealed partial class Reconciler
         if (n.Header is not null) nb.Header = n.Header;
         ApplySetters(n.Setters, nb);
         return null;
+    }
+
+    private static bool CanSynchronizeNumberBoxImmediateValueWithoutReformat(NumberBoxElement el, string text, double value)
+    {
+        if (el.NumberFormatter is not null) return false;
+        var canonical = value.ToString("G", global::System.Globalization.CultureInfo.CurrentCulture);
+        return string.Equals(text, canonical, StringComparison.CurrentCulture);
     }
 
     private UIElement? UpdateAutoSuggestBox(AutoSuggestBoxElement o, AutoSuggestBoxElement n, WinUI.AutoSuggestBox asb)

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -910,7 +910,7 @@ public sealed partial class Reconciler
     {
         if (el.NumberFormatter is not null) return false;
         var canonical = value.ToString("G", global::System.Globalization.CultureInfo.CurrentCulture);
-        return string.Equals(text, canonical, StringComparison.CurrentCulture);
+        return string.Equals(text, canonical, StringComparison.Ordinal);
     }
 
     private UIElement? UpdateAutoSuggestBox(AutoSuggestBoxElement o, AutoSuggestBoxElement n, WinUI.AutoSuggestBox asb)

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -2798,6 +2798,7 @@ public sealed partial class Reconciler : IDisposable
         public RoutedEventHandler? LostFocusTrampoline;
         public RoutedEventHandler? ToggleSwitchToggledTrampoline;
         public global::Windows.Foundation.TypedEventHandler<UIElement, Microsoft.UI.Xaml.Input.AccessKeyDisplayRequestedEventArgs>? AccessKeyDisplayRequestedTrampoline;
+        public bool NumberBoxInnerTextChanged;
 
         /// <summary>
         /// Null out every Current* user delegate so trampolines already attached


### PR DESCRIPTION
## Summary
- wire NumberBox.Immediate() to the templated inner TextBox so real keystrokes update bound state before blur
- keep the existing NumberBox.TextProperty callback as a fallback
- preserve non-canonical in-progress text while synchronizing canonical typed values with NumberBox.Value

Fixes #384

## Testing
- dotnet build src\Reactor\Reactor.csproj -p:Platform=x64 --no-restore
- dotnet test tests\Reactor.AppTests\Reactor.AppTests.csproj -p:Platform=x64 --filter "ClassName~ImmediateAndDisabledFocusableTests" --logger "console;verbosity=minimal"
