### PR TITLE
Pin pygments to 2.19.2 to fix docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs==1.6.1
 mkdocs-material==9.5.49
 pymdown-extensions==10.12
+pygments==2.19.2


### PR DESCRIPTION
## Summary
The first run of the `Publish docs` workflow on `main` (after #402 merged) failed in `mkdocs build --strict`: pip resolved pygments to **2.20.0**, but pymdown-extensions 10.12 calls `HtmlFormatter(filename=None)` which 2.20.0 no longer tolerates (`AttributeError: 'NoneType' object has no attribute 'replace'`).

Locally pip resolved 2.19.2 (which works), so the failure didn't surface in pre-merge testing. Pinning explicitly.

## Test plan
- [ ] `Publish docs` workflow run on this PR completes the `build` job (it only deploys on `main`, so green build is the success signal here).
- [ ] After merge, the workflow runs on `main`, both build + deploy succeed, and the Pages URL stops 404-ing.