### PR TITLE
Update GitHub Copilot SDK and other dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
   -->
   <PropertyGroup>
     <WindowsAppSDKVersion>2.0.1</WindowsAppSDKVersion>
-    <Win2DVersion>1.3.0</Win2DVersion>
+    <Win2DVersion>1.4.0</Win2DVersion>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
   </PropertyGroup>
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1249,7 +1249,7 @@ ToString() → string
 Equals(AsyncValue<T> other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
-Match<TResult>(Func<TResult> loading, Func<T, TResult> data, Func<Exception, TResult> error, Func<T, TResult> reloading = null) → TResult
+Match<TResult>(Func<TResult> loading, Func<T, TResult> loaded, Func<Exception, TResult> error, Func<T, TResult> reloading = null) → TResult
 ToString() → string
 
 ### record AsyncValue<T>.Data<T>

--- a/samples/apps/demo-script-tool/App/DemoScriptTool.csproj
+++ b/samples/apps/demo-script-tool/App/DemoScriptTool.csproj
@@ -18,15 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHub.Copilot.SDK" Version="0.3.0" />
+    <PackageReference Include="GitHub.Copilot.SDK" Version="1.0.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(WindowsAppSDKVersion)" />
-    <!-- Pin the transitive Nerdbank.MessagePack (via GitHub.Copilot.SDK → StreamJsonRpc)
-         to 1.2.4 — picks up GHSA-92vj-hp7m-gwcj and GHSA-qjvr-435c-5fjh fixes
-         beyond the original 1.1.62 (which covered only GHSA-2cwq-pwfr-wcw3). -->
-    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
-    <!-- Pin transitive MessagePack (via GitHub.Copilot.SDK → StreamJsonRpc) to a version
-         that includes the GHSA-hv8m-jj95-wg3x LZ4 decompression fix (>= 2.5.301). -->
-    <PackageReference Include="MessagePack" Version="2.5.301" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/apps/demo-script-tool/App/Services/CopilotSdkClient.cs
+++ b/samples/apps/demo-script-tool/App/Services/CopilotSdkClient.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 namespace DemoScriptTool.App.Services;
 
@@ -65,9 +65,9 @@ public sealed class CopilotSdkClient : IModelClient, IAsyncDisposable
             // provided — i.e. the SDK rides whichever account `gh auth` /
             // Copilot considers active. Pass an explicit token only when
             // a caller has resolved one (e.g. for a non-active gh account).
+            // We call StartAsync() ourselves below so startup failures surface here.
             var options = new CopilotClientOptions
             {
-                AutoStart = false, // we'll StartAsync ourselves so failures surface here
                 GitHubToken = _explicitToken,
             };
             var client = new CopilotClient(options);
@@ -125,7 +125,7 @@ public sealed class CopilotSdkClient : IModelClient, IAsyncDisposable
         bool sawDeltas = false;
         bool turnEnded = false;
 
-        using var subscription = session.On(evt =>
+        using var subscription = session.On<SessionEvent>(evt =>
         {
             // Trace every event type so envelope drift / unexpected sequencing
             // is visible during debugging. The line is kept short so it doesn't

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1249,7 +1249,7 @@ ToString() → string
 Equals(AsyncValue<T> other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
-Match<TResult>(Func<TResult> loading, Func<T, TResult> data, Func<Exception, TResult> error, Func<T, TResult> reloading = null) → TResult
+Match<TResult>(Func<TResult> loading, Func<T, TResult> loaded, Func<Exception, TResult> error, Func<T, TResult> reloading = null) → TResult
 ToString() → string
 
 ### record AsyncValue<T>.Data<T>

--- a/src/Reactor.Cli/Loc/AzureOpenAiProvider.cs
+++ b/src/Reactor.Cli/Loc/AzureOpenAiProvider.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 namespace Microsoft.UI.Reactor.Cli.Loc;
 
@@ -16,9 +16,12 @@ internal sealed class CopilotTranslationProvider : ITranslationProvider
 
     public CopilotTranslationProvider(string? model = null)
     {
+        // Default model: gpt-5.4-mini — a fast, low-cost model well-suited to
+        // straightforward string translation (gpt-4o is no longer offered by the
+        // Copilot runtime → session.create fails). Override via --model or COPILOT_MODEL.
         _model = model
             ?? Environment.GetEnvironmentVariable("COPILOT_MODEL")
-            ?? "gpt-4o";
+            ?? "gpt-5.4-mini";
     }
 
     public async Task<TranslationResult> TranslateAsync(TranslationBatch batch, CancellationToken ct = default)
@@ -38,7 +41,7 @@ internal sealed class CopilotTranslationProvider : ITranslationProvider
         var tcs = new TaskCompletionSource<string>();
         var responseBuilder = new StringBuilder();
 
-        session.On(evt =>
+        session.On<SessionEvent>(evt =>
         {
             switch (evt)
             {

--- a/src/Reactor.Cli/Loc/TranslateCommand.cs
+++ b/src/Reactor.Cli/Loc/TranslateCommand.cs
@@ -290,7 +290,7 @@ internal static class TranslateCommand
         Console.WriteLine("  --source <dir>     Source locale directory (default: Strings/en-US/)");
         Console.WriteLine("  --target <locales>  Comma-separated target locales (e.g., fr-FR,ar-SA)");
         Console.WriteLine("  --missing-only     Only translate missing or AI-draft keys");
-        Console.WriteLine("  --model <name>     Model to use (default: gpt-4o, or COPILOT_MODEL env var)");
+        Console.WriteLine("  --model <name>     Model to use (default: gpt-5.4-mini, or COPILOT_MODEL env var)");
         Console.WriteLine();
         Console.WriteLine("Requires GitHub CLI (gh) to be installed and authenticated with a");
         Console.WriteLine("Copilot-enabled GitHub account.");

--- a/src/Reactor.Cli/Reactor.Cli.csproj
+++ b/src/Reactor.Cli/Reactor.Cli.csproj
@@ -73,16 +73,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHub.Copilot.SDK" Version="0.1.32" />
+    <PackageReference Include="GitHub.Copilot.SDK" Version="1.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
-    <PackageReference Include="YamlDotNet" Version="16.3.0" />
-    <!-- Pin the transitive Nerdbank.MessagePack (via GitHub.Copilot.SDK → StreamJsonRpc)
-         to a version that includes the GHSA-2cwq-pwfr-wcw3 / CVE-2026-44375 fix. -->
-    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
-    <!-- Pin transitive MessagePack (via GitHub.Copilot.SDK → StreamJsonRpc) to a version
-         that includes the GHSA-hv8m-jj95-wg3x LZ4 decompression fix (>= 2.5.301). -->
-    <PackageReference Include="MessagePack" Version="2.5.301" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="YamlDotNet" Version="18.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Reactor.Devtools/Reactor.Devtools.csproj
+++ b/src/Reactor.Devtools/Reactor.Devtools.csproj
@@ -43,8 +43,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(WindowsAppSDKVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
     <PackageReference Include="MessageFormat" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -74,8 +74,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(WindowsAppSDKVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
     <PackageReference Include="MessageFormat" Version="8.0.0" />
   </ItemGroup>
 

--- a/tests/Reactor.Tests/Reactor.Tests.csproj
+++ b/tests/Reactor.Tests/Reactor.Tests.csproj
@@ -19,14 +19,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(WindowsAppSDKVersion)" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
## Summary

Bumping older dependencies, as well as the copilot sdk to a stable version that doesn't depend on MessagePack.

## Linked issue / spec

Similar to #569, since it also fixes GHSA-hv8m-jj95-wg3x

## Test plan

Manually tested string localization, which showed that gpt-4o was not available anymore, so I also bumped it.
