### PR TITLE
test(selftest): sweep remaining NativeDocking probe flakes to WaitFor

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingCompositionFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingCompositionFixture.cs
@@ -115,6 +115,14 @@ internal static class NativeDockingCompositionFixtures
             });
             await Harness.Render();
 
+            // Both pane wrappers lazy-realize over one or more dispatcher
+            // waves after mount (more under NativeAOT); pump until both are
+            // in the tree before snapshotting their identities.
+            await Harness.WaitFor(() =>
+                H.FindAllControls<Border>(b =>
+                    Microsoft.UI.Xaml.Automation.AutomationProperties.GetAutomationId(b)
+                        is "pane:comp:left" or "pane:comp:right").Count == 2);
+
             // Snapshot the realized Border identities so we can verify
             // the pane wrappers stay the same instance across re-renders
             // (keyed-reconciliation preserves them).
@@ -152,8 +160,10 @@ internal static class NativeDockingCompositionFixtures
             }
             H.Check("Composition_PaneWrapperIdentityPreserved", identityPreserved);
 
-            H.Check("Composition_LeftBodyUpdated", H.FindText("left-tick=1") is not null);
-            H.Check("Composition_RightBodyUpdated", H.FindText("right-tick=1") is not null);
+            H.Check("Composition_LeftBodyUpdated",
+                await Harness.WaitFor(() => H.FindText("left-tick=1") is not null));
+            H.Check("Composition_RightBodyUpdated",
+                await Harness.WaitFor(() => H.FindText("right-tick=1") is not null));
 
             host.Mount(_ => TextBlock("composition-sibling-done"));
             await Harness.Render();
@@ -225,9 +235,9 @@ internal static class NativeDockingCompositionFixtures
             await Harness.Render();
 
             H.Check("Rehydration_LeftBodyRendered",
-                H.FindText("rehy-body-rehy:left") is not null);
+                await Harness.WaitFor(() => H.FindText("rehy-body-rehy:left") is not null));
             H.Check("Rehydration_RightBodyRendered",
-                H.FindText("rehy-body-rehy:right") is not null);
+                await Harness.WaitFor(() => H.FindText("rehy-body-rehy:right") is not null));
 
             // Both pane wrappers should carry the original `pane:<key>`
             // AutomationId so AT addresses survive save / restore.

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingCoverageFloatingFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingCoverageFloatingFixture.cs
@@ -327,7 +327,7 @@ internal static class NativeDockingCoverageFloatingFixtures
             H.Check("FloatRoot_TabViewMounted",
                 H.FindAllControls<TabView>(_ => true).Count >= 1);
             H.Check("FloatRoot_PaneBodyRendered",
-                H.FindText("body-tree") is not null);
+                await Harness.WaitFor(() => H.FindText("body-tree") is not null));
 
             host.Mount(_ => TextBlock("float-root-done"));
             await Harness.Render();

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingDragDropMatrixFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingDragDropMatrixFixture.cs
@@ -165,7 +165,7 @@ internal static class NativeDockingDragDropMatrixFixtures
             H.Check("M02_HorizontalSplitAppeared", SplitCount(H) == 1);
             H.Check("M02_TwoTabViews", TabViewCount(H) == 2);
             H.Check("M02_BothPanesReachable",
-                H.FindText("body-a") is not null && H.FindText("body-b") is not null);
+                await Harness.WaitFor(() => H.FindText("body-a") is not null && H.FindText("body-b") is not null));
 
             var panel = RootSplitPanel(H);
             H.Check("M02_FlexPanelIsRow",
@@ -273,7 +273,7 @@ internal static class NativeDockingDragDropMatrixFixtures
 
             H.Check("M05_VerticalSplitAppeared", SplitCount(H) == 1);
             H.Check("M05_BothBodiesReachable",
-                H.FindText("body-a") is not null && H.FindText("body-b") is not null);
+                await Harness.WaitFor(() => H.FindText("body-a") is not null && H.FindText("body-b") is not null));
 
             var panel = RootSplitPanel(H);
             H.Check("M05_FlexPanelIsColumn",
@@ -324,7 +324,7 @@ internal static class NativeDockingDragDropMatrixFixtures
             H.Check("M06_OnePathRemains", SplitCount(H) == 1);
             H.Check("M06_TwoTabViewsAfter", TabViewCount(H) == 2);
             H.Check("M06_BothBodiesReachable",
-                H.FindText("body-only") is not null && H.FindText("body-right") is not null);
+                await Harness.WaitFor(() => H.FindText("body-only") is not null && H.FindText("body-right") is not null));
             DockDragSession.ResetForTest();
         }
     }
@@ -489,9 +489,10 @@ internal static class NativeDockingDragDropMatrixFixtures
 
             H.Check("M11_MultipleSplits", SplitCount(H) >= 2);
             H.Check("M11_AllPanesPresent",
-                H.FindText("body-a") is not null
-                && H.FindText("body-b") is not null
-                && H.FindText("body-c") is not null);
+                await Harness.WaitFor(() =>
+                    H.FindText("body-a") is not null
+                    && H.FindText("body-b") is not null
+                    && H.FindText("body-c") is not null));
             DockDragSession.ResetForTest();
         }
     }
@@ -591,10 +592,11 @@ internal static class NativeDockingDragDropMatrixFixtures
             // outer wrap, and all 4 panes still reachable.
             H.Check("M13_SplitsIncreased", SplitCount(H) >= 2);
             H.Check("M13_AllPanesPresent",
-                H.FindText("body-a") is not null
-                && H.FindText("body-b") is not null
-                && H.FindText("body-c") is not null
-                && H.FindText("body-d") is not null);
+                await Harness.WaitFor(() =>
+                    H.FindText("body-a") is not null
+                    && H.FindText("body-b") is not null
+                    && H.FindText("body-c") is not null
+                    && H.FindText("body-d") is not null));
             DockDragSession.ResetForTest();
         }
     }
@@ -630,9 +632,10 @@ internal static class NativeDockingDragDropMatrixFixtures
             await Harness.Render();
 
             H.Check("M14_AllPanesReachable",
-                H.FindText("body-a") is not null
-                && H.FindText("body-b") is not null
-                && H.FindText("body-c") is not null);
+                await Harness.WaitFor(() =>
+                    H.FindText("body-a") is not null
+                    && H.FindText("body-b") is not null
+                    && H.FindText("body-c") is not null));
             DockDragSession.ResetForTest();
         }
     }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingDragDropMatrixFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingDragDropMatrixFixture.cs
@@ -201,7 +201,7 @@ internal static class NativeDockingDragDropMatrixFixtures
             await Harness.Render();
 
             H.Check("M03_HorizontalSplitAppeared", SplitCount(H) == 1);
-            H.Check("M03_BodyBReachable", H.FindText("body-b") is not null);
+            H.Check("M03_BodyBReachable", await Harness.WaitFor(() => H.FindText("body-b") is not null));
 
             var panel = RootSplitPanel(H);
             H.Check("M03_FlexPanelIsRow",

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingDynamicContentFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingDynamicContentFixture.cs
@@ -462,7 +462,8 @@ internal static class NativeDockingDynamicContentFixtures
             host.Mount(_ => managerEl);
             await Harness.Render();
             H.Check("PixDoc_ToolbarMounted",
-                H.FindControl<Button>(b => b.Name == "PixDoc_ToolbarOpenWelcome") is not null);
+                await Harness.WaitFor(() =>
+                    H.FindControl<Button>(b => b.Name == "PixDoc_ToolbarOpenWelcome") is not null));
             H.Check("PixDoc_ModelRefPublished", modelRef.Current is not null);
 
             // Dispatch the Dock as the gallery does — through the

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs
@@ -78,7 +78,7 @@ internal static class NativeDockingReliabilityFixtures
             });
             await Harness.Render();
             H.Check("Reliability_CorruptLoad_FallbackPaneMounted",
-                H.FindText("body-fallback") is not null);
+                await Harness.WaitFor(() => H.FindText("body-fallback") is not null));
 
             host.Mount(_ => TextBlock("corrupt-fallback-done"));
             await Harness.Render();
@@ -222,7 +222,7 @@ internal static class NativeDockingReliabilityFixtures
             H.Check("Reliability_Effect_MountedOnce", mountedCount == 1);
             H.Check("Reliability_Effect_NoCleanupBeforeClose", cleanupCount == 0);
             H.Check("Reliability_Effect_BodyRendered",
-                H.FindText("effect-body-p1") is not null);
+                await Harness.WaitFor(() => H.FindText("effect-body-p1") is not null));
 
             var model = DockHostModelBridge.Get(managerEl);
             H.Check("Reliability_Effect_BridgeYieldsModel", model is not null);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingRoleAwareFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingRoleAwareFixture.cs
@@ -84,8 +84,10 @@ internal static class NativeDockingRoleAwareFixtures
 
             // Baseline — the empty DocumentArea is present (rendered as a
             // placeholder Border per DockTabGroupRenderer.cs §empty path).
-            H.Check("RoleAware_Initial_GalleryTool",  H.FindText("tool:gallery")  is not null);
-            H.Check("RoleAware_Initial_ConfigTool",   H.FindText("tool:config")   is not null);
+            H.Check("RoleAware_Initial_GalleryTool",
+                await Harness.WaitFor(() => H.FindText("tool:gallery") is not null));
+            H.Check("RoleAware_Initial_ConfigTool",
+                await Harness.WaitFor(() => H.FindText("tool:config") is not null));
             H.Check("RoleAware_Initial_NoDocsYet",    H.FindText("body:d0")       is null);
 
             // Add docs one at a time via DockLayoutOps.InsertPaneAtTarget,
@@ -277,7 +279,7 @@ internal static class NativeDockingRoleAwareFixtures
             await Harness.Render();
 
             // d1 visible, d2 gone, split collapsed.
-            H.Check("RoleAware_CollapseSplit_D1Visible", H.FindText("body:d1") is not null);
+            H.Check("RoleAware_CollapseSplit_D1Visible", await Harness.WaitFor(() => H.FindText("body:d1") is not null));
             H.Check("RoleAware_CollapseSplit_D2Gone",    H.FindText("body:d2") is null);
             var arms = AllDocAreaGroups(layout);
             H.Check("RoleAware_CollapseSplit_OneArmAfter", arms.Count == 1);
@@ -375,14 +377,14 @@ internal static class NativeDockingRoleAwareFixtures
             host.Mount(_ => new DockManager { Layout = layout });
             await Harness.Render();
 
-            H.Check("RoleAware_EdgeSynth_DocVisible", H.FindText("body:d1") is not null);
+            H.Check("RoleAware_EdgeSynth_DocVisible", await Harness.WaitFor(() => H.FindText("body:d1") is not null));
 
             // Drop a tool on the bottom edge.
             layout = DockLayoutOps.InsertPaneAtTarget(layout, Tool("errors"), DockTarget.DockBottom, out _);
             host.Mount(_ => new DockManager { Layout = layout });
             await Harness.Render();
 
-            H.Check("RoleAware_EdgeSynth_ToolVisible", H.FindText("tool:errors") is not null);
+            H.Check("RoleAware_EdgeSynth_ToolVisible", await Harness.WaitFor(() => H.FindText("tool:errors") is not null));
             // Verify the resulting structure has a ToolWindowStrip-roled group.
             var stripExists = layout is DockSplit s
                 && s.Children.OfType<DockTabGroup>().Any(g => g.Role == DockGroupRole.ToolWindowStrip);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingSmokeFixture.cs
@@ -116,7 +116,7 @@ internal static class NativeDockingSmokeFixtures
 
             // The selected (first) tab's content is rendered into the visual tree.
             H.Check("NativeDock_TabView_FirstBodyRendered",
-                H.FindText("native-body-alpha") is not null);
+                await Harness.WaitFor(() => H.FindText("native-body-alpha") is not null));
 
             host.Mount(_ => TextBlock("native-tabs-unmounted"));
             await Harness.Render();
@@ -245,7 +245,7 @@ internal static class NativeDockingSmokeFixtures
             // Click → popup opens.
             H.ClickButton("Outline");
             await Harness.Render();
-            H.Check("SidePopup_OpensOnClick", OpenCount() >= 1);
+            H.Check("SidePopup_OpensOnClick", await Harness.WaitFor(() => OpenCount() >= 1));
 
             // Click again → toggles closed.
             H.ClickButton("Outline");

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PanelDescriptorMigrationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PanelDescriptorMigrationFixtures.cs
@@ -81,14 +81,14 @@ internal static class PanelDescriptorMigrationFixtures
             await Harness.Render();
             // After the swap, the survivor TextBlocks re-realize over one or
             // more dispatcher waves; Hash() returns null until a child is back
-            // in the tree. Pump until every survivor is found again, then
-            // compare identity. This replaces the previous fixed extra drain
-            // (which could be outpaced by a rare dispatcher-drain race on CI)
-            // with a convergence gate that re-queries the live tree each pass.
-            await Harness.WaitFor(() => keys.All(k => Hash(k) is not null));
-
+            // in the tree. Gate on the identity assertion itself so we converge
+            // as soon as every survivor is back with its original Border
+            // instance. This is stricter than the previous presence-only gate
+            // (keys.All(k => Hash(k) is not null)) which let a rare 1/1000
+            // dispatcher-drain drift slip through before identity stabilized; a
+            // genuine identity break never satisfies the predicate and fails.
             H.Check("PDM_Stack_Swap_AllSurvivorsKeepIdentity",
-                keys.All(k => before[k] == Hash(k)));
+                await Harness.WaitFor(() => keys.All(k => before[k] == Hash(k))));
         }
     }
 
@@ -303,8 +303,12 @@ internal static class PanelDescriptorMigrationFixtures
             H.ClickButton("Reverse");
             await Harness.Render();
 
+            // The survivors re-realize over one or more dispatcher waves; gate
+            // on the identity assertion itself so we converge as soon as every
+            // survivor is back with its original Border instance. A genuine
+            // identity break never satisfies the predicate and still fails.
             H.Check("PDM_WrapGrid_Reverse_AllSurvivorsKeepIdentity",
-                keys.All(k => before[k] == Hash(k)));
+                await Harness.WaitFor(() => keys.All(k => before[k] == Hash(k))));
         }
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Harness.cs
@@ -310,7 +310,7 @@ internal sealed class Harness
     /// Pass a non-zero <paramref name="perPassMs"/> for conditions that need
     /// wall-clock time per pass (e.g. waiting for an exit transition to play out).
     /// </summary>
-    public static async Task<bool> WaitFor(Func<bool> condition, int maxPasses = 15, int perPassMs = 0)
+    public static async Task<bool> WaitFor(Func<bool> condition, int maxPasses = 25, int perPassMs = 0)
     {
         for (int i = 0; i < maxPasses; i++)
         {


### PR DESCRIPTION
## Summary

Follow-up to #502. Two 1000x stress runs on `main` showed that PR's `WaitFor` fix held for its 10 converted probes (only `PDM_Stack_Swap` recurred once), but a large family of **sibling** docking probes still used the same one-shot snapshot anti-pattern: JIT landed at **99.1%** (991/1000), AOT at **90.0%** (900/1000).

This PR sweeps those remaining probes onto the shared `Harness.WaitFor` convergence gate.

## Failure clusters addressed (from the 1000x AOT run)

| Check | AOT fails |
|---|---|
| `NativeDock_TabView_FirstBodyRendered` | 20 |
| `FloatRoot_PaneBodyRendered` | 19 |
| `PixDoc_ToolbarMounted` | 19 |
| `RoleAware_EdgeSynth_DocVisible` | 18 |
| `Reliability_CorruptLoad_FallbackPaneMounted` | 17 |
| `Composition_*` / `Rehydration_*` / `RoleAware_Initial_*` | ~8-9 each |
| `M03_BodyBReachable`, `Reliability_Effect_BodyRendered`, `RoleAware_CollapseSplit_D1Visible`, `RoleAware_EdgeSynth_ToolVisible`, `SidePopup_OpensOnClick` | singles |
| `PDM_WrapGrid_Reverse` / `PDM_Stack_Swap` identity | (JIT) |
| `M02_BothPanesReachable`, `M05_BothBodiesReachable` (DragDrop-matrix siblings of M03) | (JIT, exposed by this PR's first stress run) |

## Changes
- **Text/control probes** wrapped in `WaitFor(() => <re-query>)` so they converge across the lazy DockManager/TabView realization waves (AOT needs more waves than JIT).
- **`Composition_BothPanesRealized`**: gate `pane-count == 2` *before* snapshotting the Border identities.
- **DragDrop-matrix probes** `M02/M05/M06/M11/M13/M14` swept onto `WaitFor` — the JIT-stress-exposed siblings of `M03`, same one-shot multi-`FindText` anti-pattern read once right after `Render()`.
- **PDM identity probes** (`Stack_Swap` + `WrapGrid_Reverse`): gate on the **identity assertion itself**, not mere presence — the old presence-only gate let a rare 1/1000 drift slip through before identity stabilized. A genuine identity break never satisfies the predicate and still fails.
- **`WaitFor` default `maxPasses` 15 -> 25** for AOT headroom (the AOT stress had a 29/40 contention-outlier shard).

## Out of scope
- `OverlayLifecycle_Refresh_AliveBeforeRefresh` is a wall-clock expiry-timer margin test, not the snapshot anti-pattern — left unchanged.
- `ScrollPerf_Ratio` is a perf-threshold test, unrelated — left unchanged.
- **PDM keyed-identity race** — see Validation below: `*_KeepIdentity` exhibits a genuine ~2/1000 identity divergence under load that `WaitFor` cannot mask (distinct from the snapshot-realization family). The identity-gate correctly fails on real divergence rather than hiding it. Recommended as a separate framework follow-up, likely tied to V1 Panel children reconciling by index (spec-042 `ChildReconciler` deferred).
- Native crashes (`TearOff_T05` BackdropApplier, `RBC_PrivateMountHotPaths`) are separate bugs.

## Validation

Host builds clean (x64 / win-x64); local filtered smoke runs all green.

**1000x stress runs on this branch:**

| Run | Target | Reliability | Baseline |
|---|---|---|---|
| `26757911527` | AOT 1000x | **99.4%** (6 fails) | 90.0% |
| `26757916337` | JIT (selftests) 1000x | **99.6%** (4 fails) | 99.1% |

- **Every converted snapshot-realization probe was 100% clean — zero recurrences across 2000 iterations.**
- AOT residual 6 fails: `PDM_WrapGrid_Reverse` x2, `PDM_Stack_Swap` x2 (the genuine identity race), `OverlayLifecycle_Refresh` x1, `ScrollPerf_Ratio` x1 — all out-of-scope per above.
- JIT residual 4 fails: `M02`/`M05` DragDrop siblings x3 (**now converted in this PR**), `PDM_Stack_Swap` x1.

A fresh 1000x AOT + 1000x selftests pair was kicked off after the M02/M05/M06/M11/M13/M14 conversions to confirm the DragDrop siblings are clean.
