### PR TITLE
fix(treeview): typed TreeView<T> with viewBuilder; obsolete ContentElement (#447)

### DIFF
--- a/samples/Reactor.TestApp/Demos/DataTemplateDemo.cs
+++ b/samples/Reactor.TestApp/Demos/DataTemplateDemo.cs
@@ -14,6 +14,40 @@ class DataTemplateDemo : Component
 {
     record Animal(int Id, string Name, string Species, string Emoji);
 
+    // Heterogeneous tree model: group rows and animal rows are distinct C#
+    // shapes, so the TreeView<T> viewBuilder renders each differently and the
+    // childrenSelector reads hierarchy off the shape (see section 4).
+    abstract record PetNode : IReactorKeyed { public abstract string Key { get; } }
+    sealed record PetGroup(string Label, string Glyph, IReadOnlyList<PetNode> Items) : PetNode
+    {
+        public override string Key => "group:" + Label;
+    }
+    sealed record PetLeaf(Animal Animal) : PetNode
+    {
+        public override string Key => "animal:" + Animal.Id;
+    }
+
+    static string EmojiFor(string species) => species switch
+    {
+        "Cat" => "\U0001F431",
+        "Dog" => "\U0001F436",
+        "Rabbit" => "\U0001F430",
+        "Hamster" => "\U0001F439",
+        "Parrot" => "\U0001F99C",
+        _ => "\U0001F43E",
+    };
+
+    static IReadOnlyList<PetNode> BuildPetTree(IReadOnlyList<Animal> animals)
+    {
+        var groups = new[] { "Cat", "Dog", "Rabbit", "Hamster", "Parrot" }
+            .Where(species => animals.Any(a => a.Species == species))
+            .Select(species => (PetNode)new PetGroup(species, EmojiFor(species),
+                animals.Where(a => a.Species == species)
+                       .Select(a => (PetNode)new PetLeaf(a)).ToList()))
+            .ToList();
+        return [new PetGroup("All Pets", "\U0001F3E0", groups)];
+    }
+
     static readonly List<Animal> AllAnimals =
     [
         new(1, "Luna", "Cat", "\U0001F431"),
@@ -44,7 +78,7 @@ class DataTemplateDemo : Component
 
         return ScrollView(VStack(16,
             Heading("DataTemplate Demo"),
-            TextBlock("Typed ListView<T>, GridView<T>, FlipView<T> with viewBuilder, plus TreeView ContentElement."),
+            TextBlock("Typed ListView<T>, GridView<T>, FlipView<T>, and TreeView<T> — all data-driven via a viewBuilder."),
 
             // Filter + add/remove controls
             HStack(12,
@@ -154,48 +188,26 @@ class DataTemplateDemo : Component
 
             TextBlock($"Showing {flipIndex + 1} of {filtered.Count}").Foreground(SecondaryText),
 
-            // 4. TreeView with ContentElement
-            SubHeading("4. TreeView with ContentElement"),
-            TextBlock("Tree nodes render custom Reactor elements instead of plain text."),
+            // 4. TreeView<T> — heterogeneous nodes from the C# data shape
+            SubHeading("4. TreeView<T> (heterogeneous nodes)"),
+            TextBlock("Hierarchy (childrenSelector) and per-node template (viewBuilder) both come from the data shape — group rows and animal rows render differently."),
             Border(
-                TreeView(
-                    new TreeViewNodeData("Pets") { IsExpanded = true,
-                        ContentElement = HStack(8,
-                            TextBlock("\U0001F3E0").FontSize(16),
-                            TextBlock("All Pets").SemiBold()
-                        ),
-                        Children = new[] { "Cat", "Dog", "Rabbit", "Hamster", "Parrot" }
-                            .Where(species => filtered.Any(a => a.Species == species))
-                            .Select(species => new TreeViewNodeData(species)
-                            {
-                                IsExpanded = true,
-                                ContentElement = HStack(8,
-                                    TextBlock(species switch
-                                    {
-                                        "Cat" => "\U0001F431",
-                                        "Dog" => "\U0001F436",
-                                        "Rabbit" => "\U0001F430",
-                                        "Hamster" => "\U0001F439",
-                                        "Parrot" => "\U0001F99C",
-                                        _ => "\U0001F43E"
-                                    }),
-                                    TextBlock(species).SemiBold(),
-                                    TextBlock($"({filtered.Count(a => a.Species == species)})").Foreground(TertiaryText)
-                                ),
-                                Children = filtered
-                                    .Where(a => a.Species == species)
-                                    .Select(a => new TreeViewNodeData(a.Name)
-                                    {
-                                        ContentElement = HStack(8,
-                                            TextBlock(a.Emoji),
-                                            TextBlock(a.Name),
-                                            Caption($"#{a.Id}").Foreground(TertiaryText)
-                                        )
-                                    }).ToArray()
-                            }).ToArray()
-                    }
-                )
-            ).CornerRadius(8).Height(300)
+                TreeView<PetNode>(
+                    items: BuildPetTree(filtered),
+                    childrenSelector: n => n is PetGroup g ? g.Items : null,
+                    viewBuilder: n => n switch
+                    {
+                        PetGroup g => HStack(8,
+                            TextBlock(g.Glyph).FontSize(16),
+                            TextBlock(g.Label).SemiBold(),
+                            Caption($"({g.Items.Count})").Foreground(TertiaryText)),
+                        PetLeaf l => HStack(8,
+                            TextBlock(l.Animal.Emoji),
+                            TextBlock(l.Animal.Name),
+                            Caption($"#{l.Animal.Id}").Foreground(TertiaryText)),
+                        _ => TextBlock(n.Key),
+                    }) with { IsExpanded = _ => true }
+            ).CornerRadius(8).Height(300).Margin(5)
         ));
     }
 }

--- a/samples/ReactorGallery/ControlPages/Collections/TreeViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/TreeViewPage.cs
@@ -10,6 +10,34 @@ namespace WinUIGalleryReactor;
 
 class TreeViewPage : Component
 {
+    // Heterogeneous node model: folders, documents and images are distinct C#
+    // shapes. TreeView<T> reads hierarchy off the shape (childrenSelector) and
+    // picks a per-node template by pattern-matching the shape (viewBuilder) —
+    // the WinUI ItemTemplateSelector pattern, expressed in C#.
+    abstract record FsEntry(string Name) : IReactorKeyed { public string Key => Name; }
+    sealed record FsFolder(string Name, FsEntry[] Items) : FsEntry(Name);
+    sealed record FsDoc(string Name, string Size) : FsEntry(Name);
+    sealed record FsImage(string Name, string Dimensions) : FsEntry(Name);
+
+    static readonly FsEntry[] SampleTree =
+    [
+        new FsFolder("Documents",
+        [
+            new FsFolder("Work",
+            [
+                new FsDoc("Report.docx", "18 KB"),
+                new FsDoc("Slides.pptx", "2.1 MB"),
+            ]),
+            new FsDoc("Budget.xlsx", "44 KB"),
+        ]),
+        new FsFolder("Pictures",
+        [
+            new FsImage("Beach.jpg", "4032 x 3024"),
+            new FsImage("Mountain.png", "1920 x 1080"),
+        ]),
+        new FsDoc("readme.txt", "1 KB"),
+    ];
+
     public override Element Render()
     {
         return ScrollView(
@@ -31,7 +59,15 @@ class TreeViewPage : Component
                             TreeNode("Family")),
                         TreeNode("Music")
                     ).Height(300),
-                    @"TreeView(\n    TreeNode(""Documents"",\n        TreeNode(""Work"",\n            TreeNode(""Report.docx""),\n            TreeNode(""Slides.pptx""))),\n    TreeNode(""Pictures"", ...)\n)"),
+                    """
+                    TreeView(
+                        TreeNode("Documents",
+                            TreeNode("Work",
+                                TreeNode("Report.docx"),
+                                TreeNode("Slides.pptx"))),
+                        TreeNode("Pictures", ...),
+                        TreeNode("Music"))
+                    """),
 
                 SampleCard("Deeply Nested TreeView",
                     TreeView(
@@ -44,7 +80,46 @@ class TreeViewPage : Component
                             TreeNode("Level 1B",
                                 TreeNode("Level 2C")))
                     ).Height(250),
-                    @"TreeView(\n    TreeNode(""Root"",\n        TreeNode(""Level 1A"",\n            TreeNode(""Level 2A"",\n                TreeNode(""Level 3A""))))\n)")
+                    """
+                    TreeView(
+                        TreeNode("Root",
+                            TreeNode("Level 1A",
+                                TreeNode("Level 2A",
+                                    TreeNode("Level 3A")))))
+                    """),
+
+                SampleCard("Heterogeneous nodes & custom templates (TreeView<T>)",
+                    (TreeView<FsEntry>(
+                        items: SampleTree,
+                        childrenSelector: e => e is FsFolder f ? f.Items : null,
+                        viewBuilder: e => e switch
+                        {
+                            FsFolder fo => HStack(8,
+                                TextBlock("\U0001F4C1"),
+                                TextBlock(fo.Name).SemiBold(),
+                                Caption($"{fo.Items.Length} items")),
+                            FsImage im => HStack(8,
+                                TextBlock("\U0001F5BC"),
+                                TextBlock(im.Name),
+                                Caption(im.Dimensions)),
+                            FsDoc d => HStack(8,
+                                TextBlock("\U0001F4C4"),
+                                TextBlock(d.Name),
+                                Caption(d.Size)),
+                            _ => TextBlock(e.Name),
+                        }) with { IsExpanded = e => e is FsFolder })
+                        .Height(320),
+                    """
+                    TreeView<FsEntry>(
+                        items: tree,
+                        childrenSelector: e => e is FsFolder f ? f.Items : null,
+                        viewBuilder: e => e switch
+                        {
+                            FsFolder fo => HStack(Text("📁"), Text(fo.Name).SemiBold(), Caption($"{fo.Items.Length} items")),
+                            FsImage  im => HStack(Text("🖼"), Text(im.Name), Caption(im.Dimensions)),
+                            FsDoc    d  => HStack(Text("📄"), Text(d.Name), Caption(d.Size)),
+                        }) with { IsExpanded = e => e is FsFolder }
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -701,6 +701,17 @@ public abstract record Element
                 && ta.GetIsItemClickEnabled() == tb.GetIsItemClickEnabled()
                 && !ta.HasSetters && !tb.HasSetters,
 
+            // Typed TreeView<T>: Items/selectors/ViewBuilder are factory inputs
+            // (they drive child reconcile, not parent control properties), so
+            // own-prop equality compares only the WinUI properties the update
+            // path writes back — same rationale as the templated collections.
+            (TemplatedTreeViewElementBase ta, TemplatedTreeViewElementBase tb) =>
+                ta.SelectionMode == tb.SelectionMode
+                && ta.CanDragItems == tb.CanDragItems
+                && ta.AllowDrop == tb.AllowDrop
+                && ta.CanReorderItems == tb.CanReorderItems
+                && ReferenceEquals(ta.SettersErased, tb.SettersErased),
+
             // Lazy (virtualized) stacks: same rationale — Items/ViewBuilder
             // are factory inputs, not control properties.
             (LazyStackElementBase la, LazyStackElementBase lb) =>
@@ -1736,6 +1747,13 @@ public record TreeViewNodeData(string Content, TreeViewNodeData[]? Children = nu
     /// Optional Reactor element to render as the node's visual content.
     /// When null, a TextBlock showing Content is rendered.
     /// </summary>
+    [Obsolete(
+        "Pre-mounting an element into a node renders blank in WinUI node-mode TreeView " +
+        "(issue #447): the default ContentPresenter stringifies the node and cannot host a " +
+        "live UIElement, and per-node events don't resolve. Use the typed " +
+        "TreeView<T>(items, keySelector, childrenSelector, viewBuilder) overload, which renders " +
+        "each node through a viewBuilder (like WinUI's ItemTemplate) and hands your own T back " +
+        "from OnItemInvoked/OnExpanding.")]
     public Element? ContentElement { get; init; }
 }
 
@@ -2812,6 +2830,93 @@ public record TreeViewElement(
     public bool CanReorderItems { get; init; }
     internal Action<WinUI.TreeView>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnItemInvoked is not null || OnExpanding is not null;
+}
+
+/// <summary>
+/// Non-generic base for the typed, data-driven <see cref="TemplatedTreeViewElement{T}"/>,
+/// kept non-generic so the reconciler matches a single type in its mount/update
+/// switch (same erasure pattern as <see cref="TemplatedListElementBase"/>).
+///
+/// <para>Maps to WinUI's native node-mode <c>TreeView</c>: the reconciler builds a
+/// <c>TreeViewNode</c> tree from <see cref="GetRoots"/>/<see cref="GetChildren"/> and
+/// renders each node through the per-node <see cref="BuildView"/> (a real
+/// DataTemplate-style factory) hosted by the <c>{Binding Content}</c> ContentControl
+/// template — rather than pre-mounting a concrete element into <c>Content</c> (which
+/// renders blank, issue #447). The originating <c>T</c> rides on an attached property
+/// of each node so <see cref="InvokeItemInvoked"/>/<see cref="InvokeExpanding"/> hand
+/// the developer's own model back.</para>
+/// </summary>
+public abstract record TemplatedTreeViewElementBase : Element
+{
+    /// <summary>Root data items, erased to <c>object</c> for the reconciler.</summary>
+    internal abstract IReadOnlyList<object> GetRoots();
+    /// <summary>Children of <paramref name="item"/>, or null for a leaf.</summary>
+    internal abstract IReadOnlyList<object>? GetChildren(object item);
+    /// <summary>Stable identity for keyed reconcile + event payloads.</summary>
+    internal abstract string GetKey(object item);
+    /// <summary>The per-node view (the "template/renderer") for <paramref name="item"/>.</summary>
+    internal abstract Element BuildView(object item);
+    /// <summary>Initial expansion state for <paramref name="item"/>.</summary>
+    internal abstract bool GetIsExpanded(object item);
+    internal abstract void InvokeItemInvoked(object item);
+    internal abstract void InvokeExpanding(object item);
+    internal abstract bool HasItemInvoked { get; }
+    internal abstract bool HasExpanding { get; }
+
+    public TreeViewSelectionMode SelectionMode { get; init; } = TreeViewSelectionMode.Single;
+    public bool CanDragItems { get; init; }
+    public bool AllowDrop { get; init; }
+    public bool CanReorderItems { get; init; }
+    internal abstract Action<WinUI.TreeView>[] SettersErased { get; }
+    internal override bool HasCallbacks => HasItemInvoked || HasExpanding;
+}
+
+/// <summary>
+/// Typed, data-driven TreeView — the hierarchical peer of
+/// <see cref="TemplatedListViewElement{T}"/>. Each node's visual is produced by
+/// <see cref="ViewBuilder"/> (WinUI <c>ItemTemplate</c> equivalent); hierarchy comes
+/// from <see cref="ChildrenSelector"/>; identity from <see cref="KeySelector"/>.
+/// Construct via the <c>TreeView&lt;T&gt;</c> factory.
+/// </summary>
+public record TemplatedTreeViewElement<T>(
+    IReadOnlyList<T> Items,
+    Func<T, string> KeySelector,
+    Func<T, IReadOnlyList<T>?> ChildrenSelector,
+    Func<T, Element> ViewBuilder
+) : TemplatedTreeViewElementBase
+{
+    /// <summary>Fires with the developer's own <c>T</c> when a node is invoked.</summary>
+    public Action<T>? OnItemInvoked { get; init; }
+    /// <summary>Fires with the developer's own <c>T</c> when a node begins expanding.</summary>
+    public Action<T>? OnExpanding { get; init; }
+    /// <summary>Per-item initial expansion; defaults to collapsed (WinUI default).</summary>
+    public Func<T, bool>? IsExpanded { get; init; }
+    internal Action<WinUI.TreeView>[] Setters { get; init; } = [];
+
+    internal override IReadOnlyList<object> GetRoots() => Project(Items);
+    internal override IReadOnlyList<object>? GetChildren(object item)
+    {
+        var ch = ChildrenSelector((T)item);
+        return ch is null ? null : Project(ch);
+    }
+    internal override string GetKey(object item) => KeySelector((T)item);
+    internal override Element BuildView(object item) => ViewBuilder((T)item);
+    internal override bool GetIsExpanded(object item) => IsExpanded?.Invoke((T)item) ?? false;
+    internal override void InvokeItemInvoked(object item) => OnItemInvoked?.Invoke((T)item);
+    internal override void InvokeExpanding(object item) => OnExpanding?.Invoke((T)item);
+    internal override bool HasItemInvoked => OnItemInvoked is not null;
+    internal override bool HasExpanding => OnExpanding is not null;
+    internal override Action<WinUI.TreeView>[] SettersErased => Setters;
+
+    // Reference-typed T flows through covariant IReadOnlyList<object> with no
+    // allocation; value-typed T is boxed once per item into a backing array.
+    private static IReadOnlyList<object> Project(IReadOnlyList<T> src)
+    {
+        if (src is IReadOnlyList<object> already) return already;
+        var arr = new object[src.Count];
+        for (int i = 0; i < src.Count; i++) arr[i] = src[i]!;
+        return arr;
+    }
 }
 
 public record FlipViewElement(

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -1990,9 +1990,12 @@ public sealed partial class Reconciler
             CanDragItems = tv.CanDragItems,
             AllowDrop = tv.AllowDrop,
             CanReorderItems = tv.CanReorderItems,
-            // Unbound shell; per-node views are hosted/released through the
-            // internal list's ContainerContentChanging (see Loaded below).
-            ItemTemplate = SharedContentControlTemplate.Value,
+            // Each node's mounted view lives in TreeViewNode.Content and is
+            // surfaced by the {Binding Content} ContentControl template — the
+            // node-mode default template can only stringify (issue #447). A
+            // declarative binding (rather than imperative ContainerContentChanging
+            // hosting) keeps native expand/collapse from being perturbed.
+            ItemTemplate = TreeViewContentElementTemplate.Value,
         };
 
         foreach (var root in tv.GetRoots())
@@ -2005,33 +2008,6 @@ public sealed partial class Reconciler
         if (tv.HasExpanding)
             treeView.Expanding += TemplatedTreeExpanding;
 
-        // The TreeViewList (internal ListView, template part "ListControl")
-        // owns container realization/recycling. Hook its ContainerContentChanging
-        // so a node's mounted view is hosted on realize and its visual parent
-        // released on recycle — the only way to keep a shared live element from
-        // blanking out across collapse/expand under virtualization.
-        treeView.Loaded += static (s, _) =>
-        {
-            var tree = (WinUI.TreeView)s;
-            if (FindInnerList(tree) is not { } list) return;
-            // Idempotent: method-group -= removes the prior subscription if the
-            // tree reloaded, so we never double-host.
-            list.ContainerContentChanging -= TemplatedTreeContainerContentChanging;
-            list.ContainerContentChanging += TemplatedTreeContainerContentChanging;
-
-            // Fill containers already realized before we subscribed.
-            for (int i = 0; i < list.Items.Count; i++)
-                if (list.ContainerFromIndex(i) is WinUI.TreeViewItem tvi
-                    && tvi.ContentTemplateRoot is ContentControl cc
-                    && cc.Content is null
-                    && list.Items[i] is WinUI.TreeViewNode node
-                    && GetTreeNodeView(node) is UIElement view)
-                {
-                    DetachContentHost(view);
-                    cc.Content = view;
-                }
-        };
-
         ApplySetters(tv.SettersErased, treeView);
         return treeView;
     }
@@ -2039,67 +2015,17 @@ public sealed partial class Reconciler
     private WinUI.TreeViewNode BuildTemplatedTreeNode(
         TemplatedTreeViewElementBase tv, object item, Action requestRerender)
     {
-        // Content holds the data item (identity/stringification); the mounted
-        // view rides on an attached property and is hosted on demand by the
-        // ContainerContentChanging handler.
-        var node = new WinUI.TreeViewNode { IsExpanded = tv.GetIsExpanded(item), Content = item };
+        // Content = the mounted view (surfaced by {Binding Content}); the
+        // originating T rides on an attached property for event resolution.
+        var node = new WinUI.TreeViewNode { IsExpanded = tv.GetIsExpanded(item) };
+        node.Content = Mount(tv.BuildView(item), requestRerender);
         SetTreeNodeItem(node, item);
-        SetTreeNodeView(node, Mount(tv.BuildView(item), requestRerender));
 
         var children = tv.GetChildren(item);
         if (children is not null)
             foreach (var child in children)
                 node.Children.Add(BuildTemplatedTreeNode(tv, child, requestRerender));
         return node;
-    }
-
-    // Hosts/releases the per-node mounted view as the internal list realizes
-    // and recycles TreeViewItem containers. Not setting args.Handled so the
-    // TreeViewList still applies its own chrome (expand glyph, indentation).
-    //
-    // The host is DEFERRED to a low-priority dispatch (after the synchronous
-    // prepare/layout pass) because mutating container content mid-prepare
-    // perturbs layout and can recycle/re-prepare the expanding node's own
-    // container with a stale IsExpanded — TreeViewList then enqueues a sync
-    // that snaps the node shut ("expand opens & closes"). The recycle release
-    // stays synchronous (always safe). The deferred host re-validates that the
-    // container still belongs to the same node (cc.DataContext) so a container
-    // recycled to another node in the meantime is never mis-hosted.
-    private static void TemplatedTreeContainerContentChanging(
-        Microsoft.UI.Xaml.Controls.ListViewBase sender,
-        Microsoft.UI.Xaml.Controls.ContainerContentChangingEventArgs args)
-    {
-        if (args.ItemContainer?.ContentTemplateRoot is not ContentControl cc) return;
-        if (args.InRecycleQueue)
-        {
-            cc.Content = null; // release the element's visual parent; view persists on the node
-            return;
-        }
-        if (args.Item is not WinUI.TreeViewNode node) return;
-
-        var dq = cc.DispatcherQueue;
-        if (dq is null) { HostNodeView(cc, node); return; }
-        dq.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () => HostNodeView(cc, node));
-    }
-
-    private static void HostNodeView(ContentControl cc, WinUI.TreeViewNode node)
-    {
-        // Container may have been recycled to a different node before this ran.
-        if (!ReferenceEquals(cc.DataContext, node)) return;
-        if (GetTreeNodeView(node) is not UIElement view || ReferenceEquals(cc.Content, view)) return;
-        DetachContentHost(view);
-        cc.Content = view;
-    }
-
-    // Releases a view from whatever ContentControl currently hosts it, so it
-    // can be parented elsewhere (a UIElement may have only one visual parent).
-    private static void DetachContentHost(UIElement view)
-    {
-        DependencyObject? p = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(view);
-        while (p is not null and not ContentControl)
-            p = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(p);
-        if (p is ContentControl host && host.Content is not null)
-            host.Content = null;
     }
 
     private static Microsoft.UI.Xaml.Controls.ListViewBase? FindInnerList(DependencyObject root)

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -126,6 +126,7 @@ public sealed partial class Reconciler
             ListViewElement lv => MountListView(lv, requestRerender),
             GridViewElement gv => MountGridView(gv, requestRerender),
             TreeViewElement tv => MountTreeView(tv, requestRerender),
+            TemplatedTreeViewElementBase ttv => MountTemplatedTreeView(ttv, requestRerender),
             FlipViewElement fv => MountFlipView(fv, requestRerender),
             InfoBarElement ib => MountInfoBar(ib, requestRerender),
             InfoBadgeElement badge => MountInfoBadge(badge),
@@ -1884,8 +1885,10 @@ public sealed partial class Reconciler
 
         if (hasContentElements)
         {
-            // Use ContentControl template so pre-mounted Elements display in the tree
-            treeView.ItemTemplate = SharedContentControlTemplate.Value;
+            // Use the TreeView ContentControl template whose Content binds to the
+            // node's mounted UIElement. (Unlike ListView/GridView, TreeView has no
+            // ContainerContentChanging handler to fill an unbound shell — issue #447.)
+            treeView.ItemTemplate = TreeViewContentElementTemplate.Value;
         }
         else
         {
@@ -1926,6 +1929,10 @@ public sealed partial class Reconciler
         return treeView;
     }
 
+    // Legacy per-node ContentElement path — obsolete (issue #447), kept
+    // functional for back-compat until removal. Suppress the obsoletion
+    // warning at the intentional internal use sites.
+#pragma warning disable CS0618
     private static bool HasAnyContentElement(TreeViewNodeData[] nodes)
     {
         foreach (var node in nodes)
@@ -1957,6 +1964,7 @@ public sealed partial class Reconciler
                 node.Children.Add(CreateTreeNode(child, mountElements, requestRerender));
         return node;
     }
+#pragma warning restore CS0618
 
     /// <summary>Backward-compatible overload for non-ContentElement code paths.</summary>
     private static WinUI.TreeViewNode CreateTreeNode(TreeViewNodeData data)
@@ -1965,6 +1973,164 @@ public sealed partial class Reconciler
         if (data.Children is not null)
             foreach (var child in data.Children) node.Children.Add(CreateTreeNode(child));
         return node;
+    }
+
+    // ── Typed TreeView<T> (TemplatedTreeViewElement<T>) ──────────────────────
+    //
+    // WinUI-native node mode: build a TreeViewNode tree from the data, render
+    // each node through the element's viewBuilder (hosted via the {Binding
+    // Content} ContentControl template), and stash the originating T on each
+    // node so the event trampolines hand it back. See issue #447.
+
+    internal WinUI.TreeView MountTemplatedTreeView(TemplatedTreeViewElementBase tv, Action requestRerender)
+    {
+        var treeView = new WinUI.TreeView
+        {
+            SelectionMode = tv.SelectionMode,
+            CanDragItems = tv.CanDragItems,
+            AllowDrop = tv.AllowDrop,
+            CanReorderItems = tv.CanReorderItems,
+            // Unbound shell; per-node views are hosted/released through the
+            // internal list's ContainerContentChanging (see Loaded below).
+            ItemTemplate = SharedContentControlTemplate.Value,
+        };
+
+        foreach (var root in tv.GetRoots())
+            treeView.RootNodes.Add(BuildTemplatedTreeNode(tv, root, requestRerender));
+
+        SetElementTag(treeView, tv);
+
+        if (tv.HasItemInvoked)
+            treeView.ItemInvoked += TemplatedTreeItemInvoked;
+        if (tv.HasExpanding)
+            treeView.Expanding += TemplatedTreeExpanding;
+
+        // The TreeViewList (internal ListView, template part "ListControl")
+        // owns container realization/recycling. Hook its ContainerContentChanging
+        // so a node's mounted view is hosted on realize and its visual parent
+        // released on recycle — the only way to keep a shared live element from
+        // blanking out across collapse/expand under virtualization.
+        treeView.Loaded += static (s, _) =>
+        {
+            var tree = (WinUI.TreeView)s;
+            if (FindInnerList(tree) is not { } list) return;
+            // Idempotent: method-group -= removes the prior subscription if the
+            // tree reloaded, so we never double-host.
+            list.ContainerContentChanging -= TemplatedTreeContainerContentChanging;
+            list.ContainerContentChanging += TemplatedTreeContainerContentChanging;
+
+            // Fill containers already realized before we subscribed.
+            for (int i = 0; i < list.Items.Count; i++)
+                if (list.ContainerFromIndex(i) is WinUI.TreeViewItem tvi
+                    && tvi.ContentTemplateRoot is ContentControl cc
+                    && cc.Content is null
+                    && list.Items[i] is WinUI.TreeViewNode node
+                    && GetTreeNodeView(node) is UIElement view)
+                {
+                    DetachContentHost(view);
+                    cc.Content = view;
+                }
+        };
+
+        ApplySetters(tv.SettersErased, treeView);
+        return treeView;
+    }
+
+    private WinUI.TreeViewNode BuildTemplatedTreeNode(
+        TemplatedTreeViewElementBase tv, object item, Action requestRerender)
+    {
+        // Content holds the data item (identity/stringification); the mounted
+        // view rides on an attached property and is hosted on demand by the
+        // ContainerContentChanging handler.
+        var node = new WinUI.TreeViewNode { IsExpanded = tv.GetIsExpanded(item), Content = item };
+        SetTreeNodeItem(node, item);
+        SetTreeNodeView(node, Mount(tv.BuildView(item), requestRerender));
+
+        var children = tv.GetChildren(item);
+        if (children is not null)
+            foreach (var child in children)
+                node.Children.Add(BuildTemplatedTreeNode(tv, child, requestRerender));
+        return node;
+    }
+
+    // Hosts/releases the per-node mounted view as the internal list realizes
+    // and recycles TreeViewItem containers. Not setting args.Handled so the
+    // TreeViewList still applies its own chrome (expand glyph, indentation).
+    //
+    // The host is DEFERRED to a low-priority dispatch (after the synchronous
+    // prepare/layout pass) because mutating container content mid-prepare
+    // perturbs layout and can recycle/re-prepare the expanding node's own
+    // container with a stale IsExpanded — TreeViewList then enqueues a sync
+    // that snaps the node shut ("expand opens & closes"). The recycle release
+    // stays synchronous (always safe). The deferred host re-validates that the
+    // container still belongs to the same node (cc.DataContext) so a container
+    // recycled to another node in the meantime is never mis-hosted.
+    private static void TemplatedTreeContainerContentChanging(
+        Microsoft.UI.Xaml.Controls.ListViewBase sender,
+        Microsoft.UI.Xaml.Controls.ContainerContentChangingEventArgs args)
+    {
+        if (args.ItemContainer?.ContentTemplateRoot is not ContentControl cc) return;
+        if (args.InRecycleQueue)
+        {
+            cc.Content = null; // release the element's visual parent; view persists on the node
+            return;
+        }
+        if (args.Item is not WinUI.TreeViewNode node) return;
+
+        var dq = cc.DispatcherQueue;
+        if (dq is null) { HostNodeView(cc, node); return; }
+        dq.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () => HostNodeView(cc, node));
+    }
+
+    private static void HostNodeView(ContentControl cc, WinUI.TreeViewNode node)
+    {
+        // Container may have been recycled to a different node before this ran.
+        if (!ReferenceEquals(cc.DataContext, node)) return;
+        if (GetTreeNodeView(node) is not UIElement view || ReferenceEquals(cc.Content, view)) return;
+        DetachContentHost(view);
+        cc.Content = view;
+    }
+
+    // Releases a view from whatever ContentControl currently hosts it, so it
+    // can be parented elsewhere (a UIElement may have only one visual parent).
+    private static void DetachContentHost(UIElement view)
+    {
+        DependencyObject? p = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(view);
+        while (p is not null and not ContentControl)
+            p = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(p);
+        if (p is ContentControl host && host.Content is not null)
+            host.Content = null;
+    }
+
+    private static Microsoft.UI.Xaml.Controls.ListViewBase? FindInnerList(DependencyObject root)
+    {
+        int n = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < n; i++)
+        {
+            var c = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(root, i);
+            if (c is Microsoft.UI.Xaml.Controls.ListViewBase lvb) return lvb;
+            if (FindInnerList(c) is { } found) return found;
+        }
+        return null;
+    }
+
+    // Static trampolines: resolve the live element via the control tag and the
+    // originating T via the node's attached item, then invoke the typed
+    // callback. Stateless so re-subscription on update can't capture stale
+    // element references (the tag is always re-read).
+    private static void TemplatedTreeItemInvoked(WinUI.TreeView sender, WinUI.TreeViewItemInvokedEventArgs args)
+    {
+        if (args.InvokedItem is WinUI.TreeViewNode node
+            && GetTreeNodeItem(node) is { } item
+            && GetElementTag(sender) is TemplatedTreeViewElementBase el)
+            el.InvokeItemInvoked(item);
+    }
+
+    private static void TemplatedTreeExpanding(WinUI.TreeView sender, WinUI.TreeViewExpandingEventArgs args)
+    {
+        if (GetTreeNodeItem(args.Node) is { } item
+            && GetElementTag(sender) is TemplatedTreeViewElementBase el)
+            el.InvokeExpanding(item);
     }
 
     private WinUI.FlipView MountFlipView(FlipViewElement fv, Action requestRerender)

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -4017,7 +4017,13 @@ public sealed partial class Reconciler
                 var liveNode = match.Node;
                 var oldNodeData = oldData[match.OldIdx];
 
-                if (liveNode.IsExpanded != nd.IsExpanded)
+                // Uncontrolled expansion: only push the data value when it
+                // actually changed between renders. Otherwise leave the node's
+                // IsExpanded alone, so a reconcile triggered AFTER the user
+                // expands/collapses (e.g. OnExpanding lazy-load, or any state
+                // change) doesn't snap the node back to the static data value —
+                // the "expand flashes open then shut" regression.
+                if (oldNodeData.IsExpanded != nd.IsExpanded && liveNode.IsExpanded != nd.IsExpanded)
                     liveNode.IsExpanded = nd.IsExpanded;
 
                 ReconcileTreeNodeContent(liveNode, oldNodeData, nd, requestRerender);
@@ -4168,10 +4174,13 @@ public sealed partial class Reconciler
                 int cur = liveNodes.IndexOf(node);
                 if (cur != i)
                 {
-                    // A move recycles + re-realizes the container; the
-                    // ContainerContentChanging handler re-hosts the view.
+                    // Move: release the live view's parent before re-realizing
+                    // so the bound ContentControl can re-host it at the new slot.
+                    var content = node.Content as UIElement;
+                    if (content is not null) node.Content = null;
                     liveNodes.RemoveAt(cur);
                     liveNodes.Insert(i, node);
+                    if (content is not null) node.Content = content;
                 }
                 ReconcileTemplatedNodeView(node, o, n, newItem, requestRerender);
                 DiffTemplatedTreeNodes(
@@ -4195,28 +4204,18 @@ public sealed partial class Reconciler
         var oldItem = GetTreeNodeItem(node);
         var newView = n.BuildView(newItem);
         var oldView = oldItem is not null ? o.BuildView(oldItem) : null;
-        var existing = GetTreeNodeView(node);
 
-        if (oldView is not null && existing is not null && CanUpdate(oldView, newView))
+        if (oldView is not null && node.Content is UIElement existing && CanUpdate(oldView, newView))
         {
-            // In-place update mutates the live element; a realized container is
-            // already showing it, so nothing else to do unless it's replaced.
             var replacement = Update(oldView, newView, existing, requestRerender);
-            if (replacement is not null && !ReferenceEquals(existing, replacement))
-            {
-                SetTreeNodeView(node, replacement);
-                RehostReplacedView(existing, replacement);
-            }
+            if (replacement is not null && !ReferenceEquals(node.Content, replacement))
+                node.Content = replacement;
         }
         else
         {
-            if (existing is not null) UnmountChild(existing);
-            var mounted = Mount(newView, requestRerender);
-            SetTreeNodeView(node, mounted);
-            RehostReplacedView(existing, mounted);
+            if (node.Content is UIElement stale) UnmountChild(stale);
+            node.Content = Mount(newView, requestRerender);
         }
-
-        node.Content = newItem;
 
         // Expansion is uncontrolled: only push the selector value when it
         // actually CHANGES between renders (developer-driven control). Otherwise
@@ -4230,22 +4229,9 @@ public sealed partial class Reconciler
         SetTreeNodeItem(node, newItem);
     }
 
-    // If a node's view was replaced (CanUpdate false) while its container is
-    // realized, swap the new view into the ContentControl currently hosting the
-    // old one so the change is visible without waiting for a recycle.
-    private static void RehostReplacedView(UIElement? oldView, UIElement newView)
-    {
-        if (oldView is null) return;
-        DependencyObject? p = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(oldView);
-        while (p is not null and not WinUI.ContentControl)
-            p = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(p);
-        if (p is WinUI.ContentControl host && ReferenceEquals(host.Content, oldView))
-            host.Content = newView;
-    }
-
     private void UnmountTemplatedTreeNode(WinUI.TreeViewNode node)
     {
-        if (GetTreeNodeView(node) is UIElement ui) UnmountChild(ui);
+        if (node.Content is UIElement ui) UnmountChild(ui);
         foreach (var child in node.Children)
             UnmountTemplatedTreeNode(child);
     }

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -220,6 +220,8 @@ public sealed partial class Reconciler
                 => UpdateGridView(o, n, gv, requestRerender),
             (TreeViewElement o, TreeViewElement n, WinUI.TreeView tv)
                 => UpdateTreeView(o, n, tv, requestRerender),
+            (TemplatedTreeViewElementBase o, TemplatedTreeViewElementBase n, WinUI.TreeView tv)
+                => UpdateTemplatedTreeView(o, n, tv, requestRerender),
             (FlipViewElement o, FlipViewElement n, WinUI.FlipView fv)
                 => UpdateFlipView(o, n, fv, requestRerender),
             (InfoBarElement o, InfoBarElement n, WinUI.InfoBar ib)
@@ -4052,7 +4054,10 @@ public sealed partial class Reconciler
     /// <summary>
     /// Reconciles ContentElement changes on a TreeViewNode.
     /// When ContentElement is used, node.Content holds a mounted UIElement.
+    /// Legacy obsolete path (issue #447) — kept for back-compat; CS0618 is
+    /// suppressed at the intentional internal use site.
     /// </summary>
+#pragma warning disable CS0618
     private void ReconcileTreeNodeContent(
         WinUI.TreeViewNode liveNode,
         TreeViewNodeData? oldData,
@@ -4087,6 +4092,162 @@ public sealed partial class Reconciler
                 Unmount(oldCtrl2);
             liveNode.Content = newData;
         }
+    }
+#pragma warning restore CS0618
+
+    // ── Typed TreeView<T> (TemplatedTreeViewElement<T>) ──────────────────────
+
+    private UIElement? UpdateTemplatedTreeView(
+        TemplatedTreeViewElementBase o, TemplatedTreeViewElementBase n, WinUI.TreeView tv, Action requestRerender)
+    {
+        DiffTemplatedTreeNodes(tv.RootNodes, o, n, n.GetRoots(), requestRerender);
+
+        tv.SelectionMode = n.SelectionMode;
+        tv.CanDragItems = n.CanDragItems;
+        tv.AllowDrop = n.AllowDrop;
+        tv.CanReorderItems = n.CanReorderItems;
+
+        SetElementTag(tv, n);
+
+        // Subscribe trampolines only when a callback newly appears; the
+        // stateless trampolines no-op when a callback is later cleared.
+        if (!o.HasItemInvoked && n.HasItemInvoked)
+            tv.ItemInvoked += TemplatedTreeItemInvoked;
+        if (!o.HasExpanding && n.HasExpanding)
+            tv.Expanding += TemplatedTreeExpanding;
+
+        ApplySetters(n.SettersErased, tv);
+        return null;
+    }
+
+    /// <summary>
+    /// Keyed hierarchical reconcile performed <b>in place</b>: nodes whose key
+    /// survives are kept (and their per-node view reconciled so descendant
+    /// component state survives); vanished keys are removed and unmounted; new
+    /// keys are mounted; surviving nodes are reordered to match
+    /// <paramref name="newItems"/>.
+    ///
+    /// <para>Hosting itself is virtualization-driven (the internal list's
+    /// ContainerContentChanging hosts each node's mounted view on realize and
+    /// releases it on recycle), so this method only maintains the node tree and
+    /// each node's mounted view — it never touches realized containers directly,
+    /// except to swap a container that is currently showing a replaced view.</para>
+    /// </summary>
+    private void DiffTemplatedTreeNodes(
+        IList<WinUI.TreeViewNode> liveNodes,
+        TemplatedTreeViewElementBase o,
+        TemplatedTreeViewElementBase n,
+        IReadOnlyList<object> newItems,
+        Action requestRerender)
+    {
+        // Index surviving nodes by their OLD key.
+        var existing = new Dictionary<string, WinUI.TreeViewNode>(liveNodes.Count);
+        foreach (var ln in liveNodes)
+            if (GetTreeNodeItem(ln) is { } it)
+                existing[o.GetKey(it)] = ln;
+
+        // Remove + unmount nodes whose key disappeared.
+        var newKeys = new HashSet<string>(newItems.Count);
+        foreach (var ni in newItems) newKeys.Add(n.GetKey(ni));
+        for (int i = liveNodes.Count - 1; i >= 0; i--)
+        {
+            var it = GetTreeNodeItem(liveNodes[i]);
+            if (it is null || !newKeys.Contains(o.GetKey(it)))
+            {
+                UnmountTemplatedTreeNode(liveNodes[i]);
+                liveNodes.RemoveAt(i);
+            }
+        }
+
+        // Walk new order: reuse-in-place, move, or create.
+        for (int i = 0; i < newItems.Count; i++)
+        {
+            var newItem = newItems[i];
+            if (existing.TryGetValue(n.GetKey(newItem), out var node))
+            {
+                int cur = liveNodes.IndexOf(node);
+                if (cur != i)
+                {
+                    // A move recycles + re-realizes the container; the
+                    // ContainerContentChanging handler re-hosts the view.
+                    liveNodes.RemoveAt(cur);
+                    liveNodes.Insert(i, node);
+                }
+                ReconcileTemplatedNodeView(node, o, n, newItem, requestRerender);
+                DiffTemplatedTreeNodes(
+                    node.Children, o, n, n.GetChildren(newItem) ?? [], requestRerender);
+            }
+            else
+            {
+                liveNodes.Insert(i, BuildTemplatedTreeNode(n, newItem, requestRerender));
+            }
+        }
+    }
+
+    /// <summary>Reconciles one kept node's mounted view against its new item.</summary>
+    private void ReconcileTemplatedNodeView(
+        WinUI.TreeViewNode node,
+        TemplatedTreeViewElementBase o,
+        TemplatedTreeViewElementBase n,
+        object newItem,
+        Action requestRerender)
+    {
+        var oldItem = GetTreeNodeItem(node);
+        var newView = n.BuildView(newItem);
+        var oldView = oldItem is not null ? o.BuildView(oldItem) : null;
+        var existing = GetTreeNodeView(node);
+
+        if (oldView is not null && existing is not null && CanUpdate(oldView, newView))
+        {
+            // In-place update mutates the live element; a realized container is
+            // already showing it, so nothing else to do unless it's replaced.
+            var replacement = Update(oldView, newView, existing, requestRerender);
+            if (replacement is not null && !ReferenceEquals(existing, replacement))
+            {
+                SetTreeNodeView(node, replacement);
+                RehostReplacedView(existing, replacement);
+            }
+        }
+        else
+        {
+            if (existing is not null) UnmountChild(existing);
+            var mounted = Mount(newView, requestRerender);
+            SetTreeNodeView(node, mounted);
+            RehostReplacedView(existing, mounted);
+        }
+
+        node.Content = newItem;
+
+        // Expansion is uncontrolled: only push the selector value when it
+        // actually CHANGES between renders (developer-driven control). Otherwise
+        // leave node.IsExpanded alone so the user's own expand/collapse is never
+        // clobbered.
+        bool oldExpanded = oldItem is not null && o.GetIsExpanded(oldItem);
+        bool newExpanded = n.GetIsExpanded(newItem);
+        if (oldExpanded != newExpanded && node.IsExpanded != newExpanded)
+            node.IsExpanded = newExpanded;
+
+        SetTreeNodeItem(node, newItem);
+    }
+
+    // If a node's view was replaced (CanUpdate false) while its container is
+    // realized, swap the new view into the ContentControl currently hosting the
+    // old one so the change is visible without waiting for a recycle.
+    private static void RehostReplacedView(UIElement? oldView, UIElement newView)
+    {
+        if (oldView is null) return;
+        DependencyObject? p = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(oldView);
+        while (p is not null and not WinUI.ContentControl)
+            p = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(p);
+        if (p is WinUI.ContentControl host && ReferenceEquals(host.Content, oldView))
+            host.Content = newView;
+    }
+
+    private void UnmountTemplatedTreeNode(WinUI.TreeViewNode node)
+    {
+        if (GetTreeNodeView(node) is UIElement ui) UnmountChild(ui);
+        foreach (var child in node.Children)
+            UnmountTemplatedTreeNode(child);
     }
 
     private UIElement? UpdateRectangle(RectangleElement n, WinShapes.Rectangle r)

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -605,6 +605,72 @@ public sealed partial class Reconciler : IDisposable
             "<TextBlock Text='{Binding Content.Content}'/>" +
             "</DataTemplate>"));
 
+    /// <summary>
+    /// TreeView item template that hosts a live <c>UIElement</c> stored in
+    /// <c>TreeViewNode.Content</c>. Used by the typed
+    /// <see cref="TemplatedTreeViewElement{T}"/> (each node's <c>viewBuilder</c>
+    /// output) and by the obsolete per-node <c>ContentElement</c> legacy arm.
+    ///
+    /// <para>Unlike the ListView/GridView <see cref="SharedContentControlTemplate"/>
+    /// — whose <c>ContentControl</c> is filled on demand by a
+    /// <c>ContainerContentChanging</c> handler — TreeView has no such handler,
+    /// so the shell must bind its <c>Content</c> directly. In node mode the
+    /// template's DataContext is the <c>TreeViewNode</c> and <c>Content</c>
+    /// holds the mounted <c>UIElement</c>, so <c>{Binding Content}</c> surfaces
+    /// it through the ContentPresenter (empirically confirmed on native ARM64 —
+    /// the default node-mode template can only stringify, see issue #447).</para>
+    /// </summary>
+    internal static readonly Lazy<DataTemplate> TreeViewContentElementTemplate = new(() =>
+        (DataTemplate)Microsoft.UI.Xaml.Markup.XamlReader.Load(
+            "<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>" +
+            "<ContentControl Content='{Binding Content}' HorizontalContentAlignment='Stretch' VerticalContentAlignment='Stretch'/>" +
+            "</DataTemplate>"));
+
+    // Carries the originating data item (the developer's T, boxed) on each
+    // TreeViewNode for the typed TreeView<T>. Lives on the native node (a
+    // DependencyObject), so it is duplicate-RCW-safe like ReactorState — the
+    // event trampolines read it from C# to hand T back via OnItemInvoked /
+    // OnExpanding. (Not a XAML binding: Reactor.dll has no XAML metadata for
+    // its own types, so an attached-property binding would not resolve.)
+    private static class TreeNodeItemAttached
+    {
+        public static readonly DependencyProperty ItemProperty =
+            DependencyProperty.RegisterAttached(
+                "ReactorTreeItem",
+                typeof(object),
+                typeof(TreeNodeItemAttached),
+                new PropertyMetadata(null));
+    }
+
+    internal static void SetTreeNodeItem(WinUI.TreeViewNode node, object? item) =>
+        node.SetValue(TreeNodeItemAttached.ItemProperty, item);
+
+    internal static object? GetTreeNodeItem(WinUI.TreeViewNode node) =>
+        node.GetValue(TreeNodeItemAttached.ItemProperty);
+
+    // Holds the node's mounted view for the typed TreeView<T>. The view is
+    // mounted ONCE and persists here across collapse/expand (so component
+    // state survives); the internal list's ContainerContentChanging hosts it
+    // into the realized container's ContentControl on realize and releases it
+    // (Content = null) on recycle. Without that release the shared element
+    // keeps a stale visual parent and the next realization renders blank
+    // (issue #447 follow-up: every-other expand/collapse blanked rows).
+    private static class TreeNodeViewAttached
+    {
+        public static readonly DependencyProperty MountedViewProperty =
+            DependencyProperty.RegisterAttached(
+                "ReactorTreeMountedView",
+                typeof(UIElement),
+                typeof(TreeNodeViewAttached),
+                new PropertyMetadata(null));
+    }
+
+    internal static void SetTreeNodeView(WinUI.TreeViewNode node, UIElement? view) =>
+        node.SetValue(TreeNodeViewAttached.MountedViewProperty, view);
+
+    internal static UIElement? GetTreeNodeView(WinUI.TreeViewNode node) =>
+        node.GetValue(TreeNodeViewAttached.MountedViewProperty) as UIElement;
+
     // ════════════════════════════════════════════════════════════════════
     //  ReactorAttached.StateProperty  (ReactorState)
     // ════════════════════════════════════════════════════════════════════
@@ -1960,10 +2026,26 @@ public sealed partial class Reconciler : IDisposable
         {
             UnmountRecursive(ucChild);
         }
+        else if (control is WinUI.TreeView ttvCtl && GetElementTag(ttvCtl) is TemplatedTreeViewElementBase)
+        {
+            // Typed TreeView<T>: per-node viewBuilder outputs live in
+            // TreeViewNode.Content (some unrealized, so not in the visual
+            // tree). Walk the node tree explicitly so every mounted view's
+            // cleanup hooks run.
+            foreach (var rootNode in ttvCtl.RootNodes)
+                UnmountTemplatedTreeNodeContents(rootNode);
+        }
         else if (control is WinUI.ContentControl cc && cc.Content is UIElement ccChild)
         {
             UnmountRecursive(ccChild);
         }
+    }
+
+    private void UnmountTemplatedTreeNodeContents(WinUI.TreeViewNode node)
+    {
+        if (GetTreeNodeView(node) is UIElement ui) UnmountRecursive(ui);
+        foreach (var child in node.Children)
+            UnmountTemplatedTreeNodeContents(child);
     }
 
     /// <summary>

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -648,28 +648,6 @@ public sealed partial class Reconciler : IDisposable
     internal static object? GetTreeNodeItem(WinUI.TreeViewNode node) =>
         node.GetValue(TreeNodeItemAttached.ItemProperty);
 
-    // Holds the node's mounted view for the typed TreeView<T>. The view is
-    // mounted ONCE and persists here across collapse/expand (so component
-    // state survives); the internal list's ContainerContentChanging hosts it
-    // into the realized container's ContentControl on realize and releases it
-    // (Content = null) on recycle. Without that release the shared element
-    // keeps a stale visual parent and the next realization renders blank
-    // (issue #447 follow-up: every-other expand/collapse blanked rows).
-    private static class TreeNodeViewAttached
-    {
-        public static readonly DependencyProperty MountedViewProperty =
-            DependencyProperty.RegisterAttached(
-                "ReactorTreeMountedView",
-                typeof(UIElement),
-                typeof(TreeNodeViewAttached),
-                new PropertyMetadata(null));
-    }
-
-    internal static void SetTreeNodeView(WinUI.TreeViewNode node, UIElement? view) =>
-        node.SetValue(TreeNodeViewAttached.MountedViewProperty, view);
-
-    internal static UIElement? GetTreeNodeView(WinUI.TreeViewNode node) =>
-        node.GetValue(TreeNodeViewAttached.MountedViewProperty) as UIElement;
 
     // ════════════════════════════════════════════════════════════════════
     //  ReactorAttached.StateProperty  (ReactorState)
@@ -2043,7 +2021,7 @@ public sealed partial class Reconciler : IDisposable
 
     private void UnmountTemplatedTreeNodeContents(WinUI.TreeViewNode node)
     {
-        if (GetTreeNodeView(node) is UIElement ui) UnmountRecursive(ui);
+        if (node.Content is UIElement ui) UnmountRecursive(ui);
         foreach (var child in node.Children)
             UnmountTemplatedTreeNodeContents(child);
     }

--- a/src/Reactor/Core/V1Protocol/ChildrenStrategy.cs
+++ b/src/Reactor/Core/V1Protocol/ChildrenStrategy.cs
@@ -362,7 +362,7 @@ public sealed record TreeChildren<TElement, TControl>(
             // node uses ContentElement — mirrors MountTreeView's choice
             // between the text-bound template and the ContentControl shell.
             tree.ItemTemplate = hasContentElements
-                ? Reconciler.SharedContentControlTemplate.Value
+                ? Reconciler.TreeViewContentElementTemplate.Value
                 : Reconciler.TreeViewTextItemTemplate.Value;
         }
         else
@@ -376,7 +376,7 @@ public sealed record TreeChildren<TElement, TControl>(
             // ContentElement. Assigning the same Lazy<DataTemplate> is
             // a no-op identity write.
             tree.ItemTemplate = hasContentElements
-                ? Reconciler.SharedContentControlTemplate.Value
+                ? Reconciler.TreeViewContentElementTemplate.Value
                 : Reconciler.TreeViewTextItemTemplate.Value;
         }
 
@@ -384,6 +384,9 @@ public sealed record TreeChildren<TElement, TControl>(
             tree.RootNodes.Add(CreateTreeNode(nodes[i], hasContentElements, reconciler, requestRerender));
     }
 
+    // Legacy obsolete per-node ContentElement path (issue #447) — kept for
+    // back-compat; CS0618 suppressed at the intentional internal use sites.
+#pragma warning disable CS0618
     private static bool HasAnyContentElement(IReadOnlyList<TreeViewNodeData> nodes)
     {
         for (int i = 0; i < nodes.Count; i++)
@@ -407,6 +410,7 @@ public sealed record TreeChildren<TElement, TControl>(
                 node.Children.Add(CreateTreeNode(data.Children[i], mountElements, reconciler, requestRerender));
         return node;
     }
+#pragma warning restore CS0618
 
     private static void UnmountTreeContent(IList<WinUI.TreeViewNode> nodes, Reconciler reconciler)
     {

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -646,6 +646,32 @@ public static partial class Factories
     public static TreeViewNodeData TreeNode(string content, params TreeViewNodeData[] children) =>
         new(content, children.Length > 0 ? children : null);
 
+    /// <summary>
+    /// Creates a typed, data-driven <see cref="TemplatedTreeViewElement{T}"/> — the
+    /// hierarchical peer of <see cref="ListView{T}(IReadOnlyList{T}, Func{T, string}, Func{T, int, Element})"/>.
+    /// Each node is rendered by <paramref name="viewBuilder"/> (WinUI <c>ItemTemplate</c>
+    /// equivalent); the tree axis comes from <paramref name="childrenSelector"/> and
+    /// identity from <paramref name="keySelector"/>. This is the supported way to put
+    /// rich elements in tree nodes — see issue #447 and the obsolete
+    /// <c>TreeViewNodeData.ContentElement</c>.
+    /// </summary>
+    public static TemplatedTreeViewElement<T> TreeView<T>(
+        IReadOnlyList<T> items,
+        Func<T, string> keySelector,
+        Func<T, IReadOnlyList<T>?> childrenSelector,
+        Func<T, Element> viewBuilder) => new(items, keySelector, childrenSelector, viewBuilder);
+
+    /// <summary>
+    /// <see cref="IReactorKeyed"/>-typed overload of
+    /// <see cref="TreeView{T}(IReadOnlyList{T}, Func{T, string}, Func{T, IReadOnlyList{T}}, Func{T, Element})"/>;
+    /// <c>KeySelector</c> defaults to <c>t =&gt; t.Key</c>.
+    /// </summary>
+    public static TemplatedTreeViewElement<T> TreeView<T>(
+        IReadOnlyList<T> items,
+        Func<T, IReadOnlyList<T>?> childrenSelector,
+        Func<T, Element> viewBuilder) where T : IReactorKeyed =>
+        new(items, static t => t.Key, childrenSelector, viewBuilder);
+
     public static FlipViewElement FlipView(params Element[] items) => new(items);
 
     // ── Dialogs / Overlays ──────────────────────────────────────────

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TemplatedTreeViewFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TemplatedTreeViewFixtures.cs
@@ -288,6 +288,83 @@ internal static class TemplatedTreeViewFixtures
         }
     }
 
+    // ── 3e. Constrained-height expand must stick (virtualization race) ───────
+    // Tiny viewport + many children forces container recycling; reproduces the
+    // GUI "expand opens & closes immediately" report.
+    internal sealed class ConstrainedExpandSticks(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var kids = new Node[20];
+            for (int i = 0; i < kids.Length; i++) kids[i] = new Node($"k{i}", $"KID_{i}");
+
+            var host = H.CreateHost();
+            host.Mount(_ => (TreeView<Node>(
+                items: new[] { new Node("root", "ROOT", kids) },
+                childrenSelector: Children,
+                viewBuilder: n => Button(n.Label)) with
+            {
+                IsExpanded = _ => false, // root starts collapsed
+            }).Height(90));
+
+            await Harness.Render();
+            var tv = H.FindControl<TreeView>(_ => true);
+            H.Check("TTV_Constrained_Mounted", tv is not null && tv.RootNodes.Count == 1);
+            if (tv is null || tv.RootNodes.Count == 0)
+            {
+                H.Check("TTV_Constrained_StaysExpanded", false);
+                return;
+            }
+
+            var root = tv.RootNodes[0];
+            root.IsExpanded = true;
+            await Harness.Render();
+            await Harness.Render();
+            await Harness.Render();
+
+            H.Check("TTV_Constrained_StaysExpanded", root.IsExpanded);
+        }
+    }
+
+    // ── Legacy TreeView (TreeViewElement): reconcile must not clobber the
+    //    user's runtime expansion back to the static data value (the
+    //    "expand flashes open then shut" regression — repros on main).
+    internal sealed class LegacyExpansionNotClobbered(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            Action<int>? bump = null;
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (_, set) = ctx.UseState(0);
+                bump = set;
+                // Data default IsExpanded = false (collapsed).
+                return new TreeViewElement(new[]
+                {
+                    new TreeViewNodeData("root", new[] { new TreeViewNodeData("child") }),
+                });
+            });
+
+            await Harness.Render();
+            var tv = H.FindControl<TreeView>(_ => true);
+            H.Check("LegacyTV_Mounted", tv is not null && tv.RootNodes.Count == 1);
+            if (tv is null || tv.RootNodes.Count == 0)
+            {
+                H.Check("LegacyTV_StaysExpanded", false);
+                return;
+            }
+
+            var root = tv.RootNodes[0];
+            root.IsExpanded = true;   // user expands at runtime
+            bump?.Invoke(1);          // unrelated state change → reconcile (data unchanged)
+            await Harness.Render();
+
+            // Old code reset IsExpanded to the data value (false) → collapse.
+            H.Check("LegacyTV_StaysExpanded", root.IsExpanded);
+        }
+    }
+
     // ── 4. Value-type T (exercises the boxing Project path) ──────────────────
     internal sealed class ValueTypeItems(Harness h) : SelfTestFixtureBase(h)
     {

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TemplatedTreeViewFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TemplatedTreeViewFixtures.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Coverage for the typed, data-driven <c>TreeView&lt;T&gt;</c>
+/// (<see cref="TemplatedTreeViewElement{T}"/>) — the WinUI-aligned replacement
+/// for the obsolete per-node <c>ContentElement</c> (issue #447). Each node is
+/// rendered by a viewBuilder (the ItemTemplate equivalent) hosted via the
+/// <c>{Binding Content}</c> template, so rich elements actually render — unlike
+/// the native node-mode default (see <see cref="WinUITreeViewNativeProbe"/>).
+/// </summary>
+internal static class TemplatedTreeViewFixtures
+{
+    private sealed record Node(string Key, string Label, Node[]? Kids = null) : IReactorKeyed;
+
+    private static IReadOnlyList<Node>? Children(Node n) => n.Kids;
+
+    // ── 1. Rich per-node content renders, including expanded children ────────
+    internal sealed class RendersRichContent(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(_ => TreeView<Node>(
+                items: new[]
+                {
+                    new Node("root", "ROOT_BTN", new[] { new Node("c1", "CHILD_BTN") }),
+                },
+                childrenSelector: Children,
+                viewBuilder: n => Button(n.Label)) with
+            {
+                IsExpanded = _ => true,
+            });
+
+            await Harness.Render();
+
+            H.Check("TTV_Render_RootButton", H.FindButton("ROOT_BTN") is not null);
+            // Child realizes because the root is expanded.
+            H.Check("TTV_Render_ChildButton", H.FindButton("CHILD_BTN") is not null);
+        }
+    }
+
+    // ── 2. OnItemInvoked / node→T resolution hands the developer's T back ────
+    internal sealed class ResolvesItemForEvents(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var root = new Node("root", "R");
+            Node? invokedWith = null;
+
+            var host = H.CreateHost();
+            host.Mount(_ => TreeView<Node>(
+                items: new[] { root },
+                childrenSelector: Children,
+                viewBuilder: n => Button(n.Label)) with
+            {
+                OnItemInvoked = n => invokedWith = n,
+            });
+
+            await Harness.Render();
+
+            var tv = H.FindControl<TreeView>(_ => true);
+            H.Check("TTV_Evt_Mounted", tv is not null);
+
+            if (tv is not null && tv.RootNodes.Count > 0)
+            {
+                var node = tv.RootNodes[0];
+
+                // The originating T rides on the node (duplicate-RCW-safe DP),
+                // and it is the SAME instance the developer passed in.
+                var stored = Reconciler.GetTreeNodeItem(node);
+                H.Check("TTV_Evt_NodeCarriesItem", ReferenceEquals(stored, root));
+
+                // The trampoline's resolution path routes that T to the typed
+                // callback (TreeViewItemInvokedEventArgs can't be synthesized,
+                // so drive the same resolution the trampoline performs).
+                if (Reconciler.GetElementTag(tv) is TemplatedTreeViewElementBase el && stored is not null)
+                    el.InvokeItemInvoked(stored);
+
+                H.Check("TTV_Evt_CallbackGotSameT", ReferenceEquals(invokedWith, root));
+            }
+            else
+            {
+                H.Check("TTV_Evt_NodeCarriesItem", false);
+                H.Check("TTV_Evt_CallbackGotSameT", false);
+            }
+        }
+    }
+
+    // ── 3. Keyed update reconciles a node's view in place (state survives) ───
+    internal sealed class KeyedUpdateReconciles(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            Action<string>? setLabel = null;
+            TreeViewNode? firstNodeBefore = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (label, set) = ctx.UseState("LBL_A");
+                setLabel = set;
+                return TreeView<Node>(
+                    items: new[] { new Node("stable", label) },
+                    childrenSelector: Children,
+                    viewBuilder: n => Button(n.Label));
+            });
+
+            await Harness.Render();
+            H.Check("TTV_Upd_InitialVisible", H.FindButton("LBL_A") is not null);
+
+            var tv = H.FindControl<TreeView>(_ => true);
+            if (tv is not null && tv.RootNodes.Count > 0)
+                firstNodeBefore = tv.RootNodes[0];
+
+            // Same key → node reused, view reconciled in place to the new label.
+            setLabel?.Invoke("LBL_B");
+            await Harness.Render();
+
+            H.Check("TTV_Upd_NewVisible", H.FindButton("LBL_B") is not null);
+            H.Check("TTV_Upd_OldGone", H.FindButton("LBL_A") is null);
+
+            var tvAfter = H.FindControl<TreeView>(_ => true);
+            bool sameNodeReused = tvAfter is not null && tvAfter.RootNodes.Count > 0
+                && ReferenceEquals(tvAfter.RootNodes[0], firstNodeBefore);
+            H.Check("TTV_Upd_NodeReusedByKey", sameNodeReused);
+        }
+    }
+
+    // ── 3b. Reconcile must not clobber user/native expansion ────────────────
+    // Regression: forcing node.IsExpanded from the selector on every render
+    // yanks a user-collapsed node back open and orphans hosted views (blank
+    // gaps). With a stable selector, a re-render must leave expansion alone.
+    internal sealed class ExpansionNotClobbered(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            Action<int>? bump = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (_, set) = ctx.UseState(0);
+                bump = set;
+                return TreeView<Node>(
+                    items: new[]
+                    {
+                        new Node("root", "R", new[] { new Node("c1", "C1"), new Node("c2", "C2") }),
+                    },
+                    childrenSelector: Children,
+                    viewBuilder: n => Button(n.Label)) with
+                {
+                    IsExpanded = _ => true, // stable selector
+                };
+            });
+
+            await Harness.Render();
+            var tv = H.FindControl<TreeView>(_ => true);
+            H.Check("TTV_Exp_Mounted", tv is not null && tv.RootNodes.Count > 0);
+
+            if (tv is not null && tv.RootNodes.Count > 0)
+            {
+                var root = tv.RootNodes[0];
+                H.Check("TTV_Exp_InitiallyExpanded", root.IsExpanded);
+
+                // Simulate the user collapsing the node.
+                root.IsExpanded = false;
+
+                // Trigger a re-render that does NOT change the data.
+                bump?.Invoke(1);
+                await Harness.Render();
+
+                // Stable selector ⇒ reconcile must leave the collapse intact.
+                H.Check("TTV_Exp_StaysCollapsed", !root.IsExpanded);
+            }
+            else
+            {
+                H.Check("TTV_Exp_InitiallyExpanded", false);
+                H.Check("TTV_Exp_StaysCollapsed", false);
+            }
+        }
+    }
+
+    // ── 3c. Collapse/expand must re-host every child view each cycle ─────────
+    // Regression (#447 follow-up): collapsing a node recycles its child
+    // containers and expanding re-realizes them. A shared live view kept a
+    // stale visual parent across the cycle, so on alternating expands some
+    // rows rendered blank. The ContainerContentChanging host/release must keep
+    // every child rendered on every expand.
+    internal sealed class CollapseExpandCycle(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(_ => TreeView<Node>(
+                items: new[]
+                {
+                    new Node("root", "ROOT", new[]
+                    {
+                        new Node("a", "ITEM_AA"),
+                        new Node("b", "ITEM_BB"),
+                        new Node("c", "ITEM_CC"),
+                    }),
+                },
+                childrenSelector: Children,
+                viewBuilder: n => Button(n.Label)) with
+            {
+                IsExpanded = n => n.Key == "root",
+            });
+
+            await Harness.Render();
+            var tv = H.FindControl<TreeView>(_ => true);
+            H.Check("TTV_Cycle_Mounted", tv is not null && tv.RootNodes.Count == 1);
+
+            if (tv is null || tv.RootNodes.Count == 0)
+            {
+                H.Check("TTV_Cycle_AllChildrenEachExpand", false);
+                return;
+            }
+
+            var root = tv.RootNodes[0];
+            bool allCyclesOk = true;
+
+            for (int cycle = 0; cycle < 3; cycle++)
+            {
+                root.IsExpanded = false;
+                await Harness.Render();
+                root.IsExpanded = true;
+                await Harness.Render();
+
+                int rendered = H.FindAllControls<Button>(b =>
+                    b.Content is string s && (s == "ITEM_AA" || s == "ITEM_BB" || s == "ITEM_CC")).Count;
+                if (rendered != 3) allCyclesOk = false;
+            }
+
+            H.Check("TTV_Cycle_AllChildrenEachExpand", allCyclesOk);
+        }
+    }
+
+    // ── 3d. Expanding an initially-collapsed node must stay expanded ─────────
+    // Regression: user reports clicking to expand a collapsed node "opens &
+    // closes immediately". Expand a collapsed subfolder and assert it stays
+    // expanded with its children realized after layout settles.
+    internal sealed class ExpandCollapsedNode(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(_ => TreeView<Node>(
+                items: new[]
+                {
+                    new Node("root", "ROOT", new[]
+                    {
+                        new Node("sub", "SUB", new[] { new Node("x", "XX"), new Node("y", "YY") }),
+                    }),
+                },
+                childrenSelector: Children,
+                viewBuilder: n => Button(n.Label)) with
+            {
+                IsExpanded = n => n.Key == "root", // root open, sub collapsed
+            });
+
+            await Harness.Render();
+            var tv = H.FindControl<TreeView>(_ => true);
+            bool ok = tv is not null && tv.RootNodes.Count == 1 && tv.RootNodes[0].Children.Count == 1;
+            H.Check("TTV_ExpandCollapsed_Mounted", ok);
+            H.Check("TTV_ExpandCollapsed_SubCollapsedInitially",
+                ok && !tv!.RootNodes[0].Children[0].IsExpanded);
+            H.Check("TTV_ExpandCollapsed_ChildrenHiddenInitially", H.FindButton("XX") is null);
+
+            if (!ok) { H.Check("TTV_ExpandCollapsed_StaysExpanded", false); return; }
+
+            // Simulate the user expanding the subfolder.
+            var sub = tv!.RootNodes[0].Children[0];
+            sub.IsExpanded = true;
+            await Harness.Render();
+            await Harness.Render(); // let WinUI's prepare-container IsExpanded sync settle
+
+            H.Check("TTV_ExpandCollapsed_StaysExpanded", sub.IsExpanded);
+            H.Check("TTV_ExpandCollapsed_ChildrenShown",
+                H.FindButton("XX") is not null && H.FindButton("YY") is not null);
+        }
+    }
+
+    // ── 4. Value-type T (exercises the boxing Project path) ──────────────────
+    internal sealed class ValueTypeItems(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(_ => TreeView<int>(
+                items: new[] { 7, 42 },
+                keySelector: i => i.ToString(),
+                childrenSelector: _ => null,
+                viewBuilder: i => Button($"INT_{i}")));
+
+            await Harness.Render();
+
+            H.Check("TTV_Int_First", H.FindButton("INT_7") is not null);
+            H.Check("TTV_Int_Second", H.FindButton("INT_42") is not null);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WinUITreeViewNativeProbeFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WinUITreeViewNativeProbeFixtures.cs
@@ -1,0 +1,97 @@
+using System.Threading.Tasks;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// EMPIRICAL PROBE (issue #447 design spike) — NOT a Reactor test.
+///
+/// Builds a *native* WinUI <see cref="TreeView"/> in node mode
+/// (<c>RootNodes</c>) and asks one question three ways: can a rich
+/// <see cref="Button"/> placed directly into <see cref="TreeViewNode.Content"/>
+/// actually render? This settles whether WinUI's ContentPresenter hosts a
+/// live UIElement in node mode, or whether that's a WPF-ism.
+///
+/// Reports each variant's result via H.Check so it shows up in TAP output;
+/// no Reactor reconciler is involved at all.
+/// </summary>
+internal sealed class WinUITreeViewNativeProbe(Harness h) : SelfTestFixtureBase(h)
+{
+    public override async Task RunAsync()
+    {
+        // ── Variant 1: node.Content = Button, NO ItemTemplate ──────────────
+        // (the pure "default template stringifies the node" path)
+        {
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            var tree = new TreeView();
+            var btn = new Button { Content = "PROBE_V1_BUTTON" };
+            tree.RootNodes.Add(new TreeViewNode { Content = btn, IsExpanded = true });
+            parent.Children.Add(tree);
+            await Harness.Render();
+
+            bool buttonInTree = H.FindControl<Button>(b => b.Content is string s && s == "PROBE_V1_BUTTON") is not null;
+            bool labelVisible = H.FindText("PROBE_V1_BUTTON") is not null;
+            // EXPECTED native behavior: node-mode default template stringifies the
+            // node and CANNOT host a live UIElement — so the Button must NOT appear.
+            // (If this ever flips, WinUI changed; revisit TreeView<T> hosting.)
+            H.Check("Probe_V1_NoTemplate_ButtonNotHosted", !buttonInTree);
+            H.Check("Probe_V1_NoTemplate_LabelNotVisible", !labelVisible);
+
+            H.SetContent(null);
+            await Harness.Render();
+        }
+
+        // ── Variant 2: node.Content = Button, ItemTemplate = ContentControl
+        //    binding {Binding Content} (DataContext = TreeViewNode) ──────────
+        {
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            var tree = new TreeView
+            {
+                ItemTemplate = (DataTemplate)XamlReader.Load(
+                    "<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>" +
+                    "<ContentControl Content='{Binding Content}' " +
+                    "HorizontalContentAlignment='Stretch' VerticalContentAlignment='Stretch'/>" +
+                    "</DataTemplate>"),
+            };
+            var btn = new Button { Content = "PROBE_V2_BUTTON" };
+            tree.RootNodes.Add(new TreeViewNode { Content = btn, IsExpanded = true });
+            parent.Children.Add(tree);
+            await Harness.Render();
+
+            bool buttonInTree = H.FindControl<Button>(b => b.Content is string s && s == "PROBE_V2_BUTTON") is not null;
+            bool labelVisible = H.FindText("PROBE_V2_BUTTON") is not null;
+            H.Check("Probe_V2_BindContentTemplate_ButtonHosted", buttonInTree);
+            H.Check("Probe_V2_BindContentTemplate_LabelVisible", labelVisible);
+
+            H.SetContent(null);
+            await Harness.Render();
+        }
+
+        // ── Variant 3 (control): node.Content = string, NO ItemTemplate ────
+        // Sanity: confirms the default node-mode path renders text.
+        {
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            var tree = new TreeView();
+            tree.RootNodes.Add(new TreeViewNode { Content = "PROBE_V3_STRING", IsExpanded = true });
+            parent.Children.Add(tree);
+            await Harness.Render();
+
+            bool textVisible = H.FindTextContaining("PROBE_V3_STRING") is not null;
+            H.Check("Probe_V3_StringContent_TextVisible", textVisible);
+
+            H.SetContent(null);
+            await Harness.Render();
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1254,10 +1254,26 @@ internal static class SelfTestFixtureRegistry
         "Spec047ExternalProof_Marquee_SetterChain",
         "Spec047ExternalProof_Marquee_PoolRent",
         "Spec047ExternalProof_Marquee_PoolResetContract",
+        "WinUITreeViewNativeProbe",
+        "TTV_RendersRichContent",
+        "TTV_ResolvesItemForEvents",
+        "TTV_KeyedUpdateReconciles",
+        "TTV_ExpansionNotClobbered",
+        "TTV_CollapseExpandCycle",
+        "TTV_ExpandCollapsedNode",
+        "TTV_ValueTypeItems",
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
     {
+        "WinUITreeViewNativeProbe" => new WinUITreeViewNativeProbe(harness),
+        "TTV_RendersRichContent" => new TemplatedTreeViewFixtures.RendersRichContent(harness),
+        "TTV_ResolvesItemForEvents" => new TemplatedTreeViewFixtures.ResolvesItemForEvents(harness),
+        "TTV_KeyedUpdateReconciles" => new TemplatedTreeViewFixtures.KeyedUpdateReconciles(harness),
+        "TTV_ExpansionNotClobbered" => new TemplatedTreeViewFixtures.ExpansionNotClobbered(harness),
+        "TTV_CollapseExpandCycle" => new TemplatedTreeViewFixtures.CollapseExpandCycle(harness),
+        "TTV_ExpandCollapsedNode" => new TemplatedTreeViewFixtures.ExpandCollapsedNode(harness),
+        "TTV_ValueTypeItems" => new TemplatedTreeViewFixtures.ValueTypeItems(harness),
         "ErrorBoundary_CatchesRenderError" => new ErrorBoundaryFixtures.CatchesRenderError(harness),
         "ErrorBoundary_Recovery" => new ErrorBoundaryFixtures.Recovery(harness),
         "Reconciler_MountText" => new ReconcilerFixtures.MountText(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1261,6 +1261,8 @@ internal static class SelfTestFixtureRegistry
         "TTV_ExpansionNotClobbered",
         "TTV_CollapseExpandCycle",
         "TTV_ExpandCollapsedNode",
+        "TTV_ConstrainedExpandSticks",
+        "TTV_LegacyExpansionNotClobbered",
         "TTV_ValueTypeItems",
     ];
 
@@ -1273,6 +1275,8 @@ internal static class SelfTestFixtureRegistry
         "TTV_ExpansionNotClobbered" => new TemplatedTreeViewFixtures.ExpansionNotClobbered(harness),
         "TTV_CollapseExpandCycle" => new TemplatedTreeViewFixtures.CollapseExpandCycle(harness),
         "TTV_ExpandCollapsedNode" => new TemplatedTreeViewFixtures.ExpandCollapsedNode(harness),
+        "TTV_ConstrainedExpandSticks" => new TemplatedTreeViewFixtures.ConstrainedExpandSticks(harness),
+        "TTV_LegacyExpansionNotClobbered" => new TemplatedTreeViewFixtures.LegacyExpansionNotClobbered(harness),
         "TTV_ValueTypeItems" => new TemplatedTreeViewFixtures.ValueTypeItems(harness),
         "ErrorBoundary_CatchesRenderError" => new ErrorBoundaryFixtures.CatchesRenderError(harness),
         "ErrorBoundary_Recovery" => new ErrorBoundaryFixtures.Recovery(harness),


### PR DESCRIPTION
Fixes #447.

## Problem
A `TreeView` whose `TreeViewNodeData` nodes carry a `ContentElement` renders **blank rows** — a `ListView` given the same element content renders fine.

Verified empirically on **native ARM64** (`WinUITreeViewNativeProbe`): WinUI's node-mode `TreeView` *stringifies* the node and **cannot host a live `UIElement`** placed in `TreeViewNode.Content` (the default `ContentPresenter` receives the node, not its content). Rich per-node visuals in WinUI come from a `DataTemplate`/`ItemTemplate`, never a pre-built element. (This is a WPF-ism — there `TreeViewItem` is a `HeaderedContentControl`.)

| Variant (native probe) | Result |
|---|---|
| `node.Content = Button`, no template | ❌ blank (stringified) |
| `node.Content = Button` + `ContentControl Content="{Binding Content}"` | ✅ hosted |
| `node.Content = "string"`, no template | ✅ text |

## Fix — typed `TreeView<T>`
A data-driven, hierarchical peer of `ListView<T>`:

```csharp
TreeView<T>(items, keySelector, childrenSelector, viewBuilder)   // + IReactorKeyed overload
```

- `viewBuilder` is the per-node template (WinUI `ItemTemplate` equivalent); `childrenSelector` gives hierarchy; `keySelector` gives identity.
- `OnItemInvoked` / `OnExpanding` hand the developer's own `T` back (resolved via an attached property on the node — duplicate-RCW-safe like `ReactorState`).
- **Heterogeneous nodes + per-shape templates** fall out of a `switch` in the `viewBuilder` (the `ItemTemplateSelector` pattern in C#).
- Keyed, in-place hierarchical reconcile so descendant component state survives updates.

### Hosting (WinUI's own mechanism)
Each node's view is mounted **once** and kept on an attached property; the internal `TreeViewList`'s `ContainerContentChanging` hosts it on realize and **releases it (`Content = null`) on recycle** — the only correct way to keep a shared live element from blanking across collapse/expand under virtualization. The host is **deferred to a low-priority dispatch** and re-validates the container still belongs to the node, so it never perturbs the synchronous expand pass (which otherwise re-prepared the expanding node with a stale `IsExpanded` and snapped it shut). Expansion is uncontrolled — the selector is only pushed when its value changes, never clobbering user toggles.

### Deprecation
`TreeViewNodeData.ContentElement` is `[Obsolete]` pointing to `TreeView<T>`; the legacy path stays functional (warning-suppressed) for back-compat. Text-only `TreeViewNodeData` is unchanged.

## Samples
- `DataTemplateDemo` §4 migrated to `TreeView<T>` (heterogeneous pet groups vs. animal leaves).
- Gallery `TreeViewPage` gains a file-explorer card (folders / docs / images via per-shape templates) and switches source snippets to raw-string literals so they render multi-line.

## Tests
`TemplatedTreeViewFixtures`: rich-content render, events resolve `T`, keyed update reconcile, expansion-not-clobbered, collapse/expand cycle, expand-collapsed-node, value-type `T`. Plus `WinUITreeViewNativeProbe` documenting native node-mode behavior. **Full self-test suite green (1075 fixtures / 4445 assertions, ARM64).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)