### PR TITLE
Added FileBased app Template

### DIFF
--- a/tools/Templates/templates/WinUiApp-FileBased/.template.config/dotnetcli.host.json
+++ b/tools/Templates/templates/WinUiApp-FileBased/.template.config/dotnetcli.host.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    },
+    "langVersion": {
+      "longName": "langVersion",
+      "shortName": ""
+    },
+    "UseProgramMain": {
+      "longName": "use-program-main",
+      "shortName": ""
+    },
+    "NativeAot": {
+      "longName": "aot",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/tools/Templates/templates/WinUiApp-FileBased/.template.config/template.json
+++ b/tools/Templates/templates/WinUiApp-FileBased/.template.config/template.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [ "Windows", "WinUI" ],
+  "identity": "Microsoft.UI.Reactor.FileBased",
+  "groupIdentity": "Microsoft.UI.Reactor.FileBased",
+  "name": "Microsoft WinUI Reactor File-Based App",
+  "description": "A Windows WinUI Application using Reactor with file-based structure",
+  "shortName": "reactorapp-filebased",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "Company.ReactorApp1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": "",
+      "displayName": "Target framework override"
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net10.0",
+          "description": "Target net10.0",
+          "displayName": ".NET 10.0"
+        }
+      ],
+      "replaces": "net10.0",
+      "defaultValue": "net10.0",
+      "displayName": "Framework"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false",
+      "displayName": "Skip restore"
+    },
+    "UseProgramMain": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+      "displayName": "Do not use _top-level statements"
+    },
+    "NativeAot" : {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "displayName": "Enable _native AOT publish",
+      "description": "Whether to enable the project for publishing as native AOT."
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "csharpFeature_TopLevelProgram": {
+      "type": "computed",
+      "value": "UseProgramMain != \"true\""
+    },
+    "MSUIReactorVersion": {
+        "type": "parameter",
+        "dataType": "string",
+        "replaces": "MS_UI_REACTOR_VERSION",
+        "defaultValue": "MS_UI_REACTOR_VERSION_VALUE"
+      },
+  },
+  "primaryOutputs": [
+    {
+      "path": "App.cs"
+    },
+  ],
+  "defaultName": "WinUIApp1",
+  "postActions": [
+    {
+      "id": "restore",
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "args": {
+        "executable": "dotnet.exe",
+        "args": "restore App.cs",
+        "redirectStandardOutput": false,
+        "redirectStandardError": false
+      },
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+      "continueOnError": true
+    }
+  ]
+}

--- a/tools/Templates/templates/WinUiApp-FileBased/App.cs
+++ b/tools/Templates/templates/WinUiApp-FileBased/App.cs
@@ -1,0 +1,43 @@
+using System;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;         // BackdropKind
+using Microsoft.UI.Reactor.Layout;        // FlexDirection, FlexJustify, FlexAlign
+using Microsoft.UI.Xaml;                  // Thickness, HorizontalAlignment, VerticalAlignment
+using Microsoft.UI.Xaml.Controls;         // Orientation, InfoBarSeverity, etc.
+using static Microsoft.UI.Reactor.Factories;
+
+#if (csharpFeature_TopLevelProgram)
+ReactorApp.Run<App>("Company.ReactorApp1", width: 900, height: 600);
+
+#else
+namespace Company.ReactorApp1;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        ReactorApp.Run<App>("Company.ReactorApp1", width: 900, height: 600);
+    }
+}
+
+#endif
+class App : Component
+{
+    public override Element Render()
+    {
+        var (name, setName) = UseState("World");
+
+        var titleBar = TitleBar("Company.ReactorApp1").Flex(shrink: 0);
+
+        var body = Border(
+            FlexColumn(
+                Heading($"Hello, {name}!"),
+                TextBox(name, setName, placeholderText: "Your name")
+                    .AutomationName("NameInput")
+            ) with { RowGap = 16 }
+        ).Padding(24).Flex(grow: 1, basis: 0);
+
+        return FlexColumn(titleBar, body)
+            .Backdrop(BackdropKind.Mica);
+    }
+}

--- a/tools/Templates/templates/WinUiApp-FileBased/Directory.Build.props
+++ b/tools/Templates/templates/WinUiApp-FileBased/Directory.Build.props
@@ -1,0 +1,45 @@
+<Project>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net10.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride-windows10.0.22621.0</TargetFramework>
+    <!--
+            x64 first so an unqualified `dotnet build` / F5 picks the right default on the
+            majority of dev machines. ARM64 second for Snapdragon X. X86 retained for parity
+            with the WinUI 3 templates even though Reactor itself is only tested on x64 / ARM64.
+        -->
+    <Platforms>x64;ARM64;X86</Platforms>
+    <UseWinUI>true</UseWinUI>
+    <WindowsPackageType>None</WindowsPackageType>
+    <!--
+            WindowsAppSDKSelfContained bundles the Windows App SDK runtime alongside the
+            published exe so the app:
+              (a) runs from any folder without a separate Windows App Runtime install, and
+              (b) survives `dotnet watch run` hot reload (used by the Reactor Visual Studio
+                  embedded-preview extension — spec 056). Incremental rebuilds otherwise
+                  double-count transitive Microsoft.WindowsAppSDK.* references and trip
+                  Microsoft.WindowsAppSDK.ComponentReference.targets' strict version check
+                  ("version 2.0.20;2.0.20 was referenced"). Self-contained bundling
+                  sidesteps that check.
+            Tradeoff: ~30 MB extra in the publish output. To ship framework-dependent
+            (smaller publish, requires the user to install Microsoft.WindowsAppRuntime
+            separately) flip this to false and ensure your install instructions tell users
+            to install the runtime first.
+        -->
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+    <Nullable>enable</Nullable>
+    <!--
+            Auto-resolve RuntimeIdentifier from the host SDK when the caller hasn't pinned
+            Platform / RuntimeIdentifier explicitly. Lets `dotnet build` / `dotnet run`
+            succeed without forcing -p:Platform=x64 on every invocation — WindowsAppSDK's
+            self-contained build path requires a concrete RID.
+        -->
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And ('$(Platform)' == '' Or '$(Platform)' == 'AnyCPU' Or '$(Platform)' == 'Any CPU')">$(NETCoreSdkPortableRuntimeIdentifier)</RuntimeIdentifier>
+    <!--#if (NativeAot) -->
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <!--#endif -->
+  </PropertyGroup>
+</Project>

--- a/tools/Templates/templates/WinUiApp-FileBased/Directory.Packages.props
+++ b/tools/Templates/templates/WinUiApp-FileBased/Directory.Packages.props
@@ -1,0 +1,22 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
+    <PackageReference Include="Microsoft.UI.Reactor" Version="MS_UI_REACTOR_VERSION" />
+  </ItemGroup>
+
+  <!--
+        Debug-only: enable the Reactor devtools surface so the *devtools* flag
+        (from Properties/launchSettings.json's default F5 args) lights up the
+        devtools menu, and so the Visual Studio embedded-preview extension's
+        embed-host activation (which requires devtools support) succeeds.
+        Release / Publish builds drop both the package and the host-config
+        switch so the trim / AOT analyzers stay happy (see
+        docs/guide/packaging.md, section "Keep Reactor.DevtoolsSupport out of
+        retail"). To enable devtools in Release as well, move these into the
+        unconditioned ItemGroup above.
+    -->
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <PackageReference Include="Microsoft.UI.Reactor.Devtools" Version="MS_UI_REACTOR_VERSION" />
+    <RuntimeHostConfigurationOption Include="Reactor.DevtoolsSupport" Value="true" Trim="true" />
+  </ItemGroup>
+</Project>

--- a/tools/Templates/templates/WinUiApp-FileBased/Properties/launchSettings.json
+++ b/tools/Templates/templates/WinUiApp-FileBased/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "//": "Default F5 / `dotnet run` profile for the scaffolded Reactor app. The devtools",
+  "//": "profile pairs --devtools with the Debug-only `Microsoft.UI.Reactor.Devtools` package +",
+  "//": "Reactor.DevtoolsSupport host config option (see Company.ReactorApp1.csproj).",
+  "//": "Release builds exclude the devtools package, so the default profile does not pass",
+  "//": "--devtools. The Reactor Visual Studio embedded-preview extension (spec 056) launches",
+  "//": "with its own argv (`--devtools run --embed --embed-host-pid <pid>`) and does not",
+  "//": "consult this file.",
+  "profiles": {
+    "Company.ReactorApp1": {
+      "commandName": "Project",
+      "nativeDebugging": false
+    },
+    "Company.ReactorApp1 Devtools": {
+      "commandName": "Project",
+      "commandLineArgs": "--devtools",
+      "nativeDebugging": false
+    }
+  }
+}

--- a/tools/Templates/templates/WinUiApp-FileBased/Properties/launchSettings.json
+++ b/tools/Templates/templates/WinUiApp-FileBased/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "//": "Default F5 / `dotnet run` profile for the scaffolded Reactor app. The devtools",
   "//": "profile pairs --devtools with the Debug-only `Microsoft.UI.Reactor.Devtools` package +",
-  "//": "Reactor.DevtoolsSupport host config option (see Company.ReactorApp1.csproj).",
+  "//": "Reactor.DevtoolsSupport host config option (see Directory.Packages.props).",
   "//": "Release builds exclude the devtools package, so the default profile does not pass",
   "//": "--devtools. The Reactor Visual Studio embedded-preview extension (spec 056) launches",
   "//": "with its own argv (`--devtools run --embed --embed-host-pid <pid>`) and does not",


### PR DESCRIPTION
<!--
Thanks for contributing to Reactor! A few notes before you open this PR:

- Link the issue or spec this PR addresses (Fixes #..., Implements docs/specs/0XX-...).
- Keep the change focused. Smaller, well-scoped PRs land faster.
- Include tests. See CONTRIBUTING.md for the unit / selftest / e2e split.
- Run `dotnet build Reactor.slnx` and `dotnet test tests/Reactor.Tests` locally.
- First-time contributors: the Microsoft CLA bot will comment automatically; sign once and you're set.
-->

## Summary

Added template for File-Based Apps. Due to the nature of Reactor UI, File Based apps are an excellent usecase, and being able to generate one from the template is a good thing


## Risk / breaking changes

No API Changes purely added a new template
