### PR TITLE
Fix unit stress test isolation flakes

### DIFF
--- a/tests/Reactor.Tests/ComponentModelIntegrationTests.cs
+++ b/tests/Reactor.Tests/ComponentModelIntegrationTests.cs
@@ -10,9 +10,9 @@ namespace Microsoft.UI.Reactor.Tests;
 /// component lifecycle (BeginRender → Render → FlushEffects → RunCleanups)
 /// through a shared ContextScope.
 /// </summary>
-// Shares the process-wide ApplicationPersistedScope.Default with
-// PersistedStateTests; both Clear() it in setup/teardown, so xUnit must
-// serialize them or a Clear() can race with another class's Set/TryGet.
+// Shares the process-wide ApplicationPersistedScope.Default with other
+// persistence tests; setup/teardown Clear() must not race another class's
+// Set/TryGet against the singleton.
 [Collection("PersistedStateCache")]
 public class ComponentModelIntegrationTests : IDisposable
 {

--- a/tests/Reactor.Tests/PersistedStateTests.cs
+++ b/tests/Reactor.Tests/PersistedStateTests.cs
@@ -6,9 +6,9 @@ namespace Microsoft.UI.Reactor.Tests;
 /// <summary>
 /// Phase 4 tests: PersistedStateCache unit tests and UsePersisted hook tests.
 /// </summary>
-// Shares the process-wide ApplicationPersistedScope.Default with
-// ComponentModelIntegrationTests; both Clear() it in setup/teardown, so xUnit
-// must serialize them or a Clear() can race with another class's Set/TryGet.
+// Shares the process-wide ApplicationPersistedScope.Default with other
+// persistence tests; setup/teardown Clear() must not race another class's
+// Set/TryGet against the singleton.
 [Collection("PersistedStateCache")]
 public class PersistedStateTests : IDisposable
 {

--- a/tests/Reactor.Tests/TestIsolationCollections.cs
+++ b/tests/Reactor.Tests/TestIsolationCollections.cs
@@ -19,3 +19,12 @@ public sealed class ConsoleTestsCollection { }
 /// </summary>
 [CollectionDefinition("UnobservedTaskException", DisableParallelization = true)]
 public sealed class UnobservedTaskExceptionCollection { }
+
+/// <summary>
+/// xUnit collection marker for tests that mutate
+/// <see cref="Microsoft.UI.Reactor.Core.ApplicationPersistedScope.Default"/>.
+/// The singleton is process-wide, so tests that clear or write it must not run
+/// concurrently with other tests that assert values remain present.
+/// </summary>
+[CollectionDefinition("PersistedStateCache", DisableParallelization = true)]
+public sealed class PersistedStateCacheCollection { }

--- a/tests/Reactor.Tests/UseCommandTests.cs
+++ b/tests/Reactor.Tests/UseCommandTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.UI.Reactor.Tests;
 /// <summary>
 /// Tests for UseCommand hook — sync passthrough, async lifecycle, re-entrance guards.
 /// </summary>
+[Collection("UnobservedTaskException")]
 public class UseCommandTests
 {
     private static RenderContext CreateContext()
@@ -106,31 +107,60 @@ public class UseCommandTests
     }
 
     [Fact]
+    [Trait("Category", "Threading")]
     public async Task Error_In_ExecuteAsync_Still_Resets_IsExecuting()
     {
         // Use a semaphore to observe re-render requests from setIsExecuting.
         // Task.Yield() doesn't reliably interleave with thread pool work items
         // under xUnit's synchronization context.
-        var stateChanged = new SemaphoreSlim(0);
-        var ctx = new RenderContext();
-        ctx.BeginRender(() => stateChanged.Release());
-        var cmd = new Command
+        int unobserved = 0;
+        EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, e) =>
         {
-            Label = "Save",
-            ExecuteAsync = () => throw new InvalidOperationException("test error")
+            if (e.Exception.InnerExceptions.Any(ex =>
+                ex is InvalidOperationException { Message: "test error" }))
+            {
+                Interlocked.Increment(ref unobserved);
+                e.SetObserved();
+            }
         };
+        TaskScheduler.UnobservedTaskException += handler;
+        var stateChanged = new SemaphoreSlim(0);
+        try
+        {
+            var ctx = new RenderContext();
+            ctx.BeginRender(() => stateChanged.Release());
+            var cmd = new Command
+            {
+                Label = "Save",
+                ExecuteAsync = () => throw new InvalidOperationException("test error")
+            };
 
-        var result = ctx.UseCommand(cmd);
-        result.Execute!();
+            var result = ctx.UseCommand(cmd);
+            result.Execute!();
 
-        // Execute! synchronously sets IsExecuting=true (1st release), then Task.Run
-        // catches the error and sets IsExecuting=false in finally (2nd release).
-        await stateChanged.WaitAsync(TimeSpan.FromSeconds(5));
-        await stateChanged.WaitAsync(TimeSpan.FromSeconds(5));
+            // Execute! synchronously sets IsExecuting=true (1st release), then Task.Run
+            // lets the error fault the background task while still resetting
+            // IsExecuting=false in finally (2nd release).
+            await stateChanged.WaitAsync(TimeSpan.FromSeconds(5));
+            await stateChanged.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Rerender(ctx);
-        var result2 = ctx.UseCommand(cmd);
-        Assert.False(result2.IsExecuting);
+            Rerender(ctx);
+            var result2 = ctx.UseCommand(cmd);
+            Assert.False(result2.IsExecuting);
+
+            for (int i = 0; i < 10 && Volatile.Read(ref unobserved) == 0; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                await Task.Delay(10);
+            }
+            Assert.Equal(1, Volatile.Read(ref unobserved));
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= handler;
+            stateChanged.Dispose();
+        }
     }
 
     // ════════════════════════════════════════════════════════════════

--- a/tests/Reactor.Tests/WindowPersistedScopeIsolationTests.cs
+++ b/tests/Reactor.Tests/WindowPersistedScopeIsolationTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.UI.Reactor.Tests;
 /// type is the same instance <see cref="ReactorWindow.PersistedScope"/>
 /// surfaces, so isolation is a property of the scope object itself.
 /// </summary>
+[Collection("PersistedStateCache")]
 public class WindowPersistedScopeIsolationTests
 {
     [Fact]


### PR DESCRIPTION
## Summary
- define the PersistedStateCache xUnit collection and include window persisted scope isolation tests in it
- update persisted-state isolation comments to reflect all tests sharing ApplicationPersistedScope.Default
- isolate UseCommandTests from other UnobservedTaskException tests and explicitly drain its expected async command fault

## Validation
- dotnet test tests\Reactor.Tests\Reactor.Tests.csproj --no-restore -p:Platform=x64 --filter "FullyQualifiedName~UseCommandTests|FullyQualifiedName~UseInfiniteResourceThreadingTests|FullyQualifiedName~UseResourceThreadingTests|FullyQualifiedName~UseMutationThreadingTests|FullyQualifiedName~PersistedStateTests|FullyQualifiedName~ComponentModelIntegrationTests|FullyQualifiedName~WindowPersistedScopeIsolationTests"
- 50x loop: UseInfiniteResourceThreadingTests.Unmount_With_Multiple_Pages_InFlight_Decrements_All_Subscriber_Counts
- 50x loop: PersistedStateTests|ComponentModelIntegrationTests|WindowPersistedScopeIsolationTests
- 25x loop: UseCommandTests
- dotnet test tests\Reactor.Tests\Reactor.Tests.csproj --no-restore --no-build -p:Platform=x64 --logger "console;verbosity=minimal"