### PR TITLE
feat(#479): clickable inline RichTextHyperlink (OnClick mode)

### DIFF
--- a/docs/_pipeline/templates/text-and-media.md.dt
+++ b/docs/_pipeline/templates/text-and-media.md.dt
@@ -129,6 +129,7 @@ because you build the `Paragraph[]` from data per render.
 | `Paragraph(params RichTextInline[])` | A paragraph; one per visual break. |
 | `Run(string text)` | A plain text fragment. |
 | `Hyperlink(string text, Uri target)` | Inline link with a navigate target. |
+| `Hyperlink(string text, Action onClick)` | Clickable inline fragment — fires the delegate and suppresses platform navigation. Use to make a single rich-text run interactive (open an editor, dispatch a command) without escaping to a hosted native subtree. |
 
 Modifiers — `.MaxLines`, `.LineHeight`, `.TextAlignment`,
 `.TextTrimming`, `.CharacterSpacing` — match `TextBlock`. Inline runs do

--- a/docs/guide/text-and-media.md
+++ b/docs/guide/text-and-media.md
@@ -155,6 +155,7 @@ because you build the `Paragraph[]` from data per render.
 | `Paragraph(params RichTextInline[])` | A paragraph; one per visual break. |
 | `Run(string text)` | A plain text fragment. |
 | `Hyperlink(string text, Uri target)` | Inline link with a navigate target. |
+| `Hyperlink(string text, Action onClick)` | Clickable inline fragment — fires the delegate and suppresses platform navigation. Use to make a single rich-text run interactive (open an editor, dispatch a command) without escaping to a hosted native subtree. |
 
 Modifiers — `.MaxLines`, `.LineHeight`, `.TextAlignment`,
 `.TextTrimming`, `.CharacterSpacing` — match `TextBlock`. Inline runs do

--- a/samples/Reactor.TestApp/Demos/RichTextDemo.cs
+++ b/samples/Reactor.TestApp/Demos/RichTextDemo.cs
@@ -146,8 +146,13 @@ class RichTextDemo : Component
                         Run("preserves the WinUI identity of every embedded control across re-renders. ")
                             with { IsItalic = true },
                         Run("That is what lets the slider thumb above stay smooth while you drag — " +
-                            "and lets you press "),
-                        InlineUI(Button("this inline button", () => setSeed(seed + 1))),
+                            "and lets you click "),
+                        // Issue #479 — clickable inline hyperlink: lighter than
+                        // an InlineUI(Button(...)) because no UIElement is hosted
+                        // inside the RichTextBlock; the click is just a Hyperlink
+                        // Click event wired to a Reactor Action with NavigateUri
+                        // suppressed.
+                        Hyperlink("this inline link", () => setSeed(seed + 1)),
                         Run(" to re-roll noise without losing any control state. ")),
 
                     // A purely static paragraph — under the highlight overlay

--- a/src/Reactor/Charting/D3Charts.cs
+++ b/src/Reactor/Charting/D3Charts.cs
@@ -232,11 +232,15 @@ public static class D3Charts
 
     /// <summary>Creates a line between two points.</summary>
     public static LineElement D3Line(double x1, double y1, double x2, double y2) =>
-        new() { X1 = x1, Y1 = y1, X2 = x2, Y2 = y2 };
+        // Route through Line(...) factory so the LineElement handler is
+        // registered before first mount (spec 048 §3.3). Constructing
+        // `new LineElement(...)` directly skips the registration touch and
+        // crashes the reconciler with "No handler is registered".
+        Line(x1, y1, x2, y2);
 
     /// <summary>Creates a path from SVG path data string.  Accepts null pathData gracefully (renders nothing).</summary>
     public static PathElement D3Path(string? pathData, Brush? stroke = null, Brush? fill = null, double strokeWidth = 1.5) =>
-        new()
+        Path2D() with
         {
             Data = pathData != null ? PathDataParser.Parse(pathData) : null,
             PathDataString = pathData,
@@ -247,7 +251,7 @@ public static class D3Charts
 
     /// <summary>Creates a path from SVG path data with a translate transform.  Accepts null pathData gracefully (renders nothing).</summary>
     public static PathElement D3PathTranslated(string? pathData, double translateX, double translateY, Brush? stroke = null, Brush? fill = null, double strokeWidth = 1.5) =>
-        new()
+        Path2D() with
         {
             Data = pathData != null ? PathDataParser.Parse(pathData) : null,
             PathDataString = pathData,

--- a/src/Reactor/Charting/D3Charts.cs
+++ b/src/Reactor/Charting/D3Charts.cs
@@ -10,6 +10,12 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using static Microsoft.UI.Reactor.Factories;
+// Spec 048 §7 — direct `Reg<>` touch alias for chart hot-path factories
+// that build element records by hand (avoids the extra clone-via-`with`
+// that routing through Factories.Line()/Path2D() would incur).
+using V1 = Microsoft.UI.Reactor.Core.V1Protocol;
+using Desc = Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors;
+using WinShapes = Microsoft.UI.Xaml.Shapes;
 
 namespace Microsoft.UI.Reactor.Charting;
 
@@ -231,16 +237,23 @@ public static class D3Charts
             .Canvas(cx - r, cy - r);
 
     /// <summary>Creates a line between two points.</summary>
-    public static LineElement D3Line(double x1, double y1, double x2, double y2) =>
-        // Route through Line(...) factory so the LineElement handler is
-        // registered before first mount (spec 048 §3.3). Constructing
-        // `new LineElement(...)` directly skips the registration touch and
-        // crashes the reconciler with "No handler is registered".
-        Line(x1, y1, x2, y2);
+    public static LineElement D3Line(double x1, double y1, double x2, double y2)
+    {
+        // Spec 048 registration touch — fires once on first call, idempotent
+        // thereafter. Constructing `new LineElement(...)` without this skips
+        // the global ControlRegistry installation and crashes the reconciler
+        // with "No handler is registered". Direct touch + single allocation
+        // avoids the `Line(x1,y1,x2,y2) with { ... }` double-allocation that
+        // would otherwise be required to keep this on the registration path.
+        _ = V1.Reg<LineElement, WinShapes.Line, Desc.LineDescriptorHandler>.Done;
+        return new() { X1 = x1, Y1 = y1, X2 = x2, Y2 = y2 };
+    }
 
     /// <summary>Creates a path from SVG path data string.  Accepts null pathData gracefully (renders nothing).</summary>
-    public static PathElement D3Path(string? pathData, Brush? stroke = null, Brush? fill = null, double strokeWidth = 1.5) =>
-        Path2D() with
+    public static PathElement D3Path(string? pathData, Brush? stroke = null, Brush? fill = null, double strokeWidth = 1.5)
+    {
+        _ = V1.Reg<PathElement, WinShapes.Path, Desc.PathDescriptorHandler>.Done;
+        return new()
         {
             Data = pathData != null ? PathDataParser.Parse(pathData) : null,
             PathDataString = pathData,
@@ -248,10 +261,13 @@ public static class D3Charts
             Fill = fill,
             StrokeThickness = strokeWidth,
         };
+    }
 
     /// <summary>Creates a path from SVG path data with a translate transform.  Accepts null pathData gracefully (renders nothing).</summary>
-    public static PathElement D3PathTranslated(string? pathData, double translateX, double translateY, Brush? stroke = null, Brush? fill = null, double strokeWidth = 1.5) =>
-        Path2D() with
+    public static PathElement D3PathTranslated(string? pathData, double translateX, double translateY, Brush? stroke = null, Brush? fill = null, double strokeWidth = 1.5)
+    {
+        _ = V1.Reg<PathElement, WinShapes.Path, Desc.PathDescriptorHandler>.Done;
+        return new()
         {
             Data = pathData != null ? PathDataParser.Parse(pathData) : null,
             PathDataString = pathData,
@@ -260,6 +276,7 @@ public static class D3Charts
             StrokeThickness = strokeWidth,
             RenderTransform = new TranslateTransform { X = translateX, Y = translateY },
         };
+    }
 
     // ── Text ────────────────────────────────────────────────────────────
 

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -2197,7 +2197,31 @@ public record RichTextRun(string Text) : RichTextInline
     public Brush? Foreground { get; init; }
 }
 
-public record RichTextHyperlink(string Text, Uri NavigateUri) : RichTextInline;
+/// <summary>
+/// Inline hyperlink fragment inside a <see cref="RichTextBlockElement"/>.
+///
+/// <para><b>Two modes</b> (issue #479):
+/// <list type="bullet">
+///   <item><b>Navigate mode</b> — when <see cref="OnClick"/> is <c>null</c>
+///   the WinUI <c>Hyperlink</c> is mounted with <see cref="NavigateUri"/>
+///   set and clicks open the URI via the platform launcher.</item>
+///   <item><b>Click mode</b> — when <see cref="OnClick"/> is non-null the
+///   delegate fires on click and the WinUI <c>NavigateUri</c> is left
+///   unset, so the platform does not navigate. Use this for clickable
+///   inline fragments (open a menu, enter edit mode, dispatch an action)
+///   without escaping to a hosted native subtree.</item>
+/// </list></para>
+/// </summary>
+public record RichTextHyperlink(string Text, Uri NavigateUri) : RichTextInline
+{
+    /// <summary>
+    /// Optional click handler. When non-null, fires on every click and
+    /// suppresses navigation (the underlying WinUI <c>Hyperlink</c> is
+    /// mounted with no <c>NavigateUri</c>). When null, the inline behaves
+    /// as a pure navigation link using <see cref="NavigateUri"/>.
+    /// </summary>
+    public Action? OnClick { get; init; }
+}
 
 public record RichTextLineBreak() : RichTextInline;
 

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -250,11 +250,11 @@ public sealed partial class Reconciler
                 }
                 else
                 {
-                    var l = link?.NavigateUri ?? new Uri("about:blank");
-                    l = l.ToString().Length < 1 ? l = new Uri("about:blank") : l;
+                    var l = link.NavigateUri ?? new Uri("about:blank");
+                    if (l.ToString().Length < 1) l = new Uri("about:blank");
                     try { hl.NavigateUri = l; } catch { hl.NavigateUri = new Uri("about:blank"); }
                 }
-                hl.Inlines.Add(new Microsoft.UI.Xaml.Documents.Run { Text = link?.Text ?? ""});
+                hl.Inlines.Add(new Microsoft.UI.Xaml.Documents.Run { Text = link.Text ?? ""});
                 return hl;
             case RichTextLineBreak:
                 return new Microsoft.UI.Xaml.Documents.LineBreak();
@@ -650,11 +650,14 @@ public sealed partial class Reconciler
             if (prevControlled || prev.NavigateUri != next.NavigateUri)
             {
                 // Mirror MountInline's normalization: fall back to about:blank
-                // on null/empty/invalid URIs.
+                // on null/empty/invalid URIs. The fallback assignment is not
+                // wrapped — `about:blank` always parses and a `NavigateUri =`
+                // assignment for it should never throw; if it ever did, that
+                // is a real bug we want to surface, not silently swallow.
                 var uri = next.NavigateUri ?? new Uri("about:blank");
                 if (uri.ToString().Length < 1) uri = new Uri("about:blank");
                 try { wh.NavigateUri = uri; }
-                catch { try { wh.NavigateUri = new Uri("about:blank"); } catch { } }
+                catch { wh.NavigateUri = new Uri("about:blank"); }
                 any = true;
             }
         }

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -240,10 +240,20 @@ public sealed partial class Reconciler
                 if (run.Foreground is not null) r.Foreground = run.Foreground;
                 return r;
             case RichTextHyperlink link:
-                var l = link?.NavigateUri ?? new Uri("about:blank");
-                l = l.ToString().Length < 1 ? l = new Uri("about:blank") : l;
                 var hl = new Microsoft.UI.Xaml.Documents.Hyperlink();
-                try { hl.NavigateUri = l; } catch { hl.NavigateUri = new Uri("about:blank"); }
+                if (link.OnClick is not null)
+                {
+                    // Issue #479 click mode: fire delegate, suppress platform
+                    // navigation by leaving NavigateUri unset.
+                    s_hyperlinkClickActions.AddOrUpdate(hl, link.OnClick);
+                    hl.Click += OnHyperlinkClick;
+                }
+                else
+                {
+                    var l = link?.NavigateUri ?? new Uri("about:blank");
+                    l = l.ToString().Length < 1 ? l = new Uri("about:blank") : l;
+                    try { hl.NavigateUri = l; } catch { hl.NavigateUri = new Uri("about:blank"); }
+                }
                 hl.Inlines.Add(new Microsoft.UI.Xaml.Documents.Run { Text = link?.Text ?? ""});
                 return hl;
             case RichTextLineBreak:
@@ -611,15 +621,42 @@ public sealed partial class Reconciler
         Microsoft.UI.Xaml.Documents.Hyperlink wh)
     {
         bool any = false;
-        if (prev.NavigateUri != next.NavigateUri)
+        // Issue #479 — handle OnClick attach/detach + NavigateUri transitions.
+        bool prevControlled = prev.OnClick is not null;
+        bool nextControlled = next.OnClick is not null;
+        if (nextControlled)
         {
-            // Mirror MountInline's normalization: fall back to about:blank
-            // on null/empty/invalid URIs.
-            var uri = next.NavigateUri ?? new Uri("about:blank");
-            if (uri.ToString().Length < 1) uri = new Uri("about:blank");
-            try { wh.NavigateUri = uri; }
-            catch { try { wh.NavigateUri = new Uri("about:blank"); } catch { } }
-            any = true;
+            // AddOrUpdate keeps the existing static event subscription pointing
+            // at the latest delegate without detach/attach churn — important
+            // because authors typically pass a fresh closure per render.
+            s_hyperlinkClickActions.AddOrUpdate(wh, next.OnClick!);
+            if (!prevControlled)
+            {
+                wh.Click += OnHyperlinkClick;
+                // Clear any URI from navigate mode so the platform does not
+                // also fire its own navigation on the same click.
+                wh.ClearValue(Microsoft.UI.Xaml.Documents.Hyperlink.NavigateUriProperty);
+                any = true;
+            }
+        }
+        else
+        {
+            if (prevControlled)
+            {
+                wh.Click -= OnHyperlinkClick;
+                s_hyperlinkClickActions.Remove(wh);
+                any = true;
+            }
+            if (prevControlled || prev.NavigateUri != next.NavigateUri)
+            {
+                // Mirror MountInline's normalization: fall back to about:blank
+                // on null/empty/invalid URIs.
+                var uri = next.NavigateUri ?? new Uri("about:blank");
+                if (uri.ToString().Length < 1) uri = new Uri("about:blank");
+                try { wh.NavigateUri = uri; }
+                catch { try { wh.NavigateUri = new Uri("about:blank"); } catch { } }
+                any = true;
+            }
         }
         if (!string.Equals(prev.Text, next.Text, global::System.StringComparison.Ordinal))
         {
@@ -631,6 +668,23 @@ public sealed partial class Reconciler
             }
         }
         return any;
+    }
+
+    // Issue #479 — backing storage for the static Click handler. CWT keys are
+    // weak references so entries die when the WinUI Hyperlink is collected
+    // (e.g. after RichTextBlock.Blocks.Clear() during a full rebuild). Using
+    // one static handler + a per-Hyperlink action mapping means OnClick swaps
+    // across renders are a cheap dictionary update, never an event detach +
+    // re-attach.
+    private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<
+        Microsoft.UI.Xaml.Documents.Hyperlink, Action> s_hyperlinkClickActions = new();
+
+    private static void OnHyperlinkClick(
+        Microsoft.UI.Xaml.Documents.Hyperlink sender,
+        Microsoft.UI.Xaml.Documents.HyperlinkClickEventArgs args)
+    {
+        if (s_hyperlinkClickActions.TryGetValue(sender, out var action))
+            action?.Invoke();
     }
 
     private bool UpdateInlineUIContainerInPlace(

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -1675,6 +1675,21 @@ public static partial class Factories
     public static RichTextHyperlink Hyperlink(string text, Uri navigateUri) => new(text, navigateUri);
 
     /// <summary>
+    /// Issue #479 — clickable inline hyperlink: fires <paramref name="onClick"/>
+    /// on click and suppresses platform navigation. Use for in-flow interactive
+    /// fragments (open a flyout, enter edit mode) inside a virtualized list of
+    /// <see cref="RichTextBlock(RichTextParagraph[])"/> rows where giving each
+    /// fragment its own <c>UIElement</c> would be too heavy.
+    /// </summary>
+    public static RichTextHyperlink Hyperlink(string text, Action onClick)
+    {
+        global::System.ArgumentNullException.ThrowIfNull(onClick);
+        // Sentinel URI: ignored at mount time when OnClick is non-null
+        // (Reconciler skips NavigateUri assignment in click mode).
+        return new(text, new Uri("about:blank")) { OnClick = onClick };
+    }
+
+    /// <summary>
     /// Issue #480 — embeds a Reactor <paramref name="child"/> element inline
     /// inside a <see cref="RichTextBlock(RichTextParagraph[])"/>. Mirrors
     /// WinUI's <c>InlineUIContainer</c>. The child is reconciled as any

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoreCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoreCoverageFixtures.cs
@@ -155,6 +155,97 @@ internal static class CoreCoverageFixtures
     }
 
     // ════════════════════════════════════════════════════════════════════════
+    //  Issue #479 — clickable inline RichTextHyperlink (OnClick mode).
+    //  Verifies the structural NavigateUri toggle across navigate↔click mode
+    //  transitions and identity preservation during incremental updates.
+    // ════════════════════════════════════════════════════════════════════════
+    internal class RichTextHyperlink_OnClickMode(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int fired = 0;
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                var hyperlink = phase switch
+                {
+                    // Click mode (fresh closure per render is the realistic shape).
+                    0 => Hyperlink("clickable", () => fired++),
+                    // Click mode w/ a different captured closure — should keep same
+                    // WinUI Hyperlink instance, just update the action mapping.
+                    1 => Hyperlink("clickable", () => { fired += 2; }),
+                    // Transition to URI mode: NavigateUri must come back.
+                    2 => Hyperlink("link-mode", new Uri("https://example.com")),
+                    // Back to click mode: NavigateUri must clear again.
+                    _ => Hyperlink("clickable-again", () => fired++),
+                };
+                return VStack(
+                    Button("Next", () => set(phase + 1)),
+                    RichTextBlock(new[] { Paragraph(Run("prefix "), hyperlink, Run(" suffix")) })
+                );
+            });
+
+            await Harness.Render();
+
+            var rtb = H.FindControl<Microsoft.UI.Xaml.Controls.RichTextBlock>(_ => true);
+            H.Check("RTH_OnClick_RTBMounted", rtb is not null);
+
+            var hl0 = FindHyperlink(rtb!);
+            H.Check("RTH_OnClick_HyperlinkPresent", hl0 is not null);
+            // Click mode: NavigateUri left unset so the platform does not also navigate.
+            H.Check("RTH_OnClick_NoNavigateUriInClickMode",
+                hl0 is not null
+                && hl0.ReadLocalValue(Microsoft.UI.Xaml.Documents.Hyperlink.NavigateUriProperty)
+                    == Microsoft.UI.Xaml.DependencyProperty.UnsetValue);
+
+            // Phase 1: same controlled state, different closure — incremental
+            // path should keep the same WinUI Hyperlink instance.
+            H.ClickButton("Next");
+            await Harness.Render();
+            var rtb1 = H.FindControl<Microsoft.UI.Xaml.Controls.RichTextBlock>(_ => true);
+            var hl1 = FindHyperlink(rtb1!);
+            H.Check("RTH_OnClick_IdentityPreservedAcrossClosureSwap",
+                hl1 is not null && ReferenceEquals(hl1, hl0));
+            H.Check("RTH_OnClick_StillNoNavigateUri",
+                hl1 is not null
+                && hl1.ReadLocalValue(Microsoft.UI.Xaml.Documents.Hyperlink.NavigateUriProperty)
+                    == Microsoft.UI.Xaml.DependencyProperty.UnsetValue);
+
+            // Phase 2: transition click → navigate mode. NavigateUri must be set.
+            H.ClickButton("Next");
+            await Harness.Render();
+            var rtb2 = H.FindControl<Microsoft.UI.Xaml.Controls.RichTextBlock>(_ => true);
+            var hl2 = FindHyperlink(rtb2!);
+            H.Check("RTH_OnClick_NavigateUriRestoredOnTransition",
+                hl2 is not null
+                && hl2.NavigateUri == new Uri("https://example.com"));
+
+            // Phase 3: transition navigate → click mode. NavigateUri must be cleared.
+            H.ClickButton("Next");
+            await Harness.Render();
+            var rtb3 = H.FindControl<Microsoft.UI.Xaml.Controls.RichTextBlock>(_ => true);
+            var hl3 = FindHyperlink(rtb3!);
+            H.Check("RTH_OnClick_NavigateUriClearedOnReturn",
+                hl3 is not null
+                && hl3.ReadLocalValue(Microsoft.UI.Xaml.Documents.Hyperlink.NavigateUriProperty)
+                    == Microsoft.UI.Xaml.DependencyProperty.UnsetValue);
+        }
+
+        private static Microsoft.UI.Xaml.Documents.Hyperlink? FindHyperlink(
+            Microsoft.UI.Xaml.Controls.RichTextBlock rtb)
+        {
+            foreach (var block in rtb.Blocks)
+            {
+                if (block is not Microsoft.UI.Xaml.Documents.Paragraph p) continue;
+                foreach (var inline in p.Inlines)
+                    if (inline is Microsoft.UI.Xaml.Documents.Hyperlink hl) return hl;
+            }
+            return null;
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
     //  2. TemplatedGridView — mount + update + item count change
     //     Targets: Reconciler.Mount.cs lines 1415-1448, Reconciler.Update.cs lines 1388-1406
     // ════════════════════════════════════════════════════════════════════════

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -466,6 +466,7 @@ internal static class SelfTestFixtureRegistry
         // Core coverage tests — targeting uncovered Reconciler/RenderContext paths
         "CoreCov_RichTextBlockParagraphUpdate",
         "CoreCov_RichTextBlockInlineReconciliation",
+        "CoreCov_RichTextHyperlink_OnClickMode",
         "CoreCov_TemplatedGridViewMountUpdate",
         "CoreCov_TemplatedFlipViewMountUpdate",
         "CoreCov_LazyVStackMountUpdate",
@@ -1666,6 +1667,7 @@ internal static class SelfTestFixtureRegistry
         // Core coverage tests
         "CoreCov_RichTextBlockParagraphUpdate" => new CoreCoverageFixtures.RichTextBlockParagraphUpdate(harness),
         "CoreCov_RichTextBlockInlineReconciliation" => new CoreCoverageFixtures.RichTextBlockInlineReconciliation(harness),
+        "CoreCov_RichTextHyperlink_OnClickMode" => new CoreCoverageFixtures.RichTextHyperlink_OnClickMode(harness),
         "CoreCov_TemplatedGridViewMountUpdate" => new CoreCoverageFixtures.TemplatedGridViewMountUpdate(harness),
         "CoreCov_TemplatedFlipViewMountUpdate" => new CoreCoverageFixtures.TemplatedFlipViewMountUpdate(harness),
         "CoreCov_LazyVStackMountUpdate" => new CoreCoverageFixtures.LazyVStackMountUpdate(harness),

--- a/tests/Reactor.Tests/MoreCoverageTests.cs
+++ b/tests/Reactor.Tests/MoreCoverageTests.cs
@@ -741,6 +741,58 @@ public class MoreCoverageTests
         Assert.NotEmpty(stack.Children);
     }
 
+    // ════════════════════════════════════════════════════════════════════
+    //  Issue #479 — clickable inline Hyperlink (OnClick on RichTextHyperlink)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Hyperlink_OnClickFactory_SetsOnClickAndSentinelUri()
+    {
+        var fired = 0;
+        var link = Hyperlink("click me", () => fired++);
+
+        Assert.Equal("click me", link.Text);
+        Assert.NotNull(link.OnClick);
+        // Sentinel URI is set so the record positional ctor stays non-null.
+        Assert.Equal(new Uri("about:blank"), link.NavigateUri);
+
+        link.OnClick!.Invoke();
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public void Hyperlink_OnClickFactory_ThrowsOnNullAction()
+    {
+        Assert.Throws<ArgumentNullException>(() => Hyperlink("x", (Action)null!));
+    }
+
+    [Fact]
+    public void Hyperlink_UriFactory_LeavesOnClickNull()
+    {
+        var link = Hyperlink("text", new Uri("https://example.com"));
+        Assert.Null(link.OnClick);
+        Assert.Equal(new Uri("https://example.com"), link.NavigateUri);
+    }
+
+    [Fact]
+    public void RichTextHyperlink_RecordEquality_TracksOnClick()
+    {
+        Action a = () => { };
+        Action b = () => { };
+
+        var withA1 = new RichTextHyperlink("t", new Uri("about:blank")) { OnClick = a };
+        var withA2 = new RichTextHyperlink("t", new Uri("about:blank")) { OnClick = a };
+        var withB  = new RichTextHyperlink("t", new Uri("about:blank")) { OnClick = b };
+        var withNone = new RichTextHyperlink("t", new Uri("about:blank"));
+
+        // Same delegate → equal. Different closures → unequal. Required so
+        // the reconciler's inline diff calls UpdateHyperlinkInPlace whenever
+        // the click handler changes between renders.
+        Assert.Equal(withA1, withA2);
+        Assert.NotEqual(withA1, withB);
+        Assert.NotEqual(withA1, withNone);
+    }
+
     // PathDataParser tests were intentionally skipped — every overload of
     // PathDataParser.Parse constructs a `new PathGeometry()` even for null or
     // whitespace inputs, which requires WinUI XAML Application activation that


### PR DESCRIPTION
Closes #479.

Adds `Action? OnClick` to `RichTextHyperlink` and a new factory overload `Hyperlink(string text, Action onClick)`. When `OnClick` is set the WinUI `Hyperlink.Click` event fires the delegate and `NavigateUri` is left unset so the platform does not also navigate. Use to make a single rich-text run interactive (open an editor, dispatch a command) inside a virtualized list of fragment rows — much lighter than `InlineUI(Button(...))` because no UIElement is hosted, just a click-wired `Documents.Hyperlink`.

### API shape

```csharp
RichTextBlock(new[]
{
    Paragraph(
        Run("Set type: "),
        Hyperlink(""string"", () => OpenTypeMenu()),    // ← NEW: clickable inline
        Run("" → ""),
        Hyperlink(""docs"", new Uri(""https://..."")))   // existing navigate mode
})
```

### Reconciler wiring

* **Mount:** when `OnClick` is non-null, subscribe a static `Click` handler and skip `NavigateUri`.
* **Update:** handle navigate↔click mode transitions (clear/restore `NavigateUri`, attach/detach the static handler). The per-Hyperlink action lives in a `ConditionalWeakTable<Hyperlink, Action>` so closure swaps across renders are a cheap map update — no event detach/attach churn even when callers pass a fresh closure per render.
* CWT keys are weak; entries die when the Hyperlink is GC'd after `RichTextBlock.Blocks.Clear()` (no leak on full rebuilds).

### Drive-by: charting handler registration

While verifying the demo I found that `D3Line` / `D3Path` / `D3PathTranslated` constructed their element records with `new()` directly, bypassing the spec-048 registration touch in the `Line(...)` / `Path2D()` factories. `D3Rect` and `D3Circle` already routed correctly; aligned the remaining three so the `ControlRegistry` entry is installed on first call. Without this any chart that uses lines or paths crashes with *""No handler is registered for element type 'Microsoft.UI.Reactor.Core.LineElement'""* when mounted in a context where `Factories.Line(...)` / `Factories.Path2D()` hasn't been touched elsewhere first (e.g. the TestApp's Rich Text demo).

### Tests

| Tier | What |
|---|---|
| Unit (`MoreCoverageTests`) | Factory shape, `ArgumentNullException` on null action, URI-mode no-op, record-equality tracking `OnClick` (4 new tests, all green). |
| Selftest (`CoreCov_RichTextHyperlink_OnClickMode`) | Click-mode mount has no `NavigateUri`; identity preserved across closure swap; URI→click transition clears `NavigateUri`; click→URI restores it. 7 assertions, all green. |
| Regression | Full `Reactor.Tests` suite — 9214 passed, 0 failed. All existing `RichText`/`InlineUI` selftests still green. |

### Demo

TestApp's *Rich Text + Inline UI* page swaps the inline `Button` re-roll for the new clickable hyperlink so the new shape is exercised end-to-end. Chart paragraphs now mount cleanly thanks to the D3 factory fix.

### Docs

`docs/_pipeline/templates/text-and-media.md.dt` + compiled output updated to list the new `Hyperlink(string text, Action onClick)` helper.