### PR TITLE
chore: fix all build warnings (153 → 0)

### DIFF
--- a/samples/ReactorGallery/ControlPages/StatusAndInfo/InfoBarPage.cs
+++ b/samples/ReactorGallery/ControlPages/StatusAndInfo/InfoBarPage.cs
@@ -23,21 +23,21 @@ class InfoBarPage : Component
                     VStack(8,
                         InfoBar("Informational", "This is an informational message.")
                             .Informational()
-                            .Closable(false),
+                            .IsClosable(false),
                         InfoBar("Success", "Operation completed successfully.")
                             .Success()
-                            .Closable(false),
+                            .IsClosable(false),
                         InfoBar("Warning", "Please review before proceeding.")
                             .Warning()
-                            .Closable(false),
+                            .IsClosable(false),
                         InfoBar("Error", "Something went wrong.")
                             .Error()
-                            .Closable(false)
+                            .IsClosable(false)
                     ),
-                    @"InfoBar(""Success"", ""Completed!"").Success().Closable(false)
-InfoBar(""Warning"", ""Review..."").Warning().Closable(false)
-InfoBar(""Error"",   ""Failed!""  ).Error()  .Closable(false)
-InfoBar(""Info"",    ""FYI…""     ).Informational().Closable(false)"),
+                    @"InfoBar(""Success"", ""Completed!"").Success().IsClosable(false)
+InfoBar(""Warning"", ""Review..."").Warning().IsClosable(false)
+InfoBar(""Error"",   ""Failed!""  ).Error()  .IsClosable(false)
+InfoBar(""Info"",    ""FYI…""     ).Informational().IsClosable(false)"),
 
                 SampleCard("Closable InfoBar",
                     VStack(8,

--- a/samples/apps/demo-script-tool/App/DemoScriptTool.csproj
+++ b/samples/apps/demo-script-tool/App/DemoScriptTool.csproj
@@ -21,8 +21,9 @@
     <PackageReference Include="GitHub.Copilot.SDK" Version="0.3.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(WindowsAppSDKVersion)" />
     <!-- Pin the transitive Nerdbank.MessagePack (via GitHub.Copilot.SDK → StreamJsonRpc)
-         to a version that includes the GHSA-2cwq-pwfr-wcw3 / CVE-2026-44375 fix. -->
-    <PackageReference Include="Nerdbank.MessagePack" Version="1.1.62" />
+         to 1.2.4 — picks up GHSA-92vj-hp7m-gwcj and GHSA-qjvr-435c-5fjh fixes
+         beyond the original 1.1.62 (which covered only GHSA-2cwq-pwfr-wcw3). -->
+    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Reactor/Core/V1Protocol/Descriptor/DescriptorHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/DescriptorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor;
 /// <list type="number">
 ///   <item>Rent the control via <see cref="MountContext.RentControl{T}"/>.</item>
 ///   <item>Iterate <see cref="ControlDescriptor{TElement,TControl}.Properties"/>
-///   and invoke <see cref="PropEntry{TElement,TControl}.Mount"/> on each —
+///   and invoke <see cref="PropEntry{TElement,TControl}.Mount(TControl, TElement)"/> on each —
 ///   all bare initial writes happen first.</item>
 ///   <item>Iterate again and invoke
 ///   <see cref="PropEntry{TElement,TControl}.EnsureSubscribed"/> — controlled

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/FrameDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/FrameDescriptor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors;
 ///   three <see cref="ControlDescriptor{TElement,TControl}.HandCodedEvent{TPayload,TDelegate}"/>
 ///   entries sharing a <see cref="FrameEventPayload"/> with one trampoline
 ///   slot per event. Each trampoline reads the live element via
-///   <see cref="Reconciler.GetElementTag"/> and fires the corresponding
+///   <see cref="Reconciler.GetElementTag(Microsoft.UI.Xaml.UIElement)"/> and fires the corresponding
 ///   callback only when the element still has one wired — mirrors the
 ///   legacy arm's "always subscribe, read latest callback per fire"
 ///   pattern.</item>

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/ImageDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/ImageDescriptor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors;
 /// <c>ImageOpened</c>/<c>ImageFailed</c> route back to the element
 /// callbacks. The descriptor reuses <see cref="ImageEventPayload"/> with the
 /// established slot-gating shape; trampolines read the live element via
-/// <see cref="Reconciler.GetElementTag"/> and fire the corresponding
+/// <see cref="Reconciler.GetElementTag(Microsoft.UI.Xaml.UIElement)"/> and fire the corresponding
 /// callback only when it's wired — mirrors the
 /// "always subscribe, read latest callback per fire" pattern.</para>
 ///

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/InfoBarDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/InfoBarDescriptor.cs
@@ -34,7 +34,7 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors;
 /// <c>.OneWayBridged&lt;string?&gt;</c> entry whose set lambda creates the
 /// <c>Button</c>, wires <c>Click</c> via a closure over the parent InfoBar
 /// reference (which is rooted by the InfoBar's Tag — Click resolves
-/// <c>OnActionButtonClick</c> through <see cref="Reconciler.GetElementTag"/>
+///   <c>OnActionButtonClick</c> through <see cref="Reconciler.GetElementTag(Microsoft.UI.Xaml.FrameworkElement)"/>
 /// so a record-with that updates the callback picks up automatically). The
 /// gate matches the legacy "set when non-null" treatment: a non-null →
 /// non-null content swap rebuilds the inner button (legacy doesn't rebuild,

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/TemplatedFlipViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/TemplatedFlipViewDescriptor.cs
@@ -34,7 +34,7 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors;
 /// (gated on <c>HasCallbacks</c>) so the engine subscribes the
 /// trampoline exactly when the closed-T leaf has a callback. The
 /// trampoline re-reads the live element via
-/// <see cref="Reconciler.GetElementTag"/> and dispatches through the
+/// <see cref="Reconciler.GetElementTag(Microsoft.UI.Xaml.UIElement)"/> and dispatches through the
 /// base virtual — the closed-T leaf invokes its own <c>OnSelectedIndexChanged</c>.
 /// <see cref="ChangeEchoSuppressor"/> drains the programmatic-write
 /// echo, same as the simple <see cref="FlipViewDescriptor"/>.</para>

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/TemplatedListViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/TemplatedListViewDescriptor.cs
@@ -21,7 +21,7 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors;
 /// <para><b>Event wiring lives inside
 /// <see cref="Reconciler.BindKeyedItemsSource"/></b> (SelectionChanged +
 /// ItemClick subscribed once at Mount with trampolines that re-read the
-/// live element via <see cref="Reconciler.GetElementTag"/>) — avoiding a
+/// live element via <see cref="Reconciler.GetElementTag(Microsoft.UI.Xaml.UIElement)"/>) — avoiding a
 /// new <c>ControlEventState</c> payload box just for this descriptor.
 /// Selection / Click semantics match the legacy
 /// <c>MountTemplatedListView</c> body 1:1, including the

--- a/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
@@ -16,7 +16,7 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor;
 ///
 /// <para><b>Phase ordering inside Mount:</b>
 /// <list type="number">
-///   <item><see cref="Mount"/> runs once per entry. Controlled entries write
+///   <item><see cref="Mount(TControl, TElement)"/> runs once per entry. Controlled entries write
 ///   their initial value bare — event subscription has not yet been wired,
 ///   so a synchronous change event has no trampoline to fire (no echo).
 ///   Mirrors the KD-1b fix on the hand-coded handlers.</item>
@@ -25,7 +25,7 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor;
 ///   <see cref="DescriptorHandler{TElement,TControl}"/>'s per-control
 ///   subscription gate (so pool-reused controls do not double-subscribe).</item>
 /// </list>
-/// On Update, <see cref="Update"/> runs and writes through
+/// On Update, <see cref="Update(TControl, TElement, TElement)"/> runs and writes through
 /// <c>ReactorBinding.WriteSuppressed</c> when the entry is controlled.</para>
 /// </summary>
 public abstract class PropEntry<TElement, TControl>
@@ -58,7 +58,7 @@ public abstract class PropEntry<TElement, TControl>
     /// <summary>Event subscription hook. Default = no-op (one-way / initial
     /// entries do not subscribe to events). Controlled entries override.
     ///
-    /// <para>The interpreter calls this after every <see cref="Mount"/> in
+    /// <para>The interpreter calls this after every <see cref="Mount(TControl, TElement)"/> in
     /// the entry list so all bare initial writes complete before any event
     /// trampoline goes live (KD-1b ordering invariant).</para></summary>
     public virtual void EnsureSubscribed(

--- a/src/Reactor/Docking/Native/DockDragSession.cs
+++ b/src/Reactor/Docking/Native/DockDragSession.cs
@@ -120,6 +120,11 @@ internal sealed class DockDragSession
     /// sessions on unmount. Older callers (e.g. tests that don't model
     /// the cross-render lifecycle) may omit it.
     /// </param>
+    /// <param name="source">The pane the user grabbed.</param>
+    /// <param name="sourceManager">The <see cref="DockManager"/> the
+    /// <paramref name="source"/> currently belongs to.</param>
+    /// <param name="sourceTabIndex">The tab index of <paramref name="source"/>
+    /// within its current group (used for re-insertion on cancel).</param>
     public static DockDragSession? Begin(
         DockableContent source,
         DockManager sourceManager,

--- a/src/Reactor/Docking/Native/DockFloatingWindow.cs
+++ b/src/Reactor/Docking/Native/DockFloatingWindow.cs
@@ -53,6 +53,18 @@ public static class DockFloatingWindow
     /// window. When supplied, the window is associated with that manager's
     /// tracking set; the host unmount handler closes it. When null,
     /// the window is tracked only in the global set.</param>
+    /// <param name="opacity">Window opacity in [0, 1]. Defaults to 1.0
+    /// (fully opaque). Spec 045 §2.6 tear-off uses 0.5 for the immediate
+    /// drag preview.</param>
+    /// <param name="noActivate">When true, opens the window without
+    /// stealing focus from the source. Spec 045 §2.6 tear-off uses this
+    /// so the drag pointer-capture stays on the source TabView.</param>
+    /// <param name="ignorePointerInput">When true, the window swallows
+    /// no pointer input — drop-target overlays underneath remain hit-testable.
+    /// Spec 045 §2.6 tear-off pairs this with the 0.5 opacity preview.</param>
+    /// <param name="initialPosition">Optional explicit top-left (in DIPs).
+    /// When provided, suppresses the WindowStartPosition.Default placement
+    /// and pins the window at the supplied coordinates.</param>
     /// <returns>The opened <see cref="ReactorWindow"/>.</returns>
     public static ReactorWindow Open(
         DockableContent pane,

--- a/src/Reactor/Docking/Native/DockTabGroupRenderer.cs
+++ b/src/Reactor/Docking/Native/DockTabGroupRenderer.cs
@@ -66,6 +66,14 @@ internal static class DockTabGroupRenderer
     /// signal). Caller is responsible for opening a floating window
     /// and removing the pane from the source layout on tear-out.
     /// </param>
+    /// <param name="onTabImmediateTearOff">
+    /// Spec 045 §2.6 immediate tear-off. When supplied, the renderer
+    /// asks the host to spawn the floating tear-off preview as soon
+    /// as the drag crosses the rip threshold; the returned
+    /// <see cref="DockTabTearOff.TearOffActive"/> tracks pointer
+    /// updates until drop. When null, the renderer falls back to the
+    /// classic <c>onTabDragCompleted</c>-only sequence.
+    /// </param>
     public static Element Render(
         DockTabGroup group,
         Func<DockableContent, Element?> renderLeafContent,

--- a/src/Reactor/Hosting/ReactorHotReloadCopier.cs
+++ b/src/Reactor/Hosting/ReactorHotReloadCopier.cs
@@ -29,6 +29,9 @@ internal static class ReactorHotReloadCopier
     /// the inputs (null source/dest); a successful walk — even one that copies
     /// zero fields — returns <c>true</c>.
     /// </summary>
+    /// <param name="source">The pre-edit instance whose field values are read.</param>
+    /// <param name="dest">The freshly-constructed post-edit instance that
+    /// receives the by-name field values from <paramref name="source"/>.</param>
     /// <param name="visited">Cycle guard keyed on source reference identity.
     /// Pass <c>new HashSet&lt;object&gt;(ReferenceEqualityComparer.Instance)</c>.</param>
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Reachable only via HotReloadService.IsHotReloadLive; dead under NativeAOT (spec 049 §8).")]

--- a/tests/Reactor.AppTests.Host/Reactor.AppTests.Host.csproj
+++ b/tests/Reactor.AppTests.Host/Reactor.AppTests.Host.csproj
@@ -10,6 +10,11 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- CsWinRT1030: generic WinRT-implementing collection use (e.g. List<Border>
+         in SplitterMatrixFixtures) requires the CsWinRT-generated marshaling
+         code to use unsafe blocks. This flag enables that for the generated
+         code only; user code in this project does not opt into unsafe. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishAotInternal)' == 'true'">

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DevtoolsFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DevtoolsFixtures.cs
@@ -1178,7 +1178,7 @@ internal static class DevtoolsFixtures
         public override async Task RunAsync()
         {
             var toolsType = typeof(DevtoolsPropertyTools);
-            H.Check("Devtools_PropReflect_Start", toolsType is not null);
+            H.Check("Devtools_PropReflect_Start", true);
             object? Invoke(string name, params object?[] args) =>
                 toolsType.GetMethod(name, global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static)!
                     .Invoke(null, args);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -36,6 +36,7 @@ internal static class ReconcilerBigCoverageFixtures
         public override async Task RunAsync()
         {
             var host = H.CreateHost();
+#pragma warning disable CS0618 // exercises obsolete .AccessKeyDisplayRequested → OnAccessKeyDisplayRequested bridge
             host.Mount(ctx => VStack(
                 TextBlock("evt-target")
                     .OnSizeChanged((_, _) => { })
@@ -60,6 +61,7 @@ internal static class ReconcilerBigCoverageFixtures
                     .OnLostFocus((_, _) => { })
                     .AccessKeyDisplayRequested(() => { })
             ));
+#pragma warning restore CS0618
 
             await Harness.Render();
             var tb = H.FindText("evt-target");

--- a/tests/Reactor.Tests/Devtools/DevtoolsMcpServerOriginTests.cs
+++ b/tests/Reactor.Tests/Devtools/DevtoolsMcpServerOriginTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.UI.Reactor.Hosting.Devtools;
 using Xunit;
@@ -13,6 +14,7 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// </summary>
 public class DevtoolsMcpServerOriginTests
 {
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicMethods)]
     private static readonly Type ServerType = typeof(DevtoolsMcpServer);
 
     private static bool InvokeIsAllowedOrigin(string origin)

--- a/tests/Reactor.Tests/Docking/DockApiShapeTests.cs
+++ b/tests/Reactor.Tests/Docking/DockApiShapeTests.cs
@@ -26,7 +26,9 @@ public class DockApiShapeTests
         Assert.Null(dm.BottomSide);
         Assert.Null(dm.ActiveDocument);
         Assert.Null(dm.Adapter);
+#pragma warning disable CS0618 // intentional coverage of obsolete Behavior surface
         Assert.Null(dm.Behavior);
+#pragma warning restore CS0618
         Assert.Null(dm.PersistenceId);
         Assert.Equal(1, dm.LayoutSchemaVersion);
     }
@@ -175,6 +177,7 @@ public class DockApiShapeTests
     public void DockManager_With_PreservesAdapterAndBehavior()
     {
         var adapter = new TestAdapter();
+#pragma warning disable CS0618 // intentional coverage of obsolete Behavior/IDockBehavior surface
         var behavior = new TestBehavior();
         var dm = new DockManager { Adapter = adapter, Behavior = behavior };
 
@@ -182,6 +185,7 @@ public class DockApiShapeTests
 
         Assert.Same(adapter, renamed.Adapter);
         Assert.Same(behavior, renamed.Behavior);
+#pragma warning restore CS0618
         Assert.Equal("main", renamed.PersistenceId);
     }
 
@@ -192,9 +196,11 @@ public class DockApiShapeTests
         public Element? GetFloatingWindowTitleBar(DockableContent? draggedSource) => null;
     }
 
+#pragma warning disable CS0618 // intentional implementation of obsolete IDockBehavior for coverage
     private sealed class TestBehavior : IDockBehavior
     {
         public void OnDocked(DockableContent src, DockTarget target) { }
         public void OnFloating(DockableContent content) { }
     }
+#pragma warning restore CS0618
 }

--- a/tests/Reactor.Tests/Docking/RoleAwareRoutingTests.cs
+++ b/tests/Reactor.Tests/Docking/RoleAwareRoutingTests.cs
@@ -99,9 +99,8 @@ public class RoleAwareRoutingTests
         Assert.Null(fallback);
         var landing = FirstGroupContaining(inserted, "d1");
         Assert.Equal(DockGroupRole.DocumentArea, landing.Role);
-        Assert.Empty(((DockSplit)inserted).Children
-            .OfType<DockTabGroup>()
-            .Where(g => g.Role == DockGroupRole.ToolWindowStrip && g.Documents.Any(d => Equals(d.Key, "d1"))));
+        Assert.DoesNotContain(((DockSplit)inserted).Children.OfType<DockTabGroup>(),
+            g => g.Role == DockGroupRole.ToolWindowStrip && g.Documents.Any(d => Equals(d.Key, "d1")));
     }
 
     [Fact]

--- a/tests/Reactor.Tests/Hosting/ReactorAppStaticHelperTests.cs
+++ b/tests/Reactor.Tests/Hosting/ReactorAppStaticHelperTests.cs
@@ -215,14 +215,14 @@ public class ReactorAppStaticHelperTests
 // FindXamlMetadataProviderInAssembly has something concrete to find when
 // pointed at this test assembly. They never participate in real XAML markup.
 
-internal sealed class FakeXamlMetadataProvider : IXamlMetadataProvider
+internal sealed partial class FakeXamlMetadataProvider : IXamlMetadataProvider
 {
     public IXamlType GetXamlType(global::System.Type type) => null!;
     public IXamlType GetXamlType(string fullName) => null!;
     public XmlnsDefinition[] GetXmlnsDefinitions() => Array.Empty<XmlnsDefinition>();
 }
 
-internal sealed class AnotherFakeXamlMetadataProvider : IXamlMetadataProvider
+internal sealed partial class AnotherFakeXamlMetadataProvider : IXamlMetadataProvider
 {
     public IXamlType GetXamlType(global::System.Type type) => null!;
     public IXamlType GetXamlType(string fullName) => null!;
@@ -234,14 +234,14 @@ internal sealed class AnotherFakeXamlMetadataProvider : IXamlMetadataProvider
 // (skip abstract, skip interface, skip no-default-ctor, swallow throwing
 // ctor) doesn't return them.
 
-internal abstract class AbstractXamlMetadataProviderShouldBeSkipped : IXamlMetadataProvider
+internal abstract partial class AbstractXamlMetadataProviderShouldBeSkipped : IXamlMetadataProvider
 {
     public IXamlType GetXamlType(global::System.Type type) => null!;
     public IXamlType GetXamlType(string fullName) => null!;
     public XmlnsDefinition[] GetXmlnsDefinitions() => Array.Empty<XmlnsDefinition>();
 }
 
-internal sealed class NoDefaultCtorXamlMetadataProviderShouldBeSkipped : IXamlMetadataProvider
+internal sealed partial class NoDefaultCtorXamlMetadataProviderShouldBeSkipped : IXamlMetadataProvider
 {
     public NoDefaultCtorXamlMetadataProviderShouldBeSkipped(int _) { }
     public IXamlType GetXamlType(global::System.Type type) => null!;
@@ -249,7 +249,7 @@ internal sealed class NoDefaultCtorXamlMetadataProviderShouldBeSkipped : IXamlMe
     public XmlnsDefinition[] GetXmlnsDefinitions() => Array.Empty<XmlnsDefinition>();
 }
 
-internal sealed class ThrowingCtorXamlMetadataProviderShouldBeSwallowed : IXamlMetadataProvider
+internal sealed partial class ThrowingCtorXamlMetadataProviderShouldBeSwallowed : IXamlMetadataProvider
 {
     public ThrowingCtorXamlMetadataProviderShouldBeSwallowed()
     {

--- a/tests/Reactor.Tests/HotReload/HotReloadStateMigrationTests.cs
+++ b/tests/Reactor.Tests/HotReload/HotReloadStateMigrationTests.cs
@@ -25,11 +25,16 @@ namespace Microsoft.UI.Reactor.Tests.HotReload;
 public class HotReloadStateMigrationTests
 {
     // Distinct "before"/"after" shapes used to exercise the copier directly.
+    // CS0649 suppression: the "after" types are intentionally never assigned
+    // in test code — the copier itself populates them from the "before"
+    // instance, which is exactly the behavior under test.
+#pragma warning disable CS0649
     private class StateV1 { public int Count; public string? Name; }
     private class StateV2 { public int Count; public bool Flag; }      // Name removed, Flag added
     private class StateRetyped { public string? Count; }               // Count int -> string (incompatible)
     private class WithHandle { public int Keep; public nint Handle; }  // native handle must not copy
     private class SelfRef { public int V; public SelfRef? Next; }
+#pragma warning restore CS0649
 
     private static HashSet<object> FreshVisited() =>
         new(ReferenceEqualityComparer.Instance);

--- a/tests/Reactor.Tests/InputModifierExtensionsTests.cs
+++ b/tests/Reactor.Tests/InputModifierExtensionsTests.cs
@@ -249,7 +249,9 @@ public class InputModifierExtensionsTests
     [Fact]
     public void AccessKeyDisplayRequested_ZeroArg_WiresHandler()
     {
+#pragma warning disable CS0618 // intentional coverage of obsolete bridge
         var el = TextBlock("x").AccessKeyDisplayRequested(() => { });
+#pragma warning restore CS0618
         Assert.NotNull(el.Modifiers!.OnAccessKeyDisplayRequested);
     }
 

--- a/tests/Reactor.Tests/Markdown/SanitizeUrlTests.cs
+++ b/tests/Reactor.Tests/Markdown/SanitizeUrlTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Xunit;
 
@@ -11,7 +12,15 @@ namespace Microsoft.UI.Reactor.Tests.Markdown;
 /// </summary>
 public class SanitizeUrlTests
 {
-    private static readonly Type MarkdownHtmlType =
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicMethods)]
+    private static readonly Type MarkdownHtmlType = LoadMarkdownHtmlType();
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Test reaches a known-internal type via Assembly.GetType; the trimmer can't carry the annotation through Assembly.GetType, so we assert the type was kept manually.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2073",
+        Justification = "Same as IL2026 — Assembly.GetType return doesn't propagate DAM annotation.")]
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicMethods)]
+    private static Type LoadMarkdownHtmlType() =>
         typeof(Microsoft.UI.Reactor.Factories).Assembly
             .GetType("Microsoft.UI.Reactor.Markdown.MarkdownHtml")
         ?? throw new InvalidOperationException(

--- a/tests/Reactor.Tests/PreviewCaptureServerTests.cs
+++ b/tests/Reactor.Tests/PreviewCaptureServerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -23,6 +24,11 @@ namespace Microsoft.UI.Reactor.Tests;
 /// </summary>
 public class PreviewCaptureServerTests
 {
+    [DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicConstructors
+        | DynamicallyAccessedMemberTypes.NonPublicConstructors
+        | DynamicallyAccessedMemberTypes.NonPublicMethods
+        | DynamicallyAccessedMemberTypes.NonPublicFields)]
     private static readonly Type ServerType = typeof(PreviewCaptureServer);
 
     // ══════════════════════════════════════════════════════════════

--- a/tests/Reactor.Tests/Spec047/V1Protocol/ChildrenStrategyTests.cs
+++ b/tests/Reactor.Tests/Spec047/V1Protocol/ChildrenStrategyTests.cs
@@ -71,10 +71,10 @@ public class ChildrenStrategyTests
     [Fact]
     public void Imperative_Strategy_Invokes_Lambda()
     {
-        bool ran = false;
         var strategy = new Imperative<TestEl, UIElement>((ctx, oldEl, newEl, ctrl) =>
         {
-            ran = true;
+            // Body intentionally empty — see note below: we only assert the
+            // delegate is wired (the engine path needs a real MountContext).
         });
         // Direct invoke (the engine path needs a real MountContext; here we just
         // verify the lambda is wired). Cannot construct MountContext from a test


### PR DESCRIPTION
## Summary

Sweep across `dotnet build Reactor.slnx -p:Platform=x64` cleaning every warning category that fired. Before this PR the solution built with **0 errors / 153 warnings (54 unique)**; it now builds with **0 errors / 0 warnings**.

No production behavior changes — all fixes are XML-doc cref disambiguation, missing `<param>` tags, trim/AOT annotations, `partial` markers, an obsolete-API rename in one sample, suppressions on tests that intentionally exercise obsolete API, and one vulnerable-package version bump.

## Fixes by warning code

| Code | # unique | Fix |
|------|---|-----|
| CS0219 | 1 | Drop unused `bool ran` in `ChildrenStrategyTests` |
| CS0419 | 9 | Disambiguate `cref`s on `Mount`/`Update`/`GetElementTag` overloads with explicit signatures |
| CS0618 | 10 | `ReactorGallery.InfoBarPage` switched from obsolete `.Closable(false)` to `.IsClosable(false)`; pragma-suppressed in tests/fixtures that intentionally pin obsolete API (`DockManager.Behavior`, `IDockBehavior`, `.AccessKeyDisplayRequested` bridge) |
| CS0649 | 3 | Pragma-suppress `HotReloadStateMigrationTests` fields populated by the copier under test |
| CS1573 | 10 | Add missing `<param>` tags on `DockDragSession.Begin`, `DockFloatingWindow.Open`, `DockTabGroupRenderer.Render`, `ReactorHotReloadCopier.TryMigrate` |
| CS8602 | 1 | Drop redundant `typeof()`-can-be-null check in `DevtoolsFixtures` |
| CsWinRT1028 | 4 | Mark test `FakeXamlMetadataProvider` types `partial` |
| CsWinRT1030 | 1 | `AllowUnsafeBlocks=true` in `Reactor.AppTests.Host.csproj` for CsWinRT-generated `List<Border>` marshaling |
| IL2074 / IL2077 / IL2080 | 13 | Annotate test `Type` fields with `[DynamicallyAccessedMembers(...)]`; wrap `Assembly.GetType` in helper with `[UnconditionalSuppressMessage]` + `[return: DAM]` |
| NU1902 | 2 | Bump `Nerdbank.MessagePack` 1.1.62 → 1.2.4 in `DemoScriptTool.csproj` (matches `Reactor.Cli`; picks up GHSA-92vj-hp7m-gwcj + GHSA-qjvr-435c-5fjh) |
| xUnit2029 | 1 | `Assert.Empty(...Where(...))` → `Assert.DoesNotContain(..., predicate)` |

## Validation

- `dotnet build Reactor.slnx -p:Platform=x64` → **0 errors, 0 warnings** (was 0 / 153).
- Targeted `dotnet test tests/Reactor.Tests` filtered to every touched file (HotReload, ChildrenStrategy, RoleAware, DockApiShape, InputModifier, PreviewCaptureServer, SanitizeUrl, DevtoolsMcp, ReactorAppStaticHelper) → 215 passed, 3 skipped, 0 failed.
- Full `dotnet test tests/Reactor.Tests` + `Reactor.SelfTests` run in progress (see follow-up comment).