### PR TITLE
build: enable SourceLink and ship symbols for all packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,6 +52,14 @@
         to deterministic roots so PDBs don't leak local paths (e.g. E:\repos\...) and
         match the committed source on GitHub. Gated to CI: turning them on locally
         rewrites paths and breaks stepping into your own working-tree builds.
+
+    NOTE on '$(CI)': despite the name, this is the universal "automated build agent"
+    flag (set by GitHub Actions, ADO, etc.), NOT "the CI/PR-gate pipeline". BOTH the
+    PR-gate (OneBranch.CI.Reactor.yml) AND the release/pack pipeline
+    (OneBranch.Official.Reactor.yml) set CI=true — so the deterministic-path arm below
+    DOES run for the signed release packages. "CI" here means "not a developer's
+    interactive working-tree build", which is exactly when we want deterministic,
+    source-linked PDBs.
   -->
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,6 +40,29 @@
   </PropertyGroup>
 
   <!--
+    SourceLink — lets consumers step into Reactor source while debugging. The
+    GitHub provider (Microsoft.SourceLink.GitHub) is bundled in the .NET SDK and
+    auto-imported for GitHub-hosted repos, so no PackageReference is needed (which
+    also avoids having to seed the package into the sealed-container internal feed).
+    These properties make the published .snupkg carry SourceLink metadata:
+      - PublishRepositoryUrl embeds RepositoryUrl in the package.
+      - EmbedUntrackedSources embeds generated/untracked sources (e.g. source-gen
+        output) so every PDB document resolves.
+      - ContinuousIntegrationBuild + DeterministicSourcePaths normalize source paths
+        to deterministic roots so PDBs don't leak local paths (e.g. E:\repos\...) and
+        match the committed source on GitHub. Gated to CI: turning them on locally
+        rewrites paths and breaks stepping into your own working-tree builds.
+  -->
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(CI)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <DeterministicSourcePaths>true</DeterministicSourcePaths>
+  </PropertyGroup>
+
+  <!--
     In CI we never need the GitHub.Copilot.SDK native CLI (copilot.exe), which the
     SDK's build targets fetch from registry.npmjs.org via an unauthenticated MSBuild
     DownloadFile task. That download can fail in restricted CI environments and cannot

--- a/src/Reactor.Advanced/Reactor.Advanced.csproj
+++ b/src/Reactor.Advanced/Reactor.Advanced.csproj
@@ -31,6 +31,8 @@
     <PackageProjectUrl>https://github.com/microsoft/microsoft-ui-reactor</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/microsoft-ui-reactor</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591;CS8305;REACTOR_DOC_001;REACTOR_DOC_002</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
## What

Enable [SourceLink](https://learn.microsoft.com/dotnet/standard/library-guidance/sourcelink) for the published packages so consumers can step directly into Reactor source while debugging, and ensure every binary package ships a symbol package (`.snupkg`).

## Why

The framework already published symbol packages, but the PDBs carried no SourceLink metadata, so debuggers couldn't map them back to source on GitHub. Additionally, `Microsoft.UI.Reactor.Advanced` shipped a `.nupkg` but no `.snupkg` at all (its csproj was missing the symbol properties that `Reactor` and `Devtools` already had), so it had no published symbols to debug with.

## Changes

**`Directory.Build.props`** — enable SourceLink for all packable projects:
- `PublishRepositoryUrl` + `EmbedUntrackedSources` (always on) so the package carries the repo URL and every PDB document resolves (including source-generator output).
- `ContinuousIntegrationBuild` + `DeterministicSourcePaths` (gated to `$(CI) == 'true'`) so CI builds normalize source paths to deterministic roots that match the committed source on GitHub, without leaking local paths. Gating to CI keeps local working-tree debugging intact. A comment clarifies that `$(CI)` is the universal "automated build agent" flag — set by **both** the PR-gate and the release/pack pipeline — so deterministic paths do apply to the signed release packages.

No `PackageReference` is needed: `Microsoft.SourceLink.GitHub` is bundled in the .NET SDK and auto-imported for GitHub-hosted repos (which also avoids having to seed the package into the internal build feed).

**`src/Reactor.Advanced/Reactor.Advanced.csproj`** — add `IncludeSymbols` + `SymbolPackageFormat=snupkg`, mirroring `Reactor` and `Devtools`, so Advanced now publishes a symbol package too.

`Microsoft.UI.Reactor.ProjectTemplates` is intentionally unchanged: it's a `PackageType=Template` package with no compiled assembly (`IncludeBuildOutput=false`), so it has no PDB to symbolicate.

## Verification

Built the official pipeline against these changes and inspected the resulting signed packages. All three binary packages — `Microsoft.UI.Reactor`, `Microsoft.UI.Reactor.Advanced`, and `Microsoft.UI.Reactor.Devtools` — produce a `.snupkg`, and `sourcelink test` passes on each PDB, with documents resolving to `raw.githubusercontent.com` at the build commit.

---

> Branch note: the SourceLink work originally lived on `ci/sourcelink`, but that branch was reused by an unrelated automated MessagePack change. To keep things single-purpose, SourceLink now lives here on a fresh `build/sourcelink` branch, and the MessagePack fix is isolated on `ci/sourcelink` / #569.