### PR TITLE
test(harness): bounded convergence loop for multi-wave WinUI realization

### DIFF
--- a/src/Reactor/Hosting/ReactorHost.cs
+++ b/src/Reactor/Hosting/ReactorHost.cs
@@ -882,12 +882,16 @@ public sealed class ReactorHost : IDisposable
     /// drive bounded-convergence wait loops without polling the same fields
     /// reflectively. The renderPending read uses Volatile.Read so off-thread
     /// callers see a stable snapshot of the Interlocked-managed field.
+    /// A disposed host reports idle (nothing left to render, ever) to match
+    /// the disposed-arm short-circuit in <see cref="WaitForIdleAsync"/>;
+    /// otherwise convergence loops would spin to their pass cap during/after
+    /// host teardown and emit misleading non-idle diagnostics.
     /// </summary>
     public bool IsIdle =>
-        !_disposed &&
-        Volatile.Read(ref _renderPending) == 0 &&
-        !_isRendering &&
-        !_needsRerender;
+        _disposed ||
+        (Volatile.Read(ref _renderPending) == 0 &&
+         !_isRendering &&
+         !_needsRerender);
 
     /// <summary>
     /// Awaits until the render loop is idle (no pending or in-flight renders).

--- a/src/Reactor/Hosting/ReactorHost.cs
+++ b/src/Reactor/Hosting/ReactorHost.cs
@@ -876,6 +876,20 @@ public sealed class ReactorHost : IDisposable
     }
 
     /// <summary>
+    /// True when the render loop has no pending or in-flight render and no
+    /// re-render queued for the next tick. Mirrors the early-out predicate
+    /// inside <see cref="WaitForIdleAsync"/>; exposed so test harnesses can
+    /// drive bounded-convergence wait loops without polling the same fields
+    /// reflectively. The renderPending read uses Volatile.Read so off-thread
+    /// callers see a stable snapshot of the Interlocked-managed field.
+    /// </summary>
+    public bool IsIdle =>
+        !_disposed &&
+        Volatile.Read(ref _renderPending) == 0 &&
+        !_isRendering &&
+        !_needsRerender;
+
+    /// <summary>
     /// Awaits until the render loop is idle (no pending or in-flight renders).
     /// Yields to the dispatcher at Low priority in a loop so that Normal-priority
     /// RenderLoop callbacks and Low-priority re-renders all complete before returning.

--- a/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
@@ -224,37 +224,65 @@ internal sealed class Harness
     /// </summary>
     public static async Task Render(int ms = 0)
     {
-        // Wait for Reactor's render loop to go idle (all pending + re-renders done)
-        if (ReactorApp.PrimaryWindow?.Host is { } host)
+        // Bounded convergence loop. A single (WaitForIdle → UpdateLayout →
+        // Low-yield → UpdateLayout) pass drains one wave of WinUI's lazy
+        // realization: TabView selecting a pane → its ContentPresenter
+        // realizes → the pane's body mounts. But composed surfaces (a Reactor
+        // DockManager whose pane content is another DockManager, or a TabView
+        // inside a TabView) need MULTIPLE waves because each wave's mount
+        // schedules the next wave's Normal-priority realization message.
+        //
+        // We loop until Reactor reports idle AND we've done at least
+        // `minPasses` rounds (so purely WinUI-driven multi-wave realization
+        // — which doesn't necessarily touch Reactor's renderPending flag —
+        // still gets enough dispatcher drain). Steady state (one-wave trees)
+        // exits after pass 2 with no real cost: WaitForIdleAsync short-
+        // circuits when Reactor was already idle and UpdateLayout is a no-op
+        // when nothing's dirty.
+        //
+        // The single Low-yield + 16ms Delay combo was previously load-
+        // bearing for ~98.4% of fixtures; the multi-wave NativeDocking sites
+        // (TabView → nested DockManager → nested TabView) were the remaining
+        // ~1.6% flake source observed in 1000-iteration stress runs.
+        var host = ReactorApp.PrimaryWindow?.Host;
+        var dq = DispatcherQueue.GetForCurrentThread();
+        const int minPasses = 2;
+        const int maxPasses = 4;
+
+        int pass = 0;
+        for (; pass < maxPasses; pass++)
         {
-            await host.WaitForIdleAsync();
+            if (host is not null) await host.WaitForIdleAsync();
+
+            // Re-read window content each pass — an async mount may have
+            // replaced it between passes.
+            (_currentWindow?.Content as UIElement)?.UpdateLayout();
+
+            // Yield once at Low priority AFTER UpdateLayout so any
+            // Normal-priority TabView content-realization messages scheduled
+            // by the layout pass drain before we probe.
+            var yieldTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!dq.TryEnqueue(DispatcherQueuePriority.Low, () => yieldTcs.SetResult()))
+                yieldTcs.SetResult();
+            await yieldTcs.Task;
+
+            // Re-run layout in case the just-realized content needs an
+            // arrangement pass (e.g. a Memo body that mounted during the
+            // yield needs to size its TextBlocks before FindText can match
+            // by exact-text).
+            (_currentWindow?.Content as UIElement)?.UpdateLayout();
+
+            // Stability gate: at least `minPasses` rounds AND Reactor idle.
+            // A nested sub-host that bumpTicks during realization flips
+            // IsIdle false → loop until it settles or we hit the cap.
+            if (pass + 1 >= minPasses && (host is null || host.IsIdle)) break;
         }
 
-        var dq = DispatcherQueue.GetForCurrentThread();
-
-        // Force synchronous layout so ActualWidth/ActualHeight are ready.
-        // This is also what triggers TabView's selected-tab content presenter
-        // to schedule its content-realization work onto the dispatcher.
-        (_currentWindow?.Content as UIElement)?.UpdateLayout();
-
-        // Yield once at Low priority AFTER UpdateLayout. WaitForIdleAsync
-        // short-circuits when Reactor reports idle; that left callers racing
-        // the WinUI side because TabView lazy-realizes the selected pane's
-        // body via Normal-priority dispatcher messages SCHEDULED BY the
-        // layout pass we just forced. A Low-priority yield here guarantees
-        // those messages have drained — without it, a 16ms wall-clock delay
-        // is enough on CI but flakes on contended local machines (visible
-        // in NativeDocking_* fixtures where the pane Memo subtree probes
-        // returned null ~30–60% of the time on local 10x sweeps).
-        var yieldTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        if (!dq.TryEnqueue(DispatcherQueuePriority.Low, () => yieldTcs.SetResult()))
-            yieldTcs.SetResult();
-        await yieldTcs.Task;
-
-        // Re-run layout in case the just-realized content needs an arrangement
-        // pass (e.g. a Memo body that mounted during the yield needs to size
-        // its TextBlocks before FindText can match by exact-text).
-        (_currentWindow?.Content as UIElement)?.UpdateLayout();
+        // Diagnostic: if we exited at the cap and the host is still
+        // non-idle, surface a TAP comment so the next flake is greppable
+        // instead of silent. Mirrors WaitForIdleAsync's yield-cap log.
+        if (pass >= maxPasses && host is not null && !host.IsIdle)
+            Console.WriteLine("# Harness.Render exited at maxPasses while host was still non-idle");
 
         // Small breathing room for the compositor to finish processing
         // visual tree changes. Without this, rapid fixture transitions can


### PR DESCRIPTION
## Summary

Fixes the residual `NativeDocking_*` selftest flakes surfaced by the [1000x CI Stress run](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/26716760929): **14 hits across 8 fixtures**, all on the first probe assertion right after `Harness.Render()` returned.

## Root cause

Nested `DockManager` / `TabView` surfaces realize lazily in **multiple dispatcher waves** (a TabView selects a pane → its `ContentPresenter` realizes → which mounts a nested `DockManager` → which contains another `TabView` whose own selected-pane realization is a **second wave**…). The existing `Harness.Render()` drained exactly one wave (single `DispatcherQueuePriority.Low` yield + 16 ms compositor pause), so the inner-most `TextBlock` was still unrealized when the probe assertion fired.

This matched the documented residual race in `Harness.cs:240-262` and the `Reliability_Effect_BodyRendered` fixture's own comment about `Harness.Render`'s idle-wait targeting only the primary host.

## Fix

Replace the single-wave drain in `Harness.Render()` with a **bounded convergence loop**:

- **2 minimum passes** — covers pure-WinUI multi-wave realization that doesn't touch Reactor's `renderPending` flag (rubber-duck flagged this; `IsIdle`-only would short-circuit incorrectly).
- **Up to 4 passes** — break early once `host.IsIdle` after min-passes met. Steady-state (one-wave trees) exits after pass 2 with one extra `IsIdle` boolean read; `WaitForIdleAsync` short-circuits when Reactor is already idle.
- **Re-read `window.Content` per pass** — handles async-mount replacement between passes.
- **Diagnostic TAP comment** if it ever runs to the cap still non-idle (greppable instead of silent flake), mirroring `WaitForIdleAsync`'s existing yield-cap log.

The 16 ms compositor breathing-room delay is retained — it's load-bearing for rapid fixture transitions (without it, rapid mount/unmount cycles can outpace the WinUI compositor and cause native segfaults).

Also adds a public `ReactorHost.IsIdle` property mirroring the existing private idle predicate (`renderPending == 0 && !isRendering && !needsRerender`) with `Volatile.Read` semantics, so harnesses don't need reflective field access.

## Validation

On a local x64 dev machine (where the pre-mitigation NativeDocking flake rate was historically 30–60%):

| Scope | Result |
|---|---|
| Build (Reactor + SelfTests + AppTests.Host, x64 Debug) | 0 errors |
| 30 × `NativeDocking_DockContextHooksResolveOnRealMount` (was 0.3 %/iter in CI) | **0 / 30 failed** |
| 30 × `NativeDocking_Reliability_UseEffectCleanup_BodyRemovedOnPaneClose` (was 0.3 %/iter) | **0 / 30 failed** |
| 30 × `NativeDocking_Composition_ContentMutationFlowsToActivePane` (was 0.2 %/iter) | **0 / 30 failed** |
| 10 × broad `NativeDocking_` filter (43 fixtures each, ~430 fixture-runs) | **0 / 430 failed** |
| Full self-test suite (1007 fixtures, 3839 assertions, 274 s) | 1 unrelated pre-existing flake (`GridViewLazy_RealizedCount=252_LessThanHalf` — known per repository memory) |

Suggest re-running the 1000× CI Stress run against this branch to confirm in CI.

## Categorized stress-run failures this PR addresses

| Fixture | Hits in original 1000× run |
|---|---|
| `NativeDocking_DockContextHooksResolveOnRealMount` | 3 |
| `NativeDocking_Reliability_UseEffectCleanup_BodyRemovedOnPaneClose` | 3 |
| `NativeDocking_Composition_ContentMutationFlowsToActivePane` | 2 |
| `NativeDocking_RoleAware_CloseAllDocs_DocumentAreaSurvivesEmpty` | 2 |
| `NativeDocking_CompositionDrivenDocumentsRespectKeyedReconciliation` | 1 |
| `NativeDocking_DynamicallyDockedComponentPage_WithOuterShellState` | 1 |
| `NativeDocking_DynamicallyDockedContent_IsInteractive` | 1 |
| `NativeDocking_A11y_HostLandmarkAndPaneAutomationIds` | 1 |
| **Total** | **14 / 1000 iterations (~1.4 %)** |

The remaining 2 stress-run failures (`RBC_PrivateMountHotPaths` — native AV; `Issue142_CustomControlPrivateDp_Renders` — empty-TAP race) are not addressed by this PR and warrant separate investigation.