### PR TITLE
Fix gallery source snippets + Copy button + Optional<T> factory audit (closes #538)

### DIFF
--- a/samples/ReactorGallery/ControlPages/Collections/FlipViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/FlipViewPage.cs
@@ -26,7 +26,12 @@ class FlipViewPage : Component
                                 .Background(c).Size(300, 200)
                         ).ToArray()
                     ),
-                    @"FlipView(\n    Border(TextBlock(""Item 1"")).Background(""#FF4444"").Size(300,200),\n    Border(TextBlock(""Item 2"")).Background(""#44AA44"").Size(300,200)\n)"),
+                    """
+                    FlipView(
+                        Border(TextBlock("Item 1")).Background("#FF4444").Size(300, 200),
+                        Border(TextBlock("Item 2")).Background("#44AA44").Size(300, 200)
+                    )
+                    """),
 
                 SampleCard("Data-Driven FlipView",
                     FlipView(
@@ -39,7 +44,13 @@ class FlipViewPage : Component
                             ).Center()
                         ).Background(c).Size(300, 200)
                     ),
-                    @"FlipView(\n    colors,\n    c => c,\n    (c, i) => Border(VStack(...)).Background(c).Size(300, 200)\n)")
+                    """
+                    FlipView(
+                        colors,
+                        c => c,
+                        (c, i) => Border(VStack(...)).Background(c).Size(300, 200)
+                    )
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Collections/GridViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/GridViewPage.cs
@@ -35,7 +35,13 @@ class GridViewPage : Component
                                 .Size(100, 100)
                                 .CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft)                        ).ToArray()
                     ).SelectionMode(selectionMode),
-                    @"GridView(\n    items.Select(i =>\n        Border(TextBlock($""Item {i}"")).Size(100,100)\n    ).ToArray()\n).SelectionMode(ListViewSelectionMode.Multiple)",
+                    """
+                    GridView(
+                        items.Select(i =>
+                            Border(TextBlock($"Item {i}")).Size(100, 100)
+                        ).ToArray()
+                    ).SelectionMode(ListViewSelectionMode.Multiple)
+                    """,
                     OptionPanel(
                         TextBlock("Selection Mode"),
                         ComboBox(modes, mode, setMode)
@@ -50,7 +56,12 @@ class GridViewPage : Component
                             .Foreground("#FFFFFF")
                             .Size(80, 80).CornerRadius(ThemeResource.CornerRadius("OverlayCornerRadius").TopLeft)
                     ),
-                    @"GridView(\n    items, s => s,\n    (s, i) => Border(TextBlock(s)).Size(80,80)\n)")
+                    """
+                    GridView(
+                        items, s => s,
+                        (s, i) => Border(TextBlock(s)).Size(80, 80)
+                    )
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Collections/ItemsViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/ItemsViewPage.cs
@@ -40,7 +40,16 @@ class ItemsViewPage : Component
                             ).Padding(12)
                         ).Background(Theme.SubtleFill).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft).Margin(4)
                     ).Height(300),
-                    @"ItemsView(\n    products,\n    p => p.Name,\n    (p, i) => Border(VStack(\n        TextBlock(p.Name).Bold(),\n        TextBlock($""${p.Price:F2}"")\n    ))\n)"),
+                    """
+                    ItemsView(
+                        products,
+                        p => p.Name,
+                        (p, i) => Border(VStack(
+                            TextBlock(p.Name).Bold(),
+                            TextBlock($"${p.Price:F2}")
+                        ))
+                    )
+                    """),
 
                 SampleCard("Compact ItemsView",
                     ItemsView(
@@ -52,7 +61,12 @@ class ItemsViewPage : Component
                             TextBlock($"${p.Price:F2}").Foreground(Theme.AccentText)
                         ).Padding(8)
                     ).Height(250),
-                    @"ItemsView(\n    products, p => p.Name,\n    (p, i) => HStack(8, TextBlock(p.Name).Flex(grow:1), TextBlock(price))\n)")
+                    """
+                    ItemsView(
+                        products, p => p.Name,
+                        (p, i) => HStack(8, TextBlock(p.Name).Flex(grow: 1), TextBlock(price))
+                    )
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Collections/ListBoxPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/ListBoxPage.cs
@@ -24,7 +24,10 @@ class ListBoxPage : Component
                         ListBox(fruits, selected, setSelected),
                         TextBlock($"Selected: {fruits[selected]}").Foreground(Theme.SecondaryText)
                     ),
-                    @"var (selected, setSelected) = UseState(0);\nListBox(fruits, selected, setSelected)"),
+                    """
+                    var (selected, setSelected) = UseState(0);
+                    ListBox(fruits, selected, setSelected)
+                    """),
 
                 SampleCard("Styled ListBox",
                     ListBox(

--- a/samples/ReactorGallery/ControlPages/Collections/ListViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/ListViewPage.cs
@@ -70,7 +70,11 @@ class ListViewPage : Component
                     ListView(
                         items.Select(i => TextBlock(i) as Element).ToArray()
                     ).SelectionMode(selectionMode).Height(250),
-                    @"ListView(\n    TextBlock(""Apples""), TextBlock(""Bananas""), ...\n).SelectionMode(ListViewSelectionMode.Multiple)",
+                    """
+                    ListView(
+                        TextBlock("Apples"), TextBlock("Bananas"), ...
+                    ).SelectionMode(ListViewSelectionMode.Multiple)
+                    """,
                     OptionPanel(
                         TextBlock("Selection Mode"),
                         ComboBox(modes, mode, setMode)
@@ -86,7 +90,15 @@ class ListViewPage : Component
                             TextBlock(s)
                         )
                     ).Height(250),
-                    @"ListView(\n    items, s => s,\n    (s, i) => HStack(8,\n        Border(TextBlock($""{i+1}"")).Size(28,28),\n        TextBlock(s)\n    )\n)"),
+                    """
+                    ListView(
+                        items, s => s,
+                        (s, i) => HStack(8,
+                            Border(TextBlock($"{i + 1}")).Size(28, 28),
+                            TextBlock(s)
+                        )
+                    )
+                    """),
 
                 // ── Animated edit (spec 042 — keyed reconciliation + Animate) ──
                 SampleCard("Animated edit (spec 042)",

--- a/samples/ReactorGallery/ControlPages/Collections/TreeViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/TreeViewPage.cs
@@ -31,7 +31,15 @@ class TreeViewPage : Component
                             TreeNode("Family")),
                         TreeNode("Music")
                     ).Height(300),
-                    @"TreeView(\n    TreeNode(""Documents"",\n        TreeNode(""Work"",\n            TreeNode(""Report.docx""),\n            TreeNode(""Slides.pptx""))),\n    TreeNode(""Pictures"", ...)\n)"),
+                    """
+                    TreeView(
+                        TreeNode("Documents",
+                            TreeNode("Work",
+                                TreeNode("Report.docx"),
+                                TreeNode("Slides.pptx"))),
+                        TreeNode("Pictures", ...)
+                    )
+                    """),
 
                 SampleCard("Deeply Nested TreeView",
                     TreeView(
@@ -44,7 +52,14 @@ class TreeViewPage : Component
                             TreeNode("Level 1B",
                                 TreeNode("Level 2C")))
                     ).Height(250),
-                    @"TreeView(\n    TreeNode(""Root"",\n        TreeNode(""Level 1A"",\n            TreeNode(""Level 2A"",\n                TreeNode(""Level 3A""))))\n)")
+                    """
+                    TreeView(
+                        TreeNode("Root",
+                            TreeNode("Level 1A",
+                                TreeNode("Level 2A",
+                                    TreeNode("Level 3A"))))
+                    )
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Layout/BorderPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/BorderPage.cs
@@ -24,7 +24,12 @@ class BorderPage : Component
                         .WithBorder(Theme.CardStroke, thickness)
                         .CornerRadius(radius)
                         .Background(Theme.SubtleFill),
-                    @"Border(TextBlock(""Content"").Padding(16))\n    .WithBorder(Theme.CardStroke)\n    .CornerRadius(8)\n    .Background(Theme.SubtleFill)",
+                    """
+                    Border(TextBlock("Content").Padding(16))
+                        .WithBorder(Theme.CardStroke)
+                        .CornerRadius(8)
+                        .Background(Theme.SubtleFill)
+                    """,
                     OptionPanel(
                         TextBlock("Corner Radius"),
                         Slider(radius, 0, 32, setRadius),
@@ -38,7 +43,12 @@ class BorderPage : Component
                         Border(TextBlock("Green").Center().Padding(12)).WithBorder("#44AA44", 2).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft),
                         Border(TextBlock("Blue").Center().Padding(12)).WithBorder("#4444FF", 2).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft)
                     ),
-                    @"HStack(12,\n    Border(TextBlock(""Red"")).WithBorder(""#FF4444"", 2),\n    Border(TextBlock(""Green"")).WithBorder(""#44AA44"", 2)\n)")
+                    """
+                    HStack(12,
+                        Border(TextBlock("Red")).WithBorder("#FF4444", 2),
+                        Border(TextBlock("Green")).WithBorder("#44AA44", 2)
+                    )
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Layout/CanvasPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/CanvasPage.cs
@@ -27,7 +27,12 @@ class CanvasPage : Component
                             Rectangle().Size(80, 80).Background("#45B7D1").Canvas(left: 110, top: 90)
                         )
                     ).Size(250, 200).Background(Theme.SubtleFill).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft),
-                    @"Canvas(\n    Rectangle().Size(80,80).Background(""#FF6B6B"").Canvas(left: 10, top: 10),\n    Rectangle().Size(80,80).Background(""#4ECDC4"").Canvas(left: 60, top: 50)\n)"),
+                    """
+                    Canvas(
+                        Rectangle().Size(80, 80).Background("#FF6B6B").Canvas(left: 10, top: 10),
+                        Rectangle().Size(80, 80).Background("#4ECDC4").Canvas(left: 60, top: 50)
+                    )
+                    """),
 
                 SampleCard("Interactive Positioning",
                     VStack(8,

--- a/samples/ReactorGallery/ControlPages/Layout/ExpanderPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/ExpanderPage.cs
@@ -36,14 +36,21 @@ class ExpanderPage : Component
                             TextBlock("Log level: Debug")
                         ), expanded2, setExpanded2).Width(350)
                     ),
-                    @"Expander(""Settings"", VStack(\n    TextBlock(""Option 1: Enabled""), ...\n), expanded, setExpanded)"),
+                    """
+                    Expander("Settings", VStack(
+                        TextBlock("Option 1: Enabled"), ...
+                    ), expanded, setExpanded)
+                    """),
 
                 SampleCard("Direction Control",
                     Expander("Expand Direction", VStack(4,
                         TextBlock("This content appears based on the direction setting."),
                         TextBlock("Try switching between Down and Up.")
                     ), true).Direction(direction).Width(350),
-                    @"Expander(""Header"", content, true)\n    .Direction(ExpandDirection.Up)",
+                    """
+                    Expander("Header", content, true)
+                        .Direction(ExpandDirection.Up)
+                    """,
                     OptionPanel(
                         TextBlock("Direction"),
                         ComboBox(new[] { "Down", "Up" }, dirIndex, setDirIndex)

--- a/samples/ReactorGallery/ControlPages/Layout/FlexPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/FlexPage.cs
@@ -51,7 +51,15 @@ class FlexPage : Component
                             RowGap = 8,
                         }
                     ).Size(400, 250).Background(Theme.SubtleFill).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft),
-                    @"new FlexElement(children) {\n    Direction = FlexDirection.Row,\n    JustifyContent = FlexJustify.SpaceBetween,\n    AlignItems = FlexAlign.Center,\n    Wrap = FlexWrap.Wrap\n}",
+                    """
+                    new FlexElement(children)
+                    {
+                        Direction = FlexDirection.Row,
+                        JustifyContent = FlexJustify.SpaceBetween,
+                        AlignItems = FlexAlign.Center,
+                        Wrap = FlexWrap.Wrap,
+                    }
+                    """,
                     OptionPanel(
                         TextBlock("Direction"), ComboBox(dirs, dirIndex, setDirIndex),
                         TextBlock("Justify"), ComboBox(justifies, justifyIndex, setJustifyIndex),
@@ -75,7 +83,10 @@ class FlexPage : Component
                         Direction = FlexDirection.Row,
                         ColumnGap = 8,
                     },
-                    @"Border(...).Flex(grow: 1)  // takes 1 share\nBorder(...).Flex(grow: 2)  // takes 2 shares"),
+                    """
+                    Border(...).Flex(grow: 1)  // takes 1 share
+                    Border(...).Flex(grow: 2)  // takes 2 shares
+                    """),
 
                 SampleCard("FlexRow & FlexColumn Shortcuts",
                     HStack(16,
@@ -92,7 +103,10 @@ class FlexPage : Component
                             )
                         )
                     ),
-                    @"FlexRow(Box(""A""), Box(""B""), Box(""C""))\nFlexColumn(Box(""X""), Box(""Y""), Box(""Z""))")
+                    """
+                    FlexRow(Box("A"), Box("B"), Box("C"))
+                    FlexColumn(Box("X"), Box("Y"), Box("Z"))
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Layout/GridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/GridPage.cs
@@ -27,7 +27,14 @@ class GridPage : Component
                         Border(TextBlock("2,2").Center().Padding(12)).Background("#9B59B6").Foreground("#FFFFFF").Grid(row: 1, column: 1),
                         Border(TextBlock("2,3").Center().Padding(12)).Background("#1ABC9C").Foreground("#FFFFFF").Grid(row: 1, column: 2)
                     ).Width(400),
-                    @"Grid(\n    columns: [""*"", ""*"", ""*""],\n    rows: [""Auto"", ""Auto""],\n    Border(TextBlock(""1,1"")).Grid(row: 0, column: 0),\n    Border(TextBlock(""1,2"")).Grid(row: 0, column: 1), ...\n)"),
+                    """
+                    Grid(
+                        columns: [GridSize.Star(), GridSize.Star(), GridSize.Star()],
+                        rows: [GridSize.Auto, GridSize.Auto],
+                        Border(TextBlock("1,1")).Grid(row: 0, column: 0),
+                        Border(TextBlock("1,2")).Grid(row: 0, column: 1), ...
+                    )
+                    """),
 
                 SampleCard("Column & Row Spanning",
                     Grid(
@@ -42,7 +49,10 @@ class GridPage : Component
                         Border(TextBlock("Footer (spans 3)").Center().Foreground("#FFFFFF"))
                             .Background("#2C3E50").Grid(row: 2, column: 0, columnSpan: 3)
                     ).Width(400),
-                    @"Border(TextBlock(""Header"")).Grid(row: 0, column: 0, columnSpan: 3)\nBorder(TextBlock(""Center"")).Grid(row: 1, column: 1, columnSpan: 2)"),
+                    """
+                    Border(TextBlock("Header")).Grid(row: 0, column: 0, columnSpan: 3)
+                    Border(TextBlock("Center")).Grid(row: 1, column: 1, columnSpan: 2)
+                    """),
 
                 SampleCard("Mixed Sizing",
                     Grid(
@@ -52,7 +62,13 @@ class GridPage : Component
                         Border(TextBlock("1*").Center().Padding(8)).Background("#27AE60").Foreground("#FFFFFF").Grid(row: 0, column: 1),
                         Border(TextBlock("2*").Center().Padding(8)).Background("#8E44AD").Foreground("#FFFFFF").Grid(row: 0, column: 2)
                     ).Width(400),
-                    @"Grid(\n    columns: [""100"", ""*"", ""2*""], rows: [""Auto""],\n    // 100px fixed, 1 star, 2 star proportional\n)")
+                    """
+                    Grid(
+                        columns: [GridSize.Px(100), GridSize.Star(), GridSize.Star(2)],
+                        rows: [GridSize.Auto]
+                        // 100px fixed, 1 star, 2 star proportional
+                    )
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Layout/RelativePanelPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/RelativePanelPage.cs
@@ -34,7 +34,13 @@ class RelativePanelPage : Component
                                 .Margin(0, 8, 0, 0)
                         )
                     ).Size(400, 200).Background(Theme.SubtleFill).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft),
-                    @"RelativePanel(\n    Border(""Top-Left"").RelativePanel(name: ""topLeft"",\n        alignLeftWithPanel: true, alignTopWithPanel: true),\n    Border(""Right"").RelativePanel(name: ""r"", rightOf: ""topLeft"")\n)"),
+                    """
+                    RelativePanel(
+                        Border("Top-Left").RelativePanel(name: "topLeft",
+                            alignLeftWithPanel: true, alignTopWithPanel: true),
+                        Border("Right").RelativePanel(name: "r", rightOf: "topLeft")
+                    )
+                    """),
 
                 SampleCard("Panel Alignment",
                     Border(
@@ -52,7 +58,11 @@ class RelativePanelPage : Component
                                     alignBottomWithPanel: true)
                         )
                     ).Size(400, 200).Background(Theme.SubtleFill).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft),
-                    @"Border(""Center"").RelativePanel(name: ""center"",\n    alignHorizontalCenterWithPanel: true,\n    alignVerticalCenterWithPanel: true)")
+                    """
+                    Border("Center").RelativePanel(name: "center",
+                        alignHorizontalCenterWithPanel: true,
+                        alignVerticalCenterWithPanel: true)
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Layout/ScrollViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/ScrollViewPage.cs
@@ -29,7 +29,13 @@ class ScrollViewPage : Component
                             )
                         )
                     ).Size(300, 200).WithBorder(Theme.CardStroke).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft),
-                    @"ScrollView(\n    VStack(4, items.Select(i =>\n        Border(TextBlock($""Item {i}"")).Padding(8)\n    ).ToArray())\n)",
+                    """
+                    ScrollView(
+                        VStack(4, items.Select(i =>
+                            Border(TextBlock($"Item {i}")).Padding(8)
+                        ).ToArray())
+                    )
+                    """,
                     OptionPanel(
                         TextBlock($"Item count: {(int)itemCount}"),
                         Slider(itemCount, 5, 50, setItemCount)
@@ -46,7 +52,12 @@ class ScrollViewPage : Component
                             )
                         ) with { ContentOrientation = Microsoft.UI.Xaml.Controls.ScrollingContentOrientation.Horizontal })
                     ).Height(80).Width(350).WithBorder(Theme.CardStroke).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft),
-                    @"(ScrollView(HStack(...)) with {\n    ContentOrientation = ScrollingContentOrientation.Horizontal\n})"),
+                    """
+                    ScrollView(HStack(...)) with
+                    {
+                        ContentOrientation = ScrollingContentOrientation.Horizontal
+                    }
+                    """),
 
                 SampleCard("Classic ScrollViewer (legacy)",
                     Border(
@@ -60,7 +71,13 @@ class ScrollViewPage : Component
                         ) with { HorizontalScrollMode = Microsoft.UI.Xaml.Controls.ScrollMode.Disabled,
                                  HorizontalScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility.Disabled })
                     ).Size(300, 160).WithBorder(Theme.CardStroke).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft),
-                    @"(ScrollViewer(VStack(...)) with {\n    HorizontalScrollMode = ScrollMode.Disabled,\n    HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled\n})")
+                    """
+                    ScrollViewer(VStack(...)) with
+                    {
+                        HorizontalScrollMode = ScrollMode.Disabled,
+                        HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled
+                    }
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Layout/SplitViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/SplitViewPage.cs
@@ -44,7 +44,13 @@ class SplitViewPage : Component
                         ) with { IsPaneOpen = isOpen })
                         .Set(sv => sv.DisplayMode = displayMode)
                     ).Size(500, 250).WithBorder(Theme.CardStroke).CornerRadius(4),
-                    @"SplitView(\n    pane: VStack(8, TextBlock(""Pane""), ...),\n    content: VStack(8, ...)\n) with { IsPaneOpen = isOpen }\n.Set(sv => sv.DisplayMode = SplitViewDisplayMode.Inline)",
+                    """
+                    SplitView(
+                        pane: VStack(8, TextBlock("Pane"), ...),
+                        content: VStack(8, ...)
+                    ) with { IsPaneOpen = isOpen }
+                    .Set(sv => sv.DisplayMode = SplitViewDisplayMode.Inline)
+                    """,
                     OptionPanel(
                         TextBlock("Display Mode"),
                         ComboBox(modes, modeIndex, setModeIndex),

--- a/samples/ReactorGallery/ControlPages/Layout/StackPanelPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/StackPanelPage.cs
@@ -29,7 +29,11 @@ class StackPanelPage : Component
                         ColorBox("#2ECC71", "C"),
                         ColorBox("#F39C12", "D")
                     ),
-                    @"VStack(8,\n    Box(""A""), Box(""B""), Box(""C""), Box(""D"")\n)",
+                    """
+                    VStack(8,
+                        Box("A"), Box("B"), Box("C"), Box("D")
+                    )
+                    """,
                     OptionPanel(
                         TextBlock($"Spacing: {(int)spacing}"),
                         Slider(spacing, 0, 32, setSpacing)
@@ -42,7 +46,11 @@ class StackPanelPage : Component
                         ColorBox("#E67E22", "3"),
                         ColorBox("#2C3E50", "4")
                     ),
-                    @"HStack(8,\n    Box(""1""), Box(""2""), Box(""3""), Box(""4"")\n)"),
+                    """
+                    HStack(8,
+                        Box("1"), Box("2"), Box("3"), Box("4")
+                    )
+                    """),
 
                 SampleCard("Nested Stacks",
                     VStack(12,
@@ -56,7 +64,12 @@ class StackPanelPage : Component
                             ColorBox("#9B59B6", "R2")
                         )
                     ),
-                    @"VStack(12,\n    HStack(8, Box(""R1""), Box(""R1""), Box(""R1"")),\n    HStack(8, Box(""R2""), Box(""R2""))\n)")
+                    """
+                    VStack(12,
+                        HStack(8, Box("R1"), Box("R1"), Box("R1")),
+                        HStack(8, Box("R2"), Box("R2"))
+                    )
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Layout/ViewboxPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/ViewboxPage.cs
@@ -27,7 +27,11 @@ class ViewboxPage : Component
                             )
                         )
                     ).Size(size, size).Background(Theme.SubtleFill).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft),
-                    @"Viewbox(\n    VStack(4, TextBlock(""Hello"").Bold(), TextBlock(""Scaled""))\n)",
+                    """
+                    Viewbox(
+                        VStack(4, TextBlock("Hello").Bold(), TextBlock("Scaled"))
+                    )
+                    """,
                     OptionPanel(
                         TextBlock($"Container size: {(int)size}px"),
                         Slider(size, 50, 300, setSize)
@@ -51,7 +55,11 @@ class ViewboxPage : Component
                                 .Size(60, 150).Background(Theme.SubtleFill).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft)
                         )
                     ),
-                    @"// Same content at different sizes:\nBorder(Viewbox(TextBlock(""ABC""))).Size(100, 100)\nBorder(Viewbox(TextBlock(""ABC""))).Size(150, 80)"),
+                    """
+                    // Same content at different sizes:
+                    Border(Viewbox(TextBlock("ABC"))).Size(100, 100)
+                    Border(Viewbox(TextBlock("ABC"))).Size(150, 80)
+                    """),
 
                 SampleCard("Stretch Modes",
                     HStack(16,
@@ -76,7 +84,12 @@ class ViewboxPage : Component
                                 .Size(160, 80).Background(Theme.SubtleFill).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft)
                         )
                     ),
-                    @"Viewbox(TextBlock(""ABC"")).Stretch(Stretch.Uniform)\nViewbox(TextBlock(""ABC"")).Stretch(Stretch.Fill)\nViewbox(TextBlock(""ABC"")).Stretch(Stretch.UniformToFill)\nViewbox(TextBlock(""ABC"")).Stretch(Stretch.None)")
+                    """
+                    Viewbox(TextBlock("ABC")).Stretch(Stretch.Uniform)
+                    Viewbox(TextBlock("ABC")).Stretch(Stretch.Fill)
+                    Viewbox(TextBlock("ABC")).Stretch(Stretch.UniformToFill)
+                    Viewbox(TextBlock("ABC")).Stretch(Stretch.None)
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Layout/WrapGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/WrapGridPage.cs
@@ -28,7 +28,13 @@ class WrapGridPage : Component
                                     .Size(70, 70).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft).Margin(4)
                             ).ToArray()
                     ),
-                    @"WrapGrid(\n    items.Select(i =>\n        Border(TextBlock($""{i}"")).Size(70,70).Margin(4)\n    ).ToArray()\n)",
+                    """
+                    WrapGrid(
+                        items.Select(i =>
+                            Border(TextBlock($"{i}")).Size(70, 70).Margin(4)
+                        ).ToArray()
+                    )
+                    """,
                     OptionPanel(
                         TextBlock($"Item count: {(int)count}"),
                         Slider(count, 1, 24, setCount)
@@ -42,7 +48,11 @@ class WrapGridPage : Component
                                     .Background("#5B6ABF").Size(80, 50).CornerRadius(ThemeResource.CornerRadius("ControlCornerRadius").TopLeft).Margin(2)
                             ).ToArray()
                     ),
-                    @"WrapGrid(4,  // max 4 per row\n    items.Select(i => Border(TextBlock($""#{i}"")).Size(80,50)).ToArray()\n)")
+                    """
+                    WrapGrid(4,  // max 4 per row
+                        items.Select(i => Border(TextBlock($"#{i}")).Size(80, 50)).ToArray()
+                    )
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Text/AutoSuggestBoxPage.cs
+++ b/samples/ReactorGallery/ControlPages/Text/AutoSuggestBoxPage.cs
@@ -25,7 +25,10 @@ class AutoSuggestBoxPage : Component
                         AutoSuggestBox(query, setQuery).Width(300),
                         TextBlock($"Current text: \"{query}\"").Foreground(Theme.SecondaryText)
                     ),
-                    @"var (query, setQuery) = UseState("""");\nAutoSuggestBox(query, setQuery)"),
+                    """
+                    var (query, setQuery) = UseState("");
+                    AutoSuggestBox(query, setQuery)
+                    """),
 
                 SampleCard("With Query Submitted",
                     VStack(8,
@@ -46,7 +49,10 @@ class AutoSuggestBoxPage : Component
                                 .ToArray()
                         )
                     ),
-                    @"AutoSuggestBox(query, setQuery)\nallItems.Where(i => i.Contains(query)).Select(...)")
+                    """
+                    AutoSuggestBox(query, setQuery)
+                    allItems.Where(i => i.Contains(query)).Select(...)
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Text/RichEditBoxPage.cs
+++ b/samples/ReactorGallery/ControlPages/Text/RichEditBoxPage.cs
@@ -22,7 +22,10 @@ class RichEditBoxPage : Component
                 SampleCard("Basic RichEditBox",
                     RichEditBox(text, s => { setText(s); setCharCount(s.Length); })
                         .Width(400).Height(150),
-                    @"var (text, setText) = UseState(""Type here..."");\nRichEditBox(text, setText).Width(400).Height(150)"),
+                    """
+                    var (text, setText) = UseState("Type here...");
+                    RichEditBox(text, setText).Width(400).Height(150)
+                    """),
 
                 SampleCard("With Character Count",
                     VStack(8,
@@ -30,7 +33,10 @@ class RichEditBoxPage : Component
                             .Width(400).Height(120),
                         TextBlock($"Characters: {charCount}").Foreground(Theme.SecondaryText).FontSize(12)
                     ),
-                    @"RichEditBox(text, s => { setText(s); setCharCount(s.Length); })\nText($""Characters: {charCount}"")")
+                    """
+                    RichEditBox(text, s => { setText(s); setCharCount(s.Length); })
+                    Text($"Characters: {charCount}")
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/ControlPages/Text/RichTextBlockPage.cs
+++ b/samples/ReactorGallery/ControlPages/Text/RichTextBlockPage.cs
@@ -33,14 +33,23 @@ class RichTextBlockPage : Component
                         Paragraph(Run("Italic emphasis ") with { IsItalic = true }, Run("mixed with "), Run("bold") with { IsBold = true }, Run(".")),
                         Paragraph(Run("A third paragraph with different content to show block-level formatting."))
                     }),
-                    @"RichTextBlock(new[] {\n    Paragraph(Run(""Bold"") with { IsBold = true }, Run(""normal"")),\n    Paragraph(Run(""Italic"") with { IsItalic = true })\n})"),
+                    """
+                    RichTextBlock(new[]
+                    {
+                        Paragraph(Run("Bold") with { IsBold = true }, Run("normal")),
+                        Paragraph(Run("Italic") with { IsItalic = true })
+                    })
+                    """),
 
                 SampleCard("Simple RichTextBlock String",
                     VStack(8,
                         RichTextBlock("Line one of text content."),
                         RichTextBlock("Line two with separate blocks.")
                     ),
-                    @"RichTextBlock(""Line one"")\nRichTextBlock(""Line two"")")
+                    """
+                    RichTextBlock("Line one")
+                    RichTextBlock("Line two")
+                    """)
             ).Margin(36, 24, 36, 36)
         );
     }

--- a/samples/ReactorGallery/SamplePageHost.cs
+++ b/samples/ReactorGallery/SamplePageHost.cs
@@ -32,7 +32,7 @@ public static class SamplePageHost
     /// </summary>
     public static Element SourceBlock(string code) =>
         Border(
-            (TextBlock(code) with { IsTextSelectionEnabled = true, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap })
+            (TextBlock(code.Trim()) with { IsTextSelectionEnabled = true, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap })
                 .Set(tb =>
                 {
                     tb.FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Cascadia Code, Consolas, monospace");

--- a/samples/ReactorGallery/UserControls/GalleryControls.cs
+++ b/samples/ReactorGallery/UserControls/GalleryControls.cs
@@ -19,6 +19,9 @@ internal sealed class CopyToClipboardButton : Component<string>
     {
         var text = Props;
         var (copied, setCopied) = UseState(false, threadSafe: true);
+        // Per-click generation token: only the latest click is allowed to
+        // flip the label back, so rapid clicks can't reset early.
+        var generation = UseRef(0);
 
         return Button(copied ? "Copied" : "Copy")
             .Click(() =>
@@ -28,10 +31,17 @@ internal sealed class CopyToClipboardButton : Component<string>
                     var dp = new DataPackage();
                     dp.SetText(text);
                     Clipboard.SetContent(dp);
+                    // Click handler always runs on the UI thread, so plain ++ is safe.
+                    // The timer continuation only READS the int, which is atomic on .NET.
+                    var myGen = ++generation.Current;
                     setCopied(true);
                     _ = Task.Delay(1500).ContinueWith(_ =>
                     {
-                        try { setCopied(false); } catch { /* unmounted */ }
+                        try
+                        {
+                            if (generation.Current == myGen) setCopied(false);
+                        }
+                        catch { /* unmounted */ }
                     });
                 }
                 catch
@@ -189,7 +199,7 @@ public static class GalleryControls
             Expander("Source code",
                 Grid(
                     columns: [GridSize.Star()], rows: [GridSize.Star()],
-                    ScrollView(
+                    (ScrollView(
                         TextBlock(sourceCode.Trim())
                             .FontFamily("Consolas, 'Cascadia Code', monospace")
                             .FontSize(13)
@@ -199,7 +209,7 @@ public static class GalleryControls
                                 tb.IsTextSelectionEnabled = true;
                                 tb.TextWrapping = TextWrapping.NoWrap;
                             })
-                    )
+                    ) with { ContentOrientation = Microsoft.UI.Xaml.Controls.ScrollingContentOrientation.Both })
                     .Height(200)
                     .Background(Theme.SubtleFill)
                     .Grid(row: 0, column: 0),

--- a/samples/ReactorGallery/UserControls/GalleryControls.cs
+++ b/samples/ReactorGallery/UserControls/GalleryControls.cs
@@ -1,11 +1,48 @@
+using System.Threading.Tasks;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using Windows.ApplicationModel.DataTransfer;
 using static Microsoft.UI.Reactor.Factories;
 
 namespace WinUIGalleryReactor;
+
+/// <summary>
+/// A small "Copy" button used inside <see cref="GalleryControls.SampleCard"/>.
+/// Lives as a Component so we can use UseState for the transient "Copied" label.
+/// </summary>
+internal sealed class CopyToClipboardButton : Component<string>
+{
+    public override Element Render()
+    {
+        var text = Props;
+        var (copied, setCopied) = UseState(false, threadSafe: true);
+
+        return Button(copied ? "Copied" : "Copy")
+            .Click(() =>
+            {
+                try
+                {
+                    var dp = new DataPackage();
+                    dp.SetText(text);
+                    Clipboard.SetContent(dp);
+                    setCopied(true);
+                    _ = Task.Delay(1500).ContinueWith(_ =>
+                    {
+                        try { setCopied(false); } catch { /* unmounted */ }
+                    });
+                }
+                catch
+                {
+                    // Clipboard.SetContent can throw RPC_E_CALL_REJECTED transiently;
+                    // swallow rather than crash the gallery.
+                }
+            })
+            .SubtleButton();
+    }
+}
 
 /// <summary>
 /// Reusable UI building blocks shared across the WinUI Gallery app.
@@ -17,6 +54,7 @@ public static class GalleryControls
     static CornerRadius OverlayRadiusCR => ThemeResource.CornerRadius("OverlayCornerRadius");
     static double ControlRadius => ControlRadiusCR.TopLeft;
     static double OverlayRadius => OverlayRadiusCR.TopLeft;
+
     /// <summary>
     /// Renders a page header with a title and description.
     /// </summary>
@@ -149,14 +187,29 @@ public static class GalleryControls
 
         children.Add(
             Expander("Source code",
-                ScrollView(
-                    TextBlock(sourceCode.Trim())
-                        .FontFamily("Consolas, 'Cascadia Code', monospace")
-                        .FontSize(13)
-                        .Padding(12)
-                )
-                .Height(200)
-                .Background(Theme.SubtleFill),
+                Grid(
+                    columns: [GridSize.Star()], rows: [GridSize.Star()],
+                    ScrollView(
+                        TextBlock(sourceCode.Trim())
+                            .FontFamily("Consolas, 'Cascadia Code', monospace")
+                            .FontSize(13)
+                            .Padding(12)
+                            .Set(tb =>
+                            {
+                                tb.IsTextSelectionEnabled = true;
+                                tb.TextWrapping = TextWrapping.NoWrap;
+                            })
+                    )
+                    .Height(200)
+                    .Background(Theme.SubtleFill)
+                    .Grid(row: 0, column: 0),
+
+                    Component<CopyToClipboardButton, string>(sourceCode.Trim())
+                        .HAlign(HorizontalAlignment.Right)
+                        .VAlign(VerticalAlignment.Top)
+                        .Margin(0, 8, 12, 0)
+                        .Grid(row: 0, column: 0)
+                ),
                 isExpanded: false,
                 onIsExpandedChanged: null
             )

--- a/samples/ReactorGallery/UserControls/GalleryControls.cs
+++ b/samples/ReactorGallery/UserControls/GalleryControls.cs
@@ -22,6 +22,16 @@ internal sealed class CopyToClipboardButton : Component<string>
         // Per-click generation token: only the latest click is allowed to
         // flip the label back, so rapid clicks can't reset early.
         var generation = UseRef(0);
+        // "Mounted" flag flipped in the UseEffect cleanup below — lets the
+        // background Task.Delay continuation short-circuit if the component
+        // was unmounted before the 1.5s timer fires (avoids touching state
+        // on a torn-down RenderContext).
+        var isMounted = UseRef(true);
+        UseEffect(() =>
+        {
+            isMounted.Current = true;
+            return () => isMounted.Current = false;
+        });
 
         return Button(copied ? "Copied" : "Copy")
             .Click(() =>
@@ -37,17 +47,16 @@ internal sealed class CopyToClipboardButton : Component<string>
                     setCopied(true);
                     _ = Task.Delay(1500).ContinueWith(_ =>
                     {
-                        try
-                        {
-                            if (generation.Current == myGen) setCopied(false);
-                        }
-                        catch { /* unmounted */ }
+                        if (!isMounted.Current) return;
+                        if (generation.Current == myGen) setCopied(false);
                     });
                 }
-                catch
+                catch (System.Runtime.InteropServices.COMException)
                 {
-                    // Clipboard.SetContent can throw RPC_E_CALL_REJECTED transiently;
-                    // swallow rather than crash the gallery.
+                    // Clipboard.SetContent can throw RPC_E_CALL_REJECTED (HRESULT
+                    // 0x80010001) when another app is holding the clipboard
+                    // marshaller — swallow this specific COM transient rather
+                    // than crash the gallery. Anything else propagates.
                 }
             })
             .SubtleButton();

--- a/samples/ReactorGallery/UserControls/GalleryControls.cs
+++ b/samples/ReactorGallery/UserControls/GalleryControls.cs
@@ -219,9 +219,7 @@ public static class GalleryControls
                         .VAlign(VerticalAlignment.Top)
                         .Margin(0, 8, 12, 0)
                         .Grid(row: 0, column: 0)
-                ),
-                isExpanded: false,
-                onIsExpandedChanged: null
+                )
             )
             .OnMount(el =>
             {

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -140,16 +140,13 @@ public static partial class Factories
         error: false)]
     public static RichTextBlockElement RichText(string text) => RichTextBlock(text);
 
-    public static RichEditBoxElement RichEditBox(string text = "", Action<string>? onTextChanged = null)
-    {
-        _ = V1.Reg<RichEditBoxElement, WinUI.RichEditBox, Desc.RichEditBoxDescriptorHandler>.Done;
-        return new(Optional<string>.Of(text)) { OnTextChanged = onTextChanged };
-    }
-
     /// <summary>
-    /// Creates a rich edit box whose text is controlled only when <paramref name="text"/> has a value.
+    /// Creates a <see cref="RichEditBoxElement"/>. <paramref name="text"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the WinUI control own its text
+    /// (uncontrolled). Pass any string (implicit <c>T → Optional&lt;T&gt;</c>) to control
+    /// the text from a parent state.
     /// </summary>
-    public static RichEditBoxElement RichEditBox(Optional<string> text, Action<string>? onTextChanged = null)
+    public static RichEditBoxElement RichEditBox(Optional<string> text = default, Action<string>? onTextChanged = null)
     {
         _ = V1.Reg<RichEditBoxElement, WinUI.RichEditBox, Desc.RichEditBoxDescriptorHandler>.Done;
         return new(text) { OnTextChanged = onTextChanged };
@@ -282,23 +279,20 @@ public static partial class Factories
         };
     }
 
-    public static ToggleSplitButtonElement ToggleSplitButton(string label, bool isChecked = false, Action<bool>? onIsCheckedChanged = null, Element? flyout = null)
-    {
-        _ = V1.Reg<ToggleSplitButtonElement, WinUI.ToggleSplitButton, Desc.ToggleSplitButtonDescriptorHandler>.Done;
-        return new(label, Optional<bool>.Of(isChecked), onIsCheckedChanged, flyout);
-    }
-
     /// <summary>
-    /// Creates a toggle split button whose checked state is controlled only when <paramref name="isChecked"/> has a value.
+    /// Creates a <see cref="ToggleSplitButtonElement"/>. <paramref name="isChecked"/> defaults
+    /// to <see cref="Optional{T}.Unset"/> — omit it to let the WinUI control own its checked
+    /// state (uncontrolled). Pass <c>true</c>/<c>false</c> (implicit <c>T → Optional&lt;T&gt;</c>)
+    /// to control it from a parent state.
     /// </summary>
-    public static ToggleSplitButtonElement ToggleSplitButton(string label, Optional<bool> isChecked, Action<bool>? onIsCheckedChanged = null, Element? flyout = null)
+    public static ToggleSplitButtonElement ToggleSplitButton(string label, Optional<bool> isChecked = default, Action<bool>? onIsCheckedChanged = null, Element? flyout = null)
     {
         _ = V1.Reg<ToggleSplitButtonElement, WinUI.ToggleSplitButton, Desc.ToggleSplitButtonDescriptorHandler>.Done;
         return new(label, isChecked, onIsCheckedChanged, flyout);
     }
 
     /// <summary>Creates a ToggleSplitButton driven by a Command (fires on each toggle).</summary>
-    public static ToggleSplitButtonElement ToggleSplitButton(Core.Command command, bool isChecked = false, Element? flyout = null)
+    public static ToggleSplitButtonElement ToggleSplitButton(Core.Command command, Optional<bool> isChecked = default, Element? flyout = null)
     {
         _ = V1.Reg<ToggleSplitButtonElement, WinUI.ToggleSplitButton, Desc.ToggleSplitButtonDescriptorHandler>.Done;
         return new ToggleSplitButtonElement(command.Label, isChecked, _ => Core.CommandBindings.Invoke(command), flyout)
@@ -313,146 +307,104 @@ public static partial class Factories
     /// Creates a <see cref="TextBoxElement"/> wrapping WinUI's
     /// <c>Microsoft.UI.Xaml.Controls.TextBox</c>.
     /// </summary>
-    public static TextBoxElement TextBox(string value, Action<string>? onChanged = null, string? placeholderText = null, string? header = null)
-    {
-        _ = V1.Reg<TextBoxElement, WinUI.TextBox, Desc.TextBoxDescriptorHandler>.Done;
-        return new(Optional<string>.Of(value), onChanged, placeholderText) { Header = header };
-    }
-
     /// <summary>
-    /// Creates a text box whose text is controlled only when <paramref name="value"/> has a value.
+    /// Creates a <see cref="TextBoxElement"/>. <paramref name="value"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the WinUI control own its text
+    /// (uncontrolled). Pass any string (implicit <c>T → Optional&lt;T&gt;</c>) to control it.
     /// </summary>
-    public static TextBoxElement TextBox(Optional<string> value, Action<string>? onChanged = null, string? placeholderText = null, string? header = null)
+    public static TextBoxElement TextBox(Optional<string> value = default, Action<string>? onChanged = null, string? placeholderText = null, string? header = null)
     {
         _ = V1.Reg<TextBoxElement, WinUI.TextBox, Desc.TextBoxDescriptorHandler>.Done;
         return new(value, onChanged, placeholderText) { Header = header };
     }
 
-    public static PasswordBoxElement PasswordBox(string password, Action<string>? onPasswordChanged = null, string? placeholderText = null)
-    {
-        _ = V1.Reg<PasswordBoxElement, WinUI.PasswordBox, Desc.PasswordBoxDescriptorHandler>.Done;
-        return new(Optional<string>.Of(password), onPasswordChanged, placeholderText);
-    }
-
     /// <summary>
-    /// Creates a password box whose password is controlled only when <paramref name="password"/> has a value.
+    /// Creates a <see cref="PasswordBoxElement"/>. <paramref name="password"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the WinUI control own its password.
     /// </summary>
-    public static PasswordBoxElement PasswordBox(Optional<string> password, Action<string>? onPasswordChanged = null, string? placeholderText = null)
+    public static PasswordBoxElement PasswordBox(Optional<string> password = default, Action<string>? onPasswordChanged = null, string? placeholderText = null)
     {
         _ = V1.Reg<PasswordBoxElement, WinUI.PasswordBox, Desc.PasswordBoxDescriptorHandler>.Done;
         return new(password, onPasswordChanged, placeholderText);
     }
 
-    public static NumberBoxElement NumberBox(double value, Action<double>? onValueChanged = null, string? header = null)
-    {
-        _ = V1.Reg<NumberBoxElement, WinUI.NumberBox, Desc.NumberBoxDescriptorHandler>.Done;
-        return new(Optional<double>.Of(value), onValueChanged, header);
-    }
-
     /// <summary>
-    /// Creates a number box whose value is controlled only when <paramref name="value"/> has a value.
+    /// Creates a <see cref="NumberBoxElement"/>. <paramref name="value"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the WinUI control own its value.
     /// </summary>
-    public static NumberBoxElement NumberBox(Optional<double> value, Action<double>? onValueChanged = null, string? header = null)
+    public static NumberBoxElement NumberBox(Optional<double> value = default, Action<double>? onValueChanged = null, string? header = null)
     {
         _ = V1.Reg<NumberBoxElement, WinUI.NumberBox, Desc.NumberBoxDescriptorHandler>.Done;
         return new(value, onValueChanged, header);
     }
 
-    public static AutoSuggestBoxElement AutoSuggestBox(string text, Action<string>? onTextChanged = null, Action<string>? onQuerySubmitted = null)
-    {
-        _ = V1.Reg<AutoSuggestBoxElement, WinUI.AutoSuggestBox, Desc.AutoSuggestBoxDescriptorHandler>.Done;
-        return new(Optional<string>.Of(text), onTextChanged, onQuerySubmitted);
-    }
-
     /// <summary>
-    /// Creates an auto-suggest box whose text is controlled only when <paramref name="text"/> has a value.
+    /// Creates an <see cref="AutoSuggestBoxElement"/>. <paramref name="text"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the WinUI control own its text.
     /// </summary>
-    public static AutoSuggestBoxElement AutoSuggestBox(Optional<string> text, Action<string>? onTextChanged = null, Action<string>? onQuerySubmitted = null)
+    public static AutoSuggestBoxElement AutoSuggestBox(Optional<string> text = default, Action<string>? onTextChanged = null, Action<string>? onQuerySubmitted = null)
     {
         _ = V1.Reg<AutoSuggestBoxElement, WinUI.AutoSuggestBox, Desc.AutoSuggestBoxDescriptorHandler>.Done;
         return new(text, onTextChanged, onQuerySubmitted);
     }
 
-    public static CheckBoxElement CheckBox(bool isChecked, Action<bool>? onIsCheckedChanged = null, string? label = null)
-    {
-        _ = V1.Reg<CheckBoxElement, WinUI.CheckBox, Desc.CheckBoxDescriptorHandler>.Done;
-        return new(Optional<bool?>.Of(isChecked), onIsCheckedChanged, label);
-    }
-
     /// <summary>
-    /// Creates a check box whose checked state is controlled only when <paramref name="isChecked"/> has a value.
+    /// Creates a <see cref="CheckBoxElement"/>. <paramref name="isChecked"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the WinUI control own its checked state.
     /// </summary>
-    public static CheckBoxElement CheckBox(Optional<bool?> isChecked, Action<bool>? onIsCheckedChanged = null, string? label = null)
+    public static CheckBoxElement CheckBox(Optional<bool?> isChecked = default, Action<bool>? onIsCheckedChanged = null, string? label = null)
     {
         _ = V1.Reg<CheckBoxElement, WinUI.CheckBox, Desc.CheckBoxDescriptorHandler>.Done;
         return new(isChecked, onIsCheckedChanged, label);
     }
 
-    public static CheckBoxElement ThreeStateCheckBox(bool? checkedState, Action<bool?>? onCheckedStateChanged = null, string? label = null)
-    {
-        _ = V1.Reg<CheckBoxElement, WinUI.CheckBox, Desc.CheckBoxDescriptorHandler>.Done;
-        return new(Optional<bool?>.Of(checkedState), Label: label) { IsThreeState = true, CheckedState = checkedState, OnCheckedStateChanged = onCheckedStateChanged };
-    }
-
     /// <summary>
-    /// Creates a three-state check box whose checked state is controlled only when <paramref name="checkedState"/> has a value.
+    /// Creates a three-state <see cref="CheckBoxElement"/>. <paramref name="checkedState"/>
+    /// defaults to <see cref="Optional{T}.Unset"/> — omit it to let the control own its state.
     /// </summary>
-    public static CheckBoxElement ThreeStateCheckBox(Optional<bool?> checkedState, Action<bool?>? onCheckedStateChanged = null, string? label = null)
+    public static CheckBoxElement ThreeStateCheckBox(Optional<bool?> checkedState = default, Action<bool?>? onCheckedStateChanged = null, string? label = null)
     {
         _ = V1.Reg<CheckBoxElement, WinUI.CheckBox, Desc.CheckBoxDescriptorHandler>.Done;
         return new(checkedState, Label: label) { IsThreeState = true, CheckedState = checkedState.HasValue ? checkedState.Value : null, OnCheckedStateChanged = onCheckedStateChanged };
     }
 
-    public static RadioButtonElement RadioButton(string label, bool isChecked = false, Action<bool>? onIsCheckedChanged = null, string? groupName = null)
-    {
-        _ = V1.Reg<RadioButtonElement, WinUI.RadioButton, Desc.RadioButtonDescriptorHandler>.Done;
-        return new(label, Optional<bool>.Of(isChecked), onIsCheckedChanged, groupName);
-    }
-
     /// <summary>
-    /// Creates a radio button whose checked state is controlled only when <paramref name="isChecked"/> has a value.
+    /// Creates a <see cref="RadioButtonElement"/>. <paramref name="isChecked"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its checked state.
     /// </summary>
-    public static RadioButtonElement RadioButton(string label, Optional<bool> isChecked, Action<bool>? onIsCheckedChanged = null, string? groupName = null)
+    public static RadioButtonElement RadioButton(string label, Optional<bool> isChecked = default, Action<bool>? onIsCheckedChanged = null, string? groupName = null)
     {
         _ = V1.Reg<RadioButtonElement, WinUI.RadioButton, Desc.RadioButtonDescriptorHandler>.Done;
         return new(label, isChecked, onIsCheckedChanged, groupName);
     }
 
-    public static RadioButtonsElement RadioButtons(string[] items, int selectedIndex = -1, Action<int>? onSelectedIndexChanged = null)
-    {
-        _ = V1.Reg<RadioButtonsElement, WinUI.RadioButtons, Desc.RadioButtonsDescriptorHandler>.Done;
-        return new(items, Optional<int>.Of(selectedIndex), onSelectedIndexChanged);
-    }
-
     /// <summary>
-    /// Creates radio buttons whose selected index is controlled only when <paramref name="selectedIndex"/> has a value.
+    /// Creates a <see cref="RadioButtonsElement"/>. <paramref name="selectedIndex"/> defaults
+    /// to <see cref="Optional{T}.Unset"/> — omit it to let the control own its selection.
     /// </summary>
-    public static RadioButtonsElement RadioButtons(string[] items, Optional<int> selectedIndex, Action<int>? onSelectedIndexChanged = null)
+    public static RadioButtonsElement RadioButtons(string[] items, Optional<int> selectedIndex = default, Action<int>? onSelectedIndexChanged = null)
     {
         _ = V1.Reg<RadioButtonsElement, WinUI.RadioButtons, Desc.RadioButtonsDescriptorHandler>.Done;
         return new(items, selectedIndex, onSelectedIndexChanged);
     }
 
-    public static ComboBoxElement ComboBox(string[] items, int selectedIndex = -1, Action<int>? onSelectedIndexChanged = null)
-    {
-        _ = V1.Reg<ComboBoxElement, WinUI.ComboBox, Desc.ComboBoxDescriptorHandler>.Done;
-        return new(items, Optional<int>.Of(selectedIndex), onSelectedIndexChanged);
-    }
-
     /// <summary>
-    /// Creates a combo box whose selected index is controlled only when <paramref name="selectedIndex"/> has a value.
+    /// Creates a <see cref="ComboBoxElement"/>. <paramref name="selectedIndex"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its selection.
     /// </summary>
-    public static ComboBoxElement ComboBox(string[] items, Optional<int> selectedIndex, Action<int>? onSelectedIndexChanged = null)
+    public static ComboBoxElement ComboBox(string[] items, Optional<int> selectedIndex = default, Action<int>? onSelectedIndexChanged = null)
     {
         _ = V1.Reg<ComboBoxElement, WinUI.ComboBox, Desc.ComboBoxDescriptorHandler>.Done;
         return new(items, selectedIndex, onSelectedIndexChanged);
     }
 
-    public static ComboBoxElement ComboBox(Element[] itemElements, int selectedIndex, Action<int>? onSelectedIndexChanged) =>
-        ComboBox(itemElements, Optional<int>.Of(selectedIndex), onSelectedIndexChanged);
-
     /// <summary>
-    /// Creates a combo box from element items whose selected index is controlled only when <paramref name="selectedIndex"/> has a value.
+    /// Creates a <see cref="ComboBoxElement"/> from element items. <paramref name="selectedIndex"/>
+    /// is taken as-is — pass <see cref="Optional{T}.Unset"/> for uncontrolled, or any int
+    /// (implicit <c>int → Optional&lt;int&gt;</c>) for controlled. Both trailing args are
+    /// required (rather than defaulted) to disambiguate from the <c>string[]</c> overload —
+    /// <c>string</c> has an implicit conversion to <c>Element</c>, so a collection-expression
+    /// call like <c>ComboBox(["A","B"], selectedIndex: 0)</c> would otherwise resolve to either.
     /// </summary>
     public static ComboBoxElement ComboBox(Element[] itemElements, Optional<int> selectedIndex, Action<int>? onSelectedIndexChanged)
     {
@@ -460,61 +412,41 @@ public static partial class Factories
         return new([], selectedIndex, onSelectedIndexChanged) { ItemElements = itemElements };
     }
 
-    public static SliderElement Slider(double value, double min = 0, double max = 100, Action<double>? onValueChanged = null)
-    {
-        _ = V1.Reg<SliderElement, WinUI.Slider, Desc.SliderDescriptorHandler>.Done;
-        return new(Optional<double>.Of(value), min, max, onValueChanged);
-    }
-
     /// <summary>
-    /// Creates a slider whose value is controlled only when <paramref name="value"/> has a value.
+    /// Creates a <see cref="SliderElement"/>. <paramref name="value"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its value.
     /// </summary>
-    public static SliderElement Slider(Optional<double> value, double min = 0, double max = 100, Action<double>? onValueChanged = null)
+    public static SliderElement Slider(Optional<double> value = default, double min = 0, double max = 100, Action<double>? onValueChanged = null)
     {
         _ = V1.Reg<SliderElement, WinUI.Slider, Desc.SliderDescriptorHandler>.Done;
         return new(value, min, max, onValueChanged);
     }
 
-    public static ToggleSwitchElement ToggleSwitch(bool isOn, Action<bool>? onIsOnChanged = null, string? onContent = null, string? offContent = null, string? header = null)
-    {
-        _ = V1.Reg<ToggleSwitchElement, WinUI.ToggleSwitch, Desc.ToggleSwitchDescriptorHandler>.Done;
-        return new(Optional<bool>.Of(isOn), onIsOnChanged, onContent, offContent) { Header = header };
-    }
-
     /// <summary>
-    /// Creates a toggle switch whose on/off state is controlled only when <paramref name="isOn"/> has a value.
+    /// Creates a <see cref="ToggleSwitchElement"/>. <paramref name="isOn"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its on/off state.
     /// </summary>
-    public static ToggleSwitchElement ToggleSwitch(Optional<bool> isOn, Action<bool>? onIsOnChanged = null, string? onContent = null, string? offContent = null, string? header = null)
+    public static ToggleSwitchElement ToggleSwitch(Optional<bool> isOn = default, Action<bool>? onIsOnChanged = null, string? onContent = null, string? offContent = null, string? header = null)
     {
         _ = V1.Reg<ToggleSwitchElement, WinUI.ToggleSwitch, Desc.ToggleSwitchDescriptorHandler>.Done;
         return new(isOn, onIsOnChanged, onContent, offContent) { Header = header };
     }
 
-    public static RatingControlElement RatingControl(double value = 0, Action<double>? onValueChanged = null)
-    {
-        _ = V1.Reg<RatingControlElement, WinUI.RatingControl, Desc.RatingControlDescriptorHandler>.Done;
-        return new(Optional<double>.Of(value), onValueChanged);
-    }
-
     /// <summary>
-    /// Creates a rating control whose value is controlled only when <paramref name="value"/> has a value.
+    /// Creates a <see cref="RatingControlElement"/>. <paramref name="value"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its value.
     /// </summary>
-    public static RatingControlElement RatingControl(Optional<double> value, Action<double>? onValueChanged = null)
+    public static RatingControlElement RatingControl(Optional<double> value = default, Action<double>? onValueChanged = null)
     {
         _ = V1.Reg<RatingControlElement, WinUI.RatingControl, Desc.RatingControlDescriptorHandler>.Done;
         return new(value, onValueChanged);
     }
 
-    public static ColorPickerElement ColorPicker(global::Windows.UI.Color color, Action<global::Windows.UI.Color>? onColorChanged = null)
-    {
-        _ = V1.Reg<ColorPickerElement, WinUI.ColorPicker, Desc.ColorPickerDescriptorHandler>.Done;
-        return new(Optional<global::Windows.UI.Color>.Of(color), onColorChanged);
-    }
-
     /// <summary>
-    /// Creates a color picker whose color is controlled only when <paramref name="color"/> has a value.
+    /// Creates a <see cref="ColorPickerElement"/>. <paramref name="color"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its color.
     /// </summary>
-    public static ColorPickerElement ColorPicker(Optional<global::Windows.UI.Color> color, Action<global::Windows.UI.Color>? onColorChanged = null)
+    public static ColorPickerElement ColorPicker(Optional<global::Windows.UI.Color> color = default, Action<global::Windows.UI.Color>? onColorChanged = null)
     {
         _ = V1.Reg<ColorPickerElement, WinUI.ColorPicker, Desc.ColorPickerDescriptorHandler>.Done;
         return new(color, onColorChanged);
@@ -522,46 +454,32 @@ public static partial class Factories
 
     // ── Date / Time ─────────────────────────────────────────────────
 
-    public static CalendarDatePickerElement CalendarDatePicker(DateTimeOffset? date = null, Action<DateTimeOffset?>? onDateChanged = null)
-    {
-        _ = V1.Reg<CalendarDatePickerElement, WinUI.CalendarDatePicker, Desc.CalendarDatePickerDescriptorHandler>.Done;
-        return new(Optional<DateTimeOffset?>.Of(date), onDateChanged);
-    }
-
     /// <summary>
-    /// Creates a calendar date picker whose date is controlled only when <paramref name="date"/> has a value.
+    /// Creates a <see cref="CalendarDatePickerElement"/>. <paramref name="date"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its date.
+    /// Pass <c>null</c> to explicitly control the date to "no selection".
     /// </summary>
-    public static CalendarDatePickerElement CalendarDatePicker(Optional<DateTimeOffset?> date, Action<DateTimeOffset?>? onDateChanged = null)
+    public static CalendarDatePickerElement CalendarDatePicker(Optional<DateTimeOffset?> date = default, Action<DateTimeOffset?>? onDateChanged = null)
     {
         _ = V1.Reg<CalendarDatePickerElement, WinUI.CalendarDatePicker, Desc.CalendarDatePickerDescriptorHandler>.Done;
         return new(date, onDateChanged);
     }
 
-    public static DatePickerElement DatePicker(DateTimeOffset date, Action<DateTimeOffset>? onDateChanged = null)
-    {
-        _ = V1.Reg<DatePickerElement, WinUI.DatePicker, Desc.DatePickerDescriptorHandler>.Done;
-        return new(Optional<DateTimeOffset>.Of(date), onDateChanged);
-    }
-
     /// <summary>
-    /// Creates a date picker whose date is controlled only when <paramref name="date"/> has a value.
+    /// Creates a <see cref="DatePickerElement"/>. <paramref name="date"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its date.
     /// </summary>
-    public static DatePickerElement DatePicker(Optional<DateTimeOffset> date, Action<DateTimeOffset>? onDateChanged = null)
+    public static DatePickerElement DatePicker(Optional<DateTimeOffset> date = default, Action<DateTimeOffset>? onDateChanged = null)
     {
         _ = V1.Reg<DatePickerElement, WinUI.DatePicker, Desc.DatePickerDescriptorHandler>.Done;
         return new(date, onDateChanged);
     }
 
-    public static TimePickerElement TimePicker(TimeSpan time, Action<TimeSpan>? onTimeChanged = null)
-    {
-        _ = V1.Reg<TimePickerElement, WinUI.TimePicker, Desc.TimePickerDescriptorHandler>.Done;
-        return new(Optional<TimeSpan>.Of(time), onTimeChanged);
-    }
-
     /// <summary>
-    /// Creates a time picker whose time is controlled only when <paramref name="time"/> has a value.
+    /// Creates a <see cref="TimePickerElement"/>. <paramref name="time"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its time.
     /// </summary>
-    public static TimePickerElement TimePicker(Optional<TimeSpan> time, Action<TimeSpan>? onTimeChanged = null)
+    public static TimePickerElement TimePicker(Optional<TimeSpan> time = default, Action<TimeSpan>? onTimeChanged = null)
     {
         _ = V1.Reg<TimePickerElement, WinUI.TimePicker, Desc.TimePickerDescriptorHandler>.Done;
         return new(time, onTimeChanged);
@@ -780,16 +698,13 @@ public static partial class Factories
         return new(child!);
     }
 
-    public static ExpanderElement Expander(string header, Element content, bool isExpanded = false, Action<bool>? onIsExpandedChanged = null)
-    {
-        _ = V1.RegDecorator<ExpanderElement, V1.Handlers.ExpanderHandler>.Done;
-        return new(header, content, Optional<bool>.Of(isExpanded), onIsExpandedChanged);
-    }
-
     /// <summary>
-    /// Creates an expander whose expanded state is controlled only when <paramref name="isExpanded"/> has a value.
+    /// Creates an <see cref="ExpanderElement"/>. <paramref name="isExpanded"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it and the WinUI control owns its expansion
+    /// state (uncontrolled — user clicks persist across rerenders). Pass <c>true</c>/<c>false</c>
+    /// (implicit <c>T → Optional&lt;T&gt;</c>) to control it from a parent state.
     /// </summary>
-    public static ExpanderElement Expander(string header, Element content, Optional<bool> isExpanded, Action<bool>? onIsExpandedChanged = null)
+    public static ExpanderElement Expander(string header, Element content, Optional<bool> isExpanded = default, Action<bool>? onIsExpandedChanged = null)
     {
         _ = V1.RegDecorator<ExpanderElement, V1.Handlers.ExpanderHandler>.Done;
         return new(header, content, isExpanded, onIsExpandedChanged);
@@ -1787,16 +1702,11 @@ public static partial class Factories
         return new(zoomedInView, zoomedOutView);
     }
 
-    public static ListBoxElement ListBox(string[] items, int selectedIndex = -1, Action<int>? onSelectedIndexChanged = null)
-    {
-        _ = V1.Reg<ListBoxElement, WinUI.ListBox, Desc.ListBoxDescriptorHandler>.Done;
-        return new(items) { SelectedIndex = Optional<int>.Of(selectedIndex), OnSelectedIndexChanged = onSelectedIndexChanged };
-    }
-
     /// <summary>
-    /// Creates a list box whose selected index is controlled only when <paramref name="selectedIndex"/> has a value.
+    /// Creates a <see cref="ListBoxElement"/>. <paramref name="selectedIndex"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its selection.
     /// </summary>
-    public static ListBoxElement ListBox(string[] items, Optional<int> selectedIndex, Action<int>? onSelectedIndexChanged = null)
+    public static ListBoxElement ListBox(string[] items, Optional<int> selectedIndex = default, Action<int>? onSelectedIndexChanged = null)
     {
         _ = V1.Reg<ListBoxElement, WinUI.ListBox, Desc.ListBoxDescriptorHandler>.Done;
         return new(items) { SelectedIndex = selectedIndex, OnSelectedIndexChanged = onSelectedIndexChanged };
@@ -1804,16 +1714,11 @@ public static partial class Factories
 
     // ── Additional navigation ───────────────────────────────────────
 
-    public static SelectorBarElement SelectorBar(SelectorBarItemData[] items, int selectedIndex = 0, Action<int>? onSelectedIndexChanged = null)
-    {
-        _ = V1.Reg<SelectorBarElement, WinUI.SelectorBar, Desc.SelectorBarDescriptorHandler>.Done;
-        return new(items) { SelectedIndex = Optional<int>.Of(selectedIndex), OnSelectedIndexChanged = onSelectedIndexChanged };
-    }
-
     /// <summary>
-    /// Creates a selector bar whose selected index is controlled only when <paramref name="selectedIndex"/> has a value.
+    /// Creates a <see cref="SelectorBarElement"/>. <paramref name="selectedIndex"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its selection.
     /// </summary>
-    public static SelectorBarElement SelectorBar(SelectorBarItemData[] items, Optional<int> selectedIndex, Action<int>? onSelectedIndexChanged = null)
+    public static SelectorBarElement SelectorBar(SelectorBarItemData[] items, Optional<int> selectedIndex = default, Action<int>? onSelectedIndexChanged = null)
     {
         _ = V1.Reg<SelectorBarElement, WinUI.SelectorBar, Desc.SelectorBarDescriptorHandler>.Done;
         return new(items) { SelectedIndex = selectedIndex, OnSelectedIndexChanged = onSelectedIndexChanged };
@@ -1821,16 +1726,11 @@ public static partial class Factories
 
     public static SelectorBarItemData SelectorBarItem(string text, string? icon = null) => new(text, icon);
 
-    public static PipsPagerElement PipsPager(int numberOfPages, int selectedPageIndex = 0, Action<int>? onSelectedPageIndexChanged = null)
-    {
-        _ = V1.Reg<PipsPagerElement, WinUI.PipsPager, Desc.PipsPagerDescriptorHandler>.Done;
-        return new(numberOfPages) { SelectedPageIndex = Optional<int>.Of(selectedPageIndex), OnSelectedPageIndexChanged = onSelectedPageIndexChanged };
-    }
-
     /// <summary>
-    /// Creates a pips pager whose selected page index is controlled only when <paramref name="selectedPageIndex"/> has a value.
+    /// Creates a <see cref="PipsPagerElement"/>. <paramref name="selectedPageIndex"/> defaults to
+    /// <see cref="Optional{T}.Unset"/> — omit it to let the control own its current page.
     /// </summary>
-    public static PipsPagerElement PipsPager(int numberOfPages, Optional<int> selectedPageIndex, Action<int>? onSelectedPageIndexChanged = null)
+    public static PipsPagerElement PipsPager(int numberOfPages, Optional<int> selectedPageIndex = default, Action<int>? onSelectedPageIndexChanged = null)
     {
         _ = V1.Reg<PipsPagerElement, WinUI.PipsPager, Desc.PipsPagerDescriptorHandler>.Done;
         return new(numberOfPages) { SelectedPageIndex = selectedPageIndex, OnSelectedPageIndexChanged = onSelectedPageIndexChanged };

--- a/tests/Reactor.Tests/DslFactoryUncontrolledDefaultsTests.cs
+++ b/tests/Reactor.Tests/DslFactoryUncontrolledDefaultsTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Lock-in for the "no-arg factory call = uncontrolled" contract on every
+/// element whose underlying controlled prop is <see cref="Optional{T}"/>.
+///
+/// The bug this is guarding against: prior to the Optional-typed-factory
+/// audit, factories like <c>Expander(string, Element, bool isExpanded = false, …)</c>
+/// silently wrapped the bool default as <c>Optional&lt;bool&gt;.Of(false)</c>,
+/// which put the control in CONTROLLED-TO-FALSE mode. On every parent
+/// re-render, the handler would write <c>IsExpanded = false</c> back to the
+/// live WinUI control — collapsing whatever the user had clicked to expand.
+///
+/// The fix: each factory now takes <c>Optional&lt;T&gt; foo = default</c>
+/// (i.e. <see cref="Optional{T}.Unset"/>) so omitting the parameter yields
+/// "uncontrolled — let the WinUI control own its state". Authors who want
+/// controlled behavior pass a value, which goes through the implicit
+/// <c>T → Optional&lt;T&gt;</c> conversion and lands in <c>Optional&lt;T&gt;.Of(value)</c>.
+///
+/// Companion tests (<see cref="DslFactoryOptionalTests"/>) cover the
+/// other half of the contract: passing a value or an explicit Unset.
+/// </summary>
+public class DslFactoryUncontrolledDefaultsTests
+{
+    // ── Text inputs ────────────────────────────────────────────────
+
+    [Fact] public void TextBox_NoArgs_ValueIsUnset() => Assert.False(TextBox().Value.HasValue);
+    [Fact] public void PasswordBox_NoArgs_PasswordIsUnset() => Assert.False(PasswordBox().Password.HasValue);
+    [Fact] public void AutoSuggestBox_NoArgs_TextIsUnset() => Assert.False(AutoSuggestBox().Text.HasValue);
+    [Fact] public void RichEditBox_NoArgs_TextIsUnset() => Assert.False(RichEditBox().Text.HasValue);
+
+    // ── Numeric inputs ─────────────────────────────────────────────
+
+    [Fact] public void NumberBox_NoArgs_ValueIsUnset() => Assert.False(NumberBox().Value.HasValue);
+    [Fact] public void Slider_NoArgs_ValueIsUnset() => Assert.False(Slider().Value.HasValue);
+    [Fact] public void RatingControl_NoArgs_ValueIsUnset() => Assert.False(RatingControl().Value.HasValue);
+
+    // ── Toggles ────────────────────────────────────────────────────
+
+    [Fact] public void CheckBox_NoArgs_IsCheckedIsUnset() => Assert.False(CheckBox().IsChecked.HasValue);
+    [Fact] public void ThreeStateCheckBox_NoArgs_IsCheckedIsUnset() => Assert.False(ThreeStateCheckBox().IsChecked.HasValue);
+    [Fact] public void RadioButton_LabelOnly_IsCheckedIsUnset() => Assert.False(RadioButton("A").IsChecked.HasValue);
+    [Fact] public void ToggleSwitch_NoArgs_IsOnIsUnset() => Assert.False(ToggleSwitch().IsOn.HasValue);
+    [Fact] public void ToggleSplitButton_LabelOnly_IsCheckedIsUnset() => Assert.False(ToggleSplitButton("A").IsChecked.HasValue);
+
+    // ── Selection collections ──────────────────────────────────────
+
+    [Fact] public void RadioButtons_NoSelectedIndex_IsUnset() => Assert.False(RadioButtons(new[] { "A" }).SelectedIndex.HasValue);
+    [Fact] public void ComboBox_NoSelectedIndex_IsUnset() => Assert.False(ComboBox(new[] { "A" }).SelectedIndex.HasValue);
+    // ComboBox(Element[], ...) intentionally requires explicit selectedIndex/handler args (no defaults) —
+    // see Dsl.cs note about the implicit string→Element conversion. So there's no "no-arg" form to test;
+    // covered instead by DslFactoryOptionalTests.SelectionFactories_WrapPlainValues_AndAcceptUnset.
+    [Fact] public void ListBox_NoSelectedIndex_IsUnset() => Assert.False(ListBox(new[] { "A" }).SelectedIndex.HasValue);
+    [Fact] public void SelectorBar_NoSelectedIndex_IsUnset() => Assert.False(SelectorBar(new[] { SelectorBarItem("A") }).SelectedIndex.HasValue);
+    [Fact] public void PipsPager_NoSelectedPageIndex_IsUnset() => Assert.False(PipsPager(3).SelectedPageIndex.HasValue);
+
+    // ── Date / time / color ────────────────────────────────────────
+
+    [Fact] public void CalendarDatePicker_NoArgs_DateIsUnset() => Assert.False(CalendarDatePicker().Date.HasValue);
+    [Fact] public void DatePicker_NoArgs_DateIsUnset() => Assert.False(DatePicker().Date.HasValue);
+    [Fact] public void TimePicker_NoArgs_TimeIsUnset() => Assert.False(TimePicker().Time.HasValue);
+    [Fact] public void ColorPicker_NoArgs_ColorIsUnset() => Assert.False(ColorPicker().Color.HasValue);
+
+    // ── Decorators / containers ────────────────────────────────────
+
+    [Fact]
+    public void Expander_NoIsExpanded_IsUnset()
+    {
+        // The bug that originally motivated this audit: clicking Copy in the
+        // gallery's source-code Expander was collapsing the user-opened pane
+        // because the bool overload's `isExpanded = false` default silently
+        // forced controlled-to-false on every parent re-render.
+        var el = Expander("Header", TextBlock("Content"));
+        Assert.False(el.IsExpanded.HasValue);
+    }
+}

--- a/tests/Reactor.Tests/RichEditBoxElementTests.cs
+++ b/tests/Reactor.Tests/RichEditBoxElementTests.cs
@@ -20,7 +20,10 @@ public class RichEditBoxElementTests
     {
         var el = RichEditBox();
         Assert.IsType<RichEditBoxElement>(el);
-        Assert.Equal("", el.Text);
+        // After the Optional<T>-typed factory fix, no-arg defaults to Unset
+        // (uncontrolled). Authors who want the WinUI default empty string must
+        // not need to opt in.
+        Assert.False(el.Text.HasValue);
         Assert.False(el.IsReadOnly);
         Assert.Null(el.Header);
         Assert.Null(el.PlaceholderText);


### PR DESCRIPTION
Closes #538.

## Three changes, one PR (they're all tied to the same Source-code-expander reactor regression)

### 1. Gallery — fix the broken source snippets (the user-visible bug from #538)

The `Source code` expander on every gallery page hardcoded `\n` inside `@"…"` verbatim strings. Verbatim `\n` is the literal two-character escape, so snippets rendered as one long line with visible `\n` characters, overflowing the card.

- Rewrote every offending `@"...\n..."` source-code literal across **20 gallery pages** to a C# 11 raw string literal (`"""..."""`). The displayed text now matches exactly what the user would type — real line breaks, no `""`-doubled quotes, no escape soup.
- No post-processing of sample text — if a future sample genuinely needs `\n` displayed, it's honored.

### 2. Gallery — add a Copy button, selectable text, horizontal scroll

- New `CopyToClipboardButton : Component<string>` overlaid top-right of the source pane. Uses `Clipboard.SetContent` + `DataPackage`; flips its label to "Copied" for 1.5s. Wrapped in try/catch so a transient `RPC_E_CALL_REJECTED` from the clipboard layer can't crash the gallery. Per-click `UseRef<int>` generation token ensures rapid clicks reliably keep `Copied` showing 1.5s after the *last* click.
- `IsTextSelectionEnabled = true` and `TextWrapping.NoWrap` on the source `TextBlock` so manual Ctrl-C still works and long lines scroll horizontally instead of wrapping into noise.
- Inner `ScrollView` constructed with `ContentOrientation = ScrollingContentOrientation.Both` so the NoWrap text actually pans rather than getting clipped.

### 3. Framework — type controlled-prop factory parameters as `Optional<T>` with `Unset` default

While testing change #2, we discovered that **clicking Copy collapsed the expander**. Root cause was a framework bug exposed by the Copy button's setState: factory overloads like

`csharp
public static ExpanderElement Expander(string h, Element c,
    bool isExpanded = false, Action<bool>? onIsExpandedChanged = null) =>
    new(h, c, Optional<bool>.Of(isExpanded), onIsExpandedChanged);
`

silently wrapped the default-bool as `Optional<T>.Of(default)` → CONTROLLED-TO-FALSE. Every parent re-render (e.g. the Copy button's "Copied" → "Copy" flip) ran `ExpanderHandler.Update`, detected `IsExpanded` drift vs the live WinUI control, and wrote `false` back, collapsing the user-opened pane.

The fix: every factory whose underlying record property is `Optional<T>` now has a **single** overload typed `Optional<T>` with `= default` (==Unset):

- Omitting the parameter → uncontrolled (the WinUI control owns its state).
- Passing a value (`Slider(0.5)`, `Expander("h", c, true)`) → flows through the existing implicit `T → Optional<T>` conversion → controlled.
- Passing `Optional<T>.Unset` → explicit uncontrolled.

**Audited factories:** `TextBox`, `PasswordBox`, `NumberBox`, `AutoSuggestBox`, `RichEditBox`, `Slider`, `RatingControl`, `CheckBox`, `ThreeStateCheckBox`, `RadioButton`, `ToggleSwitch`, `ToggleSplitButton`, `RadioButtons`, `ComboBox(string[])`, `ListBox`, `SelectorBar`, `PipsPager`, `CalendarDatePicker`, `DatePicker`, `TimePicker`, `ColorPicker`, `Expander`.

**Notes:**
- `TabView` / `Pivot` / `ListView` / `GridView` / `FlipView` keep their `(int? selectedIndex, …)` overload alongside the new `(Optional<int> = default, …)` one as a convenience null→Unset shortcut.
- `ComboBox(Element[], …)` keeps its non-defaulted `selectedIndex` / `handler` parameters to disambiguate from `ComboBox(string[], …)` — there's an implicit `string → Element` conversion (`Element.cs:290`), so a collection-expression call like `ComboBox(["A","B"], selectedIndex: 0)` would otherwise match either overload.

**Tests:**
- New `tests/Reactor.Tests/DslFactoryUncontrolledDefaultsTests.cs` (23 tests) locks in "no-arg factory call → `Optional<T>.Unset`" for every Optional-typed controlled prop.
- `RichEditBoxElementTests.RichEditBox_Creates_With_Defaults` updated to assert `HasValue == false` (was previously asserting `Text == ""`, which was the silent-controlled-default bug).
- Existing `DslFactoryOptionalTests` cover the "passes a value" and "passes Optional<T>.Unset" axes — still pass.

## Verification

- `grep "@\".*\\\\n.*\"" samples\ReactorGallery` → zero matches.
- `dotnet build Reactor.slnx -p:Platform=x64` → 0 warnings, 0 errors.
- `dotnet test tests\Reactor.Tests` → **9224 passed, 0 failed, 62 skipped**.
- Gallery smoke-tested: source snippets render with real line breaks, Copy button works, **expander stays open after clicking Copy**.