### PR TITLE
feat(dsl): add .Command() modifier so custom-content buttons auto-disable (#133)

### DIFF
--- a/docs/_pipeline/templates/commanding.md.dt
+++ b/docs/_pipeline/templates/commanding.md.dt
@@ -103,6 +103,40 @@ duplicate, and the keyboard binding would have to be wired by hand.
 With it, the `Command` record is the source of truth; the surfaces are
 projections.
 
+## Custom-content buttons: the `.Command()` modifier
+
+The `Button(command)` factory renders a plain text label. When you need
+richer content — an icon next to a label, a stacked layout, or any custom
+element tree — build the button from content and attach the command with
+the `.Command(command)` fluent modifier:
+
+```csharp
+// Plain label — the factory is enough:
+Button(saveCmd)
+
+// Custom content — compose the layout, then bind the command:
+Button(HStack(Icon(SymbolIcon("Save")), Text("Save")))
+    .Command(saveCmd)
+```
+
+`.Command()` wires the same synchronized-state contract as the factory:
+it routes the click through `Execute` / `ExecuteAsync`, applies the
+command's `Icon` / `Description` / `Accelerator` / `AccessKey` metadata,
+and binds `IsEnabled` so the button **auto-disables** while
+`command.IsEnabled` is false. Crucially it re-applies `IsEnabled` on
+**every** update, so a command toggling `CanExecute` (or `IsExecuting`
+via [`UseCommand`](hooks.md)) flows straight through — you never re-thread
+`.IsEnabled(command.IsEnabled)` by hand.
+
+The modifier works on every clickable element — `Button`,
+`HyperlinkButton`, `RepeatButton`, `ToggleButton`, and `AppBarButton` —
+so custom-content variants of each stay in sync with their command.
+
+> It composes with [`.IsDisabledFocusable()`](forms.md): a disabled
+> command on a disabled-focusable button keeps the button reachable via
+> Tab (only the click is suppressed) rather than dropping it from the
+> tab order.
+
 ## Async Commands and UseCommand
 
 When a command has an `ExecuteAsync` action, wrap it with the

--- a/docs/guide/commanding.md
+++ b/docs/guide/commanding.md
@@ -165,6 +165,40 @@ duplicate, and the keyboard binding would have to be wired by hand.
 With it, the `Command` record is the source of truth; the surfaces are
 projections.
 
+## Custom-content buttons: the `.Command()` modifier
+
+The `Button(command)` factory renders a plain text label. When you need
+richer content — an icon next to a label, a stacked layout, or any custom
+element tree — build the button from content and attach the command with
+the `.Command(command)` fluent modifier:
+
+```csharp
+// Plain label — the factory is enough:
+Button(saveCmd)
+
+// Custom content — compose the layout, then bind the command:
+Button(HStack(Icon(SymbolIcon("Save")), Text("Save")))
+    .Command(saveCmd)
+```
+
+`.Command()` wires the same synchronized-state contract as the factory:
+it routes the click through `Execute` / `ExecuteAsync`, applies the
+command's `Icon` / `Description` / `Accelerator` / `AccessKey` metadata,
+and binds `IsEnabled` so the button **auto-disables** while
+`command.IsEnabled` is false. Crucially it re-applies `IsEnabled` on
+**every** update, so a command toggling `CanExecute` (or `IsExecuting`
+via [`UseCommand`](hooks.md)) flows straight through — you never re-thread
+`.IsEnabled(command.IsEnabled)` by hand.
+
+The modifier works on every clickable element — `Button`,
+`HyperlinkButton`, `RepeatButton`, `ToggleButton`, and `AppBarButton` —
+so custom-content variants of each stay in sync with their command.
+
+> It composes with [`.IsDisabledFocusable()`](forms.md): a disabled
+> command on a disabled-focusable button keeps the button reachable via
+> Tab (only the click is suppressed) rather than dropping it from the
+> tab order.
+
 ## Async Commands and UseCommand
 
 When a command has an `ExecuteAsync` action, wrap it with the

--- a/plugins/reactor/skills/reactor-commanding/SKILL.md
+++ b/plugins/reactor/skills/reactor-commanding/SKILL.md
@@ -70,6 +70,25 @@ MenuItem(save)            // + icon, accelerator, accessKey, description
 MenuItem(deleteCmd, item) // parameterized: binds item as argument
 ```
 
+Custom content (icon + label, stacked layouts) — build the element, then
+attach the command with the `.Command()` modifier. Works on `Button`,
+`HyperlinkButton`, `RepeatButton`, `ToggleButton`, and `AppBarButton`:
+
+```csharp
+// Factory takes a text label only:
+Button(save)
+
+// .Command() binds execute + isEnabled + icon/accelerator/accessKey/description
+// onto any custom-content clickable, and auto-disables while !command.IsEnabled:
+Button(HStack(Icon(SymbolIcon("Save")), Text("Save"))).Command(save)
+```
+
+`.Command()` re-applies `IsEnabled` on every update (so `UseCommand`
+toggling `IsExecuting`, or `CanExecute` changes, flow through) — never
+re-thread `.IsEnabled(command.IsEnabled)` by hand. It composes with
+`.IsDisabledFocusable()`: a disabled command keeps the button reachable
+via Tab instead of dropping it from the tab order.
+
 Per-site overrides with `with`:
 
 ```csharp

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -236,6 +236,7 @@ BreadcrumbBarElement.ItemClicked(Action<BreadcrumbBarItemData> handler) → Brea
 BreadcrumbBarElement.Set(Action<BreadcrumbBar> configure) → BreadcrumbBarElement
 ButtonElement.AccentButton() → ButtonElement
 ButtonElement.Click(Action handler) → ButtonElement
+ButtonElement.Command(Command command) → ButtonElement
 ButtonElement.IsDisabledFocusable(bool disabled = true) → ButtonElement
 ButtonElement.Set(Action<Button> configure) → ButtonElement
 ButtonElement.SubtleButton() → ButtonElement
@@ -350,6 +351,7 @@ GridViewElement.SelectionChanged(Action<IReadOnlyList<int>> handler) → GridVie
 GridViewElement.SelectionMode(ListViewSelectionMode mode) → GridViewElement
 GridViewElement.Set(Action<GridView> configure) → GridViewElement
 HyperlinkButtonElement.Click(Action handler) → HyperlinkButtonElement
+HyperlinkButtonElement.Command(Command command) → HyperlinkButtonElement
 HyperlinkButtonElement.NavigateUri(Uri uri) → HyperlinkButtonElement
 HyperlinkButtonElement.Set(Action<HyperlinkButton> configure) → HyperlinkButtonElement
 HyperlinkButtonElement.TextLink() → HyperlinkButtonElement
@@ -482,6 +484,7 @@ RefreshContainerElement.RefreshRequested(Action handler) → RefreshContainerEle
 RefreshContainerElement.Set(Action<RefreshContainer> configure) → RefreshContainerElement
 RelativePanelElement.Set(Action<RelativePanel> configure) → RelativePanelElement
 RepeatButtonElement.Click(Action handler) → RepeatButtonElement
+RepeatButtonElement.Command(Command command) → RepeatButtonElement
 RepeatButtonElement.Delay(int delay) → RepeatButtonElement
 RepeatButtonElement.Interval(int interval) → RepeatButtonElement
 RepeatButtonElement.Set(Action<RepeatButton> configure) → RepeatButtonElement
@@ -808,6 +811,7 @@ TitleBarElement.Subtitle(string subtitle) → TitleBarElement
 TitleBarElement.WithNavigation<TRoute>(NavigationHandle<TRoute> nav) → TitleBarElement
 ToggleButtonElement.CheckedState(bool? state) → ToggleButtonElement
 ToggleButtonElement.CheckedStateChanged(Action<bool?> handler) → ToggleButtonElement
+ToggleButtonElement.Command(Command command) → ToggleButtonElement
 ToggleButtonElement.IsCheckedChanged(Action<bool> handler) → ToggleButtonElement
 ToggleButtonElement.IsThreeState(bool isThreeState = true) → ToggleButtonElement
 ToggleButtonElement.Set(Action<ToggleButton> configure) → ToggleButtonElement

--- a/samples/apps/demo-script-tool/App/Components/StepCard.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepCard.cs
@@ -406,17 +406,8 @@ public sealed class StepCard : Component<StepCardProps>
             (FlexRow(
                 Image(iconPath).Width(16).Height(16),
                 TextBlock(command.Label).VAlign(VerticalAlignment.Center))
-            with { ColumnGap = 8, AlignItems = FlexAlign.Center }),
-            () =>
-            {
-                // Match the framework's CommandBindings.Invoke contract: prefer
-                // the synchronous Execute (which is what UseCommand sets after
-                // wrapping an async command), fall back to firing ExecuteAsync
-                // for raw async commands that didn't go through UseCommand.
-                if (command.Execute is not null) command.Execute();
-                else if (command.ExecuteAsync is not null) _ = command.ExecuteAsync();
-            })
-        .IsEnabled(command.IsEnabled)
+            with { ColumnGap = 8, AlignItems = FlexAlign.Center }))
+        .Command(command)
         .HAlign(HorizontalAlignment.Stretch)
         .AutomationName(automationName);
 

--- a/skills/commanding.md
+++ b/skills/commanding.md
@@ -70,6 +70,25 @@ MenuItem(save)            // + icon, accelerator, accessKey, description
 MenuItem(deleteCmd, item) // parameterized: binds item as argument
 ```
 
+Custom content (icon + label, stacked layouts) — build the element, then
+attach the command with the `.Command()` modifier. Works on `Button`,
+`HyperlinkButton`, `RepeatButton`, `ToggleButton`, and `AppBarButton`:
+
+```csharp
+// Factory takes a text label only:
+Button(save)
+
+// .Command() binds execute + isEnabled + icon/accelerator/accessKey/description
+// onto any custom-content clickable, and auto-disables while !command.IsEnabled:
+Button(HStack(Icon(SymbolIcon("Save")), Text("Save"))).Command(save)
+```
+
+`.Command()` re-applies `IsEnabled` on every update (so `UseCommand`
+toggling `IsExecuting`, or `CanExecute` changes, flow through) — never
+re-thread `.IsEnabled(command.IsEnabled)` by hand. It composes with
+`.IsDisabledFocusable()`: a disabled command keeps the button reachable
+via Tab instead of dropping it from the tab order.
+
 Per-site overrides with `with`:
 
 ```csharp

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -236,6 +236,7 @@ BreadcrumbBarElement.ItemClicked(Action<BreadcrumbBarItemData> handler) → Brea
 BreadcrumbBarElement.Set(Action<BreadcrumbBar> configure) → BreadcrumbBarElement
 ButtonElement.AccentButton() → ButtonElement
 ButtonElement.Click(Action handler) → ButtonElement
+ButtonElement.Command(Command command) → ButtonElement
 ButtonElement.IsDisabledFocusable(bool disabled = true) → ButtonElement
 ButtonElement.Set(Action<Button> configure) → ButtonElement
 ButtonElement.SubtleButton() → ButtonElement
@@ -350,6 +351,7 @@ GridViewElement.SelectionChanged(Action<IReadOnlyList<int>> handler) → GridVie
 GridViewElement.SelectionMode(ListViewSelectionMode mode) → GridViewElement
 GridViewElement.Set(Action<GridView> configure) → GridViewElement
 HyperlinkButtonElement.Click(Action handler) → HyperlinkButtonElement
+HyperlinkButtonElement.Command(Command command) → HyperlinkButtonElement
 HyperlinkButtonElement.NavigateUri(Uri uri) → HyperlinkButtonElement
 HyperlinkButtonElement.Set(Action<HyperlinkButton> configure) → HyperlinkButtonElement
 HyperlinkButtonElement.TextLink() → HyperlinkButtonElement
@@ -482,6 +484,7 @@ RefreshContainerElement.RefreshRequested(Action handler) → RefreshContainerEle
 RefreshContainerElement.Set(Action<RefreshContainer> configure) → RefreshContainerElement
 RelativePanelElement.Set(Action<RelativePanel> configure) → RelativePanelElement
 RepeatButtonElement.Click(Action handler) → RepeatButtonElement
+RepeatButtonElement.Command(Command command) → RepeatButtonElement
 RepeatButtonElement.Delay(int delay) → RepeatButtonElement
 RepeatButtonElement.Interval(int interval) → RepeatButtonElement
 RepeatButtonElement.Set(Action<RepeatButton> configure) → RepeatButtonElement
@@ -808,6 +811,7 @@ TitleBarElement.Subtitle(string subtitle) → TitleBarElement
 TitleBarElement.WithNavigation<TRoute>(NavigationHandle<TRoute> nav) → TitleBarElement
 ToggleButtonElement.CheckedState(bool? state) → ToggleButtonElement
 ToggleButtonElement.CheckedStateChanged(Action<bool?> handler) → ToggleButtonElement
+ToggleButtonElement.Command(Command command) → ToggleButtonElement
 ToggleButtonElement.IsCheckedChanged(Action<bool> handler) → ToggleButtonElement
 ToggleButtonElement.IsThreeState(bool isThreeState = true) → ToggleButtonElement
 ToggleButtonElement.Set(Action<ToggleButton> configure) → ToggleButtonElement

--- a/src/Reactor/Core/CommandBindings.cs
+++ b/src/Reactor/Core/CommandBindings.cs
@@ -24,9 +24,19 @@ internal static class CommandBindings
     /// derivatives and WinUI controls that don't derive from ButtonBase
     /// (e.g. <see cref="SplitButton"/>, <see cref="ToggleSplitButton"/>).
     /// </summary>
-    internal static void ApplyButtonBaseCommon(Control btn, Command cmd)
+    /// <param name="btn">The live command-capable control to apply metadata to.</param>
+    /// <param name="cmd">The command whose metadata (enabled state, tooltip, accelerator, access key) is applied.</param>
+    /// <param name="applyIsEnabled">
+    /// When false, the command's <see cref="Command.IsEnabled"/> is NOT written to the
+    /// control. Callers whose element already drives <see cref="Control.IsEnabled"/> through
+    /// a descriptor prop pass false so this setter doesn't clobber descriptor-owned coercion
+    /// — notably <see cref="ButtonElement"/>'s <c>IsDisabledFocusable</c>, which must keep a
+    /// disabled button <see cref="Control.IsEnabled"/>=true (reachable via Tab) even when the
+    /// bound command is disabled. (issue #133, PR review M1)
+    /// </param>
+    internal static void ApplyButtonBaseCommon(Control btn, Command cmd, bool applyIsEnabled = true)
     {
-        btn.IsEnabled = cmd.IsEnabled;
+        if (applyIsEnabled) btn.IsEnabled = cmd.IsEnabled;
         if (cmd.Description is not null)
         {
             ToolTipService.SetToolTip(btn, cmd.Description);

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -1155,7 +1155,7 @@ public static partial class Factories
     /// Accelerator, IsEnabled, AccessKey, and Description.
     /// </summary>
     public static AppBarButtonData AppBarButton(Core.Command command) =>
-        new(command.Label, command.Execute)
+        new(command.Label, () => Core.CommandBindings.Invoke(command))
         {
             IsEnabled = command.IsEnabled,
             IconElement = command.Icon,

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -172,7 +172,12 @@ public static partial class Factories
         return new ButtonElement(command.Label, () => Core.CommandBindings.Invoke(command))
         {
             IsEnabled = command.IsEnabled,
-            Setters = [b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+            // applyIsEnabled: false — the record IsEnabled prop above drives the control
+            // through ButtonElement's descriptor, which gates IsEnabled on !IsDisabledFocusable
+            // and coerces a disabled-focusable button back to IsEnabled=true. Writing IsEnabled
+            // from the setter too would override that coercion and drop a disabled-command +
+            // .IsDisabledFocusable() button out of the tab order. (issue #133, PR review)
+            Setters = [b => Core.CommandBindings.ApplyButtonBaseCommon(b, command, applyIsEnabled: false)],
         };
     }
 

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1008,7 +1008,13 @@ public static partial class ElementExtensions
         {
             OnClick = () => Core.CommandBindings.Invoke(command),
             IsEnabled = command.IsEnabled,
-            Setters = [.. el.Setters, b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+            // applyIsEnabled: false — the record IsEnabled prop above already drives the
+            // control through ButtonElement's descriptor, which gates IsEnabled on
+            // !IsDisabledFocusable and coerces a disabled-focusable button back to
+            // IsEnabled=true. Writing IsEnabled from the setter too would override that
+            // coercion and silently drop a disabled-command + .IsDisabledFocusable() button
+            // out of the tab order. (issue #133, PR review M1)
+            Setters = [.. el.Setters, b => Core.CommandBindings.ApplyButtonBaseCommon(b, command, applyIsEnabled: false)],
         };
 
     /// <summary>
@@ -1054,7 +1060,7 @@ public static partial class ElementExtensions
     public static AppBarButtonData Command(this AppBarButtonData el, Core.Command command) =>
         el with
         {
-            OnClick = command.Execute,
+            OnClick = () => Core.CommandBindings.Invoke(command),
             IsEnabled = command.IsEnabled,
             IconElement = command.Icon,
             KeyboardAccelerators = command.Accelerator is not null ? [command.Accelerator] : null,

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -982,6 +982,86 @@ public static partial class ElementExtensions
     public static ButtonElement DisabledFocusable(this ButtonElement el, bool disabled = true) =>
         el.IsDisabledFocusable(disabled);
 
+    // ── Command binding (.Command) — issue #133 ────────────────────
+    //
+    //   Button(customContent).Command(runCmd)   // disabled while !runCmd.IsEnabled
+    //
+    // Binds a Command's enabled state, click handler, and metadata
+    // (Description / Accelerator / AccessKey) onto an already-built clickable
+    // element. This closes the custom-content gap: the Button(Command) factory
+    // only accepts a vanilla label, so icon-plus-label buttons previously had to
+    // re-thread `.IsEnabled(command.IsEnabled)` by hand. The CommandBindings
+    // setter runs on every reconcile pass, so IsEnabled is re-applied whenever the
+    // command's state flips (e.g. UseCommand toggling IsExecuting) — not captured
+    // once at construction. Place `.Command(cmd)` before per-site overrides so the
+    // usual modifier-after-command ordering still lets later calls win.
+
+    /// <summary>
+    /// Binds a <see cref="Core.Command"/> to a custom-content <see cref="ButtonElement"/>:
+    /// wires Execute → Click, applies <see cref="Core.Command.IsEnabled"/> (re-applied on
+    /// every update), and flows Description / Accelerator / AccessKey via a setter. Pairs
+    /// with <c>Button(content)</c> so icon-plus-label buttons auto-disable like the
+    /// <c>Button(Command)</c> factory. (issue #133)
+    /// </summary>
+    public static ButtonElement Command(this ButtonElement el, Core.Command command) =>
+        el with
+        {
+            OnClick = () => Core.CommandBindings.Invoke(command),
+            IsEnabled = command.IsEnabled,
+            Setters = [.. el.Setters, b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+        };
+
+    /// <summary>
+    /// Binds a <see cref="Core.Command"/> to a <see cref="HyperlinkButtonElement"/>. See
+    /// <see cref="Command(ButtonElement, Core.Command)"/>. (issue #133)
+    /// </summary>
+    public static HyperlinkButtonElement Command(this HyperlinkButtonElement el, Core.Command command) =>
+        el with
+        {
+            OnClick = () => Core.CommandBindings.Invoke(command),
+            Setters = [.. el.Setters, b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+        };
+
+    /// <summary>
+    /// Binds a <see cref="Core.Command"/> to a <see cref="RepeatButtonElement"/>. See
+    /// <see cref="Command(ButtonElement, Core.Command)"/>. (issue #133)
+    /// </summary>
+    public static RepeatButtonElement Command(this RepeatButtonElement el, Core.Command command) =>
+        el with
+        {
+            OnClick = () => Core.CommandBindings.Invoke(command),
+            Setters = [.. el.Setters, b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+        };
+
+    /// <summary>
+    /// Binds a <see cref="Core.Command"/> to a <see cref="ToggleButtonElement"/>. The command
+    /// fires on each toggle (check and uncheck), matching the <c>ToggleButton(Command)</c>
+    /// factory. See <see cref="Command(ButtonElement, Core.Command)"/>. (issue #133)
+    /// </summary>
+    public static ToggleButtonElement Command(this ToggleButtonElement el, Core.Command command) =>
+        el with
+        {
+            OnIsCheckedChanged = _ => Core.CommandBindings.Invoke(command),
+            Setters = [.. el.Setters, b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+        };
+
+    /// <summary>
+    /// Binds a <see cref="Core.Command"/> to an <see cref="AppBarButtonData"/>: maps Execute,
+    /// IsEnabled, Icon, Accelerator, AccessKey, and Description — the same plumbing as the
+    /// <c>AppBarButton(Command)</c> factory, but usable on a hand-built app-bar button.
+    /// (issue #133)
+    /// </summary>
+    public static AppBarButtonData Command(this AppBarButtonData el, Core.Command command) =>
+        el with
+        {
+            OnClick = command.Execute,
+            IsEnabled = command.IsEnabled,
+            IconElement = command.Icon,
+            KeyboardAccelerators = command.Accelerator is not null ? [command.Accelerator] : null,
+            AccessKey = command.AccessKey,
+            Description = command.Description,
+        };
+
     // ── Background (Panel, Control, Border) ────────────────────────
 
     /// <summary>
@@ -2378,8 +2458,8 @@ public static partial class ElementExtensions
 
     /// <summary>
     /// Sets UIElement.AccessKey — the Alt+Key shortcut (underlined hint shown on Alt press).
-    /// When used on a button bound to a <see cref="Command"/>, this per-site access key
-    /// overrides <see cref="Command.AccessKey"/> (per-site override always wins).
+    /// When used on a button bound to a <see cref="Core.Command"/>, this per-site access key
+    /// overrides <see cref="Core.Command.AccessKey"/> (per-site override always wins).
     /// </summary>
     /// <example>Button("File", onClick).AccessKey("F")</example>
     public static T AccessKey<T>(this T el, string key) where T : Element =>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -126,4 +126,39 @@ internal static class CommandingCoverageFixtures
             H.Check("DisabledCmd_DisablesControl", sb is not null && !sb.IsEnabled);
         }
     }
+
+    /// <summary>
+    /// Issue #133 regression: a custom-content button bound via the
+    /// <c>.Command(command)</c> modifier must re-apply <c>command.IsEnabled</c> to the
+    /// live control on every update — not capture it once at construction. Mounts an
+    /// icon-style (custom content) button whose command flips from enabled to disabled
+    /// across a state-driven re-render and asserts the reused control's IsEnabled tracks it.
+    /// </summary>
+    internal class CustomContentCommandReappliesIsEnabledOnUpdate(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (disabled, setDisabled) = ctx.UseState(false);
+                var cmd = new Command { Label = "Run", Execute = () => { }, CanExecute = !disabled };
+                return VStack(
+                    Button("toggleCmdState", () => setDisabled(true)),
+                    Button(TextBlock("Run")).Command(cmd).Set(b => b.Name = "cmdContentBtn"));
+            });
+            await Harness.Render();
+
+            var btn = H.FindControl<Button>(b => b.Name == "cmdContentBtn");
+            H.Check("CmdContent_Mounted", btn is not null);
+            H.Check("CmdContent_InitiallyEnabled", btn is not null && btn.IsEnabled);
+
+            H.ClickButton("toggleCmdState");
+            await Harness.Render();
+
+            var btn2 = H.FindControl<Button>(b => b.Name == "cmdContentBtn");
+            H.Check("CmdContent_Reused", ReferenceEquals(btn, btn2));
+            H.Check("CmdContent_DisabledAfterUpdate", btn2 is not null && !btn2.IsEnabled);
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -161,4 +161,141 @@ internal static class CommandingCoverageFixtures
             H.Check("CmdContent_DisabledAfterUpdate", btn2 is not null && !btn2.IsEnabled);
         }
     }
+
+    /// <summary>
+    /// PR review M2: the HyperlinkButton / RepeatButton / ToggleButton <c>.Command()</c>
+    /// paths apply IsEnabled solely through the appended <c>ApplyButtonBaseCommon</c>
+    /// setter (they have no record IsEnabled prop like ButtonElement). Each fresh
+    /// <c>.Command()</c> render allocates a new Setters array, so the reconciler re-runs
+    /// the setter and re-applies IsEnabled. Mount each, flip CanExecute across a re-render,
+    /// and assert the reused live control becomes disabled.
+    /// </summary>
+    internal class HyperlinkButtonCommandReappliesIsEnabledOnUpdate(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (disabled, setDisabled) = ctx.UseState(false);
+                var cmd = new Command { Label = "Run", Execute = () => { }, CanExecute = !disabled };
+                return VStack(
+                    Button("toggleHl", () => setDisabled(true)),
+                    HyperlinkButton("Run").Command(cmd).Set(b => b.Name = "hlReapplyBtn"));
+            });
+            await Harness.Render();
+
+            var hb = H.FindControl<HyperlinkButton>(b => b.Name == "hlReapplyBtn");
+            H.Check("HlReapply_InitiallyEnabled", hb is not null && hb.IsEnabled);
+
+            H.ClickButton("toggleHl");
+            await Harness.Render();
+
+            var hb2 = H.FindControl<HyperlinkButton>(b => b.Name == "hlReapplyBtn");
+            H.Check("HlReapply_Reused", ReferenceEquals(hb, hb2));
+            H.Check("HlReapply_DisabledAfterUpdate", hb2 is not null && !hb2.IsEnabled);
+        }
+    }
+
+    internal class RepeatButtonCommandReappliesIsEnabledOnUpdate(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (disabled, setDisabled) = ctx.UseState(false);
+                var cmd = new Command { Label = "Tick", Execute = () => { }, CanExecute = !disabled };
+                return VStack(
+                    Button("toggleRep", () => setDisabled(true)),
+                    RepeatButton("Tick").Command(cmd).Set(b => b.Name = "repReapplyBtn"));
+            });
+            await Harness.Render();
+
+            var rb = H.FindControl<RepeatButton>(b => b.Name == "repReapplyBtn");
+            H.Check("RepReapply_InitiallyEnabled", rb is not null && rb.IsEnabled);
+
+            H.ClickButton("toggleRep");
+            await Harness.Render();
+
+            var rb2 = H.FindControl<RepeatButton>(b => b.Name == "repReapplyBtn");
+            H.Check("RepReapply_Reused", ReferenceEquals(rb, rb2));
+            H.Check("RepReapply_DisabledAfterUpdate", rb2 is not null && !rb2.IsEnabled);
+        }
+    }
+
+    internal class ToggleButtonCommandReappliesIsEnabledOnUpdate(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (disabled, setDisabled) = ctx.UseState(false);
+                var cmd = new Command { Label = "Bold", Execute = () => { }, CanExecute = !disabled };
+                return VStack(
+                    Button("toggleTog", () => setDisabled(true)),
+                    ToggleButton("Bold").Command(cmd).Set(b => b.Name = "togReapplyBtn"));
+            });
+            await Harness.Render();
+
+            var tb = H.FindControl<ToggleButton>(b => b.Name == "togReapplyBtn");
+            H.Check("TogReapply_InitiallyEnabled", tb is not null && tb.IsEnabled);
+
+            H.ClickButton("toggleTog");
+            await Harness.Render();
+
+            var tb2 = H.FindControl<ToggleButton>(b => b.Name == "togReapplyBtn");
+            H.Check("TogReapply_Reused", ReferenceEquals(tb, tb2));
+            H.Check("TogReapply_DisabledAfterUpdate", tb2 is not null && !tb2.IsEnabled);
+        }
+    }
+
+    /// <summary>
+    /// PR review M1: a disabled command bound via <c>.Command()</c> must not override
+    /// <c>.IsDisabledFocusable()</c> — the button stays IsEnabled=true (reachable via Tab,
+    /// click suppressed by the trampoline) and dimmed (Opacity 0.4). Pinned in both modifier
+    /// orderings since the fix is descriptor/record-owned, not capture-order dependent.
+    /// </summary>
+    internal class CommandDisabledFocusableStaysFocusable(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var cmd = new Command { Label = "Submit", Execute = () => { }, CanExecute = false };
+
+            var host = H.CreateHost();
+            host.Mount(ctx => Button(TextBlock("Submit"))
+                .Command(cmd)
+                .IsDisabledFocusable()
+                .Set(b => b.Name = "cmdDfBtn"));
+            await Harness.Render();
+
+            var btn = H.FindControl<Button>(b => b.Name == "cmdDfBtn");
+            H.Check("CmdDf_Mounted", btn is not null);
+            // Disabled command + IsDisabledFocusable: must stay enabled (focusable) despite the
+            // disabled command — the command setter must not clobber the descriptor coercion.
+            H.Check("CmdDf_StaysFocusable", btn is not null && btn.IsEnabled);
+            H.Check("CmdDf_Dimmed", btn is not null && global::System.Math.Abs(btn.Opacity - 0.4) < 0.001);
+        }
+    }
+
+    internal class CommandDisabledFocusableStaysFocusableReverseOrder(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var cmd = new Command { Label = "Submit", Execute = () => { }, CanExecute = false };
+
+            var host = H.CreateHost();
+            host.Mount(ctx => Button(TextBlock("Submit"))
+                .IsDisabledFocusable()
+                .Command(cmd)
+                .Set(b => b.Name = "cmdDfRevBtn"));
+            await Harness.Render();
+
+            var btn = H.FindControl<Button>(b => b.Name == "cmdDfRevBtn");
+            H.Check("CmdDfRev_Mounted", btn is not null);
+            H.Check("CmdDfRev_StaysFocusable", btn is not null && btn.IsEnabled);
+            H.Check("CmdDfRev_Dimmed", btn is not null && global::System.Math.Abs(btn.Opacity - 0.4) < 0.001);
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -846,6 +846,11 @@ internal static class SelfTestFixtureRegistry
         "Commanding_RepeatButtonCommandInvokesExecute",
         "Commanding_DisabledCommandDisablesControl",
         "Commanding_CustomContentCommandReappliesIsEnabledOnUpdate",
+        "Commanding_HyperlinkButtonCommandReappliesIsEnabledOnUpdate",
+        "Commanding_RepeatButtonCommandReappliesIsEnabledOnUpdate",
+        "Commanding_ToggleButtonCommandReappliesIsEnabledOnUpdate",
+        "Commanding_CommandDisabledFocusableStaysFocusable",
+        "Commanding_CommandDisabledFocusableStaysFocusableReverseOrder",
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag",
@@ -2228,6 +2233,11 @@ internal static class SelfTestFixtureRegistry
         "Commanding_RepeatButtonCommandInvokesExecute" => new CommandingCoverageFixtures.RepeatButtonCommandInvokesExecute(harness),
         "Commanding_DisabledCommandDisablesControl" => new CommandingCoverageFixtures.DisabledCommandDisablesControl(harness),
         "Commanding_CustomContentCommandReappliesIsEnabledOnUpdate" => new CommandingCoverageFixtures.CustomContentCommandReappliesIsEnabledOnUpdate(harness),
+        "Commanding_HyperlinkButtonCommandReappliesIsEnabledOnUpdate" => new CommandingCoverageFixtures.HyperlinkButtonCommandReappliesIsEnabledOnUpdate(harness),
+        "Commanding_RepeatButtonCommandReappliesIsEnabledOnUpdate" => new CommandingCoverageFixtures.RepeatButtonCommandReappliesIsEnabledOnUpdate(harness),
+        "Commanding_ToggleButtonCommandReappliesIsEnabledOnUpdate" => new CommandingCoverageFixtures.ToggleButtonCommandReappliesIsEnabledOnUpdate(harness),
+        "Commanding_CommandDisabledFocusableStaysFocusable" => new CommandingCoverageFixtures.CommandDisabledFocusableStaysFocusable(harness),
+        "Commanding_CommandDisabledFocusableStaysFocusableReverseOrder" => new CommandingCoverageFixtures.CommandDisabledFocusableStaysFocusableReverseOrder(harness),
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag" => new DragDropFixtures.OnDragStartAutoSetsCanDrag(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -845,6 +845,7 @@ internal static class SelfTestFixtureRegistry
         "Commanding_ToggleButtonCommandFiresOnToggle",
         "Commanding_RepeatButtonCommandInvokesExecute",
         "Commanding_DisabledCommandDisablesControl",
+        "Commanding_CustomContentCommandReappliesIsEnabledOnUpdate",
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag",
@@ -2226,6 +2227,7 @@ internal static class SelfTestFixtureRegistry
         "Commanding_ToggleButtonCommandFiresOnToggle" => new CommandingCoverageFixtures.ToggleButtonCommandFiresOnToggle(harness),
         "Commanding_RepeatButtonCommandInvokesExecute" => new CommandingCoverageFixtures.RepeatButtonCommandInvokesExecute(harness),
         "Commanding_DisabledCommandDisablesControl" => new CommandingCoverageFixtures.DisabledCommandDisablesControl(harness),
+        "Commanding_CustomContentCommandReappliesIsEnabledOnUpdate" => new CommandingCoverageFixtures.CustomContentCommandReappliesIsEnabledOnUpdate(harness),
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag" => new DragDropFixtures.OnDragStartAutoSetsCanDrag(harness),

--- a/tests/Reactor.Tests/Elements/CommandModifierTests.cs
+++ b/tests/Reactor.Tests/Elements/CommandModifierTests.cs
@@ -226,4 +226,28 @@ public class CommandModifierTests
 
         Assert.True(el.IsDisabledFocusable);
     }
+
+    // ── (M1, PR-review) The Button(Command) factory must defer IsEnabled to the
+    //    descriptor too (applyIsEnabled:false), so a disabled command chained with
+    //    .IsDisabledFocusable() stays in the tab order — same guarantee as the modifier.
+
+    [Fact]
+    public void Button_Command_Factory_Applies_IsEnabled_False_When_Disabled()
+    {
+        var cmd = new Command { Label = "Run", Execute = () => { }, CanExecute = false };
+
+        var el = Button(cmd);
+
+        Assert.False(el.IsEnabled);
+    }
+
+    [Fact]
+    public void Button_Command_Factory_With_IsDisabledFocusable_Keeps_DisabledFocusable()
+    {
+        var cmd = new Command { Label = "Run", Execute = () => { }, CanExecute = false };
+
+        var el = Button(cmd).IsDisabledFocusable();
+
+        Assert.True(el.IsDisabledFocusable);
+    }
 }

--- a/tests/Reactor.Tests/Elements/CommandModifierTests.cs
+++ b/tests/Reactor.Tests/Elements/CommandModifierTests.cs
@@ -1,0 +1,175 @@
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.Tests.Elements;
+
+/// <summary>
+/// Tests for the <c>.Command(Command)</c> fluent modifier (issue #133), which binds a
+/// <see cref="Command"/>'s enabled state, click handler, and metadata onto an
+/// already-built clickable element. This closes the custom-content gap where
+/// <c>Button(content, onClick)</c> had no command binding and callers had to re-thread
+/// <c>.IsEnabled(command.IsEnabled)</c> by hand.
+/// </summary>
+public class CommandModifierTests
+{
+    // ── (a) The modifier applies command.IsEnabled ──────────────────
+
+    [Fact]
+    public void Command_On_CustomContent_Button_Applies_IsEnabled_True()
+    {
+        var cmd = new Command { Label = "Run", Execute = () => { }, CanExecute = true };
+
+        var el = Button(TextBlock("Run")).Command(cmd);
+
+        Assert.True(el.IsEnabled);
+    }
+
+    [Fact]
+    public void Command_On_CustomContent_Button_Applies_IsEnabled_False_When_Disabled()
+    {
+        var cmd = new Command { Label = "Run", Execute = () => { }, CanExecute = false };
+
+        var el = Button(TextBlock("Run")).Command(cmd);
+
+        Assert.False(el.IsEnabled);
+    }
+
+    [Fact]
+    public void Command_Composes_With_CustomContent_Button()
+    {
+        var cmd = new Command { Label = "Run", Execute = () => { }, CanExecute = false };
+
+        var el = Button(TextBlock("Run")).Command(cmd);
+
+        Assert.False(el.IsEnabled);
+        Assert.NotNull(el.ContentElement);
+    }
+
+    [Fact]
+    public void Command_Appends_CommandBindings_Setter()
+    {
+        var cmd = new Command { Label = "Run", Execute = () => { } };
+
+        var before = Button(TextBlock("Run"));
+        var after = before.Command(cmd);
+
+        // The ApplyButtonBaseCommon setter is appended; it runs on every reconcile
+        // pass (mount AND update) which is what re-applies IsEnabled to the control.
+        Assert.Equal(before.Setters.Length + 1, after.Setters.Length);
+    }
+
+    // ── (b) IsEnabled is re-applied on update when command flips ─────
+
+    [Fact]
+    public void Command_Tracks_IsEnabled_Across_Renders()
+    {
+        // Simulate the UseCommand IsExecuting flip: the SAME render expression with a
+        // command whose IsEnabled flips must produce an element whose IsEnabled tracks
+        // the current command state — not a value captured once at construction.
+        static ButtonElement Render(Command c) => Button(TextBlock("Run")).Command(c);
+
+        var enabled = new Command { Label = "Run", Execute = () => { }, CanExecute = true };
+        var disabled = new Command { Label = "Run", Execute = () => { }, CanExecute = false };
+
+        Assert.True(Render(enabled).IsEnabled);
+        Assert.False(Render(disabled).IsEnabled);
+    }
+
+    [Fact]
+    public void Command_Produces_Fresh_Setters_So_Reconciler_Reapplies()
+    {
+        // Element equality short-circuits Update when Setters are reference-equal
+        // (see Element.cs ButtonElement equality). Each .Command() render allocates a
+        // fresh Setters array, so the reconciler never skips re-applying the command's
+        // IsEnabled — the crux of the bug, where the custom-content path captured state once.
+        var cmd = new Command { Label = "Run", Execute = () => { } };
+
+        var first = Button(TextBlock("Run")).Command(cmd);
+        var second = Button(TextBlock("Run")).Command(cmd);
+
+        Assert.False(ReferenceEquals(first.Setters, second.Setters));
+    }
+
+    // ── (c) Clicking invokes the command ────────────────────────────
+
+    [Fact]
+    public void Command_Wires_Click_To_Execute()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "Run", Execute = () => count++ };
+
+        var el = Button(TextBlock("Run")).Command(cmd);
+        Assert.NotNull(el.OnClick);
+        el.OnClick!();
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void Command_Wires_Click_To_ExecuteAsync_When_No_Sync_Execute()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "Run", ExecuteAsync = () => { count++; return Task.CompletedTask; } };
+
+        var el = Button(TextBlock("Run")).Command(cmd);
+        el.OnClick!();
+
+        Assert.Equal(1, count);
+    }
+
+    // ── Non-Button clickables ───────────────────────────────────────
+
+    [Fact]
+    public void Command_Wires_HyperlinkButton_Click()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "Details", Execute = () => count++ };
+
+        var el = HyperlinkButton("Details").Command(cmd);
+        Assert.NotNull(el.OnClick);
+        el.OnClick!();
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void Command_Wires_RepeatButton_Click()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "Tick", Execute = () => count++ };
+
+        var el = RepeatButton("Tick").Command(cmd);
+        el.OnClick!();
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void Command_Wires_ToggleButton_OnEachToggle()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "Bold", Execute = () => count++ };
+
+        var el = ToggleButton("Bold").Command(cmd);
+        Assert.NotNull(el.OnIsCheckedChanged);
+        el.OnIsCheckedChanged!(true);
+        el.OnIsCheckedChanged!(false);
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void Command_On_AppBarButton_Maps_Execute_And_IsEnabled()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "Save", Execute = () => count++, CanExecute = false };
+
+        var el = AppBarButton("Save").Command(cmd);
+
+        Assert.False(el.IsEnabled);
+        Assert.NotNull(el.OnClick);
+        el.OnClick!();
+        Assert.Equal(1, count);
+    }
+}

--- a/tests/Reactor.Tests/Elements/CommandModifierTests.cs
+++ b/tests/Reactor.Tests/Elements/CommandModifierTests.cs
@@ -172,4 +172,58 @@ public class CommandModifierTests
         el.OnClick!();
         Assert.Equal(1, count);
     }
+
+    // ── (M3) AppBarButton routes through CommandBindings.Invoke so async-only
+    //         commands (ExecuteAsync, no sync Execute) fire instead of no-opping ──
+
+    [Fact]
+    public void Command_On_AppBarButton_Modifier_Wires_Click_To_ExecuteAsync_When_No_Sync_Execute()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "Save", ExecuteAsync = () => { count++; return Task.CompletedTask; } };
+
+        var el = AppBarButton("Save").Command(cmd);
+        Assert.NotNull(el.OnClick);
+        el.OnClick!();
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void AppBarButton_Command_Factory_Wires_Click_To_ExecuteAsync_When_No_Sync_Execute()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "Save", ExecuteAsync = () => { count++; return Task.CompletedTask; } };
+
+        var el = AppBarButton(cmd);
+        Assert.NotNull(el.OnClick);
+        el.OnClick!();
+
+        Assert.Equal(1, count);
+    }
+
+    // ── (M1) A disabled command must not override .IsDisabledFocusable() ─────
+    //         The element keeps IsDisabledFocusable regardless of modifier order;
+    //         the live-control coercion (IsEnabled stays true / reachable via Tab)
+    //         is pinned by the CommandModifierDisabledFocusable* selftest fixtures.
+
+    [Fact]
+    public void Command_Before_IsDisabledFocusable_Keeps_DisabledFocusable()
+    {
+        var cmd = new Command { Label = "Run", Execute = () => { }, CanExecute = false };
+
+        var el = Button(TextBlock("Run")).Command(cmd).IsDisabledFocusable();
+
+        Assert.True(el.IsDisabledFocusable);
+    }
+
+    [Fact]
+    public void IsDisabledFocusable_Before_Command_Keeps_DisabledFocusable()
+    {
+        var cmd = new Command { Label = "Run", Execute = () => { }, CanExecute = false };
+
+        var el = Button(TextBlock("Run")).IsDisabledFocusable().Command(cmd);
+
+        Assert.True(el.IsDisabledFocusable);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #133.

`Button(Command)` and friends auto-apply `command.IsEnabled`, but the custom-content path `Button(content, onClick)` has no command binding at all — so icon-plus-label buttons had to re-thread `.IsEnabled(command.IsEnabled)` by hand, and that value was effectively captured per-render rather than bound to the command.

This adds a fluent **`.Command(Command)`** modifier that binds a command's enabled state, click handler, and metadata onto an already-built clickable element:

```csharp
Button(FlexRow(Image(icon), TextBlock(cmd.Label)))   // custom content
    .Command(runCmd)                                  // disabled while !runCmd.IsEnabled
    .AutomationName("Run");
```

Overloads are provided for `ButtonElement`, `HyperlinkButtonElement`, `RepeatButtonElement`, `ToggleButtonElement`, and `AppBarButtonData`. Each wires `Execute` → click, applies `IsEnabled`, and appends the shared `CommandBindings.ApplyButtonBaseCommon` setter (Description / Accelerator / AccessKey) — exactly the plumbing the `Button(Command)` factory already uses. Because that setter runs on **every reconcile pass**, `IsEnabled` is re-applied whenever the command's state flips (e.g. `UseCommand` toggling `IsExecuting`) instead of being captured once at construction — the core bug.

## Why the modifier (issue option 2) over the alternatives

The issue weighed three options:

1. A `Button(Element content, Command command)` factory overload.
2. A `.Command(this Element, Command)` fluent modifier.
3. Teaching `.Disabled` about commands.

I went with **option 2**. It's discoverable as a fluent modifier, composes with the existing `Button(content)` factory, and works uniformly across non-Button clickables (HyperlinkButton, RepeatButton, ToggleButton, AppBarButton) — matching how `.Set()` is already shaped per element type.

I also prototyped option 1 (`Button(Element, Command)`), but it introduces a `CS0121` ambiguity with existing `Button(content, null)` call sites (`null` matches both `Action?` and `Command`), so it does **not** "fall out naturally" and was dropped. The `.Command()` modifier covers the same ergonomic need without breaking the public API.

## API shape

```
ButtonElement.Command(Command) → ButtonElement
HyperlinkButtonElement.Command(Command) → HyperlinkButtonElement
RepeatButtonElement.Command(Command) → RepeatButtonElement
ToggleButtonElement.Command(Command) → ToggleButtonElement   // fires on each toggle
AppBarButtonData.Command(Command) → AppBarButtonData
```

## Changes
- `src/Reactor/Elements/ElementExtensions.cs` — the `.Command()` overloads.
- `samples/.../demo-script-tool/.../StepCard.cs` — action buttons now use `.Command(cmd)`, dropping the manual `onClick` lambda and `.IsEnabled(command.IsEnabled)`.
- `tests/Reactor.Tests/Elements/CommandModifierTests.cs` — 12 unit tests (IsEnabled binding, cross-render tracking, fresh-`Setters` re-apply guarantee, click invocation across all clickable types).
- `tests/Reactor.AppTests.Host/.../CommandingCoverageFixtures.cs` + registry — selftest fixture asserting a **live** control's `IsEnabled` re-applies on a state-driven update.
- `skills/reactor.api.txt` + plugin copy — regenerated API index.

## Verification
- `dotnet build src/Reactor` — clean (0 warnings, 0 errors).
- `dotnet test tests/Reactor.Tests` — **9441 passed**, 0 failed, 64 skipped.
- Commanding selftests (incl. the new live re-apply fixture) — all green.
- demo-script-tool sample builds clean.