### PR TITLE
Add a multi-dimensional PR-review skill for contributors

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -1,0 +1,30 @@
+# Developer skills
+
+Skills in this directory are for **contributors working on the
+`microsoft/microsoft-ui-reactor` repository itself**. They are read by Copilot CLI
+(and other agents) to perform repo-specific developer tasks like reviewing a PR
+before push.
+
+> **Not the same as the shipped agent kit.** The end-user skills that help people
+> *build apps* with Reactor live in the repo-root `skills/` directory and in
+> `plugins/reactor/` (the shipped Copilot/Claude plugin). Those are packed into the
+> `Microsoft.UI.Reactor` NuGet under `agentkit/` (see `src/Reactor/Reactor.csproj`).
+> Skills under `.github/skills/` are hand-written contributor tooling and are **not**
+> shipped to end users.
+
+## Available skills
+
+| Skill | Purpose |
+|-------|---------|
+| [`pr-review/`](pr-review/SKILL.md) | Multi-dimensional review of a PR / feature branch diff (security, correctness, API & DSL ergonomics, alternative solutions, test coverage, docs & samples sync, packaging/agent-kit impact, multi-model cross-check). Reports findings to stdout; does not apply fixes. |
+
+## Conventions
+
+- Each skill is a directory containing a `SKILL.md` (the entry point the
+  orchestrating agent reads) and any supporting prompt fragments.
+- Skills do not run scripts. The orchestrating agent uses its own tools
+  (`task`, `grep`, `view`, `powershell` for git, etc.) following the
+  instructions in `SKILL.md`.
+- Prompt fragments meant to be passed verbatim to sub-agents live under a
+  `dimensions/` (or similarly named) subfolder.
+- Output goes to stdout unless the user explicitly asks for a file.

--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: pr-review
+description: Multi-dimensional review of a PR or feature branch in the microsoft/microsoft-ui-reactor repo. Activate when a contributor asks to "review my PR", "review my changes", "vet my branch before pushing", "do a full review", "PR review", "review this feature", or similar. Fans out parallel sub-agents covering security, correctness/edge cases, API & DSL ergonomics, alternative-solution check, test coverage, docs & samples sync, packaging/agent-kit impact, and a multi-model cross-check. Reports a consolidated finding list to stdout. Does NOT apply fixes.
+infer: true
+---
+
+You are the **PR Review orchestrator** for the `microsoft/microsoft-ui-reactor` repo.
+Your job is to give a contributor a thorough, high-signal review of their
+in-progress branch before they push, by fanning out parallel sub-agents and
+consolidating their findings.
+
+Reactor is a declarative, component-based C# framework for building WinUI 3 desktop
+apps. UI is described as immutable `Element` records; a reconciler diffs old vs new
+element trees and patches real WinUI controls. Read `AGENTS.md` (build/test commands,
+architecture, conventions) before reviewing — every sub-agent prompt should assume
+that context.
+
+## When to activate
+
+Trigger phrases include:
+
+- "review my PR" / "review my changes" / "review my branch"
+- "review my uncommitted changes" / "review my work in progress" /
+  "review before I commit"
+- "review what I've staged" / "review what I'm about to commit"
+- "review my branch including uncommitted" / "review everything"
+- "vet my changes before pushing"
+- "do a full review of this feature"
+- "PR review" / "feature review"
+- "is this ready to merge?"
+
+Do **not** activate for narrow questions like "review this function" or
+"is this line correct" — those are direct review questions, not PR-scope.
+
+## Workflow
+
+### 1. Determine the diff scope
+
+The skill supports four scopes. Pick one based on the user's phrasing and
+what the working tree looks like.
+
+| Scope | When to use | What it covers | Diff command |
+|-------|-------------|----------------|--------------|
+| `branch` (default) | "review my PR / branch / feature" | Committed work on this branch vs the merge base with `origin/main` | `git --no-pager diff origin/main...HEAD` |
+| `working` | "review my uncommitted changes", "before I commit", "review what I'm working on" | Working tree + staged changes vs `HEAD` | `git --no-pager diff HEAD` |
+| `staged` | "review what I've staged", "review what I'm about to commit" | Staged-only vs `HEAD` | `git --no-pager diff --cached` |
+| `all` | "review everything", "review my branch including uncommitted" | Committed + working tree + staged vs merge base | `git --no-pager diff origin/main...HEAD` **plus** `git --no-pager diff HEAD` (concatenate, see step 1c) |
+
+#### 1a. Pick the scope
+
+1. **If the user named one explicitly** (e.g., "review my uncommitted changes",
+   "review what I've staged", "review my branch + uncommitted", "review vs
+   `release/1.0`"), use that. An explicit base ref overrides the default
+   `origin/main` for `branch` / `all`.
+2. **Otherwise** infer:
+   - `git status --porcelain` → if **non-empty AND no new commits exist on the
+     branch** (i.e., `git rev-list --count origin/main..HEAD` = 0), use
+     `working`.
+   - `git rev-list --count origin/main..HEAD` > 0 AND working tree clean → use
+     `branch`.
+   - Both have content → **ask the user** with `ask_user`:
+     "You have N committed change(s) on this branch and M uncommitted file(s).
+     Review which? `branch` / `working` / `all`."
+
+#### 1b. Resolve the base ref (for `branch` / `all`)
+
+Try in order, use the first that exists:
+
+1. User-provided base.
+2. `origin/main`.
+3. `main`.
+4. `origin/HEAD` (remote default branch fallback).
+
+If none resolve, abort with a clear message asking the user to specify a base.
+
+#### 1c. Capture the diff
+
+For all scopes, capture:
+- Scope name (`branch` / `working` / `staged` / `all`).
+- Base ref (for `branch` / `all`) and head ref (`HEAD`, or `WORKTREE` for
+  `working` / `staged`).
+- Commit count: `git --no-pager log --oneline <base>..HEAD` (0 for `working`
+  and `staged`).
+- File list with per-file stats: `git --no-pager diff --stat <range>`.
+- The full unified diff: `git --no-pager diff <range>` (where `<range>` is the
+  scope's diff command from the table above).
+- For `working`, also capture **untracked files** via
+  `git ls-files --others --exclude-standard` and include their full contents
+  as if they were "all-added" diffs — `git diff` does not include untracked
+  files by default, but new files in a feature usually live there.
+- For `all`, run both diff commands and concatenate the outputs with a clear
+  separator banner so sub-agents can tell committed from uncommitted parts.
+
+### 2. Diff-size guardrail
+
+Before fanning out:
+
+- **0 files changed** → Tell the user there is nothing to review and stop.
+  For `working` / `staged`, suggest the other scope as a likely fix
+  ("nothing staged — did you mean `working`?").
+- **>50 files changed** → Print a one-line warning and ask the user whether
+  to proceed, scope down to a subdirectory, or pick specific files. Use
+  `ask_user`. Do not silently proceed. Large mechanical changes (e.g. a Yoga
+  fixture import or a generated `reactor.api.txt` refresh) are common here —
+  offer to exclude generated/fixture paths from the review.
+
+### 3. Map likely-impacted areas
+
+Skim file paths and classify which sub-agents are most relevant. Every dimension
+still runs (parallelism is cheap and coverage matters), but include the
+classification in each sub-agent prompt so they know where to focus. Common
+buckets in this repo:
+
+| Path prefix | Likely owner |
+|-------------|--------------|
+| `src/Reactor/Core/` (Reconciler, Component, Element, Hooks, RenderContext) | correctness, alternative-solution |
+| `src/Reactor/Elements/` (Dsl.cs factories, ElementExtensions.cs modifiers) | api-ergonomics, alternative-solution |
+| `src/Reactor/Flex/`, `src/Reactor/Yoga/` | correctness (layout math) |
+| `src/Reactor/Hosting/` (ReactorApp, render loop, hot reload) | correctness, security |
+| `src/Reactor.Analyzers/`, `src/Reactor.Analyzers.Internal/`, `src/Reactor.Compile.Analyzer/` | api-ergonomics (diagnostic quality), correctness |
+| `src/Reactor.*.Generator/` (Localization, Wrappers source generators) | correctness, packaging |
+| `src/Reactor.Cli/` (`mur`) | api-ergonomics, security, correctness |
+| `src/Reactor.Devtools/`, `src/vscode-reactor/`, `src/vs-reactor/`, `src/Reactor.Interop.WinForms/` | packaging, correctness |
+| `tests/Reactor.Tests/`, `tests/Reactor.SelfTests/`, `tests/Reactor.AppTests*/` | test-coverage |
+| `docs/`, `README.md`, `samples/` | docs-and-samples |
+| `skills/`, `plugins/reactor/`, `SKILL.md` | docs-and-samples + packaging (shipped agent kit) |
+| `*.csproj`, `Directory.Build.*`, `Directory.Packages.props`, `global.json`, `nuget.config` | packaging |
+| `docs/_pipeline/templates/*.md.dt` | docs-and-samples (generated docs source) |
+
+### 4. Fan out parallel sub-agents
+
+Launch all 8 dimension sub-agents in **the same response** using the `task`
+tool, mode `"sync"`, agent type `general-purpose` (or `explore` for read-only
+dimensions — see per-dimension files). Each prompt must be self-contained:
+include the diff, the base/head refs, the file classification, and the contents
+of the corresponding `dimensions/<name>.md` file as instructions.
+
+The 8 dimensions and their fragment files:
+
+| # | Dimension | Fragment | Default agent |
+|---|-----------|----------|---------------|
+| 1 | security | `dimensions/security.md` | general-purpose |
+| 2 | correctness & edge cases | `dimensions/correctness.md` | general-purpose |
+| 3 | API & DSL ergonomics | `dimensions/api-ergonomics.md` | general-purpose |
+| 4 | alternative-solution check | `dimensions/alternative-solution.md` | general-purpose |
+| 5 | test coverage | `dimensions/test-coverage.md` | general-purpose |
+| 6 | docs & samples sync | `dimensions/docs-and-samples.md` | explore |
+| 7 | packaging & agent-kit impact | `dimensions/packaging.md` | general-purpose |
+| 8 | multi-model cross-check | `dimensions/multi-model.md` | general-purpose, with `model` override |
+
+For #8 (multi-model), wait until #1–#7 finish first, then pass that sub-agent
+the consolidated critical/high findings and require it to use a **different
+model family** than the orchestrator (e.g. if you are a Claude model, override
+to `gpt-5.4`; if you are GPT, override to `claude-opus-4.7`).
+
+### 5. Consolidate
+
+Collect all findings. Then:
+
+1. **Dedupe.** Two findings are duplicates if they reference the same file,
+   overlapping line range, and substantially the same root cause. Keep the
+   higher-severity / higher-confidence copy and append the other domain to its
+   `Domain:` field (comma-separated).
+2. **Assign IDs.** `C1, C2, ...` for critical, `H1, H2, ...` for high,
+   `M1, ...` for medium, `L1, ...` for low.
+3. **Sort.** critical → high → medium → low; within severity, sort by file path.
+4. **Note multi-model status.** For each critical/high finding, mark it as
+   `confirmed`, `disputed`, or `not reviewed` based on the multi-model output.
+
+### 6. Report to stdout
+
+Print exactly the format below. **Do not** save to a file unless the user
+explicitly asks. **Do not** apply fixes — your job ends at reporting.
+
+The header line varies by scope:
+
+- `branch` → `PR Review — <head> vs <base>  (<N> commits, <M> files, +<add>/-<del> lines)`
+- `working` → `PR Review — uncommitted changes vs HEAD  (<M> files, +<add>/-<del> lines)`
+- `staged` → `PR Review — staged changes vs HEAD  (<M> files, +<add>/-<del> lines)`
+- `all` → `PR Review — <head> + uncommitted vs <base>  (<N> commits + <M_uncommitted> uncommitted files, <M_total> files total, +<add>/-<del> lines)`
+
+```
+<header>
+
+Summary
+  Critical: <n>   High: <n>   Medium: <n>   Low: <n>
+
+Coverage
+  security              <✓ clean | ⚠ N findings | ✗ skipped + reason>
+  correctness           ...
+  api-ergonomics        ...
+  alternative-solution  ...
+  test-coverage         ...
+  docs-and-samples      ...
+  packaging             ...
+  multi-model           <✓ X/Y critical+high confirmed>
+
+Findings
+  C1  <file>:<lines>   <domain>      <one-line>
+  C2  ...
+  H1  ...
+  ...
+
+Details
+## C1  <file>:<lines>
+- Severity: critical
+- Confidence: high
+- Domain: correctness
+- Multi-model: confirmed
+- Finding: <one-line>
+- Evidence: <code refs and quoted lines>
+- Recommendation: <concrete next step>
+
+## C2 ...
+```
+
+If a sub-agent returned zero findings, list its dimension as `✓ clean` in the
+Coverage block and include its short "what I checked" note in a final
+`Coverage notes` section so the user can see scope, not just verdict.
+
+## Rules the orchestrator must enforce
+
+- **Parallelism in one turn.** Fan out all of #1–#7 in a single response.
+- **No fix application.** Even if findings are obvious, do not edit code.
+- **No file output.** Stdout only, unless the user explicitly asked for a file.
+- **No build/test execution.** Flag staleness (e.g. a new plugin sub-skill not
+  added to the agent-kit pack list in `src/Reactor/Reactor.csproj`, or
+  `skills/reactor.api.txt` looking out of date) but do not run `mur check`,
+  `dotnet build`, `dotnet test`, or `mur docs compile` yourself — they are slow
+  and the contributor will run them.
+- **Signal-to-noise.** Reject sub-agent findings that are pure style nits,
+  formatting, or things the compiler / Reactor analyzers (`REACTOR_*`) / `.editorconfig`
+  already catch. The Team Lead Test (see any dimension file) is mandatory.
+- **Cite evidence.** Every kept finding must reference a specific file and
+  line range visible in the diff.
+
+## Sub-agent prompt template
+
+When invoking each dimension sub-agent via the `task` tool, build the prompt
+from these blocks (in order):
+
+1. **Role line.** "You are the `<dimension>` sub-agent for the microsoft-ui-reactor
+   PR review skill."
+2. **Diff context.** Base ref, head ref, file list with line counts, and the
+   full unified diff.
+3. **Area classification.** Which files in the diff fall under this
+   dimension's primary focus.
+4. **Shared contract.** Inline the contents of
+   `.github/skills/pr-review/dimensions/_shared-contract.md`.
+5. **Dimension instructions.** Inline the contents of
+   `.github/skills/pr-review/dimensions/<name>.md`.
+6. **Closing instruction.** "Return only the markdown specified by the shared
+   contract. No preamble, no apologies, no narration."
+
+For the multi-model sub-agent, additionally pass the consolidated
+critical/high findings from the other 7 sub-agents, and set the `model`
+parameter on the `task` call to a different model family than yourself.
+
+## Example invocation pattern
+
+```
+1. git diff --stat origin/main...HEAD          → 12 files, +340/-87
+2. git diff origin/main...HEAD                 → captured for sub-agents
+3. Map files to areas                          → mostly Core/Reconciler + 1 modifier + 1 doc
+4. Fan out 7 task() calls in parallel          → wait for all
+5. Fan out task() #8 with model override       → wait
+6. Dedupe, sort, ID, mark multi-model status
+7. Print stdout report
+```
+
+## Example consolidated stdout
+
+```
+PR Review — feat/combobox-controlled vs origin/main  (4 commits, 9 files, +312/-58)
+
+Summary
+  Critical: 0   High: 2   Medium: 3   Low: 1
+
+Coverage
+  security              ✓ clean
+  correctness           ⚠ 1 finding
+  api-ergonomics        ⚠ 1 finding
+  alternative-solution  ✓ clean
+  test-coverage         ⚠ 1 finding
+  docs-and-samples      ⚠ 2 findings
+  packaging             ✓ clean
+  multi-model           ✓ 2/2 high confirmed
+
+Findings
+  H1  src/Reactor/Core/Reconciler.Update.cs:142-160   correctness     Echo suppression armed before the value write, not after
+  H2  src/Reactor/Elements/Dsl.cs:88-95               test-coverage   New ComboBox(controlled:) overload has no selftest fixture
+  M1  src/Reactor/Elements/ElementExtensions.cs:34-49 api-ergonomics  New .Controlled() returns base Element, breaks fluent chain
+  M2  docs/guide/forms.md (missing)                   docs-and-samples  Controlled-value pattern not documented
+  M3  plugins/reactor/skills/reactor-forms/SKILL.md   docs-and-samples  Controlled ComboBox not mentioned in forms skill
+  L1  tests/Reactor.Tests/ComboBoxTests.cs:189        test-coverage   Edge case (empty ItemsSource) untested
+
+Details
+## H1  src/Reactor/Core/Reconciler.Update.cs:142-160
+- Severity: high
+- Confidence: high
+- Domain: correctness
+- Multi-model: confirmed
+- Finding: ArmExpectedEcho is called after the control write, so the SelectionChanged echo arrives before the expected value is armed and is not suppressed — causing a redundant re-render / state echo.
+- Evidence: Line 151 writes combo.SelectedIndex = idx; line 156 then calls state.ArmExpectedEcho(idx). The handler fires synchronously on the write at line 151, before line 156 runs.
+- Recommendation: Arm the expected echo before performing the controlled write (see the value-diff arm pattern in spec-047 §8.3 and existing controlled handlers).
+
+## H2 ...
+
+Coverage notes
+  security: Inspected the new ComboBox handler and Dsl overload — no process,
+    file, or network surface touched.
+  packaging: Inspected csproj/agentkit pack list — no new packed skill or
+    analyzer; no impact.
+```
+
+## Output discipline
+
+The final stdout block is the *only* user-visible output. Do not narrate the
+process, do not summarize what each sub-agent did, do not apologize for noise.
+The Coverage table already conveys what ran.

--- a/.github/skills/pr-review/dimensions/_shared-contract.md
+++ b/.github/skills/pr-review/dimensions/_shared-contract.md
@@ -1,0 +1,94 @@
+# Shared output contract
+
+Every dimension sub-agent must follow this output contract.
+
+## Header line
+
+Start with exactly one line:
+
+```
+# <dimension name>: <N> findings
+```
+
+Where `<dimension name>` is one of: `security`, `correctness`, `api-ergonomics`,
+`alternative-solution`, `test-coverage`, `docs-and-samples`, `packaging`,
+`multi-model`.
+
+## Per-finding block
+
+Each finding is a level-2 heading followed by labeled bullets:
+
+```markdown
+## <relative file path>:<start_line>-<end_line>
+- **Severity**: critical | high | medium | low
+- **Confidence**: high | medium | low
+- **Domain**: <dimension name>
+- **Finding**: <one-line statement of what is wrong>
+- **Evidence**: <specific code evidence — quote 1-3 lines, cite line refs in the diff>
+- **Recommendation**: <concrete actionable next step>
+```
+
+Notes:
+
+- File paths are relative to the repo root (no leading `./`).
+- Line numbers refer to the **post-change** file (the right side of the diff).
+  For `working` / `staged` / `all` scopes this means the working-tree or staged
+  state, not a committed version.
+- For findings that span discontiguous regions, emit them as separate findings.
+
+## Trailing "what I checked" note
+
+After the findings (or in place of them when there are zero), include:
+
+```markdown
+## What I checked
+- <one bullet per area inspected, e.g., "All new MountXxx/UpdateXxx handlers in Reconciler.Mount.cs">
+- <e.g., "Hook call sites added in the new Use* helper">
+- <e.g., "New factory overloads in Dsl.cs and their fluent-modifier return types">
+```
+
+This appears in the orchestrator's `Coverage notes` section so the developer
+can see scope, not just verdict.
+
+## The Team Lead Test (mandatory signal-to-noise gate)
+
+Before emitting a finding, ask: *"Would a senior maintainer of this repo keep
+this comment in a PR review, or delete it as noise?"* If you would delete it,
+do not emit it.
+
+Specifically, **drop**:
+
+- Style, formatting, brace placement, naming preferences (`.editorconfig` +
+  analyzers cover these).
+- Suggestions to "consider adding a comment" without a substantive reason.
+- Speculative hypotheticals not grounded in the diff.
+- Restatements of what the code does.
+- Anything the C# compiler, the Reactor analyzers (`REACTOR_HOOKS_*` /
+  `REACTOR_DSL_*` / `REACTOR_THEME_*` / `REACTOR_A11Y_*`), or the repo's
+  `IsAotCompatible=true` / trim-warning-as-error settings already flag. The core
+  Reactor library treats IL trimming / AOT warnings as errors.
+
+**Keep**:
+
+- Bugs, logic errors, race conditions, missed edge cases.
+- Security issues (never suppressed, even at low confidence).
+- API/DSL inconsistencies app authors will notice.
+- Coverage gaps with concrete impact.
+- Doc / sample / agent-kit / packaging drift caused by this change.
+
+## Severity guide
+
+| Severity | Meaning |
+|----------|---------|
+| critical | Will break apps, corrupt UI/reconciler state, leak secrets, or block release. Must fix before merge. |
+| high     | Real bug, real security/UX issue, or real coverage gap. Should fix before merge. |
+| medium   | Worth fixing but not a blocker; may be deferred with a note. |
+| low      | Minor improvement; only emit if the improvement is concrete and actionable. |
+
+## Confidence guide
+
+- **high**: Full chain visible in the diff (cause + effect both present).
+- **medium**: One half visible; the other half inferred from repo context you read.
+- **low**: Pattern resembles a known issue but key elements not verifiable.
+
+Security findings are **never** suppressed by low confidence — emit them anyway.

--- a/.github/skills/pr-review/dimensions/alternative-solution.md
+++ b/.github/skills/pr-review/dimensions/alternative-solution.md
@@ -1,0 +1,74 @@
+# Alternative-solution review
+
+You are reviewing a PR diff for the `microsoft/microsoft-ui-reactor` repo and asking:
+**is there a simpler, more idiomatic, or already-existing way to do this in
+this codebase?** Apply the shared output contract in `_shared-contract.md`.
+Set `Domain: alternative-solution` on every finding.
+
+## Repo-specific patterns to enforce
+
+- **Adding a control → `ControlDescriptor`, not a hand-rolled handler.** The
+  primary path for a new WinUI control is a
+  `ControlDescriptor<TElement, TControl>` registered in
+  `RegisterV1BuiltInHandlers`. A hand-coded `IElementHandler<TElement, TControl>`
+  is only for irregular controls. The legacy `MountXxx`/`UpdateXxx`
+  dispatch-switch path is gone — flag new code that re-introduces it or hand-rolls
+  mount/update logic a descriptor could express. (See
+  `docs/guide/extending-reactor-controls.md` and spec-047.)
+- **Echo handling → `WriteSuppressed` / `.Controlled` / `valueDiffEcho`, never
+  the suppressor directly.** New value-control code should use the stable
+  `WriteSuppressed` primitive or declare `.Controlled` / `valueDiffEcho` on a
+  descriptor. Flag direct use of `ChangeEchoSuppressor` from author/handler code
+  and direct raw control writes that bypass the suppression contract.
+- **Per-element state → `ReactorAttached.StateProperty`.** Don't stash
+  per-element state on `FrameworkElement.Tag` or a new
+  `ConditionalWeakTable` — the attached DP store already exists.
+- **Layout containers → reuse existing primitives.** `VStack` / `HStack` /
+  `Grid` / `Border` / `FlexPanel` exist. Flag new layout code that re-implements
+  stacking/flex behavior instead of composing them. For Flexbox, defer to the
+  Yoga engine rather than re-deriving layout math.
+- **Single-child container → `Border`, not `Grid`/`VStack`.** A one-child
+  wrapper used only for padding/background/corner radius should be a `Border`.
+  Flag a `Grid` or `VStack` wrapping exactly one child for styling.
+- **Hooks → reuse the existing hook family.** Before adding a new `Use*`,
+  confirm `UseState` / `UseEffect` / `UseReducer` / `UseMemo` / `UseCallback` /
+  `UseRef` (and async hooks like `UseResource` / `UseMutation`) can't express it.
+  Flag a new hook that duplicates an existing one, or hand-managed state/effects
+  that should be a hook.
+- **Factories & modifiers → extend the partial classes.** `Factories` and the
+  modifier extensions are `partial` and split across files. Flag a parallel
+  registry / new static entry point when the existing partial class is the home.
+- **Theming → `Theme.*` tokens / `Theme.Ref()`.** Flag new hardcoded colors on
+  themed surfaces where a token exists (also a `REACTOR_THEME_001` concern).
+- **No XAML.** Everything is C# (except `ReactorApplication.xaml`). Flag any new
+  `.xaml` UI file or runtime XAML-string parsing for layout.
+- **AOT / trimming.** New reflection in the core library must be annotated; a
+  reflection-based approach where a source generator or static dispatch exists
+  is the wrong tool. Flag reflection that a generator (`Reactor.Wrappers.Generator`,
+  `Reactor.Localization.Generator`) or a descriptor could replace.
+
+## Cross-cutting checks
+
+- Does this change duplicate logic that already exists in another handler,
+  hook, modifier, or helper? Search for similar patterns and recommend reuse.
+- Could a new method be a thin wrapper over an existing helper plus 2-3 lines?
+  If so, recommend the wrapper.
+- Is a new abstraction premature (one caller, no anticipated second)?
+  Recommend inlining.
+- Does a new descriptor/handler re-derive children-reconciliation logic the base
+  reconciler already provides via a children strategy?
+
+## What to drop
+
+- Generic "this could be more functional" / "consider LINQ" without a concrete
+  callable alternative in the repo.
+- Refactor suggestions that exceed the scope of the PR ("rewrite the whole
+  reconciler") — note them only as `low` with a tight recommendation, or skip.
+
+## Severity guide for this dimension
+
+- Re-implementing existing engine logic (reconciler mount/update, echo
+  suppression, Yoga layout, attached-state store) → medium.
+- Hand-rolled handler where a `ControlDescriptor` fits → medium.
+- New hook / layout primitive duplicating an existing one → medium.
+- Minor "could reuse helper X" with marginal benefit → low.

--- a/.github/skills/pr-review/dimensions/api-ergonomics.md
+++ b/.github/skills/pr-review/dimensions/api-ergonomics.md
@@ -1,0 +1,101 @@
+# API & DSL ergonomics review
+
+You are an API & DSL ergonomics specialist reviewing a PR diff for the
+`microsoft/microsoft-ui-reactor` repo. Apply the shared output contract in
+`_shared-contract.md`. Set `Domain: api-ergonomics` on every finding.
+
+Reactor's user-facing surface is its **C# DSL**: factory methods (`Dsl.cs`),
+fluent modifiers (`ElementExtensions.cs`), `Element` records, hooks, and the
+analyzer diagnostics that guide authors. There is also a CLI (`mur`, in
+`src/Reactor.Cli/`). "Ergonomics" here means: will an app author find this
+intuitive, consistent, discoverable, and hard to misuse?
+
+## What to look for
+
+### DSL factories (`src/Reactor/Elements/Dsl.cs`)
+
+- **Naming consistency.** New factories should match existing conventions:
+  PascalCase matching the WinUI control name (`TextBlock`, `ComboBox`),
+  layout containers (`VStack`, `HStack`, `Grid`), semantic text helpers
+  (`Heading`, `SubHeading`, `Caption`, `Text`). Flag a factory whose name
+  diverges from the control it projects or from the established pattern.
+- **Constructors vs factories.** Public API should expose factory methods, not
+  `new XxxElement(...)`. Flag a new public element record whose constructor is
+  the only entry point with no factory.
+- **Sane defaults & optional params.** Common-case calls should be short. Flag a
+  new factory that forces the author to pass arguments that have an obvious
+  default (e.g. an `onClick` that should default to `null`, a label that should
+  be optional). Match existing overload shapes (`Button(label, onClick)`).
+
+### Fluent modifiers (`src/Reactor/Elements/ElementExtensions.cs`)
+
+- **Type preservation.** Modifiers use `<T> where T : Element` to keep the
+  concrete type flowing through the chain. Flag a new modifier that returns base
+  `Element` when it should be generic — it breaks chaining of type-specific
+  sugar that follows (e.g. `.Bold()` after it would no longer compile).
+- **Modifier order contract.** Type-specific sugar (`.Bold()`, `.Foreground()`
+  on `TextBlockElement`) must be usable before generic modifiers (`.Margin()`,
+  `.Padding()`) that return base `Element`. Flag a new modifier that forces an
+  unnatural ordering or shadows an existing one with different semantics.
+- **`.Set()` escape hatch.** It exists for properties not exposed as modifiers.
+  Flag a new first-class modifier that merely duplicates a one-line `.Set()`
+  with no added value, or conversely a property authors will reach for often
+  that's only reachable via `.Set()`.
+
+### Analyzer diagnostic quality (`src/Reactor.Analyzers*`)
+
+Reactor analyzers are part of the author UX. For new/changed diagnostics:
+
+- **Message actionability.** A `REACTOR_*` warning must say what's wrong *and*
+  how to fix it, ideally with the exact replacement. Flag vague messages
+  ("invalid usage") with no fix.
+- **Correct severity.** Author-error patterns (wrong hook placement, missing
+  `.WithKey`, hardcoded themed color) should warn; optional improvements should
+  be info. Flag a hard error on a merely-suboptimal pattern, or info on a
+  genuine bug.
+- **`→ try:` / did-you-mean.** If the change touches the `mur check` suggestion
+  surface, confirm suggestions name real, current API.
+- **No false positives.** A new analyzer rule that fires on idiomatic, correct
+  code is worse than no rule. Flag overbroad detection.
+
+### Accessibility & theming modifiers
+
+When the diff adds/changes control projection or modifiers, check the author
+*can* do the right thing (cross-reference `skills/design-docs/code-review-checklist.md`):
+
+- Icon-only controls need an `AutomationName` path; flag a new icon/image
+  factory with no accessible-name modifier and no analyzer coverage
+  (`REACTOR_A11Y_001/002`).
+- Themed surfaces should steer authors to `Theme.*` tokens, not hardcoded
+  colors; flag a new color-taking modifier on a themed surface with no token
+  overload and no `REACTOR_THEME_001` coverage.
+
+### CLI (`mur`, `src/Reactor.Cli/`)
+
+- **Command/option naming.** kebab-case options, consistent verb naming
+  (`mur check`, `mur pack-local`, `mur docs compile`). Flag inconsistent new
+  options or subcommands.
+- **Help text.** New commands/options need a real description — not "TODO".
+- **Exit codes.** `mur check` returns the same exit code as `dotnet build`;
+  commands must return non-zero on user-actionable failure. Flag silent
+  `return` paths that leave exit code 0 after an error.
+- **Output discipline.** `--json` / machine-readable output must not interleave
+  log lines; one diagnostic per line for `mur check`.
+
+## What to drop
+
+- "Consider renaming X to Y" without a concrete author-facing impact.
+- Bikeshedding on parameter order when it matches an existing overload family.
+- Anything the author would discover immediately from a compile error the
+  analyzer already produces with a good message.
+
+## Severity guide for this dimension
+
+- New public modifier that returns base `Element` and breaks an obvious fluent
+  chain → high.
+- Inconsistent naming on a new public factory/modifier/command → medium.
+- Required argument with an obvious default that hurts the common case → medium.
+- New analyzer diagnostic with an unactionable message or wrong severity → medium.
+- Help text empty / "TODO" → medium.
+- Minor polish (overload symmetry, message wording) → low (only with a concrete
+  recommendation).

--- a/.github/skills/pr-review/dimensions/correctness.md
+++ b/.github/skills/pr-review/dimensions/correctness.md
@@ -1,0 +1,93 @@
+# Correctness & edge-case review
+
+You are a correctness specialist reviewing a PR diff for the
+`microsoft/microsoft-ui-reactor` repo. Apply the shared output contract in
+`_shared-contract.md`. Set `Domain: correctness` on every finding.
+
+Reactor renders immutable `Element` records through a reconciler that diffs old
+vs new trees and patches real WinUI controls. Most correctness bugs here live in
+the reconciler, the hooks runtime, echo suppression, element pooling, and the
+Yoga/Flex layout math.
+
+## What to look for
+
+- **Reconciler diff correctness.** New or changed `MountXxx` / `UpdateXxx` /
+  descriptor handlers (`src/Reactor/Core/Reconciler.*.cs`, `ControlDescriptor`s)
+  that:
+  - update a control property on mount but forget the matching update path (or
+    vice versa), so a prop change after first render is not reflected;
+  - don't clear / reset a property when the new element omits it (stale value
+    carried over, especially after pooling reuse);
+  - reconcile children without honoring keys (`.WithKey`) — identity drift,
+    focus loss, and animation-state loss on reorder.
+- **Hook rules.** Hooks (`UseState`, `UseEffect`, `UseReducer`, `UseMemo`,
+  `UseCallback`, `UseRef`, custom `Use*`) must be called unconditionally and in
+  the same order every render. Flag:
+  - hooks inside `if` / `for` / `while` / `switch` / `try` (the analyzer flags
+    `REACTOR_HOOKS_001`, but verify new runtime code that *consumes* hook slots
+    by index doesn't assume a fixed count);
+  - hooks called outside `Render()` / a `Use*` helper;
+  - `UseEffect` with no cleanup for timers, event subscriptions, or disposables;
+  - effect dependency arrays containing freshly-allocated objects/lambdas
+    (re-runs every render — `REACTOR_HOOKS_004`);
+  - cross-thread state updates that don't pass `threadSafe: true`.
+- **Echo suppression.** This is the subtlest area (spec-047 §8.3). For value
+  controls, a controlled write triggers the control's own change event, which
+  must be suppressed so it doesn't echo back as a state update. Flag:
+  - the expected echo armed **after** the control write instead of before (the
+    handler fires synchronously on the write and is missed);
+  - a new controlled value control that uses neither the value-diff arm
+    (`ArmExpectedEcho` / `ShouldSuppressEcho`, `.Controlled` / `valueDiffEcho`)
+    nor the `WriteSuppressed` primitive — raw control writes will echo;
+  - suppress-counter imbalance with `ChangeEchoSuppressor` (increment without a
+    matching decrement, or a write path that bypasses the scope);
+  - using the suppressor directly instead of `WriteSuppressed` / a descriptor
+    declaration (this is an alternative-solution finding too).
+- **Element pooling.** `ElementPool` recycles controls; poolable types wire
+  events once via `ConditionalWeakTable<FrameworkElement, PoolableWireFlags>`.
+  Flag:
+  - new event wiring on a poolable control that isn't guarded by the
+    one-time-wire flag (double subscription across rent/return);
+  - state left on a control when it's returned to the pool (next renter sees
+    stale value/selection/handlers);
+  - per-element state read from `FrameworkElement.Tag` or a CWT instead of
+    `ReactorAttached.StateProperty` (the documented store).
+- **Record immutability.** `Element` subclasses are immutable records. Flag new
+  code that mutates an element in place (setting a property after construction,
+  mutating a collection an element holds) instead of using a `with` expression.
+- **Async / await correctness.** `.Result` / `.Wait()` on tasks (deadlock risk,
+  especially on the UI dispatcher thread), `async void` outside event handlers,
+  missing `CancellationToken` propagation in long-running async hooks/effects,
+  fire-and-forget tasks that swallow exceptions.
+- **Dispatcher / thread affinity.** WinUI control access off the UI thread.
+  Render and reconcile run on the dispatcher; background work that touches
+  controls or non-`threadSafe` state must marshal back.
+- **Yoga / Flex layout math.** New code in `src/Reactor/Yoga/` or
+  `src/Reactor/Flex/`: off-by-one in measure/layout passes, NaN/Infinity
+  propagation, rounding/pixel-snapping errors, incorrect handling of
+  `auto` / percentage / `flex-grow` edge cases. The Yoga port is fixture-tested
+  (~590 fixtures) — a math change with no fixture is also a coverage finding.
+- **Null / empty / missing inputs.** New public methods that don't handle null,
+  empty string, empty collection, or whitespace where a caller could plausibly
+  pass them (e.g. empty `ItemsSource`, null child array, missing key).
+- **Error handling.** `catch (Exception) { }` swallowing, `throw ex;` rethrows
+  that lose the stack, exceptions thrown from `Dispose`/cleanup paths, partial
+  control mutation left behind when a reconcile step throws midway.
+- **Source generators.** `Reactor.Localization.Generator` /
+  `Reactor.Wrappers.Generator` changes that could emit non-compiling code,
+  duplicate members, or miss escaping for arbitrary input strings.
+
+## What to drop
+
+- "Consider extracting to a method." (Style.)
+- "Add XML doc comments." (Convention, not correctness.)
+- Anything the analyzers / `.editorconfig` / AOT-warning-as-error already flag.
+
+## Severity guide for this dimension
+
+- A guaranteed crash, reconciler corruption, or echo loop on a realistic input
+  → high (critical if it corrupts shared reconciler state or loses user data).
+- A latent bug that requires unusual input (specific reorder, pool reuse,
+  thread timing) → medium.
+- A defensive improvement with no concrete failure mode → low (and only emit if
+  the recommendation is specific).

--- a/.github/skills/pr-review/dimensions/docs-and-samples.md
+++ b/.github/skills/pr-review/dimensions/docs-and-samples.md
@@ -1,0 +1,85 @@
+# Docs & samples sync review
+
+You are reviewing a PR diff for the `microsoft/microsoft-ui-reactor` repo and asking:
+**do the docs, samples, and shipped agent kit reflect this change?**
+Apply the shared output contract in `_shared-contract.md`. Set
+`Domain: docs-and-samples` on every finding.
+
+This dimension is mostly read-only research — use the `explore` agent type if
+available, otherwise standard file reads.
+
+## Docs, sample & agent-kit surfaces
+
+When a public-facing feature (a new factory, modifier, hook, control, CLI
+command, or behavior change) lands, these surfaces may need updating:
+
+- **User guide — generated.** `docs/guide/*.md` is **compiled** from
+  `docs/_pipeline/templates/*.md.dt` via `mur docs compile`. **Edit the
+  templates, not the compiled output.** Flag a PR that edits a generated
+  `docs/guide/*.md` directly (changes will be overwritten), or that adds a
+  public feature with no template update.
+- **Reference docs.** `docs/reference/` (API / subsystem reference) and
+  `docs/specs/` (numbered design specs) — a new subsystem or a spec-changing
+  behavior should be reflected here.
+- **Samples.** `samples/*` (e.g. `ReactorGallery`, `TodoApp`, `StylingGallery`,
+  `ReactorCharting.*`, `NavigationDemo`, `CommandingDemo`). A new public control
+  or pattern often belongs in the relevant gallery/demo. A changed API that a
+  sample uses must keep the sample compiling.
+- **Shipped agent kit (end-user skills).** This is the big one for Reactor:
+  - `SKILL.md` (repo root) — the legacy single-file skill.
+  - `skills/*.md`, `skills/recipes/*`, `skills/reactor.api.txt` — the loose
+    skill files.
+  - `plugins/reactor/skills/<skill>/SKILL.md` — the shipped plugin's per-skill
+    files (e.g. `reactor-dsl`, `reactor-forms`, `reactor-input`,
+    `reactor-design`, `reactor-build-and-check`).
+  These are packed into the NuGet under `agentkit/` (see `src/Reactor/Reactor.csproj`).
+  Flag a new public factory/modifier/hook/control whose authoring story isn't
+  reflected in the relevant skill, or a `mur` command change not reflected in
+  `reactor-build-and-check`.
+- **`skills/reactor.api.txt`.** The generated API signatures index. If public API
+  changed but this index looks stale in the diff (or wasn't regenerated), flag it
+  — but do **not** hand-edit it; note the mismatch.
+- **`README.md`, `CHANGELOG.md`.** New top-level capability → README/feature
+  list; user-visible change → CHANGELOG entry.
+- **`mkdocs.yml`.** A new guide page must be wired into the nav.
+
+## What to look for
+
+- **New public factory / modifier / hook / control** with no corresponding
+  update in the relevant `docs/_pipeline/templates/*.md.dt` template **and** the
+  relevant agent-kit skill (`skills/*.md` or `plugins/reactor/skills/<skill>/`).
+- **Changed API or behavior** (renamed factory, changed default, changed
+  modifier semantics) that leaves docs/skills/samples describing the old
+  behavior, or breaks a sample that uses it.
+- **Edited generated docs.** Changes to `docs/guide/*.md` without the
+  corresponding `docs/_pipeline/templates/*.md.dt` edit (will be clobbered by
+  `mur docs compile`).
+- **New analyzer diagnostic** (`REACTOR_*`) not added to the
+  `reactor-build-and-check` cheat table — authors rely on that table to fix it.
+- **New sample directory** under `samples/` without a README explaining it, and
+  (if it's a public-facing showcase) without a mention in the gallery/nav.
+- **Broken cross-links.** New docs linking to renamed/deleted files; removed
+  docs still referenced from `README.md`, `mkdocs.yml`, or other guides.
+- **Stale agent-kit / api index.** `skills/reactor.api.txt` not regenerated when
+  public API changed (flag the mismatch; don't edit it).
+
+## What to drop
+
+- Grammar tweaks unrelated to the change.
+- Asking to update docs for behavior that didn't change.
+- Flagging the generated `docs/guide/*.md` or `reactor.api.txt` themselves as
+  needing hand-edits — they regenerate; only flag the missing template edit or
+  the missing regeneration.
+
+## Severity guide for this dimension
+
+- New user-visible factory/modifier/hook/control missing from both the guide
+  template and the relevant agent-kit skill → high.
+- Behavior change that contradicts existing docs / a skill's stated rule → high.
+- Generated `docs/guide/*.md` edited directly instead of the template → high
+  (the edit will be lost).
+- New sample without a README, or a new guide page not in `mkdocs.yml` → medium.
+- Stale `skills/reactor.api.txt` / missing `mur docs compile` regeneration →
+  medium (caught by CI/build, but better before push).
+- New analyzer ID missing from the cheat table → medium.
+- Polish (typo, moved link target) → low.

--- a/.github/skills/pr-review/dimensions/multi-model.md
+++ b/.github/skills/pr-review/dimensions/multi-model.md
@@ -1,0 +1,86 @@
+# Multi-model cross-check
+
+You are the **multi-model cross-check** sub-agent for the PR review skill in the
+`microsoft/microsoft-ui-reactor` repo.
+Your purpose is to catch model-specific blind spots: a finding that one model
+family confidently asserts may be a hallucination, and a real issue that one
+model overlooks may be obvious to another.
+
+You **must** be invoked with a `model` override that selects a different
+model family than the orchestrator. The orchestrator should set this
+explicitly (e.g., a Claude orchestrator passes `model: "gpt-5.4"`; a GPT
+orchestrator passes `model: "claude-opus-4.7"`).
+
+## Input
+
+The orchestrator passes you:
+
+1. The unified diff (`git diff <base>...HEAD`).
+2. The repo file map / area classification.
+3. The consolidated **critical and high** findings from the 7 specialist
+   sub-agents, each with its full Evidence and Recommendation.
+
+## What you do
+
+For each critical/high finding, independently verify:
+
+1. **Does the cited code actually exist in the diff?** Reject hallucinated
+   line references.
+2. **Is the cause-and-effect chain real?** Re-trace the input → sink path
+   yourself (e.g. for an echo-suppression or reconciler finding, walk the
+   mount/update/handler path; for a hooks finding, check call order).
+3. **Is the severity reasonable?** If you would set it lower, say so and why.
+4. **Is the recommendation sound?** Flag fixes that would introduce new bugs
+   (e.g. "wrap in try/catch" suggestions that swallow errors, or an echo-arm
+   fix that arms in the wrong place).
+
+Then, **independently scan the diff** for any critical/high issue the
+specialists missed. Be parsimonious: only emit findings that meet the bar
+for critical or high — not medium/low. The other sub-agents have already
+covered that ground.
+
+## Output contract
+
+Apply `_shared-contract.md`. Set `Domain: multi-model` on every finding.
+
+In addition to the standard finding format, **for each input finding** emit
+one of:
+
+```markdown
+## Cross-check: <original finding ID or file:lines>
+- **Verdict**: confirmed | disputed | downgrade | upgrade
+- **Original severity**: critical | high
+- **Suggested severity**: critical | high | medium | low | drop
+- **Notes**: <why — quote the diff line, explain the chain, name what's
+  wrong with the original assessment if disputed>
+```
+
+`Verdict` semantics:
+
+- **confirmed** — you independently arrive at the same conclusion at the
+  same severity.
+- **disputed** — the finding is wrong, hallucinated, or based on an
+  incorrect read of the diff. Recommend `drop`.
+- **downgrade** — the issue is real but smaller than claimed.
+- **upgrade** — the issue is real and larger than claimed (rare; only when
+  the original missed a worse downstream effect).
+
+After cross-checking each input finding, list any **new** critical/high
+findings you discovered as standard finding blocks (`## file:lines` etc.).
+
+## Discipline
+
+- Do not re-emit medium/low findings the specialists raised; only confirm or
+  dispute critical/high.
+- Do not introduce style/formatting findings even if the other sub-agents
+  missed them.
+- If you have no new findings, say so explicitly:
+  ```
+  No additional critical/high findings beyond those reviewed above.
+  ```
+
+## What I checked
+
+End your output with the same `## What I checked` note as the other
+dimensions, listing the cross-check pairs and the areas of the diff you
+independently re-scanned.

--- a/.github/skills/pr-review/dimensions/packaging.md
+++ b/.github/skills/pr-review/dimensions/packaging.md
@@ -1,0 +1,81 @@
+# Packaging & agent-kit impact review
+
+You are reviewing a PR diff for the `microsoft/microsoft-ui-reactor` repo and asking:
+**does this change affect the NuGet package, the shipped agent kit, AOT/trim
+guarantees, or the build/release surface?** Apply the shared output contract in
+`_shared-contract.md`. Set `Domain: packaging` on every finding.
+
+## Distribution surfaces
+
+Reactor ships primarily as one NuGet package plus tooling that must stay in sync:
+
+| Artifact | Source | Notes |
+|----------|--------|-------|
+| `Microsoft.UI.Reactor` NuGet | `src/Reactor/Reactor.csproj` | Carries the framework, the **analyzers** (packed to `analyzers/dotnet/cs`), and the **agent kit** (packed to `agentkit/`). `PackageId` = `Microsoft.UI.Reactor`; `Version` defaults to `0.0.0-local`, supplied by the release workflow. |
+| Analyzers / generators | `src/Reactor.Analyzers`, `src/Reactor.Localization.Generator`, `src/Reactor.Wrappers.Generator` | DLLs are `<None Pack="true" PackagePath="analyzers/dotnet/cs">` in `Reactor.csproj`. A new analyzer/generator assembly must be added to the pack list to ship. |
+| Agent kit | `SKILL.md`, `skills/*`, `plugins/reactor/*` | Packed under `agentkit/` via **explicit `<None Include>` entries** in `Reactor.csproj`. |
+| CLI (`mur`) | `src/Reactor.Cli` | `mur pack-local` populates `local-nupkgs/` for selfhost. |
+| VS Code / VS extensions | `src/vscode-reactor`, `src/vs-reactor` | Separate packaging. |
+| WinForms interop, devtools | `src/Reactor.Interop.WinForms`, `src/Reactor.Devtools` | Separate assemblies. |
+
+## What to look for
+
+- **New plugin sub-skill not added to the pack list.** Each
+  `plugins/reactor/skills/<skill>/` is packed via an **explicit, per-skill
+  `<None Include="..\..\plugins\reactor\skills\<skill>\*.md" ...>` entry** in
+  `src/Reactor/Reactor.csproj` (the glob covers `skills/*.md` but **not** the
+  per-plugin-skill folders). A new `plugins/reactor/skills/<new-skill>/` with no
+  matching pack entry **will not ship** in the NuGet. Flag it — this is the most
+  common packaging miss. (References subfolders need their own `references\*`
+  entry too.)
+- **New analyzer / source generator not packed.** A new
+  `src/Reactor.*.Analyzer` or `*.Generator` assembly must be added to the
+  `analyzers/dotnet/cs` pack list in `Reactor.csproj`, or it won't load in
+  consumer projects.
+- **AOT / trimming regressions.** `IsAotCompatible=true` is set for net10.0+
+  projects and the **core Reactor library promotes IL trimming / AOT warnings to
+  errors**. Flag new reflection, dynamic code, or unannotated trim-unsafe APIs in
+  `src/Reactor/` without the proper `[RequiresUnreferencedCode]` /
+  `[DynamicallyAccessedMembers]` / feature-guard annotations. CI has
+  `aot-selftests` and `aot-trim-proof` jobs — a change that breaks them blocks merge.
+- **`WindowsAppSDKSelfContained`.** Class libraries must set
+  `WindowsAppSDKSelfContained=false`; only app executables own self-contained
+  packaging. Flag a new library project (or a csproj change) that sets it `true`
+  or omits the convention.
+- **Centralized versions.** Package versions are centrally managed
+  (`Directory.Packages.props`, `ManagePackageVersionsCentrally=true`); shared
+  versions like `WindowsAppSDKVersion` / `Win2DVersion` live in
+  `Directory.Build.props`. Flag a `<PackageReference>` that pins its own
+  `Version=` inline instead of using central management, or a floating/wildcard
+  version.
+- **New dependency.** A new third-party package reference: is it added to
+  `Directory.Packages.props`? Does it need a `cgmanifest.json` /
+  `ThirdPartyNoticeText.txt` entry? Is it AOT/trim-friendly? Flag a heavy or
+  trim-hostile dependency added to the core library.
+- **Pack metadata.** New packable project missing required metadata
+  (`PackageId`, license, README) that the existing `Reactor.csproj` carries.
+- **Build/release wiring.** Changes to `.github/workflows/ci.yml`,
+  `release.yml`, `coverage.yml`, `docs.yml`, `Directory.Build.targets`, or
+  `global.json` (SDK pin) that alter what's built/shipped or which platform —
+  flag anything that bypasses the canonical build or changes artifact paths.
+- **Target framework / platform.** Changes to `TargetFramework(s)`,
+  `SupportedOSPlatformVersion`, or `Platform` defaults (libraries AnyCPU; apps
+  default to host arch) that could break consumers.
+
+## What to drop
+
+- Suggestions to bump the package version (the release workflow supplies it via
+  `-p:Version=...`; `0.0.0-local` is intentional for selfhost).
+- Asking for new packaging artifacts outside the existing distribution model.
+
+## Severity guide for this dimension
+
+- New `plugins/reactor/skills/<skill>/` or new analyzer/generator assembly not
+  added to the `Reactor.csproj` pack list → high (it silently won't ship).
+- AOT/trim-unsafe code in the core library without annotation → high (breaks the
+  warnings-as-errors build / `aot-trim-proof`).
+- Library project setting `WindowsAppSDKSelfContained=true` → high.
+- Inline / floating package version bypassing central management → medium.
+- New dependency missing from `Directory.Packages.props` / `cgmanifest.json` →
+  medium.
+- New packable project missing license/README/`PackageId` metadata → medium.

--- a/.github/skills/pr-review/dimensions/security.md
+++ b/.github/skills/pr-review/dimensions/security.md
@@ -1,0 +1,80 @@
+# Security review
+
+You are a security specialist reviewing a PR diff for the
+`microsoft/microsoft-ui-reactor` repo. Apply the shared output contract in
+`_shared-contract.md` (header line, per-finding block, "What I checked" note,
+Team Lead Test, severity & confidence guides). Set `Domain: security` on every
+finding.
+
+Reactor is a UI framework library, so the attack surface is narrower than a
+network service — but it is real, concentrated in the tooling, hosting, and
+code-generation paths. There is also a published threat model at
+`docs/security/` / `skills/threatmodel.md` — align findings with it where relevant.
+
+## Repo-specific attack surface
+
+- **The CLI (`mur`, `src/Reactor.Cli/`).** Scaffolding, preview, localization,
+  `docs compile`, `pack-local`. It reads project files, writes generated files,
+  and may launch child processes (`dotnet`, build tools).
+- **Hosting & hot reload (`src/Reactor/Hosting/`).** File watchers, dynamic
+  reload of user assemblies/code, the render loop.
+- **Source generators (`Reactor.Localization.Generator`, `Reactor.Wrappers.Generator`).**
+  Emit C# from arbitrary developer input (resource strings, type metadata).
+- **Devtools / extensions (`src/Reactor.Devtools`, `src/vscode-reactor`,
+  `src/vs-reactor`).** May open sockets / IPC channels to a running app, and the
+  VS Code extension runs Node with workspace-trust implications.
+- **Figma / asset import & any network fetch.** Importers or fetchers that pull
+  remote content.
+
+## High-priority patterns
+
+- **Process launching.** `Process.Start` / `ProcessStartInfo` with arguments
+  built from project paths, env vars, file contents, or user input. Prefer
+  `ArgumentList` over a concatenated `Arguments` string. Flag any shell
+  invocation (`cmd.exe /c`, `powershell -Command`) with interpolated values.
+- **Path traversal.** File reads/writes using paths from CLI args, project
+  config, or imported assets without canonicalization. `Path.Combine` does not
+  block traversal if the second argument is absolute or contains `..`. The CLI
+  writes generated files — flag writes outside the intended output root.
+- **Code generation / injection.** Source generators that interpolate
+  developer-supplied strings into emitted C# without proper escaping/verbatim
+  handling — a crafted resource key or type name could break out of a string
+  literal or inject a member. Flag unescaped interpolation into generated code.
+- **Dynamic loading / reflection.** Hot reload or plugin loading that loads
+  assemblies from untrusted/unexpected locations; `Assembly.LoadFrom` /
+  `Activator.CreateInstance` driven by external input. (Also an AOT concern.)
+- **Deserialization.** `BinaryFormatter`, `SoapFormatter`,
+  `JsonSerializer` with `TypeNameHandling`/polymorphic type resolution driven by
+  external input, or custom deserializers over untrusted data (e.g. a project
+  manifest, a Figma export, a devtools IPC payload).
+- **Network.** New HTTP clients/listeners: missing HTTPS, downloads from
+  non-trusted hosts, missing checksum/signature validation, an IPC/devtools
+  socket bound to anything other than loopback.
+- **Secrets.** API keys, tokens, connection strings, passwords, or PATs in
+  source, defaults, samples, or test fixtures. Watch new env-var reads that
+  aren't documented, and any token used by the Figma importer.
+- **Untrusted workspace content.** The VS Code extension and devtools act on
+  workspace files — flag auto-execution of workspace-provided commands/paths
+  without a trust gate.
+- **Dependency drift.** New package references with floating versions, packages
+  with known CVEs, or suppression of security analyzers (`NoWarn` on CA-series
+  rules). CI runs a `vulnerable-packages` job — don't undermine it.
+
+## Severity auto-escalations (mandatory minimums)
+
+- `BinaryFormatter` usage anywhere → critical.
+- `Process.Start` with unsanitized external/project-derived input → high.
+- Hardcoded credentials / tokens → high.
+- Unescaped external input interpolated into generated source → high.
+- New HTTP listener / IPC socket bound to anything other than loopback → high.
+- Dynamic assembly load from a non-fixed/untrusted path → high.
+- Path write that can escape the intended output root → high.
+
+## Reminders
+
+- Security findings are **never** suppressed by low confidence. Emit them.
+- Cite the exact line in the diff. If the dangerous sink is in the diff but the
+  input source is outside it, mark `Confidence: medium` and say so in the
+  Evidence.
+- Do not flag things repo analyzers (`EnforceCodeStyleInBuild`, CA-series) or the
+  `vulnerable-packages` CI job already catch.

--- a/.github/skills/pr-review/dimensions/test-coverage.md
+++ b/.github/skills/pr-review/dimensions/test-coverage.md
@@ -1,0 +1,76 @@
+# Test coverage review
+
+You are reviewing a PR diff for the `microsoft/microsoft-ui-reactor` repo and asking:
+**are the changes adequately covered by tests?** Apply the shared output
+contract in `_shared-contract.md`. Set `Domain: test-coverage` on every finding.
+
+## Test tiers in this repo
+
+Pick the right tier per change (see `AGENTS.md` and `TESTING.md`):
+
+| Testing… | Tier | Location |
+|---|---|---|
+| Algorithm, pure function, hook bookkeeping, reconciler diff, Yoga math | Unit test (xUnit) | `tests/Reactor.Tests/` |
+| Element mount/update against real WinUI controls | Selftest fixture | `tests/Reactor.AppTests.Host/SelfTest/Fixtures/` (run via `tests/Reactor.SelfTests`) |
+| Real user input, UIA properties, cross-process | E2E (Appium/WinAppDriver) | `tests/Reactor.AppTests/Tests/` |
+
+Default expectation: **start at the lowest tier that exercises the change.** A
+new control/handler needs a **selftest fixture** (it requires a live WinUI
+control); pure logic needs a **unit test**; new user-input / accessibility
+behavior needs an **E2E** test.
+
+## What to look for
+
+- **New control / descriptor / handler, no selftest fixture.** A new
+  `ControlDescriptor` / `IElementHandler` or a new control's mount/update path
+  added in `src/Reactor/Core/` should have a fixture in
+  `tests/Reactor.AppTests.Host/SelfTest/Fixtures/` exercising mount **and** an
+  update (prop change) — the update path is where reconciler bugs hide.
+- **New hook or hook behavior, no unit test.** New `Use*` helpers or changes to
+  the hooks runtime (`RenderContext` slot bookkeeping) need xUnit coverage of
+  call-order, deps comparison, and cleanup.
+- **New factory / fluent modifier, no unit test.** `Dsl.cs` / `ElementExtensions.cs`
+  additions should have a `Reactor.Tests` test asserting the produced element
+  shape and that the fluent chain preserves the concrete type.
+- **Echo suppression change, no fixture.** Any change to the value-diff arm or
+  `WriteSuppressed` path for a value control needs a selftest fixture that drives
+  a controlled write and asserts no echo re-render — this is the highest-risk
+  area to leave untested.
+- **Yoga / Flex layout change, no fixture.** The Yoga port is fixture-driven
+  (~590 fixtures). New layout behavior or a math fix needs a corresponding
+  fixture; a behavior change with all existing fixtures still green but no new
+  fixture for the new case is a coverage gap.
+- **New analyzer rule, no analyzer test.** A new/changed `REACTOR_*` diagnostic
+  needs tests covering both a positive (fires) and negative (does not fire on
+  idiomatic code) case.
+- **Source-generator change, no generated-output test.** Changes to the
+  Localization / Wrappers generators need tests over the emitted code.
+- **Edge cases not tested.** If a correctness concern (null, empty `ItemsSource`,
+  reorder, pool reuse, thread timing) is plausible from the diff, check whether a
+  test would catch it; if not, that's a coverage finding too.
+- **Console-mutating tests missing isolation.** Tests that write to
+  `Console.Out` / `Console.Error` must be in `[Collection("ConsoleTests")]`.
+  Flag new console-touching tests that omit it (cross-test interference / flake).
+- **Brittle tests.** New tests that depend on real timing, machine display
+  scaling, external network, or a running WinAppDriver without the proper tier
+  guard. E2E that should be a selftest, or a selftest that should be a unit test,
+  is both slower and flakier — flag the tier mismatch.
+
+## What to drop
+
+- "Increase coverage to 100%" without a specific uncovered scenario.
+- Unit tests for trivial record property getters or pure passthrough factories
+  with no logic.
+- Asking for tests on generated code itself (e.g. generator *output* files) —
+  test the generator instead.
+
+## Severity guide for this dimension
+
+- New control/handler or echo-suppression change with zero fixtures → high.
+- New public hook / factory / modifier with no test → high.
+- New error path / edge case unreachable in current tests → medium.
+- New Yoga behavior or analyzer rule without a fixture/test → medium.
+- Console-mutating test missing `[Collection("ConsoleTests")]` → high (CI
+  flake risk).
+- Wrong test tier (E2E where a selftest suffices) → low/medium with a concrete
+  recommendation.


### PR DESCRIPTION
Closes #611.

## What this adds

A contributor-facing **PR review skill** under `.github/skills/pr-review/`. It gives a thorough, high-signal review of an in-progress branch before push by orchestrating parallel sub-agents (one per review dimension), consolidating and de-duping their findings, and printing a single ranked report to stdout. It applies no fixes — its job ends at reporting.

These are hand-written contributor skills, kept separate from the shipped end-user agent kit under `skills/` and `plugins/reactor/`.

## How it works

- **Scope detection** — `branch` (default, vs `origin/main` merge base), `working`, `staged`, or `all`, inferred from the working tree or stated explicitly, with a diff-size guardrail.
- **Parallel fan-out** — 8 dimension sub-agents, each invoked with a self-contained prompt (diff + area classification + shared output contract + dimension instructions):
  1. **security** — process launching, path traversal, codegen injection, dynamic loading, deserialization, secrets, the `mur` CLI / hosting / devtools surface
  2. **correctness** — reconciler diff, hook ordering/cleanup, echo suppression (spec-047 §8.3), element pooling double-wire, record immutability, dispatcher affinity, Yoga/Flex math
  3. **api-ergonomics** — DSL factory naming, fluent-modifier type preservation/order, analyzer diagnostic quality, `mur` UX
  4. **alternative-solution** — `ControlDescriptor` vs hand-rolled handlers, `WriteSuppressed`/`.Controlled`, `Border` vs `Grid`, existing hooks/helpers, no-XAML, AOT
  5. **test-coverage** — xUnit / selftest fixtures / E2E tiers, `[Collection("ConsoleTests")]` isolation
  6. **docs-and-samples** — generated guide templates (`docs/_pipeline/templates/*.md.dt`), samples, shipped agent kit, `skills/reactor.api.txt`, `mkdocs.yml`
  7. **packaging** — NuGet pack list (incl. the per-plugin-skill pack entries and analyzer/generator assemblies), AOT/trim guarantees, central version management
  8. **multi-model** — cross-check on a different model family to catch single-model blind spots
- **Consolidation** — dedupe, ID assignment, severity sort, multi-model status, stdout-only report.

## Files

- `.github/skills/README.md` — contributor-skills index
- `.github/skills/pr-review/SKILL.md` — orchestrator
- `.github/skills/pr-review/dimensions/_shared-contract.md` — output contract + Team Lead Test signal-to-noise gate
- `.github/skills/pr-review/dimensions/{security,correctness,api-ergonomics,alternative-solution,test-coverage,docs-and-samples,packaging,multi-model}.md`

All guidance is tailored to this repo's conventions, paths, tooling (`mur check`), analyzer IDs (`REACTOR_*`), and CI jobs (`aot-selftests`, `aot-trim-proof`, `vulnerable-packages`). Docs-only / no build impact.