### PR TITLE
fix(test): loosen DataGrid_ScrollPerfRelative ratio threshold (#209)

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs
@@ -323,17 +323,20 @@ internal static class DataGridScrollFixtures
             H.Check($"ScrollPerf_DG_Measured (median={dgMedian:F2}ms)",
                 dgTimes.Count > 0);
 
-            // DataGrid scroll-to-position should be within 40% of VirtualList.
+            // DataGrid scroll-to-position should stay within ~2x of VirtualList.
             // Both realize ~11 rows per scroll jump with the same Grid structure.
             // The DataGrid adds selection/placeholder/event-handler overhead per
             // row; this ratio depends heavily on hardware and measurement jitter
             // at the single-digit-ms range the test operates in (ARM64 dev boxes
-            // land at ~1.3–1.4x, x64 CI closer to 1.1–1.2x). The headroom to
-            // 1.4x absorbs that variance while still catching structural
-            // regressions (FlexRow wrapping, redundant Yoga passes, …) which
-            // the fixture's original comment calls out as 2x+.
+            // land at ~1.3–1.4x, x64 CI closer to 1.1–1.2x). A tighter 1.4x bound
+            // proved too tight for shared CI runners under variable load — a
+            // 1000-iteration stress run flaked twice right at the boundary
+            // (~1.46x and ~1.52x), see issue #209. The 2.0x headroom absorbs that
+            // variance while still catching structural regressions (FlexRow
+            // wrapping, redundant Yoga passes, …) which the fixture's original
+            // comment calls out as 2x+.
             H.Check($"ScrollPerf_Ratio (dg={dgMedian:F2} vl={vlMedian:F2} ratio={ratio:F1}x)",
-                ratio < 1.4);
+                ratio < 2.0);
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs
@@ -323,7 +323,10 @@ internal static class DataGridScrollFixtures
             H.Check($"ScrollPerf_DG_Measured (median={dgMedian:F2}ms)",
                 dgTimes.Count > 0);
 
-            // DataGrid scroll-to-position should stay within ~2x of VirtualList.
+            // DataGrid scroll-to-position should stay under 2x of VirtualList:
+            // the check passes only while the ratio is below 2.0x, so any
+            // regression that reaches 2x or worse fails it (the bound is
+            // exclusive — ratio >= 2.0 is caught).
             // Both realize ~11 rows per scroll jump with the same Grid structure.
             // The DataGrid adds selection/placeholder/event-handler overhead per
             // row; this ratio depends heavily on hardware and measurement jitter
@@ -333,9 +336,10 @@ internal static class DataGridScrollFixtures
             // 1000-iteration stress run flaked twice right at the boundary
             // (~1.46x and ~1.52x), see issue #209. The 2.0x headroom absorbs that
             // variance while still catching structural regressions (FlexRow
-            // wrapping, redundant Yoga passes, …) which the fixture's original
-            // comment calls out as 2x+.
-            H.Check($"ScrollPerf_Ratio (dg={dgMedian:F2} vl={vlMedian:F2} ratio={ratio:F1}x)",
+            // wrapping, redundant Yoga passes, …) that push the ratio to 2x+.
+            // The ratio is printed at full precision (F3) so a failure log shows
+            // the true measured bound rather than a rounded value (#209).
+            H.Check($"ScrollPerf_Ratio (dg={dgMedian:F2} vl={vlMedian:F2} ratio={ratio:F3}x)",
                 ratio < 2.0);
         }
     }


### PR DESCRIPTION
## Summary

Fixes the flaky `DataGrid_ScrollPerfRelative` selftest by loosening its scroll-render ratio threshold.

The fixture asserts the DataGrid scroll-to-position render rate stays within a ratio of VirtualList. The active bound was `ratio < 1.4` (the failure message rounds the displayed ratio to "1.5x"). A 1000-iteration CI stress run (Stress #25562201970) flaked **twice** right at the boundary -- measured ~1.46x and ~1.52x -- on shards 1 and 18.

## Why this is calibration, not a product bug

The test operates in the single-digit-millisecond range, where shared CI runners under variable load introduce significant measurement jitter. ARM64 dev boxes land at ~1.3-1.4x and x64 CI closer to ~1.1-1.2x in steady state, so a 1.4x bound left effectively zero headroom for transient scheduling noise.

## Change

- Bump the threshold from `ratio < 1.4` to `ratio < 2.0` in `tests/Reactor.AppTests.Host/SelfTest/Fixtures/DataGridScrollFixtures.cs`.
- Update the surrounding comment to document the CI-jitter rationale and reference issue #209.

The 2.0x band still catches the structural regressions the fixture is designed to detect (FlexRow wrapping, redundant Yoga passes) which manifest as 2x+ slowdowns, while absorbing CI variance.

## Verification

- Built `tests/Reactor.AppTests.Host` (`-r win-x64`) -- compiles cleanly.
- Full E2E suite not run (requires WinAppDriver); a build is sufficient for a threshold-constant change.

Closes #209.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>