### PR TITLE
Fix OptionalThemeInteraction NativeAOT stress flake

### DIFF
--- a/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
@@ -130,8 +130,15 @@ internal sealed class OneWayClearValuePropEntry<TElement, TControl, TValue> : Pr
         var vOpt = _get(el);
         if (vOpt.HasValue)
             _set(ctrl, vOpt.Value);
-        else
+        else if (!ReferenceEquals(ctrl.ReadLocalValue(_dp), DependencyProperty.UnsetValue))
+        {
+            // Mount path skips ClearValue when no local value exists. Fresh
+            // controls and clean pool-reused controls hit this no-op; we
+            // avoid an unnecessary native re-evaluation that has been
+            // implicated in low-rate NativeAOT crashes around style/theme
+            // resolution (OptionalThemeInteraction stress flake).
             ctrl.ClearValue(_dp);
+        }
     }
 
     public override void Update(TControl ctrl, TElement oldEl, TElement newEl)

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/OptionalThemeInteractionFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/OptionalThemeInteractionFixture.cs
@@ -21,6 +21,16 @@ internal static class OptionalThemeInteractionFixture
     {
         public override async Task RunAsync()
         {
+            // Defensive: clear any prior fixture's visual-tree state before
+            // we install raw WinUI DependencyObjects (a fresh Button + two
+            // Styles + three Brushes). Without this isolation, neighboring
+            // popup-heavy fixtures (e.g. OptionalEchoStrandRegression's
+            // AutoSuggestBox) have left WinUI in a state that races with
+            // this fixture's Style swap + ClearValue churn under NativeAOT,
+            // producing a STATUS_STACK_BUFFER_OVERRUN ~0.2% of stress runs.
+            H.SetContent(null);
+            await Harness.Render();
+
             // Two theme-keyed brushes installed as Style fallbacks. The
             // descriptor's .OneWay(...dp:) entry decides between writing a
             // local value (force-assert) and clearing the local value (Unset
@@ -36,55 +46,70 @@ internal static class OptionalThemeInteractionFixture
 
             var button = new WinUI.Button { Content = "theme-target", Style = lightStyle };
             H.SetContent(button);
-            await Harness.Render();
+            try
+            {
+                await Harness.Render();
 
-            var entry = new ControlDescriptor<ThemedElement, WinUI.Button>()
-                .OneWay(e => e.Background, (c, v) => c.Background = v, WinUI.Control.BackgroundProperty)
-                .Properties[0];
+                var entry = new ControlDescriptor<ThemedElement, WinUI.Button>()
+                    .OneWay(e => e.Background, (c, v) => c.Background = v, WinUI.Control.BackgroundProperty)
+                    .Properties[0];
 
-            // Mount with Unset → no local value → style fallback brush flows through.
-            var unsetEl = new ThemedElement(Optional<Brush>.Unset);
-            entry.Mount(button, unsetEl);
-            await Harness.Render();
-            H.Check(
-                "OptionalThemeInteraction_Unset_NoLocalValue",
-                ReferenceEquals(DependencyProperty.UnsetValue, button.ReadLocalValue(WinUI.Control.BackgroundProperty)));
-            H.Check(
-                "OptionalThemeInteraction_Unset_LightStyleFlowsThrough",
-                ReferenceEquals(button.Background, lightBrush));
+                // Mount with Unset → no local value → style fallback brush flows through.
+                var unsetEl = new ThemedElement(Optional<Brush>.Unset);
+                entry.Mount(button, unsetEl);
+                await Harness.Render();
+                H.Check(
+                    "OptionalThemeInteraction_Unset_NoLocalValue",
+                    ReferenceEquals(DependencyProperty.UnsetValue, button.ReadLocalValue(WinUI.Control.BackgroundProperty)));
+                H.Check(
+                    "OptionalThemeInteraction_Unset_LightStyleFlowsThrough",
+                    ReferenceEquals(button.Background, lightBrush));
 
-            // Simulate a theme switch by swapping the Style — equivalent to
-            // RequestedTheme=Dark resolving a different ThemeResource. The
-            // Unset prop should let the new style's default brush flow.
-            button.Style = darkStyle;
-            await Harness.Render();
-            H.Check(
-                "OptionalThemeInteraction_Unset_DarkStyleFlowsThroughAfterSwitch",
-                ReferenceEquals(button.Background, darkBrush));
-            H.Check(
-                "OptionalThemeInteraction_Unset_NoLocalValueAfterSwitch",
-                ReferenceEquals(DependencyProperty.UnsetValue, button.ReadLocalValue(WinUI.Control.BackgroundProperty)));
+                // Simulate a theme switch by swapping the Style — equivalent to
+                // RequestedTheme=Dark resolving a different ThemeResource. The
+                // Unset prop should let the new style's default brush flow.
+                button.Style = darkStyle;
+                await Harness.Render();
+                H.Check(
+                    "OptionalThemeInteraction_Unset_DarkStyleFlowsThroughAfterSwitch",
+                    ReferenceEquals(button.Background, darkBrush));
+                H.Check(
+                    "OptionalThemeInteraction_Unset_NoLocalValueAfterSwitch",
+                    ReferenceEquals(DependencyProperty.UnsetValue, button.ReadLocalValue(WinUI.Control.BackgroundProperty)));
 
-            // Force-assert via Update → local value wins regardless of style.
-            entry.Update(button, unsetEl, new ThemedElement(Optional<Brush>.Of(forceBrush)));
-            await Harness.Render();
-            H.Check(
-                "OptionalThemeInteraction_HasValue_ForcedBrushWinsOverDarkStyle",
-                ReferenceEquals(button.Background, forceBrush));
+                // Force-assert via Update → local value wins regardless of style.
+                entry.Update(button, unsetEl, new ThemedElement(Optional<Brush>.Of(forceBrush)));
+                await Harness.Render();
+                H.Check(
+                    "OptionalThemeInteraction_HasValue_ForcedBrushWinsOverDarkStyle",
+                    ReferenceEquals(button.Background, forceBrush));
 
-            // Swap style back; force-assert local value still wins.
-            button.Style = lightStyle;
-            await Harness.Render();
-            H.Check(
-                "OptionalThemeInteraction_HasValue_ForcedBrushSurvivesStyleSwitch",
-                ReferenceEquals(button.Background, forceBrush));
+                // Swap style back; force-assert local value still wins.
+                button.Style = lightStyle;
+                await Harness.Render();
+                H.Check(
+                    "OptionalThemeInteraction_HasValue_ForcedBrushSurvivesStyleSwitch",
+                    ReferenceEquals(button.Background, forceBrush));
 
-            // Back to Unset → local value cleared → new style flows through.
-            entry.Update(button, new ThemedElement(Optional<Brush>.Of(forceBrush)), unsetEl);
-            await Harness.Render();
-            H.Check(
-                "OptionalThemeInteraction_UnsetAgain_LightStyleRestored",
-                ReferenceEquals(button.Background, lightBrush));
+                // Back to Unset → local value cleared → new style flows through.
+                entry.Update(button, new ThemedElement(Optional<Brush>.Of(forceBrush)), unsetEl);
+                await Harness.Render();
+                H.Check(
+                    "OptionalThemeInteraction_UnsetAgain_LightStyleRestored",
+                    ReferenceEquals(button.Background, lightBrush));
+            }
+            finally
+            {
+                // Detach the raw button + styles + brushes from the visual
+                // tree so the next fixture starts clean. Without this, the
+                // DependencyObjects linger until GC, holding COM-backed
+                // resources whose teardown can race with the next fixture's
+                // mount under NativeAOT.
+                button.ClearValue(WinUI.Control.BackgroundProperty);
+                button.ClearValue(FrameworkElement.StyleProperty);
+                H.SetContent(null);
+                await Harness.Render();
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Two recent CI Stress runs hit `STATUS_STACK_BUFFER_OVERRUN` (0xC0000409, CRT fail-fast) inside the `OptionalThemeInteraction` selftest fixture under NativeAOT (~0.2% rate, AOT-only). Two distinct crash sites both involve the `.OneWay(...dp:)` `ClearValue` path:

| Run | Shard / iter | Crash site |
|---|---|---|
| [AOT #27065270132](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/27065270132) | shard 14 iter 18 | Immediately after `# Running: OptionalThemeInteraction`, while installing the fresh button + two Styles into a visual tree still holding the prior fixture's AutoSuggestBox popup machinery. |
| [AOT #27065270132](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/27065270132) | shard 2 iter 7 | ~1.16s after `HasValue_ForcedBrushSurvivesStyleSwitch`, inside `Harness.Render()` following the final `Update(Of → Unset)` → `ClearValue` call. |

The other 4 iteration failures across both runs were unrelated (`OverlayLifecycle`, `PDM_WrapGrid_Reverse`, `OptionalTriStateCheckBox`, `ControlledOptionalTextInputFamily`).

## Fix

Two targeted changes, validated by a rubber-duck design pass:

1. **`OneWayClearValuePropEntry.Mount`** now gates `ClearValue` on `ReadLocalValue(_dp) != UnsetValue`. Fresh controls (and clean pool-reused controls) hit the no-op path; pool-reused controls carrying stale local values are still cleared correctly. Eliminates an unnecessary native re-evaluation implicated in the stress crash.

2. **`OptionalThemeInteractionFixture`** now isolates itself with `try/finally`:
   - **Start**: `H.SetContent(null) + Render` to drain prior fixture's popup / visual-tree state before installing raw `Button` + two `Style`s + three `SolidColorBrush`es.
   - **End**: `ClearValue(Background/Style)` + `SetContent(null) + Render` to release the raw DependencyObjects promptly so the next fixture starts clean.

All 7 original `H.Check` assertions are preserved — this is purely a hardening change, not a coverage cut.

## Verification

- ✅ `dotnet build` clean (0 warnings).
- ✅ Unit tests: **9202 passed, 0 failed**.
- ✅ Adjacent Spec-050 fixtures (`OneWayClearValue`, `InitialOnly`, `OptionalEchoStrand`, `OptionalTriState`, `OptionalSetterCollision`, `ControlledOptionalTextInputFamily`) all pass.
- ✅ Local AOT stress 30× against the full `Optional*` suite (same neighbor sequence that crashed shard 14): **0/30 failures**.
- ✅ Local JIT stress 30× against `OptionalTheme*`: **0/30 failures**.
- ✅ AOT publish: no new IL warnings (same 3 pre-existing).

CI Stress should be re-run after merge to confirm the rate drop.
