### PR TITLE
Add REACTOR_HOOKS_008 analyzer for setState stale-read trap (#534)

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -110,6 +110,7 @@ via `.editorconfig`.
 | `REACTOR_HOOKS_005` | Warning | Hook called outside Render or a custom-hook method | `HookRulesAnalyzer.cs` |
 | `REACTOR_HOOKS_006` | Info | Resource fetcher looks non-idempotent | `HookRulesAnalyzer.cs` |
 | `REACTOR_HOOKS_007` | Warning | UseMemoCells builder captures variable not in deps | `UseMemoCellsAnalyzer.cs` |
+| `REACTOR_HOOKS_008` | Info | State variable read after its setter in the same synchronous handler | `HookRulesAnalyzer.cs` |
 | `REACTOR_A11Y_001` | Warning | Icon-only button needs an accessible name | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_002` | Warning | Image needs alt text or AccessibilityHidden | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_003` | Warning | Form field needs a label | `AccessibilityAnalyzers.cs` |

--- a/docs/_pipeline/templates/hooks.md.dt
+++ b/docs/_pipeline/templates/hooks.md.dt
@@ -402,6 +402,44 @@ setter is the right shape. The auto-marshal path for cross-thread setters
 described above relies on the same overload — every queued write reads
 the latest committed value, not a snapshot.
 
+### Reading state right after calling its setter
+
+```csharp
+// Don't:
+var (sizeFitIdx, setSizeFitIdx) = UseState(0);
+ComboBox(SizeFitNames, sizeFitIdx, i =>
+{
+    setSizeFitIdx(i);
+    Apply(sizeFitIdx); // reads the PREVIOUS index — the setter only queued a re-render
+});
+```
+
+A setter never mutates the local variable in the current closure; it
+schedules a re-render that produces a fresh `sizeFitIdx` on the *next*
+render pass. Reading `sizeFitIdx` again later in the same handler returns
+the stale, pre-update value — switching the dropdown appears to activate
+the previously selected item. Use the value you already have in hand:
+
+```csharp
+ComboBox(SizeFitNames, sizeFitIdx, i =>
+{
+    setSizeFitIdx(i);
+    Apply(i); // use the new value directly
+});
+```
+
+The **REACTOR_HOOKS_008** analyzer flags a state variable read after its
+setter is called in the same synchronous handler — including reads inside
+helper lambdas or local functions that are invoked before the next render.
+This applies to `UseState`, `UsePersisted`, and `UseReducer`. Truly deferred
+callbacks (an event handler you hand off without invoking) are exempt,
+because they run on a later render and observe the fresh value.
+
+> Note: for `UseState<T>`/`UsePersisted<T>` the setter is `Action<T>`, so a
+> lambda argument is the *new value* (when `T` is a delegate), not a
+> functional updater. The functional-updater API is `UseReducer`. A lambda
+> setter argument therefore does **not** exempt a later stale read.
+
 ## Tips
 
 **Use the functional setter for derived updates.** `setCount(c => c + 1)` is

--- a/docs/guide/analyzer-architecture.md
+++ b/docs/guide/analyzer-architecture.md
@@ -44,6 +44,7 @@ public override void Initialize(AnalysisContext context)
     context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
     context.EnableConcurrentExecution();
     context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    context.RegisterSyntaxNodeAction(AnalyzeSetterStaleRead, SyntaxKind.InvocationExpression);
 }
 
 private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
@@ -135,6 +136,7 @@ via `.editorconfig`.
 | `REACTOR_HOOKS_005` | Warning | Hook called outside Render or a custom-hook method | `HookRulesAnalyzer.cs` |
 | `REACTOR_HOOKS_006` | Info | Resource fetcher looks non-idempotent | `HookRulesAnalyzer.cs` |
 | `REACTOR_HOOKS_007` | Warning | UseMemoCells builder captures variable not in deps | `UseMemoCellsAnalyzer.cs` |
+| `REACTOR_HOOKS_008` | Info | State variable read after its setter in the same synchronous handler | `HookRulesAnalyzer.cs` |
 | `REACTOR_A11Y_001` | Warning | Icon-only button needs an accessible name | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_002` | Warning | Image needs alt text or AccessibilityHidden | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_003` | Warning | Form field needs a label | `AccessibilityAnalyzers.cs` |
@@ -331,6 +333,7 @@ public override void Initialize(AnalysisContext context)
     context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
     context.EnableConcurrentExecution();
     context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    context.RegisterSyntaxNodeAction(AnalyzeSetterStaleRead, SyntaxKind.InvocationExpression);
 }
 
 private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -551,6 +551,44 @@ setter is the right shape. The auto-marshal path for cross-thread setters
 described above relies on the same overload — every queued write reads
 the latest committed value, not a snapshot.
 
+### Reading state right after calling its setter
+
+```csharp
+// Don't:
+var (sizeFitIdx, setSizeFitIdx) = UseState(0);
+ComboBox(SizeFitNames, sizeFitIdx, i =>
+{
+    setSizeFitIdx(i);
+    Apply(sizeFitIdx); // reads the PREVIOUS index — the setter only queued a re-render
+});
+```
+
+A setter never mutates the local variable in the current closure; it
+schedules a re-render that produces a fresh `sizeFitIdx` on the *next*
+render pass. Reading `sizeFitIdx` again later in the same handler returns
+the stale, pre-update value — switching the dropdown appears to activate
+the previously selected item. Use the value you already have in hand:
+
+```csharp
+ComboBox(SizeFitNames, sizeFitIdx, i =>
+{
+    setSizeFitIdx(i);
+    Apply(i); // use the new value directly
+});
+```
+
+The **REACTOR_HOOKS_008** analyzer flags a state variable read after its
+setter is called in the same synchronous handler — including reads inside
+helper lambdas or local functions that are invoked before the next render.
+This applies to `UseState`, `UsePersisted`, and `UseReducer`. Truly deferred
+callbacks (an event handler you hand off without invoking) are exempt,
+because they run on a later render and observe the fresh value.
+
+> Note: for `UseState<T>`/`UsePersisted<T>` the setter is `Action<T>`, so a
+> lambda argument is the *new value* (when `T` is a delegate), not a
+> functional updater. The functional-updater API is `UseReducer`. A lambda
+> setter argument therefore does **not** exempt a later stale read.
+
 ## Tips
 
 **Use the functional setter for derived updates.** `setCount(c => c + 1)` is

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -10,6 +10,7 @@ REACTOR_HOOKS_004 | Reactor.Hooks | Warning | HookRulesAnalyzer - Hook deps cont
 REACTOR_HOOKS_005 | Reactor.Hooks | Warning | HookRulesAnalyzer - Hook called outside Render or custom-hook method
 REACTOR_HOOKS_006 | Reactor.Hooks | Info | HookRulesAnalyzer - UseResource fetcher looks non-idempotent (use UseMutation for writes)
 REACTOR_HOOKS_007 | Reactor.Hooks | Warning | UseMemoCellsAnalyzer - Builder closure capture missing from dependencies
+REACTOR_HOOKS_008 | Reactor.Hooks | Info | HookRulesAnalyzer - State variable read after its setter was called in the same synchronous handler (stale read)
 REACTOR_A11Y_001 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Icon-only button needs an accessible name
 REACTOR_A11Y_002 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Image needs alt text or AccessibilityHidden
 REACTOR_A11Y_003 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Form field needs a label

--- a/src/Reactor.Analyzers/HookRulesAnalyzer.cs
+++ b/src/Reactor.Analyzers/HookRulesAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -29,6 +30,12 @@ namespace Microsoft.UI.Reactor.Analyzers;
 ///   re-run on deps change, retry, and focus revalidation — use <c>UseMutation</c> for
 ///   writes. This is a name-based heuristic and is <see cref="DiagnosticSeverity.Info"/>.
 ///   </description></item>
+/// <item><description><c>REACTOR_HOOKS_008</c> — a state variable is read after its
+///   setter was called in the same synchronous handler (<c>setX(v); Apply(x);</c>). The
+///   setter only queues a re-render, so <c>x</c> still holds the previous value. Reads
+///   inside helper lambdas / local functions that are invoked synchronously before the
+///   next render are also flagged; truly deferred callbacks (event handlers) are exempt.
+///   <see cref="DiagnosticSeverity.Info"/>.</description></item>
 /// </list>
 ///
 /// See <c>docs/specs/tasks/async-resources-implementation.md</c> §4.3 for the full
@@ -42,6 +49,7 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
     public const string UnstableDepsId = "REACTOR_HOOKS_004";
     public const string HookOutsideRenderId = "REACTOR_HOOKS_005";
     public const string NonIdempotentFetcherId = "REACTOR_HOOKS_006";
+    public const string StaleStateReadId = "REACTOR_HOOKS_008";
 
     private static readonly DiagnosticDescriptor ConditionalHookRule = new(
         ConditionalHookId,
@@ -79,8 +87,17 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: "UseResource / UseInfiniteResource fetchers must be idempotent reads. A fetcher named Post/Create/Delete/Generate/... can execute multiple times per user action as the cache restarts on deps change or stale revalidation.");
 
+    private static readonly DiagnosticDescriptor StaleStateReadRule = new(
+        StaleStateReadId,
+        "State read after its setter in the same handler",
+        "State variable '{0}' is read after its setter was called in the same synchronous handler. The setter only queues a re-render, so '{0}' still holds the previous value here. Use the value you passed to the setter, or read from the live source of truth.",
+        "Reactor.Hooks",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Hook setters (UseState/UsePersisted/UseReducer) do not mutate the local value in the current closure — they schedule a re-render. Reading the state variable later in the same synchronous handler (including helper lambdas and local functions invoked before the next render) returns the stale, pre-update value.");
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(ConditionalHookRule, UnstableDepsRule, HookOutsideRenderRule, NonIdempotentFetcherRule);
+        ImmutableArray.Create(ConditionalHookRule, UnstableDepsRule, HookOutsideRenderRule, NonIdempotentFetcherRule, StaleStateReadRule);
 
     // Hooks that take a `deps` params-array. Only these are candidates for
     // REACTOR_HOOKS_004. For params-arrays, we skip the check if the caller
@@ -130,6 +147,7 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeSetterStaleRead, SyntaxKind.InvocationExpression);
     }
 
     private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
@@ -570,4 +588,303 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
 
     private static string StripAsyncSuffix(string name)
         => name.EndsWith("Async") && name.Length > "Async".Length ? name.Substring(0, name.Length - "Async".Length) : name;
+
+    // ────────────────────────────────────────────────────────────
+    // REACTOR_HOOKS_008 — state read after its setter in the same handler
+    // ────────────────────────────────────────────────────────────
+
+    // Hooks whose deconstruction yields a `(value, setValue)` pair: reading the value
+    // local after calling its setter/updater returns the stale, pre-update value. This
+    // includes UseReducer — its updater also only queues a re-render, so a same-handler
+    // read of the captured value is stale.
+    private static readonly ImmutableHashSet<string> StatePairHooks =
+        ImmutableHashSet.Create("UseState", "UsePersisted", "UseReducer");
+
+    /// <summary>
+    /// Detects the canonical setState stale-read trap:
+    /// <code>
+    /// var (x, setX) = UseState(0);
+    /// setX(v);
+    /// Apply(x);   // x is still the PREVIOUS value here
+    /// </code>
+    /// Anchored on the <c>setX(...)</c> invocation. Scans the statements that follow the
+    /// setter call in the same block for reads of the paired state variable, including
+    /// reads inside helper lambdas / local functions that are invoked synchronously before
+    /// the next render. Truly deferred callbacks (lambdas/local functions that are not
+    /// invoked in this synchronous path) are skipped — they run on a later render and
+    /// observe the fresh value.
+    /// </summary>
+    private static void AnalyzeSetterStaleRead(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // The setter is invoked as a bare local: `setX(...)`.
+        if (invocation.Expression is not IdentifierNameSyntax) return;
+
+        var model = context.SemanticModel;
+        if (model.GetSymbolInfo(invocation.Expression).Symbol is not ILocalSymbol setterSymbol) return;
+
+        if (!TryGetPairedStateSymbol(context, setterSymbol, out var stateSymbol) || stateSymbol is null) return;
+
+        // Locate the setter's enclosing statement that is a direct child of a block. Bail
+        // if a deferred-execution boundary (lambda / local function) sits between the
+        // setter call and that statement — the call then runs on a later render.
+        if (FindBlockStatement(invocation, out var block) is not { } setterStatement || block is null) return;
+
+        int startIndex = block.Statements.IndexOf(setterStatement);
+        if (startIndex < 0) return;
+
+        var visitedCallables = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+
+        for (int i = startIndex + 1; i < block.Statements.Count; i++)
+        {
+            var statement = block.Statements[i];
+
+            // A later top-level re-call of the same setter owns the statements after it —
+            // its own scan reports those reads. Scan the re-call's own arguments for stale
+            // reads (e.g. `setX(x + 1)`), then stop so we don't double-report.
+            if (IsDirectSetterStatement(statement, setterSymbol, model, out var reInvocation))
+            {
+                ReportStaleReads(context, reInvocation.ArgumentList, stateSymbol, model, visitedCallables);
+                return;
+            }
+
+            ReportStaleReads(context, statement, stateSymbol, model, visitedCallables);
+        }
+    }
+
+    /// <summary>
+    /// Reports every stale read of <paramref name="stateSymbol"/> reachable from
+    /// <paramref name="node"/> in this synchronous path, in document order. Lambda /
+    /// local-function <em>definitions</em> are not executed here and are pruned, but a
+    /// synchronous <em>invocation</em> of a local lambda or local function is followed into
+    /// its body (its reads run now and are therefore stale). Writes to the state local,
+    /// <c>out</c> arguments and <c>nameof</c> references are not reads and are skipped.
+    /// <paramref name="visitedCallables"/> guards against infinite recursion through
+    /// (mutually) recursive local callables.
+    /// </summary>
+    private static void ReportStaleReads(
+        SyntaxNodeAnalysisContext context,
+        SyntaxNode node,
+        ILocalSymbol stateSymbol,
+        SemanticModel model,
+        HashSet<ISymbol> visitedCallables)
+    {
+        // A lambda / local-function definition does not execute at its definition site.
+        if (IsDeferredExecutionBoundary(node)) return;
+
+        // Check the node itself, then recurse — so an expression-bodied callable whose
+        // whole body is `count` (an IdentifierNameSyntax) is still inspected.
+        if (node is IdentifierNameSyntax id && IsStaleRead(id, stateSymbol, model))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                StaleStateReadRule,
+                id.GetLocation(),
+                stateSymbol.Name));
+        }
+
+        // A synchronous call of a local lambda / local function runs its body now, so
+        // reads of the state local inside it are stale too. Follow into the body once
+        // (kept in visitedCallables to avoid re-reporting the same body or recursing
+        // through cyclic local callables).
+        if (node is InvocationExpressionSyntax invocation
+            && TryGetSynchronousCallableBody(invocation, model, visitedCallables, out var body, out var callableSymbol))
+        {
+            visitedCallables.Add(callableSymbol);
+            ReportStaleReads(context, body, stateSymbol, model, visitedCallables);
+        }
+
+        foreach (var child in node.ChildNodes())
+        {
+            ReportStaleReads(context, child, stateSymbol, model, visitedCallables);
+        }
+    }
+
+    private static bool IsStaleRead(IdentifierNameSyntax id, ILocalSymbol stateSymbol, SemanticModel model)
+    {
+        if (model.GetSymbolInfo(id).Symbol is not { } symbol) return false;
+        if (!SymbolEqualityComparer.Default.Equals(symbol, stateSymbol)) return false;
+
+        // Pure write `x = ...` (not compound `+=`, which also reads) is not a stale read.
+        if (id.Parent is AssignmentExpressionSyntax assign
+            && assign.IsKind(SyntaxKind.SimpleAssignmentExpression)
+            && assign.Left == id)
+        {
+            return false;
+        }
+
+        // `out x` writes the local; it is not a stale read. (`ref`/`in` read the value.)
+        if (id.Parent is ArgumentSyntax argument && argument.RefKindKeyword.IsKind(SyntaxKind.OutKeyword))
+        {
+            return false;
+        }
+
+        // `nameof(x)` is a compile-time reference, not a runtime read.
+        for (var ancestor = id.Parent; ancestor is not null and not StatementSyntax; ancestor = ancestor.Parent)
+        {
+            if (ancestor is InvocationExpressionSyntax { Expression: IdentifierNameSyntax { Identifier.Text: "nameof" } })
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// If <paramref name="invocation"/> is a synchronous call of a local lambda-valued
+    /// variable (<c>Action a = () =&gt; …; a();</c>) or a local function
+    /// (<c>void Apply() {…} Apply();</c>), returns the callable's body so the caller can
+    /// scan it. Returns false for ordinary method calls, already-visited callables, or
+    /// anything else.
+    /// </summary>
+    private static bool TryGetSynchronousCallableBody(
+        InvocationExpressionSyntax invocation,
+        SemanticModel model,
+        HashSet<ISymbol> visitedCallables,
+        out SyntaxNode body,
+        out ISymbol callableSymbol)
+    {
+        body = null!;
+        callableSymbol = null!;
+
+        // Accept `later(...)` and the explicit delegate form `later.Invoke(...)`.
+        ExpressionSyntax calleeExpression;
+        if (invocation.Expression is IdentifierNameSyntax)
+        {
+            calleeExpression = invocation.Expression;
+        }
+        else if (invocation.Expression is MemberAccessExpressionSyntax { Name.Identifier.Text: "Invoke", Expression: IdentifierNameSyntax receiver })
+        {
+            calleeExpression = receiver;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (model.GetSymbolInfo(calleeExpression).Symbol is not { } symbol) return false;
+        if (visitedCallables.Contains(symbol)) return false;
+
+        switch (symbol)
+        {
+            case IMethodSymbol { MethodKind: MethodKind.LocalFunction }:
+            {
+                if (symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is not LocalFunctionStatementSyntax decl)
+                    return false;
+                var local = (SyntaxNode?)decl.Body ?? decl.ExpressionBody?.Expression;
+                if (local is null) return false;
+                body = local;
+                callableSymbol = symbol;
+                return true;
+            }
+
+            case ILocalSymbol:
+            {
+                if (symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is not VariableDeclaratorSyntax declarator)
+                    return false;
+                if (declarator.Initializer?.Value is not { } initializer) return false;
+                SyntaxNode? lambdaBody = UnwrapCasts(initializer) switch
+                {
+                    SimpleLambdaExpressionSyntax sl => sl.Body,
+                    ParenthesizedLambdaExpressionSyntax pl => pl.Body,
+                    AnonymousMethodExpressionSyntax am => am.Block,
+                    _ => null,
+                };
+                if (lambdaBody is null) return false;
+                body = lambdaBody;
+                callableSymbol = symbol;
+                return true;
+            }
+
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="statement"/> is a bare <c>setX(...);</c> call of
+    /// <paramref name="setterSymbol"/> (a direct expression statement, not nested inside a
+    /// conditional or loop). Only such top-level re-calls own the statements after them.
+    /// </summary>
+    private static bool IsDirectSetterStatement(
+        StatementSyntax statement,
+        ILocalSymbol setterSymbol,
+        SemanticModel model,
+        out InvocationExpressionSyntax invocation)
+    {
+        invocation = null!;
+        if (statement is not ExpressionStatementSyntax { Expression: InvocationExpressionSyntax inv }) return false;
+        if (inv.Expression is not IdentifierNameSyntax) return false;
+        if (model.GetSymbolInfo(inv.Expression).Symbol is not ILocalSymbol symbol) return false;
+        if (!SymbolEqualityComparer.Default.Equals(symbol, setterSymbol)) return false;
+
+        invocation = inv;
+        return true;
+    }
+
+    /// <summary>
+    /// Given the setter local from <c>var (x, setX) = UseState(...)</c>, resolves the
+    /// paired state local <c>x</c>. Returns false unless the setter is the second element
+    /// of a two-element deconstruction whose initializer is a Reactor state-pair hook.
+    /// </summary>
+    private static bool TryGetPairedStateSymbol(SyntaxNodeAnalysisContext context, ILocalSymbol setterSymbol, out ILocalSymbol? stateSymbol)
+    {
+        stateSymbol = null;
+        var model = context.SemanticModel;
+
+        var declRef = setterSymbol.DeclaringSyntaxReferences.FirstOrDefault();
+        if (declRef?.GetSyntax() is not SingleVariableDesignationSyntax setterDesignation) return false;
+        if (setterDesignation.Parent is not ParenthesizedVariableDesignationSyntax pvds) return false;
+
+        // Require the `(value, setter)` shape: exactly two slots, setter is the second.
+        if (pvds.Variables.Count != 2) return false;
+        if (!ReferenceEquals(pvds.Variables[1], setterDesignation)) return false;
+        if (pvds.Variables[0] is not SingleVariableDesignationSyntax stateDesignation) return false;
+
+        if (pvds.Parent is not DeclarationExpressionSyntax decl) return false;
+        if (decl.Parent is not AssignmentExpressionSyntax assign || assign.Left != decl) return false;
+        if (assign.Right is not InvocationExpressionSyntax hookCall) return false;
+
+        var hookName = GetInvokedMethodName(hookCall);
+        if (hookName is null || !StatePairHooks.Contains(hookName)) return false;
+
+        // Anchor to Reactor hooks so unrelated `UseState`/`UsePersisted` lookalikes that
+        // happen to return a deconstructable pair aren't flagged.
+        if (!IsLikelyReactorHook(context, hookCall)) return false;
+
+        stateSymbol = model.GetDeclaredSymbol(stateDesignation) as ILocalSymbol;
+        return stateSymbol is not null;
+    }
+
+    private static bool IsDeferredExecutionBoundary(SyntaxNode node)
+        => node is SimpleLambdaExpressionSyntax
+            or ParenthesizedLambdaExpressionSyntax
+            or AnonymousMethodExpressionSyntax
+            or LocalFunctionStatementSyntax;
+
+    /// <summary>
+    /// Walks up from <paramref name="node"/> to its nearest enclosing statement. Returns
+    /// that statement and its block when the statement is a direct child of a
+    /// <see cref="BlockSyntax"/>. Returns null when a deferred-execution boundary (lambda /
+    /// local function) is crossed first (the call runs on a later render) or when the
+    /// statement is an unbraced embedded body (e.g. <c>if (c) setX(v);</c>).
+    /// </summary>
+    private static StatementSyntax? FindBlockStatement(SyntaxNode node, out BlockSyntax? block)
+    {
+        block = null;
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (IsDeferredExecutionBoundary(current)) return null;
+            if (current is StatementSyntax statement)
+            {
+                if (statement.Parent is BlockSyntax parentBlock)
+                {
+                    block = parentBlock;
+                    return statement;
+                }
+                return null;
+            }
+        }
+
+        return null;
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs
@@ -437,4 +437,532 @@ class Program
         };
         await analyzerTest.RunAsync();
     }
+
+    // ── REACTOR_HOOKS_008 — stale state read after setter ─────────────
+
+    // Generic UseState/UsePersisted stubs so tests can exercise both the value form
+    // (`UseState(0)`) and the delegate-value form used by the functional-arg exemption.
+    // Kept separate from `Stubs` so its line count doesn't shift WithSpan assertions.
+    private const string StaleStubs = @"
+namespace Microsoft.UI.Reactor.Core
+{
+    public class RenderContext { }
+
+    public abstract class Component
+    {
+        protected internal RenderContext Context { get; } = new RenderContext();
+        public abstract string Render();
+        protected (T Value, System.Action<T> Set) UseState<T>(T initial) => (initial, _ => { });
+        protected (T Value, System.Action<T> Set) UsePersisted<T>(string key, T initial) => (initial, _ => { });
+        protected (T Value, System.Action<System.Func<T, T>> Update) UseReducer<T>(T initial) => (initial, _ => { });
+    }
+}
+";
+
+    [Fact]
+    public async Task Setter_Then_Read_Same_Block_Flags()
+    {
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        System.Console.WriteLine({|REACTOR_HOOKS_008:count|});
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Read_In_If_Branch_After_Setter_Flags()
+    {
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        if ({|REACTOR_HOOKS_008:count|} > 0) System.Console.WriteLine(""hi"");
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task UsePersisted_Setter_Then_Read_Flags()
+    {
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (theme, setTheme) = UsePersisted(""theme"", 0);
+        setTheme(1);
+        System.Console.WriteLine({|REACTOR_HOOKS_008:theme|});
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Lambda_Value_Setter_Then_Read_Flags()
+    {
+        // UseState<T> returns Action<T>; when T is a delegate the lambda IS the new value,
+        // so a later read of the state local is still stale. (Not a functional updater —
+        // that is UseReducer.) The lambda argument must NOT suppress the diagnostic.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (fn, setFn) = UseState<System.Func<int, int>>(x => x);
+        setFn(p => p + 1);
+        var stale = {|REACTOR_HOOKS_008:fn|};
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task UseReducer_Updater_Then_Read_Flags()
+    {
+        // UseReducer's updater also only queues a re-render, so reading the captured value
+        // afterwards is stale.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, updateCount) = UseReducer(0);
+        updateCount(c => c + 1);
+        System.Console.WriteLine({|REACTOR_HOOKS_008:count|});
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Immediately_Invoked_Lambda_Read_Flags()
+    {
+        // The lambda is assigned to a local and invoked synchronously before any rerender,
+        // so the read inside its body runs now and is stale.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        System.Action later = () => System.Console.WriteLine({|REACTOR_HOOKS_008:count|});
+        later();
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Immediately_Invoked_Local_Function_Read_Flags()
+    {
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        void Apply() => System.Console.WriteLine({|REACTOR_HOOKS_008:count|});
+        Apply();
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Deferred_Callback_Not_Invoked_No_Diagnostic()
+    {
+        // The handler is handed off (not invoked) — it runs on a later render and sees the
+        // fresh value, so the read inside it is not stale.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    void Defer(System.Action a) { }
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        System.Action later = () => System.Console.WriteLine(count);
+        Defer(later);
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Read_Before_Setter_No_Diagnostic()
+    {
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        System.Console.WriteLine(count);
+        setCount(5);
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Two_Setters_Then_Read_Flags_Once()
+    {
+        // Only the read after the LAST setter is reported; the first setter's scan stops
+        // when it reaches the second setter call.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(1);
+        setCount(2);
+        System.Console.WriteLine({|REACTOR_HOOKS_008:count|});
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Multiple_UseState_Pairs_Flags_Only_The_Set_One()
+    {
+        // setA is called; reading `a` afterwards is stale and flagged, but `b` (whose
+        // setter was never called) is left alone.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (a, setA) = UseState(0);
+        var (b, setB) = UseState(0);
+        setA(5);
+        System.Console.WriteLine({|REACTOR_HOOKS_008:a|});
+        System.Console.WriteLine(b);
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Setter_In_Event_Lambda_Then_Read_Flags()
+    {
+        // Mirrors the real-world ComboBox handler: setter and read share the lambda body.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    void Apply(int v) { }
+    public override string Render()
+    {
+        var (idx, setIdx) = UseState(0);
+        System.Action<int> onChanged = i =>
+        {
+            setIdx(i);
+            Apply({|REACTOR_HOOKS_008:idx|});
+        };
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task ReSetter_With_Stale_Argument_Flags()
+    {
+        // `setCount(count + 1)` reads the stale `count` to compute the new value — the
+        // increment anti-pattern. The read inside the second setter's argument is flagged.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(1);
+        setCount({|REACTOR_HOOKS_008:count|} + 1);
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Nested_ReSetter_In_If_Does_Not_Stop_Outer_Scan()
+    {
+        // A setter buried in a conditional branch may not run, so it must not stop the
+        // outer scan from reaching the stale read after the if.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(1);
+        if (System.DateTime.Now.Ticks > 0) { setCount(2); }
+        System.Console.WriteLine({|REACTOR_HOOKS_008:count|});
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Write_To_State_Local_No_Diagnostic()
+    {
+        // Assigning the local (`count = 5`) is a write, not a stale read.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(1);
+        count = 5;
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Setter_In_Expression_Lambda_Then_Outer_Read_No_Diagnostic()
+    {
+        // The setter runs later (inside the event handler). The read happens during the
+        // current render, before the handler fires, so it is not stale.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        System.Action handler = () => setCount(1);
+        System.Console.WriteLine(count);
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Compound_Assignment_And_Increment_Read_Flag()
+    {
+        // `+=`, `++`, and `--` all read the current value, so they are stale reads.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        {|REACTOR_HOOKS_008:count|} += 1;
+        {|REACTOR_HOOKS_008:count|}++;
+        --{|REACTOR_HOOKS_008:count|};
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Member_Access_Tuple_And_Switch_Reads_Flag()
+    {
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    void Use(object o) { }
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        Use({|REACTOR_HOOKS_008:count|}.ToString());
+        Use(({|REACTOR_HOOKS_008:count|}, 1));
+        var label = {|REACTOR_HOOKS_008:count|} switch { 0 => ""zero"", _ => ""other"" };
+        return label;
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Out_Argument_Is_A_Write_No_Diagnostic()
+    {
+        // `out count` assigns the local; it is not a stale read.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        System.Int32.TryParse(""7"", out count);
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Expression_Bodied_Local_Function_Returning_State_Flags()
+    {
+        // The whole body is the state identifier; invoking it synchronously reads it stale.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        int Get() => {|REACTOR_HOOKS_008:count|};
+        System.Console.WriteLine(Get());
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Expression_Bodied_Lambda_Local_Returning_State_Flags()
+    {
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        System.Func<int> get = () => {|REACTOR_HOOKS_008:count|};
+        var x = get();
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
+
+    [Fact]
+    public async Task Invoke_Form_Of_Lambda_Local_Read_Flags()
+    {
+        // `later.Invoke()` is the explicit delegate-call form of `later()`.
+        var test = StaleStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        var (count, setCount) = UseState(0);
+        setCount(5);
+        System.Action later = () => System.Console.WriteLine({|REACTOR_HOOKS_008:count|});
+        later.Invoke();
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync();
+    }
 }


### PR DESCRIPTION
Closes #534.

Adds a new Roslyn analyzer rule that detects the canonical `setState` stale-read trap: calling a hook setter and then reading the state variable later in the **same synchronous handler**. The setter only queues a re-render, so the local still holds the previous value.

```csharp
var (sizeFitIdx, setSizeFitIdx) = UseState(0);
ComboBox(names, sizeFitIdx, i => {
    setSizeFitIdx(i);
    Apply(sizeFitIdx); // BUG: reads the PREVIOUS index
});
```

### What it does
- **Anchors** on each `setX(...)` call from a `var (x, setX) = UseState(...)` deconstruction (also `UsePersisted` and `UseReducer`), then scans the following statements in the same block for reads of `x`.
- **Follows synchronous invocations** of local lambdas / local functions (`later()`, `later.Invoke()`, `Apply()`, expression-bodied `int Get() => count;`) into their bodies — those run now, so the reads are stale. Truly deferred callbacks (handed off, not invoked) are exempt.
- **Skips non-reads:** simple-assignment writes, `out` arguments, and `nameof`.
- **No double-reporting:** a later top-level re-call of the same setter owns the statements after it; a `visitedCallables` set guards recursion/cycles.
- **Severity: Info** for low-noise rollout (can be promoted to Warning later).

### Notes
- Uses **`REACTOR_HOOKS_008`** — the issue proposed `007`, but that ID is already taken by `UseMemoCellsAnalyzer`.
- Cross-method reads (a handler calling a helper method that reads the state) are intentionally out of scope (intra-block analysis only), per the issue's false-positive section.

### Docs
- Updated `hooks.md.dt` (new "Reading state right after calling its setter" section) and `analyzer-architecture.md.dt` rule table; regenerated the compiled `docs/guide/*.md`.

### Tests
- 25 new tests in `HookRulesAnalyzerTests.cs` covering positive cases, event-handler/immediately-invoked lambdas and local functions, `UsePersisted`/`UseReducer`, lambda-valued state, multiple state pairs, repeated setters, nested branches, compound assignment / increment / member access / tuple / switch reads, and non-reads (`nameof`, simple assignment, `out`).
- All **115** analyzer tests pass; analyzer builds clean (0 warnings).