### PR TITLE
Fix dark-mode colors in samples and selftests

### DIFF
--- a/samples/InteropFirst/Components/OrdersDataGrid.cs
+++ b/samples/InteropFirst/Components/OrdersDataGrid.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 
 namespace InteropFirst.Components;
 
@@ -77,7 +78,9 @@ public sealed class OrdersDataGrid : Component<OrdersDataGridProps>
             HeaderCell("Placed", accent).Width(180));
 
         var rows = snapshot.Count == 0
-            ? new[] { TextBlock("No orders yet — click Add.").Foreground(subtle ?? new SolidColorBrush(Microsoft.UI.Colors.Gray)).Margin(horizontal: 0, vertical: 16) }
+            ? new[] { subtle is not null
+                ? TextBlock("No orders yet — click Add.").Foreground(subtle).Margin(horizontal: 0, vertical: 16)
+                : TextBlock("No orders yet — click Add.").Foreground(SecondaryText).Margin(horizontal: 0, vertical: 16) }
             : snapshot.Select(o => Row(o, isSelected: o.Id == selectedId, subtle, OnRowTap: () =>
                 {
                     setSelectedId(o.Id);
@@ -127,7 +130,7 @@ public sealed class OrdersDataGrid : Component<OrdersDataGridProps>
             .OnTapped((_, _) => OnRowTap())
             .Padding(horizontal: 8, vertical: 4);
         return isSelected
-            ? styled.Background(new SolidColorBrush(Microsoft.UI.Colors.LightBlue))
+            ? styled.Background(SubtleFill).WithBorder(Accent, 1)
             : styled;
     }
 }

--- a/samples/Reactor.TestApp/Demos/DataTemplateDemo.cs
+++ b/samples/Reactor.TestApp/Demos/DataTemplateDemo.cs
@@ -118,8 +118,8 @@ class DataTemplateDemo : Component
                         return Border(
                             VStack(4,
                                 TextBlock(animal.Emoji).FontSize(32).HAlign(HorizontalAlignment.Center),
-                                TextBlock(animal.Name).SemiBold().HAlign(HorizontalAlignment.Center),
-                                Caption(animal.Species).Foreground(SecondaryText).HAlign(HorizontalAlignment.Center)
+                                TextBlock(animal.Name).SemiBold().Foreground("#202020").HAlign(HorizontalAlignment.Center),
+                                Caption(animal.Species).Foreground("#555555").HAlign(HorizontalAlignment.Center)
                             )
                         ).CornerRadius(8).Background(bg).Padding(12).Width(120).Height(120);
                     }

--- a/samples/Reactor.TestApp/Demos/InputGesturesDemo.cs
+++ b/samples/Reactor.TestApp/Demos/InputGesturesDemo.cs
@@ -107,7 +107,7 @@ sealed class GesturePanSample : Component
                                 setOffset(committedRef.Current);
                             },
                             withInertia: true)
-                ).Height(220).Background("#f3f3f3").CornerRadius(8).Padding(8),
+                ).Height(220).Background(SubtleFill).CornerRadius(8).Padding(8),
 
                 Button("Reset position", Reset)
             )
@@ -127,7 +127,7 @@ sealed class LongPressSample : Component
             VStack(8,
                 Border(TextBlock("Hold me")
                     .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
-                    .Height(80).Background("#FFF4CE").CornerRadius(6).Padding(12)
+                    .Height(80).Background(SystemCautionBackground).CornerRadius(6).Padding(12)
                     .OnLongPress(
                         g => setLog($"Long press @ ({g.Position.X:F0}, {g.Position.Y:F0}) after {g.Duration.TotalMilliseconds:F0}ms"),
                         enableMouseEmulation: true),
@@ -201,10 +201,10 @@ sealed class KanbanDragDropSample : Component
                 new[] { GridSize.Star(), GridSize.Star() },
                 new[] { GridSize.Auto },
                 Border(RenderColumn("Todo", todo, setTodo))
-                    .Background("#F7F7F7").CornerRadius(6).Padding(10).Margin(4)
+                    .Background(CardBackground).CornerRadius(6).Padding(10).Margin(4)
                     .Grid(column: 0),
                 Border(RenderColumn("Done", done, setDone))
-                    .Background("#F1FFF4").CornerRadius(6).Padding(10).Margin(4)
+                    .Background(SystemSuccessBackground).CornerRadius(6).Padding(10).Margin(4)
                     .Grid(column: 1)
             )
         );
@@ -226,7 +226,7 @@ sealed class TextDragSample : Component
                     .OnDragStart<BorderElement>(() => new DragData().WithText("hello from Reactor")),
 
                 Border(TextBlock(dropped ?? "drop text here"))
-                    .Background("#E6FFFA").CornerRadius(6).Padding(12).Width(220)
+                    .Background(SystemAttentionBackground).CornerRadius(6).Padding(12).Width(220)
                     .OnDrop<BorderElement>(args =>
                     {
                         if (args.Data.TryGetText(out var text))

--- a/samples/Reactor.TestApp/Demos/TransitionsDemo.cs
+++ b/samples/Reactor.TestApp/Demos/TransitionsDemo.cs
@@ -49,6 +49,7 @@ class TransitionsDemo : Component
             ),
             Border(
                 TextBlock("Fade me").SemiBold()
+                    .Foreground("#FFFFFF")
                     .HAlign(HorizontalAlignment.Center)
                     .VAlign(VerticalAlignment.Center)
             )
@@ -65,6 +66,7 @@ class TransitionsDemo : Component
             ),
             Border(
                 TextBlock("Scale me").SemiBold()
+                    .Foreground("#FFFFFF")
                     .HAlign(HorizontalAlignment.Center)
                     .VAlign(VerticalAlignment.Center)
             )
@@ -82,6 +84,7 @@ class TransitionsDemo : Component
             ),
             Border(
                 TextBlock("Slide me").SemiBold()
+                    .Foreground("#FFFFFF")
                     .HAlign(HorizontalAlignment.Center)
                     .VAlign(VerticalAlignment.Center)
             )
@@ -315,7 +318,7 @@ class WithAnimationScopeDemo : Component
                         setOpacity(opacity > 0.5 ? 0.2 : 1.0);
                     });
             }),
-            Border(TextBlock("WithAnimation target").SemiBold().HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
+            Border(TextBlock("WithAnimation target").SemiBold().Foreground("#FFFFFF").HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
                 .Size(200, 60).Background("#4A90D9").CornerRadius(8).Padding(12)
                 .Opacity(opacity)
         );
@@ -330,7 +333,7 @@ class AnimateModifierDemo : Component
 
         return VStack(8,
             Button(active ? "Reset" : "Animate", () => setActive(!active)),
-            Border(TextBlock(".Animate()").SemiBold().HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
+            Border(TextBlock(".Animate()").SemiBold().Foreground("#FFFFFF").HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
                 .Size(200, 60).Background("#E8834A").CornerRadius(8).Padding(12)
                 .Opacity(active ? 0.5 : 1.0)
                 .Animate(Microsoft.UI.Reactor.Animation.Curve.Spring(0.65f))
@@ -343,12 +346,12 @@ class InteractionStatesDemo : Component
     public override Element Render()
     {
         return HStack(12,
-            Border(TextBlock("Hover me").SemiBold().HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
+            Border(TextBlock("Hover me").SemiBold().Foreground("#FFFFFF").HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
                 .Size(150, 60).Background("#50C878").CornerRadius(8).Padding(12)
                 .InteractionStates(states => states
                     .PointerOver(opacity: 0.85f, scale: 1.05f)
                     .Pressed(scale: 0.95f, opacity: 0.7f)),
-            Border(TextBlock("Press me").SemiBold().HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
+            Border(TextBlock("Press me").SemiBold().Foreground("#FFFFFF").HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
                 .Size(150, 60).Background("#9B59B6").CornerRadius(8).Padding(12)
                 .InteractionStates(states => states
                     .PointerOver(scale: 1.03f)
@@ -367,7 +370,7 @@ class EnterExitTransitionDemo : Component
         return VStack(8,
             Button(visible ? "Hide (exit)" : "Show (enter)", () => setVisible(!visible)),
             visible
-                ? Border(TextBlock("I fade + slide").SemiBold().HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
+                ? Border(TextBlock("I fade + slide").SemiBold().Foreground("#FFFFFF").HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
                     .Size(200, 60).Background("#E74C3C").CornerRadius(8).Padding(12)
                     .Transition(Microsoft.UI.Reactor.Animation.Transition.Fade + Microsoft.UI.Reactor.Animation.Transition.Slide(Microsoft.UI.Reactor.Animation.Edge.Bottom))
                 : (Element)TextBlock("(element removed)")
@@ -385,7 +388,7 @@ class StaggerDemo : Component
             Button("Shuffle", () => setItems(items.OrderBy(_ => Random.Shared.Next()).ToArray())),
             VStack(4,
                 items.Select(item =>
-                    Border(TextBlock(item).SemiBold().HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
+                    Border(TextBlock(item).SemiBold().Foreground("#FFFFFF").HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
                         .Height(40).Background("#4A90D9").CornerRadius(4).Padding(8)
                         .WithKey(item)
                         .LayoutAnimation()
@@ -403,7 +406,7 @@ class KeyframeDemo : Component
 
         return VStack(8,
             Button("Pulse!", () => setCount(count + 1)),
-            Border(TextBlock("Keyframes").SemiBold().HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
+            Border(TextBlock("Keyframes").SemiBold().Foreground("#FFFFFF").HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center))
                 .Size(200, 60).Background("#9B59B6").CornerRadius(8).Padding(12)
                 .Keyframes("pulse", count, kf => kf
                     .Duration(600)

--- a/samples/ReactorGallery/ControlPages/Layout/GridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/GridPage.cs
@@ -20,12 +20,12 @@ class GridPage : Component
                     Grid(
                         columns: [GridSize.Star(), GridSize.Star(), GridSize.Star()],
                         rows: [GridSize.Auto, GridSize.Auto],
-                        Border(TextBlock("1,1").Center().Padding(12)).Background("#E74C3C").Foreground("#FFFFFF").Grid(row: 0, column: 0),
-                        Border(TextBlock("1,2").Center().Padding(12)).Background("#3498DB").Foreground("#FFFFFF").Grid(row: 0, column: 1),
-                        Border(TextBlock("1,3").Center().Padding(12)).Background("#2ECC71").Foreground("#FFFFFF").Grid(row: 0, column: 2),
-                        Border(TextBlock("2,1").Center().Padding(12)).Background("#F39C12").Foreground("#FFFFFF").Grid(row: 1, column: 0),
-                        Border(TextBlock("2,2").Center().Padding(12)).Background("#9B59B6").Foreground("#FFFFFF").Grid(row: 1, column: 1),
-                        Border(TextBlock("2,3").Center().Padding(12)).Background("#1ABC9C").Foreground("#FFFFFF").Grid(row: 1, column: 2)
+                        Border(TextBlock("1,1").Center().Foreground("#FFFFFF").Padding(12)).Background("#E74C3C").Grid(row: 0, column: 0),
+                        Border(TextBlock("1,2").Center().Foreground("#FFFFFF").Padding(12)).Background("#3498DB").Grid(row: 0, column: 1),
+                        Border(TextBlock("1,3").Center().Foreground("#FFFFFF").Padding(12)).Background("#2ECC71").Grid(row: 0, column: 2),
+                        Border(TextBlock("2,1").Center().Foreground("#FFFFFF").Padding(12)).Background("#F39C12").Grid(row: 1, column: 0),
+                        Border(TextBlock("2,2").Center().Foreground("#FFFFFF").Padding(12)).Background("#9B59B6").Grid(row: 1, column: 1),
+                        Border(TextBlock("2,3").Center().Foreground("#FFFFFF").Padding(12)).Background("#1ABC9C").Grid(row: 1, column: 2)
                     ).Width(400),
                     """
                     Grid(
@@ -58,9 +58,9 @@ class GridPage : Component
                     Grid(
                         columns: [GridSize.Px(100), GridSize.Star(), GridSize.Star(2)],
                         rows: [GridSize.Auto],
-                        Border(TextBlock("100px").Center().Padding(8)).Background("#E67E22").Foreground("#FFFFFF").Grid(row: 0, column: 0),
-                        Border(TextBlock("1*").Center().Padding(8)).Background("#27AE60").Foreground("#FFFFFF").Grid(row: 0, column: 1),
-                        Border(TextBlock("2*").Center().Padding(8)).Background("#8E44AD").Foreground("#FFFFFF").Grid(row: 0, column: 2)
+                        Border(TextBlock("100px").Center().Foreground("#FFFFFF").Padding(8)).Background("#E67E22").Grid(row: 0, column: 0),
+                        Border(TextBlock("1*").Center().Foreground("#FFFFFF").Padding(8)).Background("#27AE60").Grid(row: 0, column: 1),
+                        Border(TextBlock("2*").Center().Foreground("#FFFFFF").Padding(8)).Background("#8E44AD").Grid(row: 0, column: 2)
                     ).Width(400),
                     """
                     Grid(

--- a/samples/apps/command-palette-window/Program.cs
+++ b/samples/apps/command-palette-window/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 
 var commands = new[]
 {
@@ -33,7 +34,7 @@ internal sealed class PaletteApp(IReadOnlyList<string> commands) : Component
         var filtered = commands
             .Where(c => query.Length == 0 || c.Contains(query, StringComparison.OrdinalIgnoreCase))
             .Take(5)
-            .Select(c => TextBlock(c).Padding(12).Background("#1AFFFFFF").CornerRadius(6))
+            .Select(c => TextBlock(c).Padding(12).Background(SubtleFill).CornerRadius(6))
             .Cast<Element>()
             .ToArray();
 
@@ -43,7 +44,8 @@ internal sealed class PaletteApp(IReadOnlyList<string> commands) : Component
                 TextBox(query, setQuery, placeholderText: "Type a command…"),
                 VStack(6, filtered)))
             .Padding(20)
-            .Background("#F01F1F1F")
+            .Background(LayerFill)
+            .WithBorder(SurfaceStroke, 1)
             .CornerRadius(12);
     }
 }

--- a/samples/apps/tool-palette/Program.cs
+++ b/samples/apps/tool-palette/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 
 ReactorApp.Run(_ =>
 {
@@ -31,7 +32,7 @@ internal sealed class MainWindow : Component
             TextBlock("Canvas").FontSize(28).Bold(),
             TextBlock("The floating tool palette stays above this owner window.")))
         .Padding(32)
-        .Background("#FFF7F7F7");
+        .Background(SolidBackground);
 }
 
 internal sealed class ToolsWindow : Component
@@ -44,6 +45,7 @@ internal sealed class ToolsWindow : Component
             Button("Crop", null),
             Button("Text", null)))
         .Padding(16)
-        .Background("#FFFFFFFF")
+        .Background(CardBackground)
+        .WithBorder(CardStroke, 1)
         .CornerRadius(8);
 }

--- a/samples/apps/validation-showcase/App.cs
+++ b/samples/apps/validation-showcase/App.cs
@@ -14,6 +14,7 @@ using static Microsoft.UI.Reactor.Factories;
 using static Microsoft.UI.Reactor.Controls.Validation.FormFieldDsl;
 using static Microsoft.UI.Reactor.Controls.Validation.ValidationRuleDsl;
 using static Microsoft.UI.Reactor.Controls.Validation.ValidationVisualizerDsl;
+using static Microsoft.UI.Reactor.Core.Theme;
 using Microsoft.UI.Reactor.Animation;
 
 ReactorApp.Run<ShowcaseApp>("Validation Showcase", width: 720, height: 900
@@ -431,8 +432,6 @@ class ShowcaseApp : Component
 
     static Element Separator() =>
         Border(Empty().Height(1))
-            .Set(b => b.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                Microsoft.UI.Colors.Gray))
-            .Opacity(0.15)
+            .Background(DividerStroke)
             .Margin(24, 8, 24, 8);
 }

--- a/samples/apps/window-styles/Program.cs
+++ b/samples/apps/window-styles/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 
 ReactorApp.Run(_ =>
 {
@@ -159,7 +160,7 @@ internal sealed class WindowStylesPlayground : Component
                 StatusLabel("Position", $"({winPos.X:0}, {winPos.Y:0})"),
                 StatusLabel("DPI",      $"{(win?.Dpi ?? 96):0}"),
                 StatusLabel("State",    (win?.State.ToString() ?? "—"))))
-            .Background("#1A000000")
+            .Background(SubtleFill)
             .Padding(16, 12, 16, 12);
 
         Element root = Grid(
@@ -209,7 +210,7 @@ internal sealed class WindowStylesPlayground : Component
         var rowList = new List<Element>(rows.Length * 2);
         for (int i = 0; i < rows.Length; i++)
         {
-            if (i > 0) rowList.Add(Border(null).Height(1).Background("#14FFFFFF"));
+            if (i > 0) rowList.Add(Border(null).Height(1).Background(DividerStroke));
             rowList.Add(rows[i]);
         }
         return Border(VStack(0,
@@ -220,8 +221,8 @@ internal sealed class WindowStylesPlayground : Component
                 Border(VStack(0, rowList.ToArray()))
                     .Padding(20, 0, 20, 8)))
             .CornerRadius(8)
-            .Background("#15FFFFFF")
-            .WithBorder("#22FFFFFF", 1);
+            .Background(CardBackground)
+            .WithBorder(CardStroke, 1);
     }
 
     private static Element Row(string label, string hint, Element control)

--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -591,7 +591,7 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                 {
                     var valueStr = value.ToString() ?? "";
                     if (valueStr.Contains(state.SearchQuery, StringComparison.OrdinalIgnoreCase))
-                        cellContent = cellContent.Background("#fff9c4"); // light yellow highlight
+                        cellContent = cellContent.Background(SystemAttentionBackground);
                 }
             }
 
@@ -603,12 +603,12 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                                      && state.EditValidation.HasError(col.Name);
             if (hasValidationError)
             {
-                cell = cell.WithBorder("#c62828", 2);
+                cell = cell.WithBorder(SystemCritical, 2);
             }
             // Focus indicator — property change only, no structural change
             else if (isCellFocused && !isCellEditing && !isColInRowEdit)
             {
-                cell = cell.WithBorder("#0078d4", 2);
+                cell = cell.WithBorder(Accent, 2);
             }
 
             // Click to edit (deferred) — only for Cell edit mode
@@ -685,9 +685,9 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
             }
         }
 
-        var rowBg = isSelected ? "#e3f2fd"
-            : isRowFocused ? "#f0f4ff"
-            : (index % 2 == 0 ? "#ffffff" : "#f9f9f9");
+        var rowBg = isSelected ? SubtleFill
+            : isRowFocused ? ControlFillSecondary
+            : (index % 2 == 0 ? LayerFill : CardBackground);
         // Use a WinUI Grid with pixel column definitions instead of FlexRow.
         // Grid with pixel columns avoids Yoga layout entirely — the dominant
         // cost identified by profiling.
@@ -753,7 +753,7 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
 
             row = FlexColumn(
                 row,
-                TextBlock(errorSummary).Foreground("#c62828").FontSize(11).Padding(horizontal: 8, vertical: 2)
+                TextBlock(errorSummary).Foreground(SystemCritical).FontSize(11).Padding(horizontal: 8, vertical: 2)
             );
         }
 
@@ -771,7 +771,7 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
             row = FlexColumn(
                 row,
                 FlexRow(
-                    TextBlock(commitError).Foreground("#c62828").FontSize(11).Flex(grow: 1),
+                    TextBlock(commitError).Foreground(SystemCritical).FontSize(11).Flex(grow: 1),
                     Button("Dismiss", () =>
                     {
                         Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
@@ -793,7 +793,7 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                 var detail = el.RowDetailTemplate(item!, rowKey).Padding(horizontal: 16, vertical: 8);
                 row = FlexColumn(
                     row,
-                    detail.Background("#f5f5f5")
+                    detail.Background(CardBackground)
                 );
             }
         }
@@ -1292,7 +1292,7 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
         // Vary the bar width per column so it looks organic, not uniform
         var barText = new string('\u2003', Math.Max(1, (int)(colWidth / 24)));
         return TextBlock(barText).Padding(CellPadLeft, CellPadTop, CellPadRight, CellPadBottom)
-            .Background("#e0e0e0").Opacity(0.5);
+            .Background(ControlFillSecondary).Opacity(0.5);
     }
 
     private static Element RenderDefaultLoading()
@@ -1306,7 +1306,7 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
     private static Element RenderDefaultError(Exception ex)
     {
         return FlexColumn(
-            TextBlock("Failed to load data").FontSize(14).Bold().Foreground("#c62828"),
+            TextBlock("Failed to load data").FontSize(14).Bold().Foreground(SystemCritical),
             TextBlock(ex.GetType().Name).FontSize(11).Opacity(0.6),
             TextBlock(ex.Message).FontSize(12).Opacity(0.8)
         ).Padding(16);

--- a/src/Reactor/Controls/Editors/CellRenderers.cs
+++ b/src/Reactor/Controls/Editors/CellRenderers.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Microsoft.UI.Reactor.Core;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 using WinUIColor = global::Windows.UI.Color;
 
 namespace Microsoft.UI.Reactor.Controls;
@@ -31,7 +32,7 @@ public static class CellRenderers
         {
             var on = (bool)(value ?? false);
             return TextBlock(on ? "✓" : string.Empty)
-                .Foreground(on ? "#2e7d32" : "#9e9e9e")
+                .Foreground(on ? SystemSuccess : DisabledText)
                 .FontSize(16);
         };
 
@@ -43,9 +44,9 @@ public static class CellRenderers
             // pill at its natural content width — without this, Border stretches
             // to the cell's full width and visually bleeds into the next column.
             return Border(TextBlock(on ? "ON" : "OFF")
-                    .Foreground(on ? "#FFFFFF" : "#555555")
+                    .Foreground(on ? Ref("TextOnAccentFillColorPrimaryBrush") : SecondaryText)
                     .FontSize(10))
-                .Background(on ? "#2e7d32" : "#e0e0e0")
+                .Background(on ? SystemSuccess : ControlFillSecondary)
                 .CornerRadius(8)
                 .Padding(horizontal: 6, vertical: 2)
                 .HAlign(Microsoft.UI.Xaml.HorizontalAlignment.Left)
@@ -105,8 +106,8 @@ public static class CellRenderers
                     .Background($"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}")
                     .Width(16).Height(16)
                     .CornerRadius(3)
-                    .WithBorder("#80000000", 1),
-                TextBlock(color.ToHexString()).FontSize(11).Foreground("#555555")
+                    .WithBorder(ControlStroke, 1),
+                TextBlock(color.ToHexString()).FontSize(11).Foreground(SecondaryText)
             );
         };
 

--- a/src/Reactor/Controls/Editors/Editors.cs
+++ b/src/Reactor/Controls/Editors/Editors.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Microsoft.UI.Reactor.Core;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 using WinUIColor = global::Windows.UI.Color;
 
 namespace Microsoft.UI.Reactor.Controls;
@@ -231,7 +232,7 @@ public static class Editors
                     .Background($"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}")
                     .Width(20).Height(20)
                     .CornerRadius(3)
-                    .WithBorder("#80000000", 1),
+                    .WithBorder(ControlStroke, 1),
                 TextBox(hex, s =>
                 {
                     if (TryParseHexColor(s, out var parsed))

--- a/src/Reactor/Markdown/MarkdownBuilder.cs
+++ b/src/Reactor/Markdown/MarkdownBuilder.cs
@@ -453,7 +453,7 @@ internal sealed class MarkdownBuilder
         Element element = Border(content)
             .Padding(0, 8, 16, 8)
             .Background(Theme.SubtleFill)
-            .WithBorder(Theme.DividerStroke, 1)
+            .WithBorder(Theme.DividerStroke, 0)
             .BorderInlineStart(new Thickness(3));
 
         if (_options.BlockQuote is not null)

--- a/src/Reactor/Markdown/MarkdownBuilder.cs
+++ b/src/Reactor/Markdown/MarkdownBuilder.cs
@@ -452,19 +452,9 @@ internal sealed class MarkdownBuilder
 
         Element element = Border(content)
             .Padding(0, 8, 16, 8)
-            .Background("#F5F5F5")
-            .WithBorder("#D0D0D0", 1);
-
-        // Apply left-accent via native setter for asymmetric border.
-        element = ((BorderElement)element) with
-        {
-            Setters = [.. ((BorderElement)element).Setters, b =>
-            {
-                b.BorderThickness = new Thickness(3, 0, 0, 0);
-                b.BorderBrush = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                    Microsoft.UI.Colors.Gray);
-            }]
-        };
+            .Background(Theme.SubtleFill)
+            .WithBorder(Theme.DividerStroke, 1)
+            .BorderInlineStart(new Thickness(3));
 
         if (_options.BlockQuote is not null)
             element = _options.BlockQuote(element);
@@ -591,7 +581,8 @@ internal sealed class MarkdownBuilder
                     TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap,
                 }
             )
-            .Background("#F5F5F5")
+            .Background(Theme.CardBackground)
+            .WithBorder(Theme.CardStroke, 1)
             .Padding(12)
             .CornerRadius(4);
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
@@ -244,7 +245,7 @@ internal static class DataGridScrollFixtures
                             cells[1] = TextBlock($"Emp-{index:D6}").Padding(horizontal: 8, vertical: 4).VAlign(VerticalAlignment.Center).Grid(row: 0, column: 1);
                             cells[2] = TextBlock($"Dept-{index % 12}").Padding(horizontal: 8, vertical: 4).VAlign(VerticalAlignment.Center).Grid(row: 0, column: 2);
                             cells[3] = TextBlock($"Title-{index % 50}").Padding(horizontal: 8, vertical: 4).VAlign(VerticalAlignment.Center).Grid(row: 0, column: 3);
-                            var bg = index % 2 == 0 ? "#ffffff" : "#f9f9f9";
+                            var bg = index % 2 == 0 ? LayerFill : CardBackground;
                             return Grid(colDefs, rowDef, cells).Background(bg);
                         },
                         itemHeight: 36,

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DslExtensionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DslExtensionFixtures.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
@@ -36,7 +37,7 @@ internal static class DslExtensionFixtures
                     .Bold()
                     .FontSize(18)
                     .Foreground(new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Red))
-                    .Background(new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.LightGray))
+                    .Background(SubtleFill)
                     .Padding(8)
                     .Margin(4)
                     .Width(200)

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlexLayoutFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlexLayoutFixtures.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 using WinXC = Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
@@ -33,7 +34,7 @@ internal static class FlexLayoutFixtures
                 FlexColumn(
                     FlexRow(
                         TextBlock("Logo").Flex(basis: 0, grow: 1).Background("LightCoral"),
-                        TextBlock("Nav").Flex(basis: 0, grow: 2).Background("LightBlue")
+                        TextBlock("Nav").Flex(basis: 0, grow: 2).Background(SystemAttentionBackground)
                     ).Height(50),
 
                     FlexRow(
@@ -43,7 +44,7 @@ internal static class FlexLayoutFixtures
 
                     FlexRow(
                         TextBlock("Footer").Flex(grow: 1)
-                    ).Height(40).Background("LightGray")
+                    ).Height(40).Background(SubtleFill)
                 ).Width(600).Height(400)
             );
 
@@ -99,7 +100,7 @@ internal static class FlexLayoutFixtures
                     FlexColumn(
                         TextBlock("Title").Height(40),
                         TextBlock("Body text here").Flex(grow: 1)
-                    ).Flex(basis: 0, grow: 3).Background("LightBlue")
+                    ).Flex(basis: 0, grow: 3).Background(SystemAttentionBackground)
                 ).Width(600).Height(300)
             );
 
@@ -184,7 +185,7 @@ internal static class FlexLayoutFixtures
                 Grid([GridSize.Star(), GridSize.Star(2)], [GridSize.Star(), GridSize.Star()],
                     FlexRow(
                         TextBlock("A1").Flex(grow: 1).Background("LightCoral"),
-                        TextBlock("A2").Flex(grow: 1).Background("LightBlue")
+                        TextBlock("A2").Flex(grow: 1).Background(SystemAttentionBackground)
                     ).Grid(row: 0, column: 0),
 
                     FlexColumn(
@@ -251,9 +252,9 @@ internal static class FlexLayoutFixtures
                     Border(
                         FlexRow(
                             TextBlock("Left").Flex(basis: 0, grow: 1).Background("LightCoral"),
-                            TextBlock("Right").Flex(basis: 0, grow: 1).Background("LightBlue")
+                            TextBlock("Right").Flex(basis: 0, grow: 1).Background(SystemAttentionBackground)
                         )
-                    ).Width(600).Background("LightGray"),
+                    ).Width(600).Background(SubtleFill),
 
                     TextBlock("Reference line")
                 ).Width(600).Height(400)
@@ -291,7 +292,7 @@ internal static class FlexLayoutFixtures
 
                     FlexRow(
                         TextBlock("Row1-A").Flex(basis: 0, grow: 1).Background("LightCoral"),
-                        TextBlock("Row1-B").Flex(basis: 0, grow: 2).Background("LightBlue"),
+                        TextBlock("Row1-B").Flex(basis: 0, grow: 2).Background(SystemAttentionBackground),
                         TextBlock("Row1-C").Flex(basis: 0, grow: 1).Background("LightGreen")
                     ),
 
@@ -340,7 +341,7 @@ internal static class FlexLayoutFixtures
                 ScrollViewer(
                     FlexColumn(
                         TextBlock("Item 1").Height(60).Background("LightCoral"),
-                        TextBlock("Item 2").Height(60).Background("LightBlue"),
+                        TextBlock("Item 2").Height(60).Background(SystemAttentionBackground),
                         TextBlock("Item 3").Height(60).Background("LightGreen"),
                         TextBlock("Item 4").Height(60).Background("Wheat"),
                         TextBlock("Item 5").Height(60).Background("Plum")
@@ -387,7 +388,7 @@ internal static class FlexLayoutFixtures
                         )
                     ).Flex(grow: 1),
 
-                    TextBlock("Footer").Height(50).Flex(shrink: 0).Background("LightBlue")
+                    TextBlock("Footer").Height(50).Flex(shrink: 0).Background(SystemAttentionBackground)
                 ).Width(400).Height(400)
             );
 
@@ -421,7 +422,7 @@ internal static class FlexLayoutFixtures
                 FlexColumn(
                     TextBlock("Top").Flex(basis: 0, grow: 1).Background("LightCoral"),
                     TextBlock("Middle").Flex(basis: 0, grow: 2).Background("LightGreen"),
-                    TextBlock("Bottom").Flex(basis: 0, grow: 1).Background("LightBlue")
+                    TextBlock("Bottom").Flex(basis: 0, grow: 1).Background(SystemAttentionBackground)
                 ).Width(400).Height(400)
             );
 
@@ -461,7 +462,7 @@ internal static class FlexLayoutFixtures
                 FlexRow(
                     TextBlock("Fixed1").Width(100).Background("LightCoral"),
                     TextBlock("Grow").Flex(grow: 1).Background("LightGreen"),
-                    TextBlock("Fixed2").Width(100).Background("LightBlue")
+                    TextBlock("Fixed2").Width(100).Background(SystemAttentionBackground)
                 ).Width(600).Height(60)
             );
 
@@ -497,7 +498,7 @@ internal static class FlexLayoutFixtures
                 new FlexElement([
                     TextBlock("A").Flex(basis: 0, grow: 1).Background("LightCoral"),
                     TextBlock("B").Flex(basis: 0, grow: 1).Background("LightGreen"),
-                    TextBlock("C").Flex(basis: 0, grow: 1).Background("LightBlue")
+                    TextBlock("C").Flex(basis: 0, grow: 1).Background(SystemAttentionBackground)
                 ])
                 {
                     Direction = FlexDirection.Row,
@@ -542,7 +543,7 @@ internal static class FlexLayoutFixtures
             host.Mount(ctx =>
                 FlexRow(
                     TextBlock("Padded-A").Flex(basis: 0, grow: 1).Background("LightCoral"),
-                    TextBlock("Padded-B").Flex(basis: 0, grow: 1).Background("LightBlue")
+                    TextBlock("Padded-B").Flex(basis: 0, grow: 1).Background(SystemAttentionBackground)
                 ).FlexPadding(20).Width(600).Height(100)
             );
 
@@ -580,8 +581,8 @@ internal static class FlexLayoutFixtures
                 VStack(8,
                     FlexRow(
                         TextBlock("Sidebar").Width(100).Background("LightCoral"),
-                        TextBlock(longText).Flex(grow: 1).Background("LightBlue")
-                    ).Width(600).Background("LightGray"),
+                        TextBlock(longText).Flex(grow: 1).Background(SystemAttentionBackground)
+                    ).Width(600).Background(SubtleFill),
 
                     TextBlock(longText).Width(500).Background("LightGreen"),
 
@@ -626,7 +627,7 @@ internal static class FlexLayoutFixtures
 
                     Grid([GridSize.Star(), GridSize.Star(2)], [GridSize.Star()],
                         TextBlock("GridLeft").Grid(row: 0, column: 0).Background("LightGreen"),
-                        TextBlock("GridRight").Grid(row: 0, column: 1).Background("LightBlue")
+                        TextBlock("GridRight").Grid(row: 0, column: 1).Background(SystemAttentionBackground)
                     ).Flex(grow: 1),
 
                     TextBlock("Footer").Height(50).Background("Wheat")
@@ -664,7 +665,7 @@ internal static class FlexLayoutFixtures
             host.Mount(ctx =>
                 FlexRow(
                     TextBlock("M1").Flex(basis: 0, grow: 1).Margin(10).Background("LightCoral"),
-                    TextBlock("M2").Flex(basis: 0, grow: 1).Margin(10).Background("LightBlue"),
+                    TextBlock("M2").Flex(basis: 0, grow: 1).Margin(10).Background(SystemAttentionBackground),
                     TextBlock("M3").Flex(basis: 0, grow: 1).Margin(10).Background("LightGreen")
                 ).Width(600).Height(80)
             );
@@ -700,7 +701,7 @@ internal static class FlexLayoutFixtures
                 new FlexElement([
                     TextBlock("J1").Width(100).Background("LightCoral"),
                     TextBlock("J2").Width(100).Background("LightGreen"),
-                    TextBlock("J3").Width(100).Background("LightBlue"),
+                    TextBlock("J3").Width(100).Background(SystemAttentionBackground),
                 ])
                 {
                     Direction = FlexDirection.Row,
@@ -746,7 +747,7 @@ internal static class FlexLayoutFixtures
 
                     FlexRow(
                         TextBlock("Grow-A").Flex(basis: 0, grow: 1).Background("LightGreen"),
-                        TextBlock("Grow-B").Flex(basis: 0, grow: 2).Background("LightBlue")
+                        TextBlock("Grow-B").Flex(basis: 0, grow: 2).Background(SystemAttentionBackground)
                     ).Grid(row: 0, column: 1)
                 ).Width(600).Height(300)
             );
@@ -787,7 +788,7 @@ internal static class FlexLayoutFixtures
 
                             FlexRow(
                                 TextBlock("L4-A").Flex(basis: 0, grow: 1).Background("LightCoral"),
-                                TextBlock("L4-B").Flex(basis: 0, grow: 1).Background("LightBlue"),
+                                TextBlock("L4-B").Flex(basis: 0, grow: 1).Background(SystemAttentionBackground),
                                 TextBlock("L4-C").Flex(basis: 0, grow: 1).Background("LightGreen")
                             ).Flex(grow: 1),
 
@@ -840,7 +841,7 @@ internal static class FlexLayoutFixtures
                 Grid([GridSize.Star(), GridSize.Star(2)], [GridSize.Auto, GridSize.Star()],
                     FlexRow(
                         TextBlock("Label").Width(80).Background("LightCoral"),
-                        TextBlock(longText).Flex(grow: 1).Background("LightBlue")
+                        TextBlock(longText).Flex(grow: 1).Background(SystemAttentionBackground)
                     ).Grid(row: 0, column: 0, columnSpan: 2),
 
                     FlexRow(
@@ -882,7 +883,7 @@ internal static class FlexLayoutFixtures
 
                     ScrollViewer(
                         FlexColumn(
-                            TextBlock("Item-1").Height(50).Background("LightBlue"),
+                            TextBlock("Item-1").Height(50).Background(SystemAttentionBackground),
                             TextBlock("Item-2").Height(50).Background("LightGreen"),
                             TextBlock("Item-3").Height(50).Background("Wheat"),
                             TextBlock("Item-4").Height(50).Background("Plum"),
@@ -891,7 +892,7 @@ internal static class FlexLayoutFixtures
                         ).Width(400)
                     ).Grid(row: 1, column: 0),
 
-                    TextBlock("Footer").Grid(row: 2, column: 0).Background("LightGray")
+                    TextBlock("Footer").Grid(row: 2, column: 0).Background(SubtleFill)
                 ).Width(400).Height(300)
             );
 
@@ -937,7 +938,7 @@ internal static class FlexLayoutFixtures
                 return Wrapit(
                     FlexColumn(
                         TextBlock($"blue: {cur}").Background("LightCoral"),
-                        TextBlock("red").Background("LightBlue").Flex(grow: 1)
+                        TextBlock("red").Background(SystemAttentionBackground).Flex(grow: 1)
                     ).Height(400).Width(400),
                     cur
                 );
@@ -1030,7 +1031,7 @@ internal static class FlexLayoutFixtures
                         .Flex(grow: 1, basis: 0)
                         .Background("LightGreen")
                         .AutomationId("HBF_Body"),
-                    TextBlock("Footer").Height(60).Background("LightBlue")
+                    TextBlock("Footer").Height(60).Background(SystemAttentionBackground)
                         .AutomationId("HBF_Footer"))
                     .AutomationId("HBF_Column"));
 
@@ -1116,7 +1117,7 @@ internal static class FlexLayoutFixtures
                             TextBlock("R3").Height(40))
                             .VAlign(VerticalAlignment.Top)
                             .AutomationId("Auto_TopCol"))
-                        .Background("LightBlue")
+                        .Background(SystemAttentionBackground)
                         .Flex(grow: 1, basis: 0)));
 
             await Harness.Render();

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlexPanelCssBehaviorFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlexPanelCssBehaviorFixtures.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Layout;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -39,31 +40,12 @@ internal static class FlexPanelCssBehaviorFixtures
 
     private static Brush ThemeBrush(string key)
     {
-        var resources = Application.Current?.Resources
+        var app = Application.Current
             ?? throw new InvalidOperationException("Application resources are required for theme-aware selftest brushes.");
 
-        if (TryResolveBrush(resources, key, out var brush))
-            return brush;
-
-        throw new InvalidOperationException($"Theme brush '{key}' was not found.");
-    }
-
-    private static bool TryResolveBrush(ResourceDictionary resources, string key, out Brush brush)
-    {
-        if (resources.TryGetValue(key, out var value) && value is Brush direct)
-        {
-            brush = direct;
-            return true;
-        }
-
-        foreach (var merged in resources.MergedDictionaries)
-        {
-            if (TryResolveBrush(merged, key, out brush))
-                return true;
-        }
-
-        brush = null!;
-        return false;
+        var isDark = app.RequestedTheme == ApplicationTheme.Dark;
+        return ThemeRef.Resolve(key, isDark)
+            ?? throw new InvalidOperationException($"Theme brush '{key}' was not found.");
     }
 
     private static bool Near(double a, double b, double tol = Tolerance)

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlexPanelCssBehaviorFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/FlexPanelCssBehaviorFixtures.cs
@@ -37,6 +37,35 @@ internal static class FlexPanelCssBehaviorFixtures
 {
     private const double Tolerance = 1.5;
 
+    private static Brush ThemeBrush(string key)
+    {
+        var resources = Application.Current?.Resources
+            ?? throw new InvalidOperationException("Application resources are required for theme-aware selftest brushes.");
+
+        if (TryResolveBrush(resources, key, out var brush))
+            return brush;
+
+        throw new InvalidOperationException($"Theme brush '{key}' was not found.");
+    }
+
+    private static bool TryResolveBrush(ResourceDictionary resources, string key, out Brush brush)
+    {
+        if (resources.TryGetValue(key, out var value) && value is Brush direct)
+        {
+            brush = direct;
+            return true;
+        }
+
+        foreach (var merged in resources.MergedDictionaries)
+        {
+            if (TryResolveBrush(merged, key, out brush))
+                return true;
+        }
+
+        brush = null!;
+        return false;
+    }
+
     private static bool Near(double a, double b, double tol = Tolerance)
         => Math.Abs(a - b) <= tol;
 
@@ -93,7 +122,7 @@ internal static class FlexPanelCssBehaviorFixtures
         var b = new Border
         {
             Tag = tag,
-            Background = new SolidColorBrush(Microsoft.UI.Colors.LightGray),
+            Background = ThemeBrush("SubtleFillColorSecondaryBrush"),
             Child = new TextBlock { Text = tag },
         };
         if (width is not null) b.Width = width.Value;
@@ -589,7 +618,7 @@ internal static class FlexPanelCssBehaviorFixtures
             var paneA = new Border
             {
                 Tag = "A",
-                Background = new SolidColorBrush(Microsoft.UI.Colors.LightBlue),
+                Background = ThemeBrush("SystemFillColorAttentionBackgroundBrush"),
                 Child = new Border { Width = 500, Height = 30,
                     Background = new SolidColorBrush(Microsoft.UI.Colors.SteelBlue) },
             };
@@ -802,7 +831,7 @@ internal static class FlexPanelCssBehaviorFixtures
             var paneA = new Border
             {
                 Tag = "A",
-                Background = new SolidColorBrush(Microsoft.UI.Colors.LightGray),
+                Background = ThemeBrush("SubtleFillColorSecondaryBrush"),
                 Child = new Border { Width = 100, Height = 80,
                     Background = new SolidColorBrush(Microsoft.UI.Colors.DarkSlateBlue) },
             };
@@ -840,7 +869,7 @@ internal static class FlexPanelCssBehaviorFixtures
             var paneA = new Border
             {
                 Tag = "A",
-                Background = new SolidColorBrush(Microsoft.UI.Colors.LightBlue),
+                Background = ThemeBrush("SystemFillColorAttentionBackgroundBrush"),
                 Child = new Border { Width = 50, Height = 500,
                     Background = new SolidColorBrush(Microsoft.UI.Colors.SteelBlue) },
             };

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/LayoutFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/LayoutFixtures.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 using WinXC = Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
@@ -128,14 +129,14 @@ internal static class LayoutFixtures
                     Grid([GridSize.Star(), GridSize.Star(2), GridSize.Star()], [GridSize.Star()],
                         TextBlock("G1").Grid(row: 0, column: 0).Background("LightCoral"),
                         TextBlock("G2").Grid(row: 0, column: 1).Background("LightGreen"),
-                        TextBlock("G3").Grid(row: 0, column: 2).Background("LightBlue")
+                        TextBlock("G3").Grid(row: 0, column: 2).Background(SystemAttentionBackground)
                     ).Width(ContainerWidth).Height(80),
 
                     // FlexRow with grow 1 / 2 / 1 (basis:0 to match star behavior)
                     FlexRow(
                         TextBlock("F1").Flex(grow: 1, basis: 0).Background("LightCoral"),
                         TextBlock("F2").Flex(grow: 2, basis: 0).Background("LightGreen"),
-                        TextBlock("F3").Flex(grow: 1, basis: 0).Background("LightBlue")
+                        TextBlock("F3").Flex(grow: 1, basis: 0).Background(SystemAttentionBackground)
                     ).Width(ContainerWidth).Height(80)
                 ).Width(ContainerWidth).Height(ContainerHeight * 2)
             );
@@ -188,14 +189,14 @@ internal static class LayoutFixtures
                     Grid([GridSize.Star(), GridSize.Star(2), GridSize.Star()], [GridSize.Auto],
                         TextBlock("Left").Grid(row: 0, column: 0).Background("LightCoral"),
                         TextBlock(longText).Grid(row: 0, column: 1).Background("LightGreen"),
-                        TextBlock("Right").Grid(row: 0, column: 2).Background("LightBlue")
+                        TextBlock("Right").Grid(row: 0, column: 2).Background(SystemAttentionBackground)
                     ).Width(ContainerWidth),
 
                     // Flex: same ratios with long text
                     FlexRow(
                         TextBlock("Left").Flex(grow: 1, basis: 0).Background("LightCoral"),
                         TextBlock(longText).Flex(grow: 2, basis: 0).Background("LightGreen"),
-                        TextBlock("Right").Flex(grow: 1, basis: 0).Background("LightBlue")
+                        TextBlock("Right").Flex(grow: 1, basis: 0).Background(SystemAttentionBackground)
                     ).Width(ContainerWidth)
                 ).Width(ContainerWidth)
             );

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/MarkdownFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/MarkdownFixtures.cs
@@ -732,7 +732,7 @@ internal static class MarkdownFixtures
                         Paragraph = (defaultEl) =>
                         {
                             paragraphCallCount++;
-                            return Border(defaultEl).Background("LightBlue");
+                            return Border(defaultEl).Background(Theme.SystemAttentionBackground);
                         },
                         CodeBlock = (code, lang) =>
                         {

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingDynamicContentFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingDynamicContentFixture.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
+using static Microsoft.UI.Reactor.Core.Theme;
 
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 
@@ -370,7 +371,7 @@ internal static class NativeDockingDynamicContentFixtures
                     TextBlock("Sample component:"),
                     Border(
                         Component<PixSampleControl>()
-                    ).CornerRadius(8).Background("#f5f5f5").Padding(16)
+                    ).CornerRadius(8).Background(CardBackground).Padding(16)
                 ).Padding(24)
             );
         }


### PR DESCRIPTION
## Summary
- replace hardcoded light-mode DataGrid, Markdown, and shared cell-renderer surfaces with theme-aware Reactor tokens
- update affected samples to use theme resources or explicit paired foreground/background colors
- update selftest fixtures so visual scaffolding remains readable under light and dark OS themes

## Validation
- dotnet build Reactor.slnx -p:Platform=x64
- dotnet test tests\\Reactor.Tests\\Reactor.Tests.csproj -p:Platform=x64 --no-build
- dotnet run --project tests\\Reactor.AppTests.Host\\Reactor.AppTests.Host.csproj -p:Platform=x64 --no-build -- --self-test --filter ValueDiff_RadioButton_Drift
- targeted changed selftest filters: ScrollPop, ScrollBack, ScrollPerf, CssMin, CssStack, CssDiverge, CssWinUI, FlexEdge, GridVsFlex, NativeDocking_Dynamic, Markdown

Fixes #530