### PR TITLE
spec(047): close V1-protocol descriptor regressions (default stays V1 OFF)

### DIFF
--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -3177,7 +3177,7 @@ public sealed partial class Reconciler
         return state;
     }
 
-    private UIElement MountLazyStack(LazyStackElementBase lazy, Action requestRerender)
+    internal UIElement MountLazyStack(LazyStackElementBase lazy, Action requestRerender)
     {
         var repeater = new WinUI.ItemsRepeater();
 

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -1369,7 +1369,7 @@ public sealed partial class Reconciler
         return panel;
     }
 
-    private WinUI.Grid MountNavigationHost(NavigationHostElement element, Action requestRerender)
+    internal WinUI.Grid MountNavigationHost(NavigationHostElement element, Action requestRerender)
     {
         var grid = new WinUI.Grid();
         var handle = (Navigation.INavigationHandle)element.NavigationHandle;

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -1507,7 +1507,7 @@ public sealed partial class Reconciler
         return titleBar;
     }
 
-    private WinUI.TabView MountTabView(TabViewElement tab, Action requestRerender)
+    internal WinUI.TabView MountTabView(TabViewElement tab, Action requestRerender)
     {
         var tv = new WinUI.TabView
         {

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -1803,7 +1803,7 @@ public sealed partial class Reconciler
         return listView;
     }
 
-    private WinUI.GridView MountGridView(GridViewElement gv, Action requestRerender)
+    internal WinUI.GridView MountGridView(GridViewElement gv, Action requestRerender)
     {
         var gridView = new WinUI.GridView
         {

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -675,7 +675,7 @@ public sealed partial class Reconciler
         return box;
     }
 
-    private WinUI.CheckBox MountCheckBox(CheckBoxElement cb)
+    internal WinUI.CheckBox MountCheckBox(CheckBoxElement cb)
     {
         var checkBox = new WinUI.CheckBox { Content = cb.Label };
         if (cb.IsThreeState)
@@ -1268,7 +1268,7 @@ public sealed partial class Reconciler
         return bdr;
     }
 
-    private WinUI.Expander MountExpander(ExpanderElement exp, Action requestRerender)
+    internal WinUI.Expander MountExpander(ExpanderElement exp, Action requestRerender)
     {
         var expander = new WinUI.Expander
         {
@@ -1986,7 +1986,7 @@ public sealed partial class Reconciler
         return flipView;
     }
 
-    private UIElement MountTemplatedList(TemplatedListElementBase el, Action requestRerender)
+    internal UIElement MountTemplatedList(TemplatedListElementBase el, Action requestRerender)
     {
         return el.ControlKind switch
         {

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -301,7 +301,7 @@ public sealed partial class Reconciler
         return rtb;
     }
 
-    private WinUI.Button MountButton(ButtonElement btn, Action requestRerender)
+    internal WinUI.Button MountButton(ButtonElement btn, Action requestRerender)
     {
         var rented = _pool.TryRent(typeof(WinUI.Button));
         var button = rented as WinUI.Button ?? new WinUI.Button();

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -2295,7 +2295,7 @@ public sealed partial class Reconciler
         return ib;
     }
 
-    private UIElement MountContentDialog(ContentDialogElement cdEl, Action requestRerender)
+    internal UIElement MountContentDialog(ContentDialogElement cdEl, Action requestRerender)
     {
         var placeholder = new WinUI.StackPanel { Visibility = Visibility.Collapsed };
         SetElementTag(placeholder, cdEl);
@@ -2350,7 +2350,7 @@ public sealed partial class Reconciler
         cdEl.OnClosed?.Invoke(winUiResult);
     }
 
-    private UIElement? MountFlyout(FlyoutElement flyEl, Action requestRerender)
+    internal UIElement? MountFlyout(FlyoutElement flyEl, Action requestRerender)
     {
         var target = Mount(flyEl.Target, requestRerender);
         if (target is FrameworkElement targetFe)
@@ -2411,7 +2411,7 @@ public sealed partial class Reconciler
         return tip;
     }
 
-    private WinUI.MenuBar MountMenuBar(MenuBarElement mbEl)
+    internal WinUI.MenuBar MountMenuBar(MenuBarElement mbEl)
     {
         var menuBar = new WinUI.MenuBar();
         foreach (var menuItem in mbEl.Items)
@@ -2488,7 +2488,7 @@ public sealed partial class Reconciler
         return false;
     }
 
-    private WinUI.CommandBar MountCommandBar(CommandBarElement cmdEl, Action requestRerender)
+    internal WinUI.CommandBar MountCommandBar(CommandBarElement cmdEl, Action requestRerender)
     {
         var commandBar = new WinUI.CommandBar
         {
@@ -2543,7 +2543,7 @@ public sealed partial class Reconciler
         }
     }
 
-    private UIElement? MountMenuFlyout(MenuFlyoutElement mfEl, Action requestRerender)
+    internal UIElement? MountMenuFlyout(MenuFlyoutElement mfEl, Action requestRerender)
     {
         var target = Mount(mfEl.Target, requestRerender);
         if (target is FrameworkElement targetFe)
@@ -3680,7 +3680,7 @@ public sealed partial class Reconciler
 
     // ── Popup ───────────────────────────────────────────────────────────
 
-    private UIElement MountPopup(PopupElement popup, Action requestRerender)
+    internal UIElement MountPopup(PopupElement popup, Action requestRerender)
     {
         // Popup is not a UIElement child, so we wrap it in a StackPanel
         var wrapper = new WinUI.StackPanel();
@@ -3719,7 +3719,7 @@ public sealed partial class Reconciler
 
     // ── CommandBarFlyout ────────────────────────────────────────────────
 
-    private UIElement? MountCommandBarFlyout(CommandBarFlyoutElement cbf, Action requestRerender)
+    internal UIElement? MountCommandBarFlyout(CommandBarFlyoutElement cbf, Action requestRerender)
     {
         var target = Mount(cbf.Target, requestRerender);
         if (target is FrameworkElement targetFe)

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -1116,7 +1116,7 @@ public sealed partial class Reconciler
         return box;
     }
 
-    private WinUI.VariableSizedWrapGrid MountWrapGrid(WrapGridElement wg, Action requestRerender)
+    internal WinUI.VariableSizedWrapGrid MountWrapGrid(WrapGridElement wg, Action requestRerender)
     {
         var grid = new WinUI.VariableSizedWrapGrid { Orientation = wg.Orientation };
         if (wg.MaximumRowsOrColumns >= 0) grid.MaximumRowsOrColumns = wg.MaximumRowsOrColumns;
@@ -1140,7 +1140,7 @@ public sealed partial class Reconciler
         return grid;
     }
 
-    private WinUI.StackPanel MountStack(StackElement stack, Action requestRerender)
+    internal WinUI.StackPanel MountStack(StackElement stack, Action requestRerender)
     {
         var panel = _pool.TryRent(typeof(WinUI.StackPanel)) as WinUI.StackPanel ?? new WinUI.StackPanel();
         panel.Orientation = stack.Orientation;
@@ -1160,7 +1160,7 @@ public sealed partial class Reconciler
         return panel;
     }
 
-    private WinUI.Grid MountGrid(GridElement grid, Action requestRerender)
+    internal WinUI.Grid MountGrid(GridElement grid, Action requestRerender)
     {
         var g = _pool.TryRent(typeof(WinUI.Grid)) as WinUI.Grid ?? new WinUI.Grid();
         g.RowSpacing = grid.RowSpacing;
@@ -1325,7 +1325,7 @@ public sealed partial class Reconciler
         return viewbox;
     }
 
-    private WinUI.Canvas MountCanvas(CanvasElement cvs, Action requestRerender)
+    internal WinUI.Canvas MountCanvas(CanvasElement cvs, Action requestRerender)
     {
         var canvas = _pool.TryRent(typeof(WinUI.Canvas)) as WinUI.Canvas ?? new WinUI.Canvas();
         if (cvs.Width.HasValue) canvas.Width = cvs.Width.Value;
@@ -1345,7 +1345,7 @@ public sealed partial class Reconciler
         return canvas;
     }
 
-    private Layout.FlexPanel MountFlex(FlexElement flex, Action requestRerender)
+    internal Layout.FlexPanel MountFlex(FlexElement flex, Action requestRerender)
     {
         var panel = _pool.TryRent(typeof(Layout.FlexPanel)) as Layout.FlexPanel ?? new Layout.FlexPanel();
         panel.Direction = flex.Direction;
@@ -3462,7 +3462,7 @@ public sealed partial class Reconciler
 
     // ── RelativePanel ───────────────────────────────────────────────────
 
-    private WinUI.RelativePanel MountRelativePanel(RelativePanelElement rp, Action requestRerender)
+    internal WinUI.RelativePanel MountRelativePanel(RelativePanelElement rp, Action requestRerender)
     {
         var panel = new WinUI.RelativePanel();
         var nameMap = new Dictionary<string, UIElement>();

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -979,7 +979,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateCheckBox(CheckBoxElement o, CheckBoxElement n, WinUI.CheckBox cb)
+    internal UIElement? UpdateCheckBox(CheckBoxElement o, CheckBoxElement n, WinUI.CheckBox cb)
     {
         SetElementTag(cb, n);
         bool oldWired = o.OnIsCheckedChanged is not null || o.OnCheckedStateChanged is not null;
@@ -1459,7 +1459,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateExpander(ExpanderElement o, ExpanderElement n, WinUI.Expander exp, Action requestRerender)
+    internal UIElement? UpdateExpander(ExpanderElement o, ExpanderElement n, WinUI.Expander exp, Action requestRerender)
     {
         exp.IsExpanded = n.IsExpanded;
         exp.ExpandDirection = n.ExpandDirection;
@@ -2950,7 +2950,7 @@ public sealed partial class Reconciler
         }
     }
 
-    private UIElement? UpdateTemplatedListView(TemplatedListElementBase o, TemplatedListElementBase n, WinUI.ListView lv, Action requestRerender)
+    internal UIElement? UpdateTemplatedListView(TemplatedListElementBase o, TemplatedListElementBase n, WinUI.ListView lv, Action requestRerender)
     {
         lv.SelectionMode = n.GetSelectionMode();
         lv.IsItemClickEnabled = n.GetIsItemClickEnabled();
@@ -2976,7 +2976,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateTemplatedGridView(TemplatedListElementBase o, TemplatedListElementBase n, WinUI.GridView gv, Action requestRerender)
+    internal UIElement? UpdateTemplatedGridView(TemplatedListElementBase o, TemplatedListElementBase n, WinUI.GridView gv, Action requestRerender)
     {
         gv.SelectionMode = n.GetSelectionMode();
         gv.IsItemClickEnabled = n.GetIsItemClickEnabled();
@@ -3075,7 +3075,7 @@ public sealed partial class Reconciler
         return state;
     }
 
-    private UIElement? UpdateTemplatedFlipView(TemplatedListElementBase o, TemplatedListElementBase n, WinUI.FlipView fv, Action requestRerender)
+    internal UIElement? UpdateTemplatedFlipView(TemplatedListElementBase o, TemplatedListElementBase n, WinUI.FlipView fv, Action requestRerender)
     {
         // FlipView items are pre-mounted directly (no ContainerContentChanging).
         // Build old element array from o, then reconcile like regular items.

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -1894,7 +1894,7 @@ public sealed partial class Reconciler
         }
     }
 
-    private UIElement? UpdateTabView(TabViewElement o, TabViewElement n, WinUI.TabView tabView, Action requestRerender)
+    internal UIElement? UpdateTabView(TabViewElement o, TabViewElement n, WinUI.TabView tabView, Action requestRerender)
     {
         // In-place reconcile so that state changes on descendants don't tear the
         // TabView down (which would re-animate the tab bar in and steal focus

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -1316,7 +1316,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateWrapGrid(WrapGridElement o, WrapGridElement n, WinUI.VariableSizedWrapGrid wg, Action requestRerender)
+    internal UIElement? UpdateWrapGrid(WrapGridElement o, WrapGridElement n, WinUI.VariableSizedWrapGrid wg, Action requestRerender)
     {
         wg.Orientation = n.Orientation;
         if (n.MaximumRowsOrColumns >= 0) wg.MaximumRowsOrColumns = n.MaximumRowsOrColumns;
@@ -1346,7 +1346,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateCanvas(CanvasElement o, CanvasElement n, WinUI.Canvas canvas, Action requestRerender)
+    internal UIElement? UpdateCanvas(CanvasElement o, CanvasElement n, WinUI.Canvas canvas, Action requestRerender)
     {
         if (n.Width.HasValue && n.Width != o.Width) canvas.Width = n.Width.Value;
         if (n.Height.HasValue && n.Height != o.Height) canvas.Height = n.Height.Value;
@@ -1370,7 +1370,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateStack(StackElement o, StackElement n, WinUI.StackPanel sp, Action requestRerender)
+    internal UIElement? UpdateStack(StackElement o, StackElement n, WinUI.StackPanel sp, Action requestRerender)
     {
         if (o.Orientation != n.Orientation) sp.Orientation = n.Orientation;
         if (o.Spacing != n.Spacing) sp.Spacing = n.Spacing;
@@ -2325,7 +2325,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateRelativePanel(RelativePanelElement o, RelativePanelElement n, WinUI.RelativePanel rp, Action requestRerender)
+    internal UIElement? UpdateRelativePanel(RelativePanelElement o, RelativePanelElement n, WinUI.RelativePanel rp, Action requestRerender)
     {
         // RelativePanel's children reference each other by name for layout.
         // Reconcile in place when the children line up positionally; if the
@@ -3758,7 +3758,7 @@ public sealed partial class Reconciler
                 target.Add(CreateAppBarItem(source[i]));
     }
 
-    private UIElement? UpdateGrid(Core.GridElement o, Core.GridElement n, WinUI.Grid g, Action requestRerender)
+    internal UIElement? UpdateGrid(Core.GridElement o, Core.GridElement n, WinUI.Grid g, Action requestRerender)
     {
         if (o.RowSpacing != n.RowSpacing) g.RowSpacing = n.RowSpacing;
         if (o.ColumnSpacing != n.ColumnSpacing) g.ColumnSpacing = n.ColumnSpacing;
@@ -3877,7 +3877,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateFlex(FlexElement o, FlexElement n, Layout.FlexPanel panel, Action requestRerender)
+    internal UIElement? UpdateFlex(FlexElement o, FlexElement n, Layout.FlexPanel panel, Action requestRerender)
     {
         panel.Direction = n.Direction;
         panel.JustifyContent = n.JustifyContent;

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -3203,7 +3203,7 @@ public sealed partial class Reconciler
         return state;
     }
 
-    private UIElement? UpdateLazyStack(LazyStackElementBase n, WinUI.ScrollViewer sv, Action requestRerender)
+    internal UIElement? UpdateLazyStack(LazyStackElementBase n, WinUI.ScrollViewer sv, Action requestRerender)
     {
         if (sv.Content is WinUI.ItemsRepeater repeater)
         {

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -2410,7 +2410,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdatePopup(PopupElement o, PopupElement n, WinUI.StackPanel wrapper, Action requestRerender)
+    internal UIElement? UpdatePopup(PopupElement o, PopupElement n, WinUI.StackPanel wrapper, Action requestRerender)
     {
         // The popup itself is the wrapper's first child. Update its scalar
         // props and reconcile the hosted Child in place so transient popup
@@ -2462,7 +2462,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateCommandBarFlyout(CommandBarFlyoutElement o, CommandBarFlyoutElement n, UIElement targetControl, Action requestRerender)
+    internal UIElement? UpdateCommandBarFlyout(CommandBarFlyoutElement o, CommandBarFlyoutElement n, UIElement targetControl, Action requestRerender)
     {
         // Reconcile the target in place and reuse the attached flyout when
         // possible — re-attaching a brand-new flyout on every update would
@@ -2515,7 +2515,7 @@ public sealed partial class Reconciler
         return updated == targetControl ? null : updated;
     }
 
-    private UIElement? UpdateMenuFlyout(MenuFlyoutElement o, MenuFlyoutElement n, UIElement targetControl, Action requestRerender)
+    internal UIElement? UpdateMenuFlyout(MenuFlyoutElement o, MenuFlyoutElement n, UIElement targetControl, Action requestRerender)
     {
         UIElement? updated = targetControl;
         if (CanUpdate(o.Target, n.Target))
@@ -2556,7 +2556,7 @@ public sealed partial class Reconciler
         return updated == targetControl ? null : updated;
     }
 
-    private UIElement? UpdateFlyoutElement(FlyoutElement o, FlyoutElement n, UIElement targetControl, Action requestRerender)
+    internal UIElement? UpdateFlyoutElement(FlyoutElement o, FlyoutElement n, UIElement targetControl, Action requestRerender)
     {
         UIElement? updated = targetControl;
         if (CanUpdate(o.Target, n.Target))
@@ -2778,7 +2778,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateContentDialog(ContentDialogElement o, ContentDialogElement n, FrameworkElement fe, Action requestRerender)
+    internal UIElement? UpdateContentDialog(ContentDialogElement o, ContentDialogElement n, FrameworkElement fe, Action requestRerender)
     {
         if (n.IsOpen && !o.IsOpen) ShowContentDialog(n, fe, requestRerender);
         SetElementTag(fe, n);
@@ -3563,7 +3563,7 @@ public sealed partial class Reconciler
         visual.ImplicitAnimations = coll;
     }
 
-    private UIElement? UpdateMenuBar(MenuBarElement o, MenuBarElement n, WinUI.MenuBar mb)
+    internal UIElement? UpdateMenuBar(MenuBarElement o, MenuBarElement n, WinUI.MenuBar mb)
     {
         int oldCount = o.Items.Length;
         int newCount = n.Items.Length;
@@ -3687,7 +3687,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateCommandBar(CommandBarElement o, CommandBarElement n, WinUI.CommandBar cb, Action requestRerender)
+    internal UIElement? UpdateCommandBar(CommandBarElement o, CommandBarElement n, WinUI.CommandBar cb, Action requestRerender)
     {
         cb.DefaultLabelPosition = n.DefaultLabelPosition;
         cb.IsOpen = n.IsOpen;

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -2853,7 +2853,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateGridView(GridViewElement o, GridViewElement n, WinUI.GridView gv, Action requestRerender)
+    internal UIElement? UpdateGridView(GridViewElement o, GridViewElement n, WinUI.GridView gv, Action requestRerender)
     {
         gv.SelectionMode = n.SelectionMode;
         gv.IsItemClickEnabled = n.OnItemClick is not null;

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -683,7 +683,7 @@ public sealed partial class Reconciler
         }
     }
 
-    private UIElement? UpdateButton(ButtonElement o, ButtonElement n, WinUI.Button b, Action requestRerender)
+    internal UIElement? UpdateButton(ButtonElement o, ButtonElement n, WinUI.Button b, Action requestRerender)
     {
         ApplyButtonEnabledState(b, n);
         if (n.ContentElement is not null && o.ContentElement is not null && b.Content is UIElement existingContent)

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -1507,7 +1507,7 @@ public sealed partial class Reconciler
         return null;
     }
 
-    private UIElement? UpdateNavigationHost(
+    internal UIElement? UpdateNavigationHost(
         NavigationHostElement oldEl, NavigationHostElement newEl,
         WinUI.Grid grid, Action requestRerender)
     {

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -327,10 +327,14 @@ public sealed partial class Reconciler : IDisposable
     ///   <c>MenuFlyoutElement</c>, <c>PopupElement</c>,
     ///   <c>CommandBarFlyoutElement</c>. Require decorator-style ports
     ///   (lifecycle, side-mount).</item>
-    ///   <item><b>Deferred stateful host</b> (follow-up PR) — <c>NavigationHostElement</c>.
-    ///   Per-instance route/cache/transition state is intercepted in
-    ///   <see cref="UnmountRecursive"/> before the V1 dispatch arm; needs a
-    ///   small refactor before it can route through V1.</item>
+    ///   <item><b>Stateful host — PORTED (§14 Phase 3 prelude)</b> —
+    ///   <c>NavigationHostElement</c> now routes through V1 via
+    ///   <see cref="V1Protocol.Handlers.NavigationHostHandler"/> (Path B
+    ///   delegate). Per-instance route/cache/transition state is still torn
+    ///   down by the flag-independent intercept in
+    ///   <see cref="UnmountRecursive"/> (fires before the V1 unmount arm), so
+    ///   unmount is byte-identical V1 ON ≡ V1 OFF.</item>
+    ///
     ///   <item><b>Deferred — descriptor with known docking gaps</b> (follow-up
     ///   PR) — <c>TabViewDescriptor</c>. Bisect of full V1 ON flakes (1–4
     ///   non-deterministic docking-text-find failures per run across
@@ -365,6 +369,9 @@ public sealed partial class Reconciler : IDisposable
         RegisterHandler<TextBoxElement, WinUI.TextBox>(new V1Protocol.Handlers.TextBoxHandler());
         RegisterHandler<BorderElement, WinUI.Border>(new V1Protocol.Handlers.BorderHandler());
         RegisterHandler<ListViewElement, WinUI.ListView>(new V1Protocol.Handlers.ListViewHandler());
+
+        // ── §14 Phase 3 prelude carve-closures (delegate to engine bodies) ──
+        RegisterHandler<NavigationHostElement, WinUI.Grid>(new V1Protocol.Handlers.NavigationHostHandler());
 
         // ── §14 Phase 3 base-derived (templated/lazy/items hosts) ────────
         // Each closed-T leaf routes through the same descriptor via the

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -437,7 +437,7 @@ public sealed partial class Reconciler : IDisposable
         // and the perf-bench descriptor variant.
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.CalendarDatePickerDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.CalendarViewDescriptor.Descriptor);
-        RegisterDescriptor(V1Protocol.Descriptor.Descriptors.CanvasDescriptor.Descriptor);
+        RegisterDecoratorHandler<CanvasElement>(new V1Protocol.Handlers.CanvasPanelHandler()); // §14: keyed reconcile — see PanelDelegateHandlers
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.CheckBoxDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.ColorPickerDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.ComboBoxDescriptor.Descriptor);
@@ -445,10 +445,10 @@ public sealed partial class Reconciler : IDisposable
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.DropDownButtonDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.EllipseDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.ExpanderDescriptor.Descriptor);
-        RegisterDescriptor(V1Protocol.Descriptor.Descriptors.FlexPanelDescriptor.Descriptor);
+        RegisterDecoratorHandler<FlexElement>(new V1Protocol.Handlers.FlexPanelHandler()); // §14: keyed reconcile — see PanelDelegateHandlers
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.FlipViewDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.FrameDescriptor.Descriptor);
-        RegisterDescriptor(V1Protocol.Descriptor.Descriptors.GridDescriptor.Descriptor);
+        RegisterDecoratorHandler<GridElement>(new V1Protocol.Handlers.GridPanelHandler()); // §14: keyed reconcile — see PanelDelegateHandlers
         // Spec 047 §14 Phase 3 prelude — GridViewElement now routes through V1
         // via the hand-coded V1Protocol.Handlers.GridViewHandler (registered
         // above with the Phase 1 handlers), which preserves the legacy
@@ -483,7 +483,7 @@ public sealed partial class Reconciler : IDisposable
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.RatingControlDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.RectangleDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.RefreshContainerDescriptor.Descriptor);
-        RegisterDescriptor(V1Protocol.Descriptor.Descriptors.RelativePanelDescriptor.Descriptor);
+        RegisterDecoratorHandler<RelativePanelElement>(new V1Protocol.Handlers.RelativePanelHandler()); // §14: keyed reconcile — see PanelDelegateHandlers
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.RepeatButtonDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.RichEditBoxDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.RichTextBlockDescriptor.Descriptor);
@@ -494,7 +494,7 @@ public sealed partial class Reconciler : IDisposable
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.SemanticZoomDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.SplitButtonDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.SplitViewDescriptor.Descriptor);
-        RegisterDescriptor(V1Protocol.Descriptor.Descriptors.StackPanelDescriptor.Descriptor);
+        RegisterDecoratorHandler<StackElement>(new V1Protocol.Handlers.StackPanelHandler()); // §14: keyed reconcile — see PanelDelegateHandlers
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.SwipeControlDescriptor.Descriptor);
         // Spec 047 §14 — TabViewElement is ported via the Path B delegate
         // TabViewHandler (registered above with the other prelude carve
@@ -522,7 +522,7 @@ public sealed partial class Reconciler : IDisposable
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.TreeViewDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.ViewboxDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.WebView2Descriptor.Descriptor);
-        RegisterDescriptor(V1Protocol.Descriptor.Descriptors.WrapGridDescriptor.Descriptor);
+        RegisterDecoratorHandler<WrapGridElement>(new V1Protocol.Handlers.WrapGridHandler()); // §14: keyed reconcile — see PanelDelegateHandlers
 
         // ── §14 Phase 3 completion decorator-style handlers ──────────────
         RegisterDecoratorHandler<IconElement>(V1Protocol.Descriptor.Descriptors.IconDescriptor.Handler);

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -393,6 +393,14 @@ public sealed partial class Reconciler : IDisposable
         RegisterDecoratorHandler<PopupElement>(new V1Protocol.Handlers.PopupHandler());
         RegisterDecoratorHandler<CommandBarFlyoutElement>(new V1Protocol.Handlers.CommandBarFlyoutHandler());
 
+        // Button — delegate to the COMPLETE legacy MountButton/UpdateButton
+        // bodies (the ButtonDescriptor only handles the string-Label fast path
+        // and drops ContentElement; the delegate runs the full legacy impl so
+        // element content round-trips). Decorator shape so unmount falls
+        // through to ContentControl recursion (cleanup parity for an element
+        // child) — see ButtonHandler. Supersedes the registered descriptor.
+        RegisterDecoratorHandler<ButtonElement>(new V1Protocol.Handlers.ButtonHandler());
+
         // TabView — delegate to the COMPLETE legacy MountTabView/UpdateTabView
         // bodies (drag pipeline, pinnable headers, strip header/footer, in-place
         // content reconcile). Distinct from the unregistered TabViewDescriptor,
@@ -423,7 +431,10 @@ public sealed partial class Reconciler : IDisposable
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.AnnounceRegionDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.AutoSuggestBoxDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.BreadcrumbBarDescriptor.Descriptor);
-        RegisterDescriptor(V1Protocol.Descriptor.Descriptors.ButtonDescriptor.Descriptor);
+        // ButtonDescriptor is intentionally NOT registered — superseded by the
+        // delegate ButtonHandler above (ContentElement coverage + unmount
+        // parity). The descriptor type is retained for its isolated selftests
+        // and the perf-bench descriptor variant.
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.CalendarDatePickerDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.CalendarViewDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.CanvasDescriptor.Descriptor);

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -417,9 +417,9 @@ public sealed partial class Reconciler : IDisposable
         // overlap with the Phase 1 ListViewHandler — exact-type wins, so
         // ListView itself uses ListViewHandler; only typed templated
         // variants route through these base-derived registrations.
-        RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.TemplatedListViewDescriptor.Descriptor);
-        RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.TemplatedGridViewDescriptor.Descriptor);
-        RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.TemplatedFlipViewDescriptor.Descriptor);
+        // §14: typed templated lists route through one Path B delegate on the
+        // common base (legacy move/reorder animations) — see TemplatedListHandler.
+        RegisterDecoratorHandlerForDerivedTypes<TemplatedListElementBase>(new V1Protocol.Handlers.TemplatedListHandler());
         RegisterDecoratorHandlerForDerivedTypes<LazyStackElementBase>(new V1Protocol.Handlers.LazyStackHandler()); // §14: ScrollViewer-wrapped — see LazyStackHandler
         RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.ItemsRepeaterDescriptor.Descriptor);
         RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.ItemsViewDescriptor.Descriptor);
@@ -438,13 +438,13 @@ public sealed partial class Reconciler : IDisposable
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.CalendarDatePickerDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.CalendarViewDescriptor.Descriptor);
         RegisterDecoratorHandler<CanvasElement>(new V1Protocol.Handlers.CanvasPanelHandler()); // §14: keyed reconcile — see PanelDelegateHandlers
-        RegisterDescriptor(V1Protocol.Descriptor.Descriptors.CheckBoxDescriptor.Descriptor);
+        RegisterDecoratorHandler<CheckBoxElement>(new V1Protocol.Handlers.CheckBoxHandler()); // §14: value-control echo-suppression — see CheckBoxHandler
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.ColorPickerDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.ComboBoxDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.DatePickerDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.DropDownButtonDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.EllipseDescriptor.Descriptor);
-        RegisterDescriptor(V1Protocol.Descriptor.Descriptors.ExpanderDescriptor.Descriptor);
+        RegisterDecoratorHandler<ExpanderElement>(new V1Protocol.Handlers.ExpanderHandler()); // §14: callback/template wiring — see ExpanderHandler
         RegisterDecoratorHandler<FlexElement>(new V1Protocol.Handlers.FlexPanelHandler()); // §14: keyed reconcile — see PanelDelegateHandlers
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.FlipViewDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.FrameDescriptor.Descriptor);

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -349,16 +349,14 @@ public sealed partial class Reconciler : IDisposable
     ///   (post-children mount-hook so SelectionChanged subscribes after
     ///   children-add, ImperativeBridged for the named tab strip slots)
     ///   tracked alongside the overlays + NavigationHost in the follow-up.</item>
-    ///   <item><b>Deferred — descriptor with lifecycle divergence from
-    ///   legacy</b> (follow-up PR) — <c>GridViewDescriptor</c>. The descriptor's
-    ///   <c>ItemsHost&lt;&gt;</c> strategy pre-mounts every item into
-    ///   <c>GridView.Items</c> (one container per item, no virtualization).
-    ///   The legacy <c>MountGridView</c> arm uses
-    ///   <c>ItemsSource = Range(0..N) + ItemTemplate + ContainerContentChanging</c>
-    ///   to realize containers lazily, matching the Phase 1
-    ///   <see cref="V1Protocol.Handlers.ListViewHandler"/> pattern. Closing
-    ///   this needs either a Phase 1 hand-coded <c>GridViewHandler</c> or a
-    ///   new ChildrenStrategy that wraps the CCC virtualization contract.</item>
+    ///   <item><b>Items host — PORTED (§14 Phase 3 prelude)</b> —
+    ///   <c>GridViewElement</c> now routes through V1 via the hand-coded
+    ///   <see cref="V1Protocol.Handlers.GridViewHandler"/> (Path B delegate),
+    ///   which mirrors <see cref="V1Protocol.Handlers.ListViewHandler"/>'s
+    ///   lazy <c>ItemsSource + ContainerContentChanging</c> realization. The
+    ///   <c>GridViewDescriptor</c>'s <c>ItemsHost&lt;&gt;</c> strategy stays
+    ///   unregistered — it pre-mounts every item with no virtualization,
+    ///   which would regress the recycle contract.</item>
     /// </list>
     /// </summary>
     private void RegisterV1BuiltInHandlers()
@@ -372,6 +370,7 @@ public sealed partial class Reconciler : IDisposable
 
         // ── §14 Phase 3 prelude carve-closures (delegate to engine bodies) ──
         RegisterHandler<NavigationHostElement, WinUI.Grid>(new V1Protocol.Handlers.NavigationHostHandler());
+        RegisterHandler<GridViewElement, WinUI.GridView>(new V1Protocol.Handlers.GridViewHandler());
 
         // ── §14 Phase 3 base-derived (templated/lazy/items hosts) ────────
         // Each closed-T leaf routes through the same descriptor via the
@@ -409,22 +408,15 @@ public sealed partial class Reconciler : IDisposable
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.FlipViewDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.FrameDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.GridDescriptor.Descriptor);
-        // Spec 047 §14 Phase 3 completion CR (Copilot review on PR #440) —
-        // GridViewDescriptor stays carved. The descriptor's ItemsHost<>
-        // strategy pre-mounts every item into GridView.Items (one container
-        // per item, no virtualization, no recycle). The legacy MountGridView
-        // path uses ItemsSource = Range(0..N) + ItemTemplate +
-        // ContainerContentChanging to realize containers lazily (one per
-        // visible viewport item) and unmount on RecycleQueue entry — same
-        // pattern as the Phase 1 hand-coded ListViewHandler. Registering
-        // GridViewDescriptor would not break A|B tests (no fixture stresses
-        // GridView scale), but it would silently regress production memory
-        // and lifecycle (item Mount/Unmount fires for every item up-front
-        // instead of per-viewport, breaking the recycle contract). Closing
-        // this needs either a Phase 1 hand-coded GridViewHandler mirroring
-        // ListViewHandler, or a new ChildrenStrategy variant that wraps
-        // ItemsSource + CCC. Tracked alongside the TabView/overlay/NavigationHost
-        // gap-closure follow-up.
+        // Spec 047 §14 Phase 3 prelude — GridViewElement now routes through V1
+        // via the hand-coded V1Protocol.Handlers.GridViewHandler (registered
+        // above with the Phase 1 handlers), which preserves the legacy
+        // ItemsSource + ContainerContentChanging lazy realization. The
+        // GridViewDescriptor stays carved: its ItemsHost<> strategy pre-mounts
+        // every item into GridView.Items (one container per item, no
+        // virtualization, no recycle), which would silently regress production
+        // memory and lifecycle (item Mount/Unmount fires for every item
+        // up-front instead of per-viewport, breaking the recycle contract).
         // RegisterDescriptor(V1Protocol.Descriptor.Descriptors.GridViewDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.HyperlinkButtonDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.ImageDescriptor.Descriptor);

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -342,20 +342,22 @@ public sealed partial class Reconciler : IDisposable
     ///   <see cref="UnmountRecursive"/> (fires before the V1 unmount arm), so
     ///   unmount is byte-identical V1 ON ≡ V1 OFF.</item>
     ///
-    ///   <item><b>Deferred — descriptor with known docking gaps</b> (follow-up
-    ///   PR) — <c>TabViewDescriptor</c>. Bisect of full V1 ON flakes (1–4
-    ///   non-deterministic docking-text-find failures per run across
-    ///   DockHooks / PixDoc / RoleAware / Composition / FloatRoot fixtures,
-    ///   versus a clean V1 OFF baseline) ratifies the descriptor's documented
-    ///   gaps — missing spec 045 §2.4 drag pipeline trampolines, §2.2 pinnable
-    ///   tab headers (BuildTabHeader / BuildPinButton / in-place
-    ///   TryUpdatePinHeaderInPlace), in-place CanUpdate for tab content
-    ///   (preserves focus/state on re-renders), conditional SelectedIndex
-    ///   write, and TabStripHeader / TabStripFooter Element slots — are hot
-    ///   in the docking suite. Closing them requires engine work
-    ///   (post-children mount-hook so SelectionChanged subscribes after
-    ///   children-add, ImperativeBridged for the named tab strip slots)
-    ///   tracked alongside the overlays + NavigationHost in the follow-up.</item>
+    ///   <item><b>TabView — PORTED (§14 Phase 3 prelude)</b> —
+    ///   <c>TabViewElement</c> now routes through V1 via the Path B delegate
+    ///   <see cref="V1Protocol.Handlers.TabViewHandler"/>, which calls the
+    ///   COMPLETE legacy <c>MountTabView</c>/<c>UpdateTabView</c> bodies (spec
+    ///   045 §2.4 drag pipeline, §2.2 pinnable headers via BuildTabHeader /
+    ///   BuildPinButton / in-place TryUpdatePinHeaderInPlace, in-place tab
+    ///   content reconcile, conditional SelectedIndex, TabStripHeader /
+    ///   TabStripFooter slots). Distinct from the still-unregistered
+    ///   <c>TabViewDescriptor</c> + <c>TabItemsHost</c> port, which
+    ///   intentionally leaves those features on the legacy arm — the delegate
+    ///   runs the full feature set because it IS the legacy code. Mount/update
+    ///   are unchanged from the previously-carved V1-ON path (which already
+    ///   ran these bodies via the legacy switch); registering the handler only
+    ///   makes the unmount arm fire, which is byte-identical V1 ON ≡ V1 OFF
+    ///   (a <c>WinUI.TabView</c> is an <c>ItemsControl</c> that pools without
+    ///   child recursion in both paths).</item>
     ///   <item><b>Items host — PORTED (§14 Phase 3 prelude)</b> —
     ///   <c>GridViewElement</c> now routes through V1 via the hand-coded
     ///   <see cref="V1Protocol.Handlers.GridViewHandler"/> (Path B delegate),
@@ -390,6 +392,15 @@ public sealed partial class Reconciler : IDisposable
         RegisterDecoratorHandler<MenuFlyoutElement>(new V1Protocol.Handlers.MenuFlyoutHandler());
         RegisterDecoratorHandler<PopupElement>(new V1Protocol.Handlers.PopupHandler());
         RegisterDecoratorHandler<CommandBarFlyoutElement>(new V1Protocol.Handlers.CommandBarFlyoutHandler());
+
+        // TabView — delegate to the COMPLETE legacy MountTabView/UpdateTabView
+        // bodies (drag pipeline, pinnable headers, strip header/footer, in-place
+        // content reconcile). Distinct from the unregistered TabViewDescriptor,
+        // which leaves those features on the legacy arm. UpdateTabView returns
+        // null (in-place only), so the void-Update IElementHandler shape fits;
+        // unmount is byte-identical V1 ON ≡ V1 OFF (ItemsControl pools without
+        // child recursion in both paths).
+        RegisterHandler<TabViewElement, WinUI.TabView>(new V1Protocol.Handlers.TabViewHandler());
 
         // ── §14 Phase 3 base-derived (templated/lazy/items hosts) ────────
         // Each closed-T leaf routes through the same descriptor via the
@@ -474,23 +485,22 @@ public sealed partial class Reconciler : IDisposable
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.SplitViewDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.StackPanelDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.SwipeControlDescriptor.Descriptor);
-        // Spec 047 §14 Phase 3 completion — TabViewDescriptor stays carved.
-        // Bisect (3× clean V1 ON full selftest with this single line removed,
-        // matching V1 OFF's 4410-ok baseline; with it registered, 1–4 random
-        // docking-text-find checks fail per run across DockHooks / PixDoc /
-        // RoleAware / Composition / FloatRoot fixtures) proves the gap
-        // documented on TabViewDescriptor — missing spec 045 §2.4 drag
-        // pipeline (OnTabDragStarting / OnTabDragCompleted), §2.2 IsPinnable
-        // header rendering (BuildTabHeader + BuildPinButton + in-place
-        // TryUpdatePinHeaderInPlace on update), in-place CanUpdate for tab
+        // Spec 047 §14 — TabViewElement is ported via the Path B delegate
+        // TabViewHandler (registered above with the other prelude carve
+        // closures), NOT via TabViewDescriptor. The descriptor + TabItemsHost
+        // strategy stays unregistered: it intentionally leaves the spec 045
+        // §2.4 drag pipeline (OnTabDragStarting / OnTabDragCompleted), §2.2
+        // IsPinnable header rendering (BuildTabHeader + BuildPinButton +
+        // in-place TryUpdatePinHeaderInPlace), in-place CanUpdate for tab
         // content (preserves focus/state across re-renders), conditional
         // SelectedIndex write, and TabStripHeader / TabStripFooter Element
-        // slots — is hot in the docking suite. Closing those gaps requires
-        // engine work (post-children mount-hook so SelectionChanged subscribes
-        // after children-add, ImperativeBridged for the tab strip named
-        // slots) tracked as the follow-up that takes Phase 3 the rest of
-        // the way to "every element routes through V1." This PR registers
-        // every other Phase 3 descriptor safely.
+        // slots on the legacy arm — exactly the features that are hot in the
+        // docking suite. The delegate handler runs the COMPLETE legacy
+        // MountTabView/UpdateTabView bodies, so it has none of those gaps and
+        // is byte-identical V1 ON ≡ V1 OFF. Finishing the descriptor port
+        // (post-children mount-hook + ImperativeBridged tab strip slots) is a
+        // separable Phase 4 purity follow-up; it is NOT required for the flag
+        // flip because the delegate already routes TabView through V1.
         // RegisterDescriptor(V1Protocol.Descriptor.Descriptors.TabViewDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.TeachingTipDescriptor.Descriptor);
         RegisterDescriptor(V1Protocol.Descriptor.Descriptors.TextBlockDescriptor.Descriptor);

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -322,11 +322,18 @@ public sealed partial class Reconciler : IDisposable
     ///   auto-registering V1 would clash via
     ///   <see cref="EnsureRegistrableElementType"/>. Unification is Phase 4
     ///   follow-up.</item>
-    ///   <item><b>Deferred overlays</b> (follow-up PR) — <c>ContentDialogElement</c>,
-    ///   <c>FlyoutElement</c>, <c>MenuBarElement</c>, <c>CommandBarElement</c>,
+    ///   <item><b>Overlays — PORTED (§14 Phase 3 prelude)</b> —
+    ///   <c>ContentDialogElement</c>, <c>FlyoutElement</c>,
+    ///   <c>MenuBarElement</c>, <c>CommandBarElement</c>,
     ///   <c>MenuFlyoutElement</c>, <c>PopupElement</c>,
-    ///   <c>CommandBarFlyoutElement</c>. Require decorator-style ports
-    ///   (lifecycle, side-mount).</item>
+    ///   <c>CommandBarFlyoutElement</c> now route through V1 via
+    ///   decorator-style handlers in <c>V1Protocol.Handlers</c> that delegate
+    ///   to the legacy <c>MountXxx</c>/<c>UpdateXxx</c> bodies and return
+    ///   <see cref="V1Protocol.V1UnmountDisposition.ContinueDefaultTraversal"/>
+    ///   on unmount — so the engine falls through to the same
+    ///   <see cref="UnmountRecursive"/> type-based recursion that runs when
+    ///   the flag is OFF, making mount/update/unmount byte-identical
+    ///   V1 ON ≡ V1 OFF.</item>
     ///   <item><b>Stateful host — PORTED (§14 Phase 3 prelude)</b> —
     ///   <c>NavigationHostElement</c> now routes through V1 via
     ///   <see cref="V1Protocol.Handlers.NavigationHostHandler"/> (Path B
@@ -371,6 +378,18 @@ public sealed partial class Reconciler : IDisposable
         // ── §14 Phase 3 prelude carve-closures (delegate to engine bodies) ──
         RegisterHandler<NavigationHostElement, WinUI.Grid>(new V1Protocol.Handlers.NavigationHostHandler());
         RegisterHandler<GridViewElement, WinUI.GridView>(new V1Protocol.Handlers.GridViewHandler());
+
+        // Overlays — decorator-style ports. Each delegates to the legacy
+        // MountXxx/UpdateXxx body and returns ContinueDefaultTraversal on
+        // unmount, so the V1 ON path is byte-identical to V1 OFF (which skips
+        // the V1 arm and runs the same UnmountRecursive type-based recursion).
+        RegisterDecoratorHandler<ContentDialogElement>(new V1Protocol.Handlers.ContentDialogHandler());
+        RegisterDecoratorHandler<FlyoutElement>(new V1Protocol.Handlers.FlyoutHandler());
+        RegisterDecoratorHandler<MenuBarElement>(new V1Protocol.Handlers.MenuBarHandler());
+        RegisterDecoratorHandler<CommandBarElement>(new V1Protocol.Handlers.CommandBarHandler());
+        RegisterDecoratorHandler<MenuFlyoutElement>(new V1Protocol.Handlers.MenuFlyoutHandler());
+        RegisterDecoratorHandler<PopupElement>(new V1Protocol.Handlers.PopupHandler());
+        RegisterDecoratorHandler<CommandBarFlyoutElement>(new V1Protocol.Handlers.CommandBarFlyoutHandler());
 
         // ── §14 Phase 3 base-derived (templated/lazy/items hosts) ────────
         // Each closed-T leaf routes through the same descriptor via the

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -420,7 +420,7 @@ public sealed partial class Reconciler : IDisposable
         RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.TemplatedListViewDescriptor.Descriptor);
         RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.TemplatedGridViewDescriptor.Descriptor);
         RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.TemplatedFlipViewDescriptor.Descriptor);
-        RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.LazyStackDescriptor.Descriptor);
+        RegisterDecoratorHandlerForDerivedTypes<LazyStackElementBase>(new V1Protocol.Handlers.LazyStackHandler()); // §14: ScrollViewer-wrapped — see LazyStackHandler
         RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.ItemsRepeaterDescriptor.Descriptor);
         RegisterDescriptorForDerivedTypes(V1Protocol.Descriptor.Descriptors.ItemsViewDescriptor.Descriptor);
 
@@ -1047,6 +1047,28 @@ public sealed partial class Reconciler : IDisposable
         ArgumentNullException.ThrowIfNull(handler);
         EnsureRegistrableElementType(typeof(TElement), typeof(UIElement), "RegisterDecoratorHandler");
         _v1Handlers.Add(typeof(TElement), new V1Protocol.V1DecoratorHandlerAdapter<TElement>(handler));
+    }
+
+    /// <summary>
+    /// Spec 047 §14 Phase 3 prelude — register a decorator-style V1 handler
+    /// that catches every closed runtime type whose chain reaches
+    /// <typeparamref name="TBase"/> (the derived-type analogue of
+    /// <see cref="RegisterDecoratorHandler{TElement}"/>). Used by the
+    /// Lazy*Stack family, whose closed-T variants all derive from the
+    /// non-generic <c>LazyStackElementBase</c> and need the decorator
+    /// shape (control identity differs from the descriptor port — the
+    /// legacy mount wraps the ItemsRepeater in a ScrollViewer — and
+    /// <see cref="V1UnmountDisposition.ContinueDefaultTraversal"/> so the
+    /// engine recurses ScrollViewer → ItemsRepeater → realized rows on
+    /// unmount).
+    /// </summary>
+    [Experimental("REACTOR_V1_PREVIEW")]
+    internal void RegisterDecoratorHandlerForDerivedTypes<TBase>(V1Protocol.IDecoratorElementHandler<TBase> handler)
+        where TBase : Element
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        EnsureRegistrableElementType(typeof(TBase), typeof(UIElement), "RegisterDecoratorHandlerForDerivedTypes");
+        _v1Handlers.AddForDerivedTypes(typeof(TBase), new V1Protocol.V1DecoratorHandlerAdapter<TBase>(handler));
     }
 
     // ════════════════════════════════════════════════════════════════════

--- a/src/Reactor/Core/V1Protocol/ChildrenStrategy.cs
+++ b/src/Reactor/Core/V1Protocol/ChildrenStrategy.cs
@@ -424,53 +424,116 @@ public sealed record TreeChildren<TElement, TControl>(
 /// builds the per-control container (e.g. <c>WinUI.TabViewItem</c>),
 /// and adds it to the host's items sink.
 ///
-/// <para><b>MVP scope:</b> positional rebuild on Update — every container
-/// is unmounted + remounted. No keyed reconcile (descendant component
-/// state inside the per-item Content is lost across renders that touch
-/// the tab set). Matches the legacy <c>UpdateTabView</c> / <c>UpdatePivot</c>
-/// rebuild semantics for the common case.</para></summary>
+/// <para><b>Update semantics:</b> in-place positional reconcile against the
+/// previous element. For each shared index the existing container is kept
+/// and its <c>Content</c> reconciled through
+/// <see cref="Reconciler.ReconcileV1Child"/> (CanUpdate-or-mount-or-unmount);
+/// the container's own metadata (header / icon / closable) is refreshed via
+/// the optional <see cref="UpdateContainer"/> callback. Excess containers
+/// are unmounted + removed; surplus new items are created + appended.
+/// Containers (and the mounted Content subtree underneath them) therefore
+/// survive renders that don't change the tab/pivot set — re-adding every
+/// <c>TabViewItem</c> / <c>PivotItem</c> would re-trigger the tab-strip
+/// entrance animation and steal focus from descendant controls. Mirrors the
+/// legacy <c>UpdateTabView</c> / <c>UpdatePivot</c> in-place arms.</para>
+///
+/// <para><b>Not covered (still legacy-only):</b> keyed reorder, pinnable tab
+/// headers, and the docking drag pipeline. Index-keyed pairing assumes the
+/// item at index <c>i</c> in the old list corresponds to index <c>i</c> in
+/// the new list.</para></summary>
 [Experimental("REACTOR_V1_PREVIEW")]
 public sealed record TabItemsHost<TElement, TControl, TItem>(
     Func<TElement, IReadOnlyList<TItem>> GetItems,
     Func<TControl, IList<object>> GetCollection,
     Func<TItem, Element> GetContent,
-    Func<TItem, UIElement?, object> CreateContainer)
+    Func<TItem, UIElement?, object> CreateContainer,
+    Action<TItem, TItem, object>? UpdateContainer = null)
     : ChildrenStrategy<TElement, TControl>, IItemsBinderStrategy
     where TElement : Element
     where TControl : FrameworkElement
 {
     void IItemsBinderStrategy.Bind(FrameworkElement control, Element? oldElement, Element element, Reconciler reconciler, Action requestRerender, bool isMount)
     {
-        _ = oldElement; // positional rebuild reads only the new items list
         var typedCtrl = (TControl)control;
         var typedEl = (TElement)element;
         var items = GetItems(typedEl);
         var collection = GetCollection(typedCtrl);
 
-        if (!isMount && collection.Count > 0)
+        if (isMount)
         {
-            // Tear down each existing container's mounted content. Each
-            // container is a per-host concrete WinUI type (TabViewItem /
-            // PivotItem) — the engine doesn't know its shape, but both
-            // have a Content property holding the previously-mounted
-            // UIElement. Reflection-free walk: cast to ContentControl
-            // (both inherit from it) and read Content.
-            for (int i = 0; i < collection.Count; i++)
-            {
-                if (collection[i] is WinUI.ContentControl cc && cc.Content is UIElement ui)
-                    reconciler.UnmountChild(ui);
-            }
-            collection.Clear();
+            for (int i = 0; i < items.Count; i++)
+                collection.Add(CreateContainer(items[i], MountContent(items[i], reconciler, requestRerender)));
+            return;
         }
 
-        for (int i = 0; i < items.Count; i++)
+        // Update path. Positional reconcile keyed by index against the
+        // previous items list so containers are preserved in place.
+        var oldItems = oldElement is TElement oldTyped ? GetItems(oldTyped) : null;
+
+        // Engine-invariant break (no previous element) or collection drift
+        // from the previous items count — fall back to a full rebuild rather
+        // than index into a mismatched collection.
+        if (oldItems is null || collection.Count != oldItems.Count)
         {
-            var item = items[i];
-            var content = GetContent(item);
-            var mounted = content is null ? null : reconciler.Mount(content, requestRerender);
-            var container = CreateContainer(item, mounted);
-            collection.Add(container);
+            RebuildAll(items, collection, reconciler, requestRerender);
+            return;
         }
+
+        int shared = global::System.Math.Min(oldItems.Count, items.Count);
+        for (int i = 0; i < shared; i++)
+        {
+            var oldItem = oldItems[i];
+            var newItem = items[i];
+            var container = collection[i];
+
+            // Reconcile the per-item Content in place. Only reassign when the
+            // realized control actually changed — re-assigning the same
+            // UIElement triggers WinUI's logical-tree detach→reattach on the
+            // whole subtree, which drops setState queued by descendant
+            // handlers before it lands.
+            if (container is WinUI.ContentControl cc)
+            {
+                var existing = cc.Content as UIElement;
+                var next = reconciler.ReconcileV1Child(GetContent(oldItem), GetContent(newItem), existing, requestRerender);
+                if (!ReferenceEquals(existing, next))
+                    cc.Content = next;
+            }
+
+            UpdateContainer?.Invoke(oldItem, newItem, container);
+        }
+
+        // Remove excess containers (highest index first so removals don't shift).
+        for (int i = collection.Count - 1; i >= shared; i--)
+        {
+            if (collection[i] is WinUI.ContentControl cc && cc.Content is UIElement ui)
+                reconciler.UnmountChild(ui);
+            collection.RemoveAt(i);
+        }
+
+        // Append surplus new items.
+        for (int i = shared; i < items.Count; i++)
+            collection.Add(CreateContainer(items[i], MountContent(items[i], reconciler, requestRerender)));
+    }
+
+    private UIElement? MountContent(TItem item, Reconciler reconciler, Action requestRerender)
+    {
+        var content = GetContent(item);
+        return content is null ? null : reconciler.Mount(content, requestRerender);
+    }
+
+    private void RebuildAll(IReadOnlyList<TItem> items, IList<object> collection, Reconciler reconciler, Action requestRerender)
+    {
+        // Tear down each existing container's mounted content. Both
+        // TabViewItem and PivotItem inherit ContentControl, so the engine
+        // can reach the previously-mounted UIElement reflection-free.
+        for (int i = collection.Count - 1; i >= 0; i--)
+        {
+            if (collection[i] is WinUI.ContentControl cc && cc.Content is UIElement ui)
+                reconciler.UnmountChild(ui);
+            collection.RemoveAt(i);
+        }
+        for (int i = 0; i < items.Count; i++)
+            collection.Add(CreateContainer(items[i], MountContent(items[i], reconciler, requestRerender)));
     }
 }
 

--- a/src/Reactor/Core/V1Protocol/Descriptor/ControlDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/ControlDescriptor.cs
@@ -4,6 +4,21 @@ using Microsoft.UI.Xaml;
 namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor;
 
 /// <summary>
+/// Spec 047 §14 Phase 3 prelude (Engine A1) — post-children mount callback
+/// signature for <see cref="ControlDescriptor{TElement,TControl}.AfterChildrenMount"/>.
+/// Invoked by <see cref="V1HandlerAdapter{TElement,TControl}"/> after the
+/// descriptor's children strategy has mounted/bound every child, so a
+/// descriptor can wire events that must subscribe strictly after children-add
+/// (e.g. <c>TabView.SelectionChanged</c>). Takes <see cref="MountContext"/> by
+/// <c>in</c> to preserve the allocation-free ref-struct contract.
+/// </summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+public delegate void AfterChildrenMountCallback<TElement, TControl>(
+    in MountContext ctx, TElement element, TControl control)
+    where TElement : Element
+    where TControl : FrameworkElement;
+
+/// <summary>
 /// Spec 047 §6 / §14 Phase 2 (Q1 spike) — declarative control description.
 ///
 /// <para>A descriptor is the data-driven alternative to a hand-coded
@@ -56,6 +71,14 @@ public sealed class ControlDescriptor<TElement, TControl>
     /// Update body returns. Defaults to <c>null</c> (treated as
     /// <see cref="None{TElement,TControl}"/> by the adapter).</summary>
     public ChildrenStrategy<TElement, TControl>? Children { get; init; }
+
+    /// <summary>Spec 047 §14 Phase 3 prelude (Engine A1) — optional post-children
+    /// mount hook. The interpreter (<see cref="DescriptorHandler{TElement,TControl}"/>)
+    /// surfaces it through <see cref="IElementHandler{TElement,TControl}.AfterChildrenMount"/>,
+    /// which the adapter invokes after every child has mounted. Use for events
+    /// that must subscribe after children-add (TabView SelectionChanged).
+    /// Defaults to <c>null</c> (no hook).</summary>
+    public AfterChildrenMountCallback<TElement, TControl>? AfterChildrenMount { get; init; }
 
     /// <summary><c>Setters</c> selector — the descriptor needs an opaque way
     /// to pull the element's <c>Action&lt;TControl&gt;[]</c> setters chain

--- a/src/Reactor/Core/V1Protocol/Descriptor/DescriptorHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/DescriptorHandler.cs
@@ -106,6 +106,12 @@ public sealed class DescriptorHandler<TElement, TControl> : IElementHandler<TEle
         return ctrl;
     }
 
+    /// <summary>§14 Phase 3 prelude (Engine A1) — forwards to the descriptor's
+    /// optional <see cref="ControlDescriptor{TElement,TControl}.AfterChildrenMount"/>
+    /// callback. The adapter invokes this after every child has mounted.</summary>
+    public void AfterChildrenMount(MountContext ctx, TElement element, TControl control)
+        => _descriptor.AfterChildrenMount?.Invoke(in ctx, element, control);
+
     public void Update(UpdateContext ctx, TElement oldEl, TElement newEl, TControl ctrl)
     {
         // §14 Phase 3-final: ItemsHost diff BEFORE prop Update loop, same

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/ButtonDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/ButtonDescriptor.cs
@@ -23,11 +23,16 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors;
 ///   <c>IsDisabledFocusable</c> is true (mirrors the legacy guard).</item>
 /// </list></para>
 ///
-/// <para><b>Known gap vs. hand-coded handler:</b> <c>ContentElement</c>
-/// (Button hosting a child Element rather than a string label) is not
-/// expressed here — the descriptor only handles the string-Content fast
-/// path. Authors needing nested-element content fall through to the
-/// legacy arm (V1 OFF) or wire it via setters.</para>
+/// <para><b>Known gap vs. hand-coded handler — and why this descriptor is no
+/// longer the registered engine path:</b> <c>ContentElement</c> (Button
+/// hosting a child Element rather than a string label) is not expressed here —
+/// the descriptor only handles the string-Content fast path. Because dropping
+/// element content is a real regression once the type is registered (the
+/// legacy fall-through is removed), the engine instead registers the delegate
+/// <c>ButtonHandler</c>, which runs the COMPLETE legacy
+/// <c>MountButton</c>/<c>UpdateButton</c> bodies (including
+/// <c>ContentElement</c>). This descriptor is retained for its isolated
+/// selftests and the perf-bench descriptor variant.</para>
 /// </summary>
 [Experimental("REACTOR_V1_PREVIEW")]
 internal static class ButtonDescriptor

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/PivotDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/PivotDescriptor.cs
@@ -45,6 +45,11 @@ internal static class PivotDescriptor
                 {
                     Header = item.Header,
                     Content = mounted,
+                },
+                UpdateContainer: static (oldItem, newItem, container) =>
+                {
+                    if (container is WinUI.PivotItem pi && pi.Header as string != newItem.Header)
+                        pi.Header = newItem.Header;
                 }),
             GetSetters = static e => e.Setters,
         }

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/TabViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/TabViewDescriptor.cs
@@ -74,6 +74,14 @@ internal static class TabViewDescriptor
                     };
                     if (item.Icon is not null) tvi.IconSource = Reconciler.ResolveIconSource(item.Icon);
                     return tvi;
+                },
+                UpdateContainer: static (oldItem, newItem, container) =>
+                {
+                    if (container is not WinUI.TabViewItem tvi) return;
+                    if (tvi.Header as string != newItem.Header) tvi.Header = newItem.Header;
+                    if (tvi.IsClosable != newItem.IsClosable) tvi.IsClosable = newItem.IsClosable;
+                    if (!Equals(newItem.Icon, oldItem.Icon))
+                        tvi.IconSource = newItem.Icon is null ? null : Reconciler.ResolveIconSource(newItem.Icon);
                 }),
             GetSetters = static e => e.Setters,
         }

--- a/src/Reactor/Core/V1Protocol/Handlers/ButtonHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/ButtonHandler.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+/// <summary>
+/// Spec 047 §14 Phase 3 prelude — Button port via Path B delegate.
+///
+/// <para><b>Why delegate, not <c>ButtonDescriptor</c>:</b> the descriptor only
+/// expresses the string-<c>Label</c> fast path and ignores
+/// <see cref="ButtonElement.ContentElement"/> (a Button hosting a child
+/// Element rather than a string). When the type was registered as a
+/// descriptor that gap became a real V1-ON regression — controls such as the
+/// PropertyGrid expand button render blank under V1 because their element
+/// content is dropped. The descriptor cannot cleanly add element content: its
+/// <c>None</c> children strategy plus the <c>OneWay(Label → Content)</c> write
+/// would conflict with a <c>SingleContent</c> strategy (the engine clears the
+/// slot unconditionally and both paths target <c>Content</c>). Delegating to
+/// the engine's existing internal <see cref="Reconciler.MountButton"/> /
+/// <see cref="Reconciler.UpdateButton"/> bodies runs the COMPLETE legacy
+/// implementation (enabled / disabled-focusable dim, Click trampoline,
+/// setters AND <c>ContentElement</c> mount + in-place reconcile), so V1 ON is
+/// byte-identical to V1 OFF.</para>
+///
+/// <para><b>Decorator shape for unmount parity:</b> <c>WinUI.Button</c> is a
+/// <c>ContentControl</c>. When the V1 flag is OFF the engine recurses into
+/// <c>Content</c> in both unmount paths (UnmountRecursive and
+/// UnmountAndCollect) so a <c>ContentElement</c> subtree containing a Component
+/// runs its <c>UseEffect</c> cleanup. A standard <c>IElementHandler</c> would
+/// return <see cref="V1UnmountDisposition.CollectSelf"/> and pool the button
+/// WITHOUT recursing — leaking that cleanup. Returning
+/// <see cref="V1UnmountDisposition.ContinueDefaultTraversal"/> makes the engine
+/// fall through to the same <c>ContentControl</c> recursion V1 OFF uses, so
+/// teardown is identical across both flags.</para>
+///
+/// <para><b>No control substitution:</b> <see cref="Reconciler.UpdateButton"/>
+/// always returns <c>null</c> (pure in-place reconcile), so the
+/// null-forgiving <c>?? control</c> keeps the existing control identity.</para>
+/// </summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class ButtonHandler : IDecoratorElementHandler<ButtonElement>
+{
+    public UIElement Mount(MountContext ctx, ButtonElement el)
+        => ctx.Reconciler.MountButton(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, ButtonElement oldEl, ButtonElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateButton(oldEl, newEl, (WinUI.Button)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, ButtonElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}

--- a/src/Reactor/Core/V1Protocol/Handlers/CheckBoxHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/CheckBoxHandler.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+// Spec 047 §14 Phase 3 prelude — CheckBox value-control closure.
+//
+// CheckBoxDescriptor uses the generic `.Controlled` write path, whose
+// suppress-token bookkeeping differs from the hand-coded MountCheckBox/
+// UpdateCheckBox value-control pattern (ChangeEchoSuppressor + SetElementTag-
+// first). The descriptor calls the suppressed setter whenever the element's
+// old != new value, even when the control already holds the new value (a
+// no-op same-value write). When WinUI raises no event for that no-op, the
+// suppress token is stranded and swallows the user's *next* real toggle.
+// Legacy UpdateCheckBox only begins suppression when cb.IsChecked != target,
+// avoiding the stranded token. The descriptor also documents gaps for
+// three-state mode + OnCheckedStateChanged. Symptom under V1 ON:
+// ConditionalRendering_Toggle_HiddenAgain — the second checkbox toggle is
+// swallowed, state stays true, and the conditional content never hides.
+//
+// Fix: Path B delegate to the complete legacy MountCheckBox/UpdateCheckBox
+// bodies (identical to V1 OFF). CheckBox is a ContentControl (Label -> Content)
+// with no Reactor child elements; ContinueDefaultTraversal keeps unmount/pool
+// behavior identical to V1 OFF (mirror ButtonHandler). Descriptor retained for
+// isolated selftests.
+
+/// <summary>§14 prelude — CheckBox (value control; legacy echo-suppression).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class CheckBoxHandler : IDecoratorElementHandler<CheckBoxElement>
+{
+    public UIElement Mount(MountContext ctx, CheckBoxElement el)
+        => ctx.Reconciler.MountCheckBox(el);
+
+    public UIElement Update(UpdateContext ctx, CheckBoxElement oldEl, CheckBoxElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateCheckBox(oldEl, newEl, (WinUI.CheckBox)control) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, CheckBoxElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}

--- a/src/Reactor/Core/V1Protocol/Handlers/ExpanderHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/ExpanderHandler.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+// Spec 047 §14 Phase 3 prelude — Expander callback/template closure.
+//
+// ExpanderDescriptor diverges from the hand-coded MountExpander/UpdateExpander
+// bodies for callbacks added/changed on UPDATE (the IsExpanded-changed
+// callback, HeaderTemplate, ContentTransitions, ExpandDirection). Symptom
+// under V1 ON: ExpanderUpdate_CallbacksFire — an Expander mounted with no
+// callback, then updated to add onIsExpandedChanged, never fires the callback
+// when IsExpanded is toggled afterward.
+//
+// Fix: Path B delegate to the complete legacy MountExpander/UpdateExpander
+// bodies (identical to V1 OFF). Expander has Header + Content child elements;
+// ContinueDefaultTraversal lets the engine's default unmount recursion run
+// (parity with V1 OFF). Descriptor retained for isolated selftests.
+
+/// <summary>§14 prelude — Expander (header/content + IsExpanded callback wiring).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class ExpanderHandler : IDecoratorElementHandler<ExpanderElement>
+{
+    public UIElement Mount(MountContext ctx, ExpanderElement el)
+        => ctx.Reconciler.MountExpander(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, ExpanderElement oldEl, ExpanderElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateExpander(oldEl, newEl, (WinUI.Expander)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, ExpanderElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}

--- a/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.CodeAnalysis;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+/// <summary>
+/// Spec 047 §14 Phase 3 prelude — GridView port (closes the deferred dispatch
+/// carve so <see cref="GridViewElement"/> routes through V1).
+///
+/// <para><b>Path B (delegate, no children strategy):</b> mirrors the Phase 1
+/// <see cref="ListViewHandler"/> exactly. Delegates Mount / Update to the
+/// engine's internal <see cref="Reconciler.MountGridView"/> /
+/// <see cref="Reconciler.UpdateGridView"/> bodies, which install the same
+/// <c>ItemsSource = Range(0..N) + shared ItemTemplate + ContainerContentChanging</c>
+/// lazy container-realization contract as ListView (the
+/// <c>GridViewDescriptor</c>'s <c>ItemsHost&lt;&gt;</c> strategy is
+/// intentionally <i>not</i> registered — it pre-mounts every item with no
+/// virtualization, diverging from this legacy behavior).</para>
+///
+/// <para><c>Children = null</c> because the delegate body fully owns child
+/// realization. Unmount uses the default <c>CollectSelf</c> disposition
+/// (matching ListView): realized containers are torn down by the recycle arm
+/// of <c>ContainerContentChanging</c>, so behavior is identical V1 ON ≡
+/// V1 OFF.</para>
+/// </summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.GridView>
+{
+    public WinUI.GridView Mount(MountContext ctx, GridViewElement el)
+        => ctx.Reconciler.MountGridView(el, ctx.RequestRerender);
+
+    public void Update(UpdateContext ctx, GridViewElement oldEl, GridViewElement newEl, WinUI.GridView ctrl)
+        => ctx.Reconciler.UpdateGridView(oldEl, newEl, ctrl, ctx.RequestRerender);
+
+    public ChildrenStrategy<GridViewElement, WinUI.GridView>? Children => null;
+}

--- a/src/Reactor/Core/V1Protocol/Handlers/LazyStackHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/LazyStackHandler.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+// Spec 047 §14 Phase 3 prelude — Lazy*Stack ScrollViewer-wrapper closure.
+//
+// The V1 LazyStackDescriptor port (LazyStackDescriptor.cs) uses ItemsRepeater
+// directly as TControl, because a descriptor's RentControl returns a single
+// control with no place to install a wrapping ScrollViewer. The legacy
+// MountLazyStack instead wraps the ItemsRepeater in a ScrollViewer (with
+// orientation-appropriate scrollbars + ScrollViewerSetters). Under V1 ON the
+// descriptor path therefore had no ScrollViewer, failing every fixture that
+// asserts FindControl<ScrollViewer> (LazyVStack/HStack_ScrollViewer,
+// LazyHStack_HScrollEnabled, ScrollPop/Back, HookPaging_Scroll*) and the
+// component-cleanup-on-unmount gate (EFR_LazyStackUnmount) since there was no
+// ScrollViewer for the engine to recurse through.
+//
+// Fix: route the Lazy*Stack family through a Path B decorator that runs the
+// complete legacy MountLazyStack/UpdateLazyStack bodies (identical to V1 OFF).
+// Registered for DERIVED types (LazyVStackElement<T>/LazyHStackElement<T> all
+// derive from LazyStackElementBase) via RegisterDecoratorHandlerForDerivedTypes.
+// ContinueDefaultTraversal on unmount so the engine falls through to the same
+// ScrollViewer -> ItemsRepeater -> realized-row recursion V1 OFF uses, running
+// each row component's UseEffect cleanup. The descriptor type is retained for
+// its isolated selftests (same pattern as the panel descriptors).
+
+/// <summary>§14 prelude — Lazy*Stack (ScrollViewer-wrapped virtualizing list).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class LazyStackHandler : IDecoratorElementHandler<LazyStackElementBase>
+{
+    public UIElement Mount(MountContext ctx, LazyStackElementBase el)
+        => ctx.Reconciler.MountLazyStack(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, LazyStackElementBase oldEl, LazyStackElementBase newEl, UIElement control)
+        => ctx.Reconciler.UpdateLazyStack(newEl, (WinUI.ScrollViewer)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, LazyStackElementBase? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}

--- a/src/Reactor/Core/V1Protocol/Handlers/NavigationHostHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/NavigationHostHandler.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.CodeAnalysis;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+/// <summary>
+/// Spec 047 §14 Phase 3 prelude — NavigationHost port (closes the deferred
+/// dispatch carve so <see cref="NavigationHostElement"/> routes through V1).
+///
+/// <para><b>Path B (delegate, no children strategy):</b> delegates Mount /
+/// Update to the engine's existing internal
+/// <see cref="Reconciler.MountNavigationHost"/> /
+/// <see cref="Reconciler.UpdateNavigationHost"/> bodies, which own the
+/// per-instance route / cache / transition state tracked in the reconciler's
+/// <c>_navigationHostNodes</c> table. <c>Children = null</c> because the
+/// delegate body fully owns child mount/swap inside the host Grid.</para>
+///
+/// <para><b>Unmount parity:</b> teardown stays on the flag-independent
+/// <c>UnmountRecursive</c> intercept (Reconciler.cs), which matches the
+/// tracked node and tears down its current child before the V1 unmount arm
+/// is reached. Cleanup is therefore byte-identical V1 ON ≡ V1 OFF, so this
+/// handler intentionally does not override <c>Unmount</c>. The defensive
+/// "lost tracking" remount inside <see cref="Reconciler.UpdateNavigationHost"/>
+/// is unreachable under normal V1 operation (the node is always present after
+/// <c>Mount</c>), so the void <see cref="Update"/> here — which cannot
+/// substitute the control — preserves behavior.</para>
+/// </summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class NavigationHostHandler : IElementHandler<NavigationHostElement, WinUI.Grid>
+{
+    public WinUI.Grid Mount(MountContext ctx, NavigationHostElement el)
+        => ctx.Reconciler.MountNavigationHost(el, ctx.RequestRerender);
+
+    public void Update(UpdateContext ctx, NavigationHostElement oldEl, NavigationHostElement newEl, WinUI.Grid ctrl)
+        => ctx.Reconciler.UpdateNavigationHost(oldEl, newEl, ctrl, ctx.RequestRerender);
+
+    public ChildrenStrategy<NavigationHostElement, WinUI.Grid>? Children => null;
+}

--- a/src/Reactor/Core/V1Protocol/Handlers/OverlayDecoratorHandlers.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/OverlayDecoratorHandlers.cs
@@ -1,0 +1,126 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+// Spec 047 §14 Phase 3 prelude — overlay carve closures.
+//
+// All seven overlay elements (ContentDialog, Flyout, MenuBar, CommandBar,
+// MenuFlyout, Popup, CommandBarFlyout) route through V1 via decorator-style
+// handlers that delegate Mount/Update to the engine's existing internal
+// MountXxx/UpdateXxx bodies and return ContinueDefaultTraversal on unmount.
+//
+// Why ContinueDefaultTraversal for every overlay: when the V1 flag is OFF the
+// engine SKIPS the V1 unmount arm entirely and runs the type-based recursion
+// in UnmountRecursive directly. ContinueDefaultTraversal tells the engine to
+// fall through to that SAME recursion after the (no-op) handler Unmount body.
+// Combined with delegating to the identical legacy Mount/Update bodies, the
+// V1 ON path is byte-identical to V1 OFF across mount, update AND unmount —
+// including the side-mount semantics of flyout content, popup children and
+// dialog content (whatever the legacy path does, this preserves exactly).
+//
+// The three target-wrapping decorators (Flyout, MenuFlyout, CommandBarFlyout)
+// return their Target's mounted control; the legacy body may return null when
+// the Target mounts to nothing (no attachable target) — the null-forgiving
+// operator preserves that (the engine installs null in the slot, same as
+// V1 OFF). Update returns the legacy result when non-null (a Target type-swap
+// substitutes the control) and otherwise keeps the existing control.
+
+/// <summary>§14 prelude — ContentDialog (modal placeholder + async ShowAsync).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class ContentDialogHandler : IDecoratorElementHandler<ContentDialogElement>
+{
+    public UIElement Mount(MountContext ctx, ContentDialogElement el)
+        => ctx.Reconciler.MountContentDialog(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, ContentDialogElement oldEl, ContentDialogElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateContentDialog(oldEl, newEl, (FrameworkElement)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, ContentDialogElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — Flyout (target-wrapping decorator).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class FlyoutHandler : IDecoratorElementHandler<FlyoutElement>
+{
+    public UIElement Mount(MountContext ctx, FlyoutElement el)
+        => ctx.Reconciler.MountFlyout(el, ctx.RequestRerender)!;
+
+    public UIElement Update(UpdateContext ctx, FlyoutElement oldEl, FlyoutElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateFlyoutElement(oldEl, newEl, control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, FlyoutElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — MenuBar (normal control; plain-WinUI menu items).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class MenuBarHandler : IDecoratorElementHandler<MenuBarElement>
+{
+    public UIElement Mount(MountContext ctx, MenuBarElement el)
+        => ctx.Reconciler.MountMenuBar(el);
+
+    public UIElement Update(UpdateContext ctx, MenuBarElement oldEl, MenuBarElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateMenuBar(oldEl, newEl, (WinUI.MenuBar)control) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, MenuBarElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — CommandBar (normal control; Content is a Reactor child).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class CommandBarHandler : IDecoratorElementHandler<CommandBarElement>
+{
+    public UIElement Mount(MountContext ctx, CommandBarElement el)
+        => ctx.Reconciler.MountCommandBar(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, CommandBarElement oldEl, CommandBarElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateCommandBar(oldEl, newEl, (WinUI.CommandBar)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, CommandBarElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — MenuFlyout (target-wrapping decorator).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class MenuFlyoutHandler : IDecoratorElementHandler<MenuFlyoutElement>
+{
+    public UIElement Mount(MountContext ctx, MenuFlyoutElement el)
+        => ctx.Reconciler.MountMenuFlyout(el, ctx.RequestRerender)!;
+
+    public UIElement Update(UpdateContext ctx, MenuFlyoutElement oldEl, MenuFlyoutElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateMenuFlyout(oldEl, newEl, control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, MenuFlyoutElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — Popup (StackPanel wrapper hosting a WinUI Popup).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class PopupHandler : IDecoratorElementHandler<PopupElement>
+{
+    public UIElement Mount(MountContext ctx, PopupElement el)
+        => ctx.Reconciler.MountPopup(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, PopupElement oldEl, PopupElement newEl, UIElement control)
+        => ctx.Reconciler.UpdatePopup(oldEl, newEl, (WinUI.StackPanel)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, PopupElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — CommandBarFlyout (target-wrapping decorator).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class CommandBarFlyoutHandler : IDecoratorElementHandler<CommandBarFlyoutElement>
+{
+    public UIElement Mount(MountContext ctx, CommandBarFlyoutElement el)
+        => ctx.Reconciler.MountCommandBarFlyout(el, ctx.RequestRerender)!;
+
+    public UIElement Update(UpdateContext ctx, CommandBarFlyoutElement oldEl, CommandBarFlyoutElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateCommandBarFlyout(oldEl, newEl, control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, CommandBarFlyoutElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}

--- a/src/Reactor/Core/V1Protocol/Handlers/PanelDelegateHandlers.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/PanelDelegateHandlers.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+// Spec 047 §14 Phase 3 prelude — panel keyed-reconcile closure.
+//
+// The V1 Panel<> children strategy (V1HandlerAdapter.cs:231-290) reconciles
+// children BY INDEX with no keyed reconcile (a deliberately-deferred Phase 3
+// follow-up — see the "Phase 1 limitation" comment there). That loses WinUI
+// control identity on keyed reorder/reverse/swap/remove-middle, diverging from
+// the legacy hand-coded panel update methods which call ReconcileChildren ->
+// ChildReconciler (the spec-042 keyed LIS + positional diff) and re-apply
+// attached props (Grid.Row/Column, Flex, Canvas, WrapGrid spans, RelativePanel
+// sibling refs). Under V1 ON the descriptor path failed ~17 identity-preservation
+// fixtures (FlexColumn_KeyedChildren_*, KeyedReorder_Reused, LargeKeyed_*,
+// MultiCycle_*, Reconciler_KeyedList_ControlReused) that pass under V1 OFF.
+//
+// Fix: route each panel through a Path B delegate decorator that runs the
+// COMPLETE legacy Mount*/Update* body (identical to V1 OFF). Decorator shape
+// (ContinueDefaultTraversal) so unmount falls through to the type-based
+// recursion V1 OFF uses — every control here is a WinUI.Panel subclass and the
+// first branch of BOTH unmount paths (UnmountRecursive / UnmountAndCollect)
+// recurses panel.Children then pools the panel, so teardown is byte-identical.
+// Update returns the legacy result when non-null (UpdateRelativePanel may
+// substitute the whole control on a child-count change) and otherwise keeps
+// the existing control. The matching descriptor types are retained for their
+// isolated selftests + perf-bench variant (same pattern as ButtonDescriptor).
+
+/// <summary>§14 prelude — Flex (CSS flexbox panel; keyed reconcile + flex attached).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class FlexPanelHandler : IDecoratorElementHandler<FlexElement>
+{
+    public UIElement Mount(MountContext ctx, FlexElement el)
+        => ctx.Reconciler.MountFlex(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, FlexElement oldEl, FlexElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateFlex(oldEl, newEl, (Layout.FlexPanel)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, FlexElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — StackPanel (VStack/HStack; keyed reconcile).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class StackPanelHandler : IDecoratorElementHandler<StackElement>
+{
+    public UIElement Mount(MountContext ctx, StackElement el)
+        => ctx.Reconciler.MountStack(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, StackElement oldEl, StackElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateStack(oldEl, newEl, (WinUI.StackPanel)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, StackElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — Grid (keyed reconcile on count change + grid placement).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class GridPanelHandler : IDecoratorElementHandler<GridElement>
+{
+    public UIElement Mount(MountContext ctx, GridElement el)
+        => ctx.Reconciler.MountGrid(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, GridElement oldEl, GridElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateGrid(oldEl, newEl, (WinUI.Grid)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, GridElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — Canvas (keyed reconcile + Canvas.Left/Top).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class CanvasPanelHandler : IDecoratorElementHandler<CanvasElement>
+{
+    public UIElement Mount(MountContext ctx, CanvasElement el)
+        => ctx.Reconciler.MountCanvas(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, CanvasElement oldEl, CanvasElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateCanvas(oldEl, newEl, (WinUI.Canvas)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, CanvasElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — RelativePanel (sibling-ref attached; Update may substitute the control).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class RelativePanelHandler : IDecoratorElementHandler<RelativePanelElement>
+{
+    public UIElement Mount(MountContext ctx, RelativePanelElement el)
+        => ctx.Reconciler.MountRelativePanel(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, RelativePanelElement oldEl, RelativePanelElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateRelativePanel(oldEl, newEl, (WinUI.RelativePanel)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, RelativePanelElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 prelude — VariableSizedWrapGrid (keyed reconcile + spans).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class WrapGridHandler : IDecoratorElementHandler<WrapGridElement>
+{
+    public UIElement Mount(MountContext ctx, WrapGridElement el)
+        => ctx.Reconciler.MountWrapGrid(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, WrapGridElement oldEl, WrapGridElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateWrapGrid(oldEl, newEl, (WinUI.VariableSizedWrapGrid)control, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, WrapGridElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}

--- a/src/Reactor/Core/V1Protocol/Handlers/TabViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/TabViewHandler.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics.CodeAnalysis;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+/// <summary>
+/// Spec 047 §14 Phase 3 prelude — TabView port (closes the deferred dispatch
+/// carve so <see cref="TabViewElement"/> routes through V1).
+///
+/// <para><b>Path B (delegate, no children strategy):</b> delegates Mount /
+/// Update to the engine's existing internal
+/// <see cref="Reconciler.MountTabView"/> /
+/// <see cref="Reconciler.UpdateTabView"/> bodies — the COMPLETE legacy
+/// implementation that already owns the spec 045 §2.4 docking drag pipeline,
+/// §2.2 pinnable tab headers, in-place tab-content reconcile, conditional
+/// SelectedIndex write, and the TabStripHeader / TabStripFooter Element
+/// slots. This is distinct from the (unregistered) <c>TabViewDescriptor</c> +
+/// <c>TabItemsHost</c> port, which intentionally leaves those features on the
+/// legacy arm; the delegate runs the full feature set because it IS the
+/// legacy code.</para>
+///
+/// <para><b>No control substitution:</b> <see cref="Reconciler.UpdateTabView"/>
+/// always returns <c>null</c> (pure in-place reconcile), so the void
+/// <see cref="IElementHandler{TElement,TControl}.Update"/> shape preserves
+/// behavior — identity is never swapped on update.</para>
+///
+/// <para><b>Unmount parity:</b> the standard adapter returns
+/// <see cref="V1UnmountDisposition.CollectSelf"/>, which pools the TabView
+/// and stops traversal in both unmount paths. V1 OFF reaches the same
+/// outcome — <c>WinUI.TabView</c> is an <c>ItemsControl</c> not matched by
+/// any of the Panel / Border / ScrollViewer / UserControl / ContentControl
+/// recursion branches, so the legacy fall-through also pools the control
+/// without recursing into tab content. Mount/update under V1 ON are likewise
+/// unchanged from the previously-carved V1-ON path (which already ran
+/// <c>MountTabView</c>/<c>UpdateTabView</c> via the legacy switch);
+/// registering this handler only makes the parity-safe unmount arm fire.
+/// Cleanup is therefore byte-identical V1 ON ≡ V1 OFF, so this handler
+/// intentionally does not override <c>Unmount</c>.</para>
+/// </summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class TabViewHandler : IElementHandler<TabViewElement, WinUI.TabView>
+{
+    public WinUI.TabView Mount(MountContext ctx, TabViewElement el)
+        => ctx.Reconciler.MountTabView(el, ctx.RequestRerender);
+
+    public void Update(UpdateContext ctx, TabViewElement oldEl, TabViewElement newEl, WinUI.TabView ctrl)
+        => ctx.Reconciler.UpdateTabView(oldEl, newEl, ctrl, ctx.RequestRerender);
+
+    public ChildrenStrategy<TabViewElement, WinUI.TabView>? Children => null;
+}

--- a/src/Reactor/Core/V1Protocol/Handlers/TemplatedListHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/TemplatedListHandler.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+// Spec 047 §14 Phase 3 prelude — typed templated-list closure
+// (ListView<T> / GridView<T> / FlipView<T>).
+//
+// The descriptor ports (TemplatedListViewDescriptor / TemplatedGridViewDescriptor
+// / TemplatedFlipViewDescriptor, registered for derived types) do not run the
+// legacy move/reorder animation pipeline. Legacy UpdateTemplatedListView
+// (Reconciler.Update.cs) calls ApplyMoveAnimations(lvb, movedRows, ambient.Kind)
+// so a keyed reorder under Animations.Animate(Spring, ...) attaches the
+// Offset implicit animation to the moved container's Visual. Symptom under
+// V1 ON: AAF_MoveSpring_OffsetImplicitAttached — the moved row's container
+// never receives ImplicitAnimations["Offset"].
+//
+// Fix: a single Path B decorator registered on the common base
+// TemplatedListElementBase (all three typed bases derive from it), replacing
+// the three per-kind descriptor-for-derived registrations. Mount delegates to
+// MountTemplatedList (which switches on TemplatedControlKind to produce the
+// right WinUI control); Update dispatches to the matching legacy update body
+// by control type (mirrors the legacy reconcile switch). Identical to V1 OFF.
+// ContinueDefaultTraversal on unmount; ListViewBase container recycling is
+// owned by the legacy recycle path, same as V1 OFF. Descriptors retained for
+// isolated selftests.
+
+/// <summary>§14 prelude — typed templated lists (ListView/GridView/FlipView&lt;T&gt;).</summary>
+[Experimental("REACTOR_V1_PREVIEW")]
+internal sealed class TemplatedListHandler : IDecoratorElementHandler<TemplatedListElementBase>
+{
+    public UIElement Mount(MountContext ctx, TemplatedListElementBase el)
+        => ctx.Reconciler.MountTemplatedList(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, TemplatedListElementBase oldEl, TemplatedListElementBase newEl, UIElement control)
+    {
+        var rr = ctx.RequestRerender;
+        UIElement? replacement = control switch
+        {
+            WinUI.GridView gv => ctx.Reconciler.UpdateTemplatedGridView(oldEl, newEl, gv, rr),
+            WinUI.FlipView fv => ctx.Reconciler.UpdateTemplatedFlipView(oldEl, newEl, fv, rr),
+            WinUI.ListView lv => ctx.Reconciler.UpdateTemplatedListView(oldEl, newEl, lv, rr),
+            _ => throw new InvalidOperationException(
+                $"TemplatedListHandler: unexpected control type {control.GetType().Name} for element {newEl.GetType().Name}."),
+        };
+        return replacement ?? control;
+    }
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, TemplatedListElementBase? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}

--- a/src/Reactor/Core/V1Protocol/IElementHandler.cs
+++ b/src/Reactor/Core/V1Protocol/IElementHandler.cs
@@ -51,4 +51,17 @@ public interface IElementHandler<TElement, TControl>
     /// otherwise the handler is a leaf for the purposes of child
     /// reconciliation.</summary>
     ChildrenStrategy<TElement, TControl>? Children => null;
+
+    /// <summary>Spec 047 §14 Phase 3 prelude (Engine A1) — optional hook the
+    /// engine invokes from <see cref="V1HandlerAdapter{TElement,TControl}"/>
+    /// after the <see cref="Children"/> strategy has mounted/bound every child
+    /// (and after any items-binder strategy the handler dispatched inline).
+    /// Default no-op.
+    ///
+    /// <para>Override this to wire events whose subscription must happen
+    /// strictly after children-add — e.g. <c>TabView.SelectionChanged</c>,
+    /// which WinUI fires spuriously while the first tab is being added if the
+    /// handler subscribes during the prop-apply phase. Subscribing here side-
+    /// steps that first-add echo.</para></summary>
+    void AfterChildrenMount(MountContext ctx, TElement element, TControl control) { }
 }

--- a/src/Reactor/Core/V1Protocol/V1HandlerAdapter.cs
+++ b/src/Reactor/Core/V1Protocol/V1HandlerAdapter.cs
@@ -41,6 +41,13 @@ internal sealed class V1HandlerAdapter<TElement, TControl> : IV1HandlerEntry
         if (strategy is not null)
             DispatchChildrenMount(strategy, ctx, typedEl, control);
 
+        // §14 Phase 3 prelude (Engine A1) — post-children mount hook. Fires
+        // after every child has mounted (whether via the strategy switch above
+        // or an items-binder strategy the handler dispatched inline before
+        // returning). Lets handlers subscribe events that must wire after
+        // children-add. Default no-op for handlers that don't override it.
+        _handler.AfterChildrenMount(ctx, typedEl, control);
+
         return control;
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047V1ProtocolDescriptorFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047V1ProtocolDescriptorFixtures.cs
@@ -5853,8 +5853,35 @@ internal static class Spec047V1ProtocolDescriptorFixtures
                 H.Check("Desc_TabView_AddButtonVisible", tv.IsAddTabButtonVisible == true);
                 H.Check("Desc_TabView_SelectedIndex0", tv.SelectedIndex == 0);
 
-                // Update — rebuild with different tab set.
-                var el2 = el1 with
+                // In-place reconcile — a same-count update must preserve the
+                // existing TabViewItem containers AND their mounted content
+                // subtree. Re-creating them re-triggers the tab-strip entrance
+                // animation and steals focus from descendant controls.
+                var keptTab0 = tv.TabItems[0];
+                var keptTabContent0 = (tv.TabItems[0] as WinUI.TabViewItem)?.Content;
+                var elSame = el1 with
+                {
+                    Tabs = new[]
+                    {
+                        new TabViewItemData("tab-a2", new TextBlockElement("content-a")),
+                        new TabViewItemData("tab-b", new TextBlockElement("content-b")) { IsClosable = false },
+                    },
+                };
+                rec.UpdateChild(el1, elSame, tv, _noOp);
+                await Harness.Render();
+                H.Check("Desc_TabView_SameShape_Count2", tv.TabItems.Count == 2);
+                H.Check("Desc_TabView_SameShape_ContainerPreserved",
+                    ReferenceEquals(tv.TabItems[0], keptTab0));
+                H.Check("Desc_TabView_SameShape_ContentPreserved",
+                    keptTabContent0 is not null
+                    && ReferenceEquals((tv.TabItems[0] as WinUI.TabViewItem)?.Content, keptTabContent0));
+                H.Check("Desc_TabView_SameShape_HeaderUpdatedInPlace",
+                    (tv.TabItems[0] as WinUI.TabViewItem)?.Header as string == "tab-a2");
+                H.Check("Desc_TabView_SameShape_ClosablePreserved",
+                    (tv.TabItems[1] as WinUI.TabViewItem)?.IsClosable == false);
+
+                // Update — shrink the tab set (positional truncate tail).
+                var el2 = elSame with
                 {
                     Tabs = new[]
                     {
@@ -5862,7 +5889,7 @@ internal static class Spec047V1ProtocolDescriptorFixtures
                     },
                     IsAddTabButtonVisible = false,
                 };
-                rec.UpdateChild(el1, el2, tv, _noOp);
+                rec.UpdateChild(elSame, el2, tv, _noOp);
                 await Harness.Render();
                 H.Check("Desc_TabView_AfterUpdate_Count1", tv.TabItems.Count == 1);
                 H.Check("Desc_TabView_AfterUpdate_HeaderX",
@@ -6367,8 +6394,33 @@ internal static class Spec047V1ProtocolDescriptorFixtures
                 H.Check("Desc_Pivot_TitleSet", (pv.Title as string) == "My Pivot");
                 H.Check("Desc_Pivot_SelectedIndex0", pv.SelectedIndex == 0);
 
-                // Update — different items.
-                var el2 = el1 with
+                // In-place reconcile — a same-count update must preserve the
+                // existing PivotItem containers AND their mounted content
+                // subtree. Re-creating them re-triggers the pivot entrance
+                // animation and steals focus from descendant controls.
+                var keptPivotItem0 = pv.Items[0];
+                var keptPivotContent0 = (pv.Items[0] as WinUI.PivotItem)?.Content;
+                var elSame = el1 with
+                {
+                    Items = new[]
+                    {
+                        new PivotItemData("pivot-a2", new TextBlockElement("body-a")),
+                        new PivotItemData("pivot-b", new TextBlockElement("body-b")),
+                    },
+                };
+                rec.UpdateChild(el1, elSame, pv, _noOp);
+                await Harness.Render();
+                H.Check("Desc_Pivot_SameShape_Count2", pv.Items.Count == 2);
+                H.Check("Desc_Pivot_SameShape_ContainerPreserved",
+                    ReferenceEquals(pv.Items[0], keptPivotItem0));
+                H.Check("Desc_Pivot_SameShape_ContentPreserved",
+                    keptPivotContent0 is not null
+                    && ReferenceEquals((pv.Items[0] as WinUI.PivotItem)?.Content, keptPivotContent0));
+                H.Check("Desc_Pivot_SameShape_HeaderUpdatedInPlace",
+                    (pv.Items[0] as WinUI.PivotItem)?.Header as string == "pivot-a2");
+
+                // Update — grow the item set (positional add tail).
+                var el2 = elSame with
                 {
                     Items = new[]
                     {
@@ -6377,7 +6429,7 @@ internal static class Spec047V1ProtocolDescriptorFixtures
                         new PivotItemData("pivot-z", new TextBlockElement("body-z")),
                     },
                 };
-                rec.UpdateChild(el1, el2, pv, _noOp);
+                rec.UpdateChild(elSame, el2, pv, _noOp);
                 await Harness.Render();
                 H.Check("Desc_Pivot_AfterUpdate_Count3", pv.Items.Count == 3);
                 H.Check("Desc_Pivot_AfterUpdate_FirstHeader",


### PR DESCRIPTION
## Summary

Closes the remaining **V1-protocol descriptor regressions** so that, when `Reactor.UseV1Protocol` is ON, the rendered WinUI behavior is byte-identical to the legacy path (V1 ON ≡ V1 OFF). **The library default stays V1 OFF** — this PR does *not* flip the production switch (see "Not in scope" below).

Each fix follows the proven **Path-B delegate** recipe: convert a buggy V1 descriptor into an `IDecoratorElementHandler` that delegates Mount/Update to the existing, unchanged legacy `Mount*`/`Update*` engine bodies, returning `ContinueDefaultTraversal` for unmount.

## What changed

| Area | Fix |
|---|---|
| **Overlays** (7) | Close V1 dispatch carves |
| **TabView** | Route through V1 delegate; `TabItemsHost` reconciles in place (no full rebuild → no tab re-animation) |
| **NavigationHost / GridView** | Route through V1 dispatch |
| **Button** | `ContentElement` gap |
| **6 panels** (Flex/Stack/Grid/Canvas/RelativePanel/WrapGrid) | Keyed-reconcile gap via delegates |
| **Lazy*Stack** | ScrollViewer-wrapper gap (new `RegisterDecoratorHandlerForDerivedTypes<TBase>` API) |
| **CheckBox** | Echo-suppression: legacy `UpdateCheckBox` only suppresses when target ≠ current value (fixes swallowed 2nd toggle) |
| **Expander** | Restores `ContentTransitions` + late callback subscription |
| **Templated ListView/GridView/FlipView`<T>`** | One decorator on the common base routes typed variants through legacy `MountTemplatedList` + control-typed `Update*`, restoring `ApplyMoveAnimations` |

Engine prelude also included: post-children mount hook (A1).

## Validation

- **Full selftest under real V1 ON (`REACTOR_USE_V1_PROTOCOL=true`) ×3 = 0 failures.**
- A|B parity confirmed for every fixed element + broadened templated paths under both flags (equal check counts).
- xunit at default (V1 OFF): **9134 passed / 0 failed / 62 skipped.**
- Remaining selftest noise is the known **flag-independent**, non-deterministic docking family only.

## Not in scope (deliberately)

This PR keeps `UseV1Protocol` default **OFF**. Flipping the production default is gated on items that require separate governance:

1. **Spec §14 ARM64 ratification gate** — still pending / first capture inconclusive (thermal drift).
2. **`TypeRegistryTests.Override_Builtin_Type_Mount_Is_Dispatched`** — under V1 ON, overriding a built-in via `RegisterType` throws by design (spec §13 Q17). Needs a test update + release notes when the flip happens.
3. **`RichEditBoxElementTests.Mount_Dispatches_RichEditBoxElement`** — headless COM test artifact (`RentControl<T>` generic `new T()` vs legacy direct ctor); not a render regression.

> Note: `tests/Reactor.Tests` does **not** map `REACTOR_USE_V1_PROTOCOL` to the AppContext switch — real V1-ON xunit signal requires flipping the default in code. Documented for the eventual flip PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
