### PR TITLE
feat(rich-text): add InlineUI / RichTextInlineUI inline (closes #480)

### DIFF
--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -2201,6 +2201,26 @@ public record RichTextHyperlink(string Text, Uri NavigateUri) : RichTextInline;
 
 public record RichTextLineBreak() : RichTextInline;
 
+/// <summary>
+/// Embeds an arbitrary <see cref="FrameworkElement"/> (UserControl, Button, custom control, etc.)
+/// inline within a <see cref="RichTextBlockElement"/>'s paragraph flow. Mirrors WinUI's
+/// <see cref="Microsoft.UI.Xaml.Documents.InlineUIContainer"/>.
+///
+/// <para>The <paramref name="ChildFactory"/> is invoked each time the block is (re)built — i.e.
+/// whenever the enclosing <see cref="RichTextBlockElement"/> rebuilds its blocks because
+/// the <c>Paragraphs</c> array changed or any inline within it was unequal. Two
+/// <c>RichTextInlineUI</c> records compare equal iff their factory delegates compare equal
+/// (Func.Equals = same target + method), so non-capturing <c>static</c> lambdas naturally
+/// short-circuit unnecessary rebuilds while capturing lambdas force a rebuild each render —
+/// which is the correct behaviour because captured state may have changed.</para>
+///
+/// <para>The factory should return a fresh, unparented control each invocation: each rebuild
+/// constructs a brand-new <see cref="Microsoft.UI.Xaml.Documents.InlineUIContainer"/> and
+/// assigns the returned element as its <c>Child</c>. Returning a shared instance that is
+/// already parented elsewhere will throw at WinUI write time.</para>
+/// </summary>
+public record RichTextInlineUI(Func<FrameworkElement> ChildFactory) : RichTextInline;
+
 // ════════════════════════════════════════════════════════════════════════
 //  Button elements
 // ════════════════════════════════════════════════════════════════════════

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -251,6 +251,20 @@ public sealed partial class Reconciler
                 return hl;
             case RichTextLineBreak:
                 return new Microsoft.UI.Xaml.Documents.LineBreak();
+            case RichTextInlineUI uiInline:
+                var container = new Microsoft.UI.Xaml.Documents.InlineUIContainer();
+                try
+                {
+                    var fe = uiInline.ChildFactory?.Invoke();
+                    if (fe is not null) container.Child = fe;
+                }
+                catch
+                {
+                    // Defensive: a faulty factory must not poison the whole
+                    // paragraph rebuild. Mirrors the legacy Hyperlink path
+                    // which falls back to an empty inline rather than throwing.
+                }
+                return container;
             default:
                 return new Microsoft.UI.Xaml.Documents.Run { Text = "" };
         }

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -1249,6 +1249,29 @@ public static partial class Factories
 
     public static RichTextHyperlink Hyperlink(string text, Uri navigateUri) => new(text, navigateUri);
 
+    /// <summary>
+    /// Creates a <see cref="RichTextInlineUI"/> — a rich-text inline that embeds an arbitrary
+    /// <see cref="Microsoft.UI.Xaml.FrameworkElement"/> within a <see cref="RichTextBlockElement"/>
+    /// paragraph flow. Mirrors WinUI's <c>Microsoft.UI.Xaml.Documents.InlineUIContainer</c>.
+    /// </summary>
+    /// <param name="factory">
+    /// A factory that produces a fresh, unparented control each time the enclosing rich-text
+    /// block is rebuilt. Prefer a <c>static</c> (non-capturing) lambda so the inline compares
+    /// equal across renders and avoids unnecessary rebuilds.
+    /// </param>
+    /// <example>
+    /// <code>
+    /// RichTextBlock(new[]
+    /// {
+    ///     Paragraph(
+    ///         Run("Press "),
+    ///         InlineUI(static () => new Microsoft.UI.Xaml.Controls.Button { Content = "OK" }),
+    ///         Run(" to continue."))
+    /// });
+    /// </code>
+    /// </example>
+    public static RichTextInlineUI InlineUI(Func<Microsoft.UI.Xaml.FrameworkElement> factory) => new(factory);
+
     // ── Markdown ─────────────────────────────────────────────────────
 
     /// <summary>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoreCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoreCoverageFixtures.cs
@@ -155,6 +155,93 @@ internal static class CoreCoverageFixtures
     }
 
     // ════════════════════════════════════════════════════════════════════════
+    //  Issue #480 — RichTextInlineUI / InlineUI() factory
+    //  Verifies the embedded FrameworkElement is mounted inside the
+    //  InlineUIContainer produced by MountInline() and that subsequent
+    //  rebuilds replace the embedded child rather than leaking the old one.
+    // ════════════════════════════════════════════════════════════════════════
+
+    internal class RichTextInlineUIMountAndUpdate(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                var paragraphs = phase switch
+                {
+                    0 => new[] { Paragraph(
+                        Run("Before "),
+                        InlineUI(() => new Button { Content = "InlineBtnA", Tag = "InlineUI_A" }),
+                        Run(" after")) },
+                    _ => new[] { Paragraph(
+                        Run("Before "),
+                        InlineUI(() => new TextBox { Text = "edit me", Tag = "InlineUI_B" }),
+                        Run(" after"),
+                        new RichTextLineBreak(),
+                        Run("line2 "),
+                        InlineUI(() => new CheckBox { Content = "ok", Tag = "InlineUI_C" })) },
+                };
+                return VStack(
+                    Button("Next", () => set(phase + 1)),
+                    RichTextBlock(paragraphs)
+                );
+            });
+
+            await Harness.Render();
+
+            var rtb = H.FindControl<RichTextBlock>(_ => true);
+            H.Check("InlineUI_Mounted_Block", rtb is not null && rtb.Blocks.Count == 1);
+
+            // The embedded Button should be reachable as a descendant once
+            // the InlineUIContainer is hosted inside the RichTextBlock.
+            var btnA = H.FindControl<Button>(b => (b.Tag as string) == "InlineUI_A");
+            H.Check("InlineUI_EmbeddedButton_Present", btnA is not null);
+            H.Check("InlineUI_EmbeddedButton_Content", (btnA?.Content as string) == "InlineBtnA");
+
+            // Verify the inline container is the parent of the embedded FE.
+            var container = btnA is null
+                ? null
+                : Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(btnA) as Microsoft.UI.Xaml.Documents.InlineUIContainer
+                  ?? FindInlineContainerHostingChild(rtb, btnA);
+            H.Check("InlineUI_HostedByInlineUIContainer", container is not null);
+
+            // Phase 1: factory swap from Button → TextBox + extra inlines —
+            // old Button should be gone, new TextBox + CheckBox should appear.
+            H.ClickButton("Next");
+            await Harness.Render();
+
+            var oldBtn = H.FindControl<Button>(b => (b.Tag as string) == "InlineUI_A");
+            H.Check("InlineUI_RebuiltRemovedOldChild", oldBtn is null);
+
+            var tb = H.FindControl<TextBox>(t => (t.Tag as string) == "InlineUI_B");
+            var cb = H.FindControl<CheckBox>(c => (c.Tag as string) == "InlineUI_C");
+            H.Check("InlineUI_RebuiltAddedNewTextBox", tb is not null && tb.Text == "edit me");
+            H.Check("InlineUI_RebuiltAddedNewCheckBox", cb is not null);
+        }
+
+        private static Microsoft.UI.Xaml.Documents.InlineUIContainer? FindInlineContainerHostingChild(
+            RichTextBlock? rtb, Microsoft.UI.Xaml.FrameworkElement child)
+        {
+            if (rtb is null) return null;
+            foreach (var block in rtb.Blocks)
+            {
+                if (block is not Microsoft.UI.Xaml.Documents.Paragraph p) continue;
+                foreach (var inline in p.Inlines)
+                {
+                    if (inline is Microsoft.UI.Xaml.Documents.InlineUIContainer iuc
+                        && ReferenceEquals(iuc.Child, child))
+                    {
+                        return iuc;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
     //  2. TemplatedGridView — mount + update + item count change
     //     Targets: Reconciler.Mount.cs lines 1415-1448, Reconciler.Update.cs lines 1388-1406
     // ════════════════════════════════════════════════════════════════════════

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -451,6 +451,7 @@ internal static class SelfTestFixtureRegistry
         // Core coverage tests — targeting uncovered Reconciler/RenderContext paths
         "CoreCov_RichTextBlockParagraphUpdate",
         "CoreCov_RichTextBlockInlineReconciliation",
+        "CoreCov_RichTextInlineUIMountAndUpdate",
         "CoreCov_TemplatedGridViewMountUpdate",
         "CoreCov_TemplatedFlipViewMountUpdate",
         "CoreCov_LazyVStackMountUpdate",
@@ -1616,6 +1617,7 @@ internal static class SelfTestFixtureRegistry
         // Core coverage tests
         "CoreCov_RichTextBlockParagraphUpdate" => new CoreCoverageFixtures.RichTextBlockParagraphUpdate(harness),
         "CoreCov_RichTextBlockInlineReconciliation" => new CoreCoverageFixtures.RichTextBlockInlineReconciliation(harness),
+        "CoreCov_RichTextInlineUIMountAndUpdate" => new CoreCoverageFixtures.RichTextInlineUIMountAndUpdate(harness),
         "CoreCov_TemplatedGridViewMountUpdate" => new CoreCoverageFixtures.TemplatedGridViewMountUpdate(harness),
         "CoreCov_TemplatedFlipViewMountUpdate" => new CoreCoverageFixtures.TemplatedFlipViewMountUpdate(harness),
         "CoreCov_LazyVStackMountUpdate" => new CoreCoverageFixtures.LazyVStackMountUpdate(harness),

--- a/tests/Reactor.Tests/Elements/FactoryWithExpressionTests.cs
+++ b/tests/Reactor.Tests/Elements/FactoryWithExpressionTests.cs
@@ -491,6 +491,33 @@ public class FactoryWithExpressionTests
     [Fact] public void Hyperlink_WithExpr_Sets_Property()
         => Assert.Equal("new", (Hyperlink("t", new Uri("https://x")) with { Text = "new" }).Text);
 
+    [Fact] public void InlineUI_Factory_Returns_RichTextInlineUI()
+    {
+        Func<Microsoft.UI.Xaml.FrameworkElement> f = () => null!;
+        var inline = InlineUI(f);
+        Assert.IsType<RichTextInlineUI>(inline);
+        Assert.Same(f, inline.ChildFactory);
+    }
+
+    [Fact] public void InlineUI_Equality_By_Factory_Reference()
+    {
+        Func<Microsoft.UI.Xaml.FrameworkElement> f = () => null!;
+        // Same delegate instance → records compare equal (record equality
+        // delegates to Func.Equals → reference equality for closures).
+        Assert.Equal(InlineUI(f), InlineUI(f));
+        // Different closure instances → not equal → triggers RichTextBlock rebuild.
+        Assert.NotEqual(InlineUI(() => null!), InlineUI(() => null!));
+    }
+
+    [Fact] public void InlineUI_WithExpr_Replaces_Factory()
+    {
+        Func<Microsoft.UI.Xaml.FrameworkElement> f1 = () => null!;
+        Func<Microsoft.UI.Xaml.FrameworkElement> f2 = () => null!;
+        var a = InlineUI(f1);
+        var b = a with { ChildFactory = f2 };
+        Assert.Same(f2, b.ChildFactory);
+    }
+
     // ════════════════════════════════════════════════════════════════
     //  Icons
     // ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fixes #480.

## Summary

Adds `InlineUI(Func<FrameworkElement>)` — a declarative rich-text inline that mirrors WinUI's `Microsoft.UI.Xaml.Documents.InlineUIContainer`, letting authors embed an arbitrary `FrameworkElement` (Button, TextBox, custom UserControl, etc.) inside a `RichTextBlock` paragraph flow:

```csharp
RichTextBlock(new[]
{
    Paragraph(
        Run(""Press ""),
        InlineUI(static () => new Button { Content = ""OK"" }),
        Run("" to continue.""))
});
```

This is **Route A** from the issue: factory-based, rebuilt with the block, recycling-safe. The factory delegate is the record's only field, so a non-capturing `static` lambda compares equal across renders (no rebuild), while a capturing lambda forces a rebuild each render — correct, because captured state may have changed.

Route B (Element-typed child reconciled by Reactor) is intentionally deferred — it requires threading reconciler state through inlines and managing child cleanup, and Route A is the natural fit for `RichTextBlock`'s rebuild-on-array-change model.

## Changes

| File | What |
|---|---|
| `src/Reactor/Core/Element.cs` | New record `RichTextInlineUI(Func<FrameworkElement> ChildFactory) : RichTextInline` alongside `RichTextRun` / `RichTextHyperlink` / `RichTextLineBreak`. |
| `src/Reactor/Core/Reconciler.Update.cs` | New switch arm in `MountInline()` that emits `InlineUIContainer { Child = factory() }`. Defensive `try/catch` so a faulty factory never poisons the whole paragraph rebuild. |
| `src/Reactor/Elements/Dsl.cs` | New DSL factory `InlineUI(Func<FrameworkElement>)`. |
| `tests/Reactor.Tests/Elements/FactoryWithExpressionTests.cs` | Unit tests: factory wiring, record equality semantics, `with` expression. |
| `tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoreCoverageFixtures.cs` + registry | New selftest fixture `CoreCov_RichTextInlineUIMountAndUpdate` that verifies mount + the embedded FrameworkElement is in fact a child of an `InlineUIContainer` + rebuild swap correctly removes the old child and adds new ones. |

## Verification

* `dotnet test tests/Reactor.Tests` for the new InlineUI tests + existing Hyperlink / Paragraph / Run with-expr tests → **7/7 pass**.
* `--self-test --filter RichText` runs all RichText fixtures incl. the new one → **22/22 checks pass** (no regression in existing RichTextBlock fixtures).
* Build of `src/Reactor` and `tests/Reactor.AppTests.Host` → **0 errors** (warnings are pre-existing, not from this change).
* The 117 unrelated failures in `Reactor.Tests` (Reconciler/ErrorBoundary/PanelChildReconciliation/etc.) were verified to exist on `main` before this change.