### PR TITLE
Fix: NuGet symbol package pushed twice → 409 fails nuget.org publish

### DIFF
--- a/build/pipelines/OneBranch.Official.Reactor.yml
+++ b/build/pipelines/OneBranch.Official.Reactor.yml
@@ -191,15 +191,21 @@ extends:
           # `dotnet nuget push` (a raw CLI/script) is NOT on the NonAzure allow-list; the
           # allowed publish task is NuGetCommand@2 with command: push. nuget.org credentials
           # come from a NuGet SERVICE CONNECTION (holding the API key), referenced by name —
-          # never a YAML secret/env var. The *.snupkg symbol packages are listed explicitly:
-          # NuGetCommand@2 does NOT auto-push symbols, so the .nupkg glob alone would leave
-          # symbols unpublished. allowPackageConflicts makes the push idempotent, so a symbol
-          # package already on the feed is skipped rather than failing the run.
+          # never a YAML secret/env var. The glob matches *.nupkg ONLY — never *.snupkg.
+          # NuGetCommand@2 shells out to nuget.exe, and `nuget.exe push <pkg>.nupkg`
+          # AUTOMATICALLY pushes the adjacent <pkg>.snupkg to nuget.org's symbol endpoint.
+          # Adding *.snupkg to the glob therefore pushes each symbol package twice: the second
+          # (explicit) push hits HTTP 409 "another copy of this symbols package pending
+          # validation", which allowPackageConflicts does NOT suppress (it only neutralizes the
+          # main-package "already exists" conflict, not the symbol-server pending-validation
+          # 409). Listing *.nupkg alone publishes both the package and its symbols exactly once.
+          # allowPackageConflicts keeps re-runs idempotent: a package version already on the
+          # feed is skipped rather than failing the run.
           - task: NuGetCommand@2
             displayName: 'Publish NuGet packages (nuget.org)'
             inputs:
               command: push
-              packagesToPush: '$(Pipeline.Workspace)/drop_build_main/nupkg/*.nupkg;$(Pipeline.Workspace)/drop_build_main/nupkg/*.snupkg'
+              packagesToPush: '$(Pipeline.Workspace)/drop_build_main/nupkg/*.nupkg'
               nuGetFeedType: external
               publishFeedCredentials: 'nuget-org'  # ADO NuGet service connection (create in portal)
               allowPackageConflicts: true  # idempotent re-runs: a version already on the feed is skipped, not a 409


### PR DESCRIPTION
## Summary

The approval-gated `Production_PublishNuGet` release stage in `OneBranch.Official.Reactor.yml` was pushing each `*.snupkg` symbol package to nuget.org **twice**, causing the publish task to fail with HTTP 409 even though the main package published successfully.

The `packagesToPush` glob included **both** `*.nupkg` **and** `*.snupkg`. But `NuGetCommand@2` shells out to `nuget.exe`, and `nuget.exe push <pkg>.nupkg` **already auto-pushes the adjacent `<pkg>.snupkg`** to nuget.org's symbol endpoint. Listing `*.snupkg` separately therefore pushed each symbol package a second time, and the redundant push hit:

```
409 (It looks like there is another copy of this symbols package pending
     validation(s). Please wait for the validation(s) to finish before
     trying to replace the symbols package.)
##[error]Packages failed to publish
```

`allowPackageConflicts: true` did **not** suppress this — that flag only neutralizes the *main* package "already exists" conflict, not the symbol-server *pending-validation* 409.

## Root cause

A stale/incorrect comment in the pipeline claimed *"NuGetCommand@2 does NOT auto-push symbols, so the .nupkg glob alone would leave symbols unpublished."* This is false — `nuget.exe` auto-detects and pushes the sibling `.snupkg`. The sibling template `reactor-build-steps.yml` already documents the correct behavior; the release pipeline contradicted it.

## Evidence (build 118916, task "Publish NuGet packages (nuget.org)")

A single `nuget.exe push …nupkg` invocation pushed **both**:

```
Pushing Microsoft.UI.Reactor.0.1.0-preview.1.nupkg ...   → Your package was pushed.
Pushing Microsoft.UI.Reactor.0.1.0-preview.1.snupkg ...  → Your package was pushed.   ← automatic
```

Then the explicit `*.snupkg` glob entry triggered a **second** push:

```
Pushing Microsoft.UI.Reactor.0.1.0-preview.1.snupkg ...  → Conflict 409 (pending validation)
```

## Change

`build/pipelines/OneBranch.Official.Reactor.yml` — `Production_PublishNuGet` stage, `Publish NuGet packages (nuget.org)` task:

- **Before:** `packagesToPush: '…/nupkg/*.nupkg;…/nupkg/*.snupkg'`
- **After:** `packagesToPush: '…/nupkg/*.nupkg'`
- Replaced the incorrect comment with an accurate explanation of `nuget.exe`'s automatic symbol push, why adding `*.snupkg` double-pushes, and the precise scope of `allowPackageConflicts`.

Pushing `*.nupkg` alone publishes both the package and its symbols exactly once.

## Risk

Very low. YAML-only change to a single task input plus comments. No code, no build/sign changes. The signed packages and the rest of the release flow are unaffected.

## Validation

- YAML lint: no errors.
- Confirmed against build 118916 logs that the main `.nupkg` and its `.snupkg` both publish from the single `*.nupkg` push; the second explicit symbol push was the only failing operation.

## Notes / follow-up

- `Microsoft.UI.Reactor 0.1.0-preview.1` already published successfully to nuget.org and is **immutable**. The next release must use a new tag (`v0.1.0-preview.2`); `v0.1.0-preview.1` cannot be republished.
- After merge: tag `v0.1.0-preview.2` off `main` to trigger the release (MinVer derives the version from the tag — no version-file edit needed).
