### PR TITLE
Port composites to V1 handlers; fix overlay teardown leaks

### DIFF
--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -58,11 +58,10 @@ public sealed partial class Reconciler
         try
         {
 
-        // Spec 047 §14 Phase 4 (§4.5) — dispatch is V1 registry → external
-        // `_typeRegistry` → composition-primitive switch. The 87 V1-reachable
-        // element types route through `_v1Handlers`; the legacy `MountXxx`
-        // switch arms were deleted (V1 is the production path). Only the 8
-        // composition primitives (above the protocol) remain on the switch.
+        // Spec 047 §14 Phase 4 — dispatch is V1 registry → external
+        // `_typeRegistry` → composition-primitive switch. The V1-reachable
+        // element types route through `_v1Handlers`; only the 4 composition
+        // primitives (above the protocol) remain on the switch.
         if (_v1Handlers.TryGet(element.GetType(), out var v1Entry))
         {
             control = v1Entry.Mount(element, requestRerender, this);
@@ -76,11 +75,7 @@ public sealed partial class Reconciler
         {
         control = element switch
         {
-            CommandHostElement ch => MountCommandHost(ch, requestRerender),
             ErrorBoundaryElement eb => MountErrorBoundary(eb, requestRerender),
-            Validation.FormFieldElement ff => MountFormField(ff, requestRerender),
-            Validation.ValidationVisualizerElement vv => MountValidationVisualizer(vv, requestRerender),
-            Validation.ValidationRuleElement rule => MountValidationRule(rule),
             ComponentElement comp => MountComponent(comp, requestRerender),
             FuncElement func => MountFuncComponent(func, requestRerender),
             MemoElement memo => MountMemoComponent(memo, requestRerender),
@@ -678,7 +673,7 @@ public sealed partial class Reconciler
     //  Validation elements
     // ════════════════════════════════════════════════════════════════
 
-    private WinUI.StackPanel MountFormField(FormFieldElement ff, Action requestRerender)
+    internal WinUI.StackPanel MountFormField(FormFieldElement ff, Action requestRerender)
     {
         var panel = new WinUI.StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
 
@@ -792,7 +787,7 @@ public sealed partial class Reconciler
         }
     }
 
-    private WinUI.StackPanel MountValidationVisualizer(
+    internal WinUI.StackPanel MountValidationVisualizer(
         ValidationVisualizerElement vv, Action requestRerender)
     {
         var panel = new WinUI.StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
@@ -889,7 +884,7 @@ public sealed partial class Reconciler
         return panel;
     }
 
-    private UIElement MountValidationRule(ValidationRuleElement rule)
+    internal UIElement MountValidationRule(ValidationRuleElement rule)
     {
         // Evaluate the rule against the nearest ValidationContext
         var valCtx = _contextScope.Read(ValidationContexts.Current);
@@ -1154,7 +1149,7 @@ public sealed partial class Reconciler
         return si;
     }
 
-    private WinUI.Grid MountCommandHost(CommandHostElement ch, Action requestRerender)
+    internal WinUI.Grid MountCommandHost(CommandHostElement ch, Action requestRerender)
     {
         var host = new WinUI.Grid();
         var child = Mount(ch.Child, requestRerender);

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -128,16 +128,8 @@ public sealed partial class Reconciler
         {
         result = (oldEl, newEl, control) switch
         {
-            (CommandHostElement o, CommandHostElement n, WinUI.Grid chGrid)
-                => UpdateCommandHost(o, n, chGrid, requestRerender),
             (ErrorBoundaryElement oldEb, ErrorBoundaryElement newEb, Border)
                 => UpdateErrorBoundary(oldEb, newEb, control, requestRerender),
-            (FormFieldElement oldFf, FormFieldElement newFf, WinUI.StackPanel sp)
-                => UpdateFormField(oldFf, newFf, sp, requestRerender),
-            (ValidationVisualizerElement oldVv, ValidationVisualizerElement newVv, WinUI.StackPanel sp)
-                => UpdateValidationVisualizer(oldVv, newVv, sp, requestRerender),
-            (ValidationRuleElement, ValidationRuleElement n, WinUI.StackPanel)
-                => UpdateValidationRule(n),
             (ComponentElement, ComponentElement, _)
                 => UpdateComponent(oldEl, newEl, control, requestRerender),
             (FuncElement, FuncElement, _)
@@ -530,7 +522,7 @@ public sealed partial class Reconciler
     }
 
 
-    private UIElement? UpdateCommandHost(CommandHostElement o, CommandHostElement n, WinUI.Grid host, Action requestRerender)
+    internal UIElement? UpdateCommandHost(CommandHostElement o, CommandHostElement n, WinUI.Grid host, Action requestRerender)
     {
         // Update child element
         if (host.Children.Count > 0 && host.Children[0] is UIElement existingChild)
@@ -696,7 +688,7 @@ public sealed partial class Reconciler
     // ── Typed, data-driven TreeView<T> ───────────────────────────────────
     // Mount/Update bodies relocated to Reconciler.TemplatedTree.cs (spec 047 §14).
 
-    private UIElement? UpdateFormField(
+    internal UIElement? UpdateFormField(
         FormFieldElement oldFf, FormFieldElement newFf,
         WinUI.StackPanel panel, Action requestRerender)
     {
@@ -761,7 +753,7 @@ public sealed partial class Reconciler
         return null; // patched in-place
     }
 
-    private UIElement? UpdateValidationVisualizer(
+    internal UIElement? UpdateValidationVisualizer(
         ValidationVisualizerElement oldVv, ValidationVisualizerElement newVv,
         WinUI.StackPanel panel, Action requestRerender)
     {
@@ -779,7 +771,7 @@ public sealed partial class Reconciler
         return Mount(newVv, requestRerender);
     }
 
-    private UIElement? UpdateValidationRule(ValidationRuleElement rule)
+    internal UIElement? UpdateValidationRule(ValidationRuleElement rule)
     {
         var valCtx = _contextScope.Read(ValidationContexts.Current);
         if (valCtx is not null)

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -262,7 +262,7 @@ public sealed partial class Reconciler : IDisposable
     /// <see cref="V1HandlerRegistry"/>; external authors add handlers via
     /// <see cref="RegisterHandler{TElement,TControl}"/> /
     /// <see cref="RegisterType{TElement,TControl}"/> (which populate
-    /// <c>_typeRegistry</c>). Dispatch order is V1 → external → the eight
+    /// <c>_typeRegistry</c>). Dispatch order is V1 → external → the four
     /// composition primitives that sit above the protocol.
     /// </summary>
     public Reconciler(ILogger? logger = null)
@@ -282,13 +282,23 @@ public sealed partial class Reconciler : IDisposable
     /// <list type="bullet">
     ///   <item><b>Composition primitives</b> — <see cref="ComponentElement"/>,
     ///   <see cref="FuncElement"/>, <see cref="MemoElement"/>,
-    ///   <see cref="ErrorBoundaryElement"/>, <c>CommandHostElement</c>,
+    ///   <see cref="ErrorBoundaryElement"/>. These sit <i>above</i> the V1
+    ///   handler protocol (they orchestrate child reconciliation rather than
+    ///   wrap a single WinUI control), so Phase 4 cleanup keeps their legacy
+    ///   arms.</item>
+    ///   <item><b>Composites — PORTED (§14 Phase 4)</b> —
+    ///   <c>CommandHostElement</c>,
     ///   <see cref="Controls.Validation.FormFieldElement"/>,
     ///   <see cref="Controls.Validation.ValidationVisualizerElement"/>,
-    ///   <see cref="Controls.Validation.ValidationRuleElement"/>. These sit
-    ///   <i>above</i> the V1 handler protocol (they orchestrate child
-    ///   reconciliation rather than wrap a single WinUI control), so Phase 4
-    ///   cleanup keeps their legacy arms.</item>
+    ///   <see cref="Controls.Validation.ValidationRuleElement"/> now route
+    ///   through V1 via decorator handlers in <c>V1Protocol.Handlers</c>
+    ///   (<c>CompositeHandlers.cs</c>) that delegate to the engine
+    ///   <c>MountXxx</c>/<c>UpdateXxx</c> bodies and return
+    ///   <see cref="V1Protocol.V1UnmountDisposition.ContinueDefaultTraversal"/>
+    ///   on unmount — each builds a single Grid/StackPanel root whose mounted
+    ///   Reactor children are torn down by the same
+    ///   <see cref="UnmountRecursive"/> Panel recursion the legacy arms relied
+    ///   on.</item>
     ///   <item><b>Interop bridges</b> — <see cref="Hosting.XamlHostElement"/>,
     ///   <see cref="Hosting.XamlPageElement"/>. V1 descriptors exist
     ///   (<c>XamlHostDescriptor</c>, <c>XamlPageDescriptor</c>) but stay
@@ -350,6 +360,18 @@ public sealed partial class Reconciler : IDisposable
         // ── §14 Phase 3 prelude carve-closures (delegate to engine bodies) ──
         RegisterHandler<NavigationHostElement, WinUI.Grid>(new V1Protocol.Handlers.NavigationHostHandler());
         RegisterHandler<GridViewElement, WinUI.GridView>(new V1Protocol.Handlers.GridViewHandler());
+
+        // Composites — CommandHost + the three Validation elements. Each builds a
+        // single Grid/StackPanel root and mounts Reactor children into it, so they
+        // route through V1 via decorator handlers that delegate to the engine
+        // bodies and return ContinueDefaultTraversal on unmount (the generic Panel
+        // recursion in UnmountRecursive tears the children down). Distinct from the
+        // four genuine composition primitives below, which produce no control of
+        // their own and stay on the legacy switch.
+        RegisterDecoratorHandler<CommandHostElement>(new V1Protocol.Handlers.CommandHostHandler());
+        RegisterDecoratorHandler<Controls.Validation.FormFieldElement>(new V1Protocol.Handlers.FormFieldHandler());
+        RegisterDecoratorHandler<Controls.Validation.ValidationVisualizerElement>(new V1Protocol.Handlers.ValidationVisualizerHandler());
+        RegisterDecoratorHandler<Controls.Validation.ValidationRuleElement>(new V1Protocol.Handlers.ValidationRuleHandler());
 
         // Overlays — decorator-style ports. Each delegates to the legacy
         // MountXxx/UpdateXxx body and returns ContinueDefaultTraversal on

--- a/src/Reactor/Core/V1Protocol/Handlers/CompositeHandlers.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/CompositeHandlers.cs
@@ -1,0 +1,78 @@
+using Microsoft.UI.Reactor.Controls.Validation;
+using Microsoft.UI.Xaml;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
+
+// Spec 047 §14 Phase 4 — CommandHost + the three Validation composites ported
+// off the legacy composition-primitive switch onto V1 decorator handlers.
+//
+// Unlike the genuine composition primitives (Component/Func/Memo/ErrorBoundary)
+// that orchestrate child reconciliation without producing a control of their
+// own, each of these builds a single root WinUI control (Grid / StackPanel) and
+// mounts Reactor children into it — the decorator shape. Mount/Update delegate
+// to the (now internal) Reconciler bodies; Unmount returns
+// ContinueDefaultTraversal so the engine's generic Panel branch in
+// UnmountRecursive recurses the root's Children and tears the mounted Reactor
+// subtrees down exactly as the legacy switch arms did (which had no special
+// unmount). The substitution path (FormField/ValidationVisualizer Update can
+// return a fresh control) is preserved: returning a control != the existing one
+// makes the adapter install the new one and unmount the old via parent reconcile.
+
+/// <summary>§14 — CommandHost (Grid hosting one child + keyboard accelerators).</summary>
+internal sealed class CommandHostHandler : IDecoratorElementHandler<CommandHostElement>
+{
+    public UIElement Mount(MountContext ctx, CommandHostElement el)
+        => ctx.Reconciler.MountCommandHost(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, CommandHostElement oldEl, CommandHostElement newEl, UIElement control)
+        => control is WinUI.Grid host
+            ? ctx.Reconciler.UpdateCommandHost(oldEl, newEl, host, ctx.RequestRerender) ?? control
+            : ctx.Reconciler.Mount(newEl, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, CommandHostElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 — FormField (3-child StackPanel: label / content / description).</summary>
+internal sealed class FormFieldHandler : IDecoratorElementHandler<FormFieldElement>
+{
+    public UIElement Mount(MountContext ctx, FormFieldElement el)
+        => ctx.Reconciler.MountFormField(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, FormFieldElement oldEl, FormFieldElement newEl, UIElement control)
+        => control is WinUI.StackPanel panel
+            ? ctx.Reconciler.UpdateFormField(oldEl, newEl, panel, ctx.RequestRerender) ?? control
+            : ctx.Reconciler.Mount(newEl, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, FormFieldElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 — ValidationVisualizer (StackPanel; Update always remounts).</summary>
+internal sealed class ValidationVisualizerHandler : IDecoratorElementHandler<ValidationVisualizerElement>
+{
+    public UIElement Mount(MountContext ctx, ValidationVisualizerElement el)
+        => ctx.Reconciler.MountValidationVisualizer(el, ctx.RequestRerender);
+
+    public UIElement Update(UpdateContext ctx, ValidationVisualizerElement oldEl, ValidationVisualizerElement newEl, UIElement control)
+        => control is WinUI.StackPanel panel
+            ? ctx.Reconciler.UpdateValidationVisualizer(oldEl, newEl, panel, ctx.RequestRerender) ?? control
+            : ctx.Reconciler.Mount(newEl, ctx.RequestRerender) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, ValidationVisualizerElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}
+
+/// <summary>§14 — ValidationRule (collapsed placeholder; evaluates the rule).</summary>
+internal sealed class ValidationRuleHandler : IDecoratorElementHandler<ValidationRuleElement>
+{
+    public UIElement Mount(MountContext ctx, ValidationRuleElement el)
+        => ctx.Reconciler.MountValidationRule(el);
+
+    public UIElement Update(UpdateContext ctx, ValidationRuleElement oldEl, ValidationRuleElement newEl, UIElement control)
+        => ctx.Reconciler.UpdateValidationRule(newEl) ?? control;
+
+    public V1UnmountDisposition Unmount(UnmountContext ctx, ValidationRuleElement? element, UIElement control)
+        => V1UnmountDisposition.ContinueDefaultTraversal;
+}

--- a/src/Reactor/Core/V1Protocol/Handlers/OverlayDecoratorHandlers.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/OverlayDecoratorHandlers.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 using WinUI = Microsoft.UI.Xaml.Controls;
+using WinPrim = Microsoft.UI.Xaml.Controls.Primitives;
 
 namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
 
@@ -14,13 +15,23 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol.Handlers;
 // strategy, so V1 ON ≡ V1 OFF is byte-identical and §4.5 can delete the
 // legacy delegators + the V1-OFF switch arms without touching this logic.
 //
-// Why ContinueDefaultTraversal for every overlay: when the V1 flag is OFF the
-// engine SKIPS the V1 unmount arm entirely and runs the type-based recursion
-// in UnmountRecursive directly. ContinueDefaultTraversal tells the engine to
-// fall through to that SAME recursion after the (no-op) handler Unmount body,
-// keeping unmount byte-identical V1 ON ≡ V1 OFF. Reworking overlay teardown
-// (closing/detaching the side object) is deferred to §4.5 where it can change
-// for the V1-only world without breaking the parity bar.
+// Why most overlays still return ContinueDefaultTraversal: their returned
+// control (a Target control, a CommandBar, a MenuBar, or a wrapper StackPanel)
+// is torn down by the generic type-based recursion in UnmountRecursive, and
+// their menu items / commands are imperative WinUI data (no Reactor subtree).
+// Two overlays additionally OWN side-mounted Reactor subtrees that the generic
+// recursion cannot reach, so their Unmount bodies tear those down explicitly
+// (still returning ContinueDefaultTraversal so the visual subtree teardown
+// runs):
+//   • Flyout — flyout.Content + flyout.OverlayInputPassThroughElement live on
+//     the side flyout object attached to the Target, not under the Target's
+//     visual tree; the handler unmounts both and detaches the flyout.
+//   • Popup — the wrapper StackPanel hosts a WinUI Popup whose Child is a
+//     Reactor subtree the type switch has no branch for; the handler unmounts
+//     the child and closes the otherwise-orphaned popup.
+// ContentDialog's Content is also side-mounted but has no back-reference from
+// its placeholder to the dialog object — tearing it down needs per-instance
+// tracking and is tracked as known debt.
 //
 // The three target-wrapping decorators (Flyout, MenuFlyout, CommandBarFlyout)
 // return their Target's mounted control; the strategy may return null when the
@@ -52,7 +63,42 @@ internal sealed class FlyoutHandler : IDecoratorElementHandler<FlyoutElement>
         => OverlayLifecycle.UpdateFlyoutElement(ctx.Reconciler, oldEl, newEl, control, ctx.RequestRerender) ?? control;
 
     public V1UnmountDisposition Unmount(UnmountContext ctx, FlyoutElement? element, UIElement control)
-        => V1UnmountDisposition.ContinueDefaultTraversal;
+    {
+        // §4.5: the flyout's Content + OverlayInputPassThroughElement are Reactor
+        // subtrees hung off the side flyout object (attached to the Target), NOT
+        // in the Target control's visual child tree — the generic UnmountRecursive
+        // recursion never reaches them, so their child component cleanups would
+        // leak. Tear them down here, then detach the flyout from the Target so a
+        // pooled/reused Target retains no stale flyout state. Keep
+        // ContinueDefaultTraversal so the Target subtree still tears down.
+        if (control is FrameworkElement targetFe)
+        {
+            var attached = targetFe switch
+            {
+                WinUI.SplitButton sb => sb.Flyout,
+                WinUI.Button btn => btn.Flyout,
+                _ => WinPrim.FlyoutBase.GetAttachedFlyout(targetFe),
+            };
+
+            if (attached is WinUI.Flyout flyout)
+            {
+                if (flyout.Content is UIElement content)
+                    ctx.Reconciler.UnmountChild(content);
+                flyout.Content = null;
+                if (flyout.OverlayInputPassThroughElement is UIElement passThrough)
+                    ctx.Reconciler.UnmountChild(passThrough);
+                flyout.OverlayInputPassThroughElement = null;
+            }
+
+            switch (targetFe)
+            {
+                case WinUI.SplitButton sb: sb.Flyout = null; break;
+                case WinUI.Button btn: btn.Flyout = null; break;
+                default: WinPrim.FlyoutBase.SetAttachedFlyout(targetFe, null); break;
+            }
+        }
+        return V1UnmountDisposition.ContinueDefaultTraversal;
+    }
 }
 
 /// <summary>§4.0.1 — MenuBar (normal control; plain-WinUI menu items).</summary>
@@ -104,7 +150,34 @@ internal sealed class PopupHandler : IDecoratorElementHandler<PopupElement>
         => OverlayLifecycle.UpdatePopup(ctx.Reconciler, oldEl, newEl, (WinUI.StackPanel)control, ctx.RequestRerender) ?? control;
 
     public V1UnmountDisposition Unmount(UnmountContext ctx, PopupElement? element, UIElement control)
-        => V1UnmountDisposition.ContinueDefaultTraversal;
+    {
+        // §4.5: the wrapper StackPanel hosts a WinUI Popup whose Child is a
+        // Reactor subtree. UnmountRecursive recurses the wrapper's children and
+        // reaches the Popup, but Popup has no branch in the generic type switch,
+        // so popup.Child (and its component cleanups) would leak. Tear it down
+        // here and close the otherwise-orphaned free-floating popup. Clear the
+        // wrapper tag before closing so the Closed handler — which resolves
+        // OnClosed via the tag — does not spuriously fire during teardown.
+        if (control is WinUI.StackPanel wrapper)
+        {
+            foreach (var winChild in wrapper.Children)
+            {
+                if (winChild is WinPrim.Popup popup)
+                {
+                    if (popup.Child is UIElement popupChild)
+                        ctx.Reconciler.UnmountChild(popupChild);
+                    popup.Child = null;
+                    if (popup.IsOpen)
+                    {
+                        Reconciler.ClearElementTag(wrapper);
+                        popup.IsOpen = false;
+                    }
+                    break;
+                }
+            }
+        }
+        return V1UnmountDisposition.ContinueDefaultTraversal;
+    }
 }
 
 /// <summary>§4.0.1 — CommandBarFlyout (target-wrapping decorator).</summary>

--- a/src/Reactor/Core/V1Protocol/Handlers/OverlayDecoratorHandlers.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/OverlayDecoratorHandlers.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.UI.Xaml;
 using WinUI = Microsoft.UI.Xaml.Controls;
 using WinPrim = Microsoft.UI.Xaml.Controls.Primitives;
@@ -158,22 +159,16 @@ internal sealed class PopupHandler : IDecoratorElementHandler<PopupElement>
         // here and close the otherwise-orphaned free-floating popup. Clear the
         // wrapper tag before closing so the Closed handler — which resolves
         // OnClosed via the tag — does not spuriously fire during teardown.
-        if (control is WinUI.StackPanel wrapper)
+        if (control is WinUI.StackPanel wrapper
+            && wrapper.Children.OfType<WinPrim.Popup>().FirstOrDefault() is { } popup)
         {
-            foreach (var winChild in wrapper.Children)
+            if (popup.Child is UIElement popupChild)
+                ctx.Reconciler.UnmountChild(popupChild);
+            popup.Child = null;
+            if (popup.IsOpen)
             {
-                if (winChild is WinPrim.Popup popup)
-                {
-                    if (popup.Child is UIElement popupChild)
-                        ctx.Reconciler.UnmountChild(popupChild);
-                    popup.Child = null;
-                    if (popup.IsOpen)
-                    {
-                        Reconciler.ClearElementTag(wrapper);
-                        popup.IsOpen = false;
-                    }
-                    break;
-                }
+                Reconciler.ClearElementTag(wrapper);
+                popup.IsOpen = false;
             }
         }
         return V1UnmountDisposition.ContinueDefaultTraversal;

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/OverlayTeardownFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/OverlayTeardownFixtures.cs
@@ -1,0 +1,119 @@
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Spec 047 §4.5 — overlay handler-owned Unmount. Flyout content and Popup
+/// child are Reactor subtrees hung off attached SIDE objects (the flyout
+/// attached to the target; the WinUI Popup inside the wrapper) that the generic
+/// type-switch in UnmountRecursive cannot reach. These fixtures pin that a child
+/// Component's <c>UseEffect</c> cleanup fires when the overlay unmounts — i.e.
+/// the handler tears down the side-mounted subtree rather than leaking it.
+/// </summary>
+public static class OverlayTeardownFixtures
+{
+    private static int s_cleanupCount;
+
+    private sealed class CleanupChild : Component
+    {
+        public override Element Render()
+        {
+            UseEffect(() => () => global::System.Threading.Interlocked.Increment(ref s_cleanupCount));
+            return TextBlock("c");
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Flyout — unmounting the Flyout runs its flyout-content Component cleanup.
+    // ────────────────────────────────────────────────────────────────────
+    internal class Flyout_Unmount_RunsFlyoutContentCleanup(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            s_cleanupCount = 0;
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (show, setShow) = ctx.UseState(true);
+                return VStack(
+                    Button("Toggle", () => setShow(!show)),
+                    show
+                        ? Flyout(Button("WithFlyout", () => { }), Component<CleanupChild>())
+                        : (Element)TextBlock("(hidden)")
+                );
+            });
+            await Harness.Render();
+
+            H.Check("OverlayTeardown_Flyout_NoCleanupBeforeUnmount", s_cleanupCount == 0);
+
+            H.ClickButton("Toggle");
+            await Harness.Render();
+
+            H.Check("OverlayTeardown_Flyout_CleanupRan", s_cleanupCount == 1);
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Flyout — unmounting also runs the OverlayInputPassThroughElement
+    //  Component cleanup (a second side-mounted subtree, distinct from Content).
+    // ────────────────────────────────────────────────────────────────────
+    internal class Flyout_Unmount_RunsPassThroughCleanup(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            s_cleanupCount = 0;
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (show, setShow) = ctx.UseState(true);
+                return VStack(
+                    Button("Toggle", () => setShow(!show)),
+                    show
+                        ? Flyout(Button("WithFlyout", () => { }), TextBlock("content"))
+                            .OverlayInputPassThroughElement(Component<CleanupChild>())
+                        : (Element)TextBlock("(hidden)")
+                );
+            });
+            await Harness.Render();
+
+            H.Check("OverlayTeardown_FlyoutPassThrough_NoCleanupBeforeUnmount", s_cleanupCount == 0);
+
+            H.ClickButton("Toggle");
+            await Harness.Render();
+
+            H.Check("OverlayTeardown_FlyoutPassThrough_CleanupRan", s_cleanupCount == 1);
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Popup — unmounting the Popup runs its child Component cleanup.
+    // ────────────────────────────────────────────────────────────────────
+    internal class Popup_Unmount_RunsChildCleanup(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            s_cleanupCount = 0;
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (show, setShow) = ctx.UseState(true);
+                return VStack(
+                    Button("Toggle", () => setShow(!show)),
+                    show
+                        ? Popup(Component<CleanupChild>(), isOpen: false)
+                        : (Element)TextBlock("(hidden)")
+                );
+            });
+            await Harness.Render();
+
+            H.Check("OverlayTeardown_Popup_NoCleanupBeforeUnmount", s_cleanupCount == 0);
+
+            H.ClickButton("Toggle");
+            await Harness.Render();
+
+            H.Check("OverlayTeardown_Popup_CleanupRan", s_cleanupCount == 1);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -196,6 +196,12 @@ internal static class SelfTestFixtureRegistry
         "PDM_WrapGrid_KeyedReverse_PreservesIdentity",
         "PDM_RelativePanel_KeyedReorder_PreservesIdentity_And_StaleClear",
         "PDM_Panel_Unmount_RunsChildEffectCleanup",
+        // Spec 047 §4.5 — overlay handler-owned Unmount tears down side-mounted
+        // Reactor subtrees (Flyout content, Popup child) the generic recursion
+        // cannot reach.
+        "OverlayTeardown_Flyout_Unmount_RunsFlyoutContentCleanup",
+        "OverlayTeardown_Flyout_Unmount_RunsPassThroughCleanup",
+        "OverlayTeardown_Popup_Unmount_RunsChildCleanup",
         // ElementFactory<T> + WinUI ItemsRepeater recycle contract — regression
         // for the leak fixed alongside these tests (every realize was Minting
         // a fresh UIElement, orphaning prior ones in Repeater.Children).
@@ -1367,6 +1373,9 @@ internal static class SelfTestFixtureRegistry
         "PDM_WrapGrid_KeyedReverse_PreservesIdentity" => new PanelDescriptorMigrationFixtures.WrapGrid_KeyedReverse_PreservesIdentity(harness),
         "PDM_RelativePanel_KeyedReorder_PreservesIdentity_And_StaleClear" => new PanelDescriptorMigrationFixtures.RelativePanel_KeyedReorder_PreservesIdentity_And_StaleClear(harness),
         "PDM_Panel_Unmount_RunsChildEffectCleanup" => new PanelDescriptorMigrationFixtures.Panel_Unmount_RunsChildEffectCleanup(harness),
+        "OverlayTeardown_Flyout_Unmount_RunsFlyoutContentCleanup" => new OverlayTeardownFixtures.Flyout_Unmount_RunsFlyoutContentCleanup(harness),
+        "OverlayTeardown_Flyout_Unmount_RunsPassThroughCleanup" => new OverlayTeardownFixtures.Flyout_Unmount_RunsPassThroughCleanup(harness),
+        "OverlayTeardown_Popup_Unmount_RunsChildCleanup" => new OverlayTeardownFixtures.Popup_Unmount_RunsChildCleanup(harness),
         "EFR_Factory_BoundedDistinctControls_AcrossManyRealizeCycles" => new ElementFactoryRecyclingFixtures.Factory_BoundedDistinctControls_AcrossManyRealizeCycles(harness),
         "EFR_Factory_RecycledControlIsReusedOnNextRealize" => new ElementFactoryRecyclingFixtures.Factory_RecycledControlIsReusedOnNextRealize(harness),
         "EFR_Factory_BookkeepingBoundedAcrossCycles" => new ElementFactoryRecyclingFixtures.Factory_BookkeepingBoundedAcrossCycles(harness),


### PR DESCRIPTION
## Summary

Two related cleanups in the Spec 047 §14 control-model migration:

### A1 — Port remaining composites onto V1 decorator handlers
The last four composition composites — **CommandHost, FormField, ValidationVisualizer, ValidationRule** — are moved off the legacy `Mount`/`Update` `switch` onto V1 `IDecoratorElementHandler` handlers (new `CompositeHandlers.cs`), registered in `RegisterV1BuiltInHandlers`.

- `MountXxx`/`UpdateXxx` bodies are now `internal` and delegated to (`Update` returns `body(...) ?? control` to preserve substitution paths; `Unmount` returns `ContinueDefaultTraversal` to match the old generic Grid/StackPanel teardown).
- The 4 Mount + 4 Update legacy switch arms are deleted. The composition-primitive switch now holds only **Component/Func/Memo/ErrorBoundary**.

### C — Fix overlay teardown leaks (handler-owned `Unmount`)
`Flyout` and `Popup` own Reactor subtrees hung off attached **side objects** that the generic `UnmountRecursive` type switch never reaches, so child `UseEffect` cleanups leaked. Three leaks fixed:

- **`FlyoutHandler.Unmount`** — unmounts `flyout.Content` **and** `flyout.OverlayInputPassThroughElement`, clears both slots, detaches the flyout from its target. Deliberately does **not** call `Hide()` (would fire a spurious `OnClosed` during teardown).
- **`PopupHandler.Unmount`** — unmounts the wrapper's `Popup.Child`, clears it, closes the otherwise-orphaned popup (clearing the wrapper tag first to avoid a spurious `OnClosed`).

`ContentDialog`'s side-mounted content has no back-reference from its placeholder → left as documented known debt.

## Tests
New `OverlayTeardownFixtures.cs` selftests assert a child `Component`'s `UseEffect` cleanup runs exactly once on unmount for **all three** leak paths (flyout content, flyout pass-through, popup child), each with a `NoCleanupBeforeUnmount` precondition. Verified as genuine guards via negative control (disabling a teardown branch makes the matching `CleanupRan` assertion fail).

## Verification
- Build: 0 errors.
- Unit tests: **9132 passed, 0 failed**.
- Selftests: new OverlayTeardown (3) + existing Flyout/Popup/Validation/CommandHost/FormField — all green, no regressions.