### PR TITLE
test(harness): poll re-queried predicate for lazy WinUI realization (fix NativeDocking flakes)

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingA11yFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingA11yFixture.cs
@@ -50,6 +50,16 @@ internal static class NativeDockingA11yFixtures
             });
             await Harness.Render();
 
+            // TabView lazy-realizes the selected pane's body one (or more)
+            // dispatcher waves after mount. Pump until the active pane's
+            // wrapper Border exists before snapshotting — otherwise the
+            // snapshot can miss the inner Border on a contended runner. The
+            // host landmark Border is an ancestor, so once the pane Border is
+            // realized the landmark Border is too.
+            await Harness.WaitFor(() =>
+                H.FindControl<Border>(b =>
+                    AutomationProperties.GetAutomationId(b) == "pane:a11y:editor") is not null);
+
             // Locate the docking host Border by its landmark name.
             var allBorders = H.FindAllControls<Border>(_ => true);
             Border? hostBorder = null;

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingCompositionFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingCompositionFixture.cs
@@ -52,7 +52,8 @@ internal static class NativeDockingCompositionFixtures
             });
             await Harness.Render();
 
-            H.Check("Composition_InitialCountVisible", H.FindText("count=0") is not null);
+            H.Check("Composition_InitialCountVisible",
+                await Harness.WaitFor(() => H.FindText("count=0") is not null));
 
             // Click the inc button and re-render — the pane body should
             // re-render with the new state.

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingDynamicContentFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingDynamicContentFixture.cs
@@ -200,6 +200,8 @@ internal static class NativeDockingDynamicContentFixtures
             // The handler calls model.Dock(welcomeDoc), adding it to the
             // doc area. After a render flush, the Welcome doc's button
             // must be in the visual tree.
+            await Harness.WaitFor(() =>
+                H.FindControl<Button>(b => b.Name == "DynDock_ToolbarOpenWelcome") is not null);
             var openWelcomeBtn = H.FindControl<Button>(b => b.Name == "DynDock_ToolbarOpenWelcome");
             H.Check("DynDock_OpenWelcomeButton_Mounted", openWelcomeBtn is not null);
             // Dispatch the Dock through the live DockHostModel — same
@@ -630,7 +632,8 @@ internal static class NativeDockingDynamicContentFixtures
             host.Mount(_ => Component<PixGalleryShell>());
             await Harness.Render();
             H.Check("PixShell_ToolbarMounted",
-                H.FindControl<Button>(b => b.Name == "PixDoc_ToolbarOpenWelcome") is not null);
+                await Harness.WaitFor(() =>
+                    H.FindControl<Button>(b => b.Name == "PixDoc_ToolbarOpenWelcome") is not null));
 
             // Click the toolbar "Welcome" button — this dispatches
             // model.Dock(BuildPixWelcomeDoc()) through the toolbar

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingRoleAwareFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingRoleAwareFixture.cs
@@ -167,7 +167,8 @@ internal static class NativeDockingRoleAwareFixtures
             H.Check("RoleAware_CloseAll_RevivalNoFallback", fb is null);
             host.Mount(_ => new DockManager { Layout = layout });
             await Harness.Render();
-            H.Check("RoleAware_CloseAll_RevivedDocVisible", H.FindText("body:d-revived") is not null);
+            H.Check("RoleAware_CloseAll_RevivedDocVisible",
+                await Harness.WaitFor(() => H.FindText("body:d-revived") is not null));
 
             host.Mount(_ => TextBlock("close-all-done"));
             await Harness.Render();

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
@@ -177,7 +177,7 @@ internal static class NativeDockingSmokeFixtures
             await Harness.Render();
 
             H.Check("DockHooks_Host_Resolved",
-                H.FindText("alpha-host:ok") is not null);
+                await Harness.WaitFor(() => H.FindText("alpha-host:ok") is not null));
             H.Check("DockHooks_Pane_TitleResolved",
                 H.FindText("alpha-pane-title:Alpha") is not null);
             H.Check("DockHooks_Pane_KeyResolved",
@@ -482,12 +482,16 @@ internal static class NativeDockingSmokeFixtures
             host.Mount(_ => Build());
             await Harness.Render();
 
+            // First body lazy-realizes inside the TabView one or more
+            // dispatcher waves after mount; pump until it appears before
+            // snapshotting the tabs so both probes see a realized tree.
+            bool firstBodyRendered = await Harness.WaitFor(() => H.FindText("body-first") is not null);
+
             // Baseline: two tabs visible, both bodies in the tree.
             var initialTabs = H.FindAllControls<TabView>(_ => true);
             H.Check("DocsByComposition_InitialTwoTabs",
                 initialTabs.Count == 1 && initialTabs[0].TabItems.Count == 2);
-            H.Check("DocsByComposition_InitialFirstBodyRendered",
-                H.FindText("body-first") is not null);
+            H.Check("DocsByComposition_InitialFirstBodyRendered", firstBodyRendered);
 
             // Capture the TabView reference for identity comparison after
             // the state change.

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PanelDescriptorMigrationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PanelDescriptorMigrationFixtures.cs
@@ -79,15 +79,13 @@ internal static class PanelDescriptorMigrationFixtures
 
             H.ClickButton("Swap");
             await Harness.Render();
-            // Belt-and-braces second drain. Observed flake (~0.4%) on Windows
-            // CI stress: this fixture's swap-and-probe pattern is the only
-            // panel descriptor migration test without a per-child attached
-            // property (e.g. Grid.Row, Canvas.Left). Sibling tests get an
-            // implicit extra layout pass from their PerChildAttached reapply,
-            // which appears to mask a rare dispatcher-drain race we can't
-            // reproduce locally. A second drain matches the sibling pattern
-            // without changing reconcile behavior.
-            await Harness.Render();
+            // After the swap, the survivor TextBlocks re-realize over one or
+            // more dispatcher waves; Hash() returns null until a child is back
+            // in the tree. Pump until every survivor is found again, then
+            // compare identity. This replaces the previous fixed extra drain
+            // (which could be outpaced by a rare dispatcher-drain race on CI)
+            // with a convergence gate that re-queries the live tree each pass.
+            await Harness.WaitFor(() => keys.All(k => Hash(k) is not null));
 
             H.Check("PDM_Stack_Swap_AllSurvivorsKeepIdentity",
                 keys.All(k => before[k] == Hash(k)));

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -1050,8 +1050,12 @@ internal static class ReconcilerBigCoverageFixtures
             H.Check("CondExit_Initial", H.FindText("cond-exit-child") is not null);
 
             H.ClickButton("CondExit");
-            await Harness.Render(450);
-            H.Check("CondExit_Removed", H.FindText("cond-exit-child") is null);
+            // The child plays a Fade exit transition before it leaves the
+            // tree; poll with per-pass wall-clock time so we converge as soon
+            // as the transition completes rather than betting on one fixed wait.
+            H.Check("CondExit_Removed",
+                await Harness.WaitFor(() => H.FindText("cond-exit-child") is null,
+                    maxPasses: 12, perPassMs: 100));
         }
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TemplatedTreeViewFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/TemplatedTreeViewFixtures.cs
@@ -52,15 +52,9 @@ internal static class TemplatedTreeViewFixtures
     // many pump cycles that takes (the NativeAOT host consistently needs one more
     // than JIT). Pump render passes until the condition holds rather than
     // asserting after a single Render(); returns false if it never does.
-    private static async Task<bool> WaitFor(Func<bool> condition, int maxPasses = 15)
-    {
-        for (int i = 0; i < maxPasses; i++)
-        {
-            if (condition()) return true;
-            await Harness.Render();
-        }
-        return condition();
-    }
+    // Delegates to the shared Harness.WaitFor so the polling logic lives in one place.
+    private static Task<bool> WaitFor(Func<bool> condition, int maxPasses = 15)
+        => Harness.WaitFor(condition, maxPasses);
 
     // ── 1. Rich content actually renders (the core #447 win) ──────────────
     internal class RendersRichContent(Harness h) : SelfTestFixtureBase(h)

--- a/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
@@ -290,6 +290,36 @@ internal sealed class Harness
         await Task.Delay(16 + ms);
     }
 
+    /// <summary>
+    /// Pumps render passes until <paramref name="condition"/> holds, re-evaluating
+    /// it on the live visual tree after each pass. Returns true once it holds, or
+    /// false if it never does within <paramref name="maxPasses"/>.
+    ///
+    /// This is the contention-proof alternative to asserting against a one-shot
+    /// snapshot taken right after a single <see cref="Render"/>. WinUI surfaces
+    /// like nested DockManager/TabView realize their inner content over multiple
+    /// dispatcher waves that Reactor's idle predicate cannot observe, so a fixed
+    /// wave count can be outpaced on a contended CI runner. Looping a re-queried
+    /// predicate against real pumps converges regardless of how many waves the
+    /// runtime takes (the NativeAOT host consistently needs one more than JIT).
+    ///
+    /// The predicate MUST re-query the tree each call (e.g. call
+    /// <see cref="FindText"/>/<see cref="FindControl{T}"/> inside it) — passing a
+    /// value captured from an earlier snapshot defeats the loop.
+    ///
+    /// Pass a non-zero <paramref name="perPassMs"/> for conditions that need
+    /// wall-clock time per pass (e.g. waiting for an exit transition to play out).
+    /// </summary>
+    public static async Task<bool> WaitFor(Func<bool> condition, int maxPasses = 15, int perPassMs = 0)
+    {
+        for (int i = 0; i < maxPasses; i++)
+        {
+            if (condition()) return true;
+            await Render(perPassMs);
+        }
+        return condition();
+    }
+
     private static Window? _currentWindow;
 
     // -- VisualTree query helpers ----------------------------------------


### PR DESCRIPTION
## Problem

The previous fix (#492, `IsIdle`-based bounded convergence loop) did **not** stop the NativeDocking selftest flakes — the head of the failing 1000x stress run (~98.4% reliability, 13/16 failures in NativeDocking fixtures) **is** the #492 commit.

**Root cause:** `ReactorHost.IsIdle` only tracks Reactor's render-pending state and is `true` immediately after mount. It cannot observe WinUI's nested `DockManager`/`TabView` lazily realizing inner pane content over **later dispatcher waves**. So the loop always broke at the 2-pass minimum — the `maxPasses`/`yield-cap` diagnostics fired **0x** across a failing 40-iteration shard, proving the 4-pass budget was dead code. The fixtures then asserted against a one-shot `FindAllControls(...)` snapshot of a half-realized tree.

## Fix

- **Add `Harness.WaitFor(Func<bool> condition, maxPasses = 15, perPassMs = 0)`** — pumps real `Render()` passes and re-evaluates a **re-queried** predicate against the live tree each pass, converging regardless of how many waves the runtime takes. `perPassMs` supports wall-clock waits (exit transitions).
- **De-duplicate** the copy-trapped private `WaitFor` in `TemplatedTreeViewFixtures.cs` to delegate to the shared helper (the TreeView fixtures already proved this pattern and never flaked).
- **Convert 9 failing one-shot probes** to gate on `WaitFor` (re-querying inside the predicate): A11y pane, Composition count, RoleAware revived doc, DockHooks host, DocsByComposition body/tabs, DynDock + PixShell toolbars, PDM_Stack survivor identity (replaces a `belt-and-braces` extra `Render()`), and CondExit disappear (`perPassMs: 100`).

## Validation

- Build clean (0 warn / 0 err).
- All converted checks pass; TTV suite 0 failures (hoist no-regression); `NativeDocking_` ran **6/6 clean** locally vs historical 30–60% local flake.
- A 100x selftest stress run is being kicked off against this branch to validate.

## Out of scope (separate open native crashes, not addressed here)

- `NativeDockingTearOff_T05`: native crash `0xC0000005` in `BackdropApplier.Apply` → `Window.set_SystemBackdrop` during mount.
- `RBC_PrivateMountHotPaths`: access violation (seen once in the stress run).

Both are distinct from probe-timing flakes and warrant independent triage.