### PR TITLE
docs: update README to require explicit platform flag for builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,13 @@ cd microsoft-ui-reactor
 
 dotnet new reactorapp -n MyApp
 cd MyApp
-dotnet run
+dotnet run -p:Platform=x64
 ```
+
+> ⚠️ **Platform flag required**: Always build with an explicit platform:
+> `dotnet build -p:Platform=x64` (or `ARM64`). Omitting `-p:Platform=...`
+> causes `WindowsAppSDKSelfContained` errors. This applies to `dotnet build`,
+> `dotnet run`, and `mur check` invocations alike.
 
 `bootstrap.ps1` packs `mur` as a `dotnet tool` global install (cross-shell PATH, no per-arch `$env:Path` edits), packs the framework + project templates into `local-nupkgs/`, registers the `dotnet new reactorapp` template, and installs the Reactor agent plugin under `~/.claude/plugins/reactor`. Apps reference `Microsoft.UI.Reactor`; add the optional, same-version `Microsoft.UI.Reactor.Devtools` package only when enabling `--devtools` with `Reactor.DevtoolsSupport`. Re-run it (or `mur upgrade` for a lighter refresh) after `git pull`. Verify a working install with `mur doctor`.
 
@@ -170,13 +175,13 @@ ReactorApp.Run<App>("My App", preview: true);
 
 ```bash
 # Preview a specific component with hot reload
-dotnet watch run --project MyApp -- --preview CounterDemo
+dotnet watch run --project MyApp -p:Platform=x64 -- --preview CounterDemo
 
 # Preview the first component in the project
-dotnet watch run --project MyApp -- --preview
+dotnet watch run --project MyApp -p:Platform=x64 -- --preview
 
 # List available components
-dotnet run --project MyApp -- --preview-list
+dotnet run --project MyApp -p:Platform=x64 -- --preview-list
 ```
 
 ### VS Code extension
@@ -236,7 +241,7 @@ samples/
 A word search game demonstrating grid layout, timers, and interactive state.
 
 ```bash
-dotnet run --project samples/apps/wordpuzzle
+dotnet run --project samples/apps/wordpuzzle -p:Platform=x64
 ```
 
 ---


### PR DESCRIPTION
## Summary

Documents the required `-p:Platform=x64` (or `ARM64`) build flag in the top-level `README.md`. Without it, the quick-start commands fail with `WindowsAppSDKSelfContained` errors. Adds the flag to the three bare `dotnet run` / `dotnet watch run` examples (Quick start, VS Code preview, WordPuzzle sample) and inserts the same warning callout that PR #288 added to `plugins/reactor/skills/reactor-getting-started/SKILL.md`.

## Linked issue / spec

Fixes #520. Follow-up to #288.

## Test plan

- [x] Docs-only change — no code paths touched, no tests added.
- [x] Rendered `README.md` locally to confirm the callout and updated code blocks display correctly.
- [x] Verified the new commands by running `dotnet run -p:Platform=x64` against a freshly scaffolded `dotnet new reactorapp` project.

## Risk / breaking changes

None. Documentation-only change; no public API, behavior, or perf-sensitive path is affected.