### PR TITLE
fix(bootstrap): skip template uninstall on first run + add -Verbose diagnostics

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -33,6 +33,14 @@
     non-interactive scripts that explicitly don't want the runtime
     installed. Mutually exclusive with -InstallWinAppSdk.
 
+.PARAMETER Verbose
+    Common parameter (enabled by [CmdletBinding]). Surfaces extra
+    diagnostic output at every decision point: detected SDK list,
+    winget probe exit codes, host arch / pack args, global-tool
+    install-vs-update branch, template uninstall decision, plugin
+    symlink-vs-copy fallback, etc. Use this when bootstrap fails or
+    behaves unexpectedly and you want to see *why* a branch was taken.
+
 .EXAMPLE
     ./bootstrap.ps1
     Full bootstrap (prompts before installing WindowsAppRuntime).
@@ -45,6 +53,11 @@
     ./bootstrap.ps1 -InstallWinAppSdk -SkipPlugin
     Non-interactive: install everything (incl. WindowsAppRuntime) and
     skip the agent plugin. Suitable for CI / fresh-dev-box automation.
+
+.EXAMPLE
+    ./bootstrap.ps1 -Verbose
+    Print extra `VERBOSE:` diagnostics at every decision point. Useful
+    for debugging install failures or unexpected branch behavior.
 #>
 [CmdletBinding()]
 param(
@@ -64,6 +77,16 @@ if ($InstallWinAppSdk -and $NoWinAppSdk) {
 $ErrorActionPreference = 'Stop'
 $repoRoot = $PSScriptRoot
 Set-Location $repoRoot
+
+# -Verbose is a common parameter (CmdletBinding); $VerbosePreference flips to
+# 'Continue' automatically when the caller passes it. We expose a tiny helper
+# so verbose blocks can short-circuit (e.g. skipping expensive `Out-String`
+# captures) when the flag is off.
+$script:VerboseOn = ($VerbosePreference -ne 'SilentlyContinue')
+
+function Write-Dbg($msg) {
+    Write-Verbose $msg
+}
 
 function Write-Step($msg) {
     Write-Host ''
@@ -92,7 +115,9 @@ function Install-WithWinget {
         Fail "Need to install '$Reason' but winget is not on PATH. Install App Installer from the Microsoft Store, then re-run ./bootstrap.ps1."
     }
     Write-Host "    Installing $Reason via winget ($Id)..." -ForegroundColor Yellow
+    Write-Dbg "winget install --id $Id --accept-source-agreements --accept-package-agreements --silent --disable-interactivity"
     & winget install --id $Id --accept-source-agreements --accept-package-agreements --silent --disable-interactivity
+    Write-Dbg "winget exit code: $LASTEXITCODE"
     if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne -1978335189) {
         # -1978335189 = APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE (already installed / up-to-date)
         Fail "winget install $Id failed (exit $LASTEXITCODE). Install $Reason manually and re-run ./bootstrap.ps1."
@@ -104,6 +129,7 @@ function Install-WithWinget {
         [Environment]::GetEnvironmentVariable('Path', 'Machine'),
         [Environment]::GetEnvironmentVariable('Path', 'User')
     ) -join ';'
+    Write-Dbg "Refreshed `$env:Path from registry (Machine + User scopes)"
 }
 
 # ---------------------------------------------------------------------------
@@ -111,9 +137,12 @@ function Install-WithWinget {
 # ---------------------------------------------------------------------------
 Write-Step 'Pre-flight checks'
 
+Write-Dbg "PowerShell $($PSVersionTable.PSVersion); OS arch $env:PROCESSOR_ARCHITECTURE; repo $repoRoot"
+
 function Test-DotnetSdk10 {
     if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) { return $false }
     foreach ($line in (& dotnet --list-sdks)) {
+        Write-Dbg "  dotnet SDK: $line"
         if ($line -match '^(\d+)\.' -and [int]$Matches[1] -ge 10) { return $true }
     }
     return $false
@@ -149,13 +178,23 @@ Write-Ok ".NET SDK present"
 # `-InstallWinAppSdk:$false` to skip the prompt non-interactively.
 
 function Test-WindowsAppRuntime20 {
-    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) { return $true }  # nothing we can check without winget
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        Write-Dbg "winget not on PATH; skipping WindowsAppRuntime probe"
+        return $true  # nothing we can check without winget
+    }
     # --accept-source-agreements is needed even for `list` on a winget that
     # hasn't been used before (e.g. a fresh CI runner). Without it, winget
     # prompts for msstore terms and fails on a non-interactive shell with
     # exit -1978335166.
-    & winget list --id Microsoft.WindowsAppRuntime.2.0 --exact --accept-source-agreements 2>$null | Out-Null
+    Write-Dbg "winget list --id Microsoft.WindowsAppRuntime.2.0 --exact --accept-source-agreements"
+    if ($script:VerboseOn) {
+        & winget list --id Microsoft.WindowsAppRuntime.2.0 --exact --accept-source-agreements 2>&1 |
+            ForEach-Object { Write-Dbg "  winget> $_" }
+    } else {
+        & winget list --id Microsoft.WindowsAppRuntime.2.0 --exact --accept-source-agreements 2>$null | Out-Null
+    }
     $rc = $LASTEXITCODE
+    Write-Dbg "winget list exit code: $rc"
     $global:LASTEXITCODE = 0  # don't let winget's status leak out of the probe
     return ($rc -eq 0)
 }
@@ -190,11 +229,14 @@ Write-Step "Packing mur (Reactor CLI) for dotnet global tool install"
 
 $feed = Join-Path $repoRoot 'local-nupkgs'
 New-Item -ItemType Directory -Path $feed -Force | Out-Null
+Write-Dbg "Local nupkg feed: $feed"
 
 # Match host arch so the embed-resource step (which runs the SignaturesGen
 # apphost) succeeds. The packed IL itself is platform-portable.
 $hostArch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'ARM64' } else { 'x64' }
+Write-Dbg "Host arch resolved to: $hostArch"
 
+Write-Dbg "dotnet pack src\Reactor.Cli\Reactor.Cli.csproj -c $Configuration -p:Platform=$hostArch -o $feed"
 & dotnet pack (Join-Path $repoRoot 'src\Reactor.Cli\Reactor.Cli.csproj') `
     -c $Configuration `
     "-p:Platform=$hostArch" `
@@ -214,8 +256,10 @@ if ($SkipMurInstall) {
 
     $existing = & dotnet tool list -g 2>$null | Select-String -SimpleMatch 'microsoft.ui.reactor.cli'
     if ($existing) {
+        Write-Dbg "Existing global tool detected ($($existing.Line.Trim())); using 'dotnet tool update'"
         & dotnet tool update -g --add-source $feed Microsoft.UI.Reactor.Cli --no-cache --ignore-failed-sources
     } else {
+        Write-Dbg "No existing global tool; using 'dotnet tool install'"
         & dotnet tool install -g --add-source $feed Microsoft.UI.Reactor.Cli --no-cache --ignore-failed-sources
     }
     if ($LASTEXITCODE -ne 0) { Fail '`dotnet tool install/update` failed for Microsoft.UI.Reactor.Cli' }
@@ -227,7 +271,10 @@ if ($SkipMurInstall) {
     if (Test-Path $dotnetTools) {
         $pathParts = $env:Path -split ';'
         if ($pathParts -notcontains $dotnetTools) {
+            Write-Dbg "Prepending $dotnetTools to current-process PATH"
             $env:Path = "$dotnetTools;$env:Path"
+        } else {
+            Write-Dbg "$dotnetTools already on current-process PATH"
         }
     }
     Write-Ok "mur installed as global tool (also on this shell's PATH)"
@@ -242,8 +289,10 @@ Write-Step 'Packing local Microsoft.UI.Reactor + ProjectTemplates (`mur pack-loc
 # project directly (works for -SkipMurInstall too).
 $murResolved = Get-Command mur -ErrorAction SilentlyContinue
 if ($murResolved) {
+    Write-Dbg "Using installed mur at $($murResolved.Source)"
     & mur pack-local
 } else {
+    Write-Dbg "mur not on PATH; falling back to 'dotnet run' against Reactor.Cli source"
     & dotnet run --project (Join-Path $repoRoot 'src\Reactor.Cli\Reactor.Cli.csproj') `
         -c $Configuration `
         "-p:Platform=$hostArch" `
@@ -264,7 +313,29 @@ if (-not (Test-Path $templateNupkg)) {
 
 # Uninstall first so the template engine drops its cached copy by id —
 # otherwise the previous install can win against a same-version repack.
-& dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates 2>$null | Out-Null
+# `dotnet new uninstall` (no args) lists installed template packages; skip the
+# uninstall on first run when our package isn't there yet (else the non-zero
+# exit code becomes a terminating error under $ErrorActionPreference = 'Stop'
+# in PS 7.4+, which `2>$null` doesn't intercept).
+Write-Dbg "Probing installed templates via 'dotnet new uninstall' (no args)"
+$installedTemplates = & dotnet new uninstall 2>&1 | Out-String
+if ($script:VerboseOn) {
+    foreach ($line in ($installedTemplates -split "`r?`n")) {
+        if ($line.Trim()) { Write-Dbg "  templates> $line" }
+    }
+}
+if ($installedTemplates -match 'Microsoft\.UI\.Reactor\.ProjectTemplates') {
+    Write-Dbg "Existing Microsoft.UI.Reactor.ProjectTemplates detected; uninstalling stale copy"
+    if ($script:VerboseOn) {
+        & dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates
+    } else {
+        & dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates | Out-Null
+    }
+    if ($LASTEXITCODE -ne 0) { Fail '`dotnet new uninstall` failed' }
+} else {
+    Write-Dbg "No prior install of Microsoft.UI.Reactor.ProjectTemplates; skipping uninstall (first-run path)"
+}
+Write-Dbg "dotnet new install $templateNupkg"
 & dotnet new install $templateNupkg
 if ($LASTEXITCODE -ne 0) { Fail '`dotnet new install` failed' }
 Write-Ok 'reactorapp template registered'
@@ -280,6 +351,8 @@ if ($SkipPlugin) {
 
     $pluginSrc = Join-Path $repoRoot 'plugins\reactor'
     $pluginDst = Join-Path $env:USERPROFILE '.claude\plugins\reactor'
+    Write-Dbg "Plugin src: $pluginSrc"
+    Write-Dbg "Plugin dst: $pluginDst"
 
     if (-not (Test-Path $pluginSrc)) {
         Write-Host "    [skip] $pluginSrc not present in this checkout" -ForegroundColor Yellow
@@ -287,6 +360,7 @@ if ($SkipPlugin) {
         New-Item -ItemType Directory -Path (Split-Path $pluginDst) -Force | Out-Null
 
         if (Test-Path $pluginDst) {
+            Write-Dbg "Removing existing $pluginDst before re-linking"
             Remove-Item $pluginDst -Recurse -Force
         }
 
@@ -298,7 +372,7 @@ if ($SkipPlugin) {
             New-Item -ItemType SymbolicLink -Path $pluginDst -Target $pluginSrc -ErrorAction Stop | Out-Null
             $linked = $true
         } catch {
-            # Fall through to copy.
+            Write-Dbg "Symlink failed: $($_.Exception.Message); falling back to copy"
         }
 
         if ($linked) {

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -318,13 +318,21 @@ if (-not (Test-Path $templateNupkg)) {
 # exit code becomes a terminating error under $ErrorActionPreference = 'Stop'
 # in PS 7.4+, which `2>$null` doesn't intercept).
 Write-Dbg "Probing installed templates via 'dotnet new uninstall' (no args)"
-$installedTemplates = & dotnet new uninstall 2>&1 | Out-String
 if ($script:VerboseOn) {
+    # Capture the full listing so we can both echo each line as a debug
+    # breadcrumb AND substring-match for our template id below.
+    $installedTemplates = & dotnet new uninstall 2>&1 | Out-String
     foreach ($line in ($installedTemplates -split "`r?`n")) {
         if ($line.Trim()) { Write-Dbg "  templates> $line" }
     }
+    $hasReactorTemplate = $installedTemplates -match 'Microsoft\.UI\.Reactor\.ProjectTemplates'
+} else {
+    # Quiet path: stream through Select-String -Quiet so we never materialize
+    # the multi-KB listing for what is, semantically, a single boolean test.
+    $hasReactorTemplate = [bool](& dotnet new uninstall 2>&1 |
+        Select-String -SimpleMatch 'Microsoft.UI.Reactor.ProjectTemplates' -Quiet)
 }
-if ($installedTemplates -match 'Microsoft\.UI\.Reactor\.ProjectTemplates') {
+if ($hasReactorTemplate) {
     Write-Dbg "Existing Microsoft.UI.Reactor.ProjectTemplates detected; uninstalling stale copy"
     if ($script:VerboseOn) {
         & dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates


### PR DESCRIPTION
## Problem

Running `./bootstrap.ps1` on a fresh checkout fails at step 5 (template install):

```
==> Installing `dotnet new reactorapp` template
dotnet.exe : The template package 'Microsoft.UI.Reactor.ProjectTemplates' is not found.
At C:\code\microsoft-ui-reactor\bootstrap.ps1:267 char:1
+ & dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates 2>$null  ...
    + CategoryInfo          : NotSpecified: (The template pa...' is not found.:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
```

## Root cause

The script preemptively uninstalls the template (so a same-version repack wins over the cached copy):

```powershell
& dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates 2>$null | Out-Null
```

The `2>$null` was meant to swallow the first-run "not installed" error, but it only redirects stderr. In **PowerShell 7.4+** the `$PSNativeCommandUseErrorActionPreference` preference defaults to `true`, so the non-zero exit code from `dotnet` becomes a terminating `NativeCommandError` — and the script's `$ErrorActionPreference = ''Stop''` then halts execution. The stderr redirect can''t intercept that path.

## Fix

Probe `dotnet new uninstall` (no args, which lists installed packages) first, and only run the uninstall when our package id is actually present:

```powershell
$installedTemplates = & dotnet new uninstall 2>&1 | Out-String
if ($installedTemplates -match ''Microsoft\.UI\.Reactor\.ProjectTemplates'') {
    & dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates | Out-Null
    if ($LASTEXITCODE -ne 0) { Fail ''`dotnet new uninstall` failed'' }
}
```

Silent on first run, idempotent on subsequent runs. Comment explains the PS 7.4 trap so it doesn''t get re-broken.

## Bonus: `-Verbose` diagnostics

The script already declares `[CmdletBinding()]`, so `-Verbose` is a free common parameter — no need to invent a custom flag. Added `Write-Verbose` checkpoints at every interesting decision point so future install issues are easier to debug without re-instrumenting:

- PS version + OS arch + repo path at startup
- Each `dotnet --list-sdks` line
- winget probe command + exit code (and full output under `-Verbose`)
- Host arch resolution + `dotnet pack` invocation
- Global tool `install` vs `update` branch
- `mur` resolution path (installed vs source fallback)
- Installed-template listing + uninstall decision (first-run skip vs cleanup)
- Plugin source/dest paths + symlink-vs-copy fallback reason
- PATH refresh after winget

Output that was previously sent to `Out-Null` (winget probe, `dotnet new uninstall`) is surfaced when `-Verbose` is on, so a developer can see *which* templates / packages the script actually found.

Doc block updated with a `.PARAMETER Verbose` section and a `./bootstrap.ps1 -Verbose` example.

## Verification

- Script parses clean (`[System.Management.Automation.Language.Parser]::ParseFile`)
- `Get-Command .\bootstrap.ps1` confirms `-Verbose` is bound via CmdletBinding
- End-to-end smoke of the template block in both quiet and `-Verbose` modes:
  - **Quiet / first-run (template not installed)**: skipped uninstall silently, `LASTEXITCODE = 0` — bug fixed
  - **Quiet / re-run (template installed)**: detected, uninstalled cleanly, `LASTEXITCODE = 0`
  - **`-Verbose`**: emits `VERBOSE:` lines at every checkpoint and dumps the raw template listing

Documentation/script-only change — no test suite needs to run.
