### PR TITLE
fix(navigationview): reconcile menu items in place to preserve expansion

### DIFF
--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -1450,10 +1450,7 @@ public sealed partial class Reconciler
         }
         if (nav.Content is not null) nv.Content = Mount(nav.Content, requestRerender);
         if (nav.SelectedTag is not null)
-        {
-            foreach (var mi in nv.MenuItems.OfType<WinUI.NavigationViewItem>())
-                if (mi.Tag as string == nav.SelectedTag) { nv.SelectedItem = mi; break; }
-        }
+            nv.SelectedItem = FindNavItemByTag(nv.MenuItems, nav.SelectedTag);
         SetElementTag(nv, nav);
         if (nav.OnSelectedTagChanged is not null)
             nv.SelectionChanged += (s, args) =>

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -1873,15 +1873,13 @@ public sealed partial class Reconciler
         // existing containers by Tag so matches can be reused, then rebuild the
         // collection in the new order. Reused containers retain their IsExpanded.
         var reusable = new global::System.Collections.Generic.Dictionary<string, WinUI.NavigationViewItem>();
-        foreach (var item in live)
-            if (item is WinUI.NavigationViewItem nvi && nvi.Tag is string tag)
-                reusable[tag] = nvi;
+        foreach (var nvi in live.OfType<WinUI.NavigationViewItem>().Where(x => x.Tag is string))
+            reusable[(string)nvi.Tag] = nvi;
 
         var oldByTag = new global::System.Collections.Generic.Dictionary<string, NavigationViewItemData>();
         if (oldData is not null)
-            foreach (var d in oldData)
-                if (!d.IsHeader)
-                    oldByTag[d.Tag ?? d.Content] = d;
+            foreach (var d in oldData.Where(d => !d.IsHeader))
+                oldByTag[d.Tag ?? d.Content] = d;
 
         live.Clear();
         foreach (var data in newData)
@@ -1892,8 +1890,11 @@ public sealed partial class Reconciler
                 continue;
             }
 
+            // Consume the reuse entry so duplicate sibling keys (duplicate Tags,
+            // or duplicate Content when no Tag is set) fall through to a fresh
+            // container rather than adding the same WinUI item to live twice.
             var key = data.Tag ?? data.Content;
-            if (reusable.TryGetValue(key, out var nvi))
+            if (reusable.Remove(key, out var nvi))
                 UpdateNavItemInPlace(nvi, oldByTag.GetValueOrDefault(key), data);
             else
                 nvi = CreateNavItem(data);

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -1750,17 +1750,17 @@ public sealed partial class Reconciler
         if (!double.IsNaN(n.CompactModeThresholdWidth) && nv.CompactModeThresholdWidth != n.CompactModeThresholdWidth) nv.CompactModeThresholdWidth = n.CompactModeThresholdWidth;
         if (!double.IsNaN(n.ExpandedModeThresholdWidth) && nv.ExpandedModeThresholdWidth != n.ExpandedModeThresholdWidth) nv.ExpandedModeThresholdWidth = n.ExpandedModeThresholdWidth;
 
+        // Reconcile menu items in place rather than clear-and-rebuild. The old
+        // rebuild recreated every NavigationViewItem on each render, and since
+        // per-item expansion (IsExpanded) lives only on the live container — it
+        // is not modeled in NavigationViewItemData — every re-render snapped all
+        // expanded hierarchical items shut. Because consumers typically pass a
+        // fresh MenuItems array each render (e.g. built via LINQ), the
+        // ReferenceEquals guard never held and the rebuild fired constantly,
+        // producing the "expand then collapse" flash and "child click collapses
+        // parent". Reusing containers by Tag preserves IsExpanded across renders.
         if (!ReferenceEquals(o.MenuItems, n.MenuItems))
-        {
-            nv.MenuItems.Clear();
-            foreach (var item in n.MenuItems)
-            {
-                if (item.IsHeader)
-                    nv.MenuItems.Add(new WinUI.NavigationViewItemHeader { Content = item.Content });
-                else
-                    nv.MenuItems.Add(CreateNavItem(item));
-            }
-        }
+            ReconcileNavMenuItems(nv.MenuItems, o.MenuItems, n.MenuItems);
 
         // AutoSuggestBox / PaneFooter / PaneCustomContent reconcile in place
         // when possible so the controls keep focus / scroll state across re-renders.
@@ -1833,6 +1833,123 @@ public sealed partial class Reconciler
             }
         }
         return null;
+    }
+
+    /// <summary>
+    /// Brings a live NavigationView menu-item collection into agreement with
+    /// <paramref name="newData"/> while reusing existing <see cref="WinUI.NavigationViewItem"/>
+    /// containers (matched by Tag) so their runtime <c>IsExpanded</c>/selection
+    /// state survives the re-render. Recurses into hierarchical children.
+    /// </summary>
+    private void ReconcileNavMenuItems(
+        global::System.Collections.Generic.IList<object> live,
+        NavigationViewItemData[]? oldData,
+        NavigationViewItemData[] newData)
+    {
+        // Fast path: the structure (order of headers + item Tags) is unchanged —
+        // the overwhelmingly common case, since menus are usually static. Update
+        // each container in place without detaching anything, which keeps every
+        // container's expansion, selection and animation state pristine.
+        if (NavStructureMatches(live, newData))
+        {
+            for (int i = 0; i < newData.Length; i++)
+            {
+                var data = newData[i];
+                if (data.IsHeader)
+                {
+                    if (live[i] is WinUI.NavigationViewItemHeader h && !Equals(h.Content, data.Content))
+                        h.Content = data.Content;
+                }
+                else if (live[i] is WinUI.NavigationViewItem nvi)
+                {
+                    var oldItem = oldData is not null && i < oldData.Length ? oldData[i] : null;
+                    UpdateNavItemInPlace(nvi, oldItem, data);
+                }
+            }
+            return;
+        }
+
+        // Structure changed (items added / removed / reordered): snapshot the
+        // existing containers by Tag so matches can be reused, then rebuild the
+        // collection in the new order. Reused containers retain their IsExpanded.
+        var reusable = new global::System.Collections.Generic.Dictionary<string, WinUI.NavigationViewItem>();
+        foreach (var item in live)
+            if (item is WinUI.NavigationViewItem nvi && nvi.Tag is string tag)
+                reusable[tag] = nvi;
+
+        var oldByTag = new global::System.Collections.Generic.Dictionary<string, NavigationViewItemData>();
+        if (oldData is not null)
+            foreach (var d in oldData)
+                if (!d.IsHeader)
+                    oldByTag[d.Tag ?? d.Content] = d;
+
+        live.Clear();
+        foreach (var data in newData)
+        {
+            if (data.IsHeader)
+            {
+                live.Add(new WinUI.NavigationViewItemHeader { Content = data.Content });
+                continue;
+            }
+
+            var key = data.Tag ?? data.Content;
+            if (reusable.TryGetValue(key, out var nvi))
+                UpdateNavItemInPlace(nvi, oldByTag.GetValueOrDefault(key), data);
+            else
+                nvi = CreateNavItem(data);
+            live.Add(nvi);
+        }
+    }
+
+    /// <summary>True when the live collection already matches the new data in
+    /// count and in the sequence of headers / item Tags.</summary>
+    private static bool NavStructureMatches(
+        global::System.Collections.Generic.IList<object> live,
+        NavigationViewItemData[] newData)
+    {
+        if (live.Count != newData.Length) return false;
+        for (int i = 0; i < newData.Length; i++)
+        {
+            var data = newData[i];
+            if (data.IsHeader)
+            {
+                if (live[i] is not WinUI.NavigationViewItemHeader) return false;
+            }
+            else
+            {
+                if (live[i] is not WinUI.NavigationViewItem nvi) return false;
+                if ((nvi.Tag as string) != (data.Tag ?? data.Content)) return false;
+            }
+        }
+        return true;
+    }
+
+    /// <summary>Updates a reused NavigationViewItem's Content/Icon (only when
+    /// changed) and reconciles its children, leaving IsExpanded untouched.</summary>
+    private void UpdateNavItemInPlace(WinUI.NavigationViewItem nvi, NavigationViewItemData? oldData, NavigationViewItemData data)
+    {
+        if (!Equals(nvi.Content, data.Content)) nvi.Content = data.Content;
+
+        var newTag = data.Tag ?? data.Content;
+        if (!Equals(nvi.Tag, newTag)) nvi.Tag = newTag;
+
+        // Re-resolve the icon only when the icon data actually changed (IconData
+        // records compare by value), so the FontIcon/SymbolIcon isn't reallocated
+        // on every render.
+        bool iconChanged = oldData is null
+            || !Equals(oldData.IconElement, data.IconElement)
+            || oldData.Icon != data.Icon;
+        if (iconChanged)
+        {
+            var icon = ResolveIcon(data.IconElement, data.Icon);
+            if (icon is not null) nvi.Icon = icon;
+            else if (nvi.Icon is not null) nvi.Icon = null;
+        }
+
+        if (data.Children is { Length: > 0 } children)
+            ReconcileNavMenuItems(nvi.MenuItems, oldData?.Children, children);
+        else if (nvi.MenuItems.Count > 0)
+            nvi.MenuItems.Clear();
     }
 
     private UIElement? UpdateTitleBar(TitleBarElement o, TitleBarElement n, WinUI.TitleBar titleBar, Action requestRerender)

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/NavigationViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/NavigationViewDescriptor.cs
@@ -123,8 +123,9 @@ internal static class NavigationViewDescriptor
 
     private static void ApplyMenuAndSelection(WinUI.NavigationView control, NavigationViewElement? oldElement, NavigationViewElement element)
     {
-        if (oldElement is null || !ReferenceEquals(oldElement.MenuItems, element.MenuItems))
+        if (oldElement is null)
         {
+            // Mount: build fresh.
             control.MenuItems.Clear();
             foreach (var item in element.MenuItems)
             {
@@ -133,6 +134,13 @@ internal static class NavigationViewDescriptor
                     : CreateNavItem(item));
             }
         }
+        else if (!ReferenceEquals(oldElement.MenuItems, element.MenuItems))
+        {
+            // Update: reconcile in place so reused containers keep IsExpanded.
+            // Mirrors Reconciler.ReconcileNavMenuItems (legacy arm) — see the note
+            // there on why a clear-and-rebuild collapses hierarchical items.
+            ReconcileMenuItems(control.MenuItems, oldElement.MenuItems, element.MenuItems);
+        }
 
         if (oldElement is null
             || oldElement.SelectedTag != element.SelectedTag
@@ -140,6 +148,107 @@ internal static class NavigationViewDescriptor
         {
             control.SelectedItem = FindItemByTag(control.MenuItems, element.SelectedTag);
         }
+    }
+
+    private static void ReconcileMenuItems(
+        global::System.Collections.Generic.IList<object> live,
+        NavigationViewItemData[]? oldData,
+        NavigationViewItemData[] newData)
+    {
+        if (StructureMatches(live, newData))
+        {
+            for (int i = 0; i < newData.Length; i++)
+            {
+                var data = newData[i];
+                if (data.IsHeader)
+                {
+                    if (live[i] is WinUI.NavigationViewItemHeader h && !Equals(h.Content, data.Content))
+                        h.Content = data.Content;
+                }
+                else if (live[i] is WinUI.NavigationViewItem nvi)
+                {
+                    var oldItem = oldData is not null && i < oldData.Length ? oldData[i] : null;
+                    UpdateNavItemInPlace(nvi, oldItem, data);
+                }
+            }
+            return;
+        }
+
+        var reusable = new global::System.Collections.Generic.Dictionary<string, WinUI.NavigationViewItem>();
+        foreach (var item in live)
+            if (item is WinUI.NavigationViewItem nvi && nvi.Tag is string tag)
+                reusable[tag] = nvi;
+
+        var oldByTag = new global::System.Collections.Generic.Dictionary<string, NavigationViewItemData>();
+        if (oldData is not null)
+            foreach (var d in oldData)
+                if (!d.IsHeader)
+                    oldByTag[d.Tag ?? d.Content] = d;
+
+        live.Clear();
+        foreach (var data in newData)
+        {
+            if (data.IsHeader)
+            {
+                live.Add(new WinUI.NavigationViewItemHeader { Content = data.Content });
+                continue;
+            }
+
+            var key = data.Tag ?? data.Content;
+            if (reusable.TryGetValue(key, out var nvi))
+                UpdateNavItemInPlace(nvi, oldByTag.GetValueOrDefault(key), data);
+            else
+                nvi = CreateNavItem(data);
+            live.Add(nvi);
+        }
+    }
+
+    private static bool StructureMatches(
+        global::System.Collections.Generic.IList<object> live,
+        NavigationViewItemData[] newData)
+    {
+        if (live.Count != newData.Length) return false;
+        for (int i = 0; i < newData.Length; i++)
+        {
+            var data = newData[i];
+            if (data.IsHeader)
+            {
+                if (live[i] is not WinUI.NavigationViewItemHeader) return false;
+            }
+            else
+            {
+                if (live[i] is not WinUI.NavigationViewItem nvi) return false;
+                if ((nvi.Tag as string) != (data.Tag ?? data.Content)) return false;
+            }
+        }
+        return true;
+    }
+
+    private static void UpdateNavItemInPlace(WinUI.NavigationViewItem nvi, NavigationViewItemData? oldData, NavigationViewItemData data)
+    {
+        if (!Equals(nvi.Content, data.Content)) nvi.Content = data.Content;
+
+        var newTag = data.Tag ?? data.Content;
+        if (!Equals(nvi.Tag, newTag)) nvi.Tag = newTag;
+
+        bool iconChanged = oldData is null
+            || !Equals(oldData.IconElement, data.IconElement)
+            || oldData.Icon != data.Icon;
+        if (iconChanged)
+        {
+            var icon = data.IconElement is not null
+                ? Reconciler.ResolveIconForDescriptor(data.IconElement)
+                : data.Icon is not null
+                    ? Reconciler.ResolveIconForDescriptor(new SymbolIconData(data.Icon))
+                    : null;
+            if (icon is not null) nvi.Icon = icon;
+            else if (nvi.Icon is not null) nvi.Icon = null;
+        }
+
+        if (data.Children is { Length: > 0 } children)
+            ReconcileMenuItems(nvi.MenuItems, oldData?.Children, children);
+        else if (nvi.MenuItems.Count > 0)
+            nvi.MenuItems.Clear();
     }
 
     private static WinUI.NavigationViewItem CreateNavItem(NavigationViewItemData data)

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/NavigationViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/NavigationViewDescriptor.cs
@@ -175,15 +175,13 @@ internal static class NavigationViewDescriptor
         }
 
         var reusable = new global::System.Collections.Generic.Dictionary<string, WinUI.NavigationViewItem>();
-        foreach (var item in live)
-            if (item is WinUI.NavigationViewItem nvi && nvi.Tag is string tag)
-                reusable[tag] = nvi;
+        foreach (var nvi in live.OfType<WinUI.NavigationViewItem>().Where(x => x.Tag is string))
+            reusable[(string)nvi.Tag] = nvi;
 
         var oldByTag = new global::System.Collections.Generic.Dictionary<string, NavigationViewItemData>();
         if (oldData is not null)
-            foreach (var d in oldData)
-                if (!d.IsHeader)
-                    oldByTag[d.Tag ?? d.Content] = d;
+            foreach (var d in oldData.Where(d => !d.IsHeader))
+                oldByTag[d.Tag ?? d.Content] = d;
 
         live.Clear();
         foreach (var data in newData)
@@ -194,8 +192,10 @@ internal static class NavigationViewDescriptor
                 continue;
             }
 
+            // Consume the reuse entry so duplicate sibling keys fall through to a
+            // fresh container rather than adding the same WinUI item to live twice.
             var key = data.Tag ?? data.Content;
-            if (reusable.TryGetValue(key, out var nvi))
+            if (reusable.Remove(key, out var nvi))
                 UpdateNavItemInPlace(nvi, oldByTag.GetValueOrDefault(key), data);
             else
                 nvi = CreateNavItem(data);

--- a/tests/Reactor.AppTests.Host/FixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/FixtureRegistry.cs
@@ -61,8 +61,16 @@ internal static class FixtureRegistry
         // Collections
         "ListView_TypedRendering",
 
+        // TreeView expand/collapse (mirrors ReactorGallery Basic TreeView —
+        // E2E repro/guard for the item-body-collapse bug)
+        "TreeView_BasicTextTree",
+
         // Navigation
         "Navigation_TabSwitching",
+
+        // NavigationView hierarchical expand/collapse (E2E repro/guard for the
+        // re-render rebuild-clobber that collapsed expanded categories)
+        "NavigationView_Hierarchical",
 
         // Observable
         "Observable_UseObservable_Rerender",
@@ -205,8 +213,14 @@ internal static class FixtureRegistry
         // Collections
         "ListView_TypedRendering" => CollectionFixtures.ListViewTyped(ctx),
 
+        // TreeView expand/collapse
+        "TreeView_BasicTextTree" => TreeViewE2EFixtures.BasicTextTree(ctx),
+
         // Navigation
         "Navigation_TabSwitching" => NavigationFixtures.TabSwitching(ctx),
+
+        // NavigationView hierarchical expand/collapse
+        "NavigationView_Hierarchical" => NavigationViewE2EFixtures.HierarchicalNav(ctx),
 
         // Observable
         "Observable_UseObservable_Rerender" => ObservableFixtures.UseObservable_Rerender(ctx),

--- a/tests/Reactor.AppTests.Host/Fixtures/NavigationViewE2EFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/NavigationViewE2EFixtures.cs
@@ -1,0 +1,66 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.Fixtures;
+
+/// <summary>
+/// E2E fixtures for hierarchical <c>NavigationView</c> expand/collapse, mirroring
+/// the ReactorGallery shell shape: a stateful component that holds the selected
+/// tag, re-renders on every selection, and rebuilds its <c>MenuItems</c> array
+/// fresh each render (the condition that made the old clear-and-rebuild update
+/// path collapse expanded categories on every re-render).
+///
+/// PaneDisplayMode is pinned to <c>Left</c> so the pane stays open with text
+/// labels (addressable by UIA Name) and children render inline when expanded,
+/// regardless of the host window size.
+/// </summary>
+internal static class NavigationViewE2EFixtures
+{
+    internal class HierarchicalNavComponent : Component
+    {
+        public override Element Render()
+        {
+            var (selectedTag, setSelectedTag) = UseState("alpha-1");
+
+            // Rebuilt fresh every render — exactly the pattern the Gallery uses
+            // and the one that exposed the rebuild-clobber bug.
+            var menuItems = new[]
+            {
+                NavItem("Alpha", tag: "alpha") with
+                {
+                    Children = new[]
+                    {
+                        NavItem("Alpha-1", tag: "alpha-1"),
+                        NavItem("Alpha-2", tag: "alpha-2"),
+                    }
+                },
+                NavItem("Bravo", tag: "bravo") with
+                {
+                    Children = new[]
+                    {
+                        NavItem("Bravo-1", tag: "bravo-1"),
+                    }
+                },
+            };
+
+            return NavigationView(
+                menuItems,
+                content: TextBlock($"Selected: {selectedTag}").AutomationId("NavSelectedTag")
+            ) with
+            {
+                SelectedTag = selectedTag,
+                PaneDisplayMode = NavigationViewPaneDisplayMode.Left,
+                IsSettingsVisible = false,
+                OnSelectedTagChanged = tag =>
+                {
+                    if (tag != null) setSelectedTag(tag);
+                },
+            };
+        }
+    }
+
+    internal static Element HierarchicalNav(RenderContext ctx) =>
+        Component<HierarchicalNavComponent>();
+}

--- a/tests/Reactor.AppTests.Host/Fixtures/TreeViewE2EFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/TreeViewE2EFixtures.cs
@@ -1,0 +1,57 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.Fixtures;
+
+/// <summary>
+/// E2E fixtures for the legacy text-node <c>TreeView</c> expand/collapse path.
+///
+/// This deliberately mirrors the ReactorGallery "Basic TreeView" card
+/// (<c>samples/ReactorGallery/ControlPages/Collections/TreeViewPage.cs</c>):
+/// a plain text tree built with <c>TreeView(TreeNode(...))</c>, with
+/// <b>no</b> <c>OnExpanding</c>/<c>OnItemInvoked</c> handlers and no component
+/// state. That "no handlers, no state" shape is important — clicking a node
+/// triggers no Reactor re-render, so it isolates the WinUI-level expand/collapse
+/// behavior (see <c>c:\temp\treeview-expand-collapse-investigation.md</c> §5).
+///
+/// The tree is rendered with the top two levels pre-expanded so that collapse
+/// is observable through the UIA tree: a node's children are only realized
+/// (and therefore only findable by automation) while that node is expanded.
+/// </summary>
+internal static class TreeViewE2EFixtures
+{
+    // The node text values double as the WinAppDriver UIA Names the tests look
+    // up. Keep them unique so Name-based lookup is unambiguous.
+    internal static Element BasicTextTree(RenderContext ctx)
+    {
+        static TreeViewNodeData Expanded(TreeViewNodeData n) => n with { IsExpanded = true };
+
+        return VStack(8,
+            TextBlock("Basic text TreeView — mirrors ReactorGallery Collections → TreeView (no handlers, no state).")
+                .AutomationId("TreeViewCaption"),
+
+            TreeView(
+                // Documents / Work pre-expanded → Report.docx + Slides.pptx are
+                // initially visible, so a collapse caused by clicking the item
+                // body (or a child) is detectable.
+                Expanded(TreeNode("Documents",
+                    Expanded(TreeNode("Work",
+                        TreeNode("Report.docx"),
+                        TreeNode("Slides.pptx"))),
+                    TreeNode("Personal",
+                        TreeNode("Budget.xlsx")))),
+
+                // Pictures stays collapsed → exercises the "click item body to
+                // expand, expansion should stick" path.
+                TreeNode("Pictures",
+                    TreeNode("Vacation",
+                        TreeNode("Beach.jpg"),
+                        TreeNode("Mountain.jpg")),
+                    TreeNode("Family")),
+
+                TreeNode("Music")
+            ).Height(300).AutomationId("BasicTreeView")
+        );
+    }
+}

--- a/tests/Reactor.AppTests/Tests/NavigationViewInteractionTests.cs
+++ b/tests/Reactor.AppTests/Tests/NavigationViewInteractionTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Reactor.AppTests.Infrastructure;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Windows;
+using OpenQA.Selenium.Support.UI;
+
+namespace Microsoft.UI.Reactor.AppTests.Tests;
+
+/// <summary>
+/// E2E expand/collapse tests for the hierarchical <c>NavigationView</c>, driving
+/// the real WinUI control through WinAppDriver via the
+/// <c>NavigationView_Hierarchical</c> host fixture (which mirrors the
+/// ReactorGallery shell: stateful, re-renders on every selection, rebuilds its
+/// MenuItems array each render).
+///
+/// These reproduce the rebuild-clobber bug: before the fix, every selection
+/// re-render cleared and recreated all NavigationViewItems, so an expanded
+/// category snapped shut on the same click that selected it, and selecting a
+/// child collapsed its parent. The fix reconciles menu items in place (matching
+/// by Tag) so the container's IsExpanded survives the re-render.
+///
+/// Unlike the TreeView gesture bug, this one is triggered by the re-render itself
+/// (a real SelectionChanged event), so WinAppDriver reproduces it deterministically.
+/// </summary>
+[TestClass]
+public class NavigationViewInteractionTests : AppTestBase
+{
+    private const string Fixture = "NavigationView_Hierarchical";
+
+    [ClassInitialize]
+    public static void StartAppSession(TestContext context) => TestSession.AssemblyInit(context);
+
+    [ClassCleanup]
+    public static void StopAppSession() => TestSession.AssemblyCleanup();
+
+    /// <summary>
+    /// Clicking a collapsed parent category expands it and the expansion sticks
+    /// across the selection-triggered re-render (its children stay visible).
+    /// </summary>
+    [TestMethod]
+    public void ExpandParent_StaysExpandedAfterRerender()
+    {
+        NavigateToFixtureFresh(Fixture);
+
+        // Parent starts collapsed → children not realized.
+        Assert.IsFalse(IsItemPresent("Alpha-1"), "Alpha should start collapsed.");
+
+        ClickItem("Alpha");
+        Settle();
+
+        Assert.IsTrue(WaitForItemPresent("Alpha-1"),
+            "Expanding 'Alpha' did not stick — its child 'Alpha-1' is not visible after the " +
+            "selection re-render (rebuild-clobber regression).");
+    }
+
+    /// <summary>
+    /// Selecting a child must NOT collapse its parent. Expand "Alpha", click child
+    /// "Alpha-1", and verify the sibling "Alpha-2" remains visible (parent stayed
+    /// expanded) and the selection updated.
+    /// </summary>
+    [TestMethod]
+    public void SelectChild_DoesNotCollapseParent()
+    {
+        NavigateToFixtureFresh(Fixture);
+
+        ClickItem("Alpha");
+        Settle();
+        Assert.IsTrue(WaitForItemPresent("Alpha-2"), "Alpha should be expanded with its children visible.");
+
+        ClickItem("Alpha-1");
+        Settle();
+
+        WaitForText("NavSelectedTag", "Selected: alpha-1");
+        Assert.IsTrue(IsItemPresent("Alpha-2"),
+            "Selecting child 'Alpha-1' collapsed its parent 'Alpha' " +
+            "(sibling 'Alpha-2' disappeared) — rebuild-clobber regression.");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────
+
+    private void ClickItem(string itemText) =>
+        Session.FindElement(MobileBy.Name(itemText)).Click();
+
+    private bool IsItemPresent(string itemText)
+    {
+        try
+        {
+            Session.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
+            Session.FindElement(MobileBy.Name(itemText));
+            return true;
+        }
+        catch (WebDriverException)
+        {
+            return false;
+        }
+        finally
+        {
+            Session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(2);
+        }
+    }
+
+    private bool WaitForItemPresent(string itemText, int timeoutMs = 4000)
+    {
+        var wait = new DefaultWait<WindowsDriver<WindowsElement>>(Session)
+        {
+            Timeout = TimeSpan.FromMilliseconds(timeoutMs),
+            PollingInterval = TimeSpan.FromMilliseconds(150),
+        };
+        wait.IgnoreExceptionTypes(typeof(WebDriverException));
+        try
+        {
+            return wait.Until(driver =>
+            {
+                try { driver.FindElement(MobileBy.Name(itemText)); return true; }
+                catch (WebDriverException) { return false; }
+            });
+        }
+        catch (WebDriverTimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static void Settle() => Thread.Sleep(600);
+}

--- a/tests/Reactor.AppTests/Tests/TreeViewInteractionTests.cs
+++ b/tests/Reactor.AppTests/Tests/TreeViewInteractionTests.cs
@@ -1,0 +1,181 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Reactor.AppTests.Infrastructure;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Windows;
+using OpenQA.Selenium.Support.UI;
+
+namespace Microsoft.UI.Reactor.AppTests.Tests;
+
+/// <summary>
+/// E2E expand/collapse tests for the legacy text-node <c>TreeView</c>, driving
+/// the real WinUI control through WinAppDriver. These exercise the same path as
+/// the ReactorGallery "Basic TreeView" card via the <c>TreeView_BasicTextTree</c>
+/// host fixture.
+///
+/// Why E2E and not the headless self-test harness: the bug only reproduces in a
+/// real, on-screen window with real pointer input — the headless host lays out
+/// at full desired size and does not reproduce the constrained-viewport /
+/// container-recycling timing (see
+/// <c>c:\temp\treeview-expand-collapse-investigation.md</c> §6). So these tests
+/// are the automated repro surface AND the future regression guard.
+///
+/// How expand/collapse is observed: in node-mode TreeView, a node's children are
+/// only realized (and therefore only present in the UIA tree) while that node is
+/// expanded. So "is descendant X findable by Name?" is a faithful proxy for "is
+/// its ancestor expanded?".
+///
+/// Gesture under test: <see cref="ClickNodeBody"/> clicks the node's text (the
+/// center of the content area) — NOT the expand/collapse chevron on the far left.
+/// Per the investigation, the chevron works correctly; clicking the row body is
+/// what misbehaves in the live GUI.
+///
+/// CURRENT STATUS (main, 2026-05): both tests PASS — i.e. a WinAppDriver-injected
+/// item-body click does NOT collapse the node, and clicking a child does NOT
+/// collapse its parent. That is itself useful signal: the reported collapse does
+/// not reproduce under automated pointer injection on a data-pre-expanded tree,
+/// which narrows the suspect surface toward human-gesture timing and/or the
+/// user-expands-then-it-collapses sequence (investigation §4/§5) rather than the
+/// steady-state mount path these tests cover. The tests stand as (a) a live-GUI
+/// debugging harness for the gallery path — set REACTOR_TV_TRACE=1 and navigate
+/// to TreeView_BasicTextTree — and (b) a regression guard that the steady-state
+/// expand/collapse path stays healthy. If a future change makes an item-body or
+/// child click collapse the tree, these go red.
+/// </summary>
+[TestClass]
+public class TreeViewInteractionTests : AppTestBase
+{
+    private const string Fixture = "TreeView_BasicTextTree";
+
+    [ClassInitialize]
+    public static void StartAppSession(TestContext context) => TestSession.AssemblyInit(context);
+
+    [ClassCleanup]
+    public static void StopAppSession() => TestSession.AssemblyCleanup();
+
+    /// <summary>
+    /// Symptom 1: clicking a node's item body (not the chevron) must NOT collapse
+    /// it. "Work" starts expanded, so "Report.docx" is visible; after clicking the
+    /// "Work" row body the child must remain visible.
+    /// </summary>
+    [TestMethod]
+    public void ClickItemBody_DoesNotCollapseExpandedNode()
+    {
+        NavigateToFixtureFresh(Fixture);
+
+        // Precondition: Work is expanded → its children are realized.
+        AssertNodeVisible("Report.docx", "Work should start expanded.");
+
+        ClickNodeBody("Work");
+        Settle();
+
+        // Prove the click actually landed on the row (otherwise a "stayed visible"
+        // pass would be vacuous): an item-body click in SelectionMode.Single must
+        // select the node.
+        Assert.IsTrue(IsNodeSelected("Work"),
+            "Item-body click did not register — 'Work' is not selected, so the " +
+            "'no collapse' assertion below would be meaningless.");
+
+        AssertNodeVisible(
+            "Report.docx",
+            "Clicking the 'Work' row body collapsed it (its child 'Report.docx' disappeared). " +
+            "The item body should not toggle expansion — only the chevron should.");
+    }
+
+    /// <summary>
+    /// Symptom 2: clicking a child item must NOT collapse its parent. Click
+    /// "Report.docx" (a leaf child of "Work") and verify "Work" stays expanded
+    /// (its sibling "Slides.pptx" remains visible).
+    /// </summary>
+    [TestMethod]
+    public void ClickChild_DoesNotCollapseParent()
+    {
+        NavigateToFixtureFresh(Fixture);
+
+        AssertNodeVisible("Slides.pptx", "Work should start expanded.");
+
+        ClickNodeBody("Report.docx");
+        Settle();
+
+        AssertNodeVisible(
+            "Slides.pptx",
+            "Clicking child 'Report.docx' collapsed its parent 'Work' " +
+            "(sibling 'Slides.pptx' disappeared).");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Clicks the body (text/content area) of a tree node, addressed by its text.
+    /// The element found by Name is the node's TextBlock, whose center is over the
+    /// content — well clear of the chevron on the far left.
+    /// </summary>
+    private void ClickNodeBody(string nodeText)
+    {
+        Session.FindElement(MobileBy.Name(nodeText)).Click();
+    }
+
+    /// <summary>
+    /// Whether the tree node addressed by its text reports UIA selection
+    /// (SelectionItem pattern). Used to prove an item-body click registered.
+    /// </summary>
+    private bool IsNodeSelected(string nodeText)
+    {
+        try
+        {
+            return Session.FindElement(MobileBy.Name(nodeText)).Selected;
+        }
+        catch (WebDriverException)
+        {
+            return false;
+        }
+    }
+
+    private void AssertNodeVisible(string nodeText, string because)
+    {
+        Assert.IsTrue(WaitForNodePresent(nodeText),
+            $"Expected tree node '{nodeText}' to be visible. {because}");
+    }
+
+    /// <summary>
+    /// Polls until a node with the given Name is present, or the timeout elapses.
+    /// Returns whether the node became present.
+    /// </summary>
+    private bool WaitForNodePresent(string nodeText, int timeoutMs = 4000)
+    {
+        var wait = new DefaultWait<WindowsDriver<WindowsElement>>(Session)
+        {
+            Timeout = TimeSpan.FromMilliseconds(timeoutMs),
+            PollingInterval = TimeSpan.FromMilliseconds(150),
+        };
+        wait.IgnoreExceptionTypes(typeof(WebDriverException));
+        try
+        {
+            // DefaultWait keeps polling while the lambda returns the default value
+            // (false for bool), so returning false on not-found retries until the
+            // timeout; returning true ends the wait successfully.
+            return wait.Until(driver =>
+            {
+                try
+                {
+                    driver.FindElement(MobileBy.Name(nodeText));
+                    return true;
+                }
+                catch (WebDriverException)
+                {
+                    return false; // keep polling
+                }
+            });
+        }
+        catch (WebDriverTimeoutException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Lets any expand/collapse animation or reconcile-driven "flash" settle so
+    /// assertions observe the final state, not a transient mid-toggle frame.
+    /// </summary>
+    private static void Settle() => Thread.Sleep(600);
+}


### PR DESCRIPTION
## Problem

`NavigationView` with hierarchical menu items mis-behaved on every interaction:

- clicking a category expanded it then immediately collapsed it (a flash);
- clicking a child item collapsed its parent;
- selection state churned on each render.

## Root cause

`UpdateNavigationView` (and the V1 `NavigationViewDescriptor`) did
`MenuItems.Clear()` + full rebuild whenever the `MenuItems` array reference
changed. Consumers typically build a fresh `MenuItems` array each `Render()`
(e.g. via LINQ), so the `ReferenceEquals` guard never held and the rebuild
fired on essentially every re-render.

Per-item expansion lives only on the live `NavigationViewItem` — there is no
`IsExpanded` on `NavigationViewItemData` — so recreating the containers reset
expansion to `false` every time. Because selecting an item triggers a
re-render, the just-expanded category (or a child's parent) snapped shut on the
same click.

## Fix

Reconcile menu items **in place** instead of clear-and-rebuild:

- match existing `NavigationViewItem`s by `Tag`;
- update only changed `Content` / `Icon`;
- recurse into children;
- reuse the container so its runtime `IsExpanded` (and selection) survive the
  re-render.

A fast path skips all detaching when the item structure is unchanged (the
common case). Mirrored into the V1 `NavigationViewDescriptor` so V1 ON behaves
identically to V1 OFF. Mount-time selection now recurses so a child tag selects
correctly.

## Tests

- New E2E guard: `NavigationView_Hierarchical` host fixture +
  `NavigationViewInteractionTests`. Verified to **fail on the pre-fix build**
  (expanded category collapses after the selection re-render) and **pass after**.
- Existing NavigationView self-tests, including the V1
  `Desc_NavigationView_MountUpdate` coverage, pass (0 failures).
- Also adds a TreeView E2E guard exercising the Gallery's basic text-tree path.

## Out of scope

Compact (icon-only) pane interaction is deferred to a follow-up.