### PR TITLE
refactor: rename TextField -> TextBox for WinUI parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ to land under these conventions; subsequent specs follow this shape.
 
 ### Changed
 
+- **`TextField` → `TextBox` rename.** The record type
+  `TextFieldElement` is renamed to `TextBoxElement` for parity with
+  WinUI's `Microsoft.UI.Xaml.Controls.TextBox`. The `TextField(...)`
+  factory remains as a non-erroring `[Obsolete]` forwarding alias for
+  one release; call sites should migrate to `TextBox(...)`. The
+  alias will be removed in a future release.
+
+### Deprecated
+
+- **`Factories.TextField(...)`** — use `Factories.TextBox(...)` instead.
+  Emits `CS0618` warning; will be removed in a future release.
+
 - **Spec 045 Phase 2 — §2.29 ready for human review gate.**
   Every Phase-2 implementation item in
   `docs/specs/tasks/045-docking-windows-implementation.md` is now

--- a/SKILL.md
+++ b/SKILL.md
@@ -394,7 +394,7 @@ Grid(columns: [GridSize.Star(), GridSize.Px(200)],
 TitleBar("App") with { Subtitle = "Home", Content = ..., RightHeader = ... }
 
 // Controls
-Button("Click", () => ...)      TextField(value, setValue, placeholder)
+Button("Click", () => ...)      TextBox(value, setValue, placeholder)
 CheckBox(isChecked, setChecked) ToggleSwitch(on, setOn)
 Slider(v, 0, 100, setV)         ComboBox(items, index, setIndex)
 
@@ -544,7 +544,7 @@ release you depend on.
 | `<div>` | `FlexColumn() / FlexRow() / Border()` (prefer over `VStack`/`HStack`) |
 | `<span>text</span>` | `TextBlock("text")` |
 | `<button onClick={fn}>` | `Button("label", fn)` |
-| `<input value={v} onChange={fn}>` | `TextField(v, fn)` |
+| `<input value={v} onChange={fn}>` | `TextBox(v, fn)` |
 | `{cond && <X/>}` | `cond ? X() : null` |
 | `{items.map(i => <X/>)}` | `items.Select(i => X()).ToArray()` |
 | `<Component />` | `Component<MyComponent>()` |

--- a/docs/_pipeline/apps/accessibility/App.cs
+++ b/docs/_pipeline/apps/accessibility/App.cs
@@ -23,7 +23,7 @@ class Tier1Demo : Component
             TextBlock("Profile")
                 .FontSize(18).SemiBold()
                 .HeadingLevel(AutomationHeadingLevel.Level2),
-            TextField("", _ => { }, placeholder: "Display name")
+            TextBox("", _ => { }, placeholder: "Display name")
                 .AutomationName("Display name")
                 .TabIndex(1)
                 .AccessKey("N"),
@@ -42,7 +42,7 @@ class Tier2Demo : Component
     public override Element Render()
     {
         return VStack(12,
-            TextField("", _ => { }, placeholder: "Search...")
+            TextBox("", _ => { }, placeholder: "Search...")
                 .AutomationName("Search products")
                 .HelpText("Type a product name or SKU to filter results")
                 .Width(300),
@@ -75,9 +75,9 @@ class AccessibleFormDemo : Component
         return VStack(12,
             TextBlock("Create Account").FontSize(24).Bold()
                 .HeadingLevel(AutomationHeadingLevel.Level1),
-            TextField(name, setName, header: "Full Name")
+            TextBox(name, setName, header: "Full Name")
                 .AutomationName("Full name").Required().TabIndex(1),
-            TextField(email, setEmail, header: "Email")
+            TextBox(email, setEmail, header: "Email")
                 .AutomationName("Email address").Required().TabIndex(2)
                 .HelpText("We'll send a verification link"),
             CheckBox(agree, setAgree, label: "I accept the terms")
@@ -110,7 +110,7 @@ class LandmarksDemo : Component
             ).Landmark(AutomationLandmarkType.Main)
              .AutomationName("Main content"),
 
-            TextField("", _ => { }, placeholder: "Search...")
+            TextBox("", _ => { }, placeholder: "Search...")
                 .AutomationName("Site search")
                 .Landmark(AutomationLandmarkType.Search)
         ).Padding(24);
@@ -159,7 +159,7 @@ class FocusTrapDemo : Component
                     VStack(12,
                         TextBlock("Modal Dialog").FontSize(18).Bold(),
                         TextBlock("Tab/Shift+Tab stays inside this panel."),
-                        TextField("", _ => { }, placeholder: "Name")
+                        TextBox("", _ => { }, placeholder: "Name")
                             .TabIndex(0),
                         Button("Close", () => setShowModal(false))
                             .TabIndex(1)

--- a/docs/_pipeline/apps/advanced/App.cs
+++ b/docs/_pipeline/apps/advanced/App.cs
@@ -141,7 +141,7 @@ class ObservableTreeDemo : Component
 
         return VStack(12,
             SubHeading("UseObservableTree"),
-            TextField(vm.UserName, v => vm.UserName = v,
+            TextBox(vm.UserName, v => vm.UserName = v,
                 header: "User Name"),
             ToggleSwitch(vm.DarkMode, v => vm.DarkMode = v,
                 header: "Dark Mode"),
@@ -167,7 +167,7 @@ class ObservableCollectionDemo : Component
         return VStack(12,
             SubHeading("UseCollection"),
             HStack(8,
-                TextField(input, setInput, placeholder: "New task")
+                TextBox(input, setInput, placeholder: "New task")
                     .Width(200),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(input))
@@ -196,7 +196,7 @@ class ElementRefFocusDemo : Component
 
         return VStack(12,
             SubHeading("Imperative focus via ElementRef<T>"),
-            TextField(name, setName, placeholder: "Name").Ref(fieldRef),
+            TextBox(name, setName, placeholder: "Name").Ref(fieldRef),
             Button("Focus the field", () =>
                 fieldRef.Current?.Focus(FocusState.Programmatic))
         ).Padding(24);

--- a/docs/_pipeline/apps/collections/App.cs
+++ b/docs/_pipeline/apps/collections/App.cs
@@ -130,7 +130,7 @@ class VirtualListRefDemo : Component
         return VStack(12,
             SubHeading("VirtualListRef — Imperative Scroll"),
             HStack(8,
-                TextField(targetIndex, setTargetIndex,
+                TextBox(targetIndex, setTargetIndex,
                     placeholder: "Index"),
                 Button("Scroll To", () =>
                 {
@@ -219,7 +219,7 @@ class WithKeyDemo : Component
         return VStack(12,
             SubHeading("Stable Identity with WithKey"),
             HStack(8,
-                TextField(newItem, setNewItem, placeholder: "New item"),
+                TextBox(newItem, setNewItem, placeholder: "New item"),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(newItem)) {
                         updateItems(l => [.. l, newItem.Trim()]);

--- a/docs/_pipeline/apps/commanding/App.cs
+++ b/docs/_pipeline/apps/commanding/App.cs
@@ -28,7 +28,7 @@ class BasicCommandExample : Component
         };
 
         return VStack(12,
-            TextField(text, v => { setText(v); setSaved(false); })
+            TextBox(text, v => { setText(v); setSaved(false); })
                 .Width(400),
             HStack(8,
                 Button(saveCmd),
@@ -114,7 +114,7 @@ class CommandBarExample : Component
                 secondaryCommands: new[] {
                     AppBarButton(delete) }
             ),
-            TextField(text, setText).Margin(16)
+            TextBox(text, setText).Margin(16)
         );
     }
 }

--- a/docs/_pipeline/apps/components/App.cs
+++ b/docs/_pipeline/apps/components/App.cs
@@ -18,7 +18,7 @@ class Greeting : Component
 
         return VStack(12,
             TextBlock($"Hello, {name}!").FontSize(20).Bold(),
-            TextField(name, setName, placeholder: "Your name")
+            TextBox(name, setName, placeholder: "Your name")
                 .Width(200)
         ).Padding(16);
     }

--- a/docs/_pipeline/apps/controls/App.cs
+++ b/docs/_pipeline/apps/controls/App.cs
@@ -39,7 +39,7 @@ class FormsGroup : Component
         var (volume, setVolume) = UseState(60.0);
 
         return VStack(8,
-            TextField(name, setName, placeholder: "Name").Width(200),
+            TextBox(name, setName, placeholder: "Name").Width(200),
             CheckBox(agree, setAgree, label: "I agree"),
             Slider(volume, 0, 100, setVolume).Width(200),
             Button("Submit", () => { })

--- a/docs/_pipeline/apps/dev-tooling/App.cs
+++ b/docs/_pipeline/apps/dev-tooling/App.cs
@@ -24,7 +24,7 @@ class DevToolingApp : Component
                 Button("Click me", () => setCount(count + 1)),
                 TextBlock($"Clicked {count} times").SemiBold()
             ),
-            TextField(message, setMessage, placeholder: "Type something")
+            TextBox(message, setMessage, placeholder: "Type something")
                 .Width(300)
         ).Padding(24);
     }
@@ -68,7 +68,7 @@ class IterationDemo : Component
             Heading("Iteration Cycle Demo"),
             TextBlock("Add items, then edit this code and save to see hot reload."),
             HStack(8,
-                TextField(input, setInput, placeholder: "New item")
+                TextBox(input, setInput, placeholder: "New item")
                     .Width(200),
                 Button("Add", () =>
                 {

--- a/docs/_pipeline/apps/dialogs-and-flyouts/App.cs
+++ b/docs/_pipeline/apps/dialogs-and-flyouts/App.cs
@@ -82,7 +82,7 @@ class DialogGatedPrimaryDemo : Component
                 "Rename file",
                 VStack(8,
                     TextBlock("New filename:"),
-                    TextField(name, setName, placeholder: "untitled.txt")
+                    TextBox(name, setName, placeholder: "untitled.txt")
                         .Width(280)),
                 primaryButtonText: "Rename") with
             {

--- a/docs/_pipeline/apps/effects/App.cs
+++ b/docs/_pipeline/apps/effects/App.cs
@@ -46,7 +46,7 @@ class DependencyEffectExample : Component
         }, query);
 
         return VStack(12,
-            TextField(query, setQuery, placeholder: "Search...").Width(300),
+            TextBox(query, setQuery, placeholder: "Search...").Width(300),
             TextBlock(results).Foreground(Theme.SecondaryText)
         ).Padding(24);
     }

--- a/docs/_pipeline/apps/forms/App.cs
+++ b/docs/_pipeline/apps/forms/App.cs
@@ -246,8 +246,8 @@ class InputFormattersDemo : Component
 }
 // </snippet:input-formatters>
 
-// <snippet:textfield-config>
-class TextFieldConfigDemo : Component
+// <snippet:textbox-config>
+class TextBoxConfigDemo : Component
 {
     public override Element Render()
     {
@@ -278,7 +278,7 @@ class TextFieldConfigDemo : Component
         ).Padding(24);
     }
 }
-// </snippet:textfield-config>
+// </snippet:textbox-config>
 
 // <snippet:auto-suggest>
 class AutoSuggestDemo : Component
@@ -419,7 +419,7 @@ class FormsApp : Component
                 Heading("Forms and Input"),
                 Component<ControlledInputDemo>(),
                 Component<InputTypesDemo>(),
-                Component<TextFieldConfigDemo>(),
+                Component<TextBoxConfigDemo>(),
                 Component<ValidationDemo>(),
                 Component<KeepSubmitReachableDemo>(),
                 Component<ValidationContextDemo>(),

--- a/docs/_pipeline/apps/forms/App.cs
+++ b/docs/_pipeline/apps/forms/App.cs
@@ -22,7 +22,7 @@ class ControlledInputDemo : Component
 
         return VStack(12,
             SubHeading("Controlled Input"),
-            TextField(name, setName, placeholder: "Type your name"),
+            TextBox(name, setName, placeholder: "Type your name"),
             TextBlock($"You typed: {name}").Opacity(0.6)
         ).Padding(24);
     }
@@ -44,7 +44,7 @@ class InputTypesDemo : Component
         var (priority, setPriority) = UseState(0);
 
         return VStack(12,
-            TextField(text, setText, placeholder: "Email",
+            TextBox(text, setText, placeholder: "Email",
                 header: "Email"),
             PasswordBox(password, setPassword,
                 placeholderText: "Enter password"),
@@ -78,7 +78,7 @@ class ValidationDemo : Component
 
         return VStack(12,
             SubHeading("Simple Validation"),
-            TextField(email, setEmail, placeholder: "user@example.com",
+            TextBox(email, setEmail, placeholder: "user@example.com",
                 header: "Email"),
             When(!string.IsNullOrEmpty(email) && !emailValid, () =>
                 TextBlock("Enter a valid email address")
@@ -112,7 +112,7 @@ class KeepSubmitReachableDemo : Component
 
         return VStack(12,
             SubHeading("Keeping Submit Reachable"),
-            TextField(email, setEmail, header: "Email",
+            TextBox(email, setEmail, header: "Email",
                 placeholder: "user@example.com"),
 
             // .Immediate() switches NumberBox from commit-on-blur to
@@ -142,7 +142,7 @@ class ValidationContextDemo : Component
 
         return VStack(12,
             SubHeading("Validation Context"),
-            TextField(email, v => { setEmail(v); ctx.NotifyValueChanged("email", v); },
+            TextBox(email, v => { setEmail(v); ctx.NotifyValueChanged("email", v); },
                 placeholder: "user@example.com", header: "Email")
                 .Validate("email", email,
                     Validate.Required(),
@@ -183,13 +183,13 @@ class FormFieldDemo : Component
         return VStack(12,
             SubHeading("FormField Helper"),
             FormField(
-                TextField(name, v => { setName(v); ctx.NotifyValueChanged("name", v); })
+                TextBox(name, v => { setName(v); ctx.NotifyValueChanged("name", v); })
                     .Validate("name", name, Validate.Required()),
                 label: "Full Name",
                 required: true,
                 description: "As it appears on your ID"),
             FormField(
-                TextField(email, v => { setEmail(v); ctx.NotifyValueChanged("email", v); })
+                TextBox(email, v => { setEmail(v); ctx.NotifyValueChanged("email", v); })
                     .Validate("email", email,
                         Validate.Required(), Validate.Email()),
                 label: "Email Address",
@@ -211,10 +211,10 @@ class MaskedInputDemo : Component
 
         return VStack(12,
             SubHeading("Masked Input"),
-            TextField(phoneMask.Apply(phone), v => setPhone(phoneMask.GetRawValue(v)),
+            TextBox(phoneMask.Apply(phone), v => setPhone(phoneMask.GetRawValue(v)),
                 placeholder: "(___) ___-____", header: "Phone"),
             TextBlock($"Raw: {phone}").FontSize(12).Opacity(0.6),
-            TextField(dateMask.Apply(date), v => setDate(dateMask.GetRawValue(v)),
+            TextBox(dateMask.Apply(date), v => setDate(dateMask.GetRawValue(v)),
                 placeholder: "__/__/____", header: "Date"),
             TextBlock($"Raw: {date}").FontSize(12).Opacity(0.6)
         ).Padding(24);
@@ -235,10 +235,10 @@ class InputFormattersDemo : Component
 
         return VStack(12,
             SubHeading("Input Formatters"),
-            TextField(currencyFmt.Format(currency, 0).Output,
+            TextBox(currencyFmt.Format(currency, 0).Output,
                 v => setCurrency(currencyFmt.Parse(v)),
                 placeholder: "$0.00", header: "Amount"),
-            TextField(upperFmt.Format(upper, 0).Output,
+            TextBox(upperFmt.Format(upper, 0).Output,
                 v => setUpper(upperFmt.Parse(v)),
                 placeholder: "UPPERCASE", header: "Code")
         ).Padding(24);
@@ -259,17 +259,17 @@ class TextFieldConfigDemo : Component
         var (note, setNote) = UseState("");
 
         return VStack(12,
-            TextField(qty, setQty, header: "Quantity")
+            TextBox(qty, setQty, header: "Quantity")
                 .NumericInput(),
-            TextField(email, setEmail, header: "Email")
+            TextBox(email, setEmail, header: "Email")
                 .EmailInput(),
-            TextField(url, setUrl, header: "URL")
+            TextBox(url, setUrl, header: "URL")
                 .UrlInput(),
-            TextField(phone, setPhone, header: "Phone")
+            TextBox(phone, setPhone, header: "Phone")
                 .PhoneInput(),
-            TextField(search, setSearch, placeholder: "Search…")
+            TextBox(search, setSearch, placeholder: "Search…")
                 .SearchInput(),
-            TextField(note, setNote, header: "Reference code")
+            TextBox(note, setNote, header: "Reference code")
                 .MaxLength(8)
                 .CharacterCasing(CharacterCasing.Upper)
                 .TextAlignment(TextAlignment.Center)

--- a/docs/_pipeline/apps/getting-started/App.cs
+++ b/docs/_pipeline/apps/getting-started/App.cs
@@ -14,7 +14,7 @@ class GettingStartedApp : Component
 
         return VStack(16,
             TextBlock($"Hello, {name}!").FontSize(24).Bold(),
-            TextField(name, setName, placeholder: "Enter your name").Width(250)
+            TextBox(name, setName, placeholder: "Enter your name").Width(250)
         ).Padding(24);
     }
 }
@@ -101,8 +101,8 @@ class MultipleStateExample : Component
 
         return VStack(12,
             TextBlock($"Hello, {fullName}!").FontSize(fontSize).Bold(),
-            TextField(firstName, setFirstName, placeholder: "First name").Width(200),
-            TextField(lastName, setLastName, placeholder: "Last name").Width(200),
+            TextBox(firstName, setFirstName, placeholder: "First name").Width(200),
+            TextBox(lastName, setLastName, placeholder: "Last name").Width(200),
             HStack(8,
                 TextBlock("Font size:"),
                 Slider(fontSize, 10, 40, setFontSize).Width(200),

--- a/docs/_pipeline/apps/hooks/App.cs
+++ b/docs/_pipeline/apps/hooks/App.cs
@@ -20,7 +20,7 @@ class StateDemo : Component
         return VStack(12,
             SubHeading("UseState"),
             TextBlock("Sample text").FontSize(size).Foreground(color),
-            TextField(color, setColor, placeholder: "#hex color")
+            TextBox(color, setColor, placeholder: "#hex color")
                 .Width(150),
             HStack(8,
                 TextBlock("Size:"),
@@ -42,7 +42,7 @@ class ReducerDemo : Component
         return VStack(12,
             SubHeading("UseReducer"),
             HStack(8,
-                TextField(input, setInput, placeholder: "Add item")
+                TextBox(input, setInput, placeholder: "Add item")
                     .Width(180),
                 Button("Add", () =>
                 {
@@ -141,7 +141,7 @@ class MemoDemo : Component
 
         return VStack(8,
             SubHeading("UseMemo"),
-            TextField(input, setInput).Width(250),
+            TextBox(input, setInput).Width(250),
             TextBlock($"Characters: {stats.Chars}, Words: {stats.Words}"),
             Caption($"Uppercased: {stats.Upper}")
         );
@@ -161,7 +161,7 @@ class RefDemo : Component
         return VStack(8,
             SubHeading("UseRef"),
             TextBlock($"Render count: {renderCount.Current}").SemiBold(),
-            TextField(value, setValue, placeholder: "Type to trigger renders")
+            TextBox(value, setValue, placeholder: "Type to trigger renders")
                 .Width(250),
             Caption("UseRef persists across renders without causing them")
         );
@@ -183,7 +183,7 @@ class CallbackDemo : Component
         return VStack(8,
             SubHeading("UseCallback"),
             TextBlock($"Count: {count}").FontSize(18),
-            TextField(label, setLabel, placeholder: "Button label")
+            TextBox(label, setLabel, placeholder: "Button label")
                 .Width(200),
             Button(label, stableIncrement),
             Caption("The callback identity stays stable across renders")

--- a/docs/_pipeline/apps/input-and-gestures/App.cs
+++ b/docs/_pipeline/apps/input-and-gestures/App.cs
@@ -126,7 +126,7 @@ class UseElementFocusExample : Component
 
         return VStack(12,
             TextBlock("The field below auto-focuses on mount via UseElementFocus()."),
-            TextField(name, setName, placeholder: "name").Width(280).Ref(inputRef)
+            TextBox(name, setName, placeholder: "name").Width(280).Ref(inputRef)
         ).Padding(24);
     }
 }

--- a/docs/_pipeline/apps/layout/App.cs
+++ b/docs/_pipeline/apps/layout/App.cs
@@ -40,7 +40,7 @@ class GridDemo : Component
                 columns: [GridSize.Px(120), GridSize.Star(), GridSize.Auto],
                 rows: [GridSize.Auto, GridSize.Auto],
                 TextBlock("Label").Bold().Grid(row: 0, column: 0),
-                TextField("", _ => { }, placeholder: "Input...")
+                TextBox("", _ => { }, placeholder: "Input...")
                     .Grid(row: 0, column: 1),
                 Button("Go").Grid(row: 0, column: 2),
                 TextBlock("Status").Grid(row: 1, column: 0),

--- a/docs/_pipeline/apps/navigation/App.cs
+++ b/docs/_pipeline/apps/navigation/App.cs
@@ -348,7 +348,7 @@ class PageCachingDemo : Component
     static Element CachedPage(string name) =>
         VStack(8,
             TextBlock(name).FontSize(20).Bold(),
-            TextField("", _ => { }, placeholder: "Type here — state persists")
+            TextBox("", _ => { }, placeholder: "Type here — state persists")
         ).Padding(16);
 }
 // </snippet:page-caching>

--- a/docs/_pipeline/apps/persistence/App.cs
+++ b/docs/_pipeline/apps/persistence/App.cs
@@ -35,7 +35,7 @@ class NotesEditor : Component
 
         return VStack(8,
             SubHeading("Notes"),
-            TextField(text, setText, placeholder: "Start typing…").Width(380),
+            TextBox(text, setText, placeholder: "Start typing…").Width(380),
             TextBlock($"{text.Length} characters").Opacity(0.6)
         ).Padding(16);
     }
@@ -59,9 +59,9 @@ class VersionedNotesEditor : Component
             scope: PersistedScope.Application);
 
         return VStack(8,
-            TextField(state.Title, t => setState(state with { Title = t }),
+            TextBox(state.Title, t => setState(state with { Title = t }),
                 placeholder: "Title"),
-            TextField(state.Body, b => setState(state with { Body = b, LastEdit = DateTimeOffset.Now }),
+            TextBox(state.Body, b => setState(state with { Body = b, LastEdit = DateTimeOffset.Now }),
                 placeholder: "Body")
         );
     }

--- a/docs/_pipeline/apps/readme/App.cs
+++ b/docs/_pipeline/apps/readme/App.cs
@@ -70,7 +70,7 @@ class ReadmeShowcase : Component
                     return VStack(8,
                         SubHeading("Interactive greeting"),
                         TextBlock($"Hello, {name}!").FontSize(18),
-                        TextField(name, setName, placeholder: "Your name")
+                        TextBox(name, setName, placeholder: "Your name")
                             .Width(250)
                     );
                 }),

--- a/docs/_pipeline/apps/recipe-command-palette/App.cs
+++ b/docs/_pipeline/apps/recipe-command-palette/App.cs
@@ -118,7 +118,7 @@ class CommandPalette : Component
 
         Element palette = Border(
             VStack(0,
-                TextField(query, v => { setQuery(v); setIndex(0); },
+                TextBox(query, v => { setQuery(v); setIndex(0); },
                     placeholder: "Type a command…").Width(420),
                 matches.Length == 0
                     ? TextBlock("No commands match.").Padding(12).Opacity(0.6)

--- a/docs/_pipeline/apps/recipe-login/App.cs
+++ b/docs/_pipeline/apps/recipe-login/App.cs
@@ -51,7 +51,7 @@ class LoginForm : Component
         // <snippet:render>
         return VStack(12,
             Heading("Sign in"),
-            TextField(email, setEmail, placeholder: "you@example.com",
+            TextBox(email, setEmail, placeholder: "you@example.com",
                 header: "Email").Width(280),
             PasswordBox(pwd, setPwd, placeholderText: "8+ characters"),
             error is null

--- a/docs/_pipeline/apps/recipe-multi-step-form/App.cs
+++ b/docs/_pipeline/apps/recipe-multi-step-form/App.cs
@@ -45,9 +45,9 @@ class Wizard : Component
         // <snippet:step1>
         Element StepAccount() => VStack(10,
             SubHeading("Step 1 of 3 — Account"),
-            TextField(name, setName, placeholder: "Your name",
+            TextBox(name, setName, placeholder: "Your name",
                 header: "Name").Width(340),
-            TextField(email, setEmail, placeholder: "you@example.com",
+            TextBox(email, setEmail, placeholder: "you@example.com",
                 header: "Email").Width(340)
         );
         // </snippet:step1>

--- a/docs/_pipeline/apps/recipe-search-with-suggestions/App.cs
+++ b/docs/_pipeline/apps/recipe-search-with-suggestions/App.cs
@@ -45,7 +45,7 @@ class SearchBox : Component
 
         // <snippet:render>
         return VStack(8,
-            TextField(query, setQuery, placeholder: "Search topics…").Width(300),
+            TextBox(query, setQuery, placeholder: "Search topics…").Width(300),
             suggestions.Length == 0
                 ? Empty()
                 : Border(

--- a/docs/_pipeline/apps/rules-of-reactor/App.cs
+++ b/docs/_pipeline/apps/rules-of-reactor/App.cs
@@ -109,7 +109,7 @@ class TodoListBad : Component
     public override Element Render() => VStack(4,
         Items.Select(i =>
             // No .WithKey — reorder is destructive.
-            TextField(i.Title, _ => { }, header: i.Id.ToString())
+            TextBox(i.Title, _ => { }, header: i.Id.ToString())
         ).ToArray()
     );
 }
@@ -123,7 +123,7 @@ class TodoListGood : Component
 
     public override Element Render() => VStack(4,
         Items.Select(i =>
-            TextField(i.Title, _ => { }, header: i.Id.ToString())
+            TextBox(i.Title, _ => { }, header: i.Id.ToString())
                 .WithKey(i.Id.ToString())                  // stable identity
         ).ToArray()
     );

--- a/docs/_pipeline/apps/todo-app/App.cs
+++ b/docs/_pipeline/apps/todo-app/App.cs
@@ -26,7 +26,7 @@ class TodoApp : Component
 
             // Input row
             HStack(8,
-                TextField(newText, setNewText, placeholder: "What needs to be done?")
+                TextBox(newText, setNewText, placeholder: "What needs to be done?")
                     .Width(300),
                 Button("Add", () =>
                 {

--- a/docs/_pipeline/apps/windows/App.cs
+++ b/docs/_pipeline/apps/windows/App.cs
@@ -81,7 +81,7 @@ class NotePadWindow : Component
             TextBlock(window is null
                 ? "(no owning window)"
                 : $"id={window.Id}  state={state}  dpi={window.Dpi}"),
-            TextField(text, setText, placeholder: "Type something...")
+            TextBox(text, setText, placeholder: "Type something...")
                 .Width(360),
             Button("Close", () => window?.Close())
         ).Padding(16);

--- a/docs/_pipeline/apps/winforms-interop/App.cs
+++ b/docs/_pipeline/apps/winforms-interop/App.cs
@@ -69,7 +69,7 @@ class KeyboardDemo : Component
         // Tab/Shift+Tab cycles through Reactor controls normally.
         // Tab out of the last Reactor control returns focus to WinForms.
         return VStack(12,
-            TextField(text, setText, placeholder: "Type here...")
+            TextBox(text, setText, placeholder: "Type here...")
                 .TabIndex(0),
             Button("Submit", () => { })
                 .TabIndex(1)
@@ -90,7 +90,7 @@ class AccessibleIslandComponent : Component
         return VStack(12,
             Heading("Registration")
                 .HeadingLevel(AutomationHeadingLevel.Level1),
-            TextField(name, setName, header: "Full Name")
+            TextBox(name, setName, header: "Full Name")
                 .AutomationName("Full name")
                 .Required()
                 .TabIndex(0),

--- a/docs/_pipeline/apps/xaml-developers/App.cs
+++ b/docs/_pipeline/apps/xaml-developers/App.cs
@@ -45,8 +45,8 @@ class TutorialFormPage : Component
 
         return VStack(12,
             SubHeading("Customer"),
-            TextField(name, setName, header: "Name"),
-            TextField(email, setEmail, header: "Email"),
+            TextBox(name, setName, header: "Name"),
+            TextBox(email, setEmail, header: "Email"),
             CheckBox(wantsUpdates, setWantsUpdates, label: "Email me updates"),
             HStack(8,
                 Button("Save", () => { }).IsEnabled(canSave),
@@ -67,9 +67,9 @@ class GridTranslationPage : Component
             columns: [GridSize.Auto, GridSize.Star()],
             rows: [GridSize.Auto, GridSize.Auto],
             TextBlock("First name").Bold().Grid(row: 0, column: 0),
-            TextField("", _ => { }).Grid(row: 0, column: 1),
+            TextBox("", _ => { }).Grid(row: 0, column: 1),
             TextBlock("Last name").Bold().Grid(row: 1, column: 0),
-            TextField("", _ => { }).Grid(row: 1, column: 1)
+            TextBox("", _ => { }).Grid(row: 1, column: 1)
         ) with
         {
             ColumnSpacing = 12,

--- a/docs/_pipeline/templates/accessibility.md.dt
+++ b/docs/_pipeline/templates/accessibility.md.dt
@@ -265,7 +265,7 @@ as you type in your IDE:
 |--------------|------|
 | `REACTOR_A11Y_001` | Icon-only `Button(icon, action)` calls without `.AutomationName()` |
 | `REACTOR_A11Y_002` | `Image()` without `.AutomationName()` or `.AccessibilityHidden()` |
-| `REACTOR_A11Y_003` | `TextField`/`NumberBox`/`PasswordBox` without `header:` arg or label modifier |
+| `REACTOR_A11Y_003` | `TextBox`/`NumberBox`/`PasswordBox` without `header:` arg or label modifier |
 
 These analyzers run automatically when you reference the `Reactor.Analyzers`
 package. They complement the runtime `AccessibilityScanner` by catching the

--- a/docs/_pipeline/templates/advanced.md.dt
+++ b/docs/_pipeline/templates/advanced.md.dt
@@ -370,7 +370,7 @@ static TextBox? _passwordField;
 public override Element Render()
 {
     var (pwd, setPwd) = UseState("");
-    return TextField(pwd, setPwd).Set(c => _passwordField = c);
+    return TextBox(pwd, setPwd).Set(c => _passwordField = c);
 }
 
 // Elsewhere:

--- a/docs/_pipeline/templates/charting.md.dt
+++ b/docs/_pipeline/templates/charting.md.dt
@@ -262,7 +262,7 @@ whatever actually changes. The pattern is most obvious with
 `PieChart` — a fresh `new[] { … }` on every render makes each slice
 remount, the `.Transition()` enter/exit fires for slices that haven't
 moved, and the chart "redraws itself" on every keystroke into an
-unrelated `TextField`.
+unrelated `TextBox`.
 <!-- /ai:caveat -->
 
 ## Patterns

--- a/docs/_pipeline/templates/cheat-sheet.md.dt
+++ b/docs/_pipeline/templates/cheat-sheet.md.dt
@@ -60,7 +60,7 @@ Full coverage on [Hooks](hooks.md).
 |---|---|
 | `TextBlock(s)` / `Heading(s)` / `SubHeading(s)` / `Caption(s)` | Read-only text. |
 | `Button(label, onClick)` | The click control. |
-| `TextField(value, set, placeholder?, header?)` | Single-line input. |
+| `TextBox(value, set, placeholder?, header?)` | Single-line input. |
 | `PasswordBox(pwd, set, placeholderText?)` | Obscured input. |
 | `NumberBox(value, set, header?)` | Numeric input. |
 | `CheckBox(checked, set, label?)` | Two-state checkbox. |
@@ -133,7 +133,7 @@ Full 35-token catalog on [Theming Tokens](theming-tokens.md).
 ## Patterns at a glance
 
 **Controlled input.** `var (v, set) = UseState("")` →
-`TextField(v, set)`.
+`TextBox(v, set)`.
 
 **Effect with cleanup.** Return a `Func<void>` from the effect lambda;
 Reactor calls it before the next run and on unmount.

--- a/docs/_pipeline/templates/controls.md.dt
+++ b/docs/_pipeline/templates/controls.md.dt
@@ -64,7 +64,7 @@ Forms is the category most apps spend time in; the detail page
 
 | Control | Description |
 |---|---|
-| `TextField` | Single-line text input with placeholder + header. |
+| `TextBox` | Single-line text input with placeholder + header. |
 | `PasswordBox` | Obscured text input. |
 | `NumberBox` | Numeric input with up/down spinner. |
 | `CheckBox` | Two-state checkbox with optional label. |

--- a/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
+++ b/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
@@ -21,7 +21,7 @@ arrives without a route back. Microsoft.UI.Reactor (Reactor) treats dialogs and 
 controlled components: you own the open/closed boolean, the component
 tree always contains the dialog element, and the visibility is a state
 flag the user-driven event handlers flip back. That is the same shape as
-`TextField` from [Forms](forms.md), and it makes the dialog testable —
+`TextBox` from [Forms](forms.md), and it makes the dialog testable —
 the dialog is open if and only if its driving state says so. Read this
 page when you are reaching for `ContentDialog` for a Save/Discard choice,
 `MenuFlyout` for a right-click menu, `CommandBarFlyout` for a selection
@@ -104,7 +104,7 @@ provides:
 ```csharp snippet="dialogs-and-flyouts/dialog-gated-primary"
 ```
 
-![Dialog with TextField; primary disabled until non-empty](screenshot://dialogs-and-flyouts/dialog-gated-primary)
+![Dialog with TextBox; primary disabled until non-empty](screenshot://dialogs-and-flyouts/dialog-gated-primary)
 
 <!-- ai:caveat -->
 `ContentDialog.ShowAsync` is single-instance per `XamlRoot` — the WinUI

--- a/docs/_pipeline/templates/docking.md.dt
+++ b/docs/_pipeline/templates/docking.md.dt
@@ -131,7 +131,7 @@ Reactor subtree to mount inside it, keyed off `content.Key`.
 ## Tips
 
 **Always set `Key` on panes with stateful content.** A controlled
-`TextField` inside a pane without a `Key` will lose its draft text the
+`TextBox` inside a pane without a `Key` will lose its draft text the
 moment a user drags the tab — the reconciler can't tell it's the
 "same" pane, so it remounts the subtree. Keys can be strings, GUIDs,
 enums, or any equatable domain identifier.

--- a/docs/_pipeline/templates/flex-layout.md.dt
+++ b/docs/_pipeline/templates/flex-layout.md.dt
@@ -307,9 +307,9 @@ container.
 ```csharp
 // Don't — two-dimensional alignment between rows is not what Flex does.
 FlexColumn(
-    FlexRow(TextBlock("Name:"), TextField(name, setName)) with { ColumnGap = 8 },
-    FlexRow(TextBlock("Email:"), TextField(email, setEmail)) with { ColumnGap = 8 },
-    FlexRow(TextBlock("Phone:"), TextField(phone, setPhone)) with { ColumnGap = 8 }
+    FlexRow(TextBlock("Name:"), TextBox(name, setName)) with { ColumnGap = 8 },
+    FlexRow(TextBlock("Email:"), TextBox(email, setEmail)) with { ColumnGap = 8 },
+    FlexRow(TextBlock("Phone:"), TextBox(phone, setPhone)) with { ColumnGap = 8 }
 )
 ```
 

--- a/docs/_pipeline/templates/focus-and-input-internals.md.dt
+++ b/docs/_pipeline/templates/focus-and-input-internals.md.dt
@@ -78,7 +78,7 @@ event-args records.
 focus system. Components call `useFocus.Register(name)` on each input
 during render, and the manager keeps a `List<string>` of field names
 in order. `FocusNext` and `FocusPrevious` walk that list — the
-common pattern is `<TextField>.OnEnter(() => fm.FocusNext(name))` so
+common pattern is `<TextBox>.OnEnter(() => fm.FocusNext(name))` so
 pressing Enter on a field advances to the next one, and Enter on the
 last field calls the registered submit handler. The `_controls`
 dictionary maps each field name to the live WinUI `Control`; when

--- a/docs/_pipeline/templates/forms.md.dt
+++ b/docs/_pipeline/templates/forms.md.dt
@@ -85,7 +85,7 @@ text. Check the API reference for each control's full signature.
 so you rarely need `.Set(...)`. The named-input shapes set the appropriate
 `InputScope` for soft-keyboard and IME hinting:
 
-```csharp snippet="forms/TextBox-config"
+```csharp snippet="forms/textbox-config"
 ```
 
 | Fluent | Effect |

--- a/docs/_pipeline/templates/forms.md.dt
+++ b/docs/_pipeline/templates/forms.md.dt
@@ -4,7 +4,7 @@ app: forms
 order: 7
 audience: intermediate
 goal: |
-  Cover every input control (TextField, PasswordBox, NumberBox, ComboBox,
+  Cover every input control (TextBox, PasswordBox, NumberBox, ComboBox,
   RadioButtons, CheckBox, Slider, ToggleSwitch, AutoSuggestBox, DatePicker,
   TimePicker, CalendarDatePicker, CalendarView, ColorPicker), the
   controlled-input pattern, the validation system (ValidationContext,
@@ -67,7 +67,7 @@ pattern: current value in, change handler out.
 
 | Control | Value type | Change handler |
 |---------|-----------|---------------|
-| `TextField` | `string` | `Action<string>` |
+| `TextBox` | `string` | `Action<string>` |
 | `PasswordBox` | `string` | `Action<string>` |
 | `Slider` | `double` | `Action<double>` |
 | `NumberBox` | `double` | `Action<double>` |
@@ -79,13 +79,13 @@ pattern: current value in, change handler out.
 All controls accept optional parameters for labels, headers, and placeholder
 text. Check the API reference for each control's full signature.
 
-## Configuring TextField
+## Configuring TextBox
 
-`TextField` covers the common WinUI `TextBox` knobs through dedicated fluents
+`TextBox` covers the common WinUI `TextBox` knobs through dedicated fluents
 so you rarely need `.Set(...)`. The named-input shapes set the appropriate
 `InputScope` for soft-keyboard and IME hinting:
 
-```csharp snippet="forms/textfield-config"
+```csharp snippet="forms/TextBox-config"
 ```
 
 | Fluent | Effect |
@@ -160,7 +160,7 @@ when validity is gated on async checks, required-but-untouched fields,
 cross-field rules, or any derived condition that can't be made instantaneous.
 
 > **Where not to use `.IsDisabledFocusable()`:** only buttons. For data-entry
-> controls (`TextField`, `NumberBox`, `CheckBox`, etc.), `IsEnabled=false`
+> controls (`TextBox`, `NumberBox`, `CheckBox`, etc.), `IsEnabled=false`
 > usually means "this field isn't part of your current task" (cascading
 > from another input), and tab-skipping is the correct UX. Use
 > `IsReadOnly` if you need a visible-but-non-editable text control.
@@ -384,7 +384,7 @@ per page.
 
 For a single-field form (search box, comment input), wire submission
 to Enter rather than a Submit button. `AutoSuggestBox` does this
-automatically via `onQuerySubmitted`. For `TextField`, route through
+automatically via `onQuerySubmitted`. For `TextBox`, route through
 `.KeyDown` or wrap the field in an `[ai:lock]` form panel; see
 [input-and-gestures](input-and-gestures.md) for the routed-events
 surface.
@@ -404,7 +404,7 @@ concern as [Keeping Submit Reachable](#keeping-submit-reachable).
 
 ```csharp
 // Don't:
-TextField(initial: "default value")
+TextBox(initial: "default value")
 ```
 
 ```csharp snippet="forms/controlled-input"

--- a/docs/_pipeline/templates/getting-started.md.dt
+++ b/docs/_pipeline/templates/getting-started.md.dt
@@ -274,7 +274,7 @@ survive hot reload.
 Every Reactor app eventually has the same two ingredients: an event
 handler that calls a setter, and a value rendered from the setter's
 state slot. The hello-world snippet above wires `setName` to
-`TextField`'s change handler and reads `name` back in the
+`TextBox`'s change handler and reads `name` back in the
 `Text("Hello, ...")` line — that round trip is the entire reactivity
 contract. Once it feels routine, every other [hook](hooks.md) is just
 a specialization (`UseReducer` for derived updates, `UseEffect` for

--- a/docs/_pipeline/templates/input-and-gestures.md.dt
+++ b/docs/_pipeline/templates/input-and-gestures.md.dt
@@ -78,7 +78,7 @@ was set — otherwise hit-testing would miss the unfilled shape entirely.
 ### Keyboard events
 
 ```csharp
-TextField(value, setValue)
+TextBox(value, setValue)
     .OnKeyDown((_, e) => { if (e.Key == VirtualKey.Enter) Submit(); })
     .OnPreviewKeyDown((_, e) => Trace("preview"))
     .OnCharacterReceived((_, e) => Validate(e.Character));
@@ -91,7 +91,7 @@ shortcut interception that needs to suppress further routing.
 ### Focus events
 
 ```csharp
-TextField(value, setValue)
+TextBox(value, setValue)
     .OnGotFocus((_, _) => ShowValidationHint())
     .OnLostFocus((_, _) => HideValidationHint());
 ```
@@ -259,7 +259,7 @@ public class SearchBox : Component
 
         Context.UseEffect(() => inputRef.Current?.SelectAll(), Array.Empty<object>());
 
-        return TextField(query, setQuery).Ref(inputRef);
+        return TextBox(query, setQuery).Ref(inputRef);
     }
 }
 ```
@@ -477,7 +477,7 @@ If a parent needs to see the press before children consume it, use
 ### Using `.OnKeyDown` for accelerator chords
 
 `.OnKeyDown` fires per element on focus — a `Ctrl+S` handler attached
-to a `TextField` only fires while that field has focus. For app-wide
+to a `TextBox` only fires while that field has focus. For app-wide
 accelerators (Save, Find, Run), use Reactor's
 [commanding](commanding.md) system: `new Command { ..., AccessKey =
 "S", AccessKeyModifiers = VirtualKeyModifiers.Control }` registers

--- a/docs/_pipeline/templates/reactor-vs-xaml.md.dt
+++ b/docs/_pipeline/templates/reactor-vs-xaml.md.dt
@@ -125,7 +125,7 @@ the reconciler writes the new `Text` value onto the existing
 `TextBlock`. There is no binding object — the closure that produces
 the element is the binding.
 
-`TwoWay` shows up as the controlled-input pattern. A `TextField` takes
+`TwoWay` shows up as the controlled-input pattern. A `TextBox` takes
 the current value and a setter callback; the user's input fires the
 callback, which writes the slot, which re-renders, which writes the
 new value back into the `TextBox`. Mode is implicit in whether you

--- a/docs/_pipeline/templates/recipes/command-palette.md.dt
+++ b/docs/_pipeline/templates/recipes/command-palette.md.dt
@@ -72,7 +72,7 @@ out from under the old selection.
 ```
 
 `OnPreviewKeyDown` tunnels — it fires before the bubbling pair, so
-Up / Down move the selection instead of the `TextField` caret, and
+Up / Down move the selection instead of the `TextBox` caret, and
 Enter fires the highlighted command rather than inserting a newline.
 Setting `e.Handled = true` stops further routing so the underlying
 control stays out of the way. The same handler closes the palette on

--- a/docs/_pipeline/templates/recipes/login.md.dt
+++ b/docs/_pipeline/templates/recipes/login.md.dt
@@ -81,7 +81,7 @@ a single render check; a guard inside `Submit()` runs after the user
 already pressed it and the UI looked ready. Both layers are good
 hygiene but the button gate is the load-bearing one.
 
-**Use [`PasswordBox`](../forms.md), not `TextField` with a hex style.**
+**Use [`PasswordBox`](../forms.md), not `TextBox` with a hex style.**
 The control implements paste-without-reveal, autofill, and the
 accessibility peer; reinventing it in user code drops those.
 

--- a/docs/_pipeline/templates/recipes/multi-step-form.md.dt
+++ b/docs/_pipeline/templates/recipes/multi-step-form.md.dt
@@ -27,7 +27,7 @@ visible slot changes.
 | Per-field state | `UseState<string>` / `UseState<int>` / `UseState<bool>` |
 | Step branching | `switch` on the step index returning `Element` |
 | Advance gating | `.IsEnabled(canAdvance)` on the Next button |
-| Input controls | [`TextField`](../forms.md), [`RadioButtons`](../forms.md), [`CheckBox`](../forms.md) |
+| Input controls | [`TextBox`](../forms.md), [`RadioButtons`](../forms.md), [`CheckBox`](../forms.md) |
 
 ### State
 

--- a/docs/_pipeline/templates/text-and-media.md.dt
+++ b/docs/_pipeline/templates/text-and-media.md.dt
@@ -33,7 +33,7 @@ prose, then jump to the control you need.
 # Text and Media
 
 This page covers every read-only-display and inline-rich-text control in
-Reactor. For input controls (`TextField`, `PasswordBox`, `RichEditBox`),
+Reactor. For input controls (`TextBox`, `PasswordBox`, `RichEditBox`),
 see [Forms](forms.md). For data-bound collections, see
 [Collections](collections.md).
 
@@ -153,7 +153,7 @@ text with paste-from-formatted-source, spell-check, IME composition, and
 selection. The change handler fires with the plain text content; for
 formatted output you read `RichEditBox.Document` through `.Set(...)` and
 serialize the text range yourself. Single-line text input belongs in
-[`TextField`](forms.md), not here.
+[`TextBox`](forms.md), not here.
 
 | Fluent | Effect |
 |---|---|

--- a/docs/_pipeline/templates/xaml-developers.md.dt
+++ b/docs/_pipeline/templates/xaml-developers.md.dt
@@ -44,7 +44,7 @@ Think of Reactor as "WinUI controls, but expressed like a function of state."
 |---------|------------|
 | `Page`, `UserControl`, `Window` markup | A `Component` with `Render()` |
 | `{Binding Name}` | Plain C# variable usage: `TextBlock(name)` |
-| `Mode=TwoWay` | Controlled input: `TextField(name, setName)` |
+| `Mode=TwoWay` | Controlled input: `TextBox(name, setName)` |
 | `DataContext` | Local hook state, typed props, or [context](context.md) |
 | `ICommand` | Lambdas, methods, or [commands](commanding.md) |
 | `StackPanel` | [`VStack`](layout.md) or [`HStack`](layout.md) |
@@ -86,7 +86,7 @@ In Reactor, the same screen becomes a component:
 What changed:
 
 - **Bindings became state variables.** `Name`, `Email`, and `WantsUpdates` live in `UseState`.
-- **Two-way input became explicit.** `TextField(name, setName)` makes data flow obvious.
+- **Two-way input became explicit.** `TextBox(name, setName)` makes data flow obvious.
 - **The command became normal C#.** The save button uses a lambda instead of XAML command wiring.
 - **Derived UI stayed inline.** `canSave` is just a local expression, not a converter or extra property.
 
@@ -156,10 +156,10 @@ re-runs whenever the relevant state changes.
 
 <!-- ai:caveat -->
 A XAML `Binding` with `Mode=TwoWay` becomes a Reactor controlled-input
-pattern (`TextField(name, setName)`), not a binding-with-mode. There is
+pattern (`TextBox(name, setName)`), not a binding-with-mode. There is
 **no** Reactor analogue to `Mode=OneWay` / `Mode=OneTime` / `Mode=TwoWay`
 because state IS the binding — every render re-reads from state, every
-edit calls a setter. If you write `TextField(name, _ => { })` and never
+edit calls a setter. If you write `TextBox(name, _ => { })` and never
 call a setter, the field is read-only (effectively `Mode=OneWay`); if
 you wire both, it round-trips (effectively `Mode=TwoWay`). The trap is
 "reach for the binding mode for OneTime" — there is no equivalent.
@@ -167,7 +167,7 @@ Cache the value in a `UseRef` and read `ref.Current` if you genuinely
 want to capture-and-freeze, or call a function once in a
 `UseEffect(() => …, Array.Empty<object>())` so it runs only on mount.
 The Reactor analyzer doesn't emit a specific diagnostic for "missing
-setter" — passing `null` to a `TextField` change handler is a
+setter" — passing `null` to a `TextBox` change handler is a
 `CS8625` "Cannot convert null literal" instead.
 <!-- /ai:caveat -->
 
@@ -177,7 +177,7 @@ You do not need a special command layer for every button click.
 
 - `Button("Save", Save)` is the direct equivalent of a button command.
 - `Button("Refresh", async () => await ReloadAsync())` works for async actions.
-- `TextField(text, setText)` replaces both `TextChanged` wiring and two-way binding.
+- `TextBox(text, setText)` replaces both `TextChanged` wiring and two-way binding.
 
 If you want richer busy/error behavior, Reactor also has a dedicated
 [Commanding](commanding.md) API. But the default is deliberately small: use a
@@ -195,7 +195,7 @@ a single `IsCheckedChanged` callback):
 | WinUI XAML event | Reactor fluent |
 |------------------|----------------|
 | `<Button Click="OnClick"/>` | `Button("…").Click(handler)` |
-| `<TextBox TextChanged="OnTextChanged"/>` | `TextField(text, setText).Changed(handler)` |
+| `<TextBox TextChanged="OnTextChanged"/>` | `TextBox(text, setText).Changed(handler)` |
 | `<ListView SelectionChanged="OnSelectionChanged"/>` | `ListView<T>(...).SelectionChanged(handler)` |
 | `<ComboBox SelectionChanged="OnSelectionChanged"/>` | `ComboBox(...).SelectedIndexChanged(handler)` — Reactor reports the selected index, not the args |
 | `<CheckBox Checked="…" Unchecked="…"/>` | `CheckBox(value, setValue).IsCheckedChanged(handler)` — Reactor collapses the three XAML events into a single bool callback |

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -56,7 +56,7 @@ class Tier1Demo : Component
             TextBlock("Profile")
                 .FontSize(18).SemiBold()
                 .HeadingLevel(AutomationHeadingLevel.Level2),
-            TextField("", _ => { }, placeholder: "Display name")
+            TextBox("", _ => { }, placeholder: "Display name")
                 .AutomationName("Display name")
                 .TabIndex(1)
                 .AccessKey("N"),
@@ -95,7 +95,7 @@ class Tier2Demo : Component
     public override Element Render()
     {
         return VStack(12,
-            TextField("", _ => { }, placeholder: "Search...")
+            TextBox("", _ => { }, placeholder: "Search...")
                 .AutomationName("Search products")
                 .HelpText("Type a product name or SKU to filter results")
                 .Width(300),
@@ -148,9 +148,9 @@ class AccessibleFormDemo : Component
         return VStack(12,
             TextBlock("Create Account").FontSize(24).Bold()
                 .HeadingLevel(AutomationHeadingLevel.Level1),
-            TextField(name, setName, header: "Full Name")
+            TextBox(name, setName, header: "Full Name")
                 .AutomationName("Full name").Required().TabIndex(1),
-            TextField(email, setEmail, header: "Email")
+            TextBox(email, setEmail, header: "Email")
                 .AutomationName("Email address").Required().TabIndex(2)
                 .HelpText("We'll send a verification link"),
             CheckBox(agree, setAgree, label: "I accept the terms")
@@ -196,7 +196,7 @@ class LandmarksDemo : Component
             ).Landmark(AutomationLandmarkType.Main)
              .AutomationName("Main content"),
 
-            TextField("", _ => { }, placeholder: "Search...")
+            TextBox("", _ => { }, placeholder: "Search...")
                 .AutomationName("Site search")
                 .Landmark(AutomationLandmarkType.Search)
         ).Padding(24);
@@ -269,7 +269,7 @@ class FocusTrapDemo : Component
                     VStack(12,
                         TextBlock("Modal Dialog").FontSize(18).Bold(),
                         TextBlock("Tab/Shift+Tab stays inside this panel."),
-                        TextField("", _ => { }, placeholder: "Name")
+                        TextBox("", _ => { }, placeholder: "Name")
                             .TabIndex(0),
                         Button("Close", () => setShowModal(false))
                             .TabIndex(1)
@@ -451,7 +451,7 @@ as you type in your IDE:
 |--------------|------|
 | `REACTOR_A11Y_001` | Icon-only `Button(icon, action)` calls without `.AutomationName()` |
 | `REACTOR_A11Y_002` | `Image()` without `.AutomationName()` or `.AccessibilityHidden()` |
-| `REACTOR_A11Y_003` | `TextField`/`NumberBox`/`PasswordBox` without `header:` arg or label modifier |
+| `REACTOR_A11Y_003` | `TextBox`/`NumberBox`/`PasswordBox` without `header:` arg or label modifier |
 
 These analyzers run automatically when you reference the `Reactor.Analyzers`
 package. They complement the runtime `AccessibilityScanner` by catching the

--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -191,7 +191,7 @@ class ElementRefFocusDemo : Component
 
         return VStack(12,
             SubHeading("Imperative focus via ElementRef<T>"),
-            TextField(name, setName, placeholder: "Name").Ref(fieldRef),
+            TextBox(name, setName, placeholder: "Name").Ref(fieldRef),
             Button("Focus the field", () =>
                 fieldRef.Current?.Focus(FocusState.Programmatic))
         ).Padding(24);
@@ -355,7 +355,7 @@ class ObservableTreeDemo : Component
 
         return VStack(12,
             SubHeading("UseObservableTree"),
-            TextField(vm.UserName, v => vm.UserName = v,
+            TextBox(vm.UserName, v => vm.UserName = v,
                 header: "User Name"),
             ToggleSwitch(vm.DarkMode, v => vm.DarkMode = v,
                 header: "Dark Mode"),
@@ -398,7 +398,7 @@ class ObservableCollectionDemo : Component
         return VStack(12,
             SubHeading("UseCollection"),
             HStack(8,
-                TextField(input, setInput, placeholder: "New task")
+                TextBox(input, setInput, placeholder: "New task")
                     .Width(200),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(input))
@@ -578,7 +578,7 @@ static TextBox? _passwordField;
 public override Element Render()
 {
     var (pwd, setPwd) = UseState("");
-    return TextField(pwd, setPwd).Set(c => _passwordField = c);
+    return TextBox(pwd, setPwd).Set(c => _passwordField = c);
 }
 
 // Elsewhere:

--- a/docs/guide/architecture-overview.md
+++ b/docs/guide/architecture-overview.md
@@ -145,7 +145,7 @@ public UIElement GetElement(ElementFactoryGetArgs args)
         return new TextBlock { Text = "" };
 
     var item = _items[index];
-    var element = _viewBuilder(item, index);
+    var element = BuildOrCache(key, item, index);
 
     UIElement? control;
     if (_recyclePool.Count > 0)
@@ -242,6 +242,14 @@ public UIElement? Reconcile(
         // every component re-runs Render() even when props/deps are unchanged.
         _forceFullRenderActive = ForceFullRenderPending;
         ForceFullRenderPending = false;
+
+        // Build the dirty-ancestor path. For every component node
+        // whose SelfTriggered is true, walk up the realized visual
+        // tree and add each ancestor control. Consumed by Update's
+        // shallow-equality short-circuit so the walk can reach the
+        // self-triggered descendant even when its ancestor element
+        // records are structurally unchanged.
+        PopulateDirtyAncestorPath();
     }
     try {
     try

--- a/docs/guide/charting.md
+++ b/docs/guide/charting.md
@@ -471,7 +471,7 @@ DSL. Import `using static Microsoft.UI.Reactor.Charting.D3.D3Charts` for:
 > `PieChart` — a fresh `new[] { … }` on every render makes each slice
 > remount, the `.Transition()` enter/exit fires for slices that haven't
 > moved, and the chart "redraws itself" on every keystroke into an
-> unrelated `TextField`.
+> unrelated `TextBox`.
 
 ## Patterns
 

--- a/docs/guide/cheat-sheet.md
+++ b/docs/guide/cheat-sheet.md
@@ -79,7 +79,7 @@ Full coverage on [Hooks](hooks.md).
 |---|---|
 | `TextBlock(s)` / `Heading(s)` / `SubHeading(s)` / `Caption(s)` | Read-only text. |
 | `Button(label, onClick)` | The click control. |
-| `TextField(value, set, placeholder?, header?)` | Single-line input. |
+| `TextBox(value, set, placeholder?, header?)` | Single-line input. |
 | `PasswordBox(pwd, set, placeholderText?)` | Obscured input. |
 | `NumberBox(value, set, header?)` | Numeric input. |
 | `CheckBox(checked, set, label?)` | Two-state checkbox. |
@@ -152,7 +152,7 @@ Full 35-token catalog on [Theming Tokens](theming-tokens.md).
 ## Patterns at a glance
 
 **Controlled input.** `var (v, set) = UseState("")` →
-`TextField(v, set)`.
+`TextBox(v, set)`.
 
 **Effect with cleanup.** Return a `Func<void>` from the effect lambda;
 Reactor calls it before the next run and on unmount.

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -258,7 +258,7 @@ class VirtualListRefDemo : Component
         return VStack(12,
             SubHeading("VirtualListRef — Imperative Scroll"),
             HStack(8,
-                TextField(targetIndex, setTargetIndex,
+                TextBox(targetIndex, setTargetIndex,
                     placeholder: "Index"),
                 Button("Scroll To", () =>
                 {
@@ -398,7 +398,7 @@ class WithKeyDemo : Component
         return VStack(12,
             SubHeading("Stable Identity with WithKey"),
             HStack(8,
-                TextField(newItem, setNewItem, placeholder: "New item"),
+                TextBox(newItem, setNewItem, placeholder: "New item"),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(newItem)) {
                         updateItems(l => [.. l, newItem.Trim()]);
@@ -673,7 +673,7 @@ class WithKeyDemo : Component
         return VStack(12,
             SubHeading("Stable Identity with WithKey"),
             HStack(8,
-                TextField(newItem, setNewItem, placeholder: "New item"),
+                TextBox(newItem, setNewItem, placeholder: "New item"),
                 Button("Add", () => {
                     if (!string.IsNullOrWhiteSpace(newItem)) {
                         updateItems(l => [.. l, newItem.Trim()]);

--- a/docs/guide/commanding.md
+++ b/docs/guide/commanding.md
@@ -44,7 +44,7 @@ class BasicCommandExample : Component
         };
 
         return VStack(12,
-            TextField(text, v => { setText(v); setSaved(false); })
+            TextBox(text, v => { setText(v); setSaved(false); })
                 .Width(400),
             HStack(8,
                 Button(saveCmd),
@@ -338,7 +338,7 @@ class CommandBarExample : Component
                 secondaryCommands: new[] {
                     AppBarButton(delete) }
             ),
-            TextField(text, setText).Margin(16)
+            TextBox(text, setText).Margin(16)
         );
     }
 }

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -50,7 +50,7 @@ class Greeting : Component
 
         return VStack(12,
             TextBlock($"Hello, {name}!").FontSize(20).Bold(),
-            TextField(name, setName, placeholder: "Your name")
+            TextBox(name, setName, placeholder: "Your name")
                 .Width(200)
         ).Padding(16);
     }

--- a/docs/guide/controls.md
+++ b/docs/guide/controls.md
@@ -62,7 +62,7 @@ class FormsGroup : Component
         var (volume, setVolume) = UseState(60.0);
 
         return VStack(8,
-            TextField(name, setName, placeholder: "Name").Width(200),
+            TextBox(name, setName, placeholder: "Name").Width(200),
             CheckBox(agree, setAgree, label: "I agree"),
             Slider(volume, 0, 100, setVolume).Width(200),
             Button("Submit", () => { })
@@ -75,7 +75,7 @@ class FormsGroup : Component
 
 | Control | Description |
 |---|---|
-| `TextField` | Single-line text input with placeholder + header. |
+| `TextBox` | Single-line text input with placeholder + header. |
 | `PasswordBox` | Obscured text input. |
 | `NumberBox` | Numeric input with up/down spinner. |
 | `CheckBox` | Two-state checkbox with optional label. |

--- a/docs/guide/dev-tooling.md
+++ b/docs/guide/dev-tooling.md
@@ -78,7 +78,7 @@ class DevToolingApp : Component
                 Button("Click me", () => setCount(count + 1)),
                 TextBlock($"Clicked {count} times").SemiBold()
             ),
-            TextField(message, setMessage, placeholder: "Type something")
+            TextBox(message, setMessage, placeholder: "Type something")
                 .Width(300)
         ).Padding(24);
     }
@@ -293,7 +293,7 @@ class IterationDemo : Component
             Heading("Iteration Cycle Demo"),
             TextBlock("Add items, then edit this code and save to see hot reload."),
             HStack(8,
-                TextField(input, setInput, placeholder: "New item")
+                TextBox(input, setInput, placeholder: "New item")
                     .Width(200),
                 Button("Add", () =>
                 {

--- a/docs/guide/dialogs-and-flyouts.md
+++ b/docs/guide/dialogs-and-flyouts.md
@@ -7,7 +7,7 @@ arrives without a route back. Microsoft.UI.Reactor (Reactor) treats dialogs and 
 controlled components: you own the open/closed boolean, the component
 tree always contains the dialog element, and the visibility is a state
 flag the user-driven event handlers flip back. That is the same shape as
-`TextField` from [Forms](forms.md), and it makes the dialog testable —
+`TextBox` from [Forms](forms.md), and it makes the dialog testable —
 the dialog is open if and only if its driving state says so. Read this
 page when you are reaching for `ContentDialog` for a Save/Discard choice,
 `MenuFlyout` for a right-click menu, `CommandBarFlyout` for a selection
@@ -153,7 +153,7 @@ class DialogGatedPrimaryDemo : Component
                 "Rename file",
                 VStack(8,
                     TextBlock("New filename:"),
-                    TextField(name, setName, placeholder: "untitled.txt")
+                    TextBox(name, setName, placeholder: "untitled.txt")
                         .Width(280)),
                 primaryButtonText: "Rename") with
             {
@@ -169,7 +169,7 @@ class DialogGatedPrimaryDemo : Component
 }
 ```
 
-![Dialog with TextField; primary disabled until non-empty](images/dialogs-and-flyouts/dialog-gated-primary.png)
+![Dialog with TextBox; primary disabled until non-empty](images/dialogs-and-flyouts/dialog-gated-primary.png)
 
 > **Caveat:** `ContentDialog.ShowAsync` is single-instance per `XamlRoot` — the WinUI
 > control raises `Show another ContentDialog before closing the previous`

--- a/docs/guide/docking.md
+++ b/docs/guide/docking.md
@@ -237,7 +237,7 @@ Reactor subtree to mount inside it, keyed off `content.Key`.
 ## Tips
 
 **Always set `Key` on panes with stateful content.** A controlled
-`TextField` inside a pane without a `Key` will lose its draft text the
+`TextBox` inside a pane without a `Key` will lose its draft text the
 moment a user drags the tab — the reconciler can't tell it's the
 "same" pane, so it remounts the subtree. Keys can be strings, GUIDs,
 enums, or any equatable domain identifier.

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -85,7 +85,7 @@ class DependencyEffectExample : Component
         }, query);
 
         return VStack(12,
-            TextField(query, setQuery, placeholder: "Search...").Width(300),
+            TextBox(query, setQuery, placeholder: "Search...").Width(300),
             TextBlock(results).Foreground(Theme.SecondaryText)
         ).Padding(24);
     }

--- a/docs/guide/flex-layout.md
+++ b/docs/guide/flex-layout.md
@@ -471,9 +471,9 @@ container.
 ```csharp
 // Don't — two-dimensional alignment between rows is not what Flex does.
 FlexColumn(
-    FlexRow(TextBlock("Name:"), TextField(name, setName)) with { ColumnGap = 8 },
-    FlexRow(TextBlock("Email:"), TextField(email, setEmail)) with { ColumnGap = 8 },
-    FlexRow(TextBlock("Phone:"), TextField(phone, setPhone)) with { ColumnGap = 8 }
+    FlexRow(TextBlock("Name:"), TextBox(name, setName)) with { ColumnGap = 8 },
+    FlexRow(TextBlock("Email:"), TextBox(email, setEmail)) with { ColumnGap = 8 },
+    FlexRow(TextBlock("Phone:"), TextBox(phone, setPhone)) with { ColumnGap = 8 }
 )
 ```
 

--- a/docs/guide/focus-and-input-internals.md
+++ b/docs/guide/focus-and-input-internals.md
@@ -83,7 +83,7 @@ public void FocusNext(string? currentField = null)
 focus system. Components call `useFocus.Register(name)` on each input
 during render, and the manager keeps a `List<string>` of field names
 in order. `FocusNext` and `FocusPrevious` walk that list — the
-common pattern is `<TextField>.OnEnter(() => fm.FocusNext(name))` so
+common pattern is `<TextBox>.OnEnter(() => fm.FocusNext(name))` so
 pressing Enter on a field advances to the next one, and Enter on the
 last field calls the registered submit handler. The `_controls`
 dictionary maps each field name to the live WinUI `Control`; when

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -40,7 +40,7 @@ class ControlledInputDemo : Component
 
         return VStack(12,
             SubHeading("Controlled Input"),
-            TextField(name, setName, placeholder: "Type your name"),
+            TextBox(name, setName, placeholder: "Type your name"),
             TextBlock($"You typed: {name}").Opacity(0.6)
         ).Padding(24);
     }
@@ -73,7 +73,7 @@ class InputTypesDemo : Component
         var (priority, setPriority) = UseState(0);
 
         return VStack(12,
-            TextField(text, setText, placeholder: "Email",
+            TextBox(text, setText, placeholder: "Email",
                 header: "Email"),
             PasswordBox(password, setPassword,
                 placeholderText: "Enter password"),
@@ -95,7 +95,7 @@ class InputTypesDemo : Component
 
 | Control | Value type | Change handler |
 |---------|-----------|---------------|
-| `TextField` | `string` | `Action<string>` |
+| `TextBox` | `string` | `Action<string>` |
 | `PasswordBox` | `string` | `Action<string>` |
 | `Slider` | `double` | `Action<double>` |
 | `NumberBox` | `double` | `Action<double>` |
@@ -107,44 +107,13 @@ class InputTypesDemo : Component
 All controls accept optional parameters for labels, headers, and placeholder
 text. Check the API reference for each control's full signature.
 
-## Configuring TextField
+## Configuring TextBox
 
-`TextField` covers the common WinUI `TextBox` knobs through dedicated fluents
+`TextBox` covers the common WinUI `TextBox` knobs through dedicated fluents
 so you rarely need `.Set(...)`. The named-input shapes set the appropriate
 `InputScope` for soft-keyboard and IME hinting:
 
-```csharp
-class TextFieldConfigDemo : Component
-{
-    public override Element Render()
-    {
-        var (qty, setQty) = UseState("");
-        var (email, setEmail) = UseState("");
-        var (url, setUrl) = UseState("");
-        var (phone, setPhone) = UseState("");
-        var (search, setSearch) = UseState("");
-        var (note, setNote) = UseState("");
-
-        return VStack(12,
-            TextField(qty, setQty, header: "Quantity")
-                .NumericInput(),
-            TextField(email, setEmail, header: "Email")
-                .EmailInput(),
-            TextField(url, setUrl, header: "URL")
-                .UrlInput(),
-            TextField(phone, setPhone, header: "Phone")
-                .PhoneInput(),
-            TextField(search, setSearch, placeholder: "Search…")
-                .SearchInput(),
-            TextField(note, setNote, header: "Reference code")
-                .MaxLength(8)
-                .CharacterCasing(CharacterCasing.Upper)
-                .TextAlignment(TextAlignment.Center)
-                .IsSpellCheckEnabled(false)
-                .Description("Eight characters, automatically uppercased.")
-        ).Padding(24);
-    }
-}
+```csharp snippet="forms/TextBox-config"
 ```
 
 | Fluent | Effect |
@@ -187,7 +156,7 @@ class ValidationDemo : Component
 
         return VStack(12,
             SubHeading("Simple Validation"),
-            TextField(email, setEmail, placeholder: "user@example.com",
+            TextBox(email, setEmail, placeholder: "user@example.com",
                 header: "Email"),
             When(!string.IsNullOrEmpty(email) && !emailValid, () =>
                 TextBlock("Enter a valid email address")
@@ -239,7 +208,7 @@ class KeepSubmitReachableDemo : Component
 
         return VStack(12,
             SubHeading("Keeping Submit Reachable"),
-            TextField(email, setEmail, header: "Email",
+            TextBox(email, setEmail, header: "Email",
                 placeholder: "user@example.com"),
 
             // .Immediate() switches NumberBox from commit-on-blur to
@@ -281,7 +250,7 @@ when validity is gated on async checks, required-but-untouched fields,
 cross-field rules, or any derived condition that can't be made instantaneous.
 
 > **Where not to use `.IsDisabledFocusable()`:** only buttons. For data-entry
-> controls (`TextField`, `NumberBox`, `CheckBox`, etc.), `IsEnabled=false`
+> controls (`TextBox`, `NumberBox`, `CheckBox`, etc.), `IsEnabled=false`
 > usually means "this field isn't part of your current task" (cascading
 > from another input), and tab-skipping is the correct UX. Use
 > `IsReadOnly` if you need a visible-but-non-editable text control.
@@ -304,7 +273,7 @@ class ValidationContextDemo : Component
 
         return VStack(12,
             SubHeading("Validation Context"),
-            TextField(email, v => { setEmail(v); ctx.NotifyValueChanged("email", v); },
+            TextBox(email, v => { setEmail(v); ctx.NotifyValueChanged("email", v); },
                 placeholder: "user@example.com", header: "Email")
                 .Validate("email", email,
                     Validate.Required(),
@@ -360,13 +329,13 @@ class FormFieldDemo : Component
         return VStack(12,
             SubHeading("FormField Helper"),
             FormField(
-                TextField(name, v => { setName(v); ctx.NotifyValueChanged("name", v); })
+                TextBox(name, v => { setName(v); ctx.NotifyValueChanged("name", v); })
                     .Validate("name", name, Validate.Required()),
                 label: "Full Name",
                 required: true,
                 description: "As it appears on your ID"),
             FormField(
-                TextField(email, v => { setEmail(v); ctx.NotifyValueChanged("email", v); })
+                TextBox(email, v => { setEmail(v); ctx.NotifyValueChanged("email", v); })
                     .Validate("email", email,
                         Validate.Required(), Validate.Email()),
                 label: "Email Address",
@@ -418,10 +387,10 @@ class MaskedInputDemo : Component
 
         return VStack(12,
             SubHeading("Masked Input"),
-            TextField(phoneMask.Apply(phone), v => setPhone(phoneMask.GetRawValue(v)),
+            TextBox(phoneMask.Apply(phone), v => setPhone(phoneMask.GetRawValue(v)),
                 placeholder: "(___) ___-____", header: "Phone"),
             TextBlock($"Raw: {phone}").FontSize(12).Opacity(0.6),
-            TextField(dateMask.Apply(date), v => setDate(dateMask.GetRawValue(v)),
+            TextBox(dateMask.Apply(date), v => setDate(dateMask.GetRawValue(v)),
                 placeholder: "__/__/____", header: "Date"),
             TextBlock($"Raw: {date}").FontSize(12).Opacity(0.6)
         ).Padding(24);
@@ -462,10 +431,10 @@ class InputFormattersDemo : Component
 
         return VStack(12,
             SubHeading("Input Formatters"),
-            TextField(currencyFmt.Format(currency, 0).Output,
+            TextBox(currencyFmt.Format(currency, 0).Output,
                 v => setCurrency(currencyFmt.Parse(v)),
                 placeholder: "$0.00", header: "Amount"),
-            TextField(upperFmt.Format(upper, 0).Output,
+            TextBox(upperFmt.Format(upper, 0).Output,
                 v => setUpper(upperFmt.Parse(v)),
                 placeholder: "UPPERCASE", header: "Code")
         ).Padding(24);
@@ -722,7 +691,7 @@ per page.
 
 For a single-field form (search box, comment input), wire submission
 to Enter rather than a Submit button. `AutoSuggestBox` does this
-automatically via `onQuerySubmitted`. For `TextField`, route through
+automatically via `onQuerySubmitted`. For `TextBox`, route through
 `.KeyDown` or wrap the field in an `[ai:lock]` form panel; see
 [input-and-gestures](input-and-gestures.md) for the routed-events
 surface.
@@ -742,7 +711,7 @@ concern as [Keeping Submit Reachable](#keeping-submit-reachable).
 
 ```csharp
 // Don't:
-TextField(initial: "default value")
+TextBox(initial: "default value")
 ```
 
 ```csharp
@@ -754,7 +723,7 @@ class ControlledInputDemo : Component
 
         return VStack(12,
             SubHeading("Controlled Input"),
-            TextField(name, setName, placeholder: "Type your name"),
+            TextBox(name, setName, placeholder: "Type your name"),
             TextBlock($"You typed: {name}").Opacity(0.6)
         ).Padding(24);
     }

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -144,7 +144,7 @@ class GettingStartedApp : Component
 
         return VStack(16,
             TextBlock($"Hello, {name}!").FontSize(24).Bold(),
-            TextField(name, setName, placeholder: "Enter your name").Width(250)
+            TextBox(name, setName, placeholder: "Enter your name").Width(250)
         ).Padding(24);
     }
 }
@@ -228,8 +228,8 @@ class MultipleStateExample : Component
 
         return VStack(12,
             TextBlock($"Hello, {fullName}!").FontSize(fontSize).Bold(),
-            TextField(firstName, setFirstName, placeholder: "First name").Width(200),
-            TextField(lastName, setLastName, placeholder: "Last name").Width(200),
+            TextBox(firstName, setFirstName, placeholder: "First name").Width(200),
+            TextBox(lastName, setLastName, placeholder: "Last name").Width(200),
             HStack(8,
                 TextBlock("Font size:"),
                 Slider(fontSize, 10, 40, setFontSize).Width(200),
@@ -338,7 +338,7 @@ class TodoApp : Component
 
             // Input row
             HStack(8,
-                TextField(newText, setNewText, placeholder: "What needs to be done?")
+                TextBox(newText, setNewText, placeholder: "What needs to be done?")
                     .Width(300),
                 Button("Add", () =>
                 {
@@ -539,7 +539,7 @@ survive hot reload.
 Every Reactor app eventually has the same two ingredients: an event
 handler that calls a setter, and a value rendered from the setter's
 state slot. The hello-world snippet above wires `setName` to
-`TextField`'s change handler and reads `name` back in the
+`TextBox`'s change handler and reads `name` back in the
 `Text("Hello, ...")` line — that round trip is the entire reactivity
 contract. Once it feels routine, every other [hook](hooks.md) is just
 a specialization (`UseReducer` for derived updates, `UseEffect` for

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -55,7 +55,7 @@ class StateDemo : Component
         return VStack(12,
             SubHeading("UseState"),
             TextBlock("Sample text").FontSize(size).Foreground(color),
-            TextField(color, setColor, placeholder: "#hex color")
+            TextBox(color, setColor, placeholder: "#hex color")
                 .Width(150),
             HStack(8,
                 TextBlock("Size:"),
@@ -89,7 +89,7 @@ class ReducerDemo : Component
         return VStack(12,
             SubHeading("UseReducer"),
             HStack(8,
-                TextField(input, setInput, placeholder: "Add item")
+                TextBox(input, setInput, placeholder: "Add item")
                     .Width(180),
                 Button("Add", () =>
                 {
@@ -225,7 +225,7 @@ class MemoDemo : Component
 
         return VStack(8,
             SubHeading("UseMemo"),
-            TextField(input, setInput).Width(250),
+            TextBox(input, setInput).Width(250),
             TextBlock($"Characters: {stats.Chars}, Words: {stats.Words}"),
             Caption($"Uppercased: {stats.Upper}")
         );
@@ -256,7 +256,7 @@ class RefDemo : Component
         return VStack(8,
             SubHeading("UseRef"),
             TextBlock($"Render count: {renderCount.Current}").SemiBold(),
-            TextField(value, setValue, placeholder: "Type to trigger renders")
+            TextBox(value, setValue, placeholder: "Type to trigger renders")
                 .Width(250),
             Caption("UseRef persists across renders without causing them")
         );
@@ -292,7 +292,7 @@ class CallbackDemo : Component
         return VStack(8,
             SubHeading("UseCallback"),
             TextBlock($"Count: {count}").FontSize(18),
-            TextField(label, setLabel, placeholder: "Button label")
+            TextBox(label, setLabel, placeholder: "Button label")
                 .Width(200),
             Button(label, stableIncrement),
             Caption("The callback identity stays stable across renders")

--- a/docs/guide/input-and-gestures.md
+++ b/docs/guide/input-and-gestures.md
@@ -88,7 +88,7 @@ was set — otherwise hit-testing would miss the unfilled shape entirely.
 ### Keyboard events
 
 ```csharp
-TextField(value, setValue)
+TextBox(value, setValue)
     .OnKeyDown((_, e) => { if (e.Key == VirtualKey.Enter) Submit(); })
     .OnPreviewKeyDown((_, e) => Trace("preview"))
     .OnCharacterReceived((_, e) => Validate(e.Character));
@@ -101,7 +101,7 @@ shortcut interception that needs to suppress further routing.
 ### Focus events
 
 ```csharp
-TextField(value, setValue)
+TextBox(value, setValue)
     .OnGotFocus((_, _) => ShowValidationHint())
     .OnLostFocus((_, _) => HideValidationHint());
 ```
@@ -325,7 +325,7 @@ class UseElementFocusExample : Component
 
         return VStack(12,
             TextBlock("The field below auto-focuses on mount via UseElementFocus()."),
-            TextField(name, setName, placeholder: "name").Width(280).Ref(inputRef)
+            TextBox(name, setName, placeholder: "name").Width(280).Ref(inputRef)
         ).Padding(24);
     }
 }
@@ -355,7 +355,7 @@ public class SearchBox : Component
 
         Context.UseEffect(() => inputRef.Current?.SelectAll(), Array.Empty<object>());
 
-        return TextField(query, setQuery).Ref(inputRef);
+        return TextBox(query, setQuery).Ref(inputRef);
     }
 }
 ```
@@ -622,7 +622,7 @@ If a parent needs to see the press before children consume it, use
 ### Using `.OnKeyDown` for accelerator chords
 
 `.OnKeyDown` fires per element on focus — a `Ctrl+S` handler attached
-to a `TextField` only fires while that field has focus. For app-wide
+to a `TextBox` only fires while that field has focus. For app-wide
 accelerators (Save, Find, Run), use Reactor's
 [commanding](commanding.md) system: `new Command { ..., AccessKey =
 "S", AccessKeyModifiers = VirtualKeyModifiers.Control }` registers

--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -87,7 +87,7 @@ class GridDemo : Component
                 columns: [GridSize.Px(120), GridSize.Star(), GridSize.Auto],
                 rows: [GridSize.Auto, GridSize.Auto],
                 TextBlock("Label").Bold().Grid(row: 0, column: 0),
-                TextField("", _ => { }, placeholder: "Input...")
+                TextBox("", _ => { }, placeholder: "Input...")
                     .Grid(row: 0, column: 1),
                 Button("Go").Grid(row: 0, column: 2),
                 TextBlock("Status").Grid(row: 1, column: 0),

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -429,7 +429,7 @@ class PageCachingDemo : Component
     static Element CachedPage(string name) =>
         VStack(8,
             TextBlock(name).FontSize(20).Bold(),
-            TextField("", _ => { }, placeholder: "Type here — state persists")
+            TextBox("", _ => { }, placeholder: "Type here — state persists")
         ).Padding(16);
 }
 ```

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -154,6 +154,14 @@ public UIElement? Reconcile(
         // every component re-runs Render() even when props/deps are unchanged.
         _forceFullRenderActive = ForceFullRenderPending;
         ForceFullRenderPending = false;
+
+        // Build the dirty-ancestor path. For every component node
+        // whose SelfTriggered is true, walk up the realized visual
+        // tree and add each ancestor control. Consumed by Update's
+        // shallow-equality short-circuit so the walk can reach the
+        // self-triggered descendant even when its ancestor element
+        // records are structurally unchanged.
+        PopulateDirtyAncestorPath();
     }
     try {
     try

--- a/docs/guide/persistence.md
+++ b/docs/guide/persistence.md
@@ -25,7 +25,7 @@ class NotesEditor : Component
 
         return VStack(8,
             SubHeading("Notes"),
-            TextField(text, setText, placeholder: "Start typing…").Width(380),
+            TextBox(text, setText, placeholder: "Start typing…").Width(380),
             TextBlock($"{text.Length} characters").Opacity(0.6)
         ).Padding(16);
     }
@@ -110,9 +110,9 @@ class VersionedNotesEditor : Component
             scope: PersistedScope.Application);
 
         return VStack(8,
-            TextField(state.Title, t => setState(state with { Title = t }),
+            TextBox(state.Title, t => setState(state with { Title = t }),
                 placeholder: "Title"),
-            TextField(state.Body, b => setState(state with { Body = b, LastEdit = DateTimeOffset.Now }),
+            TextBox(state.Body, b => setState(state with { Body = b, LastEdit = DateTimeOffset.Now }),
                 placeholder: "Body")
         );
     }

--- a/docs/guide/reactor-vs-xaml.md
+++ b/docs/guide/reactor-vs-xaml.md
@@ -154,7 +154,7 @@ the reconciler writes the new `Text` value onto the existing
 `TextBlock`. There is no binding object — the closure that produces
 the element is the binding.
 
-`TwoWay` shows up as the controlled-input pattern. A `TextField` takes
+`TwoWay` shows up as the controlled-input pattern. A `TextBox` takes
 the current value and a setter callback; the user's input fires the
 callback, which writes the slot, which re-renders, which writes the
 new value back into the `TextBox`. Mode is implicit in whether you

--- a/docs/guide/recipes/command-palette.md
+++ b/docs/guide/recipes/command-palette.md
@@ -131,7 +131,7 @@ void OnPaletteKey(object _, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
 ```
 
 `OnPreviewKeyDown` tunnels — it fires before the bubbling pair, so
-Up / Down move the selection instead of the `TextField` caret, and
+Up / Down move the selection instead of the `TextBox` caret, and
 Enter fires the highlighted command rather than inserting a newline.
 Setting `e.Handled = true` stops further routing so the underlying
 control stays out of the way. The same handler closes the palette on
@@ -155,7 +155,7 @@ var page = VStack(12,
 
 Element palette = Border(
     VStack(0,
-        TextField(query, v => { setQuery(v); setIndex(0); },
+        TextBox(query, v => { setQuery(v); setIndex(0); },
             placeholder: "Type a command…").Width(420),
         matches.Length == 0
             ? TextBlock("No commands match.").Padding(12).Opacity(0.6)

--- a/docs/guide/recipes/login.md
+++ b/docs/guide/recipes/login.md
@@ -71,7 +71,7 @@ captured closure keeps working.
 ```csharp
 return VStack(12,
     Heading("Sign in"),
-    TextField(email, setEmail, placeholder: "you@example.com",
+    TextBox(email, setEmail, placeholder: "you@example.com",
         header: "Email").Width(280),
     PasswordBox(pwd, setPwd, placeholderText: "8+ characters"),
     error is null
@@ -102,7 +102,7 @@ a single render check; a guard inside `Submit()` runs after the user
 already pressed it and the UI looked ready. Both layers are good
 hygiene but the button gate is the load-bearing one.
 
-**Use [`PasswordBox`](../forms.md), not `TextField` with a hex style.**
+**Use [`PasswordBox`](../forms.md), not `TextBox` with a hex style.**
 The control implements paste-without-reveal, autofill, and the
 accessibility peer; reinventing it in user code drops those.
 

--- a/docs/guide/recipes/multi-step-form.md
+++ b/docs/guide/recipes/multi-step-form.md
@@ -15,7 +15,7 @@ visible slot changes.
 | Per-field state | `UseState<string>` / `UseState<int>` / `UseState<bool>` |
 | Step branching | `switch` on the step index returning `Element` |
 | Advance gating | `.IsEnabled(canAdvance)` on the Next button |
-| Input controls | [`TextField`](../forms.md), [`RadioButtons`](../forms.md), [`CheckBox`](../forms.md) |
+| Input controls | [`TextBox`](../forms.md), [`RadioButtons`](../forms.md), [`CheckBox`](../forms.md) |
 
 ### State
 
@@ -64,9 +64,9 @@ forward action is Submit.
 ```csharp
 Element StepAccount() => VStack(10,
     SubHeading("Step 1 of 3 — Account"),
-    TextField(name, setName, placeholder: "Your name",
+    TextBox(name, setName, placeholder: "Your name",
         header: "Name").Width(340),
-    TextField(email, setEmail, placeholder: "you@example.com",
+    TextBox(email, setEmail, placeholder: "you@example.com",
         header: "Email").Width(340)
 );
 ```

--- a/docs/guide/recipes/search-with-suggestions.md
+++ b/docs/guide/recipes/search-with-suggestions.md
@@ -62,7 +62,7 @@ clears the input is essential.
 
 ```csharp
 return VStack(8,
-    TextField(query, setQuery, placeholder: "Search topics…").Width(300),
+    TextBox(query, setQuery, placeholder: "Search topics…").Width(300),
     suggestions.Length == 0
         ? Empty()
         : Border(

--- a/docs/guide/reconciliation.md
+++ b/docs/guide/reconciliation.md
@@ -73,6 +73,14 @@ public UIElement? Reconcile(
         // every component re-runs Render() even when props/deps are unchanged.
         _forceFullRenderActive = ForceFullRenderPending;
         ForceFullRenderPending = false;
+
+        // Build the dirty-ancestor path. For every component node
+        // whose SelfTriggered is true, walk up the realized visual
+        // tree and add each ancestor control. Consumed by Update's
+        // shallow-equality short-circuit so the walk can reach the
+        // self-triggered descendant even when its ancestor element
+        // records are structurally unchanged.
+        PopulateDirtyAncestorPath();
     }
     try {
     try
@@ -186,6 +194,14 @@ public UIElement? Reconcile(
         // every component re-runs Render() even when props/deps are unchanged.
         _forceFullRenderActive = ForceFullRenderPending;
         ForceFullRenderPending = false;
+
+        // Build the dirty-ancestor path. For every component node
+        // whose SelfTriggered is true, walk up the realized visual
+        // tree and add each ancestor control. Consumed by Update's
+        // shallow-equality short-circuit so the walk can reach the
+        // self-triggered descendant even when its ancestor element
+        // records are structurally unchanged.
+        PopulateDirtyAncestorPath();
     }
     try {
     try

--- a/docs/guide/rules-of-reactor.md
+++ b/docs/guide/rules-of-reactor.md
@@ -207,7 +207,7 @@ class TodoListBad : Component
     public override Element Render() => VStack(4,
         Items.Select(i =>
             // No .WithKey — reorder is destructive.
-            TextField(i.Title, _ => { }, header: i.Id.ToString())
+            TextBox(i.Title, _ => { }, header: i.Id.ToString())
         ).ToArray()
     );
 }
@@ -223,7 +223,7 @@ class TodoListGood : Component
 
     public override Element Render() => VStack(4,
         Items.Select(i =>
-            TextField(i.Title, _ => { }, header: i.Id.ToString())
+            TextBox(i.Title, _ => { }, header: i.Id.ToString())
                 .WithKey(i.Id.ToString())                  // stable identity
         ).ToArray()
     );

--- a/docs/guide/text-and-media.md
+++ b/docs/guide/text-and-media.md
@@ -20,7 +20,7 @@ prose, then jump to the control you need.
 # Text and Media
 
 This page covers every read-only-display and inline-rich-text control in
-Reactor. For input controls (`TextField`, `PasswordBox`, `RichEditBox`),
+Reactor. For input controls (`TextBox`, `PasswordBox`, `RichEditBox`),
 see [Forms](forms.md). For data-bound collections, see
 [Collections](collections.md).
 
@@ -197,7 +197,7 @@ text with paste-from-formatted-source, spell-check, IME composition, and
 selection. The change handler fires with the plain text content; for
 formatted output you read `RichEditBox.Document` through `.Set(...)` and
 serialize the text range yourself. Single-line text input belongs in
-[`TextField`](forms.md), not here.
+[`TextBox`](forms.md), not here.
 
 | Fluent | Effect |
 |---|---|

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -127,7 +127,7 @@ class NotePadWindow : Component
             TextBlock(window is null
                 ? "(no owning window)"
                 : $"id={window.Id}  state={state}  dpi={window.Dpi}"),
-            TextField(text, setText, placeholder: "Type something...")
+            TextBox(text, setText, placeholder: "Type something...")
                 .Width(360),
             Button("Close", () => window?.Close())
         ).Padding(16);

--- a/docs/guide/winforms-interop.md
+++ b/docs/guide/winforms-interop.md
@@ -144,7 +144,7 @@ class KeyboardDemo : Component
         // Tab/Shift+Tab cycles through Reactor controls normally.
         // Tab out of the last Reactor control returns focus to WinForms.
         return VStack(12,
-            TextField(text, setText, placeholder: "Type here...")
+            TextBox(text, setText, placeholder: "Type here...")
                 .TabIndex(0),
             Button("Submit", () => { })
                 .TabIndex(1)
@@ -180,7 +180,7 @@ class AccessibleIslandComponent : Component
         return VStack(12,
             Heading("Registration")
                 .HeadingLevel(AutomationHeadingLevel.Level1),
-            TextField(name, setName, header: "Full Name")
+            TextBox(name, setName, header: "Full Name")
                 .AutomationName("Full name")
                 .Required()
                 .TabIndex(0),

--- a/docs/guide/xaml-developers.md
+++ b/docs/guide/xaml-developers.md
@@ -31,7 +31,7 @@ Think of Reactor as "WinUI controls, but expressed like a function of state."
 |---------|------------|
 | `Page`, `UserControl`, `Window` markup | A `Component` with `Render()` |
 | `{Binding Name}` | Plain C# variable usage: `TextBlock(name)` |
-| `Mode=TwoWay` | Controlled input: `TextField(name, setName)` |
+| `Mode=TwoWay` | Controlled input: `TextBox(name, setName)` |
 | `DataContext` | Local hook state, typed props, or [context](context.md) |
 | `ICommand` | Lambdas, methods, or [commands](commanding.md) |
 | `StackPanel` | [`VStack`](layout.md) or [`HStack`](layout.md) |
@@ -79,8 +79,8 @@ class TutorialFormPage : Component
 
         return VStack(12,
             SubHeading("Customer"),
-            TextField(name, setName, header: "Name"),
-            TextField(email, setEmail, header: "Email"),
+            TextBox(name, setName, header: "Name"),
+            TextBox(email, setEmail, header: "Email"),
             CheckBox(wantsUpdates, setWantsUpdates, label: "Email me updates"),
             HStack(8,
                 Button("Save", () => { }).IsEnabled(canSave),
@@ -95,7 +95,7 @@ class TutorialFormPage : Component
 What changed:
 
 - **Bindings became state variables.** `Name`, `Email`, and `WantsUpdates` live in `UseState`.
-- **Two-way input became explicit.** `TextField(name, setName)` makes data flow obvious.
+- **Two-way input became explicit.** `TextBox(name, setName)` makes data flow obvious.
 - **The command became normal C#.** The save button uses a lambda instead of XAML command wiring.
 - **Derived UI stayed inline.** `canSave` is just a local expression, not a converter or extra property.
 
@@ -148,9 +148,9 @@ class GridTranslationPage : Component
             columns: [GridSize.Auto, GridSize.Star()],
             rows: [GridSize.Auto, GridSize.Auto],
             TextBlock("First name").Bold().Grid(row: 0, column: 0),
-            TextField("", _ => { }).Grid(row: 0, column: 1),
+            TextBox("", _ => { }).Grid(row: 0, column: 1),
             TextBlock("Last name").Bold().Grid(row: 1, column: 0),
-            TextField("", _ => { }).Grid(row: 1, column: 1)
+            TextBox("", _ => { }).Grid(row: 1, column: 1)
         ) with
         {
             ColumnSpacing = 12,
@@ -182,10 +182,10 @@ That is why Reactor code often looks simpler than XAML. A label like
 re-runs whenever the relevant state changes.
 
 > **Caveat:** A XAML `Binding` with `Mode=TwoWay` becomes a Reactor controlled-input
-> pattern (`TextField(name, setName)`), not a binding-with-mode. There is
+> pattern (`TextBox(name, setName)`), not a binding-with-mode. There is
 > **no** Reactor analogue to `Mode=OneWay` / `Mode=OneTime` / `Mode=TwoWay`
 > because state IS the binding — every render re-reads from state, every
-> edit calls a setter. If you write `TextField(name, _ => { })` and never
+> edit calls a setter. If you write `TextBox(name, _ => { })` and never
 > call a setter, the field is read-only (effectively `Mode=OneWay`); if
 > you wire both, it round-trips (effectively `Mode=TwoWay`). The trap is
 > "reach for the binding mode for OneTime" — there is no equivalent.
@@ -193,7 +193,7 @@ re-runs whenever the relevant state changes.
 > want to capture-and-freeze, or call a function once in a
 > `UseEffect(() => …, Array.Empty<object>())` so it runs only on mount.
 > The Reactor analyzer doesn't emit a specific diagnostic for "missing
-> setter" — passing `null` to a `TextField` change handler is a
+> setter" — passing `null` to a `TextBox` change handler is a
 > `CS8625` "Cannot convert null literal" instead.
 
 ## Events and Commands Are Just C#
@@ -202,7 +202,7 @@ You do not need a special command layer for every button click.
 
 - `Button("Save", Save)` is the direct equivalent of a button command.
 - `Button("Refresh", async () => await ReloadAsync())` works for async actions.
-- `TextField(text, setText)` replaces both `TextChanged` wiring and two-way binding.
+- `TextBox(text, setText)` replaces both `TextChanged` wiring and two-way binding.
 
 If you want richer busy/error behavior, Reactor also has a dedicated
 [Commanding](commanding.md) API. But the default is deliberately small: use a
@@ -220,7 +220,7 @@ a single `IsCheckedChanged` callback):
 | WinUI XAML event | Reactor fluent |
 |------------------|----------------|
 | `<Button Click="OnClick"/>` | `Button("…").Click(handler)` |
-| `<TextBox TextChanged="OnTextChanged"/>` | `TextField(text, setText).Changed(handler)` |
+| `<TextBox TextChanged="OnTextChanged"/>` | `TextBox(text, setText).Changed(handler)` |
 | `<ListView SelectionChanged="OnSelectionChanged"/>` | `ListView<T>(...).SelectionChanged(handler)` |
 | `<ComboBox SelectionChanged="OnSelectionChanged"/>` | `ComboBox(...).SelectedIndexChanged(handler)` — Reactor reports the selected index, not the args |
 | `<CheckBox Checked="…" Unchecked="…"/>` | `CheckBox(value, setValue).IsCheckedChanged(handler)` — Reactor collapses the three XAML events into a single bool callback |
@@ -316,7 +316,7 @@ class ObservableTreeDemo : Component
 
         return VStack(12,
             SubHeading("UseObservableTree"),
-            TextField(vm.UserName, v => vm.UserName = v,
+            TextBox(vm.UserName, v => vm.UserName = v,
                 header: "User Name"),
             ToggleSwitch(vm.DarkMode, v => vm.DarkMode = v,
                 header: "Dark Mode"),

--- a/plugins/reactor/skills/reactor-commanding/SKILL.md
+++ b/plugins/reactor/skills/reactor-commanding/SKILL.md
@@ -113,7 +113,7 @@ var undo = StandardCommand.Undo(() => UndoAction());
 CommandHost([save, undo],
     VStack(
         TextBlock("Ctrl+S / Ctrl+Z only fire inside this region"),
-        TextField(value, onChange)))
+        TextBox(value, onChange)))
 ```
 
 Commands without an `Accelerator` are ignored by `CommandHost`.
@@ -132,7 +132,7 @@ class Editor : Component
     {
         var save = UseCommand(StandardCommand.Save(async () => await SaveAsync()));
         var undo = StandardCommand.Undo(() => Undo());
-        return TextField(text, onChange)
+        return TextBox(text, onChange)
             .Provide(EditorCtx, new EditorCommands(save, undo, redo));
     }
 }

--- a/plugins/reactor/skills/reactor-design/SKILL.md
+++ b/plugins/reactor/skills/reactor-design/SKILL.md
@@ -342,13 +342,13 @@ Border(child).Margin(3)
 
 **Margin** pushes an element away from its neighbors. It works on every Reactor element.
 
-**Padding** adds space between a container's edge and its content. It only works on `Border` and `Control`-based elements (`Button`, `TextField`, etc.). Layout panels like `VStack`, `HStack`, and `Grid` do not support `.Padding()` — wrap content in a `Border` if you need inner padding on a stack.
+**Padding** adds space between a container's edge and its content. It only works on `Border` and `Control`-based elements (`Button`, `TextBox`, etc.). Layout panels like `VStack`, `HStack`, and `Grid` do not support `.Padding()` — wrap content in a `Border` if you need inner padding on a stack.
 
 | Element | `.Margin()` | `.Padding()` |
 |---------|-------------|-------------|
 | `Border` | ✓ | ✓ |
 | `Button` | ✓ | ✓ |
-| `TextField` | ✓ | ✓ |
+| `TextBox` | ✓ | ✓ |
 | `TextBlock` | ✓ | — |
 | `VStack` | ✓ | — |
 | `HStack` | ✓ | — |
@@ -361,7 +361,7 @@ TextBlock("Hello").Margin(8)
 VStack(children).Margin(16)
 Border(child).Margin(12)
 
-// Padding — only on Border and Control (Button, TextField, etc.)
+// Padding — only on Border and Control (Button, TextBox, etc.)
 Border(child).Padding(16)    // ✓ works
 Button("Go").Padding(12)     // ✓ works
 
@@ -420,7 +420,7 @@ var or = ThemeResource.CornerRadius("OverlayCornerRadius");
 // Dialog with control-radius inner elements
 Border(
     VStack(12,
-        TextField("", placeholder: "Username").CornerRadius(cr.TopLeft),
+        TextBox("", placeholder: "Username").CornerRadius(cr.TopLeft),
         Button("Sign In", onClick)
             .Background(Theme.Accent)
             .CornerRadius(cr.TopLeft)
@@ -440,7 +440,7 @@ VStack(children).MinWidth(200)
 
 // Wrong: fixed Height clips at larger text scales
 Button("Action").Height(32)
-TextField(text, setText).Height(30)
+TextBox(text, setText).Height(30)
 ```
 
 - Prefer `MinHeight`/`MinWidth` over fixed `Height`/`Width`.
@@ -572,7 +572,7 @@ var filtered = UseMemo(() =>
     items, filter);
 
 return VStack(
-    TextField(filter, setFilter, placeholder: "Filter..."),
+    TextBox(filter, setFilter, placeholder: "Filter..."),
     VStack(filtered.Select(item =>
         TextBlock(item.Name).WithKey(item.Id)
     ).ToArray()));
@@ -641,7 +641,7 @@ Button("Save", onSave).IsTabStop(true).TabIndex(0).AccessKey("S")
 These allocate an `AutomationProperties` peer only when set:
 
 ```csharp
-TextField(name, setName)
+TextBox(name, setName)
     .HelpText("Enter your full legal name")
     .Required()
 
@@ -784,7 +784,7 @@ Three compile-time analyzers catch accessibility issues:
 |----------|--------|
 | `REACTOR_A11Y_001` | Icon-only Button/ToggleButton missing `.AutomationName()` |
 | `REACTOR_A11Y_002` | Image missing `.AutomationName()` or `.AccessibilityHidden()` |
-| `REACTOR_A11Y_003` | Form field (TextField/NumberBox/PasswordBox) missing label |
+| `REACTOR_A11Y_003` | Form field (TextBox/NumberBox/PasswordBox) missing label |
 
 These run as warnings by default. Promote to errors in CI:
 
@@ -801,7 +801,7 @@ var validation = UseValidationContext();
 var (email, setEmail) = UseState("");
 
 return FormField(
-    TextField(email, setEmail)
+    TextBox(email, setEmail)
         .Validate("email", email, Validate.Required(), Validate.Email())
         .Required()
         .HelpText("We'll send a confirmation to this address"),

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -89,6 +89,7 @@ InfoBadge() → InfoBadgeElement
 InfoBadge(int value) → InfoBadgeElement
 InfoBar(string title = null, string message = null) → InfoBarElement
 InterspersedGrid(Orientation orientation, Element[] items, double[] proportions, double separatorSize, Func<int, Element> separatorFactory) → GridElement
+ItemContainer(Element child) → ItemContainerElement
 ItemsView<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → ItemsViewElement<T>
 LazyHStack<T>(IReadOnlyList<T> items, Func<T, int, Element> viewBuilder) → LazyHStackElement<T>
 LazyHStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → LazyHStackElement<T>
@@ -166,7 +167,7 @@ Tab(string header, Element content) → TabViewItemData
 TabView(TabViewItemData[] tabs) → TabViewElement
 TeachingTip(string title, string subtitle = null) → TeachingTipElement
 TextBlock(string content) → TextBlockElement
-TextField(string value, Action<string> onChanged = null, string placeholder = null, string header = null) → TextFieldElement
+TextBox(string value, Action<string> onChanged = null, string placeholder = null, string header = null) → TextBoxElement
 Thick(double horizontal, double vertical) → Thickness
 Thick(double left, double top, double right, double bottom) → Thickness
 Thick(double uniform) → Thickness
@@ -346,6 +347,7 @@ InfoBarElement.Set(Action<InfoBar> configure) → InfoBarElement
 InfoBarElement.Severity(InfoBarSeverity severity) → InfoBarElement
 InfoBarElement.Success() → InfoBarElement
 InfoBarElement.Warning() → InfoBarElement
+ItemContainerElement.Set(Action<ItemContainer> configure) → ItemContainerElement
 ItemsViewElement<T>.ItemInvoked<T>(Action<T> handler) → ItemsViewElement<T>
 ItemsViewElement<T>.SelectionChanged<T>(Action<IReadOnlyList<T>> handler) → ItemsViewElement<T>
 ItemsViewElement<T>.Set<T>(Action<ItemsView> configure) → ItemsViewElement<T>
@@ -713,25 +715,25 @@ TextBlockElement.TextAlignment(TextAlignment alignment) → TextBlockElement
 TextBlockElement.TextDecorations(TextDecorations decorations) → TextBlockElement
 TextBlockElement.TextTrimming(TextTrimming trimming) → TextBlockElement
 TextBlockElement.TextWrapping(TextWrapping wrapping = TextWrapping.Wrap) → TextBlockElement
-TextFieldElement.AcceptsReturn(bool accepts = true) → TextFieldElement
-TextFieldElement.Changed(Action<string> handler) → TextFieldElement
-TextFieldElement.CharacterCasing(CharacterCasing casing) → TextFieldElement
-TextFieldElement.Description(string description) → TextFieldElement
-TextFieldElement.EmailInput() → TextFieldElement
-TextFieldElement.Focus(FocusManager fm, string fieldName, bool autoFocus = false) → TextFieldElement
-TextFieldElement.Header(string header) → TextFieldElement
-TextFieldElement.InputScope(InputScopeNameValue scope) → TextFieldElement
-TextFieldElement.IsReadOnly(bool readOnly = true) → TextFieldElement
-TextFieldElement.IsSpellCheckEnabled(bool enabled = true) → TextFieldElement
-TextFieldElement.MaxLength(int maxLength) → TextFieldElement
-TextFieldElement.NumericInput() → TextFieldElement
-TextFieldElement.PhoneInput() → TextFieldElement
-TextFieldElement.SearchInput() → TextFieldElement
-TextFieldElement.SelectionChanged(Action<string, int, int> handler) → TextFieldElement
-TextFieldElement.Set(Action<TextBox> configure) → TextFieldElement
-TextFieldElement.TextAlignment(TextAlignment alignment) → TextFieldElement
-TextFieldElement.TextWrapping(TextWrapping wrapping = TextWrapping.Wrap) → TextFieldElement
-TextFieldElement.UrlInput() → TextFieldElement
+TextBoxElement.AcceptsReturn(bool accepts = true) → TextBoxElement
+TextBoxElement.Changed(Action<string> handler) → TextBoxElement
+TextBoxElement.CharacterCasing(CharacterCasing casing) → TextBoxElement
+TextBoxElement.Description(string description) → TextBoxElement
+TextBoxElement.EmailInput() → TextBoxElement
+TextBoxElement.Focus(FocusManager fm, string fieldName, bool autoFocus = false) → TextBoxElement
+TextBoxElement.Header(string header) → TextBoxElement
+TextBoxElement.InputScope(InputScopeNameValue scope) → TextBoxElement
+TextBoxElement.IsReadOnly(bool readOnly = true) → TextBoxElement
+TextBoxElement.IsSpellCheckEnabled(bool enabled = true) → TextBoxElement
+TextBoxElement.MaxLength(int maxLength) → TextBoxElement
+TextBoxElement.NumericInput() → TextBoxElement
+TextBoxElement.PhoneInput() → TextBoxElement
+TextBoxElement.SearchInput() → TextBoxElement
+TextBoxElement.SelectionChanged(Action<string, int, int> handler) → TextBoxElement
+TextBoxElement.Set(Action<TextBox> configure) → TextBoxElement
+TextBoxElement.TextAlignment(TextAlignment alignment) → TextBoxElement
+TextBoxElement.TextWrapping(TextWrapping wrapping = TextWrapping.Wrap) → TextBoxElement
+TextBoxElement.UrlInput() → TextBoxElement
 TimePickerElement.Set(Action<TimePicker> configure) → TimePickerElement
 TimePickerElement.TimeChanged(Action<TimeSpan> handler) → TimePickerElement
 TitleBarElement.BackButtonEnabled(bool enabled) → TitleBarElement

--- a/plugins/reactor/skills/reactor-forms/SKILL.md
+++ b/plugins/reactor/skills/reactor-forms/SKILL.md
@@ -14,7 +14,7 @@ declarative `.Validate()` modifiers.
 
 | API | Purpose |
 |-----|---------|
-| `TextField(value, setValue)` | Controlled text input |
+| `TextBox(value, setValue)` | Controlled text input |
 | `UseValidationContext()` | Track validation messages, touched/dirty state |
 | `.Validate(...)` | Attach built-in validators to an input |
 | `FormField(input, label: ...)` | Wraps input with label, error display, required marker |
@@ -31,7 +31,7 @@ var (age, setAge) = UseState(0);
 var (agreed, setAgreed) = UseState(false);
 
 return VStack(12,
-    TextField(name, setName, placeholder: "Name"),
+    TextBox(name, setName, placeholder: "Name"),
     NumberBox(age, setAge),
     CheckBox(agreed, setAgreed, label: "I agree"),
     Button("Submit", onSubmit).IsEnabled(!(string.IsNullOrEmpty(name) || !agreed))
@@ -42,7 +42,7 @@ return VStack(12,
 
 | Factory | Value type | Common modifiers |
 |---------|-----------|------------------|
-| `TextField(value, setValue, placeholder, header)` | `string` | `.Header()`, `.IsReadOnly()`, `.AcceptsReturn()`, `.TextWrapping()`, `.MaxLength(n)`, `.NumericInput()`, `.EmailInput()`, `.Changed(handler)` |
+| `TextBox(value, setValue, placeholder, header)` | `string` | `.Header()`, `.IsReadOnly()`, `.AcceptsReturn()`, `.TextWrapping()`, `.MaxLength(n)`, `.NumericInput()`, `.EmailInput()`, `.Changed(handler)` |
 | `PasswordBox(password, setPassword, placeholder)` | `string` | `.Header(text)`, `.MaxLength(n)`, `.PasswordChanged(handler)` |
 | `NumberBox(value, setValue, placeholder, header)` | `double` | `.Range(min, max)`, `.SpinButtons(...)` |
 | `Slider(value, min, max, setValue)` | `double` | `.Header()`, `.StepFrequency()` |
@@ -61,7 +61,7 @@ preconfigure `InputScope` and IME hints so on-screen / soft keyboards open
 in the right mode. Stack them with validators:
 
 ```csharp
-TextField(email, setEmail, placeholder: "you@example.com")
+TextBox(email, setEmail, placeholder: "you@example.com")
     .EmailInput()
     .MaxLength(254)
     .Validate("email", email, Validate.Required(), Validate.Email())
@@ -80,7 +80,7 @@ var (email, setEmail) = UseState("");
 var isValid = email.Contains('@') && email.Length > 3;
 
 return VStack(12,
-    TextField(email, setEmail, placeholder: "Email"),
+    TextBox(email, setEmail, placeholder: "Email"),
     Button("Submit", onSubmit).IsEnabled(isValid)
 );
 ```
@@ -98,12 +98,12 @@ var (name, setName) = UseState("");
 var (email, setEmail) = UseState("");
 
 return VStack(12,
-    TextField(name, setName, placeholder: "Name")
+    TextBox(name, setName, placeholder: "Name")
         .Validate("name", name,
             Validate.Required("Name is required"),
             Validate.MinLength(2, "Name too short")),
 
-    TextField(email, setEmail, placeholder: "Email")
+    TextBox(email, setEmail, placeholder: "Email")
         .Validate("email", email,
             Validate.Required("Email is required"),
             Validate.Email("Invalid email")),
@@ -165,7 +165,7 @@ var validation = UseValidationContext();
 var (name, setName) = UseState("");
 
 return FormField(
-    TextField(name, setName, placeholder: "Enter your name")
+    TextBox(name, setName, placeholder: "Enter your name")
         .Validate("name", name, Validate.Required("Required")),
     label: "Full Name",
     required: true,
@@ -188,7 +188,7 @@ return FormField(
 var mask = UseMemo(() => new MaskEngine(MaskPreset.PhoneUS));
 var (phone, setPhone) = UseState("");
 
-return TextField(phone, v => setPhone(mask.Apply(v)),
+return TextBox(phone, v => setPhone(mask.Apply(v)),
     placeholder: "(555) 555-0123");
 ```
 
@@ -213,7 +213,7 @@ Custom masks: `new MaskEngine("AA-####")` where `A` = letter,
 ```csharp
 var (amount, setAmount) = UseState("");
 
-return TextField(amount,
+return TextBox(amount,
     v => setAmount(InputFormatter.Currency(symbol: "$").Format(v)),
     placeholder: "$0.00");
 ```

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -23,7 +23,7 @@ description: "Reactor essentials in one place — React-to-Reactor mental model,
 | `<span>text</span>` | `TextBlock("text")` |
 | `<h1>` / `<h2>` / small caption | `Heading(...)` / `SubHeading(...)` / `Caption(...)` |
 | `<button onClick={fn}>` | `Button("label", fn)` |
-| `<input value={v} onChange={e=>…}>` | `TextField(v, setV)` |
+| `<input value={v} onChange={e=>…}>` | `TextBox(v, setV)` |
 | `<select>` | `ComboBox(items, index, setIndex)` |
 | `<input type="checkbox">` | `CheckBox(checked, setChecked)` |
 | `{cond && <X/>}` | `cond ? X() : null` (null children are filtered) |
@@ -192,7 +192,7 @@ Button("Save", onClick: handler).Background(Theme.Accent)     // named-arg form 
 // `onClick` is a Button ctor parameter — NOT a chained `.OnClick(...)` /
 // `.OnTapped(...)`. `.OnTapped` is a gesture event with different input
 // semantics (long-press, touch, pen) and is the wrong fix for click intent.
-TextField(value, setValue, placeholder: "...")
+TextBox(value, setValue, placeholder: "...")
 CheckBox(isChecked, onChanged: setChecked, label: "label")
 ToggleSwitch(on, setOn)
 Slider(v, 0, 100, setV)

--- a/plugins/reactor/skills/reactor-input/SKILL.md
+++ b/plugins/reactor/skills/reactor-input/SKILL.md
@@ -54,7 +54,7 @@ Border(child)
 ## 3. Keyboard events
 
 ```csharp
-TextField(text, setText)
+TextBox(text, setText)
     .OnKeyDown((s, e) =>
     {
         if (e.Key == VirtualKey.Enter)
@@ -162,7 +162,7 @@ Border(child)
 var focusRef = UseElementFocus();
 
 return VStack(12,
-    TextField(text, setText).Ref(focusRef.Ref),
+    TextBox(text, setText).Ref(focusRef.Ref),
     Button("Focus the field", () => focusRef.RequestFocus())
 );
 ```
@@ -181,7 +181,7 @@ var inputRef = UseElementRef<TextBox>();
 
 UseEffect(() => inputRef.Current?.SelectAll(), Array.Empty<object>());
 
-return TextField(query, setQuery).Ref(inputRef);
+return TextBox(query, setQuery).Ref(inputRef);
 ```
 
 The constraint is `T : FrameworkElement`. In `DEBUG` builds Reactor asserts
@@ -191,7 +191,7 @@ the actual mounted element is a `T`; in release the mismatch is silent and
 ### Focus events
 
 ```csharp
-TextField(text, setText)
+TextBox(text, setText)
     .OnGotFocus((s, e) => ShowSuggestions())
     .OnLostFocus((s, e) => HideSuggestions())
 ```
@@ -205,8 +205,8 @@ Button("Save", onSave).AccessKey("S")  // Alt+S
 ### Tab order
 
 ```csharp
-TextField(name, setName).IsTabStop(true).TabIndex(1)
-TextField(email, setEmail).IsTabStop(true).TabIndex(2)
+TextBox(name, setName).IsTabStop(true).TabIndex(1)
+TextBox(email, setEmail).IsTabStop(true).TabIndex(2)
 Button("Submit", onSubmit).IsTabStop(true).TabIndex(3)
 ```
 

--- a/plugins/reactor/skills/reactor-recipes/references/async-fetch-list.cs
+++ b/plugins/reactor/skills/reactor-recipes/references/async-fetch-list.cs
@@ -52,7 +52,7 @@ class App : Component
 
         return VStack(12,
             HStack(8,
-                TextField(owner, setOwner, placeholder: "GitHub owner").Flex(grow: 1),
+                TextBox(owner, setOwner, placeholder: "GitHub owner").Flex(grow: 1),
                 Caption("(try \"fail\" to see error state)").VAlign(VerticalAlignment.Center)),
 
             repos.Match<Element>(

--- a/plugins/reactor/skills/reactor-recipes/references/form-with-validation.cs
+++ b/plugins/reactor/skills/reactor-recipes/references/form-with-validation.cs
@@ -56,14 +56,14 @@ class App : Component
             Heading("Sign up"),
 
             FormField(
-                TextField(name, v => { setName(v); ctx.MarkTouched("name"); }, placeholder: "Your name")
+                TextBox(name, v => { setName(v); ctx.MarkTouched("name"); }, placeholder: "Your name")
                     .Validate("name", name,
                         Validate.Required("Name is required"),
                         Validate.MinLength(2, "At least 2 characters")),
                 label: "Name", required: true, showWhen: sw),
 
             FormField(
-                TextField(email, v => { setEmail(v); ctx.MarkTouched("email"); }, placeholder: "you@example.com")
+                TextBox(email, v => { setEmail(v); ctx.MarkTouched("email"); }, placeholder: "you@example.com")
                     .EmailInput()
                     .Validate("email", email,
                         Validate.Required("Email is required"),
@@ -71,7 +71,7 @@ class App : Component
                 label: "Email", required: true, showWhen: sw),
 
             FormField(
-                TextField(age, v => { setAge(v); ctx.MarkTouched("age"); }, placeholder: "Age")
+                TextBox(age, v => { setAge(v); ctx.MarkTouched("age"); }, placeholder: "Age")
                     .NumericInput()
                     .MaxLength(3)
                     .Validate("age", age,

--- a/plugins/reactor/skills/reactor-recipes/references/list-add-delete.cs
+++ b/plugins/reactor/skills/reactor-recipes/references/list-add-delete.cs
@@ -66,7 +66,7 @@ class App : Component
         return CommandHost([add],
             VStack(12,
                 HStack(8,
-                    TextField(draft, setDraft, placeholder: "What needs doing?")
+                    TextBox(draft, setDraft, placeholder: "What needs doing?")
                         .Flex(grow: 1),
                     Button(add).Flex(shrink: 0)),
 

--- a/plugins/reactor/skills/reactor-recipes/references/use-custom-hook.cs
+++ b/plugins/reactor/skills/reactor-recipes/references/use-custom-hook.cs
@@ -81,7 +81,7 @@ class App : Component
         var debouncedQuery = this.UseDebouncedValue(query, delayMs: 300);
 
         return VStack(12,
-            TextField(query, setQuery, placeholder: "Type to search…"),
+            TextBox(query, setQuery, placeholder: "Type to search…"),
             TextBlock($"Live: {query}").Opacity(0.7),
             TextBlock($"Debounced (300ms): {debouncedQuery}").Bold()
         ).Padding(24);

--- a/samples/CommandingDemo/App.cs
+++ b/samples/CommandingDemo/App.cs
@@ -114,7 +114,7 @@ class StandardCommandsDemo : Component
                     MenuSeparator(),
                     MenuItem(selectAll))),
 
-            (TextField(text, setText, placeholder: "Type here...") with
+            (TextBox(text, setText, placeholder: "Type here...") with
             {
                 OnSelectionChanged = (sel, start, len) =>
                 {
@@ -253,7 +253,7 @@ class CommandHostDemo : Component
                 VStack(8,
                     TextBlock("INSIDE CommandHost scope — Ctrl+S / Ctrl+Z / Ctrl+Y fire here:")
                         .Set(tb => tb.FontWeight = Microsoft.UI.Text.FontWeights.SemiBold),
-                    TextField("", _ => { }, placeholder: "Click here and press Ctrl+S..."),
+                    TextBox("", _ => { }, placeholder: "Click here and press Ctrl+S..."),
                     Caption(log).Foreground(SecondaryText))
                 .Padding(16)
                 .Background(SystemAttentionBackground)
@@ -263,7 +263,7 @@ class CommandHostDemo : Component
             VStack(8,
                 TextBlock("OUTSIDE CommandHost scope — accelerators do NOT fire here:")
                     .Set(tb => tb.FontWeight = Microsoft.UI.Text.FontWeights.SemiBold),
-                TextField("", _ => { }, placeholder: "Click here and press Ctrl+S — nothing should happen...")
+                TextBox("", _ => { }, placeholder: "Click here and press Ctrl+S — nothing should happen...")
             ).Padding(16).Margin(horizontal: 16, vertical: 0).Background(SystemCriticalBackground).CornerRadius(8));
     }
 }
@@ -360,7 +360,7 @@ class ContextSharingDemo : Component
                 Component<ToolbarComponent>(),
                 VStack(4,
                     Caption("Editor:").Foreground(SecondaryText),
-                    TextField(content, newText =>
+                    TextBox(content, newText =>
                     {
                         setContent(newText);
                         updateHistory(h => [.. h, newText]);

--- a/samples/NavigationDemo/App.cs
+++ b/samples/NavigationDemo/App.cs
@@ -621,9 +621,9 @@ class ProfilePage : Component<string>
 
                 VStack(8,
                     TextBlock("Display Name"),
-                    TextField(displayName, v => { setDisplayName(v); setSaved(false); }).Width(300),
+                    TextBox(displayName, v => { setDisplayName(v); setSaved(false); }).Width(300),
                     TextBlock("Bio"),
-                    TextField(bio, v => { setBio(v); setSaved(false); }).Width(300),
+                    TextBox(bio, v => { setBio(v); setSaved(false); }).Width(300),
                     When(hasUnsavedChanges, () =>
                         TextBlock("You have unsaved changes. Navigation is blocked until you save or discard.")
                             .Foreground(SystemCritical)),

--- a/samples/Reactor.TestApp/Demos/AsyncValueSamplesDemo.cs
+++ b/samples/Reactor.TestApp/Demos/AsyncValueSamplesDemo.cs
@@ -167,7 +167,7 @@ class DepsChangeCancelScenario : Component
         return VStack(8,
             SubHeading("1c. Deps-change cancellation"),
             TextBlock("Each keystroke cancels the previous fetch and starts a new one — only the last lands."),
-            TextField(query, v => setQuery(v ?? ""), placeholder: "type here…"),
+            TextBox(query, v => setQuery(v ?? ""), placeholder: "type here…"),
             TextBlock(result switch
             {
                 AsyncValue<string>.Loading => "⏳ Loading…",
@@ -388,7 +388,7 @@ class SearchInfiniteScenario : Component
         return VStack(8,
             SubHeading("2b. Search-as-you-type"),
             TextBlock("Type to filter. Each keystroke cancels the pending fetch; only the matching deps' pages land."),
-            TextField(query, v => setQuery(v ?? ""), placeholder: "e.g. Seattle"),
+            TextBox(query, v => setQuery(v ?? ""), placeholder: "e.g. Seattle"),
             TextBlock($"Matches: {resource.TotalCount?.ToString() ?? "…"}  /  LoadState: {SearchInfiniteLabel(resource.LoadState)}"),
 
             Border(
@@ -548,7 +548,7 @@ class DataSourceAdapterScenario : Component
         return VStack(8,
             SubHeading("2d. UseDataSource (IDataSource adapter)"),
             TextBlock("UseDataSource projects any IDataSource<T> into an InfiniteResource<T> — existing data-ecosystem interfaces work with the hook surface."),
-            TextField(search, v => setSearch(v ?? ""), placeholder: "search rows…"),
+            TextBox(search, v => setSearch(v ?? ""), placeholder: "search rows…"),
             TextBlock($"Matches: {resource.TotalCount?.ToString() ?? "…"}"),
 
             Border(

--- a/samples/Reactor.TestApp/Demos/ContextDemo.cs
+++ b/samples/Reactor.TestApp/Demos/ContextDemo.cs
@@ -35,7 +35,7 @@ class ContextDemo : Component
             ),
             HStack(8,
                 TextBlock("User name:"),
-                TextField(userName, setUserName, placeholder: "Enter name").Width(200)
+                TextBox(userName, setUserName, placeholder: "Enter name").Width(200)
             ),
 
             // 2. Consumers

--- a/samples/Reactor.TestApp/Demos/DataSystemDemo.cs
+++ b/samples/Reactor.TestApp/Demos/DataSystemDemo.cs
@@ -380,7 +380,7 @@ class DataSourceDemo : Microsoft.UI.Reactor.Core.Component
                 ComboBox(departments, Math.Max(0, Array.IndexOf(departments, filterDept)),
                     i => { setToken(null); setFilterDept(departments[i]); }).Width(140),
                 TextBlock("Search:"),
-                TextField(searchQuery, s => { setToken(null); setSearchQuery(s); }, placeholder: "Search...").Width(180)
+                TextBox(searchQuery, s => { setToken(null); setSearchQuery(s); }, placeholder: "Search...").Width(180)
             ).Flex(shrink: 0),
 
             loading

--- a/samples/Reactor.TestApp/Demos/DataTemplateDemo.cs
+++ b/samples/Reactor.TestApp/Demos/DataTemplateDemo.cs
@@ -48,7 +48,7 @@ class DataTemplateDemo : Component
 
             // Filter + add/remove controls
             HStack(12,
-                TextField(filter, setFilter, placeholder: "Filter animals...").Width(200),
+                TextBox(filter, setFilter, placeholder: "Filter animals...").Width(200),
                 Button("Add Random", () => updateAnimals(list =>
                 {
                     var id = list.Count + 1;

--- a/samples/Reactor.TestApp/Demos/FormDemo.cs
+++ b/samples/Reactor.TestApp/Demos/FormDemo.cs
@@ -42,12 +42,12 @@ class FormDemo : Component
 
             VStack(8,
                 TextBlock("Name"),
-                TextField(name, setName, placeholder: "Enter your name").Width(300)
+                TextBox(name, setName, placeholder: "Enter your name").Width(300)
             ),
 
             VStack(8,
                 TextBlock("Email"),
-                TextField(email, setEmail, placeholder: "you@example.com").Width(300)
+                TextBox(email, setEmail, placeholder: "you@example.com").Width(300)
             ),
 
             ToggleSwitch(darkMode, setDarkMode, onContent: "Dark", offContent: "Light"),

--- a/samples/Reactor.TestApp/Demos/InputGesturesDemo.cs
+++ b/samples/Reactor.TestApp/Demos/InputGesturesDemo.cs
@@ -256,7 +256,7 @@ sealed class UseFocusSample : Component
             "UseElementFocus: imperative focus via ref",
             "Click the button to imperatively focus the input via ctx.UseElementFocus().",
             VStack(8,
-                TextField(name, setName, placeholder: "name").Width(280).Ref(inputRef),
+                TextBox(name, setName, placeholder: "name").Width(280).Ref(inputRef),
                 HStack(8,
                     Button("Focus input", () => requestFocus()),
                     TextBlock("wired via UseElementFocus()").FontFamily("Consolas")

--- a/samples/Reactor.TestApp/Demos/IntegratedDataDemo.cs
+++ b/samples/Reactor.TestApp/Demos/IntegratedDataDemo.cs
@@ -251,7 +251,7 @@ class IntegratedDataDemo : Microsoft.UI.Reactor.Core.Component
                         .Where(m => m is not null).ToList();
                     var allErrors = nameErrors.Concat(priorityErrors).Concat(budgetErrors).ToList();
 
-                    var nameEditor = TextField(selectedItem.Name, v =>
+                    var nameEditor = TextBox(selectedItem.Name, v =>
                     {
                         selectedItem.Name = (string)v;
                     }, placeholder: "Task name...");

--- a/samples/Reactor.TestApp/Demos/NavigationDemo.cs
+++ b/samples/Reactor.TestApp/Demos/NavigationDemo.cs
@@ -102,7 +102,7 @@ class NavDetailPage : Component<int>
         return VStack(8,
             SubHeading($"Detail Page — Item #{id}"),
             TextBlock($"Viewing details for item {id}."),
-            TextField(notes, setNotes)
+            TextBox(notes, setNotes)
                 .Set(t => t.PlaceholderText = "Notes (persisted via UsePersisted)"),
             HStack(8,
                 Button("Home", () => nav.Reset(new NavHome())),

--- a/samples/Reactor.TestApp/Demos/PersistedDemo.cs
+++ b/samples/Reactor.TestApp/Demos/PersistedDemo.cs
@@ -34,8 +34,8 @@ class PersistedDemo : Component
         {
             return VStack(12,
                 SubHeading(heading),
-                VStack(4, TextBlock("Name"), TextField(name, setName, placeholder: "Enter name").Width(220)),
-                VStack(4, TextBlock("Email"), TextField(email, setEmail, placeholder: "you@example.com").Width(220)),
+                VStack(4, TextBlock("Name"), TextBox(name, setName, placeholder: "Enter name").Width(220)),
+                VStack(4, TextBlock("Email"), TextBox(email, setEmail, placeholder: "you@example.com").Width(220)),
                 VStack(4,
                     TextBlock("Color"),
                     HStack(4, colors.Select(c =>

--- a/samples/Reactor.TestApp/Demos/SlotsDemo.cs
+++ b/samples/Reactor.TestApp/Demos/SlotsDemo.cs
@@ -89,7 +89,7 @@ class SlotsDemo : Component
 
             // 3. Dynamic slot content
             SubHeading("3. Dynamic slot content"),
-            TextField(name, setName, placeholder: "Type a name...").Width(220),
+            TextBox(name, setName, placeholder: "Type a name...").Width(220),
             Component<Card, CardProps>(new(
                 Header: HStack(8,
                     Border(Empty()).Background(Accent).CornerRadius(12).Size(24, 24),

--- a/samples/Reactor.TestApp/Demos/TodoDemo.cs
+++ b/samples/Reactor.TestApp/Demos/TodoDemo.cs
@@ -33,7 +33,7 @@ class TodoDemo : Component
 
             // Add new item
             HStack(8,
-                TextField(newText, setNewText, placeholder: "What needs to be done?").Width(300),
+                TextBox(newText, setNewText, placeholder: "What needs to be done?").Width(300),
                 Button("Add", () =>
                 {
                     if (!string.IsNullOrWhiteSpace(newText))

--- a/samples/ReactorCharting.Gallery/Samples/ComponentHierarchy.cs
+++ b/samples/ReactorCharting.Gallery/Samples/ComponentHierarchy.cs
@@ -38,7 +38,7 @@ public sealed class ComponentHierarchySample : GallerySample
             "Button"       => Button(node.Name, null),
             "ToggleSwitch" => ToggleSwitch(false, null, "On", "Off"),
             "Slider"       => Slider(50, 0, 100).Width(90),
-            "TextBox"      => TextField("", placeholder: node.Name).Width(90),
+            "TextBox"      => TextBox("", placeholder: node.Name).Width(90),
             "CheckBox"     => CheckBox(false, label: node.Name),
             _              => HeaderBadge(node.Name),
         };
@@ -102,7 +102,7 @@ public sealed class ComponentHierarchySample : GallerySample
         "Button" => Button(node.Name, null).Set(b => { b.FontSize = 11; b.Padding = new Thickness(10, 4, 10, 4); }),
         "ToggleSwitch" => ToggleSwitch(false, null, "On", "Off").Set(ts => { ts.MinWidth = 0; ts.FontSize = 10; }),
         "Slider" => Slider(50, 0, 100).Width(90).Height(32),
-        "TextBox" => TextField("", placeholder: node.Name).Width(90).Set(tb => { tb.FontSize = 11; tb.Padding = new Thickness(6, 4, 6, 4); }),
+        "TextBox" => TextBox("", placeholder: node.Name).Width(90).Set(tb => { tb.FontSize = 11; tb.Padding = new Thickness(6, 4, 6, 4); }),
         "CheckBox" => CheckBox(false, label: node.Name).Set(cb => { cb.FontSize = 10; cb.MinWidth = 0; }),
         _ => HeaderBadge(node.Name),
     };

--- a/samples/ReactorGallery/ControlPages/BasicInput/TextFieldPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/TextFieldPage.cs
@@ -23,60 +23,60 @@ class TextFieldPage: Component
 
             SampleCard("Basic TextField",
                 VStack(8,
-                    TextField(text, v => setText(v), "Type here..."),
+                    TextBox(text, v => setText(v), "Type here..."),
                     TextBlock($"Characters: {text.Length}").Foreground(Theme.SecondaryText)),
                 sourceCode: @"
-TextField(text, v => setText(v), ""Type here..."")
+TextBox(text, v => setText(v), ""Type here..."")
 "),
 
             SampleCard("Multiline TextField",
-                TextField(multiline, v => setMultiline(v), "Enter multiple lines...")
+                TextBox(multiline, v => setMultiline(v), "Enter multiple lines...")
                     .Set(tb => { tb.AcceptsReturn = true; tb.TextWrapping = TextWrapping.Wrap; })
                     .Height(120),
                 sourceCode: @"
-TextField(multiline, v => setMultiline(v), ""Enter multiple lines..."")
+TextBox(multiline, v => setMultiline(v), ""Enter multiple lines..."")
     .Set(tb => { tb.AcceptsReturn = true; tb.TextWrapping = TextWrapping.Wrap; })
     .Height(120)
 "),
 
             SampleCard("TextField with Header",
-                TextField(headerText, v => setHeaderText(v), "user@example.com").Header("Email"),
+                TextBox(headerText, v => setHeaderText(v), "user@example.com").Header("Email"),
                 sourceCode: @"
-TextField(headerText, v => setHeaderText(v), ""user@example.com"").Header(""Email"")
+TextBox(headerText, v => setHeaderText(v), ""user@example.com"").Header(""Email"")
 "),
 
             // Phase 8.1 — InputScope fluents (spec 039 §17.3) + .Description() (§5).
             SampleCard("Numeric input — .NumericInput()",
-                TextField(numericText, v => setNumericText(v), "0")
+                TextBox(numericText, v => setNumericText(v), "0")
                     .Header("Quantity")
                     .NumericInput()
                     .Description("Soft keyboards show a number pad."),
                 sourceCode: @"
-TextField(numericText, v => setNumericText(v), ""0"")
+TextBox(numericText, v => setNumericText(v), ""0"")
     .Header(""Quantity"")
     .NumericInput()
     .Description(""Soft keyboards show a number pad."")
 "),
 
             SampleCard("Email input — .EmailInput()",
-                TextField(emailText, v => setEmailText(v), "name@contoso.com")
+                TextBox(emailText, v => setEmailText(v), "name@contoso.com")
                     .Header("Email address")
                     .EmailInput()
                     .Description("Hints the IME to surface '@' and '.com'."),
                 sourceCode: @"
-TextField(emailText, v => setEmailText(v), ""name@contoso.com"")
+TextBox(emailText, v => setEmailText(v), ""name@contoso.com"")
     .Header(""Email address"")
     .EmailInput()
     .Description(""Hints the IME to surface '@' and '.com'."")
 "),
 
             SampleCard("URL input — .UrlInput()",
-                TextField(urlText, v => setUrlText(v), "https://example.com")
+                TextBox(urlText, v => setUrlText(v), "https://example.com")
                     .Header("Homepage")
                     .UrlInput()
                     .Description("Hints the IME to surface '/' and '.com'."),
                 sourceCode: @"
-TextField(urlText, v => setUrlText(v), ""https://example.com"")
+TextBox(urlText, v => setUrlText(v), ""https://example.com"")
     .Header(""Homepage"")
     .UrlInput()
     .Description(""Hints the IME to surface '/' and '.com'."")

--- a/samples/ReactorGallery/ControlPages/DesignGuidance/GeometryPage.cs
+++ b/samples/ReactorGallery/ControlPages/DesignGuidance/GeometryPage.cs
@@ -116,7 +116,7 @@ Border(dialog).CornerRadius(overlayRadius.TopLeft)");
 
                 // Text inputs
                 TextBlock("Text Input").SemiBold().Foreground(Theme.PrimaryText),
-                TextField("", placeholder: "Type here...")
+                TextBox("", placeholder: "Type here...")
                     .Width(280)
                     .CornerRadius(cr.TopLeft),
 
@@ -159,7 +159,7 @@ Border(dialog).CornerRadius(overlayRadius.TopLeft)");
 Button(""Standard"", () => { }).CornerRadius(cr.TopLeft)
 
 // Text input
-TextField(""Placeholder"", value, onChange).CornerRadius(cr.TopLeft)
+TextBox(""Placeholder"", value, onChange).CornerRadius(cr.TopLeft)
 
 // Card
 Border(content)
@@ -279,9 +279,9 @@ Border(tipContent)
                     VStack(12,
                         TextBlock("Sign In")
                             .FontSize(16).SemiBold().Foreground(Theme.PrimaryText),
-                        TextField("", placeholder: "Username")
+                        TextBox("", placeholder: "Username")
                             .CornerRadius(cr.TopLeft),
-                        TextField("", placeholder: "Password")
+                        TextBox("", placeholder: "Password")
                             .CornerRadius(cr.TopLeft),
                         Button("Sign In", () => { })
                             .Background(Theme.Accent)
@@ -317,7 +317,7 @@ var or = ThemeResource.CornerRadius(""OverlayCornerRadius"");
 // Overlay container with control-radius inner elements
 Border(
     VStack(12,
-        TextField(""Username"", value, onChange).CornerRadius(cr.TopLeft),
+        TextBox(""Username"", value, onChange).CornerRadius(cr.TopLeft),
         Button(""Sign In"", onClick)
             .Background(Theme.Accent)
             .CornerRadius(cr.TopLeft)

--- a/samples/ReactorGallery/ControlPages/Media/PersonPicturePage.cs
+++ b/samples/ReactorGallery/ControlPages/Media/PersonPicturePage.cs
@@ -37,11 +37,11 @@ class PersonPicturePage : Component
                 SampleCard("Interactive Display Name",
                     VStack(8,
                         PersonPicture().DisplayName(name).Width(72).Height(72),
-                        TextField(name, s => setName(s), placeholder: "Enter name").Width(250)
+                        TextBox(name, s => setName(s), placeholder: "Enter name").Width(250)
                     ),
                     @"var (name, setName) = UseState(""Jane Doe"");
 PersonPicture().DisplayName(name).Width(72).Height(72)
-TextField(name, s => setName(s))")
+TextBox(name, s => setName(s))")
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Media/WebView2Page.cs
+++ b/samples/ReactorGallery/ControlPages/Media/WebView2Page.cs
@@ -20,7 +20,7 @@ class WebView2Page : Component
 
                 SampleCard("Load URL",
                     VStack(8,
-                        TextField(url, s => setUrl(s), placeholder: "Enter URL").Width(400),
+                        TextBox(url, s => setUrl(s), placeholder: "Enter URL").Width(400),
                         WebView2(new Uri(url)).Width(600).Height(400)
                     ),
                     @"WebView2(new Uri(""https://learn.microsoft.com""))

--- a/samples/ReactorGallery/ControlPages/Navigation/TitleBarPage.cs
+++ b/samples/ReactorGallery/ControlPages/Navigation/TitleBarPage.cs
@@ -29,12 +29,12 @@ class TitleBarPage : Component
                         Border(
                             TitleBar("My App").Subtitle(subtitle)
                         ).Background(Theme.LayerFill).CornerRadius(4).Height(48),
-                        TextField(subtitle, s => setSubtitle(s), placeholder: "Enter subtitle")
+                        TextBox(subtitle, s => setSubtitle(s), placeholder: "Enter subtitle")
                             .Width(250)
                     ),
                     @"TitleBar(""My App"").Subtitle(""Preview"")",
                     options: OptionPanel(
-                        TextField(subtitle, s => setSubtitle(s), header: "Subtitle")
+                        TextBox(subtitle, s => setSubtitle(s), header: "Subtitle")
                     )),
 
                 SampleCard("TitleBar with Content",

--- a/samples/ReactorHostControlDemo/MainWindow.xaml.cs
+++ b/samples/ReactorHostControlDemo/MainWindow.xaml.cs
@@ -29,7 +29,7 @@ public sealed partial class MainWindow : Window
                 TextBlock("Todo List").FontSize(20).Bold().Margin(16, 16, 16, 0),
 
                 HStack(8,
-                    TextField(draft, onChanged: setDraft, placeholder: "What needs doing?"),
+                    TextBox(draft, onChanged: setDraft, placeholder: "What needs doing?"),
                     Button("Add", () =>
                     {
                         if (string.IsNullOrWhiteSpace(draft)) return;

--- a/samples/TodoApp/Program.cs
+++ b/samples/TodoApp/Program.cs
@@ -170,7 +170,7 @@ class TodoApp : Component
 
     static Element InputRow(string text, Command addCmd, Action<TodoAction> dispatch) =>
         (FlexRow(
-            TextField(text, v => dispatch(new SetNewItemText(v)),
+            TextBox(text, v => dispatch(new SetNewItemText(v)),
                       placeholder: "What needs to be done?")
                 .Flex(grow: 1),
             Button(addCmd).Flex(shrink: 0)

--- a/samples/WinFormsInterop/SampleDuctComponent.cs
+++ b/samples/WinFormsInterop/SampleDuctComponent.cs
@@ -43,7 +43,7 @@ class SampleReactorComponent : Component
             HStack(
                 TextBlock("Name: ")
                     .VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center),
-                TextField(name, setName)
+                TextBox(name, setName)
                     .Width(200)
             ).Margin(0, 0, 0, 8),
 

--- a/samples/apps/a11y-showcase/App.cs
+++ b/samples/apps/a11y-showcase/App.cs
@@ -99,7 +99,7 @@ sealed class App : Component
 
                     // header: associates the visible label with the input for
                     // screen readers and meets REACTOR_A11Y_003.
-                    TextField(newTitle, setNewTitle, placeholder: "New task...", header: "New task")
+                    TextBox(newTitle, setNewTitle, placeholder: "New task...", header: "New task")
                         .Width(280),
 
                     Button(CreateIcon(Symbol.Add), () =>
@@ -140,7 +140,7 @@ sealed class App : Component
             // ── Footer ──────────────────────────────────────────────
             Border(
                 HStack(12,
-                    TextField("", _ => { }, header: "Quick note")
+                    TextBox("", _ => { }, header: "Quick note")
                         .Width(300),
 
                     Caption("v1.0.0 — A11y Showcase").Opacity(0.5)

--- a/samples/apps/chat/Chat.UI/InputBar.cs
+++ b/samples/apps/chat/Chat.UI/InputBar.cs
@@ -51,7 +51,7 @@ public class InputBar : Component<InputBarProps>
                     b.MinWidth = 0; b.MinHeight = 0;
                     b.CornerRadius = new CornerRadius(4);
                 }).VAlign(VerticalAlignment.Bottom).Grid(row: 0, column: 0),
-                TextField(inputState.Value, v => inputState.Set(v))
+                TextBox(inputState.Value, v => inputState.Set(v))
                     .Set(tb =>
                     {
                         tb.PlaceholderText = placeholder;

--- a/samples/apps/chat/Chat.UI/LandingPage.cs
+++ b/samples/apps/chat/Chat.UI/LandingPage.cs
@@ -76,7 +76,7 @@ public class LandingPage : Component<LandingPageProps>
                 Grid([GridSize.Auto, GridSize.Star(), GridSize.Auto], [GridSize.Star()],
                     Caption("+").Foreground(SecondaryText).VAlign(VerticalAlignment.Center)
                         .Padding(8, 0, 0, 0).Grid(row: 0, column: 0),
-                    TextField(inputState.Value, v => inputState.Set(v))
+                    TextBox(inputState.Value, v => inputState.Set(v))
                         .Set(tb =>
                         {
                             tb.PlaceholderText = "Ask the sample assistant...";

--- a/samples/apps/demo-script-tool/App/Components/DemoPromptPanel.cs
+++ b/samples/apps/demo-script-tool/App/Components/DemoPromptPanel.cs
@@ -48,7 +48,7 @@ public sealed class DemoPromptPanel : Component<DemoPromptPanelProps>
             setPrompt(Props.Model.DemoPrompt);
         }, Props.Model);
 
-        var titleField = (TextField(title, v =>
+        var titleField = (TextBox(title, v =>
         {
             setTitle(v);
             Props.OnTitleChanged(v);
@@ -58,7 +58,7 @@ public sealed class DemoPromptPanel : Component<DemoPromptPanelProps>
             .FontWeight(Microsoft.UI.Text.FontWeights.SemiBold)
             .AutomationName("Demo title");
 
-        var promptField = (TextField(prompt, v =>
+        var promptField = (TextBox(prompt, v =>
         {
             setPrompt(v);
             Props.OnPromptChanged(v);

--- a/samples/apps/demo-script-tool/App/Components/StepCard.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepCard.cs
@@ -112,7 +112,7 @@ public sealed class StepCard : Component<StepCardProps>
         // OwnPropsEqual short-circuit (it requires Setters.Length == 0). We
         // reach for typed modifiers and `with { … }` everywhere we can — the
         // values diff structurally and the WinUI control isn't re-poked.
-        var promptField = (TextField(localPrompt,
+        var promptField = (TextBox(localPrompt,
                 v =>
                 {
                     setLocalPrompt(v);
@@ -291,7 +291,7 @@ public sealed class StepCard : Component<StepCardProps>
         // the FlexRow's center baseline then shifts with it, which reads
         // as a "bobbling" title. 36px = FontSize 18 + default vertical
         // padding (~9px each side); the explicit value freezes the metric.
-        var titleField = (TextField(localTitle,
+        var titleField = (TextBox(localTitle,
                 v =>
                 {
                     setLocalTitle(v);

--- a/samples/apps/dock-showcase/App.cs
+++ b/samples/apps/dock-showcase/App.cs
@@ -354,7 +354,7 @@ class SceneAIde : Component
             // of the optional modifiers / multi-line config.
             return VStack(6,
                 TextBlock(banner).SemiBold(),
-                TextField(text, setText, placeholder: "edit me…")
+                TextBox(text, setText, placeholder: "edit me…")
             ).Padding(12);
         });
 
@@ -370,7 +370,7 @@ class SceneAIde : Component
                 .ToArray();
             return VStack(4,
                 TextBlock(banner).SemiBold(),
-                TextField(filter, setFilter, placeholder: filterPlaceholder),
+                TextBox(filter, setFilter, placeholder: filterPlaceholder),
                 VStack(2, rowElements)
             ).Padding(8);
         });
@@ -401,7 +401,7 @@ class SceneAIde : Component
                 TextBlock("Branch: feat/045-docking-windows-p2").Opacity(0.8),
                 VStack(2, changeElements),
                 TextBlock("Commit message").SemiBold().Margin(0, 8, 0, 0),
-                TextField(message, setMessage, placeholder: "Describe the change…")
+                TextBox(message, setMessage, placeholder: "Describe the change…")
                     .Set(tb => { tb.AcceptsReturn = true; tb.MinHeight = 60; }),
                 Button("Commit", Commit),
                 TextBlock("History").SemiBold().Margin(0, 8, 0, 0),
@@ -427,7 +427,7 @@ class SceneAIde : Component
                 .ToArray();
             return VStack(6,
                 TextBlock($"⚠ 0 Errors    ⚠ {entries.Length} Warnings    ℹ 1 Message").Opacity(0.8),
-                TextField(filter, setFilter, placeholder: "Filter by code, file, or message…"),
+                TextBox(filter, setFilter, placeholder: "Filter by code, file, or message…"),
                 VStack(2, rowElements)
             ).Padding(8);
         });
@@ -453,7 +453,7 @@ class SceneAIde : Component
             return VStack(6,
                 VStack(2, lines),
                 HStack(6,
-                    TextField(entry, setEntry, placeholder: "Append output line… (Enter)")
+                    TextBox(entry, setEntry, placeholder: "Append output line… (Enter)")
                         .Set(tb =>
                         {
                             tb.KeyDown += (s, e) =>
@@ -499,7 +499,7 @@ class SceneAIde : Component
                 VStack(2, lines),
                 HStack(6,
                     TextBlock("PS&gt;").FontFamily("Consolas, Courier New, monospace").SemiBold(),
-                    TextField(input, setInput, placeholder: "Type a command and press Enter…")
+                    TextBox(input, setInput, placeholder: "Type a command and press Enter…")
                         .Set(tb =>
                         {
                             tb.FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas, Courier New, monospace");

--- a/samples/apps/minesweeper/Components/Dialogs/DialogContent.cs
+++ b/samples/apps/minesweeper/Components/Dialogs/DialogContent.cs
@@ -54,9 +54,9 @@ internal static class DialogContent
         string? error)
     {
         return VStack(10,
-            HStack(8, TextBlock("Rows (4–24):").Width(140), TextField(rows, onRowsChanged).Width(80)),
-            HStack(8, TextBlock("Columns (4–30):").Width(140), TextField(columns, onColumnsChanged).Width(80)),
-            HStack(8, TextBlock("Mines:").Width(140), TextField(mines, onMinesChanged).Width(80)),
+            HStack(8, TextBlock("Rows (4–24):").Width(140), TextBox(rows, onRowsChanged).Width(80)),
+            HStack(8, TextBlock("Columns (4–30):").Width(140), TextBox(columns, onColumnsChanged).Width(80)),
+            HStack(8, TextBlock("Mines:").Width(140), TextBox(mines, onMinesChanged).Width(80)),
             error is null
                 ? TextBlock("").Height(0)
                 : TextBlock(error).Foreground(Theme.SystemCritical)

--- a/samples/apps/regedit/App.cs
+++ b/samples/apps/regedit/App.cs
@@ -745,7 +745,7 @@ class RegeditApp : Component
             Strings.RenameKeyTitle,
             VStack(8,
                 TextBlock(Strings.NewKeyName),
-                TextField(editValueData, setEditValueData)
+                TextBox(editValueData, setEditValueData)
             ).Width(350),
             Strings.OK
         ) with
@@ -766,7 +766,7 @@ class RegeditApp : Component
             Strings.RenameValueTitle,
             VStack(8,
                 TextBlock(Strings.NewKeyName),
-                TextField(editValueData, setEditValueData)
+                TextBox(editValueData, setEditValueData)
             ).Width(350),
             Strings.OK
         ) with

--- a/samples/apps/regedit/Components/Dialogs/EditBinaryDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/EditBinaryDialog.cs
@@ -24,12 +24,12 @@ internal sealed class EditBinaryDialog : Component<EditBinaryDialogProps>
             VStack(12,
                 VStack(4,
                     TextBlock(Strings.ValueName),
-                    TextField(Props.ValueName, _ => { })
+                    TextBox(Props.ValueName, _ => { })
                         .IsReadOnly()
                 ),
                 VStack(4,
                     TextBlock(Strings.ValueData),
-                    TextField(Props.ValueData, Props.OnValueDataChanged)
+                    TextBox(Props.ValueData, Props.OnValueDataChanged)
                         .Set(tb =>
                         {
                             tb.FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas");

--- a/samples/apps/regedit/Components/Dialogs/EditDwordDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/EditDwordDialog.cs
@@ -26,12 +26,12 @@ internal sealed class EditDwordDialog : Component<EditDwordDialogProps>
             VStack(12,
                 VStack(4,
                     TextBlock(Strings.ValueName),
-                    TextField(Props.ValueName, _ => { })
+                    TextBox(Props.ValueName, _ => { })
                         .IsReadOnly()
                 ),
                 VStack(4,
                     TextBlock(Strings.ValueData),
-                    TextField(Props.ValueData, Props.OnValueDataChanged)
+                    TextBox(Props.ValueData, Props.OnValueDataChanged)
                 ),
                 VStack(4,
                     TextBlock(Strings.Base),

--- a/samples/apps/regedit/Components/Dialogs/EditMultiStringDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/EditMultiStringDialog.cs
@@ -24,12 +24,12 @@ internal sealed class EditMultiStringDialog : Component<EditMultiStringDialogPro
             VStack(12,
                 VStack(4,
                     TextBlock(Strings.ValueName),
-                    TextField(Props.ValueName, _ => { })
+                    TextBox(Props.ValueName, _ => { })
                         .IsReadOnly()
                 ),
                 VStack(4,
                     TextBlock(Strings.ValueData),
-                    TextField(Props.ValueData, Props.OnValueDataChanged)
+                    TextBox(Props.ValueData, Props.OnValueDataChanged)
                         .Set(tb =>
                         {
                             tb.AcceptsReturn = true;

--- a/samples/apps/regedit/Components/Dialogs/EditQwordDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/EditQwordDialog.cs
@@ -26,12 +26,12 @@ internal sealed class EditQwordDialog : Component<EditQwordDialogProps>
             VStack(12,
                 VStack(4,
                     TextBlock(Strings.ValueName),
-                    TextField(Props.ValueName, _ => { })
+                    TextBox(Props.ValueName, _ => { })
                         .IsReadOnly()
                 ),
                 VStack(4,
                     TextBlock(Strings.ValueData),
-                    TextField(Props.ValueData, Props.OnValueDataChanged)
+                    TextBox(Props.ValueData, Props.OnValueDataChanged)
                 ),
                 VStack(4,
                     TextBlock(Strings.Base),

--- a/samples/apps/regedit/Components/Dialogs/EditStringDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/EditStringDialog.cs
@@ -24,12 +24,12 @@ internal sealed class EditStringDialog : Component<EditStringDialogProps>
             VStack(12,
                 VStack(4,
                     TextBlock(Strings.ValueName),
-                    TextField(Props.ValueName, _ => { })
+                    TextBox(Props.ValueName, _ => { })
                         .IsReadOnly()
                 ),
                 VStack(4,
                     TextBlock(Strings.ValueData),
-                    TextField(Props.ValueData, Props.OnValueDataChanged)
+                    TextBox(Props.ValueData, Props.OnValueDataChanged)
                 )
             ).Width(400),
             Strings.OK

--- a/samples/apps/regedit/Components/Dialogs/ExportDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/ExportDialog.cs
@@ -33,7 +33,7 @@ internal sealed class ExportDialog : Component<ExportDialogProps>
                         "exportRange")
                 ),
                 When(!Props.ExportAll, () =>
-                    TextField(Props.SelectedBranch, _ => { })
+                    TextBox(Props.SelectedBranch, _ => { })
                         .IsReadOnly()
                 )
             ).Width(400),

--- a/samples/apps/regedit/Components/Dialogs/FavoritesDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/FavoritesDialog.cs
@@ -23,7 +23,7 @@ internal sealed class AddFavoriteDialog : Component<AddFavoriteDialogProps>
             Strings.AddFavoriteTitle,
             VStack(8,
                 TextBlock(Strings.FavoriteName),
-                TextField(Props.FavoriteName, Props.OnNameChanged)
+                TextBox(Props.FavoriteName, Props.OnNameChanged)
             ).Width(350),
             Strings.OK
         ) with

--- a/samples/apps/regedit/Components/Dialogs/FindDialog.cs
+++ b/samples/apps/regedit/Components/Dialogs/FindDialog.cs
@@ -25,7 +25,7 @@ internal sealed class FindDialog : Component<FindDialogProps>
             VStack(12,
                 VStack(4,
                     TextBlock(Strings.FindWhat),
-                    TextField(Props.SearchText, Props.OnSearchTextChanged)
+                    TextBox(Props.SearchText, Props.OnSearchTextChanged)
                 ),
                 VStack(4,
                     TextBlock(Strings.LookAt),

--- a/samples/apps/validation-showcase/App.cs
+++ b/samples/apps/validation-showcase/App.cs
@@ -76,7 +76,7 @@ class BasicValidationDemo : Component
                 // FormField auto-renders label, content, and description/error area.
                 // .Validate() with value triggers automatic validation — no manual calls.
                 FormField(
-                    TextField(email, v => { setEmail(v); ctx.MarkTouched("email"); setInfoDismissed(false); },
+                    TextBox(email, v => { setEmail(v); ctx.MarkTouched("email"); setInfoDismissed(false); },
                             placeholder: "user@example.com")
                         .Validate("email", email,
                             Validate.Required("Email is required"),
@@ -97,7 +97,7 @@ class BasicValidationDemo : Component
                     showWhen: sw),
 
                 FormField(
-                    TextField(website, v => { setWebsite(v); ctx.MarkTouched("website"); setInfoDismissed(false); },
+                    TextBox(website, v => { setWebsite(v); ctx.MarkTouched("website"); setInfoDismissed(false); },
                             placeholder: "https://example.com")
                         .Validate("website", website,
                             Validate.Url("Enter a valid URL (https://...)"))
@@ -234,7 +234,7 @@ class MaskedInputDemo : Component
 
             VStack(8,
                 TextBlock("Phone (US) — digits only").Foreground(Theme.SecondaryText),
-                TextField(phone, v => setPhone(new string(v.Where(char.IsDigit).ToArray())),
+                TextBox(phone, v => setPhone(new string(v.Where(char.IsDigit).ToArray())),
                     placeholder: "5551234567"),
                 When(phone.Length > 0, () =>
                     HStack(8,
@@ -247,7 +247,7 @@ class MaskedInputDemo : Component
 
             VStack(8,
                 TextBlock("SSN — digits only").Foreground(Theme.SecondaryText),
-                TextField(ssn, v => setSsn(new string(v.Where(char.IsDigit).ToArray())),
+                TextBox(ssn, v => setSsn(new string(v.Where(char.IsDigit).ToArray())),
                     placeholder: "123456789"),
                 When(ssn.Length > 0, () =>
                     TextBlock($"Formatted: {ssnFormatted}").Foreground(Theme.SecondaryText))
@@ -255,7 +255,7 @@ class MaskedInputDemo : Component
 
             VStack(8,
                 TextBlock("ZIP Code — digits only").Foreground(Theme.SecondaryText),
-                TextField(zip, v => setZip(new string(v.Where(char.IsDigit).ToArray())),
+                TextBox(zip, v => setZip(new string(v.Where(char.IsDigit).ToArray())),
                     placeholder: "90210"),
                 When(zip.Length > 0, () =>
                     TextBlock($"Formatted: {zipFormatted}").Foreground(Theme.SecondaryText))
@@ -263,7 +263,7 @@ class MaskedInputDemo : Component
 
             VStack(8,
                 TextBlock("Currency (InputFormatter)").Foreground(Theme.SecondaryText),
-                TextField(amount,
+                TextBox(amount,
                     v => setAmount(new string(v.Where(c => char.IsDigit(c) || c == '.').ToArray())),
                     placeholder: "1234.56"),
                 When(amount.Length > 0, () =>
@@ -273,7 +273,7 @@ class MaskedInputDemo : Component
 
             VStack(8,
                 TextBlock("Uppercase Formatter").Foreground(Theme.SecondaryText),
-                TextField(shout, v => setShout(v.ToUpperInvariant()),
+                TextBox(shout, v => setShout(v.ToUpperInvariant()),
                     placeholder: "auto uppercased")
                     .Set(tb => tb.CharacterCasing = CharacterCasing.Upper)
             )
@@ -312,7 +312,7 @@ class DirtyResetDemo : Component
             VStack(4,
                 TextBlock("Name")
                     .Set(t => t.FontWeight = Microsoft.UI.Text.FontWeights.SemiBold),
-                TextField(name, v => { setName(v); ctx.MarkTouched("name"); }),
+                TextBox(name, v => { setName(v); ctx.MarkTouched("name"); }),
                 TextBlock("Initial: \"John Doe\"").Foreground(Theme.SecondaryText)
             ),
 
@@ -370,11 +370,11 @@ class FocusDemo : Component
             SubHeading("Focus Management"),
             Caption("UseFocus provides programmatic focus control and enter-to-advance."),
 
-            TextField(f1, setF1, placeholder: "First field", header: "First Name")
+            TextBox(f1, setF1, placeholder: "First field", header: "First Name")
                 .Focus(fm, "first"),
-            TextField(f2, setF2, placeholder: "Second field", header: "Last Name")
+            TextBox(f2, setF2, placeholder: "Second field", header: "Last Name")
                 .Focus(fm, "last"),
-            TextField(f3, setF3, placeholder: "Third (last) field", header: "Nickname")
+            TextBox(f3, setF3, placeholder: "Third (last) field", header: "Nickname")
                 .Focus(fm, "nick"),
 
             HStack(8,

--- a/skills/commanding.md
+++ b/skills/commanding.md
@@ -119,7 +119,7 @@ var undo = StandardCommand.Undo(() => UndoAction());
 CommandHost([save, undo],
     VStack(
         TextBlock("Ctrl+S / Ctrl+Z only fire inside this region"),
-        TextField(value, onChange)))
+        TextBox(value, onChange)))
 ```
 
 Commands without an `Accelerator` are ignored by `CommandHost`.
@@ -138,7 +138,7 @@ class Editor : Component
     {
         var save = UseCommand(StandardCommand.Save(async () => await SaveAsync()));
         var undo = StandardCommand.Undo(() => Undo());
-        return TextField(text, onChange)
+        return TextBox(text, onChange)
             .Provide(EditorCtx, new EditorCommands(save, undo, redo));
     }
 }

--- a/skills/design-docs/layout-and-scaling.md
+++ b/skills/design-docs/layout-and-scaling.md
@@ -101,7 +101,7 @@ Grid(
     rows: [GridSize.Auto, GridSize.Star()],
 
     TextBlock("Label").Grid(row: 0, column: 0),
-    TextField(value, setValue).Grid(row: 0, column: 1),
+    TextBox(value, setValue).Grid(row: 0, column: 1),
     Button("Go", onClick).Grid(row: 0, column: 2),
 
     ScrollView(
@@ -197,11 +197,11 @@ VStack(
 // Correct: flexible sizing
 Button("Submit").MinHeight(40)
 VStack(content).MinWidth(200).MaxWidth(600)
-TextField(value, setValue).MinHeight(32)
+TextBox(value, setValue).MinHeight(32)
 
 // Wrong: fixed sizing clips at larger text scales
 Button("Submit").Height(32)
-TextField(value, setValue).Height(30).Width(200)
+TextBox(value, setValue).Height(30).Width(200)
 ```
 
 ### No Fixed Widths on Buttons

--- a/skills/design.md
+++ b/skills/design.md
@@ -85,7 +85,7 @@ Pick each control by what it does, not by what looks similar. Defaults match the
 
 **Data display:** Vertical list → `ListView`. Tiles / image grid → `GridView`. Hierarchy → `TreeView`. Tabular → `ListView` with `Grid` rows. Master–detail → `ListView` + detail panel. Carousel → `FlipView`.
 
-**Input:** Text → `TextField`. Number → `NumberBox`. Search → `AutoSuggestBox`. Date → `CalendarDatePicker`. Time → `TimePicker`. Boolean → `ToggleSwitch`. Pick 1 of 2–3 → `RadioButtons`. Pick 1 of 4+ → `ComboBox`. Continuous value → `Slider`. Password → `PasswordBox`.
+**Input:** Text → `TextBox`. Number → `NumberBox`. Search → `AutoSuggestBox`. Date → `CalendarDatePicker`. Time → `TimePicker`. Boolean → `ToggleSwitch`. Pick 1 of 2–3 → `RadioButtons`. Pick 1 of 4+ → `ComboBox`. Continuous value → `Slider`. Password → `PasswordBox`.
 
 **Feedback:** Blocking decision → `ContentDialog`. Contextual action → `Flyout` / `MenuFlyout`. Onboarding callout → `TeachingTip`. Inline status banner → `InfoBar`. Non-blocking screen-reader announcement → `UseAnnounce()` — the returned handle exposes a `Region` element that must be rendered somewhere in the component tree, or announcements no-op.
 
@@ -130,7 +130,7 @@ These are the specific mistakes that make a Reactor app look like a port from an
 | Custom toggle-button row for "Light / Dark / Auto" mode | `SelectorBar(...)` or `RadioButtons(...)` | Step 2 |
 | Clickable `Border` or `TextBlock` for primary actions | Real `Button` / `HyperlinkButton` — needed for AT, keyboard, focus | §7 Accessibility |
 | Icon-only `Button` without `.AutomationName("...")` | Always set `.AutomationName()` on icon-only buttons — required by `REACTOR_A11Y_001` | §7 Accessibility |
-| `TextField` without a label (relying on `placeholder` alone) | `FormField(TextField(...), label: "Name")` — wires label and automation name | Step 2 |
+| `TextBox` without a label (relying on `placeholder` alone) | `FormField(TextBox(...), label: "Name")` — wires label and automation name | Step 2 |
 | Spacer `Border` element used for layout gaps | `VStack(spacing, ...)` / `HStack(spacing, ...)` / `FlexColumn(...) with { RowGap = n }` | §5 Spacing |
 | Unkeyed children in a dynamic list | `.WithKey(item.Id)` on every list item | §10 Reconciliation |
 | `ScrollView` wrapping a `ListView` | `ListView` already scrolls — wrap content, not list controls | §5 ScrollView |
@@ -444,13 +444,13 @@ Border(child).Margin(3)
 
 **Margin** pushes an element away from its neighbors. It works on every Reactor element.
 
-**Padding** adds space between a container's edge and its content. It only works on `Border` and `Control`-based elements (`Button`, `TextField`, etc.). Layout panels like `VStack`, `HStack`, and `Grid` do not support `.Padding()` — wrap content in a `Border` if you need inner padding on a stack.
+**Padding** adds space between a container's edge and its content. It only works on `Border` and `Control`-based elements (`Button`, `TextBox`, etc.). Layout panels like `VStack`, `HStack`, and `Grid` do not support `.Padding()` — wrap content in a `Border` if you need inner padding on a stack.
 
 | Element | `.Margin()` | `.Padding()` |
 |---------|-------------|-------------|
 | `Border` | ✓ | ✓ |
 | `Button` | ✓ | ✓ |
-| `TextField` | ✓ | ✓ |
+| `TextBox` | ✓ | ✓ |
 | `TextBlock` | ✓ | — |
 | `VStack` | ✓ | — |
 | `HStack` | ✓ | — |
@@ -463,7 +463,7 @@ TextBlock("Hello").Margin(8)
 VStack(children).Margin(16)
 Border(child).Margin(12)
 
-// Padding — only on Border and Control (Button, TextField, etc.)
+// Padding — only on Border and Control (Button, TextBox, etc.)
 Border(child).Padding(16)    // ✓ works
 Button("Go").Padding(12)     // ✓ works
 
@@ -522,7 +522,7 @@ var or = ThemeResource.CornerRadius("OverlayCornerRadius");
 // Dialog with control-radius inner elements
 Border(
     VStack(12,
-        TextField("", placeholder: "Username").CornerRadius(cr.TopLeft),
+        TextBox("", placeholder: "Username").CornerRadius(cr.TopLeft),
         Button("Sign In", onClick)
             .Background(Theme.Accent)
             .CornerRadius(cr.TopLeft)
@@ -542,7 +542,7 @@ VStack(children).MinWidth(200)
 
 // Wrong: fixed Height clips at larger text scales
 Button("Action").Height(32)
-TextField(text, setText).Height(30)
+TextBox(text, setText).Height(30)
 ```
 
 - Prefer `MinHeight`/`MinWidth` over fixed `Height`/`Width`.
@@ -676,7 +676,7 @@ var filtered = UseMemo(() =>
     items, filter);
 
 return VStack(
-    TextField(filter, setFilter, placeholder: "Filter..."),
+    TextBox(filter, setFilter, placeholder: "Filter..."),
     VStack(filtered.Select(item =>
         TextBlock(item.Name).WithKey(item.Id)
     ).ToArray()));
@@ -745,7 +745,7 @@ Button("Save", onSave).IsTabStop(true).TabIndex(0).AccessKey("S")
 These allocate an `AutomationProperties` peer only when set:
 
 ```csharp
-TextField(name, setName)
+TextBox(name, setName)
     .HelpText("Enter your full legal name")
     .Required()
 
@@ -888,7 +888,7 @@ Three compile-time analyzers catch accessibility issues:
 |----------|--------|
 | `REACTOR_A11Y_001` | Icon-only Button/ToggleButton missing `.AutomationName()` |
 | `REACTOR_A11Y_002` | Image missing `.AutomationName()` or `.AccessibilityHidden()` |
-| `REACTOR_A11Y_003` | Form field (TextField/NumberBox/PasswordBox) missing label |
+| `REACTOR_A11Y_003` | Form field (TextBox/NumberBox/PasswordBox) missing label |
 
 These run as warnings by default. Promote to errors in CI:
 
@@ -905,7 +905,7 @@ var validation = UseValidationContext();
 var (email, setEmail) = UseState("");
 
 return FormField("Email",
-    TextField(email, setEmail)
+    TextBox(email, setEmail)
         .Validate(validation, "email", Validators.Required(), Validators.Email())
         .Required(true)
         .HelpText("We'll send a confirmation to this address"),

--- a/skills/dsl-reference.md
+++ b/skills/dsl-reference.md
@@ -47,7 +47,7 @@ All factories live on `Microsoft.UI.Reactor.Factories` — use
 
 | Factory | Signature |
 |---------|-----------|
-| `TextField(value, onChanged?, placeholder?)` | `(string, Action<string>?, string?)` |
+| `TextBox(value, onChanged?, placeholder?)` | `(string, Action<string>?, string?)` |
 | `PasswordBox(password, onPasswordChanged?, placeholderText?)` | `(string, Action<string>?, string?)` |
 | `NumberBox(value, onValueChanged?, header?)` | `(double, Action<double>?, string?)` |
 | `AutoSuggestBox(text, onTextChanged?, onQuerySubmitted?)` | `(string, Action<string>?, Action<string>?)` |
@@ -173,7 +173,7 @@ Border(ListView(items, ...)).Flex(grow: 1, basis: 0)
 // 2. Put shrink: 0 on every fixed-size sibling.
 FlexColumn(
     Heading("Title").Flex(shrink: 0),
-    TextField(name, setName).Flex(shrink: 0),
+    TextBox(name, setName).Flex(shrink: 0),
     Border(ListView(items, ...)).Flex(grow: 1))
 ```
 
@@ -388,7 +388,7 @@ Rectangle().Fill(brush) / Ellipse().Fill(brush)
 Popup(c, open).IsLightDismissEnabled(true).Offset(h, v)
 ScrollView(c).ZoomMode(...).HorizontalScrollMode(...).VerticalScrollMode(...)         // modern; enums under WinUI.Scrolling*
 ScrollViewer(c).ZoomMode(...).HorizontalScrollMode(...).VerticalScrollMode(...)        // classic; enums under WinUI.ScrollMode / .ZoomMode
-TextField(v, setV).Header("...")
+TextBox(v, setV).Header("...")
 element.WithKey("stable-id")  // always last
 ```
 

--- a/skills/forms.md
+++ b/skills/forms.md
@@ -17,7 +17,7 @@ declarative `.Validate()` modifiers.
 
 | API | Purpose |
 |-----|---------|
-| `TextField(value, setValue)` | Controlled text input |
+| `TextBox(value, setValue)` | Controlled text input |
 | `UseValidationContext()` | Track validation messages, touched/dirty state |
 | `.Validate(...)` | Attach built-in validators to an input |
 | `FormField(label, input)` | Wraps input with label, error display, required marker |
@@ -34,7 +34,7 @@ var (age, setAge) = UseState(0);
 var (agreed, setAgreed) = UseState(false);
 
 return VStack(12,
-    TextField(name, setName, placeholder: "Name"),
+    TextBox(name, setName, placeholder: "Name"),
     NumberBox(age, setAge),
     CheckBox("I agree", agreed, setAgreed),
     Button("Submit", onSubmit).IsEnabled(!(string.IsNullOrEmpty(name) || !agreed))
@@ -45,7 +45,7 @@ return VStack(12,
 
 | Factory | Value type | Common modifiers |
 |---------|-----------|------------------|
-| `TextField(text, setText)` | `string` | `.Placeholder()`, `.MaxLength(n)`, `.NumericInput()`, `.EmailInput()`, `.Changed(handler)` |
+| `TextBox(text, setText)` | `string` | `.Placeholder()`, `.MaxLength(n)`, `.NumericInput()`, `.EmailInput()`, `.Changed(handler)` |
 | `PasswordBox(text, setText)` | `string` | `.Placeholder()`, `.MaxLength(n)`, `.PasswordRevealMode()`, `.PasswordChanged(handler)` |
 | `NumberBox(value, setValue)` | `double` | `.Min()`, `.Max()`, `.SmallChange()` |
 | `Slider(value, min, max, setValue)` | `double` | `.StepFrequency()` |
@@ -68,7 +68,7 @@ var (email, setEmail) = UseState("");
 var isValid = email.Contains('@') && email.Length > 3;
 
 return VStack(12,
-    TextField(email, setEmail, placeholder: "Email"),
+    TextBox(email, setEmail, placeholder: "Email"),
     Button("Submit", onSubmit).IsEnabled(isValid)
 );
 ```
@@ -86,12 +86,12 @@ var (name, setName) = UseState("");
 var (email, setEmail) = UseState("");
 
 return VStack(12,
-    TextField(name, setName, placeholder: "Name")
+    TextBox(name, setName, placeholder: "Name")
         .Validate(validation, "name",
             Validate.Required("Name is required"),
             Validate.MinLength(2, "Name too short")),
 
-    TextField(email, setEmail, placeholder: "Email")
+    TextBox(email, setEmail, placeholder: "Email")
         .Validate(validation, "email",
             Validate.Required("Email is required"),
             Validate.Email("Invalid email")),
@@ -143,7 +143,7 @@ var validation = UseValidationContext();
 var (name, setName) = UseState("");
 
 return FormField("Full Name",
-    TextField(name, setName, placeholder: "Enter your name")
+    TextBox(name, setName, placeholder: "Enter your name")
         .Validate(validation, "name", Validate.Required("Required")),
     required: true,
     description: "As it appears on your ID",
@@ -165,7 +165,7 @@ return FormField("Full Name",
 var mask = UseMemo(() => new MaskEngine(MaskPreset.PhoneUS));
 var (phone, setPhone) = UseState("");
 
-return TextField(phone, v => setPhone(mask.Apply(v)),
+return TextBox(phone, v => setPhone(mask.Apply(v)),
     placeholder: "(555) 555-0123");
 ```
 
@@ -190,7 +190,7 @@ Custom masks: `new MaskEngine("AA-####")` where `A` = letter,
 ```csharp
 var (amount, setAmount) = UseState("");
 
-return TextField(amount,
+return TextBox(amount,
     v => setAmount(InputFormatter.Currency(symbol: "$").Format(v)),
     placeholder: "$0.00");
 ```

--- a/skills/input.md
+++ b/skills/input.md
@@ -59,7 +59,7 @@ Border(child)
 ## 3. Keyboard events
 
 ```csharp
-TextField(text, setText)
+TextBox(text, setText)
     .OnKeyDown((s, e) =>
     {
         if (e.Key == VirtualKey.Enter)
@@ -167,7 +167,7 @@ Border(child)
 var focusRef = UseElementFocus();
 
 return VStack(12,
-    TextField(text, setText).Ref(focusRef.Ref),
+    TextBox(text, setText).Ref(focusRef.Ref),
     Button("Focus the field", () => focusRef.RequestFocus())
 );
 ```
@@ -186,7 +186,7 @@ var inputRef = UseElementRef<TextBox>();
 
 UseEffect(() => inputRef.Current?.SelectAll(), Array.Empty<object>());
 
-return TextField(query, setQuery).Ref(inputRef);
+return TextBox(query, setQuery).Ref(inputRef);
 ```
 
 The constraint is `T : FrameworkElement`. In `DEBUG` builds Reactor asserts
@@ -196,7 +196,7 @@ the actual mounted element is a `T`; in release the mismatch is silent and
 ### Focus events
 
 ```csharp
-TextField(text, setText)
+TextBox(text, setText)
     .OnGotFocus((s, e) => ShowSuggestions())
     .OnLostFocus((s, e) => HideSuggestions())
 ```
@@ -210,8 +210,8 @@ Button("Save", onSave).AccessKey("S")  // Alt+S
 ### Tab order
 
 ```csharp
-TextField(name, setName).IsTabStop(true).TabIndex(1)
-TextField(email, setEmail).IsTabStop(true).TabIndex(2)
+TextBox(name, setName).IsTabStop(true).TabIndex(1)
+TextBox(email, setEmail).IsTabStop(true).TabIndex(2)
 Button("Submit", onSubmit).IsTabStop(true).TabIndex(3)
 ```
 

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -89,6 +89,7 @@ InfoBadge() → InfoBadgeElement
 InfoBadge(int value) → InfoBadgeElement
 InfoBar(string title = null, string message = null) → InfoBarElement
 InterspersedGrid(Orientation orientation, Element[] items, double[] proportions, double separatorSize, Func<int, Element> separatorFactory) → GridElement
+ItemContainer(Element child) → ItemContainerElement
 ItemsView<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → ItemsViewElement<T>
 LazyHStack<T>(IReadOnlyList<T> items, Func<T, int, Element> viewBuilder) → LazyHStackElement<T>
 LazyHStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → LazyHStackElement<T>
@@ -166,7 +167,7 @@ Tab(string header, Element content) → TabViewItemData
 TabView(TabViewItemData[] tabs) → TabViewElement
 TeachingTip(string title, string subtitle = null) → TeachingTipElement
 TextBlock(string content) → TextBlockElement
-TextField(string value, Action<string> onChanged = null, string placeholder = null, string header = null) → TextFieldElement
+TextBox(string value, Action<string> onChanged = null, string placeholder = null, string header = null) → TextBoxElement
 Thick(double horizontal, double vertical) → Thickness
 Thick(double left, double top, double right, double bottom) → Thickness
 Thick(double uniform) → Thickness
@@ -346,6 +347,7 @@ InfoBarElement.Set(Action<InfoBar> configure) → InfoBarElement
 InfoBarElement.Severity(InfoBarSeverity severity) → InfoBarElement
 InfoBarElement.Success() → InfoBarElement
 InfoBarElement.Warning() → InfoBarElement
+ItemContainerElement.Set(Action<ItemContainer> configure) → ItemContainerElement
 ItemsViewElement<T>.ItemInvoked<T>(Action<T> handler) → ItemsViewElement<T>
 ItemsViewElement<T>.SelectionChanged<T>(Action<IReadOnlyList<T>> handler) → ItemsViewElement<T>
 ItemsViewElement<T>.Set<T>(Action<ItemsView> configure) → ItemsViewElement<T>
@@ -713,25 +715,25 @@ TextBlockElement.TextAlignment(TextAlignment alignment) → TextBlockElement
 TextBlockElement.TextDecorations(TextDecorations decorations) → TextBlockElement
 TextBlockElement.TextTrimming(TextTrimming trimming) → TextBlockElement
 TextBlockElement.TextWrapping(TextWrapping wrapping = TextWrapping.Wrap) → TextBlockElement
-TextFieldElement.AcceptsReturn(bool accepts = true) → TextFieldElement
-TextFieldElement.Changed(Action<string> handler) → TextFieldElement
-TextFieldElement.CharacterCasing(CharacterCasing casing) → TextFieldElement
-TextFieldElement.Description(string description) → TextFieldElement
-TextFieldElement.EmailInput() → TextFieldElement
-TextFieldElement.Focus(FocusManager fm, string fieldName, bool autoFocus = false) → TextFieldElement
-TextFieldElement.Header(string header) → TextFieldElement
-TextFieldElement.InputScope(InputScopeNameValue scope) → TextFieldElement
-TextFieldElement.IsReadOnly(bool readOnly = true) → TextFieldElement
-TextFieldElement.IsSpellCheckEnabled(bool enabled = true) → TextFieldElement
-TextFieldElement.MaxLength(int maxLength) → TextFieldElement
-TextFieldElement.NumericInput() → TextFieldElement
-TextFieldElement.PhoneInput() → TextFieldElement
-TextFieldElement.SearchInput() → TextFieldElement
-TextFieldElement.SelectionChanged(Action<string, int, int> handler) → TextFieldElement
-TextFieldElement.Set(Action<TextBox> configure) → TextFieldElement
-TextFieldElement.TextAlignment(TextAlignment alignment) → TextFieldElement
-TextFieldElement.TextWrapping(TextWrapping wrapping = TextWrapping.Wrap) → TextFieldElement
-TextFieldElement.UrlInput() → TextFieldElement
+TextBoxElement.AcceptsReturn(bool accepts = true) → TextBoxElement
+TextBoxElement.Changed(Action<string> handler) → TextBoxElement
+TextBoxElement.CharacterCasing(CharacterCasing casing) → TextBoxElement
+TextBoxElement.Description(string description) → TextBoxElement
+TextBoxElement.EmailInput() → TextBoxElement
+TextBoxElement.Focus(FocusManager fm, string fieldName, bool autoFocus = false) → TextBoxElement
+TextBoxElement.Header(string header) → TextBoxElement
+TextBoxElement.InputScope(InputScopeNameValue scope) → TextBoxElement
+TextBoxElement.IsReadOnly(bool readOnly = true) → TextBoxElement
+TextBoxElement.IsSpellCheckEnabled(bool enabled = true) → TextBoxElement
+TextBoxElement.MaxLength(int maxLength) → TextBoxElement
+TextBoxElement.NumericInput() → TextBoxElement
+TextBoxElement.PhoneInput() → TextBoxElement
+TextBoxElement.SearchInput() → TextBoxElement
+TextBoxElement.SelectionChanged(Action<string, int, int> handler) → TextBoxElement
+TextBoxElement.Set(Action<TextBox> configure) → TextBoxElement
+TextBoxElement.TextAlignment(TextAlignment alignment) → TextBoxElement
+TextBoxElement.TextWrapping(TextWrapping wrapping = TextWrapping.Wrap) → TextBoxElement
+TextBoxElement.UrlInput() → TextBoxElement
 TimePickerElement.Set(Action<TimePicker> configure) → TimePickerElement
 TimePickerElement.TimeChanged(Action<TimeSpan> handler) → TimePickerElement
 TitleBarElement.BackButtonEnabled(bool enabled) → TitleBarElement

--- a/skills/recipes/async-fetch-list.cs
+++ b/skills/recipes/async-fetch-list.cs
@@ -52,7 +52,7 @@ class App : Component
 
         return VStack(12,
             HStack(8,
-                TextField(owner, setOwner, placeholder: "GitHub owner").Flex(grow: 1),
+                TextBox(owner, setOwner, placeholder: "GitHub owner").Flex(grow: 1),
                 Caption("(try \"fail\" to see error state)").VAlign(VerticalAlignment.Center)),
 
             repos.Match<Element>(

--- a/skills/recipes/form-with-validation.cs
+++ b/skills/recipes/form-with-validation.cs
@@ -56,14 +56,14 @@ class App : Component
             Heading("Sign up"),
 
             FormField(
-                TextField(name, v => { setName(v); ctx.MarkTouched("name"); }, placeholder: "Your name")
+                TextBox(name, v => { setName(v); ctx.MarkTouched("name"); }, placeholder: "Your name")
                     .Validate("name", name,
                         Validate.Required("Name is required"),
                         Validate.MinLength(2, "At least 2 characters")),
                 label: "Name", required: true, showWhen: sw),
 
             FormField(
-                TextField(email, v => { setEmail(v); ctx.MarkTouched("email"); }, placeholder: "you@example.com")
+                TextBox(email, v => { setEmail(v); ctx.MarkTouched("email"); }, placeholder: "you@example.com")
                     .EmailInput()
                     .Validate("email", email,
                         Validate.Required("Email is required"),
@@ -71,7 +71,7 @@ class App : Component
                 label: "Email", required: true, showWhen: sw),
 
             FormField(
-                TextField(age, v => { setAge(v); ctx.MarkTouched("age"); }, placeholder: "Age")
+                TextBox(age, v => { setAge(v); ctx.MarkTouched("age"); }, placeholder: "Age")
                     .NumericInput()
                     .MaxLength(3)
                     .Validate("age", age,

--- a/skills/recipes/list-add-delete.cs
+++ b/skills/recipes/list-add-delete.cs
@@ -66,7 +66,7 @@ class App : Component
         return CommandHost([add],
             VStack(12,
                 HStack(8,
-                    TextField(draft, setDraft, placeholder: "What needs doing?")
+                    TextBox(draft, setDraft, placeholder: "What needs doing?")
                         .Flex(grow: 1),
                     Button(add).Flex(shrink: 0)),
 

--- a/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
+++ b/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
@@ -197,7 +197,7 @@ public sealed class FormFieldLabelAnalyzer : DiagnosticAnalyzer
         description: Description);
 
     private static readonly ImmutableHashSet<string> FormFieldMethods =
-        ImmutableHashSet.Create("TextField", "NumberBox", "PasswordBox", "AutoSuggestBox");
+        ImmutableHashSet.Create("TextBox", "TextField", "NumberBox", "PasswordBox", "AutoSuggestBox");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);

--- a/src/Reactor.Cli/Loc/LocalizableStringScanner.cs
+++ b/src/Reactor.Cli/Loc/LocalizableStringScanner.cs
@@ -24,6 +24,7 @@ internal static class LocalizableStringScanner
     // DSL factory methods with named string parameters that are localizable
     private static readonly Dictionary<string, HashSet<string>> LocalizableNamedParams = new(StringComparer.Ordinal)
     {
+        ["TextBox"] = new(StringComparer.Ordinal) { "placeholder", "header" },
         ["TextField"] = new(StringComparer.Ordinal) { "placeholder", "header" },
         ["PasswordBox"] = new(StringComparer.Ordinal) { "placeholderText" },
         ["NumberBox"] = new(StringComparer.Ordinal) { "header" },
@@ -132,12 +133,12 @@ internal static class LocalizableStringScanner
             }
 
             // Also check positional arguments that map to localizable params
-            // For TextField: placeholder is arg index 2, header is set via property
-            if (methodName == "TextField" && args.Count >= 3 && args[2].NameColon == null)
+            // For TextBox/TextField: placeholder is arg index 2, header is set via property
+            if ((methodName == "TextBox" || methodName == "TextField") && args.Count >= 3 && args[2].NameColon == null)
             {
                 var placeholderArg = args[2].Expression;
                 if (!IsMessageCall(placeholderArg))
-                    ProcessExpression(placeholderArg, className, "TextField.placeholder");
+                    ProcessExpression(placeholderArg, className, $"{methodName}.placeholder");
             }
             if (methodName == "PasswordBox" && args.Count >= 3 && args[2].NameColon == null)
             {

--- a/src/Reactor.Cli/Loc/LocalizableStringScanner.cs
+++ b/src/Reactor.Cli/Loc/LocalizableStringScanner.cs
@@ -133,12 +133,21 @@ internal static class LocalizableStringScanner
             }
 
             // Also check positional arguments that map to localizable params
-            // For TextBox/TextField: placeholder is arg index 2, header is set via property
-            if ((methodName == "TextBox" || methodName == "TextField") && args.Count >= 3 && args[2].NameColon == null)
+            // For TextBox/TextField: placeholder is arg index 2, header is arg index 3
+            if (methodName == "TextBox" || methodName == "TextField")
             {
-                var placeholderArg = args[2].Expression;
-                if (!IsMessageCall(placeholderArg))
-                    ProcessExpression(placeholderArg, className, $"{methodName}.placeholder");
+                if (args.Count >= 3 && args[2].NameColon == null)
+                {
+                    var placeholderArg = args[2].Expression;
+                    if (!IsMessageCall(placeholderArg))
+                        ProcessExpression(placeholderArg, className, $"{methodName}.placeholder");
+                }
+                if (args.Count >= 4 && args[3].NameColon == null)
+                {
+                    var headerArg = args[3].Expression;
+                    if (!IsMessageCall(headerArg))
+                        ProcessExpression(headerArg, className, $"{methodName}.header");
+                }
             }
             if (methodName == "PasswordBox" && args.Count >= 3 && args[2].NameColon == null)
             {

--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -255,7 +255,7 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
         {
             var searchQuery = state.SearchQuery ?? "";
             gridChildren.Add(
-                TextField(searchQuery, q =>
+                TextBox(searchQuery, q =>
                 {
                     Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
                     {
@@ -336,7 +336,7 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                     {
                         if (!state.IsEditing && !state.IsRowEditing) return;
                         // Defer the entire check to the next tick. During DOM transitions
-                        // (e.g., cell switching from TextBlock to TextField), the old element
+                        // (e.g., cell switching from TextBlock to TextBox), the old element
                         // fires LostFocus before the new element receives GotFocus. Checking
                         // synchronously would falsely conclude that focus left the grid.
                         Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
@@ -852,7 +852,7 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
         if (editor is not null)
             return editor(currentValue!, v => state.UpdateEditingValue(v)).Padding(2);
 
-        return TextField(currentValue?.ToString() ?? "", s => state.UpdateEditingValue(s)).Padding(2);
+        return TextBox(currentValue?.ToString() ?? "", s => state.UpdateEditingValue(s)).Padding(2);
     }
 
     private static Element RenderRowEditingCell(
@@ -870,7 +870,7 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
         if (editor is not null)
             return editor(currentValue!, v => state.UpdateRowEditValue(colName, v)).Padding(2);
 
-        return TextField(currentValue?.ToString() ?? "", s => state.UpdateRowEditValue(colName, s)).Padding(2);
+        return TextBox(currentValue?.ToString() ?? "", s => state.UpdateRowEditValue(colName, s)).Padding(2);
     }
 
     // ── Header rendering ────────────────────────────────────────────

--- a/src/Reactor/Controls/Editors/Editors.cs
+++ b/src/Reactor/Controls/Editors/Editors.cs
@@ -29,7 +29,7 @@ public static class Editors
         int? maxLength = null)
         => (value, onChange) =>
         {
-            var el = TextField((string?)value ?? string.Empty, s => onChange(s), placeholder: placeholder);
+            var el = TextBox((string?)value ?? string.Empty, s => onChange(s), placeholder: placeholder);
             return maxLength is { } max
                 ? el.Set(tb => tb.MaxLength = max)
                 : el;
@@ -177,7 +177,7 @@ public static class Editors
                 null => string.Empty,
                 _ => value.ToString() ?? string.Empty,
             };
-            return TextField(text, s =>
+            return TextBox(text, s =>
             {
                 // Only commit valid Uris; leave the field alone for partial input.
                 if (global::System.Uri.TryCreate(s, UriKind.RelativeOrAbsolute, out var uri))
@@ -232,7 +232,7 @@ public static class Editors
                     .Width(20).Height(20)
                     .CornerRadius(3)
                     .WithBorder("#80000000", 1),
-                TextField(hex, s =>
+                TextBox(hex, s =>
                 {
                     if (TryParseHexColor(s, out var parsed))
                         onChange(parsed);

--- a/src/Reactor/Controls/MaskedTextBox/MaskedTextFieldElement.cs
+++ b/src/Reactor/Controls/MaskedTextBox/MaskedTextFieldElement.cs
@@ -50,11 +50,9 @@ public static class MaskedTextFieldDsl
     /// no first-party equivalent).
     /// </summary>
     /// <remarks>
-    /// Named for parity with the sibling <c>TextField</c> rather than
-    /// <c>MaskedTextBox</c>; the deviation is deliberate and matches the
-    /// <c>TextField</c> naming choice (see spec 039 §13 / §16.3). If
-    /// <c>TextField</c> is ever renamed to <c>TextBox</c>, this is bundled
-    /// in the same change.
+    /// <c>TextField</c> has been renamed to <c>TextBox</c> (see Dsl.cs);
+    /// this masked sibling still uses the legacy <c>TextField</c> name
+    /// and is slated to be renamed to <c>MaskedTextBox</c> in a follow-up PR.
     /// </remarks>
     public static MaskedTextFieldElement MaskedTextField(
         string value,

--- a/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
+++ b/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
@@ -123,7 +123,7 @@ public class PropertyGridComponent : Component<PropertyGridElement>
         if (el.ShowSearch)
         {
             return FlexColumn(
-                TextField(searchText, setSearchText, placeholder: "Filter properties...")
+                TextBox(searchText, setSearchText, placeholder: "Filter properties...")
                     .Width(300),
                 content.Flex(grow: 1)
             ) with { RowGap = 8 };
@@ -271,7 +271,7 @@ public class PropertyGridComponent : Component<PropertyGridElement>
         if (type == typeof(bool))
             return ToggleSwitch((bool)(value ?? false), null).IsEnabled(false);
         if (type == typeof(string))
-            return TextField((string)(value ?? ""), null).IsEnabled(false);
+            return TextBox((string)(value ?? ""), null).IsEnabled(false);
         return TextBlock(value?.ToString() ?? "(null)");
     }
 

--- a/src/Reactor/Controls/PropertyGrid/TypeRegistry.cs
+++ b/src/Reactor/Controls/PropertyGrid/TypeRegistry.cs
@@ -129,7 +129,7 @@ public class TypeRegistry
             metadata = new TypeMetadata
             {
                 Editor = (value, onChange) =>
-                    TextField((string)(value ?? ""), s => onChange(s))
+                    TextBox((string)(value ?? ""), s => onChange(s))
             };
             return true;
         }

--- a/src/Reactor/Controls/Validation/ImmediateExtensions.cs
+++ b/src/Reactor/Controls/Validation/ImmediateExtensions.cs
@@ -21,7 +21,7 @@ public static class ImmediateExtensions
     /// <summary>
     /// Requests that the control commit its value on every keystroke instead
     /// of on blur. Has no effect on controls whose default already fires
-    /// per-keystroke (TextField, PasswordBox, AutoSuggestBox, etc.).
+    /// per-keystroke (TextBox, PasswordBox, AutoSuggestBox, etc.).
     /// </summary>
     public static T Immediate<T>(this T el) where T : Element
         => (T)el.SetAttached(new ImmediateValueAttached());

--- a/src/Reactor/Core/AccessibilityScanner.cs
+++ b/src/Reactor/Core/AccessibilityScanner.cs
@@ -88,10 +88,10 @@ public record A11yContext
     /// <summary>Type names of immediate children.</summary>
     public string[]? ChildTypes { get; init; }
 
-    /// <summary>Header property value (for TextFieldElement etc.).</summary>
+    /// <summary>Header property value (for TextBoxElement etc.).</summary>
     public string? Header { get; init; }
 
-    /// <summary>Placeholder text (for TextFieldElement etc.).</summary>
+    /// <summary>Placeholder text (for TextBoxElement etc.).</summary>
     public string? PlaceholderText { get; init; }
 }
 
@@ -309,7 +309,7 @@ public static partial class AccessibilityScanner
         string? placeholder = null;
         switch (el)
         {
-            case TextFieldElement tf:
+            case TextBoxElement tf:
                 header = tf.Header;
                 placeholder = tf.Placeholder;
                 break;
@@ -403,7 +403,7 @@ public static partial class AccessibilityScanner
     private static void CheckConcreteBrushOnInteractive(Element el, ScanContext ctx, List<A11yDiagnostic> findings)
     {
         // Only flag interactive controls
-        bool isInteractive = el is ButtonElement or TextFieldElement or NumberBoxElement
+        bool isInteractive = el is ButtonElement or TextBoxElement or NumberBoxElement
             or PasswordBoxElement or CheckBoxElement or RadioButtonElement
             or ComboBoxElement or SliderElement or ToggleSwitchElement
             or ToggleButtonElement;

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -316,7 +316,7 @@ public abstract record Element
                 && ReferenceEquals(ca.ItemElements, cb.ItemElements)
                 && ReferenceEquals(ca.Setters, cb.Setters),
 
-            (TextFieldElement ta, TextFieldElement tb) =>
+            (TextBoxElement ta, TextBoxElement tb) =>
                 ta.Value == tb.Value
                 && ta.Placeholder == tb.Placeholder
                 && ta.Header == tb.Header
@@ -1993,7 +1993,7 @@ public record ToggleSplitButtonElement(string Label, bool IsChecked = false, Act
 //  Input elements
 // ════════════════════════════════════════════════════════════════════════
 
-public record TextFieldElement(
+public record TextBoxElement(
     string Value,
     Action<string>? OnChanged = null,
     string? Placeholder = null

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -77,7 +77,7 @@ public sealed partial class Reconciler
             SplitButtonElement spBtn => MountSplitButton(spBtn, requestRerender),
             ToggleSplitButtonElement tspBtn => MountToggleSplitButton(tspBtn, requestRerender),
             RichEditBoxElement reb => MountRichEditBox(reb),
-            TextFieldElement tf => MountTextField(tf, requestRerender),
+            TextBoxElement tf => MountTextField(tf, requestRerender),
             PasswordBoxElement pw => MountPasswordBox(pw),
             NumberBoxElement nb => MountNumberBox(nb),
             AutoSuggestBoxElement asb => MountAutoSuggestBox(asb),
@@ -482,7 +482,7 @@ public sealed partial class Reconciler
         return tsb;
     }
 
-    private TextBox MountTextField(TextFieldElement tf, Action requestRerender)
+    private TextBox MountTextField(TextBoxElement tf, Action requestRerender)
     {
         var rented = _pool.TryRent(typeof(TextBox));
         var textBox = rented as TextBox ?? new TextBox();
@@ -518,12 +518,12 @@ public sealed partial class Reconciler
     }
 
     /// <summary>
-    /// Wires TextField's TextChanged/SelectionChanged trampolines only when the
+    /// Wires TextBox's TextChanged/SelectionChanged trampolines only when the
     /// element has a corresponding handler AND the control hasn't been wired
     /// yet. Called from both Mount (fresh or pooled) and Update (null→non-null
     /// transition). The CWT flags survive pool round-trips.
     /// </summary>
-    internal static void EnsureTextFieldWiring(TextBox textBox, TextFieldElement tf, Action requestRerender)
+    internal static void EnsureTextFieldWiring(TextBox textBox, TextBoxElement tf, Action requestRerender)
     {
         if (tf.OnChanged is null && tf.OnSelectionChanged is null) return;
         var flags = GetPoolableWireFlags(textBox);
@@ -533,7 +533,7 @@ public sealed partial class Reconciler
             textBox.TextChanged += (_, _) =>
             {
                 if (ChangeEchoSuppressor.ShouldSuppress(textBox)) return;
-                var tag = GetElementTag(textBox) as TextFieldElement;
+                var tag = GetElementTag(textBox) as TextBoxElement;
                 tag?.OnChanged?.Invoke(textBox.Text);
                 // Controlled input: when onChange is wired, always request a
                 // re-render so UpdateTextField can enforce the controlled value.
@@ -546,7 +546,7 @@ public sealed partial class Reconciler
         if (tf.OnSelectionChanged is not null && !flags.TextBoxSelectionChanged)
         {
             flags.TextBoxSelectionChanged = true;
-            textBox.SelectionChanged += (_, _) => (GetElementTag(textBox) as TextFieldElement)?.OnSelectionChanged?.Invoke(textBox.SelectedText, textBox.SelectionStart, textBox.SelectionLength);
+            textBox.SelectionChanged += (_, _) => (GetElementTag(textBox) as TextBoxElement)?.OnSelectionChanged?.Invoke(textBox.SelectedText, textBox.SelectionStart, textBox.SelectionLength);
         }
     }
 

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -814,6 +814,7 @@ public sealed partial class Reconciler
         }
         tb.PlaceholderText = n.Placeholder ?? "";
         if (n.Header is not null) tb.Header = n.Header;
+        else if (o.Header is not null) tb.ClearValue(TextBox.HeaderProperty);
         if (n.IsReadOnly.HasValue) tb.IsReadOnly = n.IsReadOnly.Value;
         if (n.AcceptsReturn.HasValue) tb.AcceptsReturn = n.AcceptsReturn.Value;
         if (n.TextWrapping.HasValue) tb.TextWrapping = n.TextWrapping.Value;
@@ -823,6 +824,7 @@ public sealed partial class Reconciler
         if (tb.CharacterCasing != n.CharacterCasing) tb.CharacterCasing = n.CharacterCasing;
         if (tb.TextAlignment != n.TextAlignment) tb.TextAlignment = n.TextAlignment;
         if (n.Description is not null) tb.Description = n.Description;
+        else if (o.Description is not null) tb.ClearValue(TextBox.DescriptionProperty);
         // Apply selection position after text — must come after Text is set so the range is valid
         if (n.SelectionStart.HasValue) tb.SelectionStart = Math.Min(n.SelectionStart.Value, tb.Text.Length);
         if (n.SelectionLength.HasValue) tb.SelectionLength = Math.Min(n.SelectionLength.Value, tb.Text.Length - tb.SelectionStart);

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -133,7 +133,7 @@ public sealed partial class Reconciler
                 => UpdateToggleSplitButton(o, n, tsb),
             (RichEditBoxElement o, RichEditBoxElement n, WinUI.RichEditBox reb)
                 => UpdateRichEditBox(o, n, reb),
-            (TextFieldElement o, TextFieldElement n, TextBox tb)
+            (TextBoxElement o, TextBoxElement n, TextBox tb)
                 => UpdateTextField(o, n, tb, requestRerender),
             (PasswordBoxElement o, PasswordBoxElement n, WinUI.PasswordBox pb)
                 => UpdatePasswordBox(o, n, pb),
@@ -778,7 +778,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateTextField(TextFieldElement o, TextFieldElement n, TextBox tb, Action requestRerender)
+    private UIElement? UpdateTextField(TextBoxElement o, TextBoxElement n, TextBox tb, Action requestRerender)
     {
         // Tag first so any echoed TextChanged sees this element.
         SetElementTag(tb, n);
@@ -807,7 +807,7 @@ public sealed partial class Reconciler
             // Uncontrolled divergence: value is set but no onChange to reconcile.
             // Log once per field to help developers catch mismatched bindings.
             _logger?.LogWarning(
-                "TextField value diverged from controlled value with no OnChanged handler. " +
+                "TextBox value diverged from controlled value with no OnChanged handler. " +
                 "Controlled: \"{ControlledValue}\", Actual: \"{ActualValue}\". " +
                 "Wire up OnChanged to keep state in sync, or this field won't reflect user edits after re-renders.",
                 Truncate(n.Value, 20), Truncate(tb.Text, 20));

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -1521,7 +1521,7 @@ public sealed partial class Reconciler : IDisposable
         CheckBoxElement cbe => cbe.Label,
         RadioButtonElement rbe => rbe.Label,
         ToggleSwitchElement tse => tse.Header as string ?? tse.OnContent ?? tse.OffContent,
-        TextFieldElement tfe => tfe.Header as string ?? tfe.Placeholder,
+        TextBoxElement tfe => tfe.Header as string ?? tfe.Placeholder,
         _ => null,
     };
 

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -210,18 +210,21 @@ public static partial class Factories
     // ── Input controls ──────────────────────────────────────────────
 
     /// <summary>
-    /// Creates a <see cref="TextFieldElement"/> — the Reactor name for WinUI's
+    /// Creates a <see cref="TextBoxElement"/> wrapping WinUI's
     /// <c>Microsoft.UI.Xaml.Controls.TextBox</c>.
     /// </summary>
-    /// <remarks>
-    /// Reactor uses <c>TextField</c> (HTML / iOS / Android / SwiftUI vocabulary)
-    /// rather than WinUI's legacy WinForms-era <c>TextBox</c>. The deviation
-    /// is deliberate — see spec 039 §3.1 / §16 for the impact analysis and
-    /// §16.5 for the decision (keep as-is). The reconciler still maps this to
-    /// a real WinUI <c>TextBox</c> internally. (spec 039 §3.1 / §16)
-    /// </remarks>
-    public static TextFieldElement TextField(string value, Action<string>? onChanged = null, string? placeholder = null, string? header = null) =>
+    public static TextBoxElement TextBox(string value, Action<string>? onChanged = null, string? placeholder = null, string? header = null) =>
         new(value, onChanged, placeholder) { Header = header };
+
+    /// <summary>
+    /// Deprecated forwarding alias for <see cref="TextBox(string, Action{string}?, string?, string?)"/>.
+    /// </summary>
+    [global::System.Obsolete(
+        "Renamed to TextBox for parity with WinUI's Microsoft.UI.Xaml.Controls.TextBox. " +
+        "TextField will be removed in a future release.",
+        error: false)]
+    public static TextBoxElement TextField(string value, Action<string>? onChanged = null, string? placeholder = null, string? header = null) =>
+        TextBox(value, onChanged, placeholder, header);
 
     public static PasswordBoxElement PasswordBox(string password, Action<string>? onPasswordChanged = null, string? placeholderText = null) =>
         new(password, onPasswordChanged, placeholderText);

--- a/src/Reactor/Elements/ElementExtensions.Events.cs
+++ b/src/Reactor/Elements/ElementExtensions.Events.cs
@@ -69,11 +69,11 @@ public static partial class ElementExtensions
     // ── §3 Input ───────────────────────────────────────────────────────
 
     /// <summary>Wires the text-changed handler. Receives the new text. Passing <c>null</c> clears.</summary>
-    public static TextFieldElement Changed(this TextFieldElement el, Action<string>? handler) =>
+    public static TextBoxElement Changed(this TextBoxElement el, Action<string>? handler) =>
         el with { OnChanged = handler };
 
     /// <summary>Wires the selection-changed handler. Receives (selectedText, selectionStart, selectionLength). Passing <c>null</c> clears.</summary>
-    public static TextFieldElement SelectionChanged(this TextFieldElement el, Action<string, int, int>? handler) =>
+    public static TextBoxElement SelectionChanged(this TextBoxElement el, Action<string, int, int>? handler) =>
         el with { OnSelectionChanged = handler };
 
     /// <summary>Wires the password-changed handler. Passing <c>null</c> clears.</summary>

--- a/src/Reactor/Elements/ElementExtensions.NamedStyles.cs
+++ b/src/Reactor/Elements/ElementExtensions.NamedStyles.cs
@@ -68,29 +68,29 @@ public static partial class ElementExtensions
 
     /// <summary>Sets <c>InputScope = Number</c>. Drives the soft-keyboard
     /// layout and IME hints on platforms that respect it.</summary>
-    public static TextFieldElement NumericInput(this TextFieldElement el) =>
+    public static TextBoxElement NumericInput(this TextBoxElement el) =>
         el.InputScope(InputScopeNameValue.Number);
 
     /// <summary>Sets <c>InputScope = EmailSmtpAddress</c>.</summary>
-    public static TextFieldElement EmailInput(this TextFieldElement el) =>
+    public static TextBoxElement EmailInput(this TextBoxElement el) =>
         el.InputScope(InputScopeNameValue.EmailSmtpAddress);
 
     /// <summary>Sets <c>InputScope = Url</c>.</summary>
-    public static TextFieldElement UrlInput(this TextFieldElement el) =>
+    public static TextBoxElement UrlInput(this TextBoxElement el) =>
         el.InputScope(InputScopeNameValue.Url);
 
     /// <summary>Sets <c>InputScope = TelephoneNumber</c>.</summary>
-    public static TextFieldElement PhoneInput(this TextFieldElement el) =>
+    public static TextBoxElement PhoneInput(this TextBoxElement el) =>
         el.InputScope(InputScopeNameValue.TelephoneNumber);
 
     /// <summary>Sets <c>InputScope = Search</c>.</summary>
-    public static TextFieldElement SearchInput(this TextFieldElement el) =>
+    public static TextBoxElement SearchInput(this TextBoxElement el) =>
         el.InputScope(InputScopeNameValue.Search);
 
     /// <summary>Sets a specific <see cref="InputScopeNameValue"/>. Escape hatch
     /// for input scopes outside the named helpers above (e.g. <c>Chat</c>,
     /// <c>FormulaNumber</c>, <c>AlphanumericFullWidth</c>).</summary>
-    public static TextFieldElement InputScope(this TextFieldElement el, InputScopeNameValue scope) =>
+    public static TextBoxElement InputScope(this TextBoxElement el, InputScopeNameValue scope) =>
         el.Set(tb =>
         {
             var s = new InputScope();

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -641,41 +641,41 @@ public static partial class ElementExtensions
     public static RichEditBoxElement SelectionHighlightColor(this RichEditBoxElement el, Microsoft.UI.Xaml.Media.SolidColorBrush brush) =>
         el with { SelectionHighlightColor = brush };
 
-    // ── TextField sugar ────────────────────────────────────────────────
+    // ── TextBox sugar ────────────────────────────────────────────────
 
     /// <summary>Sets whether the text field is read-only.</summary>
-    public static TextFieldElement IsReadOnly(this TextFieldElement el, bool readOnly = true) =>
+    public static TextBoxElement IsReadOnly(this TextBoxElement el, bool readOnly = true) =>
         el with { IsReadOnly = readOnly };
 
-    /// <inheritdoc cref="IsReadOnly(TextFieldElement, bool)"/>
+    /// <inheritdoc cref="IsReadOnly(TextBoxElement, bool)"/>
     [Obsolete("Use IsReadOnly() — aligns with WinUI naming (see #268).")]
-    public static TextFieldElement ReadOnly(this TextFieldElement el, bool readOnly = true) =>
+    public static TextBoxElement ReadOnly(this TextBoxElement el, bool readOnly = true) =>
         el.IsReadOnly(readOnly);
 
-    public static TextFieldElement AcceptsReturn(this TextFieldElement el, bool accepts = true) =>
+    public static TextBoxElement AcceptsReturn(this TextBoxElement el, bool accepts = true) =>
         el with { AcceptsReturn = accepts };
 
-    public static TextFieldElement TextWrapping(this TextFieldElement el, TextWrapping wrapping = Microsoft.UI.Xaml.TextWrapping.Wrap) =>
+    public static TextBoxElement TextWrapping(this TextBoxElement el, TextWrapping wrapping = Microsoft.UI.Xaml.TextWrapping.Wrap) =>
         el with { TextWrapping = wrapping };
 
     /// <summary>Maximum number of characters allowed in the box. Use <c>0</c> for no limit.</summary>
-    public static TextFieldElement MaxLength(this TextFieldElement el, int maxLength) =>
+    public static TextBoxElement MaxLength(this TextBoxElement el, int maxLength) =>
         el with { MaxLength = maxLength };
 
     /// <summary>Enable or disable built-in spell-check.</summary>
-    public static TextFieldElement IsSpellCheckEnabled(this TextFieldElement el, bool enabled = true) =>
+    public static TextBoxElement IsSpellCheckEnabled(this TextBoxElement el, bool enabled = true) =>
         el with { IsSpellCheckEnabled = enabled };
 
     /// <summary>Forces input to upper/lower-case as the user types.</summary>
-    public static TextFieldElement CharacterCasing(this TextFieldElement el, CharacterCasing casing) =>
+    public static TextBoxElement CharacterCasing(this TextBoxElement el, CharacterCasing casing) =>
         el with { CharacterCasing = casing };
 
     /// <summary>Sets horizontal text alignment within the box.</summary>
-    public static TextFieldElement TextAlignment(this TextFieldElement el, TextAlignment alignment) =>
+    public static TextBoxElement TextAlignment(this TextBoxElement el, TextAlignment alignment) =>
         el with { TextAlignment = alignment };
 
     /// <summary>Sets the help/description text rendered below the box.</summary>
-    public static TextFieldElement Description(this TextFieldElement el, string description) =>
+    public static TextBoxElement Description(this TextBoxElement el, string description) =>
         el with { Description = description };
 
     // ── Path sugar ─────────────────────────────────────────────────────
@@ -915,9 +915,9 @@ public static partial class ElementExtensions
     public static StackElement Spacing(this StackElement el, double spacing) =>
         el with { Spacing = spacing };
 
-    // ── TextField sugar ─────────────────────────────────────────────
+    // ── TextBox sugar ─────────────────────────────────────────────
 
-    public static TextFieldElement Header(this TextFieldElement el, string header) =>
+    public static TextBoxElement Header(this TextBoxElement el, string header) =>
         el with { Header = header };
 
     // ── ComboBox sugar ──────────────────────────────────────────────
@@ -1578,7 +1578,7 @@ public static partial class ElementExtensions
         el with { Setters = [.. el.Setters, configure] };
 
     // Input
-    public static TextFieldElement Set(this TextFieldElement el, Action<WinUI.TextBox> configure) =>
+    public static TextBoxElement Set(this TextBoxElement el, Action<WinUI.TextBox> configure) =>
         el with { Setters = [.. el.Setters, configure] };
 
     public static PasswordBoxElement Set(this PasswordBoxElement el, Action<WinUI.PasswordBox> configure) =>
@@ -2170,7 +2170,7 @@ public static partial class ElementExtensions
     /// </summary>
     /// <example>
     /// var (inputRef, requestFocus) = ctx.UseElementFocus();
-    /// return TextField(value, setValue).Ref(inputRef);
+    /// return TextBox(value, setValue).Ref(inputRef);
     /// </example>
     public static T Ref<T>(this T el, Microsoft.UI.Reactor.Input.ElementRef target) where T : Element =>
         Modify(el, new ElementModifiers { Ref = target });
@@ -2198,7 +2198,7 @@ public static partial class ElementExtensions
     /// Sets AutomationProperties.HelpText — supplemental text read by screen readers
     /// after the Name. Analogous to SwiftUI's .accessibilityHint().
     /// </summary>
-    /// <example>TextField(email, setEmail).HelpText("Enter your work email address")</example>
+    /// <example>TextBox(email, setEmail).HelpText("Enter your work email address")</example>
     public static T HelpText<T>(this T el, string text) where T : Element =>
         ModifyA11y(el, new AccessibilityModifiers { HelpText = text });
 
@@ -2236,7 +2236,7 @@ public static partial class ElementExtensions
     /// <summary>
     /// Sets AutomationProperties.IsRequiredForForm. Screen readers announce "required".
     /// </summary>
-    /// <example>TextField(name, setName).Required()</example>
+    /// <example>TextBox(name, setName).Required()</example>
     public static T Required<T>(this T el) where T : Element =>
         ModifyA11y(el, new AccessibilityModifiers { IsRequiredForForm = true });
 
@@ -2273,7 +2273,7 @@ public static partial class ElementExtensions
     /// Associates this element with a labelling element via its AutomationId.
     /// The reconciler resolves the reference at mount time.
     /// </summary>
-    /// <example>TextField(email, setEmail).LabeledBy("EmailLabel")</example>
+    /// <example>TextBox(email, setEmail).LabeledBy("EmailLabel")</example>
     public static T LabeledBy<T>(this T el, string labelAutomationId) where T : Element =>
         ModifyA11y(el, new AccessibilityModifiers { LabeledBy = labelAutomationId });
 

--- a/src/Reactor/Hooks/UseElementFocus.cs
+++ b/src/Reactor/Hooks/UseElementFocus.cs
@@ -22,7 +22,7 @@ public static class UseElementFocusExtensions
     /// <example>
     /// var (inputRef, requestFocus) = ctx.UseElementFocus();
     /// ctx.UseEffect(() => requestFocus(), Array.Empty&lt;object&gt;()); // focus on first render
-    /// return TextField(value, setValue).Ref(inputRef);
+    /// return TextBox(value, setValue).Ref(inputRef);
     /// </example>
     public static (ElementRef Ref, Action RequestFocus) UseElementFocus(this RenderContext ctx,
         FocusState state = FocusState.Programmatic)

--- a/src/Reactor/Hooks/UseFocus.cs
+++ b/src/Reactor/Hooks/UseFocus.cs
@@ -173,9 +173,9 @@ public sealed record FocusAttached(
 public static class FocusExtensions
 {
     /// <summary>
-    /// Registers this TextField with a FocusManager for programmatic focus control.
+    /// Registers this TextBox with a FocusManager for programmatic focus control.
     /// </summary>
-    public static TextFieldElement Focus(this TextFieldElement el, FocusManager fm, string fieldName, bool autoFocus = false)
+    public static TextBoxElement Focus(this TextBoxElement el, FocusManager fm, string fieldName, bool autoFocus = false)
     {
         fm.Register(fieldName);
         return el.Set(tb =>

--- a/tests/Reactor.AppTests.Host/Fixtures/AccessibilityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/AccessibilityFixtures.cs
@@ -55,7 +55,7 @@ internal static class AccessibilityFixtures
             VStack(
                 // ── WCAG 3.3.2: Labels and Instructions ───────
                 // Form field with full accessibility annotations
-                TextField("user@example.com")
+                TextBox("user@example.com")
                     .AutomationName("Email address")
                     .Required()
                     .HelpText("Enter your primary contact email")

--- a/tests/Reactor.AppTests.Host/Fixtures/AccessibilityInteractionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/AccessibilityInteractionFixtures.cs
@@ -25,22 +25,22 @@ internal static class AccessibilityInteractionFixtures
                 .HeadingLevel(AutomationHeadingLevel.Level1)
                 .AutomationId("A11yNav_Title"),
 
-            TextField("", _ => { }, placeholder: "First")
+            TextBox("", _ => { }, placeholder: "First")
                 .AutomationName("First field")
                 .TabIndex(1)
                 .AutomationId("A11yNav_Field1"),
 
-            TextField("", _ => { }, placeholder: "Second")
+            TextBox("", _ => { }, placeholder: "Second")
                 .AutomationName("Second field")
                 .TabIndex(2)
                 .AutomationId("A11yNav_Field2"),
 
-            TextField("", _ => { }, placeholder: "Third")
+            TextBox("", _ => { }, placeholder: "Third")
                 .AutomationName("Third field")
                 .TabIndex(3)
                 .AutomationId("A11yNav_Field3"),
 
-            TextField("", _ => { }, placeholder: "Fourth")
+            TextBox("", _ => { }, placeholder: "Fourth")
                 .AutomationName("Fourth field")
                 .TabIndex(4)
                 .AutomationId("A11yNav_Field4"),
@@ -243,12 +243,12 @@ internal static class AccessibilityInteractionFixtures
                 .AutomationId("A11yLbl_EmailLabel"),
 
             // Field referencing the label
-            TextField("user@example.com")
+            TextBox("user@example.com")
                 .LabeledBy("A11yLbl_EmailLabel")
                 .AutomationId("A11yLbl_EmailField"),
 
             // Self-labeled field (uses AutomationName instead)
-            TextField("")
+            TextBox("")
                 .AutomationName("Phone number")
                 .AutomationId("A11yLbl_PhoneField")
 
@@ -268,7 +268,7 @@ internal static class AccessibilityInteractionFixtures
                 .AutomationId("A11yTabNav_Title"),
 
             // Regular field before toolbar
-            TextField("", _ => { })
+            TextBox("", _ => { })
                 .AutomationName("Before toolbar")
                 .AutomationId("A11yTabNav_Before"),
 
@@ -285,7 +285,7 @@ internal static class AccessibilityInteractionFixtures
              .AutomationId("A11yTabNav_Toolbar"),
 
             // Regular field after toolbar
-            TextField("", _ => { })
+            TextBox("", _ => { })
                 .AutomationName("After toolbar")
                 .AutomationId("A11yTabNav_After")
         ).Landmark(AutomationLandmarkType.Main)

--- a/tests/Reactor.AppTests.Host/Fixtures/DockingInputE2EFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/DockingInputE2EFixtures.cs
@@ -42,7 +42,7 @@ internal static class DockingInputE2EFixtures
                 CanClose = true,
                 CanPin = true,
                 Content = VStack(6,
-                    TextField(left, setLeft, placeholder: "left input")
+                    TextBox(left, setLeft, placeholder: "left input")
                         .AutomationId("DockEditor_Left"),
                     TextBlock($"Left state: {left}").AutomationId("DockEditor_Left_State")
                 ).Padding(12),
@@ -54,7 +54,7 @@ internal static class DockingInputE2EFixtures
                 CanClose = true,
                 CanPin = true,
                 Content = VStack(6,
-                    TextField(right, setRight, placeholder: "right input")
+                    TextBox(right, setRight, placeholder: "right input")
                         .AutomationId("DockEditor_Right"),
                     TextBlock($"Right state: {right}").AutomationId("DockEditor_Right_State")
                 ).Padding(12),
@@ -105,7 +105,7 @@ internal static class DockingInputE2EFixtures
                 Key: "dock-input-nopin:left",
                 CanClose: true,
                 Content: VStack(6,
-                    TextField(left, setLeft, placeholder: "left input")
+                    TextBox(left, setLeft, placeholder: "left input")
                         .AutomationId("DockEditorNoPin_Left"),
                     TextBlock($"Left state: {left}").AutomationId("DockEditorNoPin_Left_State")
                 ).Padding(12));
@@ -114,7 +114,7 @@ internal static class DockingInputE2EFixtures
                 Key: "dock-input-nopin:right",
                 CanClose: true,
                 Content: VStack(6,
-                    TextField(right, setRight, placeholder: "right input")
+                    TextBox(right, setRight, placeholder: "right input")
                         .AutomationId("DockEditorNoPin_Right"),
                     TextBlock($"Right state: {right}").AutomationId("DockEditorNoPin_Right_State")
                 ).Padding(12));

--- a/tests/Reactor.AppTests.Host/Fixtures/EventHandlerFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/EventHandlerFixtures.cs
@@ -121,7 +121,7 @@ internal static class EventHandlerFixtures
             var (text, setText) = UseState("");
 
             return VStack(8,
-                TextField(text, v => setText(v), placeholder: "Type here")
+                TextBox(text, v => setText(v), placeholder: "Type here")
                     .Width(300)
                     .OnKeyDown((s, e) =>
                     {

--- a/tests/Reactor.AppTests.Host/Fixtures/ImmediateAndDisabledFocusableFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/ImmediateAndDisabledFocusableFixtures.cs
@@ -38,7 +38,7 @@ internal static class ImmediateAndDisabledFocusableFixtures
             var formValid = emailValid && ageValid;
 
             return VStack(8,
-                TextField(email, setEmail)
+                TextBox(email, setEmail)
                     .AutomationId("ValImmediate_Email"),
 
                 NumberBox(age, v =>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlCatalogFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlCatalogFixtures.cs
@@ -89,7 +89,7 @@ internal static class ControlCatalogFixtures
             Add("ToggleSplitButton", ToggleSplitButton("CatalogTSB"), "CatalogTSB");
 
             // ── Input controls ──
-            Add("TextField", TextField("CatalogTF"), null);
+            Add("TextField", TextBox("CatalogTF"), null);
             Add("PasswordBox", PasswordBox("pw"), null);
             Add("NumberBox", NumberBox(42, header: "CatalogNB"), "CatalogNB");
             Add("AutoSuggestBox", AutoSuggestBox("CatalogASB"), null);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlUpdateFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlUpdateFixtures.cs
@@ -103,7 +103,7 @@ internal static class ControlUpdateFixtures
                     Button("UpdInputs", () => set(1)),
                     phase == 0
                         ? VStack(
-                            TextField("hello", placeholder: "type here", header: "FieldHdr"),
+                            TextBox("hello", placeholder: "type here", header: "FieldHdr"),
                             CheckBox(false, label: "ChkLabel"),
                             Slider(25, 0, 100),
                             ToggleSwitch(false, header: "TsHdr"),
@@ -115,7 +115,7 @@ internal static class ControlUpdateFixtures
                             ProgressRing(0.5)
                           )
                         : VStack(
-                            TextField("world", placeholder: "changed", header: "FieldHdr2"),
+                            TextBox("world", placeholder: "changed", header: "FieldHdr2"),
                             CheckBox(true, label: "ChkLabel2"),
                             Slider(75, 0, 100),
                             ToggleSwitch(true, header: "TsHdr2"),

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoverageBoostFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoverageBoostFixtures.cs
@@ -205,7 +205,7 @@ internal static class CoverageBoostFixtures
                     0 => VStack(
                         TextBlock("PoolTest"),
                         Button("PoolBtn", () => { }),
-                        TextField("initial", _ => { }),
+                        TextBox("initial", _ => { }),
                         ToggleSwitch(false, _ => { }),
                         Progress(50),
                         ProgressRing(50.0),
@@ -223,7 +223,7 @@ internal static class CoverageBoostFixtures
                     _ => VStack(
                         TextBlock("Remounted"),
                         Button("Reuse", () => { }),
-                        TextField("reused", _ => { }),
+                        TextBox("reused", _ => { }),
                         ToggleSwitch(true, _ => { }),
                         Progress(75),
                         ProgressRing(75.0),

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoverageBoostFixtures2.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoverageBoostFixtures2.cs
@@ -88,7 +88,7 @@ internal static class CoverageBoostFixtures2
                         VisualizerStyle.InfoBar,
                         VStack(
                             TextBlock("InfoBarViz"),
-                            TextField("", _ => { })
+                            TextBox("", _ => { })
                                 .Validate("testField", "", Validate.Required("Required"))
                         ),
                         title: "Validation Errors",
@@ -102,7 +102,7 @@ internal static class CoverageBoostFixtures2
                         VisualizerStyle.Summary,
                         VStack(
                             TextBlock("SummaryViz"),
-                            TextField("", _ => { })
+                            TextBox("", _ => { })
                                 .Validate("testField2", "", Validate.Required("Required"))
                         ),
                         title: "Validation Summary",
@@ -116,7 +116,7 @@ internal static class CoverageBoostFixtures2
                         msgs => TextBlock($"Custom:{msgs.Count} errors"),
                         VStack(
                             TextBlock("CustomViz"),
-                            TextField("", _ => { })
+                            TextBox("", _ => { })
                                 .Validate("testField3", "", Validate.Required("Required"))
                         ),
                         showWhen: ShowWhen.Always
@@ -493,7 +493,7 @@ internal static class CoverageBoostFixtures2
                 {
                     0 => VStack(
                         Button("PoolBtn1", () => { }),
-                        TextField("text1", _ => { }),
+                        TextBox("text1", _ => { }),
                         ToggleSwitch(true, _ => { }, header: "Toggle1"),
                         CheckBox(true, _ => { }, label: "Check1"),
                         Slider(50, onValueChanged: _ => { }),
@@ -506,7 +506,7 @@ internal static class CoverageBoostFixtures2
                     ),
                     _ => VStack(
                         Button("PoolBtn2", () => { }),
-                        TextField("text2", _ => { }),
+                        TextBox("text2", _ => { }),
                         ToggleSwitch(false, _ => { }),
                         CheckBox(false, _ => { }, label: "Check2"),
                         Slider(75, onValueChanged: _ => { }),

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
@@ -496,7 +496,7 @@ internal static class DataGridEditFixtures
                 // Four children matching the DataGrid row layout: [Id][Name][Cat][Price].
                 // Middle child flips between Text and TextField based on `editing`.
                 var nameCell = editing
-                    ? (Element)TextField("Alice", _ => { }).Padding(2)
+                    ? (Element)TextBox("Alice", _ => { }).Padding(2)
                     : (Element)TextBlock("Alice").Padding(horizontal: 8, vertical: 4);
 
                 return Grid(

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DevtoolsFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DevtoolsFixtures.cs
@@ -129,7 +129,7 @@ internal static class DevtoolsFixtures
             return VStack(
                 TextBlock($"count:{count}").AutomationId("count-label"),
                 Button("Increment", () => setCount(count + 1)).AutomationId("btn-increment"),
-                TextField(text, setText).AutomationId("txt-input"),
+                TextBox(text, setText).AutomationId("txt-input"),
                 CheckBox(toggled, setToggled, label: "Accept").AutomationId("chk-accept"),
                 // Delayed-update button: used by waitFor.
                 Button("DelayedBump", async () =>
@@ -767,11 +767,11 @@ internal static class DevtoolsFixtures
         public override Element Render() => VStack(
             VStack(
                 TextBlock("Name").AutomationId("lbl-name"),
-                TextField("a", _ => { }).AutomationId("tb-name")
+                TextBox("a", _ => { }).AutomationId("tb-name")
             ),
             VStack(
                 TextBlock("Email").AutomationId("lbl-email"),
-                TextField("b", _ => { }).AutomationId("tb-email")
+                TextBox("b", _ => { }).AutomationId("tb-email")
             )
         );
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
@@ -477,7 +477,7 @@ internal static class EchoSuppressionFixtures
                 var t = phase == 0 ? "initial" : "next";
                 return VStack(
                     Button("Go_TF", () => setPhase(1)),
-                    TextField(t, s => calls.Add(s), placeholder: "test")
+                    TextBox(t, s => calls.Add(s), placeholder: "test")
                 );
             });
             await Harness.Render();

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FocusFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FocusFixtures.cs
@@ -37,9 +37,9 @@ internal static class FocusFixtures
         {
             var host = H.CreateHost();
             host.Mount(ctx => VStack(
-                TextField("a", _ => { }).Set(tb => tb.Name = "ts1"),
-                TextField("b", _ => { }).Set(tb => tb.Name = "ts2").IsTabStop(false),
-                TextField("c", _ => { }).Set(tb => tb.Name = "ts3")));
+                TextBox("a", _ => { }).Set(tb => tb.Name = "ts1"),
+                TextBox("b", _ => { }).Set(tb => tb.Name = "ts2").IsTabStop(false),
+                TextBox("c", _ => { }).Set(tb => tb.Name = "ts3")));
             await Harness.Render();
 
             var middle = H.FindControl<TextBox>(tb => tb.Name == "ts2");
@@ -53,7 +53,7 @@ internal static class FocusFixtures
         public override async Task RunAsync()
         {
             var host = H.CreateHost();
-            host.Mount(ctx => TextField("xyf", _ => { })
+            host.Mount(ctx => TextBox("xyf", _ => { })
                 .Set(tb => tb.Name = "xyfTarget")
                 .XYFocusKeyboardNavigation(Microsoft.UI.Xaml.Input.XYFocusKeyboardNavigationMode.Enabled));
             await Harness.Render();
@@ -71,7 +71,7 @@ internal static class FocusFixtures
         {
             var host = H.CreateHost();
             var elRef = new ElementRef();
-            host.Mount(ctx => TextField("refTest", _ => { })
+            host.Mount(ctx => TextBox("refTest", _ => { })
                 .Set(tb => tb.Name = "refTarget")
                 .Ref(elRef));
             await Harness.Render();
@@ -88,7 +88,7 @@ internal static class FocusFixtures
         {
             var host = H.CreateHost();
             var elRef = new ElementRef();
-            host.Mount(ctx => TextField("focusMe", _ => { })
+            host.Mount(ctx => TextBox("focusMe", _ => { })
                 .Set(tb => tb.Name = "focusTarget")
                 .Ref(elRef));
             await Harness.Render();
@@ -116,7 +116,7 @@ internal static class FocusFixtures
             host.Mount(ctx =>
             {
                 typed = ctx.UseElementRef<TextBox>();
-                return TextField("typedRefTest", _ => { })
+                return TextBox("typedRefTest", _ => { })
                     .Set(tb => tb.Name = "typedRefTarget")
                     .Ref(typed);
             });
@@ -143,7 +143,7 @@ internal static class FocusFixtures
                 seenRefs.Add(r);
                 var (_, set) = ctx.UseState(0);
                 bump = () => { trigger++; set(trigger); };
-                return TextField("identTest", _ => { })
+                return TextBox("identTest", _ => { })
                     .Set(tb => tb.Name = "identTarget")
                     .Ref(r);
             });
@@ -175,8 +175,8 @@ internal static class FocusFixtures
                 a = ctx.UseElementRef<TextBox>();
                 b = ctx.UseElementRef<TextBox>();
                 return VStack(
-                    TextField("ma", _ => { }).Set(tb => tb.Name = "mra").Ref(a),
-                    TextField("mb", _ => { }).Set(tb => tb.Name = "mrb").Ref(b));
+                    TextBox("ma", _ => { }).Set(tb => tb.Name = "mra").Ref(a),
+                    TextBox("mb", _ => { }).Set(tb => tb.Name = "mrb").Ref(b));
             });
             await Harness.Render();
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HooksCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/HooksCoverageFixtures.cs
@@ -115,8 +115,8 @@ internal static class HooksCoverageFixtures
                 fm.Register("second");
 
                 return VStack(
-                    TextField("", placeholder: "First").Set(tb => fm.SetControl("first", tb)),
-                    TextField("", placeholder: "Second").Set(tb => fm.SetControl("second", tb))
+                    TextBox("", placeholder: "First").Set(tb => fm.SetControl("first", tb)),
+                    TextBox("", placeholder: "Second").Set(tb => fm.SetControl("second", tb))
                 );
             });
 
@@ -157,8 +157,8 @@ internal static class HooksCoverageFixtures
                 fm.Register("password");
 
                 return VStack(
-                    TextField("", placeholder: "Username").Set(tb => fm.SetControl("username", tb)),
-                    TextField("", placeholder: "Password").Set(tb => fm.SetControl("password", tb))
+                    TextBox("", placeholder: "Username").Set(tb => fm.SetControl("username", tb)),
+                    TextBox("", placeholder: "Password").Set(tb => fm.SetControl("password", tb))
                 );
             });
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PointerModifierFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PointerModifierFixtures.cs
@@ -112,11 +112,11 @@ internal static class PointerModifierFixtures
             int gotA = 0, lostA = 0, gotB = 0;
             var host = H.CreateHost();
             host.Mount(ctx => VStack(
-                TextField("a")
+                TextBox("a")
                     .Set(tb => tb.Name = "tbA")
                     .OnGotFocus((_, _) => gotA++)
                     .OnLostFocus((_, _) => lostA++),
-                TextField("b")
+                TextBox("b")
                     .Set(tb => tb.Name = "tbB")
                     .OnGotFocus((_, _) => gotB++)
             ));

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -146,8 +146,8 @@ internal static class ReconcilerBigCoverageFixtures
                     ? NumberBox(5, header: "wire-nb")
                     : NumberBox(5, onValueChanged: v => nbHits++, header: "wire-nb");
                 Element tf = phase == 0
-                    ? TextField("wire-tf-text", placeholder: "tf")
-                    : TextField("wire-tf-text", onChanged: v => textHits++, placeholder: "tf");
+                    ? TextBox("wire-tf-text", placeholder: "tf")
+                    : TextBox("wire-tf-text", onChanged: v => textHits++, placeholder: "tf");
                 Element pw = phase == 0
                     ? PasswordBox("init")
                     : PasswordBox("init", onPasswordChanged: v => pwHits++);
@@ -649,7 +649,7 @@ internal static class ReconcilerBigCoverageFixtures
             var host = H.CreateHost();
             host.Mount(ctx => VStack(
                 TextBlock("EmailLabel").AutomationId("EmailLabelId"),
-                TextField("user@example.com").LabeledBy("EmailLabelId")
+                TextBox("user@example.com").LabeledBy("EmailLabelId")
             ));
 
             await Harness.Render();
@@ -904,20 +904,20 @@ internal static class ReconcilerBigCoverageFixtures
                     ValidationVisualizer(
                         VisualizerStyle.Summary,
                         VStack(
-                            FormField(TextField("").Validate("email", "", Validate.Required()), label: "Email"),
-                            FormField(TextField("a").Validate("name", "a", Validate.MinLength(3)), label: "Name")
+                            FormField(TextBox("").Validate("email", "", Validate.Required()), label: "Email"),
+                            FormField(TextBox("a").Validate("name", "a", Validate.MinLength(3)), label: "Name")
                         ),
                         title: "Summary errors").Provide(ValidationContexts.Current, valCtx),
                     ValidationVisualizer(
                         VisualizerStyle.InfoBar,
                         VStack(
-                            FormField(TextField("").Validate("ib1", "", Validate.Required()), label: "IB1")
+                            FormField(TextBox("").Validate("ib1", "", Validate.Required()), label: "IB1")
                         ),
                         title: "InfoBar errors").Provide(ValidationContexts.Current, valCtx),
                     ValidationVisualizer(
                         caught => TextBlock($"Custom: {caught.Count} errors"),
                         VStack(
-                            FormField(TextField("").Validate("c1", "", Validate.Required()), label: "C1")
+                            FormField(TextBox("").Validate("c1", "", Validate.Required()), label: "C1")
                         )).Provide(ValidationContexts.Current, valCtx)
                 );
             });

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TextFieldMountFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TextFieldMountFixtures.cs
@@ -26,7 +26,7 @@ internal static class TextFieldMountFixtures
         {
             var host = H.CreateHost();
             host.Mount(_ =>
-                (TextField(MultiLine, placeholder: "ml-test")
+                (TextBox(MultiLine, placeholder: "ml-test")
                     with { AcceptsReturn = true, TextWrapping = TextWrapping.Wrap })
                 .MinHeight(80)
                 .AutomationName("ml-target")
@@ -57,7 +57,7 @@ internal static class TextFieldMountFixtures
         {
             var host = H.CreateHost();
             host.Mount(_ =>
-                TextField("hello world", placeholder: "sl-test")
+                TextBox("hello world", placeholder: "sl-test")
                     .AutomationName("sl-target")
             );
 
@@ -85,7 +85,7 @@ internal static class TextFieldMountFixtures
                 var value = phase == 0 ? "First" : MultiLine;
                 return VStack(
                     Button("TF_ML_Upd", () => set(1)),
-                    (TextField(value, placeholder: "ml-upd-test")
+                    (TextBox(value, placeholder: "ml-upd-test")
                         with { AcceptsReturn = true, TextWrapping = TextWrapping.Wrap })
                     .MinHeight(80));
             });

--- a/tests/Reactor.Tests/A11yShowcaseScannerTest.cs
+++ b/tests/Reactor.Tests/A11yShowcaseScannerTest.cs
@@ -59,7 +59,7 @@ public class A11yShowcaseScannerTest
                 Button("Active", null),
 
                 // A11Y_003: TextField without header, AutomationName, or LabeledBy
-                TextField("", null, placeholder: "New task..."),
+                TextBox("", null, placeholder: "New task..."),
 
                 // A11Y_001: Another icon-only button
                 IconBtn("add")
@@ -86,7 +86,7 @@ public class A11yShowcaseScannerTest
             HStack(12,
                 TextBlock("Quick note:"),
                 // A11Y_003: TextField with mistyped LabeledBy → A11Y_008
-                TextField("", null).LabeledBy("FooterNoteLabel_TYPO")
+                TextBox("", null).LabeledBy("FooterNoteLabel_TYPO")
             )
         );
         // NOTE: No .Landmark(Main) on any element → A11Y_006

--- a/tests/Reactor.Tests/AccessibilityScannerTests.cs
+++ b/tests/Reactor.Tests/AccessibilityScannerTests.cs
@@ -95,7 +95,7 @@ public class AccessibilityScannerTests
     public void A11Y_003_TextField_Without_Label()
     {
         var tree = VStack(
-            TextField("", null, placeholder: "Enter email")
+            TextBox("", null, placeholder: "Enter email")
         );
 
         var findings = AccessibilityScanner.Scan(tree);
@@ -106,7 +106,7 @@ public class AccessibilityScannerTests
     public void A11Y_003_TextField_With_Header_Passes()
     {
         var tree = VStack(
-            TextField("", null, header: "Email address")
+            TextBox("", null, header: "Email address")
         );
 
         var findings = AccessibilityScanner.Scan(tree);
@@ -117,7 +117,7 @@ public class AccessibilityScannerTests
     public void A11Y_003_TextField_With_AutomationName_Passes()
     {
         var tree = VStack(
-            TextField("", null).AutomationName("Email address")
+            TextBox("", null).AutomationName("Email address")
         );
 
         var findings = AccessibilityScanner.Scan(tree);
@@ -129,7 +129,7 @@ public class AccessibilityScannerTests
     {
         var tree = VStack(
             TextBlock("Email").AutomationId("EmailLabel"),
-            TextField("", null).LabeledBy("EmailLabel")
+            TextBox("", null).LabeledBy("EmailLabel")
         );
 
         var findings = AccessibilityScanner.Scan(tree);
@@ -211,7 +211,7 @@ public class AccessibilityScannerTests
     public void A11Y_008_LabeledBy_Missing_AutomationId()
     {
         var tree = VStack(
-            TextField("", null).LabeledBy("NonExistentLabel")
+            TextBox("", null).LabeledBy("NonExistentLabel")
                 .AutomationName("Email") // prevent A11Y_003
         );
 
@@ -224,7 +224,7 @@ public class AccessibilityScannerTests
     {
         var tree = VStack(
             TextBlock("Email").AutomationId("EmailLabel"),
-            TextField("", null).LabeledBy("EmailLabel")
+            TextBox("", null).LabeledBy("EmailLabel")
                 .AutomationName("Email") // prevent A11Y_003
         );
 
@@ -241,7 +241,7 @@ public class AccessibilityScannerTests
     {
         var tree = VStack(
             Heading("Settings"),
-            TextField("", null, header: "Name"),
+            TextBox("", null, header: "Name"),
             Button("Save", null)
         ).Landmark(AutomationLandmarkType.Main);
 
@@ -258,7 +258,7 @@ public class AccessibilityScannerTests
     {
         var tree = VStack(
             Image("test.png"), // triggers A11Y_002
-            TextField("", null) // triggers A11Y_003
+            TextBox("", null) // triggers A11Y_003
         );
 
         var findings = AccessibilityScanner.Scan(tree);

--- a/tests/Reactor.Tests/AnalyzerTests/AccessibilityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AccessibilityAnalyzerTests.cs
@@ -169,11 +169,11 @@ public class FormFieldLabelAnalyzerTests
         var test = @"
 class C
 {
-    static dynamic TextField(dynamic value, string header = null) => null;
+    static dynamic TextBox(dynamic value, string header = null) => null;
 
     void M(dynamic value)
     {
-        TextField(value);
+        TextBox(value);
     }
 }";
         var expected = Diagnostic(FormFieldLabelAnalyzer.DiagnosticId)
@@ -193,11 +193,11 @@ class C
         var test = @"
 class C
 {
-    static dynamic TextField(dynamic value, string header = null) => null;
+    static dynamic TextBox(dynamic value, string header = null) => null;
 
     void M(dynamic value)
     {
-        TextField(value, header: ""Name"");
+        TextBox(value, header: ""Name"");
     }
 }";
         var analyzerTest = new CSharpAnalyzerTest<FormFieldLabelAnalyzer, DefaultVerifier>
@@ -213,11 +213,11 @@ class C
         var test = @"
 class C
 {
-    static dynamic TextField(dynamic value, string header = null) => null;
+    static dynamic TextBox(dynamic value, string header = null) => null;
 
     void M(dynamic value)
     {
-        TextField(value).AutomationName(""Search"");
+        TextBox(value).AutomationName(""Search"");
     }
 }";
         var analyzerTest = new CSharpAnalyzerTest<FormFieldLabelAnalyzer, DefaultVerifier>
@@ -233,11 +233,11 @@ class C
         var test = @"
 class C
 {
-    static dynamic TextField(dynamic value, string header = null) => null;
+    static dynamic TextBox(dynamic value, string header = null) => null;
 
     void M(dynamic value, dynamic label)
     {
-        TextField(value).LabeledBy(label);
+        TextBox(value).LabeledBy(label);
     }
 }";
         var analyzerTest = new CSharpAnalyzerTest<FormFieldLabelAnalyzer, DefaultVerifier>

--- a/tests/Reactor.Tests/AnalyzerTests/AccessibilityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AccessibilityAnalyzerTests.cs
@@ -177,7 +177,7 @@ class C
     }
 }";
         var expected = Diagnostic(FormFieldLabelAnalyzer.DiagnosticId)
-            .WithSpan(8, 9, 8, 25);
+            .WithSpan(8, 9, 8, 23);
 
         var analyzerTest = new CSharpAnalyzerTest<FormFieldLabelAnalyzer, DefaultVerifier>
         {

--- a/tests/Reactor.Tests/Controls/EditChainTests.cs
+++ b/tests/Reactor.Tests/Controls/EditChainTests.cs
@@ -428,7 +428,7 @@ public class EditChainTests
     {
         var method = GetStatic("RenderReadOnlyValue");
         var el = (Element)method.Invoke(null, new object?[] { "hello", typeof(string) })!;
-        var field = Assert.IsType<TextFieldElement>(el);
+        var field = Assert.IsType<TextBoxElement>(el);
         Assert.Equal("hello", field.Value);
         Assert.Equal(false, field.Modifiers?.IsEnabled);
     }
@@ -438,7 +438,7 @@ public class EditChainTests
     {
         var method = GetStatic("RenderReadOnlyValue");
         var el = (Element)method.Invoke(null, new object?[] { null, typeof(string) })!;
-        var field = Assert.IsType<TextFieldElement>(el);
+        var field = Assert.IsType<TextBoxElement>(el);
         Assert.Equal("", field.Value);
     }
 

--- a/tests/Reactor.Tests/Controls/EditorsBehaviorTests.cs
+++ b/tests/Reactor.Tests/Controls/EditorsBehaviorTests.cs
@@ -247,7 +247,7 @@ public class EditorsBehaviorTests
     {
         // Bug: factory((string?)null, _) would NRE without the ?? "" guard.
         var factory = Editors.Text();
-        var el = (TextFieldElement)factory(null!, _ => { });
+        var el = (TextBoxElement)factory(null!, _ => { });
         Assert.Equal(string.Empty, el.Value);
     }
 
@@ -255,7 +255,7 @@ public class EditorsBehaviorTests
     public void Text_Value_Pass_Through()
     {
         var factory = Editors.Text();
-        var el = (TextFieldElement)factory("hello", _ => { });
+        var el = (TextBoxElement)factory("hello", _ => { });
         Assert.Equal("hello", el.Value);
     }
 
@@ -263,7 +263,7 @@ public class EditorsBehaviorTests
     public void Text_Placeholder_Propagates()
     {
         var factory = Editors.Text(placeholder: "type here");
-        var el = (TextFieldElement)factory("", _ => { });
+        var el = (TextBoxElement)factory("", _ => { });
         Assert.Equal("type here", el.Placeholder);
     }
 
@@ -272,7 +272,7 @@ public class EditorsBehaviorTests
     {
         // Branch coverage: the `maxLength is { } max` ternary's false arm.
         var factory = Editors.Text();
-        var el = (TextFieldElement)factory("x", _ => { });
+        var el = (TextBoxElement)factory("x", _ => { });
         Assert.Empty(el.Setters);
     }
 
@@ -283,7 +283,7 @@ public class EditorsBehaviorTests
         // we can't invoke it without a TextBox — counting setters is enough
         // to catch a regression that drops the .Set call.
         var factory = Editors.Text(maxLength: 50);
-        var el = (TextFieldElement)factory("x", _ => { });
+        var el = (TextBoxElement)factory("x", _ => { });
         Assert.Single(el.Setters);
     }
 
@@ -292,7 +292,7 @@ public class EditorsBehaviorTests
     {
         object? captured = null;
         var factory = Editors.Text();
-        var el = (TextFieldElement)factory("", v => captured = v);
+        var el = (TextBoxElement)factory("", v => captured = v);
         el.OnChanged!.Invoke("typed");
         Assert.Equal("typed", captured);
     }
@@ -580,7 +580,7 @@ public class EditorsBehaviorTests
     public void Uri_Uri_Object_Stringifies()
     {
         var factory = Editors.Uri();
-        var el = (TextFieldElement)factory(new global::System.Uri("https://example.com/path"), _ => { });
+        var el = (TextBoxElement)factory(new global::System.Uri("https://example.com/path"), _ => { });
         Assert.Equal("https://example.com/path", el.Value.TrimEnd('/'));
     }
 
@@ -588,7 +588,7 @@ public class EditorsBehaviorTests
     public void Uri_Null_Defaults_To_Empty_String()
     {
         var factory = Editors.Uri();
-        var el = (TextFieldElement)factory(null!, _ => { });
+        var el = (TextBoxElement)factory(null!, _ => { });
         Assert.Equal(string.Empty, el.Value);
     }
 
@@ -596,7 +596,7 @@ public class EditorsBehaviorTests
     public void Uri_Non_Uri_Object_ToStrings()
     {
         var factory = Editors.Uri();
-        var el = (TextFieldElement)factory(42, _ => { });
+        var el = (TextBoxElement)factory(42, _ => { });
         Assert.Equal("42", el.Value);
     }
 
@@ -607,7 +607,7 @@ public class EditorsBehaviorTests
         // garbage strings as Uri instances, breaking model invariants.
         object? captured = null;
         var factory = Editors.Uri();
-        var el = (TextFieldElement)factory("", v => captured = v);
+        var el = (TextBoxElement)factory("", v => captured = v);
         el.OnChanged!.Invoke("https://docs.microsoft.com");
         Assert.IsType<global::System.Uri>(captured);
         Assert.Equal("https://docs.microsoft.com/", ((global::System.Uri)captured!).ToString());
@@ -620,7 +620,7 @@ public class EditorsBehaviorTests
         // tightened it to Absolute would silently drop relative inputs.
         object? captured = null;
         var factory = Editors.Uri();
-        var el = (TextFieldElement)factory("", v => captured = v);
+        var el = (TextBoxElement)factory("", v => captured = v);
         el.OnChanged!.Invoke("/relative/path");
         Assert.IsType<global::System.Uri>(captured);
     }
@@ -634,7 +634,7 @@ public class EditorsBehaviorTests
         object? captured = null;
         bool changed = false;
         var factory = Editors.Uri();
-        var el = (TextFieldElement)factory("", v => { captured = v; changed = true; });
+        var el = (TextBoxElement)factory("", v => { captured = v; changed = true; });
         // Use explicit \x## escapes for the control characters so the test
         // input is visible in source (embedded raw bytes get mangled by
         // editors and are invisible in reviews).

--- a/tests/Reactor.Tests/Controls/PropertyGridDefaultsTests.cs
+++ b/tests/Reactor.Tests/Controls/PropertyGridDefaultsTests.cs
@@ -98,7 +98,7 @@ public class PropertyGridDefaultsTests
     {
         var desc = Field("x");
         var label = (Element)Microsoft.UI.Reactor.Factories.TextBlock("L");
-        var editor = (Element)Microsoft.UI.Reactor.Factories.TextField("v");
+        var editor = (Element)Microsoft.UI.Reactor.Factories.TextBox("v");
         var row = PropertyGridDefaults.PropertyRowTemplate(desc, label, editor, 0);
 
         var flex = Assert.IsType<FlexElement>(row);
@@ -115,7 +115,7 @@ public class PropertyGridDefaultsTests
         // two prefixes never collide.
         var desc = Field("x", displayName: "Counter");
         var label = (Element)Microsoft.UI.Reactor.Factories.TextBlock("L");
-        var editor = (Element)Microsoft.UI.Reactor.Factories.TextField("v");
+        var editor = (Element)Microsoft.UI.Reactor.Factories.TextBox("v");
         var row = PropertyGridDefaults.PropertyRowTemplate(desc, label, editor, 0);
 
         // Children[1] is the editor, with AutomationName modifier applied.
@@ -130,7 +130,7 @@ public class PropertyGridDefaultsTests
         // label slot — this is the visible nesting indent in the grid.
         var desc = Field("x");
         var label = (Element)Microsoft.UI.Reactor.Factories.TextBlock("L");
-        var editor = (Element)Microsoft.UI.Reactor.Factories.TextField("v");
+        var editor = (Element)Microsoft.UI.Reactor.Factories.TextBox("v");
         var row = PropertyGridDefaults.PropertyRowTemplate(desc, label, editor, 2);
 
         var labelOut = ((FlexElement)row).Children[0];

--- a/tests/Reactor.Tests/Controls/TypedColumnsBehaviorTests.cs
+++ b/tests/Reactor.Tests/Controls/TypedColumnsBehaviorTests.cs
@@ -91,7 +91,7 @@ public class TypedColumnsBehaviorTests
         object? captured = null;
         var factory = new TypeRegistry().ResolveEditor(typeof(global::System.Uri), EditorTier.Standard);
         var input = new global::System.Uri("https://example.com");
-        var el = (TextFieldElement)factory!(input, v => captured = v);
+        var el = (TextBoxElement)factory!(input, v => captured = v);
         Assert.Contains("example.com", el.Value);
         el.OnChanged!.Invoke("https://docs.microsoft.com");
         Assert.IsType<global::System.Uri>(captured);
@@ -158,7 +158,7 @@ public class TypedColumnsBehaviorTests
         var desc = ReflectionTypeMetadataProvider.CreateDescriptor(prop, 0);
 
         object? captured = null;
-        var el = (TextFieldElement)desc.Editor!("https://example.com", v => captured = v);
+        var el = (TextBoxElement)desc.Editor!("https://example.com", v => captured = v);
         Assert.Equal("https://...", el.Placeholder);
         el.OnChanged!.Invoke("https://docs.microsoft.com");
         Assert.IsType<string>(captured);
@@ -176,7 +176,7 @@ public class TypedColumnsBehaviorTests
         var desc = ReflectionTypeMetadataProvider.CreateDescriptor(prop, 0);
 
         object? captured = null;
-        var el = (TextFieldElement)desc.Editor!(new global::System.Uri("https://x"), v => captured = v);
+        var el = (TextBoxElement)desc.Editor!(new global::System.Uri("https://x"), v => captured = v);
         el.OnChanged!.Invoke("https://docs.microsoft.com");
         Assert.IsType<global::System.Uri>(captured);
     }
@@ -367,7 +367,7 @@ public class TypedColumnsBehaviorTests
             nameof(Row.UriField), r => r.UriField);
 
         object? captured = null;
-        var el = (TextFieldElement)col.Editor!(new global::System.Uri("https://x"), v => captured = v);
+        var el = (TextBoxElement)col.Editor!(new global::System.Uri("https://x"), v => captured = v);
         el.OnChanged!.Invoke("https://docs.microsoft.com");
         Assert.IsType<global::System.Uri>(captured);
     }
@@ -384,7 +384,7 @@ public class TypedColumnsBehaviorTests
             nameof(Row.UrlString), r => r.UrlString);
 
         object? captured = null;
-        var el = (TextFieldElement)col.Editor!("https://x", v => captured = v);
+        var el = (TextBoxElement)col.Editor!("https://x", v => captured = v);
         Assert.Equal("https://...", el.Placeholder);
         el.OnChanged!.Invoke("partial input that is not a valid uri");
         Assert.IsType<string>(captured);

--- a/tests/Reactor.Tests/DslFactoryLogicTests.cs
+++ b/tests/Reactor.Tests/DslFactoryLogicTests.cs
@@ -97,7 +97,7 @@ public class DslFactoryLogicTests
     [Fact]
     public void TextField_With_All_Parameters()
     {
-        var el = TextField("val", s => { }, "hint", "Header");
+        var el = TextBox("val", s => { }, "hint", "Header");
         Assert.Equal("val", el.Value);
         Assert.Equal("hint", el.Placeholder);
         Assert.Equal("Header", el.Header);

--- a/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
@@ -245,7 +245,7 @@ public class ElementExtensionsCoverageTests
     [Fact]
     public void TextField_Sugar()
     {
-        var el = TextField("x", _ => { })
+        var el = TextBox("x", _ => { })
             .IsReadOnly()
             .AcceptsReturn()
             .TextWrapping()
@@ -262,7 +262,7 @@ public class ElementExtensionsCoverageTests
     [Obsolete("Tests the deprecated ReadOnly shim for TextField")]
     public void TextField_ReadOnly_Shim()
     {
-        var el = TextField("x", _ => { }).ReadOnly();
+        var el = TextBox("x", _ => { }).ReadOnly();
         Assert.True(el.IsReadOnly);
     }
 
@@ -493,7 +493,7 @@ public class ElementExtensionsCoverageTests
         var b = Button("Y").Set(btn => btn.Width = 50);
         Assert.Single(b.Setters);
 
-        var tf = TextField("x", _ => { }).Set(tb => tb.MaxLength = 5);
+        var tf = TextBox("x", _ => { }).Set(tb => tb.MaxLength = 5);
         Assert.Single(tf.Setters);
 
         var s = VStack().Set(sp => sp.Spacing = 4);

--- a/tests/Reactor.Tests/ElementTests.cs
+++ b/tests/Reactor.Tests/ElementTests.cs
@@ -128,7 +128,7 @@ public class ElementTests
     [Fact]
     public void TextField_Creates_With_Value_And_Placeholder()
     {
-        var el = TextField("val", placeholder: "hint");
+        var el = TextBox("val", placeholder: "hint");
         Assert.Equal("val", el.Value);
         Assert.Equal("hint", el.Placeholder);
     }

--- a/tests/Reactor.Tests/Elements/EventFluentNullClearTests.cs
+++ b/tests/Reactor.Tests/Elements/EventFluentNullClearTests.cs
@@ -161,7 +161,7 @@ public class EventFluentNullClearTests
     [Fact]
     public void TextField_Changed_NullClears()
     {
-        var el = TextField("x").Changed(SentinelStr);
+        var el = TextBox("x").Changed(SentinelStr);
         Assert.Same(SentinelStr, el.OnChanged);
         Assert.Null(el.Changed(null).OnChanged);
     }
@@ -170,7 +170,7 @@ public class EventFluentNullClearTests
     public void TextField_SelectionChanged_NullClears()
     {
         Action<string, int, int> h = (_, _, _) => { };
-        var el = TextField("x").SelectionChanged(h);
+        var el = TextBox("x").SelectionChanged(h);
         Assert.Same(h, el.OnSelectionChanged);
         Assert.Null(el.SelectionChanged(null).OnSelectionChanged);
     }

--- a/tests/Reactor.Tests/Elements/FactoryWithExpressionTests.cs
+++ b/tests/Reactor.Tests/Elements/FactoryWithExpressionTests.cs
@@ -88,7 +88,7 @@ public class FactoryWithExpressionTests
     // ════════════════════════════════════════════════════════════════
 
     [Fact] public void TextField_WithExpr_Sets_Property()
-        => Assert.Equal("hint", (TextField("v") with { Placeholder = "hint" }).Placeholder);
+        => Assert.Equal("hint", (TextBox("v") with { Placeholder = "hint" }).Placeholder);
 
     [Fact] public void PasswordBox_WithExpr_Sets_Key()
         => Assert.Equal("k", (PasswordBox("p") with { Key = "k" }).Key);

--- a/tests/Reactor.Tests/Elements/GallerySampleConstructionSmokeTests.cs
+++ b/tests/Reactor.Tests/Elements/GallerySampleConstructionSmokeTests.cs
@@ -53,9 +53,9 @@ public class GallerySampleConstructionSmokeTests
     public void TextFieldPage_FluentChains_Construct()
     {
         // Mirrors the InputScope + Description chains in TextFieldPage.cs.
-        var numeric = TextField("", _ => { }, "0").Header("Qty").NumericInput().Description("hint");
-        var email = TextField("", _ => { }, "you@x.com").Header("Email").EmailInput();
-        var url = TextField("", _ => { }, "https://").Header("URL").UrlInput();
+        var numeric = TextBox("", _ => { }, "0").Header("Qty").NumericInput().Description("hint");
+        var email = TextBox("", _ => { }, "you@x.com").Header("Email").EmailInput();
+        var url = TextBox("", _ => { }, "https://").Header("URL").UrlInput();
         Assert.NotNull(numeric);
         Assert.NotNull(email);
         Assert.NotNull(url);

--- a/tests/Reactor.Tests/Elements/NamedStyleFluentTests.cs
+++ b/tests/Reactor.Tests/Elements/NamedStyleFluentTests.cs
@@ -72,42 +72,42 @@ public class NamedStyleFluentTests
     [Fact]
     public void NumericInput_Adds_Setter()
     {
-        var el = TextField("").NumericInput();
+        var el = TextBox("").NumericInput();
         Assert.NotEmpty(GetSetters(el));
     }
 
     [Fact]
     public void EmailInput_Adds_Setter()
     {
-        var el = TextField("").EmailInput();
+        var el = TextBox("").EmailInput();
         Assert.NotEmpty(GetSetters(el));
     }
 
     [Fact]
     public void UrlInput_Adds_Setter()
     {
-        var el = TextField("").UrlInput();
+        var el = TextBox("").UrlInput();
         Assert.NotEmpty(GetSetters(el));
     }
 
     [Fact]
     public void PhoneInput_Adds_Setter()
     {
-        var el = TextField("").PhoneInput();
+        var el = TextBox("").PhoneInput();
         Assert.NotEmpty(GetSetters(el));
     }
 
     [Fact]
     public void SearchInput_Adds_Setter()
     {
-        var el = TextField("").SearchInput();
+        var el = TextBox("").SearchInput();
         Assert.NotEmpty(GetSetters(el));
     }
 
     [Fact]
     public void Generic_InputScope_Adds_Setter()
     {
-        var el = TextField("").InputScope(Microsoft.UI.Xaml.Input.InputScopeNameValue.Chat);
+        var el = TextBox("").InputScope(Microsoft.UI.Xaml.Input.InputScopeNameValue.Chat);
         Assert.NotEmpty(GetSetters(el));
     }
 
@@ -206,8 +206,8 @@ public class NamedStyleFluentTests
 
     // ─────────────────────────────────────────────────────────────────
 
-    private static global::System.Collections.IEnumerable GetSetters(TextFieldElement el) =>
-        (global::System.Collections.IEnumerable)typeof(TextFieldElement)
+    private static global::System.Collections.IEnumerable GetSetters(TextBoxElement el) =>
+        (global::System.Collections.IEnumerable)typeof(TextBoxElement)
             .GetProperty("Setters", global::System.Reflection.BindingFlags.Instance | global::System.Reflection.BindingFlags.NonPublic)!
             .GetValue(el)!;
 }

--- a/tests/Reactor.Tests/Elements/Phase4InitFluentTests.cs
+++ b/tests/Reactor.Tests/Elements/Phase4InitFluentTests.cs
@@ -345,36 +345,36 @@ public class Phase4InitFluentTests
     [Fact]
     public void TextField_MaxLength_Sets()
     {
-        var el = TextField("").MaxLength(32);
+        var el = TextBox("").MaxLength(32);
         Assert.Equal(32, el.MaxLength);
     }
 
     [Fact]
     public void TextField_IsSpellCheckEnabled_Sets()
     {
-        var el = TextField("").IsSpellCheckEnabled();
+        var el = TextBox("").IsSpellCheckEnabled();
         Assert.True(el.IsSpellCheckEnabled);
-        Assert.False(TextField("").IsSpellCheckEnabled(false).IsSpellCheckEnabled);
+        Assert.False(TextBox("").IsSpellCheckEnabled(false).IsSpellCheckEnabled);
     }
 
     [Fact]
     public void TextField_CharacterCasing_Sets()
     {
-        var el = TextField("").CharacterCasing(Microsoft.UI.Xaml.Controls.CharacterCasing.Upper);
+        var el = TextBox("").CharacterCasing(Microsoft.UI.Xaml.Controls.CharacterCasing.Upper);
         Assert.Equal(Microsoft.UI.Xaml.Controls.CharacterCasing.Upper, el.CharacterCasing);
     }
 
     [Fact]
     public void TextField_TextAlignment_Sets()
     {
-        var el = TextField("").TextAlignment(Microsoft.UI.Xaml.TextAlignment.Right);
+        var el = TextBox("").TextAlignment(Microsoft.UI.Xaml.TextAlignment.Right);
         Assert.Equal(Microsoft.UI.Xaml.TextAlignment.Right, el.TextAlignment);
     }
 
     [Fact]
     public void TextField_Description_Sets()
     {
-        var el = TextField("").Description("enter your name");
+        var el = TextBox("").Description("enter your name");
         Assert.Equal("enter your name", el.Description);
     }
 

--- a/tests/Reactor.Tests/ErrorStylingTests.cs
+++ b/tests/Reactor.Tests/ErrorStylingTests.cs
@@ -121,7 +121,7 @@ public class ErrorStylingTests
         var ctx = new ValidationContext();
         ctx.Add("email", "Required", Severity.Error);
 
-        var el = TextField("").WithErrorStyling(ctx, "email", ShowWhen.Always);
+        var el = TextBox("").WithErrorStyling(ctx, "email", ShowWhen.Always);
 
         Assert.NotNull(el.Modifiers);
         Assert.Equal(ErrorStyling.ErrorBorderThickness, el.Modifiers!.BorderThickness);
@@ -135,7 +135,7 @@ public class ErrorStylingTests
     {
         var ctx = new ValidationContext();
 
-        var el = TextField("").WithErrorStyling(ctx, "email", ShowWhen.Always);
+        var el = TextBox("").WithErrorStyling(ctx, "email", ShowWhen.Always);
 
         Assert.Null(el.ThemeBindings);
     }
@@ -146,7 +146,7 @@ public class ErrorStylingTests
         var ctx = new ValidationContext();
         ctx.Add("f", "warning", Severity.Warning);
 
-        var el = TextField("").WithErrorStyling(ctx, "f", ShowWhen.Always);
+        var el = TextBox("").WithErrorStyling(ctx, "f", ShowWhen.Always);
 
         Assert.NotNull(el.ThemeBindings);
         Assert.Equal("SystemFillColorCautionBrush", el.ThemeBindings!["BorderBrush"].ResourceKey);
@@ -159,12 +159,12 @@ public class ErrorStylingTests
         ctx.Add("email", "Required");
 
         // With error
-        var el1 = TextField("").WithErrorStyling(ctx, "email", ShowWhen.Always);
+        var el1 = TextBox("").WithErrorStyling(ctx, "email", ShowWhen.Always);
         Assert.NotNull(el1.ThemeBindings);
 
         // Clear error
         ctx.Clear("email");
-        var el2 = TextField("").WithErrorStyling(ctx, "email", ShowWhen.Always);
+        var el2 = TextBox("").WithErrorStyling(ctx, "email", ShowWhen.Always);
         Assert.Null(el2.ThemeBindings);
     }
 
@@ -179,7 +179,7 @@ public class ErrorStylingTests
         ctx.Add("email", "Required");
 
         // Default is WhenTouched, field not touched
-        var el = TextField("").WithErrorStyling(ctx, "email");
+        var el = TextBox("").WithErrorStyling(ctx, "email");
         Assert.Null(el.ThemeBindings);
     }
 
@@ -190,7 +190,7 @@ public class ErrorStylingTests
         ctx.Add("email", "Required");
         ctx.MarkTouched("email");
 
-        var el = TextField("").WithErrorStyling(ctx, "email");
+        var el = TextBox("").WithErrorStyling(ctx, "email");
         Assert.NotNull(el.ThemeBindings);
     }
 
@@ -224,7 +224,7 @@ public class ErrorStylingTests
         var ctx = new ValidationContext();
         ctx.Add("email", "Required");
 
-        var el = TextField("")
+        var el = TextBox("")
             .OnError(e => e.Margin(99))
             .WithErrorStyling(ctx, "email", ShowWhen.Always);
 
@@ -238,7 +238,7 @@ public class ErrorStylingTests
         var ctx = new ValidationContext();
         ctx.Add("f", "hint", Severity.Warning);
 
-        var el = TextField("")
+        var el = TextBox("")
             .OnWarning(e => e.Opacity(0.5))
             .WithErrorStyling(ctx, "f", ShowWhen.Always);
 
@@ -253,14 +253,14 @@ public class ErrorStylingTests
         ctx.Add("f", "error");
 
         // With error: custom styling applied
-        var el1 = TextField("")
+        var el1 = TextBox("")
             .OnError(e => e.Margin(99))
             .WithErrorStyling(ctx, "f", ShowWhen.Always);
         Assert.Equal(new Microsoft.UI.Xaml.Thickness(99), el1.Modifiers!.Margin);
 
         // Clear error
         ctx.Clear("f");
-        var el2 = TextField("")
+        var el2 = TextBox("")
             .OnError(e => e.Margin(99))
             .WithErrorStyling(ctx, "f", ShowWhen.Always);
         // No custom styling applied since no error
@@ -278,7 +278,7 @@ public class ErrorStylingTests
         ctx.Add("f", "info", Severity.Info);
         ctx.Add("f", "warning", Severity.Warning);
 
-        var el = TextField("").WithErrorStyling(ctx, "f", ShowWhen.Always);
+        var el = TextBox("").WithErrorStyling(ctx, "f", ShowWhen.Always);
         Assert.Equal("SystemFillColorCautionBrush", el.ThemeBindings!["BorderBrush"].ResourceKey);
     }
 
@@ -289,7 +289,7 @@ public class ErrorStylingTests
         ctx.Add("f", "info", Severity.Info);
         ctx.Add("f", "error", Severity.Error);
 
-        var el = TextField("").WithErrorStyling(ctx, "f", ShowWhen.Always);
+        var el = TextBox("").WithErrorStyling(ctx, "f", ShowWhen.Always);
         Assert.Equal("SystemFillColorCriticalBrush", el.ThemeBindings!["BorderBrush"].ResourceKey);
     }
 }

--- a/tests/Reactor.Tests/FormFieldDescriptorTests.cs
+++ b/tests/Reactor.Tests/FormFieldDescriptorTests.cs
@@ -85,7 +85,7 @@ public class FormFieldDescriptorTests
         };
 
         var el = FormField(fd, "test", _ => { }, registry);
-        Assert.IsType<TextFieldElement>(el.Content);
+        Assert.IsType<TextBoxElement>(el.Content);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/FormFieldTests.cs
+++ b/tests/Reactor.Tests/FormFieldTests.cs
@@ -16,34 +16,34 @@ public class FormFieldTests
     public void FormField_Creates_With_Label_And_Content()
     {
         var el = FormField(
-            TextField("test"),
+            TextBox("test"),
             label: "Email",
             description: "Enter your email address");
 
         Assert.IsType<FormFieldElement>(el);
         Assert.Equal("Email", el.Label);
         Assert.Equal("Enter your email address", el.Description);
-        Assert.IsType<TextFieldElement>(el.Content);
+        Assert.IsType<TextBoxElement>(el.Content);
     }
 
     [Fact]
     public void FormField_Required_True()
     {
-        var el = FormField(TextField(""), label: "Name", required: true);
+        var el = FormField(TextBox(""), label: "Name", required: true);
         Assert.True(el.Required);
     }
 
     [Fact]
     public void FormField_Default_ShowWhen_Is_WhenTouched()
     {
-        var el = FormField(TextField(""), label: "Name");
+        var el = FormField(TextBox(""), label: "Name");
         Assert.Equal(ShowWhen.WhenTouched, el.ShowWhen);
     }
 
     [Fact]
     public void FormField_Explicit_FieldName()
     {
-        var el = FormField(TextField(""), fieldName: "email");
+        var el = FormField(TextBox(""), fieldName: "email");
         Assert.Equal("email", el.FieldName);
     }
 
@@ -215,7 +215,7 @@ public class FormFieldTests
     [Fact]
     public void DetectFieldName_From_ValidationAttached()
     {
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("email", Validate.Required());
 
         Assert.Equal("email", FormFieldHelpers.DetectFieldName(el));
@@ -224,14 +224,14 @@ public class FormFieldTests
     [Fact]
     public void DetectFieldName_Returns_Null_Without_Validation()
     {
-        var el = TextField("test");
+        var el = TextBox("test");
         Assert.Null(FormFieldHelpers.DetectFieldName(el));
     }
 
     [Fact]
     public void ResolveFieldName_Prefers_Explicit()
     {
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("auto", Validate.Required());
 
         Assert.Equal("explicit", FormFieldHelpers.ResolveFieldName("explicit", el));
@@ -240,7 +240,7 @@ public class FormFieldTests
     [Fact]
     public void ResolveFieldName_Falls_Back_To_Auto()
     {
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("auto", Validate.Required());
 
         Assert.Equal("auto", FormFieldHelpers.ResolveFieldName(null, el));
@@ -253,7 +253,7 @@ public class FormFieldTests
     [Fact]
     public void Validate_With_Value_Stores_Value_On_Attached()
     {
-        var el = TextField("hello")
+        var el = TextBox("hello")
             .Validate("email", "hello", Validate.Required());
 
         var attached = el.GetValidation();
@@ -266,7 +266,7 @@ public class FormFieldTests
     [Fact]
     public void Validate_With_Value_Merges_Validators()
     {
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("email", "test", Validate.Required())
             .Validate("email", "test", Validate.Email());
 
@@ -278,7 +278,7 @@ public class FormFieldTests
     [Fact]
     public void Validate_Without_Value_Has_Null_Value()
     {
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("email", Validate.Required());
 
         var attached = el.GetValidation();
@@ -289,7 +289,7 @@ public class FormFieldTests
     [Fact]
     public void FormField_With_Validated_Content_Auto_Detects_FieldName()
     {
-        var content = TextField("test")
+        var content = TextBox("test")
             .Validate("email", "test", Validate.Required());
 
         var ff = FormField(content, label: "Email");

--- a/tests/Reactor.Tests/Localization/LocalizableStringScannerTests.cs
+++ b/tests/Reactor.Tests/Localization/LocalizableStringScannerTests.cs
@@ -247,7 +247,7 @@ public class LocalizableStringScannerTests
         var source = """
             class Settings : Component {
                 public override Element Render() {
-                    return TextField("", OnChanged).Header("User Name");
+                    return TextBox("", OnChanged).Header("User Name");
                 }
             }
             """;
@@ -382,7 +382,7 @@ public class LocalizableStringScannerTests
         var source = """
             class CatalogPage : Component {
                 public override Element Render() {
-                    return TextField("", null, placeholder: "Search products...");
+                    return TextBox("", null, placeholder: "Search products...");
                 }
             }
             """;

--- a/tests/Reactor.Tests/ReconcilerHelperTests.cs
+++ b/tests/Reactor.Tests/ReconcilerHelperTests.cs
@@ -141,14 +141,14 @@ public class ReconcilerHelperTests
     [Fact]
     public void ResolveCaptionForElement_TextField_Prefers_Header()
     {
-        var tf = new TextFieldElement("", Placeholder: "Enter name") { Header = "Name" };
+        var tf = new TextBoxElement("", Placeholder: "Enter name") { Header = "Name" };
         Assert.Equal("Name", Reconciler.ResolveCaptionForElement(tf));
     }
 
     [Fact]
     public void ResolveCaptionForElement_TextField_Falls_Back_To_Placeholder()
     {
-        var tf = new TextFieldElement("", Placeholder: "Enter name") { Header = null };
+        var tf = new TextBoxElement("", Placeholder: "Enter name") { Header = null };
         Assert.Equal("Enter name", Reconciler.ResolveCaptionForElement(tf));
     }
 

--- a/tests/Reactor.Tests/RichEditBoxElementTests.cs
+++ b/tests/Reactor.Tests/RichEditBoxElementTests.cs
@@ -138,7 +138,7 @@ public class RichEditBoxElementTests
     public void CanUpdate_RichEditBox_Vs_TextField_Returns_False()
     {
         var reconciler = new Reconciler();
-        Assert.False(reconciler.CanUpdate(RichEditBox("a"), TextField("a")));
+        Assert.False(reconciler.CanUpdate(RichEditBox("a"), TextBox("a")));
     }
 
     [Fact]

--- a/tests/Reactor.Tests/SetExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/SetExtensionsCoverageTests.cs
@@ -18,7 +18,7 @@ public class SetExtensionsCoverageTests
     [Fact]
     public void Set_TextField_Appends_Setter()
     {
-        var el = TextField("val").Set(tb => tb.IsEnabled = false);
+        var el = TextBox("val").Set(tb => tb.IsEnabled = false);
         Assert.Single(el.Setters);
     }
 

--- a/tests/Reactor.Tests/UseFocusTests.cs
+++ b/tests/Reactor.Tests/UseFocusTests.cs
@@ -67,7 +67,7 @@ public class UseFocusTests
     public void Focus_Extension_Registers_Field()
     {
         var fm = new FocusManager();
-        var el = TextField("test").Focus(fm, "email");
+        var el = TextBox("test").Focus(fm, "email");
 
         Assert.Contains("email", fm.Fields);
     }

--- a/tests/Reactor.Tests/UseFocusTests.cs
+++ b/tests/Reactor.Tests/UseFocusTests.cs
@@ -67,7 +67,7 @@ public class UseFocusTests
     public void Focus_Extension_Registers_Field()
     {
         var fm = new FocusManager();
-        var el = TextBox("test").Focus(fm, "email");
+        TextBox("test").Focus(fm, "email");
 
         Assert.Contains("email", fm.Fields);
     }

--- a/tests/Reactor.Tests/ValidateExtensionTests.cs
+++ b/tests/Reactor.Tests/ValidateExtensionTests.cs
@@ -14,7 +14,7 @@ public class ValidateExtensionTests
     [Fact]
     public void Validate_On_TextField_Attaches_Validators()
     {
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("email", Validate.Required(), Validate.Email());
 
         var attached = el.GetValidation();
@@ -26,10 +26,10 @@ public class ValidateExtensionTests
     [Fact]
     public void Validate_On_TextField_Preserves_Element_Type()
     {
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("email", Validate.Required());
 
-        Assert.IsType<TextFieldElement>(el);
+        Assert.IsType<TextBoxElement>(el);
         Assert.Equal("test", el.Value);
     }
 
@@ -71,12 +71,12 @@ public class ValidateExtensionTests
     [Fact]
     public void Validate_Can_Chain_With_Other_Modifiers()
     {
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("email", Validate.Required())
             .Margin(10)
             .Width(200);
 
-        Assert.IsType<TextFieldElement>(el);
+        Assert.IsType<TextBoxElement>(el);
         Assert.NotNull(el.GetValidation());
         Assert.NotNull(el.Modifiers);
         Assert.Equal(200, el.Modifiers!.Width);
@@ -85,7 +85,7 @@ public class ValidateExtensionTests
     [Fact]
     public void Validate_Merges_When_Called_Twice()
     {
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("email", Validate.Required())
             .Validate("email", Validate.Email());
 
@@ -106,7 +106,7 @@ public class ValidateExtensionTests
             return s.Length > 0;
         }, "Required");
 
-        var el = TextField("test")
+        var el = TextBox("test")
             .ValidateAsync("email", asyncValidator);
 
         var attached = el.GetValidation();
@@ -124,7 +124,7 @@ public class ValidateExtensionTests
             return true;
         }, "Async check");
 
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("email", Validate.Required())
             .ValidateAsync("email", asyncValidator);
 
@@ -243,7 +243,7 @@ public class ValidateExtensionTests
     [Fact]
     public void GetValidation_Returns_Null_When_No_Validators()
     {
-        var el = TextField("test");
+        var el = TextBox("test");
         Assert.Null(el.GetValidation());
     }
 }

--- a/tests/Reactor.Tests/ValidationVisualizerTests.cs
+++ b/tests/Reactor.Tests/ValidationVisualizerTests.cs
@@ -191,19 +191,19 @@ public class ValidationVisualizerTests
     [Fact]
     public void ShowErrors_Creates_Inline_Visualizer()
     {
-        var el = TextField("test")
+        var el = TextBox("test")
             .Validate("email", Validate.Required())
             .ShowErrors();
 
         Assert.IsType<ValidationVisualizerElement>(el);
         Assert.Equal(VisualizerStyle.Inline, el.Style);
-        Assert.IsType<TextFieldElement>(el.Content);
+        Assert.IsType<TextBoxElement>(el.Content);
     }
 
     [Fact]
     public void ShowErrors_Respects_ShowWhen()
     {
-        var el = TextField("test").ShowErrors(ShowWhen.WhenTouched);
+        var el = TextBox("test").ShowErrors(ShowWhen.WhenTouched);
         Assert.Equal(ShowWhen.WhenTouched, el.ShowWhen);
     }
 
@@ -216,7 +216,7 @@ public class ValidationVisualizerTests
     {
         var el = ValidationVisualizer(
             VisualizerStyle.Summary,
-            VStack(TextField("a"), TextField("b")),
+            VStack(TextBox("a"), TextBox("b")),
             title: "Please fix:");
 
         Assert.Equal(VisualizerStyle.Summary, el.Style);
@@ -244,7 +244,7 @@ public class ValidationVisualizerTests
     {
         var el = ValidationVisualizer(
             VisualizerStyle.InfoBar,
-            VStack(TextField("a")));
+            VStack(TextBox("a")));
 
         Assert.Equal(VisualizerStyle.InfoBar, el.Style);
     }
@@ -271,7 +271,7 @@ public class ValidationVisualizerTests
 
         var el = ValidationVisualizer(
             render: msgs => { receivedMessages = msgs; return TextBlock("errors"); },
-            content: TextField("a"));
+            content: TextBox("a"));
 
         Assert.Equal(VisualizerStyle.Custom, el.Style);
         Assert.NotNull(el.CustomRender);

--- a/tests/Reactor.WinFormsTests.Host/TestDuctComponent.cs
+++ b/tests/Reactor.WinFormsTests.Host/TestDuctComponent.cs
@@ -22,7 +22,7 @@ class TestReactorComponent : Component
                     .AutomationId("Reactor_Title"),
 
                 // Focusable text field — first Tab stop inside the island
-                TextField(text, setText, placeholder: "Type in island")
+                TextBox(text, setText, placeholder: "Type in island")
                     .Width(250)
                     .AutomationId("Reactor_TextField1")
                     .AutomationName("Island text field"),
@@ -39,7 +39,7 @@ class TestReactorComponent : Component
                     .AutomationId("Reactor_CountDisplay"),
 
                 // A second text field — third Tab stop
-                TextField("", _ => { }, placeholder: "Second field")
+                TextBox("", _ => { }, placeholder: "Second field")
                     .Width(250)
                     .AutomationId("Reactor_TextField2")
                     .AutomationName("Island second field"),

--- a/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Reactor/InteractivePoolApp.cs
+++ b/tests/perf_bench/PerfBench.InteractivePool/InteractivePool.Reactor/InteractivePoolApp.cs
@@ -81,7 +81,7 @@ public class InteractivePoolApp : Component
                 item => item.ButtonLabel,
                 (item, i) => HStack(8,
                     Button(item.ButtonLabel, () => { }),
-                    TextField(item.TextValue, _ => { }),
+                    TextBox(item.TextValue, _ => { }),
                     ToggleSwitch(item.IsToggled, _ => { })
                 ).Padding(2)
             ).Set(sv => scrollRef.Current = sv).Height(800)

--- a/tests/perf_bench/PerfBench.Priorities/Priorities.Reactor/PrioritiesApp.cs
+++ b/tests/perf_bench/PerfBench.Priorities/Priorities.Reactor/PrioritiesApp.cs
@@ -90,7 +90,7 @@ public class PrioritiesApp : Component
 
         var children = new List<Element?>
         {
-            TextField(searchText, text =>
+            TextBox(searchText, text =>
             {
                 _tracker.BeginUpdate();
                 setSearchText(text);

--- a/tools/Templates/templates/WinUIApp-CSharp/App.cs
+++ b/tools/Templates/templates/WinUIApp-CSharp/App.cs
@@ -32,7 +32,7 @@ class App : Component
         var body = Border(
             FlexColumn(
                 Heading($"Hello, {name}!"),
-                TextField(name, setName, placeholder: "Your name")
+                TextBox(name, setName, placeholder: "Your name")
                     .AutomationName("NameInput")
             ) with { RowGap = 16 }
         ).Padding(24).Flex(grow: 1, basis: 0);


### PR DESCRIPTION
## Summary

- Rename the record `TextFieldElement` → `TextBoxElement` and introduce `TextBox(...)` as the canonical DSL factory, matching WinUI's `Microsoft.UI.Xaml.Controls.TextBox`.
- Keep `TextField(...)` as a `[Obsolete(error: false)]` forwarding alias for one release; removal is scheduled for a follow-up PR.
- Update analyzers (`REACTOR_A11Y_003`) and the localization scanner to recognize **both** names so the deprecation window doesn't lose accessibility/localization coverage.
- Migrate all call sites — `src/Reactor/Controls/**`, `samples/**`, `docs/_pipeline/apps/**`, `tests/**`, `skills/**`, `plugins/reactor/skills/**`, root `SKILL.md` — to `TextBox(...)`.
- Update `docs/_pipeline/templates/*.md.dt`; regenerated `docs/guide/*.md` via `mur docs compile` (exit 0).
- `MaskedTextField` → `MaskedTextBox` is **intentionally deferred** to a follow-up PR; its docstring notes this.
- `RichEditBox` is left as-is to match WinUI naming.

## Test plan

- [ ] `dotnet build src/Reactor/Reactor.csproj` clean
- [ ] `dotnet test tests/Reactor.Tests`
- [ ] `dotnet test tests/Reactor.AppTests`
- [ ] `mur docs compile` clean (already verified locally)
- [ ] Spot-check that `TextField(...)` callers see CS0618 warning and that switching to `TextBox(...)` clears it
- [ ] Confirm `REACTOR_A11Y_003` still fires on `TextBox(value)` without a header / AutomationName / LabeledBy
- [ ] Confirm `mur check loc` still picks up `placeholder`/`header` strings from both `TextBox` and `TextField`

🤖 Generated with [Claude Code](https://claude.com/claude-code)