### PR TITLE
Add REACTOR_DOCK_001 analyzer: flag DockManager OnLiveLayoutChanged round-trip (#439)

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -117,6 +117,7 @@ via `.editorconfig`.
 | `REACTOR_THEME_002` | Warning | Prefer lightweight styling | `UseLightweightStylingAnalyzer.cs` |
 | `REACTOR_THEME_003` | Warning | RequestedTheme set on a non-root element | `RequestedThemeSetAnalyzer.cs` |
 | `REACTOR_DSL_001` | Warning | Dynamic list item missing .WithKey | `MissingWithKeyAnalyzer.cs` |
+| `REACTOR_DOCK_001` | Warning | OnLiveLayoutChanged feeds the live layout back into state | `OnLiveLayoutRoundTripAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_DOC_002` | Warning | XML doc cref does not resolve | `XmlDocCrefAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |

--- a/docs/guide/analyzer-architecture.md
+++ b/docs/guide/analyzer-architecture.md
@@ -142,6 +142,7 @@ via `.editorconfig`.
 | `REACTOR_THEME_002` | Warning | Prefer lightweight styling | `UseLightweightStylingAnalyzer.cs` |
 | `REACTOR_THEME_003` | Warning | RequestedTheme set on a non-root element | `RequestedThemeSetAnalyzer.cs` |
 | `REACTOR_DSL_001` | Warning | Dynamic list item missing .WithKey | `MissingWithKeyAnalyzer.cs` |
+| `REACTOR_DOCK_001` | Warning | OnLiveLayoutChanged feeds the live layout back into state | `OnLiveLayoutRoundTripAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_DOC_002` | Warning | XML doc cref does not resolve | `XmlDocCrefAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -14,5 +14,6 @@ REACTOR_A11Y_001 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityA
 REACTOR_A11Y_002 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Image needs alt text or AccessibilityHidden
 REACTOR_A11Y_003 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Form field needs a label
 REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list item missing .WithKey
+REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback

--- a/src/Reactor.Analyzers/OnLiveLayoutRoundTripAnalyzer.cs
+++ b/src/Reactor.Analyzers/OnLiveLayoutRoundTripAnalyzer.cs
@@ -1,0 +1,179 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_DOCK_001</c> — flags the <c>DockManager</c> round-trip footgun:
+/// assigning <c>OnLiveLayoutChanged</c> a lambda that forwards its parameter
+/// straight back into a state setter.
+///
+/// <para>
+/// The host owns the user's drag-modified <em>shape</em> internally (spec 045
+/// §2.30) and resolves content by <c>Key</c> from <c>manager.Layout</c> each
+/// render. Feeding the live layout back into app state double-owns the shape:
+/// drag-back-to-redock breaks, tab selection resets, splitter drags snap back.
+/// <c>OnLiveLayoutChanged</c> is for <strong>observation only</strong>.
+/// </para>
+///
+/// <para>
+/// Heuristic (mirrors <see cref="MissingWithKeyAnalyzer"/>'s conservative,
+/// syntax-only style): an assignment whose left side names
+/// <c>OnLiveLayoutChanged</c> and whose right side is a single-parameter lambda
+/// whose body <em>forwards the parameter straight into</em>:
+/// </para>
+/// <list type="bullet">
+///   <item>a bare-identifier invocation — <c>next =&gt; setLayout(next)</c>
+///   (the UseState setter shape); member-access calls such as
+///   <c>Console.WriteLine(next)</c> or <c>inspector.Update(next)</c> are
+///   treated as observation/logging and ignored, or</item>
+///   <item>an assignment to a <c>Layout</c> target —
+///   <c>next =&gt; manager.Layout = next</c>.</item>
+/// </list>
+/// Empty bodies, and bodies that don't forward the parameter, never fire.
+///
+/// <para>
+/// The same heuristic also fires on the idiomatic fluent modifier —
+/// <c>manager.LiveLayoutChanged(next =&gt; setLayout(next))</c> — which wires the
+/// handler through an invocation rather than a raw assignment.
+/// </para>
+///
+/// <para>
+/// Note: observation routed through a <em>local delegate or method</em> —
+/// <c>next =&gt; observe(next)</c> — is intentionally NOT exempt and will warn,
+/// because syntactically it is indistinguishable from a state setter. Only
+/// member-access calls (<c>inspector.Update(next)</c>) are treated as
+/// observation; route observation through a named object to avoid the warning.
+/// </para>
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class OnLiveLayoutRoundTripAnalyzer : DiagnosticAnalyzer
+{
+    public const string Id = "REACTOR_DOCK_001";
+
+    private const string HandlerName = "OnLiveLayoutChanged";
+
+    private const string ModifierName = "LiveLayoutChanged";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        Id,
+        "OnLiveLayoutChanged feeds the live layout back into state",
+        "OnLiveLayoutChanged forwards the host's live layout straight into a setter. The host already owns the drag-modified shape — round-tripping it double-owns the layout and breaks re-docking, tab selection, and splitter drags. OnLiveLayoutChanged is for observation only.",
+        "Reactor.Docking",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Per the reactor-docking skill — the app owns content (which panes exist, keyed via manager.Layout) and the host owns shape (drag arrangement). Never store the host's live layout in app state. Reset is a .WithKey($\"dock-{epoch}\") remount; persistence is PersistenceId. OnLiveLayoutChanged should only observe (e.g. a layout inspector).");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeAssignment, SyntaxKind.SimpleAssignmentExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    static void AnalyzeAssignment(SyntaxNodeAnalysisContext ctx)
+    {
+        var assignment = (AssignmentExpressionSyntax)ctx.Node;
+
+        // Left side must name the handler — either `OnLiveLayoutChanged = ...`
+        // (object initializer) or `manager.OnLiveLayoutChanged = ...`.
+        var leftName = assignment.Left switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+            _ => null,
+        };
+        if (leftName != HandlerName) return;
+
+        // Right side must be a forwarding single-parameter lambda.
+        if (IsForwardingLambda(assignment.Right))
+            ctx.ReportDiagnostic(Diagnostic.Create(Rule, assignment.GetLocation()));
+    }
+
+    // The idiomatic fluent modifier `manager.LiveLayoutChanged(next => setLayout(next))`
+    // wires the handler through an invocation rather than a raw assignment.
+    static void AnalyzeInvocation(SyntaxNodeAnalysisContext ctx)
+    {
+        var invocation = (InvocationExpressionSyntax)ctx.Node;
+
+        // Target must be a member access named `LiveLayoutChanged`.
+        if (invocation.Expression is not MemberAccessExpressionSyntax member) return;
+        if (member.Name.Identifier.ValueText != ModifierName) return;
+
+        // Exactly one argument, a forwarding single-parameter lambda.
+        if (invocation.ArgumentList.Arguments.Count != 1) return;
+        if (IsForwardingLambda(invocation.ArgumentList.Arguments[0].Expression))
+            ctx.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
+    }
+
+    // True when `expr` is a single-parameter lambda (simple or parenthesized)
+    // whose body forwards the parameter straight into a state setter. A bare
+    // `handler` identifier (the modifier definition `el with { ... = handler }`)
+    // is not a lambda and never fires.
+    static bool IsForwardingLambda(ExpressionSyntax expr)
+    {
+        var (parameter, body) = expr switch
+        {
+            SimpleLambdaExpressionSyntax simple => (simple.Parameter.Identifier.ValueText, simple.Body),
+            ParenthesizedLambdaExpressionSyntax paren when paren.ParameterList.Parameters.Count == 1
+                => (paren.ParameterList.Parameters[0].Identifier.ValueText, paren.Body),
+            _ => (null, (CSharpSyntaxNode?)null),
+        };
+        if (parameter is null || body is null) return false;
+
+        // Unwrap a single-statement block: `next => { setLayout(next); }`.
+        if (body is BlockSyntax block)
+        {
+            if (block.Statements.Count != 1) return false;
+            // An Action lambda can only forward via an expression statement;
+            // a value-returning `return` arm is unreachable for a void delegate.
+            if (block.Statements[0] is not ExpressionStatementSyntax stmt) return false;
+            body = stmt.Expression;
+        }
+
+        return ForwardsParameter(body as ExpressionSyntax, parameter);
+    }
+
+    // True when `expr` hands `parameter` straight into a state setter — either a
+    // bare-identifier invocation (`setLayout(p)`) or an assignment to a `Layout`
+    // target (`x.Layout = p`). Member-access invocations (Console.WriteLine(p),
+    // inspector.Update(p)) are observation/logging and deliberately excluded.
+    static bool ForwardsParameter(ExpressionSyntax? expr, string parameter)
+    {
+        switch (expr)
+        {
+            case InvocationExpressionSyntax inv:
+                if (inv.Expression is not IdentifierNameSyntax) return false;
+                return IsSingleArgEqualToParameter(inv, parameter);
+
+            case AssignmentExpressionSyntax inner
+                when inner.IsKind(SyntaxKind.SimpleAssignmentExpression):
+                var targetName = inner.Left switch
+                {
+                    IdentifierNameSyntax id => id.Identifier.ValueText,
+                    MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+                    _ => null,
+                };
+                return targetName == "Layout" && IsIdentifier(inner.Right, parameter);
+
+            default:
+                return false;
+        }
+    }
+
+    static bool IsSingleArgEqualToParameter(InvocationExpressionSyntax inv, string parameter)
+    {
+        if (inv.ArgumentList.Arguments.Count != 1) return false;
+        return IsIdentifier(inv.ArgumentList.Arguments[0].Expression, parameter);
+    }
+
+    static bool IsIdentifier(ExpressionSyntax expr, string name)
+        => expr is IdentifierNameSyntax id && id.Identifier.ValueText == name;
+}

--- a/src/Reactor.Cli/Check/CheckCommand.cs
+++ b/src/Reactor.Cli/Check/CheckCommand.cs
@@ -410,6 +410,7 @@ public static class CheckCommand
             "REACTOR_THEME_002" => "skills/design.md §1 (use Theme tokens, not hex)",
             "REACTOR_A11Y_001"  => "skills/design.md §a11y (set AutomationName on icon-only controls)",
             "REACTOR_DSL_001"   => "SKILL.md gotcha #6 (.WithKey on dynamic list items)",
+            "REACTOR_DOCK_001"  => "skills/reactor-docking SKILL.md (OnLiveLayoutChanged is observation-only)",
             _ => null,
         };
     }

--- a/tests/Reactor.Tests/AnalyzerTests/OnLiveLayoutRoundTripAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/OnLiveLayoutRoundTripAnalyzerTests.cs
@@ -1,0 +1,434 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="OnLiveLayoutRoundTripAnalyzer"/>
+/// (<c>REACTOR_DOCK_001</c>). Stubs the real <c>DockManager</c> shape — a
+/// <c>sealed record : Element</c> with <c>init</c>-only <c>Layout</c> and
+/// <c>OnLiveLayoutChanged</c>, plus the fluent <c>LiveLayoutChanged</c> modifier
+/// — so the analyzer's syntax-only heuristic fires without pulling the framework
+/// in. Positive cases: forwarding the live layout into a state setter (raw
+/// assignment, block body, parenthesized lambda, fluent modifier). Negative
+/// cases: observation-only, logging, empty/multi-statement bodies, transformed
+/// or extra arguments, method groups, and null handlers.
+/// </summary>
+public class OnLiveLayoutRoundTripAnalyzerTests
+{
+    // Faithful Reactor docking surface: DockManager is a record deriving from
+    // Element with init-only Layout / OnLiveLayoutChanged, the DockNode shape,
+    // the fluent LiveLayoutChanged modifier, and a LayoutInspector for
+    // observation tests. `IsExternalInit` is required for records + init.
+    private const string Stubs = @"
+namespace System.Runtime.CompilerServices
+{
+    public static class IsExternalInit { }
+}
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public abstract record Element { }
+}
+
+namespace Microsoft.UI.Reactor.Docking
+{
+    using System;
+    using Microsoft.UI.Reactor.Core;
+
+    public abstract record DockNode;
+
+    public sealed record DockManager : Element
+    {
+        public DockNode? Layout { get; init; }
+        public Action<DockNode?>? OnLiveLayoutChanged { get; init; }
+    }
+
+    public static class DockManagerExtensions
+    {
+        public static DockManager LiveLayoutChanged(this DockManager el, System.Action<DockNode?>? h)
+            => el with { OnLiveLayoutChanged = h };
+    }
+
+    public sealed class LayoutInspector
+    {
+        public void Update(DockNode? layout) { }
+    }
+
+    // App-owned state mirror with a settable Layout — models storing the live
+    // layout back into application state (the footgun the analyzer flags).
+    public sealed class LayoutHolder
+    {
+        public DockNode? Layout { get; set; }
+    }
+}
+";
+
+    // ── Positive: setter forwarding ─────────────────────────────────────
+
+    [Fact]
+    public async Task Fires_When_Handler_Forwards_To_State_Setter()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System;
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build(Action<DockNode?> setLayout)
+            => new DockManager
+            {
+                {|REACTOR_DOCK_001:OnLiveLayoutChanged = next => setLayout(next)|}
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task Fires_When_Handler_Forwards_Via_Block_Body()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System;
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build(Action<DockNode?> setLayout)
+            => new DockManager
+            {
+                {|REACTOR_DOCK_001:OnLiveLayoutChanged = next => { setLayout(next); }|}
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task Fires_When_Handler_Assigns_Back_To_Layout()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build(LayoutHolder target)
+            => new DockManager
+            {
+                {|REACTOR_DOCK_001:OnLiveLayoutChanged = next => target.Layout = next|}
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task Fires_For_Parenthesized_Lambda()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System;
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build(Action<DockNode?> setLayout)
+            => new DockManager
+            {
+                {|REACTOR_DOCK_001:OnLiveLayoutChanged = (next) => setLayout(next)|}
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task Fires_For_Fluent_Modifier_Setter()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System;
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build(DockManager someManager, Action<DockNode?> setLayout)
+            => {|REACTOR_DOCK_001:someManager.LiveLayoutChanged(next => setLayout(next))|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    // ── Negative: observation-only ──────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Observation_Only_Handler()
+    {
+        // Forwards the layout into an inspector (member-access call) — this is
+        // the sanctioned observation-only use, not a state round-trip.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build(LayoutInspector inspector)
+            => new DockManager
+            {
+                OnLiveLayoutChanged = next => inspector.Update(next)
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Fluent_Observation()
+    {
+        // Fluent modifier whose body is a member-access call — observation, not
+        // a round-trip. Proves the shared helper applies the same exclusion.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build(DockManager someManager, LayoutInspector inspector)
+            => someManager.LiveLayoutChanged(next => inspector.Update(next));
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    // ── Negative: logging ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Logging_Handler()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System;
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build()
+            => new DockManager
+            {
+                OnLiveLayoutChanged = next => Console.WriteLine(next)
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    // ── Negative: empty body ────────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Empty_Handler_Body()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build()
+            => new DockManager
+            {
+                OnLiveLayoutChanged = next => { }
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    // ── Negative: null handler ──────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Null_Handler()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build()
+            => new DockManager
+            {
+                OnLiveLayoutChanged = null
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    // ── Negative: method group ──────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Method_Group()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        static void Observe(DockNode? n) {}
+
+        public static DockManager Build()
+            => new DockManager
+            {
+                OnLiveLayoutChanged = Observe
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    // ── Negative: multi-statement block ─────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_MultiStatement_Block()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        static void Inspect(DockNode? n) {}
+
+        public static DockManager Build()
+            => new DockManager
+            {
+                OnLiveLayoutChanged = next => { Inspect(next); Inspect(next); }
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    // ── Negative: transformed parameter ─────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Transformed_Param()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System;
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        static DockNode? Wrap(DockNode? n) => n;
+
+        public static DockManager Build(Action<DockNode?> setLayout)
+            => new DockManager
+            {
+                OnLiveLayoutChanged = next => setLayout(Wrap(next))
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+
+    // ── Negative: extra arguments ───────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Extra_Args()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System;
+    using Microsoft.UI.Reactor.Docking;
+
+    public static class C
+    {
+        public static DockManager Build(Action<DockNode?, bool> setLayout2)
+            => new DockManager
+            {
+                OnLiveLayoutChanged = next => setLayout2(next, true)
+            };
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnLiveLayoutRoundTripAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a non-breaking Roslyn analyzer **`REACTOR_DOCK_001`** (severity: **Warning**, category `Reactor.Docking`) that flags the `DockManager.OnLiveLayoutChanged` *round-trip* anti-pattern — where the live-layout callback simply forwards its parameter straight back into a state setter, recreating the layout you were already given:

```csharp
// ⚠ REACTOR_DOCK_001 — round-trip: the handler just echoes the layout back into state
DockManager() with { OnLiveLayoutChanged = next => SetLayout(next) }

// ✅ fine — observation only
DockManager() with { OnLiveLayoutChanged = next => _telemetry.Record(next) }
```

This implements **Option 1** from #439 (analyzer, non-breaking) following the house-style precedent `MissingWithKeyAnalyzer` / `REACTOR_DSL_001`.

Closes #439.

## What it detects

Syntax-only (no semantic model), registered on both authoring forms:

| Form | Example | Fires? |
|---|---|---|
| Object-initializer / assignment | `OnLiveLayoutChanged = next => SetLayout(next)` | ✅ |
| Block body | `next => { SetLayout(next); }` | ✅ |
| Assign back to `Layout` | `next => x.Layout = next` | ✅ |
| Parenthesized lambda | `(next) => SetLayout(next)` | ✅ |
| Fluent modifier | `mgr.LiveLayoutChanged(next => SetLayout(next))` | ✅ |
| Observation (member-access call) | `next => inspector.Update(next)` | ❌ |
| Logging | `next => Console.WriteLine(next)` | ❌ |
| Method group | `OnLiveLayoutChanged = SetLayout` | ❌ |
| Transformed / extra args / multi-statement / empty / null | — | ❌ |

The precision boundary: a **bare-identifier** invocation (`SetLayout(p)`) or a `Layout = p` assignment is a state round-trip and fires; a **member-access** invocation (`x.Update(p)`) is treated as observation and is deliberately exempt.

### Known limitation (documented)
Observation routed through a *local delegate* (`next => observe(next)` where `observe` is a local that logs) cannot be distinguished syntactically from a state setter and will warn. Documented in the analyzer doc; suppress with `#pragma` if intentional.

## Validation

| Gate | Result |
|---|---|
| Focused analyzer tests | **14 / 14 pass** |
| Full `Reactor.Tests` suite | **9280 passed / 0 failed / 64 skipped** |
| `Reactor.Analyzers` build | **0 warning / 0 error** (warnings-as-errors, RS2008 manifest satisfied) |
| Analyzer coverage | **line 94.4% / branch 87.0%** |

The 4 uncovered lines are defensive switch-discard arms unreachable with valid compiling C# (no behavioral gap). The reviewer-flagged dead `ReturnStatementSyntax` arm (an `Action` lambda cannot `return <expr>;`) was removed, raising branch coverage 82.75% → 87.0%.

## Code review

Independent review verdict: **ship-ready**. The fluent-modifier detection gap surfaced in review (`mgr.LiveLayoutChanged(lambda)` originally escaped detection) was closed in a follow-up pass — the analyzer now registers on `InvocationExpression` as well as `SimpleAssignmentExpression`, the test stub was made faithful to the real `DockManager` (`init`-only props, real `DockNode`), and parenthesized-lambda + matrix tests were added.

## Files

- `src/Reactor.Analyzers/OnLiveLayoutRoundTripAnalyzer.cs` (new)
- `tests/Reactor.Tests/AnalyzerTests/OnLiveLayoutRoundTripAnalyzerTests.cs` (new, 14 tests)
- `src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md` (RS2008 rule manifest)
- `src/Reactor.Cli/Check/CheckCommand.cs` (`mur check` skill wiring)
- `docs/_pipeline/templates/analyzer-architecture.md.dt` + generated `docs/guide/analyzer-architecture.md`

## How to verify locally

```bash
dotnet build src/Reactor.Analyzers/Reactor.Analyzers.csproj
dotnet test tests/Reactor.Tests --filter "FullyQualifiedName~OnLiveLayoutRoundTrip"
```
