### PR TITLE
Fix UseEffect cleanup leak under docking pane Border wrapper (#375)

### DIFF
--- a/docs/specs/tasks/045-docking-windows-implementation.md
+++ b/docs/specs/tasks/045-docking-windows-implementation.md
@@ -1576,20 +1576,29 @@ integration.*
   (b) `DockDragSession.ResetForTest` (simulating process exit) clears
   the slot, (c) the reloaded layout has the same root shape and
   key set as the pre-drag tree.
-- [~] `useEffect` cleanup on pane close runs in dependency order
+- [x] `useEffect` cleanup on pane close runs in dependency order
   (Reactor invariant; selftest with effect-counter pattern verifies
   for docking). Selftest
-  `NativeDocking_Reliability_UseEffectCleanup_RunsOnPaneClose` lands
-  the visual-unmount half — `model.Close(pane)` drains and the
-  component's body disappears from the rendered tree. The matching
-  cleanup-fires-on-close assertion surfaced a Reactor-side gap:
-  `ComponentElement` instances embedded under
-  `DockableContent.Content` (i.e. wrapped through the host's
-  `WrapLeafWithPaneContext` Border + Padding + Provide chain) do
-  not get their `UseEffect` cleanups fired when the leaf
-  disappears. The known-failing assertion is left commented in the
-  fixture with a pointer to this gap; closes when the reconciler
-  drops to that case.
+  `NativeDocking_Reliability_UseEffectCleanup_BodyRemovedOnPaneClose`
+  asserts the visual-unmount half — `model.Close(pane)` drains and
+  the component's body disappears from the rendered tree — and the
+  cleanup-fires-on-close half (`Reliability_Effect_CleanupRanOnClose`).
+  Issue #375 — the cleanup-half landed via a Reactor-side fix that
+  added an unmount-side strategy dispatch to `V1HandlerAdapter`: when
+  a `ComponentElement` is embedded under `DockableContent.Content`
+  (i.e. wrapped through the host's `WrapLeafWithPaneContext`
+  Border + Padding + Provide chain), the engine's V1 arm previously
+  early-returned on `CollectSelf` before recursing into the parent
+  strategy's live children, so the component-wrapper `Border` that
+  anchors the `_componentNodes` lookup was never visited. The fix
+  walks `SingleContent` / `NamedSlots` / `ItemsHost` /
+  `IItemsBinderStrategy` strategies on unmount via the new
+  `IElementHandler.ChildrenForUnmount` accessor (which descriptor
+  handlers override to surface items-binder strategies hidden from
+  `Children` for ordering reasons) and the new
+  `IItemsBinderStrategy.Unbind` teardown hook (implemented by
+  `TabItemsHost` / `PreMountedItems` to walk their own
+  `GetCollection` — TabView populates `TabItems`, not `Items`).
 - [x] Floating window outliving its host: `DockingNativeInterop`'s
   registered unmount handler iterates `DockFloatingTracker.SnapshotFor(manager)`
   and calls `Close()` on each floating window opened from that host,

--- a/src/Reactor/Core/V1Protocol/ChildrenStrategy.cs
+++ b/src/Reactor/Core/V1Protocol/ChildrenStrategy.cs
@@ -202,8 +202,10 @@ internal interface IItemsBinderStrategy
     /// Component <c>UseEffect</c> cleanups fire. Keyed-state binders
     /// (templated lists) no-op here because the reconciler-side keyed
     /// pipeline (<c>BindKeyedItemsSource</c>) owns container teardown.
-    /// Default no-op so legacy strategies that haven't been audited keep
-    /// today's behavior (no extra teardown).</summary>
+    /// Default no-op is reserved for binders whose realized children are
+    /// torn down elsewhere; positional / hierarchical binders that own
+    /// realization (TabItemsHost, PreMountedItems, TreeChildren) override
+    /// it.</summary>
     void Unbind(FrameworkElement control, Reconciler reconciler) { }
 }
 
@@ -419,6 +421,20 @@ public sealed record TreeChildren<TElement, TControl>(
             if (node.Content is UIElement ui) reconciler.UnmountChild(ui);
             UnmountTreeContent(node.Children, reconciler);
         }
+    }
+
+    void IItemsBinderStrategy.Unbind(FrameworkElement control, Reconciler reconciler)
+    {
+        // Issue #375 — tear down every mounted TreeViewNodeData.ContentElement
+        // subtree so descendant Component UseEffect cleanups fire on host
+        // unmount. Without this hook the V1HandlerAdapter dispatcher would
+        // fall into the default no-op Unbind for TreeChildren (it's an
+        // IItemsBinderStrategy but neither ITemplatedItemsStrategy nor
+        // IErasedTemplatedItemsStrategy), leaking the same class of cleanups
+        // the issue tracked under DockableContent. Reuses the same
+        // UnmountTreeContent helper the bind-update path already invokes.
+        var tree = (TControl)control;
+        UnmountTreeContent(tree.RootNodes, reconciler);
     }
 }
 

--- a/src/Reactor/Core/V1Protocol/ChildrenStrategy.cs
+++ b/src/Reactor/Core/V1Protocol/ChildrenStrategy.cs
@@ -194,6 +194,17 @@ internal interface IItemsBinderStrategy
     /// <see cref="Reconciler.ReconcileV1Child"/>.
     /// </summary>
     void Bind(FrameworkElement control, Element? oldElement, Element element, Reconciler reconciler, Action requestRerender, bool isMount);
+
+    /// <summary>Issue #375 — teardown hook the engine invokes from
+    /// <c>V1HandlerAdapter</c>'s unmount-side child walk. Implementations
+    /// iterate their realized children and call
+    /// <see cref="Reconciler.UnmountChild"/> on each so descendant
+    /// Component <c>UseEffect</c> cleanups fire. Keyed-state binders
+    /// (templated lists) no-op here because the reconciler-side keyed
+    /// pipeline (<c>BindKeyedItemsSource</c>) owns container teardown.
+    /// Default no-op so legacy strategies that haven't been audited keep
+    /// today's behavior (no extra teardown).</summary>
+    void Unbind(FrameworkElement control, Reconciler reconciler) { }
 }
 
 /// <summary>Non-generic marker the engine dispatcher uses to reach an
@@ -528,6 +539,22 @@ public sealed record TabItemsHost<TElement, TControl, TItem>(
         for (int i = 0; i < items.Count; i++)
             collection.Add(CreateContainer(items[i], MountContent(items[i], reconciler, requestRerender)));
     }
+
+    void IItemsBinderStrategy.Unbind(FrameworkElement control, Reconciler reconciler)
+    {
+        // Issue #375 — tear down every realized container's content so
+        // descendant Component UseEffect cleanups fire on host unmount.
+        // The host control owns the container list (e.g. TabView.TabItems
+        // — NOT TabView.Items), so we reach it through the strategy's own
+        // GetCollection accessor rather than ItemsControl.Items.
+        var typedCtrl = (TControl)control;
+        var collection = GetCollection(typedCtrl);
+        for (int i = collection.Count - 1; i >= 0; i--)
+        {
+            if (collection[i] is WinUI.ContentControl cc && cc.Content is UIElement ui)
+                reconciler.UnmountChild(ui);
+        }
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -682,6 +709,19 @@ public sealed record PreMountedItems<TElement, TControl>(
                 throw new global::System.InvalidOperationException(
                     "PreMountedItems<>: item Element at index " + i + " mounted to a null UIElement.");
             items.Add(ctrl);
+        }
+    }
+
+    void IItemsBinderStrategy.Unbind(FrameworkElement control, Reconciler reconciler)
+    {
+        // Issue #375 — tear down realized item controls so descendant
+        // Component UseEffect cleanups fire on host unmount.
+        var typedCtrl = (TControl)control;
+        var items = GetCollection(typedCtrl);
+        for (int i = items.Count - 1; i >= 0; i--)
+        {
+            if (items[i] is UIElement ctrl)
+                reconciler.UnmountChild(ctrl);
         }
     }
 }

--- a/src/Reactor/Core/V1Protocol/Descriptor/DescriptorHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/DescriptorHandler.cs
@@ -68,6 +68,16 @@ public sealed class DescriptorHandler<TElement, TControl> : IElementHandler<TEle
             _ => _descriptor.Children,
         };
 
+    /// <summary>Issue #375 — on Unmount the bind-before-props ordering
+    /// constraint that motivates hiding <see cref="ItemsHost{TElement,TControl}"/>
+    /// / <see cref="IItemsBinderStrategy"/> strategies from
+    /// <see cref="Children"/> no longer applies, so expose the descriptor's
+    /// real strategy here. Lets <c>V1HandlerAdapter</c>'s unmount-side
+    /// dispatch walk descendant items (e.g. <c>TabView</c> tabs whose
+    /// content holds Components) and fire their <c>UseEffect</c>
+    /// cleanups.</summary>
+    public ChildrenStrategy<TElement, TControl>? ChildrenForUnmount => _descriptor.Children;
+
     // <snippet:descriptor-mount>
     public TControl Mount(MountContext ctx, TElement el)
     {

--- a/src/Reactor/Core/V1Protocol/IElementHandler.cs
+++ b/src/Reactor/Core/V1Protocol/IElementHandler.cs
@@ -52,6 +52,17 @@ public interface IElementHandler<TElement, TControl>
     /// reconciliation.</summary>
     ChildrenStrategy<TElement, TControl>? Children => null;
 
+    /// <summary>Issue #375 — children strategy the engine uses for the
+    /// unmount-side child walk. Defaults to <see cref="Children"/>; some
+    /// implementations (notably <see cref="Descriptor.DescriptorHandler{TElement,TControl}"/>)
+    /// suppress <see cref="Children"/> when they dispatch a strategy inline
+    /// during Mount/Update for ordering reasons (e.g. items-binder
+    /// strategies whose collection must be populated before
+    /// <c>SelectedIndex</c> initial writes land). On Unmount the ordering
+    /// constraint no longer applies, so they expose the real strategy here
+    /// so descendant Component <c>UseEffect</c> cleanups still fire.</summary>
+    ChildrenStrategy<TElement, TControl>? ChildrenForUnmount => Children;
+
     /// <summary>Spec 047 §14 Phase 3 prelude (Engine A1) — optional hook the
     /// engine invokes from <see cref="V1HandlerAdapter{TElement,TControl}"/>
     /// after the <see cref="Children"/> strategy has mounted/bound every child

--- a/src/Reactor/Core/V1Protocol/V1HandlerAdapter.cs
+++ b/src/Reactor/Core/V1Protocol/V1HandlerAdapter.cs
@@ -89,11 +89,30 @@ internal sealed class V1HandlerAdapter<TElement, TControl> : IV1HandlerEntry
         // child — byte-identical to the legacy decorator panel handlers, which
         // also return ContinueDefaultTraversal. Without this, CollectSelf would
         // early-return before the panel-child recursion and leak child Component
-        // effect cleanups. All other (non-panel) standard handlers tear down
-        // their own children via SingleContent/NamedSlots/items-binder strategy
-        // dispatch and correctly opt into CollectSelf.
-        if (_handler.Children is Panel<TElement, TControl>)
+        // effect cleanups.
+        if (_handler.ChildrenForUnmount is Panel<TElement, TControl>)
             return V1UnmountDisposition.ContinueDefaultTraversal;
+
+        // Issue #375 — strategy-driven child teardown on Unmount. Without
+        // this, a Component nested under a SingleContent / NamedSlots /
+        // ItemsHost / IItemsBinderStrategy parent (e.g. Border, SplitView,
+        // ListBox, TabView) leaks its UseEffect cleanups when the parent
+        // unmounts: the engine's V1 arm early-returns on CollectSelf before
+        // the legacy `border.Child` / `cc.Content` recursion can reach the
+        // component wrapper Border that anchors the component-node lookup
+        // in _componentNodes. Walk the strategy's live children and run
+        // UnmountChild on each — the recursive UnmountRecursive call
+        // surfaces every nested component wrapper and fires RunCleanups.
+        //
+        // We consult ChildrenForUnmount (not Children) because descriptor
+        // handlers hide ItemsHost / IItemsBinderStrategy strategies from
+        // Children (they dispatch those inline during Mount/Update so the
+        // collection is populated before SelectedIndex initial writes
+        // land); on Unmount the ordering constraint doesn't apply, so the
+        // descriptor exposes the real strategy here for the teardown walk.
+        var strategy = _handler.ChildrenForUnmount;
+        if (strategy is not null)
+            DispatchChildrenUnmount(strategy, reconciler, typedControl);
 
         // Standard handlers always opt into pool collection — matches
         // the pre-Phase-3-completion behavior.
@@ -360,6 +379,104 @@ internal sealed class V1HandlerAdapter<TElement, TControl> : IV1HandlerEntry
                 }
                 return;
             }
+        }
+    }
+
+    // ── Unmount strategy dispatch (issue #375) ───────────────────────
+    //
+    // When a parent control is unmounted, walk its children strategy and
+    // tear down the live child(ren) so descendant Component UseEffect
+    // cleanups run. Before this dispatch existed, only Panel strategy
+    // was covered (via ContinueDefaultTraversal + the legacy
+    // `control is WinUI.Panel` recursion); SingleContent / NamedSlots /
+    // ItemsHost / IItemsBinderStrategy parents silently leaked any
+    // nested component cleanups because CollectSelf early-returned in
+    // the engine's V1 arm before the legacy `border.Child` / `cc.Content`
+    // recursion could reach the inner component wrapper.
+    //
+    // The teardown delegates to <c>reconciler.UnmountChild</c> (which
+    // runs the full <c>UnmountRecursive</c> path on each child), so any
+    // depth of nesting is handled — including a component nested deep
+    // under multiple Border / SplitView / TabView layers.
+    private static void DispatchChildrenUnmount(
+        ChildrenStrategy<TElement, TControl> strategy,
+        Reconciler reconciler, TControl control)
+    {
+        // IItemsBinderStrategy covers templated lists (keyed item realization
+        // owned by the reconciler-side BindKeyedItemsSource pipeline) plus
+        // TabItemsHost / PreMountedItems (positional containers whose
+        // realized content lives in TabViewItem / PivotItem / FlipViewItem
+        // ContentControl slots). Keyed-templated strategies tear down their
+        // realized containers via the reconciler-side pipeline; the
+        // positional binder strategies need explicit per-container teardown.
+        //
+        // Issue #375 — dispatch through the strategy's own Unbind hook
+        // rather than iterating ItemsControl.Items. TabView populates
+        // TabItems (not Items), so a blanket .Items walk would miss tabs
+        // entirely. Each concrete strategy reaches its real collection via
+        // GetCollection (TabView.TabItems / FlipView.Items / etc).
+        if (strategy is IItemsBinderStrategy binder)
+        {
+            if (strategy is ITemplatedItemsStrategy or IErasedTemplatedItemsStrategy)
+            {
+                // Keyed templated strategies — reconciler-side teardown of
+                // the realization channel runs out-of-band on container
+                // recycle; nothing to do here.
+                return;
+            }
+            if (control is FrameworkElement fe)
+                binder.Unbind(fe, reconciler);
+            return;
+        }
+
+        switch (strategy)
+        {
+            case None<TElement, TControl>:
+                return;
+
+            case SingleContent<TElement, TControl> single:
+            {
+                if (single.GetCurrentChild is { } getCur
+                    && getCur(control) is UIElement child)
+                {
+                    reconciler.UnmountChild(child);
+                }
+                return;
+            }
+
+            case NamedSlots<TElement, TControl> ns:
+            {
+                for (int i = 0; i < ns.Slots.Count; i++)
+                {
+                    var slot = ns.Slots[i];
+                    if (slot.GetCurrentChild is { } getCur
+                        && getCur(control) is UIElement child)
+                    {
+                        reconciler.UnmountChild(child);
+                    }
+                }
+                return;
+            }
+
+            case ItemsHost<TElement, TControl> ih:
+            {
+                var collection = ih.GetCollection(control);
+                // Walk top-down so we don't surprise an inner unmount with
+                // a sibling already collected by the strategy's flat sink.
+                for (int i = 0; i < collection.Count; i++)
+                {
+                    if (collection[i] is UIElement childCtrl)
+                        reconciler.UnmountChild(childCtrl);
+                }
+                return;
+            }
+
+            case Imperative<TElement, TControl>:
+                // The handler owns reconciliation and child identity for
+                // an Imperative strategy; its own Unmount body is
+                // responsible for teardown (no generic walk possible
+                // because the engine has no view onto the slots).
+                return;
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs
@@ -173,21 +173,20 @@ internal static class NativeDockingReliabilityFixtures
     /// programmatically closes the pane via <c>model.Close</c>. Asserts:
     /// (a) the close drains through the §2.16 mutation queue, (b) the
     /// component's body is removed from the visual tree, (c) the
-    /// component's mount effect ran exactly once. Spec §8.10 reliability
-    /// invariant on the visual unmount.
+    /// component's mount effect ran exactly once, and (d) the component's
+    /// UseEffect cleanup fired exactly once on pane close. Spec §8.10
+    /// reliability invariant on the visual unmount.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Open follow-up (tracked as §2.25): when a <see cref="DockableContent.Content"/>
-    /// holds a <see cref="ComponentElement"/>, the reconciler removes the
-    /// element from the visual tree on pane close but does not fire the
-    /// component's <c>UseEffect</c> cleanup. This fixture intentionally
-    /// does NOT assert that cleanup ran — a perpetual SKIP rotted
-    /// because nothing ever forced anyone to look at it. The cleanup-
-    /// fires-on-close contract is tracked separately in
-    /// <c>docs/specs/045-docking-windows-implementation.md §2.25</c>;
-    /// when the underlying reconciler gap is closed, add a fresh
-    /// assertion here.
+    /// Issue #375 — the UseEffect cleanup assertion is the regression
+    /// test for the V1HandlerAdapter unmount-side strategy dispatch:
+    /// when a <see cref="DockableContent.Content"/> holds a
+    /// <see cref="ComponentElement"/> nested under the docking host's
+    /// Border wrapper (<c>WrapLeafWithPaneContext</c>), the SingleContent
+    /// strategy must walk its live child on Unmount so the component
+    /// wrapper Border that anchors the <c>_componentNodes</c> lookup is
+    /// reached and <c>RunCleanups()</c> fires.
     /// </para>
     /// </remarks>
     internal class UseEffectCleanup_BodyRemovedOnPaneClose(Harness h) : SelfTestFixtureBase(h)
@@ -245,11 +244,14 @@ internal static class NativeDockingReliabilityFixtures
             H.Check("Reliability_Effect_BodyGoneFromTree",
                 H.FindText("effect-body-p1") is null);
 
-            // The matching cleanup-fires-on-close assertion is
-            // deliberately not emitted here. See class docstring for
-            // the §2.25 follow-up; cleanupCount stays wired so a fresh
-            // assertion can land here without reshape.
-            _ = cleanupCount;
+            // Issue #375 regression — the cleanup must fire when the pane
+            // is closed. Before the V1HandlerAdapter unmount-side strategy
+            // dispatch landed, this counter stayed at 0 because the docking
+            // host's BorderElement wrapper around the pane Content was
+            // unmounted via the V1 arm returning CollectSelf — which short-
+            // circuited before the engine could recurse into the component
+            // wrapper Border that anchors RunCleanups().
+            H.Check("Reliability_Effect_CleanupRanOnClose", cleanupCount == 1);
 
             host.Mount(_ => TextBlock("effect-cleanup-done"));
             await Harness.Render();


### PR DESCRIPTION
Fixes #375 — `UseEffect` cleanup did not fire when a `Component` was embedded under `DockableContent.Content` and the pane was closed.

## Root cause

Three compounding gaps in the spec 047 V1 protocol unmount path:

1. **`V1HandlerAdapter.Unmount`** returned `CollectSelf` for non-`Panel` strategies (`SingleContent` / `NamedSlots` / `ItemsHost` / `IItemsBinderStrategy`), short-circuiting the engine before the legacy `border.Child` / `cc.Content` recursion could reach the component-wrapper `Border` that anchors the `_componentNodes` lookup. Any `Component` nested under a `BorderElement` (i.e. `WrapLeafWithPaneContext`) leaked its `UseEffect` cleanups.

2. **`DescriptorHandler.Children`** hides `ItemsHost` / `IItemsBinderStrategy` strategies from `V1HandlerAdapter` (those get dispatched inline during Mount/Update so the collection is populated before `SelectedIndex` initial writes land — otherwise WinUI silently clamps selection against the empty list). On Unmount the ordering constraint doesn't apply, but there was no way to surface the real strategy for the teardown walk.

3. **`TabItemsHost` populates `TabView.TabItems`**, not `TabView.Items` — so a generic `ItemsControl.Items` walk would miss tabs entirely.

## Fix

- Add `IElementHandler.ChildrenForUnmount` accessor (default returns `Children`). `DescriptorHandler` overrides it to surface the real descriptor strategy on the unmount path.
- `V1HandlerAdapter.Unmount` now consults `ChildrenForUnmount` and calls a new `DispatchChildrenUnmount` that walks `SingleContent` / `NamedSlots` / `ItemsHost` via their `GetCurrentChild` / `GetCollection` accessors and delegates to `reconciler.UnmountChild` (which runs the full `UnmountRecursive` path, surfacing every nested component wrapper and firing `RunCleanups`).
- Add `IItemsBinderStrategy.Unbind(control, reconciler)` hook (default no-op). `TabItemsHost` and `PreMountedItems` implement it to iterate their own `GetCollection` (`TabView.TabItems`, `FlipView.Items`, etc.) and `UnmountChild` each realized container's `Content`. Keyed templated strategies (`ITemplatedItemsStrategy` / `IErasedTemplatedItemsStrategy`) stay no-op because the reconciler-side `BindKeyedItemsSource` pipeline owns container teardown.

Spec 045 §2.25 `useEffect`-cleanup-on-pane-close checkbox flipped from `[~]` to `[x]`; the previously-commented `Reliability_Effect_CleanupRanOnClose` assertion is now active.

## Verification

- `Reliability_Effect_CleanupRanOnClose` now passes — all 8 assertions in `NativeDocking_Reliability_UseEffectCleanup_BodyRemovedOnPaneClose` green.
- Full `NativeDocking_Reliability` selftest suite green (`UseEffectCleanup`, `CorruptLayoutFallback`, `OffThreadMutation`, `DragSessionPayload`, `CrashMidDrag`, `FloatingWindowClosesOnHostUnmount`, `EventSubscriptionLeakBaseline`).
- Broader `TabView` / `FlipView` / `Pivot` / `Border` / `Component` / `NavigationHost` / `ListView` / `GridView` / `ScrollView` / `SplitView` selftests green — no regressions in the affected dispatch surface.
- All **9132 unit tests** pass (62 skipped, 0 failed).

## Files changed

| File | Change |
|---|---|
| `src/Reactor/Core/V1Protocol/IElementHandler.cs` | New `ChildrenForUnmount` accessor (default `=> Children`). |
| `src/Reactor/Core/V1Protocol/Descriptor/DescriptorHandler.cs` | Override `ChildrenForUnmount` to return real descriptor strategy. |
| `src/Reactor/Core/V1Protocol/V1HandlerAdapter.cs` | `Unmount` consults `ChildrenForUnmount`; new `DispatchChildrenUnmount` for `SingleContent`/`NamedSlots`/`ItemsHost`/`IItemsBinderStrategy`/`Imperative`/`None`. |
| `src/Reactor/Core/V1Protocol/ChildrenStrategy.cs` | New `IItemsBinderStrategy.Unbind` hook; `TabItemsHost` and `PreMountedItems` implement it. |
| `tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs` | Activate the regression assertion; update docstring. |
| `docs/specs/tasks/045-docking-windows-implementation.md` | Flip §2.25 `useEffect` cleanup checkbox from `[~]` to `[x]`. |
