### PR TITLE
build(signing): sign only packaged wrappers DLL copy

### DIFF
--- a/build/pipelines/templates/reactor-build-steps.yml
+++ b/build/pipelines/templates/reactor-build-steps.yml
@@ -295,7 +295,7 @@ steps:
         inputs:
           command: 'sign'
           signing_profile: external_distribution
-          files_to_sign: 'Reactor\bin\**\Reactor.dll;Reactor\bin\**\Reactor.resources.dll;Reactor\bin\**\Reactor.Wrappers.Abstractions.dll;Reactor.Wrappers.Abstractions\bin\**\Reactor.Wrappers.Abstractions.dll;Reactor.Advanced\bin\**\Reactor.Advanced.dll;Reactor.Devtools\bin\**\Microsoft.UI.Reactor.Devtools.dll;Reactor.Analyzers\bin\**\Reactor.Analyzers.dll;Reactor.Localization.Generator\bin\**\Reactor.Localization.Generator.dll'
+          files_to_sign: 'Reactor\bin\**\Reactor.dll;Reactor\bin\**\Reactor.resources.dll;Reactor\bin\**\Reactor.Wrappers.Abstractions.dll;Reactor.Advanced\bin\**\Reactor.Advanced.dll;Reactor.Devtools\bin\**\Microsoft.UI.Reactor.Devtools.dll;Reactor.Analyzers\bin\**\Reactor.Analyzers.dll;Reactor.Localization.Generator\bin\**\Reactor.Localization.Generator.dll'
           search_root: '$(Build.SourcesDirectory)\src'
 
     - pwsh: |

--- a/build/pipelines/templates/reactor-build-steps.yml
+++ b/build/pipelines/templates/reactor-build-steps.yml
@@ -295,7 +295,7 @@ steps:
         inputs:
           command: 'sign'
           signing_profile: external_distribution
-          files_to_sign: 'Reactor\bin\**\Reactor.dll;Reactor\bin\**\Reactor.resources.dll;Reactor.Wrappers.Abstractions\bin\**\Reactor.Wrappers.Abstractions.dll;Reactor.Advanced\bin\**\Reactor.Advanced.dll;Reactor.Devtools\bin\**\Microsoft.UI.Reactor.Devtools.dll;Reactor.Analyzers\bin\**\Reactor.Analyzers.dll;Reactor.Localization.Generator\bin\**\Reactor.Localization.Generator.dll'
+          files_to_sign: 'Reactor\bin\**\Reactor.dll;Reactor\bin\**\Reactor.resources.dll;Reactor\bin\**\Reactor.Wrappers.Abstractions.dll;Reactor.Wrappers.Abstractions\bin\**\Reactor.Wrappers.Abstractions.dll;Reactor.Advanced\bin\**\Reactor.Advanced.dll;Reactor.Devtools\bin\**\Microsoft.UI.Reactor.Devtools.dll;Reactor.Analyzers\bin\**\Reactor.Analyzers.dll;Reactor.Localization.Generator\bin\**\Reactor.Localization.Generator.dll'
           search_root: '$(Build.SourcesDirectory)\src'
 
     - pwsh: |


### PR DESCRIPTION
## Summary

This updates the OneBranch pre-pack Authenticode signing list to sign the `Reactor.Wrappers.Abstractions.dll` copy under `src/Reactor/bin`, which is the exact file later bundled into the `Microsoft.UI.Reactor` NuGet package.

## Why

The package currently bundles `Reactor.Wrappers.Abstractions.dll` from the Reactor output directory during `dotnet pack --no-build`. Signing only the wrappers project output is broader than necessary and can still miss the packaged copy. Restricting the signing glob to the packaged Reactor output keeps the signing scope conservative and aligns the signed file with the file that ends up inside the `.nupkg`.

## Validation

- Local solution build completed on the fix branch.
- CI/package signing validation should confirm the packaged DLL is now signed in the produced NuGet package.
