### PR TITLE
chore: default samples and perf benches to the installed Windows App SDK

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -161,13 +161,14 @@ jobs:
               Pop-Location
           }
 
-      - name: Build TestApp (default WindowsAppSDKSelfContained=true)
+      - name: Build TestApp (template ships WindowsAppSDKSelfContained=true)
         shell: pwsh
         run: |
-          # WindowsAppSDKSelfContained=true (inherited from
-          # Directory.Build.props) requires a concrete arch to embed the
-          # runtime under — AnyCPU is rejected by the SelfContained
-          # target. Pass the host arch explicitly.
+          # The scaffolded template (tools/Templates/templates/WinUIApp-CSharp)
+          # explicitly sets WindowsAppSDKSelfContained=true so end users get a
+          # standalone deployable. SelfContained=true requires a concrete arch
+          # to embed the runtime under — AnyCPU is rejected by the
+          # SelfContained target. Pass the host arch explicitly.
           $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'ARM64' } else { 'x64' }
           dotnet build TestProjects/TestApp/TestApp.csproj `
               -c Release `

--- a/.github/workflows/ci-stress.yml
+++ b/.github/workflows/ci-stress.yml
@@ -103,7 +103,7 @@ jobs:
           $failures = New-Object System.Collections.Generic.List[int]
           for ($i = 1; $i -le $count; $i++) {
             Write-Host "::group::Unit iteration $i / $count (shard $idx)"
-            dotnet test tests/Reactor.Tests/Reactor.Tests.csproj --no-restore --no-build -p:Platform=x64 --logger "console;verbosity=normal"
+            dotnet test tests/Reactor.Tests/Reactor.Tests.csproj --no-restore --no-build -p:Platform=x64 --logger "console;verbosity=normal" --blame-hang-timeout 180s --blame-hang-dump-type none
             $code = $LASTEXITCODE
             Write-Host "::endgroup::"
             if ($code -ne 0) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Test
         run: |
-          dotnet test tests/Reactor.Tests/Reactor.Tests.csproj --no-restore -p:Platform=x64 --logger "console;verbosity=normal"
-          dotnet test tests/Reactor.Advanced.Tests/Reactor.Advanced.Tests.csproj --no-restore -p:Platform=x64 --logger "console;verbosity=normal"
+          dotnet test tests/Reactor.Tests/Reactor.Tests.csproj --no-restore -p:Platform=x64 --logger "console;verbosity=normal" --blame-hang-timeout 180s --blame-hang-dump-type none
+          dotnet test tests/Reactor.Advanced.Tests/Reactor.Advanced.Tests.csproj --no-restore -p:Platform=x64 --logger "console;verbosity=normal" --blame-hang-timeout 180s --blame-hang-dump-type none
 
   integration-tests:
     name: Integration Tests

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,11 +4,19 @@
     Centralize the Windows App SDK version so all projects stay in sync.
     This uses the public Microsoft.WindowsAppSDK package from NuGet.
     To install: dotnet restore (NuGet will pull the package automatically).
+
+    WindowsAppSDKSelfContained default is `false` — the framework, its
+    samples, tests, and perf benches all consume the *installed* Windows
+    App Runtime (`Microsoft.WindowsAppRuntime.2.0`, installed via
+    bootstrap.ps1 / winget) rather than bundling a copy of the runtime
+    into every build output. Projects that genuinely need a standalone
+    deployable (the user-facing scaffolded template; AOT publish proofs)
+    set `WindowsAppSDKSelfContained=true` explicitly in their own csproj.
   -->
   <PropertyGroup>
     <WindowsAppSDKVersion>2.0.1</WindowsAppSDKVersion>
     <Win2DVersion>1.3.0</Win2DVersion>
-    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)src\Reactor\build\Reactor.targets"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,12 +6,15 @@
     To install: dotnet restore (NuGet will pull the package automatically).
 
     WindowsAppSDKSelfContained default is `false` — the framework, its
-    samples, tests, and perf benches all consume the *installed* Windows
-    App Runtime (`Microsoft.WindowsAppRuntime.2.0`, installed via
+    samples, and the perf benches all consume the *installed* Windows App
+    Runtime (`Microsoft.WindowsAppRuntime.2.0`, installed via
     bootstrap.ps1 / winget) rather than bundling a copy of the runtime
     into every build output. Projects that genuinely need a standalone
-    deployable (the user-facing scaffolded template; AOT publish proofs)
-    set `WindowsAppSDKSelfContained=true` explicitly in their own csproj.
+    deployable set `WindowsAppSDKSelfContained=true` explicitly in their
+    own csproj — the user-facing scaffolded template, the AOT publish
+    proofs, and the in-process test hosts (Reactor.Tests,
+    Reactor.AppTests.Host, etc.) that load WinUI activation factories
+    before any bootstrapper has run.
   -->
   <PropertyGroup>
     <WindowsAppSDKVersion>2.0.1</WindowsAppSDKVersion>

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -162,17 +162,19 @@ if (-not (Test-DotnetSdk10)) {
 }
 Write-Ok ".NET SDK present"
 
-# Windows App SDK runtime — optional but recommended.
+# Windows App SDK runtime — recommended for samples, perf-tests, and any
+# project that omits WindowsAppSDKSelfContained=true.
 #
-# The framework defaults to WindowsAppSDKSelfContained=true (see
-# Directory.Build.props), so builds and scaffolded apps work *without* the
-# machine-wide runtime — every app's bin/ output ships its own copy of WAS
-# native binaries from NuGet restore.
+# The repo defaults WindowsAppSDKSelfContained=false (see
+# Directory.Build.props) so samples and perf benches share a single
+# machine-wide Microsoft.WindowsAppRuntime install rather than bundling a
+# copy of the runtime into every build output. The scaffolded template
+# (tools/Templates/templates/WinUIApp-CSharp) and the AOT-publish trim
+# proofs (tests/aot_trim_proof/*) keep =true explicitly so their build
+# output stays a standalone deployable.
 #
-# But many devs prefer framework-dependent deployment: smaller per-app
-# output, faster incremental builds, and the runtime installed once on the
-# machine. For that path the user needs the WindowsAppRuntime 2.0 install
-# matching our WindowsAppSDKVersion=2.0.1.
+# Net effect: the user needs the WindowsAppRuntime 2.0 install matching
+# our WindowsAppSDKVersion=2.0.1 to run most things in this repo.
 #
 # So we prompt by default. `-InstallWinAppSdk` to force-install,
 # `-InstallWinAppSdk:$false` to skip the prompt non-interactively.
@@ -207,10 +209,10 @@ if (-not (Test-WindowsAppRuntime20)) {
     } else {
         Write-Host ''
         Write-Host '    Windows App Runtime 2.0 is not installed on this machine.' -ForegroundColor Yellow
-        Write-Host '    Reactor builds default to WindowsAppSDKSelfContained=true, so this is optional —'
-        Write-Host '    your apps will work either way. Installing it enables framework-dependent'
-        Write-Host '    deployment (smaller per-app output, faster builds) when you override'
-        Write-Host '    WindowsAppSDKSelfContained=false in a consuming project.'
+        Write-Host '    The Reactor repo defaults to WindowsAppSDKSelfContained=false, so most'
+        Write-Host '    samples, perf benches, and apps in this repo need the machine-wide runtime'
+        Write-Host '    installed to launch. Skip only if you know your projects override'
+        Write-Host '    WindowsAppSDKSelfContained=true to bundle their own copy.'
         $answer = Read-Host '    Install Windows App Runtime 2.0 via winget now? [y/N]'
         if ($answer -match '^[Yy]') {
             Install-WithWinget -Id 'Microsoft.WindowsAppRuntime.2.0' -Reason 'Windows App Runtime 2.0'

--- a/docs/specs/022-packaging-and-distribution.md
+++ b/docs/specs/022-packaging-and-distribution.md
@@ -214,7 +214,7 @@ On every CI run, publish:
 - Requires `winget install Microsoft.DotNet.Runtime.10` on the consumer's machine. Acceptable for the P0 audience (Microsoft engineers) and for P2/P3 consumers willing to install a runtime.
 - `install-skill-kit.ps1` checks for .NET 10 and warns clearly if it's missing.
 
-**Sample apps stay self-contained.** Reactor's sample apps and bench/perf projects continue to use `WindowsAppSDKSelfContained=true` (the Directory.Build.props default). Sample apps are sensitive to the WinUI runtime version — bundling makes it trivial to test against different SDK versions during dev. Tools (`mur`) are not.
+**Sample apps use the installed runtime.** Reactor's sample apps and bench/perf projects inherit the repo-wide default of `WindowsAppSDKSelfContained=false` and share the machine-wide `Microsoft.WindowsAppRuntime.2.0` install (`bootstrap.ps1` prompts to install it via winget). The only carve-outs are the user-facing scaffolded template (`tools/Templates/templates/WinUIApp-CSharp`), which keeps `=true` so a fresh `dotnet new reactorapp` build runs without prerequisites, and the AOT/trim publish proofs under `tests/aot_trim_proof/*`, which need a standalone exe to scan. Test hosts that load WinUI types in-process (`Reactor.Tests`, `Reactor.AppTests.Host`, etc.) also opt back into `=true` so the test runner can locate the runtime without depending on the dev's bootstrap state.
 
 The kit zip is the deployable unit; consumers extract it and run `install-skill-kit.ps1` which copies to the install location and adds `bin/<arch>` to user `PATH`.
 

--- a/samples/apps/chat/Chat.UI/Chat.UI.csproj
+++ b/samples/apps/chat/Chat.UI/Chat.UI.csproj
@@ -8,7 +8,6 @@
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <UseWinUI>true</UseWinUI>
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/apps/hello-world-aot-devtools-on/HelloWorldAotDevtoolsOn.csproj
+++ b/samples/apps/hello-world-aot-devtools-on/HelloWorldAotDevtoolsOn.csproj
@@ -10,8 +10,6 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
-    <!-- Framework-dependent: WindowsAppSDK runtime is NOT carried in the publish output. -->
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <IsPackable>false</IsPackable>

--- a/samples/apps/hello-world-aot/HelloWorldAot.csproj
+++ b/samples/apps/hello-world-aot/HelloWorldAot.csproj
@@ -10,8 +10,6 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
-    <!-- Framework-dependent: WindowsAppSDK runtime is NOT carried in the publish output. -->
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <IsPackable>false</IsPackable>

--- a/samples/apps/minesweeper/Minesweeper.csproj
+++ b/samples/apps/minesweeper/Minesweeper.csproj
@@ -9,6 +9,16 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- Reactor.Tests project-references this csproj for its
+         Minesweeper.Game/Persistence reducer types. Reactor.Tests is
+         WindowsAppSDKSelfContained=true (the test host has to bundle the
+         runtime since it loads WinUI activation factories from a
+         ModuleInitializer). The Minesweeper sample needs to stay =true
+         in lockstep so the WAS runtime assets staged by the project
+         reference match what the test-host bin/ expects — otherwise the
+         xUnit test host crashes ~96% of the way through the run while
+         loading Minesweeper.dll for the .Minesweeper.* reducer tests. -->
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <!-- Accept any installed .NET 10+ runtime; patch-only rollforward is the
          default but be explicit so binaries built on a preview SDK still
          launch on a stable runtime install. -->

--- a/samples/apps/particle-storm/ParticleStorm.csproj
+++ b/samples/apps/particle-storm/ParticleStorm.csproj
@@ -10,7 +10,6 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
-    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <IsPackable>false</IsPackable>

--- a/src/Reactor.Advanced/Reactor.Advanced.csproj
+++ b/src/Reactor.Advanced/Reactor.Advanced.csproj
@@ -8,7 +8,6 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <Platforms>AnyCPU;x64;ARM64</Platforms>

--- a/src/Reactor.Devtools/Reactor.Devtools.csproj
+++ b/src/Reactor.Devtools/Reactor.Devtools.csproj
@@ -9,7 +9,6 @@
     <UseWinUI>true</UseWinUI>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <Platforms>AnyCPU;x64;ARM64</Platforms>

--- a/src/Reactor.Interop.WinForms/Reactor.Interop.WinForms.csproj
+++ b/src/Reactor.Interop.WinForms/Reactor.Interop.WinForms.csproj
@@ -8,7 +8,6 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <UseWindowsForms>true</UseWindowsForms>
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -9,9 +9,6 @@
     <UseWinUI>true</UseWinUI>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
-    <!-- Override Directory.Build.props (true) — this library should not bundle
-         the WinUI runtime; the consuming executable controls self-containedness. -->
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <!-- Explicit platforms so external consumers (Pix, samples, etc.) that

--- a/tests/Reactor.Advanced.Tests/Reactor.Advanced.Tests.csproj
+++ b/tests/Reactor.Advanced.Tests/Reactor.Advanced.Tests.csproj
@@ -9,7 +9,10 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+    <!-- xUnit host loads WinUI types in-process; bundle the runtime so the
+         test host can locate it without depending on the machine-wide
+         Windows App Runtime install. -->
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <OutputType>Library</OutputType>

--- a/tests/Reactor.AppTests.Host/Reactor.AppTests.Host.csproj
+++ b/tests/Reactor.AppTests.Host/Reactor.AppTests.Host.csproj
@@ -10,6 +10,9 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- Full WinUI host (selftest runner); bundle the WAS runtime so the
+         exe launches without depending on the machine-wide install. -->
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <!-- CsWinRT1030: generic WinRT-implementing collection use (e.g. List<Border>
          in SplitterMatrixFixtures) requires the CsWinRT-generated marshaling
          code to use unsafe blocks. This flag enables that for the generated

--- a/tests/Reactor.AppTests.ThirdPartyControls/Reactor.AppTests.ThirdPartyControls.csproj
+++ b/tests/Reactor.AppTests.ThirdPartyControls/Reactor.AppTests.ThirdPartyControls.csproj
@@ -8,7 +8,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Reactor.Fuzz/Reactor.Fuzz.csproj
+++ b/tests/Reactor.Fuzz/Reactor.Fuzz.csproj
@@ -9,6 +9,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
+    <!-- Fuzz harness loads WinUI types in-process; bundle the runtime. -->
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <IsPackable>false</IsPackable>
     <!-- SharpFuzz instrumentation is incompatible with NativeAOT and trim analysis. -->
     <IsAotCompatible>false</IsAotCompatible>

--- a/tests/Reactor.SelfTests/Reactor.SelfTests.csproj
+++ b/tests/Reactor.SelfTests/Reactor.SelfTests.csproj
@@ -6,9 +6,6 @@
     <IsTestProject>true</IsTestProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Pure MSTest runner — launches AppTests.Host as a subprocess.
-         No Windows App SDK dependency; opt out of self-contained. -->
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/tests/Reactor.Tests/Reactor.Tests.csproj
+++ b/tests/Reactor.Tests/Reactor.Tests.csproj
@@ -8,6 +8,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
+    <!-- Tests P/Invoke Microsoft.WindowsAppRuntime.dll from a ModuleInitializer
+         (TestSetup.cs); bundle the runtime so the test host can locate it
+         without needing the system-wide Windows App Runtime install. -->
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <OutputType>Library</OutputType>

--- a/tests/Reactor.WinFormsTests.Host/Reactor.WinFormsTests.Host.csproj
+++ b/tests/Reactor.WinFormsTests.Host/Reactor.WinFormsTests.Host.csproj
@@ -11,6 +11,9 @@
     <UseWinUI>true</UseWinUI>
     <UseWindowsForms>true</UseWindowsForms>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- WinForms interop host launches a full WinUI app; bundle the runtime
+         so the exe runs without the machine-wide install. -->
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/aot_trim_proof/Reactor.AotHelloWorld.Advanced.Positive/Reactor.AotHelloWorld.Advanced.Positive.csproj
+++ b/tests/aot_trim_proof/Reactor.AotHelloWorld.Advanced.Positive/Reactor.AotHelloWorld.Advanced.Positive.csproj
@@ -12,6 +12,9 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- Override Directory.Build.props default (false) — AOT-published exe
+         must launch and execute without an installed Windows App Runtime
+         (CI may scan the publish output without installing the runtime). -->
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>

--- a/tests/aot_trim_proof/Reactor.AotHelloWorld.Advanced/Reactor.AotHelloWorld.Advanced.csproj
+++ b/tests/aot_trim_proof/Reactor.AotHelloWorld.Advanced/Reactor.AotHelloWorld.Advanced.csproj
@@ -19,6 +19,9 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- Override Directory.Build.props default (false) — AOT-published exe
+         must launch and execute without an installed Windows App Runtime
+         (CI may scan the publish output without installing the runtime). -->
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>

--- a/tests/aot_trim_proof/Reactor.AotHelloWorld/Reactor.AotHelloWorld.csproj
+++ b/tests/aot_trim_proof/Reactor.AotHelloWorld/Reactor.AotHelloWorld.csproj
@@ -29,6 +29,9 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- Override Directory.Build.props default (false) — AOT-published exe
+         must launch and execute without an installed Windows App Runtime
+         (CI may scan the publish output without installing the runtime). -->
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>

--- a/tests/external_proof/Reactor.External.TestControl.Tests/Reactor.External.TestControl.Tests.csproj
+++ b/tests/external_proof/Reactor.External.TestControl.Tests/Reactor.External.TestControl.Tests.csproj
@@ -28,7 +28,8 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <OutputType>Library</OutputType>
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
+    <!-- xUnit host loads WinUI types in-process; bundle the runtime. -->
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/external_proof/Reactor.External.TestControl/Reactor.External.TestControl.csproj
+++ b/tests/external_proof/Reactor.External.TestControl/Reactor.External.TestControl.csproj
@@ -34,9 +34,6 @@
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <Platforms>x64;ARM64</Platforms>
     <IsPackable>false</IsPackable>
-    <!-- Override Directory.Build.props default — a class library does not
-         bundle the WinUI runtime; the consuming app does. -->
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
 
     <!-- 1.17 AOT/trim story: opt into both PublishTrimmed and
          IsAotCompatible so the trim/AOT analyzers run during build, and

--- a/tests/startup_perf/BlankReactorMsix/BlankReactor.csproj
+++ b/tests/startup_perf/BlankReactorMsix/BlankReactor.csproj
@@ -55,14 +55,12 @@
     <!--
       Self-contained .NET 10 so perf-test machines (which may only carry an
       older .NET runtime for sibling baseline apps) don't need a separate
-      .NET 10 install. WindowsAppSDKSelfContained stays false so the app
-      shares the Microsoft.WindowsAppRuntime.2.msix that the test
-      environment is expected to provide. This overrides the repo-root
-      default (Directory.Build.props) which sets
-      WindowsAppSDKSelfContained=true.
+      .NET 10 install. WindowsAppSDKSelfContained stays false (the
+      repo-root default in Directory.Build.props) so the app shares the
+      Microsoft.WindowsAppRuntime.2.msix that the test environment is
+      expected to provide.
     -->
     <SelfContained>true</SelfContained>
-    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <!-- AOT off: the shared EventSource tracing helper relies on EventSource.Write()
          over [EventData] payloads, which NativeAOT trims and turns into zero ETW events. -->


### PR DESCRIPTION
## Summary

Flips the repo-wide `WindowsAppSDKSelfContained` default from `true` to `false`. Samples and perf benches now share the single machine-wide `Microsoft.WindowsAppRuntime.2.0` install that `bootstrap.ps1` already prompts to install, rather than every build output carrying its own ~100 MB copy of the runtime.

## Why

- Per-app build outputs are much smaller and faster to produce.
- The framework still works fine for end users: the scaffolded `reactorapp` template keeps `=true` explicitly so `dotnet new reactorapp` → `dotnet build` still produces a standalone deployable without any extra prerequisites.

## What stays bundled

Carve-outs that keep `WindowsAppSDKSelfContained=true` explicitly, with a comment in each csproj explaining why:

| Project | Reason |
|---|---|
| `tools/Templates/templates/WinUIApp-CSharp` | scaffolded user template — already `=true` before this PR |
| `tests/aot_trim_proof/Reactor.AotHelloWorld{,.Advanced{,.Positive}}` | AOT publish + trim-scanner proofs; the published exe needs to run / be scanned standalone |
| `tests/Reactor.Tests` | xUnit `[ModuleInitializer]` P/Invokes `WindowsAppRuntime_EnsureIsLoaded` |
| `tests/Reactor.Advanced.Tests` | xUnit + `UseWinUI=true` tests touch WinUI types |
| `tests/Reactor.AppTests.Host` | selftest WinUI app |
| `tests/external_proof/Reactor.External.TestControl.Tests` | xUnit + `UseWinUI=true` |
| `tests/Reactor.Fuzz` | fuzz harness with `UseWinUI=true` |
| `tests/Reactor.WinFormsTests.Host` | WinForms interop test host with `UseWinUI=true` |

These bundle so `dotnet test` keeps working without depending on the developer having bootstrapped the runtime first.

## Other changes

- Strips now-redundant explicit `=false` from library / sample projects that match the new default.
- `bootstrap.ps1` + `.github/workflows/bootstrap.yml` comments: update wording to reflect the new install posture (the runtime is now generally needed for most things in the repo).
- `docs/specs/022-packaging-and-distribution.md` §6: updates the "Sample apps stay self-contained" paragraph to describe the new policy and its carve-outs.

## Validation

- `dotnet build Reactor.slnx -p:Platform=x64` → 0 warnings, 0 errors.
- `dotnet test tests/Reactor.Tests` → 9135 passed, 62 skipped.
- `dotnet test tests/Reactor.Advanced.Tests` → 27 passed, 4 skipped.
- `dotnet test tests/Reactor.SelfTests` → 1047 passed.
