### PR TITLE
test(stress): raise default FixtureTimeout 15s -> 30s

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureBase.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureBase.cs
@@ -9,7 +9,15 @@ internal abstract class SelfTestFixtureBase
 
     protected SelfTestFixtureBase(Harness harness) => H = harness;
 
-    public virtual TimeSpan FixtureTimeout => TimeSpan.FromSeconds(15);
+    // 30 s default chosen empirically from stress-run timing data: the
+    // Framerate.* fixture family completes in ~7 s on a dev box, and
+    // CI VMs under contention run 2-4x slower, putting fixture work at
+    // ~28 s on the worst tick. Previously several fixtures had explicit
+    // 30 s overrides (PR #397, #399); raising the default folds them in
+    // and prevents new sister fixtures from inheriting a budget that
+    // doesn't survive CI variance. The host-level HangWatchdogLoop at
+    // 60 s (SelfTestRunner.cs) continues to catch true dispatcher hangs.
+    public virtual TimeSpan FixtureTimeout => TimeSpan.FromSeconds(30);
 
     public abstract Task RunAsync();
 }


### PR DESCRIPTION
## Summary

- Raises the default `SelfTestFixtureBase.FixtureTimeout` from 15 s to 30 s. One-line change (plus a comment block explaining why).
- Eliminates the dominant stress-failure mode (CI VM variance busting tight per-fixture budgets) without touching any fixture internals.
- Preserves the 60 s `HangWatchdogLoop` (`SelfTestRunner.cs`) dump-on-hang backstop for genuine dispatcher-starvation hangs.

## Evidence

CI Stress run [26364109146](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/26364109146) (1000 iter on `main` post-#399): 8 failures total, **5 of them 15 s timeout trips across 5 different fixtures** — `AsyncResource.Framerate.RapidEnsureRange`, `AsyncResource.Framerate.RenderShortCircuit`, `NativeDocking_DragSessionConfirmMutatesLayout`, `RareControl_RelativePanel`, `PropertyGrid_Target_Switching`. Two of those are direct sisters of fixtures that already have a 30 s override from #397 — same code family, missed only because the override is per-class.

Per-fixture overrides have not converged after four rounds (#395, #397, #399 added overrides; new sisters keep appearing in subsequent runs). This is whack-a-mole.

Local timing (documented in the investigation doc): Framerate.* completes in ~7 s on a dev box; CI VMs under contention run 2-4x slower → ~28 s on the worst tick. The 15 s budget can't survive that. 30 s matches the explicit override budget already used by four fixtures (`DataGridScroll`, `DataGridEditMutation`, `PerGroupDropTargetVisualDemo`, etc.) and leaves a clean signal gap below the 60 s `HangWatchdogLoop`.

## Why 30 s and not 20 / 25 s

| Value | Local fixture budget at 4x CI slowdown | Verdict |
|---|---|---|
| 20 s | <= 5 s local | Framerate family at ~7 s local still trips. Rejected. |
| 25 s | <= 6.25 s local | Borderline; same family still at risk. Rejected. |
| **30 s** | **<= 7.5 s local — clears the 7 s family** | **Matches PR #397 / #399 precedent.** |

## What this PR does NOT do

- Does not remove the existing `=> 30 s` overrides (3 sites). Left explicit so a future revert of the default doesn't silently lower their budget. The `=> 60 s` override on `EventSubscriptionLeakBaseline` stays as-is.
- Does not add dump-capture infra (deferred Path B). Current symptom set is fully explained by budget-vs-variance; not a deadlock family.
- Does not touch fixture internals. Render-pump counts and `Task.Delay` budgets are unchanged.

## Predicted outcome

Reliability should rise from **99.2% to ~99.7%** (3 / 1000 failures, down from 8). Remaining failures: Cluster O' (`AliveBeforeRefresh` — separate small fix), Cluster A11y (single hit, deferred), Cluster C-KeyReflect (2 / 2000 lifetime, deferred).

## Test plan

- [ ] Local: `dotnet build tests/Reactor.AppTests.Host -c Debug -p:Platform=x64` succeeds.
- [ ] Local: `--self-test` runs and currently-passing fixtures still pass (no behavioral change, just a longer watchdog).
- [ ] CI Stress (post-merge): `gh workflow run "CI Stress" --ref main -f iterations=1000 -f target=selftests -f shards=20`. Validate per-iter failure rate drops to ~0.3% with zero 15 s timeout signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)