### PR TITLE
ci(ob): gate releases on NuGet.org Microsoft compliance + fix ProjectTemplates ProjectUrl

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,23 @@
   </PropertyGroup>
 
   <!--
+    Repository / project URL metadata for every packable project. NuGet.org's
+    Microsoft compliance policy (https://aka.ms/Microsoft-NuGet-Compliance)
+    REJECTS any Microsoft-signed package that is missing ProjectUrl — the push
+    fails with HTTP 400 at publish time, AFTER earlier packages in the same
+    push loop have already gone out (the loop is not atomic). Centralizing the
+    defaults here guarantees every current and future package id (framework,
+    Advanced, Devtools, ProjectTemplates, …) inherits compliant metadata, so a
+    new package can never silently ship without it. Individual csprojs may still
+    override (the '== ' guard makes these defaults, not forced values).
+  -->
+  <PropertyGroup>
+    <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">https://github.com/microsoft/microsoft-ui-reactor</PackageProjectUrl>
+    <RepositoryUrl Condition="'$(RepositoryUrl)' == ''">https://github.com/microsoft/microsoft-ui-reactor</RepositoryUrl>
+    <RepositoryType Condition="'$(RepositoryType)' == ''">git</RepositoryType>
+  </PropertyGroup>
+
+  <!--
     In CI we never need the GitHub.Copilot.SDK native CLI (copilot.exe), which the
     SDK's build targets fetch from registry.npmjs.org via an unauthenticated MSBuild
     DownloadFile task. That download can fail in restricted CI environments and cannot

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,7 +31,7 @@
     defaults here guarantees every current and future package id (framework,
     Advanced, Devtools, ProjectTemplates, …) inherits compliant metadata, so a
     new package can never silently ship without it. Individual csprojs may still
-    override (the '== ' guard makes these defaults, not forced values).
+    override (the '== '' guard makes these defaults, not forced values).
   -->
   <PropertyGroup>
     <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">https://github.com/microsoft/microsoft-ui-reactor</PackageProjectUrl>

--- a/build/pipelines/templates/reactor-build-steps.yml
+++ b/build/pipelines/templates/reactor-build-steps.yml
@@ -332,6 +332,71 @@ steps:
           -o "${{ parameters.outputDirectory }}\nupkg"
       displayName: 'Pack Templates'
 
+    # ── NuGet.org Microsoft-compliance pre-flight (fail BEFORE the gated publish). ──
+    # nuget.org enforces https://aka.ms/Microsoft-NuGet-Compliance on every
+    # Microsoft-signed package: a missing ProjectUrl (or other required field) is
+    # rejected with HTTP 400 *at push time*. The release push loop is NOT atomic —
+    # a mid-list rejection leaves the earlier packages permanently published while
+    # the offending one never ships, producing a half-released (and immutable)
+    # version. This step validates every packed package up front so any compliance
+    # gap breaks the BUILD stage, before approval — never after a partial publish.
+    #
+    # We run the OFFICIAL verifier `NuGet.VerifyMicrosoftPackage` (authored by the
+    # NuGetGallery team) rather than a hand-rolled nuspec check, so the rules can
+    # never drift from what nuget.org actually enforces — the tool embeds the same
+    # default rule set the server uses (required ProjectUrl + license, authors must
+    # be "Microsoft", allowed copyright notices, etc.) and emits the identical
+    # "missing required ProjectUrl" message we saw reject ProjectTemplates at push
+    # time. It is a net472 console exe shipped INSIDE the package's tools/ folder
+    # (NOT a dotnet tool — `dotnet tool install` rejects it), so we restore the
+    # package from the INTERNAL feed (it has been seeded there; the sealed build
+    # container cannot reach nuget.org) via a throwaway PackageReference project,
+    # then invoke the extracted exe against every packed .nupkg. Exit code 1 on any
+    # non-compliant package fails the build.
+    - pwsh: |
+        $ErrorActionPreference = 'Stop'
+        $nupkgDir = "${{ parameters.outputDirectory }}\nupkg"
+        $pkgs = Get-ChildItem -Path $nupkgDir -Filter *.nupkg -ErrorAction SilentlyContinue
+        if (-not $pkgs) { throw "No .nupkg files found in $nupkgDir to validate." }
+
+        # Restore the verifier from the internal feed via a throwaway project. The
+        # package is tools-only (no lib/dependencies) so a net10.0 PackageReference
+        # restores cleanly with no TFM-compat error; it just lands in --packages.
+        $work = Join-Path "$(Agent.TempDirectory)" 'nuget-verifier'
+        $pkgsDir = Join-Path $work 'pkgs'
+        New-Item -ItemType Directory -Force -Path $work | Out-Null
+        $proj = Join-Path $work 'verifier.csproj'
+        @'
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <IsPackable>false</IsPackable>
+          </PropertyGroup>
+          <ItemGroup>
+            <PackageReference Include="NuGet.VerifyMicrosoftPackage" Version="1.0.0" />
+          </ItemGroup>
+        </Project>
+        '@ | Set-Content -Path $proj -Encoding utf8
+
+        dotnet restore $proj --packages $pkgsDir --configfile "${{ parameters.nugetConfig }}"
+        if ($LASTEXITCODE -ne 0) { throw "Failed to restore NuGet.VerifyMicrosoftPackage from the internal feed." }
+
+        $exe = Get-ChildItem -Path $pkgsDir -Recurse -Filter 'NuGet.VerifyMicrosoftPackage.exe' |
+               Select-Object -First 1 -ExpandProperty FullName
+        if (-not $exe) { throw "NuGet.VerifyMicrosoftPackage.exe not found after restore under $pkgsDir." }
+        Write-Host "Using verifier: $exe"
+
+        # The tool accepts a filename wildcard (directory wildcards are NOT supported)
+        # and validates every match, printing per-package VALID/INVALID + a summary.
+        & $exe "$nupkgDir\*.nupkg"
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "##[error]One or more packages are NOT compliant with https://aka.ms/Microsoft-NuGet-Compliance."
+          Write-Host "##[error]Fix the package metadata before release — the gated publish is NOT atomic and a mid-push rejection leaves a partial, immutable release."
+          throw "NuGet.VerifyMicrosoftPackage reported non-compliant package(s) (exit $LASTEXITCODE)."
+        }
+        Write-Host "All $($pkgs.Count) package(s) passed the official NuGet.VerifyMicrosoftPackage compliance check."
+      displayName: 'Verify NuGet.org Microsoft compliance (NuGet.VerifyMicrosoftPackage)'
+
     - pwsh: |
         dotnet publish src/Reactor.Cli/Reactor.Cli.csproj `
           --configuration ${{ parameters.configuration }} `

--- a/docs/specs/057-release-channels.md
+++ b/docs/specs/057-release-channels.md
@@ -347,6 +347,50 @@ minutes or hours later still publishes the exact bits signed at tag time.
 > Surface the resolved version in the stage/run display name so the approver can
 > eyeball it before clicking.
 
+### 8.4 Pre-publish compliance gate (NuGet.org Microsoft policy)
+
+The approval gate (§8.1) makes the publish _deliberate_; it does **not** make it
+_valid_. A maintainer approving "Publish `0.2.0-preview.3` to nuget.org?" cannot
+see, from the prompt, that one of the four packages is missing required
+metadata. nuget.org enforces the
+[Microsoft NuGet compliance policy](https://aka.ms/Microsoft-NuGet-Compliance)
+(ProjectUrl, license, `Microsoft` authors, an approved copyright notice, …) on
+**every** Microsoft-signed package, and rejects a non-compliant one with an
+HTTP 400 **at push time**.
+
+That is the worst possible moment to find out, because **the push loop is not
+atomic.** `NuGetCommand@2 push` iterates the packages one at a time, so a
+rejection on the _last_ package lands after the earlier ones are already public
+and permanent (§8.1 — unlist-only). This actually happened: build 118951 pushed
+`Microsoft.UI.Reactor`, `.Advanced`, and `.Devtools` successfully, then failed on
+`Microsoft.UI.Reactor.ProjectTemplates` ("The package metadata is missing
+required ProjectUrl"), leaving a half-published `preview.3`.
+
+To convert that irreversible publish-time failure into a cheap build-time one,
+the **build stage** runs the official Microsoft verifier **before** the gate:
+
+- **Step:** `Verify NuGet.org Microsoft compliance (NuGet.VerifyMicrosoftPackage)`
+  in `build/pipelines/templates/reactor-build-steps.yml`, gated by `pack: true`,
+  positioned after the last `dotnet pack` and before any publish.
+- **Tool:** [`NuGet.VerifyMicrosoftPackage`](https://github.com/NuGet/NuGetGallery/tree/main/src/VerifyMicrosoftPackage)
+  — the NuGetGallery team's own verifier, so the rule set never drifts from what
+  nuget.org actually enforces. It is a `net472` console exe shipped _inside_ the
+  `1.0.0` package's `tools/` folder (not a `dotnet tool`). The sealed build
+  container can't reach nuget.org, so the package is seeded into the internal
+  feed and restored via a throwaway `PackageReference` project; the step then
+  runs `NuGet.VerifyMicrosoftPackage.exe out\nupkg\*.nupkg` (the `*.nupkg`
+  wildcard correctly excludes `.snupkg`).
+- **Effect:** any non-compliant package makes the tool exit `1`, which fails the
+  build stage **before** the artifact ever reaches the publish stage. A
+  metadata regression can no longer produce a partial public release; it shows
+  up as a red build on the PR/tag instead.
+
+The durable fix for the specific ProjectUrl gap is centralized in the root
+`Directory.Build.props` (guarded `PackageProjectUrl` / `RepositoryUrl` /
+`RepositoryType` defaults) so every current and future packable project inherits
+compliant metadata; this verifier step is the backstop that proves it for every
+package on every build.
+
 ## 9. Consumer Experience
 
 ```xml

--- a/src/Reactor.Advanced/Reactor.Advanced.csproj
+++ b/src/Reactor.Advanced/Reactor.Advanced.csproj
@@ -22,6 +22,7 @@
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Description>Advanced Reactor components — first inhabitant: Win2D canvas.</Description>
+    <PackageTags>WinUI;WinUI3;Windows App SDK;WinAppSDK;XAML;Windows;desktop;UI;declarative;Reactor;Win2D;canvas;graphics;charts</PackageTags>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageIcon>Icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Reactor.Devtools/Reactor.Devtools.csproj
+++ b/src/Reactor.Devtools/Reactor.Devtools.csproj
@@ -21,6 +21,7 @@
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Description>Optional devtools host for Microsoft.UI.Reactor.</Description>
+    <PackageTags>WinUI;WinUI3;Windows App SDK;WinAppSDK;Windows;desktop;Reactor;devtools;diagnostics;hot-reload;preview;MCP</PackageTags>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageIcon>Icon.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -34,6 +34,7 @@
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Description>Functional, declarative UI framework for WinUI 3.</Description>
+    <PackageTags>WinUI;WinUI3;Windows App SDK;WinAppSDK;XAML;Windows;desktop;UI;declarative;functional;reactive;MVU;components;hooks;Reactor</PackageTags>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageIcon>Icon.png</PackageIcon>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/tools/Templates/Microsoft.UI.Reactor.Templates.csproj
+++ b/tools/Templates/Microsoft.UI.Reactor.Templates.csproj
@@ -10,7 +10,7 @@
     <PackageIcon>Icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageTags>dotnet-new;templates;WinUI;Reactor;Windows App SDK</PackageTags>
+    <PackageTags>dotnet-new;templates;WinUI;WinUI3;Windows App SDK;WinAppSDK;Windows;desktop;Reactor</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
## Why

The `v0.1.0-preview.3` release half-published. The release push loop (`NuGetCommand@2 push`) is **not atomic** — it iterates packages one at a time. `Microsoft.UI.Reactor`, `.Advanced`, and `.Devtools` pushed successfully, then `Microsoft.UI.Reactor.ProjectTemplates` was rejected by nuget.org with **HTTP 400 — "The package metadata is missing required ProjectUrl."** That left 3 packages permanently public at `preview.3` and ProjectTemplates never shipped.

Root cause: `tools/Templates/Microsoft.UI.Reactor.Templates.csproj` declared its own metadata block but had no `PackageProjectUrl`/`RepositoryUrl`. The other three csprojs each declared them individually, so only ProjectTemplates was non-compliant with the [Microsoft NuGet compliance policy](https://aka.ms/Microsoft-NuGet-Compliance).

## What this PR does

1. **Pipeline gate (`build/pipelines/templates/reactor-build-steps.yml`)** — a new build-stage step **`Verify NuGet.org Microsoft compliance (NuGet.VerifyMicrosoftPackage)`** runs after the last `dotnet pack` and **before** any publish. It uses the official NuGetGallery verifier (`NuGet.VerifyMicrosoftPackage`, restored from the build feed since the sealed container can't reach nuget.org) against the packed `*.nupkg`. Any non-compliant package fails the build *before* the artifact can reach the gated publish stage — converting an irreversible publish-time 400 into a cheap red build.

2. **Durable metadata fix (`Directory.Build.props`)** — centralized guarded `PackageProjectUrl` / `RepositoryUrl` / `RepositoryType` defaults so every current and future packable project inherits compliant metadata; per-csproj values still override.

3. **Docs (`docs/specs/057-release-channels.md` §8.4)** — documents the pre-publish compliance gate (the non-atomic push hazard, the verifier, where/how it runs).

4. **`PackageTags`** added to all four packable projects for nuget.org discoverability (not enforced by the verifier; SEO only).

## Validation

Exercised end-to-end on the release pipeline against real build machines:

- **Negative test** (props fix held back): the build **failed** at the compliance step on ProjectTemplates "missing required ProjectUrl" → proves the gate catches it.
- **Positive test** (props fix in): **Valid package count: 4 / Invalid: 0**, build **green** end-to-end → proves the fix.

## Follow-up (not in this PR)

Recovery of the orphaned `preview.3` trio on nuget.org: publish a clean `preview.4` set and unlist the 3 orphaned `preview.3` packages (nuget.org is unlist-only, no delete).