### PR TITLE
Ci/nightly internal feed

### DIFF
--- a/build/pipelines/OneBranch.Nightly.Reactor.yml
+++ b/build/pipelines/OneBranch.Nightly.Reactor.yml
@@ -1,0 +1,88 @@
+#################################################################################
+#                               OneBranch Pipelines                             #
+# Internal nightly pipeline for Microsoft.UI.Reactor.                           #
+# Builds, signs, packs, and publishes signed nightly NuGet packages to the      #
+# internal Azure Artifacts feed on a daily schedule.                            #
+#################################################################################
+
+trigger: none
+pr: none
+
+schedules:
+- cron: '0 9 * * *'
+  displayName: 'Nightly build main'
+  branches:
+    include:
+      - main
+  always: true
+
+parameters:
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+- name: 'publishNuGet'
+  displayName: 'Publish packages to the internal Azure Artifacts feed.'
+  type: boolean
+  default: true
+
+variables:
+  CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]
+  system.debug: ${{ parameters.debug }}
+  CI: true
+  CopilotSkipCliDownload: true
+  BuildSolution: $(Build.SourcesDirectory)\Reactor.slnx
+  BuildConfiguration: Release
+  NuGetConfig: $(Build.SourcesDirectory)\build\pipelines\nuget.internal.config
+  InternalNuGetFeed: 'https://pkgs.dev.azure.com/github-private/microsoft/_packaging/microsoft-ui-reactor/nuget/v3/index.json'
+
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+extends:
+  template: v2/OneBranch.Official.CrossPlat.yml@templates
+  parameters:
+    cloudvault:
+      enabled: false
+    globalSdl:
+      tsa:
+        enabled: true
+      policheck:
+        break: true
+
+    stages:
+    - stage: build
+      jobs:
+      - job: main
+        pool:
+          type: windows
+          hostVersion:
+            Version: 2022
+
+        variables:
+          ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+          ob_git_fetchDepth: -1
+          ob_sdl_binskim_enabled: true
+          ob_sdl_binskim_break: true
+          ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+            ob_symbolsPublishing_enabled: true
+
+        steps:
+          - template: /build/pipelines/templates/reactor-build-steps.yml@self
+            parameters:
+              outputDirectory: '$(Build.SourcesDirectory)\out'
+              solution: '$(BuildSolution)'
+              configuration: '$(BuildConfiguration)'
+              nugetConfig: '$(NuGetConfig)'
+              channel: nightly
+              runTests: true
+              pack: true
+              sign: true
+              publishNuGet: ${{ parameters.publishNuGet }}
+              nuGetFeed: '$(InternalNuGetFeed)'

--- a/build/pipelines/OneBranch.Nightly.Reactor.yml
+++ b/build/pipelines/OneBranch.Nightly.Reactor.yml
@@ -34,7 +34,7 @@ variables:
   BuildSolution: $(Build.SourcesDirectory)\Reactor.slnx
   BuildConfiguration: Release
   NuGetConfig: $(Build.SourcesDirectory)\build\pipelines\nuget.internal.config
-  InternalNuGetFeed: 'https://pkgs.dev.azure.com/github-private/microsoft/_packaging/microsoft-ui-reactor/nuget/v3/index.json'
+  InternalNuGetFeed: 'https://pkgs.dev.azure.com/github-private/microsoft/_packaging/microsoft-ui-reactor-internal/nuget/v3/index.json'
 
   WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
 

--- a/build/pipelines/templates/reactor-build-steps.yml
+++ b/build/pipelines/templates/reactor-build-steps.yml
@@ -32,6 +32,10 @@ parameters:
     displayName: 'Explicit version; "auto" or blank => MinVer.'
     type: string
     default: 'auto'
+  - name: channel
+    displayName: 'Package channel; nightly appends a nightly prerelease suffix, auto preserves existing tag/PR behavior.'
+    type: string
+    default: 'auto'
   - name: runTests
     displayName: 'Run headless unit tests (tests/Reactor.Tests).'
     type: boolean
@@ -45,13 +49,9 @@ parameters:
     type: boolean
     default: false
   - name: publishNuGet
-    displayName: 'Push the packed .nupkg files to a feed from the BUILD job. Reserved for the internal nightly channel; the public nuget.org release uses the gated release stage, NOT this. Requires the NuGetApiKey secret variable.'
+    displayName: 'Push the packed .nupkg files to a feed from the BUILD job. Reserved for the internal nightly channel; the public nuget.org release uses the gated release stage, NOT this.'
     type: boolean
     default: false
-  - name: nuGetApiKeyVariable
-    displayName: 'Name of the SECRET pipeline variable holding the target-feed API key.'
-    type: string
-    default: 'NuGetApiKey'
   - name: nuGetFeed
     displayName: 'Target NuGet feed (push destination). Default is nuget.org, but the build-job push is intended for the internal nightly feed.'
     type: string
@@ -129,6 +129,7 @@ steps:
 
     - pwsh: |
         $manualVersion = '${{ parameters.version }}'
+        $channel = '${{ parameters.channel }}'.Trim().ToLowerInvariant()
 
         if (-not [string]::IsNullOrWhiteSpace($manualVersion) -and $manualVersion.Trim() -ne 'auto') {
           # Explicit override always wins, verbatim.
@@ -153,12 +154,34 @@ steps:
           }
         }
 
+        if ([string]::IsNullOrWhiteSpace($channel) -or $channel -eq 'auto') {
+          if ($env:BUILD_SOURCEBRANCH -like 'refs/tags/v*') {
+            $channel = if ($version.Contains('-preview.')) { 'preview' } else { 'stable' }
+          } elseif ($env:BUILD_REASON -eq 'PullRequest') {
+            $channel = 'pr'
+          } else {
+            $channel = 'default'
+          }
+        }
+
+        if ($channel -eq 'nightly') {
+          $counter = $env:CDP_DEFINITION_BUILD_COUNT
+          if ([string]::IsNullOrWhiteSpace($counter)) {
+            throw 'CDP_DEFINITION_BUILD_COUNT is required for nightly versioning.'
+          }
+
+          $base = $version.Split('-')[0]  # nightly versions hang off the next reachable base version
+          $date = (Get-Date).ToUniversalTime().ToString('yyyyMMdd')
+          $version = "$base-nightly.$date.$counter"
+        }
+
         if (-not $version) { throw 'Could not resolve version' }
 
         $isPrerelease = $version.Contains('-')
         Write-Host "##vso[task.setvariable variable=PackageVersion]$version"
+        Write-Host "##vso[task.setvariable variable=PackageChannel]$channel"
         Write-Host "##vso[task.setvariable variable=IsPrerelease]$($isPrerelease.ToString().ToLower())"
-        Write-Host "Version: $version (isPrerelease=$isPrerelease)"
+        Write-Host "Version: $version (channel=$channel isPrerelease=$isPrerelease)"
       displayName: 'Resolve version'
 
   - pwsh: |
@@ -500,20 +523,15 @@ steps:
     # the internal feed, never nuget.org.
     #
     # Gated behind a parameter so a normal Official build only PRODUCES the signed packages
-    # (uploaded as artifacts). The API key comes from a SECRET pipeline variable (default name:
-    # NuGetApiKey) -- never committed. Secrets are NOT auto-exposed to script env, so it is
-    # mapped explicitly via `env:`; `--skip-duplicate` makes re-runs idempotent (a version
-    # already on the feed is immutable and would otherwise 409). `dotnet nuget push` also
-    # auto-pushes the adjacent *.snupkg symbol package for each *.nupkg when the target feed
-    # supports symbols, so symbols travel with the package without a separate glob.
+    # (uploaded as artifacts). Nightly/internal pushes authenticate through the existing
+    # NuGetAuthenticate@1 step + feed identity; Azure Artifacts accepts `--api-key az` as the
+    # credential-provider handshake token, so no separate API key secret is required here.
+    # `--skip-duplicate` makes re-runs idempotent (a version already on the feed is immutable
+    # and would otherwise 409). `dotnet nuget push` also auto-pushes the adjacent *.snupkg
+    # symbol package for each *.nupkg when the target feed supports symbols, so symbols travel
+    # with the package without a separate glob.
     - ${{ if eq(parameters.publishNuGet, true) }}:
       - pwsh: |
-          $key = $env:NUGET_API_KEY
-          if ([string]::IsNullOrWhiteSpace($key)) {
-            throw "publishNuGet=true but the secret variable '${{ parameters.nuGetApiKeyVariable }}' is empty or not set. " +
-                  "Add it as a SECRET pipeline variable before queueing a publish run."
-          }
-
           $packages = Get-ChildItem "${{ parameters.outputDirectory }}\nupkg" -Filter *.nupkg -File
           if ($packages.Count -eq 0) { throw "No .nupkg files found to publish." }
 
@@ -524,10 +542,6 @@ steps:
 
           dotnet nuget push "${{ parameters.outputDirectory }}\nupkg\*.nupkg" `
             --source "${{ parameters.nuGetFeed }}" `
-            --api-key $key `
+            --api-key az `
             --skip-duplicate
         displayName: 'Publish NuGet packages (internal nightly feed)'
-        env:
-          # Map the secret pipeline variable into the script environment; secrets are not
-          # injected automatically. The variable NAME is templated; its VALUE stays secret.
-          NUGET_API_KEY: $(${{ parameters.nuGetApiKeyVariable }})

--- a/build/pipelines/templates/reactor-build-steps.yml
+++ b/build/pipelines/templates/reactor-build-steps.yml
@@ -532,16 +532,26 @@ steps:
     # with the package without a separate glob.
     - ${{ if eq(parameters.publishNuGet, true) }}:
       - pwsh: |
+          $feed = '${{ parameters.nuGetFeed }}'
+          if ([string]::IsNullOrWhiteSpace($feed)) {
+            throw 'publishNuGet=true but nuGetFeed is empty.'
+          }
+
+          # Build-job publishing is reserved for internal Azure Artifacts feeds.
+          if ($feed -notlike 'https://pkgs.dev.azure.com/github-private/microsoft/_packaging/*/nuget/v3/index.json') {
+            throw "publishNuGet=true requires an internal Azure Artifacts feed under github-private/microsoft. Refusing feed: $feed"
+          }
+
           $packages = Get-ChildItem "${{ parameters.outputDirectory }}\nupkg" -Filter *.nupkg -File
           if ($packages.Count -eq 0) { throw "No .nupkg files found to publish." }
 
-          Write-Host "Publishing $($packages.Count) package(s) to ${{ parameters.nuGetFeed }}"
+          Write-Host "Publishing $($packages.Count) package(s) to $feed"
           foreach ($pkg in $packages) {
             Write-Host "  -> $($pkg.Name)"
           }
 
           dotnet nuget push "${{ parameters.outputDirectory }}\nupkg\*.nupkg" `
-            --source "${{ parameters.nuGetFeed }}" `
+            --source "$feed" `
             --api-key az `
             --skip-duplicate
         displayName: 'Publish NuGet packages (internal nightly feed)'

--- a/docs/contributing/release-runbook.md
+++ b/docs/contributing/release-runbook.md
@@ -10,9 +10,10 @@ the Azure Artifacts feed used by the OneBranch build. The nightly pipeline is
 builds `main`, and publishes versions shaped like
 `0.2.0-nightly.<yyyyMMdd>.<counter>` to the internal feed.
 
-To consume the nightly channel internally, add the feed source from
-`build/pipelines/nuget.internal.config` to your `nuget.config` and float the
-package version on the nightly label, for example:
+To consume the nightly channel internally, add this feed source to your
+`nuget.config` and float the package version on the nightly label, for example:
+
+`https://pkgs.dev.azure.com/github-private/microsoft/_packaging/microsoft-ui-reactor-internal/nuget/v3/index.json`
 
 ```xml
 <PackageReference Include="Microsoft.UI.Reactor" Version="0.*-nightly*" />

--- a/docs/contributing/release-runbook.md
+++ b/docs/contributing/release-runbook.md
@@ -2,6 +2,25 @@
 
 This runbook describes how to prepare and trigger a public Microsoft.UI.Reactor preview release.
 
+## Internal nightly channel
+
+Reactor also has an internal nightly channel for signed pre-release packages on
+the Azure Artifacts feed used by the OneBranch build. The nightly pipeline is
+`build/pipelines/OneBranch.Nightly.Reactor.yml`; it runs on a daily schedule,
+builds `main`, and publishes versions shaped like
+`0.2.0-nightly.<yyyyMMdd>.<counter>` to the internal feed.
+
+To consume the nightly channel internally, add the feed source from
+`build/pipelines/nuget.internal.config` to your `nuget.config` and float the
+package version on the nightly label, for example:
+
+```xml
+<PackageReference Include="Microsoft.UI.Reactor" Version="0.*-nightly*" />
+```
+
+Nightly packages are internal-only and auto-published; they do not go through
+the public NuGet.org approval gate below.
+
 ## Release model
 
 Reactor versions are tag-driven. A tag named `v0.1.0-preview.3` makes MinVer resolve package version `0.1.0-preview.3` for that exact commit. The tag push starts the GitHub packaging workflow and the OneBranch official pipeline; the OneBranch NuGet publish stage is approval-gated.

--- a/docs/specs/057-release-channels.md
+++ b/docs/specs/057-release-channels.md
@@ -66,9 +66,10 @@ constraints.
   publish.** A tag push auto-builds and signs; the irreversible nuget.org push
   waits behind a one-click approval gate so a fat-fingered tag never reaches the
   public.
-- Reuse the existing `publishNuGet` / `nuGetFeed` / `nuGetApiKeyVariable`
-  parameters (added to `reactor-build-steps.yml`) rather than inventing new
-  publish plumbing.
+- Reuse the existing `publishNuGet` / `nuGetFeed` parameters in
+  `reactor-build-steps.yml` rather than inventing new publish plumbing.
+  Internal nightly pushes should flow through `NuGetAuthenticate` + the build
+  identity rather than a separate API key secret.
 - Every channel build remains uniquely and monotonically versioned (no
   collisions on any feed).
 
@@ -171,8 +172,9 @@ delimiter, which is safe.
 ## 7. Pipeline Design
 
 The build seams already exist. `reactor-build-steps.yml` exposes `publishNuGet`
-(bool), `nuGetFeed` (push destination), and `nuGetApiKeyVariable` (secret name).
-The **internal nightly** push reuses this build-job plumbing directly. The
+(bool) and `nuGetFeed` (push destination). The **internal nightly** push
+reuses this build-job plumbing directly through `NuGetAuthenticate` / feed
+identity. The
 **public nuget.org** push is different: on the governed OneBranch pipeline,
 publishing to a public, non-Azure feed is its own _release_ pathway and must run
 in a dedicated release stage, not from the build job (§8.3). A channel switch
@@ -500,6 +502,14 @@ through the release stage.
    `publishNuGet: true`, `nuGetFeed: <internal ADO feed>`.
 3. Document the internal-feed `nuget.config` + `0.*-nightly*` consumption for
    insiders.
+
+Implemented shape:
+
+- `build/pipelines/OneBranch.Nightly.Reactor.yml` schedules the nightly run on
+  `main` and passes `channel: nightly` + `publishNuGet: true` into the shared
+  build template.
+- The shared publish step uses `NuGetAuthenticate` / feed identity and pushes to
+  the internal Azure Artifacts feed with `dotnet nuget push --api-key az`.
 
 ### Phase C — (deferred) Public nightly
 


### PR DESCRIPTION
## Summary

This PR adds a dedicated OneBranch nightly pipeline path for Reactor and wires internal-feed publishing end to end.

Included changes:

- Adds a new nightly pipeline YAML that runs on a daily schedule on `main`.
- Enables pack/sign/test flow for nightly runs and publishes to the dedicated internal NuGet feed.
- Extends shared version resolution with channel-aware nightly versioning:
  - `<MinVer base>-nightly.<yyyyMMdd>.<counter>`
- Updates shared internal publish flow to use existing feed authentication (`NuGetAuthenticate`) for internal Azure Artifacts pushes.
- Updates release-channel and runbook docs for nightly behavior and internal feed consumption.

## Why

We needed a separate internal nightly channel to support automated validation and internal consumption without using the public release path.

## Scope

Files changed:

- `build/pipelines/OneBranch.Nightly.Reactor.yml`
- `build/pipelines/templates/reactor-build-steps.yml`
- `docs/specs/057-release-channels.md`
- `docs/contributing/release-runbook.md`

## Validation

- Queued and executed the dedicated nightly definition against this branch.
- Confirmed the branch and pipeline path are wired correctly for nightly runs.

## Notes

- This does not change the public NuGet release gating path.
- Public release flow remains in the existing official release pipeline and gated publish stage.
