### PR TITLE
fix(reactor): §8.2 — setters run inside echo-suppression scope

### DIFF
--- a/docs/specs/047-extensible-control-model.md
+++ b/docs/specs/047-extensible-control-model.md
@@ -458,6 +458,8 @@ This is the version of the design where the framework gets a *fundamentally diff
 
 A latent issue worth fixing as part of this work, called out in §13 Q8 below: `ApplySetters` runs after declarative property writes today and bypasses any echo suppression scope. A user writing `Set(ts => ts.IsOn = true)` on a `ToggleSwitch` whose `el.IsOn = false` produces an unmasked write that *will* fire `Toggled` and feed back into state on the next event-loop tick. The descriptor model should require setters to either run inside the same suppression / round-trip scope as declared props, or be opted into an explicit raw-write mode (`Set.Raw(...)`) that the author has audited and accepted responsibility for. Default behavior should match declared props.
 
+**Resolved** as a carve-out ahead of Phase 1 (per [`047/factoring-recommendation.md`](047/factoring-recommendation.md)). `ApplySetters` now enters a scope-based suppression mode on the control's `ReactorState` (a depth counter alongside the existing paired `EchoSuppressCount`) for the duration of the setter chain, so any change event raised by a setter-driven write is dropped without consuming a paired token. The M13 perf-bench check flips from `OnIsOnChangedFireCount = 1` to `0` on both `ReactorToday` and `ReactorV2`. Default behavior now matches declared props as called for above; an explicit raw-write opt-out (`Set.Raw(...)`) is still a future refinement should it become needed.
+
 ---
 
 ## §9 Simplification direction: per-control trampoline tables

--- a/docs/specs/047/baseline-results/summary.md
+++ b/docs/specs/047/baseline-results/summary.md
@@ -98,7 +98,12 @@ total — divide by iterations for per-op alloc.
   **Confirms the §8.2 bug exists in the baseline.** Phase 1's fix
   (the §8.2 standalone setter-suppression PR per
   [`factoring-recommendation.md`](../factoring-recommendation.md))
-  flips this counter to 0.
+  flips this counter to 0. **Follow-up:** carve-out PR landed —
+  `ApplySetters` now enters a scope-based suppression scope on the
+  control's `ReactorState`; re-running M13 against the post-fix build
+  shows `OnIsOnChangedFireCount = 0` on every ReactorToday and ReactorV2
+  row. The Phase-0 JSONL above is deliberately left intact as the
+  witness to the failing baseline.
 - **M11 `ModifierEHS_Frequency`** — placeholder counter at Phase 0.
   Real EventSource counter wiring deferred to Phase 1.
 - **V2 vs Today columns** range from -16.7% to +16.7%. None are real

--- a/docs/specs/047/factoring-recommendation.md
+++ b/docs/specs/047/factoring-recommendation.md
@@ -71,6 +71,13 @@ the §8.2 description in the PR.
   bug. M13's Phase-0 baseline flips from `fires=1` to `fires=0`. ~1
   PR, ~50 lines of change in `Reconciler.cs` to thread `BeginSuppress`
   around `ApplySetters` for value-bearing controls.
+  **Status:** landed via the carve-out PR. `ApplySetters` now enters
+  a scope-based suppression mode on the control's `ReactorState`
+  (a depth counter alongside the existing paired `EchoSuppressCount`)
+  for the duration of the setter chain. M13 re-run confirms
+  `OnIsOnChangedFireCount = 0` on both ReactorToday and ReactorV2.
+  Reactor.Tests + Reactor.SelfTests pass; three new SettersScope_*
+  fixtures lock the behavior under the SelfTest batch.
 
 That's the only one. Everything else stays in spec 047.
 

--- a/docs/specs/tasks/047-extensible-control-model-implementation.md
+++ b/docs/specs/tasks/047-extensible-control-model-implementation.md
@@ -146,6 +146,8 @@ implementation is intentionally identical to `ReactorToday`.
       verify callback fires exactly once today (the bug per §8.2), zero times
       after Phase 1's fix. Phase 0 records the failing behavior as baseline
       (`OnIsOnChangedFireCount = 1`) so the Phase 1 fix has a target to flip.
+      (Carve-out PR flipped this to 0; baseline JSONL preserved as the
+      failing-state witness — see `baseline-results/summary.md` follow-up.)
 - [x] Each bench reports: mean ns + 95% CI, allocation bytes, Gen0/1/2 collections,
       managed heap delta. `BenchRunner` instruments `GC.GetAllocatedBytesForCurrentThread`
       + `GC.CollectionCount` + `GC.GetTotalMemory` per rep; aggregator computes
@@ -316,4 +318,6 @@ proposal can move to greenlight (spec §14).
       factoring-recommendation.md.
 - [x] 0.7 Factoring recommendation committed and reviewed. Outcome: keep
       spec 047 unified; only the §8.2 setter-suppression fix is carved out
-      as a standalone PR ahead of Phase 1.
+      as a standalone PR ahead of Phase 1. (Carve-out landed: `ApplySetters`
+      now runs inside a scope-based suppression scope on the control's
+      `ReactorState`. M13 flipped from `OnIsOnChangedFireCount = 1` to `0`.)

--- a/src/Reactor/Core/ChangeEchoSuppressor.cs
+++ b/src/Reactor/Core/ChangeEchoSuppressor.cs
@@ -56,8 +56,13 @@ internal static class ChangeEchoSuppressor
     internal static bool ShouldSuppress(UIElement control)
     {
         if (control is not FrameworkElement fe) return false;
-        if (fe.GetValue(Reconciler.ReactorAttached.StateProperty) is Reconciler.ReactorState state
-            && state.EchoSuppressCount > 0)
+        if (fe.GetValue(Reconciler.ReactorAttached.StateProperty) is not Reconciler.ReactorState state)
+            return false;
+        // §8.2 — setter-suppression scope: drop the echo without consuming a
+        // counter token. The scope wraps ApplySetters, where the engine can't
+        // predict which value-bearing DPs the user's `.Set(...)` will write.
+        if (state.EchoSuppressScopeDepth > 0) return true;
+        if (state.EchoSuppressCount > 0)
         {
             state.EchoSuppressCount--;
             return true;

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -300,6 +300,10 @@ public sealed partial class Reconciler : IDisposable
         // wrapper and ShouldSuppress on a different wrapper for the same native
         // DependencyObject see the same counter. See ChangeEchoSuppressor.cs.
         public int EchoSuppressCount;
+        // §8.2 — depth of the active setter-suppression scope. While > 0, any
+        // change event on this control is dropped without consuming a token
+        // from EchoSuppressCount. See ApplySetters / ChangeEchoSuppressor.
+        public int EchoSuppressScopeDepth;
         // Spec 042 Phase 1 — keyed-list reconciliation state. Set when the
         // host element is a templated items control (ListView/GridView/
         // ItemsRepeater). The internal ObservableCollection<ReactorRow> in
@@ -405,6 +409,7 @@ public sealed partial class Reconciler : IDisposable
         {
             state.Events?.ClearCurrentHandlers();
             state.EchoSuppressCount = 0;
+            state.EchoSuppressScopeDepth = 0;
         }
     }
 
@@ -425,6 +430,7 @@ public sealed partial class Reconciler : IDisposable
         state.Events?.ClearCurrentHandlers();
         state.Events = null;
         state.EchoSuppressCount = 0;
+        state.EchoSuppressScopeDepth = 0;
     }
 
     // ════════════════════════════════════════════════════════════════════
@@ -1435,7 +1441,27 @@ public sealed partial class Reconciler : IDisposable
 
     internal static void ApplySetters<T>(Action<T>[] setters, T control) where T : class
     {
-        foreach (var setter in setters) setter(control);
+        if (setters.Length == 0) return;
+        // §8.2 — run setters inside the echo-suppression scope so that a
+        // user-authored `.Set(c => c.IsOn = true)` write does not echo back
+        // through the OnXChanged callback the engine already wired. Only
+        // enters scope when ReactorState already exists; value-bearing mounts
+        // call SetElementTag before ApplySetters, so the state is present for
+        // every control that can fire a suppressed change event. Bare leaves
+        // (TextBlock, RichTextBlock) skip the scope and pay no allocation.
+        ReactorState? state =
+            control is FrameworkElement fe
+            && fe.GetValue(ReactorAttached.StateProperty) is ReactorState rs
+                ? rs : null;
+        if (state is not null) state.EchoSuppressScopeDepth++;
+        try
+        {
+            foreach (var setter in setters) setter(control);
+        }
+        finally
+        {
+            if (state is not null) state.EchoSuppressScopeDepth--;
+        }
     }
 
     // WPF/WinUI auto-populate UIA Name from a control's string Content through the

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
@@ -585,6 +585,45 @@ internal static class EchoSuppressionFixtures
         }
     }
 
+    /// <summary>
+    /// Dispatcher-queued change-event coverage. PasswordBox is the documented
+    /// case where PasswordChanged can be raised via the dispatcher rather than
+    /// synchronously in the setter — see the PasswordBoxNoEcho fixture's double
+    /// pump. The §8.2 setter-suppression scope is synchronous (it exits when
+    /// ApplySetters returns), so a queued PasswordChanged fires after the
+    /// scope has already exited. Pumping the dispatcher between the setter run
+    /// and the assertion gives the queued event a chance to land, so this
+    /// fixture is the canary if a future change reorders PasswordChanged to be
+    /// synchronous and lets the scope catch it implicitly.
+    /// </summary>
+    internal class SettersScope_PasswordBox_NoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<string>();
+            var host = H.CreateHost();
+            host.Mount(_ =>
+                PasswordBox("initial", onPasswordChanged: s => calls.Add(s))
+                    .Set(pb => pb.Password = "next"));
+            // Pump twice: the second pump lets any dispatcher-queued
+            // PasswordChanged land (matches the EchoSuppress_PasswordBox
+            // fixture's pattern for the same reason).
+            await Harness.Render();
+            await Harness.Render();
+
+            var pb = H.FindControl<PasswordBox>(_ => true);
+            H.Check("SettersScope_PasswordBox_SetterAppliedValue",
+                pb?.Password == "next");
+            H.Check("SettersScope_PasswordBox_MountNoFire", calls.Count == 0);
+
+            if (pb is not null) pb.Password = "typed";
+            await Harness.Render();
+            await Harness.Render();
+            H.Check("SettersScope_PasswordBox_UserEditStillFires",
+                calls.Count >= 1 && calls[^1] == "typed");
+        }
+    }
+
     // ── ToggleSplitButton ─────────────────────────────────────────────
 
     internal class ToggleSplitButtonNoEcho(Harness h) : SelfTestFixtureBase(h)

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
@@ -503,6 +503,88 @@ internal static class EchoSuppressionFixtures
         }
     }
 
+    // ── §8.2 setter-suppression scope ─────────────────────────────────
+    //
+    // Until the §8.2 carve-out, `ApplySetters` ran outside the echo-suppression
+    // scope so a user-authored `.Set(c => c.Value = ...)` write fed back into
+    // the OnXChanged callback the engine had already wired. The fixtures below
+    // pin three properties:
+    //   1. The mount + setter combo does not echo into the callback even when
+    //      the setter writes a value-bearing DP whose change event the engine
+    //      subscribed to (the headline §8.2 case for ToggleSwitch).
+    //   2. After mount completes, a real user-style write to the same DP still
+    //      reaches the callback. This rules out a regression where the scope
+    //      leaks past ApplySetters and silences genuine input.
+    //   3. The behavior covers a representative spread of value-bearing
+    //      controls (ToggleSwitch / Slider / NumberBox) so a future regression
+    //      that re-introduces the bug on one shape is caught.
+
+    internal class SettersScope_ToggleSwitch_NoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<bool>();
+            var host = H.CreateHost();
+            host.Mount(_ =>
+                ToggleSwitch(isOn: false, onIsOnChanged: v => calls.Add(v))
+                    .Set(ts => ts.IsOn = true));
+            await Harness.Render();
+            H.Check("SettersScope_ToggleSwitch_MountNoFire", calls.Count == 0);
+
+            var ts = H.FindControl<ToggleSwitch>(_ => true);
+            H.Check("SettersScope_ToggleSwitch_SetterAppliedValue", ts?.IsOn == true);
+
+            if (ts is not null) ts.IsOn = false;
+            await Harness.Render();
+            H.Check("SettersScope_ToggleSwitch_UserEditStillFires",
+                calls.Count >= 1 && calls[^1] == false);
+        }
+    }
+
+    internal class SettersScope_Slider_NoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<double>();
+            var host = H.CreateHost();
+            host.Mount(_ =>
+                Slider(value: 25.0, min: 0.0, max: 100.0, onValueChanged: v => calls.Add(v))
+                    .Set(s => s.Value = 75.0));
+            await Harness.Render();
+            H.Check("SettersScope_Slider_MountNoFire", calls.Count == 0);
+
+            var sl = H.FindControl<Slider>(_ => true);
+            H.Check("SettersScope_Slider_SetterAppliedValue", sl?.Value == 75.0);
+
+            if (sl is not null) sl.Value = 50.0;
+            await Harness.Render();
+            H.Check("SettersScope_Slider_UserEditStillFires",
+                calls.Count >= 1 && calls[^1] == 50.0);
+        }
+    }
+
+    internal class SettersScope_NumberBox_NoEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<double>();
+            var host = H.CreateHost();
+            host.Mount(_ =>
+                NumberBox(value: 10.0, onValueChanged: v => calls.Add(v))
+                    .Set(nb => nb.Value = 42.0));
+            await Harness.Render();
+            H.Check("SettersScope_NumberBox_MountNoFire", calls.Count == 0);
+
+            var nb = H.FindControl<NumberBox>(_ => true);
+            H.Check("SettersScope_NumberBox_SetterAppliedValue", nb?.Value == 42.0);
+
+            if (nb is not null) nb.Value = 77.0;
+            await Harness.Render();
+            H.Check("SettersScope_NumberBox_UserEditStillFires",
+                calls.Count >= 1 && calls[^1] == 77.0);
+        }
+    }
+
     // ── ToggleSplitButton ─────────────────────────────────────────────
 
     internal class ToggleSplitButtonNoEcho(Harness h) : SelfTestFixtureBase(h)

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -558,6 +558,7 @@ internal static class SelfTestFixtureRegistry
         "SettersScope_ToggleSwitch",
         "SettersScope_Slider",
         "SettersScope_NumberBox",
+        "SettersScope_PasswordBox",
         // TextBox mount property-ordering: AcceptsReturn must precede Text.
         "TB_Mount_MultiLinePreserved",
         "TB_Mount_SingleLineCorrect",
@@ -1551,6 +1552,7 @@ internal static class SelfTestFixtureRegistry
         "SettersScope_ToggleSwitch" => new EchoSuppressionFixtures.SettersScope_ToggleSwitch_NoEcho(harness),
         "SettersScope_Slider" => new EchoSuppressionFixtures.SettersScope_Slider_NoEcho(harness),
         "SettersScope_NumberBox" => new EchoSuppressionFixtures.SettersScope_NumberBox_NoEcho(harness),
+        "SettersScope_PasswordBox" => new EchoSuppressionFixtures.SettersScope_PasswordBox_NoEcho(harness),
         "TB_Mount_MultiLinePreserved" => new TextBoxMountFixtures.MultiLineTextPreserved(harness),
         "TB_Mount_SingleLineCorrect" => new TextBoxMountFixtures.SingleLineMountCorrect(harness),
         "TB_Mount_MultiLineUpdatePreserved" => new TextBoxMountFixtures.MultiLineUpdatePreserved(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -554,6 +554,10 @@ internal static class SelfTestFixtureRegistry
         "EchoSuppress_PasswordBox",
         "EchoSuppress_TextBox",
         "EchoSuppress_ToggleSplitButton",
+        // §8.2 setter-suppression scope — Set(c => c.X = ...) must not echo.
+        "SettersScope_ToggleSwitch",
+        "SettersScope_Slider",
+        "SettersScope_NumberBox",
         // TextBox mount property-ordering: AcceptsReturn must precede Text.
         "TB_Mount_MultiLinePreserved",
         "TB_Mount_SingleLineCorrect",
@@ -1544,6 +1548,9 @@ internal static class SelfTestFixtureRegistry
         "EchoSuppress_PasswordBox" => new EchoSuppressionFixtures.PasswordBoxNoEcho(harness),
         "EchoSuppress_TextBox" => new EchoSuppressionFixtures.TextBoxNoEcho(harness),
         "EchoSuppress_ToggleSplitButton" => new EchoSuppressionFixtures.ToggleSplitButtonNoEcho(harness),
+        "SettersScope_ToggleSwitch" => new EchoSuppressionFixtures.SettersScope_ToggleSwitch_NoEcho(harness),
+        "SettersScope_Slider" => new EchoSuppressionFixtures.SettersScope_Slider_NoEcho(harness),
+        "SettersScope_NumberBox" => new EchoSuppressionFixtures.SettersScope_NumberBox_NoEcho(harness),
         "TB_Mount_MultiLinePreserved" => new TextBoxMountFixtures.MultiLineTextPreserved(harness),
         "TB_Mount_SingleLineCorrect" => new TextBoxMountFixtures.SingleLineMountCorrect(harness),
         "TB_Mount_MultiLineUpdatePreserved" => new TextBoxMountFixtures.MultiLineUpdatePreserved(harness),


### PR DESCRIPTION
## Summary

Carve-out fix from [spec 047 §8.2](../blob/main/docs/specs/047-extensible-control-model.md#82-setters-precedence--a-current-correctness-hole) per the [factoring recommendation](../blob/main/docs/specs/047/factoring-recommendation.md#carve-outs-to-execute-before-phase-1-starts). Plumbs a scope-based echo-suppression mode around `ApplySetters` so a user-authored `.Set(c => c.X = ...)` write on a value-bearing control does not echo back into the OnXChanged callback the engine already wired.

The repro (M13 in the Phase-0 perf bench): `ToggleSwitch(false, onIsOnChanged: …).Set(ts => ts.IsOn = true)` fires the callback once at mount today — the same cross-state-echo shape as spec-030, just triggered by the setter chain instead of an Update path.

## What changed

- `ReactorState` gets a new `EchoSuppressScopeDepth` int alongside the existing paired `EchoSuppressCount`.
- `ChangeEchoSuppressor.ShouldSuppress` checks the scope depth first; if nonzero, the event is dropped without consuming a counter token, so the existing paired `BeginSuppress` ↔ change-event flow keeps working unchanged for declarative property writes.
- `Reconciler.ApplySetters` enters the scope iff `ReactorState` already exists on the control. Value-bearing mounts call `SetElementTag` before `ApplySetters`, so the state is present for every control that can fire a suppressed change event; bare leaves like `TextBlock`/`RichTextBlock` skip the scope and pay no allocation.
- Scope is reset alongside `EchoSuppressCount` in `ClearCurrentEventHandlers` and `DetachReactorState` so a stranded depth (from an exception inside a setter) can't leak across pool reuse.

~15 LOC of production change in `Reconciler.cs` + `ChangeEchoSuppressor.cs`.

## Before / after — M13 `OnIsOnChangedFireCount`

| Variant | Before (PR #411 baseline) | After |
|---|---:|---:|
| ReactorToday | **1** (all 5 reps) | **0** (all 5 reps) |
| ReactorV2    | **1** (all 5 reps) | **0** (all 5 reps) |

Phase-0 baseline JSONL is intentionally left intact as the pre-fix witness; a follow-up paragraph in `baseline-results/summary.md` records the post-fix counter values.

## Test plan

- [x] M13 bench re-run (ARM64 Release, 1000 iterations × 5 reps) — counter = 0 on both Reactor variants.
- [x] `dotnet test tests/Reactor.Tests/Reactor.Tests.csproj -c Release -p:Platform=x64` — 9036 passed, 0 failed, 46 skipped (matches baseline).
- [x] `dotnet test tests/Reactor.SelfTests/Reactor.SelfTests.csproj -c Release -p:Platform=x64` — 827 passed.
- [x] Three new SelfTest fixtures (`SettersScope_ToggleSwitch`, `SettersScope_Slider`, `SettersScope_NumberBox`) lock the behavior with a mount-no-echo + user-edit-still-fires pair so a future regression on any of the three shapes surfaces immediately.

## Docs updated

- `docs/specs/047-extensible-control-model.md` §8.2 — Resolved note pointing at this PR.
- `docs/specs/047/baseline-results/summary.md` — M13 takeaway gets a follow-up paragraph noting the post-fix counter.
- `docs/specs/047/factoring-recommendation.md` — carve-out marked landed.
- `docs/specs/tasks/047-extensible-control-model-implementation.md` — Phase 0 exit checklist 0.7 and the M13 line note the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)