### PR TITLE
Expose native rich text properties

### DIFF
--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -504,9 +504,29 @@ public abstract record Element
             (RichTextBlockElement ra, RichTextBlockElement rb) =>
                 ra.Text == rb.Text
                 && ra.FontSize == rb.FontSize
+                && FontFamiliesEqual(ra.FontFamily, rb.FontFamily)
+                && ra.FontWeight == rb.FontWeight
+                && ra.FontStyle == rb.FontStyle
+                && ra.FontStretch == rb.FontStretch
+                && BrushesEqual(ra.Foreground, rb.Foreground)
                 && ra.IsTextSelectionEnabled == rb.IsTextSelectionEnabled
                 && ra.TextWrapping == rb.TextWrapping
+                && ra.MaxLines == rb.MaxLines
+                && ra.LineHeight == rb.LineHeight
                 && ParagraphsEqual(ra.Paragraphs, rb.Paragraphs)
+                && ra.TextAlignment == rb.TextAlignment
+                && ra.HorizontalTextAlignment == rb.HorizontalTextAlignment
+                && ra.TextTrimming == rb.TextTrimming
+                && ra.CharacterSpacing == rb.CharacterSpacing
+                && ra.TextDecorations == rb.TextDecorations
+                && ra.LineStackingStrategy == rb.LineStackingStrategy
+                && ra.TextIndent == rb.TextIndent
+                && ra.TextLineBounds == rb.TextLineBounds
+                && ra.TextReadingOrder == rb.TextReadingOrder
+                && ra.IsTextScaleFactorEnabled == rb.IsTextScaleFactorEnabled
+                && ra.IsColorFontEnabled == rb.IsColorFontEnabled
+                && ra.OpticalMarginAlignment == rb.OpticalMarginAlignment
+                && BrushesEqual(ra.SelectionHighlightColor, rb.SelectionHighlightColor)
                 && ReferenceEquals(ra.Setters, rb.Setters),
 
             // Container elements: compare own props + children by reference.
@@ -877,14 +897,78 @@ public abstract record Element
     internal static bool ParagraphEqual(RichTextParagraph a, RichTextParagraph b)
     {
         if (ReferenceEquals(a, b)) return true;
+        if (!ParagraphPropertiesEqual(a, b)) return false;
         var ai = a.Inlines;
         var bi = b.Inlines;
         if (ai.Length != bi.Length) return false;
         for (int j = 0; j < ai.Length; j++)
         {
-            if (!ai[j].Equals(bi[j])) return false;
+            if (!RichTextInlineEqual(ai[j], bi[j])) return false;
         }
         return true;
+    }
+
+    private static bool ParagraphPropertiesEqual(RichTextParagraph a, RichTextParagraph b)
+        => a.Margin == b.Margin
+            && a.TextIndent == b.TextIndent
+            && a.TextAlignment == b.TextAlignment
+            && a.HorizontalTextAlignment == b.HorizontalTextAlignment
+            && a.LineHeight == b.LineHeight
+            && a.LineStackingStrategy == b.LineStackingStrategy
+            && a.FontSize == b.FontSize
+            && string.Equals(a.FontFamily, b.FontFamily, StringComparison.Ordinal)
+            && a.FontWeight == b.FontWeight
+            && a.FontStyle == b.FontStyle
+            && a.FontStretch == b.FontStretch
+            && BrushesEqual(a.Foreground, b.Foreground)
+            && a.CharacterSpacing == b.CharacterSpacing
+            && a.TextDecorations == b.TextDecorations
+            && a.IsTextScaleFactorEnabled == b.IsTextScaleFactorEnabled
+            && string.Equals(a.Language, b.Language, StringComparison.Ordinal);
+
+    private static bool RichTextInlineTextPropertiesEqual(RichTextInline a, RichTextInline b)
+        => a.FontSize == b.FontSize
+            && string.Equals(a.FontFamily, b.FontFamily, StringComparison.Ordinal)
+            && a.FontWeight == b.FontWeight
+            && a.FontStyle == b.FontStyle
+            && a.FontStretch == b.FontStretch
+            && BrushesEqual(a.Foreground, b.Foreground)
+            && a.CharacterSpacing == b.CharacterSpacing
+            && a.TextDecorations == b.TextDecorations
+            && a.IsTextScaleFactorEnabled == b.IsTextScaleFactorEnabled
+            && string.Equals(a.Language, b.Language, StringComparison.Ordinal);
+
+    private static bool RichTextInlineEqual(RichTextInline a, RichTextInline b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a.GetType() != b.GetType()) return false;
+        if (!RichTextInlineTextPropertiesEqual(a, b)) return false;
+
+        return (a, b) switch
+        {
+            (RichTextRun ra, RichTextRun rb) =>
+                ra.Text == rb.Text
+                && ra.IsBold == rb.IsBold
+                && ra.IsItalic == rb.IsItalic
+                && ra.IsStrikethrough == rb.IsStrikethrough
+                && ra.FlowDirection == rb.FlowDirection,
+
+            (RichTextHyperlink ha, RichTextHyperlink hb) =>
+                ha.Text == hb.Text
+                && ha.NavigateUri == hb.NavigateUri
+                && ReferenceEquals(ha.OnClick, hb.OnClick)
+                && ha.UnderlineStyle == hb.UnderlineStyle
+                && ha.IsTabStop == hb.IsTabStop
+                && ha.TabIndex == hb.TabIndex,
+
+            (RichTextLineBreak, RichTextLineBreak) => true,
+
+            (RichTextInlineUIContainer ia, RichTextInlineUIContainer ib) =>
+                ReferenceEquals(ia.Child, ib.Child)
+                && ReferenceEquals(ia.Factory, ib.Factory),
+
+            _ => a.Equals(b),
+        };
     }
 
     /// <summary>
@@ -2166,6 +2250,11 @@ internal enum TextPropChanged : ushort
 public record RichTextBlockElement(string Text) : Element
 {
     public double? FontSize { get; init; }
+    public Microsoft.UI.Xaml.Media.FontFamily? FontFamily { get; init; }
+    public global::Windows.UI.Text.FontWeight? FontWeight { get; init; }
+    public global::Windows.UI.Text.FontStyle? FontStyle { get; init; }
+    public global::Windows.UI.Text.FontStretch? FontStretch { get; init; }
+    public Brush? Foreground { get; init; }
     public RichTextParagraph[]? Paragraphs { get; init; }
     public bool IsTextSelectionEnabled { get; init; }
     public TextWrapping? TextWrapping { get; init; }
@@ -2175,26 +2264,65 @@ public record RichTextBlockElement(string Text) : Element
     public double? LineHeight { get; init; }
     /// <summary>Horizontal alignment of text within the block. <c>null</c> uses the WinUI default (Left).</summary>
     public TextAlignment? TextAlignment { get; init; }
+    /// <summary>Horizontal text alignment using the newer WinUI property. <c>null</c> uses the WinUI default.</summary>
+    public TextAlignment? HorizontalTextAlignment { get; init; }
     /// <summary>How overflowing text is truncated. <c>null</c> uses the WinUI default (None).</summary>
     public TextTrimming? TextTrimming { get; init; }
     /// <summary>Extra spacing between characters, in units of 1/1000em. Defaults to <c>0</c>.</summary>
     public int CharacterSpacing { get; init; }
+    public global::Windows.UI.Text.TextDecorations? TextDecorations { get; init; }
+    public LineStackingStrategy? LineStackingStrategy { get; init; }
+    public double? TextIndent { get; init; }
+    public TextLineBounds? TextLineBounds { get; init; }
+    public TextReadingOrder? TextReadingOrder { get; init; }
+    public bool? IsTextScaleFactorEnabled { get; init; }
+    public bool? IsColorFontEnabled { get; init; }
+    public OpticalMarginAlignment? OpticalMarginAlignment { get; init; }
+    public Microsoft.UI.Xaml.Media.SolidColorBrush? SelectionHighlightColor { get; init; }
     internal Action<WinUI.RichTextBlock>[] Setters { get; init; } = [];
 }
 
 // Rich text inline content types
-public record RichTextParagraph(RichTextInline[] Inlines);
+public record RichTextParagraph(RichTextInline[] Inlines)
+{
+    public Thickness? Margin { get; init; }
+    public double? TextIndent { get; init; }
+    public TextAlignment? TextAlignment { get; init; }
+    public TextAlignment? HorizontalTextAlignment { get; init; }
+    public double? LineHeight { get; init; }
+    public LineStackingStrategy? LineStackingStrategy { get; init; }
+    public double? FontSize { get; init; }
+    public string? FontFamily { get; init; }
+    public global::Windows.UI.Text.FontWeight? FontWeight { get; init; }
+    public global::Windows.UI.Text.FontStyle? FontStyle { get; init; }
+    public global::Windows.UI.Text.FontStretch? FontStretch { get; init; }
+    public Brush? Foreground { get; init; }
+    public int? CharacterSpacing { get; init; }
+    public global::Windows.UI.Text.TextDecorations? TextDecorations { get; init; }
+    public bool? IsTextScaleFactorEnabled { get; init; }
+    public string? Language { get; init; }
+}
 
-public abstract record RichTextInline;
+public abstract record RichTextInline
+{
+    public double? FontSize { get; init; }
+    public string? FontFamily { get; init; }
+    public global::Windows.UI.Text.FontWeight? FontWeight { get; init; }
+    public global::Windows.UI.Text.FontStyle? FontStyle { get; init; }
+    public global::Windows.UI.Text.FontStretch? FontStretch { get; init; }
+    public Brush? Foreground { get; init; }
+    public int? CharacterSpacing { get; init; }
+    public global::Windows.UI.Text.TextDecorations? TextDecorations { get; init; }
+    public bool? IsTextScaleFactorEnabled { get; init; }
+    public string? Language { get; init; }
+}
 
 public record RichTextRun(string Text) : RichTextInline
 {
     public bool IsBold { get; init; }
     public bool IsItalic { get; init; }
     public bool IsStrikethrough { get; init; }
-    public double? FontSize { get; init; }
-    public string? FontFamily { get; init; }
-    public Brush? Foreground { get; init; }
+    public FlowDirection? FlowDirection { get; init; }
 }
 
 /// <summary>
@@ -2221,6 +2349,9 @@ public record RichTextHyperlink(string Text, Uri NavigateUri) : RichTextInline
     /// as a pure navigation link using <see cref="NavigateUri"/>.
     /// </summary>
     public Action? OnClick { get; init; }
+    public Microsoft.UI.Xaml.Documents.UnderlineStyle? UnderlineStyle { get; init; }
+    public bool? IsTabStop { get; init; }
+    public int? TabIndex { get; init; }
 }
 
 public record RichTextLineBreak() : RichTextInline;

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using WinUI = Microsoft.UI.Xaml.Controls;
 using WinPrim = Microsoft.UI.Xaml.Controls.Primitives;
 using WinShapes = Microsoft.UI.Xaml.Shapes;
+using WinDocs = Microsoft.UI.Xaml.Documents;
 using Windows.UI.WebUI;
 
 namespace Microsoft.UI.Reactor.Core;
@@ -250,16 +251,11 @@ public sealed partial class Reconciler
         switch (inline)
         {
             case RichTextRun run:
-                var r = new Microsoft.UI.Xaml.Documents.Run { Text = run.Text };
-                if (run.IsBold) r.FontWeight = Microsoft.UI.Text.FontWeights.Bold;
-                if (run.IsItalic) r.FontStyle = global::Windows.UI.Text.FontStyle.Italic;
-                if (run.IsStrikethrough) r.TextDecorations = global::Windows.UI.Text.TextDecorations.Strikethrough;
-                if (run.FontSize.HasValue) r.FontSize = run.FontSize.Value;
-                if (run.FontFamily is not null) r.FontFamily = WinRTCache.GetFontFamily(run.FontFamily);
-                if (run.Foreground is not null) r.Foreground = run.Foreground;
+                var r = new WinDocs.Run { Text = run.Text };
+                ApplyRunProperties(r, run);
                 return r;
             case RichTextHyperlink link:
-                var hl = new Microsoft.UI.Xaml.Documents.Hyperlink();
+                var hl = new WinDocs.Hyperlink();
                 if (link.OnClick is not null)
                 {
                     // Issue #479 click mode: fire delegate, suppress platform
@@ -273,14 +269,22 @@ public sealed partial class Reconciler
                     if (l.ToString().Length < 1) l = new Uri("about:blank");
                     try { hl.NavigateUri = l; } catch { hl.NavigateUri = new Uri("about:blank"); }
                 }
-                hl.Inlines.Add(new Microsoft.UI.Xaml.Documents.Run { Text = link.Text ?? ""});
+                ApplyInlineTextProperties(hl, link);
+                ApplyHyperlinkProperties(hl, link);
+                var linkRun = new WinDocs.Run { Text = link.Text ?? "" };
+                ApplyInlineTextProperties(linkRun, link);
+                hl.Inlines.Add(linkRun);
                 return hl;
             case RichTextLineBreak:
-                return new Microsoft.UI.Xaml.Documents.LineBreak();
+                var lb = new WinDocs.LineBreak();
+                ApplyInlineTextProperties(lb, inline);
+                return lb;
             case RichTextInlineUIContainer iuc:
-                return MountInlineUIContainer(iuc, requestRerender);
+                var container = MountInlineUIContainer(iuc, requestRerender);
+                ApplyInlineTextProperties(container, iuc);
+                return container;
             default:
-                return new Microsoft.UI.Xaml.Documents.Run { Text = "" };
+                return new WinDocs.Run { Text = "" };
         }
     }
 
@@ -294,10 +298,10 @@ public sealed partial class Reconciler
     /// stashed on the container so the surrounding RichTextBlock's unmount /
     /// rebuild paths can walk and tear it down before <c>Blocks.Clear()</c>.
     /// </summary>
-    private Microsoft.UI.Xaml.Documents.InlineUIContainer MountInlineUIContainer(
+    private WinDocs.InlineUIContainer MountInlineUIContainer(
         RichTextInlineUIContainer iuc, Action requestRerender)
     {
-        var container = new Microsoft.UI.Xaml.Documents.InlineUIContainer();
+        var container = new WinDocs.InlineUIContainer();
         UIElement? mounted = null;
         if (iuc.Child is not null)
         {
@@ -355,7 +359,7 @@ public sealed partial class Reconciler
         {
             switch (inline)
             {
-                case Microsoft.UI.Xaml.Documents.InlineUIContainer iuc:
+                case WinDocs.InlineUIContainer iuc:
                     if (iuc.Child is FrameworkElement childFe
                         && (bool)childFe.GetValue(s_inlineUIRouteAProperty))
                     {
@@ -363,16 +367,17 @@ public sealed partial class Reconciler
                     }
                     iuc.Child = null;
                     break;
-                case Microsoft.UI.Xaml.Documents.Span span:
+                case WinDocs.Span span:
                     UnmountInlineUIChildrenInInlines(span.Inlines);
                     break;
             }
         }
     }
 
-    private Microsoft.UI.Xaml.Documents.Paragraph MountParagraph(RichTextParagraph para, Action requestRerender)
+    private WinDocs.Paragraph MountParagraph(RichTextParagraph para, Action requestRerender)
     {
-        var p = new Microsoft.UI.Xaml.Documents.Paragraph();
+        var p = new WinDocs.Paragraph();
+        ApplyParagraphProperties(p, para);
         foreach (var inline in para.Inlines)
             p.Inlines.Add(MountInline(inline, requestRerender));
         return p;
@@ -440,9 +445,9 @@ public sealed partial class Reconciler
         if (prev.Paragraphs is null && next.Paragraphs is null)
         {
             if (rtb.Blocks.Count != 1) return false;
-            if (rtb.Blocks[0] is not Microsoft.UI.Xaml.Documents.Paragraph p1) return false;
+            if (rtb.Blocks[0] is not WinDocs.Paragraph p1) return false;
             if (p1.Inlines.Count != 1) return false;
-            if (p1.Inlines[0] is not Microsoft.UI.Xaml.Documents.Run r1) return false;
+            if (p1.Inlines[0] is not WinDocs.Run r1) return false;
             if (string.Equals(prev.Text, next.Text, global::System.StringComparison.Ordinal))
                 return true;
             r1.Text = next.Text ?? string.Empty;
@@ -464,7 +469,7 @@ public sealed partial class Reconciler
         // etc.) only to discover later we have to tear everything down.
         for (int pi = 0; pi < nextPs.Length; pi++)
         {
-            if (rtb.Blocks[pi] is not Microsoft.UI.Xaml.Documents.Paragraph winPara)
+            if (rtb.Blocks[pi] is not WinDocs.Paragraph winPara)
                 return false;
             var prevInlines = prevPs[pi].Inlines;
             var nextInlines = nextPs[pi].Inlines;
@@ -483,7 +488,7 @@ public sealed partial class Reconciler
         {
             var prevPara = prevPs[pi];
             var nextPara = nextPs[pi];
-            var winPara = (Microsoft.UI.Xaml.Documents.Paragraph)rtb.Blocks[pi];
+            var winPara = (WinDocs.Paragraph)rtb.Blocks[pi];
             if (ReferenceEquals(prevPara, nextPara))
             {
                 // Paragraph object is unchanged at the structural level, but
@@ -496,7 +501,7 @@ public sealed partial class Reconciler
                 {
                     if (nextPara.Inlines[ii] is RichTextInlineUIContainer rinl
                         && rinl.Child is not null
-                        && winPara.Inlines[ii] is Microsoft.UI.Xaml.Documents.InlineUIContainer wc)
+                        && winPara.Inlines[ii] is WinDocs.InlineUIContainer wc)
                     {
                         if (UpdateInlineUIContainerInPlace(rinl, rinl, wc, requestRerender))
                             anyMutation = true;
@@ -504,6 +509,8 @@ public sealed partial class Reconciler
                 }
                 continue;
             }
+            if (UpdateParagraphProperties(prevPara, nextPara, winPara))
+                anyMutation = true;
             for (int ii = 0; ii < nextPara.Inlines.Length; ii++)
             {
                 var prevInline = prevPara.Inlines[ii];
@@ -526,15 +533,15 @@ public sealed partial class Reconciler
     private static bool CanUpdateInlineInPlace(
         RichTextInline prev,
         RichTextInline next,
-        Microsoft.UI.Xaml.Documents.Inline existing)
+        WinDocs.Inline existing)
     {
         return (prev, next, existing) switch
         {
-            (RichTextRun, RichTextRun, Microsoft.UI.Xaml.Documents.Run) => true,
-            (RichTextHyperlink, RichTextHyperlink, Microsoft.UI.Xaml.Documents.Hyperlink hl)
-                => hl.Inlines.Count == 1 && hl.Inlines[0] is Microsoft.UI.Xaml.Documents.Run,
-            (RichTextLineBreak, RichTextLineBreak, Microsoft.UI.Xaml.Documents.LineBreak) => true,
-            (RichTextInlineUIContainer p, RichTextInlineUIContainer n, Microsoft.UI.Xaml.Documents.InlineUIContainer)
+            (RichTextRun, RichTextRun, WinDocs.Run) => true,
+            (RichTextHyperlink, RichTextHyperlink, WinDocs.Hyperlink hl)
+                => hl.Inlines.Count == 1 && hl.Inlines[0] is WinDocs.Run,
+            (RichTextLineBreak, RichTextLineBreak, WinDocs.LineBreak) => true,
+            (RichTextInlineUIContainer p, RichTextInlineUIContainer n, WinDocs.InlineUIContainer)
                 => CanUpdateInlineUIContainerInPlace(p, n),
             _ => false,
         };
@@ -563,26 +570,26 @@ public sealed partial class Reconciler
     private bool UpdateInlineInPlace(
         RichTextInline prev,
         RichTextInline next,
-        Microsoft.UI.Xaml.Documents.Inline existing,
+        WinDocs.Inline existing,
         Action requestRerender)
     {
         switch (prev, next, existing)
         {
-            case (RichTextRun p, RichTextRun n, Microsoft.UI.Xaml.Documents.Run wr):
+            case (RichTextRun p, RichTextRun n, WinDocs.Run wr):
                 return UpdateRunInPlace(p, n, wr);
-            case (RichTextHyperlink p, RichTextHyperlink n, Microsoft.UI.Xaml.Documents.Hyperlink wh):
+            case (RichTextHyperlink p, RichTextHyperlink n, WinDocs.Hyperlink wh):
                 return UpdateHyperlinkInPlace(p, n, wh);
-            case (RichTextLineBreak, RichTextLineBreak, _):
-                return false;
+            case (RichTextLineBreak p, RichTextLineBreak n, WinDocs.LineBreak wb):
+                return UpdateInlineTextProperties(p, n, wb);
             case (RichTextInlineUIContainer p, RichTextInlineUIContainer n,
-                  Microsoft.UI.Xaml.Documents.InlineUIContainer wc):
+                  WinDocs.InlineUIContainer wc):
                 return UpdateInlineUIContainerInPlace(p, n, wc, requestRerender);
             default:
                 return false; // unreachable per preflight
         }
     }
 
-    private static bool UpdateRunInPlace(RichTextRun prev, RichTextRun next, Microsoft.UI.Xaml.Documents.Run wr)
+    private static bool UpdateRunInPlace(RichTextRun prev, RichTextRun next, WinDocs.Run wr)
     {
         bool any = false;
         if (!string.Equals(prev.Text, next.Text, global::System.StringComparison.Ordinal))
@@ -590,45 +597,40 @@ public sealed partial class Reconciler
             wr.Text = next.Text ?? string.Empty;
             any = true;
         }
-        if (prev.IsBold != next.IsBold)
+        if (UpdateInlineTextProperties(prev, next, wr, includeFontShape: false))
+            any = true;
+
+        var oldWeight = EffectiveFontWeight(prev);
+        var newWeight = EffectiveFontWeight(next);
+        if (oldWeight != newWeight)
         {
-            wr.FontWeight = next.IsBold
-                ? Microsoft.UI.Text.FontWeights.Bold
-                : Microsoft.UI.Text.FontWeights.Normal;
+            if (newWeight.HasValue) wr.FontWeight = newWeight.Value;
+            else wr.ClearValue(WinDocs.TextElement.FontWeightProperty);
             any = true;
         }
-        if (prev.IsItalic != next.IsItalic)
+
+        var oldStyle = EffectiveFontStyle(prev);
+        var newStyle = EffectiveFontStyle(next);
+        if (oldStyle != newStyle)
         {
-            wr.FontStyle = next.IsItalic
-                ? global::Windows.UI.Text.FontStyle.Italic
-                : global::Windows.UI.Text.FontStyle.Normal;
+            if (newStyle.HasValue) wr.FontStyle = newStyle.Value;
+            else wr.ClearValue(WinDocs.TextElement.FontStyleProperty);
             any = true;
         }
-        if (prev.IsStrikethrough != next.IsStrikethrough)
+
+        var oldDecorations = EffectiveTextDecorations(prev);
+        var newDecorations = EffectiveTextDecorations(next);
+        if (oldDecorations != newDecorations)
         {
-            wr.TextDecorations = next.IsStrikethrough
-                ? global::Windows.UI.Text.TextDecorations.Strikethrough
-                : global::Windows.UI.Text.TextDecorations.None;
+            if (newDecorations.HasValue) wr.TextDecorations = newDecorations.Value;
+            else wr.ClearValue(WinDocs.TextElement.TextDecorationsProperty);
             any = true;
         }
-        if (prev.FontSize != next.FontSize)
+
+        if (prev.FlowDirection != next.FlowDirection)
         {
-            if (next.FontSize.HasValue) wr.FontSize = next.FontSize.Value;
-            else wr.ClearValue(Microsoft.UI.Xaml.Documents.TextElement.FontSizeProperty);
-            any = true;
-        }
-        if (!string.Equals(prev.FontFamily, next.FontFamily, global::System.StringComparison.Ordinal))
-        {
-            if (next.FontFamily is not null)
-                wr.FontFamily = WinRTCache.GetFontFamily(next.FontFamily);
-            else
-                wr.ClearValue(Microsoft.UI.Xaml.Documents.TextElement.FontFamilyProperty);
-            any = true;
-        }
-        if (!ReferenceEquals(prev.Foreground, next.Foreground))
-        {
-            if (next.Foreground is not null) wr.Foreground = next.Foreground;
-            else wr.ClearValue(Microsoft.UI.Xaml.Documents.TextElement.ForegroundProperty);
+            if (next.FlowDirection.HasValue) wr.FlowDirection = next.FlowDirection.Value;
+            else wr.ClearValue(WinDocs.Run.FlowDirectionProperty);
             any = true;
         }
         return any;
@@ -637,7 +639,7 @@ public sealed partial class Reconciler
     private static bool UpdateHyperlinkInPlace(
         RichTextHyperlink prev,
         RichTextHyperlink next,
-        Microsoft.UI.Xaml.Documents.Hyperlink wh)
+        WinDocs.Hyperlink wh)
     {
         bool any = false;
         // Issue #479 — handle OnClick attach/detach + NavigateUri transitions.
@@ -680,16 +682,227 @@ public sealed partial class Reconciler
                 any = true;
             }
         }
+        var innerRun = wh.Inlines.Count > 0
+            ? wh.Inlines[0] as WinDocs.Run
+            : null;
+
         if (!string.Equals(prev.Text, next.Text, global::System.StringComparison.Ordinal))
         {
-            if (wh.Inlines.Count > 0
-                && wh.Inlines[0] is Microsoft.UI.Xaml.Documents.Run innerRun)
+            if (innerRun is not null)
             {
                 innerRun.Text = next.Text ?? string.Empty;
                 any = true;
             }
         }
+        if (UpdateInlineTextProperties(prev, next, wh))
+            any = true;
+        if (innerRun is not null && UpdateInlineTextProperties(prev, next, innerRun))
+            any = true;
+        if (UpdateHyperlinkProperties(prev, next, wh))
+            any = true;
         return any;
+    }
+
+    private static void ApplyParagraphProperties(WinDocs.Paragraph target, RichTextParagraph paragraph)
+    {
+        if (paragraph.Margin.HasValue) target.Margin = paragraph.Margin.Value;
+        if (paragraph.TextIndent.HasValue) target.TextIndent = paragraph.TextIndent.Value;
+        if (paragraph.TextAlignment.HasValue) target.TextAlignment = paragraph.TextAlignment.Value;
+        if (paragraph.HorizontalTextAlignment.HasValue) target.HorizontalTextAlignment = paragraph.HorizontalTextAlignment.Value;
+        if (paragraph.LineHeight.HasValue) target.LineHeight = paragraph.LineHeight.Value;
+        if (paragraph.LineStackingStrategy.HasValue) target.LineStackingStrategy = paragraph.LineStackingStrategy.Value;
+        ApplyParagraphTextProperties(target, paragraph);
+    }
+
+    private static bool UpdateParagraphProperties(
+        RichTextParagraph prev,
+        RichTextParagraph next,
+        WinDocs.Paragraph target)
+    {
+        bool any = false;
+        if (UpdateNullableStruct(prev.Margin, next.Margin, target, WinDocs.Block.MarginProperty, v => target.Margin = v)) any = true;
+        if (UpdateNullableStruct(prev.TextIndent, next.TextIndent, target, WinDocs.Paragraph.TextIndentProperty, v => target.TextIndent = v)) any = true;
+        if (UpdateNullableStruct(prev.TextAlignment, next.TextAlignment, target, WinDocs.Block.TextAlignmentProperty, v => target.TextAlignment = v)) any = true;
+        if (UpdateNullableStruct(prev.HorizontalTextAlignment, next.HorizontalTextAlignment, target, WinDocs.Block.HorizontalTextAlignmentProperty, v => target.HorizontalTextAlignment = v)) any = true;
+        if (UpdateNullableStruct(prev.LineHeight, next.LineHeight, target, WinDocs.Block.LineHeightProperty, v => target.LineHeight = v)) any = true;
+        if (UpdateNullableStruct(prev.LineStackingStrategy, next.LineStackingStrategy, target, WinDocs.Block.LineStackingStrategyProperty, v => target.LineStackingStrategy = v)) any = true;
+        if (UpdateParagraphTextProperties(prev, next, target)) any = true;
+        return any;
+    }
+
+    private static void ApplyParagraphTextProperties(WinDocs.TextElement target, RichTextParagraph paragraph)
+    {
+        if (paragraph.FontSize.HasValue) target.FontSize = paragraph.FontSize.Value;
+        if (paragraph.FontFamily is not null) target.FontFamily = WinRTCache.GetFontFamily(paragraph.FontFamily);
+        if (paragraph.FontWeight.HasValue) target.FontWeight = paragraph.FontWeight.Value;
+        if (paragraph.FontStyle.HasValue) target.FontStyle = paragraph.FontStyle.Value;
+        if (paragraph.FontStretch.HasValue) target.FontStretch = paragraph.FontStretch.Value;
+        if (paragraph.Foreground is not null) target.Foreground = paragraph.Foreground;
+        if (paragraph.CharacterSpacing.HasValue) target.CharacterSpacing = paragraph.CharacterSpacing.Value;
+        if (paragraph.TextDecorations.HasValue) target.TextDecorations = paragraph.TextDecorations.Value;
+        if (paragraph.IsTextScaleFactorEnabled.HasValue) target.IsTextScaleFactorEnabled = paragraph.IsTextScaleFactorEnabled.Value;
+        if (paragraph.Language is not null) target.Language = paragraph.Language;
+    }
+
+    private static bool UpdateParagraphTextProperties(
+        RichTextParagraph prev,
+        RichTextParagraph next,
+        WinDocs.TextElement target)
+    {
+        bool any = false;
+        if (UpdateNullableStruct(prev.FontSize, next.FontSize, target, WinDocs.TextElement.FontSizeProperty, v => target.FontSize = v)) any = true;
+        if (UpdateFontFamily(prev.FontFamily, next.FontFamily, target)) any = true;
+        if (UpdateNullableStruct(prev.FontWeight, next.FontWeight, target, WinDocs.TextElement.FontWeightProperty, v => target.FontWeight = v)) any = true;
+        if (UpdateNullableStruct(prev.FontStyle, next.FontStyle, target, WinDocs.TextElement.FontStyleProperty, v => target.FontStyle = v)) any = true;
+        if (UpdateNullableStruct(prev.FontStretch, next.FontStretch, target, WinDocs.TextElement.FontStretchProperty, v => target.FontStretch = v)) any = true;
+        if (UpdateReference(prev.Foreground, next.Foreground, target, WinDocs.TextElement.ForegroundProperty, v => target.Foreground = v)) any = true;
+        if (UpdateNullableStruct(prev.CharacterSpacing, next.CharacterSpacing, target, WinDocs.TextElement.CharacterSpacingProperty, v => target.CharacterSpacing = v)) any = true;
+        if (UpdateNullableStruct(prev.TextDecorations, next.TextDecorations, target, WinDocs.TextElement.TextDecorationsProperty, v => target.TextDecorations = v)) any = true;
+        if (UpdateNullableStruct(prev.IsTextScaleFactorEnabled, next.IsTextScaleFactorEnabled, target, WinDocs.TextElement.IsTextScaleFactorEnabledProperty, v => target.IsTextScaleFactorEnabled = v)) any = true;
+        if (UpdateString(prev.Language, next.Language, target, WinDocs.TextElement.LanguageProperty, v => target.Language = v)) any = true;
+        return any;
+    }
+
+    private static void ApplyRunProperties(WinDocs.Run target, RichTextRun run)
+    {
+        ApplyInlineTextProperties(target, run, includeFontShape: false);
+
+        var weight = EffectiveFontWeight(run);
+        if (weight.HasValue) target.FontWeight = weight.Value;
+
+        var style = EffectiveFontStyle(run);
+        if (style.HasValue) target.FontStyle = style.Value;
+
+        var decorations = EffectiveTextDecorations(run);
+        if (decorations.HasValue) target.TextDecorations = decorations.Value;
+
+        if (run.FlowDirection.HasValue) target.FlowDirection = run.FlowDirection.Value;
+    }
+
+    private static void ApplyInlineTextProperties(
+        WinDocs.TextElement target,
+        RichTextInline inline,
+        bool includeFontShape = true)
+    {
+        if (inline.FontSize.HasValue) target.FontSize = inline.FontSize.Value;
+        if (inline.FontFamily is not null) target.FontFamily = WinRTCache.GetFontFamily(inline.FontFamily);
+        if (includeFontShape && inline.FontWeight.HasValue) target.FontWeight = inline.FontWeight.Value;
+        if (includeFontShape && inline.FontStyle.HasValue) target.FontStyle = inline.FontStyle.Value;
+        if (inline.FontStretch.HasValue) target.FontStretch = inline.FontStretch.Value;
+        if (inline.Foreground is not null) target.Foreground = inline.Foreground;
+        if (inline.CharacterSpacing.HasValue) target.CharacterSpacing = inline.CharacterSpacing.Value;
+        if (includeFontShape && inline.TextDecorations.HasValue) target.TextDecorations = inline.TextDecorations.Value;
+        if (inline.IsTextScaleFactorEnabled.HasValue) target.IsTextScaleFactorEnabled = inline.IsTextScaleFactorEnabled.Value;
+        if (inline.Language is not null) target.Language = inline.Language;
+    }
+
+    private static bool UpdateInlineTextProperties(
+        RichTextInline prev,
+        RichTextInline next,
+        WinDocs.TextElement target,
+        bool includeFontShape = true)
+    {
+        bool any = false;
+        if (UpdateNullableStruct(prev.FontSize, next.FontSize, target, WinDocs.TextElement.FontSizeProperty, v => target.FontSize = v)) any = true;
+        if (UpdateFontFamily(prev.FontFamily, next.FontFamily, target)) any = true;
+        if (includeFontShape && UpdateNullableStruct(prev.FontWeight, next.FontWeight, target, WinDocs.TextElement.FontWeightProperty, v => target.FontWeight = v)) any = true;
+        if (includeFontShape && UpdateNullableStruct(prev.FontStyle, next.FontStyle, target, WinDocs.TextElement.FontStyleProperty, v => target.FontStyle = v)) any = true;
+        if (UpdateNullableStruct(prev.FontStretch, next.FontStretch, target, WinDocs.TextElement.FontStretchProperty, v => target.FontStretch = v)) any = true;
+        if (UpdateReference(prev.Foreground, next.Foreground, target, WinDocs.TextElement.ForegroundProperty, v => target.Foreground = v)) any = true;
+        if (UpdateNullableStruct(prev.CharacterSpacing, next.CharacterSpacing, target, WinDocs.TextElement.CharacterSpacingProperty, v => target.CharacterSpacing = v)) any = true;
+        if (includeFontShape && UpdateNullableStruct(prev.TextDecorations, next.TextDecorations, target, WinDocs.TextElement.TextDecorationsProperty, v => target.TextDecorations = v)) any = true;
+        if (UpdateNullableStruct(prev.IsTextScaleFactorEnabled, next.IsTextScaleFactorEnabled, target, WinDocs.TextElement.IsTextScaleFactorEnabledProperty, v => target.IsTextScaleFactorEnabled = v)) any = true;
+        if (UpdateString(prev.Language, next.Language, target, WinDocs.TextElement.LanguageProperty, v => target.Language = v)) any = true;
+        return any;
+    }
+
+    private static void ApplyHyperlinkProperties(WinDocs.Hyperlink target, RichTextHyperlink link)
+    {
+        if (link.UnderlineStyle.HasValue) target.UnderlineStyle = link.UnderlineStyle.Value;
+        if (link.IsTabStop.HasValue) target.IsTabStop = link.IsTabStop.Value;
+        if (link.TabIndex.HasValue) target.TabIndex = link.TabIndex.Value;
+    }
+
+    private static bool UpdateHyperlinkProperties(
+        RichTextHyperlink prev,
+        RichTextHyperlink next,
+        WinDocs.Hyperlink target)
+    {
+        bool any = false;
+        if (UpdateNullableStruct(prev.UnderlineStyle, next.UnderlineStyle, target, WinDocs.Hyperlink.UnderlineStyleProperty, v => target.UnderlineStyle = v)) any = true;
+        if (UpdateNullableStruct(prev.IsTabStop, next.IsTabStop, target, WinDocs.Hyperlink.IsTabStopProperty, v => target.IsTabStop = v)) any = true;
+        if (UpdateNullableStruct(prev.TabIndex, next.TabIndex, target, WinDocs.Hyperlink.TabIndexProperty, v => target.TabIndex = v)) any = true;
+        return any;
+    }
+
+    private static global::Windows.UI.Text.FontWeight? EffectiveFontWeight(RichTextRun run)
+        => run.FontWeight ?? (run.IsBold ? Microsoft.UI.Text.FontWeights.Bold : null);
+
+    private static global::Windows.UI.Text.FontStyle? EffectiveFontStyle(RichTextRun run)
+        => run.FontStyle ?? (run.IsItalic ? global::Windows.UI.Text.FontStyle.Italic : null);
+
+    private static global::Windows.UI.Text.TextDecorations? EffectiveTextDecorations(RichTextRun run)
+        => run.TextDecorations
+            ?? (run.IsStrikethrough ? global::Windows.UI.Text.TextDecorations.Strikethrough : null);
+
+    private static bool UpdateNullableStruct<T>(
+        T? prev,
+        T? next,
+        DependencyObject target,
+        DependencyProperty property,
+        Action<T> set)
+        where T : struct
+    {
+        if (EqualityComparer<T?>.Default.Equals(prev, next))
+            return false;
+
+        if (next.HasValue) set(next.Value);
+        else target.ClearValue(property);
+        return true;
+    }
+
+    private static bool UpdateReference<T>(
+        T? prev,
+        T? next,
+        DependencyObject target,
+        DependencyProperty property,
+        Action<T> set)
+        where T : class
+    {
+        if (ReferenceEquals(prev, next))
+            return false;
+
+        if (next is not null) set(next);
+        else target.ClearValue(property);
+        return true;
+    }
+
+    private static bool UpdateString(
+        string? prev,
+        string? next,
+        DependencyObject target,
+        DependencyProperty property,
+        Action<string> set)
+    {
+        if (string.Equals(prev, next, global::System.StringComparison.Ordinal))
+            return false;
+
+        if (next is not null) set(next);
+        else target.ClearValue(property);
+        return true;
+    }
+
+    private static bool UpdateFontFamily(
+        string? prev,
+        string? next,
+        WinDocs.TextElement target)
+    {
+        if (string.Equals(prev, next, global::System.StringComparison.Ordinal))
+            return false;
+
+        if (next is not null) target.FontFamily = WinRTCache.GetFontFamily(next);
+        else target.ClearValue(WinDocs.TextElement.FontFamilyProperty);
+        return true;
     }
 
     // Issue #479 — backing storage for the static Click handler. CWT keys are
@@ -699,11 +912,11 @@ public sealed partial class Reconciler
     // across renders are a cheap dictionary update, never an event detach +
     // re-attach.
     private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<
-        Microsoft.UI.Xaml.Documents.Hyperlink, Action> s_hyperlinkClickActions = new();
+        WinDocs.Hyperlink, Action> s_hyperlinkClickActions = new();
 
     private static void OnHyperlinkClick(
-        Microsoft.UI.Xaml.Documents.Hyperlink sender,
-        Microsoft.UI.Xaml.Documents.HyperlinkClickEventArgs args)
+        WinDocs.Hyperlink sender,
+        WinDocs.HyperlinkClickEventArgs args)
     {
         if (s_hyperlinkClickActions.TryGetValue(sender, out var action))
             action?.Invoke();
@@ -712,7 +925,7 @@ public sealed partial class Reconciler
     private bool UpdateInlineUIContainerInPlace(
         RichTextInlineUIContainer prev,
         RichTextInlineUIContainer next,
-        Microsoft.UI.Xaml.Documents.InlineUIContainer container,
+        WinDocs.InlineUIContainer container,
         Action requestRerender)
     {
         // Route A both (preflight already confirmed Child ↔ Child).

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -583,7 +583,12 @@ public sealed partial class Reconciler
                 return UpdateInlineTextProperties(p, n, wb);
             case (RichTextInlineUIContainer p, RichTextInlineUIContainer n,
                   WinDocs.InlineUIContainer wc):
-                return UpdateInlineUIContainerInPlace(p, n, wc, requestRerender);
+            {
+                var any = UpdateInlineUIContainerInPlace(p, n, wc, requestRerender);
+                if (UpdateInlineTextProperties(p, n, wc))
+                    any = true;
+                return any;
+            }
             default:
                 return false; // unreachable per preflight
         }

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/RichTextBlockDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/RichTextBlockDescriptor.cs
@@ -60,45 +60,99 @@ internal static class RichTextBlockDescriptor
         .OneWay(
             get: static e => e.IsTextSelectionEnabled,
             set: static (c, v) => c.IsTextSelectionEnabled = v)
-        .OneWayConditional(
-            get:         static e => e.TextWrapping,
-            set:         static (c, v) => c.TextWrapping = v!.Value,
-            shouldWrite: static e => e.TextWrapping.HasValue)
-        .OneWayConditional(
-            get:         static e => e.FontSize,
-            set:         static (c, v) => c.FontSize = v!.Value,
-            shouldWrite: static e => e.FontSize.HasValue)
-        .OneWayConditional(
-            get:         static e => e.MaxLines,
-            set:         static (c, v) => c.MaxLines = v,
-            shouldWrite: static e => e.MaxLines > 0)
-        .OneWayConditional(
-            get:         static e => e.LineHeight,
-            set:         static (c, v) => c.LineHeight = v!.Value,
-            shouldWrite: static e => e.LineHeight.HasValue)
-        .OneWayConditional(
-            get:         static e => e.TextAlignment,
-            set:         static (c, v) => c.TextAlignment = v!.Value,
-            shouldWrite: static e => e.TextAlignment.HasValue)
-        .OneWayConditional(
-            get:         static e => e.TextTrimming,
-            set:         static (c, v) => c.TextTrimming = v!.Value,
-            shouldWrite: static e => e.TextTrimming.HasValue)
-        .OneWayConditional(
-            get:         static e => e.CharacterSpacing,
-            set:         static (c, v) => c.CharacterSpacing = v,
-            shouldWrite: static e => e.CharacterSpacing != 0)
-        // RichTextBlock.Padding maps directly from the standard Element.Padding
-        // modifier (Layout.Padding sub-record). Without this OneWayConditional
-        // any .Padding(...) on the cell silently no-ops because the
-        // descriptor's Children=None handler doesn't fall back to a generic
-        // FrameworkElement padding writer. Verified via WinUI reflection that
-        // Microsoft.UI.Xaml.Controls.RichTextBlock exposes a Padding property
-        // of type Thickness; we just have to write to it.
-        .OneWayConditional(
-            get:         static e => e.Padding,
-            set:         static (c, v) => c.Padding = v!.Value,
-            shouldWrite: static e => e.Padding.HasValue);
+        .OneWay(
+            get: static e => e.TextWrapping.HasValue ? e.TextWrapping.Value : Optional<TextWrapping>.Unset,
+            set: static (c, v) => c.TextWrapping = v,
+            dp:  WinUI.RichTextBlock.TextWrappingProperty)
+        .OneWay(
+            get: static e => e.FontSize.HasValue ? e.FontSize.Value : Optional<double>.Unset,
+            set: static (c, v) => c.FontSize = v,
+            dp:  WinUI.RichTextBlock.FontSizeProperty)
+        .OneWay(
+            get: static e => e.FontFamily is null ? Optional<Microsoft.UI.Xaml.Media.FontFamily>.Unset : e.FontFamily,
+            set: static (c, v) => c.FontFamily = v,
+            dp:  WinUI.RichTextBlock.FontFamilyProperty)
+        .OneWay(
+            get: static e => e.FontWeight.HasValue ? e.FontWeight.Value : Optional<global::Windows.UI.Text.FontWeight>.Unset,
+            set: static (c, v) => c.FontWeight = v,
+            dp:  WinUI.RichTextBlock.FontWeightProperty)
+        .OneWay(
+            get: static e => e.FontStyle.HasValue ? e.FontStyle.Value : Optional<global::Windows.UI.Text.FontStyle>.Unset,
+            set: static (c, v) => c.FontStyle = v,
+            dp:  WinUI.RichTextBlock.FontStyleProperty)
+        .OneWay(
+            get: static e => e.FontStretch.HasValue ? e.FontStretch.Value : Optional<global::Windows.UI.Text.FontStretch>.Unset,
+            set: static (c, v) => c.FontStretch = v,
+            dp:  WinUI.RichTextBlock.FontStretchProperty)
+        .OneWay(
+            get: static e => e.Foreground is null ? Optional<Microsoft.UI.Xaml.Media.Brush>.Unset : e.Foreground,
+            set: static (c, v) => c.Foreground = v,
+            dp:  WinUI.RichTextBlock.ForegroundProperty)
+        .OneWay(
+            get: static e => e.MaxLines,
+            set: static (c, v) => c.MaxLines = v)
+        .OneWay(
+            get: static e => e.LineHeight.HasValue ? e.LineHeight.Value : Optional<double>.Unset,
+            set: static (c, v) => c.LineHeight = v,
+            dp:  WinUI.RichTextBlock.LineHeightProperty)
+        .OneWay(
+            get: static e => e.LineStackingStrategy.HasValue ? e.LineStackingStrategy.Value : Optional<LineStackingStrategy>.Unset,
+            set: static (c, v) => c.LineStackingStrategy = v,
+            dp:  WinUI.RichTextBlock.LineStackingStrategyProperty)
+        .OneWay(
+            get: static e => e.TextAlignment.HasValue ? e.TextAlignment.Value : Optional<TextAlignment>.Unset,
+            set: static (c, v) => c.TextAlignment = v,
+            dp:  WinUI.RichTextBlock.TextAlignmentProperty)
+        .OneWay(
+            get: static e => e.HorizontalTextAlignment.HasValue ? e.HorizontalTextAlignment.Value : Optional<TextAlignment>.Unset,
+            set: static (c, v) => c.HorizontalTextAlignment = v,
+            dp:  WinUI.RichTextBlock.HorizontalTextAlignmentProperty)
+        .OneWay(
+            get: static e => e.TextTrimming.HasValue ? e.TextTrimming.Value : Optional<TextTrimming>.Unset,
+            set: static (c, v) => c.TextTrimming = v,
+            dp:  WinUI.RichTextBlock.TextTrimmingProperty)
+        .OneWay(
+            get: static e => e.CharacterSpacing,
+            set: static (c, v) => c.CharacterSpacing = v)
+        .OneWay(
+            get: static e => e.TextDecorations.HasValue ? e.TextDecorations.Value : Optional<global::Windows.UI.Text.TextDecorations>.Unset,
+            set: static (c, v) => c.TextDecorations = v,
+            dp:  WinUI.RichTextBlock.TextDecorationsProperty)
+        .OneWay(
+            get: static e => e.TextIndent.HasValue ? e.TextIndent.Value : Optional<double>.Unset,
+            set: static (c, v) => c.TextIndent = v,
+            dp:  WinUI.RichTextBlock.TextIndentProperty)
+        .OneWay(
+            get: static e => e.TextLineBounds.HasValue ? e.TextLineBounds.Value : Optional<TextLineBounds>.Unset,
+            set: static (c, v) => c.TextLineBounds = v,
+            dp:  WinUI.RichTextBlock.TextLineBoundsProperty)
+        .OneWay(
+            get: static e => e.TextReadingOrder.HasValue ? e.TextReadingOrder.Value : Optional<TextReadingOrder>.Unset,
+            set: static (c, v) => c.TextReadingOrder = v,
+            dp:  WinUI.RichTextBlock.TextReadingOrderProperty)
+        .OneWay(
+            get: static e => e.IsTextScaleFactorEnabled.HasValue ? e.IsTextScaleFactorEnabled.Value : Optional<bool>.Unset,
+            set: static (c, v) => c.IsTextScaleFactorEnabled = v,
+            dp:  WinUI.RichTextBlock.IsTextScaleFactorEnabledProperty)
+        .OneWay(
+            get: static e => e.IsColorFontEnabled.HasValue ? e.IsColorFontEnabled.Value : Optional<bool>.Unset,
+            set: static (c, v) => c.IsColorFontEnabled = v,
+            dp:  WinUI.RichTextBlock.IsColorFontEnabledProperty)
+        .OneWay(
+            get: static e => e.OpticalMarginAlignment.HasValue ? e.OpticalMarginAlignment.Value : Optional<OpticalMarginAlignment>.Unset,
+            set: static (c, v) => c.OpticalMarginAlignment = v,
+            dp:  WinUI.RichTextBlock.OpticalMarginAlignmentProperty)
+        .OneWay(
+            get: static e => e.SelectionHighlightColor is null ? Optional<Microsoft.UI.Xaml.Media.SolidColorBrush>.Unset : e.SelectionHighlightColor,
+            set: static (c, v) => c.SelectionHighlightColor = v,
+            dp:  WinUI.RichTextBlock.SelectionHighlightColorProperty)
+        // RichTextBlock.Padding maps from the standard Element.Padding modifier.
+        // Use the Optional + DP path so padded -> unpadded updates clear stale
+        // local padding on recycled controls.
+        .OneWay(
+            get: static e => e.Padding.HasValue ? e.Padding.Value : Optional<Thickness>.Unset,
+            set: static (c, v) => c.Padding = v,
+            dp:  WinUI.RichTextBlock.PaddingProperty);
 }
 
 /// <summary>

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/RichTextBlockDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/RichTextBlockDescriptor.cs
@@ -87,7 +87,18 @@ internal static class RichTextBlockDescriptor
         .OneWayConditional(
             get:         static e => e.CharacterSpacing,
             set:         static (c, v) => c.CharacterSpacing = v,
-            shouldWrite: static e => e.CharacterSpacing != 0);
+            shouldWrite: static e => e.CharacterSpacing != 0)
+        // RichTextBlock.Padding maps directly from the standard Element.Padding
+        // modifier (Layout.Padding sub-record). Without this OneWayConditional
+        // any .Padding(...) on the cell silently no-ops because the
+        // descriptor's Children=None handler doesn't fall back to a generic
+        // FrameworkElement padding writer. Verified via WinUI reflection that
+        // Microsoft.UI.Xaml.Controls.RichTextBlock exposes a Padding property
+        // of type Thickness; we just have to write to it.
+        .OneWayConditional(
+            get:         static e => e.Padding,
+            set:         static (c, v) => c.Padding = v!.Value,
+            shouldWrite: static e => e.Padding.HasValue);
 }
 
 /// <summary>

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -624,6 +624,194 @@ public static partial class ElementExtensions
     public static RichTextBlockElement CharacterSpacing(this RichTextBlockElement el, int spacing) =>
         el with { CharacterSpacing = spacing };
 
+    public static RichTextBlockElement FontFamily(this RichTextBlockElement el, string family) =>
+        el with { FontFamily = WinRTCache.GetFontFamily(family) };
+
+    public static RichTextBlockElement FontFamily(this RichTextBlockElement el, Microsoft.UI.Xaml.Media.FontFamily family) =>
+        el with { FontFamily = family };
+
+    public static RichTextBlockElement FontWeight(this RichTextBlockElement el, global::Windows.UI.Text.FontWeight weight) =>
+        el with { FontWeight = weight };
+
+    public static RichTextBlockElement FontStyle(this RichTextBlockElement el, global::Windows.UI.Text.FontStyle style) =>
+        el with { FontStyle = style };
+
+    public static RichTextBlockElement FontStretch(this RichTextBlockElement el, global::Windows.UI.Text.FontStretch stretch) =>
+        el with { FontStretch = stretch };
+
+    public static RichTextBlockElement Foreground(this RichTextBlockElement el, string color) =>
+        el with { Foreground = BrushHelper.Parse(color) };
+
+    public static RichTextBlockElement Foreground(this RichTextBlockElement el, Brush brush) =>
+        el with { Foreground = brush };
+
+    public static RichTextBlockElement TextDecorations(this RichTextBlockElement el, global::Windows.UI.Text.TextDecorations decorations) =>
+        el with { TextDecorations = decorations };
+
+    public static RichTextBlockElement LineStackingStrategy(this RichTextBlockElement el, LineStackingStrategy strategy) =>
+        el with { LineStackingStrategy = strategy };
+
+    public static RichTextBlockElement TextIndent(this RichTextBlockElement el, double indent) =>
+        el with { TextIndent = indent };
+
+    public static RichTextBlockElement HorizontalTextAlignment(this RichTextBlockElement el, TextAlignment alignment) =>
+        el with { HorizontalTextAlignment = alignment };
+
+    public static RichTextBlockElement TextLineBounds(this RichTextBlockElement el, TextLineBounds bounds) =>
+        el with { TextLineBounds = bounds };
+
+    public static RichTextBlockElement TextReadingOrder(this RichTextBlockElement el, TextReadingOrder order) =>
+        el with { TextReadingOrder = order };
+
+    public static RichTextBlockElement IsTextScaleFactorEnabled(this RichTextBlockElement el, bool enabled = true) =>
+        el with { IsTextScaleFactorEnabled = enabled };
+
+    public static RichTextBlockElement IsColorFontEnabled(this RichTextBlockElement el, bool enabled = true) =>
+        el with { IsColorFontEnabled = enabled };
+
+    public static RichTextBlockElement OpticalMarginAlignment(this RichTextBlockElement el, OpticalMarginAlignment alignment) =>
+        el with { OpticalMarginAlignment = alignment };
+
+    public static RichTextBlockElement SelectionHighlightColor(this RichTextBlockElement el, Microsoft.UI.Xaml.Media.SolidColorBrush brush) =>
+        el with { SelectionHighlightColor = brush };
+
+    // ── Rich text paragraph / inline sugar ────────────────────────────────
+
+    public static RichTextParagraph Margin(this RichTextParagraph paragraph, double uniform) =>
+        paragraph with { Margin = new Thickness(uniform) };
+
+    public static RichTextParagraph Margin(this RichTextParagraph paragraph, double horizontal, double vertical) =>
+        paragraph with { Margin = new Thickness(horizontal, vertical, horizontal, vertical) };
+
+    public static RichTextParagraph Margin(this RichTextParagraph paragraph, double left = 0.0, double top = 0.0, double right = 0.0, double bottom = 0.0) =>
+        paragraph with { Margin = new Thickness(left, top, right, bottom) };
+
+    public static RichTextParagraph TextIndent(this RichTextParagraph paragraph, double indent) =>
+        paragraph with { TextIndent = indent };
+
+    public static RichTextParagraph TextAlignment(this RichTextParagraph paragraph, TextAlignment alignment) =>
+        paragraph with { TextAlignment = alignment };
+
+    public static RichTextParagraph HorizontalTextAlignment(this RichTextParagraph paragraph, TextAlignment alignment) =>
+        paragraph with { HorizontalTextAlignment = alignment };
+
+    public static RichTextParagraph LineHeight(this RichTextParagraph paragraph, double height) =>
+        paragraph with { LineHeight = height };
+
+    public static RichTextParagraph LineStackingStrategy(this RichTextParagraph paragraph, LineStackingStrategy strategy) =>
+        paragraph with { LineStackingStrategy = strategy };
+
+    public static RichTextParagraph FontSize(this RichTextParagraph paragraph, double size) =>
+        paragraph with { FontSize = size };
+
+    public static RichTextParagraph FontFamily(this RichTextParagraph paragraph, string family) =>
+        paragraph with { FontFamily = family };
+
+    public static RichTextParagraph FontWeight(this RichTextParagraph paragraph, global::Windows.UI.Text.FontWeight weight) =>
+        paragraph with { FontWeight = weight };
+
+    public static RichTextParagraph FontStyle(this RichTextParagraph paragraph, global::Windows.UI.Text.FontStyle style) =>
+        paragraph with { FontStyle = style };
+
+    public static RichTextParagraph FontStretch(this RichTextParagraph paragraph, global::Windows.UI.Text.FontStretch stretch) =>
+        paragraph with { FontStretch = stretch };
+
+    public static RichTextParagraph Foreground(this RichTextParagraph paragraph, string color) =>
+        paragraph with { Foreground = BrushHelper.Parse(color) };
+
+    public static RichTextParagraph Foreground(this RichTextParagraph paragraph, Brush brush) =>
+        paragraph with { Foreground = brush };
+
+    public static RichTextParagraph CharacterSpacing(this RichTextParagraph paragraph, int spacing) =>
+        paragraph with { CharacterSpacing = spacing };
+
+    public static RichTextParagraph TextDecorations(this RichTextParagraph paragraph, global::Windows.UI.Text.TextDecorations decorations) =>
+        paragraph with { TextDecorations = decorations };
+
+    public static RichTextParagraph IsTextScaleFactorEnabled(this RichTextParagraph paragraph, bool enabled = true) =>
+        paragraph with { IsTextScaleFactorEnabled = enabled };
+
+    public static RichTextParagraph Language(this RichTextParagraph paragraph, string language) =>
+        paragraph with { Language = language };
+
+    public static RichTextRun FontSize(this RichTextRun run, double size) =>
+        run with { FontSize = size };
+
+    public static RichTextHyperlink FontSize(this RichTextHyperlink link, double size) =>
+        link with { FontSize = size };
+
+    public static RichTextRun FontFamily(this RichTextRun run, string family) =>
+        run with { FontFamily = family };
+
+    public static RichTextHyperlink FontFamily(this RichTextHyperlink link, string family) =>
+        link with { FontFamily = family };
+
+    public static RichTextRun FontWeight(this RichTextRun run, global::Windows.UI.Text.FontWeight weight) =>
+        run with { FontWeight = weight };
+
+    public static RichTextHyperlink FontWeight(this RichTextHyperlink link, global::Windows.UI.Text.FontWeight weight) =>
+        link with { FontWeight = weight };
+
+    public static RichTextRun FontStyle(this RichTextRun run, global::Windows.UI.Text.FontStyle style) =>
+        run with { FontStyle = style };
+
+    public static RichTextHyperlink FontStyle(this RichTextHyperlink link, global::Windows.UI.Text.FontStyle style) =>
+        link with { FontStyle = style };
+
+    public static RichTextRun FontStretch(this RichTextRun run, global::Windows.UI.Text.FontStretch stretch) =>
+        run with { FontStretch = stretch };
+
+    public static RichTextHyperlink FontStretch(this RichTextHyperlink link, global::Windows.UI.Text.FontStretch stretch) =>
+        link with { FontStretch = stretch };
+
+    public static RichTextRun Foreground(this RichTextRun run, string color) =>
+        run with { Foreground = BrushHelper.Parse(color) };
+
+    public static RichTextRun Foreground(this RichTextRun run, Brush brush) =>
+        run with { Foreground = brush };
+
+    public static RichTextHyperlink Foreground(this RichTextHyperlink link, string color) =>
+        link with { Foreground = BrushHelper.Parse(color) };
+
+    public static RichTextHyperlink Foreground(this RichTextHyperlink link, Brush brush) =>
+        link with { Foreground = brush };
+
+    public static RichTextRun CharacterSpacing(this RichTextRun run, int spacing) =>
+        run with { CharacterSpacing = spacing };
+
+    public static RichTextHyperlink CharacterSpacing(this RichTextHyperlink link, int spacing) =>
+        link with { CharacterSpacing = spacing };
+
+    public static RichTextRun TextDecorations(this RichTextRun run, global::Windows.UI.Text.TextDecorations decorations) =>
+        run with { TextDecorations = decorations };
+
+    public static RichTextHyperlink TextDecorations(this RichTextHyperlink link, global::Windows.UI.Text.TextDecorations decorations) =>
+        link with { TextDecorations = decorations };
+
+    public static RichTextRun IsTextScaleFactorEnabled(this RichTextRun run, bool enabled = true) =>
+        run with { IsTextScaleFactorEnabled = enabled };
+
+    public static RichTextHyperlink IsTextScaleFactorEnabled(this RichTextHyperlink link, bool enabled = true) =>
+        link with { IsTextScaleFactorEnabled = enabled };
+
+    public static RichTextRun Language(this RichTextRun run, string language) =>
+        run with { Language = language };
+
+    public static RichTextHyperlink Language(this RichTextHyperlink link, string language) =>
+        link with { Language = language };
+
+    public static RichTextRun FlowDirection(this RichTextRun run, FlowDirection direction) =>
+        run with { FlowDirection = direction };
+
+    public static RichTextHyperlink UnderlineStyle(this RichTextHyperlink link, Microsoft.UI.Xaml.Documents.UnderlineStyle style) =>
+        link with { UnderlineStyle = style };
+
+    public static RichTextHyperlink IsTabStop(this RichTextHyperlink link, bool isTabStop = true) =>
+        link with { IsTabStop = isTabStop };
+
+    public static RichTextHyperlink TabIndex(this RichTextHyperlink link, int tabIndex) =>
+        link with { TabIndex = tabIndex };
+
     // ── RichEditBox sugar ───────────────────────────────────────────────
 
     /// <summary>Enable or disable built-in spell-check.</summary>

--- a/src/Reactor/Markdown/MarkdownBuilder.cs
+++ b/src/Reactor/Markdown/MarkdownBuilder.cs
@@ -42,6 +42,27 @@ public record MarkdownOptions
     /// <summary>Override image rendering. (altText, src)</summary>
     public Func<string, Uri, Element>? Image { get; init; }
 
+    /// <summary>
+    /// Per-cell padding applied to every cell of the default markdown table
+    /// renderer. Default <c>(12, 6, 12, 6)</c> — wide enough that adjacent
+    /// numeric columns don't visually touch on Star-sized auto-shrunk tables
+    /// (as happens when the table is hosted inside an
+    /// <see cref="RichTextInlineUIContainer"/> under
+    /// <see cref="UnifiedRichText"/>). Ignored when <see cref="Table"/> is
+    /// overridden.
+    /// </summary>
+    public Microsoft.UI.Xaml.Thickness TableCellPadding { get; init; } = new(12, 6, 12, 6);
+
+    /// <summary>
+    /// Background brush applied to header-row cells (<c>th</c>) of the default
+    /// markdown table renderer. Defaults to <see cref="Core.Theme.SubtleFill"/>
+    /// so the header is visually distinct in both light and dark themes (the
+    /// historical hardcoded <c>#F0F0F0</c> was invisible in dark mode). Set to
+    /// <c>null</c> to skip the highlight. Ignored when <see cref="Table"/> is
+    /// overridden.
+    /// </summary>
+    public Core.ThemeRef? TableHeaderBackground { get; init; } = Core.Theme.SubtleFill;
+
     /// <summary>Font family for inline code and code blocks. Default: "Consolas".</summary>
     public string CodeFontFamily { get; init; } = "Consolas";
     /// <summary>Parser flags. Default: DialectGitHub (tables, strikethrough, task lists).</summary>
@@ -682,14 +703,18 @@ internal sealed class MarkdownBuilder
             _ => cell.HAlign(HorizontalAlignment.Left),
         };
 
-        // Position in grid and add padding.
+        // Apply padding directly on the cell — RichTextBlockDescriptor now
+        // wires the standard Element.Padding modifier through to
+        // Microsoft.UI.Xaml.Controls.RichTextBlock.Padding, so no extra Border
+        // layer is needed (which would change the layout-bounds shape).
+        var pad = _options.TableCellPadding;
         cell = cell
-            .Grid(row: _tableRowIndex, column: _tableCellIndex)
-            .Padding(4, 2, 4, 2);
+            .Padding(pad.Left, pad.Top, pad.Right, pad.Bottom)
+            .Grid(row: _tableRowIndex, column: _tableCellIndex);
 
-        // Header row gets subtle background.
-        if (isHeader)
-            cell = cell.Background("#F0F0F0");
+        // Header row gets a theme-aware background (default Theme.SubtleFill).
+        if (isHeader && _options.TableHeaderBackground is { } headerBg)
+            cell = cell.Background(headerBg);
 
         _tableAllCells.Add(cell);
         _tableCellIndex++;

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/RichTextPropertyFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/RichTextPropertyFixtures.cs
@@ -1,0 +1,367 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Media;
+using static Microsoft.UI.Reactor.Factories;
+using WinBlock = Microsoft.UI.Xaml.Documents.Block;
+using WinHyperlink = Microsoft.UI.Xaml.Documents.Hyperlink;
+using WinParagraph = Microsoft.UI.Xaml.Documents.Paragraph;
+using WinRichTextBlock = Microsoft.UI.Xaml.Controls.RichTextBlock;
+using WinRun = Microsoft.UI.Xaml.Documents.Run;
+using WinTextElement = Microsoft.UI.Xaml.Documents.TextElement;
+using WinUnderlineStyle = Microsoft.UI.Xaml.Documents.UnderlineStyle;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+internal static class RichTextPropertyFixtures
+{
+    internal class RichTextProps_Block_MountUpdateClear(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (styled, setStyled) = ctx.UseState(true);
+                var block = RichTextBlock("root") with { IsTextSelectionEnabled = true };
+                if (styled)
+                {
+                    block = block with
+                    {
+                        FontSize = 23,
+                        FontFamily = new FontFamily("Consolas"),
+                        FontWeight = Microsoft.UI.Text.FontWeights.Bold,
+                        FontStyle = global::Windows.UI.Text.FontStyle.Italic,
+                        FontStretch = global::Windows.UI.Text.FontStretch.Expanded,
+                        Foreground = Brush(200, 20, 30),
+                        MaxLines = 3,
+                        LineHeight = 31,
+                        TextAlignment = TextAlignment.Center,
+                        HorizontalTextAlignment = TextAlignment.Center,
+                        TextTrimming = TextTrimming.WordEllipsis,
+                        CharacterSpacing = 120,
+                        TextDecorations = global::Windows.UI.Text.TextDecorations.Underline,
+                        LineStackingStrategy = LineStackingStrategy.BlockLineHeight,
+                        TextIndent = 11,
+                        TextLineBounds = TextLineBounds.Tight,
+                        TextReadingOrder = TextReadingOrder.DetectFromContent,
+                        IsTextScaleFactorEnabled = false,
+                        IsColorFontEnabled = false,
+                        OpticalMarginAlignment = OpticalMarginAlignment.TrimSideBearings,
+                        SelectionHighlightColor = Brush(10, 20, 200),
+                        Padding = new Thickness(1, 2, 3, 4),
+                    };
+                }
+
+                return VStack(
+                    Button("ToggleRootProps", () => setStyled(!styled)),
+                    block);
+            });
+
+            await Harness.Render();
+
+            var rtb = H.FindControl<WinRichTextBlock>(_ => true);
+            H.Check("RichTextProps_Block_Mounted", rtb is not null);
+            H.Check("RichTextProps_Block_FontSize", rtb!.FontSize == 23);
+            H.Check("RichTextProps_Block_FontFamily", rtb.FontFamily.Source.Contains("Consolas", StringComparison.OrdinalIgnoreCase));
+            H.Check("RichTextProps_Block_FontWeight", rtb.FontWeight.Weight >= 700);
+            H.Check("RichTextProps_Block_FontStyle", rtb.FontStyle == global::Windows.UI.Text.FontStyle.Italic);
+            H.Check("RichTextProps_Block_FontStretch", rtb.FontStretch == global::Windows.UI.Text.FontStretch.Expanded);
+            H.Check("RichTextProps_Block_Foreground", IsColor(rtb.Foreground, 200, 20, 30));
+            H.Check("RichTextProps_Block_MaxLines", rtb.MaxLines == 3);
+            H.Check("RichTextProps_Block_LineHeight", rtb.LineHeight == 31);
+            H.Check("RichTextProps_Block_TextAlignment", rtb.TextAlignment == TextAlignment.Center);
+            H.Check("RichTextProps_Block_HorizontalTextAlignment", rtb.HorizontalTextAlignment == TextAlignment.Center);
+            H.Check("RichTextProps_Block_TextTrimming", rtb.TextTrimming == TextTrimming.WordEllipsis);
+            H.Check("RichTextProps_Block_CharacterSpacing", rtb.CharacterSpacing == 120);
+            H.Check("RichTextProps_Block_TextDecorations", rtb.TextDecorations == global::Windows.UI.Text.TextDecorations.Underline);
+            H.Check("RichTextProps_Block_LineStackingStrategy", rtb.LineStackingStrategy == LineStackingStrategy.BlockLineHeight);
+            H.Check("RichTextProps_Block_TextIndent", rtb.TextIndent == 11);
+            H.Check("RichTextProps_Block_TextLineBounds", rtb.TextLineBounds == TextLineBounds.Tight);
+            H.Check("RichTextProps_Block_TextReadingOrder", rtb.TextReadingOrder == TextReadingOrder.DetectFromContent);
+            H.Check("RichTextProps_Block_IsTextScaleFactorEnabled", rtb.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_Block_IsColorFontEnabled", rtb.IsColorFontEnabled == false);
+            H.Check("RichTextProps_Block_OpticalMarginAlignment", rtb.OpticalMarginAlignment == OpticalMarginAlignment.TrimSideBearings);
+            H.Check("RichTextProps_Block_SelectionHighlightColor", IsColor(rtb.SelectionHighlightColor, 10, 20, 200));
+            H.Check("RichTextProps_Block_Padding", rtb.Padding == new Thickness(1, 2, 3, 4));
+
+            H.ClickButton("ToggleRootProps");
+            await Harness.Render();
+
+            H.Check("RichTextProps_Block_IdentityPreserved", ReferenceEquals(rtb, H.FindControl<WinRichTextBlock>(_ => true)));
+            H.Check("RichTextProps_Block_FontSizeCleared", IsUnset(rtb, WinRichTextBlock.FontSizeProperty));
+            H.Check("RichTextProps_Block_FontFamilyCleared", IsUnset(rtb, WinRichTextBlock.FontFamilyProperty));
+            H.Check("RichTextProps_Block_FontWeightCleared", IsUnset(rtb, WinRichTextBlock.FontWeightProperty));
+            H.Check("RichTextProps_Block_FontStyleCleared", IsUnset(rtb, WinRichTextBlock.FontStyleProperty));
+            H.Check("RichTextProps_Block_FontStretchCleared", IsUnset(rtb, WinRichTextBlock.FontStretchProperty));
+            H.Check("RichTextProps_Block_ForegroundCleared", IsUnset(rtb, WinRichTextBlock.ForegroundProperty));
+            H.Check("RichTextProps_Block_MaxLinesReset", rtb.MaxLines == 0);
+            H.Check("RichTextProps_Block_LineHeightCleared", IsUnset(rtb, WinRichTextBlock.LineHeightProperty));
+            H.Check("RichTextProps_Block_TextAlignmentCleared", IsUnset(rtb, WinRichTextBlock.TextAlignmentProperty));
+            H.Check("RichTextProps_Block_HorizontalTextAlignmentCleared", IsUnset(rtb, WinRichTextBlock.HorizontalTextAlignmentProperty));
+            H.Check("RichTextProps_Block_TextTrimmingCleared", IsUnset(rtb, WinRichTextBlock.TextTrimmingProperty));
+            H.Check("RichTextProps_Block_CharacterSpacingReset", rtb.CharacterSpacing == 0);
+            H.Check("RichTextProps_Block_TextDecorationsCleared", IsUnset(rtb, WinRichTextBlock.TextDecorationsProperty));
+            H.Check("RichTextProps_Block_LineStackingStrategyCleared", IsUnset(rtb, WinRichTextBlock.LineStackingStrategyProperty));
+            H.Check("RichTextProps_Block_TextIndentCleared", IsUnset(rtb, WinRichTextBlock.TextIndentProperty));
+            H.Check("RichTextProps_Block_TextLineBoundsCleared", IsUnset(rtb, WinRichTextBlock.TextLineBoundsProperty));
+            H.Check("RichTextProps_Block_TextReadingOrderCleared", IsUnset(rtb, WinRichTextBlock.TextReadingOrderProperty));
+            H.Check("RichTextProps_Block_IsTextScaleFactorEnabledCleared", IsUnset(rtb, WinRichTextBlock.IsTextScaleFactorEnabledProperty));
+            H.Check("RichTextProps_Block_IsColorFontEnabledCleared", IsUnset(rtb, WinRichTextBlock.IsColorFontEnabledProperty));
+            H.Check("RichTextProps_Block_OpticalMarginAlignmentCleared", IsUnset(rtb, WinRichTextBlock.OpticalMarginAlignmentProperty));
+            H.Check("RichTextProps_Block_SelectionHighlightColorCleared", IsUnset(rtb, WinRichTextBlock.SelectionHighlightColorProperty));
+            H.Check("RichTextProps_Block_PaddingCleared", IsUnset(rtb, WinRichTextBlock.PaddingProperty));
+        }
+    }
+
+    internal class RichTextProps_Paragraph_MountUpdateClear(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (styled, setStyled) = ctx.UseState(true);
+                var paragraph = Paragraph(Run("paragraph"));
+                if (styled)
+                {
+                    paragraph = paragraph with
+                    {
+                        Margin = new Thickness(2, 3, 4, 5),
+                        TextIndent = 9,
+                        TextAlignment = TextAlignment.Right,
+                        HorizontalTextAlignment = TextAlignment.Right,
+                        LineHeight = 28,
+                        LineStackingStrategy = LineStackingStrategy.BlockLineHeight,
+                        FontSize = 18,
+                        FontFamily = "Consolas",
+                        FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                        FontStyle = global::Windows.UI.Text.FontStyle.Italic,
+                        FontStretch = global::Windows.UI.Text.FontStretch.Condensed,
+                        Foreground = Brush(20, 160, 80),
+                        CharacterSpacing = 75,
+                        TextDecorations = global::Windows.UI.Text.TextDecorations.Underline,
+                        IsTextScaleFactorEnabled = false,
+                        Language = "fr-FR",
+                    };
+                }
+
+                return VStack(
+                    Button("ToggleParagraphProps", () => setStyled(!styled)),
+                    RichTextBlock(new[] { paragraph }));
+            });
+
+            await Harness.Render();
+
+            var rtb = H.FindControl<WinRichTextBlock>(_ => true);
+            var paragraph = FirstParagraph(rtb!);
+            H.Check("RichTextProps_Paragraph_Mounted", paragraph is not null);
+            H.Check("RichTextProps_Paragraph_Margin", paragraph!.Margin == new Thickness(2, 3, 4, 5));
+            H.Check("RichTextProps_Paragraph_TextIndent", paragraph.TextIndent == 9);
+            H.Check("RichTextProps_Paragraph_TextAlignment", paragraph.TextAlignment == TextAlignment.Right);
+            H.Check("RichTextProps_Paragraph_HorizontalTextAlignment", paragraph.HorizontalTextAlignment == TextAlignment.Right);
+            H.Check("RichTextProps_Paragraph_LineHeight", paragraph.LineHeight == 28);
+            H.Check("RichTextProps_Paragraph_LineStackingStrategy", paragraph.LineStackingStrategy == LineStackingStrategy.BlockLineHeight);
+            H.Check("RichTextProps_Paragraph_FontSize", paragraph.FontSize == 18);
+            H.Check("RichTextProps_Paragraph_FontFamily", paragraph.FontFamily.Source.Contains("Consolas", StringComparison.OrdinalIgnoreCase));
+            H.Check("RichTextProps_Paragraph_FontWeight", paragraph.FontWeight.Weight >= 600);
+            H.Check("RichTextProps_Paragraph_FontStyle", paragraph.FontStyle == global::Windows.UI.Text.FontStyle.Italic);
+            H.Check("RichTextProps_Paragraph_FontStretch", paragraph.FontStretch == global::Windows.UI.Text.FontStretch.Condensed);
+            H.Check("RichTextProps_Paragraph_Foreground", IsColor(paragraph.Foreground, 20, 160, 80));
+            H.Check("RichTextProps_Paragraph_CharacterSpacing", paragraph.CharacterSpacing == 75);
+            H.Check("RichTextProps_Paragraph_TextDecorations", paragraph.TextDecorations == global::Windows.UI.Text.TextDecorations.Underline);
+            H.Check("RichTextProps_Paragraph_IsTextScaleFactorEnabled", paragraph.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_Paragraph_Language", paragraph.Language == "fr-FR");
+
+            H.ClickButton("ToggleParagraphProps");
+            await Harness.Render();
+
+            H.Check("RichTextProps_Paragraph_IdentityPreserved", ReferenceEquals(paragraph, FirstParagraph(rtb!)));
+            H.Check("RichTextProps_Paragraph_MarginCleared", IsUnset(paragraph, WinBlock.MarginProperty));
+            H.Check("RichTextProps_Paragraph_TextIndentCleared", IsUnset(paragraph, WinParagraph.TextIndentProperty));
+            H.Check("RichTextProps_Paragraph_TextAlignmentCleared", IsUnset(paragraph, WinBlock.TextAlignmentProperty));
+            H.Check("RichTextProps_Paragraph_HorizontalTextAlignmentCleared", IsUnset(paragraph, WinBlock.HorizontalTextAlignmentProperty));
+            H.Check("RichTextProps_Paragraph_LineHeightCleared", IsUnset(paragraph, WinBlock.LineHeightProperty));
+            H.Check("RichTextProps_Paragraph_LineStackingStrategyCleared", IsUnset(paragraph, WinBlock.LineStackingStrategyProperty));
+            H.Check("RichTextProps_Paragraph_FontSizeCleared", IsUnset(paragraph, WinTextElement.FontSizeProperty));
+            H.Check("RichTextProps_Paragraph_FontFamilyCleared", IsUnset(paragraph, WinTextElement.FontFamilyProperty));
+            H.Check("RichTextProps_Paragraph_FontWeightCleared", IsUnset(paragraph, WinTextElement.FontWeightProperty));
+            H.Check("RichTextProps_Paragraph_FontStyleCleared", IsUnset(paragraph, WinTextElement.FontStyleProperty));
+            H.Check("RichTextProps_Paragraph_FontStretchCleared", IsUnset(paragraph, WinTextElement.FontStretchProperty));
+            H.Check("RichTextProps_Paragraph_ForegroundCleared", IsUnset(paragraph, WinTextElement.ForegroundProperty));
+            H.Check("RichTextProps_Paragraph_CharacterSpacingCleared", IsUnset(paragraph, WinTextElement.CharacterSpacingProperty));
+            H.Check("RichTextProps_Paragraph_TextDecorationsCleared", IsUnset(paragraph, WinTextElement.TextDecorationsProperty));
+            H.Check("RichTextProps_Paragraph_IsTextScaleFactorEnabledCleared", IsUnset(paragraph, WinTextElement.IsTextScaleFactorEnabledProperty));
+            H.Check("RichTextProps_Paragraph_LanguageCleared", IsUnset(paragraph, WinTextElement.LanguageProperty));
+        }
+    }
+
+    internal class RichTextProps_Run_MountUpdateClear(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (styled, setStyled) = ctx.UseState(true);
+                var run = Run("run");
+                if (styled)
+                {
+                    run = run with
+                    {
+                        FontSize = 19,
+                        FontFamily = "Consolas",
+                        FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                        FontStyle = global::Windows.UI.Text.FontStyle.Italic,
+                        FontStretch = global::Windows.UI.Text.FontStretch.Expanded,
+                        Foreground = Brush(140, 40, 220),
+                        CharacterSpacing = 90,
+                        TextDecorations = global::Windows.UI.Text.TextDecorations.Underline | global::Windows.UI.Text.TextDecorations.Strikethrough,
+                        IsTextScaleFactorEnabled = false,
+                        Language = "es-ES",
+                        FlowDirection = FlowDirection.RightToLeft,
+                    };
+                }
+
+                return VStack(
+                    Button("ToggleRunProps", () => setStyled(!styled)),
+                    RichTextBlock(new[] { Paragraph(run) }));
+            });
+
+            await Harness.Render();
+
+            var rtb = H.FindControl<WinRichTextBlock>(_ => true);
+            var run = FirstRun(rtb!);
+            H.Check("RichTextProps_Run_Mounted", run is not null);
+            H.Check("RichTextProps_Run_FontSize", run!.FontSize == 19);
+            H.Check("RichTextProps_Run_FontFamily", run.FontFamily.Source.Contains("Consolas", StringComparison.OrdinalIgnoreCase));
+            H.Check("RichTextProps_Run_FontWeight", run.FontWeight.Weight >= 600);
+            H.Check("RichTextProps_Run_FontStyle", run.FontStyle == global::Windows.UI.Text.FontStyle.Italic);
+            H.Check("RichTextProps_Run_FontStretch", run.FontStretch == global::Windows.UI.Text.FontStretch.Expanded);
+            H.Check("RichTextProps_Run_Foreground", IsColor(run.Foreground, 140, 40, 220));
+            H.Check("RichTextProps_Run_CharacterSpacing", run.CharacterSpacing == 90);
+            H.Check("RichTextProps_Run_TextDecorations", run.TextDecorations.HasFlag(global::Windows.UI.Text.TextDecorations.Underline)
+                && run.TextDecorations.HasFlag(global::Windows.UI.Text.TextDecorations.Strikethrough));
+            H.Check("RichTextProps_Run_IsTextScaleFactorEnabled", run.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_Run_Language", run.Language == "es-ES");
+            H.Check("RichTextProps_Run_FlowDirection", run.FlowDirection == FlowDirection.RightToLeft);
+
+            H.ClickButton("ToggleRunProps");
+            await Harness.Render();
+
+            H.Check("RichTextProps_Run_IdentityPreserved", ReferenceEquals(run, FirstRun(rtb!)));
+            H.Check("RichTextProps_Run_FontSizeCleared", IsUnset(run, WinTextElement.FontSizeProperty));
+            H.Check("RichTextProps_Run_FontFamilyCleared", IsUnset(run, WinTextElement.FontFamilyProperty));
+            H.Check("RichTextProps_Run_FontWeightCleared", IsUnset(run, WinTextElement.FontWeightProperty));
+            H.Check("RichTextProps_Run_FontStyleCleared", IsUnset(run, WinTextElement.FontStyleProperty));
+            H.Check("RichTextProps_Run_FontStretchCleared", IsUnset(run, WinTextElement.FontStretchProperty));
+            H.Check("RichTextProps_Run_ForegroundCleared", IsUnset(run, WinTextElement.ForegroundProperty));
+            H.Check("RichTextProps_Run_CharacterSpacingCleared", IsUnset(run, WinTextElement.CharacterSpacingProperty));
+            H.Check("RichTextProps_Run_TextDecorationsCleared", IsUnset(run, WinTextElement.TextDecorationsProperty));
+            H.Check("RichTextProps_Run_IsTextScaleFactorEnabledCleared", IsUnset(run, WinTextElement.IsTextScaleFactorEnabledProperty));
+            H.Check("RichTextProps_Run_LanguageCleared", IsUnset(run, WinTextElement.LanguageProperty));
+            H.Check("RichTextProps_Run_FlowDirectionCleared", IsUnset(run, WinRun.FlowDirectionProperty));
+        }
+    }
+
+    internal class RichTextProps_Hyperlink_MountUpdateClear(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (styled, setStyled) = ctx.UseState(true);
+                var link = Hyperlink("link", new Uri("https://example.com"));
+                if (styled)
+                {
+                    link = link with
+                    {
+                        FontSize = 20,
+                        FontFamily = "Consolas",
+                        FontWeight = Microsoft.UI.Text.FontWeights.Bold,
+                        FontStyle = global::Windows.UI.Text.FontStyle.Italic,
+                        FontStretch = global::Windows.UI.Text.FontStretch.Expanded,
+                        Foreground = Brush(220, 110, 20),
+                        CharacterSpacing = 130,
+                        TextDecorations = global::Windows.UI.Text.TextDecorations.Underline,
+                        IsTextScaleFactorEnabled = false,
+                        Language = "de-DE",
+                        UnderlineStyle = WinUnderlineStyle.None,
+                        IsTabStop = false,
+                        TabIndex = 7,
+                    };
+                }
+
+                return VStack(
+                    Button("ToggleHyperlinkProps", () => setStyled(!styled)),
+                    RichTextBlock(new[] { Paragraph(link) }));
+            });
+
+            await Harness.Render();
+
+            var rtb = H.FindControl<WinRichTextBlock>(_ => true);
+            var link = FirstHyperlink(rtb!);
+            var linkRun = FirstHyperlinkRun(rtb!);
+            H.Check("RichTextProps_Hyperlink_Mounted", link is not null);
+            H.Check("RichTextProps_Hyperlink_FontSize", link!.FontSize == 20);
+            H.Check("RichTextProps_Hyperlink_FontFamily", link.FontFamily.Source.Contains("Consolas", StringComparison.OrdinalIgnoreCase));
+            H.Check("RichTextProps_Hyperlink_FontWeight", link.FontWeight.Weight >= 700);
+            H.Check("RichTextProps_Hyperlink_FontStyle", link.FontStyle == global::Windows.UI.Text.FontStyle.Italic);
+            H.Check("RichTextProps_Hyperlink_FontStretch", link.FontStretch == global::Windows.UI.Text.FontStretch.Expanded);
+            H.Check("RichTextProps_Hyperlink_Foreground", IsColor(link.Foreground, 220, 110, 20));
+            H.Check("RichTextProps_Hyperlink_CharacterSpacing", link.CharacterSpacing == 130);
+            H.Check("RichTextProps_Hyperlink_TextDecorations", linkRun?.TextDecorations == global::Windows.UI.Text.TextDecorations.Underline);
+            H.Check("RichTextProps_Hyperlink_IsTextScaleFactorEnabled", link.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_Hyperlink_Language", link.Language == "de-DE");
+            H.Check("RichTextProps_Hyperlink_UnderlineStyle", link.UnderlineStyle == WinUnderlineStyle.None);
+            H.Check("RichTextProps_Hyperlink_IsTabStop", link.IsTabStop == false);
+            H.Check("RichTextProps_Hyperlink_TabIndex", link.TabIndex == 7);
+
+            H.ClickButton("ToggleHyperlinkProps");
+            await Harness.Render();
+
+            H.Check("RichTextProps_Hyperlink_IdentityPreserved", ReferenceEquals(link, FirstHyperlink(rtb!)));
+            H.Check("RichTextProps_Hyperlink_FontSizeCleared", IsUnset(link, WinTextElement.FontSizeProperty));
+            H.Check("RichTextProps_Hyperlink_FontFamilyCleared", IsUnset(link, WinTextElement.FontFamilyProperty));
+            H.Check("RichTextProps_Hyperlink_FontWeightCleared", IsUnset(link, WinTextElement.FontWeightProperty));
+            H.Check("RichTextProps_Hyperlink_FontStyleCleared", IsUnset(link, WinTextElement.FontStyleProperty));
+            H.Check("RichTextProps_Hyperlink_FontStretchCleared", IsUnset(link, WinTextElement.FontStretchProperty));
+            H.Check("RichTextProps_Hyperlink_ForegroundCleared", IsUnset(link, WinTextElement.ForegroundProperty));
+            H.Check("RichTextProps_Hyperlink_CharacterSpacingCleared", IsUnset(link, WinTextElement.CharacterSpacingProperty));
+            H.Check("RichTextProps_Hyperlink_TextDecorationsCleared", linkRun is not null && IsUnset(linkRun, WinTextElement.TextDecorationsProperty));
+            H.Check("RichTextProps_Hyperlink_IsTextScaleFactorEnabledCleared", IsUnset(link, WinTextElement.IsTextScaleFactorEnabledProperty));
+            H.Check("RichTextProps_Hyperlink_LanguageCleared", IsUnset(link, WinTextElement.LanguageProperty));
+            H.Check("RichTextProps_Hyperlink_UnderlineStyleCleared", IsUnset(link, WinHyperlink.UnderlineStyleProperty));
+            H.Check("RichTextProps_Hyperlink_IsTabStopCleared", IsUnset(link, WinHyperlink.IsTabStopProperty));
+            H.Check("RichTextProps_Hyperlink_TabIndexCleared", IsUnset(link, WinHyperlink.TabIndexProperty));
+        }
+    }
+
+    private static WinParagraph? FirstParagraph(WinRichTextBlock rtb)
+        => rtb.Blocks.OfType<WinParagraph>().FirstOrDefault();
+
+    private static WinRun? FirstRun(WinRichTextBlock rtb)
+        => FirstParagraph(rtb)?.Inlines.OfType<WinRun>().FirstOrDefault();
+
+    private static WinHyperlink? FirstHyperlink(WinRichTextBlock rtb)
+        => FirstParagraph(rtb)?.Inlines.OfType<WinHyperlink>().FirstOrDefault();
+
+    private static WinRun? FirstHyperlinkRun(WinRichTextBlock rtb)
+        => FirstHyperlink(rtb)?.Inlines.OfType<WinRun>().FirstOrDefault();
+
+    private static SolidColorBrush Brush(byte r, byte g, byte b) =>
+        new(global::Windows.UI.Color.FromArgb(255, r, g, b));
+
+    private static bool IsColor(Brush? brush, byte r, byte g, byte b) =>
+        brush is SolidColorBrush sb
+        && sb.Color.A == 255
+        && sb.Color.R == r
+        && sb.Color.G == g
+        && sb.Color.B == b;
+
+    private static bool IsUnset(DependencyObject target, DependencyProperty property) =>
+        ReferenceEquals(target.ReadLocalValue(property), DependencyProperty.UnsetValue);
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/RichTextPropertyFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/RichTextPropertyFixtures.cs
@@ -89,8 +89,8 @@ internal static class RichTextPropertyFixtures
             H.Check("RichTextProps_Block_TextIndent", IsClose(rtb.TextIndent, 11));
             H.Check("RichTextProps_Block_TextLineBounds", rtb.TextLineBounds == TextLineBounds.Tight);
             H.Check("RichTextProps_Block_TextReadingOrder", rtb.TextReadingOrder == TextReadingOrder.DetectFromContent);
-            H.Check("RichTextProps_Block_IsTextScaleFactorEnabled", rtb.IsTextScaleFactorEnabled == false);
-            H.Check("RichTextProps_Block_IsColorFontEnabled", rtb.IsColorFontEnabled == false);
+            H.Check("RichTextProps_Block_IsTextScaleFactorEnabled", !rtb.IsTextScaleFactorEnabled);
+            H.Check("RichTextProps_Block_IsColorFontEnabled", !rtb.IsColorFontEnabled);
             H.Check("RichTextProps_Block_OpticalMarginAlignment", rtb.OpticalMarginAlignment == OpticalMarginAlignment.TrimSideBearings);
             H.Check("RichTextProps_Block_SelectionHighlightColor", IsColor(rtb.SelectionHighlightColor, 10, 20, 200));
             H.Check("RichTextProps_Block_Padding", rtb.Padding == new Thickness(1, 2, 3, 4));
@@ -185,7 +185,7 @@ internal static class RichTextPropertyFixtures
             H.Check("RichTextProps_Paragraph_Foreground", IsColor(paragraph.Foreground, 20, 160, 80));
             H.Check("RichTextProps_Paragraph_CharacterSpacing", paragraph.CharacterSpacing == 75);
             H.Check("RichTextProps_Paragraph_TextDecorations", paragraph.TextDecorations == global::Windows.UI.Text.TextDecorations.Underline);
-            H.Check("RichTextProps_Paragraph_IsTextScaleFactorEnabled", paragraph.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_Paragraph_IsTextScaleFactorEnabled", !paragraph.IsTextScaleFactorEnabled);
             H.Check("RichTextProps_Paragraph_Language", paragraph.Language == "fr-FR");
 
             H.ClickButton("ToggleParagraphProps");
@@ -262,7 +262,7 @@ internal static class RichTextPropertyFixtures
             H.Check("RichTextProps_Run_CharacterSpacing", run.CharacterSpacing == 90);
             H.Check("RichTextProps_Run_TextDecorations", run.TextDecorations.HasFlag(global::Windows.UI.Text.TextDecorations.Underline)
                 && run.TextDecorations.HasFlag(global::Windows.UI.Text.TextDecorations.Strikethrough));
-            H.Check("RichTextProps_Run_IsTextScaleFactorEnabled", run.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_Run_IsTextScaleFactorEnabled", !run.IsTextScaleFactorEnabled);
             H.Check("RichTextProps_Run_Language", run.Language == "es-ES");
             H.Check("RichTextProps_Run_FlowDirection", run.FlowDirection == FlowDirection.RightToLeft);
 
@@ -337,10 +337,10 @@ internal static class RichTextPropertyFixtures
             H.Check("RichTextProps_Hyperlink_Foreground", IsColor(link.Foreground, 220, 110, 20));
             H.Check("RichTextProps_Hyperlink_CharacterSpacing", link.CharacterSpacing == 130);
             H.Check("RichTextProps_Hyperlink_TextDecorations", linkRun?.TextDecorations == global::Windows.UI.Text.TextDecorations.Underline);
-            H.Check("RichTextProps_Hyperlink_IsTextScaleFactorEnabled", link.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_Hyperlink_IsTextScaleFactorEnabled", !link.IsTextScaleFactorEnabled);
             H.Check("RichTextProps_Hyperlink_Language", link.Language == "de-DE");
             H.Check("RichTextProps_Hyperlink_UnderlineStyle", link.UnderlineStyle == WinUnderlineStyle.None);
-            H.Check("RichTextProps_Hyperlink_IsTabStop", link.IsTabStop == false);
+            H.Check("RichTextProps_Hyperlink_IsTabStop", !link.IsTabStop);
             H.Check("RichTextProps_Hyperlink_TabIndex", link.TabIndex == 7);
 
             H.ClickButton("ToggleHyperlinkProps");
@@ -428,7 +428,7 @@ internal static class RichTextPropertyFixtures
             H.Check("RichTextProps_LineBreak_Foreground", IsColor(lineBreak.Foreground, 30, 60, 180));
             H.Check("RichTextProps_LineBreak_CharacterSpacing", lineBreak.CharacterSpacing == 42);
             H.Check("RichTextProps_LineBreak_TextDecorations", lineBreak.TextDecorations == global::Windows.UI.Text.TextDecorations.Underline);
-            H.Check("RichTextProps_LineBreak_IsTextScaleFactorEnabled", lineBreak.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_LineBreak_IsTextScaleFactorEnabled", !lineBreak.IsTextScaleFactorEnabled);
             H.Check("RichTextProps_LineBreak_Language", lineBreak.Language == "it-IT");
 
             H.Check("RichTextProps_InlineUI_FontSize", IsClose(inlineUi.FontSize, 17));
@@ -439,7 +439,7 @@ internal static class RichTextPropertyFixtures
             H.Check("RichTextProps_InlineUI_Foreground", IsColor(inlineUi.Foreground, 80, 30, 160));
             H.Check("RichTextProps_InlineUI_CharacterSpacing", inlineUi.CharacterSpacing == 55);
             H.Check("RichTextProps_InlineUI_TextDecorations", inlineUi.TextDecorations == global::Windows.UI.Text.TextDecorations.Strikethrough);
-            H.Check("RichTextProps_InlineUI_IsTextScaleFactorEnabled", inlineUi.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_InlineUI_IsTextScaleFactorEnabled", !inlineUi.IsTextScaleFactorEnabled);
             H.Check("RichTextProps_InlineUI_Language", inlineUi.Language == "pt-BR");
 
             H.ClickButton("ToggleLineBreakInlineUIProps");

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/RichTextPropertyFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/RichTextPropertyFixtures.cs
@@ -1,5 +1,7 @@
+using System;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
@@ -7,6 +9,8 @@ using Microsoft.UI.Xaml.Media;
 using static Microsoft.UI.Reactor.Factories;
 using WinBlock = Microsoft.UI.Xaml.Documents.Block;
 using WinHyperlink = Microsoft.UI.Xaml.Documents.Hyperlink;
+using WinInlineUIContainer = Microsoft.UI.Xaml.Documents.InlineUIContainer;
+using WinLineBreak = Microsoft.UI.Xaml.Documents.LineBreak;
 using WinParagraph = Microsoft.UI.Xaml.Documents.Paragraph;
 using WinRichTextBlock = Microsoft.UI.Xaml.Controls.RichTextBlock;
 using WinRun = Microsoft.UI.Xaml.Documents.Run;
@@ -17,6 +21,8 @@ namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
 internal static class RichTextPropertyFixtures
 {
+    private static readonly FontFamily s_consolas = WinRTCache.GetFontFamily("Consolas");
+
     internal class RichTextProps_Block_MountUpdateClear(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()
@@ -31,7 +37,7 @@ internal static class RichTextPropertyFixtures
                     block = block with
                     {
                         FontSize = 23,
-                        FontFamily = new FontFamily("Consolas"),
+                        FontFamily = s_consolas,
                         FontWeight = Microsoft.UI.Text.FontWeights.Bold,
                         FontStyle = global::Windows.UI.Text.FontStyle.Italic,
                         FontStretch = global::Windows.UI.Text.FontStretch.Expanded,
@@ -64,21 +70,23 @@ internal static class RichTextPropertyFixtures
 
             var rtb = H.FindControl<WinRichTextBlock>(_ => true);
             H.Check("RichTextProps_Block_Mounted", rtb is not null);
-            H.Check("RichTextProps_Block_FontSize", rtb!.FontSize == 23);
+            if (rtb is null) return;
+
+            H.Check("RichTextProps_Block_FontSize", IsClose(rtb.FontSize, 23));
             H.Check("RichTextProps_Block_FontFamily", rtb.FontFamily.Source.Contains("Consolas", StringComparison.OrdinalIgnoreCase));
             H.Check("RichTextProps_Block_FontWeight", rtb.FontWeight.Weight >= 700);
             H.Check("RichTextProps_Block_FontStyle", rtb.FontStyle == global::Windows.UI.Text.FontStyle.Italic);
             H.Check("RichTextProps_Block_FontStretch", rtb.FontStretch == global::Windows.UI.Text.FontStretch.Expanded);
             H.Check("RichTextProps_Block_Foreground", IsColor(rtb.Foreground, 200, 20, 30));
             H.Check("RichTextProps_Block_MaxLines", rtb.MaxLines == 3);
-            H.Check("RichTextProps_Block_LineHeight", rtb.LineHeight == 31);
+            H.Check("RichTextProps_Block_LineHeight", IsClose(rtb.LineHeight, 31));
             H.Check("RichTextProps_Block_TextAlignment", rtb.TextAlignment == TextAlignment.Center);
             H.Check("RichTextProps_Block_HorizontalTextAlignment", rtb.HorizontalTextAlignment == TextAlignment.Center);
             H.Check("RichTextProps_Block_TextTrimming", rtb.TextTrimming == TextTrimming.WordEllipsis);
             H.Check("RichTextProps_Block_CharacterSpacing", rtb.CharacterSpacing == 120);
             H.Check("RichTextProps_Block_TextDecorations", rtb.TextDecorations == global::Windows.UI.Text.TextDecorations.Underline);
             H.Check("RichTextProps_Block_LineStackingStrategy", rtb.LineStackingStrategy == LineStackingStrategy.BlockLineHeight);
-            H.Check("RichTextProps_Block_TextIndent", rtb.TextIndent == 11);
+            H.Check("RichTextProps_Block_TextIndent", IsClose(rtb.TextIndent, 11));
             H.Check("RichTextProps_Block_TextLineBounds", rtb.TextLineBounds == TextLineBounds.Tight);
             H.Check("RichTextProps_Block_TextReadingOrder", rtb.TextReadingOrder == TextReadingOrder.DetectFromContent);
             H.Check("RichTextProps_Block_IsTextScaleFactorEnabled", rtb.IsTextScaleFactorEnabled == false);
@@ -156,15 +164,20 @@ internal static class RichTextPropertyFixtures
             await Harness.Render();
 
             var rtb = H.FindControl<WinRichTextBlock>(_ => true);
-            var paragraph = FirstParagraph(rtb!);
+            H.Check("RichTextProps_Paragraph_RTBMounted", rtb is not null);
+            if (rtb is null) return;
+
+            var paragraph = FirstParagraph(rtb);
             H.Check("RichTextProps_Paragraph_Mounted", paragraph is not null);
-            H.Check("RichTextProps_Paragraph_Margin", paragraph!.Margin == new Thickness(2, 3, 4, 5));
-            H.Check("RichTextProps_Paragraph_TextIndent", paragraph.TextIndent == 9);
+            if (paragraph is null) return;
+
+            H.Check("RichTextProps_Paragraph_Margin", paragraph.Margin == new Thickness(2, 3, 4, 5));
+            H.Check("RichTextProps_Paragraph_TextIndent", IsClose(paragraph.TextIndent, 9));
             H.Check("RichTextProps_Paragraph_TextAlignment", paragraph.TextAlignment == TextAlignment.Right);
             H.Check("RichTextProps_Paragraph_HorizontalTextAlignment", paragraph.HorizontalTextAlignment == TextAlignment.Right);
-            H.Check("RichTextProps_Paragraph_LineHeight", paragraph.LineHeight == 28);
+            H.Check("RichTextProps_Paragraph_LineHeight", IsClose(paragraph.LineHeight, 28));
             H.Check("RichTextProps_Paragraph_LineStackingStrategy", paragraph.LineStackingStrategy == LineStackingStrategy.BlockLineHeight);
-            H.Check("RichTextProps_Paragraph_FontSize", paragraph.FontSize == 18);
+            H.Check("RichTextProps_Paragraph_FontSize", IsClose(paragraph.FontSize, 18));
             H.Check("RichTextProps_Paragraph_FontFamily", paragraph.FontFamily.Source.Contains("Consolas", StringComparison.OrdinalIgnoreCase));
             H.Check("RichTextProps_Paragraph_FontWeight", paragraph.FontWeight.Weight >= 600);
             H.Check("RichTextProps_Paragraph_FontStyle", paragraph.FontStyle == global::Windows.UI.Text.FontStyle.Italic);
@@ -178,7 +191,7 @@ internal static class RichTextPropertyFixtures
             H.ClickButton("ToggleParagraphProps");
             await Harness.Render();
 
-            H.Check("RichTextProps_Paragraph_IdentityPreserved", ReferenceEquals(paragraph, FirstParagraph(rtb!)));
+            H.Check("RichTextProps_Paragraph_IdentityPreserved", ReferenceEquals(paragraph, FirstParagraph(rtb)));
             H.Check("RichTextProps_Paragraph_MarginCleared", IsUnset(paragraph, WinBlock.MarginProperty));
             H.Check("RichTextProps_Paragraph_TextIndentCleared", IsUnset(paragraph, WinParagraph.TextIndentProperty));
             H.Check("RichTextProps_Paragraph_TextAlignmentCleared", IsUnset(paragraph, WinBlock.TextAlignmentProperty));
@@ -233,9 +246,14 @@ internal static class RichTextPropertyFixtures
             await Harness.Render();
 
             var rtb = H.FindControl<WinRichTextBlock>(_ => true);
-            var run = FirstRun(rtb!);
+            H.Check("RichTextProps_Run_RTBMounted", rtb is not null);
+            if (rtb is null) return;
+
+            var run = FirstRun(rtb);
             H.Check("RichTextProps_Run_Mounted", run is not null);
-            H.Check("RichTextProps_Run_FontSize", run!.FontSize == 19);
+            if (run is null) return;
+
+            H.Check("RichTextProps_Run_FontSize", IsClose(run.FontSize, 19));
             H.Check("RichTextProps_Run_FontFamily", run.FontFamily.Source.Contains("Consolas", StringComparison.OrdinalIgnoreCase));
             H.Check("RichTextProps_Run_FontWeight", run.FontWeight.Weight >= 600);
             H.Check("RichTextProps_Run_FontStyle", run.FontStyle == global::Windows.UI.Text.FontStyle.Italic);
@@ -251,7 +269,7 @@ internal static class RichTextPropertyFixtures
             H.ClickButton("ToggleRunProps");
             await Harness.Render();
 
-            H.Check("RichTextProps_Run_IdentityPreserved", ReferenceEquals(run, FirstRun(rtb!)));
+            H.Check("RichTextProps_Run_IdentityPreserved", ReferenceEquals(run, FirstRun(rtb)));
             H.Check("RichTextProps_Run_FontSizeCleared", IsUnset(run, WinTextElement.FontSizeProperty));
             H.Check("RichTextProps_Run_FontFamilyCleared", IsUnset(run, WinTextElement.FontFamilyProperty));
             H.Check("RichTextProps_Run_FontWeightCleared", IsUnset(run, WinTextElement.FontWeightProperty));
@@ -303,10 +321,15 @@ internal static class RichTextPropertyFixtures
             await Harness.Render();
 
             var rtb = H.FindControl<WinRichTextBlock>(_ => true);
-            var link = FirstHyperlink(rtb!);
-            var linkRun = FirstHyperlinkRun(rtb!);
+            H.Check("RichTextProps_Hyperlink_RTBMounted", rtb is not null);
+            if (rtb is null) return;
+
+            var link = FirstHyperlink(rtb);
+            var linkRun = FirstHyperlinkRun(rtb);
             H.Check("RichTextProps_Hyperlink_Mounted", link is not null);
-            H.Check("RichTextProps_Hyperlink_FontSize", link!.FontSize == 20);
+            if (link is null) return;
+
+            H.Check("RichTextProps_Hyperlink_FontSize", IsClose(link.FontSize, 20));
             H.Check("RichTextProps_Hyperlink_FontFamily", link.FontFamily.Source.Contains("Consolas", StringComparison.OrdinalIgnoreCase));
             H.Check("RichTextProps_Hyperlink_FontWeight", link.FontWeight.Weight >= 700);
             H.Check("RichTextProps_Hyperlink_FontStyle", link.FontStyle == global::Windows.UI.Text.FontStyle.Italic);
@@ -323,7 +346,7 @@ internal static class RichTextPropertyFixtures
             H.ClickButton("ToggleHyperlinkProps");
             await Harness.Render();
 
-            H.Check("RichTextProps_Hyperlink_IdentityPreserved", ReferenceEquals(link, FirstHyperlink(rtb!)));
+            H.Check("RichTextProps_Hyperlink_IdentityPreserved", ReferenceEquals(link, FirstHyperlink(rtb)));
             H.Check("RichTextProps_Hyperlink_FontSizeCleared", IsUnset(link, WinTextElement.FontSizeProperty));
             H.Check("RichTextProps_Hyperlink_FontFamilyCleared", IsUnset(link, WinTextElement.FontFamilyProperty));
             H.Check("RichTextProps_Hyperlink_FontWeightCleared", IsUnset(link, WinTextElement.FontWeightProperty));
@@ -340,6 +363,114 @@ internal static class RichTextPropertyFixtures
         }
     }
 
+    internal class RichTextProps_LineBreakInlineUI_MountUpdateClear(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (styled, setStyled) = ctx.UseState(true);
+                var lineBreak = new RichTextLineBreak();
+                var inlineUi = InlineUI(Button("InlineChild", () => { }));
+                if (styled)
+                {
+                    lineBreak = lineBreak with
+                    {
+                        FontSize = 16,
+                        FontFamily = "Consolas",
+                        FontWeight = Microsoft.UI.Text.FontWeights.Bold,
+                        FontStyle = global::Windows.UI.Text.FontStyle.Italic,
+                        FontStretch = global::Windows.UI.Text.FontStretch.Expanded,
+                        Foreground = Brush(30, 60, 180),
+                        CharacterSpacing = 42,
+                        TextDecorations = global::Windows.UI.Text.TextDecorations.Underline,
+                        IsTextScaleFactorEnabled = false,
+                        Language = "it-IT",
+                    };
+                    inlineUi = inlineUi with
+                    {
+                        FontSize = 17,
+                        FontFamily = "Consolas",
+                        FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                        FontStyle = global::Windows.UI.Text.FontStyle.Italic,
+                        FontStretch = global::Windows.UI.Text.FontStretch.Condensed,
+                        Foreground = Brush(80, 30, 160),
+                        CharacterSpacing = 55,
+                        TextDecorations = global::Windows.UI.Text.TextDecorations.Strikethrough,
+                        IsTextScaleFactorEnabled = false,
+                        Language = "pt-BR",
+                    };
+                }
+
+                return VStack(
+                    Button("ToggleLineBreakInlineUIProps", () => setStyled(!styled)),
+                    RichTextBlock(new[] { Paragraph(Run("before"), lineBreak, inlineUi, Run("after")) }));
+            });
+
+            await Harness.Render();
+
+            var rtb = H.FindControl<WinRichTextBlock>(_ => true);
+            H.Check("RichTextProps_LineBreakInlineUI_RTBMounted", rtb is not null);
+            if (rtb is null) return;
+
+            var lineBreak = FirstLineBreak(rtb);
+            var inlineUi = FirstInlineUIContainer(rtb);
+            H.Check("RichTextProps_LineBreak_Mounted", lineBreak is not null);
+            H.Check("RichTextProps_InlineUI_Mounted", inlineUi is not null);
+            if (lineBreak is null || inlineUi is null) return;
+
+            H.Check("RichTextProps_LineBreak_FontSize", IsClose(lineBreak.FontSize, 16));
+            H.Check("RichTextProps_LineBreak_FontFamily", lineBreak.FontFamily.Source.Contains("Consolas", StringComparison.OrdinalIgnoreCase));
+            H.Check("RichTextProps_LineBreak_FontWeight", lineBreak.FontWeight.Weight >= 700);
+            H.Check("RichTextProps_LineBreak_FontStyle", lineBreak.FontStyle == global::Windows.UI.Text.FontStyle.Italic);
+            H.Check("RichTextProps_LineBreak_FontStretch", lineBreak.FontStretch == global::Windows.UI.Text.FontStretch.Expanded);
+            H.Check("RichTextProps_LineBreak_Foreground", IsColor(lineBreak.Foreground, 30, 60, 180));
+            H.Check("RichTextProps_LineBreak_CharacterSpacing", lineBreak.CharacterSpacing == 42);
+            H.Check("RichTextProps_LineBreak_TextDecorations", lineBreak.TextDecorations == global::Windows.UI.Text.TextDecorations.Underline);
+            H.Check("RichTextProps_LineBreak_IsTextScaleFactorEnabled", lineBreak.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_LineBreak_Language", lineBreak.Language == "it-IT");
+
+            H.Check("RichTextProps_InlineUI_FontSize", IsClose(inlineUi.FontSize, 17));
+            H.Check("RichTextProps_InlineUI_FontFamily", inlineUi.FontFamily.Source.Contains("Consolas", StringComparison.OrdinalIgnoreCase));
+            H.Check("RichTextProps_InlineUI_FontWeight", inlineUi.FontWeight.Weight >= 600);
+            H.Check("RichTextProps_InlineUI_FontStyle", inlineUi.FontStyle == global::Windows.UI.Text.FontStyle.Italic);
+            H.Check("RichTextProps_InlineUI_FontStretch", inlineUi.FontStretch == global::Windows.UI.Text.FontStretch.Condensed);
+            H.Check("RichTextProps_InlineUI_Foreground", IsColor(inlineUi.Foreground, 80, 30, 160));
+            H.Check("RichTextProps_InlineUI_CharacterSpacing", inlineUi.CharacterSpacing == 55);
+            H.Check("RichTextProps_InlineUI_TextDecorations", inlineUi.TextDecorations == global::Windows.UI.Text.TextDecorations.Strikethrough);
+            H.Check("RichTextProps_InlineUI_IsTextScaleFactorEnabled", inlineUi.IsTextScaleFactorEnabled == false);
+            H.Check("RichTextProps_InlineUI_Language", inlineUi.Language == "pt-BR");
+
+            H.ClickButton("ToggleLineBreakInlineUIProps");
+            await Harness.Render();
+
+            H.Check("RichTextProps_LineBreak_IdentityPreserved", ReferenceEquals(lineBreak, FirstLineBreak(rtb)));
+            H.Check("RichTextProps_InlineUI_IdentityPreserved", ReferenceEquals(inlineUi, FirstInlineUIContainer(rtb)));
+            H.Check("RichTextProps_LineBreak_FontSizeCleared", IsUnset(lineBreak, WinTextElement.FontSizeProperty));
+            H.Check("RichTextProps_LineBreak_FontFamilyCleared", IsUnset(lineBreak, WinTextElement.FontFamilyProperty));
+            H.Check("RichTextProps_LineBreak_FontWeightCleared", IsUnset(lineBreak, WinTextElement.FontWeightProperty));
+            H.Check("RichTextProps_LineBreak_FontStyleCleared", IsUnset(lineBreak, WinTextElement.FontStyleProperty));
+            H.Check("RichTextProps_LineBreak_FontStretchCleared", IsUnset(lineBreak, WinTextElement.FontStretchProperty));
+            H.Check("RichTextProps_LineBreak_ForegroundCleared", IsUnset(lineBreak, WinTextElement.ForegroundProperty));
+            H.Check("RichTextProps_LineBreak_CharacterSpacingCleared", IsUnset(lineBreak, WinTextElement.CharacterSpacingProperty));
+            H.Check("RichTextProps_LineBreak_TextDecorationsCleared", IsUnset(lineBreak, WinTextElement.TextDecorationsProperty));
+            H.Check("RichTextProps_LineBreak_IsTextScaleFactorEnabledCleared", IsUnset(lineBreak, WinTextElement.IsTextScaleFactorEnabledProperty));
+            H.Check("RichTextProps_LineBreak_LanguageCleared", IsUnset(lineBreak, WinTextElement.LanguageProperty));
+
+            H.Check("RichTextProps_InlineUI_FontSizeCleared", IsUnset(inlineUi, WinTextElement.FontSizeProperty));
+            H.Check("RichTextProps_InlineUI_FontFamilyCleared", IsUnset(inlineUi, WinTextElement.FontFamilyProperty));
+            H.Check("RichTextProps_InlineUI_FontWeightCleared", IsUnset(inlineUi, WinTextElement.FontWeightProperty));
+            H.Check("RichTextProps_InlineUI_FontStyleCleared", IsUnset(inlineUi, WinTextElement.FontStyleProperty));
+            H.Check("RichTextProps_InlineUI_FontStretchCleared", IsUnset(inlineUi, WinTextElement.FontStretchProperty));
+            H.Check("RichTextProps_InlineUI_ForegroundCleared", IsUnset(inlineUi, WinTextElement.ForegroundProperty));
+            H.Check("RichTextProps_InlineUI_CharacterSpacingCleared", IsUnset(inlineUi, WinTextElement.CharacterSpacingProperty));
+            H.Check("RichTextProps_InlineUI_TextDecorationsCleared", IsUnset(inlineUi, WinTextElement.TextDecorationsProperty));
+            H.Check("RichTextProps_InlineUI_IsTextScaleFactorEnabledCleared", IsUnset(inlineUi, WinTextElement.IsTextScaleFactorEnabledProperty));
+            H.Check("RichTextProps_InlineUI_LanguageCleared", IsUnset(inlineUi, WinTextElement.LanguageProperty));
+        }
+    }
+
     private static WinParagraph? FirstParagraph(WinRichTextBlock rtb)
         => rtb.Blocks.OfType<WinParagraph>().FirstOrDefault();
 
@@ -351,6 +482,12 @@ internal static class RichTextPropertyFixtures
 
     private static WinRun? FirstHyperlinkRun(WinRichTextBlock rtb)
         => FirstHyperlink(rtb)?.Inlines.OfType<WinRun>().FirstOrDefault();
+
+    private static WinLineBreak? FirstLineBreak(WinRichTextBlock rtb)
+        => FirstParagraph(rtb)?.Inlines.OfType<WinLineBreak>().FirstOrDefault();
+
+    private static WinInlineUIContainer? FirstInlineUIContainer(WinRichTextBlock rtb)
+        => FirstParagraph(rtb)?.Inlines.OfType<WinInlineUIContainer>().FirstOrDefault();
 
     private static SolidColorBrush Brush(byte r, byte g, byte b) =>
         new(global::Windows.UI.Color.FromArgb(255, r, g, b));
@@ -364,4 +501,7 @@ internal static class RichTextPropertyFixtures
 
     private static bool IsUnset(DependencyObject target, DependencyProperty property) =>
         ReferenceEquals(target.ReadLocalValue(property), DependencyProperty.UnsetValue);
+
+    private static bool IsClose(double actual, double expected) =>
+        Math.Abs(actual - expected) < 0.001d;
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -221,6 +221,10 @@ internal static class SelfTestFixtureRegistry
         // Issue #480 follow-up — incremental RTB update preserves child identity
         "InlineUI_IncrementalUpdate_PreservesChildIdentity",
         "InlineUI_IncrementalUpdate_RunMutatedInPlace",
+        "RichTextProps_Block_MountUpdateClear",
+        "RichTextProps_Paragraph_MountUpdateClear",
+        "RichTextProps_Run_MountUpdateClear",
+        "RichTextProps_Hyperlink_MountUpdateClear",
         // ElementFactory<T> + WinUI ItemsRepeater recycle contract — regression
         // for the leak fixed alongside these tests (every realize was Minting
         // a fresh UIElement, orphaning prior ones in Repeater.Children).
@@ -1542,6 +1546,10 @@ internal static class SelfTestFixtureRegistry
         // Issue #480 follow-up — incremental RTB update preserves child identity.
         "InlineUI_IncrementalUpdate_PreservesChildIdentity" => new InlineUIContainerFixtures.InlineUI_IncrementalUpdate_PreservesChildIdentity(harness),
         "InlineUI_IncrementalUpdate_RunMutatedInPlace" => new InlineUIContainerFixtures.InlineUI_IncrementalUpdate_RunMutatedInPlace(harness),
+        "RichTextProps_Block_MountUpdateClear" => new RichTextPropertyFixtures.RichTextProps_Block_MountUpdateClear(harness),
+        "RichTextProps_Paragraph_MountUpdateClear" => new RichTextPropertyFixtures.RichTextProps_Paragraph_MountUpdateClear(harness),
+        "RichTextProps_Run_MountUpdateClear" => new RichTextPropertyFixtures.RichTextProps_Run_MountUpdateClear(harness),
+        "RichTextProps_Hyperlink_MountUpdateClear" => new RichTextPropertyFixtures.RichTextProps_Hyperlink_MountUpdateClear(harness),
         "EFR_Factory_BoundedDistinctControls_AcrossManyRealizeCycles" => new ElementFactoryRecyclingFixtures.Factory_BoundedDistinctControls_AcrossManyRealizeCycles(harness),
         "EFR_Factory_RecycledControlIsReusedOnNextRealize" => new ElementFactoryRecyclingFixtures.Factory_RecycledControlIsReusedOnNextRealize(harness),
         "EFR_Factory_BookkeepingBoundedAcrossCycles" => new ElementFactoryRecyclingFixtures.Factory_BookkeepingBoundedAcrossCycles(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -225,6 +225,7 @@ internal static class SelfTestFixtureRegistry
         "RichTextProps_Paragraph_MountUpdateClear",
         "RichTextProps_Run_MountUpdateClear",
         "RichTextProps_Hyperlink_MountUpdateClear",
+        "RichTextProps_LineBreakInlineUI_MountUpdateClear",
         // ElementFactory<T> + WinUI ItemsRepeater recycle contract — regression
         // for the leak fixed alongside these tests (every realize was Minting
         // a fresh UIElement, orphaning prior ones in Repeater.Children).
@@ -1550,6 +1551,7 @@ internal static class SelfTestFixtureRegistry
         "RichTextProps_Paragraph_MountUpdateClear" => new RichTextPropertyFixtures.RichTextProps_Paragraph_MountUpdateClear(harness),
         "RichTextProps_Run_MountUpdateClear" => new RichTextPropertyFixtures.RichTextProps_Run_MountUpdateClear(harness),
         "RichTextProps_Hyperlink_MountUpdateClear" => new RichTextPropertyFixtures.RichTextProps_Hyperlink_MountUpdateClear(harness),
+        "RichTextProps_LineBreakInlineUI_MountUpdateClear" => new RichTextPropertyFixtures.RichTextProps_LineBreakInlineUI_MountUpdateClear(harness),
         "EFR_Factory_BoundedDistinctControls_AcrossManyRealizeCycles" => new ElementFactoryRecyclingFixtures.Factory_BoundedDistinctControls_AcrossManyRealizeCycles(harness),
         "EFR_Factory_RecycledControlIsReusedOnNextRealize" => new ElementFactoryRecyclingFixtures.Factory_RecycledControlIsReusedOnNextRealize(harness),
         "EFR_Factory_BookkeepingBoundedAcrossCycles" => new ElementFactoryRecyclingFixtures.Factory_BookkeepingBoundedAcrossCycles(harness),

--- a/tests/Reactor.Tests/MarkdownUnifiedRichTextTests.cs
+++ b/tests/Reactor.Tests/MarkdownUnifiedRichTextTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Markdown;
 using Microsoft.UI.Xaml;
@@ -198,9 +199,8 @@ public class MarkdownUnifiedRichTextTests
         var grid = Assert.IsType<GridElement>(inlineTable.Child);
 
         Assert.Equal(4, grid.Children.Length);
-        foreach (var child in grid.Children)
+        foreach (var cell in grid.Children.Select(child => Assert.IsType<RichTextBlockElement>(child)))
         {
-            var cell = Assert.IsType<RichTextBlockElement>(child);
             Assert.Equal(padding, cell.Padding);
         }
     }

--- a/tests/Reactor.Tests/MarkdownUnifiedRichTextTests.cs
+++ b/tests/Reactor.Tests/MarkdownUnifiedRichTextTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Markdown;
+using Microsoft.UI.Xaml;
 using Xunit;
 using static Microsoft.UI.Reactor.Factories;
 
@@ -174,5 +175,33 @@ public class MarkdownUnifiedRichTextTests
         Assert.Equal(2, rtb.Paragraphs!.Length);
         Assert.IsType<RichTextRun>(rtb.Paragraphs[0].Inlines[0]);
         Assert.IsType<RichTextRun>(rtb.Paragraphs[1].Inlines[0]);
+    }
+
+    [Fact]
+    public void TableCellPadding_IsAppliedToInlineTableCells()
+    {
+        var padding = new Thickness(3, 4, 5, 6);
+        var rtb = BuildRich(
+            """
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+            """,
+            new MarkdownOptions
+            {
+                TableHeaderBackground = null,
+                TableCellPadding = padding,
+            });
+
+        var paragraph = Assert.Single(rtb.Paragraphs!);
+        var inlineTable = Assert.IsType<RichTextInlineUIContainer>(Assert.Single(paragraph.Inlines));
+        var grid = Assert.IsType<GridElement>(inlineTable.Child);
+
+        Assert.Equal(4, grid.Children.Length);
+        foreach (var child in grid.Children)
+        {
+            var cell = Assert.IsType<RichTextBlockElement>(child);
+            Assert.Equal(padding, cell.Padding);
+        }
     }
 }

--- a/tests/Reactor.Tests/RichTextBlockDescriptorTests.cs
+++ b/tests/Reactor.Tests/RichTextBlockDescriptorTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Reflection;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Core.V1Protocol.Descriptor;
+using Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors;
+using Microsoft.UI.Xaml;
+using WinUI = Microsoft.UI.Xaml.Controls;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+public class RichTextBlockDescriptorTests
+{
+    [Fact]
+    public void Descriptor_BindsStandardElementPaddingToRichTextBlockPadding()
+    {
+        var entry = Assert.Single(RichTextBlockDescriptor.Descriptor.Properties, IsPaddingEntry);
+        var get = GetPrivateField<Func<RichTextBlockElement, Optional<Thickness>>>(entry, "_get");
+        var set = GetPrivateField<Action<WinUI.RichTextBlock, Thickness>>(entry, "_set");
+
+        var unset = new RichTextBlockElement("cell");
+        var padded = unset.Padding(1, 2, 3, 4);
+
+        Assert.False(get(unset).HasValue);
+        Assert.True(get(padded).HasValue);
+        Assert.Equal(new Thickness(1, 2, 3, 4), get(padded).Value);
+        Assert.NotNull(set);
+    }
+
+    private static bool IsPaddingEntry(PropEntry<RichTextBlockElement, WinUI.RichTextBlock> entry)
+    {
+        var type = entry.GetType();
+        return type.IsGenericType
+            && type.GetGenericTypeDefinition().Name == "OneWayClearValuePropEntry`3"
+            && type.GenericTypeArguments[2] == typeof(Thickness);
+    }
+
+    private static T GetPrivateField<T>(object owner, string name)
+    {
+        var field = owner.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return Assert.IsType<T>(field.GetValue(owner));
+    }
+}


### PR DESCRIPTION
## Summary
- expose WinUI-backed RichTextBlock root typography/layout properties, paragraph properties, and run/hyperlink inline text properties
- wire mount/update/clear behavior through the descriptor and incremental rich-text reconciler
- add unit coverage for RichTextBlock padding and markdown table cell padding, plus focused WinUI selftests for root/paragraph/run/hyperlink properties

## Validation
- dotnet test tests\Reactor.Tests\Reactor.Tests.csproj -p:Platform=x64 -m:1 --filter "FullyQualifiedName~RichTextBlockDescriptorTests|FullyQualifiedName~MarkdownUnifiedRichTextTests"
- dotnet run --project tests\Reactor.AppTests.Host\Reactor.AppTests.Host.csproj -p:Platform=x64 -- --self-test --filter RichTextProps
- dotnet test tests\Reactor.Tests\Reactor.Tests.csproj -p:Platform=x64 -m:1
- dotnet build Reactor.slnx -p:Platform=x64 -m:1
- mur pack-local
