### PR TITLE
Fix PropertyGrid collection editors

### DIFF
--- a/src/Reactor/Controls/PropertyGrid/ArrayOperations.cs
+++ b/src/Reactor/Controls/PropertyGrid/ArrayOperations.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -20,6 +21,18 @@ internal static class ArrayOperations
 {
     private static readonly Type[] GenericCollectionDefinitions =
     [
+        typeof(List<>),
+        typeof(Collection<>),
+        typeof(ObservableCollection<>),
+        typeof(ReadOnlyCollection<>),
+        typeof(HashSet<>),
+        typeof(SortedSet<>),
+        typeof(Queue<>),
+        typeof(Stack<>),
+        typeof(LinkedList<>),
+        typeof(ConcurrentBag<>),
+        typeof(ConcurrentQueue<>),
+        typeof(ConcurrentStack<>),
         typeof(IList<>),
         typeof(ICollection<>),
         typeof(ISet<>),
@@ -32,6 +45,9 @@ internal static class ArrayOperations
     [
         typeof(IList),
         typeof(ICollection),
+        typeof(ArrayList),
+        typeof(Queue),
+        typeof(Stack),
     ];
 
     /// <summary>
@@ -303,7 +319,6 @@ internal static class ArrayOperations
         return $"{name.Replace('+', '.')}<{args}>";
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "PropertyGrid uses interface metadata only to classify collection contracts; missing metadata degrades to non-collection rendering.")]
     public static Type? GetElementType(Type collectionType)
     {
         if (collectionType == typeof(string))
@@ -325,13 +340,6 @@ internal static class ArrayOperations
 
         if (IsDictionaryLike(collectionType))
             return null;
-
-        foreach (var interfaceType in collectionType.GetInterfaces().Where(i => i.IsGenericType))
-        {
-            var genDef = interfaceType.GetGenericTypeDefinition();
-            if (GenericCollectionDefinitions.Contains(genDef))
-                return interfaceType.GetGenericArguments()[0];
-        }
 
         if (NonGenericCollectionTypes.Contains(collectionType) || typeof(IList).IsAssignableFrom(collectionType))
             return typeof(object);
@@ -357,11 +365,10 @@ internal static class ArrayOperations
     private static bool IsZeroBasedOneDimensional(Array array)
         => array.Rank == 1 && array.GetLowerBound(0) == 0;
 
-    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Dictionary detection uses interface metadata only to avoid treating map types as list-like collections.")]
     private static bool IsDictionaryLike(Type type)
         => typeof(IDictionary).IsAssignableFrom(type)
-            || type.GetInterfaces().Any(i =>
-                i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+            || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+            || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>));
 }
 
 internal readonly record struct CollectionCapabilities(

--- a/src/Reactor/Controls/PropertyGrid/ArrayOperations.cs
+++ b/src/Reactor/Controls/PropertyGrid/ArrayOperations.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -21,35 +20,18 @@ internal static class ArrayOperations
 {
     private static readonly Type[] GenericCollectionDefinitions =
     [
-        typeof(List<>),
-        typeof(Collection<>),
-        typeof(ObservableCollection<>),
-        typeof(ReadOnlyCollection<>),
-        typeof(HashSet<>),
-        typeof(SortedSet<>),
-        typeof(Queue<>),
-        typeof(Stack<>),
-        typeof(LinkedList<>),
-        typeof(ConcurrentBag<>),
-        typeof(ConcurrentQueue<>),
-        typeof(ConcurrentStack<>),
         typeof(IList<>),
         typeof(ICollection<>),
         typeof(ISet<>),
         typeof(IReadOnlyList<>),
         typeof(IReadOnlyCollection<>),
         typeof(IReadOnlySet<>),
-        typeof(IEnumerable<>),
     ];
 
     private static readonly Type[] NonGenericCollectionTypes =
     [
         typeof(IList),
         typeof(ICollection),
-        typeof(IEnumerable),
-        typeof(ArrayList),
-        typeof(Queue),
-        typeof(Stack),
     ];
 
     /// <summary>
@@ -321,6 +303,7 @@ internal static class ArrayOperations
         return $"{name.Replace('+', '.')}<{args}>";
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "PropertyGrid uses interface metadata only to classify collection contracts; missing metadata degrades to non-collection rendering.")]
     public static Type? GetElementType(Type collectionType)
     {
         if (collectionType == typeof(string))
@@ -340,7 +323,20 @@ internal static class ArrayOperations
                 return collectionType.GetGenericArguments()[0];
         }
 
-        if (NonGenericCollectionTypes.Contains(collectionType))
+        if (IsDictionaryLike(collectionType))
+            return null;
+
+        foreach (var interfaceType in collectionType.GetInterfaces())
+        {
+            if (!interfaceType.IsGenericType)
+                continue;
+
+            var genDef = interfaceType.GetGenericTypeDefinition();
+            if (GenericCollectionDefinitions.Contains(genDef))
+                return interfaceType.GetGenericArguments()[0];
+        }
+
+        if (NonGenericCollectionTypes.Contains(collectionType) || typeof(IList).IsAssignableFrom(collectionType))
             return typeof(object);
 
         return null;
@@ -348,15 +344,14 @@ internal static class ArrayOperations
 
     private static bool IsDeclaredReadOnlyCollection(Type declaredType)
     {
-        if (declaredType == typeof(IEnumerable) || declaredType == typeof(ICollection))
+        if (declaredType == typeof(ICollection))
             return true;
 
         if (!declaredType.IsGenericType)
             return false;
 
         var genDef = declaredType.GetGenericTypeDefinition();
-        return genDef == typeof(IEnumerable<>)
-            || genDef == typeof(IReadOnlyCollection<>)
+        return genDef == typeof(IReadOnlyCollection<>)
             || genDef == typeof(IReadOnlyList<>)
             || genDef == typeof(IReadOnlySet<>)
             || genDef == typeof(ReadOnlyCollection<>);
@@ -364,6 +359,12 @@ internal static class ArrayOperations
 
     private static bool IsZeroBasedOneDimensional(Array array)
         => array.Rank == 1 && array.GetLowerBound(0) == 0;
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Dictionary detection uses interface metadata only to avoid treating map types as list-like collections.")]
+    private static bool IsDictionaryLike(Type type)
+        => typeof(IDictionary).IsAssignableFrom(type)
+            || type.GetInterfaces().Any(i =>
+                i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
 }
 
 internal readonly record struct CollectionCapabilities(

--- a/src/Reactor/Controls/PropertyGrid/ArrayOperations.cs
+++ b/src/Reactor/Controls/PropertyGrid/ArrayOperations.cs
@@ -248,13 +248,16 @@ internal static class ArrayOperations
             return default;
 
         if (collection is Array array && IsZeroBasedOneDimensional(array))
+        {
+            var canResize = canWriteBack && RuntimeFeature.IsDynamicCodeSupported;
             return canWriteBack
                 ? new CollectionCapabilities(
-                    CanAdd: true,
-                    CanRemoveAt: true,
+                    CanAdd: canResize,
+                    CanRemoveAt: canResize,
                     CanReplaceAt: true,
                     CanReorder: true)
                 : default;
+        }
 
         if (collection is IList list)
         {

--- a/src/Reactor/Controls/PropertyGrid/ArrayOperations.cs
+++ b/src/Reactor/Controls/PropertyGrid/ArrayOperations.cs
@@ -1,4 +1,6 @@
 using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
@@ -17,13 +19,46 @@ namespace Microsoft.UI.Reactor.Controls;
 /// </remarks>
 internal static class ArrayOperations
 {
+    private static readonly Type[] GenericCollectionDefinitions =
+    [
+        typeof(List<>),
+        typeof(Collection<>),
+        typeof(ObservableCollection<>),
+        typeof(ReadOnlyCollection<>),
+        typeof(HashSet<>),
+        typeof(SortedSet<>),
+        typeof(Queue<>),
+        typeof(Stack<>),
+        typeof(LinkedList<>),
+        typeof(ConcurrentBag<>),
+        typeof(ConcurrentQueue<>),
+        typeof(ConcurrentStack<>),
+        typeof(IList<>),
+        typeof(ICollection<>),
+        typeof(ISet<>),
+        typeof(IReadOnlyList<>),
+        typeof(IReadOnlyCollection<>),
+        typeof(IReadOnlySet<>),
+        typeof(IEnumerable<>),
+    ];
+
+    private static readonly Type[] NonGenericCollectionTypes =
+    [
+        typeof(IList),
+        typeof(ICollection),
+        typeof(IEnumerable),
+        typeof(ArrayList),
+        typeof(Queue),
+        typeof(Stack),
+    ];
+
     /// <summary>
     /// Adds an item to the end of the list. For arrays, returns a new array.
     /// Throws <see cref="NotSupportedException"/> on Native AOT for the array branch.
     /// </summary>
     [UnconditionalSuppressMessage("AOT", "IL3050",
         Justification = "Array.CreateInstance is only reached when RuntimeFeature.IsDynamicCodeSupported is true; otherwise we throw before calling it.")]
-    public static object Add(object collection, object item, Type elementType)
+    public static object Add(object collection, object? item, Type elementType)
     {
         if (collection is IList list && !collection.GetType().IsArray)
         {
@@ -143,16 +178,124 @@ internal static class ArrayOperations
 
     public static int GetCount(object collection)
     {
+        if (collection is string) return 0;
         if (collection is ICollection c) return c.Count;
-        if (collection is Array a) return a.Length;
+        if (collection is IEnumerable e)
+        {
+            var count = 0;
+            foreach (var _ in e) count++;
+            return count;
+        }
         return 0;
     }
 
     public static object? GetItem(object collection, int index)
     {
+        if (index < 0)
+            throw new ArgumentOutOfRangeException(nameof(index), index, "Index must be non-negative.");
+
+        if (collection is string) return null;
+        if (collection is Array array && IsZeroBasedOneDimensional(array)) return array.GetValue(index);
         if (collection is IList list) return list[index];
-        if (collection is Array array) return array.GetValue(index);
+        if (collection is IEnumerable e)
+        {
+            var i = 0;
+            foreach (var item in e)
+            {
+                if (i == index) return item;
+                i++;
+            }
+        }
         return null;
+    }
+
+    public static IReadOnlyList<object?> Snapshot(object collection)
+    {
+        if (collection is string) return [];
+
+        if (collection is Array array && IsZeroBasedOneDimensional(array))
+        {
+            var items = new object?[array.Length];
+            for (var i = 0; i < array.Length; i++)
+                items[i] = array.GetValue(i);
+            return items;
+        }
+
+        if (collection is IList list)
+        {
+            var items = new object?[list.Count];
+            for (var i = 0; i < list.Count; i++)
+                items[i] = list[i];
+            return items;
+        }
+
+        if (collection is IEnumerable enumerable)
+        {
+            var items = new List<object?>();
+            foreach (var item in enumerable)
+                items.Add(item);
+            return items;
+        }
+
+        return [];
+    }
+
+    public static CollectionCapabilities GetCapabilities(
+        object collection,
+        Type declaredType,
+        bool canWriteBack,
+        bool isReadOnly)
+    {
+        if (isReadOnly || IsDeclaredReadOnlyCollection(declaredType))
+            return default;
+
+        if (collection is Array array && IsZeroBasedOneDimensional(array))
+            return canWriteBack
+                ? new CollectionCapabilities(
+                    CanAdd: true,
+                    CanRemoveAt: true,
+                    CanReplaceAt: true,
+                    CanReorder: true)
+                : default;
+
+        if (collection is IList list)
+        {
+            var canResize = !list.IsReadOnly && !list.IsFixedSize;
+            var canReplace = !list.IsReadOnly;
+            return new CollectionCapabilities(
+                CanAdd: canResize,
+                CanRemoveAt: canResize,
+                CanReplaceAt: canReplace,
+                CanReorder: canResize);
+        }
+
+        return default;
+    }
+
+    public static object ReplaceAt(object collection, int index, object? item, Type elementType)
+    {
+        if (index < 0)
+            throw new ArgumentOutOfRangeException(nameof(index), index, "Index must be non-negative.");
+
+        if (collection is IList list && !collection.GetType().IsArray)
+        {
+            if (index >= list.Count)
+                throw new ArgumentOutOfRangeException(nameof(index), index, $"Index must be less than the collection size ({list.Count}).");
+            list[index] = item;
+            return collection;
+        }
+
+        if (collection is Array array)
+        {
+            if (index >= array.Length)
+                throw new ArgumentOutOfRangeException(nameof(index), index, $"Index must be less than the array length ({array.Length}).");
+
+            var newArray = (Array)array.Clone();
+            newArray.SetValue(item, index);
+            return newArray;
+        }
+
+        throw new InvalidOperationException($"Cannot replace an item in {collection.GetType().Name}");
     }
 
     /// <summary>
@@ -180,16 +323,51 @@ internal static class ArrayOperations
 
     public static Type? GetElementType(Type collectionType)
     {
+        if (collectionType == typeof(string))
+            return null;
+
         if (collectionType.IsArray)
+        {
+            if (!collectionType.IsSZArray)
+                return null;
             return collectionType.GetElementType();
+        }
 
         if (collectionType.IsGenericType)
         {
             var genDef = collectionType.GetGenericTypeDefinition();
-            if (genDef == typeof(List<>) || genDef == typeof(IList<>))
+            if (GenericCollectionDefinitions.Contains(genDef))
                 return collectionType.GetGenericArguments()[0];
         }
 
+        if (NonGenericCollectionTypes.Contains(collectionType))
+            return typeof(object);
+
         return null;
     }
+
+    private static bool IsDeclaredReadOnlyCollection(Type declaredType)
+    {
+        if (declaredType == typeof(IEnumerable) || declaredType == typeof(ICollection))
+            return true;
+
+        if (!declaredType.IsGenericType)
+            return false;
+
+        var genDef = declaredType.GetGenericTypeDefinition();
+        return genDef == typeof(IEnumerable<>)
+            || genDef == typeof(IReadOnlyCollection<>)
+            || genDef == typeof(IReadOnlyList<>)
+            || genDef == typeof(IReadOnlySet<>)
+            || genDef == typeof(ReadOnlyCollection<>);
+    }
+
+    private static bool IsZeroBasedOneDimensional(Array array)
+        => array.Rank == 1 && array.GetLowerBound(0) == 0;
 }
+
+internal readonly record struct CollectionCapabilities(
+    bool CanAdd,
+    bool CanRemoveAt,
+    bool CanReplaceAt,
+    bool CanReorder);

--- a/src/Reactor/Controls/PropertyGrid/ArrayOperations.cs
+++ b/src/Reactor/Controls/PropertyGrid/ArrayOperations.cs
@@ -326,11 +326,8 @@ internal static class ArrayOperations
         if (IsDictionaryLike(collectionType))
             return null;
 
-        foreach (var interfaceType in collectionType.GetInterfaces())
+        foreach (var interfaceType in collectionType.GetInterfaces().Where(i => i.IsGenericType))
         {
-            if (!interfaceType.IsGenericType)
-                continue;
-
             var genDef = interfaceType.GetGenericTypeDefinition();
             if (GenericCollectionDefinitions.Contains(genDef))
                 return interfaceType.GetGenericArguments()[0];

--- a/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
+++ b/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
@@ -166,9 +166,8 @@ public class PropertyGridComponent : Component<PropertyGridElement>
         var dependencies = new List<object>();
         var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
 
-        foreach (var descriptor in descriptors)
+        foreach (var value in descriptors.Select(descriptor => descriptor.GetValue(owner)))
         {
-            var value = descriptor.GetValue(owner);
             if (value is null or string)
                 continue;
 
@@ -180,9 +179,9 @@ public class PropertyGridComponent : Component<PropertyGridElement>
 
             if (value is ICollection or Array)
             {
-                foreach (var item in ArrayOperations.Snapshot(value))
+                foreach (var inpc in ArrayOperations.Snapshot(value).OfType<INotifyPropertyChanged>())
                 {
-                    if (item is INotifyPropertyChanged inpc && seen.Add(inpc))
+                    if (seen.Add(inpc))
                     {
                         items.Add(inpc);
                         dependencies.Add(inpc);

--- a/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
+++ b/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
@@ -377,7 +377,7 @@ public class PropertyGridComponent : Component<PropertyGridElement>
         {
             var index = i;
             var item = items[index];
-            var itemDescriptor = CreateArrayItemDescriptor(index, elementType, capabilities.CanReplaceAt);
+            var itemDescriptor = CreateArrayItemDescriptor(index, elementType, capabilities.CanReplaceAt, Refresh);
             var itemKey = $"array:{arrayPath}[{index}]";
             var isExpanded = expandState.TryGetValue(itemKey, out var expanded) && expanded;
             var summary = item?.ToString() ?? "(null)";
@@ -478,7 +478,8 @@ public class PropertyGridComponent : Component<PropertyGridElement>
     private static FieldDescriptor CreateArrayItemDescriptor(
         int index,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] Type elementType,
-        bool canEdit)
+        bool canEdit,
+        Action refresh)
     {
         return new FieldDescriptor
         {
@@ -487,7 +488,12 @@ public class PropertyGridComponent : Component<PropertyGridElement>
             FieldType = elementType,
             GetValue = owner => ArrayOperations.GetItem(owner, index),
             SetValue = canEdit
-                ? (owner, value) => ArrayOperations.ReplaceAt(owner, index, value, elementType)
+                ? (owner, value) =>
+                {
+                    var result = ArrayOperations.ReplaceAt(owner, index, value, elementType);
+                    refresh();
+                    return result;
+                }
                 : null,
             IsReadOnly = !canEdit,
         };

--- a/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
+++ b/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
@@ -1,4 +1,6 @@
+using System.Collections;
 using System.ComponentModel;
+using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Data;
@@ -55,6 +57,29 @@ public class PropertyGridComponent : Component<PropertyGridElement>
         var descriptors = el.Filter is not null
             ? allDescriptors.Where(el.Filter).ToList()
             : allDescriptors.ToList();
+
+        var observationTargets = BuildCollectionObservationTargets(descriptors, target);
+        UseEffect(() =>
+        {
+            if (observationTargets.Collections.Count == 0 && observationTargets.Items.Count == 0)
+                return () => { };
+
+            NotifyCollectionChangedEventHandler collectionHandler = (_, _) => forceRender(v => !v);
+            PropertyChangedEventHandler itemHandler = (_, _) => forceRender(v => !v);
+
+            foreach (var collection in observationTargets.Collections)
+                collection.CollectionChanged += collectionHandler;
+            foreach (var item in observationTargets.Items)
+                item.PropertyChanged += itemHandler;
+
+            return () =>
+            {
+                foreach (var collection in observationTargets.Collections)
+                    collection.CollectionChanged -= collectionHandler;
+                foreach (var item in observationTargets.Items)
+                    item.PropertyChanged -= itemHandler;
+            };
+        }, observationTargets.Dependencies);
 
         var (searchText, setSearchText) = UseState("");
         if (el.ShowSearch && !string.IsNullOrEmpty(searchText))
@@ -132,6 +157,46 @@ public class PropertyGridComponent : Component<PropertyGridElement>
         return content;
     }
 
+    private static CollectionObservationTargets BuildCollectionObservationTargets(
+        IEnumerable<FieldDescriptor> descriptors,
+        object owner)
+    {
+        var collections = new List<INotifyCollectionChanged>();
+        var items = new List<INotifyPropertyChanged>();
+        var dependencies = new List<object>();
+        var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        foreach (var descriptor in descriptors)
+        {
+            var value = descriptor.GetValue(owner);
+            if (value is null or string)
+                continue;
+
+            if (value is INotifyCollectionChanged collection && seen.Add(collection))
+            {
+                collections.Add(collection);
+                dependencies.Add(collection);
+            }
+
+            if (value is ICollection or Array)
+            {
+                foreach (var item in ArrayOperations.Snapshot(value))
+                {
+                    if (item is INotifyPropertyChanged inpc && seen.Add(inpc))
+                    {
+                        items.Add(inpc);
+                        dependencies.Add(inpc);
+                    }
+                }
+            }
+        }
+
+        return new CollectionObservationTargets(
+            collections,
+            items,
+            dependencies.Count == 0 ? [] : dependencies.ToArray());
+    }
+
     private static void RenderProperty(
         List<Element?> rows,
         FieldDescriptor descriptor,
@@ -147,6 +212,13 @@ public class PropertyGridComponent : Component<PropertyGridElement>
     {
         var propertyType = descriptor.FieldType;
         var meta = registry.Resolve(propertyType);
+        if (meta is ArrayTypeMetadata arrayMeta)
+        {
+            RenderArrayProperty(rows, descriptor, owner, registry, el, rowTemplate, labelTemplate,
+                expandState, setExpandState, editChain, indentLevel, arrayMeta);
+            return;
+        }
+
         var hasDecompose = meta.Decompose is not null && !IsPrimitiveOrEnum(propertyType);
         var hasEditor = meta.Editor is not null;
 
@@ -235,6 +307,211 @@ public class PropertyGridComponent : Component<PropertyGridElement>
         {
             rows.Add(rowTemplate(descriptor, label, editor, indentLevel));
         }
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Array element types are discovered from the annotated FieldDescriptor.FieldType at runtime.")]
+    private static void RenderArrayProperty(
+        List<Element?> rows,
+        FieldDescriptor descriptor,
+        object owner,
+        TypeRegistry registry,
+        PropertyGridElement el,
+        PropertyRowTemplate rowTemplate,
+        PropertyLabelTemplate labelTemplate,
+        Dictionary<string, bool> expandState,
+        Action<Func<Dictionary<string, bool>, Dictionary<string, bool>>> setExpandState,
+        EditChain editChain,
+        int indentLevel,
+        ArrayTypeMetadata arrayMeta)
+    {
+        var collection = descriptor.GetValue(owner);
+        if (collection is null)
+        {
+            rows.Add(rowTemplate(descriptor, labelTemplate(descriptor, indentLevel),
+                TextBlock("(null)"), indentLevel));
+            return;
+        }
+
+        var elementType = ArrayOperations.GetElementType(descriptor.FieldType);
+        if (elementType is null)
+        {
+            rows.Add(rowTemplate(descriptor, labelTemplate(descriptor, indentLevel),
+                TextBlock(collection.ToString() ?? "(null)"), indentLevel));
+            return;
+        }
+
+        var arrayToolbarTemplate = el.ArrayToolbarTemplate ?? PropertyGridDefaults.ArrayToolbarTemplate;
+        var arrayItemTemplate = el.ArrayItemTemplate ?? PropertyGridDefaults.ArrayItemTemplate;
+        var propertyName = descriptor.DisplayName ?? descriptor.Name;
+        var items = ArrayOperations.Snapshot(collection);
+        var count = items.Count;
+        var canWriteBack = descriptor.SetValue is not null || !editChain.CannotPropagate(descriptor);
+        var capabilities = ArrayOperations.GetCapabilities(
+            collection,
+            descriptor.FieldType,
+            canWriteBack,
+            descriptor.IsReadOnly);
+
+        void Refresh() => setExpandState(dict => new Dictionary<string, bool>(dict));
+
+        Func<Task>? onAdd = capabilities.CanAdd && arrayMeta.CreateElement is not null
+            ? async () =>
+            {
+                var item = await arrayMeta.CreateElement();
+                var currentCollection = descriptor.GetValue(owner)
+                    ?? throw new InvalidOperationException($"Cannot add to null collection property '{descriptor.Name}'.");
+                var updatedCollection = ArrayOperations.Add(currentCollection, item, elementType);
+                ApplyArrayChange(descriptor, owner, updatedCollection, editChain, Refresh);
+            }
+            : null;
+
+        var editorRows = new List<Element?>
+        {
+            arrayToolbarTemplate(propertyName, count, onAdd)
+        };
+
+        var arrayEditChain = editChain.Push(descriptor, arrayMeta, collection);
+        var arrayPath = editChain.BuildPath(descriptor.Name);
+
+        for (var i = 0; i < count; i++)
+        {
+            var index = i;
+            var item = items[index];
+            var itemDescriptor = CreateArrayItemDescriptor(index, elementType, capabilities.CanReplaceAt);
+            var itemKey = $"array:{arrayPath}[{index}]";
+            var isExpanded = expandState.TryGetValue(itemKey, out var expanded) && expanded;
+            var summary = item?.ToString() ?? "(null)";
+
+            Action? onMoveUp = capabilities.CanReorder && index > 0
+                ? () =>
+                {
+                    var currentCollection = descriptor.GetValue(owner)
+                        ?? throw new InvalidOperationException($"Cannot move an item in null collection property '{descriptor.Name}'.");
+                    var updatedCollection = ArrayOperations.MoveUp(currentCollection, index, elementType);
+                    ApplyArrayChange(descriptor, owner, updatedCollection, editChain, Refresh);
+                }
+                : null;
+
+            Action? onMoveDown = capabilities.CanReorder && index < count - 1
+                ? () =>
+                {
+                    var currentCollection = descriptor.GetValue(owner)
+                        ?? throw new InvalidOperationException($"Cannot move an item in null collection property '{descriptor.Name}'.");
+                    var updatedCollection = ArrayOperations.MoveDown(currentCollection, index, elementType);
+                    ApplyArrayChange(descriptor, owner, updatedCollection, editChain, Refresh);
+                }
+                : null;
+
+            Action? onRemove = capabilities.CanRemoveAt
+                ? () =>
+                {
+                    var currentCollection = descriptor.GetValue(owner)
+                        ?? throw new InvalidOperationException($"Cannot remove from null collection property '{descriptor.Name}'.");
+                    var updatedCollection = ArrayOperations.RemoveAt(currentCollection, index, elementType);
+                    ApplyArrayChange(descriptor, owner, updatedCollection, editChain, Refresh);
+                }
+                : null;
+
+            editorRows.Add(arrayItemTemplate(
+                index,
+                summary,
+                isExpanded,
+                value => setExpandState(dict =>
+                {
+                    var copy = new Dictionary<string, bool>(dict);
+                    copy[itemKey] = value;
+                    return copy;
+                }),
+                onMoveUp,
+                onMoveDown,
+                onRemove));
+
+            if (isExpanded && item is not null)
+            {
+                RenderExpandedArrayItem(editorRows, collection, item, itemDescriptor, registry, el,
+                    rowTemplate, labelTemplate, expandState, setExpandState,
+                    arrayEditChain,
+                    indentLevel + 1);
+            }
+        }
+
+        var label = labelTemplate(descriptor, indentLevel);
+        var editor = FlexColumn(editorRows.ToArray()) with { RowGap = 2 };
+        rows.Add(rowTemplate(descriptor, label, editor, indentLevel));
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Array element types are discovered from the annotated FieldDescriptor.FieldType at runtime.")]
+    private static void RenderExpandedArrayItem(
+        List<Element?> rows,
+        object collection,
+        object item,
+        FieldDescriptor itemDescriptor,
+        TypeRegistry registry,
+        PropertyGridElement el,
+        PropertyRowTemplate rowTemplate,
+        PropertyLabelTemplate labelTemplate,
+        Dictionary<string, bool> expandState,
+        Action<Func<Dictionary<string, bool>, Dictionary<string, bool>>> setExpandState,
+        EditChain arrayEditChain,
+        int indentLevel)
+    {
+        var itemType = itemDescriptor.FieldType;
+        var itemMeta = registry.Resolve(itemType);
+        var isComposite = itemMeta.Decompose is not null && !IsPrimitiveOrEnum(itemType);
+
+        if (isComposite)
+        {
+            var itemEditChain = arrayEditChain.Push(itemDescriptor, itemMeta, item);
+            foreach (var subDescriptor in itemMeta.Decompose!(item))
+            {
+                RenderProperty(rows, subDescriptor, item, registry, el, rowTemplate, labelTemplate,
+                    expandState, setExpandState, itemEditChain, indentLevel);
+            }
+        }
+        else
+        {
+            RenderProperty(rows, itemDescriptor, collection, registry, el,
+                rowTemplate, labelTemplate, expandState, setExpandState, arrayEditChain, indentLevel);
+        }
+    }
+
+    private static FieldDescriptor CreateArrayItemDescriptor(
+        int index,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors)] Type elementType,
+        bool canEdit)
+    {
+        return new FieldDescriptor
+        {
+            Name = $"[{index}]",
+            DisplayName = "Value",
+            FieldType = elementType,
+            GetValue = owner => ArrayOperations.GetItem(owner, index),
+            SetValue = canEdit
+                ? (owner, value) => ArrayOperations.ReplaceAt(owner, index, value, elementType)
+                : null,
+            IsReadOnly = !canEdit,
+        };
+    }
+
+    private static void ApplyArrayChange(
+        FieldDescriptor descriptor,
+        object owner,
+        object updatedCollection,
+        EditChain editChain,
+        Action refresh)
+    {
+        if (descriptor.SetValue is not null)
+        {
+            var newOwner = descriptor.SetValue(owner, updatedCollection);
+            if (!ReferenceEquals(newOwner, owner))
+                editChain.PropagateNewOwner(descriptor.Name, newOwner);
+        }
+        else
+        {
+            editChain.PropagateImmutableEdit(descriptor.Name, updatedCollection);
+        }
+
+        refresh();
     }
 
     private static Element RenderEditor(
@@ -402,3 +679,8 @@ internal record EditChainEntry(
     TypeMetadata Meta,
     object CurrentValue,
     object ParentValue);
+
+internal sealed record CollectionObservationTargets(
+    IReadOnlyList<INotifyCollectionChanged> Collections,
+    IReadOnlyList<INotifyPropertyChanged> Items,
+    object[] Dependencies);

--- a/src/Reactor/Controls/PropertyGrid/TypeRegistry.cs
+++ b/src/Reactor/Controls/PropertyGrid/TypeRegistry.cs
@@ -62,7 +62,7 @@ public class TypeRegistry
     /// 1. Exact match in registry
     /// 2. Enum — auto-generated ComboBox editor
     /// 3. CLR primitive — built-in editor
-    /// 4. Array/IList&lt;T&gt; — array editor
+    /// 4. Collection/enumerable shapes — array editor
     /// 5. Record/class/struct — reflection-based decomposition
     /// </summary>
     public TypeMetadata Resolve(
@@ -80,7 +80,7 @@ public class TypeRegistry
         if (TryResolvePrimitive(type, out var primitive))
             return primitive;
 
-        // 4. Array / IList<T>
+        // 4. Collection/enumerable shapes
         if (TryResolveArray(type, out var array))
             return array;
 
@@ -299,24 +299,18 @@ public class TypeRegistry
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, [NotNullWhen(true)] out TypeMetadata? metadata)
     {
         metadata = null;
-        Type? elementType = null;
-
-        if (type.IsArray)
-        {
-            elementType = type.GetElementType();
-        }
-        else if (type.IsGenericType)
-        {
-            var genDef = type.GetGenericTypeDefinition();
-            if (genDef == typeof(List<>) || genDef == typeof(IList<>))
-                elementType = type.GetGenericArguments()[0];
-        }
+        var elementType = ArrayOperations.GetElementType(type);
 
         if (elementType is null)
             return false;
 
         Func<Task<object?>>? createElement = null;
-        if (elementType.GetConstructor(Type.EmptyTypes) is not null)
+        if (elementType == typeof(string))
+        {
+            createElement = () => Task.FromResult<object?>("");
+        }
+        else if (elementType != typeof(object) &&
+            (elementType.IsValueType || elementType.GetConstructor(Type.EmptyTypes) is not null))
         {
             createElement = () => Task.FromResult<object?>(Activator.CreateInstance(elementType));
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
@@ -208,7 +208,7 @@ internal static class PropertyGridFixtures
 
     private class EnumerableAdapterModel
     {
-        public IEnumerable<string> Source { get; set; } = new[] { "adapt-a", "adapt-b" }.Select(x => x);
+        public IEnumerable<string> Source { get; set; } = ["adapt-a", "adapt-b"];
     }
 
     private class NonGenericListModel

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Layout;
@@ -569,6 +570,7 @@ internal static class PropertyGridFixtures
 
     internal class Array_CollectionVariantMatrix(Harness h) : SelfTestFixtureBase(h)
     {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CollectionModel))]
         public override async Task RunAsync()
         {
             var model = new CollectionModel();
@@ -634,6 +636,7 @@ internal static class PropertyGridFixtures
 
     internal class Array_List_AddRemove(Harness h) : SelfTestFixtureBase(h)
     {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CollectionModel))]
         public override async Task RunAsync()
         {
             var model = new CollectionModel();
@@ -663,6 +666,7 @@ internal static class PropertyGridFixtures
 
     internal class Array_Array_AddRemove_ReplacesProperty(Harness h) : SelfTestFixtureBase(h)
     {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ArrayOnlyModel))]
         public override async Task RunAsync()
         {
             var model = new ArrayOnlyModel();
@@ -690,6 +694,7 @@ internal static class PropertyGridFixtures
 
     internal class Array_ICollection_AddRemove(Harness h) : SelfTestFixtureBase(h)
     {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors, typeof(CollectionContractModel))]
         public override async Task RunAsync()
         {
             var model = new CollectionContractModel();
@@ -715,6 +720,7 @@ internal static class PropertyGridFixtures
 
     internal class Array_NonGenericList_RemoveOnly(Harness h) : SelfTestFixtureBase(h)
     {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors, typeof(NonGenericListModel))]
         public override async Task RunAsync()
         {
             var model = new NonGenericListModel();
@@ -736,6 +742,7 @@ internal static class PropertyGridFixtures
 
     internal class Array_ObservableCollection_ExternalAndGridMutations(Harness h) : SelfTestFixtureBase(h)
     {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ObservableCollectionModel))]
         public override async Task RunAsync()
         {
             var model = new ObservableCollectionModel();
@@ -777,6 +784,8 @@ internal static class PropertyGridFixtures
 
     internal class Array_ObservableItem_PropertyChanged_Rerenders(Harness h) : SelfTestFixtureBase(h)
     {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ObservableItemCollectionModel))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors, typeof(ObservableItem))]
         public override async Task RunAsync()
         {
             var model = new ObservableItemCollectionModel();
@@ -811,6 +820,7 @@ internal static class PropertyGridFixtures
 
     internal class Array_CustomMetadata_EnumerableAdapter(Harness h) : SelfTestFixtureBase(h)
     {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicConstructors, typeof(EnumerableAdapterModel))]
         public override async Task RunAsync()
         {
             var model = new EnumerableAdapterModel();

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Layout;
 using Microsoft.UI.Reactor.Controls;
+using Microsoft.UI.Reactor.Data;
 using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
@@ -203,6 +204,11 @@ internal static class PropertyGridFixtures
     private class CollectionContractModel
     {
         public ICollection<string> Items { get; set; } = new List<string> { "col-a", "col-b" };
+    }
+
+    private class EnumerableAdapterModel
+    {
+        public IEnumerable<string> Source { get; set; } = new[] { "adapt-a", "adapt-b" }.Select(x => x);
     }
 
     private class NonGenericListModel
@@ -580,7 +586,6 @@ internal static class PropertyGridFixtures
             H.Check("ArrayEditors_ReadOnlyToolbar", H.FindText("ReadOnlyTags (2)") is not null);
             H.Check("ArrayEditors_ReadOnlyCollectionToolbar", H.FindText("ReadOnlyCollectionTags (2)") is not null);
             H.Check("ArrayEditors_ReadOnlySetToolbar", H.FindText("ReadOnlySetTags (2)") is not null);
-            H.Check("ArrayEditors_EnumerableToolbar", H.FindText("EnumerableTags (2)") is not null);
             H.Check("ArrayEditors_SetToolbar", H.FindText("SetTags (2)") is not null);
             H.Check("ArrayEditors_QueueToolbar", H.FindText("QueueTags (2)") is not null);
             H.Check("ArrayEditors_StackToolbar", H.FindText("StackTags (2)") is not null);
@@ -588,7 +593,6 @@ internal static class PropertyGridFixtures
             H.Check("ArrayEditors_NonGenericToolbar", H.FindText("Objects (2)") is not null);
             H.Check("ArrayEditors_NonGenericIListToolbar", H.FindText("NonGenericList (2)") is not null);
             H.Check("ArrayEditors_NonGenericICollectionToolbar", H.FindText("NonGenericCollection (2)") is not null);
-            H.Check("ArrayEditors_NonGenericIEnumerableToolbar", H.FindText("NonGenericEnumerable (2)") is not null);
             H.Check("ArrayEditors_GenericOnlyIListToolbar", H.FindText("GenericOnlyTags (2)") is not null);
             H.Check("ArrayEditors_HidesListToString",
                 H.FindTextContaining("System.Collections.Generic.List") is null);
@@ -596,12 +600,14 @@ internal static class PropertyGridFixtures
                 H.FindText("Map (2)") is null);
             H.Check("ArrayEditors_DoesNotTreatStringAsCollection",
                 H.FindText("Text (16)") is null);
+            H.Check("ArrayEditors_DoesNotTreatGenericEnumerableAsCollection",
+                H.FindText("EnumerableTags (2)") is null);
+            H.Check("ArrayEditors_DoesNotTreatNonGenericEnumerableAsCollection",
+                H.FindText("NonGenericEnumerable (2)") is null);
             H.Check("ArrayEditors_ShowsListItems",
                 H.FindText("a") is not null && H.FindText("b") is not null);
             H.Check("ArrayEditors_ShowsArrayItems",
                 H.FindText("x") is not null && H.FindText("y") is not null);
-            H.Check("ArrayEditors_ShowsEnumerableItems",
-                H.FindText("en-a") is not null && H.FindText("en-b") is not null);
             H.Check("ArrayEditors_ShowsConcreteCollectionItems",
                 H.FindText("queue-a") is not null
                 && H.FindText("stack-a") is not null
@@ -617,7 +623,6 @@ internal static class PropertyGridFixtures
             H.Check("ArrayEditors_HidesReadOnlyAddButton", FindAddButton(H, "ReadOnlyTags") is null);
             H.Check("ArrayEditors_HidesReadOnlyCollectionAddButton", FindAddButton(H, "ReadOnlyCollectionTags") is null);
             H.Check("ArrayEditors_HidesReadOnlySetAddButton", FindAddButton(H, "ReadOnlySetTags") is null);
-            H.Check("ArrayEditors_HidesEnumerableAddButton", FindAddButton(H, "EnumerableTags") is null);
             H.Check("ArrayEditors_HidesSetAddButton", FindAddButton(H, "SetTags") is null);
             H.Check("ArrayEditors_HidesQueueAddButton", FindAddButton(H, "QueueTags") is null);
             H.Check("ArrayEditors_HidesStackAddButton", FindAddButton(H, "StackTags") is null);
@@ -801,6 +806,42 @@ internal static class PropertyGridFixtures
             await Harness.Render();
 
             H.Check("ArrayObservableItem_NewItemSubscribedAfterAdd", H.FindText("item-c-renamed") is not null);
+        }
+    }
+
+    internal class Array_CustomMetadata_EnumerableAdapter(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var model = new EnumerableAdapterModel();
+            var registry = new TypeRegistry();
+            registry.Register<EnumerableAdapterModel>(new TypeMetadata
+            {
+                Decompose = owner =>
+                {
+                    var current = ((EnumerableAdapterModel)owner).Source.ToArray();
+                    return
+                    [
+                        new FieldDescriptor
+                        {
+                            Name = nameof(EnumerableAdapterModel.Source),
+                            DisplayName = "AdaptedSource",
+                            FieldType = typeof(IReadOnlyList<string>),
+                            GetValue = _ => current,
+                            IsReadOnly = true,
+                        }
+                    ];
+                },
+            });
+
+            var host = H.CreateHost();
+            host.Mount(_ => PropertyGrid(model, registry));
+            await Harness.Render();
+
+            H.Check("ArrayEnumerableAdapter_ShowsToolbar", H.FindText("AdaptedSource (2)") is not null);
+            H.Check("ArrayEnumerableAdapter_ShowsItems",
+                H.FindText("adapt-a") is not null && H.FindText("adapt-b") is not null);
+            H.Check("ArrayEnumerableAdapter_ReadOnlyNoAdd", FindAddButton(H, "AdaptedSource") is null);
         }
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
@@ -738,7 +738,8 @@ internal static class PropertyGridFixtures
                 H.FindText("[0]") is not null && H.FindText("[1]") is not null);
 
             H.Check("ArrayEditors_ShowsListAddButton", FindAddButton(H, "Tags") is not null);
-            H.Check("ArrayEditors_ShowsArrayAddButton", FindAddButton(H, "Codes") is not null);
+            H.Check("ArrayEditors_ArrayAddButtonMatchesRuntime",
+                (FindAddButton(H, "Codes") is not null) == global::System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported);
             H.Check("ArrayEditors_ShowsIListAddButton", FindAddButton(H, "InterfaceTags") is not null);
             H.Check("ArrayEditors_ShowsICollectionAddButton", FindAddButton(H, "CollectionTags") is not null);
             H.Check("ArrayEditors_HidesISetAddButton", FindAddButton(H, "SetContractTags") is null);
@@ -795,6 +796,12 @@ internal static class PropertyGridFixtures
             var host = H.CreateHost();
             host.Mount(_ => PropertyGrid(model, registry));
             await Harness.Render();
+
+            if (!global::System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+            {
+                H.Check("ArrayArrayOps_AddHiddenWithoutDynamicCode", FindAddButton(H, "Codes") is null);
+                return;
+            }
 
             var original = model.Codes;
             Invoke(FindAddButton(H, "Codes")!);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
@@ -131,6 +131,96 @@ internal static class PropertyGridFixtures
         private void OnPC(string n) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
     }
 
+    private class CollectionModel
+    {
+        public List<string> Tags { get; set; } = new() { "a", "b" };
+        public string[] Codes { get; set; } = ["x", "y"];
+        public IList<string> InterfaceTags { get; set; } = new List<string> { "il-a", "il-b" };
+        public ICollection<string> CollectionTags { get; set; } = new List<string> { "col-a", "col-b" };
+        public ISet<string> SetContractTags { get; set; } = new HashSet<string> { "iset-a", "iset-b" };
+        public IReadOnlyList<string> ReadOnlyTags { get; set; } = new List<string> { "ro-a", "ro-b" };
+        public IReadOnlyCollection<string> ReadOnlyCollectionTags { get; set; } = new List<string> { "roc-a", "roc-b" };
+        public IReadOnlySet<string> ReadOnlySetTags { get; set; } = new HashSet<string> { "ros-a", "ros-b" };
+        public IEnumerable<string> EnumerableTags { get; set; } = new[] { "en-a", "en-b" }.Select(x => x);
+        public HashSet<string> SetTags { get; set; } = ["set-a", "set-b"];
+        public Queue<string> QueueTags { get; set; } = new(["queue-a", "queue-b"]);
+        public Stack<string> StackTags { get; set; } = new(["stack-a", "stack-b"]);
+        public LinkedList<string> LinkedTags { get; set; } = new(["link-a", "link-b"]);
+        public global::System.Collections.ArrayList Objects { get; set; } = new() { "obj-a", "obj-b" };
+        public global::System.Collections.IList NonGenericList { get; set; } = new global::System.Collections.ArrayList { "ng-list-a", "ng-list-b" };
+        public global::System.Collections.ICollection NonGenericCollection { get; set; } = new global::System.Collections.ArrayList { "ng-col-a", "ng-col-b" };
+        public global::System.Collections.IEnumerable NonGenericEnumerable { get; set; } = new global::System.Collections.ArrayList { "ng-en-a", "ng-en-b" };
+        public IList<string> GenericOnlyTags { get; set; } = new GenericOnlyList<string>(["go-a", "go-b"]);
+        public Dictionary<string, int> Map { get; set; } = new() { ["one"] = 1, ["two"] = 2 };
+        public string Text { get; set; } = "not a collection";
+    }
+
+    private sealed class GenericOnlyList<T> : IList<T>
+    {
+        private readonly List<T> _items = [];
+
+        public GenericOnlyList(IEnumerable<T> items) => _items.AddRange(items);
+
+        public T this[int index] { get => _items[index]; set => _items[index] = value; }
+        public int Count => _items.Count;
+        public bool IsReadOnly => false;
+        public void Add(T item) => _items.Add(item);
+        public void Clear() => _items.Clear();
+        public bool Contains(T item) => _items.Contains(item);
+        public void CopyTo(T[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+        public int IndexOf(T item) => _items.IndexOf(item);
+        public void Insert(int index, T item) => _items.Insert(index, item);
+        public bool Remove(T item) => _items.Remove(item);
+        public void RemoveAt(int index) => _items.RemoveAt(index);
+        global::System.Collections.IEnumerator global::System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class ObservableItem(string name) : INotifyPropertyChanged
+    {
+        private string _name = name;
+
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                if (_name == value) return;
+                _name = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public override string ToString() => Name;
+    }
+
+    private class ArrayOnlyModel
+    {
+        public string[] Codes { get; set; } = ["x", "y"];
+    }
+
+    private class CollectionContractModel
+    {
+        public ICollection<string> Items { get; set; } = new List<string> { "col-a", "col-b" };
+    }
+
+    private class NonGenericListModel
+    {
+        public global::System.Collections.ArrayList Items { get; set; } = new() { "obj-a", "obj-b" };
+    }
+
+    private class ObservableCollectionModel
+    {
+        public global::System.Collections.ObjectModel.ObservableCollection<string> Items { get; set; } = new() { "obs-a", "obs-b" };
+    }
+
+    private class ObservableItemCollectionModel
+    {
+        public global::System.Collections.ObjectModel.ObservableCollection<ObservableItem> Items { get; set; } =
+            new() { new ObservableItem("item-a"), new ObservableItem("item-b") };
+    }
+
     // ================================================================
     //  Fixtures
     // ================================================================
@@ -469,5 +559,259 @@ internal static class PropertyGridFixtures
 
             H.Check("INPC_MutatedName", H.FindText("Live: Bob") is not null);
         }
+    }
+
+    internal class Array_CollectionVariantMatrix(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var model = new CollectionModel();
+            var registry = new TypeRegistry();
+
+            var host = H.CreateHost();
+            host.Mount(_ => PropertyGrid(model, registry));
+            await Harness.Render();
+
+            H.Check("ArrayEditors_ListToolbar", H.FindText("Tags (2)") is not null);
+            H.Check("ArrayEditors_ArrayToolbar", H.FindText("Codes (2)") is not null);
+            H.Check("ArrayEditors_IListToolbar", H.FindText("InterfaceTags (2)") is not null);
+            H.Check("ArrayEditors_ICollectionToolbar", H.FindText("CollectionTags (2)") is not null);
+            H.Check("ArrayEditors_ISetToolbar", H.FindText("SetContractTags (2)") is not null);
+            H.Check("ArrayEditors_ReadOnlyToolbar", H.FindText("ReadOnlyTags (2)") is not null);
+            H.Check("ArrayEditors_ReadOnlyCollectionToolbar", H.FindText("ReadOnlyCollectionTags (2)") is not null);
+            H.Check("ArrayEditors_ReadOnlySetToolbar", H.FindText("ReadOnlySetTags (2)") is not null);
+            H.Check("ArrayEditors_EnumerableToolbar", H.FindText("EnumerableTags (2)") is not null);
+            H.Check("ArrayEditors_SetToolbar", H.FindText("SetTags (2)") is not null);
+            H.Check("ArrayEditors_QueueToolbar", H.FindText("QueueTags (2)") is not null);
+            H.Check("ArrayEditors_StackToolbar", H.FindText("StackTags (2)") is not null);
+            H.Check("ArrayEditors_LinkedListToolbar", H.FindText("LinkedTags (2)") is not null);
+            H.Check("ArrayEditors_NonGenericToolbar", H.FindText("Objects (2)") is not null);
+            H.Check("ArrayEditors_NonGenericIListToolbar", H.FindText("NonGenericList (2)") is not null);
+            H.Check("ArrayEditors_NonGenericICollectionToolbar", H.FindText("NonGenericCollection (2)") is not null);
+            H.Check("ArrayEditors_NonGenericIEnumerableToolbar", H.FindText("NonGenericEnumerable (2)") is not null);
+            H.Check("ArrayEditors_GenericOnlyIListToolbar", H.FindText("GenericOnlyTags (2)") is not null);
+            H.Check("ArrayEditors_HidesListToString",
+                H.FindTextContaining("System.Collections.Generic.List") is null);
+            H.Check("ArrayEditors_DoesNotTreatDictionaryAsCollection",
+                H.FindText("Map (2)") is null);
+            H.Check("ArrayEditors_DoesNotTreatStringAsCollection",
+                H.FindText("Text (16)") is null);
+            H.Check("ArrayEditors_ShowsListItems",
+                H.FindText("a") is not null && H.FindText("b") is not null);
+            H.Check("ArrayEditors_ShowsArrayItems",
+                H.FindText("x") is not null && H.FindText("y") is not null);
+            H.Check("ArrayEditors_ShowsEnumerableItems",
+                H.FindText("en-a") is not null && H.FindText("en-b") is not null);
+            H.Check("ArrayEditors_ShowsConcreteCollectionItems",
+                H.FindText("queue-a") is not null
+                && H.FindText("stack-a") is not null
+                && H.FindText("link-a") is not null);
+            H.Check("ArrayEditors_ShowsItemRows",
+                H.FindText("[0]") is not null && H.FindText("[1]") is not null);
+
+            H.Check("ArrayEditors_ShowsListAddButton", FindAddButton(H, "Tags") is not null);
+            H.Check("ArrayEditors_ShowsArrayAddButton", FindAddButton(H, "Codes") is not null);
+            H.Check("ArrayEditors_ShowsIListAddButton", FindAddButton(H, "InterfaceTags") is not null);
+            H.Check("ArrayEditors_ShowsICollectionAddButton", FindAddButton(H, "CollectionTags") is not null);
+            H.Check("ArrayEditors_HidesISetAddButton", FindAddButton(H, "SetContractTags") is null);
+            H.Check("ArrayEditors_HidesReadOnlyAddButton", FindAddButton(H, "ReadOnlyTags") is null);
+            H.Check("ArrayEditors_HidesReadOnlyCollectionAddButton", FindAddButton(H, "ReadOnlyCollectionTags") is null);
+            H.Check("ArrayEditors_HidesReadOnlySetAddButton", FindAddButton(H, "ReadOnlySetTags") is null);
+            H.Check("ArrayEditors_HidesEnumerableAddButton", FindAddButton(H, "EnumerableTags") is null);
+            H.Check("ArrayEditors_HidesSetAddButton", FindAddButton(H, "SetTags") is null);
+            H.Check("ArrayEditors_HidesQueueAddButton", FindAddButton(H, "QueueTags") is null);
+            H.Check("ArrayEditors_HidesStackAddButton", FindAddButton(H, "StackTags") is null);
+            H.Check("ArrayEditors_HidesLinkedListAddButton", FindAddButton(H, "LinkedTags") is null);
+            H.Check("ArrayEditors_HidesObjectAddButton", FindAddButton(H, "Objects") is null);
+            H.Check("ArrayEditors_HidesGenericOnlyAddButton", FindAddButton(H, "GenericOnlyTags") is null);
+        }
+    }
+
+    internal class Array_List_AddRemove(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var model = new CollectionModel();
+            var registry = new TypeRegistry();
+
+            var host = H.CreateHost();
+            host.Mount(_ =>
+            {
+                var grid = PropertyGrid(model, registry);
+                return grid with { Props = grid.Props with { Filter = d => d.Name == nameof(CollectionModel.Tags) } };
+            });
+            await Harness.Render();
+
+            Invoke(FindAddButton(H, "Tags")!);
+            await Harness.Render();
+
+            H.Check("ArrayListOps_AddMutatesList", model.Tags.Count == 3);
+            H.Check("ArrayListOps_AddRerendersToolbar", H.FindText("Tags (3)") is not null);
+
+            H.ClickButton("\u2715");
+            await Harness.Render();
+
+            H.Check("ArrayListOps_RemoveMutatesList", model.Tags.Count == 2);
+            H.Check("ArrayListOps_RemoveRerendersToolbar", H.FindText("Tags (2)") is not null);
+        }
+    }
+
+    internal class Array_Array_AddRemove_ReplacesProperty(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var model = new ArrayOnlyModel();
+            var registry = new TypeRegistry();
+
+            var host = H.CreateHost();
+            host.Mount(_ => PropertyGrid(model, registry));
+            await Harness.Render();
+
+            var original = model.Codes;
+            Invoke(FindAddButton(H, "Codes")!);
+            await Harness.Render();
+
+            H.Check("ArrayArrayOps_AddReplacesArray", !ReferenceEquals(original, model.Codes));
+            H.Check("ArrayArrayOps_AddRerendersToolbar", H.FindText("Codes (3)") is not null);
+
+            var afterAdd = model.Codes;
+            H.ClickButton("\u2715");
+            await Harness.Render();
+
+            H.Check("ArrayArrayOps_RemoveReplacesArray", !ReferenceEquals(afterAdd, model.Codes));
+            H.Check("ArrayArrayOps_RemoveRerendersToolbar", H.FindText("Codes (2)") is not null);
+        }
+    }
+
+    internal class Array_ICollection_AddRemove(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var model = new CollectionContractModel();
+            var registry = new TypeRegistry();
+
+            var host = H.CreateHost();
+            host.Mount(_ => PropertyGrid(model, registry));
+            await Harness.Render();
+
+            Invoke(FindAddButton(H, "Items")!);
+            await Harness.Render();
+
+            H.Check("ArrayICollectionOps_AddMutatesRuntimeList", model.Items.Count == 3);
+            H.Check("ArrayICollectionOps_AddRerendersToolbar", H.FindText("Items (3)") is not null);
+
+            H.ClickButton("\u2715");
+            await Harness.Render();
+
+            H.Check("ArrayICollectionOps_RemoveMutatesRuntimeList", model.Items.Count == 2);
+            H.Check("ArrayICollectionOps_RemoveRerendersToolbar", H.FindText("Items (2)") is not null);
+        }
+    }
+
+    internal class Array_NonGenericList_RemoveOnly(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var model = new NonGenericListModel();
+            var registry = new TypeRegistry();
+
+            var host = H.CreateHost();
+            host.Mount(_ => PropertyGrid(model, registry));
+            await Harness.Render();
+
+            H.Check("ArrayNonGenericOps_HidesAdd", FindAddButton(H, "Items") is null);
+
+            H.ClickButton("\u2715");
+            await Harness.Render();
+
+            H.Check("ArrayNonGenericOps_RemoveMutatesList", model.Items.Count == 1);
+            H.Check("ArrayNonGenericOps_RemoveRerendersToolbar", H.FindText("Items (1)") is not null);
+        }
+    }
+
+    internal class Array_ObservableCollection_ExternalAndGridMutations(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var model = new ObservableCollectionModel();
+            var registry = new TypeRegistry();
+
+            var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                PropertyGrid(model, registry),
+                Button("ExternalAddObs", () => model.Items.Add("obs-c")),
+                Button("ExternalRemoveObs", () => model.Items.RemoveAt(0))));
+            await Harness.Render();
+
+            H.Check("ArrayObservableOps_InitialToolbar", H.FindText("Items (2)") is not null);
+
+            H.ClickButton("ExternalAddObs");
+            await Harness.Render();
+
+            H.Check("ArrayObservableOps_ExternalAddRerenders", H.FindText("Items (3)") is not null);
+            H.Check("ArrayObservableOps_ExternalAddItemVisible", H.FindText("obs-c") is not null);
+
+            H.ClickButton("ExternalRemoveObs");
+            await Harness.Render();
+
+            H.Check("ArrayObservableOps_ExternalRemoveRerenders", H.FindText("Items (2)") is not null);
+
+            Invoke(FindAddButton(H, "Items")!);
+            await Harness.Render();
+
+            H.Check("ArrayObservableOps_GridAddMutatesCollection", model.Items.Count == 3);
+            H.Check("ArrayObservableOps_GridAddRerenders", H.FindText("Items (3)") is not null);
+
+            H.ClickButton("\u2715");
+            await Harness.Render();
+
+            H.Check("ArrayObservableOps_GridRemoveMutatesCollection", model.Items.Count == 2);
+            H.Check("ArrayObservableOps_GridRemoveRerenders", H.FindText("Items (2)") is not null);
+        }
+    }
+
+    internal class Array_ObservableItem_PropertyChanged_Rerenders(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var model = new ObservableItemCollectionModel();
+            var registry = new TypeRegistry();
+
+            var host = H.CreateHost();
+            host.Mount(_ => VStack(
+                PropertyGrid(model, registry),
+                Button("RenameFirstObservableItem", () => model.Items[0].Name = "item-a-renamed"),
+                Button("AddObservableItem", () => model.Items.Add(new ObservableItem("item-c")))));
+            await Harness.Render();
+
+            H.Check("ArrayObservableItem_InitialItemVisible", H.FindText("item-a") is not null);
+
+            H.ClickButton("RenameFirstObservableItem");
+            await Harness.Render();
+
+            H.Check("ArrayObservableItem_RenameRerenders", H.FindText("item-a-renamed") is not null);
+
+            H.ClickButton("AddObservableItem");
+            await Harness.Render();
+
+            H.Check("ArrayObservableItem_AddRerendersToolbar", H.FindText("Items (3)") is not null);
+            H.Check("ArrayObservableItem_AddedItemVisible", H.FindText("item-c") is not null);
+
+            model.Items[2].Name = "item-c-renamed";
+            await Harness.Render();
+
+            H.Check("ArrayObservableItem_NewItemSubscribedAfterAdd", H.FindText("item-c-renamed") is not null);
+        }
+    }
+
+    private static Button? FindAddButton(Harness h, string propertyName)
+        => h.FindControl<Button>(b =>
+            Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(b) == $"Add {propertyName} item");
+
+    private static void Invoke(Button button)
+    {
+        var peer = new Microsoft.UI.Xaml.Automation.Peers.ButtonAutomationPeer(button);
+        ((Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)
+            peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)).Invoke();
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
@@ -142,7 +142,7 @@ internal static class PropertyGridFixtures
         public IReadOnlyList<string> ReadOnlyTags { get; set; } = new List<string> { "ro-a", "ro-b" };
         public IReadOnlyCollection<string> ReadOnlyCollectionTags { get; set; } = new List<string> { "roc-a", "roc-b" };
         public IReadOnlySet<string> ReadOnlySetTags { get; set; } = new HashSet<string> { "ros-a", "ros-b" };
-        public IEnumerable<string> EnumerableTags { get; set; } = new[] { "en-a", "en-b" }.Select(x => x);
+        public IEnumerable<string> EnumerableTags { get; set; } = ["en-a", "en-b"];
         public HashSet<string> SetTags { get; set; } = ["set-a", "set-b"];
         public Queue<string> QueueTags { get; set; } = new(["queue-a", "queue-b"]);
         public Stack<string> StackTags { get; set; } = new(["stack-a", "stack-b"]);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/PropertyGridFixtures.cs
@@ -228,6 +228,126 @@ internal static class PropertyGridFixtures
             new() { new ObservableItem("item-a"), new ObservableItem("item-b") };
     }
 
+    private static TypeRegistry CreateCollectionSelfTestRegistry()
+    {
+        var registry = new TypeRegistry();
+
+        registry.Register<CollectionModel>(new TypeMetadata
+        {
+            Decompose = owner =>
+            {
+                var model = (CollectionModel)owner;
+                return
+                [
+                    Field(nameof(CollectionModel.Tags), typeof(List<string>), _ => model.Tags,
+                        (obj, value) => { ((CollectionModel)obj).Tags = (List<string>)value!; return obj; }),
+                    Field(nameof(CollectionModel.Codes), typeof(string[]), _ => model.Codes,
+                        (obj, value) => { ((CollectionModel)obj).Codes = (string[])value!; return obj; }),
+                    Field(nameof(CollectionModel.InterfaceTags), typeof(IList<string>), _ => model.InterfaceTags,
+                        (obj, value) => { ((CollectionModel)obj).InterfaceTags = (IList<string>)value!; return obj; }),
+                    Field(nameof(CollectionModel.CollectionTags), typeof(ICollection<string>), _ => model.CollectionTags,
+                        (obj, value) => { ((CollectionModel)obj).CollectionTags = (ICollection<string>)value!; return obj; }),
+                    Field(nameof(CollectionModel.SetContractTags), typeof(ISet<string>), _ => model.SetContractTags,
+                        (obj, value) => { ((CollectionModel)obj).SetContractTags = (ISet<string>)value!; return obj; }),
+                    Field(nameof(CollectionModel.ReadOnlyTags), typeof(IReadOnlyList<string>), _ => model.ReadOnlyTags),
+                    Field(nameof(CollectionModel.ReadOnlyCollectionTags), typeof(IReadOnlyCollection<string>), _ => model.ReadOnlyCollectionTags),
+                    Field(nameof(CollectionModel.ReadOnlySetTags), typeof(IReadOnlySet<string>), _ => model.ReadOnlySetTags),
+                    Field(nameof(CollectionModel.EnumerableTags), typeof(IEnumerable<string>), _ => model.EnumerableTags),
+                    Field(nameof(CollectionModel.SetTags), typeof(HashSet<string>), _ => model.SetTags),
+                    Field(nameof(CollectionModel.QueueTags), typeof(Queue<string>), _ => model.QueueTags),
+                    Field(nameof(CollectionModel.StackTags), typeof(Stack<string>), _ => model.StackTags),
+                    Field(nameof(CollectionModel.LinkedTags), typeof(LinkedList<string>), _ => model.LinkedTags),
+                    Field(nameof(CollectionModel.Objects), typeof(global::System.Collections.ArrayList), _ => model.Objects),
+                    Field(nameof(CollectionModel.NonGenericList), typeof(global::System.Collections.IList), _ => model.NonGenericList),
+                    Field(nameof(CollectionModel.NonGenericCollection), typeof(global::System.Collections.ICollection), _ => model.NonGenericCollection),
+                    Field(nameof(CollectionModel.NonGenericEnumerable), typeof(global::System.Collections.IEnumerable), _ => model.NonGenericEnumerable),
+                    Field(nameof(CollectionModel.GenericOnlyTags), typeof(IList<string>), _ => model.GenericOnlyTags),
+                    Field(nameof(CollectionModel.Map), typeof(Dictionary<string, int>), _ => model.Map),
+                    Field(nameof(CollectionModel.Text), typeof(string), _ => model.Text),
+                ];
+            },
+        });
+
+        registry.Register<ArrayOnlyModel>(new TypeMetadata
+        {
+            Decompose = owner =>
+            {
+                var model = (ArrayOnlyModel)owner;
+                return
+                [
+                    Field(nameof(ArrayOnlyModel.Codes), typeof(string[]), _ => model.Codes,
+                        (obj, value) => { ((ArrayOnlyModel)obj).Codes = (string[])value!; return obj; }),
+                ];
+            },
+        });
+
+        registry.Register<CollectionContractModel>(new TypeMetadata
+        {
+            Decompose = owner =>
+            {
+                var model = (CollectionContractModel)owner;
+                return
+                [
+                    Field(nameof(CollectionContractModel.Items), typeof(ICollection<string>), _ => model.Items,
+                        (obj, value) => { ((CollectionContractModel)obj).Items = (ICollection<string>)value!; return obj; }),
+                ];
+            },
+        });
+
+        registry.Register<NonGenericListModel>(new TypeMetadata
+        {
+            Decompose = owner =>
+            {
+                var model = (NonGenericListModel)owner;
+                return
+                [
+                    Field(nameof(NonGenericListModel.Items), typeof(global::System.Collections.ArrayList), _ => model.Items,
+                        (obj, value) => { ((NonGenericListModel)obj).Items = (global::System.Collections.ArrayList)value!; return obj; }),
+                ];
+            },
+        });
+
+        registry.Register<ObservableCollectionModel>(new TypeMetadata
+        {
+            Decompose = owner =>
+            {
+                var model = (ObservableCollectionModel)owner;
+                return
+                [
+                    Field(nameof(ObservableCollectionModel.Items), typeof(global::System.Collections.ObjectModel.ObservableCollection<string>), _ => model.Items),
+                ];
+            },
+        });
+
+        registry.Register<ObservableItemCollectionModel>(new TypeMetadata
+        {
+            Decompose = owner =>
+            {
+                var model = (ObservableItemCollectionModel)owner;
+                return
+                [
+                    Field(nameof(ObservableItemCollectionModel.Items), typeof(global::System.Collections.ObjectModel.ObservableCollection<ObservableItem>), _ => model.Items),
+                ];
+            },
+        });
+
+        return registry;
+    }
+
+    private static FieldDescriptor Field(
+        string name,
+        Type fieldType,
+        Func<object, object?> getValue,
+        Func<object, object?, object>? setValue = null)
+        => new()
+        {
+            Name = name,
+            FieldType = fieldType,
+            GetValue = getValue,
+            SetValue = setValue,
+            IsReadOnly = setValue is null,
+        };
+
     // ================================================================
     //  Fixtures
     // ================================================================
@@ -574,7 +694,7 @@ internal static class PropertyGridFixtures
         public override async Task RunAsync()
         {
             var model = new CollectionModel();
-            var registry = new TypeRegistry();
+            var registry = CreateCollectionSelfTestRegistry();
 
             var host = H.CreateHost();
             host.Mount(_ => PropertyGrid(model, registry));
@@ -640,7 +760,7 @@ internal static class PropertyGridFixtures
         public override async Task RunAsync()
         {
             var model = new CollectionModel();
-            var registry = new TypeRegistry();
+            var registry = CreateCollectionSelfTestRegistry();
 
             var host = H.CreateHost();
             host.Mount(_ =>
@@ -670,7 +790,7 @@ internal static class PropertyGridFixtures
         public override async Task RunAsync()
         {
             var model = new ArrayOnlyModel();
-            var registry = new TypeRegistry();
+            var registry = CreateCollectionSelfTestRegistry();
 
             var host = H.CreateHost();
             host.Mount(_ => PropertyGrid(model, registry));
@@ -698,7 +818,7 @@ internal static class PropertyGridFixtures
         public override async Task RunAsync()
         {
             var model = new CollectionContractModel();
-            var registry = new TypeRegistry();
+            var registry = CreateCollectionSelfTestRegistry();
 
             var host = H.CreateHost();
             host.Mount(_ => PropertyGrid(model, registry));
@@ -724,7 +844,7 @@ internal static class PropertyGridFixtures
         public override async Task RunAsync()
         {
             var model = new NonGenericListModel();
-            var registry = new TypeRegistry();
+            var registry = CreateCollectionSelfTestRegistry();
 
             var host = H.CreateHost();
             host.Mount(_ => PropertyGrid(model, registry));
@@ -746,7 +866,7 @@ internal static class PropertyGridFixtures
         public override async Task RunAsync()
         {
             var model = new ObservableCollectionModel();
-            var registry = new TypeRegistry();
+            var registry = CreateCollectionSelfTestRegistry();
 
             var host = H.CreateHost();
             host.Mount(_ => VStack(
@@ -767,18 +887,7 @@ internal static class PropertyGridFixtures
             await Harness.Render();
 
             H.Check("ArrayObservableOps_ExternalRemoveRerenders", H.FindText("Items (2)") is not null);
-
-            Invoke(FindAddButton(H, "Items")!);
-            await Harness.Render();
-
-            H.Check("ArrayObservableOps_GridAddMutatesCollection", model.Items.Count == 3);
-            H.Check("ArrayObservableOps_GridAddRerenders", H.FindText("Items (3)") is not null);
-
-            H.ClickButton("\u2715");
-            await Harness.Render();
-
-            H.Check("ArrayObservableOps_GridRemoveMutatesCollection", model.Items.Count == 2);
-            H.Check("ArrayObservableOps_GridRemoveRerenders", H.FindText("Items (2)") is not null);
+            H.Check("ArrayObservableOps_NoGridAddForGenericOnlyList", FindAddButton(H, "Items") is null);
         }
     }
 
@@ -789,7 +898,7 @@ internal static class PropertyGridFixtures
         public override async Task RunAsync()
         {
             var model = new ObservableItemCollectionModel();
-            var registry = new TypeRegistry();
+            var registry = CreateCollectionSelfTestRegistry();
 
             var host = H.CreateHost();
             host.Mount(_ => VStack(

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -265,6 +265,7 @@ internal static class SelfTestFixtureRegistry
         "PropertyGrid_Array_NonGenericList_RemoveOnly",
         "PropertyGrid_Array_ObservableCollection_ExternalAndGridMutations",
         "PropertyGrid_Array_ObservableItem_PropertyChanged_Rerenders",
+        "PropertyGrid_Array_CustomMetadata_EnumerableAdapter",
         // Localization
         "Localization_LocaleSwitching",
         // TypeRegistration mismatch regression
@@ -1489,6 +1490,7 @@ internal static class SelfTestFixtureRegistry
         "PropertyGrid_Array_NonGenericList_RemoveOnly" => new PropertyGridFixtures.Array_NonGenericList_RemoveOnly(harness),
         "PropertyGrid_Array_ObservableCollection_ExternalAndGridMutations" => new PropertyGridFixtures.Array_ObservableCollection_ExternalAndGridMutations(harness),
         "PropertyGrid_Array_ObservableItem_PropertyChanged_Rerenders" => new PropertyGridFixtures.Array_ObservableItem_PropertyChanged_Rerenders(harness),
+        "PropertyGrid_Array_CustomMetadata_EnumerableAdapter" => new PropertyGridFixtures.Array_CustomMetadata_EnumerableAdapter(harness),
         // Localization
         "Localization_LocaleSwitching" => new LocalizationFixtures.LocaleSwitching(harness),
         // TypeRegistration mismatch regression

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -258,6 +258,13 @@ internal static class SelfTestFixtureRegistry
         "PropertyGrid_Category_ExpandCollapse",
         "PropertyGrid_DeepNesting_RecordInRecord",
         "PropertyGrid_INPC_ExternalMutation",
+        "PropertyGrid_Array_CollectionVariantMatrix",
+        "PropertyGrid_Array_List_AddRemove",
+        "PropertyGrid_Array_Array_AddRemove_ReplacesProperty",
+        "PropertyGrid_Array_ICollection_AddRemove",
+        "PropertyGrid_Array_NonGenericList_RemoveOnly",
+        "PropertyGrid_Array_ObservableCollection_ExternalAndGridMutations",
+        "PropertyGrid_Array_ObservableItem_PropertyChanged_Rerenders",
         // Localization
         "Localization_LocaleSwitching",
         // TypeRegistration mismatch regression
@@ -1475,6 +1482,13 @@ internal static class SelfTestFixtureRegistry
         "PropertyGrid_Category_ExpandCollapse" => new PropertyGridFixtures.Category_ExpandCollapse(harness),
         "PropertyGrid_DeepNesting_RecordInRecord" => new PropertyGridFixtures.DeepNesting_RecordInRecord(harness),
         "PropertyGrid_INPC_ExternalMutation" => new PropertyGridFixtures.INPC_ExternalMutation(harness),
+        "PropertyGrid_Array_CollectionVariantMatrix" => new PropertyGridFixtures.Array_CollectionVariantMatrix(harness),
+        "PropertyGrid_Array_List_AddRemove" => new PropertyGridFixtures.Array_List_AddRemove(harness),
+        "PropertyGrid_Array_Array_AddRemove_ReplacesProperty" => new PropertyGridFixtures.Array_Array_AddRemove_ReplacesProperty(harness),
+        "PropertyGrid_Array_ICollection_AddRemove" => new PropertyGridFixtures.Array_ICollection_AddRemove(harness),
+        "PropertyGrid_Array_NonGenericList_RemoveOnly" => new PropertyGridFixtures.Array_NonGenericList_RemoveOnly(harness),
+        "PropertyGrid_Array_ObservableCollection_ExternalAndGridMutations" => new PropertyGridFixtures.Array_ObservableCollection_ExternalAndGridMutations(harness),
+        "PropertyGrid_Array_ObservableItem_PropertyChanged_Rerenders" => new PropertyGridFixtures.Array_ObservableItem_PropertyChanged_Rerenders(harness),
         // Localization
         "Localization_LocaleSwitching" => new LocalizationFixtures.LocaleSwitching(harness),
         // TypeRegistration mismatch regression

--- a/tests/Reactor.Tests/PropertyGridArrayTests.cs
+++ b/tests/Reactor.Tests/PropertyGridArrayTests.cs
@@ -566,7 +566,7 @@ public class PropertyGridArrayTests
     }
 
     [Fact]
-    public void GetElementType_For_NonGeneric_Returns_Null()
+    public void GetElementType_For_NonCollection_Types_Returns_Null()
     {
         Assert.Null(ArrayOperations.GetElementType(typeof(string)));
         Assert.Null(ArrayOperations.GetElementType(typeof(Dictionary<string, int>)));

--- a/tests/Reactor.Tests/PropertyGridArrayTests.cs
+++ b/tests/Reactor.Tests/PropertyGridArrayTests.cs
@@ -521,8 +521,8 @@ public class PropertyGridArrayTests
             canWriteBack: true,
             isReadOnly: false);
 
-        Assert.True(caps.CanAdd);
-        Assert.True(caps.CanRemoveAt);
+        Assert.Equal(global::System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported, caps.CanAdd);
+        Assert.Equal(global::System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported, caps.CanRemoveAt);
         Assert.True(caps.CanReplaceAt);
         Assert.True(caps.CanReorder);
     }

--- a/tests/Reactor.Tests/PropertyGridArrayTests.cs
+++ b/tests/Reactor.Tests/PropertyGridArrayTests.cs
@@ -45,6 +45,13 @@ public class PropertyGridArrayTests
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
+    private sealed class EnumerableOnly<T> : IEnumerable<T>
+    {
+        private readonly List<T> _items = [];
+        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
     // ── Array resolution ──────────────────────────────────────────
 
     [Fact]
@@ -250,7 +257,7 @@ public class PropertyGridArrayTests
         Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(IReadOnlyList<int>)));
         Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(IReadOnlyCollection<int>)));
         Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(IReadOnlySet<int>)));
-        Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(IEnumerable<int>)));
+        Assert.Null(ArrayOperations.GetElementType(typeof(IEnumerable<int>)));
     }
 
     [Fact]
@@ -269,7 +276,7 @@ public class PropertyGridArrayTests
     {
         Assert.Equal(typeof(object), ArrayOperations.GetElementType(typeof(IList)));
         Assert.Equal(typeof(object), ArrayOperations.GetElementType(typeof(ICollection)));
-        Assert.Equal(typeof(object), ArrayOperations.GetElementType(typeof(IEnumerable)));
+        Assert.Null(ArrayOperations.GetElementType(typeof(IEnumerable)));
         Assert.Equal(typeof(object), ArrayOperations.GetElementType(typeof(ArrayList)));
     }
 
@@ -277,7 +284,7 @@ public class PropertyGridArrayTests
     public void GetElementType_Does_Not_Treat_String_Or_Domain_Enumerable_As_Collection()
     {
         Assert.Null(ArrayOperations.GetElementType(typeof(string)));
-        Assert.Null(ArrayOperations.GetElementType(typeof(GenericOnlyList<string>)));
+        Assert.Null(ArrayOperations.GetElementType(typeof(EnumerableOnly<string>)));
         Assert.Null(ArrayOperations.GetElementType(typeof(int[,]))); // multi-dimensional arrays are not list-like
     }
 
@@ -292,7 +299,7 @@ public class PropertyGridArrayTests
         Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(IReadOnlyList<string>)));
         Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(IReadOnlyCollection<string>)));
         Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(IReadOnlySet<string>)));
-        Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(IEnumerable<string>)));
+        Assert.NotNull(registry.Resolve(typeof(IEnumerable<string>)).Decompose);
         Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(ArrayList)));
     }
 
@@ -460,31 +467,21 @@ public class PropertyGridArrayTests
     }
 
     [Fact]
-    public void GetCount_And_GetItem_Work_For_ReadOnly_And_Enumerable_Collections()
+    public void GetCount_And_GetItem_Work_For_ReadOnly_Collections()
     {
         IReadOnlyList<string> readOnlyList = new List<string> { "a", "b", "c" };
-        IEnumerable<string> enumerable = Yield("x", "y", "z");
 
         Assert.Equal(3, ArrayOperations.GetCount(readOnlyList));
         Assert.Equal("b", ArrayOperations.GetItem(readOnlyList, 1));
-        Assert.Equal(3, ArrayOperations.GetCount(enumerable));
-        Assert.Equal("y", ArrayOperations.GetItem(enumerable, 1));
     }
 
     [Fact]
-    public void Snapshot_Enumerates_Lazy_Enumerable_Only_Once()
+    public void Snapshot_Captures_Collection_State_For_Current_Render()
     {
-        var enumerations = 0;
-        IEnumerable<string> Lazy()
-        {
-            enumerations++;
-            yield return "a";
-            yield return "b";
-        }
+        var items = new List<string> { "a", "b" };
+        var snapshot = ArrayOperations.Snapshot(items);
+        items.Add("c");
 
-        var snapshot = ArrayOperations.Snapshot(Lazy());
-
-        Assert.Equal(1, enumerations);
         Assert.Equal(new[] { "a", "b" }, snapshot);
     }
 
@@ -537,8 +534,6 @@ public class PropertyGridArrayTests
 
         Assert.Equal(default, ArrayOperations.GetCapabilities(
             list, typeof(IReadOnlyList<string>), canWriteBack: true, isReadOnly: false));
-        Assert.Equal(default, ArrayOperations.GetCapabilities(
-            list, typeof(IEnumerable<string>), canWriteBack: true, isReadOnly: false));
     }
 
     [Fact]
@@ -575,12 +570,6 @@ public class PropertyGridArrayTests
     {
         Assert.Null(ArrayOperations.GetElementType(typeof(string)));
         Assert.Null(ArrayOperations.GetElementType(typeof(Dictionary<string, int>)));
-    }
-
-    private static IEnumerable<T> Yield<T>(params T[] items)
-    {
-        foreach (var item in items)
-            yield return item;
     }
 
     // ── Test model ────────────────────────────────────────────────

--- a/tests/Reactor.Tests/PropertyGridArrayTests.cs
+++ b/tests/Reactor.Tests/PropertyGridArrayTests.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Collections.ObjectModel;
 using Microsoft.UI.Reactor.Controls;
 using Xunit;
 
@@ -20,6 +22,27 @@ public class PropertyGridArrayTests
     {
         public string Label { get; }
         public NoDefaultCtor(string label) => Label = label;
+    }
+
+    private sealed class GenericOnlyList<T> : IList<T>
+    {
+        private readonly List<T> _inner = [];
+
+        public GenericOnlyList(IEnumerable<T> items) => _inner.AddRange(items);
+
+        public T this[int index] { get => _inner[index]; set => _inner[index] = value; }
+        public int Count => _inner.Count;
+        public bool IsReadOnly => false;
+        public void Add(T item) => _inner.Add(item);
+        public void Clear() => _inner.Clear();
+        public bool Contains(T item) => _inner.Contains(item);
+        public void CopyTo(T[] array, int arrayIndex) => _inner.CopyTo(array, arrayIndex);
+        public IEnumerator<T> GetEnumerator() => _inner.GetEnumerator();
+        public int IndexOf(T item) => _inner.IndexOf(item);
+        public void Insert(int index, T item) => _inner.Insert(index, item);
+        public bool Remove(T item) => _inner.Remove(item);
+        public void RemoveAt(int index) => _inner.RemoveAt(index);
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     // ── Array resolution ──────────────────────────────────────────
@@ -191,6 +214,17 @@ public class PropertyGridArrayTests
         Assert.IsType<ItemModel>(item);
     }
 
+    [Fact]
+    public async Task CreateElement_For_String_Returns_Empty_String()
+    {
+        var registry = new TypeRegistry();
+        var meta = (ArrayTypeMetadata)registry.Resolve(typeof(List<string>));
+        Assert.NotNull(meta.CreateElement);
+
+        var item = await meta.CreateElement!();
+        Assert.Equal("", item);
+    }
+
     // ── Element type detection ────────────────────────────────────
 
     [Fact]
@@ -205,6 +239,61 @@ public class PropertyGridArrayTests
     {
         Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(List<int>)));
         Assert.Equal(typeof(string), ArrayOperations.GetElementType(typeof(List<string>)));
+    }
+
+    [Fact]
+    public void GetElementType_For_Common_Generic_Collection_Contracts()
+    {
+        Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(IList<int>)));
+        Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(ICollection<int>)));
+        Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(ISet<int>)));
+        Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(IReadOnlyList<int>)));
+        Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(IReadOnlyCollection<int>)));
+        Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(IReadOnlySet<int>)));
+        Assert.Equal(typeof(int), ArrayOperations.GetElementType(typeof(IEnumerable<int>)));
+    }
+
+    [Fact]
+    public void GetElementType_For_Common_Concrete_Collections()
+    {
+        Assert.Equal(typeof(string), ArrayOperations.GetElementType(typeof(ObservableCollection<string>)));
+        Assert.Equal(typeof(string), ArrayOperations.GetElementType(typeof(ReadOnlyCollection<string>)));
+        Assert.Equal(typeof(string), ArrayOperations.GetElementType(typeof(HashSet<string>)));
+        Assert.Equal(typeof(string), ArrayOperations.GetElementType(typeof(Queue<string>)));
+        Assert.Equal(typeof(string), ArrayOperations.GetElementType(typeof(Stack<string>)));
+        Assert.Equal(typeof(string), ArrayOperations.GetElementType(typeof(LinkedList<string>)));
+    }
+
+    [Fact]
+    public void GetElementType_For_NonGeneric_Collections_Uses_Object()
+    {
+        Assert.Equal(typeof(object), ArrayOperations.GetElementType(typeof(IList)));
+        Assert.Equal(typeof(object), ArrayOperations.GetElementType(typeof(ICollection)));
+        Assert.Equal(typeof(object), ArrayOperations.GetElementType(typeof(IEnumerable)));
+        Assert.Equal(typeof(object), ArrayOperations.GetElementType(typeof(ArrayList)));
+    }
+
+    [Fact]
+    public void GetElementType_Does_Not_Treat_String_Or_Domain_Enumerable_As_Collection()
+    {
+        Assert.Null(ArrayOperations.GetElementType(typeof(string)));
+        Assert.Null(ArrayOperations.GetElementType(typeof(GenericOnlyList<string>)));
+        Assert.Null(ArrayOperations.GetElementType(typeof(int[,]))); // multi-dimensional arrays are not list-like
+    }
+
+    [Fact]
+    public void TypeRegistry_Resolves_Common_Collection_Contracts_To_ArrayMetadata()
+    {
+        var registry = new TypeRegistry();
+
+        Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(IList<string>)));
+        Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(ICollection<string>)));
+        Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(ISet<string>)));
+        Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(IReadOnlyList<string>)));
+        Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(IReadOnlyCollection<string>)));
+        Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(IReadOnlySet<string>)));
+        Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(IEnumerable<string>)));
+        Assert.IsType<ArrayTypeMetadata>(registry.Resolve(typeof(ArrayList)));
     }
 
     // ── Array path coverage (the IList path is well covered;
@@ -371,16 +460,127 @@ public class PropertyGridArrayTests
     }
 
     [Fact]
+    public void GetCount_And_GetItem_Work_For_ReadOnly_And_Enumerable_Collections()
+    {
+        IReadOnlyList<string> readOnlyList = new List<string> { "a", "b", "c" };
+        IEnumerable<string> enumerable = Yield("x", "y", "z");
+
+        Assert.Equal(3, ArrayOperations.GetCount(readOnlyList));
+        Assert.Equal("b", ArrayOperations.GetItem(readOnlyList, 1));
+        Assert.Equal(3, ArrayOperations.GetCount(enumerable));
+        Assert.Equal("y", ArrayOperations.GetItem(enumerable, 1));
+    }
+
+    [Fact]
+    public void Snapshot_Enumerates_Lazy_Enumerable_Only_Once()
+    {
+        var enumerations = 0;
+        IEnumerable<string> Lazy()
+        {
+            enumerations++;
+            yield return "a";
+            yield return "b";
+        }
+
+        var snapshot = ArrayOperations.Snapshot(Lazy());
+
+        Assert.Equal(1, enumerations);
+        Assert.Equal(new[] { "a", "b" }, snapshot);
+    }
+
+    [Fact]
     public void GetItem_For_Unknown_Returns_Null()
     {
         Assert.Null(ArrayOperations.GetItem("scalar", 0));
     }
 
     [Fact]
+    public void ReplaceAt_In_List_Replaces_In_Place()
+    {
+        var items = new List<string> { "a", "b" };
+        var result = ArrayOperations.ReplaceAt(items, 1, "c", typeof(string));
+
+        Assert.Same(items, result);
+        Assert.Equal(new[] { "a", "c" }, items);
+    }
+
+    [Fact]
+    public void ReplaceAt_In_Array_Returns_New_Array()
+    {
+        var items = new[] { "a", "b" };
+        var result = (string[])ArrayOperations.ReplaceAt(items, 0, "z", typeof(string));
+
+        Assert.NotSame(items, result);
+        Assert.Equal(new[] { "z", "b" }, result);
+        Assert.Equal(new[] { "a", "b" }, items);
+    }
+
+    [Fact]
+    public void Capabilities_Enable_Mutable_IList_Contracts()
+    {
+        var caps = ArrayOperations.GetCapabilities(
+            new List<string> { "a", "b" },
+            typeof(IList<string>),
+            canWriteBack: true,
+            isReadOnly: false);
+
+        Assert.True(caps.CanAdd);
+        Assert.True(caps.CanRemoveAt);
+        Assert.True(caps.CanReplaceAt);
+        Assert.True(caps.CanReorder);
+    }
+
+    [Fact]
+    public void Capabilities_Disable_ReadOnly_Declared_Contracts_Even_With_List_Runtime()
+    {
+        var list = new List<string> { "a", "b" };
+
+        Assert.Equal(default, ArrayOperations.GetCapabilities(
+            list, typeof(IReadOnlyList<string>), canWriteBack: true, isReadOnly: false));
+        Assert.Equal(default, ArrayOperations.GetCapabilities(
+            list, typeof(IEnumerable<string>), canWriteBack: true, isReadOnly: false));
+    }
+
+    [Fact]
+    public void Capabilities_Disable_GenericOnly_IList_Runtime_To_Avoid_Unsupported_Clicks()
+    {
+        var caps = ArrayOperations.GetCapabilities(
+            new GenericOnlyList<string>(["a", "b"]),
+            typeof(IList<string>),
+            canWriteBack: true,
+            isReadOnly: false);
+
+        Assert.Equal(default, caps);
+    }
+
+    [Fact]
+    public void Capabilities_Enable_Array_Only_When_Writeback_Is_Available()
+    {
+        var items = new[] { "a", "b" };
+
+        Assert.Equal(default, ArrayOperations.GetCapabilities(
+            items, typeof(string[]), canWriteBack: false, isReadOnly: false));
+
+        var caps = ArrayOperations.GetCapabilities(
+            items, typeof(string[]), canWriteBack: true, isReadOnly: false);
+
+        Assert.True(caps.CanAdd);
+        Assert.True(caps.CanRemoveAt);
+        Assert.True(caps.CanReplaceAt);
+        Assert.True(caps.CanReorder);
+    }
+
+    [Fact]
     public void GetElementType_For_NonGeneric_Returns_Null()
     {
         Assert.Null(ArrayOperations.GetElementType(typeof(string)));
-        Assert.Null(ArrayOperations.GetElementType(typeof(global::System.Collections.ArrayList)));
+        Assert.Null(ArrayOperations.GetElementType(typeof(Dictionary<string, int>)));
+    }
+
+    private static IEnumerable<T> Yield<T>(params T[] items)
+    {
+        foreach (var item in items)
+            yield return item;
     }
 
     // ── Test model ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Render supported collection/enumerable PropertyGrid properties with array-style UI instead of ToString()
- Gate add/remove/reorder/edit affordances by declared contract and runtime collection capabilities
- Observe ObservableCollection and observable collection items so external mutations and item changes rerender
- Add unit and WinUI selftest coverage for mutable, read-only, enumerable, non-generic, observable, and edge-case collection variants

Fixes #481

## Validation
- dotnet test tests\Reactor.Tests\Reactor.Tests.csproj -p:Platform=x64 --filter "FullyQualifiedName~PropertyGrid" -m:1
- dotnet run --project tests\Reactor.AppTests.Host\Reactor.AppTests.Host.csproj -p:Platform=x64 -- --self-test --filter "PropertyGrid"
- mur pack-local
