### PR TITLE
fix(pack): ship Reactor.Wrappers.Generator in the NuGet package

### DIFF
--- a/Reactor.slnx
+++ b/Reactor.slnx
@@ -454,6 +454,7 @@
     <Platform Solution="*|x64" Project="x64" />
   </Project>
   <Project Path="src/Reactor.Localization.Generator/Reactor.Localization.Generator.csproj" />
+  <Project Path="src/Reactor.Wrappers.Generator/Reactor.Wrappers.Generator.csproj" />
   <Project Path="src/Reactor.Devtools/Reactor.Devtools.csproj" />
   <Project Path="src/Reactor/Reactor.csproj" />
   <Project Path="src/Reactor.Wrappers.Abstractions/Reactor.Wrappers.Abstractions.csproj">

--- a/SKILL.md
+++ b/SKILL.md
@@ -112,6 +112,25 @@ for the intent → recipe map. Available today: list-add-delete, sidebar-nav,
 form-with-validation, async-fetch-list, themed-card, canvas-positioning,
 named-styles, calendar-multiselect.
 
+## Wrapping native / third-party controls (source generator)
+
+Need a control Reactor has no built-in factory for (a vendor control or your own
+custom `Control`)? Annotate an empty partial record and the
+`[GenerateReactorWrapper]` source generator emits the element, descriptor,
+registration, and a factory named after the control — no hand-written wrapper:
+
+```csharp
+using Microsoft.UI.Reactor.Wrappers;
+[GenerateReactorWrapper(typeof(Acme.Controls.RatingDial))]
+public partial record RatingDialElement;   // → using static …RatingDialElement; RatingDial(value: …, onValueChanged: …)
+```
+
+Full guidance — auto-inference, the `[Wrap*]` annotation cheat-sheet, imperative
+lifecycle, diagnostics, and a gallery of worked examples — is in the
+`reactor-wrapping` skill (`plugins/reactor/skills/reactor-wrapping/`, or
+`agentkit/plugins/reactor/skills/reactor-wrapping/` in the nupkg). Spec:
+`docs/specs/058-control-wrapper-generator.md`.
+
 ## `mur check` — fast feedback with skill pointers
 
 **`mur check` is the build, not a separate check step.** It runs `dotnet build`

--- a/build/pipelines/templates/reactor-build-steps.yml
+++ b/build/pipelines/templates/reactor-build-steps.yml
@@ -284,6 +284,7 @@ steps:
     #   lib/<tfm>/Reactor.Wrappers.Abstractions.dll
     #   analyzers/dotnet/cs/Reactor.Analyzers.dll
     #   analyzers/dotnet/cs/Reactor.Localization.Generator.dll
+    #   analyzers/dotnet/cs/Reactor.Wrappers.Generator.dll
     # And inside Microsoft.UI.Reactor.Advanced.nupkg:
     #   lib/<tfm>/Reactor.Advanced.dll
     # And inside Microsoft.UI.Reactor.Devtools.nupkg:
@@ -295,7 +296,7 @@ steps:
         inputs:
           command: 'sign'
           signing_profile: external_distribution
-          files_to_sign: 'Reactor\bin\**\Reactor.dll;Reactor\bin\**\Reactor.resources.dll;Reactor\bin\**\Reactor.Wrappers.Abstractions.dll;Reactor.Advanced\bin\**\Reactor.Advanced.dll;Reactor.Devtools\bin\**\Microsoft.UI.Reactor.Devtools.dll;Reactor.Analyzers\bin\**\Reactor.Analyzers.dll;Reactor.Localization.Generator\bin\**\Reactor.Localization.Generator.dll'
+          files_to_sign: 'Reactor\bin\**\Reactor.dll;Reactor\bin\**\Reactor.resources.dll;Reactor\bin\**\Reactor.Wrappers.Abstractions.dll;Reactor.Advanced\bin\**\Reactor.Advanced.dll;Reactor.Devtools\bin\**\Microsoft.UI.Reactor.Devtools.dll;Reactor.Analyzers\bin\**\Reactor.Analyzers.dll;Reactor.Localization.Generator\bin\**\Reactor.Localization.Generator.dll;Reactor.Wrappers.Generator\bin\**\Reactor.Wrappers.Generator.dll'
           search_root: '$(Build.SourcesDirectory)\src'
 
     - pwsh: |

--- a/plugins/reactor/skills/reactor-getting-started/SKILL.md
+++ b/plugins/reactor/skills/reactor-getting-started/SKILL.md
@@ -451,7 +451,7 @@ Nested `.Provide()` overrides the outer for its subtree only. If no provider is 
 
 ## Where the skill content comes from (and the api index)
 
-You're reading this through the **`reactor` plugin** — the most efficient channel. The plugin SDK preloads `reactor-getting-started`; topical skills (`reactor-async`, `reactor-design`, `reactor-forms`, `reactor-navigation`, `reactor-input`, `reactor-recipes`, `reactor-advanced` for Win2D canvases via the optional `Microsoft.UI.Reactor.Advanced` package, etc.) load only when the task explicitly needs them.
+You're reading this through the **`reactor` plugin** — the most efficient channel. The plugin SDK preloads `reactor-getting-started`; topical skills (`reactor-async`, `reactor-design`, `reactor-forms`, `reactor-navigation`, `reactor-input`, `reactor-recipes`, `reactor-wrapping` for turning any WinUI, vendor, or custom control into a declarative element via the `[GenerateReactorWrapper]` source generator, `reactor-advanced` for Win2D canvases via the optional `Microsoft.UI.Reactor.Advanced` package, etc.) load only when the task explicitly needs them.
 
 Full API index (every factory, modifier, hook, theme token, with parameter lists): `references/reactor.api.txt` inside the `reactor-dsl` skill (also bundled into the Microsoft.UI.Reactor nupkg's `agentkit/` tree if you need to find it from a consumer).
 

--- a/plugins/reactor/skills/reactor-wrapping/SKILL.md
+++ b/plugins/reactor/skills/reactor-wrapping/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: reactor-wrapping
+description: "Turn ANY WinUI control — a vendor/third-party control, your own custom Control, or a Windows Community Toolkit one — into a first-class declarative Reactor element with the [GenerateReactorWrapper] source generator, zero hand-written wrapper code. Covers auto-inference (props, content, two-way pairs, panel/items children, events), the [Wrap*] annotation cheat-sheet, imperative-lifecycle controls, diagnostics, and when to fall back to a hand-written ControlDescriptor."
+---
+
+# Reactor — Wrapping Arbitrary Controls (source generator)
+
+Use this skill when the app needs a control Reactor has **no built-in factory
+for** — a Windows Community Toolkit control, a third-party vendor control, or the
+app's own custom `Control` subclass. The `Reactor.Wrappers.Generator` source
+generator turns the control into a first-class declarative element (init-props +
+`ControlDescriptor` + Pattern-A registration + a parameterized factory named after
+the control) from a single annotated partial record. **No hand-written wrapper,
+handler, or registration code.**
+
+> Canonical worked example: `samples/apps/wct-controls/` (declarations in
+> `WctControls.cs`, usage in `Program.cs`). Design spec: `docs/specs/058-control-wrapper-generator.md`.
+> For controls the generator still can't express, drop to the hand-written
+> `ControlDescriptor` / `IElementHandler` path in `docs/guide/extending-reactor-controls.md`.
+
+## The whole feature in one example
+
+```csharp
+using Microsoft.UI.Reactor.Wrappers;   // the [Wrap*] authoring attributes
+
+namespace MyApp;
+
+// 1. Declare an empty partial record, annotated with the control to wrap.
+[GenerateReactorWrapper(typeof(CommunityToolkit.WinUI.Controls.SettingsCard))]
+public partial record SettingsCardElement;
+```
+
+```csharp
+// 2. Consume the generated factory via `using static` (named after the control).
+using static MyApp.SettingsCardElement;
+
+SettingsCard(
+    header: "Wi-Fi",
+    description: wifiOn ? "Connected" : "Disconnected",
+    content: ToggleSwitch(isOn: wifiOn, onIsOnChanged: setWifiOn))  // a Reactor child INSIDE a WCT control
+```
+
+The generator fills the rest of that partial: one init-property per surfaced
+control property, the single-content/children slot, `On{Event}` callbacks, the
+`ControlDescriptor`, the trim-rooting `static` cctor registration, and the
+`SettingsCard(...)` factory. `Setters` is always emitted as an escape hatch
+(`.Set(c => c.Foo = …)`) for anything not surfaced.
+
+**You never call `ReactorApp.RegisterControlAssembly` yourself** — the generator
+emits it in the element's static constructor, so a control library's
+`Themes/Generic.xaml` resolves before first realization (avoids the `0xC000027B`
+crash, spec 058 §9a).
+
+## Requirements & setup
+
+- Reference `Microsoft.UI.Reactor` (carries the generator in `analyzers/dotnet/cs/`
+  and the authoring attributes in `Reactor.Wrappers.Abstractions.dll`).
+- Reference the control's own package (e.g. the WCT
+  `CommunityToolkit.WinUI.Controls.*` packages).
+- The target must be a **non-static `FrameworkElement`** with a **public
+  parameterless constructor** (else `REACTORGEN001`).
+- Keep the record `partial` (the generator fills the other half) and in a
+  namespace you control.
+
+## What is auto-inferred (zero config)
+
+The generator walks members from the most-derived type **up to but excluding**
+`Control`/`FrameworkElement` (Reactor already models that layout plumbing via
+generic modifiers like `.Margin()`, `.Width()`):
+
+| Control shape | Becomes |
+|---|---|
+| Settable value prop (`string`/`object`→text, `bool`/`int`/`double`/enum, structs like `Thickness`/`Color`, `Brush`/`FontFamily`, `bool?`/`DateTimeOffset?` tri-state) | a nullable / `Optional<T>` **one-way** init-prop (skipped when unset) |
+| Value prop `P` **paired with** a `{P}Changed` event | a **two-way controlled** `Optional<T>` prop + `On{P}Changed` callback, with echo suppression |
+| The control's `[ContentProperty]` (a `UIElement` child, or `object` named exactly `Content`) | the single **`content:`** child slot |
+| A public `Children` of `UIElementCollection` (a `Panel`) | a `params Element[]` children slot |
+| A public `Items` whose type is/implements `IList<object>` (an `ItemsControl`) | a `params object[] items` slot |
+| A fire-and-forget `RoutedEventHandler` / `TypedEventHandler<,>` / `EventHandler<A>` event | an `On{Event}` callback (typed events auto-surface the whole args as `Action<A>`) |
+
+Two-way auto-pairing keys **strictly on the `{P}Changed` name**. Controls whose
+change event breaks that convention (`ToggleSwitch.IsOn`↔`Toggled`,
+`Segmented.SelectedIndex`↔`SelectionChanged`) stay one-way until you add
+`[WrapControlled]`.
+
+## Annotation cheat-sheet (opt-in, when inference isn't enough)
+
+All live in `Microsoft.UI.Reactor.Wrappers`. All are repeatable unless noted.
+
+| Attribute | Use it to… |
+|---|---|
+| `[GenerateReactorWrapper(typeof(T), Exclude/Include/AutoDiscover)]` | wrap `T`; prune noisy inherited props (`Exclude = new[]{ "CommandParameter" }`) or switch to explicit opt-in (`AutoDiscover = false, Include = new[]{ … }`). |
+| `[WrapControlled("P", ChangedEvent = "…")]` | make `P` two-way when its event isn't `{P}Changed`. Use `Events = new[]{ "Checked","Unchecked" }` for multi-event values (read back after any fire). `Deferred = true` for deferred/coercing string boxes (`PasswordBox.Password`, `AutoSuggestBox.Text`). A control has **one** controlled slot — two `[WrapControlled]` on one control warns `REACTORGEN012`. |
+| `[WrapOneWay("P")]` | opt a prop **out** of two-way auto-pairing (display-only despite a `{P}Changed`, e.g. `ProgressBar.Value`). |
+| `[WrapAlias("FriendlyName", "ControlProperty")]` | surface a control prop under a nicer name (`"Min"`→`"Minimum"`). Aliasing the content property turns it into a string value prop (no child slot). |
+| `[WrapContent("Prop")]` | override which property is the `content:` child slot. |
+| `[WrapConvert("Prop")]` | surface a struct prop (`CornerRadius`, `Thickness`) as an ergonomic scalar via its single-arg constructor (`double?` → `new CornerRadius(v)`). |
+| `[WrapEvent("Foo", Arg = "ErrorMessage")]` | project event args into a typed `On{Event}(args.Arg)` callback; `Args = new[]{ … }` for multi-param. |
+| `[WrapLifecycle(nameof(Start), OnUnmounted = nameof(Stop))]` | run a `static void M(TControl)` on mount/unmount for imperative controls (`CameraPreview.StartAsync`) — **no call-site boilerplate**. |
+| `[WrapPanelChildren(PerChild = …)]` | wire per-child attached props (`Grid.SetRow`, `Canvas.SetLeft`) onto a panel; `AfterAll` for two-pass (RelativePanel). |
+| `[WrapManual("P")]` + `static partial Customize(d)` | hand-chain one entry the generator can't infer while it still generates the rest. |
+| `[WrapPolymorphic(nameof(Resolve))]` / `[WrapDecorator(nameof(Create))]` | controls whose concrete type is chosen at runtime, or that need a fully custom mount/update/unmount lifecycle (emit an `IDecoratorElementHandler`, not a descriptor). |
+
+### Imperative control (lifecycle) — paste-ready
+
+```csharp
+// CameraPreview must be StartAsync'd after mount and Stop'd on unmount. Declared
+// ONCE here, so every call site is a plain declarative `CameraPreview(...)`.
+[GenerateReactorWrapper(typeof(CommunityToolkit.WinUI.Controls.CameraPreview))]
+[WrapEvent("PreviewFailed", Arg = "Error")]
+[WrapLifecycle(nameof(StartPreview), OnUnmounted = nameof(StopPreview))]
+public partial record CameraPreviewElement
+{
+    private static async void StartPreview(CommunityToolkit.WinUI.Controls.CameraPreview cp)
+    {
+        try { await cp.StartAsync(cp.CameraHelper); } catch { /* surfaced via PreviewFailed */ }
+    }
+    private static void StopPreview(CommunityToolkit.WinUI.Controls.CameraPreview cp)
+    {
+        try { cp.Stop(); } catch { /* already torn down */ }
+    }
+}
+```
+
+### Non-conventional two-way event
+
+```csharp
+// SelectedIndex changes through SelectionChanged, not SelectedIndexChanged.
+[GenerateReactorWrapper(typeof(CommunityToolkit.WinUI.Controls.Segmented))]
+[WrapControlled("SelectedIndex", ChangedEvent = "SelectionChanged")]
+public partial record SegmentedElement;
+// → Segmented(selectedIndex: idx, onSelectedIndexChanged: setIdx, items: …)
+```
+
+## Hand-tuning a single generated member
+
+Write the member yourself in your half of the partial; the generator skips any
+member you declare. Example — treat `Header` as templated Reactor content instead
+of plain text:
+
+```csharp
+public partial record SettingsCardElement
+{
+    public Element? Header { get; init; }
+}
+```
+
+## Diagnostics
+
+`REACTORGEN001` (target isn't a non-static `FrameworkElement` with a public
+parameterless ctor) · `…002` (bad Include/Exclude name) · `…003`/`…004`
+(WrapControlled property / change-event) · `…005` (WrapAlias control property) ·
+`…006` (WrapOneWay) · `…007` (WrapContent) · `…008` (WrapConvert) · `…012` (two
+controlled props share one control). Run `mur check <path>` — it surfaces these
+with skill pointers.
+
+## When to drop to a hand-written descriptor
+
+The generator targets the common case. Reach for the manual
+`ControlDescriptor` / `IElementHandler` path (`docs/guide/extending-reactor-controls.md`,
+registered via `ControlRegistry.RegisterHandler`) only when a control's contract
+is something the attributes above can't yet express — and prefer adding a reusable
+`[Wrap*]` capability over a one-off handler when the shape is general.

--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -85,8 +85,12 @@
                       ReferenceOutputAssembly="false" />
     <!-- Spec 058 §15 (P5.3): the wrapper generator is wired in so built-in
          element descriptors can be generated from [GenerateReactorDescriptor]
-         annotations (e.g. ViewboxElement). Build-time analyzer only — not packed
-         into the nupkg. -->
+         annotations (e.g. ViewboxElement). It is ALSO packed into the nupkg
+         (analyzers/dotnet/cs, in the <None> block below) so consumers can run it
+         against their own [GenerateReactorWrapper] annotations — spec 058 §6's
+         per-consumer generation model. The bundled Reactor.Wrappers.Abstractions.dll
+         (lib/, above) carries the authoring attributes; without the generator
+         shipping beside it those attributes would resolve but be inert. -->
     <ProjectReference Include="..\Reactor.Wrappers.Generator\Reactor.Wrappers.Generator.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
@@ -165,6 +169,12 @@
           Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\Reactor.Localization.Generator\$(_ReactorAnalyzerBinDir)\Reactor.Localization.Generator.dll"
           Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <!-- The wrapper source generator (spec 058). Shipped so consumers' own
+         [GenerateReactorWrapper] / [GenerateReactorDescriptor] annotations are
+         processed; the authoring attributes ship in lib/ via
+         Reactor.Wrappers.Abstractions.dll. -->
+    <None Include="..\Reactor.Wrappers.Generator\$(_ReactorAnalyzerBinDir)\Reactor.Wrappers.Generator.dll"
+          Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false" />
     <None Include="..\..\assets\Icon.png" Pack="true" PackagePath="" Visible="false" />
     <None Include="README.md" Pack="true" PackagePath="" Visible="false" />
@@ -224,6 +234,8 @@
           Pack="true" PackagePath="agentkit/plugins/reactor/skills/reactor-recipes/" Visible="false" />
     <None Include="..\..\plugins\reactor\skills\reactor-recipes\references\*"
           Pack="true" PackagePath="agentkit/plugins/reactor/skills/reactor-recipes/references/" Visible="false" />
+    <None Include="..\..\plugins\reactor\skills\reactor-wrapping\*.md"
+          Pack="true" PackagePath="agentkit/plugins/reactor/skills/reactor-wrapping/" Visible="false" />
   </ItemGroup>
 
   <!-- ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Problem

The control-wrapper source generator added in spec 058 (#572) shipped **only its authoring attributes**, not the generator that processes them. A consumer of the `Microsoft.UI.Reactor` package could write `[GenerateReactorWrapper(typeof(SomeControl))]` — the attribute resolves (it's in `Reactor.Wrappers.Abstractions.dll`, bundled into `lib/`) — but nothing fills the partial record, so the build fails with missing-factory/missing-member errors.

Root cause: `src/Reactor/Reactor.csproj` packed `Reactor.Analyzers.dll` and `Reactor.Localization.Generator.dll` into `analyzers/dotnet/cs/`, but **not** `Reactor.Wrappers.Generator.dll` — it was wired in only as a build-time analyzer on the framework's own build. Shipping the attributes without the generator is the bug; it also contradicts spec 058 §6 (per-consumer generation requires the generator on the consumer's machine).

Fixes #605.

## Changes

- **`src/Reactor/Reactor.csproj`** — pack `Reactor.Wrappers.Generator.dll` into `analyzers/dotnet/cs/` alongside the other two; updated the stale "not packed into the nupkg" comment.
- **`build/pipelines/templates/reactor-build-steps.yml`** — added the generator DLL to the pre-pack Authenticode signing list (and the packed-assemblies comment) so the shipped copy is signed; Guardian CodeSign would otherwise fail the build.
- **AI Skills** — new `plugins/reactor/skills/reactor-wrapping/SKILL.md` documenting how to host arbitrary controls via the generator (auto-inference, the `[Wrap*]` cheat-sheet, imperative lifecycle, diagnostics, fall-back boundary). Wired into the agentkit pack list, the `reactor-getting-started` index, and a pointer in the monolith `SKILL.md`.

## Verification

Re-packed locally and inspected the nupkg:

```
analyzers/dotnet/cs/Reactor.Analyzers.dll
analyzers/dotnet/cs/Reactor.Localization.Generator.dll
analyzers/dotnet/cs/Reactor.Wrappers.Generator.dll      ← now present
lib/net10.0-windows10.0.22621/Reactor.Wrappers.Abstractions.dll
agentkit/plugins/reactor/skills/reactor-wrapping/SKILL.md ← now present
```