### PR TITLE
docs: fix UseState functional-updater examples (#347)

### DIFF
--- a/docs/_pipeline/templates/animation.md.dt
+++ b/docs/_pipeline/templates/animation.md.dt
@@ -458,7 +458,7 @@ value that changes every render (`DateTime.Now`, a freshly-allocated
 list, an inline lambda) restarts the animation on every reconcile —
 the element flickers as the keyframes constantly reset. Use a state
 counter that increments only when you mean to retrigger
-(`setCount(c => c + 1)`).
+(`var (count, updateCount) = UseReducer(0)`, then `updateCount(c => c + 1)`).
 
 ## Tips
 

--- a/docs/_pipeline/templates/charting.md.dt
+++ b/docs/_pipeline/templates/charting.md.dt
@@ -274,14 +274,14 @@ window of points. Hold the window in `UseState`, append on tick, drop
 the head once `Count` exceeds the window size:
 
 ```csharp
-var (samples, setSamples) = UseState<IReadOnlyList<Sample>>(Array.Empty<Sample>());
+var (samples, updateSamples) = UseReducer<IReadOnlyList<Sample>>(Array.Empty<Sample>());
 
 UseEffect(() =>
 {
     using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(200));
     while (await timer.WaitForNextTickAsync(token))
     {
-        setSamples(prev =>
+        updateSamples(prev =>
         {
             var next = prev.Append(Sample.Now()).ToList();
             return next.Count > 60 ? next.Skip(next.Count - 60).ToList() : next;

--- a/docs/_pipeline/templates/charting.md.dt
+++ b/docs/_pipeline/templates/charting.md.dt
@@ -270,8 +270,9 @@ unrelated `TextBox`.
 ### Live-updating chart from a ticking source
 
 A streaming chart — a price feed, a sensor reading — drives a sliding
-window of points. Hold the window in `UseState`, append on tick, drop
-the head once `Count` exceeds the window size:
+window of points. Hold the window in `UseReducer` (each tick derives the
+next window from the previous one), append on tick, drop the head once
+`Count` exceeds the window size:
 
 ```csharp
 var (samples, updateSamples) = UseReducer<IReadOnlyList<Sample>>(Array.Empty<Sample>());

--- a/docs/_pipeline/templates/effects-scheduling.md.dt
+++ b/docs/_pipeline/templates/effects-scheduling.md.dt
@@ -220,6 +220,7 @@ events arrive in the same order as the user's actions.
 
 ```csharp
 // Don't:
+var (count, setCount) = UseState(0);
 UseEffect(() => {
     setCount(count + 1);   // no deps → runs every commit → infinite loop
 });

--- a/docs/_pipeline/templates/effects-scheduling.md.dt
+++ b/docs/_pipeline/templates/effects-scheduling.md.dt
@@ -174,6 +174,8 @@ own [`Observable.cs#observable-bridge`](#) bridge follows this shape;
 so does any timer, event subscription, or background task.
 
 ```csharp
+var (seconds, updateSeconds) = UseReducer(0);
+
 UseEffect(() =>
 {
     var cts = new CancellationTokenSource();
@@ -181,13 +183,13 @@ UseEffect(() =>
     {
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
         while (await timer.WaitForNextTickAsync(cts.Token))
-            setSeconds(s => s + 1);
+            updateSeconds(s => s + 1);
     });
     return () => cts.Cancel();
 }, Array.Empty<object>());
 ```
 
-The setter `setSeconds` auto-marshals back to the UI thread (see
+The updater `updateSeconds` auto-marshals back to the UI thread (see
 [hooks](hooks.md) "Updating state from background work"). The cleanup
 cancels the token; the timer's `using` disposes when the
 `WaitForNextTickAsync` loop unblocks. No state leaks between mounts.
@@ -219,7 +221,7 @@ events arrive in the same order as the user's actions.
 ```csharp
 // Don't:
 UseEffect(() => {
-    setCount(c => c + 1);   // no deps → runs every commit → infinite loop
+    setCount(count + 1);   // no deps → runs every commit → infinite loop
 });
 ```
 

--- a/docs/_pipeline/templates/effects.md.dt
+++ b/docs/_pipeline/templates/effects.md.dt
@@ -179,9 +179,11 @@ WinUI control's `RoutedEventHandler`. Subscribe in the body, return an
 unsubscribe in the cleanup:
 
 ```csharp
+var (tick, updateTick) = UseReducer(0);
+
 UseEffect(() =>
 {
-    void Handler(object? s, EventArgs e) => setTick(t => t + 1);
+    void Handler(object? s, EventArgs e) => updateTick(t => t + 1);
     Source.Changed += Handler;
     return () => Source.Changed -= Handler;
 }, Source); // re-attach if Source identity changes
@@ -230,13 +232,15 @@ stable across renders.
 
 ```csharp
 // Don't:
+var (tick, updateTick) = UseReducer(0);
+
 UseEffect(() =>
 {
     var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
     _ = Task.Run(async () =>
     {
         while (await timer.WaitForNextTickAsync())
-            setTick(t => t + 1);
+            updateTick(t => t + 1);
     });
 }, Array.Empty<object>()); // no cleanup → timer fires forever after unmount
 ```
@@ -247,6 +251,8 @@ silently leaks the closure tree the timer captured). Always return a
 cleanup that cancels the producer:
 
 ```csharp
+var (tick, updateTick) = UseReducer(0);
+
 UseEffect(() =>
 {
     var cts = new CancellationTokenSource();
@@ -254,7 +260,7 @@ UseEffect(() =>
     _ = Task.Run(async () =>
     {
         while (await timer.WaitForNextTickAsync(cts.Token))
-            setTick(t => t + 1);
+            updateTick(t => t + 1);
     });
     return () => { cts.Cancel(); timer.Dispose(); };
 }, Array.Empty<object>());

--- a/docs/_pipeline/templates/hooks.md.dt
+++ b/docs/_pipeline/templates/hooks.md.dt
@@ -61,8 +61,11 @@ The most common hook. Returns the current value and a setter function:
 ![UseState demo](screenshot://hooks/usestate)
 
 Call `setColor("#FF0000")` and Reactor re-renders the component with the new
-value. The setter also accepts a function: `setSize(s => s + 1)` — this is
-safer when the update depends on the previous value.
+value. The setter is an `Action<T>` — it takes the **new value**, not a
+function of the previous one. When an update derives from the previous value
+(or you call the setter several times in one event), use
+[`UseReducer`](#usereducer-functional) instead — its updater receives the live
+previous value.
 
 ## UseReducer (Functional)
 
@@ -152,7 +155,7 @@ unnecessarily:
 
 ![UseCallback demo](screenshot://hooks/usecallback)
 
-Without `UseCallback`, the lambda `() => setCount(c => c + 1)` would be a new
+Without `UseCallback`, the lambda `() => updateCount(c => c + 1)` would be a new
 object every render. `UseCallback` returns the same delegate instance as long
 as the dependencies haven't changed. This matters when passing callbacks to
 memoized [child components](components.md).
@@ -170,7 +173,7 @@ you'd write on the UI thread:
 ```csharp
 public override Element Render()
 {
-    var (seconds, setSeconds) = UseState(0);
+    var (seconds, updateSeconds) = UseReducer(0);
 
     UseEffect(() =>
     {
@@ -179,7 +182,7 @@ public override Element Render()
         {
             using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
             while (await timer.WaitForNextTickAsync(cts.Token))
-                setSeconds(s => s + 1);   // auto-marshals to the UI thread
+                updateSeconds(s => s + 1);   // auto-marshals to the UI thread
         });
         return () => cts.Cancel();
     });
@@ -376,31 +379,34 @@ UseEffect(() =>
 
 The effect's empty deps array means it captures `count` once at mount.
 The timer fires forever with the stale closure, so the counter sticks at
-1. The fix is the functional-setter pattern — `setCount(c => c + 1)` —
-which reads the live cell value instead of the captured variable. The
-`Func<T,T>` overload of `UseState` and the entire `UseReducer` API are
-built around this.
+1. The fix is `UseReducer`'s functional updater — declare
+`var (count, updateCount) = UseReducer(0)` and call `updateCount(c => c + 1)`,
+which reads the live cell value instead of the captured variable. (`UseState`'s
+setter is an `Action<T>`; it only takes a value, so it can't express a
+previous-value update.)
 
-### Setter chain that should be `set(prev => ...)`
+### Setter chain that should use `UseReducer`
 
 ```csharp
 // Don't:
+var (count, setCount) = UseState(0);
 Button("+3", () => { setCount(count + 1); setCount(count + 1); setCount(count + 1); });
 ```
 
 The three setter calls all read the same captured `count` and all write
-`count + 1` — the button advances by one, not three. Use the functional
-form so each call sees the previous setter's result:
+`count + 1` — the button advances by one, not three. Switch to `UseReducer`
+so each functional update sees the previous one's result:
 
 ```csharp
-Button("+3", () => { setCount(c => c + 1); setCount(c => c + 1); setCount(c => c + 1); });
+var (count, updateCount) = UseReducer(0);
+Button("+3", () => { updateCount(c => c + 1); updateCount(c => c + 1); updateCount(c => c + 1); });
 ```
 
 This is the same Reactor-wide rule as the [stale closure](#stale-closures)
-pattern: when an update derives from the previous value, the functional
-setter is the right shape. The auto-marshal path for cross-thread setters
-described above relies on the same overload — every queued write reads
-the latest committed value, not a snapshot.
+pattern: when an update derives from the previous value, `UseReducer`'s
+functional updater is the right shape. The auto-marshal path for cross-thread
+updaters described above relies on the same mechanism — every queued update
+reads the latest committed value, not a snapshot.
 
 ### Reading state right after calling its setter
 
@@ -442,8 +448,10 @@ because they run on a later render and observe the fresh value.
 
 ## Tips
 
-**Use the functional setter for derived updates.** `setCount(c => c + 1)` is
-safer than `setCount(count + 1)` when multiple updates might batch together.
+**Use `UseReducer` for derived updates.** `updateCount(c => c + 1)` is safer
+than `setCount(count + 1)` when an update depends on the previous value or
+several updates run in one event — the functional updater reads the live
+value, while `UseState`'s `Action<T>` setter only stores what you pass it.
 
 **Always return cleanup from effects that create resources.** Timers,
 subscriptions, and event handlers must be disposed. The cleanup function is

--- a/docs/guide/animation.md
+++ b/docs/guide/animation.md
@@ -735,7 +735,7 @@ value that changes every render (`DateTime.Now`, a freshly-allocated
 list, an inline lambda) restarts the animation on every reconcile —
 the element flickers as the keyframes constantly reset. Use a state
 counter that increments only when you mean to retrigger
-(`setCount(c => c + 1)`).
+(`var (count, updateCount) = UseReducer(0)`, then `updateCount(c => c + 1)`).
 
 ## Tips
 

--- a/docs/guide/charting.md
+++ b/docs/guide/charting.md
@@ -482,14 +482,14 @@ window of points. Hold the window in `UseState`, append on tick, drop
 the head once `Count` exceeds the window size:
 
 ```csharp
-var (samples, setSamples) = UseState<IReadOnlyList<Sample>>(Array.Empty<Sample>());
+var (samples, updateSamples) = UseReducer<IReadOnlyList<Sample>>(Array.Empty<Sample>());
 
 UseEffect(() =>
 {
     using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(200));
     while (await timer.WaitForNextTickAsync(token))
     {
-        setSamples(prev =>
+        updateSamples(prev =>
         {
             var next = prev.Append(Sample.Now()).ToList();
             return next.Count > 60 ? next.Skip(next.Count - 60).ToList() : next;

--- a/docs/guide/charting.md
+++ b/docs/guide/charting.md
@@ -478,8 +478,9 @@ DSL. Import `using static Microsoft.UI.Reactor.Charting.D3.D3Charts` for:
 ### Live-updating chart from a ticking source
 
 A streaming chart — a price feed, a sensor reading — drives a sliding
-window of points. Hold the window in `UseState`, append on tick, drop
-the head once `Count` exceeds the window size:
+window of points. Hold the window in `UseReducer` (each tick derives the
+next window from the previous one), append on tick, drop the head once
+`Count` exceeds the window size:
 
 ```csharp
 var (samples, updateSamples) = UseReducer<IReadOnlyList<Sample>>(Array.Empty<Sample>());

--- a/docs/guide/effects-scheduling.md
+++ b/docs/guide/effects-scheduling.md
@@ -275,6 +275,7 @@ events arrive in the same order as the user's actions.
 
 ```csharp
 // Don't:
+var (count, setCount) = UseState(0);
 UseEffect(() => {
     setCount(count + 1);   // no deps → runs every commit → infinite loop
 });

--- a/docs/guide/effects-scheduling.md
+++ b/docs/guide/effects-scheduling.md
@@ -229,6 +229,8 @@ own [`Observable.cs#observable-bridge`](#) bridge follows this shape;
 so does any timer, event subscription, or background task.
 
 ```csharp
+var (seconds, updateSeconds) = UseReducer(0);
+
 UseEffect(() =>
 {
     var cts = new CancellationTokenSource();
@@ -236,13 +238,13 @@ UseEffect(() =>
     {
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
         while (await timer.WaitForNextTickAsync(cts.Token))
-            setSeconds(s => s + 1);
+            updateSeconds(s => s + 1);
     });
     return () => cts.Cancel();
 }, Array.Empty<object>());
 ```
 
-The setter `setSeconds` auto-marshals back to the UI thread (see
+The updater `updateSeconds` auto-marshals back to the UI thread (see
 [hooks](hooks.md) "Updating state from background work"). The cleanup
 cancels the token; the timer's `using` disposes when the
 `WaitForNextTickAsync` loop unblocks. No state leaks between mounts.
@@ -274,7 +276,7 @@ events arrive in the same order as the user's actions.
 ```csharp
 // Don't:
 UseEffect(() => {
-    setCount(c => c + 1);   // no deps → runs every commit → infinite loop
+    setCount(count + 1);   // no deps → runs every commit → infinite loop
 });
 ```
 

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -275,9 +275,11 @@ WinUI control's `RoutedEventHandler`. Subscribe in the body, return an
 unsubscribe in the cleanup:
 
 ```csharp
+var (tick, updateTick) = UseReducer(0);
+
 UseEffect(() =>
 {
-    void Handler(object? s, EventArgs e) => setTick(t => t + 1);
+    void Handler(object? s, EventArgs e) => updateTick(t => t + 1);
     Source.Changed += Handler;
     return () => Source.Changed -= Handler;
 }, Source); // re-attach if Source identity changes
@@ -326,13 +328,15 @@ stable across renders.
 
 ```csharp
 // Don't:
+var (tick, updateTick) = UseReducer(0);
+
 UseEffect(() =>
 {
     var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
     _ = Task.Run(async () =>
     {
         while (await timer.WaitForNextTickAsync())
-            setTick(t => t + 1);
+            updateTick(t => t + 1);
     });
 }, Array.Empty<object>()); // no cleanup → timer fires forever after unmount
 ```
@@ -343,6 +347,8 @@ silently leaks the closure tree the timer captured). Always return a
 cleanup that cancels the producer:
 
 ```csharp
+var (tick, updateTick) = UseReducer(0);
+
 UseEffect(() =>
 {
     var cts = new CancellationTokenSource();
@@ -350,7 +356,7 @@ UseEffect(() =>
     _ = Task.Run(async () =>
     {
         while (await timer.WaitForNextTickAsync(cts.Token))
-            setTick(t => t + 1);
+            updateTick(t => t + 1);
     });
     return () => { cts.Cancel(); timer.Dispose(); };
 }, Array.Empty<object>());

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -69,8 +69,11 @@ class StateDemo : Component
 ![UseState demo](images/hooks/usestate.png)
 
 Call `setColor("#FF0000")` and Reactor re-renders the component with the new
-value. The setter also accepts a function: `setSize(s => s + 1)` — this is
-safer when the update depends on the previous value.
+value. The setter is an `Action<T>` — it takes the **new value**, not a
+function of the previous one. When an update derives from the previous value
+(or you call the setter several times in one event), use
+[`UseReducer`](#usereducer-functional) instead — its updater receives the live
+previous value.
 
 ## UseReducer (Functional)
 
@@ -303,7 +306,7 @@ class CallbackDemo : Component
 
 ![UseCallback demo](images/hooks/usecallback.png)
 
-Without `UseCallback`, the lambda `() => setCount(c => c + 1)` would be a new
+Without `UseCallback`, the lambda `() => updateCount(c => c + 1)` would be a new
 object every render. `UseCallback` returns the same delegate instance as long
 as the dependencies haven't changed. This matters when passing callbacks to
 memoized [child components](components.md).
@@ -321,7 +324,7 @@ you'd write on the UI thread:
 ```csharp
 public override Element Render()
 {
-    var (seconds, setSeconds) = UseState(0);
+    var (seconds, updateSeconds) = UseReducer(0);
 
     UseEffect(() =>
     {
@@ -330,7 +333,7 @@ public override Element Render()
         {
             using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
             while (await timer.WaitForNextTickAsync(cts.Token))
-                setSeconds(s => s + 1);   // auto-marshals to the UI thread
+                updateSeconds(s => s + 1);   // auto-marshals to the UI thread
         });
         return () => cts.Cancel();
     });
@@ -525,31 +528,34 @@ UseEffect(() =>
 
 The effect's empty deps array means it captures `count` once at mount.
 The timer fires forever with the stale closure, so the counter sticks at
-1. The fix is the functional-setter pattern — `setCount(c => c + 1)` —
-which reads the live cell value instead of the captured variable. The
-`Func<T,T>` overload of `UseState` and the entire `UseReducer` API are
-built around this.
+1. The fix is `UseReducer`'s functional updater — declare
+`var (count, updateCount) = UseReducer(0)` and call `updateCount(c => c + 1)`,
+which reads the live cell value instead of the captured variable. (`UseState`'s
+setter is an `Action<T>`; it only takes a value, so it can't express a
+previous-value update.)
 
-### Setter chain that should be `set(prev => ...)`
+### Setter chain that should use `UseReducer`
 
 ```csharp
 // Don't:
+var (count, setCount) = UseState(0);
 Button("+3", () => { setCount(count + 1); setCount(count + 1); setCount(count + 1); });
 ```
 
 The three setter calls all read the same captured `count` and all write
-`count + 1` — the button advances by one, not three. Use the functional
-form so each call sees the previous setter's result:
+`count + 1` — the button advances by one, not three. Switch to `UseReducer`
+so each functional update sees the previous one's result:
 
 ```csharp
-Button("+3", () => { setCount(c => c + 1); setCount(c => c + 1); setCount(c => c + 1); });
+var (count, updateCount) = UseReducer(0);
+Button("+3", () => { updateCount(c => c + 1); updateCount(c => c + 1); updateCount(c => c + 1); });
 ```
 
 This is the same Reactor-wide rule as the [stale closure](#stale-closures)
-pattern: when an update derives from the previous value, the functional
-setter is the right shape. The auto-marshal path for cross-thread setters
-described above relies on the same overload — every queued write reads
-the latest committed value, not a snapshot.
+pattern: when an update derives from the previous value, `UseReducer`'s
+functional updater is the right shape. The auto-marshal path for cross-thread
+updaters described above relies on the same mechanism — every queued update
+reads the latest committed value, not a snapshot.
 
 ### Reading state right after calling its setter
 
@@ -591,8 +597,10 @@ because they run on a later render and observe the fresh value.
 
 ## Tips
 
-**Use the functional setter for derived updates.** `setCount(c => c + 1)` is
-safer than `setCount(count + 1)` when multiple updates might batch together.
+**Use `UseReducer` for derived updates.** `updateCount(c => c + 1)` is safer
+than `setCount(count + 1)` when an update depends on the previous value or
+several updates run in one event — the functional updater reads the live
+value, while `UseState`'s `Action<T>` setter only stores what you pass it.
 
 **Always return cleanup from effects that create resources.** Timers,
 subscriptions, and event handlers must be disposed. The cleanup function is


### PR DESCRIPTION
Fixes #347.

## Problem

The Hooks guide (and several other pages) documented a functional updater on the **`UseState`** setter, e.g. `setSize(s => s + 1)`. But `UseState<T>`'s setter is `Action<T>` — it takes a **value**, not a function. Only `UseReducer<T>` returns `Action<Func<T,T>>`.

This is more than a typo:
- `setCount(c => c + 1)` **does not compile** on a `UseState` setter for value types (`CS1503`).
- Multi-call-per-tick paths (`setCount(count + 1)` ×3 in one handler) silently lose all but the last update, because each call reads the same stale closure value.

Option (a) from the issue (add a functional-updater overload to `UseState`'s setter) is **infeasible in type-safe C#** — `setCount(value)` and `setCount(c => c + 1)` can't both bind through a single `Action<T>`. That's precisely why the framework already splits `UseState` (`Action<T>`) from `UseReducer` (`Action<Func<T,T>>`). So this PR takes **option (b)**: fix the docs.

## Changes

Routed every functional / derived / multi-call example through `UseReducer`, following the established repo convention:
- `set*` = `UseState` value setter
- `update*` = `UseReducer` functional updater

Also made `UseState → UseReducer` discoverable from the `UseState` narrative, and made the standalone effect fragments declare their `UseReducer` hook **inline** so the `update*` updater is always self-contained (no dangling references).

Edits applied to **both** the source templates (`docs/_pipeline/templates/*.md.dt`) and the regenerated guide output (`docs/guide/*.md`) for: `hooks`, `effects`, `effects-scheduling`, `charting`, `animation`.

## Verification

- Regenerated the affected guides via `mur docs compile` (reference markers resolved, tier + cross-link lint clean).
- `set*(x => …)` antipattern count in `docs/guide/`: **0**.
- No code/snippet changes needed — the compiled doc-app snippets (`apps/hooks`, `apps/effects`) already used `UseReducer`/`update*` correctly; only inline prose/examples were wrong.