### PR TITLE
Stress fixes: Cluster F poll, leak baseline timeout bump

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs
@@ -523,7 +523,12 @@ internal static class NativeDockingReliabilityFixtures
     /// </summary>
     internal class EventSubscriptionLeakBaseline(Harness h) : SelfTestFixtureBase(h)
     {
-        public override TimeSpan FixtureTimeout => TimeSpan.FromSeconds(30);
+        // 100 mount/unmount cycles × 2 Harness.Render() each = 200 renders + 200
+        // reconcile passes. Locally this runs ~15s; CI VMs under contention have
+        // been measured at 2-4× slower per INVESTIGATION.md Cluster T, easily
+        // overshooting the prior 30s budget on a heavy iteration. The cap exists
+        // to catch a hung fixture, not to set a perf target.
+        public override TimeSpan FixtureTimeout => TimeSpan.FromSeconds(60);
 
         public override async Task RunAsync()
         {

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
@@ -1652,9 +1652,18 @@ internal static class NativeDockingSmokeFixtures
                 H.Check("FloatingTitleBar_TabViewHasStripFooter",
                     tabViews.Count == 1 && tabViews[0].TabStripFooter is not null);
 
-                // Pane body must be reachable.
+                // Pane body must be reachable. Chrome (TabView etc.) materializes on
+                // the first render pump after Open(), but on a loaded CI runner the
+                // inner content TextBlock can lag one or two pumps behind. Poll for
+                // up to 2s — see INVESTIGATION.md Cluster F.
                 var bodyTexts = FindAllInTree<TextBlock>(content, t => t.Text == "floating-tb-body");
-                H.Check("FloatingTitleBar_PaneBodyVisible", bodyTexts.Count >= 1);
+                var deadline = Environment.TickCount64 + 2_000;
+                while (bodyTexts.Count < 1 && Environment.TickCount64 < deadline)
+                {
+                    await Harness.Render(50);
+                    bodyTexts = FindAllInTree<TextBlock>(content, t => t.Text == "floating-tb-body");
+                }
+                H.Check($"FloatingTitleBar_PaneBodyVisible (bodies={bodyTexts.Count})", bodyTexts.Count >= 1);
 
                 floatingWindow.Close();
                 await Harness.Render();


### PR DESCRIPTION
## Summary

Two independent stress-flake fixes per INVESTIGATION.md session 4, follow-up to #397:

- **Cluster F** (4/1000 hits in the latest 1000x stress run) — `FloatingTitleBar_PaneBodyVisible` asserted body `TextBlock` visibility after a single `Harness.Render()` following `DockFloatingWindow.Open`. The chrome (TabView, TitleBar absence, TabStripFooter) materializes on that first pump, but the inner pane content lags one or two pumps behind on a loaded CI runner. Same UI-realization-race family as Cluster C (fixed in #397); apply the same poll pattern (2s budget, 50ms between pumps) and annotate the check name with the observed body count for future-hit diagnostics.
- **Cluster T-new** (2/1000 hits) — `EventSubscriptionLeakBaseline` timing out at its existing 30s override. Local timing across 3 fresh-process runs: 14.5 / 15.6 / 15.4 s (avg 15.2s) on a dev box. The fixture is 100 mount/unmount cycles × 2 `Harness.Render()` = 200 renders + 200 reconcile passes; the work itself is substantial. CI VMs under load are 2–4× slower per other entries in the investigation doc, easily overshooting 30s. Not a hang — just budget vs CI variance. Bump `FixtureTimeout` to 60s (~4× local baseline) with a comment block explaining the math.

## Test plan

- [x] Build clean (`dotnet build` on `Reactor.AppTests.Host.csproj`).
- [x] Single-shot local: all 7 sub-checks pass for the floating-window fixture, including the new `(bodies=1)` annotation; `EventSubscriptionLeakBaseline` passes in ~15s.
- [x] 30-iter local stress on the floating-window fixture with `Start-Process -Wait` (the `&` redirect drops GUI-subsystem stdout): **0/30 failures, 47s wall**.
- [ ] Post-merge: kick off CI Stress (1000 iter × 20 shards, selftests) to validate both fixes drop their respective hit rates to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)