### PR TITLE
feat(045): cross-window tab dock-in (Center) + floating tab chrome

### DIFF
--- a/docs/specs/tasks/045-docking-windows-implementation.md
+++ b/docs/specs/tasks/045-docking-windows-implementation.md
@@ -596,9 +596,22 @@ WinUI.Dock wrapper for side-by-side review.
   WinUI.Dock string-keyed GUID table — spec §8.9 security).
   `DockDragSession` carries object refs to the dragged pane + source
   manager; there is no GUID table, no static dict keyed by string,
-  no serializable payload. Cross-window HWND-boundary drag itself
-  remains deferred to a follow-up (TabView's native cross-HWND drag
-  is the WinUI primitive there).
+  no serializable payload. **Cross-window HWND-boundary dock-in
+  (Center only) lands via a drop-completion cursor hit-test:**
+  `DockFloatingPaneRouter` (`src/Reactor/Docking/Native/`) maintains a
+  global `ReactorWindow → append-as-tab` registry; floating windows
+  self-register on mount (via dispatcher-deferred `UseEffect`) and
+  unregister on close. `HandleTabDragCompleted` (and the equivalent
+  hook on floating windows for floating→floating) Win32-hit-tests
+  `GetCursorPos` against each registered window's
+  `GetWindowRect` *before* falling back to tear-out, so a tab dropped
+  over another window's chrome appends as a new tab in that window's
+  tab group. The WinUI cross-window drag pipeline itself is
+  window-local (drag events do not cross XAML islands), so this
+  drop-completion hit-test is the canonical workaround; live-overlay
+  N/E/S/W targeting across windows remains deferred (the
+  `DockDropOverlayMode.CenterOnly` enum value is reserved for the
+  future overlay UX).
 - [x] Keyboard-initiated move: `Ctrl+Shift+M` enters drop-target focus
   mode (spec §5.3.3 / §8.7). Landed in §2.10 via the chord-bridge
   wiring on `DockHostNativeComponent.EnterKeyboardDropMode`; flips
@@ -2061,44 +2074,73 @@ re-run with new chrome plus eight visual items.
 
 ### 4.2 `TitleBar` control adoption (spec §7.1.1)
 
-- [ ] Floating dockable windows use
-  `Microsoft.UI.Xaml.Controls.TitleBar` as root chrome.
-- [ ] `ReactorWindow.NativeWindow.ExtendsContentIntoTitleBar = true`.
-- [ ] Root content gets `TitleBar` slot at top; docking tab strip lives
-  inside its content area.
-- [ ] Reactor's existing `TitleBar(...)` element (`src/Reactor/Elements/
-  Dsl.cs:610`, `TitleBarElement`) wires through `DockHost` for the
-  floating-window path.
+- [x] Floating dockable windows extend their content into the title-bar
+  zone so the tab strip becomes the visible chrome
+  (`WindowSpec.ExtendsContentIntoTitleBar = true`). *(The WinUI 3
+  `Microsoft.UI.Xaml.Controls.TitleBar` control is intentionally NOT
+  used here — its `Content` slot is a small in-row chrome slot
+  designed for things like Edge's address bar and cannot host a full
+  TabView with bodies. The Edge / Files pattern uses
+  `Window.SetTitleBar(...)` directly on a strip-footer drag region
+  instead. Reactor's `TitleBarElement` remains available for app
+  shells that want the control's distinct row layout.)*
+- [x] `ReactorWindow.NativeWindow.ExtendsContentIntoTitleBar = true`.
+- [x] Root content puts the docking tab strip in the title-bar zone
+  (Edge / Files / VS Code "tabs in title bar" layout).
+- [x] `Window.SetTitleBar(dragRegion)` is wired from a `TabStripFooter`
+  element so the OS reserves caption-button inset and treats the
+  footer area as window drag-move surface.
+
+*(Landed: `DockFloatingWindow.BuildFloatingRoot`
+(`src/Reactor/Docking/Native/DockFloatingWindow.cs`) renders the
+`DockTabGroup` as the floating window's root and adds a transparent
+`BorderElement` to `TabStripFooter` whose `OnMount` calls
+`floatingWindow.NativeWindow.SetTitleBar(self)`. `Open()` sets
+`WindowSpec.ExtendsContentIntoTitleBar = true`. Unit tests in
+`tests/Reactor.Tests/Docking/Native/DockFloatingWindowTests.cs`;
+visual coverage in selftest fixture
+`NativeDocking_FloatingWindow_TitleBarChromeAndTabsInTitleBar`.)*
 
 ### 4.3 Tabs in the title bar (spec §7.1.2) — headline feature
 
-- [ ] **Single-group float:** tab strip renders inside `TitleBar`
-  content slot, flush with caption buttons, active tab styles as
-  window's identity (Edge / Files / modern-VS pattern).
+- [x] **Single-group float:** tab strip occupies the title-bar zone at
+  y=0, flush with OS caption buttons, active tab styles as the
+  window's identity (Edge / Files / modern-VS pattern). *(Implemented
+  via `ExtendsContentIntoTitleBar=true` + TabView at root + drag
+  region in `TabStripFooter` registered via `Window.SetTitleBar`.)*
 - [ ] **Multi-group float:** revert to standard floating title (via
   `IDockAdapter.GetFloatingWindowTitleBar`); tabs render in normal pane
-  position. The same `GetFloatingWindowTitleBar` surface continues to
-  exist — it supplies the non-tab portion (text/branding) in both
-  modes.
+  position. *(Deferred: floating windows are single-pane today; the
+  multi-group float infrastructure itself is a separate slice.)*
 - [ ] Drag semantics:
-  - [ ] Drag a **tab** → tear it out (most-tested case; tab now lives
-    inside OS-managed title-bar hit-test surface).
-  - [ ] Drag **title-bar background** (non-tab, non-caption) → move
-    floating window. OS-handled.
+  - [x] Drag a **tab** → tear it out. *(Existing `onTabDragStarting`
+    path continues to work in the new layout.)*
+  - [x] Drag **title-bar background** (non-tab, non-caption) → move
+    floating window. *(OS-handled via the `TabStripFooter` drag region
+    registered with `Window.SetTitleBar` — `MinWidth(180)` ensures a
+    grabbable region even with many tabs.)*
   - [ ] Drag **active tab when it is the only tab** → moves whole
-    window (single-tab floats behave like normal windows).
+    window. *(Deferred: `onTabDragStarting` currently fires tear-out
+    unconditionally.)*
 - [ ] `AppWindow.TitleBar.SetDragRectangles` integration: hit-test
   regions computed per frame from tab-strip measured geometry; pushed
   to OS so it knows interactive vs drag-region sub-rects.
-- [ ] **Debounce `SetDragRectangles` to layout-measure-change events**
-  (not every-frame). Perf budget per spec §7.3 + §8.5.
+  *(N/A — we hand the OS a single `TabStripFooter` element via
+  `Window.SetTitleBar`, which is the modern WinUI 3 replacement for
+  explicit `SetDragRectangles` plumbing.)*
+- [ ] **Debounce `SetDragRectangles` to layout-measure-change events.**
+  *(N/A — see above.)*
 
 ### 4.4 Caption-button area awareness (spec §7.1.5)
 
-- [ ] Tab strip reserves `AppWindow.TitleBar.RightInset` as
-  right-padding (LeftInset in RTL).
-- [ ] Subscribe to `AppWindowTitleBar.LayoutMetricsChanged`; re-measure
-  on next layout pass (handles theme switch flipping RTL mid-flight).
+- [x] Tab strip reserves caption-button inset automatically — the
+  `Window.SetTitleBar(footer)` registration tells the OS where
+  caption buttons should sit (top-right) and the buttons render over
+  the right edge of the footer drag region.
+- [x] OS handles RTL / theme-switch caption-button placement via the
+  same `SetTitleBar` registration; no manual
+  `LayoutMetricsChanged` subscription required for the current
+  Window-level inset behavior.
 
 ### 4.5 Snap Layouts (spec §7.1.3)
 
@@ -2113,8 +2155,16 @@ re-run with new chrome plus eight visual items.
 - [ ] Floating dockable windows inherit `WindowSpec.Backdrop`
   (spec 036 §4.1, §5).
 - [ ] Splitter gutters semi-transparent under Mica / Acrylic.
-- [ ] Tab-strip background uses `TitleBarBackgroundFillBrush`, not a
-  hard color.
+- [x] Tab-strip background uses `TitleBarBackgroundFillBrush`, not a
+  hard color. *(Phase 4 slice landed: `TabChrome` enum on `DockTabGroup`
+  with `Win11` / `Flat` / `TitleBar` presets, scoped to each TabView's
+  `Resources` via `DockTabGroupRenderer.BuildSetters`. `TitleBar` preset
+  resolves `TitleBarBackgroundFillBrush` from `Application.Current.Resources`
+  and writes to `TabViewBackground`; pool-safe via a "blanker" setter
+  that strips all managed keys before applying a new preset. JSON
+  persistence: optional `tabChrome` field, omitted on `Win11` for
+  legacy-file back-compat. Dock-showcase **Scene I — Tab Styles** is
+  the visual gate input for §4.11 Item 23.)*
 
 ### 4.7 Dark mode / accent color (spec §7.1.6)
 
@@ -2124,9 +2174,15 @@ re-run with new chrome plus eight visual items.
 
 ### 4.8 Floating-window persona (spec §7.1.7)
 
-- [ ] Single-tab float: tab `Title` and `Icon` → `AppWindow.Title` and
-  `AppWindow.SetIcon`. Alt-tab shows the tab title.
-- [ ] Multi-tab float: active tab's title reflected.
+- [x] Single-tab float: tab `Title` → `AppWindow.Title`. Alt-tab shows
+  the tab title. *(Title landed: `DockFloatingWindow.Open` passes
+  `pane.Title` as `WindowSpec.Title`. Icon deferred: `DockableContent`
+  has no `Icon` field yet — adding one is a separate slice.
+  Note: in the Edge tabs-in-titlebar layout the tab itself displays
+  the title text; there is no separate WinUI 3 `TitleBar` widget to
+  also bind to. `AppWindow.Title` still controls taskbar / alt-tab.)*
+- [ ] Multi-tab float: active tab's title reflected. *(Deferred with
+  multi-tab float — see §4.3 above.)*
 - [ ] Composition with spec 036 §8 persistence: persisted Window
   identity is the dockable-window key, not the transient tab content.
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -89,6 +89,7 @@ InfoBadge() → InfoBadgeElement
 InfoBadge(int value) → InfoBadgeElement
 InfoBar(string title = null, string message = null) → InfoBarElement
 InterspersedGrid(Orientation orientation, Element[] items, double[] proportions, double separatorSize, Func<int, Element> separatorFactory) → GridElement
+ItemContainer(Element child) → ItemContainerElement
 ItemsView<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → ItemsViewElement<T>
 LazyHStack<T>(IReadOnlyList<T> items, Func<T, int, Element> viewBuilder) → LazyHStackElement<T>
 LazyHStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → LazyHStackElement<T>
@@ -346,6 +347,7 @@ InfoBarElement.Set(Action<InfoBar> configure) → InfoBarElement
 InfoBarElement.Severity(InfoBarSeverity severity) → InfoBarElement
 InfoBarElement.Success() → InfoBarElement
 InfoBarElement.Warning() → InfoBarElement
+ItemContainerElement.Set(Action<ItemContainer> configure) → ItemContainerElement
 ItemsViewElement<T>.ItemInvoked<T>(Action<T> handler) → ItemsViewElement<T>
 ItemsViewElement<T>.SelectionChanged<T>(Action<IReadOnlyList<T>> handler) → ItemsViewElement<T>
 ItemsViewElement<T>.Set<T>(Action<ItemsView> configure) → ItemsViewElement<T>
@@ -918,6 +920,7 @@ DockOperationKind { Mount, DragStart, DragHover, DragConfirm, DragCancel, DragTe
 DockPaneState { Docked, Floating, AutoHidden, AutoHiddenExpanded, Hidden }
 DockSide { Left, Top, Right, Bottom }
 DockTarget { Center, SplitLeft, SplitTop, SplitRight, SplitBottom, DockLeft, DockTop, DockRight, DockBottom }
+TabChrome { Win11, Flat, TitleBar }
 TabPosition { Top, Bottom }
 DragOperations { None, Copy, Move, Link, All }
 GesturePhase { Began, Changed, Ended, Cancelled }

--- a/samples/apps/dock-showcase/App.cs
+++ b/samples/apps/dock-showcase/App.cs
@@ -1142,7 +1142,7 @@ class SceneITabStyles : Component
         // Persistence note
         TextBlock(
             "Persistence — TabChrome serializes via the DockLayoutSerializer JSON; " +
-            "legacy layouts without the 	abChrome field default to Win11."
+            "legacy layouts without the tabChrome field default to Win11."
         ).Opacity(0.55).FontSize(11)
             .Grid(row: 5, column: 0, columnSpan: 2)
     ).Padding(16);

--- a/samples/apps/dock-showcase/App.cs
+++ b/samples/apps/dock-showcase/App.cs
@@ -63,7 +63,8 @@ class DockShowcaseRoot : Component
             SceneButton("persist",      "Scene E — Persistence",       scene, setScene),
             SceneButton("programmatic", "Scene F — Programmatic Dock", scene, setScene),
             SceneButton("sliders",      "Scene G — Slider Resize",     scene, setScene),
-            SceneButton("droptargets",  "Scene H — Drop Targets",      scene, setScene)
+            SceneButton("droptargets",  "Scene H — Drop Targets",      scene, setScene),
+            SceneButton("tabstyles",    "Scene I — Tab Styles",        scene, setScene)
         ).Width(240).Padding(8);
 
         Element body = scene switch
@@ -76,6 +77,7 @@ class DockShowcaseRoot : Component
             "programmatic" => Component<SceneFProgrammatic>(),
             "sliders"      => Component<SceneGSliders>(),
             "droptargets"  => Component<SceneHDropTargets>(),
+            "tabstyles"    => Component<SceneITabStyles>(),
             _              => TextBlock("Unknown scene"),
         };
 
@@ -1039,4 +1041,126 @@ class SceneGSliders : Component
             dock.Grid(row: 3)
         ).Padding(16);
     }
+}
+
+
+// ════════════════════════════════════════════════════════════════════════
+//  Scene I — Tab Styles (spec 045 §4.6)
+// ════════════════════════════════════════════════════════════════════════
+//
+//  Three tab-chrome presets side-by-side, plus the spec-documented
+//  fallback for TabPosition.Bottom (renders as Top in WinUI 3 — see
+//  microsoft-ui-xaml#7395; the upstream workaround requires subclassing
+//  TabViewItem to counter-scale the template parts).
+
+class SceneITabStyles : Component
+{
+    public override Element Render() => Grid(
+        new[] { GridSize.Star(1), GridSize.Star(1) },
+        new[] { GridSize.Auto, GridSize.Auto, GridSize.Star(1), GridSize.Star(1), GridSize.Auto, GridSize.Auto },
+
+        TextBlock("Scene I — Tab Styles").FontSize(20).SemiBold()
+            .Grid(row: 0, column: 0, columnSpan: 2),
+
+        TextBlock(
+            "Three preset chromes for DockTabGroup.TabChrome. Same underlying " +
+            "WinUI TabView (full accessibility/keyboard parity) — only theme " +
+            "resources differ. Pick whichever matches your app's identity."
+        ).Opacity(0.8).Margin(0, 0, 0, 12)
+            .Grid(row: 1, column: 0, columnSpan: 2),
+
+        // Top-left — Win11 default
+        StyleCard(
+            "Win11 (default)",
+            "Rounded corners, theme background. The shipping Win11 TabView look.",
+            new DockTabGroup(
+                Documents: new[]
+                {
+                    new DockableContent("Welcome.md",  ChromeBody("# Welcome",         "Win11"),  Key: "i:w11:welcome"),
+                    new DockableContent("App.cs",      ChromeBody("class App {…}",     "Win11"),  Key: "i:w11:appcs"),
+                    new DockableContent("README",      ChromeBody("Project readme.",    "Win11"), Key: "i:w11:readme"),
+                },
+                TabChrome: TabChrome.Win11))
+            .Grid(row: 2, column: 0),
+
+        // Top-right — Flat (VS Code-style)
+        StyleCard(
+            "Flat (VS Code style)",
+            "Zero corner radius, tighter header padding. Modeled on the modern IDE document strip.",
+            new DockTabGroup(
+                Documents: new[]
+                {
+                    new DockableContent("Welcome.md",  ChromeBody("# Welcome",         "Flat"),   Key: "i:flat:welcome"),
+                    new DockableContent("App.cs",      ChromeBody("class App {…}",     "Flat"),   Key: "i:flat:appcs"),
+                    new DockableContent("README",      ChromeBody("Project readme.",    "Flat"),  Key: "i:flat:readme"),
+                },
+                TabChrome: TabChrome.Flat))
+            .Grid(row: 2, column: 1),
+
+        // Bottom-left — TitleBar (mica-ish; tab strip uses the title-bar brush)
+        StyleCard(
+            "TitleBar (chromeless feel)",
+            "Tab strip uses the system TitleBarBackgroundFillBrush so the strip " +
+            "blends with the window chrome (effective when ExtendsContentIntoTitleBar is on).",
+            new DockTabGroup(
+                Documents: new[]
+                {
+                    new DockableContent("Welcome.md",  ChromeBody("# Welcome",         "TitleBar"), Key: "i:tb:welcome"),
+                    new DockableContent("App.cs",      ChromeBody("class App {…}",     "TitleBar"), Key: "i:tb:appcs"),
+                    new DockableContent("README",      ChromeBody("Project readme.",    "TitleBar"), Key: "i:tb:readme"),
+                },
+                TabChrome: TabChrome.TitleBar))
+            .Grid(row: 3, column: 0),
+
+        // Bottom-right — Flat + CompactTabs (full classic VS feel)
+        StyleCard(
+            "Flat + CompactTabs",
+            "Same flat chrome paired with tightly-packed tabs — the closest match " +
+            "to the dense tool-window strip in classic Visual Studio.",
+            new DockTabGroup(
+                Documents: new[]
+                {
+                    new DockableContent("Errors",     ChromeBody("0 errors.",           "Flat compact"), Key: "i:flatc:err"),
+                    new DockableContent("Warnings",   ChromeBody("12 warnings.",        "Flat compact"), Key: "i:flatc:warn"),
+                    new DockableContent("Output",     ChromeBody("Build complete.",     "Flat compact"), Key: "i:flatc:out"),
+                    new DockableContent("Terminal",   ChromeBody("PS> _",               "Flat compact"), Key: "i:flatc:term"),
+                },
+                TabChrome: TabChrome.Flat,
+                CompactTabs: true))
+            .Grid(row: 3, column: 1),
+
+        // Position note
+        TextBlock(
+            "Note — TabPosition.Bottom currently renders as Top under WinUI 3. " +
+            "Microsoft.UI.Xaml.Controls.TabView has no TabStripPlacement property " +
+            "(microsoft-ui-xaml#7395). Spec 045 §4.6 / DockTabGroupRenderer line 196 " +
+            "documents the deferral; a real bottom strip lands when a custom " +
+            "TabViewItem subclass replaces the shared WinUI template."
+        ).Opacity(0.65).FontSize(11).Margin(0, 12, 0, 4)
+            .Grid(row: 4, column: 0, columnSpan: 2),
+
+        // Persistence note
+        TextBlock(
+            "Persistence — TabChrome serializes via the DockLayoutSerializer JSON; " +
+            "legacy layouts without the 	abChrome field default to Win11."
+        ).Opacity(0.55).FontSize(11)
+            .Grid(row: 5, column: 0, columnSpan: 2)
+    ).Padding(16);
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    static Element StyleCard(string heading, string body, DockTabGroup group)
+        => VStack(6,
+            TextBlock(heading).SemiBold(),
+            TextBlock(body).Opacity(0.7).FontSize(11),
+            new DockManager { Layout = group }
+                .Height(180)
+                .Margin(0, 4, 0, 0)
+        ).Margin(0, 0, 8, 16);
+
+    static Element ChromeBody(string title, string chromeLabel)
+        => VStack(4,
+            TextBlock(title).SemiBold(),
+            TextBlock($"(rendered under TabChrome.{chromeLabel})").Opacity(0.55).FontSize(11)
+        ).Padding(12);
 }

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -89,6 +89,7 @@ InfoBadge() → InfoBadgeElement
 InfoBadge(int value) → InfoBadgeElement
 InfoBar(string title = null, string message = null) → InfoBarElement
 InterspersedGrid(Orientation orientation, Element[] items, double[] proportions, double separatorSize, Func<int, Element> separatorFactory) → GridElement
+ItemContainer(Element child) → ItemContainerElement
 ItemsView<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → ItemsViewElement<T>
 LazyHStack<T>(IReadOnlyList<T> items, Func<T, int, Element> viewBuilder) → LazyHStackElement<T>
 LazyHStack<T>(IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder) → LazyHStackElement<T>
@@ -346,6 +347,7 @@ InfoBarElement.Set(Action<InfoBar> configure) → InfoBarElement
 InfoBarElement.Severity(InfoBarSeverity severity) → InfoBarElement
 InfoBarElement.Success() → InfoBarElement
 InfoBarElement.Warning() → InfoBarElement
+ItemContainerElement.Set(Action<ItemContainer> configure) → ItemContainerElement
 ItemsViewElement<T>.ItemInvoked<T>(Action<T> handler) → ItemsViewElement<T>
 ItemsViewElement<T>.SelectionChanged<T>(Action<IReadOnlyList<T>> handler) → ItemsViewElement<T>
 ItemsViewElement<T>.Set<T>(Action<ItemsView> configure) → ItemsViewElement<T>
@@ -918,6 +920,7 @@ DockOperationKind { Mount, DragStart, DragHover, DragConfirm, DragCancel, DragTe
 DockPaneState { Docked, Floating, AutoHidden, AutoHiddenExpanded, Hidden }
 DockSide { Left, Top, Right, Bottom }
 DockTarget { Center, SplitLeft, SplitTop, SplitRight, SplitBottom, DockLeft, DockTop, DockRight, DockBottom }
+TabChrome { Win11, Flat, TitleBar }
 TabPosition { Top, Bottom }
 DragOperations { None, Copy, Move, Link, All }
 GesturePhase { Began, Changed, Ended, Cancelled }

--- a/src/Reactor/Docking/DockHostModel.cs
+++ b/src/Reactor/Docking/DockHostModel.cs
@@ -308,6 +308,23 @@ public sealed class DockHostModel
     /// </summary>
     /// <remarks>Spec 045 §2.16 — drain trigger.</remarks>
     internal Action? OnMutationQueued { get; set; }
+
+    /// <summary>
+    /// Spec 045 §4.2 cross-window dock-in. Invoked by a different window's
+    /// drop-target overlay (notably <see cref="DockFloatingWindow"/>) when
+    /// a pane belonging to this host's layout was dropped into a tab group
+    /// in that other window. The native host wires a closure that removes
+    /// the pane from this host's effective layout, stores the override,
+    /// fires <c>OnContentFloated</c> / <c>OnLiveLayoutChanged</c>, and
+    /// emits a diagnostics op-log entry. Null when the model is detached.
+    /// </summary>
+    /// <remarks>
+    /// The receiving overlay is responsible for adding the pane into its
+    /// own tab group BEFORE invoking this hook; calling order matters
+    /// only inasmuch as the source removal and destination insertion
+    /// both run synchronously on the UI thread.
+    /// </remarks>
+    internal Action<DockableContent>? OnExternalCrossWindowDrop { get; set; }
 }
 
 /// <summary>

--- a/src/Reactor/Docking/DockNode.cs
+++ b/src/Reactor/Docking/DockNode.cs
@@ -45,7 +45,8 @@ public sealed record DockTabGroup(
     bool ShowWhenEmpty = false,
     int SelectedIndex = -1,
     double? Width = null,
-    double? Height = null) : DockNode;
+    double? Height = null,
+    TabChrome TabChrome = TabChrome.Win11) : DockNode;
 
 /// <summary>
 /// A single dockable pane — the leaf of the dock tree. Carries

--- a/src/Reactor/Docking/Enums.cs
+++ b/src/Reactor/Docking/Enums.cs
@@ -12,6 +12,40 @@ public enum TabPosition
 }
 
 /// <summary>
+/// Visual chrome preset applied to a <see cref="DockTabGroup"/>'s tab strip.
+/// Maps onto WinUI <c>TabView</c> resource-dictionary overrides — the
+/// underlying control and accessibility tree are unchanged across presets.
+/// </summary>
+/// <remarks>
+/// Spec 045 §4.6 — partial close-out. Selecting a preset doesn't replace
+/// the control's template; it scopes a handful of theme-resource overrides
+/// to that one <c>TabView</c>. New presets land additively; default is
+/// <see cref="Win11"/> so existing layouts re-render unchanged.
+/// </remarks>
+public enum TabChrome
+{
+    /// <summary>
+    /// Default Windows 11 TabView look: rounded header corners, theme
+    /// background. No resource overrides applied.
+    /// </summary>
+    Win11,
+
+    /// <summary>
+    /// Sharp, dense IDE chrome: zero corner radius on tab headers, tighter
+    /// header padding. Modeled after the VS Code / classic-Visual-Studio
+    /// document-tab look.
+    /// </summary>
+    Flat,
+
+    /// <summary>
+    /// Tab-strip background uses <c>TitleBarBackgroundFillBrush</c> (when
+    /// available) so the strip blends into the system title bar. Corner
+    /// radius is unchanged from <see cref="Win11"/>. Spec 045 §4.6.
+    /// </summary>
+    TitleBar,
+}
+
+/// <summary>
 /// Where to dock a pane when programmatically issuing
 /// <c>DockTo(target, DockTarget)</c>. Split targets land inside the
 /// current group's split parent; edge targets land at the manager root.

--- a/src/Reactor/Docking/Native/DockDropTargetOverlayControl.cs
+++ b/src/Reactor/Docking/Native/DockDropTargetOverlayControl.cs
@@ -88,6 +88,14 @@ internal enum DockDropOverlayMode
     Host,
     /// <summary>Tab-group-scope 5-target overlay (Center + 4 splits).</summary>
     GroupInner,
+    /// <summary>
+    /// Floating-window-scope single-target overlay — only the Center button
+    /// surfaces (add-as-tab). Spec 045 §4.2 / §4.3: floating windows in the
+    /// tabs-in-titlebar layout don't host splits (would require collapsing
+    /// the titlebar pattern back to a standard chrome+content layout), so
+    /// the cross-window dock-in path is intentionally limited to Center.
+    /// </summary>
+    CenterOnly,
 }
 
 /// <summary>
@@ -261,6 +269,7 @@ internal sealed partial class DockDropTargetOverlayControl : Grid
         //     across its full area.
         if (_buttons is null) return;
         bool hostMode = _mode == DockDropOverlayMode.Host;
+        bool centerOnly = _mode == DockDropOverlayMode.CenterOnly;
         foreach (var entry in _buttons)
         {
             bool isEdge = entry.Target is DockTarget.DockLeft or DockTarget.DockRight
@@ -270,6 +279,19 @@ internal sealed partial class DockDropTargetOverlayControl : Grid
                 // Host: edges always visible (they're the only buttons
                 // surfaced); inner cluster always hidden.
                 entry.Button.Visibility = isEdge ? Visibility.Visible : Visibility.Collapsed;
+            }
+            else if (centerOnly)
+            {
+                // CenterOnly (spec 045 §4.2/§4.3 floating-window scope):
+                // edges always collapsed; inner cluster except Center
+                // permanently hidden; Center hidden until DragEnter
+                // reveals it.
+                if (isEdge || entry.Target != DockTarget.Center)
+                    entry.Button.Visibility = Visibility.Collapsed;
+                else
+                    entry.Button.Visibility = _groupOverlayRevealed
+                        ? Visibility.Visible
+                        : Visibility.Collapsed;
             }
             else
             {
@@ -695,11 +717,11 @@ internal sealed partial class DockDropTargetOverlayControl : Grid
 
     private void OnDragEnter(object sender, DragEventArgs e)
     {
-        // Per-group overlay: reveal its 5 inner buttons only while the
-        // drag is over THIS group. Reduces visual clutter to a single
-        // overlay at a time. Host-level overlay is unaffected (its
-        // 4 outer Dock-edge buttons are always visible).
-        if (_mode == DockDropOverlayMode.GroupInner)
+        // Per-group / center-only overlay: reveal its inner button(s)
+        // only while the drag is over THIS surface. Reduces visual
+        // clutter to a single overlay at a time. Host-level overlay is
+        // unaffected (its 4 outer Dock-edge buttons are always visible).
+        if (_mode == DockDropOverlayMode.GroupInner || _mode == DockDropOverlayMode.CenterOnly)
             SetGroupOverlayRevealed(true);
         var p = e.GetPosition(this);
         var target = HitTestForTarget(p);
@@ -716,7 +738,7 @@ internal sealed partial class DockDropTargetOverlayControl : Grid
         // Reveal-while-dragging: in case DragEnter was suppressed by
         // capture timing (e.g. fast drag entered the area), DragOver
         // is the safer signal for revealing.
-        if (_mode == DockDropOverlayMode.GroupInner)
+        if (_mode == DockDropOverlayMode.GroupInner || _mode == DockDropOverlayMode.CenterOnly)
             SetGroupOverlayRevealed(true);
         var p = e.GetPosition(this);
         var target = HitTestForTarget(p);
@@ -729,7 +751,7 @@ internal sealed partial class DockDropTargetOverlayControl : Grid
 
     private void OnDragLeave(object sender, DragEventArgs e)
     {
-        if (_mode == DockDropOverlayMode.GroupInner)
+        if (_mode == DockDropOverlayMode.GroupInner || _mode == DockDropOverlayMode.CenterOnly)
             SetGroupOverlayRevealed(false);
         if (_hoveredTarget is not null) SetHovered(null);
     }
@@ -758,7 +780,7 @@ internal sealed partial class DockDropTargetOverlayControl : Grid
             // expensive — instead of cancelling). Fire OverlayDismissed
             // so the host clears drag state.
             e.AcceptedOperation = DataPackageOperation.Move;
-            if (_mode == DockDropOverlayMode.GroupInner)
+            if (_mode == DockDropOverlayMode.GroupInner || _mode == DockDropOverlayMode.CenterOnly)
                 SetGroupOverlayRevealed(false);
             OverlayDismissed?.Invoke(this, EventArgs.Empty);
         }

--- a/src/Reactor/Docking/Native/DockDropTargetOverlayControl.cs
+++ b/src/Reactor/Docking/Native/DockDropTargetOverlayControl.cs
@@ -286,12 +286,9 @@ internal sealed partial class DockDropTargetOverlayControl : Grid
                 // edges always collapsed; inner cluster except Center
                 // permanently hidden; Center hidden until DragEnter
                 // reveals it.
-                if (isEdge || entry.Target != DockTarget.Center)
-                    entry.Button.Visibility = Visibility.Collapsed;
-                else
-                    entry.Button.Visibility = _groupOverlayRevealed
-                        ? Visibility.Visible
-                        : Visibility.Collapsed;
+                entry.Button.Visibility = (isEdge || entry.Target != DockTarget.Center)
+                    ? Visibility.Collapsed
+                    : (_groupOverlayRevealed ? Visibility.Visible : Visibility.Collapsed);
             }
             else
             {

--- a/src/Reactor/Docking/Native/DockFloatingPaneRouter.cs
+++ b/src/Reactor/Docking/Native/DockFloatingPaneRouter.cs
@@ -1,0 +1,138 @@
+using System.Runtime.InteropServices;
+using Microsoft.UI.Reactor.Hosting;
+
+namespace Microsoft.UI.Reactor.Docking.Native;
+
+// ════════════════════════════════════════════════════════════════════════
+//  Spec 045 §4.2 / §4.3 — cross-window tab dock-in router.
+//
+//  WinUI's `TabView.CanDragTabs` drag pipeline is window-local: drag
+//  events (`DragEnter` / `DragOver` / `Drop`) fire only on `AllowDrop`
+//  elements inside the SAME XAML island as the source TabView. A drag
+//  initiated in window A does NOT deliver events to AllowDrop elements
+//  in window B — so the `DockDropTargetOverlay` mounted inside a floating
+//  window never sees the drag and can't reveal its drop targets.
+//
+//  This router lets the SOURCE host (the window that owns the dragged
+//  pane) detect at drop-completion time whether the cursor is over a
+//  registered floating window, and if so, route the pane there as a
+//  new tab (the "Add as tab" / Center target — spec §4.2 limits the
+//  cross-window dock-in to Center to avoid the splits-in-titlebar
+//  problem documented in §4.3).
+//
+//  Each `DockFloatingWindowComponent` registers itself on mount with a
+//  closure that appends a pane to its local pane state, and unregisters
+//  on unmount. The source host iterates the registry, checks the
+//  cursor's screen position against each registered window's HWND rect,
+//  and invokes the matching appender when a hit is found.
+// ════════════════════════════════════════════════════════════════════════
+
+internal static class DockFloatingPaneRouter
+{
+    // Lock around the dictionary — Register / Unregister are called
+    // from the UI thread but TryAppendUnderCursor is called from
+    // tab-drag-completed which is also UI thread; the lock guards
+    // against future scenarios where a teardown races a hit-test.
+    private static readonly object _gate = new();
+    private static readonly Dictionary<ReactorWindow, Action<DockableContent>> _appenders = new();
+
+    /// <summary>
+    /// Registers an "append-as-tab" callback for the given floating window.
+    /// Called by <see cref="DockFloatingWindowComponent"/> from its
+    /// <c>UseEffect</c> mount handler.
+    /// </summary>
+    public static void Register(ReactorWindow window, Action<DockableContent> append)
+    {
+        lock (_gate) _appenders[window] = append;
+    }
+
+    /// <summary>
+    /// Removes the registration. Called from the matching <c>UseEffect</c>
+    /// cleanup so the dictionary doesn't leak when a floating window closes.
+    /// </summary>
+    public static void Unregister(ReactorWindow window)
+    {
+        lock (_gate) _appenders.Remove(window);
+    }
+
+    /// <summary>
+    /// Hit-tests the current cursor screen position against every registered
+    /// floating window's HWND rect. When a hit is found, invokes that
+    /// window's appender with <paramref name="pane"/> and returns
+    /// <c>true</c>. Returns <c>false</c> when the cursor is not over any
+    /// registered floating window (caller should fall back to its normal
+    /// tear-out / cancel path).
+    /// </summary>
+    public static bool TryAppendUnderCursor(DockableContent pane)
+    {
+        if (!NativeInterop.GetCursorPos(out var cursor))
+            return false;
+
+        // Copy the snapshot under lock so we can iterate without holding
+        // it across the appender invocation (which mutates component
+        // state and may re-enter).
+        KeyValuePair<ReactorWindow, Action<DockableContent>>[] snapshot;
+        lock (_gate)
+        {
+            if (_appenders.Count == 0) return false;
+            snapshot = new KeyValuePair<ReactorWindow, Action<DockableContent>>[_appenders.Count];
+            int i = 0;
+            foreach (var kv in _appenders) snapshot[i++] = kv;
+        }
+
+        for (int i = 0; i < snapshot.Length; i++)
+        {
+            var win = snapshot[i].Key;
+            global::Microsoft.UI.Xaml.Window? native;
+            try { native = win.NativeWindow; }
+            catch { continue; }
+            if (native is null) continue;
+            nint hwnd;
+            try { hwnd = WinRT.Interop.WindowNative.GetWindowHandle(native); }
+            catch { continue; }
+            if (hwnd == 0) continue;
+            if (!NativeInterop.GetWindowRect(hwnd, out var rect)) continue;
+            if (cursor.X < rect.Left || cursor.X >= rect.Right) continue;
+            if (cursor.Y < rect.Top || cursor.Y >= rect.Bottom) continue;
+
+            // Bring the window forward so the user has visible
+            // confirmation that the pane landed there (matches the
+            // perceived UX of "I dropped it on the floating window").
+            try { NativeInterop.SetForegroundWindow(hwnd); } catch { /* best-effort */ }
+            snapshot[i].Value(pane);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// True when any floating window is currently registered. Lets the
+    /// source host fast-skip the hit-test when no floating windows exist.
+    /// </summary>
+    public static bool HasRegisteredWindows
+    {
+        get { lock (_gate) return _appenders.Count > 0; }
+    }
+
+    // ── Win32 hit-test interop ────────────────────────────────────────
+    private static class NativeInterop
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        public struct POINT { public int X; public int Y; }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RECT { public int Left, Top, Right, Bottom; }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetCursorPos(out POINT lpPoint);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetWindowRect(nint hwnd, out RECT lpRect);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetForegroundWindow(nint hwnd);
+    }
+}

--- a/src/Reactor/Docking/Native/DockFloatingPaneRouter.cs
+++ b/src/Reactor/Docking/Native/DockFloatingPaneRouter.cs
@@ -84,12 +84,20 @@ internal static class DockFloatingPaneRouter
         {
             var win = snapshot[i].Key;
             global::Microsoft.UI.Xaml.Window? native;
+            // Typed catches for the recoverable cases we expect when a
+            // floating window is mid-close / disposed / WinRT proxy is
+            // torn down. Anything else propagates so unknown failures
+            // don't get silently swallowed.
             try { native = win.NativeWindow; }
-            catch { continue; }
+            catch (COMException) { continue; }
+            catch (ObjectDisposedException) { continue; }
+            catch (InvalidOperationException) { continue; }
             if (native is null) continue;
             nint hwnd;
             try { hwnd = WinRT.Interop.WindowNative.GetWindowHandle(native); }
-            catch { continue; }
+            catch (COMException) { continue; }
+            catch (ObjectDisposedException) { continue; }
+            catch (InvalidOperationException) { continue; }
             if (hwnd == 0) continue;
             if (!NativeInterop.GetWindowRect(hwnd, out var rect)) continue;
             if (cursor.X < rect.Left || cursor.X >= rect.Right) continue;
@@ -98,7 +106,14 @@ internal static class DockFloatingPaneRouter
             // Bring the window forward so the user has visible
             // confirmation that the pane landed there (matches the
             // perceived UX of "I dropped it on the floating window").
-            try { NativeInterop.SetForegroundWindow(hwnd); } catch { /* best-effort */ }
+            // SetForegroundWindow is best-effort: Windows refuses the
+            // foreground promotion under several documented conditions
+            // (foreground-lock timer, no input focus on caller) — these
+            // surface as a benign Win32 SetLastError, not an exception,
+            // but be defensive about COM/disposed shutdowns regardless.
+            try { NativeInterop.SetForegroundWindow(hwnd); }
+            catch (COMException) { /* best-effort */ }
+            catch (ObjectDisposedException) { /* best-effort */ }
             snapshot[i].Value(pane);
             return true;
         }

--- a/src/Reactor/Docking/Native/DockFloatingWindow.cs
+++ b/src/Reactor/Docking/Native/DockFloatingWindow.cs
@@ -78,12 +78,17 @@ public static class DockFloatingWindow
             Height = bounds?.Height ?? height,
             Owner = owner,
             // Spec 045 §4.2 — floating dockable windows extend their
-            // content into the title-bar zone so the wrapping
-            // `TitleBarElement` (which mounts to WinUI 3
-            // `Microsoft.UI.Xaml.Controls.TitleBar`) acts as the
-            // window's chrome. MountTitleBar then auto-calls
-            // Window.SetTitleBar so OS drag-move + caption inset are
-            // wired without app-side plumbing (§4.4).
+            // content into the title-bar zone so the docking TabView
+            // (rendered as the window's root by BuildChrome) acts as
+            // the window's visible chrome. The drag region is a
+            // transparent BorderElement placed in the TabView's
+            // TabStripFooter; its OnMount calls Window.SetTitleBar so
+            // the OS reserves the caption-button inset and treats the
+            // footer area as a window drag-move surface (§4.4).
+            // We do NOT use Microsoft.UI.Xaml.Controls.TitleBar /
+            // TitleBarElement here — its Content slot is an in-row
+            // chrome slot (Edge address-bar style) and cannot host a
+            // full TabView with bodies.
             ExtendsContentIntoTitleBar = true,
         };
 
@@ -266,8 +271,24 @@ public static class DockFloatingWindow
                     var win = windowHolder[0]?.NativeWindow;
                     win?.SetTitleBar(fe);
                 }
-                if (fe.IsLoaded) Apply();
-                else fe.Loaded += (_, _) => Apply();
+                if (fe.IsLoaded)
+                {
+                    Apply();
+                }
+                else
+                {
+                    global::Microsoft.UI.Xaml.RoutedEventHandler? handler = null;
+                    handler = (_, _) =>
+                    {
+                        // One-shot: SetTitleBar only needs to be wired
+                        // once, and WinUI Loaded can re-fire on
+                        // reparent/reload. Unsubscribe ourselves so we
+                        // don't leak the delegate or re-call SetTitleBar.
+                        if (handler is not null) fe.Loaded -= handler;
+                        Apply();
+                    };
+                    fe.Loaded += handler;
+                }
             });
 
         return rendered with { TabStripFooter = dragRegion };
@@ -313,6 +334,32 @@ internal sealed class DockFloatingWindowComponent : Component<DockFloatingWindow
         var holder = Props.WindowHolder;
         var manager = Props.Manager;
 
+        // Shared append-as-tab callback. Used by both the UseEffect
+        // router registration AND the floating→floating drag-completed
+        // gap reAppend below — keeping a single implementation
+        // guarantees that any side-effect (notably the AppWindow title
+        // update on first-tab append) stays consistent across both
+        // registration paths.
+        Action<DockableContent> append = src =>
+        {
+            updatePanes(current =>
+            {
+                for (int i = 0; i < current.Count; i++)
+                    if (ReferenceEquals(current[i], src)) return current;
+                var list = new List<DockableContent>(current.Count + 1);
+                list.AddRange(current);
+                list.Add(src);
+                return list;
+            });
+            try
+            {
+                var win = holder[0];
+                var native = win?.NativeWindow;
+                if (native is not null) native.Title = src.Title ?? string.Empty;
+            }
+            catch { /* window may already be closing */ }
+        };
+
         // Register an append-as-tab callback so the source host's
         // `HandleTabDragCompleted` can route a cross-window dock-in
         // (cursor over this floating window at drop time) to us
@@ -329,25 +376,6 @@ internal sealed class DockFloatingWindowComponent : Component<DockFloatingWindow
         // the floating window invisible to the cross-window router.
         UseEffect(() =>
         {
-            Action<DockableContent> append = src =>
-            {
-                updatePanes(current =>
-                {
-                    for (int i = 0; i < current.Count; i++)
-                        if (ReferenceEquals(current[i], src)) return current;
-                    var list = new List<DockableContent>(current.Count + 1);
-                    list.AddRange(current);
-                    list.Add(src);
-                    return list;
-                });
-                try
-                {
-                    var win = holder[0];
-                    var native = win?.NativeWindow;
-                    if (native is not null) native.Title = src.Title ?? string.Empty;
-                }
-                catch { /* window may already be closing */ }
-            };
             bool alive = true;
             ReactorWindow? registered = null;
             var dispatcher = global::Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
@@ -459,23 +487,16 @@ internal sealed class DockFloatingWindowComponent : Component<DockFloatingWindow
                     finally
                     {
                         // Re-register ourselves so subsequent drags
-                        // can target us again.
+                        // can target us again. Reuse the shared
+                        // `append` closure declared above so a pane
+                        // appended via this gap-bridge still updates
+                        // the AppWindow title — the UseEffect
+                        // re-registration on the next render would
+                        // restore that behavior eventually, but the
+                        // window may be a drop target during the gap.
                         if (ownWindow is not null)
                         {
-                            // Re-build the same closure (UseEffect will
-                            // re-register on next render too, but this
-                            // bridges the small gap until then).
-                            Action<DockableContent> reAppend = src =>
-                                updatePanes(current =>
-                                {
-                                    for (int i = 0; i < current.Count; i++)
-                                        if (ReferenceEquals(current[i], src)) return current;
-                                    var list = new List<DockableContent>(current.Count + 1);
-                                    list.AddRange(current);
-                                    list.Add(src);
-                                    return list;
-                                });
-                            DockFloatingPaneRouter.Register(ownWindow, reAppend);
+                            DockFloatingPaneRouter.Register(ownWindow, append);
                         }
                     }
                 }
@@ -496,13 +517,6 @@ internal sealed class DockFloatingWindowComponent : Component<DockFloatingWindow
         return chrome
             .Provide(DockContexts.Pane, (DockPaneInfo?)info)
             .Provide(DockContexts.PaneState, DockPaneState.Floating);
-    }
-
-    private static bool ContainsByRef(IReadOnlyList<DockableContent> list, DockableContent target)
-    {
-        for (int i = 0; i < list.Count; i++)
-            if (ReferenceEquals(list[i], target)) return true;
-        return false;
     }
 }
 

--- a/src/Reactor/Docking/Native/DockFloatingWindow.cs
+++ b/src/Reactor/Docking/Native/DockFloatingWindow.cs
@@ -1,6 +1,8 @@
 using System.Runtime.CompilerServices;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Hosting;
+using Microsoft.UI.Xaml;
+using static Microsoft.UI.Reactor.Factories;
 
 namespace Microsoft.UI.Reactor.Docking.Native;
 
@@ -75,6 +77,14 @@ public static class DockFloatingWindow
             Width = bounds?.Width ?? width,
             Height = bounds?.Height ?? height,
             Owner = owner,
+            // Spec 045 §4.2 — floating dockable windows extend their
+            // content into the title-bar zone so the wrapping
+            // `TitleBarElement` (which mounts to WinUI 3
+            // `Microsoft.UI.Xaml.Controls.TitleBar`) acts as the
+            // window's chrome. MountTitleBar then auto-calls
+            // Window.SetTitleBar so OS drag-move + caption inset are
+            // wired without app-side plumbing (§4.4).
+            ExtendsContentIntoTitleBar = true,
         };
 
         // Wrap the pane content with the same DockContext envelope used
@@ -88,7 +98,10 @@ public static class DockFloatingWindow
         // by the host's dispatcher loop after OpenWindow returns, so
         // the holder is always populated by the time it's read.
         var windowHolder = new ReactorWindow?[] { null };
-        var window = ReactorApp.OpenWindow(spec, _ => BuildFloatingRoot(pane, windowHolder, manager));
+        var window = ReactorApp.OpenWindow(spec, _ =>
+            new Microsoft.UI.Reactor.Core.ComponentElement<DockFloatingWindowProps>(
+                typeof(DockFloatingWindowComponent),
+                new DockFloatingWindowProps(pane, windowHolder, manager)));
         windowHolder[0] = window;
         DockFloatingTracker.Register(window);
         DockFloatingTracker.RegisterEntry(window, pane, spec.Width, spec.Height);
@@ -118,73 +131,378 @@ public static class DockFloatingWindow
         return window;
     }
 
-    private static Element BuildFloatingRoot(DockableContent pane, ReactorWindow?[] windowHolder, DockManager? manager)
+    // Internal so the unit tests can exercise the floating-window
+    // visual-tree shape (TitleBar wrap + tab chrome) without spinning
+    // up a real WinUI window. The render-time host wiring still goes
+    // through `Open()` for full coverage; unit tests assert tree
+    // structure only.
+    internal static Element BuildFloatingRoot(DockableContent pane, ReactorWindow?[] windowHolder, DockManager? manager)
     {
-        // Spec 045 §2.4 cross-window dock-back. The floating window's
-        // content is a `DockTabGroup`-rendered `TabView` with the pane
-        // as its single tab. The tab carries CanDragTabs=true so the
-        // user can drag it OUT of the floating window — when WinUI
-        // signals wasOutside=true, our handler:
-        //   • If session.Current is null after the drag, the drop was
-        //     consumed by another host's overlay (e.g. the main shell's
-        //     per-group cluster). Close this floating window so the
-        //     pane only lives in the destination.
-        //   • Otherwise the drop landed nowhere (Esc, drop on desktop,
-        //     unrecognised surface). End the session and keep the pane
-        //     here — preserves the user's pane against an accidental
-        //     drag.
-        //
-        // The chrome wrapper also gives the floating window a visible
-        // tab header (Title + close-X), addressing the §2.6 "tab header
-        // missing in floating window" gap that drove this slice.
-        var tabGroup = new DockTabGroup(new DockableContent[] { pane });
-        var info = new DockPaneInfo(pane.Key, pane.Title ?? string.Empty, pane);
-        var rendered = DockTabGroupRenderer.Render(
-            tabGroup,
-            renderLeafContent: doc => doc.Content ?? (Element)new BorderElement(null),
-            onSelectedIndexChanged: null,
+        var chrome = BuildChrome(
+            new[] { pane },
+            windowHolder,
+            manager,
             onTabClosing: _ =>
             {
-                // Closing the last tab closes the window.
+                // Closing the last tab closes the window. Single-pane
+                // legacy path keeps this 1:1; the multi-pane component
+                // overrides this with state-driven removal logic.
                 windowHolder[0]?.Close();
             },
-            onTabDragStarting: (doc, _) =>
+            onTabDragCompleted: (_, _) =>
             {
-                // Begin a cross-window session. The `manager` reference
-                // is the main host that originally owned this pane —
-                // SourceManager is non-null per the session contract.
-                if (DockDragSession.Current is { IsActive: true }) return;
-                if (manager is null) return;
-                DockDragSession.Begin(doc, manager, 0);
-            },
-            onTabDragCompleted: (_, _, _) =>
-            {
-                // Cross-window dock-back signal: a dock surface
-                // (this app's main host or any other DockHost) set
-                // `DockDragSession.Consumed = true` in its overlay
-                // OnConfirm before ending the session. When we see
-                // that here, the pane has been re-docked into another
-                // host and this floating window should close.
-                //
-                // `wasOutside` is unreliable for this decision because
-                // the receiving overlay accepts the drop with
-                // `DataPackageOperation.Move` to suppress WinUI's
-                // tear-out fallback — that flips wasOutside to false
-                // even though the tab visually left every TabView.
                 if (DockDragSession.Consumed)
                 {
                     windowHolder[0]?.Close();
                     return;
                 }
-                // Drop landed outside any docking surface (or session
-                // is still running). End any in-flight session so the
-                // pane stays put in this floating window.
                 DockDragSession.Current?.Cancel();
             });
 
-        return rendered
+        var info = new DockPaneInfo(pane.Key, pane.Title ?? string.Empty, pane);
+        return chrome
             .Provide(DockContexts.Pane, (DockPaneInfo?)info)
             .Provide(DockContexts.PaneState, DockPaneState.Floating);
+    }
+
+    // Shared TabViewElement builder. Constructs the DockTabGroup-rendered
+    // tab strip plus the TabStripFooter drag-region element that gets
+    // registered with the window via `SetTitleBar` on Loaded. Caller
+    // controls what happens on tab-close / tab-drag-complete so the
+    // multi-pane Component can drive state mutations while the
+    // single-pane legacy path closes the window directly.
+    //
+    // Spec 045 §2.4 cross-window dock-back. The floating window's
+    // content is a `DockTabGroup`-rendered `TabView`. The tabs carry
+    // CanDragTabs=true so the user can drag one OUT — when WinUI
+    // signals wasOutside / tear-out, the caller's
+    // `onTabDragCompleted` runs and decides whether to close the
+    // window or restore the drag.
+    //
+    // Spec 045 §4.2 / §4.3 — Edge / Files / VS Code "tabs in the
+    // title bar" pattern. The TabView lives at the root of the
+    // floating window. Combined with `WindowSpec.ExtendsContent
+    // IntoTitleBar = true`, the tab strip occupies the title-bar
+    // zone at y=0 (flush against caption buttons) and the tab
+    // body fills the client area below.
+    //
+    // Why not the WinUI 3 `Microsoft.UI.Xaml.Controls.TitleBar`
+    // control? Its `Content` slot is a small in-row chrome slot
+    // (intended for things like Edge's address bar) and cannot
+    // host a TabView with bodies — putting a TabView there
+    // collapses the body to zero height. The Edge pattern instead
+    // uses `Window.SetTitleBar(dragRegion)` directly against a
+    // strip-footer element (between last tab and caption buttons)
+    // so the OS knows where dragging is enabled while caption
+    // buttons float at the right via `ExtendsContentIntoTitleBar`.
+    internal static TabViewElement BuildChrome(
+        IReadOnlyList<DockableContent> panes,
+        ReactorWindow?[] windowHolder,
+        DockManager? manager,
+        Action<DockableContent> onTabClosing,
+        Action<DockableContent, bool> onTabDragCompleted)
+    {
+        var tabGroup = new DockTabGroup(
+            panes is DockableContent[] arr ? arr : panes.ToArray(),
+            // §4.6 + §7.1.4 — the tab strip background uses
+            // `TitleBarBackgroundFillBrush` so it visually merges into
+            // the OS title-bar zone (single continuous chrome row).
+            TabChrome: TabChrome.TitleBar);
+        var rendered = (TabViewElement)DockTabGroupRenderer.Render(
+            tabGroup,
+            renderLeafContent: doc => doc.Content ?? (Element)new BorderElement(null),
+            onSelectedIndexChanged: null,
+            onTabClosing: onTabClosing,
+            onTabDragStarting: (doc, idx) =>
+            {
+                // Begin a cross-window session. The `manager` reference
+                // is the host that originally owned this pane —
+                // SourceManager is non-null per the session contract.
+                if (DockDragSession.Current is { IsActive: true }) return;
+                if (manager is null) return;
+                DockDragSession.Begin(doc, manager, idx);
+            },
+            onTabDragCompleted: (pane, _, wasOutside) => onTabDragCompleted(pane, wasOutside));
+
+        // Spec 045 §4.2 / §4.4 — drag-region element in TabStripFooter.
+        // The footer lays out in TabView's template column with
+        // `Width="*"`, so a `HAlign(Stretch)` Border with a transparent
+        // background fills the entire empty area between the last tab
+        // and the OS caption-button cluster. On Loaded we hand this
+        // element to `Window.SetTitleBar(...)` so the OS treats it as
+        // the window-drag surface and reserves caption-button inset on
+        // its right (the new WinUI 3 caption inset handling).
+        //
+        // The Background brush must be set (even Transparent) for the
+        // OS to recognize the element as occupying space — a Border
+        // with `Background = null` is treated as zero-area for drag
+        // hit-testing and dragging the empty space won't move the
+        // window. We assign the brush inside OnMount rather than via
+        // `.Background("Transparent")` because that helper calls
+        // `BrushHelper.Parse` eagerly at element-tree-build time,
+        // constructing a WinRT `SolidColorBrush` — which throws a
+        // bare COMException in headless unit tests where no WinUI
+        // runtime is loaded. OnMount only fires at reconcile time
+        // under a real WinUI host, so brush creation is deferred to
+        // a safe context.
+        //
+        // `SetTitleBar` is deferred to FrameworkElement.Loaded because
+        // OnMount fires during reconcile, BEFORE `_window.Content` is
+        // assigned at the end of the reconcile pass — so at OnMount
+        // time the Border lives in a detached subtree and SetTitleBar
+        // silently no-ops.
+        var dragRegion = new BorderElement(null)
+            .HAlign(HorizontalAlignment.Stretch)
+            .VAlign(VerticalAlignment.Stretch)
+            .MinWidth(180)
+            .OnMount(fe =>
+            {
+                if (fe is global::Microsoft.UI.Xaml.Controls.Border border)
+                {
+                    border.Background = BrushHelper.Parse("Transparent");
+                }
+                void Apply()
+                {
+                    var win = windowHolder[0]?.NativeWindow;
+                    win?.SetTitleBar(fe);
+                }
+                if (fe.IsLoaded) Apply();
+                else fe.Loaded += (_, _) => Apply();
+            });
+
+        return rendered with { TabStripFooter = dragRegion };
+    }
+}
+
+/// <summary>
+/// Props for <see cref="DockFloatingWindowComponent"/> — the per-window
+/// boot tuple. Equality drives <see cref="Component{TProps}.ShouldUpdate"/>;
+/// these references are stable for the lifetime of a floating window so
+/// the component never re-mounts.
+/// </summary>
+internal sealed record DockFloatingWindowProps(
+    DockableContent InitialPane,
+    ReactorWindow?[] WindowHolder,
+    DockManager? Manager);
+
+/// <summary>
+/// Stateful component for floating windows. Owns the per-window tab list
+/// (so cross-window dock-in can add tabs without re-mounting), subscribes
+/// to <see cref="DockDragSession.SessionChanged"/> to surface the
+/// CenterOnly drop overlay (spec 045 §4.2 / §4.3) when a foreign drag is
+/// in flight, and removes consumed tabs from local state on tab-drag-out.
+/// </summary>
+internal sealed class DockFloatingWindowComponent : Component<DockFloatingWindowProps>
+{
+    public override Element Render()
+    {
+        var (panes, updatePanes) = UseReducer<IReadOnlyList<DockableContent>>(new[] { Props.InitialPane });
+        var (_, bumpTick) = UseReducer(0);
+
+        // §2.4 cross-window — re-render whenever any drag session in
+        // the process starts / ends. The session is global so we can't
+        // depend on prop-equality; UseEffect attaches once and the
+        // tick reducer triggers re-renders without inflating state.
+        UseEffect(() =>
+        {
+            Action onChanged = () => bumpTick(t => t + 1);
+            DockDragSession.SessionChanged += onChanged;
+            return () => DockDragSession.SessionChanged -= onChanged;
+        });
+
+        var holder = Props.WindowHolder;
+        var manager = Props.Manager;
+
+        // Register an append-as-tab callback so the source host's
+        // `HandleTabDragCompleted` can route a cross-window dock-in
+        // (cursor over this floating window at drop time) to us
+        // without needing a direct reference to this component
+        // instance. See `DockFloatingPaneRouter` for the rationale
+        // around drop-time hit-testing vs. WinUI drag events.
+        //
+        // The registration is deferred to the next dispatcher tick
+        // because this UseEffect mount fires synchronously during
+        // `ReactorApp.OpenWindow` → `MountAndActivate` — BEFORE
+        // `DockFloatingWindow.Open` writes `windowHolder[0] = window`
+        // after OpenWindow returns. Reading `holder[0]` directly here
+        // would always see null and skip the registration, leaving
+        // the floating window invisible to the cross-window router.
+        UseEffect(() =>
+        {
+            Action<DockableContent> append = src =>
+            {
+                updatePanes(current =>
+                {
+                    for (int i = 0; i < current.Count; i++)
+                        if (ReferenceEquals(current[i], src)) return current;
+                    var list = new List<DockableContent>(current.Count + 1);
+                    list.AddRange(current);
+                    list.Add(src);
+                    return list;
+                });
+                try
+                {
+                    var win = holder[0];
+                    var native = win?.NativeWindow;
+                    if (native is not null) native.Title = src.Title ?? string.Empty;
+                }
+                catch { /* window may already be closing */ }
+            };
+            bool alive = true;
+            ReactorWindow? registered = null;
+            var dispatcher = global::Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+            void TryRegister()
+            {
+                if (!alive) return;
+                var win = holder[0];
+                if (win is null)
+                {
+                    // Holder still not populated — try again on the
+                    // next dispatcher tick. OpenWindow's caller writes
+                    // holder[0] immediately after the call returns;
+                    // a single re-enqueue handles the common case.
+                    dispatcher?.TryEnqueue(TryRegister);
+                    return;
+                }
+                DockFloatingPaneRouter.Register(win, append);
+                registered = win;
+            }
+            if (dispatcher is not null) dispatcher.TryEnqueue(TryRegister);
+            else TryRegister();
+            return () =>
+            {
+                alive = false;
+                if (registered is not null) DockFloatingPaneRouter.Unregister(registered);
+            };
+        });
+
+        var currentPanes = panes;
+
+        void RemoveLocal(DockableContent pane)
+        {
+            // Filter by reference (Key equality is unreliable — apps
+            // can ship multiple panes with the same Key). When the
+            // pane list empties, close the window so the user isn't
+            // left with an empty floating shell. The window-close
+            // side-effect lives outside the reducer so it only fires
+            // once even if React-strict-mode double-invokes; reading
+            // current.Count==1 after the filter is the trigger.
+            bool willEmpty = false;
+            string? newTitle = null;
+            updatePanes(current =>
+            {
+                var keep = new List<DockableContent>(current.Count);
+                for (int i = 0; i < current.Count; i++)
+                {
+                    if (!ReferenceEquals(current[i], pane))
+                        keep.Add(current[i]);
+                }
+                if (keep.Count == current.Count) return current; // no change
+                if (keep.Count == 0) { willEmpty = true; return current; /* don't commit empty list */ }
+                newTitle = keep[0].Title;
+                return keep;
+            });
+            if (willEmpty)
+            {
+                holder[0]?.Close();
+                return;
+            }
+            if (newTitle is not null)
+            {
+                try
+                {
+                    var native = holder[0]?.NativeWindow;
+                    if (native is not null) native.Title = newTitle;
+                }
+                catch { /* window may already be closing */ }
+            }
+        }
+
+        var chrome = DockFloatingWindow.BuildChrome(
+            currentPanes,
+            holder,
+            manager,
+            onTabClosing: RemoveLocal,
+            onTabDragCompleted: (pane, wasOutside) =>
+            {
+                if (DockDragSession.Consumed)
+                {
+                    // The pane was docked into another surface (main
+                    // host's per-group overlay, another floating
+                    // window's CenterOnly overlay, etc.). Remove it
+                    // from us; if it was the only tab, the window
+                    // closes itself.
+                    RemoveLocal(pane);
+                    return;
+                }
+                // §4.2 cross-window dock-in (Center only): if the
+                // user dragged a tab OUT of this floating window and
+                // released the cursor over ANOTHER registered
+                // floating window, route the pane to that window
+                // instead of letting WinUI tear it into a new
+                // floating window.
+                if (wasOutside && DockFloatingPaneRouter.HasRegisteredWindows)
+                {
+                    // Don't append to ourselves.
+                    var ownWindow = holder[0];
+                    if (ownWindow is not null) DockFloatingPaneRouter.Unregister(ownWindow);
+                    try
+                    {
+                        if (DockFloatingPaneRouter.TryAppendUnderCursor(pane))
+                        {
+                            RemoveLocal(pane);
+                            DockDragSession.MarkConsumed();
+                            DockDragSession.Current?.End();
+                            return;
+                        }
+                    }
+                    finally
+                    {
+                        // Re-register ourselves so subsequent drags
+                        // can target us again.
+                        if (ownWindow is not null)
+                        {
+                            // Re-build the same closure (UseEffect will
+                            // re-register on next render too, but this
+                            // bridges the small gap until then).
+                            Action<DockableContent> reAppend = src =>
+                                updatePanes(current =>
+                                {
+                                    for (int i = 0; i < current.Count; i++)
+                                        if (ReferenceEquals(current[i], src)) return current;
+                                    var list = new List<DockableContent>(current.Count + 1);
+                                    list.AddRange(current);
+                                    list.Add(src);
+                                    return list;
+                                });
+                            DockFloatingPaneRouter.Register(ownWindow, reAppend);
+                        }
+                    }
+                }
+                // Drop landed nowhere (Esc, drop on desktop). End any
+                // in-flight session so the pane stays put in this
+                // floating window — the TabView re-renders with the
+                // pane still in its `documents` list.
+                DockDragSession.Current?.Cancel();
+            });
+
+        // Provide the FIRST pane's DockPaneInfo as the floating window's
+        // pane context. Per-tab context wiring is a future refinement;
+        // hook resolution inside an active pane's body works because
+        // the active tab's WinUI subtree inherits this context.
+        var primary = currentPanes[0];
+        var info = new DockPaneInfo(primary.Key, primary.Title ?? string.Empty, primary);
+
+        return chrome
+            .Provide(DockContexts.Pane, (DockPaneInfo?)info)
+            .Provide(DockContexts.PaneState, DockPaneState.Floating);
+    }
+
+    private static bool ContainsByRef(IReadOnlyList<DockableContent> list, DockableContent target)
+    {
+        for (int i = 0; i < list.Count; i++)
+            if (ReferenceEquals(list[i], target)) return true;
+        return false;
     }
 }
 

--- a/src/Reactor/Docking/Native/DockHostNativeComponent.cs
+++ b/src/Reactor/Docking/Native/DockHostNativeComponent.cs
@@ -292,6 +292,27 @@ internal sealed class DockHostNativeComponent : Component<DockHostNativeProps>
                 target: target);
         }
 
+        // Spec 045 §4.2 cross-window dock-in source hook. Re-installed
+        // every render so the closure captures the latest
+        // `effectiveLayout` / `StoreOverride` / `LogOp` references. A
+        // foreign overlay (the floating window's CenterOnly drop target)
+        // invokes this after it has added the pane into its own group;
+        // we yank the pane out of this host's layout and fire the same
+        // events the tear-out path fires so the app can persist /
+        // observe the change.
+        model.OnExternalCrossWindowDrop = pane =>
+        {
+            var (afterRemove, removed) = DockLayoutMutator.RemovePane(effectiveLayout, pane);
+            if (!removed) return;
+            StoreOverride(afterRemove);
+            manager.OnContentFloated?.Invoke(new DockContentFloatedEventArgs { Content = pane });
+            manager.OnLiveLayoutChanged?.Invoke(afterRemove);
+            LogOp(Diagnostics.DockOperationKind.DragConfirm,
+                $"cross-window dock-in: pane='{pane.Key}' removed from source",
+                paneKey: pane.Key?.ToString(),
+                layoutOverride: afterRemove);
+        };
+
         // §2.4 — tab-drag callbacks fed to every DockTabGroup so any tab
         // in the layout can begin a session. Captures `manager` from the
         // current render closure for OnContentFloating/Floated event
@@ -342,6 +363,38 @@ internal sealed class DockHostNativeComponent : Component<DockHostNativeProps>
                         paneKey: pane.Key?.ToString());
                     session.End();
                     setDragActive(false);
+                    return;
+                }
+                // Spec 045 §4.2 cross-window dock-in (Center only):
+                // WinUI's TabView drag pipeline is window-local — the
+                // floating window's overlay never receives DragEnter
+                // because the drag originated in a different XAML
+                // island. So at drop-completion time, hit-test the
+                // cursor against every registered floating window's
+                // HWND rect; if a hit is found, route the pane there
+                // as a new tab instead of tearing out into a new
+                // floating window. Deferred to drop-time only — no
+                // overlay is shown during the drag itself.
+                if (DockFloatingPaneRouter.HasRegisteredWindows
+                    && DockFloatingPaneRouter.TryAppendUnderCursor(pane))
+                {
+                    var (afterRemoveX, removedX) = DockLayoutMutator.RemovePane(effectiveLayout, pane);
+                    if (removedX)
+                    {
+                        StoreOverride(afterRemoveX);
+                        manager.OnContentFloated?.Invoke(new DockContentFloatedEventArgs { Content = pane });
+                        manager.OnLiveLayoutChanged?.Invoke(afterRemoveX);
+                        LogOp(Diagnostics.DockOperationKind.DragTearOut,
+                            $"cross-window dock-in pane='{pane.Key}' to existing floating window",
+                            paneKey: pane.Key?.ToString(),
+                            layoutOverride: afterRemoveX);
+                        DockHostLiveAnnouncer.Announce(manager,
+                            DockingStrings.LiveAnnouncement(DockingStringKeys.LiveDocked, pane.Title));
+                    }
+                    DockDragSession.MarkConsumed();
+                    session.End();
+                    setDragActive(false);
+                    bumpTick(t => t + 1);
                     return;
                 }
                 // §2.15 — record container before tearing out so a later

--- a/src/Reactor/Docking/Native/DockHostNativeComponent.cs
+++ b/src/Reactor/Docking/Native/DockHostNativeComponent.cs
@@ -384,7 +384,13 @@ internal sealed class DockHostNativeComponent : Component<DockHostNativeProps>
                         StoreOverride(afterRemoveX);
                         manager.OnContentFloated?.Invoke(new DockContentFloatedEventArgs { Content = pane });
                         manager.OnLiveLayoutChanged?.Invoke(afterRemoveX);
-                        LogOp(Diagnostics.DockOperationKind.DragTearOut,
+                        // This is a cross-window dock-in (append-as-tab
+                        // into an existing floating window), NOT a
+                        // tear-out into a new floating window. Use
+                        // DragConfirm to keep the operation log /
+                        // replay analysis honest — matches the
+                        // semantics used by OnExternalCrossWindowDrop.
+                        LogOp(Diagnostics.DockOperationKind.DragConfirm,
                             $"cross-window dock-in pane='{pane.Key}' to existing floating window",
                             paneKey: pane.Key?.ToString(),
                             layoutOverride: afterRemoveX);

--- a/src/Reactor/Docking/Native/DockTabGroupRenderer.cs
+++ b/src/Reactor/Docking/Native/DockTabGroupRenderer.cs
@@ -194,25 +194,93 @@ internal static class DockTabGroupRenderer
     }
 
     /// <summary>
-    /// Hook for applying <see cref="DockTabGroup.TabPosition"/>-driven
-    /// chrome to the rendered <see cref="TabView"/>. WinUI's
-    /// <see cref="TabView"/> has no native bottom-tab mode; the upstream
-    /// WinUI.Dock workaround composes <c>ScaleY = -1</c> on the outer
-    /// control with counter-scales on every tab header (text + close
-    /// button) AND on every tab body — requiring access to template
-    /// parts of <c>TabViewItem</c> that aren't reachable without
-    /// subclassing.
+    /// Apply <see cref="DockTabGroup.TabChrome"/>-driven chrome to the
+    /// rendered <see cref="TabView"/>. Each preset is implemented as a
+    /// scoped resource-dictionary override on the <c>TabView</c> instance
+    /// — the underlying control template / accessibility tree are
+    /// unchanged across presets (spec 045 §4.6).
     ///
-    /// For P2 the bottom-tab variant intentionally renders as a
-    /// top-tab variant: legible, no upside-down text, but visually it
-    /// doesn't match upstream's bottom-strip placement. A true
-    /// translation lands when a dedicated tab-item subclass (or a
-    /// manual strip+content composition) replaces the shared
+    /// <para>
+    /// Pool-safety: a <c>TabView</c> may be reused across renders with a
+    /// different chrome. Every preset first calls <see cref="ClearManagedKeys"/>
+    /// to remove any keys a previous chrome may have written, then re-adds
+    /// only what the new chrome wants. <c>Win11</c> is the no-override
+    /// baseline — its setters strip prior overrides without adding anything.
+    /// </para>
+    ///
+    /// <para>
+    /// <see cref="DockTabGroup.TabPosition"/> is intentionally NOT wired
+    /// here. WinUI 3's <c>TabView</c> has no <c>TabStripPlacement</c> property
+    /// (microsoft-ui-xaml#7395); the upstream WinUI.Dock workaround composes
+    /// <c>ScaleY = -1</c> on the outer control with counter-scales on every
+    /// tab header (text + close button) AND on every tab body, requiring
+    /// access to template parts of <c>TabViewItem</c> that aren't reachable
+    /// without subclassing. For P2/P4 the bottom-tab variant intentionally
+    /// renders as a top-tab variant: legible, no upside-down text. A true
+    /// translation lands when a dedicated tab-item subclass (or a manual
+    /// strip+content composition) replaces the shared
     /// <see cref="TabViewElement"/>.
+    /// </para>
     /// </summary>
-    private static Action<TabView>[] BuildSetters(DockTabGroup group)
+    internal static Action<TabView>[] BuildSetters(DockTabGroup group) => group.TabChrome switch
     {
-        _ = group;
-        return Array.Empty<Action<TabView>>();
+        TabChrome.Win11    => [ClearManagedKeys],
+        TabChrome.Flat     => [ClearManagedKeys, ApplyFlatChrome],
+        TabChrome.TitleBar => [ClearManagedKeys, ApplyTitleBarChrome],
+        _                  => [ClearManagedKeys],
+    };
+
+    /// <summary>
+    /// Keys this renderer writes into <c>TabView.Resources</c>. Pool-safety
+    /// requires every chrome preset to remove all of these before writing
+    /// its own values; otherwise a Flat → Win11 transition would leak the
+    /// sharp-corner overrides into a control reused under a new chrome.
+    /// </summary>
+    internal static readonly string[] ManagedResourceKeys =
+    {
+        "TabViewItemHeaderCornerRadius",
+        "TabViewItemHeaderPadding",
+        "TabViewItemHeaderBackgroundSelected",
+        "TabViewItemHeaderBackgroundPointerOver",
+        "TabViewBackground",
+    };
+
+    private static void ClearManagedKeys(TabView tabView)
+    {
+        var res = tabView.Resources;
+        for (int i = 0; i < ManagedResourceKeys.Length; i++)
+        {
+            var key = ManagedResourceKeys[i];
+            if (res.ContainsKey(key)) res.Remove(key);
+        }
+    }
+
+    private static void ApplyFlatChrome(TabView tabView)
+    {
+        var res = tabView.Resources;
+        // Zero corner radius on every header state — header rests, pointer-
+        // over, selected, and pressed all share the resource. WinUI's
+        // TabView template reads it through a single ThemeResource key.
+        res["TabViewItemHeaderCornerRadius"] = new global::Microsoft.UI.Xaml.CornerRadius(0);
+        // Tighter padding squares up the IDE / VS Code feel; matches the
+        // density of a true document-tab strip rather than the looser
+        // Win11 default. Numbers chosen against the WinUI 2.0.1 default
+        // (8,0,8,0 horizontal) — drop top/bottom and tighten horizontals.
+        res["TabViewItemHeaderPadding"] = new global::Microsoft.UI.Xaml.Thickness(6, 0, 6, 0);
+    }
+
+    private static void ApplyTitleBarChrome(TabView tabView)
+    {
+        // Spec 045 §4.6 — tab-strip background uses TitleBarBackgroundFillBrush
+        // (when defined). Resolved against the running app's resources at
+        // render time; falls back silently when the brush isn't registered
+        // (e.g. test host with no theme dictionary loaded).
+        var res = tabView.Resources;
+        if (global::Microsoft.UI.Xaml.Application.Current?.Resources is { } appResources
+            && appResources.TryGetValue("TitleBarBackgroundFillBrush", out var brush)
+            && brush is global::Microsoft.UI.Xaml.Media.Brush)
+        {
+            res["TabViewBackground"] = brush;
+        }
     }
 }

--- a/src/Reactor/Docking/Persistence/DockLayoutJson.cs
+++ b/src/Reactor/Docking/Persistence/DockLayoutJson.cs
@@ -101,6 +101,14 @@ internal sealed class DockLayoutNode
     [JsonPropertyName("compactTabs")]
     public bool? CompactTabs { get; set; }
 
+    /// <summary>
+    /// Visual chrome preset for tabGroup nodes ("win11" | "flat" | "titleBar").
+    /// Missing/null = "win11" (back-compat — legacy layout files predate the
+    /// field). Spec 045 §4.6.
+    /// </summary>
+    [JsonPropertyName("tabChrome")]
+    public string? TabChrome { get; set; }
+
     /// <summary>Whether the group renders when empty (tabGroup nodes).</summary>
     [JsonPropertyName("showWhenEmpty")]
     public bool? ShowWhenEmpty { get; set; }

--- a/src/Reactor/Docking/Persistence/DockLayoutSerializer.cs
+++ b/src/Reactor/Docking/Persistence/DockLayoutSerializer.cs
@@ -228,6 +228,14 @@ public static class DockLayoutSerializer
             Documents = grp.Documents.Select(ConvertPane).ToList(),
             TabPosition = grp.TabPosition == Docking.TabPosition.Top ? "top" : "bottom",
             CompactTabs = grp.CompactTabs ? true : null,
+            // §4.6: only emit when non-default. Keeps legacy files unchanged.
+            TabChrome = grp.TabChrome switch
+            {
+                Docking.TabChrome.Win11    => null,
+                Docking.TabChrome.Flat     => "flat",
+                Docking.TabChrome.TitleBar => "titleBar",
+                _ => null,
+            },
             ShowWhenEmpty = grp.ShowWhenEmpty ? true : null,
             SelectedIndex = grp.SelectedIndex >= 0 ? grp.SelectedIndex : null,
             Width = grp.Width, Height = grp.Height,
@@ -332,12 +340,20 @@ public static class DockLayoutSerializer
             "bottom"      => Docking.TabPosition.Bottom,
             _ => throw new InvalidOperationException($"tabGroup node has invalid tabPosition '{node.TabPosition}'"),
         };
+        var chrome = node.TabChrome switch
+        {
+            null or "win11" => Docking.TabChrome.Win11,
+            "flat"          => Docking.TabChrome.Flat,
+            "titleBar"      => Docking.TabChrome.TitleBar,
+            _ => throw new InvalidOperationException($"tabGroup node has invalid tabChrome '{node.TabChrome}'"),
+        };
         return new DockTabGroup(docs,
             TabPosition: tabPos,
             CompactTabs: node.CompactTabs ?? false,
             ShowWhenEmpty: node.ShowWhenEmpty ?? false,
             SelectedIndex: node.SelectedIndex ?? -1,
-            Width: node.Width, Height: node.Height);
+            Width: node.Width, Height: node.Height,
+            TabChrome: chrome);
     }
 
     private static DockableContent ConvertPaneBackAsLeaf(DockLayoutPane pane) =>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
@@ -1504,9 +1504,16 @@ internal static class NativeDockingSmokeFixtures
                 && right.Resources.TryGetValue("TabViewItemHeaderCornerRadius", out var cr)
                 && cr is CornerRadius radius)
             {
+                // Production sets `new CornerRadius(0)` which produces
+                // exact 0.0 doubles, but CodeQL flags any `== 0.0` on a
+                // double — use an epsilon to silence the rule without
+                // changing the intent ("effectively zero").
+                const double epsilon = 1e-9;
                 H.Check("TabChrome_Flat_CornerRadiusIsZero",
-                    radius.TopLeft == 0 && radius.TopRight == 0
-                    && radius.BottomLeft == 0 && radius.BottomRight == 0);
+                    Math.Abs(radius.TopLeft) < epsilon
+                    && Math.Abs(radius.TopRight) < epsilon
+                    && Math.Abs(radius.BottomLeft) < epsilon
+                    && Math.Abs(radius.BottomRight) < epsilon);
             }
             else
             {
@@ -1559,17 +1566,14 @@ internal static class NativeDockingSmokeFixtures
         // or StackPanel with a TextBlock) matches `header`.
         private static bool HasHeader(TabView tv, string header)
         {
-            foreach (var item in tv.TabItems)
+            foreach (var tvi in tv.TabItems.OfType<TabViewItem>())
             {
-                if (item is TabViewItem tvi)
+                if (tvi.Header is string s && s == header) return true;
+                if (tvi.Header is StackPanel sp)
                 {
-                    if (tvi.Header is string s && s == header) return true;
-                    if (tvi.Header is StackPanel sp)
+                    foreach (var tb in sp.Children.OfType<TextBlock>())
                     {
-                        foreach (var child in sp.Children)
-                        {
-                            if (child is TextBlock tb && tb.Text == header) return true;
-                        }
+                        if (tb.Text == header) return true;
                     }
                 }
             }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
@@ -1437,4 +1437,399 @@ internal static class NativeDockingSmokeFixtures
             await Harness.Render();
         }
     }
+
+    /// <summary>
+    /// Spec 045 §4.6 — TabChrome chrome presets land as scoped resource-
+    /// dictionary overrides on the underlying <see cref="TabView"/>. The
+    /// fixture mounts three groups (Win11 / Flat / TitleBar) side-by-side
+    /// and verifies each TabView's <c>Resources</c> matches the contract.
+    /// Then flips Flat → Win11 to lock in the pool-safety "blanker"
+    /// behavior: a TabView reused under a new chrome must not leak
+    /// the prior preset's overrides.
+    /// </summary>
+    internal class TabChromePresetsApplyAndClear(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            DockingNativeInterop.Register(host.Reconciler);
+
+            DockManager BuildPair(TabChrome leftChrome, TabChrome rightChrome) => new DockManager
+            {
+                Layout = new DockSplit(
+                    Orientation.Horizontal,
+                    new DockNode[]
+                    {
+                        new DockTabGroup(
+                            new DockableContent[]
+                            {
+                                new("L1", TextBlock("chrome-left-1"), Key: "ch:l:1"),
+                                new("L2", TextBlock("chrome-left-2"), Key: "ch:l:2"),
+                            },
+                            TabChrome: leftChrome),
+                        new DockTabGroup(
+                            new DockableContent[]
+                            {
+                                new("R1", TextBlock("chrome-right-1"), Key: "ch:r:1"),
+                                new("R2", TextBlock("chrome-right-2"), Key: "ch:r:2"),
+                            },
+                            TabChrome: rightChrome),
+                    }),
+            };
+
+            // ── Mount: Win11 (left) + Flat (right) ──────────────────
+            host.Mount(_ => BuildPair(TabChrome.Win11, TabChrome.Flat));
+            await Harness.Render();
+
+            var tabs = H.FindAllControls<TabView>(_ => true);
+            H.Check("TabChrome_TwoTabViewsMounted", tabs.Count == 2);
+
+            // Pair them by header text. Order isn't guaranteed across
+            // FindAllControls iteration; we look for "L1" vs "R1" headers.
+            TabView? left  = tabs.FirstOrDefault(tv => HasHeader(tv, "L1"));
+            TabView? right = tabs.FirstOrDefault(tv => HasHeader(tv, "R1"));
+            H.Check("TabChrome_LeftFound",  left  is not null);
+            H.Check("TabChrome_RightFound", right is not null);
+
+            // Win11 — no overrides for any managed key.
+            H.Check("TabChrome_Win11_NoCornerRadiusOverride",
+                left is not null && !left.Resources.ContainsKey("TabViewItemHeaderCornerRadius"));
+            H.Check("TabChrome_Win11_NoPaddingOverride",
+                left is not null && !left.Resources.ContainsKey("TabViewItemHeaderPadding"));
+
+            // Flat — zero corner radius + tightened padding.
+            H.Check("TabChrome_Flat_HasCornerRadiusOverride",
+                right is not null && right.Resources.ContainsKey("TabViewItemHeaderCornerRadius"));
+            if (right is not null
+                && right.Resources.TryGetValue("TabViewItemHeaderCornerRadius", out var cr)
+                && cr is CornerRadius radius)
+            {
+                H.Check("TabChrome_Flat_CornerRadiusIsZero",
+                    radius.TopLeft == 0 && radius.TopRight == 0
+                    && radius.BottomLeft == 0 && radius.BottomRight == 0);
+            }
+            else
+            {
+                H.Check("TabChrome_Flat_CornerRadiusIsZero", false);
+            }
+
+            H.Check("TabChrome_Flat_HasPaddingOverride",
+                right is not null && right.Resources.ContainsKey("TabViewItemHeaderPadding"));
+
+            // ── Update: flip right Flat → Win11 (pool blanker) ──────
+            host.Mount(_ => BuildPair(TabChrome.Win11, TabChrome.Win11));
+            await Harness.Render();
+
+            tabs = H.FindAllControls<TabView>(_ => true);
+            right = tabs.FirstOrDefault(tv => HasHeader(tv, "R1"));
+            H.Check("TabChrome_FlatToWin11_StillMounted", right is not null);
+            H.Check("TabChrome_FlatToWin11_CornerRadiusCleared",
+                right is not null && !right.Resources.ContainsKey("TabViewItemHeaderCornerRadius"));
+            H.Check("TabChrome_FlatToWin11_PaddingCleared",
+                right is not null && !right.Resources.ContainsKey("TabViewItemHeaderPadding"));
+
+            // ── Update: flip to TitleBar — Resources entry for background ──
+            // The TitleBar preset only sets TabViewBackground when the app
+            // exposes TitleBarBackgroundFillBrush in its resources. The
+            // selftest host registers XamlControlsResources, so the brush
+            // resolves; assert the key lands.
+            host.Mount(_ => BuildPair(TabChrome.TitleBar, TabChrome.Win11));
+            await Harness.Render();
+
+            tabs = H.FindAllControls<TabView>(_ => true);
+            left = tabs.FirstOrDefault(tv => HasHeader(tv, "L1"));
+            H.Check("TabChrome_TitleBar_LeftRemounted", left is not null);
+            // Background may or may not resolve depending on theme stack —
+            // assert tolerantly: either it's present (real app), or absent
+            // (running before XamlControlsResources binds). The pool-safe
+            // contract is that no _other_ managed key is set.
+            if (left is not null)
+            {
+                H.Check("TabChrome_TitleBar_NoCornerRadiusOverride",
+                    !left.Resources.ContainsKey("TabViewItemHeaderCornerRadius"));
+                H.Check("TabChrome_TitleBar_NoPaddingOverride",
+                    !left.Resources.ContainsKey("TabViewItemHeaderPadding"));
+            }
+
+            host.Mount(_ => TextBlock("chrome-done"));
+            await Harness.Render();
+        }
+
+        // Walk a TabView's items and check if any header (string Header
+        // or StackPanel with a TextBlock) matches `header`.
+        private static bool HasHeader(TabView tv, string header)
+        {
+            foreach (var item in tv.TabItems)
+            {
+                if (item is TabViewItem tvi)
+                {
+                    if (tvi.Header is string s && s == header) return true;
+                    if (tvi.Header is StackPanel sp)
+                    {
+                        foreach (var child in sp.Children)
+                        {
+                            if (child is TextBlock tb && tb.Text == header) return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Spec 045 §4.2 / §4.3 — floating dockable windows render the
+    /// <c>DockTabGroup</c> tab strip directly into the OS title-bar
+    /// zone (Edge / Files / VS Code pattern). The fixture opens a
+    /// floating window with one pane and asserts:
+    ///   • the window has <c>ExtendsContentIntoTitleBar=true</c>
+    ///   • a WinUI <c>TabView</c> sits at the root (no separate
+    ///     WinUI 3 <c>TitleBar</c> control wrapping it)
+    ///   • the TabView has a <c>TabStripFooter</c> (drag region
+    ///     handed to <c>Window.SetTitleBar</c> on mount)
+    ///   • the pane body is reachable
+    /// </summary>
+    internal class FloatingWindow_TitleBarChromeAndTabsInTitleBar(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            DockingNativeInterop.Register(host.Reconciler);
+
+            host.Mount(_ => new DockManager
+            {
+                Layout = new DockTabGroup(new[]
+                {
+                    new DockableContent("Center", TextBlock("center-body"), Key: "k:center"),
+                }),
+            });
+            await Harness.Render();
+
+            var pane = new DockableContent(
+                Title: "Floater",
+                Key: "k:tb-float",
+                Content: TextBlock("floating-tb-body"));
+
+            var savedPolicy = ReactorApp.ShutdownPolicy;
+            ReactorApp.ShutdownPolicy = ShutdownPolicy.Explicit;
+            try
+            {
+                var floatingWindow = DockFloatingWindow.Open(pane, width: 600, height: 400);
+                await Harness.Render();
+                H.Check("FloatingTitleBar_WindowOpened", floatingWindow is not null);
+
+                // §4.2 — ExtendsContentIntoTitleBar must be set by Open()
+                // so the tab strip occupies the title-bar zone.
+                H.Check("FloatingTitleBar_ExtendsContentIntoTitleBar",
+                    floatingWindow!.NativeWindow.ExtendsContentIntoTitleBar);
+
+                // Walk the floating window's visual tree (Harness.FindAllControls
+                // searches the harness's main window only).
+                var content = floatingWindow.NativeWindow.Content as DependencyObject;
+                H.Check("FloatingTitleBar_HasContent", content is not null);
+
+                // §4.3 — Edge pattern: TabView is the root chrome. The
+                // WinUI 3 `TitleBar` control is intentionally NOT used
+                // (its Content slot can't host a full TabView).
+                var tabViews = FindAllInTree<TabView>(content);
+                H.Check("FloatingTitleBar_TabViewAtRoot", tabViews.Count == 1);
+
+                var titleBars = FindAllInTree<Microsoft.UI.Xaml.Controls.TitleBar>(content);
+                H.Check("FloatingTitleBar_NoSeparateTitleBarControl", titleBars.Count == 0);
+
+                // §4.2 / §4.4 — TabStripFooter holds the drag region;
+                // OnMount on this element calls Window.SetTitleBar.
+                H.Check("FloatingTitleBar_TabViewHasStripFooter",
+                    tabViews.Count == 1 && tabViews[0].TabStripFooter is not null);
+
+                // Pane body must be reachable.
+                var bodyTexts = FindAllInTree<TextBlock>(content, t => t.Text == "floating-tb-body");
+                H.Check("FloatingTitleBar_PaneBodyVisible", bodyTexts.Count >= 1);
+
+                floatingWindow.Close();
+                await Harness.Render();
+            }
+            finally
+            {
+                ReactorApp.ShutdownPolicy = savedPolicy;
+            }
+
+            host.Mount(_ => TextBlock("floating-tb-done"));
+            await Harness.Render();
+        }
+
+        private static List<T> FindAllInTree<T>(DependencyObject? root, Func<T, bool>? predicate = null)
+            where T : DependencyObject
+        {
+            var results = new List<T>();
+            if (root is not null) Walk(root, predicate, results);
+            return results;
+        }
+
+        private static void Walk<T>(DependencyObject root, Func<T, bool>? predicate, List<T> results)
+            where T : DependencyObject
+        {
+            if (root is T match && (predicate is null || predicate(match))) results.Add(match);
+            int count = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < count; i++)
+                Walk(Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(root, i), predicate, results);
+        }
+    }
+
+    /// <summary>
+    /// Spec 045 §4.2 multi-window isolation — opening two floating
+    /// windows concurrently must give each window its own TabView
+    /// rendered into its own AppWindow. The OS-level
+    /// `Window.SetTitleBar` registration in `BuildFloatingRoot.OnMount`
+    /// captures `windowHolder` per-call, so there's no cross-wiring.
+    /// </summary>
+    internal class FloatingWindow_TitleBarPerWindow_NoCrossWiring(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            DockingNativeInterop.Register(host.Reconciler);
+
+            host.Mount(_ => new DockManager
+            {
+                Layout = new DockTabGroup(new[]
+                {
+                    new DockableContent("Center", TextBlock("multi-center-body"), Key: "k:multi-center"),
+                }),
+            });
+            await Harness.Render();
+
+            var pane1 = new DockableContent("FA", TextBlock("body-a"), Key: "k:fa");
+            var pane2 = new DockableContent("FB", TextBlock("body-b"), Key: "k:fb");
+
+            var savedPolicy = ReactorApp.ShutdownPolicy;
+            ReactorApp.ShutdownPolicy = ShutdownPolicy.Explicit;
+            try
+            {
+                var w1 = DockFloatingWindow.Open(pane1, width: 500, height: 300);
+                var w2 = DockFloatingWindow.Open(pane2, width: 500, height: 300);
+                await Harness.Render();
+
+                H.Check("FloatingMulti_W1_ExtendsContent",
+                    w1.NativeWindow.ExtendsContentIntoTitleBar);
+                H.Check("FloatingMulti_W2_ExtendsContent",
+                    w2.NativeWindow.ExtendsContentIntoTitleBar);
+
+                // Each window has its own TabView at the root (Edge
+                // tabs-in-titlebar pattern — no separate WinUI 3
+                // `TitleBar` control).
+                var tv1 = FindFirst<TabView>(w1.NativeWindow.Content as DependencyObject);
+                var tv2 = FindFirst<TabView>(w2.NativeWindow.Content as DependencyObject);
+                H.Check("FloatingMulti_W1_HasOwnTabView", tv1 is not null);
+                H.Check("FloatingMulti_W2_HasOwnTabView", tv2 is not null);
+                H.Check("FloatingMulti_TabViewsAreDistinctInstances",
+                    tv1 is not null && tv2 is not null && !ReferenceEquals(tv1, tv2));
+
+                // Each window's TabView shows its own pane (no swap).
+                H.Check("FloatingMulti_W1_TabHeaderIsFA",
+                    tv1 is not null && tv1.TabItems.Count == 1
+                    && tv1.TabItems[0] is TabViewItem ti1 && ti1.Header is string h1 && h1 == "FA");
+                H.Check("FloatingMulti_W2_TabHeaderIsFB",
+                    tv2 is not null && tv2.TabItems.Count == 1
+                    && tv2.TabItems[0] is TabViewItem ti2 && ti2.Header is string h2 && h2 == "FB");
+
+                w1.Close();
+                w2.Close();
+                await Harness.Render();
+            }
+            finally
+            {
+                ReactorApp.ShutdownPolicy = savedPolicy;
+            }
+
+            host.Mount(_ => TextBlock("floating-multi-done"));
+            await Harness.Render();
+        }
+
+        private static T? FindFirst<T>(DependencyObject? root) where T : DependencyObject
+        {
+            if (root is null) return null;
+            if (root is T match) return match;
+            int count = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < count; i++)
+            {
+                var hit = FindFirst<T>(Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(root, i));
+                if (hit is not null) return hit;
+            }
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Spec 045 §2.4 / §4.2 regression — the Edge-pattern floating root
+    /// (TabView with TabStripFooter drag region) must not break the
+    /// close-window path. Open a floating window, close it, and assert
+    /// the tracker drops it.
+    /// </summary>
+    internal class FloatingWindow_ClosingLastTabClosesWindow(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            DockingNativeInterop.Register(host.Reconciler);
+
+            host.Mount(_ => new DockManager
+            {
+                Layout = new DockTabGroup(new[]
+                {
+                    new DockableContent("Center", TextBlock("close-center"), Key: "k:close-center"),
+                }),
+            });
+            await Harness.Render();
+
+            var pane = new DockableContent(
+                Title: "ToClose",
+                Key: "k:to-close",
+                Content: TextBlock("close-floating-body"),
+                CanClose: true);
+
+            var savedPolicy = ReactorApp.ShutdownPolicy;
+            ReactorApp.ShutdownPolicy = ShutdownPolicy.Explicit;
+            try
+            {
+                var baseline = DockFloatingTracker.Count;
+                var floatingWindow = DockFloatingWindow.Open(pane, width: 500, height: 300);
+                await Harness.Render();
+                H.Check("FloatingClose_RegisteredOnOpen",
+                    DockFloatingTracker.Count == baseline + 1);
+
+                // Window's TabView (root chrome) must still be
+                // reachable — guards against tree-shape regressions.
+                var contentRoot = floatingWindow.NativeWindow.Content as DependencyObject;
+                var tabView = FindFirst<TabView>(contentRoot);
+                H.Check("FloatingClose_TabViewReachable", tabView is not null);
+
+                floatingWindow.Close();
+                await Harness.Render();
+
+                H.Check("FloatingClose_WindowRemovedAfterClose",
+                    DockFloatingTracker.Count == baseline);
+            }
+            finally
+            {
+                ReactorApp.ShutdownPolicy = savedPolicy;
+            }
+
+            host.Mount(_ => TextBlock("floating-close-done"));
+            await Harness.Render();
+        }
+
+        private static T? FindFirst<T>(DependencyObject? root) where T : DependencyObject
+        {
+            if (root is null) return null;
+            if (root is T match) return match;
+            int count = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < count; i++)
+            {
+                var hit = FindFirst<T>(Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(root, i));
+                if (hit is not null) return hit;
+            }
+            return null;
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -910,6 +910,11 @@ internal static class SelfTestFixtureRegistry
         "NativeDocking_DropTargetOverlayShowsAndDismisses",
         "NativeDocking_DragSessionConfirmMutatesLayout",
         "NativeDocking_ModelDrain_DockCloseActivatePinAffectsLiveTree",
+        "NativeDocking_TabChromePresetsApplyAndClear",
+        // Floating window TitleBar chrome (spec 045 §4.2 / §4.3 / §4.8).
+        "NativeDocking_FloatingWindow_TitleBarChromeAndTabsInTitleBar",
+        "NativeDocking_FloatingWindow_TitleBarPerWindow_NoCrossWiring",
+        "NativeDocking_FloatingWindow_ClosingLastTabClosesWindow",
         // Reliability + security (spec 045 §2.24, §2.25).
         "NativeDocking_Reliability_CorruptLayoutFallback_HostMounted",
         "NativeDocking_Reliability_OffThreadMutation_ThrowsAndDoesNotQueue",
@@ -1842,6 +1847,10 @@ internal static class SelfTestFixtureRegistry
         "NativeDocking_DropTargetOverlayShowsAndDismisses" => new NativeDockingSmokeFixtures.DropTargetOverlayShowsAndDismisses(harness),
         "NativeDocking_DragSessionConfirmMutatesLayout" => new NativeDockingSmokeFixtures.DragSessionConfirmMutatesLayout(harness),
         "NativeDocking_ModelDrain_DockCloseActivatePinAffectsLiveTree" => new NativeDockingSmokeFixtures.ModelDrain_DockCloseActivatePinAffectsLiveTree(harness),
+        "NativeDocking_TabChromePresetsApplyAndClear" => new NativeDockingSmokeFixtures.TabChromePresetsApplyAndClear(harness),
+        "NativeDocking_FloatingWindow_TitleBarChromeAndTabsInTitleBar" => new NativeDockingSmokeFixtures.FloatingWindow_TitleBarChromeAndTabsInTitleBar(harness),
+        "NativeDocking_FloatingWindow_TitleBarPerWindow_NoCrossWiring" => new NativeDockingSmokeFixtures.FloatingWindow_TitleBarPerWindow_NoCrossWiring(harness),
+        "NativeDocking_FloatingWindow_ClosingLastTabClosesWindow" => new NativeDockingSmokeFixtures.FloatingWindow_ClosingLastTabClosesWindow(harness),
         "NativeDocking_Reliability_CorruptLayoutFallback_HostMounted" => new NativeDockingReliabilityFixtures.CorruptLayoutFallback_HostMounted(harness),
         "NativeDocking_Reliability_OffThreadMutation_ThrowsAndDoesNotQueue" => new NativeDockingReliabilityFixtures.OffThreadMutation_ThrowsAndDoesNotQueue(harness),
         "NativeDocking_Reliability_UseEffectCleanup_BodyRemovedOnPaneClose" => new NativeDockingReliabilityFixtures.UseEffectCleanup_BodyRemovedOnPaneClose(harness),

--- a/tests/Reactor.Tests/Docking/LayoutSerializerTests.cs
+++ b/tests/Reactor.Tests/Docking/LayoutSerializerTests.cs
@@ -100,6 +100,91 @@ public class LayoutSerializerTests
         Assert.Equal(1, loaded.SelectedIndex);
     }
 
+    // ── TabChrome (spec 045 §4.6) ──────────────────────────────────────
+
+    [Theory]
+    [InlineData(TabChrome.Win11)]
+    [InlineData(TabChrome.Flat)]
+    [InlineData(TabChrome.TitleBar)]
+    public void RoundTrip_TabChrome(TabChrome chrome)
+    {
+        var tabs = new DockTabGroup(
+            new DockableContent[] { new Document { Title = "T1", Key = "t1" } },
+            TabChrome: chrome);
+
+        var json = DockLayoutSerializer.Save(tabs);
+        var loaded = Assert.IsType<DockTabGroup>(DockLayoutSerializer.Load(json).Root);
+        Assert.Equal(chrome, loaded.TabChrome);
+    }
+
+    [Fact]
+    public void Save_OmitsTabChromeFieldWhenDefault()
+    {
+        // §4.6 — Win11 is the back-compat default; serializer keeps JSON
+        // small + legacy files untouched by skipping the field on default.
+        var tabs = new DockTabGroup(
+            new DockableContent[] { new Document { Title = "T1", Key = "t1" } });
+
+        var json = DockLayoutSerializer.Save(tabs);
+        Assert.DoesNotContain("tabChrome", json);
+    }
+
+    [Fact]
+    public void Save_EmitsTabChromeFieldWhenNonDefault()
+    {
+        var tabs = new DockTabGroup(
+            new DockableContent[] { new Document { Title = "T1", Key = "t1" } },
+            TabChrome: TabChrome.Flat);
+
+        var json = DockLayoutSerializer.Save(tabs);
+        Assert.Contains("\"tabChrome\":\"flat\"", json);
+    }
+
+    [Fact]
+    public void Load_LegacyJsonWithoutTabChrome_DefaultsToWin11()
+    {
+        // §4.6 back-compat: layouts written before TabChrome must still
+        // load with the default chrome. Builds a synthetic JSON without
+        // the field to lock in the contract.
+        var json = """
+        {
+          "$schema": 2,
+          "root": {
+            "kind": "tabGroup",
+            "documents": [ { "title": "T1", "key": "t1", "role": "document" } ],
+            "tabPosition": "top"
+          }
+        }
+        """;
+        var loaded = Assert.IsType<DockTabGroup>(DockLayoutSerializer.Load(json).Root);
+        Assert.Equal(TabChrome.Win11, loaded.TabChrome);
+    }
+
+    [Fact]
+    public void Load_UnknownTabChrome_FailsValidationToFallback()
+    {
+        // Load() wraps validation errors into a fallback result rather
+        // than throwing, so callers can recover layout gracefully (§2.7).
+        // We still want the contract: unknown TabChrome strings are
+        // not silently coerced — the load is reported as a failure with
+        // a "tabChrome" mention in the diagnostic message.
+        var json = """
+        {
+          "$schema": 2,
+          "root": {
+            "kind": "tabGroup",
+            "documents": [ { "title": "T1", "key": "t1", "role": "document" } ],
+            "tabPosition": "top",
+            "tabChrome": "neon-pink"
+          }
+        }
+        """;
+        var result = DockLayoutSerializer.Load(json);
+        Assert.True(result.IsFallback);
+        Assert.NotNull(result.FailureReason);
+        Assert.Contains("tabChrome", result.FailureReason);
+    }
+
     [Fact]
     public void RoundTrip_Sides()
     {

--- a/tests/Reactor.Tests/Docking/Native/DockFloatingWindowTests.cs
+++ b/tests/Reactor.Tests/Docking/Native/DockFloatingWindowTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Docking;
+using Microsoft.UI.Reactor.Docking.Native;
+using Microsoft.UI.Reactor.Hosting;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.Docking.Native;
+
+/// <summary>
+/// Spec 045 §4.2 / §4.3 — floating-window root shape: Edge / Files
+/// "tabs-in-titlebar" pattern. The root is a <c>TabViewElement</c>
+/// (rendered <c>DockTabGroup</c>) directly — no separate WinUI 3
+/// <c>TitleBar</c> wrapper. The tab strip sits in the title-bar zone
+/// at y=0 (via <c>ExtendsContentIntoTitleBar = true</c> on the
+/// WindowSpec); a <c>TabStripFooter</c> drag region is registered via
+/// <c>Window.SetTitleBar</c> on mount so the OS knows where dragging
+/// is enabled. Asserts element-tree shape without booting a UI thread.
+/// </summary>
+public class DockFloatingWindowTests
+{
+    private static TabViewElement BuildRoot(DockableContent pane)
+    {
+        // Holder + manager are nullable in `BuildFloatingRoot`; the
+        // close / drag-completion callbacks use the holder lazily so
+        // a null window is safe for tree-shape tests.
+        //
+        // `Provide(...)` does not wrap the element — it sets the
+        // ContextValues bag on the existing element (`with { ... }`)
+        // so the returned record is still the underlying TabViewElement
+        // (see ContextExtensions.Provide).
+        var holder = new ReactorWindow?[] { null };
+        var root = DockFloatingWindow.BuildFloatingRoot(pane, holder, manager: null);
+        return Assert.IsType<TabViewElement>(root);
+    }
+
+    [Fact]
+    public void BuildFloatingRoot_RootIsTabView()
+    {
+        // §4.3 — tabs-in-titlebar (Edge pattern): the TabView is the
+        // window root so its strip occupies the title-bar zone.
+        var pane = new DockableContent(Title: "FloatPane", Content: new TextBlockElement("body"));
+        var tv = BuildRoot(pane);
+        Assert.NotNull(tv);
+    }
+
+    [Fact]
+    public void BuildFloatingRoot_HasOneTabWithPaneTitle()
+    {
+        var pane = new DockableContent(Title: "MyDoc", Content: new TextBlockElement("body"));
+        var tv = BuildRoot(pane);
+        Assert.Single(tv.Tabs);
+        Assert.Equal("MyDoc", tv.Tabs[0].Header);
+    }
+
+    [Fact]
+    public void BuildFloatingRoot_UsesTitleBarTabChrome()
+    {
+        // §4.6 — the tab strip is themed to merge with the OS title bar
+        // (TabChrome.TitleBar applies TitleBarBackgroundFillBrush).
+        var pane = new DockableContent(Title: "P", Content: new TextBlockElement("body"));
+        var tv = BuildRoot(pane);
+        Assert.NotEmpty(tv.Setters);
+    }
+
+    [Fact]
+    public void BuildFloatingRoot_HasDragRegionInTabStripFooter()
+    {
+        // §4.2 / §4.4 — drag region in TabStripFooter is what gets
+        // handed to Window.SetTitleBar on mount so the OS reserves
+        // caption-button inset and treats the footer as drag-move
+        // surface.
+        var pane = new DockableContent(Title: "P", Content: new TextBlockElement("body"));
+        var tv = BuildRoot(pane);
+        Assert.NotNull(tv.TabStripFooter);
+        // The drag region is a BorderElement with an OnMount handler
+        // that calls Window.SetTitleBar. We can't invoke OnMount without
+        // a real FrameworkElement, but we can verify the element shape.
+        Assert.IsType<BorderElement>(tv.TabStripFooter);
+    }
+
+    [Fact]
+    public void BuildFloatingRoot_ProvidesFloatingPaneState()
+    {
+        // §2.17 — UseDockState consumers inside the floating window
+        // resolve to PaneState=Floating. Lock the context wiring.
+        var pane = new DockableContent(Title: "P", Content: new TextBlockElement("body"));
+        var holder = new ReactorWindow?[] { null };
+        var root = DockFloatingWindow.BuildFloatingRoot(pane, holder, manager: null);
+        Assert.NotNull(root.ContextValues);
+        Assert.True(root.ContextValues!.ContainsKey(DockContexts.PaneState));
+        Assert.Equal(DockPaneState.Floating, root.ContextValues[DockContexts.PaneState]);
+    }
+}

--- a/tests/Reactor.Tests/Docking/Native/DockTabGroupRendererTests.cs
+++ b/tests/Reactor.Tests/Docking/Native/DockTabGroupRendererTests.cs
@@ -287,4 +287,44 @@ public class DockTabGroupRendererTests
 
         Assert.False(tab.Tabs[0].IsPinnable);
     }
+
+    // ── §4.6 TabChrome ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Render_DefaultTabChrome_IsWin11()
+    {
+        var group = new DockTabGroup(new DockableContent[] { new("A") });
+        Assert.Equal(TabChrome.Win11, group.TabChrome);
+    }
+
+    [Theory]
+    [InlineData(TabChrome.Win11,    1)] // blanker only
+    [InlineData(TabChrome.Flat,     2)] // blanker + apply
+    [InlineData(TabChrome.TitleBar, 2)] // blanker + apply
+    public void BuildSetters_HasBlankerPlusOptionalApply(TabChrome chrome, int expectedCount)
+    {
+        // Pool-safety contract per §4.6 — every preset starts with the
+        // shared "clear managed keys" setter so a TabView reused across
+        // chrome flips doesn't leak prior overrides.
+        var group = new DockTabGroup(new DockableContent[] { new("A") }, TabChrome: chrome);
+        var setters = DockTabGroupRenderer.BuildSetters(group);
+        Assert.Equal(expectedCount, setters.Length);
+    }
+
+    [Fact]
+    public void ManagedResourceKeys_AreLocked()
+    {
+        // The exact key set is part of the §4.6 chrome contract: it
+        // defines what gets blanked between chrome flips. Lock the list
+        // so a refactor that drops a key without adjusting consumers
+        // surfaces here.
+        Assert.Equal(new[]
+        {
+            "TabViewItemHeaderCornerRadius",
+            "TabViewItemHeaderPadding",
+            "TabViewItemHeaderBackgroundSelected",
+            "TabViewItemHeaderBackgroundPointerOver",
+            "TabViewBackground",
+        }, DockTabGroupRenderer.ManagedResourceKeys);
+    }
 }


### PR DESCRIPTION
## Summary

Adds support for dragging a tab from any `DockHost` (main window or floating) into another floating window's tab group, materializing it as an appended tab. Also lands the §4.2 `TitleBar`-zone tab chrome for floating windows (Edge / Files / modern-VS pattern).

## Cross-window dock-in (spec 045 §4.6 / §2.4)

WinUI's `TabView.CanDragTabs` drag pipeline is **window-local**: drag events never reach AllowDrop elements in another XAML island, so the P3 live-overlay path cannot deliver Center-only dock-in across HWNDs. **Workaround:** drop-completion cursor hit-test.

- `src/Reactor/Docking/Native/DockFloatingPaneRouter.cs` (new) — global `ReactorWindow → append-as-tab` registry guarded by a lock. Uses Win32 `GetCursorPos` + `GetWindowRect` + `SetForegroundWindow` (P/Invoke) for the HWND-boundary hit-test.
- `DockHostNativeComponent.HandleTabDragCompleted` — consults the router **before** falling back to tear-out, so a tab dropped over a floating window's chrome appends as a new tab in that window.
- `DockFloatingWindowComponent` — self-registers with the router on mount via `UseEffect` deferred through `DispatcherQueue.TryEnqueue` (so the post-`Open` `windowHolder[0]` assignment lands first), and unregisters on close. Floating-to-floating redirect lives in the component's `onTabDragCompleted` closure.
- `DockDropTargetOverlayControl` — reserved `DockDropOverlayMode.CenterOnly` enum value + `ApplyModeVisibility` branch for the future live-overlay UX.

## Floating tab chrome (spec 045 §4.2 / §4.3)

- `DockFloatingWindow.Open()` now mounts `DockFloatingWindowComponent` with `WindowSpec.ExtendsContentIntoTitleBar = true`. `BuildChrome` renders `DockTabGroup` at the root + a transparent `BorderElement` in `TabStripFooter` whose `OnMount` calls `window.SetTitleBar(self)`.
- Component owns panes via `UseReducer<IReadOnlyList<DockableContent>>` (functional updater avoids stale-closure bugs); subscribes to `DockDragSession.SessionChanged`.
- Brush construction deferred to `OnMount` to keep `BuildFloatingRoot` headless-safe for unit tests.

## Manual test matrix

| From → To | Status |
|---|---|
| Floating → main window | ✅ works |
| Main window → empty space (creates new floating) | ✅ works |
| Main window → existing floating (appends as tab) | ✅ works |
| Existing floating → other existing floating (appends as tab) | ✅ works |

## Verification

- `dotnet build Reactor.slnx -c Debug -p:Platform=x64` — 0 errors.
- Full unit suite (`tests/Reactor.Tests`): **8773 passed**, 0 failed, 46 skipped.
- Selftests (`Reactor.AppTests.Host --self-test`): **826 / 827 pass**. One flake in `DynDock_OpenWelcomeButton_Mounted` is a pre-existing render-timing flake — passes in isolation, unrelated to this change.
- E2E (`tests/Reactor.AppTests`): **64 / 64 pass**.
- `tests/Reactor.Tests/Docking/Native/DockFloatingWindowTests.cs` (new): 5 unit tests pinning the `BuildFloatingRoot` element-tree shape.

## Spec doc updates

- §4.2 / §4.3: tick TitleBar-zone chrome bullets.
- §2.4: document the cross-window Center dock-in router + the WinUI window-local limitation.

## Scope note

This PR consolidates the full Phase 4 docking-windows arc that built up across several sessions: titlebar-tab chrome adoption, floating window drag region, and now cross-window dock-in. Persistence / sample / serializer / renderer touch-ups from the same arc are included.