### PR TITLE
docs: add NuGet package READMEs and wire PackageReadmeFile

### DIFF
--- a/src/Reactor.Advanced/README.md
+++ b/src/Reactor.Advanced/README.md
@@ -1,20 +1,85 @@
 # Microsoft.UI.Reactor.Advanced
 
-`Microsoft.UI.Reactor.Advanced` hosts optional Reactor components that depend on heavier native or graphics stacks. Its first surface is a Win2D canvas family for immediate-mode drawing inside a Reactor element tree.
+**Optional Reactor components with heavier native and graphics dependencies — starting with a Win2D canvas family for immediate-mode drawing inside a Reactor element tree.**
 
-The package is separate from `Microsoft.UI.Reactor` so apps that do not use Win2D keep their trim/AOT closure and native payload isolated.
+## About
 
-## Links
+`Microsoft.UI.Reactor.Advanced` extends [`Microsoft.UI.Reactor`](https://www.nuget.org/packages/Microsoft.UI.Reactor) with components that pull in larger native or graphics stacks. Its first surface is a Win2D canvas family (manual, animated, and virtual) that lets you draw with `CanvasDrawingSession` directly from a declarative Reactor component.
 
-- Guide: `docs/guide/win2d-canvas.md` (lands in Phase 3)
-- Sample: `samples/apps/particle-storm/` (lands in Phase 2)
+This package is intentionally separate from the core framework so that apps which don't need Win2D keep their trim/AOT closure and native payload isolated.
 
-## Baseline Win2D trim/AOT warnings
+## How to Use
 
-Phase 1B baseline command:
+Install the package alongside `Microsoft.UI.Reactor`:
 
-```powershell
-dotnet publish src/Reactor.Advanced/Reactor.Advanced.csproj -p:PublishTrimmed=true -p:Platform=x64 -r win-x64 -c Release
+```shell
+dotnet add package Microsoft.UI.Reactor.Advanced
 ```
 
-Current baseline: **0 warnings**. `Reactor.Advanced` is a library, so the project treats `PublishTrimmed` as a local project property and publishes as a trimmable/AOT-compatible library (`IsTrimmable=true`, `IsAotCompatible=true`) instead of invoking ILLink as if the library were an executable root.
+Drop a Win2D canvas into any component. The `onDraw` callback runs on the UI thread with a `CanvasDrawingSession`; pass a `redrawKey` to trigger invalidation when your state changes:
+
+```csharp
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Windows.UI;
+using static Microsoft.UI.Reactor.Factories;          // core DSL
+using static Microsoft.UI.Reactor.Advanced.Factories; // Win2D DSL
+
+internal sealed class CanvasDemo : Component
+{
+    public override Element Render()
+    {
+        var (radius, setRadius) = UseState(40f);
+
+        return VStack(12,
+            Win2DCanvas(
+                onDraw: (session, args) =>
+                {
+                    session.Clear(Colors.Black);
+                    session.FillCircle(120, 120, radius, Colors.DeepSkyBlue);
+                },
+                redrawKey: radius),
+            Button("Grow", () => setRadius(radius + 10f))
+        ).Padding(24);
+    }
+}
+```
+
+When `radius` changes, the new `redrawKey` tells Reactor to invalidate the canvas and redraw.
+
+## Key Features
+
+- **`Win2DCanvas`** — manual-invalidate canvas (`CanvasControl`); redraws when its `redrawKey` changes.
+- **`Win2DAnimatedCanvas`** — game-loop canvas (`CanvasAnimatedControl`) whose update and draw callbacks run on the Win2D game thread.
+- **`Win2DVirtualCanvas`** — virtualized canvas (`CanvasVirtualControl`) for very large drawing surfaces.
+- **Async resource creation** — overloads accept an `onCreateResources` callback tracked by Win2D for loading bitmaps and other device resources.
+- **Isolated native payload** — keeps Win2D out of the core framework's trim/AOT closure.
+
+## Main Types
+
+| Type | Description |
+|------|-------------|
+| `Win2DCanvas(...)` | Factory for a manual-invalidate Win2D canvas. |
+| `Win2DAnimatedCanvas(...)` | Factory for an animated game-loop canvas. |
+| `Win2DVirtualCanvas(...)` | Factory for a virtualized canvas. |
+| `Win2DCanvasElement` | Immutable element produced by `Win2DCanvas`. |
+
+## Additional Documentation
+
+- [Win2D canvas guide](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/guide/win2d-canvas.md)
+- [Samples](https://github.com/microsoft/microsoft-ui-reactor/tree/main/samples)
+- [Win2D documentation](https://microsoft.github.io/Win2D/WinUI3/html/Introduction.htm)
+
+## Related Packages
+
+- [`Microsoft.UI.Reactor`](https://www.nuget.org/packages/Microsoft.UI.Reactor) — the core declarative WinUI 3 framework (required).
+- [`Microsoft.UI.Reactor.Devtools`](https://www.nuget.org/packages/Microsoft.UI.Reactor.Devtools) — optional developer-loop devtools host.
+- [`Microsoft.UI.Reactor.ProjectTemplates`](https://www.nuget.org/packages/Microsoft.UI.Reactor.ProjectTemplates) — `dotnet new` templates.
+
+## Feedback & Contributing
+
+`Microsoft.UI.Reactor.Advanced` is part of the open-source Reactor project. File issues, ask questions, and contribute on [GitHub](https://github.com/microsoft/microsoft-ui-reactor). See [CONTRIBUTING.md](https://github.com/microsoft/microsoft-ui-reactor/blob/main/CONTRIBUTING.md) to get started.
+
+## Support Policy
+
+This package is currently released as a preview and is provided under the [MIT License](https://github.com/microsoft/microsoft-ui-reactor/blob/main/LICENSE). APIs may change between preview releases.

--- a/src/Reactor.Advanced/Reactor.Advanced.csproj
+++ b/src/Reactor.Advanced/Reactor.Advanced.csproj
@@ -25,6 +25,7 @@
     <PackageTags>WinUI;WinUI3;Windows App SDK;WinAppSDK;XAML;Windows;desktop;UI;declarative;Reactor;Win2D;canvas;graphics;charts</PackageTags>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageIcon>Icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/microsoft/microsoft-ui-reactor</PackageProjectUrl>
@@ -48,6 +49,7 @@
     <None Include="..\..\skills\advanced.md"
           Pack="true" PackagePath="agentkit/skills/reactor-advanced.md" Visible="false" />
     <None Include="..\..\assets\Icon.png" Pack="true" PackagePath="" Visible="false" />
+    <None Include="README.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Reactor.Devtools/INTERNALS.md
+++ b/src/Reactor.Devtools/INTERNALS.md
@@ -1,0 +1,137 @@
+# Reactor Devtools — MCP Surface
+
+This folder implements the `--devtools` runtime path: the MCP server that
+exposes `reactor.*` tools (tree, screenshot, click, state, fire, …), the
+`mur devtools` supervisor, and the rolling log that records every call.
+
+Reference specs: [024-ai-agent-devtools.md](../../Docs/specs/024-ai-agent-devtools.md),
+[task list](../../../../docs/specs/tasks/ai-agent-devtools-implementation.md).
+
+## Security model
+
+The devtools surface is **developer-loop only**. It is not designed to be a
+production endpoint and ships with three hard gates:
+
+1. **Opt in at build time and launch time.**
+   `<RuntimeHostConfigurationOption Include="Reactor.DevtoolsSupport" Value="true" Trim="true" />`
+   is the build-time capability gate; `--devtools run` / `--devtools app` is the
+   session-time activation gate. Both must be present before the MCP server,
+   capture server, logger, or in-app dev menu is enabled. Samples keep the
+   MSBuild switch Debug-conditional so Release/AOT builds have no devtools
+   surface at all.
+2. **Loopback-only binding.** The MCP `HttpListener` binds to
+   `http://127.0.0.1:{port}/`. It is never exposed on any non-loopback adapter
+   and the `ScreenshotCapture` path only reads the local window.
+
+### Caveat: any local process can connect
+
+There is **no authentication on the MCP port in v1**. Any process running on
+the same machine as the app — including unrelated applications, browser
+tabs connecting over `fetch("http://127.0.0.1:NNNN/mcp", …)`, other user
+sessions with local access, etc. — can call every registered tool. That is
+acceptable for the dev-inner-loop use case (a human running `mur devtools`
+with an agent in the same terminal session), but it means:
+
+- **Do not run `mur devtools` in an environment with untrusted local
+  processes.** `reactor.fire` can reach any handler on the live component;
+  `reactor.state` can enumerate hook shapes; `reactor.click` can drive the UI.
+- **Do not enable `Reactor.DevtoolsSupport` in Release builds that ship to end users.**
+  The Debug-conditional MSBuild convention makes this hard to do by accident.
+- **Do not assume the MCP surface is safe to expose beyond localhost** — e.g.
+  via a reverse proxy, SSH tunnel with remote binding, or container port
+  forwarding to 0.0.0.0. Loopback is the only supported deployment.
+
+If v1 usage signals push us toward scenarios where these caveats bite
+(e.g., CI runners, remote pair-programming), we revisit with an auth story
+in a follow-up spec.
+
+## Wire protocol versioning
+
+Embedded-preview HTTP endpoints advertise their protocol in `/status` as
+`"embed-v1"`. Any breaking change to the embed endpoints must bump the suffix
+(for example, `embed-v2`), and the Visual Studio extension must reject unknown
+protocol values rather than guessing compatibility.
+
+## Observability
+
+`DevtoolsLogger` writes one line per tool call to
+`%LOCALAPPDATA%/Reactor/devtools/{pid}.log` (Windows) or
+`$XDG_STATE_HOME/reactor/devtools/` (non-Windows). Files roll at 10 MB
+and we keep the newest five archives. Log level is configured via
+`--devtools-log-level off|error|call|trace` (default: `call`).
+
+Line shape (tab-separated):
+
+```
+2026-04-18T12:34:56.789Z	tree	r:main/btn-inc	42ms	ok	0
+```
+
+Columns: UTC timestamp, tool name, selector (or `-`), latency, `ok`/`err`,
+JSON-RPC result code.
+
+## ETW trace correlation
+
+Reactor emits a TraceLogging-style `EventSource` at `Microsoft-UI-Reactor`
+(see `Core/Diagnostics/ReactorEventSource.cs`). Hot-path emit sites are
+guarded by call-site `IsEnabled()` checks, so when no listener is attached
+the disabled path does no Stopwatch, type-name, or event-method work beyond
+a single word-sized flag read. Events cover reconcile passes, component
+render start/stop with trigger (self/parent), effects flush, child
+reconcile, state writes, unmounts, render errors, and MCP call start/stop.
+
+Keywords: `Reconcile=0x1`, `Render=0x2`, `State=0x4`, `Mcp=0x8`,
+`Lifecycle=0x10`, `Errors=0x20`. Full keyword mask = `0x3F`.
+
+Provider GUIDs:
+
+- `Microsoft-UI-Reactor` → `{2BA6BC23-ABF9-56DE-3922-8CC701F16EDE}` (name-hashed by EventSource)
+- `Microsoft-Windows-XAML` → `{531A35AB-63CE-4BCF-AA98-F88C7A89E455}` (WinUI 3 core, native ETW)
+
+### Required: capture via `xperf` (not `dotnet-trace`)
+
+The WinUI core provider is a **native ETW provider** emitted from WinUI's C++
+code. `dotnet-trace` uses the managed EventPipe transport and **cannot
+surface native ETW providers** — it will silently drop `Microsoft-Windows-XAML`
+events and you will get a Reactor-only trace. To get the correlated
+Reactor + XAML timeline you need a classic ETW session via `xperf`, `wpr`,
+`logman`, or PerfView.
+
+Recipe (xperf ships with the Windows Performance Toolkit at
+`C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\xperf.exe`):
+
+```
+set XPERF="C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\xperf.exe"
+
+%XPERF% -start ReactorSession ^
+    -on "2BA6BC23-ABF9-56DE-3922-8CC701F16EDE:0x3F:5+531A35AB-63CE-4BCF-AA98-F88C7A89E455:0x9240:5" ^
+    -f trace.etl -BufferSize 1024 -MinBuffers 32 -MaxBuffers 256
+
+REM …launch / exercise the app…
+
+%XPERF% -stop ReactorSession
+```
+
+The `0x9240` mask on `Microsoft-Windows-XAML` enables **Layout + Rendering +
+Input + DComp** keywords. Verbose level (`5`) is recommended so the full
+frame-timing / composition events come through.
+
+### Viewing the trace
+
+`.etl` opens natively in **PerfView** (github.com/microsoft/perfview) and
+**WPA** (`C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\wpa.exe`).
+PerfView is recommended for CLR + ETW correlation; WPA for composition /
+GPU / CPU-sampling views.
+
+For a web-based timeline (Perfetto / Firefox Profiler / Speedscope /
+`chrome://tracing`) the ETW stream needs to be converted to Chromium JSON
+— `dotnet-trace convert --format Chromium` only handles CPU samples, not
+custom `EventSource` events, so a custom `.etl`-to-Chromium converter is
+required. One is tracked separately; when it lands, swap the `.etl` path
+into it and the resulting JSON drops into https://ui.perfetto.dev/ directly.
+
+## `--print-config`
+
+`mur devtools --print-config [--mcp-port N]` emits JSON fragments for
+Claude Code, VS Code, and GitHub Copilot MCP configs, parameterized with
+the requested port. The tool never writes to disk — the user pastes the
+fragment they want into the target config file themselves.

--- a/src/Reactor.Devtools/README.md
+++ b/src/Reactor.Devtools/README.md
@@ -1,137 +1,75 @@
-# Reactor Devtools — MCP Surface
+# Microsoft.UI.Reactor.Devtools
 
-This folder implements the `--devtools` runtime path: the MCP server that
-exposes `reactor.*` tools (tree, screenshot, click, state, fire, …), the
-`mur devtools` supervisor, and the rolling log that records every call.
+**Optional developer-loop devtools host for [`Microsoft.UI.Reactor`](https://www.nuget.org/packages/Microsoft.UI.Reactor) — live element-tree inspection, hot reload, preview, and an agent-friendly MCP surface.**
 
-Reference specs: [024-ai-agent-devtools.md](../../Docs/specs/024-ai-agent-devtools.md),
-[task list](../../../../docs/specs/tasks/ai-agent-devtools-implementation.md).
+## About
+
+`Microsoft.UI.Reactor.Devtools` adds an opt-in, developer-loop tooling surface to a Reactor app. It hosts a loopback Model Context Protocol (MCP) server that exposes `reactor.*` tools (inspect the element tree, capture screenshots, click, read state, fire handlers) plus the `mur devtools` supervisor and a rolling per-call log.
+
+It is designed strictly for the inner development loop — not for production endpoints. See the security model below.
+
+## How to Use
+
+Install the package into your Reactor app (typically as a Debug-only reference):
+
+```shell
+dotnet add package Microsoft.UI.Reactor.Devtools
+```
+
+Enable the build-time capability gate (keep it Debug-conditional so Release/AOT builds carry no devtools surface):
+
+```xml
+<ItemGroup Condition="'$(Configuration)' == 'Debug'">
+  <RuntimeHostConfigurationOption Include="Reactor.DevtoolsSupport" Value="true" Trim="true" />
+</ItemGroup>
+```
+
+Then launch the devtools supervisor for your app:
+
+```shell
+mur devtools run
+```
+
+To wire an agent (Claude Code, VS Code, GitHub Copilot) to the MCP surface, print a ready-to-paste config fragment:
+
+```shell
+mur devtools --print-config --mcp-port 5000
+```
+
+The tool prints the JSON fragment — it never writes to disk; you paste it into your agent's config yourself.
 
 ## Security model
 
-The devtools surface is **developer-loop only**. It is not designed to be a
-production endpoint and ships with three hard gates:
+The devtools surface is **developer-loop only** and ships with hard gates:
 
-1. **Opt in at build time and launch time.**
-   `<RuntimeHostConfigurationOption Include="Reactor.DevtoolsSupport" Value="true" Trim="true" />`
-   is the build-time capability gate; `--devtools run` / `--devtools app` is the
-   session-time activation gate. Both must be present before the MCP server,
-   capture server, logger, or in-app dev menu is enabled. Samples keep the
-   MSBuild switch Debug-conditional so Release/AOT builds have no devtools
-   surface at all.
-2. **Loopback-only binding.** The MCP `HttpListener` binds to
-   `http://127.0.0.1:{port}/`. It is never exposed on any non-loopback adapter
-   and the `ScreenshotCapture` path only reads the local window.
+1. **Opt in at build time and launch time.** The `Reactor.DevtoolsSupport` MSBuild switch is the build-time gate; `mur devtools run` / `mur devtools app` is the session-time gate. Both must be present before the MCP server, capture server, logger, or in-app dev menu is enabled.
+2. **Loopback-only binding.** The MCP `HttpListener` binds to `http://127.0.0.1:{port}/` and is never exposed on a non-loopback adapter.
+3. **No authentication in v1.** Any local process can connect to the MCP port. Do **not** run `mur devtools` in an environment with untrusted local processes, do **not** enable `Reactor.DevtoolsSupport` in Release builds that ship to end users, and do **not** expose the MCP surface beyond localhost (reverse proxy, remote-binding SSH tunnel, or `0.0.0.0` container forwarding).
 
-### Caveat: any local process can connect
+## Key Features
 
-There is **no authentication on the MCP port in v1**. Any process running on
-the same machine as the app — including unrelated applications, browser
-tabs connecting over `fetch("http://127.0.0.1:NNNN/mcp", …)`, other user
-sessions with local access, etc. — can call every registered tool. That is
-acceptable for the dev-inner-loop use case (a human running `mur devtools`
-with an agent in the same terminal session), but it means:
+- **MCP tool surface** — `reactor.tree`, `reactor.screenshot`, `reactor.click`, `reactor.state`, `reactor.fire`, and more.
+- **`mur devtools` supervisor** — launches and supervises the devtools session for your app.
+- **Rolling call log** — one line per tool call to `%LOCALAPPDATA%/Reactor/devtools/{pid}.log`, rolling at 10 MB with five archives kept.
+- **ETW trace correlation** — emits a `Microsoft-UI-Reactor` `EventSource` for correlated Reactor + WinUI timelines (see [`INTERNALS.md`](https://github.com/microsoft/microsoft-ui-reactor/blob/main/src/Reactor.Devtools/INTERNALS.md)).
+- **Agent config generation** — `mur devtools --print-config` emits MCP config fragments for popular agents.
 
-- **Do not run `mur devtools` in an environment with untrusted local
-  processes.** `reactor.fire` can reach any handler on the live component;
-  `reactor.state` can enumerate hook shapes; `reactor.click` can drive the UI.
-- **Do not enable `Reactor.DevtoolsSupport` in Release builds that ship to end users.**
-  The Debug-conditional MSBuild convention makes this hard to do by accident.
-- **Do not assume the MCP surface is safe to expose beyond localhost** — e.g.
-  via a reverse proxy, SSH tunnel with remote binding, or container port
-  forwarding to 0.0.0.0. Loopback is the only supported deployment.
+## Additional Documentation
 
-If v1 usage signals push us toward scenarios where these caveats bite
-(e.g., CI runners, remote pair-programming), we revisit with an auth story
-in a follow-up spec.
+- [Devtools internals & ETW guide](https://github.com/microsoft/microsoft-ui-reactor/blob/main/src/Reactor.Devtools/INTERNALS.md)
+- [User guide](https://github.com/microsoft/microsoft-ui-reactor/tree/main/docs/guide)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
 
-## Wire protocol versioning
+## Related Packages
 
-Embedded-preview HTTP endpoints advertise their protocol in `/status` as
-`"embed-v1"`. Any breaking change to the embed endpoints must bump the suffix
-(for example, `embed-v2`), and the Visual Studio extension must reject unknown
-protocol values rather than guessing compatibility.
+- [`Microsoft.UI.Reactor`](https://www.nuget.org/packages/Microsoft.UI.Reactor) — the core declarative WinUI 3 framework (required).
+- [`Microsoft.UI.Reactor.Advanced`](https://www.nuget.org/packages/Microsoft.UI.Reactor.Advanced) — optional Win2D/graphics components.
+- [`Microsoft.UI.Reactor.ProjectTemplates`](https://www.nuget.org/packages/Microsoft.UI.Reactor.ProjectTemplates) — `dotnet new` templates.
 
-## Observability
+## Feedback & Contributing
 
-`DevtoolsLogger` writes one line per tool call to
-`%LOCALAPPDATA%/Reactor/devtools/{pid}.log` (Windows) or
-`$XDG_STATE_HOME/reactor/devtools/` (non-Windows). Files roll at 10 MB
-and we keep the newest five archives. Log level is configured via
-`--devtools-log-level off|error|call|trace` (default: `call`).
+`Microsoft.UI.Reactor.Devtools` is part of the open-source Reactor project. File issues, ask questions, and contribute on [GitHub](https://github.com/microsoft/microsoft-ui-reactor). See [CONTRIBUTING.md](https://github.com/microsoft/microsoft-ui-reactor/blob/main/CONTRIBUTING.md) to get started.
 
-Line shape (tab-separated):
+## Support Policy
 
-```
-2026-04-18T12:34:56.789Z	tree	r:main/btn-inc	42ms	ok	0
-```
-
-Columns: UTC timestamp, tool name, selector (or `-`), latency, `ok`/`err`,
-JSON-RPC result code.
-
-## ETW trace correlation
-
-Reactor emits a TraceLogging-style `EventSource` at `Microsoft-UI-Reactor`
-(see `Core/Diagnostics/ReactorEventSource.cs`). Hot-path emit sites are
-guarded by call-site `IsEnabled()` checks, so when no listener is attached
-the disabled path does no Stopwatch, type-name, or event-method work beyond
-a single word-sized flag read. Events cover reconcile passes, component
-render start/stop with trigger (self/parent), effects flush, child
-reconcile, state writes, unmounts, render errors, and MCP call start/stop.
-
-Keywords: `Reconcile=0x1`, `Render=0x2`, `State=0x4`, `Mcp=0x8`,
-`Lifecycle=0x10`, `Errors=0x20`. Full keyword mask = `0x3F`.
-
-Provider GUIDs:
-
-- `Microsoft-UI-Reactor` → `{2BA6BC23-ABF9-56DE-3922-8CC701F16EDE}` (name-hashed by EventSource)
-- `Microsoft-Windows-XAML` → `{531A35AB-63CE-4BCF-AA98-F88C7A89E455}` (WinUI 3 core, native ETW)
-
-### Required: capture via `xperf` (not `dotnet-trace`)
-
-The WinUI core provider is a **native ETW provider** emitted from WinUI's C++
-code. `dotnet-trace` uses the managed EventPipe transport and **cannot
-surface native ETW providers** — it will silently drop `Microsoft-Windows-XAML`
-events and you will get a Reactor-only trace. To get the correlated
-Reactor + XAML timeline you need a classic ETW session via `xperf`, `wpr`,
-`logman`, or PerfView.
-
-Recipe (xperf ships with the Windows Performance Toolkit at
-`C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\xperf.exe`):
-
-```
-set XPERF="C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\xperf.exe"
-
-%XPERF% -start ReactorSession ^
-    -on "2BA6BC23-ABF9-56DE-3922-8CC701F16EDE:0x3F:5+531A35AB-63CE-4BCF-AA98-F88C7A89E455:0x9240:5" ^
-    -f trace.etl -BufferSize 1024 -MinBuffers 32 -MaxBuffers 256
-
-REM …launch / exercise the app…
-
-%XPERF% -stop ReactorSession
-```
-
-The `0x9240` mask on `Microsoft-Windows-XAML` enables **Layout + Rendering +
-Input + DComp** keywords. Verbose level (`5`) is recommended so the full
-frame-timing / composition events come through.
-
-### Viewing the trace
-
-`.etl` opens natively in **PerfView** (github.com/microsoft/perfview) and
-**WPA** (`C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\wpa.exe`).
-PerfView is recommended for CLR + ETW correlation; WPA for composition /
-GPU / CPU-sampling views.
-
-For a web-based timeline (Perfetto / Firefox Profiler / Speedscope /
-`chrome://tracing`) the ETW stream needs to be converted to Chromium JSON
-— `dotnet-trace convert --format Chromium` only handles CPU samples, not
-custom `EventSource` events, so a custom `.etl`-to-Chromium converter is
-required. One is tracked separately; when it lands, swap the `.etl` path
-into it and the resulting JSON drops into https://ui.perfetto.dev/ directly.
-
-## `--print-config`
-
-`mur devtools --print-config [--mcp-port N]` emits JSON fragments for
-Claude Code, VS Code, and GitHub Copilot MCP configs, parameterized with
-the requested port. The tool never writes to disk — the user pastes the
-fragment they want into the target config file themselves.
+This package is currently released as a preview and is provided under the [MIT License](https://github.com/microsoft/microsoft-ui-reactor/blob/main/LICENSE). APIs may change between preview releases.

--- a/src/Reactor.Devtools/Reactor.Devtools.csproj
+++ b/src/Reactor.Devtools/Reactor.Devtools.csproj
@@ -24,6 +24,7 @@
     <PackageTags>WinUI;WinUI3;Windows App SDK;WinAppSDK;Windows;desktop;Reactor;devtools;diagnostics;hot-reload;preview;MCP</PackageTags>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageIcon>Icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/microsoft/microsoft-ui-reactor</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/microsoft-ui-reactor</RepositoryUrl>
@@ -54,6 +55,7 @@
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false" />
     <None Include="..\..\assets\Icon.png" Pack="true" PackagePath="" Visible="false" />
+    <None Include="README.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Reactor/README.md
+++ b/src/Reactor/README.md
@@ -1,0 +1,107 @@
+# Microsoft.UI.Reactor
+
+**Functional, declarative UI for WinUI 3 — build native Windows desktop apps with a React-style programming model, in pure C#.**
+
+## About
+
+`Microsoft.UI.Reactor` lets you describe your UI as a tree of immutable C# records and lightweight components. A virtual element tree and reconciler diff your declared UI against what's on screen and patch only what changed on the real WinUI controls underneath — so you get the productivity of a declarative, state-driven model with the fidelity and performance of native WinUI 3.
+
+- **No XAML.** Your whole UI is C# — composable, refactorable, and testable.
+- **Real WinUI controls.** Reactor renders genuine WinUI 3 controls, not a custom render surface.
+- **Hooks for state.** `UseState`, `UseEffect`, `UseReducer`, `UseMemo` and friends manage component state and side effects, following the familiar rules of hooks.
+- **AOT-friendly.** The core library is trim- and Native AOT-compatible.
+
+## How to Use
+
+Install the package into a WinUI 3 desktop project:
+
+```shell
+dotnet add package Microsoft.UI.Reactor
+```
+
+Your project should target a Windows TFM with WinUI enabled:
+
+```xml
+<PropertyGroup>
+  <OutputType>WinExe</OutputType>
+  <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
+  <UseWinUI>true</UseWinUI>
+  <ImplicitUsings>enable</ImplicitUsings>
+  <Nullable>enable</Nullable>
+</PropertyGroup>
+
+<ItemGroup>
+  <PackageReference Include="Microsoft.WindowsAppSDK" />
+  <PackageReference Include="Microsoft.UI.Reactor" />
+</ItemGroup>
+```
+
+Then write a component and run it. The example below is a complete, working counter app — a `Component` with state, declarative layout, and event handlers:
+
+```csharp
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+ReactorApp.Run<Counter>("Counter", width: 360, height: 220);
+
+internal sealed class Counter : Component
+{
+    public override Element Render()
+    {
+        var (count, setCount) = UseState(0);
+
+        return VStack(12,
+            TextBlock($"Count: {count}").FontSize(24).SemiBold(),
+            HStack(8,
+                Button("-", () => setCount(count - 1)),
+                Button("Reset", () => setCount(0)),
+                Button("+", () => setCount(count + 1))
+            )
+        ).Padding(24);
+    }
+}
+```
+
+`ReactorApp.Run<TRoot>` opens a window, mounts your root component, and starts the render loop. When `setCount` updates state, Reactor re-renders the component and patches only the `TextBlock` that changed.
+
+## Key Features
+
+- **Declarative components** — describe UI as immutable records via factory methods (`TextBlock`, `Button`, `VStack`, `HStack`, …); never construct or mutate WinUI controls directly.
+- **Hooks** — `UseState`, `UseEffect`, `UseReducer`, `UseMemo`, `UseRef`, and more, with cross-thread state updates via `threadSafe: true`.
+- **Fluent modifiers** — chain `.FontSize()`, `.SemiBold()`, `.Padding()`, `.Width()`, `.Foreground()`, `.IsEnabled()`, and others while preserving the concrete element type.
+- **Flexbox layout** — `FlexPanel` brings CSS Flexbox to WinUI via an embedded pure-C# port of Meta's Yoga engine.
+- **Efficient reconciliation** — a diffing reconciler plus control pooling keep updates minimal and allocation-light.
+- **Trim & Native AOT support** — ship small, fast, self-contained native binaries.
+
+## Main Types
+
+| Type | Description |
+|------|-------------|
+| `ReactorApp` | Entry point — `Run<TRoot>(...)` creates the window and starts the render loop. |
+| `Component` | Base class for your components; override `Render()` to return an `Element` tree. |
+| `Element` | Immutable record describing a piece of UI. |
+| `Factories` | Static factory methods (`TextBlock`, `Button`, `VStack`, `HStack`, `Slider`, …) — the DSL entry point. |
+| `RenderContext` | Hosts the hooks (`UseState`, `UseEffect`, …) available inside `Render()`. |
+
+## Additional Documentation
+
+- [Getting started guide](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/guide/getting-started.md)
+- [User guide](https://github.com/microsoft/microsoft-ui-reactor/tree/main/docs/guide)
+- [Samples](https://github.com/microsoft/microsoft-ui-reactor/tree/main/samples)
+- [Windows App SDK documentation](https://learn.microsoft.com/windows/apps/windows-app-sdk/)
+- [WinUI 3 documentation](https://learn.microsoft.com/windows/apps/winui/winui3/)
+
+## Related Packages
+
+- [`Microsoft.UI.Reactor.Advanced`](https://www.nuget.org/packages/Microsoft.UI.Reactor.Advanced) — optional components with heavier native/graphics dependencies (Win2D canvas, charts).
+- [`Microsoft.UI.Reactor.Devtools`](https://www.nuget.org/packages/Microsoft.UI.Reactor.Devtools) — optional developer-loop devtools host (live tree inspection, hot reload, preview).
+- [`Microsoft.UI.Reactor.ProjectTemplates`](https://www.nuget.org/packages/Microsoft.UI.Reactor.ProjectTemplates) — `dotnet new` templates for scaffolding Reactor apps.
+
+## Feedback & Contributing
+
+`Microsoft.UI.Reactor` is an open-source project. File issues, ask questions, and contribute on [GitHub](https://github.com/microsoft/microsoft-ui-reactor). See [CONTRIBUTING.md](https://github.com/microsoft/microsoft-ui-reactor/blob/main/CONTRIBUTING.md) to get started.
+
+## Support Policy
+
+This package is currently released as a preview and is provided under the [MIT License](https://github.com/microsoft/microsoft-ui-reactor/blob/main/LICENSE). APIs may change between preview releases.

--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -37,6 +37,7 @@
     <PackageTags>WinUI;WinUI3;Windows App SDK;WinAppSDK;XAML;Windows;desktop;UI;declarative;functional;reactive;MVU;components;hooks;Reactor</PackageTags>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageIcon>Icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/microsoft/microsoft-ui-reactor</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/microsoft-ui-reactor</RepositoryUrl>
@@ -122,6 +123,7 @@
           Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false" />
     <None Include="..\..\assets\Icon.png" Pack="true" PackagePath="" Visible="false" />
+    <None Include="README.md" Pack="true" PackagePath="" Visible="false" />
     <!-- Packed under the PackageId-matching name so NuGet auto-imports it into
          consuming projects (build/<PackageId>.targets). The source file keeps
          the short name for the repo's own Directory.Build.props import. -->

--- a/tools/Templates/Microsoft.UI.Reactor.Templates.csproj
+++ b/tools/Templates/Microsoft.UI.Reactor.Templates.csproj
@@ -8,6 +8,7 @@
     <Description>Project templates for Microsoft.UI.Reactor</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageIcon>Icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>dotnet-new;templates;WinUI;WinUI3;Windows App SDK;WinAppSDK;Windows;desktop;Reactor</PackageTags>
@@ -23,6 +24,7 @@
 
   <ItemGroup>
     <None Include="..\..\assets\Icon.png" Pack="true" PackagePath="" Visible="false" />
+    <None Include="README.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
  <ItemGroup>

--- a/tools/Templates/README.md
+++ b/tools/Templates/README.md
@@ -1,0 +1,51 @@
+# Microsoft.UI.Reactor.ProjectTemplates
+
+**`dotnet new` templates for scaffolding [`Microsoft.UI.Reactor`](https://www.nuget.org/packages/Microsoft.UI.Reactor) apps — a ready-to-run WinUI 3 Reactor project in one command.**
+
+## About
+
+This package installs project templates for the .NET CLI and Visual Studio so you can create a new declarative WinUI 3 desktop app powered by Reactor without wiring up the project by hand.
+
+## How to Use
+
+Install the templates:
+
+```shell
+dotnet new install Microsoft.UI.Reactor.ProjectTemplates
+```
+
+Create a new Reactor app:
+
+```shell
+dotnet new reactorapp -n MyApp
+cd MyApp
+dotnet run -p:Platform=x64
+```
+
+This scaffolds a runnable WinUI 3 project that references `Microsoft.UI.Reactor` and the Windows App SDK, with a root component already wired up through `ReactorApp.Run`.
+
+## Included Templates
+
+| Template | Short name | Description |
+|----------|-----------|-------------|
+| Microsoft WinUI Reactor App | `reactorapp` | A Windows WinUI 3 application using Reactor (C#). |
+
+## Additional Documentation
+
+- [Getting started guide](https://github.com/microsoft/microsoft-ui-reactor/blob/main/docs/guide/getting-started.md)
+- [`dotnet new` documentation](https://learn.microsoft.com/dotnet/core/tools/dotnet-new)
+- [Custom templates for dotnet new](https://learn.microsoft.com/dotnet/core/tools/custom-templates)
+
+## Related Packages
+
+- [`Microsoft.UI.Reactor`](https://www.nuget.org/packages/Microsoft.UI.Reactor) — the core declarative WinUI 3 framework.
+- [`Microsoft.UI.Reactor.Advanced`](https://www.nuget.org/packages/Microsoft.UI.Reactor.Advanced) — optional Win2D/graphics components.
+- [`Microsoft.UI.Reactor.Devtools`](https://www.nuget.org/packages/Microsoft.UI.Reactor.Devtools) — optional developer-loop devtools host.
+
+## Feedback & Contributing
+
+These templates are part of the open-source Reactor project. File issues, ask questions, and contribute on [GitHub](https://github.com/microsoft/microsoft-ui-reactor). See [CONTRIBUTING.md](https://github.com/microsoft/microsoft-ui-reactor/blob/main/CONTRIBUTING.md) to get started.
+
+## Support Policy
+
+This package is currently released as a preview and is provided under the [MIT License](https://github.com/microsoft/microsoft-ui-reactor/blob/main/LICENSE). APIs may change between preview releases.


### PR DESCRIPTION
## Summary

Adds consumer-facing `README.md` files to all four packable NuGet packages and wires them into each package via `PackageReadmeFile`, so the READMEs render on the package's nuget.org page.

Each README follows a consistent template: **About → How to Use (with a runnable example) → Key Features → Main Types → Additional Documentation → Related Packages → Feedback & Contributing → Support Policy.**

## Packages

| Package | README | Notes |
|---------|--------|-------|
| `Microsoft.UI.Reactor` | new `src/Reactor/README.md` | Flagship. Carries a counter example as the compelling sample. |
| `Microsoft.UI.Reactor.Advanced` | `src/Reactor.Advanced/README.md` | Win2D canvas walkthrough. |
| `Microsoft.UI.Reactor.Devtools` | `src/Reactor.Devtools/README.md` | MCP surface + security model summary. |
| `Microsoft.UI.Reactor.ProjectTemplates` | new `tools/Templates/README.md` | `dotnet new reactorapp` usage. |

## Validation

- The flagship counter example was **compiled against the real `Reactor.dll`** in a throwaway consumer project (`ProjectReference` to `src/Reactor/Reactor.csproj`, `dotnet build -p:Platform=x64`) — **0 warnings, 0 errors**. The scratch project was deleted afterward.
- `dotnet pack` confirmed for `Microsoft.UI.Reactor` and `Microsoft.UI.Reactor.ProjectTemplates`: `README.md` lands at the nupkg root and the generated `.nuspec` declares `<readme>README.md</readme>`.
- Win2D and devtools examples were checked against the actual factory signatures (`Win2DCanvas`, `mur devtools` flows).

## Wiring

Each csproj gains `<PackageReadmeFile>README.md</PackageReadmeFile>` plus a `<None Include="README.md" Pack="true" PackagePath="" />` so the README packs to the package root alongside `LICENSE`/`Icon.png`.

`PackageReadmeFile` is a Microsoft packaging recommendation (warning-only; not enforced by the package-validation gate), so this is a safe, additive change.

## Preserved content

The Devtools package previously had a developer-focused deep-dive in its `README.md` (MCP wire protocol, ETW capture, observability). That content is preserved as `src/Reactor.Devtools/INTERNALS.md` and is linked from the new consumer README.