### PR TITLE
Prepare 0.1.0-preview.3 release

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -151,7 +151,11 @@ jobs:
           New-Item -ItemType Directory -Path TestProjects | Out-Null
           Push-Location TestProjects
           try {
-              dotnet new reactorapp -n TestApp
+              # Bootstrap validates the local 0.0.0-local feed produced by
+              # mur pack-local. The template's normal default may point at a
+              # not-yet-published public preview while a release-prep PR is in
+              # flight, so opt into the local package version explicitly here.
+              dotnet new reactorapp -n TestApp --MSUIReactorVersion 0.0.0-local
               if ($LASTEXITCODE -ne 0) { throw "dotnet new reactorapp exited $LASTEXITCODE" }
               if (-not (Test-Path 'TestApp/TestApp.csproj')) { throw "TestApp/TestApp.csproj not produced" }
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Many of the experiments in this repo — the charting stack, accessibility valid
 
 ## Quick start
 
-Reactor doesn't ship a signed NuGet yet, so you build the framework, the `mur` CLI, and the project template from source. `bootstrap.ps1` collapses that into a single command — ~3 minutes per machine.
+Reactor ships the public preview package `Microsoft.UI.Reactor` version `0.1.0-preview.3` on NuGet.org. The project template is still installed from source for now; `bootstrap.ps1` installs the `mur` CLI, packs/registers the local `reactorapp` template, and that template references the public preview package by default.
 
 ```powershell
 git clone https://github.com/microsoft/microsoft-ui-reactor.git
@@ -88,9 +88,11 @@ dotnet run -p:Platform=x64
 > causes `WindowsAppSDKSelfContained` errors. This applies to `dotnet build`,
 > `dotnet run`, and `mur check` invocations alike.
 
-`bootstrap.ps1` packs `mur` as a `dotnet tool` global install (cross-shell PATH, no per-arch `$env:Path` edits), packs the framework + the optional `Microsoft.UI.Reactor.Advanced` sibling + project templates into `local-nupkgs/`, registers the `dotnet new reactorapp` template, and installs the Reactor agent plugin under `~/.claude/plugins/reactor`. Apps reference `Microsoft.UI.Reactor`; add the optional, same-version `Microsoft.UI.Reactor.Advanced` package when you need Win2D canvases, and the optional, same-version `Microsoft.UI.Reactor.Devtools` package when enabling `--devtools` with `Reactor.DevtoolsSupport`. Re-run it (or `mur upgrade` for a lighter refresh) after `git pull`. Verify a working install with `mur doctor`.
+`bootstrap.ps1` packs `mur` as a `dotnet tool` global install (cross-shell PATH, no per-arch `$env:Path` edits), packs local framework snapshots plus project templates into `local-nupkgs/`, registers the `dotnet new reactorapp` template, and installs the Reactor agent plugin under `~/.claude/plugins/reactor`. Apps created by the template reference `Microsoft.UI.Reactor` `0.1.0-preview.3` from NuGet.org by default; pass `--MSUIReactorVersion 0.0.0-local` when you intentionally want a scaffolded app to consume the local source-built package instead. The optional `Microsoft.UI.Reactor.Advanced` and `Microsoft.UI.Reactor.Devtools` sibling packages are version-matched to the framework package when published. Re-run `bootstrap.ps1` (or `mur upgrade` for a lighter refresh) after `git pull` when you want updated local templates or CLI/plugin bits. Verify a working developer install with `mur doctor`.
 
 Prefer to wire it up by hand? **[Getting Started](https://microsoft.github.io/microsoft-ui-reactor/getting-started/#manual-setup)** has a no-magic walkthrough of the exact `dotnet pack` / `dotnet tool install` / `dotnet new install` calls `bootstrap.ps1` makes, plus the full hello-world → todo → calculator tour.
+
+Release owners: see the [release runbook](docs/contributing/release-runbook.md) before minting a new version tag.
 
 ---
 

--- a/docs/_pipeline/templates/dev-tooling.md.dt
+++ b/docs/_pipeline/templates/dev-tooling.md.dt
@@ -157,7 +157,7 @@ subcommands map one-to-one to the workflows below.
 | `mur loc` | Run the localization pipeline (extract strings, validate `.resw`, generate manifests) | `mur loc extract` |
 | `mur devtools` | Start the MCP server for VS Code or agent integration | `mur devtools serve` |
 | `mur check` | Repo-health checks (cref validity, namespace policy, "did you mean" suggestions) | `mur check` |
-| `mur pack-local` / `mur clean-local` | Package / clean the local NuGet feed for samples that consume `Microsoft.UI.Reactor` as a package | `mur pack-local` |
+| `mur pack-local` / `mur clean-local` | Package / clean the local NuGet feed for source-built framework smoke tests; the app template defaults to the public Reactor preview unless `--MSUIReactorVersion` is supplied | `mur pack-local` |
 
 `mur docs compile` is the workflow you reach for most often. See
 [the doc-pipeline contributor guide](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/contributing/doc-pipeline.md)

--- a/docs/_pipeline/templates/getting-started.md.dt
+++ b/docs/_pipeline/templates/getting-started.md.dt
@@ -30,10 +30,11 @@ the rest of the docset elaborates.
 > **Prerequisites:** .NET 10+ and the Windows App SDK.
 <!-- /ai:lock -->
 
-> **Heads up — no signed NuGet yet.** Reactor doesn't ship a signed NuGet
-> package today, so you build the framework, the `mur` CLI, and the project
-> template from source. `bootstrap.ps1` automates all of that — one command,
-> ~3 minutes per machine. The signed distribution is tracked in
+> **Public preview package available.** Reactor ships `Microsoft.UI.Reactor`
+> `0.1.0-preview.3` on NuGet.org. The project template package is still
+> installed from source for now; `bootstrap.ps1` installs `mur`, packs/registers
+> the local `reactorapp` template, and stamps generated apps to reference the
+> public preview package by default. Broader signed distribution is tracked in
 > [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md).
 
 Reactor is a declarative UI framework for building native Windows apps in pure C#.
@@ -50,10 +51,11 @@ cd microsoft-ui-reactor
 
 That's it. `bootstrap.ps1` packs and installs `mur` as a `dotnet tool` global
 install (so it's on PATH cross-shell with no manual `$env:Path` edits), runs
-`mur pack-local` to produce `local-nupkgs/Microsoft.UI.Reactor.0.0.0-local.nupkg`
-and the matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
+`mur pack-local` to produce local source-built framework snapshots and the
+matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
 template, and drops the Reactor agent plugin under `~/.claude/plugins/reactor`
-(symlink when allowed, copy otherwise).
+(symlink when allowed, copy otherwise). Apps created from that template reference
+`Microsoft.UI.Reactor` version `0.1.0-preview.3` from NuGet.org by default.
 
 When it finishes you can immediately run:
 
@@ -65,8 +67,9 @@ dotnet run
 
 ### After `git pull`
 
-The framework changes — your local NuGet snapshot and `dotnet new` template do
-not, unless you repack them. Two options:
+The source checkout changes — your local template package, CLI, plugin, and
+optional source-built framework snapshots do not, unless you repack them. Two
+options:
 
 ```powershell
 mur upgrade           # repacks the framework + templates and refreshes plugin
@@ -83,22 +86,23 @@ mur doctor
 ```
 
 Lists every dependency the rest of this guide assumes — .NET 10+ SDK, `mur` on
-PATH, current `local-nupkgs/` feed, the `reactorapp` template registration, and
-the optional Claude plugin. Each line is PASS / WARN / FAIL with a one-line
-remediation for anything broken.
+PATH, current `local-nupkgs/` developer feed, the `reactorapp` template
+registration, and the optional Claude plugin. Each line is PASS / WARN / FAIL
+with a one-line remediation for anything broken.
 
 > **What this gets you.** A globally-resolvable `mur` (via `~/.dotnet/tools`),
-> a local NuGet feed at `<repo>/local-nupkgs/` that apps in any folder can
-> consume via `<PackageReference Include="Microsoft.UI.Reactor"
-> Version="0.0.0-local" />`, and an agent plugin so AI assistants generate
+> a locally installed `reactorapp` template that references
+> `<PackageReference Include="Microsoft.UI.Reactor"
+> Version="0.1.0-preview.3" />`, a local NuGet feed at `<repo>/local-nupkgs/`
+> for source-built smoke tests, and an agent plugin so AI assistants generate
 > against the real factories (`mur --skill` / `mur --api` print the same
-> content). Run `mur upgrade` whenever you pull new framework changes.
+> content). Run `mur upgrade` whenever you pull new template, CLI, plugin, or
+> framework changes.
 
-> **Already have a signed package?** Skip the bootstrap. Reference the
-> published `Microsoft.UI.Reactor` package directly and run the consumer-side
-> `install-skill-kit.ps1` shipped in the release archive (covered in
-> [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md) §4.4).
-> Until that release ships, the bootstrap above is the supported path.
+> **Only need the framework package?** Reference the published
+> `Microsoft.UI.Reactor` package directly from NuGet.org. Run the bootstrap only
+> when you want the local project template, the `mur` CLI, or the agent plugin
+> from this source checkout.
 
 ### Manual setup
 
@@ -115,7 +119,7 @@ anything goes wrong.
 | 2 | `git clone` + `cd` | Local source checkout |
 | 3 | `dotnet pack src/Reactor.Cli` | `Microsoft.UI.Reactor.Cli.<ver>.nupkg` in `local-nupkgs/` |
 | 4 | `dotnet tool install -g` | `mur` resolvable cross-shell from `~/.dotnet/tools` |
-| 5 | `mur pack-local` | Framework + `Advanced` + `ProjectTemplates` 0.0.0-local nupkgs |
+| 5 | `mur pack-local` | Source-built framework snapshots plus a local `ProjectTemplates` nupkg; generated apps default to the public Reactor preview |
 | 6 | `dotnet new uninstall` + `install` | `dotnet new reactorapp` template registered |
 | 7 | Symlink/copy `plugins/reactor` | Reactor agent kit under `~/.claude/plugins/reactor` (optional) |
 | 8 | `mur doctor` | Verification that 1–7 all stuck |
@@ -176,9 +180,11 @@ $env:Path = "$env:USERPROFILE\.dotnet\tools;$env:Path"
 
 New PowerShell windows pick up the user-PATH change on their own.
 
-**5. Pack the framework and project templates.** This is what produces the
-two `0.0.0-local` nupkgs that the `dotnet new reactorapp` template
-references.
+**5. Pack local framework snapshots and project templates.** This produces the
+source-built `0.0.0-local` framework nupkgs for smoke tests plus the local
+`ProjectTemplates` nupkg that installs `dotnet new reactorapp`. The template's
+normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.3`
+package.
 
 ```powershell
 mur pack-local
@@ -228,7 +234,7 @@ For Copilot CLI or other agents, follow that tool's plugin-install path and
 point it at `<repo>/plugins/reactor`.
 
 **8. Verify.** `mur doctor` performs the same checks the bootstrap script's
-final stage relies on — SDK version, `mur` resolvability, both `0.0.0-local`
+final stage relies on — SDK version, `mur` resolvability, local developer
 nupkgs present, template registered, and plugin installed.
 
 ```powershell
@@ -251,14 +257,11 @@ the install must happen from a shell that isn't already running `mur`).
 > upgrade verb.
 
 <!-- ai:caveat -->
-The bootstrap is the supported developer path *only* until the signed public
-NuGet ships under spec 022. If you skip `bootstrap.ps1` and try `dotnet new
-reactorapp` anyway, the scaffolder fails with `NU1101: Unable to find package
-Microsoft.UI.Reactor.ProjectTemplates` because nothing has produced
-`local-nupkgs/` yet — `dotnet` looks at the configured feeds and the package
-isn't on nuget.org. The fix is to re-run `bootstrap.ps1` (or `mur upgrade`)
-after every `git pull`; the snapshot is regenerated from the current branch,
-not cached. The template installer caches by package id, so a same-version
+The core framework package is public, but the `reactorapp` project-template
+package is still source-installed. If `dotnet new reactorapp` is missing, run
+`bootstrap.ps1` (or `mur upgrade` from an already bootstrapped checkout) to
+repack and reinstall `Microsoft.UI.Reactor.ProjectTemplates` from
+`local-nupkgs/`. The template installer caches by package id, so a same-version
 repack can lose to the cached copy — `mur upgrade` handles this by running
 `dotnet new uninstall` first.
 <!-- /ai:caveat -->
@@ -277,6 +280,13 @@ The template wires up the `Microsoft.UI.Reactor` package reference, the
 WinUI 3 target framework, and a working `App.cs` that mounts a single
 Reactor component. No `App.xaml`, no `MainWindow.xaml.cs` — just one C#
 file.
+
+By default that package reference is
+`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.3" />`.
+For local framework smoke tests, generate with
+`dotnet new reactorapp -n MyLocalApp --MSUIReactorVersion 0.0.0-local` and run
+from inside the source checkout or another folder that has the local feed
+configured.
 
 > **Why a custom template?** A `dotnet new console` does not produce a WinUI
 > app — it builds a console target with no UI thread, no `OutputType=WinExe`,

--- a/docs/_pipeline/templates/packaging.md.dt
+++ b/docs/_pipeline/templates/packaging.md.dt
@@ -242,11 +242,10 @@ never ships. That split is the whole reason Advanced is a sibling
 package and not a folder inside `Reactor.dll`.
 
 **`Reactor.dll` is in your publish output as a managed assembly,
-not a tucked-away framework package.** Reactor ships as
-`Microsoft.UI.Reactor` (see [spec 022 / Phase 0 release-asset
-flow](https://github.com/microsoft/microsoft-ui-reactor) — local
-builds get `0.0.0-local` via `mur pack-local`). Trim-friendly
-deployments don't get any framework-side magic; the same trimmer
+not a tucked-away framework package.** Reactor ships as the public preview
+NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.3`; local
+source-built smoke packages still use `0.0.0-local` via `mur pack-local`.
+Trim-friendly deployments don't get any framework-side magic; the same trimmer
 configuration that works for any WinUI 3 app works here.
 
 **`Microsoft.WindowsAppSDK` is explicitly pinned in the template, not

--- a/docs/contributing/release-runbook.md
+++ b/docs/contributing/release-runbook.md
@@ -1,0 +1,145 @@
+# Release runbook
+
+This runbook describes how to prepare and trigger a public Microsoft.UI.Reactor preview release.
+
+## Release model
+
+Reactor versions are tag-driven. A tag named `v0.1.0-preview.3` makes MinVer resolve package version `0.1.0-preview.3` for that exact commit. The tag push starts the GitHub packaging workflow and the OneBranch official pipeline; the OneBranch NuGet publish stage is approval-gated.
+
+Prepare release content in a PR before tagging. Do not create the release tag first if templates or docs need to point at the new version; otherwise the release assets are built from a commit that still points at the previous version.
+
+Recommended order:
+
+1. Create a release-prep PR that updates docs and template defaults to the new version.
+2. Merge that PR to `main`.
+3. Tag the merged `main` commit.
+4. Push the tag to start the release workflows.
+5. Approve/publish the gated OneBranch NuGet release.
+
+## Choose the version
+
+Use SemVer prerelease tags with the `v` prefix:
+
+```powershell
+$version = "0.1.0-preview.3"
+$tag = "v$version"
+```
+
+Before starting, check that the tag and package version do not already exist:
+
+```powershell
+git fetch origin --tags
+git tag --list $tag
+gh release view $tag
+```
+
+Also check NuGet.org for already-published packages:
+
+- `Microsoft.UI.Reactor`
+- `Microsoft.UI.Reactor.Advanced`
+- `Microsoft.UI.Reactor.Devtools`
+- `Microsoft.UI.Reactor.ProjectTemplates`
+
+## Prepare the release PR
+
+Start from current `main`:
+
+```powershell
+git checkout main
+git pull origin main
+git switch -c release/$version
+```
+
+Update versioned references that consumer-facing templates or docs should show. At minimum, check:
+
+```powershell
+rg "0\.1\.0-preview\.[0-9]+|MicrosoftUIReactorVersion|Microsoft\.UI\.Reactor" `
+  README.md `
+  tools/Templates `
+  docs/_pipeline/templates `
+  .github/workflows `
+  build/pipelines
+```
+
+The app template default lives in:
+
+```text
+tools/Templates/Microsoft.UI.Reactor.Templates.csproj
+```
+
+Set `MicrosoftUIReactorVersion` to the release version so locally installed templates and the release template package generate apps that reference the public package:
+
+```xml
+<MicrosoftUIReactorVersion Condition="'$(MicrosoftUIReactorVersion)' == ''">0.1.0-preview.3</MicrosoftUIReactorVersion>
+```
+
+Update authored docs under `docs/_pipeline/templates/`, not generated `docs/guide/` files directly. Then regenerate the guide. Use a full compile for release-prep changes because some pages (for example `getting-started`) pull snippets from other topics:
+
+```powershell
+mur docs compile --skip-screenshots --skip-diagrams
+```
+
+## Validate the release PR
+
+Run the focused template tests:
+
+```powershell
+dotnet test tests/Reactor.Tests/Reactor.Tests.csproj `
+  -p:Platform=x64 `
+  --filter FullyQualifiedName~TemplateMetadataTests
+```
+
+Pack the template locally and inspect the generated default:
+
+```powershell
+dotnet pack tools/Templates/Microsoft.UI.Reactor.Templates.csproj `
+  --configuration Release `
+  -p:Version=0.0.0-local `
+  -p:Platform=AnyCPU `
+  -o local-nupkgs
+```
+
+Create a throwaway app from the packed template and verify its `.csproj` references the chosen public version. Skip restore before the tag is published because the new package version will not exist on NuGet.org yet:
+
+```powershell
+dotnet new uninstall Microsoft.UI.Reactor.ProjectTemplates
+dotnet new install local-nupkgs/Microsoft.UI.Reactor.ProjectTemplates.0.0.0-local.nupkg
+
+$scratch = Join-Path $env:TEMP "reactor-template-smoke"
+Remove-Item $scratch -Recurse -Force -ErrorAction SilentlyContinue
+dotnet new reactorapp -n ReactorTemplateSmoke -o $scratch --no-restore
+Select-String "$scratch\ReactorTemplateSmoke.csproj" -Pattern $version
+```
+
+Open the PR and wait for CI. Do not tag until the release PR is merged.
+
+## Tag the merged release commit
+
+After the release PR merges:
+
+```powershell
+git checkout main
+git pull origin main
+git tag -a v0.1.0-preview.3 -m "Release 0.1.0-preview.3"
+git push origin v0.1.0-preview.3
+```
+
+Tagging the merge commit ensures the generated packages, template defaults, docs, GitHub Release assets, and OneBranch official packages all correspond to the same source tree.
+
+## Monitor and publish
+
+After pushing the tag:
+
+1. Confirm the GitHub `Package` workflow runs for the tag and creates a GitHub Release.
+2. Confirm the OneBranch official pipeline starts for the tag.
+3. Approve the `Production_PublishNuGet` stage when ready to publish to NuGet.org.
+4. Verify the packages appear on NuGet.org.
+5. Install the released template package or a locally packed template and create a smoke app that restores against NuGet.org.
+
+## If a release tag is wrong
+
+Do not move or rewrite a pushed release tag after release workflows or publishing have started. Instead:
+
+1. Fix the issue in a new PR.
+2. Merge to `main`.
+3. Mint the next preview version with a new tag.

--- a/docs/guide/dev-tooling.md
+++ b/docs/guide/dev-tooling.md
@@ -177,7 +177,7 @@ subcommands map one-to-one to the workflows below.
 | `mur loc` | Run the localization pipeline (extract strings, validate `.resw`, generate manifests) | `mur loc extract` |
 | `mur devtools` | Start the MCP server for VS Code or agent integration | `mur devtools serve` |
 | `mur check` | Repo-health checks (cref validity, namespace policy, "did you mean" suggestions) | `mur check` |
-| `mur pack-local` / `mur clean-local` | Package / clean the local NuGet feed for samples that consume `Microsoft.UI.Reactor` as a package | `mur pack-local` |
+| `mur pack-local` / `mur clean-local` | Package / clean the local NuGet feed for source-built framework smoke tests; the app template defaults to the public Reactor preview unless `--MSUIReactorVersion` is supplied | `mur pack-local` |
 
 `mur docs compile` is the workflow you reach for most often. See
 [the doc-pipeline contributor guide](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/contributing/doc-pipeline.md)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -18,10 +18,11 @@ the rest of the docset elaborates.
 > **Prerequisites:** .NET 10+ and the Windows App SDK.
 <!-- /ai:lock -->
 
-> **Heads up — no signed NuGet yet.** Reactor doesn't ship a signed NuGet
-> package today, so you build the framework, the `mur` CLI, and the project
-> template from source. `bootstrap.ps1` automates all of that — one command,
-> ~3 minutes per machine. The signed distribution is tracked in
+> **Public preview package available.** Reactor ships `Microsoft.UI.Reactor`
+> `0.1.0-preview.3` on NuGet.org. The project template package is still
+> installed from source for now; `bootstrap.ps1` installs `mur`, packs/registers
+> the local `reactorapp` template, and stamps generated apps to reference the
+> public preview package by default. Broader signed distribution is tracked in
 > [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md).
 
 Reactor is a declarative UI framework for building native Windows apps in pure C#.
@@ -38,10 +39,11 @@ cd microsoft-ui-reactor
 
 That's it. `bootstrap.ps1` packs and installs `mur` as a `dotnet tool` global
 install (so it's on PATH cross-shell with no manual `$env:Path` edits), runs
-`mur pack-local` to produce `local-nupkgs/Microsoft.UI.Reactor.0.0.0-local.nupkg`
-and the matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
+`mur pack-local` to produce local source-built framework snapshots and the
+matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
 template, and drops the Reactor agent plugin under `~/.claude/plugins/reactor`
-(symlink when allowed, copy otherwise).
+(symlink when allowed, copy otherwise). Apps created from that template reference
+`Microsoft.UI.Reactor` version `0.1.0-preview.3` from NuGet.org by default.
 
 When it finishes you can immediately run:
 
@@ -53,8 +55,9 @@ dotnet run
 
 ### After `git pull`
 
-The framework changes — your local NuGet snapshot and `dotnet new` template do
-not, unless you repack them. Two options:
+The source checkout changes — your local template package, CLI, plugin, and
+optional source-built framework snapshots do not, unless you repack them. Two
+options:
 
 ```powershell
 mur upgrade           # repacks the framework + templates and refreshes plugin
@@ -71,22 +74,23 @@ mur doctor
 ```
 
 Lists every dependency the rest of this guide assumes — .NET 10+ SDK, `mur` on
-PATH, current `local-nupkgs/` feed, the `reactorapp` template registration, and
-the optional Claude plugin. Each line is PASS / WARN / FAIL with a one-line
-remediation for anything broken.
+PATH, current `local-nupkgs/` developer feed, the `reactorapp` template
+registration, and the optional Claude plugin. Each line is PASS / WARN / FAIL
+with a one-line remediation for anything broken.
 
 > **What this gets you.** A globally-resolvable `mur` (via `~/.dotnet/tools`),
-> a local NuGet feed at `<repo>/local-nupkgs/` that apps in any folder can
-> consume via `<PackageReference Include="Microsoft.UI.Reactor"
-> Version="0.0.0-local" />`, and an agent plugin so AI assistants generate
+> a locally installed `reactorapp` template that references
+> `<PackageReference Include="Microsoft.UI.Reactor"
+> Version="0.1.0-preview.3" />`, a local NuGet feed at `<repo>/local-nupkgs/`
+> for source-built smoke tests, and an agent plugin so AI assistants generate
 > against the real factories (`mur --skill` / `mur --api` print the same
-> content). Run `mur upgrade` whenever you pull new framework changes.
+> content). Run `mur upgrade` whenever you pull new template, CLI, plugin, or
+> framework changes.
 
-> **Already have a signed package?** Skip the bootstrap. Reference the
-> published `Microsoft.UI.Reactor` package directly and run the consumer-side
-> `install-skill-kit.ps1` shipped in the release archive (covered in
-> [spec 022](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/specs/022-packaging-and-distribution.md) §4.4).
-> Until that release ships, the bootstrap above is the supported path.
+> **Only need the framework package?** Reference the published
+> `Microsoft.UI.Reactor` package directly from NuGet.org. Run the bootstrap only
+> when you want the local project template, the `mur` CLI, or the agent plugin
+> from this source checkout.
 
 ### Manual setup
 
@@ -103,7 +107,7 @@ anything goes wrong.
 | 2 | `git clone` + `cd` | Local source checkout |
 | 3 | `dotnet pack src/Reactor.Cli` | `Microsoft.UI.Reactor.Cli.<ver>.nupkg` in `local-nupkgs/` |
 | 4 | `dotnet tool install -g` | `mur` resolvable cross-shell from `~/.dotnet/tools` |
-| 5 | `mur pack-local` | Framework + `Advanced` + `ProjectTemplates` 0.0.0-local nupkgs |
+| 5 | `mur pack-local` | Source-built framework snapshots plus a local `ProjectTemplates` nupkg; generated apps default to the public Reactor preview |
 | 6 | `dotnet new uninstall` + `install` | `dotnet new reactorapp` template registered |
 | 7 | Symlink/copy `plugins/reactor` | Reactor agent kit under `~/.claude/plugins/reactor` (optional) |
 | 8 | `mur doctor` | Verification that 1–7 all stuck |
@@ -164,9 +168,11 @@ $env:Path = "$env:USERPROFILE\.dotnet\tools;$env:Path"
 
 New PowerShell windows pick up the user-PATH change on their own.
 
-**5. Pack the framework and project templates.** This is what produces the
-two `0.0.0-local` nupkgs that the `dotnet new reactorapp` template
-references.
+**5. Pack local framework snapshots and project templates.** This produces the
+source-built `0.0.0-local` framework nupkgs for smoke tests plus the local
+`ProjectTemplates` nupkg that installs `dotnet new reactorapp`. The template's
+normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.3`
+package.
 
 ```powershell
 mur pack-local
@@ -216,7 +222,7 @@ For Copilot CLI or other agents, follow that tool's plugin-install path and
 point it at `<repo>/plugins/reactor`.
 
 **8. Verify.** `mur doctor` performs the same checks the bootstrap script's
-final stage relies on — SDK version, `mur` resolvability, both `0.0.0-local`
+final stage relies on — SDK version, `mur` resolvability, local developer
 nupkgs present, template registered, and plugin installed.
 
 ```powershell
@@ -238,14 +244,11 @@ the install must happen from a shell that isn't already running `mur`).
 > with no arch-aware PATH munging, and `dotnet tool update -g` becomes the
 > upgrade verb.
 
-> **Caveat:** The bootstrap is the supported developer path *only* until the signed public
-> NuGet ships under spec 022. If you skip `bootstrap.ps1` and try `dotnet new
-> reactorapp` anyway, the scaffolder fails with `NU1101: Unable to find package
-> Microsoft.UI.Reactor.ProjectTemplates` because nothing has produced
-> `local-nupkgs/` yet — `dotnet` looks at the configured feeds and the package
-> isn't on nuget.org. The fix is to re-run `bootstrap.ps1` (or `mur upgrade`)
-> after every `git pull`; the snapshot is regenerated from the current branch,
-> not cached. The template installer caches by package id, so a same-version
+> **Caveat:** The core framework package is public, but the `reactorapp` project-template
+> package is still source-installed. If `dotnet new reactorapp` is missing, run
+> `bootstrap.ps1` (or `mur upgrade` from an already bootstrapped checkout) to
+> repack and reinstall `Microsoft.UI.Reactor.ProjectTemplates` from
+> `local-nupkgs/`. The template installer caches by package id, so a same-version
 > repack can lose to the cached copy — `mur upgrade` handles this by running
 > `dotnet new uninstall` first.
 
@@ -263,6 +266,13 @@ The template wires up the `Microsoft.UI.Reactor` package reference, the
 WinUI 3 target framework, and a working `App.cs` that mounts a single
 Reactor component. No `App.xaml`, no `MainWindow.xaml.cs` — just one C#
 file.
+
+By default that package reference is
+`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.3" />`.
+For local framework smoke tests, generate with
+`dotnet new reactorapp -n MyLocalApp --MSUIReactorVersion 0.0.0-local` and run
+from inside the source checkout or another folder that has the local feed
+configured.
 
 > **Why a custom template?** A `dotnet new console` does not produce a WinUI
 > app — it builds a console target with no UI thread, no `OutputType=WinExe`,

--- a/docs/guide/packaging.md
+++ b/docs/guide/packaging.md
@@ -225,11 +225,10 @@ never ships. That split is the whole reason Advanced is a sibling
 package and not a folder inside `Reactor.dll`.
 
 **`Reactor.dll` is in your publish output as a managed assembly,
-not a tucked-away framework package.** Reactor ships as
-`Microsoft.UI.Reactor` (see [spec 022 / Phase 0 release-asset
-flow](https://github.com/microsoft/microsoft-ui-reactor) — local
-builds get `0.0.0-local` via `mur pack-local`). Trim-friendly
-deployments don't get any framework-side magic; the same trimmer
+not a tucked-away framework package.** Reactor ships as the public preview
+NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.3`; local
+source-built smoke packages still use `0.0.0-local` via `mur pack-local`.
+Trim-friendly deployments don't get any framework-side magic; the same trimmer
 configuration that works for any WinUI 3 app works here.
 
 **`Microsoft.WindowsAppSDK` is explicitly pinned in the template, not

--- a/tools/Templates/Microsoft.UI.Reactor.Templates.csproj
+++ b/tools/Templates/Microsoft.UI.Reactor.Templates.csproj
@@ -18,7 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>$(NoWarn);NU5128</NoWarn> <!-- Ignore warning generated when setting IncludeBuildOutput=False https://github.com/nuget/home/issues/8583 -->
     <Version Condition="'$(Version)' == ''">0.0.0-local</Version>
-    <MicrosoftUIReactorVersion Condition="'$(MicrosoftUIReactorVersion)' == ''">$(Version)</MicrosoftUIReactorVersion> <!-- NuGet version template should reference -->
+    <MicrosoftUIReactorVersion Condition="'$(MicrosoftUIReactorVersion)' == ''">0.1.0-preview.3</MicrosoftUIReactorVersion> <!-- NuGet version generated apps should reference by default. Override for local framework smoke tests. -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add a release runbook covering release-prep PRs, merged-main tagging, workflow monitoring, and NuGet publish approval
- link the runbook from README
- update the app template and public package docs to reference Microsoft.UI.Reactor 0.1.0-preview.3

## Release order
The release-prep PR should merge before creating `v0.1.0-preview.3`. After merge, tag the merge commit on `main` so release assets and template defaults are built from the same source tree:

```powershell
git checkout main
git pull origin main
git tag -a v0.1.0-preview.3 -m "Release 0.1.0-preview.3"
git push origin v0.1.0-preview.3
```

## Validation
- `mur docs compile --skip-screenshots --skip-diagrams`
- `dotnet test tests/Reactor.Tests/Reactor.Tests.csproj -p:Platform=x64 --filter FullyQualifiedName~TemplateMetadataTests --nologo -m:1`
- `dotnet pack tools\Templates\Microsoft.UI.Reactor.Templates.csproj --nologo -v:m -c Release -p:Version=0.0.0-local -p:Platform=AnyCPU -o local-nupkgs`
- custom-hive `dotnet new reactorapp --no-restore` smoke check produced `<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.3" />`