### PR TITLE
fix(selftest): drain dispatcher after UpdateLayout to fix local TabView race

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
@@ -229,16 +229,31 @@ internal sealed class Harness
         {
             await host.WaitForIdleAsync();
         }
-        else
-        {
-            // No active host — yield once at Low priority as a fallback
-            var dq = DispatcherQueue.GetForCurrentThread();
-            var tcs = new TaskCompletionSource();
-            dq.TryEnqueue(DispatcherQueuePriority.Low, () => tcs.SetResult());
-            await tcs.Task;
-        }
 
-        // Force synchronous layout so ActualWidth/ActualHeight are ready
+        var dq = DispatcherQueue.GetForCurrentThread();
+
+        // Force synchronous layout so ActualWidth/ActualHeight are ready.
+        // This is also what triggers TabView's selected-tab content presenter
+        // to schedule its content-realization work onto the dispatcher.
+        (_currentWindow?.Content as UIElement)?.UpdateLayout();
+
+        // Yield once at Low priority AFTER UpdateLayout. WaitForIdleAsync
+        // short-circuits when Reactor reports idle; that left callers racing
+        // the WinUI side because TabView lazy-realizes the selected pane's
+        // body via Normal-priority dispatcher messages SCHEDULED BY the
+        // layout pass we just forced. A Low-priority yield here guarantees
+        // those messages have drained — without it, a 16ms wall-clock delay
+        // is enough on CI but flakes on contended local machines (visible
+        // in NativeDocking_* fixtures where the pane Memo subtree probes
+        // returned null ~30–60% of the time on local 10x sweeps).
+        var yieldTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!dq.TryEnqueue(DispatcherQueuePriority.Low, () => yieldTcs.SetResult()))
+            yieldTcs.SetResult();
+        await yieldTcs.Task;
+
+        // Re-run layout in case the just-realized content needs an arrangement
+        // pass (e.g. a Memo body that mounted during the yield needs to size
+        // its TextBlocks before FindText can match by exact-text).
         (_currentWindow?.Content as UIElement)?.UpdateLayout();
 
         // Small breathing room for the compositor to finish processing


### PR DESCRIPTION
## Summary
- Local 10x sweeps of `Reactor.SelfTests` flaked at ~60% (top offender 3/10), all clustered in `NativeDocking_*` fixtures whose pane bodies render through a WinUI `TabView`. CI was stable.
- Root cause: `Harness.Render()` did `WaitForIdleAsync() → UpdateLayout() → Task.Delay(16)`. `WaitForIdleAsync` short-circuits when Reactor reports idle (a known footgun — flagged in the comment at `ReactorHost.cs:910`), leaving 16 ms wall-clock as the only safety net for WinUI work that `UpdateLayout()` itself schedules (notably TabView's lazy `ContentPresenter` realization for the selected tab). CI dispatchers had steady enough load that 16 ms always covered it; local boxes (IDE, file watchers, AV) lost the race ~30–60% of the time.
- Fix: yield once at Low priority between two `UpdateLayout()` calls in `Harness.Render`. The first layout schedules content-realization onto the dispatcher; the Low yield drains it (guaranteed, not timing-dependent); the second layout arranges the just-realized content. The 16 ms `Task.Delay` is now just compositor breathing room rather than the entire safety margin.

This is the same pattern `WaitForIdleAsync` uses internally and what the `else` (no-host) fallback already did — pulled up so the host-present path benefits too.

Affected flakes observed in the original 10x sweep (all eliminated):
- `NativeDocking_TabGroupRendersToTabView` (3/10)
- `NativeDocking_Composition_ContentMutationFlowsToActivePane` (2/10)
- `NativeDocking_DockContextHooksResolveOnRealMount` (1/10)
- `NativeDocking_Reliability_UseEffectCleanup_BodyRemovedOnPaneClose` (1/10)
- `NativeDocking_DynamicallyDockedComponentPage_WithOuterShellState` (1/10)

## Verification
Three 10x sweeps on local (`tools/flake-loop.ps1` against `Reactor.SelfTests`, x64 Release):

| Variant | Clean runs | Distinct flaky fixtures |
|---|---|---|
| Before | 4 / 10 | 5 |
| Low yield **before** `UpdateLayout` (wrong order) | 7 / 10 | 5 |
| **This PR** (yield **after** `UpdateLayout`, second layout to arrange) | **10 / 10** | **0** |

## Test plan
- [ ] CI green on this branch (the existing CI signal is the strongest validation that nothing regresses elsewhere — the 815 non-flaky fixtures all still pass each local run)
- [ ] One more local 10x or 20x sweep on a reviewer's box if desired, but 10/10 is consistent with the explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)