### PR TITLE
feat(hosting): layered-window attrs — Opacity, NoActivate, IgnorePointerInput

### DIFF
--- a/src/Reactor/Hosting/ReactorWindow.cs
+++ b/src/Reactor/Hosting/ReactorWindow.cs
@@ -1002,12 +1002,18 @@ public sealed class ReactorWindow : IDisposable
         if (opacity >= 1.0)
         {
             // Strip WS_EX_LAYERED so the compositor fast-path is restored.
-            // No-op when it wasn't set (the common case).
-            if (isLayered)
-            {
-                nint cleared = (nint)((long)current & ~NativeOpacity.WS_EX_LAYERED);
-                _ = NativeOpacity.SetWindowLongPtr(_hwnd, NativeOpacity.GWL_EXSTYLE, cleared);
-            }
+            // Also strip WS_EX_TRANSPARENT — that style is only meaningful
+            // on layered windows, so leaving it set after un-layering would
+            // wedge the window in an inconsistent extended-style state.
+            // Mirror IgnorePointerInput=false into _spec so Update() diffs
+            // see the live state.
+            long currentBits = (long)current;
+            long strippedBits = currentBits & ~(NativeOpacity.WS_EX_LAYERED | NativeOpacity.WS_EX_TRANSPARENT);
+            if (strippedBits != currentBits)
+                _ = NativeOpacity.SetWindowLongPtr(_hwnd, NativeOpacity.GWL_EXSTYLE, (nint)strippedBits);
+            var prevSpec = Volatile.Read(ref _spec);
+            if (prevSpec.IgnorePointerInput)
+                Volatile.Write(ref _spec, prevSpec with { IgnorePointerInput = false });
             return;
         }
 
@@ -1046,15 +1052,31 @@ public sealed class ReactorWindow : IDisposable
     /// <summary>
     /// Toggle the <c>WS_EX_TRANSPARENT</c> extended style on the underlying
     /// HWND. When set, mouse events pass THROUGH the window to whatever's
-    /// underneath. Only effective on layered windows (i.e. paired with
-    /// <see cref="SetOpacity"/> &lt; 1.0). UI-thread only. No-op after disposal.
+    /// underneath. The window must already be layered (via
+    /// <see cref="SetOpacity"/> with a value &lt; 1.0) when enabling —
+    /// the OS only honors transparent on layered windows. UI-thread only.
+    /// No-op after disposal.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="ignore"/> is true but the window is not
+    /// currently layered. Call <see cref="SetOpacity"/> with a value &lt; 1.0
+    /// first.
+    /// </exception>
     public void SetIgnorePointerInput(bool ignore)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetIgnorePointerInput));
         if (_disposed) return;
         var current = NativeOpacity.GetWindowLongPtr(_hwnd, NativeOpacity.GWL_EXSTYLE);
         long bits = (long)current;
+
+        // Enabling transparent on a non-layered window is a silent no-op at
+        // the OS level — reject up front rather than leave the caller with
+        // a flag that doesn't do anything.
+        if (ignore && (bits & NativeOpacity.WS_EX_LAYERED) == 0)
+            throw new InvalidOperationException(
+                "SetIgnorePointerInput(true) requires the window to be layered. " +
+                "Call SetOpacity with a value < 1.0 first.");
+
         long updated = ignore
             ? bits | NativeOpacity.WS_EX_TRANSPARENT
             : bits & ~NativeOpacity.WS_EX_TRANSPARENT;

--- a/src/Reactor/Hosting/ReactorWindow.cs
+++ b/src/Reactor/Hosting/ReactorWindow.cs
@@ -412,6 +412,11 @@ public sealed class ReactorWindow : IDisposable
         else if (isInitial)
             TryApplyExeIconFallback();
 
+        // Spec 045 §2.6 tear-off — window-wide alpha via WS_EX_LAYERED +
+        // SetLayeredWindowAttributes. Skipped when Opacity==1.0 so opaque
+        // windows pay zero layering overhead (Windows compositor fast-path).
+        ApplyOpacity(spec.Opacity);
+
         // Owner relationship — only meaningful at initial apply time.
         // Subsequent Update calls do not re-parent (changing ownership of a
         // realized window has no AppWindow API and is rarely the right thing
@@ -958,6 +963,72 @@ public sealed class ReactorWindow : IDisposable
         try { _appWindow.Move(DipToPhysicalPoint(x, y)); }
         catch (COMException ex) when (HResults.IsTeardownReentry(ex.HResult))
         { DiagnosticLog.SwallowedError(LogCategory.Hosting, "ReactorWindow.SetPosition", ex); }
+    }
+
+    /// <summary>
+    /// Set window-wide alpha in [0..1]. 1.0 strips the layered-window
+    /// extended style; values below 1.0 install it and call
+    /// <c>SetLayeredWindowAttributes</c>. UI-thread only. No-op after disposal.
+    /// </summary>
+    public void SetOpacity(double opacity)
+    {
+        ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetOpacity));
+        if (_disposed) return;
+        if (!(opacity >= 0.0 && opacity <= 1.0) || double.IsNaN(opacity))
+            throw new ArgumentOutOfRangeException(nameof(opacity), "Opacity must be in [0, 1].");
+        ApplyOpacity(opacity);
+        // Mirror into _spec so a subsequent Update() diff doesn't fight the
+        // imperative call. Volatile.Write because Spec is read from any thread.
+        var prev = Volatile.Read(ref _spec);
+        Volatile.Write(ref _spec, prev with { Opacity = opacity });
+    }
+
+    private void ApplyOpacity(double opacity)
+    {
+        // Clamp defensively even though Validate() / SetOpacity already
+        // checked — the Win32 LWA_ALPHA byte is [0..255].
+        if (opacity < 0.0) opacity = 0.0;
+        if (opacity > 1.0) opacity = 1.0;
+
+        var current = NativeOpacity.GetWindowLongPtr(_hwnd, NativeOpacity.GWL_EXSTYLE);
+        bool isLayered = ((long)current & NativeOpacity.WS_EX_LAYERED) != 0;
+
+        if (opacity >= 1.0)
+        {
+            // Strip WS_EX_LAYERED so the compositor fast-path is restored.
+            // No-op when it wasn't set (the common case).
+            if (isLayered)
+            {
+                nint cleared = (nint)((long)current & ~NativeOpacity.WS_EX_LAYERED);
+                _ = NativeOpacity.SetWindowLongPtr(_hwnd, NativeOpacity.GWL_EXSTYLE, cleared);
+            }
+            return;
+        }
+
+        if (!isLayered)
+        {
+            nint withLayered = (nint)((long)current | NativeOpacity.WS_EX_LAYERED);
+            _ = NativeOpacity.SetWindowLongPtr(_hwnd, NativeOpacity.GWL_EXSTYLE, withLayered);
+        }
+        byte alpha = (byte)Math.Round(opacity * 255.0);
+        _ = NativeOpacity.SetLayeredWindowAttributes(_hwnd, 0, alpha, NativeOpacity.LWA_ALPHA);
+    }
+
+    private static class NativeOpacity
+    {
+        public const int GWL_EXSTYLE = -20;
+        public const long WS_EX_LAYERED = 0x00080000;
+        public const uint LWA_ALPHA = 0x00000002;
+
+        [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]
+        public static extern nint GetWindowLongPtr(nint hWnd, int nIndex);
+
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
+        public static extern nint SetWindowLongPtr(nint hWnd, int nIndex, nint dwNewLong);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetLayeredWindowAttributes(nint hwnd, uint crKey, byte bAlpha, uint dwFlags);
     }
 
     /// <summary>Center on the window's current monitor. UI-thread only.</summary>

--- a/src/Reactor/Hosting/ReactorWindow.cs
+++ b/src/Reactor/Hosting/ReactorWindow.cs
@@ -417,6 +417,12 @@ public sealed class ReactorWindow : IDisposable
         // windows pay zero layering overhead (Windows compositor fast-path).
         ApplyOpacity(spec.Opacity);
 
+        // Spec 045 §2.6 tear-off — NoActivate must be applied before
+        // Activate fires (in MountAndActivate) so the window's first show
+        // observes the flag. Re-applied on Update so flips stick.
+        SetNoActivate(spec.NoActivate);
+        SetIgnorePointerInput(spec.IgnorePointerInput);
+
         // Owner relationship — only meaningful at initial apply time.
         // Subsequent Update calls do not re-parent (changing ownership of a
         // realized window has no AppWindow API and is rarely the right thing
@@ -1014,10 +1020,57 @@ public sealed class ReactorWindow : IDisposable
         _ = NativeOpacity.SetLayeredWindowAttributes(_hwnd, 0, alpha, NativeOpacity.LWA_ALPHA);
     }
 
+    /// <summary>
+    /// Toggle the <c>WS_EX_NOACTIVATE</c> extended style on the underlying
+    /// HWND. When set, the window appears without stealing foreground
+    /// activation (matches VS tool-window / drag-preview behavior).
+    /// UI-thread only. No-op after disposal.
+    /// </summary>
+    public void SetNoActivate(bool noActivate)
+    {
+        ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetNoActivate));
+        if (_disposed) return;
+        var current = NativeOpacity.GetWindowLongPtr(_hwnd, NativeOpacity.GWL_EXSTYLE);
+        long bits = (long)current;
+        long updated = noActivate
+            ? bits | NativeOpacity.WS_EX_NOACTIVATE
+            : bits & ~NativeOpacity.WS_EX_NOACTIVATE;
+        if (updated != bits)
+            _ = NativeOpacity.SetWindowLongPtr(_hwnd, NativeOpacity.GWL_EXSTYLE, (nint)updated);
+        // Mirror into _spec so Update() diffs see the live value.
+        var prev = Volatile.Read(ref _spec);
+        if (prev.NoActivate != noActivate)
+            Volatile.Write(ref _spec, prev with { NoActivate = noActivate });
+    }
+
+    /// <summary>
+    /// Toggle the <c>WS_EX_TRANSPARENT</c> extended style on the underlying
+    /// HWND. When set, mouse events pass THROUGH the window to whatever's
+    /// underneath. Only effective on layered windows (i.e. paired with
+    /// <see cref="SetOpacity"/> &lt; 1.0). UI-thread only. No-op after disposal.
+    /// </summary>
+    public void SetIgnorePointerInput(bool ignore)
+    {
+        ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetIgnorePointerInput));
+        if (_disposed) return;
+        var current = NativeOpacity.GetWindowLongPtr(_hwnd, NativeOpacity.GWL_EXSTYLE);
+        long bits = (long)current;
+        long updated = ignore
+            ? bits | NativeOpacity.WS_EX_TRANSPARENT
+            : bits & ~NativeOpacity.WS_EX_TRANSPARENT;
+        if (updated != bits)
+            _ = NativeOpacity.SetWindowLongPtr(_hwnd, NativeOpacity.GWL_EXSTYLE, (nint)updated);
+        var prev = Volatile.Read(ref _spec);
+        if (prev.IgnorePointerInput != ignore)
+            Volatile.Write(ref _spec, prev with { IgnorePointerInput = ignore });
+    }
+
     private static class NativeOpacity
     {
         public const int GWL_EXSTYLE = -20;
         public const long WS_EX_LAYERED = 0x00080000;
+        public const long WS_EX_NOACTIVATE = 0x08000000;
+        public const long WS_EX_TRANSPARENT = 0x00000020;
         public const uint LWA_ALPHA = 0x00000002;
 
         [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]

--- a/src/Reactor/Hosting/WindowSpec.cs
+++ b/src/Reactor/Hosting/WindowSpec.cs
@@ -125,12 +125,17 @@ public sealed record WindowSpec
 
     /// <summary>
     /// Apply the Win32 <c>WS_EX_TRANSPARENT</c> extended style so mouse events
-    /// pass THROUGH the window to whatever's underneath. Requires
-    /// <see cref="Opacity"/> &lt; 1.0 (the OS only honors transparent on
-    /// layered windows). Default false. Used by spec 045 §2.6 tear-off so
-    /// the drag preview doesn't block clicks on drop-target overlays
-    /// below it.
+    /// pass THROUGH the window to whatever's underneath. Default false.
+    /// Used by spec 045 §2.6 tear-off so the drag preview doesn't block
+    /// clicks on drop-target overlays below it.
     /// </summary>
+    /// <remarks>
+    /// <para>Requires <see cref="Opacity"/> &lt; 1.0 — the OS only honors
+    /// <c>WS_EX_TRANSPARENT</c> on layered windows. <see cref="Validate"/>
+    /// throws when this field is true with <c>Opacity == 1.0</c>; the
+    /// runtime mutator <c>ReactorWindow.SetIgnorePointerInput(true)</c>
+    /// also throws if the live window is not layered.</para>
+    /// </remarks>
     public bool IgnorePointerInput { get; init; }
 
     /// <summary>
@@ -182,5 +187,14 @@ public sealed record WindowSpec
         if (!(Opacity >= 0.0 && Opacity <= 1.0) || double.IsNaN(Opacity))
             throw new ArgumentException(
                 $"WindowSpec.Opacity ({Opacity}) must be in [0, 1].", nameof(Opacity));
+
+        // WS_EX_TRANSPARENT is only honored by the OS when WS_EX_LAYERED is
+        // also set; a non-layered window with the transparent style is a
+        // silent no-op for click-through. Reject up front rather than ship
+        // a misleading contract.
+        if (IgnorePointerInput && Opacity >= 1.0)
+            throw new ArgumentException(
+                "WindowSpec.IgnorePointerInput requires Opacity < 1.0 (click-through is only effective on layered windows).",
+                nameof(IgnorePointerInput));
     }
 }

--- a/src/Reactor/Hosting/WindowSpec.cs
+++ b/src/Reactor/Hosting/WindowSpec.cs
@@ -106,6 +106,16 @@ public sealed record WindowSpec
     public bool ActivateOnOpen { get; init; } = true;
 
     /// <summary>
+    /// Window-wide alpha in [0..1]. 1.0 = fully opaque (default, no layering
+    /// overhead). Values below 1.0 are applied via Win32
+    /// <c>SetLayeredWindowAttributes</c> on the underlying HWND. Used by the
+    /// docking subsystem to render an in-flight tear-off floating window at
+    /// reduced opacity (spec 045 §2.6 tear-off follow-up); apps may also set
+    /// it for HUD overlays etc.
+    /// </summary>
+    public double Opacity { get; init; } = 1.0;
+
+    /// <summary>
     /// Construct with explicit field values. Validation runs after the record
     /// auto-init.
     /// </summary>
@@ -150,5 +160,9 @@ public sealed record WindowSpec
         if (StartPosition != WindowStartPosition.Manual && ManualPosition is not null)
             throw new ArgumentException(
                 "WindowSpec.ManualPosition must be null unless StartPosition == Manual.", nameof(ManualPosition));
+
+        if (!(Opacity >= 0.0 && Opacity <= 1.0) || double.IsNaN(Opacity))
+            throw new ArgumentException(
+                $"WindowSpec.Opacity ({Opacity}) must be in [0, 1].", nameof(Opacity));
     }
 }

--- a/src/Reactor/Hosting/WindowSpec.cs
+++ b/src/Reactor/Hosting/WindowSpec.cs
@@ -116,6 +116,24 @@ public sealed record WindowSpec
     public double Opacity { get; init; } = 1.0;
 
     /// <summary>
+    /// Apply the Win32 <c>WS_EX_NOACTIVATE</c> extended style so the window
+    /// appears without stealing foreground activation. Matches VS tool-window
+    /// / drag-preview behavior. Default false. The flag is applied during
+    /// chrome setup (before Activate) so the first show observes it.
+    /// </summary>
+    public bool NoActivate { get; init; }
+
+    /// <summary>
+    /// Apply the Win32 <c>WS_EX_TRANSPARENT</c> extended style so mouse events
+    /// pass THROUGH the window to whatever's underneath. Requires
+    /// <see cref="Opacity"/> &lt; 1.0 (the OS only honors transparent on
+    /// layered windows). Default false. Used by spec 045 §2.6 tear-off so
+    /// the drag preview doesn't block clicks on drop-target overlays
+    /// below it.
+    /// </summary>
+    public bool IgnorePointerInput { get; init; }
+
+    /// <summary>
     /// Construct with explicit field values. Validation runs after the record
     /// auto-init.
     /// </summary>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowModelFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowModelFixtures.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
 using Microsoft.UI.Xaml;
 using static Microsoft.UI.Reactor.Factories;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
@@ -490,6 +491,154 @@ internal static class WindowModelFixtures
             }
 
             H.Check("WindowMut_OwnedRemoved", child is null || !parent.OwnedWindows.Contains(child));
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Layered-window attrs — Opacity / NoActivate / IgnorePointerInput
+    //
+    //  Verifies the Win32 WS_EX_LAYERED / WS_EX_NOACTIVATE / WS_EX_TRANSPARENT
+    //  extended-style bits flip via WindowSpec at construction and via the
+    //  runtime mutators (SetOpacity / SetNoActivate / SetIgnorePointerInput).
+    //  Each fixture reads GWL_EXSTYLE directly to confirm the OS-level flag
+    //  is set; the managed spec mirror is exercised in parallel so the next
+    //  Update() diff sees the live values. (spec 045 §2.6 tear-off
+    //  foundation primitives.)
+    // ════════════════════════════════════════════════════════════════════
+
+    private static class WindowAttrInterop
+    {
+        public const int GWL_EXSTYLE = -20;
+        public const long WS_EX_LAYERED = 0x00080000;
+        public const long WS_EX_NOACTIVATE = 0x08000000;
+        public const long WS_EX_TRANSPARENT = 0x00000020;
+
+        [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]
+        public static extern nint GetWindowLongPtr(nint hWnd, int nIndex);
+
+        public static long ExStyle(nint hwnd) => (long)GetWindowLongPtr(hwnd, GWL_EXSTYLE);
+        public static bool HasFlag(nint hwnd, long flag) => (ExStyle(hwnd) & flag) != 0;
+    }
+
+    private static nint HwndOf(ReactorWindow win) =>
+        WinRT.Interop.WindowNative.GetWindowHandle(win.NativeWindow);
+
+    internal class WindowOpacityRoundTrip(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            EnsureUIDispatcher();
+
+            // Spec-set opacity at construction → WS_EX_LAYERED on.
+            var win = await OpenAndSettle(
+                new WindowSpec { Title = "Opacity Test", Width = 320, Height = 200, Opacity = 0.5 },
+                () => new StubComponent());
+            try
+            {
+                var hwnd = HwndOf(win);
+                H.Check("WindowAttr_Opacity_SpecValue", Math.Abs(win.Spec.Opacity - 0.5) < 0.0001);
+                H.Check("WindowAttr_Opacity_LayeredOnAtSpec",
+                    WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_LAYERED));
+
+                // Mutator round-trip to 0.25 → still layered, spec updated.
+                win.SetOpacity(0.25);
+                await Harness.Render();
+                H.Check("WindowAttr_Opacity_SpecAfterMutator", Math.Abs(win.Spec.Opacity - 0.25) < 0.0001);
+                H.Check("WindowAttr_Opacity_LayeredOnAfterMutator",
+                    WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_LAYERED));
+
+                // 1.0 strips WS_EX_LAYERED (compositor fast-path restored).
+                win.SetOpacity(1.0);
+                await Harness.Render();
+                H.Check("WindowAttr_Opacity_LayeredOffAt1",
+                    !WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_LAYERED));
+
+                // Out-of-range throws.
+                bool threw = false;
+                try { win.SetOpacity(1.5); }
+                catch (ArgumentOutOfRangeException) { threw = true; }
+                H.Check("WindowAttr_Opacity_OutOfRangeThrows", threw);
+            }
+            finally
+            {
+                await CloseAndSettle(win);
+            }
+        }
+    }
+
+    internal class WindowNoActivateRoundTrip(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            EnsureUIDispatcher();
+
+            // Spec-set NoActivate → flag on at first show.
+            var win = await OpenAndSettle(
+                new WindowSpec { Title = "NoActivate Test", Width = 320, Height = 200, NoActivate = true },
+                () => new StubComponent());
+            try
+            {
+                var hwnd = HwndOf(win);
+                H.Check("WindowAttr_NoActivate_SpecValue", win.Spec.NoActivate);
+                H.Check("WindowAttr_NoActivate_FlagOnAtSpec",
+                    WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_NOACTIVATE));
+
+                // Mutator off → flag clears, spec mirrors.
+                win.SetNoActivate(false);
+                H.Check("WindowAttr_NoActivate_SpecAfterMutator", !win.Spec.NoActivate);
+                H.Check("WindowAttr_NoActivate_FlagOffAfterMutator",
+                    !WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_NOACTIVATE));
+
+                // Mutator back on → flag returns.
+                win.SetNoActivate(true);
+                H.Check("WindowAttr_NoActivate_FlagOnAgain",
+                    WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_NOACTIVATE));
+            }
+            finally
+            {
+                await CloseAndSettle(win);
+            }
+        }
+    }
+
+    internal class WindowIgnorePointerInputRoundTrip(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            EnsureUIDispatcher();
+
+            // Spec-set IgnorePointerInput together with Opacity<1.0 (the OS
+            // only honors transparent on layered windows).
+            var win = await OpenAndSettle(
+                new WindowSpec
+                {
+                    Title = "IgnorePointer Test",
+                    Width = 320,
+                    Height = 200,
+                    Opacity = 0.5,
+                    IgnorePointerInput = true,
+                },
+                () => new StubComponent());
+            try
+            {
+                var hwnd = HwndOf(win);
+                H.Check("WindowAttr_IgnorePointer_SpecValue", win.Spec.IgnorePointerInput);
+                H.Check("WindowAttr_IgnorePointer_FlagOnAtSpec",
+                    WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_TRANSPARENT));
+
+                win.SetIgnorePointerInput(false);
+                H.Check("WindowAttr_IgnorePointer_SpecAfterMutator", !win.Spec.IgnorePointerInput);
+                H.Check("WindowAttr_IgnorePointer_FlagOffAfterMutator",
+                    !WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_TRANSPARENT));
+
+                win.SetIgnorePointerInput(true);
+                H.Check("WindowAttr_IgnorePointer_FlagOnAgain",
+                    WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_TRANSPARENT));
+            }
+            finally
+            {
+                await CloseAndSettle(win);
+            }
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowModelFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowModelFixtures.cs
@@ -566,6 +566,77 @@ internal static class WindowModelFixtures
         }
     }
 
+    /// <summary>
+    /// Cross-field invariant: <c>IgnorePointerInput=true</c> with
+    /// <c>Opacity&gt;=1.0</c> is rejected by <c>WindowSpec.Validate</c>
+    /// (the OS only honors WS_EX_TRANSPARENT on layered windows). And
+    /// <c>SetOpacity(1.0)</c> on a window that had IgnorePointerInput
+    /// enabled must strip both WS_EX_LAYERED and WS_EX_TRANSPARENT so
+    /// the extended-style bits don't stay in an inconsistent combo.
+    /// </summary>
+    internal class WindowOpacityIgnorePointerInvariants(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            EnsureUIDispatcher();
+
+            // Validate() rejects the invalid combo before any HWND is built.
+            bool specThrew = false;
+            try
+            {
+                new WindowSpec { IgnorePointerInput = true, Opacity = 1.0 }.Validate();
+            }
+            catch (ArgumentException) { specThrew = true; }
+            H.Check("WindowAttr_Invariant_SpecValidateThrows", specThrew);
+
+            // Live path: open layered + transparent, then drive Opacity
+            // back to 1.0 and confirm BOTH bits cleared and _spec mirrored.
+            var win = await OpenAndSettle(
+                new WindowSpec
+                {
+                    Title = "Invariants Test",
+                    Width = 320,
+                    Height = 200,
+                    Opacity = 0.5,
+                    IgnorePointerInput = true,
+                },
+                () => new StubComponent());
+            try
+            {
+                var hwnd = HwndOf(win);
+                H.Check("WindowAttr_Invariant_LayeredAndTransparentAtSpec",
+                    WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_LAYERED)
+                    && WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_TRANSPARENT));
+
+                win.SetOpacity(1.0);
+                await Harness.Render();
+                H.Check("WindowAttr_Invariant_LayeredClearedAt1",
+                    !WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_LAYERED));
+                H.Check("WindowAttr_Invariant_TransparentClearedAt1",
+                    !WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_TRANSPARENT));
+                H.Check("WindowAttr_Invariant_SpecIgnorePointerFalse",
+                    !win.Spec.IgnorePointerInput);
+
+                // Now SetIgnorePointerInput(true) on the now-opaque window
+                // must throw — layered is gone.
+                bool mutatorThrew = false;
+                try { win.SetIgnorePointerInput(true); }
+                catch (InvalidOperationException) { mutatorThrew = true; }
+                H.Check("WindowAttr_Invariant_MutatorThrowsWhenNotLayered", mutatorThrew);
+
+                // Re-layer, then SetIgnorePointerInput(true) should succeed.
+                win.SetOpacity(0.5);
+                win.SetIgnorePointerInput(true);
+                H.Check("WindowAttr_Invariant_MutatorWorksAfterRelayer",
+                    WindowAttrInterop.HasFlag(hwnd, WindowAttrInterop.WS_EX_TRANSPARENT));
+            }
+            finally
+            {
+                await CloseAndSettle(win);
+            }
+        }
+    }
+
     internal class WindowNoActivateRoundTrip(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -893,6 +893,7 @@ internal static class SelfTestFixtureRegistry
         "WindowModel_OpacityRoundTrip",
         "WindowModel_NoActivateRoundTrip",
         "WindowModel_IgnorePointerInputRoundTrip",
+        "WindowModel_OpacityIgnorePointerInvariants",
         // Spec 045 §2.19 — Phase-1 wrapper-based Docking_* smoke fixtures
         // were retired with the XAML wrapper at the §2.29 review gate.
         // NativeDocking_* below covers the same surface against the P2
@@ -1945,6 +1946,7 @@ internal static class SelfTestFixtureRegistry
         "WindowModel_OpacityRoundTrip" => new WindowModelFixtures.WindowOpacityRoundTrip(harness),
         "WindowModel_NoActivateRoundTrip" => new WindowModelFixtures.WindowNoActivateRoundTrip(harness),
         "WindowModel_IgnorePointerInputRoundTrip" => new WindowModelFixtures.WindowIgnorePointerInputRoundTrip(harness),
+        "WindowModel_OpacityIgnorePointerInvariants" => new WindowModelFixtures.WindowOpacityIgnorePointerInvariants(harness),
         // Spec 045 §2.19 — Phase-1 DockingSmokeFixtures retired alongside
         // the XAML wrapper unhooking. NativeDockingSmokeFixtures (below)
         // covers the same mount/update/unmount surface against the P2

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -890,6 +890,9 @@ internal static class SelfTestFixtureRegistry
         "WindowModel_TrayIconRoundTrip",
         "WindowModel_UseOpenWindowReusesByKey",
         "WindowModel_MutatorsOwnerAndGuards",
+        "WindowModel_OpacityRoundTrip",
+        "WindowModel_NoActivateRoundTrip",
+        "WindowModel_IgnorePointerInputRoundTrip",
         // Spec 045 §2.19 — Phase-1 wrapper-based Docking_* smoke fixtures
         // were retired with the XAML wrapper at the §2.29 review gate.
         // NativeDocking_* below covers the same surface against the P2
@@ -1939,6 +1942,9 @@ internal static class SelfTestFixtureRegistry
         "WindowModel_TrayIconRoundTrip" => new WindowModelFixtures.TrayIconRoundTrip(harness),
         "WindowModel_UseOpenWindowReusesByKey" => new WindowModelFixtures.UseOpenWindowReusesByKey(harness),
         "WindowModel_MutatorsOwnerAndGuards" => new WindowModelFixtures.WindowMutatorsOwnerAndGuards(harness),
+        "WindowModel_OpacityRoundTrip" => new WindowModelFixtures.WindowOpacityRoundTrip(harness),
+        "WindowModel_NoActivateRoundTrip" => new WindowModelFixtures.WindowNoActivateRoundTrip(harness),
+        "WindowModel_IgnorePointerInputRoundTrip" => new WindowModelFixtures.WindowIgnorePointerInputRoundTrip(harness),
         // Spec 045 §2.19 — Phase-1 DockingSmokeFixtures retired alongside
         // the XAML wrapper unhooking. NativeDockingSmokeFixtures (below)
         // covers the same mount/update/unmount surface against the P2


### PR DESCRIPTION
## Summary

Adds three Win32 layered-window extended-style primitives to `WindowSpec` + `ReactorWindow`, with matching runtime mutators and selftest coverage. These are foundation primitives for the upcoming spec 045 §2.6 VS-style tab tear-off, but they're independently useful (HUD overlays, drag previews, splash/loading windows that shouldn't steal focus, etc.) and decoupled here to keep the eventual docking PR smaller.

- **`Opacity`** (commit `dfb42fa9`) — window-wide alpha in [0..1] via `WS_EX_LAYERED` + `SetLayeredWindowAttributes`. `1.0` strips the layered style so opaque windows pay zero compositor overhead. Already useful standalone.
- **`NoActivate`** — applies `WS_EX_NOACTIVATE` so the window appears without stealing foreground activation. Matches VS tool-window / drag-preview behavior. Applied during chrome setup **before** `Activate` so the first show observes the flag.
- **`IgnorePointerInput`** — applies `WS_EX_TRANSPARENT` so mouse events pass **through** the window to whatever's underneath. Only effective on layered windows (i.e. paired with `Opacity < 1.0`). Lets a translucent preview sit on top of clickable UI without blocking input.

All three follow the same shape: declarative field on `WindowSpec` (applied during `ApplyChrome`) plus a public mutator on `ReactorWindow` that mirrors the new value into `_spec` so a later `Update()` diff sees the live state.

## Test plan

Selftest fixtures in `WindowModelFixtures.cs`, registered in `SelfTestFixtureRegistry.cs`:

- [x] `WindowModel_OpacityRoundTrip` — spec + mutator round-trip, asserts `WS_EX_LAYERED` bit, `1.0` strips it, out-of-range throws (6 asserts)
- [x] `WindowModel_NoActivateRoundTrip` — spec + mutator + `WS_EX_NOACTIVATE` bit (5 asserts)
- [x] `WindowModel_IgnorePointerInputRoundTrip` — spec + mutator + `WS_EX_TRANSPARENT` bit (5 asserts)

All three pass on ARM64 (16/16 asserts).

## Context

This PR is split out of a larger spec 045 §2.6 implementation (VS-style tab tear-off floating windows). A spike validated that these three primitives are necessary for the tear-off visual to coexist with WinUI's drop-target overlay, so they're being landed first to keep the eventual docking PR focused on the dock-specific changes.