### PR TITLE
Fix #548: rename AsyncValue.Match 'data' arm to 'loaded'; omitted reloading -> loading()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,16 @@ Conventions for contributors:
 
 ### Changed (breaking)
 
+- **`AsyncValue<T>.Match` success arm renamed `data` → `loaded`; omitted
+  `reloading` now falls through to `loading()`.** The success delegate parameter
+  was renamed (source-breaking for named-argument callers; no back-compat
+  overload is possible because overloads can't differ by parameter name alone).
+  When the value is `Reloading` and no `reloading:` handler is supplied, `Match`
+  now renders the `loading()` arm instead of reusing the success arm
+  (`(reloading ?? data)(r.Previous)`). Pass `reloading:` explicitly to keep the
+  last-known value visible during a refresh (stale-while-revalidate).
+  (issue #548, spec 020 §5.1)
+
 - **`ReactorApp.Run` devtools parameters removed (spec 051 §13).** The
   `devtools:` and `preview:` overload parameters are gone. Enable devtools
   capability in the app project with `<RuntimeHostConfigurationOption

--- a/docs/_pipeline/apps/async-resources-cookbook/App.cs
+++ b/docs/_pipeline/apps/async-resources-cookbook/App.cs
@@ -104,7 +104,7 @@ class AfterUseResourceExample : Component
 
         return user.Match<Element>(
             loading: () => TextBlock("Loading…").Padding(24),
-            data: u => VStack(4,
+            loaded: u => VStack(4,
                 Heading("After: one hook").FontSize(14),
                 TextBlock(u.Name).FontSize(20).Bold(),
                 TextBlock(u.Role).Opacity(0.6)
@@ -200,7 +200,7 @@ class PendingFallbackExample : Component
                 deps: new object[] { "user-1" });
             return user.Match<Element>(
                 loading: () => TextBlock("• user loading…").Opacity(0.5),
-                data: u => TextBlock($"• {u.Name} ({u.Role})"),
+                loaded: u => TextBlock($"• {u.Name} ({u.Role})"),
                 error: ex => TextBlock($"• error: {ex.Message}"));
         }
     }
@@ -229,7 +229,7 @@ class PendingFallbackExample : Component
                 deps: new object[] { "stats" });
             return user.Match(
                 loading: () => TextBlock("• stats loading…").Opacity(0.5),
-                data: _ => TextBlock("• stats ready"),
+                loaded: _ => TextBlock("• stats ready"),
                 error: ex => TextBlock($"• error: {ex.Message}"));
         }
     }

--- a/docs/_pipeline/templates/async-resources.md.dt
+++ b/docs/_pipeline/templates/async-resources.md.dt
@@ -53,8 +53,10 @@ an `AsyncValue<T>` you pattern-match against:
 `AsyncValue<T>.Match` dispatches on the four states:
 `Loading` (first fetch), `Data(value)` (success), `Error(exception)` (failure),
 and `Reloading(previous)` (stale-while-revalidate — a refetch with the old value
-still available). Omitting the `reloading` arm makes it fall back to `data`, so
-the UI keeps the last-known value visible while revalidating.
+still available). Omitting the `reloading` arm makes it fall through to the
+`loading` arm, so a refresh shows the loading UI. To keep the last-known value
+visible while revalidating (stale-while-revalidate), pass a `reloading:` handler
+explicitly.
 
 ## Infinite Scroll with UseInfiniteResource
 

--- a/docs/guide/async-resources.md
+++ b/docs/guide/async-resources.md
@@ -89,7 +89,7 @@ class AfterUseResourceExample : Component
 
         return user.Match<Element>(
             loading: () => TextBlock("Loading…").Padding(24),
-            data: u => VStack(4,
+            loaded: u => VStack(4,
                 Heading("After: one hook").FontSize(14),
                 TextBlock(u.Name).FontSize(20).Bold(),
                 TextBlock(u.Role).Opacity(0.6)
@@ -104,8 +104,10 @@ class AfterUseResourceExample : Component
 `AsyncValue<T>.Match` dispatches on the four states:
 `Loading` (first fetch), `Data(value)` (success), `Error(exception)` (failure),
 and `Reloading(previous)` (stale-while-revalidate — a refetch with the old value
-still available). Omitting the `reloading` arm makes it fall back to `data`, so
-the UI keeps the last-known value visible while revalidating.
+still available). Omitting the `reloading` arm makes it fall through to the
+`loading` arm, so a refresh shows the loading UI. To keep the last-known value
+visible while revalidating (stale-while-revalidate), pass a `reloading:` handler
+explicitly.
 
 ## Infinite Scroll with UseInfiniteResource
 
@@ -268,7 +270,7 @@ class PendingFallbackExample : Component
                 deps: new object[] { "user-1" });
             return user.Match<Element>(
                 loading: () => TextBlock("• user loading…").Opacity(0.5),
-                data: u => TextBlock($"• {u.Name} ({u.Role})"),
+                loaded: u => TextBlock($"• {u.Name} ({u.Role})"),
                 error: ex => TextBlock($"• error: {ex.Message}"));
         }
     }
@@ -297,7 +299,7 @@ class PendingFallbackExample : Component
                 deps: new object[] { "stats" });
             return user.Match(
                 loading: () => TextBlock("• stats loading…").Opacity(0.5),
-                data: _ => TextBlock("• stats ready"),
+                loaded: _ => TextBlock("• stats ready"),
                 error: ex => TextBlock($"• error: {ex.Message}"));
         }
     }

--- a/docs/reference/async-system.md
+++ b/docs/reference/async-system.md
@@ -91,7 +91,7 @@ race-condition argument in §11:
 
 ## 2. The core ADT — `AsyncValue<T>`
 
-`AsyncValue.cs:15-72`. Four sealed records under an abstract record, constructor
+`AsyncValue.cs:15-81`. Four sealed records under an abstract record, constructor
 closed with `private protected`:
 
 | Case | Payload | When entered |
@@ -101,10 +101,11 @@ closed with `private protected`:
 | `Error(Exception)` | The exception | Fetch failed (or retries exhausted); prior data discarded |
 | `Reloading(T Previous)` | Last-good value | Cache hit past `StaleTime`, OR a refetch started with `Data` on screen |
 
-`Match` is a non-hot-path convenience that lets `Reloading` fall through to the
-`data:` lambda by default (`AsyncValue.cs:59-71`). The spec's §5.1 prefers a C#
-`switch` expression per render; the switch gets exhaustiveness checking and
-avoids one delegate allocation per case.
+`Match` is a non-hot-path convenience that, by default, renders the `loading:`
+lambda for `Reloading` — pass `reloading:` explicitly for stale-while-revalidate
+(`AsyncValue.cs:68-80`). The success arm is named `loaded:`. The spec's §5.1
+prefers a C# `switch` expression per render; the switch gets exhaustiveness
+checking and avoids one delegate allocation per case.
 
 Note that `Loading` is a singleton (`Loading.Instance`) and carries no payload —
 allocation-free on transition. The hook exploits this in `StartAttempt` to

--- a/docs/specs/020-async-resources-design.md
+++ b/docs/specs/020-async-resources-design.md
@@ -258,19 +258,36 @@ The switch also supports guards (`Data d when d.Value.IsStale => ...`),
 per-arm debugging breakpoints, and partial matches where the compiler
 warns on the uncovered cases — all things a helper method can't give you.
 
-**When to use `.Match()`:** as a convenience when (a) you explicitly want
-`Reloading` to render the same tree as `Data` and don't want to duplicate
-the expression, or (b) you're in a non-hot-path site where the two or
-three delegate allocations per call are irrelevant and you prefer the
-named-argument reading. Everywhere else, prefer the switch.
+**When to use `.Match()`:** as a convenience when (a) you want a refresh to
+render the loading UI and don't want to duplicate the `loading` arm — omit
+`reloading` and `Reloading` falls through to `loading()`, or (b) you're in a
+non-hot-path site where the two or three delegate allocations per call are
+irrelevant and you prefer the named-argument reading. Everywhere else, prefer
+the switch. To keep the last-known value visible during a refresh
+(stale-while-revalidate), pass a `reloading:` handler explicitly.
 
 ```csharp
-// Both read Reloading as Data — fallback is automatic.
+// No reloading arm → Reloading shows the loading UI.
 return user.Match(
     loading: () => Skeleton().Height(120),
-    data:    u  => VStack(Heading(u.Name), Text(u.Email)),
+    loaded:  u  => VStack(Heading(u.Name), Text(u.Email)),
     error:   e  => Text($"Failed: {e.Message}").Foreground(Red));
+
+// Pass reloading: explicitly to keep stale data visible while revalidating.
+return user.Match(
+    loading:   () => Skeleton().Height(120),
+    loaded:    u  => VStack(Heading(u.Name), Text(u.Email)),
+    reloading: u  => VStack(Heading(u.Name), Text(u.Email)).Opacity(0.6),
+    error:     e  => Text($"Failed: {e.Message}").Foreground(Red));
 ```
+
+> **ADR note (reactor-spec-as-adr) — supersedes the original §5.1 `Match` default (issue #548):**
+> The success arm was renamed `data` → `loaded`, and an omitted `reloading`
+> arm now falls through to `loading()` instead of reusing the success arm
+> (`(reloading ?? data)(r.Previous)`). The previous default silently rendered
+> stale data on every refresh; the new default shows the loading UI and makes
+> stale-while-revalidate an explicit opt-in via `reloading:`, so authors no
+> longer have to duplicate — or accidentally inherit — the success arm.
 
 ### Why four states, not three
 

--- a/docs/specs/020-async-resources-design.md
+++ b/docs/specs/020-async-resources-design.md
@@ -222,15 +222,15 @@ public abstract record AsyncValue<T>
     // Convenience shorthand — see §5.1.
     public TResult Match<TResult>(
         Func<TResult> loading,
-        Func<T, TResult> data,
+        Func<T, TResult> loaded,
         Func<Exception, TResult> error,
         Func<T, TResult>? reloading = null)
         => this switch
         {
             Loading       => loading(),
-            Data d        => data(d.Value),
+            Data d        => loaded(d.Value),
             Error e       => error(e.Exception),
-            Reloading r   => (reloading ?? data)(r.Previous),
+            Reloading r   => reloading is not null ? reloading(r.Previous) : loading(),
             _             => throw new UnreachableException()
         };
 }

--- a/docs/specs/tasks/async-resources-implementation.md
+++ b/docs/specs/tasks/async-resources-implementation.md
@@ -38,14 +38,14 @@ Scope: new files `Reactor/Core/AsyncValue.cs`, `Reactor/Core/QueryCache.cs`, `Re
 
 - [x] Create `Reactor/Core/AsyncValue.cs`
 - [x] Define `abstract record AsyncValue<T>` with nested sealed records `Loading`, `Data(T Value)`, `Error(Exception Exception)`, `Reloading(T Previous)`
-- [x] Implement `.Match<TResult>(loading, data, error, reloading = null)` convenience method per spec §5 — `reloading ?? data` fallback
+- [x] Implement `.Match<TResult>(loading, loaded, error, reloading = null)` convenience method per spec §5 — omitted `reloading` falls through to `loading()` (historical: originally shipped as `reloading ?? data`, flipped per issue #548)
 - [x] Add XML docs linking each state to the transition rules in §6.2
 - [x] Verify record equality: `Data(5)` equals `Data(5)`, `Reloading(5)` does not equal `Data(5)`
 
 #### Tests — unit (pure)
 
 - [x] Construct every state; assert type-discrimination via pattern match
-- [x] `Match` invokes the correct delegate for each state; `reloading` fallback lands in `data` when null
+- [x] `Match` invokes the correct delegate for each state; omitted `reloading` falls through to `loading()` (historical: originally landed in `data`, flipped per issue #548)
 - [x] Record equality for each pair (same-state-same-value, same-state-different-value, different-state-same-value)
 - [x] Equality when `T` is itself an `AsyncValue<_>` (nested) — guard against regression if callers accidentally wrap
 - [x] Equality when `T` holds a mutable reference type and the underlying value mutates (equality should still be reference-equal for the record; document this)

--- a/plugins/reactor/skills/reactor-recipes/references/async-fetch-list.cs
+++ b/plugins/reactor/skills/reactor-recipes/references/async-fetch-list.cs
@@ -58,7 +58,7 @@ class App : Component
 
             repos.Match<Element>(
                 loading: () => HStack(8, ProgressRing(), TextBlock("Loading…")),
-                data: list => VStack(8, list.Select(r =>
+                loaded: list => VStack(8, list.Select(r =>
                     Border(VStack(2,
                             TextBlock(r.Name).Bold(),
                             Caption(r.Description)))

--- a/skills/recipes/async-fetch-list.cs
+++ b/skills/recipes/async-fetch-list.cs
@@ -57,7 +57,7 @@ class App : Component
 
             repos.Match<Element>(
                 loading: () => HStack(8, ProgressRing(), TextBlock("Loading…")),
-                data: list => VStack(8, list.Select(r =>
+                loaded: list => VStack(8, list.Select(r =>
                     Border(VStack(2,
                             TextBlock(r.Name).Bold(),
                             Caption(r.Description)))

--- a/src/Reactor/Core/AsyncValue.cs
+++ b/src/Reactor/Core/AsyncValue.cs
@@ -49,24 +49,33 @@ public abstract record AsyncValue<T>
     public sealed record Reloading(T Previous) : AsyncValue<T>;
 
     /// <summary>
-    /// Convenience match that treats <see cref="Reloading"/> as <see cref="Data"/> by default.
-    /// Pass <paramref name="reloading"/> explicitly to distinguish (e.g. dim stale content).
+    /// Convenience match that renders the <paramref name="loading"/> arm for <see cref="Reloading"/>
+    /// by default. Pass <paramref name="reloading"/> explicitly to show stale content while a
+    /// refresh is in progress (stale-while-revalidate).
     /// </summary>
     /// <remarks>
+    /// Omitting <paramref name="reloading"/> means a refresh shows the loading UI, so authors don't
+    /// have to duplicate the loading arm. Provide <paramref name="reloading"/> to keep the previous
+    /// value visible while revalidating.
+    /// <para>
+    /// The success arm is named <paramref name="loaded"/>. This is a source-breaking rename from the
+    /// previous <c>data</c> parameter for named-argument callers; a back-compat overload is impossible
+    /// because overloads cannot differ by parameter name alone.
+    /// </para>
     /// Allocates a delegate per arm at the call site; prefer a <c>switch</c> expression in
     /// per-row render paths (see spec §5.1).
     /// </remarks>
     public TResult Match<TResult>(
         Func<TResult> loading,
-        Func<T, TResult> data,
+        Func<T, TResult> loaded,
         Func<Exception, TResult> error,
         Func<T, TResult>? reloading = null)
         => this switch
         {
             Loading => loading(),
-            Data d => data(d.Value),
+            Data d => loaded(d.Value),
             Error e => error(e.Exception),
-            Reloading r => (reloading ?? data)(r.Previous),
+            Reloading r => reloading is not null ? reloading(r.Previous) : loading(),
             _ => throw new UnreachableException()
         };
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue522TextBlockStyleResetFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue522TextBlockStyleResetFixture.cs
@@ -222,7 +222,7 @@ internal static class Issue522TextBlockStyleResetFixture
 
                 return value.Match<Element>(
                     loading: () => Heading("Loading url..."),
-                    data: (s) => TextBlock("Valid URL: " + s),
+                    loaded: (s) => TextBlock("Valid URL: " + s),
                     error: (e) => TextBlock("Error: " + e.Message).Foreground(new ThemeRef("SystemFillColorCriticalBrush")),
                     reloading: (s) => Heading("Reloading url..."));
             });

--- a/tests/Reactor.Tests/Core/AsyncValueTests.cs
+++ b/tests/Reactor.Tests/Core/AsyncValueTests.cs
@@ -53,7 +53,7 @@ public class AsyncValueTests
         AsyncValue<int> v = AsyncValue<int>.Loading.Instance;
         var result = v.Match(
             loading: () => "L",
-            data: d => $"D{d}",
+            loaded: d => $"D{d}",
             error: e => $"E{e.Message}");
         Assert.Equal("L", result);
     }
@@ -64,7 +64,7 @@ public class AsyncValueTests
         AsyncValue<int> v = new AsyncValue<int>.Data(7);
         var result = v.Match(
             loading: () => "L",
-            data: d => $"D{d}",
+            loaded: d => $"D{d}",
             error: e => $"E{e.Message}");
         Assert.Equal("D7", result);
     }
@@ -75,20 +75,20 @@ public class AsyncValueTests
         AsyncValue<int> v = new AsyncValue<int>.Error(new InvalidOperationException("boom"));
         var result = v.Match(
             loading: () => "L",
-            data: d => $"D{d}",
+            loaded: d => $"D{d}",
             error: e => $"E{e.Message}");
         Assert.Equal("Eboom", result);
     }
 
     [Fact]
-    public void Match_Reloading_Falls_Through_To_Data_When_Null()
+    public void Match_Reloading_Falls_Through_To_Loading_When_Null()
     {
         AsyncValue<int> v = new AsyncValue<int>.Reloading(9);
         var result = v.Match(
             loading: () => "L",
-            data: d => $"D{d}",
+            loaded: d => $"D{d}",
             error: e => $"E{e.Message}");
-        Assert.Equal("D9", result);
+        Assert.Equal("L", result);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class AsyncValueTests
         AsyncValue<int> v = new AsyncValue<int>.Reloading(9);
         var result = v.Match(
             loading: () => "L",
-            data: d => $"D{d}",
+            loaded: d => $"D{d}",
             error: e => $"E{e.Message}",
             reloading: r => $"R{r}");
         Assert.Equal("R9", result);


### PR DESCRIPTION
## Issue
- [#548](https://github.com/microsoft/microsoft-ui-reactor/issues/548) — Improve `UseResource.Match` arm naming and reloading default

## Fix
`AsyncValue<T>.Match<TResult>` gets two changes requested in the issue:

1. **Rename** the success-arm parameter `data` → `loaded` (reads better; matches how authors think about the *Loaded* state).
2. **Flip the omitted-`reloading` default.** When the value is `Reloading` and no `reloading:` handler is supplied, `Match` now falls through to the `loading()` arm (shows the loading UI) instead of reusing the success arm via `(reloading ?? data)(r.Previous)`. Authors who want stale-while-revalidate now opt in explicitly by passing `reloading:`.

```csharp
// after
Func<T, TResult> loaded,                                              // was: data
...
Data d => loaded(d.Value),
Reloading r => reloading is not null ? reloading(r.Previous) : loading(),  // was: (reloading ?? data)(r.Previous)
```

All in-repo call sites, the reloading-default unit test, the spec (020 §5.1, with an ADR supersession note), the user-guide template + generated guide, the historical task log, and `CHANGELOG.md` were updated.

> ⚠️ **Source-breaking:** external callers using the named argument `data:` must rename to `loaded:`. A back-compat overload is impossible (C# can't overload on parameter name alone). Flagged in the commit message, CHANGELOG, and spec ADR note.

## Validation
| Gate | Result |
|------|--------|
| `dotnet build src/Reactor/Reactor.csproj` (incl. AOT/trim-as-error) | ✅ 0 warnings, 0 errors |
| `dotnet test tests/Reactor.Tests` (full suite) | ✅ **9266 passed, 0 failed, 64 skipped** |
| `AsyncValue` focused suite | ✅ 19/19 |

Both behavioral tests pin the new contract:
- `Match_Reloading_Falls_Through_To_Loading_When_Null` — omitted `reloading:` → `loading()`.
- `Match_Reloading_Uses_Override_When_Provided` — explicit `reloading:` → handler used.

## Code review
Reviewed by the crew reviewer. Verdict was **REQUEST-CHANGES** on the first pass — code was correct/complete but docs (spec 020 §5.1, the `.md.dt` template prose, and a CHANGELOG entry) hadn't been updated. **All flagged items are now addressed in this PR.**

## Proof
**Change kind:** library / public-API change.

**What it does (user-visible):** the success arm is now `loaded:`; omitting `reloading:` shows the loading UI on refresh instead of silently re-rendering stale data; stale-while-revalidate is now an explicit opt-in.

**Evidence:** the two behavioral tests above exercise both the changed default and the explicit-opt-in path; the source diff shows the one-line dispatch flip. (No standalone driver `.exe` — the repo's `Reactor.SignaturesGen` codegen crashes on ARM64 dev boxes, pre-existing and unrelated; the xUnit tests run the same code paths.)

## How to verify locally
```bash
dotnet build src/Reactor/Reactor.csproj
dotnet test tests/Reactor.Tests --filter "FullyQualifiedName~AsyncValue"
# (on an ARM64 dev box add: -p:SkipSignaturesGen=true -r win-arm64)
```

## Conventions honored
- Immutable records; no new reflection (AOT/trim-as-error stays clean)
- Docs are generated — edited the `.md.dt` template (+ synced the generated guide)
- Spec-as-ADR: recorded the behavior flip as a supersession note in spec 020 §5.1
- CHANGELOG breaking-change entry added

Closes #548.
