### PR TITLE
fix(gridview): suppress programmatic SelectedIndex echoes (#464)

### DIFF
--- a/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
@@ -65,6 +65,13 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
         gridView.SelectionChanged += (s, _) =>
         {
             var g = (WinUI.GridView)s!;
+            // Issue #464 — consume any pending echo-suppress token before
+            // dispatching to the user callback. The trampoline must check
+            // ShouldSuppress in the same shape as every other value-control
+            // (CheckBox/Slider/TextBox/etc.) so the programmatic SelectedIndex
+            // writes below in Mount / Update don't echo back into
+            // OnSelectedIndexChanged.
+            if (ChangeEchoSuppressor.ShouldSuppress(g)) return;
             if (Reconciler.GetElementTag(g) is not GridViewElement el) return;
             el.OnSelectedIndexChanged?.Invoke(g.SelectedIndex);
             if (el.OnSelectionChanged is { } h)
@@ -82,7 +89,16 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
 
         gridView.ItemsSource = Enumerable.Range(0, gv.Items.Length).ToList();
 
-        if (gv.SelectedIndex >= 0) gridView.SelectedIndex = gv.SelectedIndex;
+        // Issue #464 — wrap the initial SelectedIndex write so the deferred
+        // SelectionChanged that GridView fires after container realization is
+        // suppressed instead of leaking into OnSelectedIndexChanged. Only
+        // arm when the value would actually drift (a no-op write raises no
+        // echo and would strand a token that swallows the next real input).
+        if (gv.SelectedIndex >= 0 && gridView.SelectedIndex != gv.SelectedIndex)
+        {
+            ChangeEchoSuppressor.BeginSuppress(gridView);
+            gridView.SelectedIndex = gv.SelectedIndex;
+        }
         Reconciler.ApplySetters(gv.Setters, gridView);
         return gridView;
     }
@@ -113,7 +129,19 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
                     (Reconciler.GetElementTag(g) as GridViewElement)?.OnItemClick?.Invoke(idx);
             };
 
-        if (n.SelectedIndex >= 0) gv.SelectedIndex = n.SelectedIndex;
+        // Issue #464 — wrap the SelectedIndex write so the deferred
+        // SelectionChanged GridView fires after the property set doesn't echo
+        // back into OnSelectedIndexChanged. Only arm on real drift to avoid
+        // stranding a token for a no-op write (see Mount comment, and
+        // ChangeEchoSuppressor.BeginSuppress / ShouldSuppress in
+        // src/Reactor/Core/ChangeEchoSuppressor.cs — BeginSuppress always
+        // increments, ShouldSuppress only consumes on a real event, so an
+        // unconsumed token swallows the next user input).
+        if (n.SelectedIndex >= 0 && gv.SelectedIndex != n.SelectedIndex)
+        {
+            ChangeEchoSuppressor.BeginSuppress(gv);
+            gv.SelectedIndex = n.SelectedIndex;
+        }
         Reconciler.ApplySetters(n.Setters, gv);
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047ValueDiffEchoFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047ValueDiffEchoFixtures.cs
@@ -414,4 +414,98 @@ internal static class Spec047ValueDiffEchoFixtures
             }
         }
     }
+
+    /// <summary>Probe / regression guard for issue #464 — GridView raised
+    /// duplicate <c>OnSelectedIndexChanged</c> echoes for two same-frame
+    /// programmatic <c>SelectedIndex</c> writes (no render/drain between
+    /// them). Asserts the production-reachable single-write path (1 fire,
+    /// suppressed → 0) AND the rapid-double-write path (2 fires →
+    /// suppressed → 0). ListBox is included as the negative control —
+    /// it never exhibited the regression and must stay clean.</summary>
+    internal class GridViewRapidDoubleWriteEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            await ProbeAsync<WinUI.GridView>(static items => new GridViewElement(items)
+                {
+                    SelectedIndex = 0,
+                },
+                static (el, cb) => ((GridViewElement)el) with { OnSelectedIndexChanged = cb },
+                static (el, i) => ((GridViewElement)el) with { SelectedIndex = i },
+                static gv => gv.SelectedIndex,
+                "GridView");
+
+            await ProbeAsync<WinUI.ListBox>(static items =>
+                {
+                    // ListBox carries items as string[]; map element labels.
+                    var labels = new string[items.Length];
+                    for (int i = 0; i < items.Length; i++) labels[i] = $"i{i}";
+                    return new ListBoxElement(labels) { SelectedIndex = 0 };
+                },
+                static (el, cb) => ((ListBoxElement)el) with { OnSelectedIndexChanged = cb },
+                static (el, i) => ((ListBoxElement)el) with { SelectedIndex = i },
+                static lb => lb.SelectedIndex,
+                "ListBox");
+        }
+
+        private async Task ProbeAsync<TCtrl>(
+            Func<Element[], Element> seedFactory,
+            Func<Element, Action<int>, Element> withCallback,
+            Func<Element, int, Element> withSelectedIndex,
+            Func<TCtrl, int> readIndex,
+            string label) where TCtrl : WinUI.Control
+        {
+            var rec = new Reconciler();
+            var parent = new Grid { Background = new SolidColorBrush(Colors.Transparent) };
+            H.SetContent(parent);
+
+            int fireCount = 0;
+            var items = new Element[]
+            {
+                new TextBlockElement("i0"), new TextBlockElement("i1"),
+                new TextBlockElement("i2"), new TextBlockElement("i3"),
+            };
+            var elBase = seedFactory(items);
+            var el = withCallback(elBase, _ => fireCount++);
+
+            if (rec.Mount(el, _noOp) is not TCtrl ctrl)
+            {
+                H.Check($"Issue464_{label}_Mounted", false);
+                return;
+            }
+            parent.Children.Add(ctrl);
+            await Harness.Render();
+            await Harness.Render(); // realize containers
+
+            // ── Single-write per render: must not leak. ──
+            fireCount = 0;
+            var elNext = withSelectedIndex(el, 2);
+            rec.UpdateChild(el, elNext, ctrl, _noOp);
+            await Harness.Render();
+            H.Check($"Issue464_{label}_SingleWrite_Index", readIndex(ctrl) == 2);
+            H.Check($"Issue464_{label}_SingleWrite_NoEcho", fireCount == 0);
+            el = elNext;
+
+            // ── Two writes in the same frame (no render between): must not leak. ──
+            fireCount = 0;
+            var elTwo = withSelectedIndex(el, 1);
+            rec.UpdateChild(el, elTwo, ctrl, _noOp);
+            var elThree = withSelectedIndex(elTwo, 3);
+            rec.UpdateChild(elTwo, elThree, ctrl, _noOp);
+            await Harness.Render();
+            H.Check($"Issue464_{label}_DoubleWrite_FinalIndex", readIndex(ctrl) == 3);
+            H.Check($"Issue464_{label}_DoubleWrite_NoEcho", fireCount == 0);
+
+            // ── Real user interaction must still fire after the suppression
+            // tokens have been drained. ──
+            fireCount = 0;
+            if (ctrl is WinUI.GridView gv) gv.SelectedIndex = 0;
+            else if (ctrl is WinUI.ListBox lb) lb.SelectedIndex = 0;
+            await Harness.Render();
+            H.Check($"Issue464_{label}_RealUserStillFires", fireCount == 1);
+
+            rec.UnmountChild(ctrl);
+            parent.Children.Clear();
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1159,6 +1159,7 @@ internal static class SelfTestFixtureRegistry
         "ValueDiff_ComboBox_Drift",
         "ValueDiff_ToggleSwitch_Drift",
         "ValueDiff_GridView_GuardedNoOpStrand",
+        "Issue464_GridView_RapidDoubleWriteEcho",
 
         // Spec 047 §14 Phase 1 (1.16) — external-assembly proof fixtures.
         // The MarqueeHandler is authored in tests/external_proof/
@@ -2317,6 +2318,7 @@ internal static class SelfTestFixtureRegistry
         "ValueDiff_ComboBox_Drift" => new Spec047ValueDiffEchoFixtures.ComboBoxProgrammaticDrift(harness),
         "ValueDiff_ToggleSwitch_Drift" => new Spec047ValueDiffEchoFixtures.ToggleSwitchProgrammaticDrift(harness),
         "ValueDiff_GridView_GuardedNoOpStrand" => new Spec047ValueDiffEchoFixtures.GridViewGuardedNoOpStrand(harness),
+        "Issue464_GridView_RapidDoubleWriteEcho" => new Spec047ValueDiffEchoFixtures.GridViewRapidDoubleWriteEcho(harness),
 
         // Spec 047 §14 Phase 1 (1.16) — external-assembly proof fixtures.
         "Spec047ExternalProof_Marquee_MountUpdate" => new Spec047ExternalProofFixtures.MarqueeMountUpdate(harness),


### PR DESCRIPTION
Fixes #464.

## Root cause

The simple GridViewElement arm — legacy Reconciler.MountGridView / UpdateGridView, still active via the Phase-3-prelude GridViewHandler Path B delegate — had **no echo-suppression wiring at all**:

* The SelectionChanged trampoline did **not** call ChangeEchoSuppressor.ShouldSuppress, so the deferred SelectionChanged that WinUI fires after a programmatic `SelectedIndex` write was always dispatched to `OnSelectedIndexChanged` / `OnSelectionChanged`.
* The Mount + Update `SelectedIndex` writes were bare (no `BeginSuppress` / `WriteSuppressed`), so every programmatic write echoed back into the user callback.

Empirically verified on `main` (new `Issue464_GridView_RapidDoubleWriteEcho` self-test fixture probe):

| scenario | fires (before) | fires (after) |
|---|---|---|
| single programmatic Update write | **1** ❌ | 0 ✅ |
| two same-frame Update writes (#464 repro) | **2** ❌ | 0 ✅ |
| real user click after suppression | 1 ✅ | 1 ✅ |

So the production-reachable single-write path was broken too, not just the rapid double-write case the issue calls out.

## Fix

Mirror the standard value-control pattern used everywhere else (`CheckBox` / `Slider` / `TextBox` / etc., and the descriptor controlled fast path used by `ListBoxDescriptor`):

1. Add `ChangeEchoSuppressor.ShouldSuppress(g)` early-return to the `SelectionChanged` trampoline in `MountGridView`.
2. Wrap both Mount + Update `SelectedIndex` writes with `BeginSuppress`, **arming only on real drift** (`gv.SelectedIndex != n.SelectedIndex`) so a no-op write — which raises no echo — does not strand a token that would later swallow the user's next genuine selection. This is the same invariant the descriptor controlled-prop `Update` already enforces.

`ListBox` (descriptor-based) is unaffected and is included in the new fixture as a negative control. The fixture also asserts the rapid double-write case from the issue stays clean — the hypothesized **"extra deferred GridView fire beyond N"** does not manifest under proper N-paired suppression, so coalescing same-frame controlled writes is not needed.

## Validation

* ✅ New `Issue464_GridView_RapidDoubleWriteEcho` fixture: 10/10 checks (GridView single, GridView double, ListBox single/double, real-user-still-fires).
* ✅ Existing `ValueDiff_GridView_GuardedNoOpStrand` (-1 setter-guarded write does not arm, no strand): pass.
* ✅ All `KLR_GridView_*`, `SelectionEvt_GridView`, `RareControl_GridView*`, `CoreCov_TemplatedGridViewMountUpdate`, `ValueDiff_*` selftest suites: pass.
* ✅ Full `--self-test` suite: only flake is `GridViewLazy_RealizedCount=252_LessThanHalf` (passes 3/3 in isolation with count=96 — known full-suite contention flake, not related to this change).
* ✅ `dotnet test ... --filter ~Reconciler`: pre/post change identical (140 pass, 43 pre-existing NumberBox WinRT activation failures from running the Reconciler outside a live WinUI runtime).

## Note for reviewers

This change touches only the legacy `MountGridView` / `UpdateGridView` bodies that `GridViewHandler` delegates to. The `GridViewDescriptor` (carved per `RegisterV1BuiltInHandlers`) is unchanged. The `ListView` arm has a structurally parallel gap (its `SelectionChanged` trampoline also lacks `ShouldSuppress` and its `SelectedIndex` writes are bare) — out of scope here since #464 is specifically about `GridView`, but worth a follow-up.
