### PR TITLE
feat: one-command bootstrap (bootstrap.ps1 + mur doctor/upgrade + dotnet-tool mur)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,21 @@ Many of the experiments in this repo — the charting stack, accessibility valid
 
 ## Quick start
 
-See **[docs/guide/getting-started.md](docs/guide/getting-started.md)** for the full walkthrough — prerequisites, building the framework and `mur` CLI from source, scaffolding your first app, and running through hello-world, a todo list, and a calculator with screenshots at each step.
+Reactor doesn't ship a signed NuGet yet, so you build the framework, the `mur` CLI, and the project template from source. `bootstrap.ps1` collapses that into a single command — ~3 minutes per machine.
 
+```powershell
+git clone https://github.com/microsoft/microsoft-ui-reactor.git
+cd microsoft-ui-reactor
+./bootstrap.ps1
 
+dotnet new reactorapp -n MyApp
+cd MyApp
+dotnet run
+```
+
+`bootstrap.ps1` packs `mur` as a `dotnet tool` global install (cross-shell PATH, no per-arch `$env:Path` edits), packs the framework + project templates into `local-nupkgs/`, registers the `dotnet new reactorapp` template, and installs the Reactor agent plugin under `~/.claude/plugins/reactor`. Re-run it (or `mur upgrade` for a lighter refresh) after `git pull`. Verify a working install with `mur doctor`.
+
+Prefer to wire it up by hand? **[docs/guide/getting-started.md](docs/guide/getting-started.md#manual-setup)** has a no-magic walkthrough of the exact `dotnet pack` / `dotnet tool install` / `dotnet new install` calls `bootstrap.ps1` makes, plus the full hello-world → todo → calculator tour.
 
 ---
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -73,10 +73,14 @@ foreach ($line in $sdkOutput) {
     }
 }
 if (-not $has10OrLater) {
-    Write-Host '    [warn] .NET 10 SDK not detected — Reactor requires 10+. https://dotnet.microsoft.com/download' -ForegroundColor Yellow
-} else {
-    Write-Ok ".NET SDK present"
+    Fail @"
+.NET 10+ SDK not detected — Reactor requires 10 or later.
+Installed SDKs:
+$($sdkOutput -join "`n")
+Install the latest .NET SDK from https://dotnet.microsoft.com/download and re-run ./bootstrap.ps1.
+"@
 }
+Write-Ok ".NET SDK present"
 
 # ---------------------------------------------------------------------------
 # 2. Pack `mur` as a global-tool nupkg

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,222 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    One-command setup for a Microsoft.UI.Reactor source checkout.
+
+.DESCRIPTION
+    Builds the `mur` CLI, installs it as a dotnet global tool, packs the
+    framework + ProjectTemplates into local-nupkgs/, installs the
+    `dotnet new reactorapp` template, and (optionally) drops the Claude
+    Code plugin under ~/.claude/plugins/reactor.
+
+    Idempotent — safe to re-run after `git pull` to refresh everything.
+    For a less heavyweight refresh (mur stays put), run `mur upgrade`.
+
+.PARAMETER SkipPlugin
+    Skip installing the Claude Code plugin under ~/.claude/plugins.
+
+.PARAMETER SkipMurInstall
+    Build and pack the CLI but don't run `dotnet tool install/update`.
+    Useful for CI or for users who manage tool installs externally.
+
+.PARAMETER Configuration
+    Build configuration for the CLI nupkg. Default: Release.
+
+.EXAMPLE
+    ./bootstrap.ps1
+    Full bootstrap.
+
+.EXAMPLE
+    ./bootstrap.ps1 -SkipPlugin
+    Skip the Claude plugin step.
+#>
+[CmdletBinding()]
+param(
+    [switch]$SkipPlugin,
+    [switch]$SkipMurInstall,
+    [string]$Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = $PSScriptRoot
+Set-Location $repoRoot
+
+function Write-Step($msg) {
+    Write-Host ''
+    Write-Host "==> $msg" -ForegroundColor Cyan
+}
+
+function Write-Ok($msg) {
+    Write-Host "    [ok] $msg" -ForegroundColor Green
+}
+
+function Fail($msg) {
+    Write-Host ''
+    Write-Host "ERROR: $msg" -ForegroundColor Red
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# 1. Pre-flight
+# ---------------------------------------------------------------------------
+Write-Step 'Pre-flight checks'
+
+$dotnetCmd = Get-Command dotnet -ErrorAction SilentlyContinue
+if (-not $dotnetCmd) {
+    Fail '`dotnet` not found on PATH. Install the .NET 10+ SDK: https://dotnet.microsoft.com/download'
+}
+$sdkOutput = & dotnet --list-sdks
+$has10OrLater = $false
+foreach ($line in $sdkOutput) {
+    if ($line -match '^(\d+)\.') {
+        if ([int]$Matches[1] -ge 10) { $has10OrLater = $true; break }
+    }
+}
+if (-not $has10OrLater) {
+    Write-Host '    [warn] .NET 10 SDK not detected — Reactor requires 10+. https://dotnet.microsoft.com/download' -ForegroundColor Yellow
+} else {
+    Write-Ok ".NET SDK present"
+}
+
+# ---------------------------------------------------------------------------
+# 2. Pack `mur` as a global-tool nupkg
+# ---------------------------------------------------------------------------
+Write-Step "Packing mur (Reactor CLI) for dotnet global tool install"
+
+$feed = Join-Path $repoRoot 'local-nupkgs'
+New-Item -ItemType Directory -Path $feed -Force | Out-Null
+
+# Match host arch so the embed-resource step (which runs the SignaturesGen
+# apphost) succeeds. The packed IL itself is platform-portable.
+$hostArch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'ARM64' } else { 'x64' }
+
+& dotnet pack (Join-Path $repoRoot 'src\Reactor.Cli\Reactor.Cli.csproj') `
+    -c $Configuration `
+    "-p:Platform=$hostArch" `
+    -o $feed `
+    --nologo -v:m
+if ($LASTEXITCODE -ne 0) { Fail 'dotnet pack failed for Reactor.Cli' }
+Write-Ok "Packed Microsoft.UI.Reactor.Cli -> $feed"
+
+# ---------------------------------------------------------------------------
+# 3. Install / update the global tool
+# ---------------------------------------------------------------------------
+if ($SkipMurInstall) {
+    Write-Host ''
+    Write-Host '    Skipping `dotnet tool install` (per -SkipMurInstall).' -ForegroundColor Yellow
+} else {
+    Write-Step 'Installing mur as a dotnet global tool'
+
+    $existing = & dotnet tool list -g 2>$null | Select-String -SimpleMatch 'microsoft.ui.reactor.cli'
+    if ($existing) {
+        & dotnet tool update -g --add-source $feed Microsoft.UI.Reactor.Cli --no-cache --ignore-failed-sources
+    } else {
+        & dotnet tool install -g --add-source $feed Microsoft.UI.Reactor.Cli --no-cache --ignore-failed-sources
+    }
+    if ($LASTEXITCODE -ne 0) { Fail '`dotnet tool install/update` failed for Microsoft.UI.Reactor.Cli' }
+
+    # Make ~/.dotnet/tools visible to the rest of this script even if this is
+    # the first global tool the user has ever installed (dotnet adds it to the
+    # User PATH but not the current process).
+    $dotnetTools = Join-Path $env:USERPROFILE '.dotnet\tools'
+    if (Test-Path $dotnetTools) {
+        $pathParts = $env:Path -split ';'
+        if ($pathParts -notcontains $dotnetTools) {
+            $env:Path = "$dotnetTools;$env:Path"
+        }
+    }
+    Write-Ok "mur installed as global tool (also on this shell's PATH)"
+}
+
+# ---------------------------------------------------------------------------
+# 4. Pack the in-source framework + templates via the freshly-installed mur
+# ---------------------------------------------------------------------------
+Write-Step 'Packing local Microsoft.UI.Reactor + ProjectTemplates (`mur pack-local`)'
+
+# Use the freshly-installed `mur` if available; otherwise call the source
+# project directly (works for -SkipMurInstall too).
+$murResolved = Get-Command mur -ErrorAction SilentlyContinue
+if ($murResolved) {
+    & mur pack-local
+} else {
+    & dotnet run --project (Join-Path $repoRoot 'src\Reactor.Cli\Reactor.Cli.csproj') `
+        -c $Configuration `
+        "-p:Platform=$hostArch" `
+        --nologo `
+        -- pack-local
+}
+if ($LASTEXITCODE -ne 0) { Fail 'mur pack-local failed' }
+
+# ---------------------------------------------------------------------------
+# 5. Install the `dotnet new reactorapp` template
+# ---------------------------------------------------------------------------
+Write-Step 'Installing `dotnet new reactorapp` template'
+
+$templateNupkg = Join-Path $feed 'Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg'
+if (-not (Test-Path $templateNupkg)) {
+    Fail "Template nupkg not produced at $templateNupkg"
+}
+
+# Uninstall first so the template engine drops its cached copy by id —
+# otherwise the previous install can win against a same-version repack.
+& dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates 2>$null | Out-Null
+& dotnet new install $templateNupkg
+if ($LASTEXITCODE -ne 0) { Fail '`dotnet new install` failed' }
+Write-Ok 'reactorapp template registered'
+
+# ---------------------------------------------------------------------------
+# 6. Claude Code plugin (optional)
+# ---------------------------------------------------------------------------
+if ($SkipPlugin) {
+    Write-Host ''
+    Write-Host '    Skipping Claude plugin install (per -SkipPlugin).' -ForegroundColor Yellow
+} else {
+    Write-Step 'Installing Reactor plugin for Claude Code'
+
+    $pluginSrc = Join-Path $repoRoot 'plugins\reactor'
+    $pluginDst = Join-Path $env:USERPROFILE '.claude\plugins\reactor'
+
+    if (-not (Test-Path $pluginSrc)) {
+        Write-Host "    [skip] $pluginSrc not present in this checkout" -ForegroundColor Yellow
+    } else {
+        New-Item -ItemType Directory -Path (Split-Path $pluginDst) -Force | Out-Null
+
+        if (Test-Path $pluginDst) {
+            Remove-Item $pluginDst -Recurse -Force
+        }
+
+        # Prefer symlink so plugin edits in the checkout are immediately visible.
+        # Falls back to copy when symlink creation is unprivileged (Developer
+        # Mode off + non-admin shell).
+        $linked = $false
+        try {
+            New-Item -ItemType SymbolicLink -Path $pluginDst -Target $pluginSrc -ErrorAction Stop | Out-Null
+            $linked = $true
+        } catch {
+            # Fall through to copy.
+        }
+
+        if ($linked) {
+            Write-Ok "Symlinked $pluginDst -> $pluginSrc"
+        } else {
+            Copy-Item $pluginSrc $pluginDst -Recurse -Force
+            Write-Ok "Copied $pluginSrc -> $pluginDst (re-run bootstrap or `mur upgrade` to refresh)"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Host 'Bootstrap complete.' -ForegroundColor Green
+Write-Host ''
+Write-Host 'Next:'
+Write-Host '    dotnet new reactorapp -n MyApp'
+Write-Host '    cd MyApp'
+Write-Host '    dotnet run'
+Write-Host ''
+Write-Host 'Other useful commands:'
+Write-Host '    mur doctor     verify your install'
+Write-Host '    mur upgrade    refresh local packages + plugin after `git pull`'
+Write-Host '    mur --help     full command list'

--- a/docs/_pipeline/templates/getting-started.md.dt
+++ b/docs/_pipeline/templates/getting-started.md.dt
@@ -100,6 +100,144 @@ remediation for anything broken.
 > [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md) §4.4).
 > Until that release ships, the bootstrap above is the supported path.
 
+### Manual setup
+
+If you'd rather not run `bootstrap.ps1`, here is exactly what it does, step
+by step. Every command is a stock `dotnet` or `git` invocation — no Reactor
+tooling required until the very last step, where you build `mur` from source
+and install it as a global tool. Each block below corresponds to a numbered
+phase in `bootstrap.ps1`, so the script is a useful cross-reference if
+anything goes wrong.
+
+**1. Confirm prerequisites.** Reactor requires .NET 10 or later. The Windows
+App SDK is pulled in transitively when the framework builds.
+
+```powershell
+dotnet --list-sdks
+# Expect at least one entry starting with "10."
+```
+
+**2. Clone and enter the repo.** Everything below assumes the working
+directory is the repo root.
+
+```powershell
+git clone https://github.com/microsoft/microsoft-ui-reactor.git
+cd microsoft-ui-reactor
+```
+
+**3. Pack `mur` as a global-tool nupkg.** `Reactor.Cli.csproj` sets
+`PackAsTool=true`, so `dotnet pack` produces a tool package. The
+`-p:Platform` flag matters because the build step runs the SignaturesGen
+apphost to refresh `skills/reactor.api.txt`; that apphost must match the
+host architecture.
+
+```powershell
+$hostArch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'ARM64' } else { 'x64' }
+dotnet pack src/Reactor.Cli/Reactor.Cli.csproj `
+    -c Release `
+    "-p:Platform=$hostArch" `
+    -o local-nupkgs `
+    --nologo
+# Produces local-nupkgs/Microsoft.UI.Reactor.Cli.<version>.nupkg
+```
+
+**4. Install `mur` as a dotnet global tool.** This is what puts `mur` on
+PATH cross-shell with no `$env:Path` edits. If a previous install exists,
+use `update` instead of `install`.
+
+```powershell
+dotnet tool install -g `
+    --add-source ./local-nupkgs `
+    Microsoft.UI.Reactor.Cli `
+    --no-cache --ignore-failed-sources
+
+# If `mur` was already installed:
+# dotnet tool update -g --add-source ./local-nupkgs Microsoft.UI.Reactor.Cli --no-cache --ignore-failed-sources
+```
+
+`dotnet tool install -g` adds `~/.dotnet/tools` to the **user** PATH, which
+the current shell does not automatically inherit. For this session only,
+prepend it manually so the next step finds `mur`:
+
+```powershell
+$env:Path = "$env:USERPROFILE\.dotnet\tools;$env:Path"
+```
+
+New PowerShell windows pick up the user-PATH change on their own.
+
+**5. Pack the framework and project templates.** This is what produces the
+two `0.0.0-local` nupkgs that the `dotnet new reactorapp` template
+references.
+
+```powershell
+mur pack-local
+# Produces:
+#   local-nupkgs/Microsoft.UI.Reactor.0.0.0-local.nupkg
+#   local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg
+```
+
+If you'd rather not depend on the freshly-installed `mur`, you can invoke
+the source project directly:
+
+```powershell
+dotnet run --project src/Reactor.Cli/Reactor.Cli.csproj `
+    -c Release "-p:Platform=$hostArch" -- pack-local
+```
+
+**6. Install the `dotnet new reactorapp` template.** The template engine
+caches by package id, so a same-version repack can lose to the cached copy.
+Always uninstall first.
+
+```powershell
+dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates 2>$null
+dotnet new install local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg
+```
+
+**7. (Optional) Install the Reactor agent plugin.** If you use Claude Code
+or another agent and want it to author Reactor code with the right
+factories, drop the in-repo plugin folder into your agent's plugin path. A
+symlink is preferred so edits in the checkout are immediately visible; a
+copy works when you can't create symlinks (Developer Mode off + non-admin
+shell).
+
+```powershell
+$pluginSrc = (Resolve-Path "plugins/reactor").Path
+$pluginDst = "$env:USERPROFILE\.claude\plugins\reactor"
+New-Item -ItemType Directory -Path (Split-Path $pluginDst) -Force | Out-Null
+if (Test-Path $pluginDst) { Remove-Item $pluginDst -Recurse -Force }
+try {
+    New-Item -ItemType SymbolicLink -Path $pluginDst -Target $pluginSrc -ErrorAction Stop | Out-Null
+} catch {
+    Copy-Item $pluginSrc $pluginDst -Recurse -Force
+}
+```
+
+For Copilot CLI or other agents, follow that tool's plugin-install path and
+point it at `<repo>/plugins/reactor`.
+
+**8. Verify.** `mur doctor` performs the same checks the bootstrap script's
+final stage relies on — SDK version, `mur` resolvability, both `0.0.0-local`
+nupkgs present, template registered, and plugin installed.
+
+```powershell
+mur doctor
+```
+
+#### Refreshing after `git pull`
+
+Without the bootstrap script, repeat **steps 5 and 6** after every pull —
+the framework nupkg and the template both need to be regenerated against
+the new source. Repeat **steps 3 and 4** only when `src/Reactor.Cli/`
+itself changes (a running `mur` process cannot replace its own binary, so
+the install must happen from a shell that isn't already running `mur`).
+
+> **Why a global tool instead of just running from `bin/<arch>/`?** Both
+> work. The repo's CLI csproj still mirrors `mur.exe` to `bin/<arch>/` after
+> every build for the legacy PATH layout. The global-tool install is just
+> the friendliest default — it puts `mur` on PATH cross-shell, cross-CWD,
+> with no arch-aware PATH munging, and `dotnet tool update -g` becomes the
+> upgrade verb.
+
 <!-- ai:caveat -->
 The bootstrap is the supported developer path *only* until the signed public
 NuGet ships under spec 022. If you skip `bootstrap.ps1` and try `dotnet new

--- a/docs/_pipeline/templates/getting-started.md.dt
+++ b/docs/_pipeline/templates/getting-started.md.dt
@@ -30,11 +30,11 @@ the rest of the docset elaborates.
 > **Prerequisites:** .NET 10+ and the Windows App SDK.
 <!-- /ai:lock -->
 
-> **Heads up — manual setup required today.** Reactor does not yet ship a
-> signed NuGet package or a one-click installer. Until those land you build the
-> framework, the `mur` CLI, and the project template from source. The steps
-> below take ~3 minutes and only need to be run once per machine. The signed
-> distribution is tracked in [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md).
+> **Heads up — no signed NuGet yet.** Reactor doesn't ship a signed NuGet
+> package today, so you build the framework, the `mur` CLI, and the project
+> template from source. `bootstrap.ps1` automates all of that — one command,
+> ~3 minutes per machine. The signed distribution is tracked in
+> [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md).
 
 Reactor is a declarative UI framework for building native Windows apps in pure C#.
 No XAML, no data binding, no view models. You describe your UI as a function of
@@ -42,75 +42,75 @@ state and Reactor keeps the screen in sync.
 
 ## Setup (one-time)
 
-Clone the framework, build the CLI, pack the local NuGets, and install the
-project template. From an admin or regular PowerShell:
-
 ```powershell
-# 1. Clone the framework
 git clone https://github.com/microsoft/microsoft-ui-reactor.git
 cd microsoft-ui-reactor
-
-# 2. Build mur — the build auto-mirrors mur.exe to bin/<arch>/
-dotnet build src/Reactor.Cli/Reactor.Cli.csproj -c Release
-
-# 3. Put mur on your user PATH (one-time; takes effect in new shells)
-$arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x64' }
-$murBin = (Resolve-Path "bin/$arch").Path
-$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-if (($userPath -split ';') -notcontains $murBin) {
-    [Environment]::SetEnvironmentVariable('Path', "$murBin;$userPath", 'User')
-}
-
-# 4. Open a new shell so `mur` resolves, then pack the local NuGets
-mur pack-local
-# Produces local-nupkgs/Microsoft.UI.Reactor.0.0.0-local.nupkg
-# and       local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg
-
-# 5. Install the project template so `dotnet new reactorapp` works anywhere
-dotnet new install local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg
+./bootstrap.ps1
 ```
 
-Then install the agent kit so Claude / Copilot can author Reactor code with
-the right factories, hooks, and patterns:
+That's it. `bootstrap.ps1` packs and installs `mur` as a `dotnet tool` global
+install (so it's on PATH cross-shell with no manual `$env:Path` edits), runs
+`mur pack-local` to produce `local-nupkgs/Microsoft.UI.Reactor.0.0.0-local.nupkg`
+and the matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
+template, and drops the Reactor agent plugin under `~/.claude/plugins/reactor`
+(symlink when allowed, copy otherwise).
+
+When it finishes you can immediately run:
 
 ```powershell
-# 6. Install the Reactor agent skills
-#    Source clone — point your agent at the in-repo plugin folder:
-$pluginDir = (Resolve-Path "plugins/reactor").Path
-# Claude Code: copy or symlink to ~/.claude/plugins/reactor
-New-Item -ItemType SymbolicLink `
-    -Path "$env:USERPROFILE\.claude\plugins\reactor" `
-    -Target $pluginDir -Force | Out-Null
-#    (For Copilot CLI / other agents, follow your tool's plugin-install path
-#     and point it at <repo>/plugins/reactor.)
+dotnet new reactorapp -n MyApp
+cd MyApp
+dotnet run
 ```
 
-> **What this gets you.** `mur` builds local-NuGet snapshots of the framework
-> so apps in any folder can `<PackageReference Include="Microsoft.UI.Reactor"
-> Version="0.0.0-local" />` against your clone. The agent skills give AI
-> assistants the up-to-date API surface (`mur --skill` / `mur --api` print the
-> same content) so generated code targets the real factories rather than
-> hallucinated XAML-shaped APIs. Re-run `mur pack-local` whenever you pull new
-> framework changes.
+### After `git pull`
 
-> **Already have a signed package?** Skip steps 1–4. Reference the published
-> `Microsoft.UI.Reactor` package directly and run the consumer-side
-> `install-skill-kit.ps1` shipped in the release archive (covered in [spec
-> 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md) §4.4). Until that release
-> ships, the steps above are the supported path.
+The framework changes — your local NuGet snapshot and `dotnet new` template do
+not, unless you repack them. Two options:
+
+```powershell
+mur upgrade           # repacks the framework + templates and refreshes plugin
+./bootstrap.ps1       # same, plus updates the `mur` global tool itself
+```
+
+`mur upgrade` is the lightweight path. Re-run `bootstrap.ps1` when you want to
+pick up CLI changes (a `mur` process can't replace its own binary mid-run).
+
+### Verify the install
+
+```powershell
+mur doctor
+```
+
+Lists every dependency the rest of this guide assumes — .NET 10+ SDK, `mur` on
+PATH, current `local-nupkgs/` feed, the `reactorapp` template registration, and
+the optional Claude plugin. Each line is PASS / WARN / FAIL with a one-line
+remediation for anything broken.
+
+> **What this gets you.** A globally-resolvable `mur` (via `~/.dotnet/tools`),
+> a local NuGet feed at `<repo>/local-nupkgs/` that apps in any folder can
+> consume via `<PackageReference Include="Microsoft.UI.Reactor"
+> Version="0.0.0-local" />`, and an agent plugin so AI assistants generate
+> against the real factories (`mur --skill` / `mur --api` print the same
+> content). Run `mur upgrade` whenever you pull new framework changes.
+
+> **Already have a signed package?** Skip the bootstrap. Reference the
+> published `Microsoft.UI.Reactor` package directly and run the consumer-side
+> `install-skill-kit.ps1` shipped in the release archive (covered in
+> [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md) §4.4).
+> Until that release ships, the bootstrap above is the supported path.
 
 <!-- ai:caveat -->
-The `mur pack-local` + `dotnet new install` flow is the supported developer
-path *only* until the signed public NuGet ships under spec 022. If you skip
-step 4 (`mur pack-local`) but try `dotnet new reactorapp` anyway, the template
-installer fails with `NU1101: Unable to find package
+The bootstrap is the supported developer path *only* until the signed public
+NuGet ships under spec 022. If you skip `bootstrap.ps1` and try `dotnet new
+reactorapp` anyway, the scaffolder fails with `NU1101: Unable to find package
 Microsoft.UI.Reactor.ProjectTemplates` because nothing has produced
 `local-nupkgs/` yet — `dotnet` looks at the configured feeds and the package
-isn't on nuget.org. The fix is to re-run `mur pack-local` after every pull;
-the snapshot is regenerated from the current branch, not cached. The template
-installer also caches by package id, so if you bump the local version you
-must `dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates` first or
-the old template wins.
+isn't on nuget.org. The fix is to re-run `bootstrap.ps1` (or `mur upgrade`)
+after every `git pull`; the snapshot is regenerated from the current branch,
+not cached. The template installer caches by package id, so a same-version
+repack can lose to the cached copy — `mur upgrade` handles this by running
+`dotnet new uninstall` first.
 <!-- /ai:caveat -->
 
 ## Creating a Project

--- a/docs/_pipeline/templates/getting-started.md.dt
+++ b/docs/_pipeline/templates/getting-started.md.dt
@@ -109,6 +109,17 @@ and install it as a global tool. Each block below corresponds to a numbered
 phase in `bootstrap.ps1`, so the script is a useful cross-reference if
 anything goes wrong.
 
+| # | Step | What it produces |
+|---|------|------------------|
+| 1 | `dotnet --list-sdks` | Confirms .NET 10+ is installed |
+| 2 | `git clone` + `cd` | Local source checkout |
+| 3 | `dotnet pack src/Reactor.Cli` | `Microsoft.UI.Reactor.Cli.<ver>.nupkg` in `local-nupkgs/` |
+| 4 | `dotnet tool install -g` | `mur` resolvable cross-shell from `~/.dotnet/tools` |
+| 5 | `mur pack-local` | Framework + `ProjectTemplates` 0.0.0-local nupkgs |
+| 6 | `dotnet new uninstall` + `install` | `dotnet new reactorapp` template registered |
+| 7 | Symlink/copy `plugins/reactor` | Reactor agent kit under `~/.claude/plugins/reactor` (optional) |
+| 8 | `mur doctor` | Verification that 1–7 all stuck |
+
 **1. Confirm prerequisites.** Reactor requires .NET 10 or later. The Windows
 App SDK is pulled in transitively when the framework builds.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -18,11 +18,11 @@ the rest of the docset elaborates.
 > **Prerequisites:** .NET 10+ and the Windows App SDK.
 <!-- /ai:lock -->
 
-> **Heads up — manual setup required today.** Reactor does not yet ship a
-> signed NuGet package or a one-click installer. Until those land you build the
-> framework, the `mur` CLI, and the project template from source. The steps
-> below take ~3 minutes and only need to be run once per machine. The signed
-> distribution is tracked in [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md).
+> **Heads up — no signed NuGet yet.** Reactor doesn't ship a signed NuGet
+> package today, so you build the framework, the `mur` CLI, and the project
+> template from source. `bootstrap.ps1` automates all of that — one command,
+> ~3 minutes per machine. The signed distribution is tracked in
+> [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md).
 
 Reactor is a declarative UI framework for building native Windows apps in pure C#.
 No XAML, no data binding, no view models. You describe your UI as a function of
@@ -30,74 +30,74 @@ state and Reactor keeps the screen in sync.
 
 ## Setup (one-time)
 
-Clone the framework, build the CLI, pack the local NuGets, and install the
-project template. From an admin or regular PowerShell:
-
 ```powershell
-# 1. Clone the framework
 git clone https://github.com/microsoft/microsoft-ui-reactor.git
 cd microsoft-ui-reactor
-
-# 2. Build mur — the build auto-mirrors mur.exe to bin/<arch>/
-dotnet build src/Reactor.Cli/Reactor.Cli.csproj -c Release
-
-# 3. Put mur on your user PATH (one-time; takes effect in new shells)
-$arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x64' }
-$murBin = (Resolve-Path "bin/$arch").Path
-$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-if (($userPath -split ';') -notcontains $murBin) {
-    [Environment]::SetEnvironmentVariable('Path', "$murBin;$userPath", 'User')
-}
-
-# 4. Open a new shell so `mur` resolves, then pack the local NuGets
-mur pack-local
-# Produces local-nupkgs/Microsoft.UI.Reactor.0.0.0-local.nupkg
-# and       local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg
-
-# 5. Install the project template so `dotnet new reactorapp` works anywhere
-dotnet new install local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg
+./bootstrap.ps1
 ```
 
-Then install the agent kit so Claude / Copilot can author Reactor code with
-the right factories, hooks, and patterns:
+That's it. `bootstrap.ps1` packs and installs `mur` as a `dotnet tool` global
+install (so it's on PATH cross-shell with no manual `$env:Path` edits), runs
+`mur pack-local` to produce `local-nupkgs/Microsoft.UI.Reactor.0.0.0-local.nupkg`
+and the matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
+template, and drops the Reactor agent plugin under `~/.claude/plugins/reactor`
+(symlink when allowed, copy otherwise).
+
+When it finishes you can immediately run:
 
 ```powershell
-# 6. Install the Reactor agent skills
-#    Source clone — point your agent at the in-repo plugin folder:
-$pluginDir = (Resolve-Path "plugins/reactor").Path
-# Claude Code: copy or symlink to ~/.claude/plugins/reactor
-New-Item -ItemType SymbolicLink `
-    -Path "$env:USERPROFILE\.claude\plugins\reactor" `
-    -Target $pluginDir -Force | Out-Null
-#    (For Copilot CLI / other agents, follow your tool's plugin-install path
-#     and point it at <repo>/plugins/reactor.)
+dotnet new reactorapp -n MyApp
+cd MyApp
+dotnet run
 ```
 
-> **What this gets you.** `mur` builds local-NuGet snapshots of the framework
-> so apps in any folder can `<PackageReference Include="Microsoft.UI.Reactor"
-> Version="0.0.0-local" />` against your clone. The agent skills give AI
-> assistants the up-to-date API surface (`mur --skill` / `mur --api` print the
-> same content) so generated code targets the real factories rather than
-> hallucinated XAML-shaped APIs. Re-run `mur pack-local` whenever you pull new
-> framework changes.
+### After `git pull`
 
-> **Already have a signed package?** Skip steps 1–4. Reference the published
-> `Microsoft.UI.Reactor` package directly and run the consumer-side
-> `install-skill-kit.ps1` shipped in the release archive (covered in [spec
-> 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md) §4.4). Until that release
-> ships, the steps above are the supported path.
+The framework changes — your local NuGet snapshot and `dotnet new` template do
+not, unless you repack them. Two options:
 
-> **Caveat:** The `mur pack-local` + `dotnet new install` flow is the supported developer
-> path *only* until the signed public NuGet ships under spec 022. If you skip
-> step 4 (`mur pack-local`) but try `dotnet new reactorapp` anyway, the template
-> installer fails with `NU1101: Unable to find package
+```powershell
+mur upgrade           # repacks the framework + templates and refreshes plugin
+./bootstrap.ps1       # same, plus updates the `mur` global tool itself
+```
+
+`mur upgrade` is the lightweight path. Re-run `bootstrap.ps1` when you want to
+pick up CLI changes (a `mur` process can't replace its own binary mid-run).
+
+### Verify the install
+
+```powershell
+mur doctor
+```
+
+Lists every dependency the rest of this guide assumes — .NET 10+ SDK, `mur` on
+PATH, current `local-nupkgs/` feed, the `reactorapp` template registration, and
+the optional Claude plugin. Each line is PASS / WARN / FAIL with a one-line
+remediation for anything broken.
+
+> **What this gets you.** A globally-resolvable `mur` (via `~/.dotnet/tools`),
+> a local NuGet feed at `<repo>/local-nupkgs/` that apps in any folder can
+> consume via `<PackageReference Include="Microsoft.UI.Reactor"
+> Version="0.0.0-local" />`, and an agent plugin so AI assistants generate
+> against the real factories (`mur --skill` / `mur --api` print the same
+> content). Run `mur upgrade` whenever you pull new framework changes.
+
+> **Already have a signed package?** Skip the bootstrap. Reference the
+> published `Microsoft.UI.Reactor` package directly and run the consumer-side
+> `install-skill-kit.ps1` shipped in the release archive (covered in
+> [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md) §4.4).
+> Until that release ships, the bootstrap above is the supported path.
+
+> **Caveat:** The bootstrap is the supported developer path *only* until the signed public
+> NuGet ships under spec 022. If you skip `bootstrap.ps1` and try `dotnet new
+> reactorapp` anyway, the scaffolder fails with `NU1101: Unable to find package
 > Microsoft.UI.Reactor.ProjectTemplates` because nothing has produced
 > `local-nupkgs/` yet — `dotnet` looks at the configured feeds and the package
-> isn't on nuget.org. The fix is to re-run `mur pack-local` after every pull;
-> the snapshot is regenerated from the current branch, not cached. The template
-> installer also caches by package id, so if you bump the local version you
-> must `dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates` first or
-> the old template wins.
+> isn't on nuget.org. The fix is to re-run `bootstrap.ps1` (or `mur upgrade`)
+> after every `git pull`; the snapshot is regenerated from the current branch,
+> not cached. The template installer caches by package id, so a same-version
+> repack can lose to the cached copy — `mur upgrade` handles this by running
+> `dotnet new uninstall` first.
 
 ## Creating a Project
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -88,6 +88,144 @@ remediation for anything broken.
 > [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md) §4.4).
 > Until that release ships, the bootstrap above is the supported path.
 
+### Manual setup
+
+If you'd rather not run `bootstrap.ps1`, here is exactly what it does, step
+by step. Every command is a stock `dotnet` or `git` invocation — no Reactor
+tooling required until the very last step, where you build `mur` from source
+and install it as a global tool. Each block below corresponds to a numbered
+phase in `bootstrap.ps1`, so the script is a useful cross-reference if
+anything goes wrong.
+
+**1. Confirm prerequisites.** Reactor requires .NET 10 or later. The Windows
+App SDK is pulled in transitively when the framework builds.
+
+```powershell
+dotnet --list-sdks
+# Expect at least one entry starting with "10."
+```
+
+**2. Clone and enter the repo.** Everything below assumes the working
+directory is the repo root.
+
+```powershell
+git clone https://github.com/microsoft/microsoft-ui-reactor.git
+cd microsoft-ui-reactor
+```
+
+**3. Pack `mur` as a global-tool nupkg.** `Reactor.Cli.csproj` sets
+`PackAsTool=true`, so `dotnet pack` produces a tool package. The
+`-p:Platform` flag matters because the build step runs the SignaturesGen
+apphost to refresh `skills/reactor.api.txt`; that apphost must match the
+host architecture.
+
+```powershell
+$hostArch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'ARM64' } else { 'x64' }
+dotnet pack src/Reactor.Cli/Reactor.Cli.csproj `
+    -c Release `
+    "-p:Platform=$hostArch" `
+    -o local-nupkgs `
+    --nologo
+# Produces local-nupkgs/Microsoft.UI.Reactor.Cli.<version>.nupkg
+```
+
+**4. Install `mur` as a dotnet global tool.** This is what puts `mur` on
+PATH cross-shell with no `$env:Path` edits. If a previous install exists,
+use `update` instead of `install`.
+
+```powershell
+dotnet tool install -g `
+    --add-source ./local-nupkgs `
+    Microsoft.UI.Reactor.Cli `
+    --no-cache --ignore-failed-sources
+
+# If `mur` was already installed:
+# dotnet tool update -g --add-source ./local-nupkgs Microsoft.UI.Reactor.Cli --no-cache --ignore-failed-sources
+```
+
+`dotnet tool install -g` adds `~/.dotnet/tools` to the **user** PATH, which
+the current shell does not automatically inherit. For this session only,
+prepend it manually so the next step finds `mur`:
+
+```powershell
+$env:Path = "$env:USERPROFILE\.dotnet\tools;$env:Path"
+```
+
+New PowerShell windows pick up the user-PATH change on their own.
+
+**5. Pack the framework and project templates.** This is what produces the
+two `0.0.0-local` nupkgs that the `dotnet new reactorapp` template
+references.
+
+```powershell
+mur pack-local
+# Produces:
+#   local-nupkgs/Microsoft.UI.Reactor.0.0.0-local.nupkg
+#   local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg
+```
+
+If you'd rather not depend on the freshly-installed `mur`, you can invoke
+the source project directly:
+
+```powershell
+dotnet run --project src/Reactor.Cli/Reactor.Cli.csproj `
+    -c Release "-p:Platform=$hostArch" -- pack-local
+```
+
+**6. Install the `dotnet new reactorapp` template.** The template engine
+caches by package id, so a same-version repack can lose to the cached copy.
+Always uninstall first.
+
+```powershell
+dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates 2>$null
+dotnet new install local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg
+```
+
+**7. (Optional) Install the Reactor agent plugin.** If you use Claude Code
+or another agent and want it to author Reactor code with the right
+factories, drop the in-repo plugin folder into your agent's plugin path. A
+symlink is preferred so edits in the checkout are immediately visible; a
+copy works when you can't create symlinks (Developer Mode off + non-admin
+shell).
+
+```powershell
+$pluginSrc = (Resolve-Path "plugins/reactor").Path
+$pluginDst = "$env:USERPROFILE\.claude\plugins\reactor"
+New-Item -ItemType Directory -Path (Split-Path $pluginDst) -Force | Out-Null
+if (Test-Path $pluginDst) { Remove-Item $pluginDst -Recurse -Force }
+try {
+    New-Item -ItemType SymbolicLink -Path $pluginDst -Target $pluginSrc -ErrorAction Stop | Out-Null
+} catch {
+    Copy-Item $pluginSrc $pluginDst -Recurse -Force
+}
+```
+
+For Copilot CLI or other agents, follow that tool's plugin-install path and
+point it at `<repo>/plugins/reactor`.
+
+**8. Verify.** `mur doctor` performs the same checks the bootstrap script's
+final stage relies on — SDK version, `mur` resolvability, both `0.0.0-local`
+nupkgs present, template registered, and plugin installed.
+
+```powershell
+mur doctor
+```
+
+#### Refreshing after `git pull`
+
+Without the bootstrap script, repeat **steps 5 and 6** after every pull —
+the framework nupkg and the template both need to be regenerated against
+the new source. Repeat **steps 3 and 4** only when `src/Reactor.Cli/`
+itself changes (a running `mur` process cannot replace its own binary, so
+the install must happen from a shell that isn't already running `mur`).
+
+> **Why a global tool instead of just running from `bin/<arch>/`?** Both
+> work. The repo's CLI csproj still mirrors `mur.exe` to `bin/<arch>/` after
+> every build for the legacy PATH layout. The global-tool install is just
+> the friendliest default — it puts `mur` on PATH cross-shell, cross-CWD,
+> with no arch-aware PATH munging, and `dotnet tool update -g` becomes the
+> upgrade verb.
+
 > **Caveat:** The bootstrap is the supported developer path *only* until the signed public
 > NuGet ships under spec 022. If you skip `bootstrap.ps1` and try `dotnet new
 > reactorapp` anyway, the scaffolder fails with `NU1101: Unable to find package

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -97,6 +97,17 @@ and install it as a global tool. Each block below corresponds to a numbered
 phase in `bootstrap.ps1`, so the script is a useful cross-reference if
 anything goes wrong.
 
+| # | Step | What it produces |
+|---|------|------------------|
+| 1 | `dotnet --list-sdks` | Confirms .NET 10+ is installed |
+| 2 | `git clone` + `cd` | Local source checkout |
+| 3 | `dotnet pack src/Reactor.Cli` | `Microsoft.UI.Reactor.Cli.<ver>.nupkg` in `local-nupkgs/` |
+| 4 | `dotnet tool install -g` | `mur` resolvable cross-shell from `~/.dotnet/tools` |
+| 5 | `mur pack-local` | Framework + `ProjectTemplates` 0.0.0-local nupkgs |
+| 6 | `dotnet new uninstall` + `install` | `dotnet new reactorapp` template registered |
+| 7 | Symlink/copy `plugins/reactor` | Reactor agent kit under `~/.claude/plugins/reactor` (optional) |
+| 8 | `mur doctor` | Verification that 1–7 all stuck |
+
 **1. Confirm prerequisites.** Reactor requires .NET 10 or later. The Windows
 App SDK is pulled in transitively when the framework builds.
 

--- a/src/Reactor.Cli/Doctor/DoctorCommand.cs
+++ b/src/Reactor.Cli/Doctor/DoctorCommand.cs
@@ -1,17 +1,24 @@
 // `mur doctor` — diagnose a Reactor developer install.
 //
 // Verifies the prerequisites and post-bootstrap state that getting-started.md
-// depends on. Prints a one-line PASS / WARN / FAIL per check and exits 0 only
-// if every check passes. Designed to be the first thing a confused user runs
-// after `dotnet new reactorapp` fails — every failure should print a
-// copy-pasteable next step.
+// depends on. Prints a one-line PASS / WARN / FAIL per check and exits non-zero
+// only when there are FAILs — WARNs (e.g. missing-template-enumeration or a
+// stale-looking checkout) still exit 0 since the install is usable. Designed
+// to be the first thing a confused user runs after `dotnet new reactorapp`
+// fails — every FAIL prints a copy-pasteable next step.
 //
 // Checks (in order):
 //   1. .NET SDK >= 10
-//   2. `mur` itself: which install (global-tool / bin-mirror), version
-//   3. local-nupkgs/ feed present + Microsoft.UI.Reactor nupkg current
-//   4. dotnet new reactorapp template registered
-//   5. Claude plugin installed at ~/.claude/plugins/reactor (informational)
+//   2. `mur` itself: global-tool install or PATH-resolved bin-mirror; with
+//      --verbose, also the resolved version string
+//   3. Repo-checkout discovery (warns if not inside a Reactor source checkout,
+//      and skips the two `local-nupkgs/` checks below)
+//   4. local-nupkgs/Microsoft.UI.Reactor.<ver>.nupkg present (framework)
+//   5. local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.<ver>.nupkg present
+//   6. `dotnet new` template list includes `reactorapp` (always runs — does
+//      not depend on the repo checkout being found)
+//   7. Claude plugin at ~/.claude/plugins/reactor (informational only; not
+//      every developer uses Claude Code)
 
 using System.Diagnostics;
 using Microsoft.UI.Reactor.Cli.Pack;
@@ -77,7 +84,7 @@ public static class DoctorCommand
                     ?? RepoRootFinder.FindRepoRoot();
         if (repoRoot is null)
         {
-            Warn("repo checkout", "not running inside a Reactor source checkout — skipping local-feed and template checks");
+            Warn("repo checkout", "not running inside a Reactor source checkout — skipping local-feed checks (the `dotnet new` template check below still runs)");
             warnings++;
         }
         else

--- a/src/Reactor.Cli/Doctor/DoctorCommand.cs
+++ b/src/Reactor.Cli/Doctor/DoctorCommand.cs
@@ -1,0 +1,323 @@
+// `mur doctor` — diagnose a Reactor developer install.
+//
+// Verifies the prerequisites and post-bootstrap state that getting-started.md
+// depends on. Prints a one-line PASS / WARN / FAIL per check and exits 0 only
+// if every check passes. Designed to be the first thing a confused user runs
+// after `dotnet new reactorapp` fails — every failure should print a
+// copy-pasteable next step.
+//
+// Checks (in order):
+//   1. .NET SDK >= 10
+//   2. `mur` itself: which install (global-tool / bin-mirror), version
+//   3. local-nupkgs/ feed present + Microsoft.UI.Reactor nupkg current
+//   4. dotnet new reactorapp template registered
+//   5. Claude plugin installed at ~/.claude/plugins/reactor (informational)
+
+using System.Diagnostics;
+using Microsoft.UI.Reactor.Cli.Pack;
+
+namespace Microsoft.UI.Reactor.Cli.Doctor;
+
+public static class DoctorCommand
+{
+    public static int Run(string[] args)
+    {
+        var verbose = args.Contains("--verbose") || args.Contains("-v");
+        var failures = 0;
+        var warnings = 0;
+
+        Console.WriteLine("mur doctor — checking your Reactor install");
+        Console.WriteLine();
+
+        // 1. .NET SDK
+        var sdks = GetDotnetSdks();
+        if (sdks is null)
+        {
+            Fail("dotnet SDK", "`dotnet` not found on PATH. Install .NET 10+: https://dotnet.microsoft.com/download");
+            failures++;
+        }
+        else
+        {
+            var has10 = sdks.Any(v => v.Major >= 10);
+            if (has10)
+            {
+                var newest = sdks.Max()!;
+                Pass(".NET SDK", $"{newest} installed");
+            }
+            else
+            {
+                var newest = sdks.Count > 0 ? sdks.Max()!.ToString() : "(none)";
+                Fail(".NET SDK", $"latest installed is {newest}; Reactor requires .NET 10+. https://dotnet.microsoft.com/download");
+                failures++;
+            }
+        }
+
+        // 2. mur location and version
+        var murCmd = ResolveCommand("mur");
+        var globalTool = IsGlobalToolInstalled();
+        if (murCmd is null && !globalTool)
+        {
+            Fail("mur on PATH", "`mur` is not resolvable. Run ./bootstrap.ps1 from the repo root.");
+            failures++;
+        }
+        else
+        {
+            var kind = globalTool ? "global tool" : "PATH";
+            var loc = murCmd ?? "(global tool)";
+            Pass("mur installed", $"{kind} — {loc}");
+            if (verbose)
+            {
+                var ver = TryGetMurVersion();
+                if (ver is not null) Console.WriteLine($"           version: {ver}");
+            }
+        }
+
+        // 3. local-nupkgs feed
+        var repoRoot = RepoRootFinder.FindRepoRoot(Directory.GetCurrentDirectory())
+                    ?? RepoRootFinder.FindRepoRoot();
+        if (repoRoot is null)
+        {
+            Warn("repo checkout", "not running inside a Reactor source checkout — skipping local-feed and template checks");
+            warnings++;
+        }
+        else
+        {
+            var feed = Path.Combine(repoRoot, "local-nupkgs");
+            var frameworkNupkg = Path.Combine(feed, $"Microsoft.UI.Reactor.{PackLocalCommand.DefaultLocalVersion}.nupkg");
+            var templateNupkg = Path.Combine(feed, $"Microsoft.UI.Reactor.ProjectTemplates.{PackLocalCommand.DefaultLocalVersion}.nupkg");
+
+            if (!File.Exists(frameworkNupkg))
+            {
+                Fail("local Reactor nupkg", $"missing {frameworkNupkg}. Run `mur pack-local` (or `mur upgrade`).");
+                failures++;
+            }
+            else
+            {
+                Pass("local Reactor nupkg", $"{Path.GetFileName(frameworkNupkg)} ({FormatAge(File.GetLastWriteTimeUtc(frameworkNupkg))})");
+            }
+
+            if (!File.Exists(templateNupkg))
+            {
+                Fail("local template nupkg", $"missing {templateNupkg}. Run `mur pack-local`.");
+                failures++;
+            }
+            else
+            {
+                Pass("local template nupkg", $"{Path.GetFileName(templateNupkg)}");
+            }
+        }
+
+        // 4. dotnet new reactorapp template
+        var templates = ListInstalledTemplates();
+        if (templates is null)
+        {
+            Warn("dotnet new template", "could not enumerate `dotnet new` templates");
+            warnings++;
+        }
+        else if (templates.Any(t => t.IndexOf("reactorapp", StringComparison.OrdinalIgnoreCase) >= 0))
+        {
+            Pass("dotnet new template", "reactorapp registered");
+        }
+        else
+        {
+            Fail("dotnet new template", "reactorapp not registered. Run `mur upgrade` or `dotnet new install <repo>/local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg`.");
+            failures++;
+        }
+
+        // 5. Claude plugin (informational only — many devs don't use it)
+        var claudePluginDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".claude", "plugins", "reactor");
+        if (Directory.Exists(claudePluginDir))
+        {
+            var pluginJson = Path.Combine(claudePluginDir, "plugin.json");
+            if (File.Exists(pluginJson))
+                Pass("Claude plugin", $"installed at {claudePluginDir}");
+            else
+                Warn("Claude plugin", $"{claudePluginDir} exists but missing plugin.json");
+        }
+        else
+        {
+            Info("Claude plugin", "not installed (run `mur upgrade` or `./bootstrap.ps1` if you use Claude Code)");
+        }
+
+        Console.WriteLine();
+        if (failures > 0)
+        {
+            Console.WriteLine($"  {failures} failure(s), {warnings} warning(s). Fix the FAIL lines above, then re-run `mur doctor`.");
+            return 1;
+        }
+        if (warnings > 0)
+        {
+            Console.WriteLine($"  OK — {warnings} warning(s). Your install is functional.");
+            return 0;
+        }
+        Console.WriteLine("  All checks passed. You're ready to `dotnet new reactorapp -n MyApp`.");
+        return 0;
+    }
+
+    // -----------------------------------------------------------------------
+    //  Output formatting
+    // -----------------------------------------------------------------------
+
+    static void Pass(string label, string detail) => Line("PASS", label, detail, ConsoleColor.Green);
+    static void Warn(string label, string detail) { Line("WARN", label, detail, ConsoleColor.Yellow); }
+    static void Fail(string label, string detail) { Line("FAIL", label, detail, ConsoleColor.Red); }
+    static void Info(string label, string detail) => Line("info", label, detail, ConsoleColor.Gray);
+
+    static void Line(string status, string label, string detail, ConsoleColor color)
+    {
+        var prev = Console.ForegroundColor;
+        Console.ForegroundColor = color;
+        Console.Write($"  [{status}]");
+        Console.ForegroundColor = prev;
+        Console.WriteLine($" {label,-22} {detail}");
+    }
+
+    // -----------------------------------------------------------------------
+    //  Probes
+    // -----------------------------------------------------------------------
+
+    static List<Version>? GetDotnetSdks()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList = { "--list-sdks" },
+            };
+            using var proc = Process.Start(psi);
+            if (proc is null) return null;
+            var output = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
+
+            var versions = new List<Version>();
+            foreach (var raw in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var line = raw.Trim();
+                var space = line.IndexOf(' ');
+                if (space <= 0) continue;
+                var verStr = line[..space];
+                // Trim preview/RC suffixes — Version.Parse can't eat them.
+                var dash = verStr.IndexOf('-');
+                if (dash > 0) verStr = verStr[..dash];
+                if (Version.TryParse(verStr, out var v)) versions.Add(v);
+            }
+            return versions;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static string? ResolveCommand(string command)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo(OperatingSystem.IsWindows() ? "where" : "which")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList = { command },
+            };
+            using var proc = Process.Start(psi);
+            if (proc is null) return null;
+            var output = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
+            if (proc.ExitCode != 0) return null;
+            return output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                         .Select(s => s.Trim())
+                         .FirstOrDefault();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static bool IsGlobalToolInstalled()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList = { "tool", "list", "-g" },
+            };
+            using var proc = Process.Start(psi);
+            if (proc is null) return false;
+            var output = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
+            return output.IndexOf("microsoft.ui.reactor.cli", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    static string? TryGetMurVersion()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("mur")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList = { "--version" },
+            };
+            using var proc = Process.Start(psi);
+            if (proc is null) return null;
+            var output = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
+            return proc.ExitCode == 0 ? output.Trim() : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static List<string>? ListInstalledTemplates()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList = { "new", "list" },
+            };
+            using var proc = Process.Start(psi);
+            if (proc is null) return null;
+            var output = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
+            return output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                         .Select(s => s.TrimEnd())
+                         .ToList();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static string FormatAge(DateTime utc)
+    {
+        var age = DateTime.UtcNow - utc;
+        if (age.TotalMinutes < 1) return "just now";
+        if (age.TotalHours < 1) return $"{(int)age.TotalMinutes}m ago";
+        if (age.TotalDays < 1) return $"{(int)age.TotalHours}h ago";
+        if (age.TotalDays < 30) return $"{(int)age.TotalDays}d ago";
+        return utc.ToLocalTime().ToString("yyyy-MM-dd");
+    }
+}

--- a/src/Reactor.Cli/Pack/PackLocalCommand.cs
+++ b/src/Reactor.Cli/Pack/PackLocalCommand.cs
@@ -135,5 +135,10 @@ public static class PackLocalCommand
         return null;
     }
 
-    static string? FindRepoRoot() => RepoRootFinder.FindRepoRoot();
+    // Prefer CWD so a globally-installed `mur` (under ~/.dotnet/tools) still
+    // discovers the source checkout the user is sitting in. Fall back to the
+    // tool's own location for the legacy `bin/<arch>/mur.exe` install layout.
+    static string? FindRepoRoot()
+        => RepoRootFinder.FindRepoRoot(Directory.GetCurrentDirectory())
+        ?? RepoRootFinder.FindRepoRoot();
 }

--- a/src/Reactor.Cli/Program.cs
+++ b/src/Reactor.Cli/Program.cs
@@ -84,6 +84,16 @@ if (arg == "clean-local")
     return Microsoft.UI.Reactor.Cli.Pack.CleanLocalCommand.Run(args.Skip(1).ToArray());
 }
 
+if (arg == "doctor")
+{
+    return Microsoft.UI.Reactor.Cli.Doctor.DoctorCommand.Run(args.Skip(1).ToArray());
+}
+
+if (arg == "upgrade")
+{
+    return Microsoft.UI.Reactor.Cli.Upgrade.UpgradeCommand.Run(args.Skip(1).ToArray());
+}
+
 Console.Error.WriteLine($"Unknown option: {args[0]}");
 Console.Error.WriteLine();
 ShowHelp();
@@ -118,6 +128,8 @@ void ShowHelp()
     Console.WriteLine("  check [path]     Build and emit one-line diagnostics with skill-file pointers");
     Console.WriteLine("  pack-local       Pack the in-source framework to <repo>/local-nupkgs/ as 0.0.0-local");
     Console.WriteLine("  clean-local      Remove local packages, NuGet cache entries, and templates");
+    Console.WriteLine("  doctor           Verify the install (SDK, mur, local feed, template, plugin)");
+    Console.WriteLine("  upgrade          Re-pack framework + templates and refresh plugin after `git pull`");
 }
 
 int ShowSkill()
@@ -153,20 +165,24 @@ int ShowApi()
 
 int RegenApi()
 {
-    // Walk up from the running mur binary to find the repo root (the dir that
-    // contains src/Reactor and tools/Reactor.SignaturesGen). Then invoke the
-    // generator project. Selfhost only — NuGet consumers don't have the source.
-    var dir = AppContext.BaseDirectory;
-    string? repoRoot = null;
-    for (var d = new DirectoryInfo(dir); d is not null; d = d.Parent)
+    // Walk up from CWD first (so a globally-installed `mur` still resolves the
+    // checkout the user is sitting in), then fall back to the running binary's
+    // location for the legacy bin/<arch>/mur.exe layout. Selfhost only — NuGet
+    // consumers don't have the source.
+    static string? FindGenRoot(string start)
     {
-        if (Directory.Exists(Path.Combine(d.FullName, "tools", "Reactor.SignaturesGen"))
-            && Directory.Exists(Path.Combine(d.FullName, "src", "Reactor")))
+        for (var d = new DirectoryInfo(start); d is not null; d = d.Parent)
         {
-            repoRoot = d.FullName;
-            break;
+            if (Directory.Exists(Path.Combine(d.FullName, "tools", "Reactor.SignaturesGen"))
+                && Directory.Exists(Path.Combine(d.FullName, "src", "Reactor")))
+            {
+                return d.FullName;
+            }
         }
+        return null;
     }
+    var repoRoot = FindGenRoot(Directory.GetCurrentDirectory())
+                ?? FindGenRoot(AppContext.BaseDirectory);
     if (repoRoot is null)
     {
         Console.Error.WriteLine("Error: --regen-api must be run from a Reactor source checkout (could not locate tools/Reactor.SignaturesGen).");

--- a/src/Reactor.Cli/Reactor.Cli.csproj
+++ b/src/Reactor.Cli/Reactor.Cli.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
+    <!-- TFM is plain net10.0 (no -windows suffix) so PackAsTool produces a
+         valid global-tool nupkg — `PackAsTool` rejects TargetPlatformIdentifier
+         (NETSDK1146). The CLI doesn't use WinUI APIs directly; the
+         SignaturesGen ProjectReference brings WindowsAppSDK in at build-time
+         only (ReferenceOutputAssembly=false). -->
+    <TargetFramework>net10.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <AssemblyName>mur</AssemblyName>
     <RootNamespace>Microsoft.UI.Reactor.Cli</RootNamespace>
@@ -15,6 +20,24 @@
          layout via a self-contained `dotnet publish`. -->
   </PropertyGroup>
 
+  <!-- Pack `mur` as a dotnet global tool. `bootstrap.ps1` installs the produced
+       nupkg via `dotnet tool install -g`, which puts `mur` on PATH cross-shell
+       without arch-specific PATH munging. The mirror-to-bin/<arch>/ Target
+       below remains for legacy PATH-based installs. -->
+  <PropertyGroup>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>mur</ToolCommandName>
+    <PackageId>Microsoft.UI.Reactor.Cli</PackageId>
+    <Description>Microsoft.UI.Reactor CLI — scaffolding, doc pipeline, find, check, localization, devtools supervisor, and Roslyn analyzer host.</Description>
+    <Authors>Microsoft</Authors>
+    <Company>Microsoft</Company>
+    <PackageProjectUrl>https://github.com/microsoft/microsoft-ui-reactor</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RollForward>LatestMajor</RollForward>
+    <!-- IsPackable defaults to true with PackAsTool; explicit for clarity. -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
   <!-- Resolve the effective architecture from Platform or RuntimeIdentifier
        so the bin/<arch> mirror layout stays consistent with the skill kit. -->
   <PropertyGroup>
@@ -23,6 +46,16 @@
     <_ReactorArch Condition="'$(_ReactorArch)' == '' and '$(RuntimeIdentifier)' == 'win-arm64'">arm64</_ReactorArch>
     <ReactorBinDir Condition="'$(_ReactorArch)' != ''">$(MSBuildThisFileDirectory)..\..\bin\$(_ReactorArch)</ReactorBinDir>
   </PropertyGroup>
+
+  <!-- Declare the assembly Windows-only at the metadata level. Dropping the
+       `-windows` TFM (required for PackAsTool) otherwise causes CA1416 to fire
+       on System.Drawing usage in Docs/ImageProcessor.cs. Reactor itself is
+       Windows-only by virtue of WinUI, so this is semantically accurate. -->
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatform">
+      <_Parameter1>windows</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Reactor.Tests" />
@@ -71,15 +104,18 @@
     <_SignaturesGenPlatform Condition="'$(_SignaturesGenPlatform)' == ''">x64</_SignaturesGenPlatform>
   </PropertyGroup>
 
-  <!-- Build-order only: ensures the signatures generator runs (and writes
-       skills/reactor.api.txt) before this project embeds it. The generator
-       isn't a runtime dependency of mur. -->
-  <ItemGroup>
-    <ProjectReference Include="..\..\tools\Reactor.SignaturesGen\Reactor.SignaturesGen.csproj"
-                      ReferenceOutputAssembly="false"
-                      Private="false"
-                      SetPlatform="Platform=$(_SignaturesGenPlatform)" />
-  </ItemGroup>
+  <!-- Build-order only: invoke SignaturesGen via Exec rather than ProjectReference.
+       The CLI targets plain net10.0 (required by PackAsTool); SignaturesGen
+       targets net10.0-windows10.0.22621.0. A ProjectReference across that TFM
+       boundary fails NuGet asset resolution at pack time, so we shell out
+       instead — SignaturesGen runs its own AfterBuild step that writes
+       skills/reactor.api.txt, which this csproj then embeds as a resource. -->
+  <Target Name="RunSignaturesGen" BeforeTargets="BeforeBuild"
+          Condition="'$(SkipSignaturesGen)' != 'true'">
+    <Exec Command="dotnet build &quot;$(MSBuildThisFileDirectory)..\..\tools\Reactor.SignaturesGen\Reactor.SignaturesGen.csproj&quot; -c $(Configuration) -p:Platform=$(_SignaturesGenPlatform) --nologo -v:q"
+          ConsoleToMSBuild="true"
+          ContinueOnError="false" />
+  </Target>
 
   <!-- After build, mirror the CLI output to <repo>/bin/<arch>/ so it matches
        the deployed skill-kit layout. Add that directory to your PATH once and

--- a/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
+++ b/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
@@ -1,0 +1,149 @@
+// `mur upgrade` — refresh a Reactor developer install after `git pull`.
+//
+// Re-runs the source-side steps of bootstrap.ps1:
+//   1. Re-pack the framework + ProjectTemplates into local-nupkgs/
+//      (delegates to `mur pack-local`).
+//   2. Reinstall the `dotnet new reactorapp` template (uninstall first so the
+//      template engine drops its cached copy).
+//   3. Refresh the Claude Code plugin install.
+//
+// Does NOT update the `mur` global tool itself — a process can't replace its
+// own binary mid-run. To bump `mur`, re-run ./bootstrap.ps1 from the repo
+// root (or `dotnet tool update -g --add-source <repo>/local-nupkgs
+// Microsoft.UI.Reactor.Cli`). `mur upgrade` prints that hint on completion.
+
+using System.Diagnostics;
+using Microsoft.UI.Reactor.Cli.Pack;
+
+namespace Microsoft.UI.Reactor.Cli.Upgrade;
+
+public static class UpgradeCommand
+{
+    public static int Run(string[] args)
+    {
+        var skipPlugin = args.Contains("--skip-plugin");
+
+        var repoRoot = RepoRootFinder.FindRepoRoot(Directory.GetCurrentDirectory())
+                    ?? RepoRootFinder.FindRepoRoot();
+        if (repoRoot is null)
+        {
+            Console.Error.WriteLine("mur upgrade: must be run from inside a Reactor source checkout (could not locate src/Reactor).");
+            return 1;
+        }
+
+        // 1. Re-pack framework + templates.
+        Console.WriteLine("==> Repacking Microsoft.UI.Reactor + ProjectTemplates");
+        var rc = PackLocalCommand.Run(Array.Empty<string>());
+        if (rc != 0)
+        {
+            Console.Error.WriteLine("mur upgrade: pack-local failed.");
+            return rc;
+        }
+
+        // 2. Reinstall the dotnet new template. Uninstall first so the template
+        //    engine drops the cached version by id (the installer otherwise wins
+        //    against a same-id repack — see getting-started.md caveat).
+        Console.WriteLine();
+        Console.WriteLine("==> Reinstalling `dotnet new reactorapp` template");
+        var feed = Path.Combine(repoRoot, "local-nupkgs");
+        var templateNupkg = Path.Combine(feed, $"Microsoft.UI.Reactor.ProjectTemplates.{PackLocalCommand.DefaultLocalVersion}.nupkg");
+        if (!File.Exists(templateNupkg))
+        {
+            Console.Error.WriteLine($"mur upgrade: template nupkg not found at {templateNupkg} after pack-local.");
+            return 1;
+        }
+        // Uninstall is best-effort: non-zero exit just means it wasn't installed.
+        RunDotnet(repoRoot, ignoreExitCode: true, "new", "uninstall", CleanLocalCommand.TemplatePackageId);
+        rc = RunDotnet(repoRoot, ignoreExitCode: false, "new", "install", templateNupkg);
+        if (rc != 0)
+        {
+            Console.Error.WriteLine("mur upgrade: template install failed.");
+            return rc;
+        }
+
+        // 3. Refresh Claude plugin (best-effort; not every user has Claude Code).
+        if (!skipPlugin)
+        {
+            Console.WriteLine();
+            Console.WriteLine("==> Refreshing Claude plugin");
+            var pluginSrc = Path.Combine(repoRoot, "plugins", "reactor");
+            if (!Directory.Exists(pluginSrc))
+            {
+                Console.WriteLine($"  (skipped — {pluginSrc} not present in this checkout)");
+            }
+            else
+            {
+                var claudePluginsDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".claude", "plugins");
+                var pluginDst = Path.Combine(claudePluginsDir, "reactor");
+                try
+                {
+                    Directory.CreateDirectory(claudePluginsDir);
+                    if (Directory.Exists(pluginDst))
+                    {
+                        // If it's already a symlink to the source, nothing to do.
+                        var info = new DirectoryInfo(pluginDst);
+                        if ((info.Attributes & FileAttributes.ReparsePoint) != 0
+                            && string.Equals(info.LinkTarget, pluginSrc, StringComparison.OrdinalIgnoreCase))
+                        {
+                            Console.WriteLine($"  Symlink already current: {pluginDst} -> {pluginSrc}");
+                        }
+                        else
+                        {
+                            Directory.Delete(pluginDst, recursive: true);
+                            CopyDirectory(pluginSrc, pluginDst);
+                            Console.WriteLine($"  Refreshed plugin (copy): {pluginDst}");
+                        }
+                    }
+                    else
+                    {
+                        CopyDirectory(pluginSrc, pluginDst);
+                        Console.WriteLine($"  Installed plugin (copy): {pluginDst}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"  Plugin refresh failed: {ex.Message}");
+                    // Non-fatal — don't bail out of the whole upgrade for a plugin issue.
+                }
+            }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Upgrade complete.");
+        Console.WriteLine();
+        Console.WriteLine("  To bump `mur` itself (which can't update its own running process), run:");
+        Console.WriteLine($"    dotnet tool update -g --add-source \"{feed}\" Microsoft.UI.Reactor.Cli");
+        Console.WriteLine("  Or just re-run ./bootstrap.ps1 from the repo root.");
+        return 0;
+    }
+
+    static int RunDotnet(string workingDirectory, bool ignoreExitCode, params string[] arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory,
+        };
+        foreach (var a in arguments) psi.ArgumentList.Add(a);
+        using var proc = Process.Start(psi)!;
+        proc.WaitForExit();
+        return ignoreExitCode ? 0 : proc.ExitCode;
+    }
+
+    static void CopyDirectory(string src, string dst)
+    {
+        Directory.CreateDirectory(dst);
+        foreach (var dir in Directory.EnumerateDirectories(src, "*", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(src, dir);
+            Directory.CreateDirectory(Path.Combine(dst, rel));
+        }
+        foreach (var file in Directory.EnumerateFiles(src, "*", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(src, file);
+            File.Copy(file, Path.Combine(dst, rel), overwrite: true);
+        }
+    }
+}

--- a/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
+++ b/src/Reactor.Cli/Upgrade/UpgradeCommand.cs
@@ -127,9 +127,30 @@ public static class UpgradeCommand
             WorkingDirectory = workingDirectory,
         };
         foreach (var a in arguments) psi.ArgumentList.Add(a);
-        using var proc = Process.Start(psi)!;
-        proc.WaitForExit();
-        return ignoreExitCode ? 0 : proc.ExitCode;
+
+        Process? proc;
+        try
+        {
+            proc = Process.Start(psi);
+        }
+        catch (Exception ex)
+        {
+            if (ignoreExitCode) return 0;
+            Console.Error.WriteLine($"mur upgrade: failed to start `dotnet {string.Join(' ', arguments)}`: {ex.Message}");
+            Console.Error.WriteLine("  Verify .NET 10+ is installed and `dotnet` resolves on PATH.");
+            return 1;
+        }
+        if (proc is null)
+        {
+            if (ignoreExitCode) return 0;
+            Console.Error.WriteLine($"mur upgrade: `dotnet {string.Join(' ', arguments)}` did not start (Process.Start returned null).");
+            return 1;
+        }
+        using (proc)
+        {
+            proc.WaitForExit();
+            return ignoreExitCode ? 0 : proc.ExitCode;
+        }
     }
 
     static void CopyDirectory(string src, string dst)


### PR DESCRIPTION
## Summary

Collapses the six-step Setup in `docs/guide/getting-started.md` into a single command: `./bootstrap.ps1`. Adds two new `mur` verbs (`doctor`, `upgrade`) and packs `mur` as a `dotnet tool` global install so it's on PATH cross-shell with no per-arch `$env:Path` editing.

The signed-NuGet path (spec 022) is unchanged — this is strictly the source-checkout developer flow.

- **`bootstrap.ps1`** — pre-flight → `dotnet pack` mur → `dotnet tool install/update -g` → `mur pack-local` → `dotnet new uninstall && install` template → symlink/copy `plugins/reactor`. Idempotent; flags: `-SkipPlugin`, `-SkipMurInstall`, `-Configuration`.
- **`mur doctor`** — five checks (SDK ≥ 10 / `mur` resolvability / `local-nupkgs/` currency / `reactorapp` template registration / Claude plugin). Each FAIL prints a copy-pasteable remediation.
- **`mur upgrade`** — lightweight refresh path (re-pack framework + templates, reinstall template with uninstall-first, refresh plugin). Does **not** update `mur` itself (a process can't replace its own binary mid-run) — prints the bump-mur command on completion.
- **`Reactor.Cli.csproj`** — `PackAsTool=true`, `ToolCommandName=mur`, `PackageId=Microsoft.UI.Reactor.Cli`. Legacy `bin/<arch>/` mirror layout retained for existing PATH-based installs.
- **`PackLocalCommand` / `--regen-api`** — repo-root discovery now prefers CWD before `AppContext.BaseDirectory`, so a globally-installed `mur` (living under `~/.dotnet/tools`) still resolves the checkout the user is sitting in.
- **`docs/guide/getting-started.md`** — Setup rewritten around `bootstrap.ps1`, new "After `git pull`" / "Verify the install" subsections, and a "Manual setup" section that walks through exactly what bootstrap does step-by-step (eight numbered `dotnet pack` / `dotnet tool install` / `mur pack-local` / `dotnet new install` / symlink calls — no Reactor magic).
- **`README.md`** — "Quick start" replaced its one-line guide-link with the actual `git clone` + `./bootstrap.ps1` + `dotnet new reactorapp` block plus a paragraph of what bootstrap does. Links to the manual walkthrough.

## Test plan

- [x] `dotnet build src/Reactor.Cli/Reactor.Cli.csproj -c Release -p:Platform=ARM64` succeeds with 0 warnings
- [x] `./bootstrap.ps1` ran end-to-end from a checkout with no global `mur` installed — produced both `local-nupkgs/Microsoft.UI.Reactor.0.0.0-local.nupkg` and the templates nupkg, registered `dotnet new reactorapp`, symlinked the Claude plugin
- [x] `mur --version` resolves cross-shell from `~/.dotnet/tools/mur.exe` after bootstrap
- [x] `mur doctor` reports **PASS** on all 6 checks post-bootstrap
- [ ] `dotnet new reactorapp -n MyApp && cd MyApp && dotnet run` (not yet exercised on this PR — covered by existing template tests)
- [ ] x64 host validation (verified on ARM64 only — bootstrap detects `$env:PROCESSOR_ARCHITECTURE` so x64 should follow the same path)
- [ ] `mur upgrade` smoke-tested (the moving parts are exercised separately by `pack-local` + `dotnet new install`, but the verb itself wasn't run end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)