### PR TITLE
feat: implement UseSharedDevice for Win2D canvas elements to ensure resource compatibility

### DIFF
--- a/docs/_pipeline/apps/win2d-canvas/App.cs
+++ b/docs/_pipeline/apps/win2d-canvas/App.cs
@@ -83,6 +83,10 @@ class AnimatedCanvasDemo : Component
                     .TargetFps(60)
                     .Width(420)
                     .Height(220)
+                    // UseCanvasResources builds the sprite on Win2D's shared device, so the
+                    // canvas must draw with that same device — otherwise the cross-device
+                    // DrawImage raises a fatal stowed exception.
+                    .UseSharedDevice()
             ).Padding(20);
         });
     }

--- a/docs/_pipeline/templates/win2d-canvas.md.dt
+++ b/docs/_pipeline/templates/win2d-canvas.md.dt
@@ -104,6 +104,8 @@ Win2DAnimatedCanvas(onUpdate: ..., onDraw: ..., drawState: dots.Current)
 
 The modifier is available on all three canvas elements (`Win2DCanvas`, `Win2DAnimatedCanvas`, `Win2DVirtualCanvas`). Resources created and drawn entirely within a single canvas's own `OnCreateResources` (using that control's device) do not need it.
 
+`UseSharedDevice` is a **device-construction setting**: Win2D evaluates it once when the control first realizes its device. It is fixed for the control's lifetime — toggling `.UseSharedDevice()` on a live canvas across re-renders is not supported (it would force a crash-prone in-place device recreation, so Reactor ignores the change in release builds and throws a clear error in debug builds). To switch devices, remount the canvas via a different `key`.
+
 #### Choosing between `UseCanvasResources` and `OnCreateResources`
 
 Both create device-backed resources with device-loss recovery; they differ in *which* device owns the resource:

--- a/docs/_pipeline/templates/win2d-canvas.md.dt
+++ b/docs/_pipeline/templates/win2d-canvas.md.dt
@@ -88,6 +88,45 @@ Keep tile math deterministic. Region callbacks can arrive in any visible tile or
 ```csharp snippet="win2d-canvas/use-canvas-resources"
 ```
 
+> **Shared device required.** `UseCanvasResources` builds resources on Win2D's process-wide shared device. Any canvas that draws those resources must opt into the same device with `.UseSharedDevice()` — see [Shared device](#shared-device).
+
+### Shared device
+
+Win2D resources (bitmaps, geometries, render targets) are **device-affine**: a resource created on one `CanvasDevice` can only be drawn by a drawing session from that same device. By default each canvas control owns a *dedicated* device, while `UseCanvasResources` builds resources on the *shared* device returned by `CanvasDevice.GetSharedDevice()`. Drawing a shared-device resource with a control that owns a different device raises a cross-device error that surfaces as a **fatal stowed exception** (the app crashes, not throws).
+
+Opt the canvas into the shared device with the declarative `.UseSharedDevice()` modifier whenever it draws `UseCanvasResources` output (or any resource built from `CanvasDevice.GetSharedDevice()`):
+
+```csharp
+Win2DAnimatedCanvas(onUpdate: ..., onDraw: ..., drawState: dots.Current)
+    .TargetFps(60)
+    .UseSharedDevice();
+```
+
+The modifier is available on all three canvas elements (`Win2DCanvas`, `Win2DAnimatedCanvas`, `Win2DVirtualCanvas`). Resources created and drawn entirely within a single canvas's own `OnCreateResources` (using that control's device) do not need it.
+
+#### Choosing between `UseCanvasResources` and `OnCreateResources`
+
+Both create device-backed resources with device-loss recovery; they differ in *which* device owns the resource:
+
+| | `UseCanvasResources` hook | Canvas `OnCreateResources` callback |
+|---|---|---|
+| Device | Win2D's process-wide **shared** device | The **canvas's own** device (`ctrl.Device`) |
+| Requires `.UseSharedDevice()` | Yes, on every canvas that draws the resource | No |
+| Reuse across multiple canvases | Yes — one hook, many canvases | No — per canvas |
+| Resource lifetime | Owned by the hook (ref + auto-dispose on unmount) | You store/dispose it yourself |
+| Best for | Sprites/atlases shared by several canvases, or component-level resource state | A resource only one canvas draws |
+
+The `create` callback you pass to `UseCanvasResources` already receives the `CanvasDevice` to build on — the hook deliberately supplies the *shared* device so a single resource can feed any number of canvases. Passing a canvas's own device into the hook instead is not supported: the control creates its device lazily (it is usually not realized when the hook's effect runs) and replaces it on device loss, so there is no stable per-canvas device to hand the hook. When you want a resource bound to one canvas's device, create it in that canvas's `OnCreateResources` — Win2D re-raises the callback with the fresh device after a loss:
+
+```csharp
+Win2DAnimatedCanvas(
+    onUpdate: ...,
+    onDraw: (session, _, _) => { if (_sprite is { } s) session.DrawImage(s); }) with
+{
+    OnCreateResources = async ctrl => _sprite = await CanvasBitmap.LoadAsync(ctrl.Device, spriteUri)
+};
+```
+
 ### `UseDrawCommand`
 
 `UseDrawCommand` is the Win2D equivalent of `UseCallback`: memoize a manual draw delegate when rebuilding the delegate would allocate or capture too much on every render.
@@ -136,7 +175,7 @@ The [Particle Storm sample](../../samples/apps/particle-storm/) is the canonical
 
 - **Manual invalidate pattern.** Derive a `RedrawKey` from every value the manual scene reads, and let reconciliation schedule exactly one invalidate.
 - **Reactive game-loop pattern.** Store particle/physics buffers in `UseDrawState`; drive parameters from [hooks](hooks.md) and let `OnUpdate` read the latest values on the next tick.
-- **Device-loss-safe resource pattern.** Acquire bitmaps and render targets through `UseCanvasResources`, draw only when the ref is non-null, and dispose custom resources in the hook's `dispose` callback when needed.
+- **Device-loss-safe resource pattern.** Acquire bitmaps and render targets through `UseCanvasResources`, draw only when the ref is non-null, and dispose custom resources in the hook's `dispose` callback when needed. Add `.UseSharedDevice()` to the canvas that draws them (see [Shared device](#shared-device)).
 - **Virtual tile pattern.** Use coordinate-derived drawing and pass a new `InvalidateRegions` list for changed tiles.
 
 ## Common Mistakes
@@ -145,6 +184,7 @@ The [Particle Storm sample](../../samples/apps/particle-storm/) is the canonical
 - Missing `RedrawKey` for value-driven manual scenes, which leaves stale pixels until a resize or DPI change.
 - Allocating bitmaps, brushes, arrays, or strings per frame in `OnDraw` instead of reusing draw state and resources.
 - Passing the same `InvalidateRegions` list instance after mutating it; Reactor keys invalidation by reference change.
+- Drawing `UseCanvasResources` output (or any `CanvasDevice.GetSharedDevice()` resource) on a canvas that has not opted into `.UseSharedDevice()`; the cross-device draw crashes the app with a stowed exception. See [Shared device](#shared-device).
 
 ## Next Steps
 

--- a/docs/guide/win2d-canvas.md
+++ b/docs/guide/win2d-canvas.md
@@ -276,6 +276,8 @@ Win2DAnimatedCanvas(onUpdate: ..., onDraw: ..., drawState: dots.Current)
 
 The modifier is available on all three canvas elements (`Win2DCanvas`, `Win2DAnimatedCanvas`, `Win2DVirtualCanvas`). Resources created and drawn entirely within a single canvas's own `OnCreateResources` (using that control's device) do not need it.
 
+`UseSharedDevice` is a **device-construction setting**: Win2D evaluates it once when the control first realizes its device. It is fixed for the control's lifetime — toggling `.UseSharedDevice()` on a live canvas across re-renders is not supported (it would force a crash-prone in-place device recreation, so Reactor ignores the change in release builds and throws a clear error in debug builds). To switch devices, remount the canvas via a different `key`.
+
 #### Choosing between `UseCanvasResources` and `OnCreateResources`
 
 Both create device-backed resources with device-loss recovery; they differ in *which* device owns the resource:

--- a/docs/guide/win2d-canvas.md
+++ b/docs/guide/win2d-canvas.md
@@ -99,6 +99,10 @@ class AnimatedCanvasDemo : Component
                     .TargetFps(60)
                     .Width(420)
                     .Height(220)
+                    // UseCanvasResources builds the sprite on Win2D's shared device, so the
+                    // canvas must draw with that same device — otherwise the cross-device
+                    // DrawImage raises a fatal stowed exception.
+                    .UseSharedDevice()
             ).Padding(20);
         });
     }
@@ -221,6 +225,10 @@ class AnimatedCanvasDemo : Component
                     .TargetFps(60)
                     .Width(420)
                     .Height(220)
+                    // UseCanvasResources builds the sprite on Win2D's shared device, so the
+                    // canvas must draw with that same device — otherwise the cross-device
+                    // DrawImage raises a fatal stowed exception.
+                    .UseSharedDevice()
             ).Padding(20);
         });
     }
@@ -250,6 +258,45 @@ var sprite = ctx.UseCanvasResources<CanvasBitmap>(device =>
         Windows.Graphics.DirectX.DirectXPixelFormat.B8G8R8A8UIntNormalized);
     return ValueTask.FromResult(bitmap);
 });
+```
+
+> **Shared device required.** `UseCanvasResources` builds resources on Win2D's process-wide shared device. Any canvas that draws those resources must opt into the same device with `.UseSharedDevice()` — see [Shared device](#shared-device).
+
+### Shared device
+
+Win2D resources (bitmaps, geometries, render targets) are **device-affine**: a resource created on one `CanvasDevice` can only be drawn by a drawing session from that same device. By default each canvas control owns a *dedicated* device, while `UseCanvasResources` builds resources on the *shared* device returned by `CanvasDevice.GetSharedDevice()`. Drawing a shared-device resource with a control that owns a different device raises a cross-device error that surfaces as a **fatal stowed exception** (the app crashes, not throws).
+
+Opt the canvas into the shared device with the declarative `.UseSharedDevice()` modifier whenever it draws `UseCanvasResources` output (or any resource built from `CanvasDevice.GetSharedDevice()`):
+
+```csharp
+Win2DAnimatedCanvas(onUpdate: ..., onDraw: ..., drawState: dots.Current)
+    .TargetFps(60)
+    .UseSharedDevice();
+```
+
+The modifier is available on all three canvas elements (`Win2DCanvas`, `Win2DAnimatedCanvas`, `Win2DVirtualCanvas`). Resources created and drawn entirely within a single canvas's own `OnCreateResources` (using that control's device) do not need it.
+
+#### Choosing between `UseCanvasResources` and `OnCreateResources`
+
+Both create device-backed resources with device-loss recovery; they differ in *which* device owns the resource:
+
+| | `UseCanvasResources` hook | Canvas `OnCreateResources` callback |
+|---|---|---|
+| Device | Win2D's process-wide **shared** device | The **canvas's own** device (`ctrl.Device`) |
+| Requires `.UseSharedDevice()` | Yes, on every canvas that draws the resource | No |
+| Reuse across multiple canvases | Yes — one hook, many canvases | No — per canvas |
+| Resource lifetime | Owned by the hook (ref + auto-dispose on unmount) | You store/dispose it yourself |
+| Best for | Sprites/atlases shared by several canvases, or component-level resource state | A resource only one canvas draws |
+
+The `create` callback you pass to `UseCanvasResources` already receives the `CanvasDevice` to build on — the hook deliberately supplies the *shared* device so a single resource can feed any number of canvases. Passing a canvas's own device into the hook instead is not supported: the control creates its device lazily (it is usually not realized when the hook's effect runs) and replaces it on device loss, so there is no stable per-canvas device to hand the hook. When you want a resource bound to one canvas's device, create it in that canvas's `OnCreateResources` — Win2D re-raises the callback with the fresh device after a loss:
+
+```csharp
+Win2DAnimatedCanvas(
+    onUpdate: ...,
+    onDraw: (session, _, _) => { if (_sprite is { } s) session.DrawImage(s); }) with
+{
+    OnCreateResources = async ctrl => _sprite = await CanvasBitmap.LoadAsync(ctrl.Device, spriteUri)
+};
 ```
 
 ### `UseDrawCommand`
@@ -300,7 +347,7 @@ The [Particle Storm sample](../../samples/apps/particle-storm/) is the canonical
 
 - **Manual invalidate pattern.** Derive a `RedrawKey` from every value the manual scene reads, and let reconciliation schedule exactly one invalidate.
 - **Reactive game-loop pattern.** Store particle/physics buffers in `UseDrawState`; drive parameters from [hooks](hooks.md) and let `OnUpdate` read the latest values on the next tick.
-- **Device-loss-safe resource pattern.** Acquire bitmaps and render targets through `UseCanvasResources`, draw only when the ref is non-null, and dispose custom resources in the hook's `dispose` callback when needed.
+- **Device-loss-safe resource pattern.** Acquire bitmaps and render targets through `UseCanvasResources`, draw only when the ref is non-null, and dispose custom resources in the hook's `dispose` callback when needed. Add `.UseSharedDevice()` to the canvas that draws them (see [Shared device](#shared-device)).
 - **Virtual tile pattern.** Use coordinate-derived drawing and pass a new `InvalidateRegions` list for changed tiles.
 
 ## Common Mistakes
@@ -309,6 +356,7 @@ The [Particle Storm sample](../../samples/apps/particle-storm/) is the canonical
 - Missing `RedrawKey` for value-driven manual scenes, which leaves stale pixels until a resize or DPI change.
 - Allocating bitmaps, brushes, arrays, or strings per frame in `OnDraw` instead of reusing draw state and resources.
 - Passing the same `InvalidateRegions` list instance after mutating it; Reactor keys invalidation by reference change.
+- Drawing `UseCanvasResources` output (or any `CanvasDevice.GetSharedDevice()` resource) on a canvas that has not opted into `.UseSharedDevice()`; the cross-device draw crashes the app with a stowed exception. See [Shared device](#shared-device).
 
 ## Next Steps
 

--- a/docs/specs/053-reactor-advanced-and-win2d-canvas.md
+++ b/docs/specs/053-reactor-advanced-and-win2d-canvas.md
@@ -1123,12 +1123,19 @@ compositor-effects toolkit; it doesn't belong in the Win2D surface.
      set before the control realizes its device. Instead we ship a
      declarative `.UseSharedDevice()` modifier on all three canvas
      elements (`Win2DCanvas`/`Win2DAnimatedCanvas`/`Win2DVirtualCanvas`),
-     wired through each handler's Mount/Update before resource
-     creation. The hook XML docs and the
+     applied by each handler **at Mount only** — before the control
+     realizes its device. It is a device-construction setting fixed for
+     the control's lifetime: toggling it on a live control would force a
+     crash-prone in-place device recreation (observed intermittent
+     access violation), so Update does not write it; instead a debug
+     guard (`Win2DSharedDeviceGuard`) throws a clear message on change,
+     and release builds ignore it (to change devices, remount via a
+     `key`). The hook XML docs and the
      [shared-device guide section](../guide/win2d-canvas.md#shared-device)
      state the requirement. Without it the cross-device draw raises a
      fatal stowed exception (process crash). Regression-guarded by the
-     `Win2D_AnimatedCanvas_SharedDeviceResourceDraws` selftest.
+     `Win2D_AnimatedCanvas_SharedDeviceResourceDraws` selftest and the
+     `Win2DSharedDeviceGuardTests` unit tests.
 4. **Sample under AOT publish.** Verify Particle Storm publishes
    AOT-clean. Spec 048 §1 and prior AOT spec hooks expect this; Win2D
    has documented AOT compatibility from 1.2.0 forward, so the

--- a/docs/specs/053-reactor-advanced-and-win2d-canvas.md
+++ b/docs/specs/053-reactor-advanced-and-win2d-canvas.md
@@ -1113,6 +1113,22 @@ compositor-effects toolkit; it doesn't belong in the Win2D surface.
    into shared-device when called from a parent component above
    multiple canvases? Probably yes, but the implementation has subtle
    ordering concerns. Defer to implementation PR.
+   - **CLOSE-OUT (resolved): explicit author opt-in, not automatic.**
+     `UseCanvasResources` builds resources on the shared device
+     (`CanvasDevice.GetSharedDevice()`). Win2D resources are
+     device-affine, so a canvas drawing them must use the *same*
+     device. Auto-opt-in is unworkable: the hook lives in a parent
+     component and cannot know which (potentially several) descendant
+     canvases will draw its resources, and `UseSharedDevice` must be
+     set before the control realizes its device. Instead we ship a
+     declarative `.UseSharedDevice()` modifier on all three canvas
+     elements (`Win2DCanvas`/`Win2DAnimatedCanvas`/`Win2DVirtualCanvas`),
+     wired through each handler's Mount/Update before resource
+     creation. The hook XML docs and the
+     [shared-device guide section](../guide/win2d-canvas.md#shared-device)
+     state the requirement. Without it the cross-device draw raises a
+     fatal stowed exception (process crash). Regression-guarded by the
+     `Win2D_AnimatedCanvas_SharedDeviceResourceDraws` selftest.
 4. **Sample under AOT publish.** Verify Particle Storm publishes
    AOT-clean. Spec 048 §1 and prior AOT spec hooks expect this; Win2D
    has documented AOT compatibility from 1.2.0 forward, so the

--- a/src/Reactor.Advanced/Win2D/Hooks/UseCanvasResources.cs
+++ b/src/Reactor.Advanced/Win2D/Hooks/UseCanvasResources.cs
@@ -13,9 +13,20 @@ public static class UseCanvasResourcesHook
     /// after <see cref="CanvasDevice.DeviceLost"/>, and disposes them on unmount.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Resources are created on the process-wide shared device
+    /// (<see cref="CanvasDevice.GetSharedDevice()"/>). Win2D resources are device-affine, so any
+    /// canvas that draws these resources <b>must</b> opt into the shared device via
+    /// <c>.UseSharedDevice()</c> (or <c>UseSharedDevice = true</c>). A canvas defaults to its own
+    /// dedicated device; drawing a shared-device resource with that device raises a cross-device
+    /// error that surfaces as a fatal stowed exception. See
+    /// <see href="docs/guide/win2d-canvas.md#shared-device">the shared-device guidance</see>.
+    /// </para>
+    /// <para>
     /// The resource factory can run on a Win2D worker or game thread depending on
     /// the host canvas. See <see href="docs/guide/win2d-canvas.md#threading">the
     /// Win2D canvas threading guide</see> and <see href="docs/guide/win2d-canvas.md#device-loss">device loss</see>.
+    /// </para>
     /// </remarks>
     public static Ref<TResources?> UseCanvasResources<TResources>(
         this RenderContext ctx,

--- a/src/Reactor.Advanced/Win2D/Win2DAnimatedCanvasElement.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DAnimatedCanvasElement.cs
@@ -73,6 +73,8 @@ public sealed record Win2DAnimatedCanvasElement : Element
     /// drawing a shared-device resource with a control that owns a different device raises a
     /// cross-device error that surfaces as a fatal stowed exception. See
     /// <see href="docs/guide/win2d-canvas.md#shared-device">the shared-device guidance</see>.
+    /// This is a device-construction setting evaluated once when the control mounts; to change it,
+    /// remount the canvas (e.g. via a different key) rather than toggling it on a live control.
     /// </remarks>
     public bool UseSharedDevice { get; init; }
 

--- a/src/Reactor.Advanced/Win2D/Win2DAnimatedCanvasElement.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DAnimatedCanvasElement.cs
@@ -63,6 +63,20 @@ public sealed record Win2DAnimatedCanvasElement : Element
     public Color ClearColor { get; init; } = new() { A = 0, R = 0, G = 0, B = 0 };
 
     /// <summary>
+    /// Whether the control draws with Win2D's process-wide shared <see cref="CanvasDevice"/>
+    /// (<see cref="CanvasAnimatedControl.UseSharedDevice"/>) instead of its own dedicated device.
+    /// </summary>
+    /// <remarks>
+    /// This <b>must</b> be <c>true</c> when the canvas draws resources created by the
+    /// <c>UseCanvasResources</c> hook (or any other resource built from
+    /// <see cref="CanvasDevice.GetSharedDevice()"/>). Win2D resources are device-affine:
+    /// drawing a shared-device resource with a control that owns a different device raises a
+    /// cross-device error that surfaces as a fatal stowed exception. See
+    /// <see href="docs/guide/win2d-canvas.md#shared-device">the shared-device guidance</see>.
+    /// </remarks>
+    public bool UseSharedDevice { get; init; }
+
+    /// <summary>
     /// Raw Win2D control setters applied after typed properties.
     /// </summary>
     public Action<CanvasAnimatedControl>[] Setters { get; init; } = Array.Empty<Action<CanvasAnimatedControl>>();

--- a/src/Reactor.Advanced/Win2D/Win2DAnimatedCanvasHandler.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DAnimatedCanvasHandler.cs
@@ -30,6 +30,12 @@ public sealed class Win2DAnimatedCanvasHandler : IElementHandler<Win2DAnimatedCa
         var ctrl = ctx.RentControl<CanvasAnimatedControl>();
         Reconciler.SetElementTag(ctrl, el);
 
+        // Set UseSharedDevice before the control realizes its device so resource creation
+        // (incl. UseCanvasResources, which builds on CanvasDevice.GetSharedDevice) targets
+        // the same device the control draws with. Rented controls may carry a stale value.
+        if (ctrl.UseSharedDevice != el.UseSharedDevice)
+            ctrl.UseSharedDevice = el.UseSharedDevice;
+
         if (ctrl.ClearColor != el.ClearColor)
             ctrl.ClearColor = el.ClearColor;
         if (ctrl.TargetElapsedTime != el.TargetElapsedTime)
@@ -75,6 +81,9 @@ public sealed class Win2DAnimatedCanvasHandler : IElementHandler<Win2DAnimatedCa
             subscriptions.Element = newEl;
 
         Reconciler.SetElementTag(ctrl, newEl);
+
+        if (ctrl.UseSharedDevice != newEl.UseSharedDevice)
+            ctrl.UseSharedDevice = newEl.UseSharedDevice;
 
         // IsPaused is enforced inside InvokeUpdate/InvokeDraw by skipping the user's
         // delegate when the latest element says paused. We do NOT write

--- a/src/Reactor.Advanced/Win2D/Win2DAnimatedCanvasHandler.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DAnimatedCanvasHandler.cs
@@ -82,8 +82,8 @@ public sealed class Win2DAnimatedCanvasHandler : IElementHandler<Win2DAnimatedCa
 
         Reconciler.SetElementTag(ctrl, newEl);
 
-        if (ctrl.UseSharedDevice != newEl.UseSharedDevice)
-            ctrl.UseSharedDevice = newEl.UseSharedDevice;
+        // UseSharedDevice is fixed at mount; toggling it on a live control can crash (see guard).
+        Win2DSharedDeviceGuard.EnsureUseSharedDeviceUnchanged(oldEl.UseSharedDevice, newEl.UseSharedDevice);
 
         // IsPaused is enforced inside InvokeUpdate/InvokeDraw by skipping the user's
         // delegate when the latest element says paused. We do NOT write

--- a/src/Reactor.Advanced/Win2D/Win2DCanvasElement.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DCanvasElement.cs
@@ -26,6 +26,20 @@ public sealed record Win2DCanvasElement : Element
     public Color ClearColor { get; init; } = new() { A = 0, R = 0, G = 0, B = 0 };
 
     /// <summary>
+    /// Whether the control draws with Win2D's process-wide shared <see cref="CanvasDevice"/>
+    /// (<see cref="CanvasControl.UseSharedDevice"/>) instead of its own dedicated device.
+    /// </summary>
+    /// <remarks>
+    /// This <b>must</b> be <c>true</c> when the canvas draws resources created by the
+    /// <c>UseCanvasResources</c> hook (or any other resource built from
+    /// <see cref="CanvasDevice.GetSharedDevice()"/>). Win2D resources are device-affine:
+    /// drawing a shared-device resource with a control that owns a different device raises a
+    /// cross-device error that surfaces as a fatal stowed exception. See
+    /// <see href="docs/guide/win2d-canvas.md#shared-device">the shared-device guidance</see>.
+    /// </remarks>
+    public bool UseSharedDevice { get; init; }
+
+    /// <summary>
     /// Opaque key that triggers <see cref="CanvasControl.Invalidate"/> when the key object changes.
     /// </summary>
     public object? RedrawKey { get; init; }

--- a/src/Reactor.Advanced/Win2D/Win2DCanvasElement.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DCanvasElement.cs
@@ -36,6 +36,8 @@ public sealed record Win2DCanvasElement : Element
     /// drawing a shared-device resource with a control that owns a different device raises a
     /// cross-device error that surfaces as a fatal stowed exception. See
     /// <see href="docs/guide/win2d-canvas.md#shared-device">the shared-device guidance</see>.
+    /// This is a device-construction setting evaluated once when the control mounts; to change it,
+    /// remount the canvas (e.g. via a different key) rather than toggling it on a live control.
     /// </remarks>
     public bool UseSharedDevice { get; init; }
 

--- a/src/Reactor.Advanced/Win2D/Win2DCanvasHandler.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DCanvasHandler.cs
@@ -51,8 +51,8 @@ public sealed class Win2DCanvasHandler : IElementHandler<Win2DCanvasElement, Can
         Reconciler.SetElementTag(ctrl, newEl);
         var bind = ctx.BindFor(ctrl, newEl);
 
-        if (ctrl.UseSharedDevice != newEl.UseSharedDevice)
-            ctrl.UseSharedDevice = newEl.UseSharedDevice;
+        // UseSharedDevice is fixed at mount; toggling it on a live control can crash (see guard).
+        Win2DSharedDeviceGuard.EnsureUseSharedDeviceUnchanged(oldEl.UseSharedDevice, newEl.UseSharedDevice);
 
         if (ctrl.ClearColor != newEl.ClearColor)
             bind.WriteSuppressed(() => ctrl.ClearColor = newEl.ClearColor);

--- a/src/Reactor.Advanced/Win2D/Win2DCanvasHandler.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DCanvasHandler.cs
@@ -18,6 +18,12 @@ public sealed class Win2DCanvasHandler : IElementHandler<Win2DCanvasElement, Can
         var ctrl = ctx.RentControl<CanvasControl>();
         Reconciler.SetElementTag(ctrl, el);
 
+        // Set UseSharedDevice before the control realizes its device so resource creation
+        // (incl. UseCanvasResources, which builds on CanvasDevice.GetSharedDevice) targets
+        // the same device the control draws with. Rented controls may carry a stale value.
+        if (ctrl.UseSharedDevice != el.UseSharedDevice)
+            ctrl.UseSharedDevice = el.UseSharedDevice;
+
         if (ctrl.ClearColor != el.ClearColor)
             ctrl.ClearColor = el.ClearColor;
 
@@ -44,6 +50,9 @@ public sealed class Win2DCanvasHandler : IElementHandler<Win2DCanvasElement, Can
     {
         Reconciler.SetElementTag(ctrl, newEl);
         var bind = ctx.BindFor(ctrl, newEl);
+
+        if (ctrl.UseSharedDevice != newEl.UseSharedDevice)
+            ctrl.UseSharedDevice = newEl.UseSharedDevice;
 
         if (ctrl.ClearColor != newEl.ClearColor)
             bind.WriteSuppressed(() => ctrl.ClearColor = newEl.ClearColor);

--- a/src/Reactor.Advanced/Win2D/Win2DCanvasModifiers.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DCanvasModifiers.cs
@@ -41,6 +41,27 @@ public static class Win2DCanvasModifiers
     }
 
     /// <summary>
+    /// Opts a manual Win2D canvas into Win2D's process-wide shared device. Required when the
+    /// canvas draws resources created by the <c>UseCanvasResources</c> hook.
+    /// </summary>
+    public static Win2DCanvasElement UseSharedDevice(this Win2DCanvasElement el, bool useSharedDevice = true) =>
+        el with { UseSharedDevice = useSharedDevice };
+
+    /// <summary>
+    /// Opts an animated Win2D canvas into Win2D's process-wide shared device. Required when the
+    /// canvas draws resources created by the <c>UseCanvasResources</c> hook.
+    /// </summary>
+    public static Win2DAnimatedCanvasElement UseSharedDevice(this Win2DAnimatedCanvasElement el, bool useSharedDevice = true) =>
+        el with { UseSharedDevice = useSharedDevice };
+
+    /// <summary>
+    /// Opts a virtual Win2D canvas into Win2D's process-wide shared device. Required when the
+    /// canvas draws resources created by the <c>UseCanvasResources</c> hook.
+    /// </summary>
+    public static Win2DVirtualCanvasElement UseSharedDevice(this Win2DVirtualCanvasElement el, bool useSharedDevice = true) =>
+        el with { UseSharedDevice = useSharedDevice };
+
+    /// <summary>
     /// Adds a raw <see cref="CanvasControl"/> setter to a manual Win2D canvas.
     /// </summary>
     public static Win2DCanvasElement Set(this Win2DCanvasElement el, Action<CanvasControl> setter) =>

--- a/src/Reactor.Advanced/Win2D/Win2DSharedDeviceGuard.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DSharedDeviceGuard.cs
@@ -1,0 +1,33 @@
+namespace Microsoft.UI.Reactor.Advanced.Win2D;
+
+/// <summary>
+/// Shared guard for the Win2D canvas handlers' <c>UseSharedDevice</c> contract.
+/// </summary>
+internal static class Win2DSharedDeviceGuard
+{
+    /// <summary>
+    /// <c>UseSharedDevice</c> is a device-construction setting: Win2D evaluates it once when the
+    /// control first realizes its device. Changing it on a live control forces an in-place device
+    /// recreation that can race the render/teardown and crash (observed intermittent access
+    /// violation). Handlers set it only at mount; this verifies the value did not change across a
+    /// re-render. In release builds the new value is intentionally ignored (the control keeps its
+    /// mount-time device), so a stray toggle is stable rather than crash-prone. In debug builds it
+    /// throws a clear, actionable message instead of failing later with a native crash.
+    /// </summary>
+    public static void EnsureUseSharedDeviceUnchanged(bool oldValue, bool newValue)
+    {
+#if DEBUG
+        if (oldValue != newValue)
+        {
+            throw new InvalidOperationException(
+                "Win2D canvas UseSharedDevice cannot change after mount: it is a device-construction " +
+                "setting and toggling it on a live control triggers an in-place device recreation that " +
+                "can crash. Remount the canvas (e.g. via a different key) to switch devices. See " +
+                "docs/guide/win2d-canvas.md#shared-device.");
+        }
+#else
+        _ = oldValue;
+        _ = newValue;
+#endif
+    }
+}

--- a/src/Reactor.Advanced/Win2D/Win2DVirtualCanvasElement.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DVirtualCanvasElement.cs
@@ -26,6 +26,20 @@ public sealed record Win2DVirtualCanvasElement : Element
     public Size ContentSize { get; init; } = new(800, 600);
 
     /// <summary>
+    /// Whether the control draws with Win2D's process-wide shared <see cref="CanvasDevice"/>
+    /// (<see cref="CanvasVirtualControl.UseSharedDevice"/>) instead of its own dedicated device.
+    /// </summary>
+    /// <remarks>
+    /// This <b>must</b> be <c>true</c> when the canvas draws resources created by the
+    /// <c>UseCanvasResources</c> hook (or any other resource built from
+    /// <see cref="CanvasDevice.GetSharedDevice()"/>). Win2D resources are device-affine:
+    /// drawing a shared-device resource with a control that owns a different device raises a
+    /// cross-device error that surfaces as a fatal stowed exception. See
+    /// <see href="docs/guide/win2d-canvas.md#shared-device">the shared-device guidance</see>.
+    /// </remarks>
+    public bool UseSharedDevice { get; init; }
+
+    /// <summary>
     /// Regions to invalidate when the list instance changes.
     /// </summary>
     public IReadOnlyList<Rect>? InvalidateRegions { get; init; }

--- a/src/Reactor.Advanced/Win2D/Win2DVirtualCanvasElement.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DVirtualCanvasElement.cs
@@ -36,6 +36,8 @@ public sealed record Win2DVirtualCanvasElement : Element
     /// drawing a shared-device resource with a control that owns a different device raises a
     /// cross-device error that surfaces as a fatal stowed exception. See
     /// <see href="docs/guide/win2d-canvas.md#shared-device">the shared-device guidance</see>.
+    /// This is a device-construction setting evaluated once when the control mounts; to change it,
+    /// remount the canvas (e.g. via a different key) rather than toggling it on a live control.
     /// </remarks>
     public bool UseSharedDevice { get; init; }
 

--- a/src/Reactor.Advanced/Win2D/Win2DVirtualCanvasHandler.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DVirtualCanvasHandler.cs
@@ -49,8 +49,8 @@ public sealed class Win2DVirtualCanvasHandler : IElementHandler<Win2DVirtualCanv
     {
         Reconciler.SetElementTag(ctrl, newEl);
 
-        if (ctrl.UseSharedDevice != newEl.UseSharedDevice)
-            ctrl.UseSharedDevice = newEl.UseSharedDevice;
+        // UseSharedDevice is fixed at mount; toggling it on a live control can crash (see guard).
+        Win2DSharedDeviceGuard.EnsureUseSharedDeviceUnchanged(oldEl.UseSharedDevice, newEl.UseSharedDevice);
 
         if (!SizesEqual(ctrl.Width, ctrl.Height, newEl.ContentSize.Width, newEl.ContentSize.Height))
             ApplyContentSize(ctrl, newEl);

--- a/src/Reactor.Advanced/Win2D/Win2DVirtualCanvasHandler.cs
+++ b/src/Reactor.Advanced/Win2D/Win2DVirtualCanvasHandler.cs
@@ -17,6 +17,13 @@ public sealed class Win2DVirtualCanvasHandler : IElementHandler<Win2DVirtualCanv
     {
         var ctrl = ctx.RentControl<CanvasVirtualControl>();
         Reconciler.SetElementTag(ctrl, el);
+
+        // Set UseSharedDevice before the control realizes its device so resource creation
+        // (incl. UseCanvasResources, which builds on CanvasDevice.GetSharedDevice) targets
+        // the same device the control draws with. Rented controls may carry a stale value.
+        if (ctrl.UseSharedDevice != el.UseSharedDevice)
+            ctrl.UseSharedDevice = el.UseSharedDevice;
+
         ApplyContentSize(ctrl, el);
 
         var bind = ctx.BindFor(ctrl, el);
@@ -41,6 +48,9 @@ public sealed class Win2DVirtualCanvasHandler : IElementHandler<Win2DVirtualCanv
     public void Update(UpdateContext ctx, Win2DVirtualCanvasElement oldEl, Win2DVirtualCanvasElement newEl, CanvasVirtualControl ctrl)
     {
         Reconciler.SetElementTag(ctrl, newEl);
+
+        if (ctrl.UseSharedDevice != newEl.UseSharedDevice)
+            ctrl.UseSharedDevice = newEl.UseSharedDevice;
 
         if (!SizesEqual(ctrl.Width, ctrl.Height, newEl.ContentSize.Width, newEl.ContentSize.Height))
             ApplyContentSize(ctrl, newEl);

--- a/tests/Reactor.Advanced.Tests/Win2DCanvasModifiersTests.cs
+++ b/tests/Reactor.Advanced.Tests/Win2DCanvasModifiersTests.cs
@@ -72,5 +72,33 @@ public sealed class Win2DCanvasModifiersTests
 
         Assert.Throws<ArgumentOutOfRangeException>(() => original.TargetFps(0));
     }
+
+    [Fact]
+    public void UseSharedDevice_OptsInForAllCanvasKindsWithoutMutatingOriginal()
+    {
+        var canvas = Win2DCanvas(static (CanvasDrawingSession _, CanvasDrawEventArgs _) => { });
+        var animated = Win2DAnimatedCanvas(
+            static (CanvasAnimatedUpdateEventArgs _, object? _) => { },
+            static (CanvasDrawingSession _, CanvasAnimatedDrawEventArgs _, object? _) => { });
+        var virtualCanvas = Win2DVirtualCanvas(static (CanvasDrawingSession _, Rect _) => { }, new Size(10, 10));
+
+        Assert.False(canvas.UseSharedDevice);
+        Assert.False(animated.UseSharedDevice);
+        Assert.False(virtualCanvas.UseSharedDevice);
+
+        var canvasUpdated = canvas.UseSharedDevice();
+        var animatedUpdated = animated.UseSharedDevice();
+        var virtualUpdated = virtualCanvas.UseSharedDevice();
+
+        Assert.NotSame(canvas, canvasUpdated);
+        Assert.False(canvas.UseSharedDevice);
+        Assert.False(animated.UseSharedDevice);
+        Assert.False(virtualCanvas.UseSharedDevice);
+        Assert.True(canvasUpdated.UseSharedDevice);
+        Assert.True(animatedUpdated.UseSharedDevice);
+        Assert.True(virtualUpdated.UseSharedDevice);
+
+        Assert.False(animatedUpdated.UseSharedDevice(false).UseSharedDevice);
+    }
 }
 

--- a/tests/Reactor.Advanced.Tests/Win2DSharedDeviceGuardTests.cs
+++ b/tests/Reactor.Advanced.Tests/Win2DSharedDeviceGuardTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Microsoft.UI.Reactor.Advanced.Win2D;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Advanced.Tests;
+
+/// <summary>
+/// Verifies the internal <c>Win2DSharedDeviceGuard</c> contract that backs the canvas handlers'
+/// "UseSharedDevice is fixed at mount" rule. The guard is internal, so it is invoked via reflection
+/// (the same approach <see cref="ElementConstructorTests"/> uses for internal element members).
+/// </summary>
+public sealed class Win2DSharedDeviceGuardTests
+{
+    private static MethodInfo GuardMethod()
+    {
+        var type = typeof(Win2DCanvasElement).Assembly
+            .GetType("Microsoft.UI.Reactor.Advanced.Win2D.Win2DSharedDeviceGuard", throwOnError: true)!;
+        return type.GetMethod("EnsureUseSharedDeviceUnchanged", BindingFlags.Public | BindingFlags.Static)!;
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void EnsureUseSharedDeviceUnchanged_SameValue_DoesNotThrow(bool oldValue, bool newValue)
+    {
+        var ex = Record.Exception(() => GuardMethod().Invoke(null, [oldValue, newValue]));
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void EnsureUseSharedDeviceUnchanged_ChangedValue_FailsFastInDebug(bool oldValue, bool newValue)
+    {
+        var ex = Record.Exception(() => GuardMethod().Invoke(null, [oldValue, newValue]));
+#if DEBUG
+        // Reactor.Advanced built Debug: toggling across renders fails fast with a clear message
+        // rather than performing the crash-prone in-place device recreation.
+        Assert.IsType<InvalidOperationException>(Assert.IsType<TargetInvocationException>(ex).InnerException);
+#else
+        // Release: the new value is intentionally ignored (control keeps its mount-time device).
+        Assert.Null(ex);
+#endif
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Win2DCanvasFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Win2DCanvasFixtures.cs
@@ -252,6 +252,73 @@ internal static class Win2DCanvasFixtures
         }
     }
 
+    /// <summary>
+    /// Regression guard for the cross-device crash: <c>UseCanvasResources</c> builds a
+    /// <c>CanvasBitmap</c> on Win2D's shared device, so the canvas drawing it must opt into
+    /// the shared device via <c>.UseSharedDevice()</c>. Without it the game-thread
+    /// <c>DrawImage</c> raises a cross-device error that surfaces as a fatal stowed exception
+    /// (process crash). With it, the canvas draws the shared-device resource cleanly.
+    /// </summary>
+    internal class AnimatedCanvasSharedDeviceResourceDraws(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var drawCount = 0;
+            var spriteDrawn = 0;
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var sprite = ctx.UseCanvasResources<CanvasBitmap>(device =>
+                {
+                    byte[] pixels =
+                    [
+                        0x00, 0x78, 0xD4, 0xFF,
+                        0x50, 0xC8, 0x78, 0xFF,
+                        0xFF, 0xB9, 0x00, 0xFF,
+                        0xD8, 0x3B, 0x01, 0xFF,
+                    ];
+
+                    var bitmap = CanvasBitmap.CreateFromBytes(
+                        device,
+                        pixels,
+                        widthInPixels: 2,
+                        heightInPixels: 2,
+                        global::Windows.Graphics.DirectX.DirectXPixelFormat.B8G8R8A8UIntNormalized);
+                    return ValueTask.FromResult(bitmap);
+                });
+
+                return VStack(8,
+                    Win2DAnimatedCanvas(
+                        onUpdate: (_, _) => { },
+                        onDraw: (session, _, _) =>
+                        {
+                            Interlocked.Increment(ref drawCount);
+                            session.Clear(Colors.Black);
+                            if (sprite.Current is { } bitmap)
+                            {
+                                // Cross-device draw when the canvas owns a different device →
+                                // fatal stowed exception. Safe only because of .UseSharedDevice().
+                                session.DrawImage(bitmap, 8, 8, new Rect(0, 0, 2, 2), 0.85f);
+                                Interlocked.Increment(ref spriteDrawn);
+                            }
+                        })
+                        .TargetFps(30)
+                        .Width(240)
+                        .Height(120)
+                        .UseSharedDevice());
+            });
+
+            H.Check("Win2D_AnimatedCanvas_SharedDeviceDraws",
+                await Harness.WaitFor(() => Volatile.Read(ref drawCount) >= 1, maxPasses: 60, perPassMs: 25));
+
+            H.Check("Win2D_AnimatedCanvas_SharedDeviceSpriteDrawn",
+                await Harness.WaitFor(() => Volatile.Read(ref spriteDrawn) >= 1, maxPasses: 120, perPassMs: 25));
+
+            host.Mount(_ => TextBlock("Win2D shared-device resource unmounted"));
+            await Harness.Render();
+        }
+    }
+
     private sealed class AnimatedProbe
     {
         public int Ticks;

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Win2DCanvasFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Win2DCanvasFixtures.cs
@@ -308,10 +308,10 @@ internal static class Win2DCanvasFixtures
                         .UseSharedDevice());
             });
 
-            H.Check("Win2D_AnimatedCanvas_SharedDeviceDraws",
+            H.Check("Win2D_AnimatedCanvas_SharedDeviceResourceDraws_Draws",
                 await Harness.WaitFor(() => Volatile.Read(ref drawCount) >= 1, maxPasses: 60, perPassMs: 25));
 
-            H.Check("Win2D_AnimatedCanvas_SharedDeviceSpriteDrawn",
+            H.Check("Win2D_AnimatedCanvas_SharedDeviceResourceDraws_SpriteDrawn",
                 await Harness.WaitFor(() => Volatile.Read(ref spriteDrawn) >= 1, maxPasses: 120, perPassMs: 25));
 
             host.Mount(_ => TextBlock("Win2D shared-device resource unmounted"));

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -238,6 +238,7 @@ internal static class SelfTestFixtureRegistry
         "Win2D_VirtualCanvas_Mount",
         "Win2D_AnimatedCanvas_InitialPausedResumes",
         "Win2D_Canvas_SameRedrawKeyNoExtraDraws",
+        "Win2D_AnimatedCanvas_SharedDeviceResourceDraws",
         // PR #324 review fixes — heterogeneous rows, RefreshRealizedItems
         // sync, and ItemsRepeater unmount cleanup.
         "EFR_Factory_ReplacementOnRootTypeChange_DropsOldControlTracking",
@@ -1516,6 +1517,7 @@ internal static class SelfTestFixtureRegistry
         "Win2D_VirtualCanvas_Mount" => new Win2DCanvasFixtures.VirtualCanvasMount(harness),
         "Win2D_AnimatedCanvas_InitialPausedResumes" => new Win2DCanvasFixtures.AnimatedCanvasInitialPausedResumes(harness),
         "Win2D_Canvas_SameRedrawKeyNoExtraDraws" => new Win2DCanvasFixtures.CanvasSameRedrawKeyNoExtraDraws(harness),
+        "Win2D_AnimatedCanvas_SharedDeviceResourceDraws" => new Win2DCanvasFixtures.AnimatedCanvasSharedDeviceResourceDraws(harness),
 
         "MdHtml_HtmlGeneration" => new MarkdownHtmlFixtures.HtmlGeneration(harness),
         "MdHtml_HtmlInWebView2" => new MarkdownHtmlFixtures.HtmlInWebView2(harness),


### PR DESCRIPTION
## Summary

Adds a declarative .UseSharedDevice() modifier (and backing property) to all three Win2D canvas elements, wired through their handlers, so canvases that draw UseCanvasResources output run on the same shared device the resources are created on. This fixes a fatal cross-device stowed-exception crash (0xC000027B) that occurred when drawing shared-device resources on a canvas using its own default device.

## Linked issue / spec

Fixes #577 

## Test plan

- [X] Added unit tests in tests/Reactor.Tests/...
- [X] Added selftest fixture in tests/Reactor.AppTests.Host/SelfTest/Fixtures/...
- [X] Ran `dotnet test tests/Reactor.Tests`