### PR TITLE
fix(deps): bump Microsoft.Data.Sqlite to 11.0.0-preview.5.26302.115

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
     <PackageVersion Include="System.Reflection.DispatchProxy" Version="4.8.2" />
     <PackageVersion Include="MessageFormat" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="11.0.0-preview.5.26302.115" />
     <PackageVersion Include="YamlDotNet" Version="18.0.0" />
     <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.1" />
     <PackageVersion Include="MessagePack" Version="2.5.301" />


### PR DESCRIPTION
## Summary

Bumps `Microsoft.Data.Sqlite` from `10.0.9` to `11.0.0-preview.5.26302.115` to resolve a High severity advisory in a transitive dependency.

- **Advisory:** [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (High)
- **Affected package:** `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (transitive, brought in by `Microsoft.Data.Sqlite`)
- This advisory was failing the repo's **Vulnerable packages** CI check on every PR.

`Microsoft.Data.Sqlite` 11.0.0-preview transitively pulls a patched `SQLitePCLRaw`, which resolves the advisory.

## Change

Exactly one line in `Directory.Packages.props` (Central Package Management):

```diff
- <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+ <PackageVersion Include="Microsoft.Data.Sqlite" Version="11.0.0-preview.5.26302.115" />
```

## Verification

```
dotnet restore Reactor.slnx                # succeeds
dotnet list samples/apps/headtrax/HeadTrax/HeadTrax.csproj package --vulnerable --include-transitive
# -> "has no vulnerable packages given the current sources"
```

No new NuGet sources were needed; the preview package resolves from nuget.org.

Fixes #608