### PR TITLE
Remove obsolete TextField factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,17 +29,11 @@ to land under these conventions; subsequent specs follow this shape.
 
 ### Changed
 
-- **`TextField` → `TextBox` rename.** The record type
-  `TextFieldElement` is renamed to `TextBoxElement` for parity with
-  WinUI's `Microsoft.UI.Xaml.Controls.TextBox`. The `TextField(...)`
-  factory remains as a non-erroring `[Obsolete]` forwarding alias for
-  one release; call sites should migrate to `TextBox(...)`. The
-  alias will be removed in a future release.
+- **`TextBox` is now the only text-input factory.** The deprecated
+  `TextField(...)` forwarding alias has been removed after the
+  `TextFieldElement` → `TextBoxElement` rename. Use `TextBox(...)`.
 
 ### Deprecated
-
-- **`Factories.TextField(...)`** — use `Factories.TextBox(...)` instead.
-  Emits `CS0618` warning; will be removed in a future release.
 
 - **Spec 045 Phase 2 — §2.29 ready for human review gate.**
   Every Phase-2 implementation item in

--- a/samples/CommandingDemo/App.cs
+++ b/samples/CommandingDemo/App.cs
@@ -58,7 +58,7 @@ class StandardCommandsDemo : Component
 
         // Tracks a one-shot selection we want to apply after a programmatic
         // text mutation (Cut/Paste/SelectAll). Cleared back to null as soon
-        // as the TextField consumes it, so normal user clicks don't trigger
+        // as the TextBox consumes it, so normal user clicks don't trigger
         // a programmatic selection write.
         var (pendingSelection, setPendingSelection) = UseState<(int Start, int Length)?>(null);
 
@@ -131,7 +131,7 @@ class StandardCommandsDemo : Component
                 SelectionLength = pendingSelection?.Length,
             }).Margin(horizontal: 16, vertical: 8),
 
-            // Clear the pending selection once the TextField has had a chance
+            // Clear the pending selection once the TextBox has had a chance
             // to apply it. Runs after render; no-op when nothing pending.
             PendingSelectionConsumer(pendingSelection, setPendingSelection),
 

--- a/samples/Reactor.TestApp/Demos/InputGesturesDemo.cs
+++ b/samples/Reactor.TestApp/Demos/InputGesturesDemo.cs
@@ -247,7 +247,7 @@ sealed class UseFocusSample : Component
         var (name, setName) = UseState("");
         var (inputRef, requestFocus) = this.UseElementFocus();
 
-        // Deliberately NOT auto-focusing on mount in this gallery: a TextField
+        // Deliberately NOT auto-focusing on mount in this gallery: a TextBox
         // deep inside a ScrollView that takes focus pulls the viewport down via
         // WinUI's BringIntoView — and it re-triggers every time the window
         // regains foreground. Real apps that auto-focus a first input (login

--- a/samples/ReactorGallery/ControlPages/BasicInput/TextBoxPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/TextBoxPage.cs
@@ -7,7 +7,7 @@ using static WinUIGalleryReactor.SamplePageHost;
 
 namespace WinUIGalleryReactor.ControlPages.BasicInput;
 
-class TextFieldPage: Component
+class TextBoxPage: Component
 {
     public override Element Render()
     {
@@ -19,9 +19,9 @@ class TextFieldPage: Component
         var (urlText, setUrlText) = UseState("");
 
         return ScrollView(VStack(16,
-            PageHeader("TextField", "A single-line or multi-line plain text input field."),
+            PageHeader("TextBox", "A single-line or multi-line plain text input field."),
 
-            SampleCard("Basic TextField",
+            SampleCard("Basic TextBox",
                 VStack(8,
                     TextBox(text, v => setText(v), "Type here..."),
                     TextBlock($"Characters: {text.Length}").Foreground(Theme.SecondaryText)),
@@ -29,7 +29,7 @@ class TextFieldPage: Component
 TextBox(text, v => setText(v), ""Type here..."")
 "),
 
-            SampleCard("Multiline TextField",
+            SampleCard("Multiline TextBox",
                 TextBox(multiline, v => setMultiline(v), "Enter multiple lines...")
                     .Set(tb => { tb.AcceptsReturn = true; tb.TextWrapping = TextWrapping.Wrap; })
                     .Height(120),
@@ -39,7 +39,7 @@ TextBox(multiline, v => setMultiline(v), ""Enter multiple lines..."")
     .Height(120)
 "),
 
-            SampleCard("TextField with Header",
+            SampleCard("TextBox with Header",
                 TextBox(headerText, v => setHeaderText(v), "user@example.com").Header("Email"),
                 sourceCode: @"
 TextBox(headerText, v => setHeaderText(v), ""user@example.com"").Header(""Email"")

--- a/samples/ReactorGallery/ControlPages/DesignGuidance/SpacingPage.cs
+++ b/samples/ReactorGallery/ControlPages/DesignGuidance/SpacingPage.cs
@@ -75,7 +75,7 @@ class SpacingPage : Component
     static Element MarginVsPaddingSection() =>
         SampleCard("Margin vs Padding",
             VStack(16,
-                TextBlock("Margin adds space outside an element; Padding adds space inside. In Reactor, .Padding() only works on Border and Control elements (Button, TextField, etc.). Layout panels like VStack and HStack only support .Margin() — wrap content in a Border if you need inner padding on a stack.")
+                TextBlock("Margin adds space outside an element; Padding adds space inside. In Reactor, .Padding() only works on Border and Control elements (Button, TextBox, etc.). Layout panels like VStack and HStack only support .Margin() — wrap content in a Border if you need inner padding on a stack.")
                     .Foreground(Theme.SecondaryText)
                     .FontSize(13)
                     .Set(tb => tb.TextWrapping = TextWrapping.Wrap)
@@ -140,7 +140,7 @@ class SpacingPage : Component
                 VStack(2,
                     CompatRow("Border",    true,  true),
                     CompatRow("Button",    true,  true),
-                    CompatRow("TextField", true,  true),
+                    CompatRow("TextBox",   true,  true),
                     CompatRow("Text",      true,  false),
                     CompatRow("VStack",    true,  false),
                     CompatRow("HStack",    true,  false),
@@ -153,7 +153,7 @@ TextBlock(""Hello"").Margin(8)
 VStack(children).Margin(16)
 Border(child).Margin(12)
 
-// Padding — only on Border and Control (Button, TextField, etc.)
+// Padding — only on Border and Control (Button, TextBox, etc.)
 Border(child).Padding(16)    // ✓ works
 Button(""Go"").Padding(12)    // ✓ works
 

--- a/samples/ReactorGallery/ControlRegistry.cs
+++ b/samples/ReactorGallery/ControlRegistry.cs
@@ -27,7 +27,7 @@ public static class ControlRegistry
         new("RepeatButton", "A button that raises click events repeatedly while pressed.", "Basic Input", "\uE73A", "repeat-button", "RepeatButton.png"),
         new("Slider", "A control that lets the user select from a range of values by moving a thumb.", "Basic Input", "\uE73A", "slider", "Slider.png"),
         new("SplitButton", "A button with two parts: a primary action and a flyout menu.", "Basic Input", "\uE73A", "split-button", "SplitButton.png"),
-        new("TextField", "A single-line or multi-line plain text input field.", "Basic Input", "\uE73A", "text-field", "TextBox.png"),
+        new("TextBox", "A single-line or multi-line plain text input field.", "Basic Input", "\uE73A", "text-box", "TextBox.png"),
         new("ToggleButton", "A button that can be toggled between two states.", "Basic Input", "\uE73A", "toggle-button", "ToggleButton.png"),
         new("ToggleSwitch", "A switch that toggles between two mutually exclusive states.", "Basic Input", "\uE73A", "toggle-switch", "ToggleSwitch.png"),
 

--- a/samples/ReactorGallery/PageRouter.cs
+++ b/samples/ReactorGallery/PageRouter.cs
@@ -25,7 +25,7 @@ static class PageRouter
         "repeat-button" => Component<ControlPages.BasicInput.RepeatButtonPage>(),
         "slider" => Component<ControlPages.BasicInput.SliderPage>(),
         "split-button" => Component<ControlPages.BasicInput.SplitButtonPage>(),
-        "text-field" => Component<ControlPages.BasicInput.TextFieldPage>(),
+        "text-box" => Component<ControlPages.BasicInput.TextBoxPage>(),
         "toggle-button" => Component<ControlPages.BasicInput.ToggleButtonPage>(),
         "toggle-switch" => Component<ControlPages.BasicInput.ToggleSwitchPage>(),
 

--- a/samples/apps/demo-script-tool/App/DemoScriptShell.cs
+++ b/samples/apps/demo-script-tool/App/DemoScriptShell.cs
@@ -77,7 +77,7 @@ public sealed class DemoScriptShell : Component
         // file watcher fires for a write WE just made, the disk hash equals
         // this value and we suppress the reload — otherwise our own debounced
         // save round-trips through the watcher, replaces the model with a new
-        // instance, re-syncs every TextField's local buffer, and resets the
+        // instance, re-syncs every TextBox's local buffer, and resets the
         // user's caret to position 0 mid-keystroke.
         var lastSyncedHashRef = UseRef<string?>(null);
         var announce = UseAnnounce();

--- a/samples/apps/dock-showcase/App.cs
+++ b/samples/apps/dock-showcase/App.cs
@@ -329,16 +329,16 @@ class SceneAIde : Component
 
     // ── Editable pane content factories ────────────────────────────────
     //
-    // Each docked pane gets a TextField (or AcceptsReturn=multiline) so
+    // Each docked pane gets a TextBox (or AcceptsReturn=multiline) so
     // we can observe keyboard focus / input routing through the docking
     // host. Spec 045 §2.10 + §2.14 invariants we're stressing here:
-    //   • Clicking a TextField inside a pane gives it keyboard focus.
-    //   • Typing into the focused TextField does NOT trigger chord
+    //   • Clicking a TextBox inside a pane gives it keyboard focus.
+    //   • Typing into the focused TextBox does NOT trigger chord
     //     accelerators (Ctrl+Tab / Ctrl+W must reach the editor when it
     //     owns focus, not the host's KeyboardAccelerator surface).
-    //   • Tab inside a TextField should advance focus within the pane,
+    //   • Tab inside a TextBox should advance focus within the pane,
     //     not skip to the next docked group.
-    //   • A drag of the pane preserves the TextField's current value
+    //   • A drag of the pane preserves the TextBox's current value
     //     (controlled-input pattern through the §2.30 shape-only
     //     override + Memo-component state slot).
     //
@@ -349,10 +349,10 @@ class SceneAIde : Component
         Memo(ctx =>
         {
             var (text, setText) = ctx.UseState(initial);
-            // INTENTIONALLY MINIMAL: a single-line controlled TextField,
+            // INTENTIONALLY MINIMAL: a single-line controlled TextBox,
             // no .Set, no AcceptsReturn, no typography modifiers. This
             // isolates whether the focus-loss-on-keystroke bug is in
-            // the controlled-TextField/Memo-state base case or in one
+            // the controlled-TextBox/Memo-state base case or in one
             // of the optional modifiers / multi-line config.
             return VStack(6,
                 TextBlock(banner).SemiBold(),

--- a/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
+++ b/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
@@ -170,7 +170,7 @@ public sealed class ImageAccessibilityAnalyzer : DiagnosticAnalyzer
 
 /// <summary>
 /// REACTOR_A11Y_003: Form fields need a label for screen readers.
-/// Detects <c>TextField(...)</c>, <c>NumberBox(...)</c>, <c>PasswordBox(...)</c>,
+/// Detects <c>TextBox(...)</c>, <c>NumberBox(...)</c>, <c>PasswordBox(...)</c>,
 /// and <c>AutoSuggestBox(...)</c> factory calls without a <c>header:</c> named argument,
 /// <c>.AutomationName()</c>, or <c>.LabeledBy()</c> in the fluent chain.
 /// </summary>
@@ -197,7 +197,7 @@ public sealed class FormFieldLabelAnalyzer : DiagnosticAnalyzer
         description: Description);
 
     private static readonly ImmutableHashSet<string> FormFieldMethods =
-        ImmutableHashSet.Create("TextBox", "TextField", "NumberBox", "PasswordBox", "AutoSuggestBox");
+        ImmutableHashSet.Create("TextBox", "NumberBox", "PasswordBox", "AutoSuggestBox");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);

--- a/src/Reactor.Cli/Loc/KeyNamer.cs
+++ b/src/Reactor.Cli/Loc/KeyNamer.cs
@@ -108,7 +108,7 @@ internal static class KeyNamer
         // For modifier contexts like "ToolTip", "Header", "Placeholder", append to value hint
         if (context.Contains('.'))
         {
-            // Named param: "TextField.placeholder" → hint from value + "Placeholder"
+            // Named param: "TextBox.placeholder" -> hint from value + "Placeholder"
             var parts = context.Split('.');
             var suffix = ToPascalCase(parts[^1]);
             var valueHint = GenerateHintFromValue(ls.Value);

--- a/src/Reactor.Cli/Loc/LocalizableStringScanner.cs
+++ b/src/Reactor.Cli/Loc/LocalizableStringScanner.cs
@@ -25,7 +25,6 @@ internal static class LocalizableStringScanner
     private static readonly Dictionary<string, HashSet<string>> LocalizableNamedParams = new(StringComparer.Ordinal)
     {
         ["TextBox"] = new(StringComparer.Ordinal) { "placeholder", "header" },
-        ["TextField"] = new(StringComparer.Ordinal) { "placeholder", "header" },
         ["PasswordBox"] = new(StringComparer.Ordinal) { "placeholderText" },
         ["NumberBox"] = new(StringComparer.Ordinal) { "header" },
         ["CheckBox"] = new(StringComparer.Ordinal) { "label" },
@@ -85,7 +84,7 @@ internal static class LocalizableStringScanner
                 {
                     ProcessDslFactoryCall(node, methodName);
                 }
-                // Check DSL factory methods with named params: TextField(value, placeholder: "Search")
+                // Check DSL factory methods with named params: TextBox(value, placeholder: "Search")
                 else if (LocalizableNamedParams.TryGetValue(methodName, out var paramNames))
                 {
                     ProcessNamedParamCall(node, methodName, paramNames);
@@ -133,8 +132,8 @@ internal static class LocalizableStringScanner
             }
 
             // Also check positional arguments that map to localizable params
-            // For TextBox/TextField: placeholder is arg index 2, header is arg index 3
-            if (methodName == "TextBox" || methodName == "TextField")
+            // For TextBox: placeholder is arg index 2, header is arg index 3
+            if (methodName == "TextBox")
             {
                 if (args.Count >= 3 && args[2].NameColon == null)
                 {

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -77,7 +77,7 @@ public sealed partial class Reconciler
             SplitButtonElement spBtn => MountSplitButton(spBtn, requestRerender),
             ToggleSplitButtonElement tspBtn => MountToggleSplitButton(tspBtn, requestRerender),
             RichEditBoxElement reb => MountRichEditBox(reb),
-            TextBoxElement tf => MountTextBox(tf, requestRerender),
+            TextBoxElement textBoxElement => MountTextBox(textBoxElement, requestRerender),
             PasswordBoxElement pw => MountPasswordBox(pw),
             NumberBoxElement nb => MountNumberBox(nb),
             AutoSuggestBoxElement asb => MountAutoSuggestBox(asb),
@@ -482,7 +482,7 @@ public sealed partial class Reconciler
         return tsb;
     }
 
-    private TextBox MountTextBox(TextBoxElement tf, Action requestRerender)
+    private TextBox MountTextBox(TextBoxElement textBoxElement, Action requestRerender)
     {
         var rented = _pool.TryRent(typeof(TextBox));
         var textBox = rented as TextBox ?? new TextBox();
@@ -491,29 +491,29 @@ public sealed partial class Reconciler
         // event handler. Setting the new tag first ensures the handler reads
         // this mount's element, not the pool's last owner. The BeginSuppress
         // guard below is additional belt-and-suspenders against echo.
-        SetElementTag(textBox, tf);
+        SetElementTag(textBox, textBoxElement);
         // AcceptsReturn and TextWrapping must be set BEFORE Text. WinUI TextBox
         // defaults to single-line mode (AcceptsReturn=false); assigning Text
         // with embedded \r\n while in single-line mode silently strips the
         // newlines, keeping only the first paragraph. Setting these first
         // ensures multi-line content round-trips correctly on mount.
-        if (tf.AcceptsReturn == true) textBox.AcceptsReturn = true;
-        if (tf.TextWrapping.HasValue) textBox.TextWrapping = tf.TextWrapping.Value;
-        if (rented is not null && textBox.Text != tf.Value)
+        if (textBoxElement.AcceptsReturn == true) textBox.AcceptsReturn = true;
+        if (textBoxElement.TextWrapping.HasValue) textBox.TextWrapping = textBoxElement.TextWrapping.Value;
+        if (rented is not null && textBox.Text != textBoxElement.Value)
             ChangeEchoSuppressor.BeginSuppress(textBox);
-        textBox.Text = tf.Value;
-        textBox.PlaceholderText = tf.Placeholder ?? "";
-        if (tf.Header is not null) textBox.Header = tf.Header;
-        if (tf.IsReadOnly == true) textBox.IsReadOnly = true;
-        if (tf.SelectionStart.HasValue) textBox.SelectionStart = tf.SelectionStart.Value;
-        if (tf.SelectionLength.HasValue) textBox.SelectionLength = tf.SelectionLength.Value;
-        if (tf.MaxLength != 0) textBox.MaxLength = tf.MaxLength;
-        if (tf.IsSpellCheckEnabled.HasValue) textBox.IsSpellCheckEnabled = tf.IsSpellCheckEnabled.Value;
-        if (tf.CharacterCasing != CharacterCasing.Normal) textBox.CharacterCasing = tf.CharacterCasing;
-        if (tf.TextAlignment != TextAlignment.Left) textBox.TextAlignment = tf.TextAlignment;
-        if (tf.Description is not null) textBox.Description = tf.Description;
-        EnsureTextBoxWiring(textBox, tf, requestRerender);
-        ApplySetters(tf.Setters, textBox);
+        textBox.Text = textBoxElement.Value;
+        textBox.PlaceholderText = textBoxElement.Placeholder ?? "";
+        if (textBoxElement.Header is not null) textBox.Header = textBoxElement.Header;
+        if (textBoxElement.IsReadOnly == true) textBox.IsReadOnly = true;
+        if (textBoxElement.SelectionStart.HasValue) textBox.SelectionStart = textBoxElement.SelectionStart.Value;
+        if (textBoxElement.SelectionLength.HasValue) textBox.SelectionLength = textBoxElement.SelectionLength.Value;
+        if (textBoxElement.MaxLength != 0) textBox.MaxLength = textBoxElement.MaxLength;
+        if (textBoxElement.IsSpellCheckEnabled.HasValue) textBox.IsSpellCheckEnabled = textBoxElement.IsSpellCheckEnabled.Value;
+        if (textBoxElement.CharacterCasing != CharacterCasing.Normal) textBox.CharacterCasing = textBoxElement.CharacterCasing;
+        if (textBoxElement.TextAlignment != TextAlignment.Left) textBox.TextAlignment = textBoxElement.TextAlignment;
+        if (textBoxElement.Description is not null) textBox.Description = textBoxElement.Description;
+        EnsureTextBoxWiring(textBox, textBoxElement, requestRerender);
+        ApplySetters(textBoxElement.Setters, textBox);
         return textBox;
     }
 
@@ -523,11 +523,11 @@ public sealed partial class Reconciler
     /// yet. Called from both Mount (fresh or pooled) and Update (null→non-null
     /// transition). The CWT flags survive pool round-trips.
     /// </summary>
-    internal static void EnsureTextBoxWiring(TextBox textBox, TextBoxElement tf, Action requestRerender)
+    internal static void EnsureTextBoxWiring(TextBox textBox, TextBoxElement textBoxElement, Action requestRerender)
     {
-        if (tf.OnChanged is null && tf.OnSelectionChanged is null) return;
+        if (textBoxElement.OnChanged is null && textBoxElement.OnSelectionChanged is null) return;
         var flags = GetPoolableWireFlags(textBox);
-        if (tf.OnChanged is not null && !flags.TextBoxTextChanged)
+        if (textBoxElement.OnChanged is not null && !flags.TextBoxTextChanged)
         {
             flags.TextBoxTextChanged = true;
             textBox.TextChanged += (_, _) =>
@@ -543,7 +543,7 @@ public sealed partial class Reconciler
                     requestRerender();
             };
         }
-        if (tf.OnSelectionChanged is not null && !flags.TextBoxSelectionChanged)
+        if (textBoxElement.OnSelectionChanged is not null && !flags.TextBoxSelectionChanged)
         {
             flags.TextBoxSelectionChanged = true;
             textBox.SelectionChanged += (_, _) => (GetElementTag(textBox) as TextBoxElement)?.OnSelectionChanged?.Invoke(textBox.SelectedText, textBox.SelectionStart, textBox.SelectionLength);

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -77,7 +77,7 @@ public sealed partial class Reconciler
             SplitButtonElement spBtn => MountSplitButton(spBtn, requestRerender),
             ToggleSplitButtonElement tspBtn => MountToggleSplitButton(tspBtn, requestRerender),
             RichEditBoxElement reb => MountRichEditBox(reb),
-            TextBoxElement tf => MountTextField(tf, requestRerender),
+            TextBoxElement tf => MountTextBox(tf, requestRerender),
             PasswordBoxElement pw => MountPasswordBox(pw),
             NumberBoxElement nb => MountNumberBox(nb),
             AutoSuggestBoxElement asb => MountAutoSuggestBox(asb),
@@ -482,7 +482,7 @@ public sealed partial class Reconciler
         return tsb;
     }
 
-    private TextBox MountTextField(TextBoxElement tf, Action requestRerender)
+    private TextBox MountTextBox(TextBoxElement tf, Action requestRerender)
     {
         var rented = _pool.TryRent(typeof(TextBox));
         var textBox = rented as TextBox ?? new TextBox();
@@ -512,7 +512,7 @@ public sealed partial class Reconciler
         if (tf.CharacterCasing != CharacterCasing.Normal) textBox.CharacterCasing = tf.CharacterCasing;
         if (tf.TextAlignment != TextAlignment.Left) textBox.TextAlignment = tf.TextAlignment;
         if (tf.Description is not null) textBox.Description = tf.Description;
-        EnsureTextFieldWiring(textBox, tf, requestRerender);
+        EnsureTextBoxWiring(textBox, tf, requestRerender);
         ApplySetters(tf.Setters, textBox);
         return textBox;
     }
@@ -523,7 +523,7 @@ public sealed partial class Reconciler
     /// yet. Called from both Mount (fresh or pooled) and Update (null→non-null
     /// transition). The CWT flags survive pool round-trips.
     /// </summary>
-    internal static void EnsureTextFieldWiring(TextBox textBox, TextBoxElement tf, Action requestRerender)
+    internal static void EnsureTextBoxWiring(TextBox textBox, TextBoxElement tf, Action requestRerender)
     {
         if (tf.OnChanged is null && tf.OnSelectionChanged is null) return;
         var flags = GetPoolableWireFlags(textBox);
@@ -536,7 +536,7 @@ public sealed partial class Reconciler
                 var tag = GetElementTag(textBox) as TextBoxElement;
                 tag?.OnChanged?.Invoke(textBox.Text);
                 // Controlled input: when onChange is wired, always request a
-                // re-render so UpdateTextField can enforce the controlled value.
+                // re-render so UpdateTextBox can enforce the controlled value.
                 // Coalesces with any setState re-render (CAS gate).
                 // Without onChange the field is uncontrolled — no snap-back.
                 if (tag?.OnChanged is not null)

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -134,7 +134,7 @@ public sealed partial class Reconciler
             (RichEditBoxElement o, RichEditBoxElement n, WinUI.RichEditBox reb)
                 => UpdateRichEditBox(o, n, reb),
             (TextBoxElement o, TextBoxElement n, TextBox tb)
-                => UpdateTextField(o, n, tb, requestRerender),
+                => UpdateTextBox(o, n, tb, requestRerender),
             (PasswordBoxElement o, PasswordBoxElement n, WinUI.PasswordBox pb)
                 => UpdatePasswordBox(o, n, pb),
             (NumberBoxElement o, NumberBoxElement n, WinUI.NumberBox nb)
@@ -778,11 +778,11 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateTextField(TextBoxElement o, TextBoxElement n, TextBox tb, Action requestRerender)
+    private UIElement? UpdateTextBox(TextBoxElement o, TextBoxElement n, TextBox tb, Action requestRerender)
     {
         // Tag first so any echoed TextChanged sees this element.
         SetElementTag(tb, n);
-        EnsureTextFieldWiring(tb, n, requestRerender);
+        EnsureTextBoxWiring(tb, n, requestRerender);
         if (o.Value != n.Value)
         {
             // Element value changed — always enforce

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -216,16 +216,6 @@ public static partial class Factories
     public static TextBoxElement TextBox(string value, Action<string>? onChanged = null, string? placeholder = null, string? header = null) =>
         new(value, onChanged, placeholder) { Header = header };
 
-    /// <summary>
-    /// Deprecated forwarding alias for <see cref="TextBox(string, Action{string}?, string?, string?)"/>.
-    /// </summary>
-    [global::System.Obsolete(
-        "Renamed to TextBox for parity with WinUI's Microsoft.UI.Xaml.Controls.TextBox. " +
-        "TextField will be removed in a future release.",
-        error: false)]
-    public static TextBoxElement TextField(string value, Action<string>? onChanged = null, string? placeholder = null, string? header = null) =>
-        TextBox(value, onChanged, placeholder, header);
-
     public static PasswordBoxElement PasswordBox(string password, Action<string>? onPasswordChanged = null, string? placeholderText = null) =>
         new(password, onPasswordChanged, placeholderText);
 

--- a/tests/Reactor.AppTests.Host/FixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/FixtureRegistry.cs
@@ -146,8 +146,8 @@ internal static class FixtureRegistry
 
         // Docking input (spec 045 — E2E validation of keyboard focus
         // across docking layout mutations)
-        "DockingInput_TwoPaneTextFields",
-        "DockingInput_TwoPaneTextFieldsNoPin",
+        "DockingInput_TwoPaneTextBoxes",
+        "DockingInput_TwoPaneTextBoxesNoPin",
     ];
 
     public static Element? Build(string name, RenderContext ctx) => name switch
@@ -284,8 +284,8 @@ internal static class FixtureRegistry
         "DragDrop_TextFormat" => DragDropE2EFixtures.TextFormatTest(ctx),
 
         // Docking input (spec 045 — E2E validation)
-        "DockingInput_TwoPaneTextFields" => DockingInputE2EFixtures.TwoPaneTextFieldTest(ctx),
-        "DockingInput_TwoPaneTextFieldsNoPin" => DockingInputE2EFixtures.TwoPaneTextFieldNoPinTest(ctx),
+        "DockingInput_TwoPaneTextBoxes" => DockingInputE2EFixtures.TwoPaneTextBoxTest(ctx),
+        "DockingInput_TwoPaneTextBoxesNoPin" => DockingInputE2EFixtures.TwoPaneTextBoxNoPinTest(ctx),
 
         _ => null,
     };

--- a/tests/Reactor.AppTests.Host/Fixtures/DockingInputE2EFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/DockingInputE2EFixtures.cs
@@ -7,20 +7,20 @@ using static Microsoft.UI.Reactor.Factories;
 namespace Microsoft.UI.Reactor.AppTests.Host.Fixtures;
 
 /// <summary>
-/// Spec 045 — E2E fixtures that put real editable TextFields inside docked
+/// Spec 045 — E2E fixtures that put real editable TextBoxes inside docked
 /// panes so WinAppDriver/Appium can verify keyboard focus, tab traversal,
 /// and the controlled-input contract across docking layout mutations.
 /// </summary>
 /// <remarks>
 /// The matching tests live in <c>tests/Reactor.AppTests/Tests/DockingInputTests.cs</c>.
-/// Each pane's TextField mirrors its state into a sibling TextBlock with
+/// Each pane's TextBox mirrors its state into a sibling TextBlock with
 /// AutomationId <c>*_State</c> so tests assert against the model rather
 /// than reading the TextBox's runtime <c>Text</c> property (which lags
 /// behind state in the controlled-input cycle).
 /// </remarks>
 internal static class DockingInputE2EFixtures
 {
-    internal class TwoPaneTextFieldComponent : Component
+    internal class TwoPaneTextBoxComponent : Component
     {
         public override Element Render()
         {
@@ -82,18 +82,18 @@ internal static class DockingInputE2EFixtures
         }
     }
 
-    internal static Element TwoPaneTextFieldTest(RenderContext ctx) =>
-        Component<TwoPaneTextFieldComponent>();
+    internal static Element TwoPaneTextBoxTest(RenderContext ctx) =>
+        Component<TwoPaneTextBoxComponent>();
 
     /// <summary>
-    /// Control variant of <see cref="TwoPaneTextFieldComponent"/>: identical
+    /// Control variant of <see cref="TwoPaneTextBoxComponent"/>: identical
     /// layout but the panes are bare <see cref="DockableContent"/>s (not
     /// <see cref="ToolWindow"/>s) and <c>CanPin: false</c> on both. Used to
     /// isolate whether the keystroke-loses-focus bug is gated by the pin-
     /// affordance code paths in <c>UpdateTabView</c> or by something more
     /// general about docking-host reconciles.
     /// </summary>
-    internal class TwoPaneTextFieldNoPinComponent : Component
+    internal class TwoPaneTextBoxNoPinComponent : Component
     {
         public override Element Render()
         {
@@ -135,6 +135,6 @@ internal static class DockingInputE2EFixtures
         }
     }
 
-    internal static Element TwoPaneTextFieldNoPinTest(RenderContext ctx) =>
-        Component<TwoPaneTextFieldNoPinComponent>();
+    internal static Element TwoPaneTextBoxNoPinTest(RenderContext ctx) =>
+        Component<TwoPaneTextBoxNoPinComponent>();
 }

--- a/tests/Reactor.AppTests.Host/Fixtures/EventHandlerFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/EventHandlerFixtures.cs
@@ -110,7 +110,7 @@ internal static class EventHandlerFixtures
         Component<PointerPressedTestComponent>();
 
     // ── OnKeyDown ─────────────────────────────────────────────────
-    // Uses a TextField — it naturally receives focus and key events,
+    // Uses a TextBox - it naturally receives focus and key events,
     // and WinAppDriver can locate it and send keys.
 
     internal class KeyDownTestComponent : Component

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlCatalogFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlCatalogFixtures.cs
@@ -89,7 +89,7 @@ internal static class ControlCatalogFixtures
             Add("ToggleSplitButton", ToggleSplitButton("CatalogTSB"), "CatalogTSB");
 
             // ── Input controls ──
-            Add("TextBox", TextBox("CatalogTF"), null);
+            Add("TextBox", TextBox("CatalogTB"), null);
             Add("PasswordBox", PasswordBox("pw"), null);
             Add("NumberBox", NumberBox(42, header: "CatalogNB"), "CatalogNB");
             Add("AutoSuggestBox", AutoSuggestBox("CatalogASB"), null);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlCatalogFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlCatalogFixtures.cs
@@ -89,7 +89,7 @@ internal static class ControlCatalogFixtures
             Add("ToggleSplitButton", ToggleSplitButton("CatalogTSB"), "CatalogTSB");
 
             // ── Input controls ──
-            Add("TextField", TextBox("CatalogTF"), null);
+            Add("TextBox", TextBox("CatalogTF"), null);
             Add("PasswordBox", PasswordBox("pw"), null);
             Add("NumberBox", NumberBox(42, header: "CatalogNB"), "CatalogNB");
             Add("AutoSuggestBox", AutoSuggestBox("CatalogASB"), null);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlUpdateFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlUpdateFixtures.cs
@@ -88,7 +88,7 @@ internal static class ControlUpdateFixtures
     // ════════════════════════════════════════════════════════════════════
 
     /// <summary>
-    /// Updates TextField, CheckBox, Slider, ToggleSwitch, NumberBox, PasswordBox,
+    /// Updates TextBox, CheckBox, Slider, ToggleSwitch, NumberBox, PasswordBox,
     /// and RadioButton in a single test to hit all their UpdateXxx methods.
     /// </summary>
     internal class InputControlsUpdate(Harness h) : SelfTestFixtureBase(h)
@@ -135,7 +135,7 @@ internal static class ControlUpdateFixtures
             H.ClickButton("UpdInputs");
             await Harness.Render();
 
-            H.Check("InputUpdate_TextFieldHeader", H.FindText("FieldHdr2") is not null);
+            H.Check("InputUpdate_TextBoxHeader", H.FindText("FieldHdr2") is not null);
             H.Check("InputUpdate_CheckBoxLabel", H.FindText("ChkLabel2") is not null);
             H.Check("InputUpdate_ToggleSwitchHeader", H.FindText("TsHdr2") is not null);
             H.Check("InputUpdate_NumberBoxHeader", H.FindText("NbHdr2") is not null);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridEditFixtures.cs
@@ -477,7 +477,7 @@ internal static class DataGridEditFixtures
     /// sibling's AutomationName carrying the flipped cell's text.
     ///
     /// This fixture mounts a tiny hand-rolled Grid whose middle child flips between
-    /// <c>Text</c> and <c>TextField</c> based on a state bit, then asserts the
+    /// <c>Text</c> and <c>TextBox</c> based on a state bit, then asserts the
     /// Grid's child count and per-child <c>AutomationProperties.Name</c> values
     /// survive the flip and the flip-back.
     /// </summary>
@@ -494,7 +494,7 @@ internal static class DataGridEditFixtures
                 setEditing = setEd;
 
                 // Four children matching the DataGrid row layout: [Id][Name][Cat][Price].
-                // Middle child flips between Text and TextField based on `editing`.
+                // Middle child flips between Text and TextBox based on `editing`.
                 var nameCell = editing
                     ? (Element)TextBox("Alice", _ => { }).Padding(2)
                     : (Element)TextBlock("Alice").Padding(horizontal: 8, vertical: 4);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
@@ -463,9 +463,9 @@ internal static class EchoSuppressionFixtures
         }
     }
 
-    // ── TextField ─────────────────────────────────────────────────────
+    // ── TextBox ───────────────────────────────────────────────────────
 
-    internal class TextFieldNoEcho(Harness h) : SelfTestFixtureBase(h)
+    internal class TextBoxNoEcho(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()
         {
@@ -481,24 +481,24 @@ internal static class EchoSuppressionFixtures
                 );
             });
             await Harness.Render();
-            H.Check("EchoSuppress_TextField_MountNoFire", calls.Count == 0);
+            H.Check("EchoSuppress_TextBox_MountNoFire", calls.Count == 0);
 
             H.ClickButton("Go_TF");
             await Harness.Render();
 
             var tb = H.FindControl<TextBox>(t => t.PlaceholderText == "test");
-            H.Check("EchoSuppress_TextField_UpdateAppliedValue", tb?.Text == "next");
+            H.Check("EchoSuppress_TextBox_UpdateAppliedValue", tb?.Text == "next");
             // Note: after a setState-driven change to "next", the controlled
-            // TextField's onChange MAY receive a trailing call from the
+            // TextBox's onChange MAY receive a trailing call from the
             // re-render snap-back path. We allow at most one non-echo call
             // that equals the current value (not a cross-value echo).
             bool onlyCurrentOrEmpty = calls.All(s => s == "next");
-            H.Check("EchoSuppress_TextField_NoEchoCallCrossValue", onlyCurrentOrEmpty);
+            H.Check("EchoSuppress_TextBox_NoEchoCallCrossValue", onlyCurrentOrEmpty);
 
             var precedingCount = calls.Count;
             if (tb is not null) tb.Text = "typed";
             await Harness.Render();
-            H.Check("EchoSuppress_TextField_UserEditFires",
+            H.Check("EchoSuppress_TextBox_UserEditFires",
                 calls.Count > precedingCount && calls[^1] == "typed");
         }
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
@@ -476,14 +476,14 @@ internal static class EchoSuppressionFixtures
                 var (phase, setPhase) = ctx.UseState(0);
                 var t = phase == 0 ? "initial" : "next";
                 return VStack(
-                    Button("Go_TF", () => setPhase(1)),
+                    Button("Go_TB", () => setPhase(1)),
                     TextBox(t, s => calls.Add(s), placeholder: "test")
                 );
             });
             await Harness.Render();
             H.Check("EchoSuppress_TextBox_MountNoFire", calls.Count == 0);
 
-            H.ClickButton("Go_TF");
+            H.ClickButton("Go_TB");
             await Harness.Render();
 
             var tb = H.FindControl<TextBox>(t => t.PlaceholderText == "test");

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -145,9 +145,9 @@ internal static class ReconcilerBigCoverageFixtures
                 Element nb = phase == 0
                     ? NumberBox(5, header: "wire-nb")
                     : NumberBox(5, onValueChanged: v => nbHits++, header: "wire-nb");
-                Element tf = phase == 0
-                    ? TextBox("wire-tf-text", placeholder: "tf")
-                    : TextBox("wire-tf-text", onChanged: v => textHits++, placeholder: "tf");
+                Element textBoxInput = phase == 0
+                    ? TextBox("wire-tb-text", placeholder: "tb")
+                    : TextBox("wire-tb-text", onChanged: v => textHits++, placeholder: "tb");
                 Element pw = phase == 0
                     ? PasswordBox("init")
                     : PasswordBox("init", onPasswordChanged: v => pwHits++);
@@ -157,7 +157,7 @@ internal static class ReconcilerBigCoverageFixtures
 
                 return VStack(
                     Button("WirePhase", () => set(1)),
-                    cb, rb, sl, ts, nb, tf, pw, reb
+                    cb, rb, sl, ts, nb, textBoxInput, pw, reb
                 );
             });
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -117,7 +117,7 @@ internal static class ReconcilerBigCoverageFixtures
     /// Mount each input control without any handlers, then re-render with handlers
     /// attached. This hits the once-only handler-wiring code path in Update<XYZ>
     /// for CheckBox, RadioButton, Slider, ToggleSwitch, NumberBox, RichEditBox,
-    /// TextField, PasswordBox, TreeView (handler-only path).
+    /// TextBox, PasswordBox, TreeView (handler-only path).
     /// </summary>
     internal class HandlerWiringOnSecondRender(Harness h) : SelfTestFixtureBase(h)
     {

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TextBoxMountFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TextBoxMountFixtures.cs
@@ -35,15 +35,15 @@ internal static class TextBoxMountFixtures
             await Harness.Render();
 
             var tb = H.FindControl<TextBox>(t => t.PlaceholderText == "ml-test");
-            H.Check("TF_MultiLine_Mounted", tb is not null);
+            H.Check("TB_MultiLine_Mounted", tb is not null);
 
             // All three lines must be present. WinUI normalizes \r\n → \r internally,
             // so we check for \r rather than \r\n.
             var text = tb?.Text ?? "";
-            H.Check("TF_MultiLine_Line1Present", text.Contains("Line one"));
-            H.Check("TF_MultiLine_Line2Present", text.Contains("Line two"));
-            H.Check("TF_MultiLine_Line3Present", text.Contains("Line three"));
-            H.Check("TF_MultiLine_AcceptsReturn", tb?.AcceptsReturn == true);
+            H.Check("TB_MultiLine_Line1Present", text.Contains("Line one"));
+            H.Check("TB_MultiLine_Line2Present", text.Contains("Line two"));
+            H.Check("TB_MultiLine_Line3Present", text.Contains("Line three"));
+            H.Check("TB_MultiLine_AcceptsReturn", tb?.AcceptsReturn == true);
         }
     }
 
@@ -64,9 +64,9 @@ internal static class TextBoxMountFixtures
             await Harness.Render();
 
             var tb = H.FindControl<TextBox>(t => t.PlaceholderText == "sl-test");
-            H.Check("TF_SingleLine_Mounted", tb is not null);
-            H.Check("TF_SingleLine_TextCorrect", tb?.Text == "hello world");
-            H.Check("TF_SingleLine_AcceptsReturnFalse", tb?.AcceptsReturn == false);
+            H.Check("TB_SingleLine_Mounted", tb is not null);
+            H.Check("TB_SingleLine_TextCorrect", tb?.Text == "hello world");
+            H.Check("TB_SingleLine_AcceptsReturnFalse", tb?.AcceptsReturn == false);
         }
     }
 
@@ -84,7 +84,7 @@ internal static class TextBoxMountFixtures
                 var (phase, set) = ctx.UseState(0);
                 var value = phase == 0 ? "First" : MultiLine;
                 return VStack(
-                    Button("TF_ML_Upd", () => set(1)),
+                    Button("TB_ML_Upd", () => set(1)),
                     (TextBox(value, placeholder: "ml-upd-test")
                         with { AcceptsReturn = true, TextWrapping = TextWrapping.Wrap })
                     .MinHeight(80));
@@ -92,15 +92,15 @@ internal static class TextBoxMountFixtures
 
             await Harness.Render();
             var tb = H.FindControl<TextBox>(t => t.PlaceholderText == "ml-upd-test");
-            H.Check("TF_MLUpd_InitialText", tb?.Text == "First");
+            H.Check("TB_MLUpd_InitialText", tb?.Text == "First");
 
-            H.ClickButton("TF_ML_Upd");
+            H.ClickButton("TB_ML_Upd");
             await Harness.Render();
 
             var text = tb?.Text ?? "";
-            H.Check("TF_MLUpd_Line1", text.Contains("Line one"));
-            H.Check("TF_MLUpd_Line2", text.Contains("Line two"));
-            H.Check("TF_MLUpd_Line3", text.Contains("Line three"));
+            H.Check("TB_MLUpd_Line1", text.Contains("Line one"));
+            H.Check("TB_MLUpd_Line2", text.Contains("Line two"));
+            H.Check("TB_MLUpd_Line3", text.Contains("Line three"));
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TextBoxMountFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TextBoxMountFixtures.cs
@@ -6,18 +6,18 @@ using static Microsoft.UI.Reactor.Factories;
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
 /// <summary>
-/// Verifies that TextField mount correctly applies AcceptsReturn / TextWrapping
+/// Verifies that TextBox mount correctly applies AcceptsReturn / TextWrapping
 /// BEFORE setting Text. WinUI TextBox silently strips \r\n when in single-line
-/// mode (AcceptsReturn=false), so the property order in MountTextField matters.
+/// mode (AcceptsReturn=false), so the property order in MountTextBox matters.
 /// </summary>
-internal static class TextFieldMountFixtures
+internal static class TextBoxMountFixtures
 {
     // Multi-paragraph value used across tests.
     const string MultiLine = "Line one\r\nLine two\r\nLine three";
 
     /// <summary>
     /// AcceptsReturn=true with multi-line text: all lines must survive the mount.
-    /// Regression test for the MountTextField property-ordering bug where Text was
+    /// Regression test for the MountTextBox property-ordering bug where Text was
     /// set before AcceptsReturn, causing WinUI to silently drop lines 2+.
     /// </summary>
     internal class MultiLineTextPreserved(Harness h) : SelfTestFixtureBase(h)
@@ -48,7 +48,7 @@ internal static class TextFieldMountFixtures
     }
 
     /// <summary>
-    /// Single-line TextField (AcceptsReturn omitted/false): Text is set in single-line
+    /// Single-line TextBox (AcceptsReturn omitted/false): Text is set in single-line
     /// mode which is correct. Verifies single-line mounts without regression.
     /// </summary>
     internal class SingleLineMountCorrect(Harness h) : SelfTestFixtureBase(h)
@@ -72,7 +72,7 @@ internal static class TextFieldMountFixtures
 
     /// <summary>
     /// Update path: after mount with multi-line text, a state change that updates
-    /// the value preserves all lines via UpdateTextField.
+    /// the value preserves all lines via UpdateTextBox.
     /// </summary>
     internal class MultiLineUpdatePreserved(Harness h) : SelfTestFixtureBase(h)
     {

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -552,12 +552,12 @@ internal static class SelfTestFixtureRegistry
         "EchoSuppress_CalendarDatePicker",
         "EchoSuppress_TimePicker",
         "EchoSuppress_PasswordBox",
-        "EchoSuppress_TextField",
+        "EchoSuppress_TextBox",
         "EchoSuppress_ToggleSplitButton",
-        // TextField mount property-ordering: AcceptsReturn must precede Text.
-        "TF_Mount_MultiLinePreserved",
-        "TF_Mount_SingleLineCorrect",
-        "TF_Mount_MultiLineUpdatePreserved",
+        // TextBox mount property-ordering: AcceptsReturn must precede Text.
+        "TB_Mount_MultiLinePreserved",
+        "TB_Mount_SingleLineCorrect",
+        "TB_Mount_MultiLineUpdatePreserved",
         // Control identity preservation under unrelated sibling re-render.
         // Regression coverage for the "Update falls through to Mount" bug
         // fixed in #76 — verifies the 14 controls' WinUI instances survive.
@@ -1493,11 +1493,11 @@ internal static class SelfTestFixtureRegistry
         "EchoSuppress_CalendarDatePicker" => new EchoSuppressionFixtures.CalendarDatePickerNoEcho(harness),
         "EchoSuppress_TimePicker" => new EchoSuppressionFixtures.TimePickerNoEcho(harness),
         "EchoSuppress_PasswordBox" => new EchoSuppressionFixtures.PasswordBoxNoEcho(harness),
-        "EchoSuppress_TextField" => new EchoSuppressionFixtures.TextFieldNoEcho(harness),
+        "EchoSuppress_TextBox" => new EchoSuppressionFixtures.TextBoxNoEcho(harness),
         "EchoSuppress_ToggleSplitButton" => new EchoSuppressionFixtures.ToggleSplitButtonNoEcho(harness),
-        "TF_Mount_MultiLinePreserved" => new TextFieldMountFixtures.MultiLineTextPreserved(harness),
-        "TF_Mount_SingleLineCorrect" => new TextFieldMountFixtures.SingleLineMountCorrect(harness),
-        "TF_Mount_MultiLineUpdatePreserved" => new TextFieldMountFixtures.MultiLineUpdatePreserved(harness),
+        "TB_Mount_MultiLinePreserved" => new TextBoxMountFixtures.MultiLineTextPreserved(harness),
+        "TB_Mount_SingleLineCorrect" => new TextBoxMountFixtures.SingleLineMountCorrect(harness),
+        "TB_Mount_MultiLineUpdatePreserved" => new TextBoxMountFixtures.MultiLineUpdatePreserved(harness),
         // Control identity preservation
         "IdentityPreserve_ComboBox" => new IdentityPreservationFixtures.ComboBoxSurvivesSiblingUpdate(harness),
         "IdentityPreserve_ComboBoxElements" => new IdentityPreservationFixtures.ComboBoxElementItemsSurvivesSiblingUpdate(harness),

--- a/tests/Reactor.AppTests/Tests/DockingInputTests.cs
+++ b/tests/Reactor.AppTests/Tests/DockingInputTests.cs
@@ -9,10 +9,10 @@ namespace Microsoft.UI.Reactor.AppTests.Tests;
 /// <summary>
 /// Spec 045 — E2E keyboard-input + focus tests across docking layout
 /// mutations. The bug class this guards against: a parent component's
-/// setState (here, a controlled TextField's <c>OnChanged</c> handler)
+/// setState (here, a controlled TextBox's <c>OnChanged</c> handler)
 /// causes the docking host to re-render, and some unconditional
 /// property write deep inside the reconciler's tab-header update steals
-/// focus from the focused TextField on every keystroke. Symptom:
+/// focus from the focused TextBox on every keystroke. Symptom:
 /// "I type one character and have to click back in the textbox to type
 /// another." The fix lives in
 /// <c>Reconciler.Update.UpdateTabView</c> +
@@ -28,7 +28,7 @@ public class DockingInputTests : AppTestBase
     public static void StopAppSession() => TestSession.AssemblyCleanup();
 
     /// <summary>
-    /// Type a multi-character string into the left pane's TextField,
+    /// Type a multi-character string into the left pane's TextBox,
     /// then Tab to the right pane and type another string. Both panes
     /// are pinnable ToolWindows in separate tab groups — the
     /// configuration that previously triggered the
@@ -38,14 +38,14 @@ public class DockingInputTests : AppTestBase
     [TestMethod]
     public void DockingInput_TypeAndTabAcrossPanes()
     {
-        NavigateToFixtureFresh("DockingInput_TwoPaneTextFields");
+        NavigateToFixtureFresh("DockingInput_TwoPaneTextBoxes");
 
         // Baseline: both states empty (the state TextBlocks read
         // "Left state: " / "Right state: " with a trailing space).
         WaitForText("DockEditor_Left_State", "Left state: ");
         WaitForText("DockEditor_Right_State", "Right state: ");
 
-        // Click into the left TextField and type. The Thread.Sleep
+        // Click into the left TextBox and type. The Thread.Sleep
         // gives WinUI time to settle focus into the inner Edit
         // control before SendKeys delivers the first character — a
         // brief grace window that matches the WinFormsInteropTests
@@ -59,7 +59,7 @@ public class DockingInputTests : AppTestBase
 
         // Tab from the focused left field. WinUI's tab traversal should
         // hop out of the left pane (past any tab strip / splitter
-        // chrome) and land on the right pane's TextField.
+        // chrome) and land on the right pane's TextBox.
         leftField.SendKeys(Keys.Tab);
 
         var rightField = FindById("DockEditor_Right");
@@ -82,7 +82,7 @@ public class DockingInputTests : AppTestBase
     [TestMethod]
     public void DockingInput_NoPin_TypeAndTabAcrossPanes()
     {
-        NavigateToFixtureFresh("DockingInput_TwoPaneTextFieldsNoPin");
+        NavigateToFixtureFresh("DockingInput_TwoPaneTextBoxesNoPin");
 
         WaitForText("DockEditorNoPin_Left_State", "Left state: ");
         WaitForText("DockEditorNoPin_Right_State", "Right state: ");
@@ -113,7 +113,7 @@ public class DockingInputTests : AppTestBase
     [TestMethod]
     public void DockingInput_DragToTab_PreservesFocusAndState()
     {
-        NavigateToFixtureFresh("DockingInput_TwoPaneTextFields");
+        NavigateToFixtureFresh("DockingInput_TwoPaneTextBoxes");
 
         // Seed both editors before the layout change so we can verify
         // post-mutation state survival.
@@ -180,7 +180,7 @@ public class DockingInputTests : AppTestBase
     [TestMethod]
     public void DockingInput_DragToTab_PreservesPreDragState()
     {
-        NavigateToFixtureFresh("DockingInput_TwoPaneTextFields");
+        NavigateToFixtureFresh("DockingInput_TwoPaneTextBoxes");
 
         var leftField = FindById("DockEditor_Left");
         leftField.Click();

--- a/tests/Reactor.AppTests/Tests/EventHandlerTests.cs
+++ b/tests/Reactor.AppTests/Tests/EventHandlerTests.cs
@@ -82,7 +82,7 @@ public class EventHandlerTests : AppTestBase
     }
 
     /// <summary>
-    /// OnKeyDown: focus a TextField and send a key, verify the key is captured
+    /// OnKeyDown: focus a TextBox and send a key, verify the key is captured
     /// by the declarative .OnKeyDown() handler.
     /// </summary>
     [TestMethod]

--- a/tests/Reactor.AppTests/Tests/WinFormsInteropTests.cs
+++ b/tests/Reactor.AppTests/Tests/WinFormsInteropTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.UI.Reactor.AppTests.Tests;
 /// Test host layout:
 ///   Top bar (WinForms):     WF_TextBox3 (TabIndex=4, after island)
 ///   Left panel (WinForms):  WF_TextBox1, WF_Button1, WF_TextBox2
-///   Right panel (Island):   Reactor_TextField1, Reactor_Button1, Reactor_TextField2
+///   Right panel (Island):   Reactor_TextBox1, Reactor_Button1, Reactor_TextBox2
 /// </summary>
 [TestClass]
 public class WinFormsInteropTests : WinFormsTestBase
@@ -83,11 +83,11 @@ public class WinFormsInteropTests : WinFormsTestBase
     [TestMethod]
     public void Interop_Rendering_TextInputWorks()
     {
-        // Type into the Reactor text field inside the island
-        var textField = FindById("Reactor_TextField1");
-        textField.Click();
-        textField.Clear();
-        textField.SendKeys("hello island");
+        // Type into the Reactor TextBox inside the island
+        var textBox = FindById("Reactor_TextBox1");
+        textBox.Click();
+        textBox.Clear();
+        textBox.SendKeys("hello island");
 
         // Verify the display updates
         WaitForText("Reactor_TextDisplay", "Text: hello island");
@@ -118,9 +118,9 @@ public class WinFormsInteropTests : WinFormsTestBase
         "WF_TextBox1",       // leftPanel child 0
         "WF_Button1",        // leftPanel child 1
         "WF_TextBox2",       // leftPanel child 2
-        "Reactor_TextField1",   // island — first WinUI control
+        "Reactor_TextBox1",     // island - first WinUI control
         "Reactor_Button1",      // island — second WinUI control
-        "Reactor_TextField2",   // island — third WinUI control
+        "Reactor_TextBox2",     // island - third WinUI control
         "WF_TextBox3",       // bottomBar child 0
     ];
 
@@ -178,8 +178,8 @@ public class WinFormsInteropTests : WinFormsTestBase
         var title = FindById("Reactor_Title");
         Assert.IsNotNull(title, "Reactor_Title should be findable by AutomationId through UIA");
 
-        var textField = FindById("Reactor_TextField1");
-        Assert.IsNotNull(textField, "Reactor_TextField1 should be findable by AutomationId");
+        var textBox = FindById("Reactor_TextBox1");
+        Assert.IsNotNull(textBox, "Reactor_TextBox1 should be findable by AutomationId");
 
         var button = FindById("Reactor_Button1");
         Assert.IsNotNull(button, "Reactor_Button1 should be findable by AutomationId");
@@ -189,10 +189,10 @@ public class WinFormsInteropTests : WinFormsTestBase
     public void Interop_A11y_IslandControlsHaveAccessibleNames()
     {
         // Verify accessible names are exposed through UIA
-        var textField = FindById("Reactor_TextField1");
-        var name = textField.GetAttribute("Name");
-        Assert.AreEqual("Island text field", name,
-            "Reactor TextField should expose its AutomationName through UIA");
+        var textBox = FindById("Reactor_TextBox1");
+        var name = textBox.GetAttribute("Name");
+        Assert.AreEqual("Island TextBox", name,
+            "Reactor TextBox should expose its AutomationName through UIA");
 
         var button = FindById("Reactor_Button1");
         var buttonName = button.GetAttribute("Name");
@@ -232,15 +232,15 @@ public class WinFormsInteropTests : WinFormsTestBase
     }
 
     [TestMethod]
-    public void Interop_A11y_TextFieldIsEditable()
+    public void Interop_A11y_TextBoxIsEditable()
     {
-        // Verify the text field inside the island is recognized as editable
-        var textField = FindById("Reactor_TextField1");
-        var controlType = textField.GetAttribute("LocalizedControlType");
+        // Verify the TextBox inside the island is recognized as editable
+        var textBox = FindById("Reactor_TextBox1");
+        var controlType = textBox.GetAttribute("LocalizedControlType");
 
         // WinUI TextBox reports as "edit" in UIA
         Assert.IsTrue(
             controlType != null && controlType.Contains("edit", StringComparison.OrdinalIgnoreCase),
-            $"Island TextField should be an editable control type, got: {controlType}");
+            $"Island TextBox should be an editable control type, got: {controlType}");
     }
 }

--- a/tests/Reactor.Tests/A11yShowcaseScannerTest.cs
+++ b/tests/Reactor.Tests/A11yShowcaseScannerTest.cs
@@ -58,7 +58,7 @@ public class A11yShowcaseScannerTest
                 Button("All", null),
                 Button("Active", null),
 
-                // A11Y_003: TextField without header, AutomationName, or LabeledBy
+                // A11Y_003: TextBox without header, AutomationName, or LabeledBy
                 TextBox("", null, placeholder: "New task..."),
 
                 // A11Y_001: Another icon-only button
@@ -85,7 +85,7 @@ public class A11yShowcaseScannerTest
             // Footer
             HStack(12,
                 TextBlock("Quick note:"),
-                // A11Y_003: TextField with mistyped LabeledBy → A11Y_008
+                // A11Y_003: TextBox with mistyped LabeledBy -> A11Y_008
                 TextBox("", null).LabeledBy("FooterNoteLabel_TYPO")
             )
         );

--- a/tests/Reactor.Tests/AccessibilityScannerTests.cs
+++ b/tests/Reactor.Tests/AccessibilityScannerTests.cs
@@ -92,7 +92,7 @@ public class AccessibilityScannerTests
     // ════════════════════════════════════════════════════════════════
 
     [Fact]
-    public void A11Y_003_TextField_Without_Label()
+    public void A11Y_003_TextBox_Without_Label()
     {
         var tree = VStack(
             TextBox("", null, placeholder: "Enter email")
@@ -103,7 +103,7 @@ public class AccessibilityScannerTests
     }
 
     [Fact]
-    public void A11Y_003_TextField_With_Header_Passes()
+    public void A11Y_003_TextBox_With_Header_Passes()
     {
         var tree = VStack(
             TextBox("", null, header: "Email address")
@@ -114,7 +114,7 @@ public class AccessibilityScannerTests
     }
 
     [Fact]
-    public void A11Y_003_TextField_With_AutomationName_Passes()
+    public void A11Y_003_TextBox_With_AutomationName_Passes()
     {
         var tree = VStack(
             TextBox("", null).AutomationName("Email address")
@@ -125,7 +125,7 @@ public class AccessibilityScannerTests
     }
 
     [Fact]
-    public void A11Y_003_TextField_With_LabeledBy_Passes()
+    public void A11Y_003_TextBox_With_LabeledBy_Passes()
     {
         var tree = VStack(
             TextBlock("Email").AutomationId("EmailLabel"),

--- a/tests/Reactor.Tests/AnalyzerTests/AccessibilityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AccessibilityAnalyzerTests.cs
@@ -164,7 +164,7 @@ public class FormFieldLabelAnalyzerTests
             .Diagnostic(id);
 
     [Fact]
-    public async Task TextField_Without_Label_Produces_Diagnostic()
+    public async Task TextBox_Without_Label_Produces_Diagnostic()
     {
         var test = @"
 class C
@@ -188,7 +188,7 @@ class C
     }
 
     [Fact]
-    public async Task TextField_With_Header_No_Diagnostic()
+    public async Task TextBox_With_Header_No_Diagnostic()
     {
         var test = @"
 class C
@@ -208,7 +208,7 @@ class C
     }
 
     [Fact]
-    public async Task TextField_With_AutomationName_No_Diagnostic()
+    public async Task TextBox_With_AutomationName_No_Diagnostic()
     {
         var test = @"
 class C
@@ -228,7 +228,7 @@ class C
     }
 
     [Fact]
-    public async Task TextField_With_LabeledBy_No_Diagnostic()
+    public async Task TextBox_With_LabeledBy_No_Diagnostic()
     {
         var test = @"
 class C

--- a/tests/Reactor.Tests/Controls/EditChainTests.cs
+++ b/tests/Reactor.Tests/Controls/EditChainTests.cs
@@ -424,7 +424,7 @@ public class EditChainTests
     }
 
     [Fact]
-    public void RenderReadOnlyValue_String_Returns_Disabled_TextField()
+    public void RenderReadOnlyValue_String_Returns_Disabled_TextBox()
     {
         var method = GetStatic("RenderReadOnlyValue");
         var el = (Element)method.Invoke(null, new object?[] { "hello", typeof(string) })!;

--- a/tests/Reactor.Tests/Controls/TypedColumnsBehaviorTests.cs
+++ b/tests/Reactor.Tests/Controls/TypedColumnsBehaviorTests.cs
@@ -84,7 +84,7 @@ public class TypedColumnsBehaviorTests
     [Fact]
     public void Registry_Uri_Editor_Stringifies_Uri_And_Commits_Uri()
     {
-        // The Uri editor uses TextField under the hood but commits Uri objects
+        // The Uri editor uses TextBox under the hood but commits Uri objects
         // through Uri.TryCreate. A regression that resolved Uri to a string
         // editor would commit raw strings to a Uri property → ArgumentException
         // on the model setter.

--- a/tests/Reactor.Tests/DslFactoryLogicTests.cs
+++ b/tests/Reactor.Tests/DslFactoryLogicTests.cs
@@ -95,7 +95,7 @@ public class DslFactoryLogicTests
     // ════════════════════════════════════════════════════════════════
 
     [Fact]
-    public void TextField_With_All_Parameters()
+    public void TextBox_With_All_Parameters()
     {
         var el = TextBox("val", s => { }, "hint", "Header");
         Assert.Equal("val", el.Value);

--- a/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
@@ -243,7 +243,7 @@ public class ElementExtensionsCoverageTests
     }
 
     [Fact]
-    public void TextField_Sugar()
+    public void TextBox_Sugar()
     {
         var el = TextBox("x", _ => { })
             .IsReadOnly()
@@ -259,8 +259,8 @@ public class ElementExtensionsCoverageTests
     // Path.StrokeDashArray uses DoubleCollection (WinUI), tested in selftest.
 
     [Fact]
-    [Obsolete("Tests the deprecated ReadOnly shim for TextField")]
-    public void TextField_ReadOnly_Shim()
+    [Obsolete("Tests the deprecated ReadOnly shim for TextBox")]
+    public void TextBox_ReadOnly_Shim()
     {
         var el = TextBox("x", _ => { }).ReadOnly();
         Assert.True(el.IsReadOnly);

--- a/tests/Reactor.Tests/ElementTests.cs
+++ b/tests/Reactor.Tests/ElementTests.cs
@@ -126,7 +126,7 @@ public class ElementTests
     // ════════════════════════════════════════════════════════════════
 
     [Fact]
-    public void TextField_Creates_With_Value_And_Placeholder()
+    public void TextBox_Creates_With_Value_And_Placeholder()
     {
         var el = TextBox("val", placeholder: "hint");
         Assert.Equal("val", el.Value);

--- a/tests/Reactor.Tests/Elements/EventFluentNullClearTests.cs
+++ b/tests/Reactor.Tests/Elements/EventFluentNullClearTests.cs
@@ -159,7 +159,7 @@ public class EventFluentNullClearTests
     // ── §3 Input ──────────────────────────────────────────────────────
 
     [Fact]
-    public void TextField_Changed_NullClears()
+    public void TextBox_Changed_NullClears()
     {
         var el = TextBox("x").Changed(SentinelStr);
         Assert.Same(SentinelStr, el.OnChanged);
@@ -167,7 +167,7 @@ public class EventFluentNullClearTests
     }
 
     [Fact]
-    public void TextField_SelectionChanged_NullClears()
+    public void TextBox_SelectionChanged_NullClears()
     {
         Action<string, int, int> h = (_, _, _) => { };
         var el = TextBox("x").SelectionChanged(h);

--- a/tests/Reactor.Tests/Elements/FactoryWithExpressionTests.cs
+++ b/tests/Reactor.Tests/Elements/FactoryWithExpressionTests.cs
@@ -87,7 +87,7 @@ public class FactoryWithExpressionTests
     //  Input controls
     // ════════════════════════════════════════════════════════════════
 
-    [Fact] public void TextField_WithExpr_Sets_Property()
+    [Fact] public void TextBox_WithExpr_Sets_Property()
         => Assert.Equal("hint", (TextBox("v") with { Placeholder = "hint" }).Placeholder);
 
     [Fact] public void PasswordBox_WithExpr_Sets_Key()

--- a/tests/Reactor.Tests/Elements/GallerySampleConstructionSmokeTests.cs
+++ b/tests/Reactor.Tests/Elements/GallerySampleConstructionSmokeTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.UI.Reactor.Tests.Elements;
 ///
 /// Phase 8 page inventory:
 ///   - ButtonPage           — .Click / .AccentButton / .SubtleButton / .TextLink
-///   - TextFieldPage        — .NumericInput / .EmailInput / .UrlInput / .Description
+///   - TextBoxPage          — .NumericInput / .EmailInput / .UrlInput / .Description
 ///   - InfoBarPage          — .Informational / .Success / .Warning / .Error
 ///   - TypeRampPage         — Title / Subtitle / Body / BodyStrong / BodyLarge
 ///   - CardPage             — Card(child)
@@ -50,9 +50,9 @@ public class GallerySampleConstructionSmokeTests
     }
 
     [Fact]
-    public void TextFieldPage_FluentChains_Construct()
+    public void TextBoxPage_FluentChains_Construct()
     {
-        // Mirrors the InputScope + Description chains in TextFieldPage.cs.
+        // Mirrors the InputScope + Description chains in TextBoxPage.cs.
         var numeric = TextBox("", _ => { }, "0").Header("Qty").NumericInput().Description("hint");
         var email = TextBox("", _ => { }, "you@x.com").Header("Email").EmailInput();
         var url = TextBox("", _ => { }, "https://").Header("URL").UrlInput();

--- a/tests/Reactor.Tests/Elements/Phase4InitFluentTests.cs
+++ b/tests/Reactor.Tests/Elements/Phase4InitFluentTests.cs
@@ -340,17 +340,17 @@ public class Phase4InitFluentTests
         Assert.Equal(new Uri("ms-appx:///Assets/Logo.ico"), icon.Source);
     }
 
-    // ── 4.7 TextField ─────────────────────────────────────────────────
+    // ── 4.7 TextBox ───────────────────────────────────────────────────
 
     [Fact]
-    public void TextField_MaxLength_Sets()
+    public void TextBox_MaxLength_Sets()
     {
         var el = TextBox("").MaxLength(32);
         Assert.Equal(32, el.MaxLength);
     }
 
     [Fact]
-    public void TextField_IsSpellCheckEnabled_Sets()
+    public void TextBox_IsSpellCheckEnabled_Sets()
     {
         var el = TextBox("").IsSpellCheckEnabled();
         Assert.True(el.IsSpellCheckEnabled);
@@ -358,21 +358,21 @@ public class Phase4InitFluentTests
     }
 
     [Fact]
-    public void TextField_CharacterCasing_Sets()
+    public void TextBox_CharacterCasing_Sets()
     {
         var el = TextBox("").CharacterCasing(Microsoft.UI.Xaml.Controls.CharacterCasing.Upper);
         Assert.Equal(Microsoft.UI.Xaml.Controls.CharacterCasing.Upper, el.CharacterCasing);
     }
 
     [Fact]
-    public void TextField_TextAlignment_Sets()
+    public void TextBox_TextAlignment_Sets()
     {
         var el = TextBox("").TextAlignment(Microsoft.UI.Xaml.TextAlignment.Right);
         Assert.Equal(Microsoft.UI.Xaml.TextAlignment.Right, el.TextAlignment);
     }
 
     [Fact]
-    public void TextField_Description_Sets()
+    public void TextBox_Description_Sets()
     {
         var el = TextBox("").Description("enter your name");
         Assert.Equal("enter your name", el.Description);

--- a/tests/Reactor.Tests/Localization/KeyNamerTests.cs
+++ b/tests/Reactor.Tests/Localization/KeyNamerTests.cs
@@ -139,7 +139,7 @@ public class KeyNamerTests
             {
                 FilePath = "CatalogPage.cs",
                 ClassName = "CatalogPage",
-                Context = "TextField.placeholder",
+                Context = "TextBox.placeholder",
                 Value = "Search products...",
                 SpanStart = 100,
                 SpanLength = 20,

--- a/tests/Reactor.Tests/Localization/LocalizableStringScannerTests.cs
+++ b/tests/Reactor.Tests/Localization/LocalizableStringScannerTests.cs
@@ -254,7 +254,7 @@ public class LocalizableStringScannerTests
 
         var results = Scan(source);
 
-        // TextField value "" is empty (skipped), Header should be found
+        // TextBox value "" is empty (skipped), Header should be found
         Assert.Single(results);
         Assert.Equal("User Name", results[0].Value);
         Assert.Equal("Header", results[0].Context);

--- a/tests/Reactor.Tests/ReconcilerHelperTests.cs
+++ b/tests/Reactor.Tests/ReconcilerHelperTests.cs
@@ -139,14 +139,14 @@ public class ReconcilerHelperTests
     }
 
     [Fact]
-    public void ResolveCaptionForElement_TextField_Prefers_Header()
+    public void ResolveCaptionForElement_TextBox_Prefers_Header()
     {
         var tf = new TextBoxElement("", Placeholder: "Enter name") { Header = "Name" };
         Assert.Equal("Name", Reconciler.ResolveCaptionForElement(tf));
     }
 
     [Fact]
-    public void ResolveCaptionForElement_TextField_Falls_Back_To_Placeholder()
+    public void ResolveCaptionForElement_TextBox_Falls_Back_To_Placeholder()
     {
         var tf = new TextBoxElement("", Placeholder: "Enter name") { Header = null };
         Assert.Equal("Enter name", Reconciler.ResolveCaptionForElement(tf));

--- a/tests/Reactor.Tests/RichEditBoxElementTests.cs
+++ b/tests/Reactor.Tests/RichEditBoxElementTests.cs
@@ -135,7 +135,7 @@ public class RichEditBoxElementTests
     }
 
     [Fact]
-    public void CanUpdate_RichEditBox_Vs_TextField_Returns_False()
+    public void CanUpdate_RichEditBox_Vs_TextBox_Returns_False()
     {
         var reconciler = new Reconciler();
         Assert.False(reconciler.CanUpdate(RichEditBox("a"), TextBox("a")));

--- a/tests/Reactor.Tests/SetExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/SetExtensionsCoverageTests.cs
@@ -16,7 +16,7 @@ public class SetExtensionsCoverageTests
     // ── Input controls ──────────────────────────────────────────────
 
     [Fact]
-    public void Set_TextField_Appends_Setter()
+    public void Set_TextBox_Appends_Setter()
     {
         var el = TextBox("val").Set(tb => tb.IsEnabled = false);
         Assert.Single(el.Setters);

--- a/tests/Reactor.Tests/ValidateExtensionTests.cs
+++ b/tests/Reactor.Tests/ValidateExtensionTests.cs
@@ -8,11 +8,11 @@ namespace Microsoft.UI.Reactor.Tests;
 public class ValidateExtensionTests
 {
     // ════════════════════════════════════════════════════════════════
-    //  .Validate() on TextField
+    //  .Validate() on TextBox
     // ════════════════════════════════════════════════════════════════
 
     [Fact]
-    public void Validate_On_TextField_Attaches_Validators()
+    public void Validate_On_TextBox_Attaches_Validators()
     {
         var el = TextBox("test")
             .Validate("email", Validate.Required(), Validate.Email());
@@ -24,7 +24,7 @@ public class ValidateExtensionTests
     }
 
     [Fact]
-    public void Validate_On_TextField_Preserves_Element_Type()
+    public void Validate_On_TextBox_Preserves_Element_Type()
     {
         var el = TextBox("test")
             .Validate("email", Validate.Required());

--- a/tests/Reactor.WinFormsTests.Host/TestDuctComponent.cs
+++ b/tests/Reactor.WinFormsTests.Host/TestDuctComponent.cs
@@ -21,11 +21,11 @@ class TestReactorComponent : Component
                     .FontSize(16)
                     .AutomationId("Reactor_Title"),
 
-                // Focusable text field — first Tab stop inside the island
+                // Focusable TextBox - first Tab stop inside the island
                 TextBox(text, setText, placeholder: "Type in island")
                     .Width(250)
-                    .AutomationId("Reactor_TextField1")
-                    .AutomationName("Island text field"),
+                    .AutomationId("Reactor_TextBox1")
+                    .AutomationName("Island TextBox"),
 
                 TextBlock($"Text: {text}")
                     .AutomationId("Reactor_TextDisplay"),
@@ -38,11 +38,11 @@ class TestReactorComponent : Component
                 TextBlock($"Count: {count}")
                     .AutomationId("Reactor_CountDisplay"),
 
-                // A second text field — third Tab stop
+                // A second TextBox - third Tab stop
                 TextBox("", _ => { }, placeholder: "Second field")
                     .Width(250)
-                    .AutomationId("Reactor_TextField2")
-                    .AutomationName("Island second field"),
+                    .AutomationId("Reactor_TextBox2")
+                    .AutomationName("Island second TextBox"),
 
                 // Accessibility test targets
                 TextBlock("Status: Ready")

--- a/tests/Reactor.WinFormsTests.Host/TestForm.cs
+++ b/tests/Reactor.WinFormsTests.Host/TestForm.cs
@@ -12,7 +12,7 @@ namespace Microsoft.UI.Reactor.WinFormsTests.Host;
 ///   Bottom bar (WinForms):  WF_TextBox3 — Tab stop AFTER the island
 ///
 /// Tab order is controlled by TabIndex on the container panels:
-///   leftPanel (TabIndex=0) → island (TabIndex=1) → bottomBar (TabIndex=2)
+///   leftPanel (TabIndex=0) -> island (TabIndex=1) -> bottomBar (TabIndex=2)
 ///
 /// Expected forward Tab order:
 ///   WF_TextBox1 -> WF_Button1 -> WF_TextBox2 -> [Island] -> Reactor_TextBox1 ->

--- a/tests/Reactor.WinFormsTests.Host/TestForm.cs
+++ b/tests/Reactor.WinFormsTests.Host/TestForm.cs
@@ -8,15 +8,15 @@ namespace Microsoft.UI.Reactor.WinFormsTests.Host;
 ///
 /// Layout:
 ///   Left panel (WinForms):  WF_TextBox1, WF_Button1, WF_TextBox2
-///   Right panel (Island):   Reactor_TextField1, Reactor_Button1, Reactor_TextField2
+///   Right panel (Island):   Reactor_TextBox1, Reactor_Button1, Reactor_TextBox2
 ///   Bottom bar (WinForms):  WF_TextBox3 — Tab stop AFTER the island
 ///
 /// Tab order is controlled by TabIndex on the container panels:
 ///   leftPanel (TabIndex=0) → island (TabIndex=1) → bottomBar (TabIndex=2)
 ///
 /// Expected forward Tab order:
-///   WF_TextBox1 → WF_Button1 → WF_TextBox2 → [Island] → Reactor_TextField1 →
-///   Reactor_Button1 → Reactor_TextField2 → [exit island] → WF_TextBox3 → wrap
+///   WF_TextBox1 -> WF_Button1 -> WF_TextBox2 -> [Island] -> Reactor_TextBox1 ->
+///   Reactor_Button1 -> Reactor_TextBox2 -> [exit island] -> WF_TextBox3 -> wrap
 /// </summary>
 class TestForm : SWF.Form
 {


### PR DESCRIPTION
## Summary
- remove the obsolete `TextField(...)` forwarding factory so `TextBox(...)` is the only text-input DSL factory
- update analyzer and localization scanner support to stop recognizing `TextField` as a current factory
- rename internal TextBox reconciler helpers, gallery/sample labels, fixture names, and tests/docs references from TextField to TextBox

## Validation
- `dotnet test tests\Reactor.Tests -p:Platform=ARM64 --logger "console;verbosity=minimal"`
- `dotnet test tests\Reactor.SelfTests -p:Platform=ARM64 --logger "console;verbosity=minimal"`

## Follow-up
- Created #389 to track renaming `MaskedTextField` to `MaskedTextBox`.