### PR TITLE
Fix unit stress flakes in JumpList and QueryCache threading tests

### DIFF
--- a/tests/Reactor.Tests/Core/QueryCacheThreadingTests.cs
+++ b/tests/Reactor.Tests/Core/QueryCacheThreadingTests.cs
@@ -19,8 +19,11 @@ public class QueryCacheThreadingTests
     // tests finish in milliseconds; on shared CI runners (virtualized cores,
     // bursty scheduling) flushing the Task scheduler after cancellation can
     // stretch unpredictably. A generous ceiling kills flakes without weakening
-    // the deadlock guarantee.
-    private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(60);
+    // the deadlock guarantee. Bumped 60s→120s after a 1-in-1000 stress hit on
+    // Concurrent_Subscribe_Unsubscribe_Converges_To_Zero where the workload is
+    // pure lock-bound bookkeeping (no eviction is reachable in 60s given the
+    // 5-minute default CacheTime) — i.e. the timeout was scheduler-induced.
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(120);
 
     // ════════════════════════════════════════════════════════════════
     //  Concurrent Set + TryGet — no torn reads

--- a/tests/Reactor.Tests/JumpListItemTests.cs
+++ b/tests/Reactor.Tests/JumpListItemTests.cs
@@ -182,6 +182,7 @@ public class LaunchActivationTests
 /// Spec 036 §11.3 — JumpList static state. We don't exercise the live shell
 /// here (that's a selftest fixture); only the public state surface.
 /// </summary>
+[Collection("JumpListGlobals")]
 public class JumpListStateTests
 {
     [Fact]

--- a/tests/Reactor.Tests/JumpListUpdateValidationTests.cs
+++ b/tests/Reactor.Tests/JumpListUpdateValidationTests.cs
@@ -12,8 +12,12 @@ namespace Microsoft.UI.Reactor.Tests;
 /// caller-error gates that run synchronously before any platform call.
 ///
 /// Each test uses <c>JumpList.ResetForTests()</c> to isolate the static
-/// state.
+/// state. The <c>JumpListGlobals</c> collection serializes these tests
+/// with <see cref="JumpListStateTests"/> so the shared static
+/// <c>JumpList.AppUserModelId</c> is not clobbered by a concurrent
+/// <c>ResetForTests()</c> in another class.
 /// </summary>
+[Collection("JumpListGlobals")]
 public class JumpListUpdateValidationTests : IDisposable
 {
     public JumpListUpdateValidationTests() => JumpList.ResetForTests();

--- a/tests/Reactor.Tests/TestIsolationCollections.cs
+++ b/tests/Reactor.Tests/TestIsolationCollections.cs
@@ -28,3 +28,14 @@ public sealed class UnobservedTaskExceptionCollection { }
 /// </summary>
 [CollectionDefinition("PersistedStateCache", DisableParallelization = true)]
 public sealed class PersistedStateCacheCollection { }
+
+/// <summary>
+/// xUnit collection marker for tests that mutate
+/// <see cref="Microsoft.UI.Reactor.JumpList"/> static state
+/// (<c>AppUserModelId</c>, <c>ShowRecent</c>, <c>ShowFrequent</c>) or call
+/// <c>JumpList.ResetForTests()</c>. The statics are process-wide, so a concurrent
+/// <c>ResetForTests()</c> from another class can clobber an in-flight test's
+/// configuration mid-execution.
+/// </summary>
+[CollectionDefinition("JumpListGlobals", DisableParallelization = true)]
+public sealed class JumpListGlobalsCollection { }


### PR DESCRIPTION
## Summary

Two 1-in-1000 unit-stress flakes surfaced in the latest CI Stress run (#26345012652):

1. **`JumpListUpdateValidationTests.UpdateAsync_Separator_With_Empty_Title_Is_Allowed`** — real isolation bug. Static `JumpList.AppUserModelId` is mutated by both this class and `JumpListStateTests`, and both call `JumpList.ResetForTests()` (which clears the static). xUnit's default parallelizes test classes, so a concurrent `ResetForTests()` from `JumpListStateTests` could wipe the AumiD between this test's setter (`= "Test.App"`) and its `UpdateAsync` call, tripping the unpackaged-AumiD guard and throwing `InvalidOperationException`. Fix: put both classes into `[Collection(\"JumpListGlobals\")]`, matching the pattern already used for `PersistedStateCache`, `UnobservedTaskException`, and `DockingGlobals`.

2. **`QueryCacheThreadingTests.Concurrent_Subscribe_Unsubscribe_Converges_To_Zero`** — environmental. Hit the 60s `DrainTimeout`. Static analysis: the workload is 8 threads × 1000 lock-bound bookkeeping ops on one slot; eviction physically cannot fire within 60s given the 5-minute default `CacheTime`, so this is scheduler-induced (ThreadPool ramp-up / hosted-VM noise), not a deadlock. Bump the drain ceiling to 120s without weakening the deadlock guarantee.

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test --filter ~JumpList` — 32/32 pass
- [ ] Re-run CI Stress (1000x unit) and confirm both flakes are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)