### PR TITLE
Stress test fixes: visual demo budgets, GC marshaling, InfiniteBasic pump

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/AsyncInfiniteResourceFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/AsyncInfiniteResourceFixtures.cs
@@ -84,9 +84,13 @@ internal static class AsyncInfiniteResourceFixtures
                 res!.TotalCount == 200);
 
             // Pull next 4 pages by walking ItemAt (simulating virtualized scroll).
+            // Three pumps per page so the 10ms Task.Delay in FetchPageAsync plus
+            // the Apply continuation reliably lands before the next ItemAt — the
+            // 2-pump variant flaked under CI load (got 4 / expected >= 5).
             for (int i = 0; i < 5; i++)
             {
                 _ = res!.ItemAt(25 * i + 12);
+                await Harness.Render();
                 await Harness.Render();
                 await Harness.Render();
             }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/AsyncInfiniteResourceFramerateFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/AsyncInfiniteResourceFramerateFixtures.cs
@@ -181,9 +181,12 @@ internal static class AsyncInfiniteResourceFramerateFixtures
     {
         public override async Task RunAsync()
         {
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            await Task.Run(() =>
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            });
 
             int unobserved = 0;
             EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, e) =>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/AsyncResourceFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/AsyncResourceFixtures.cs
@@ -286,9 +286,12 @@ internal static class AsyncResourceFixtures
                 // Give any lingering continuations one more frame to settle and force a GC
                 // to trigger finalization of any tasks that might throw unobserved.
                 await Harness.Render();
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
+                await Task.Run(() =>
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                });
                 await Harness.Render();
 
                 H.Check($"AsyncResource_UnmountDuringFetch_NoUnobserved (got {unobserved})",

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/AsyncResourceFramerateFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/AsyncResourceFramerateFixtures.cs
@@ -30,10 +30,15 @@ internal static class AsyncResourceFramerateFixtures
         {
             // Drain any unobserved tasks that earlier fixtures finalized but whose
             // events haven't fired yet — otherwise the test "inherits" unrelated
-            // noise and flakes.
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            // noise and flakes. Marshal off the UI dispatcher: a finalizer that
+            // needs to release a UI-thread-affine RCW would deadlock if the
+            // dispatcher were blocked inside WaitForPendingFinalizers.
+            await Task.Run(() =>
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            });
 
             int unobserved = 0;
             EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, e) =>
@@ -120,9 +125,12 @@ internal static class AsyncResourceFramerateFixtures
                 // cancelled via UseEffect teardown before we drain for unobserved exceptions.
                 host.Dispose();
                 await Harness.Render();
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
+                await Task.Run(() =>
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                });
                 await Harness.Render();
                 H.Check($"DepsThrashing_NoUnobserved (got {unobserved})", unobserved == 0);
             }
@@ -302,9 +310,12 @@ internal static class AsyncResourceFramerateFixtures
     {
         public override async Task RunAsync()
         {
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            await Task.Run(() =>
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            });
 
             int unobserved = 0;
             EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, e) =>
@@ -345,9 +356,12 @@ internal static class AsyncResourceFramerateFixtures
                 // Final unmount and let any cancellation callbacks drain.
                 setVisible!(false);
                 for (int i = 0; i < 4; i++) await Harness.Render();
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
+                await Task.Run(() =>
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                });
                 await Harness.Render();
 
                 // Every mount should have kicked off a fetch. Every one must be cancelled
@@ -405,9 +419,12 @@ internal static class AsyncResourceFramerateFixtures
     {
         public override async Task RunAsync()
         {
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            await Task.Run(() =>
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            });
 
             int unobserved = 0;
             EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, e) =>
@@ -531,9 +548,12 @@ internal static class AsyncResourceFramerateFixtures
                     finalInRange);
 
                 // Invariant 7: no unobserved exceptions leaked from any pending mutator.
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
+                await Task.Run(() =>
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                });
                 await Harness.Render();
                 H.Check($"DataGridEditMutation_NoUnobserved (got {unobserved})", unobserved == 0);
             }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridParityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridParityFixtures.cs
@@ -306,7 +306,7 @@ internal static class DataGridParityFixtures
                 sv.ChangeView(null, 0, null, disableAnimation: true);
                 await Harness.Render(600);
 
-                GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+                await Task.Run(() => { GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect(); });
 
                 H.Check("HookPaging_Framerate_FinalData",
                     H.FindTextContaining("Emp-") is not null);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs
@@ -543,10 +543,15 @@ internal static class NativeDockingReliabilityFixtures
             host.Mount(_ => TextBlock("warmup-done"));
             await Harness.Render();
 
-            // Force GC so the baseline reflects steady state.
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            // Force GC so the baseline reflects steady state. Marshal off
+            // the UI dispatcher to avoid a finalizer-deadlock on UI-thread-
+            // affine RCWs.
+            await Task.Run(() =>
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            });
 
             long baseline = GC.GetAllocatedBytesForCurrentThread();
 
@@ -568,9 +573,12 @@ internal static class NativeDockingReliabilityFixtures
                 await Harness.Render();
             }
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            await Task.Run(() =>
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            });
             long after = GC.GetAllocatedBytesForCurrentThread();
             long delta = after - baseline;
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
@@ -1047,10 +1047,10 @@ internal static class NativeDockingSmokeFixtures
             var liveLayout = BuildInitial();
             host.Mount(_ => new DockManager { Layout = liveLayout });
             await Harness.Render();
-            // Visual-demo "let the eye register" pauses kept short so the
-            // 20-step walk stays well inside the default fixture timeout
-            // (15s) under CI load. Bump back up locally for slow-motion runs.
-            await Task.Delay(50);
+            // Visual-demo "let the eye register" pauses — tightened for
+            // CI stress runs (target ~4s total). Bump back up locally
+            // for slow-motion manual viewing.
+            await Task.Delay(20);
 
             // Targets we walk through in each group.
             var targets = new[]
@@ -1085,7 +1085,7 @@ internal static class NativeDockingSmokeFixtures
                     liveLayout = BuildInitial();
                     host.Mount(_ => new DockManager { Layout = liveLayout });
                     await Harness.Render();
-                    await Task.Delay(20);
+                    await Task.Delay(5);
 
                     // Find the target group in the fresh tree by anchor.
                     var targetGroup = FindGroupContaining(liveLayout, anchor);
@@ -1117,7 +1117,7 @@ internal static class NativeDockingSmokeFixtures
                     int splits = CountSplits(liveLayout);
                     if (target != DockTarget.Center && splits > 3) splitObserved++;
 
-                    await Task.Delay(30); // observer pause — minimal for CI; bump for manual demo
+                    await Task.Delay(5); // observer pause — minimal for CI; bump for manual demo
                 }
             }
 
@@ -1233,16 +1233,17 @@ internal static class NativeDockingSmokeFixtures
 
             host.Mount(_ => Build());
             await Harness.Render();
-            // Timing budget (must fit under the default fixture timeout):
-            //   initial settle:      700ms
-            //   5 loops × (5 nudges × 200ms + after-final 400ms): 7000ms
-            //   total delay budget:  ~7.7s
+            // Timing budget (target ~5s, 15s timeout):
+            //   initial settle:      200ms
+            //   5 loops × (5 nudges × 60ms + after-final 120ms): 2100ms
+            //   total delay budget:  ~2.3s
             //   render overhead (~80ms × ~26 renders): ~2s
-            //   grand total:         ~9.7s → comfortable margin under 15s
-            // The fixture is meant as a paced visual demo — 200ms per
-            // nudge is still humanly observable (5 frames/sec); the prior
-            // 400ms × 25 nudges + extras blew past the timeout by ~1s.
-            await Task.Delay(700);
+            //   grand total:         ~4.4s → comfortable margin under 5s
+            // Nudge pacing still leaves the resize visible (~17fps);
+            // tighter than the original 200ms but still observable for
+            // manual debug runs. Stress runs benefit from the shorter
+            // wall clock per shard.
+            await Task.Delay(200);
 
             var splitters = H.FindAllControls<DockSplitterControl>(_ => true);
             var rowSplitter = splitters.FirstOrDefault(s => s.Direction == DockSplitterDirection.Rows);
@@ -1256,55 +1257,55 @@ internal static class NativeDockingSmokeFixtures
             {
                 FireResizeDelta(rowSplitter!, delta: 40, isFinal: false);
                 await Harness.Render();
-                await Task.Delay(200);
+                await Task.Delay(60);
             }
             FireResizeDelta(rowSplitter!, delta: 0, isFinal: true);
             await Harness.Render();
-            await Task.Delay(400);
+            await Task.Delay(120);
 
             // 2) Grow the top row back — five -40-DIP nudges.
             for (int i = 0; i < 5; i++)
             {
                 FireResizeDelta(rowSplitter!, delta: -40, isFinal: false);
                 await Harness.Render();
-                await Task.Delay(200);
+                await Task.Delay(60);
             }
             FireResizeDelta(rowSplitter!, delta: 0, isFinal: true);
             await Harness.Render();
-            await Task.Delay(400);
+            await Task.Delay(120);
 
             // 3) Shrink the top-row's left column (editor) — five 40 DIP.
             for (int i = 0; i < 5; i++)
             {
                 FireResizeDelta(colSplitters[0], delta: 40, isFinal: false);
                 await Harness.Render();
-                await Task.Delay(200);
+                await Task.Delay(60);
             }
             FireResizeDelta(colSplitters[0], delta: 0, isFinal: true);
             await Harness.Render();
-            await Task.Delay(400);
+            await Task.Delay(120);
 
             // 4) Restore the top-row's left column — five -40 DIP.
             for (int i = 0; i < 5; i++)
             {
                 FireResizeDelta(colSplitters[0], delta: -40, isFinal: false);
                 await Harness.Render();
-                await Task.Delay(200);
+                await Task.Delay(60);
             }
             FireResizeDelta(colSplitters[0], delta: 0, isFinal: true);
             await Harness.Render();
-            await Task.Delay(400);
+            await Task.Delay(120);
 
             // 5) Shrink the bottom-row's left column (output) — five 40 DIP.
             for (int i = 0; i < 5; i++)
             {
                 FireResizeDelta(colSplitters[1], delta: 40, isFinal: false);
                 await Harness.Render();
-                await Task.Delay(200);
+                await Task.Delay(60);
             }
             FireResizeDelta(colSplitters[1], delta: 0, isFinal: true);
             await Harness.Render();
-            await Task.Delay(400);
+            await Task.Delay(120);
 
             H.Check("VizDemo_CompletedAllFourQuadrants", true);
 


### PR DESCRIPTION
## Summary

Three independent fixes for the post-#395 stress-failure landscape (CI run 26348014478, 6/20 failed shards, 7 total failures). After landing #395 (Cluster A), the remaining failures break into:

- **Cluster T (5 / 7)** — fixtures timing out at the 15s watchdog
- **Cluster I (1 / 7)** — `AsyncResource.InfiniteBasic_MultiplePagesFetched (got 4)`
- **Cluster F (1 / 7)** — `FloatingTitleBar_PaneBodyVisible` (does not reproduce in isolation; not addressed here)

This PR addresses Cluster T and Cluster I.

### 1. Tighten visual-demo timing budgets (Cluster T1)

`NativeDocking_SplitterProgrammaticVisualDemo` was designed with an explicit ~9.7s timing budget (per the comment block at the top of the fixture) against a 15s timeout, assuming ~80ms/render. Under CI load renders can exceed 200ms, pushing total runtime over the timeout. `NativeDocking_PerGroupDropTargetVisualDemo` has the same shape with smaller margins.

Reduced pacing delays:
- Splitter: initial 700ms → 200ms; per-nudge 200ms → 60ms; after-final 400ms → 120ms. New budget ~4.4s.
- PerGroup: initial 50ms → 20ms; per-step 20ms → 5ms; observer 30ms → 5ms.

Smoke-tested locally: splitter at 4.8s wall-clock (~1.8s fixture runtime), PerGroup at 7.2s wall-clock (~4.2s fixture runtime), both well under 15s timeout. The pacing is still observable for manual debug viewing.

### 2. Marshal `GC.WaitForPendingFinalizers` off the UI dispatcher (Cluster T2)

`AsyncResource.Framerate.DataGridScroll`, `Framerate.DataGridEditMutation`, and `PropertyGrid_Target_Switching` were timing out at 15s but should normally complete in 1-3s. Every Framerate fixture (and several others) starts and/or ends with `GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();`. Running that on the UI dispatcher thread is a known deadlock anti-pattern: a finalizer that needs to release a UI-thread-affine RCW (e.g. a WinUI control) marshals back to the dispatcher, but the dispatcher is blocked inside `WaitForPendingFinalizers` waiting for that very finalizer.

Migrated all 11 call sites onto a background thread via `await Task.Run(() => { GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect(); })`. The UI dispatcher continues pumping while the finalizer drains, breaking the deadlock potential.

Files affected: `AsyncResourceFramerateFixtures.cs` (6), `AsyncResourceFixtures.cs`, `AsyncInfiniteResourceFramerateFixtures.cs`, `DataGridParityFixtures.cs`, `NativeDockingReliabilityFixture.cs` (2).

The fix is speculative — the local repro (40 iter × 13 Framerate fixtures, 0 hits) is inconclusive against the ~0.075% CI rate. Suggesting a follow-up to add `DOTNET_DbgEnableMiniDump=1` to the stress workflow env so the next CI hit (if any) yields a definitive dump.

### 3. Extra render pump in InfiniteBasic page-walk (Cluster I)

`InfiniteBasic_MultiplePagesFetched (got 4)` failed at shard 9 iter 10. The fixture pumps 2 renders after each `ItemAt()` call. The fetcher has a 10ms `Task.Delay` plus an Apply continuation; under CI load that occasionally outlives the 2-pump budget. The fixture's existing comment already admits the analogous race for page 1 and pumps three times in the initial-page path — extending the same pattern to the loop.

## Test plan

- [x] `dotnet build` — 0 errors, only pre-existing warnings
- [x] Smoke test affected fixtures locally; all clean
- [ ] Run CI Stress workflow on this branch (200 iter × 20 shards, target=selftests)
- [ ] Confirm Cluster T and Cluster I hits drop to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)