### PR TITLE
fix(vsix-tests): avoid CS5001 in TF_BUILD inert mode

### DIFF
--- a/src/vs-reactor/Tests/Reactor.VsExtension.SdkTests/Reactor.VsExtension.SdkTests.csproj
+++ b/src/vs-reactor/Tests/Reactor.VsExtension.SdkTests/Reactor.VsExtension.SdkTests.csproj
@@ -6,7 +6,8 @@
     <TargetFramework Condition="'$(TF_BUILD)' == 'true'">net10.0</TargetFramework>
     <EnableDefaultItems Condition="'$(TF_BUILD)' == 'true'">false</EnableDefaultItems>
     <EnableDefaultCompileItems Condition="'$(TF_BUILD)' == 'true'">false</EnableDefaultCompileItems>
-    <OutputType>Exe</OutputType>
+    <OutputType Condition="'$(TF_BUILD)' != 'true'">Exe</OutputType>
+    <OutputType Condition="'$(TF_BUILD)' == 'true'">Library</OutputType>
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>false</IsAotCompatible>
     <IsPackable>false</IsPackable>

--- a/src/vs-reactor/Tests/Reactor.VsExtension.Tests/Reactor.VsExtension.Tests.csproj
+++ b/src/vs-reactor/Tests/Reactor.VsExtension.Tests/Reactor.VsExtension.Tests.csproj
@@ -7,7 +7,8 @@
     <UseWPF Condition="'$(TF_BUILD)' != 'true'">true</UseWPF>
     <EnableDefaultItems Condition="'$(TF_BUILD)' == 'true'">false</EnableDefaultItems>
     <EnableDefaultCompileItems Condition="'$(TF_BUILD)' == 'true'">false</EnableDefaultCompileItems>
-    <OutputType>Exe</OutputType>
+    <OutputType Condition="'$(TF_BUILD)' != 'true'">Exe</OutputType>
+    <OutputType Condition="'$(TF_BUILD)' == 'true'">Library</OutputType>
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>false</IsAotCompatible>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary

Fixes CI failures where VSIX test projects were built in inert `TF_BUILD` mode but still emitted `Exe`, causing `CS5001` (missing `Main`).

## Follow-up

- Tracking issue for VSIX build/test parity across CI lanes: #599
- https://github.com/microsoft/microsoft-ui-reactor/issues/599

## Root Cause

Both VSIX test projects intentionally switch to an inert configuration under `TF_BUILD == true`:

- retarget to `net10.0`
- disable default compile items

In that inert mode, `OutputType` was still `Exe`, so C# expected an entry point and failed with:

- `CSC : error CS5001: Program does not contain a static 'Main' method suitable for an entry point`

## Changes

Updated `OutputType` to be conditional in the two affected projects:

- `Exe` when `TF_BUILD != true` (normal/local behavior unchanged)
- `Library` when `TF_BUILD == true` (inert CI mode)

### Files changed

- `src/vs-reactor/Tests/Reactor.VsExtension.Tests/Reactor.VsExtension.Tests.csproj`
- `src/vs-reactor/Tests/Reactor.VsExtension.SdkTests/Reactor.VsExtension.SdkTests.csproj`

## Validation

Built both projects with `TF_BUILD=true` locally:

- `dotnet build src/vs-reactor/Tests/Reactor.VsExtension.Tests/Reactor.VsExtension.Tests.csproj -c Release -p:TF_BUILD=true`
- `dotnet build src/vs-reactor/Tests/Reactor.VsExtension.SdkTests/Reactor.VsExtension.SdkTests.csproj -c Release -p:TF_BUILD=true`

Both now succeed and no longer hit `CS5001`.

## Risk / Impact

Low risk:

- No product/runtime code changes.
- No behavioral change for normal test runs (`TF_BUILD != true` still uses `Exe`).
- Only affects inert CI path that previously failed due to entry-point expectations.
