### PR TITLE
Fix #114: dedupe poolable wiring on native DO identity, not RCW

### DIFF
--- a/src/Reactor/Core/ElementPool.cs
+++ b/src/Reactor/Core/ElementPool.cs
@@ -204,7 +204,7 @@ public sealed class ElementPool : IDisposable
         // pool return so a pooled control can't fire the previous component's
         // captured rerender closure into the next mount. The underlying
         // trampoline subscription stays attached — that's intentional, see
-        // the comment block in Reconciler.cs above PoolableWireFlags.
+        // the comment block in Reconciler.cs above EventHandlerState.
         Reconciler.ClearCurrentEventHandlers(fe);
         fe.Tag = null;
         fe.Margin = new Thickness(0);

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -375,17 +375,17 @@ public sealed partial class Reconciler
 
     /// <summary>
     /// Wires Button.Click trampoline only when the element has a handler AND
-    /// the control hasn't been wired yet. The CWT flag survives pool round-
-    /// trips (Button is a poolable type, and ElementPool intentionally retains
-    /// event subscriptions across rent/return cycles).
+    /// the control hasn't been wired yet. Dedupe key is the EventHandlerState
+    /// trampoline reference, attached on ReactorAttached.StateProperty (native
+    /// DO identity), so two managed RCWs over the same native Button share one
+    /// trampoline. Survives pool round-trips for the same reason.
     /// </summary>
     internal static void EnsureButtonWiring(WinUI.Button button, ButtonElement btn)
     {
         if (btn.OnClick is null) return;
-        var flags = GetPoolableWireFlags(button);
-        if (flags.ButtonClick) return;
-        flags.ButtonClick = true;
-        button.Click += (s, _) =>
+        var state = GetOrCreateEventState(button);
+        if (state.ButtonClickTrampoline is not null) return;
+        state.ButtonClickTrampoline = (s, _) =>
         {
             if (GetElementTag((UIElement)s!) is ButtonElement live)
             {
@@ -393,6 +393,7 @@ public sealed partial class Reconciler
                 live.OnClick?.Invoke();
             }
         };
+        button.Click += state.ButtonClickTrampoline;
     }
 
     private WinUI.HyperlinkButton MountHyperlinkButton(HyperlinkButtonElement hlBtn)
@@ -521,16 +522,16 @@ public sealed partial class Reconciler
     /// Wires TextBox's TextChanged/SelectionChanged trampolines only when the
     /// element has a corresponding handler AND the control hasn't been wired
     /// yet. Called from both Mount (fresh or pooled) and Update (null→non-null
-    /// transition). The CWT flags survive pool round-trips.
+    /// transition). Dedupe through EventHandlerState (native-DO-keyed) so
+    /// pool round-trips and RCW projection both share one trampoline.
     /// </summary>
     internal static void EnsureTextBoxWiring(TextBox textBox, TextBoxElement textBoxElement, Action requestRerender)
     {
         if (textBoxElement.OnChanged is null && textBoxElement.OnSelectionChanged is null) return;
-        var flags = GetPoolableWireFlags(textBox);
-        if (textBoxElement.OnChanged is not null && !flags.TextBoxTextChanged)
+        var state = GetOrCreateEventState(textBox);
+        if (textBoxElement.OnChanged is not null && state.TextBoxTextChangedTrampoline is null)
         {
-            flags.TextBoxTextChanged = true;
-            textBox.TextChanged += (_, _) =>
+            state.TextBoxTextChangedTrampoline = (_, _) =>
             {
                 if (ChangeEchoSuppressor.ShouldSuppress(textBox)) return;
                 var tag = GetElementTag(textBox) as TextBoxElement;
@@ -542,11 +543,14 @@ public sealed partial class Reconciler
                 if (tag?.OnChanged is not null)
                     requestRerender();
             };
+            textBox.TextChanged += state.TextBoxTextChangedTrampoline;
         }
-        if (textBoxElement.OnSelectionChanged is not null && !flags.TextBoxSelectionChanged)
+        if (textBoxElement.OnSelectionChanged is not null && state.TextBoxSelectionChangedTrampoline is null)
         {
-            flags.TextBoxSelectionChanged = true;
-            textBox.SelectionChanged += (_, _) => (GetElementTag(textBox) as TextBoxElement)?.OnSelectionChanged?.Invoke(textBox.SelectedText, textBox.SelectionStart, textBox.SelectionLength);
+            state.TextBoxSelectionChangedTrampoline = (_, _) =>
+                (GetElementTag(textBox) as TextBoxElement)?.OnSelectionChanged?.Invoke(
+                    textBox.SelectedText, textBox.SelectionStart, textBox.SelectionLength);
+            textBox.SelectionChanged += state.TextBoxSelectionChangedTrampoline;
         }
     }
 
@@ -1035,21 +1039,22 @@ public sealed partial class Reconciler
     /// Wires ImageOpened/ImageFailed trampolines once per pooled Image. The
     /// handler resolves the live element via GetElementTag so a later
     /// record-with that attaches a handler picks up without re-subscribing.
+    /// Dedupe through EventHandlerState (native-DO-keyed).
     /// </summary>
     internal static void EnsureImageWiring(WinUI.Image image)
     {
-        var flags = GetPoolableWireFlags(image);
-        if (!flags.ImageOpened)
+        var state = GetOrCreateEventState(image);
+        if (state.ImageOpenedTrampoline is null)
         {
-            flags.ImageOpened = true;
-            image.ImageOpened += (s, _) =>
+            state.ImageOpenedTrampoline = (s, _) =>
                 (GetElementTag((UIElement)s!) as ImageElement)?.OnImageOpened?.Invoke();
+            image.ImageOpened += state.ImageOpenedTrampoline;
         }
-        if (!flags.ImageFailed)
+        if (state.ImageFailedTrampoline is null)
         {
-            flags.ImageFailed = true;
-            image.ImageFailed += (s, args) =>
+            state.ImageFailedTrampoline = (s, args) =>
                 (GetElementTag((UIElement)s!) as ImageElement)?.OnImageFailed?.Invoke(args.ErrorMessage);
+            image.ImageFailed += state.ImageFailedTrampoline;
         }
     }
 
@@ -1224,15 +1229,16 @@ public sealed partial class Reconciler
     {
         // Pooled control: wire the trampoline exactly once. The handler reads
         // the live element via GetElementTag so a later record-with that
-        // attaches OnViewChanged picks up without re-subscribing.
-        var flags = GetPoolableWireFlags(sv);
-        if (flags.ScrollViewerViewChanged) return;
-        flags.ScrollViewerViewChanged = true;
-        sv.ViewChanged += (s, e) =>
+        // attaches OnViewChanged picks up without re-subscribing. Dedupe
+        // through EventHandlerState (native-DO-keyed).
+        var state = GetOrCreateEventState(sv);
+        if (state.ScrollViewerViewChangedTrampoline is not null) return;
+        state.ScrollViewerViewChangedTrampoline = (s, e) =>
         {
             if (GetElementTag((WinUI.ScrollViewer)s!) is ScrollViewerElement el && el.OnViewChanged is { } h)
                 h(e);
         };
+        sv.ViewChanged += state.ScrollViewerViewChangedTrampoline;
     }
 
     private WinUI.ScrollView MountScrollView(ScrollViewElement scroll, Action requestRerender)
@@ -1259,14 +1265,14 @@ public sealed partial class Reconciler
 
     private static void EnsureScrollViewViewChangedWired(WinUI.ScrollView sv)
     {
-        var flags = GetPoolableWireFlags(sv);
-        if (flags.ScrollViewViewChanged) return;
-        flags.ScrollViewViewChanged = true;
-        sv.ViewChanged += (s, _) =>
+        var state = GetOrCreateEventState(sv);
+        if (state.ScrollViewViewChangedTrampoline is not null) return;
+        state.ScrollViewViewChangedTrampoline = (s, _) =>
         {
             if (GetElementTag((WinUI.ScrollView)s!) is ScrollViewElement el && el.OnViewChanged is { } h)
                 h();
         };
+        sv.ViewChanged += state.ScrollViewViewChangedTrampoline;
     }
 
     private WinUI.Border MountBorder(BorderElement border, Action requestRerender)

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -439,36 +439,17 @@ public sealed partial class Reconciler : IDisposable
     // intentionally retains WinRT event subscriptions across rent/return (see
     // ElementPool.CleanElement), but clears Tag. So "Tag is null" on rent does
     // NOT mean "unwired" — the control may already have a trampoline attached.
-    // We need a per-control flag that survives pool cycles to avoid double-
-    // subscription.
+    // We need a per-control dedupe key that survives pool cycles to avoid
+    // double-subscription.
     //
-    // Two dedupe schemes coexist:
-    //   - Button.Click and TextBox.TextChanged/SelectionChanged use the CWT
-    //     below, keyed by managed FrameworkElement identity. This is fragile
-    //     when WinRT projection produces a second RCW over the same native
-    //     DependencyObject (each RCW gets its own entry, both pass dedupe,
-    //     trampoline subscribed twice). See issue #114 for the migration.
-    //   - ToggleSwitch.Toggled uses EventHandlerState (attached on
-    //     ReactorAttached.StateProperty), which is keyed by native DO identity
-    //     and so is RCW-stable. New poolable wiring should follow this pattern
-    //     — see EnsureToggleSwitchWiring and the EnsureXxxSubscribed helpers
-    //     for the input events.
-
-    internal sealed class PoolableWireFlags
-    {
-        public bool ButtonClick;
-        public bool TextBoxTextChanged;
-        public bool TextBoxSelectionChanged;
-        public bool ScrollViewerViewChanged;
-        public bool ScrollViewViewChanged;
-        public bool ImageOpened;
-        public bool ImageFailed;
-    }
-
-    private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<FrameworkElement, PoolableWireFlags> _poolableWireFlags = new();
-
-    internal static PoolableWireFlags GetPoolableWireFlags(FrameworkElement fe) =>
-        _poolableWireFlags.GetValue(fe, static _ => new PoolableWireFlags());
+    // All poolable wiring dedupes through EventHandlerState (attached on
+    // ReactorAttached.StateProperty, which is a DependencyProperty keyed by
+    // native DO identity). Two managed RCWs over the same native DependencyObject
+    // resolve to the same EventHandlerState, so the *Trampoline-is-not-null
+    // check correctly short-circuits. This was previously split between an
+    // unsafe managed-FE-keyed CWT (Button, TextBox, Image, ScrollViewer) and
+    // EventHandlerState (ToggleSwitch); issue #114 unified everything onto
+    // EventHandlerState.
 
     // ════════════════════════════════════════════════════════════════════
     //  Canvas anchor positioning
@@ -2852,6 +2833,16 @@ public sealed partial class Reconciler : IDisposable
         public RoutedEventHandler? LostFocusTrampoline;
         public RoutedEventHandler? ToggleSwitchToggledTrampoline;
         public global::Windows.Foundation.TypedEventHandler<UIElement, Microsoft.UI.Xaml.Input.AccessKeyDisplayRequestedEventArgs>? AccessKeyDisplayRequestedTrampoline;
+        // Issue #114 — these former PoolableWireFlags entries are now keyed by native DO
+        // identity through ReactorAttached.StateProperty, so two RCWs over the same control
+        // share one trampoline (no double-subscribe).
+        public RoutedEventHandler? ButtonClickTrampoline;
+        public WinUI.TextChangedEventHandler? TextBoxTextChangedTrampoline;
+        public RoutedEventHandler? TextBoxSelectionChangedTrampoline;
+        public RoutedEventHandler? ImageOpenedTrampoline;
+        public Microsoft.UI.Xaml.ExceptionRoutedEventHandler? ImageFailedTrampoline;
+        public global::System.EventHandler<WinUI.ScrollViewerViewChangedEventArgs>? ScrollViewerViewChangedTrampoline;
+        public global::Windows.Foundation.TypedEventHandler<WinUI.ScrollView, object>? ScrollViewViewChangedTrampoline;
         public bool NumberBoxInnerTextChanged;
 
         /// <summary>


### PR DESCRIPTION
## Summary

- Move Button.Click, TextBox.TextChanged/SelectionChanged, Image.ImageOpened/ImageFailed, ScrollViewer.ViewChanged, and ScrollView.ViewChanged off the managed-FE-keyed `PoolableWireFlags` CWT onto `EventHandlerState` (already used by ToggleSwitch).
- `EventHandlerState` lives on `ReactorAttached.StateProperty`, a DependencyProperty, so two managed RCWs over the same native DependencyObject resolve to the same state object and share one trampoline.
- Delete `PoolableWireFlags` type, its CWT, and `GetPoolableWireFlags`.

## Why

Under the old scheme, a fresh RCW for the same native control had an empty CWT entry, passed dedupe, and a second trampoline was subscribed — every subsequent event fired the user callback twice. The new `NativeDocking_Dynamic*` fixtures cross the boundary that produces a duplicate RCW (the docking sub-host's reconcile re-entrance), which is why this latent bug only started showing up in stress.

## Local repro

Against `NativeDocking_` selftest filter, 30 iterations per process:

| | Before | After |
|---|---|---|
| Total failures / 30 | 3 (10%) | 1 (3.3%) |
| `DynDock_CounterButton_ClickHandlerFiredTwice` | 3 | **0** |
| Other (`FloatingTitleBar_PaneBodyVisible`) | 0 | 1 |

The one remaining failure is unrelated — it was already in the CI Stress data (1 hit on shard 11 iter 19 of run 26343151571) and is not part of Cluster A.

## Test plan

- [ ] CI stress run (selftests target) passes without `*_ClickHandlerFiredTwice` hits
- [ ] Unit/integration tests pass
- [ ] Verify echo-suppression on TextBox still works under load