### PR TITLE
Prepare 0.1.0-preview.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Many of the experiments in this repo — the charting stack, accessibility valid
 
 ## Quick start
 
-Reactor ships the public preview package `Microsoft.UI.Reactor` version `0.1.0-preview.3` on NuGet.org. The project template is still installed from source for now; `bootstrap.ps1` installs the `mur` CLI, packs/registers the local `reactorapp` template, and that template references the public preview package by default.
+Reactor ships the public preview package `Microsoft.UI.Reactor` version `0.1.0-preview.4` on NuGet.org. The project template is still installed from source for now; `bootstrap.ps1` installs the `mur` CLI, packs/registers the local `reactorapp` template, and that template references the public preview package by default.
 
 ```powershell
 git clone https://github.com/microsoft/microsoft-ui-reactor.git
@@ -88,7 +88,7 @@ dotnet run -p:Platform=x64
 > causes `WindowsAppSDKSelfContained` errors. This applies to `dotnet build`,
 > `dotnet run`, and `mur check` invocations alike.
 
-`bootstrap.ps1` packs `mur` as a `dotnet tool` global install (cross-shell PATH, no per-arch `$env:Path` edits), packs local framework snapshots plus project templates into `local-nupkgs/`, registers the `dotnet new reactorapp` template, and installs the Reactor agent plugin under `~/.claude/plugins/reactor`. Apps created by the template reference `Microsoft.UI.Reactor` `0.1.0-preview.3` from NuGet.org by default; pass `--MSUIReactorVersion 0.0.0-local` when you intentionally want a scaffolded app to consume the local source-built package instead. The optional `Microsoft.UI.Reactor.Advanced` and `Microsoft.UI.Reactor.Devtools` sibling packages are version-matched to the framework package when published. Re-run `bootstrap.ps1` (or `mur upgrade` for a lighter refresh) after `git pull` when you want updated local templates or CLI/plugin bits. Verify a working developer install with `mur doctor`.
+`bootstrap.ps1` packs `mur` as a `dotnet tool` global install (cross-shell PATH, no per-arch `$env:Path` edits), packs local framework snapshots plus project templates into `local-nupkgs/`, registers the `dotnet new reactorapp` template, and installs the Reactor agent plugin under `~/.claude/plugins/reactor`. Apps created by the template reference `Microsoft.UI.Reactor` `0.1.0-preview.4` from NuGet.org by default; pass `--MSUIReactorVersion 0.0.0-local` when you intentionally want a scaffolded app to consume the local source-built package instead. The optional `Microsoft.UI.Reactor.Advanced` and `Microsoft.UI.Reactor.Devtools` sibling packages are version-matched to the framework package when published. Re-run `bootstrap.ps1` (or `mur upgrade` for a lighter refresh) after `git pull` when you want updated local templates or CLI/plugin bits. Verify a working developer install with `mur doctor`.
 
 Prefer to wire it up by hand? **[Getting Started](https://microsoft.github.io/microsoft-ui-reactor/getting-started/#manual-setup)** has a no-magic walkthrough of the exact `dotnet pack` / `dotnet tool install` / `dotnet new install` calls `bootstrap.ps1` makes, plus the full hello-world → todo → calculator tour.
 

--- a/docs/_pipeline/templates/getting-started.md.dt
+++ b/docs/_pipeline/templates/getting-started.md.dt
@@ -31,7 +31,7 @@ the rest of the docset elaborates.
 <!-- /ai:lock -->
 
 > **Public preview package available.** Reactor ships `Microsoft.UI.Reactor`
-> `0.1.0-preview.3` on NuGet.org. The project template package is still
+> `0.1.0-preview.4` on NuGet.org. The project template package is still
 > installed from source for now; `bootstrap.ps1` installs `mur`, packs/registers
 > the local `reactorapp` template, and stamps generated apps to reference the
 > public preview package by default. Broader signed distribution is tracked in
@@ -55,7 +55,7 @@ install (so it's on PATH cross-shell with no manual `$env:Path` edits), runs
 matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
 template, and drops the Reactor agent plugin under `~/.claude/plugins/reactor`
 (symlink when allowed, copy otherwise). Apps created from that template reference
-`Microsoft.UI.Reactor` version `0.1.0-preview.3` from NuGet.org by default.
+`Microsoft.UI.Reactor` version `0.1.0-preview.4` from NuGet.org by default.
 
 When it finishes you can immediately run:
 
@@ -93,7 +93,7 @@ with a one-line remediation for anything broken.
 > **What this gets you.** A globally-resolvable `mur` (via `~/.dotnet/tools`),
 > a locally installed `reactorapp` template that references
 > `<PackageReference Include="Microsoft.UI.Reactor"
-> Version="0.1.0-preview.3" />`, a local NuGet feed at `<repo>/local-nupkgs/`
+> Version="0.1.0-preview.4" />`, a local NuGet feed at `<repo>/local-nupkgs/`
 > for source-built smoke tests, and an agent plugin so AI assistants generate
 > against the real factories (`mur --skill` / `mur --api` print the same
 > content). Run `mur upgrade` whenever you pull new template, CLI, plugin, or
@@ -183,7 +183,7 @@ New PowerShell windows pick up the user-PATH change on their own.
 **5. Pack local framework snapshots and project templates.** This produces the
 source-built `0.0.0-local` framework nupkgs for smoke tests plus the local
 `ProjectTemplates` nupkg that installs `dotnet new reactorapp`. The template's
-normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.3`
+normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.4`
 package.
 
 ```powershell
@@ -282,7 +282,7 @@ Reactor component. No `App.xaml`, no `MainWindow.xaml.cs` — just one C#
 file.
 
 By default that package reference is
-`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.3" />`.
+`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.4" />`.
 For local framework smoke tests, generate with
 `dotnet new reactorapp -n MyLocalApp --MSUIReactorVersion 0.0.0-local` and run
 from inside the source checkout or another folder that has the local feed

--- a/docs/_pipeline/templates/packaging.md.dt
+++ b/docs/_pipeline/templates/packaging.md.dt
@@ -243,7 +243,7 @@ package and not a folder inside `Reactor.dll`.
 
 **`Reactor.dll` is in your publish output as a managed assembly,
 not a tucked-away framework package.** Reactor ships as the public preview
-NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.3`; local
+NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.4`; local
 source-built smoke packages still use `0.0.0-local` via `mur pack-local`.
 Trim-friendly deployments don't get any framework-side magic; the same trimmer
 configuration that works for any WinUI 3 app works here.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -19,7 +19,7 @@ the rest of the docset elaborates.
 <!-- /ai:lock -->
 
 > **Public preview package available.** Reactor ships `Microsoft.UI.Reactor`
-> `0.1.0-preview.3` on NuGet.org. The project template package is still
+> `0.1.0-preview.4` on NuGet.org. The project template package is still
 > installed from source for now; `bootstrap.ps1` installs `mur`, packs/registers
 > the local `reactorapp` template, and stamps generated apps to reference the
 > public preview package by default. Broader signed distribution is tracked in
@@ -43,7 +43,7 @@ install (so it's on PATH cross-shell with no manual `$env:Path` edits), runs
 matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
 template, and drops the Reactor agent plugin under `~/.claude/plugins/reactor`
 (symlink when allowed, copy otherwise). Apps created from that template reference
-`Microsoft.UI.Reactor` version `0.1.0-preview.3` from NuGet.org by default.
+`Microsoft.UI.Reactor` version `0.1.0-preview.4` from NuGet.org by default.
 
 When it finishes you can immediately run:
 
@@ -81,7 +81,7 @@ with a one-line remediation for anything broken.
 > **What this gets you.** A globally-resolvable `mur` (via `~/.dotnet/tools`),
 > a locally installed `reactorapp` template that references
 > `<PackageReference Include="Microsoft.UI.Reactor"
-> Version="0.1.0-preview.3" />`, a local NuGet feed at `<repo>/local-nupkgs/`
+> Version="0.1.0-preview.4" />`, a local NuGet feed at `<repo>/local-nupkgs/`
 > for source-built smoke tests, and an agent plugin so AI assistants generate
 > against the real factories (`mur --skill` / `mur --api` print the same
 > content). Run `mur upgrade` whenever you pull new template, CLI, plugin, or
@@ -171,7 +171,7 @@ New PowerShell windows pick up the user-PATH change on their own.
 **5. Pack local framework snapshots and project templates.** This produces the
 source-built `0.0.0-local` framework nupkgs for smoke tests plus the local
 `ProjectTemplates` nupkg that installs `dotnet new reactorapp`. The template's
-normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.3`
+normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.4`
 package.
 
 ```powershell
@@ -268,7 +268,7 @@ Reactor component. No `App.xaml`, no `MainWindow.xaml.cs` — just one C#
 file.
 
 By default that package reference is
-`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.3" />`.
+`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.4" />`.
 For local framework smoke tests, generate with
 `dotnet new reactorapp -n MyLocalApp --MSUIReactorVersion 0.0.0-local` and run
 from inside the source checkout or another folder that has the local feed

--- a/docs/guide/packaging.md
+++ b/docs/guide/packaging.md
@@ -226,7 +226,7 @@ package and not a folder inside `Reactor.dll`.
 
 **`Reactor.dll` is in your publish output as a managed assembly,
 not a tucked-away framework package.** Reactor ships as the public preview
-NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.3`; local
+NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.4`; local
 source-built smoke packages still use `0.0.0-local` via `mur pack-local`.
 Trim-friendly deployments don't get any framework-side magic; the same trimmer
 configuration that works for any WinUI 3 app works here.

--- a/tools/Templates/Microsoft.UI.Reactor.Templates.csproj
+++ b/tools/Templates/Microsoft.UI.Reactor.Templates.csproj
@@ -18,7 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>$(NoWarn);NU5128</NoWarn> <!-- Ignore warning generated when setting IncludeBuildOutput=False https://github.com/nuget/home/issues/8583 -->
     <Version Condition="'$(Version)' == ''">0.0.0-local</Version>
-    <MicrosoftUIReactorVersion Condition="'$(MicrosoftUIReactorVersion)' == ''">0.1.0-preview.3</MicrosoftUIReactorVersion> <!-- NuGet version generated apps should reference by default. Override for local framework smoke tests. -->
+    <MicrosoftUIReactorVersion Condition="'$(MicrosoftUIReactorVersion)' == ''">0.1.0-preview.4</MicrosoftUIReactorVersion> <!-- NuGet version generated apps should reference by default. Override for local framework smoke tests. -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps the app template default and public docs from `0.1.0-preview.3` to `0.1.0-preview.4`, per the release runbook (`docs/contributing/release-runbook.md` → "Prepare the release PR").

## Changes
- `tools/Templates/Microsoft.UI.Reactor.Templates.csproj` — `MicrosoftUIReactorVersion` default bumped to `0.1.0-preview.4` (the version scaffolded apps reference by default).
- `README.md` — quick-start / bootstrap version references.
- `docs/_pipeline/templates/getting-started.md.dt`, `docs/_pipeline/templates/packaging.md.dt` — authored doc templates.
- `docs/guide/getting-started.md`, `docs/guide/packaging.md` — regenerated via `mur docs compile --skip-screenshots --skip-diagrams` (not hand-edited).

## Notes
- All changes are pure version-string bumps; no behavioral changes.
- The runbook's own worked-example version strings were intentionally left at `preview.3` (illustrative).
- Do **not** tag until this merges. Reminder per runbook: the OneBranch publish approver must differ from the tag pusher.