### PR TITLE
perf(reconciler): coalesce ReactorState DP read in change handlers (#207)

### DIFF
--- a/src/Reactor/Core/ChangeEchoSuppressor.cs
+++ b/src/Reactor/Core/ChangeEchoSuppressor.cs
@@ -58,6 +58,19 @@ internal static class ChangeEchoSuppressor
         if (control is not FrameworkElement fe) return false;
         if (fe.GetValue(Reconciler.ReactorAttached.StateProperty) is not Reconciler.ReactorState state)
             return false;
+        return ShouldSuppress(state);
+    }
+
+    /// <summary>
+    /// Issue #207 — suppression check for trampolines that already hold the
+    /// control's <see cref="Reconciler.ReactorState"/> (read once via
+    /// <see cref="Reconciler.TryGetReactorState"/>). Identical decrement-and-
+    /// suppress semantics to <see cref="ShouldSuppress(UIElement)"/>; the
+    /// UIElement overload delegates here after a single attached-DP read so a
+    /// change handler pays one DP read instead of two.
+    /// </summary>
+    internal static bool ShouldSuppress(Reconciler.ReactorState state)
+    {
         // §8.2 — setter-suppression scope: drop the echo without consuming a
         // counter token. The scope wraps ApplySetters, where the engine can't
         // predict which value-bearing DPs the user's `.Set(...)` will write.
@@ -76,7 +89,7 @@ internal static class ChangeEchoSuppressor
     /// recognizes the engine-synthesized change event for a programmatic
     /// controlled write by its readback value. Pair with a bare write (no
     /// counter bump). The matching change-event trampoline calls
-    /// <see cref="ShouldSuppressEcho"/> which consumes the arm. Used only on
+    /// <see cref="ShouldSuppressEcho(UIElement, object?)"/> which consumes the arm. Used only on
     /// migrated single-value, exact-comparable, synchronous controlled
     /// round-trips; the counter remains the mechanism everywhere else.
     /// </summary>
@@ -96,7 +109,7 @@ internal static class ChangeEchoSuppressor
     }
 
     /// <summary>
-    /// Value-diff counterpart of <see cref="ShouldSuppress"/> for change-event
+    /// Value-diff counterpart of <see cref="ShouldSuppress(UIElement)"/> for change-event
     /// trampolines. Returns <c>true</c> if this fire is an engine-synthesized
     /// echo that should be dropped.
     ///
@@ -117,7 +130,18 @@ internal static class ChangeEchoSuppressor
         if (control is not FrameworkElement fe) return false;
         if (fe.GetValue(Reconciler.ReactorAttached.StateProperty) is not Reconciler.ReactorState state)
             return false;
+        return ShouldSuppressEcho(state, currentReadback);
+    }
 
+    /// <summary>
+    /// Issue #207 — value-diff counterpart of
+    /// <see cref="ShouldSuppress(Reconciler.ReactorState)"/> for trampolines that
+    /// already hold the control's <see cref="Reconciler.ReactorState"/>. Same
+    /// semantics as <see cref="ShouldSuppressEcho(UIElement, object?)"/>, which
+    /// delegates here after a single attached-DP read.
+    /// </summary>
+    internal static bool ShouldSuppressEcho(Reconciler.ReactorState state, object? currentReadback)
+    {
         if (state.EchoSuppressScopeDepth > 0 || state.EchoSuppressCount > 0)
         {
             // The counter/scope is suppressing THIS event. Any value-diff arm

--- a/src/Reactor/Core/Element.TabView.cs
+++ b/src/Reactor/Core/Element.TabView.cs
@@ -15,7 +15,7 @@ public partial record TabViewElement
     private static readonly WinUI.SelectionChangedEventHandler __SelectionChangedTrampoline = (s, _) =>
     {
         var t = (WinUI.TabView)s!;
-        if (!Reconciler.TryGetReactorState(t, out var state) || state is null) return;
+        if (!Reconciler.TryGetReactorState(t, out var state)) return;
         if (ChangeEchoSuppressor.ShouldSuppressEcho(state, t.SelectedIndex)) return;
         (state.Element as TabViewElement)?.OnSelectedIndexChanged?.Invoke(t.SelectedIndex);
     };

--- a/src/Reactor/Core/Element.TabView.cs
+++ b/src/Reactor/Core/Element.TabView.cs
@@ -15,8 +15,9 @@ public partial record TabViewElement
     private static readonly WinUI.SelectionChangedEventHandler __SelectionChangedTrampoline = (s, _) =>
     {
         var t = (WinUI.TabView)s!;
-        if (ChangeEchoSuppressor.ShouldSuppressEcho(t, t.SelectedIndex)) return;
-        (Reconciler.GetElementTag(t) as TabViewElement)?.OnSelectedIndexChanged?.Invoke(t.SelectedIndex);
+        if (!Reconciler.TryGetReactorState(t, out var state) || state is null) return;
+        if (ChangeEchoSuppressor.ShouldSuppressEcho(state, t.SelectedIndex)) return;
+        (state.Element as TabViewElement)?.OnSelectedIndexChanged?.Invoke(t.SelectedIndex);
     };
 
     private static readonly TypedEventHandler<WinUI.TabView, WinUI.TabViewTabCloseRequestedEventArgs>

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -2770,7 +2770,7 @@ public partial record TextBoxElement(
     private static readonly WinUI.TextChangedEventHandler __TextChangedTrampoline = (s, _) =>
     {
         var tb = (WinUI.TextBox)s!;
-        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(tb, out var state) || state is null) return;
+        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(tb, out var state)) return;
         if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
         (state.Element as TextBoxElement)?.OnChanged?.Invoke(tb.Text);
     };
@@ -2878,7 +2878,7 @@ public partial record NumberBoxElement(
         __ValueChangedTrampoline = (s, _) =>
         {
             var box = (WinUI.NumberBox)s!;
-            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(box, out var state) || state is null) return;
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(box, out var state)) return;
             if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
             (state.Element as NumberBoxElement)?.OnValueChanged?.Invoke(box.Value);
         };
@@ -2948,7 +2948,7 @@ public partial record AutoSuggestBoxElement(
         {
             if (args.Reason != WinUI.AutoSuggestionBoxTextChangeReason.UserInput) return;
             var asb = (WinUI.AutoSuggestBox)s!;
-            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(asb, out var state) || state is null) return;
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(asb, out var state)) return;
             if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
             (state.Element as AutoSuggestBoxElement)?.OnTextChanged?.Invoke(asb.Text);
         };
@@ -3133,7 +3133,7 @@ public partial record ComboBoxElement(
     private static readonly WinUI.SelectionChangedEventHandler __SelectionChangedTrampoline = (s, _) =>
     {
         var cb = (WinUI.ComboBox)s!;
-        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(cb, out var state) || state is null) return;
+        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(cb, out var state)) return;
         if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppressEcho(state, cb.SelectedIndex)) return;
         (state.Element as ComboBoxElement)
             ?.OnSelectedIndexChanged?.Invoke(cb.SelectedIndex);
@@ -3610,7 +3610,7 @@ public partial record RichEditBoxElement(
     private static readonly global::Microsoft.UI.Xaml.RoutedEventHandler __TextChangedTrampoline = (s, _) =>
     {
         var r = (WinUI.RichEditBox)s!;
-        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(r, out var state) || state is null) return;
+        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(r, out var state)) return;
         if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
         r.Document.GetText(global::Microsoft.UI.Text.TextGetOptions.None, out var text);
         (state.Element as RichEditBoxElement)
@@ -3865,7 +3865,7 @@ public partial record ExpanderElement(
     private static readonly global::Windows.Foundation.TypedEventHandler<WinUI.Expander, WinUI.ExpanderExpandingEventArgs>
         __ExpandingTrampoline = (s, _) =>
         {
-            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(s, out var state) || state is null) return;
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(s, out var state)) return;
             if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
             (state.Element as ExpanderElement)?.OnIsExpandedChanged?.Invoke(true);
         };
@@ -3873,7 +3873,7 @@ public partial record ExpanderElement(
     private static readonly global::Windows.Foundation.TypedEventHandler<WinUI.Expander, WinUI.ExpanderCollapsedEventArgs>
         __CollapsedTrampoline = (s, _) =>
         {
-            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(s, out var state) || state is null) return;
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(s, out var state)) return;
             if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
             (state.Element as ExpanderElement)?.OnIsExpandedChanged?.Invoke(false);
         };
@@ -4360,7 +4360,7 @@ internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
 private static readonly WinUI.SelectionChangedEventHandler __SelectionChangedTrampoline = (s, _) =>
 {
     var p = (WinUI.Pivot)s!;
-    if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(p, out var state) || state is null) return;
+    if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(p, out var state)) return;
     if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppressEcho(state, p.SelectedIndex)) return;
     (state.Element as PivotElement)?.OnSelectedIndexChanged?.Invoke(p.SelectedIndex);
 };
@@ -5768,7 +5768,7 @@ public partial record ListBoxElement(string[] Items) : Element
     private static readonly WinUI.SelectionChangedEventHandler __SelectionChangedTrampoline = (s, _) =>
     {
         var lb = (WinUI.ListBox)s!;
-        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(lb, out var state) || state is null) return;
+        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(lb, out var state)) return;
         if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
         if (state.Element is not ListBoxElement el) return;
         el.OnSelectedIndexChanged?.Invoke(lb.SelectedIndex);
@@ -5824,7 +5824,7 @@ public partial record SelectorBarElement(SelectorBarItemData[] Items) : Element
         {
             var bar = (WinUI.SelectorBar)s!;
             var idx = bar.Items.IndexOf(bar.SelectedItem);
-            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(bar, out var state) || state is null) return;
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(bar, out var state)) return;
             if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppressEcho(state, idx)) return;
             if (state.Element is not SelectorBarElement el) return;
             el.OnSelectedIndexChanged?.Invoke(idx);
@@ -6004,7 +6004,7 @@ public partial record CalendarViewElement() : Element
         __SelectedDatesChangedTrampoline = static (s, _) =>
         {
             var c = (WinUI.CalendarView)s!;
-            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(c, out var state) || state is null) return;
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(c, out var state)) return;
             if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
             if (state.Element is CalendarViewElement el && el.OnSelectedDatesChanged is { } h)
                 h(global::System.Linq.Enumerable.ToArray(c.SelectedDates));

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -2770,8 +2770,9 @@ public partial record TextBoxElement(
     private static readonly WinUI.TextChangedEventHandler __TextChangedTrampoline = (s, _) =>
     {
         var tb = (WinUI.TextBox)s!;
-        if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(tb)) return;
-        (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(tb) as TextBoxElement)?.OnChanged?.Invoke(tb.Text);
+        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(tb, out var state) || state is null) return;
+        if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
+        (state.Element as TextBoxElement)?.OnChanged?.Invoke(tb.Text);
     };
 
     private static readonly global::Microsoft.UI.Xaml.RoutedEventHandler __SelectionChangedTrampoline = (s, _) =>
@@ -2877,8 +2878,9 @@ public partial record NumberBoxElement(
         __ValueChangedTrampoline = (s, _) =>
         {
             var box = (WinUI.NumberBox)s!;
-            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(box)) return;
-            (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(box) as NumberBoxElement)?.OnValueChanged?.Invoke(box.Value);
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(box, out var state) || state is null) return;
+            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            (state.Element as NumberBoxElement)?.OnValueChanged?.Invoke(box.Value);
         };
 
     // Min/Max BEFORE Value (Customize entries emit first) so a fresh in-range Value isn't
@@ -2946,8 +2948,9 @@ public partial record AutoSuggestBoxElement(
         {
             if (args.Reason != WinUI.AutoSuggestionBoxTextChangeReason.UserInput) return;
             var asb = (WinUI.AutoSuggestBox)s!;
-            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(asb)) return;
-            (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(asb) as AutoSuggestBoxElement)?.OnTextChanged?.Invoke(asb.Text);
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(asb, out var state) || state is null) return;
+            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            (state.Element as AutoSuggestBoxElement)?.OnTextChanged?.Invoke(asb.Text);
         };
 
     private static readonly global::Windows.Foundation.TypedEventHandler<WinUI.AutoSuggestBox, WinUI.AutoSuggestBoxQuerySubmittedEventArgs>
@@ -3130,8 +3133,9 @@ public partial record ComboBoxElement(
     private static readonly WinUI.SelectionChangedEventHandler __SelectionChangedTrampoline = (s, _) =>
     {
         var cb = (WinUI.ComboBox)s!;
-        if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppressEcho(cb, cb.SelectedIndex)) return;
-        (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(cb) as ComboBoxElement)
+        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(cb, out var state) || state is null) return;
+        if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppressEcho(state, cb.SelectedIndex)) return;
+        (state.Element as ComboBoxElement)
             ?.OnSelectedIndexChanged?.Invoke(cb.SelectedIndex);
     };
 
@@ -3606,9 +3610,10 @@ public partial record RichEditBoxElement(
     private static readonly global::Microsoft.UI.Xaml.RoutedEventHandler __TextChangedTrampoline = (s, _) =>
     {
         var r = (WinUI.RichEditBox)s!;
-        if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(r)) return;
+        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(r, out var state) || state is null) return;
+        if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
         r.Document.GetText(global::Microsoft.UI.Text.TextGetOptions.None, out var text);
-        (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(r) as RichEditBoxElement)
+        (state.Element as RichEditBoxElement)
             ?.OnTextChanged?.Invoke(text?.TrimEnd('\r') ?? "");
     };
 
@@ -3860,15 +3865,17 @@ public partial record ExpanderElement(
     private static readonly global::Windows.Foundation.TypedEventHandler<WinUI.Expander, WinUI.ExpanderExpandingEventArgs>
         __ExpandingTrampoline = (s, _) =>
         {
-            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(s)) return;
-            (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(s) as ExpanderElement)?.OnIsExpandedChanged?.Invoke(true);
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(s, out var state) || state is null) return;
+            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            (state.Element as ExpanderElement)?.OnIsExpandedChanged?.Invoke(true);
         };
 
     private static readonly global::Windows.Foundation.TypedEventHandler<WinUI.Expander, WinUI.ExpanderCollapsedEventArgs>
         __CollapsedTrampoline = (s, _) =>
         {
-            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(s)) return;
-            (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(s) as ExpanderElement)?.OnIsExpandedChanged?.Invoke(false);
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(s, out var state) || state is null) return;
+            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            (state.Element as ExpanderElement)?.OnIsExpandedChanged?.Invoke(false);
         };
 
     private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<ExpanderElement, WinUI.Expander> Customize(
@@ -4353,8 +4360,9 @@ internal override bool HasCallbacks => OnSelectedIndexChanged is not null;
 private static readonly WinUI.SelectionChangedEventHandler __SelectionChangedTrampoline = (s, _) =>
 {
     var p = (WinUI.Pivot)s!;
-    if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppressEcho(p, p.SelectedIndex)) return;
-    (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(p) as PivotElement)?.OnSelectedIndexChanged?.Invoke(p.SelectedIndex);
+    if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(p, out var state) || state is null) return;
+    if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppressEcho(state, p.SelectedIndex)) return;
+    (state.Element as PivotElement)?.OnSelectedIndexChanged?.Invoke(p.SelectedIndex);
 };
 
 private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<PivotElement, WinUI.Pivot> Customize(
@@ -5760,8 +5768,9 @@ public partial record ListBoxElement(string[] Items) : Element
     private static readonly WinUI.SelectionChangedEventHandler __SelectionChangedTrampoline = (s, _) =>
     {
         var lb = (WinUI.ListBox)s!;
-        if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(lb)) return;
-        if (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(lb) is not ListBoxElement el) return;
+        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(lb, out var state) || state is null) return;
+        if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
+        if (state.Element is not ListBoxElement el) return;
         el.OnSelectedIndexChanged?.Invoke(lb.SelectedIndex);
         if (el.OnSelectionChanged is { } h)
         {
@@ -5815,8 +5824,9 @@ public partial record SelectorBarElement(SelectorBarItemData[] Items) : Element
         {
             var bar = (WinUI.SelectorBar)s!;
             var idx = bar.Items.IndexOf(bar.SelectedItem);
-            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppressEcho(bar, idx)) return;
-            if (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(bar) is not SelectorBarElement el) return;
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(bar, out var state) || state is null) return;
+            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppressEcho(state, idx)) return;
+            if (state.Element is not SelectorBarElement el) return;
             el.OnSelectedIndexChanged?.Invoke(idx);
         };
 
@@ -5994,8 +6004,9 @@ public partial record CalendarViewElement() : Element
         __SelectedDatesChangedTrampoline = static (s, _) =>
         {
             var c = (WinUI.CalendarView)s!;
-            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(c)) return;
-            if (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(c) is CalendarViewElement el && el.OnSelectedDatesChanged is { } h)
+            if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(c, out var state) || state is null) return;
+            if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            if (state.Element is CalendarViewElement el && el.OnSelectedDatesChanged is { } h)
                 h(global::System.Linq.Enumerable.ToArray(c.SelectedDates));
         };
 

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -463,7 +463,7 @@ public sealed partial class Reconciler : IDisposable
     /// paths (TextChanged per keystroke, Slider.ValueChanged during drag) this
     /// halves the per-event DP traffic.
     /// </summary>
-    internal static bool TryGetReactorState(FrameworkElement fe, out ReactorState? state)
+    internal static bool TryGetReactorState(FrameworkElement fe, [NotNullWhen(true)] out ReactorState? state)
     {
         state = fe.GetValue(ReactorAttached.StateProperty) as ReactorState;
         return state is not null;

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -453,6 +453,22 @@ public sealed partial class Reconciler : IDisposable
         return state;
     }
 
+    /// <summary>
+    /// Issue #207 — single attached-DP read for change-event trampolines.
+    /// Returns the control's <see cref="ReactorState"/> (or <c>null</c>) with one
+    /// <c>GetValue(StateProperty)</c> COM-interop read so a handler can check
+    /// suppression (<see cref="ChangeEchoSuppressor.ShouldSuppress(ReactorState)"/>)
+    /// and resolve the live element (<see cref="ReactorState.Element"/>) without a
+    /// second DP read via <see cref="GetElementTag(FrameworkElement)"/>. On hot
+    /// paths (TextChanged per keystroke, Slider.ValueChanged during drag) this
+    /// halves the per-event DP traffic.
+    /// </summary>
+    internal static bool TryGetReactorState(FrameworkElement fe, out ReactorState? state)
+    {
+        state = fe.GetValue(ReactorAttached.StateProperty) as ReactorState;
+        return state is not null;
+    }
+
     // ── Typed TreeView<T> container hosting ──────────────────────────────
     //
     // The typed TreeView hosts each node's view imperatively (the WinUI
@@ -1078,6 +1094,21 @@ public sealed partial class Reconciler : IDisposable
     {
         if (fe.GetValue(ReactorAttached.StateProperty) is ReactorState state
             && state.ControlEventState is ControlEventStateBox box
+            && box.HandlerType == typeof(T))
+        {
+            return (T)box.Payload;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #207 — payload accessor for trampolines that already hold the
+    /// control's <see cref="ReactorState"/> (read once via
+    /// <see cref="TryGetReactorState"/>), avoiding a second attached-DP read.
+    /// </summary>
+    internal static T? TryGetControlEventPayload<T>(ReactorState state) where T : class
+    {
+        if (state.ControlEventState is ControlEventStateBox box
             && box.HandlerType == typeof(T))
         {
             return (T)box.Payload;

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/GridViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/GridViewDescriptor.cs
@@ -32,8 +32,9 @@ internal static class GridViewDescriptor
     private static readonly WinUI.SelectionChangedEventHandler SelectionChangedTrampoline = (s, _) =>
     {
         var gv = (WinUI.GridView)s!;
-        if (ChangeEchoSuppressor.ShouldSuppress(gv)) return;
-        if (Reconciler.GetElementTag(gv) is not GridViewElement el) return;
+        if (!Reconciler.TryGetReactorState(gv, out var state) || state is null) return;
+        if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
+        if (state.Element is not GridViewElement el) return;
 
         el.OnSelectedIndexChanged?.Invoke(gv.SelectedIndex);
         if (el.OnSelectionChanged is { } h)

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/GridViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/GridViewDescriptor.cs
@@ -32,7 +32,7 @@ internal static class GridViewDescriptor
     private static readonly WinUI.SelectionChangedEventHandler SelectionChangedTrampoline = (s, _) =>
     {
         var gv = (WinUI.GridView)s!;
-        if (!Reconciler.TryGetReactorState(gv, out var state) || state is null) return;
+        if (!Reconciler.TryGetReactorState(gv, out var state)) return;
         if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
         if (state.Element is not GridViewElement el) return;
 

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/ListViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/ListViewDescriptor.cs
@@ -17,7 +17,7 @@ internal static class ListViewDescriptor
     private static readonly WinUI.SelectionChangedEventHandler SelectionChangedTrampoline = (s, _) =>
     {
         var lv = (WinUI.ListView)s!;
-        if (!Reconciler.TryGetReactorState(lv, out var state) || state is null) return;
+        if (!Reconciler.TryGetReactorState(lv, out var state)) return;
         if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
         if (state.Element is not ListViewElement el) return;
 

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/ListViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/ListViewDescriptor.cs
@@ -17,8 +17,9 @@ internal static class ListViewDescriptor
     private static readonly WinUI.SelectionChangedEventHandler SelectionChangedTrampoline = (s, _) =>
     {
         var lv = (WinUI.ListView)s!;
-        if (ChangeEchoSuppressor.ShouldSuppress(lv)) return;
-        if (Reconciler.GetElementTag(lv) is not ListViewElement el) return;
+        if (!Reconciler.TryGetReactorState(lv, out var state) || state is null) return;
+        if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
+        if (state.Element is not ListViewElement el) return;
 
         el.OnSelectedIndexChanged?.Invoke(lv.SelectedIndex);
         if (el.OnSelectionChanged is { } h)

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/TemplatedFlipViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/TemplatedFlipViewDescriptor.cs
@@ -50,7 +50,7 @@ internal static class TemplatedFlipViewDescriptor
     private static readonly WinUI.SelectionChangedEventHandler SelectionChangedTrampoline = (s, _) =>
     {
         var f = (WinUI.FlipView)s!;
-        if (!Reconciler.TryGetReactorState(f, out var state) || state is null) return;
+        if (!Reconciler.TryGetReactorState(f, out var state)) return;
         if (ChangeEchoSuppressor.ShouldSuppressEcho(state, f.SelectedIndex)) return;
         (state.Element as TemplatedFlipViewElementBase)?.InvokeSelectionChanged(f.SelectedIndex);
     };

--- a/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/TemplatedFlipViewDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/Descriptors/TemplatedFlipViewDescriptor.cs
@@ -50,8 +50,9 @@ internal static class TemplatedFlipViewDescriptor
     private static readonly WinUI.SelectionChangedEventHandler SelectionChangedTrampoline = (s, _) =>
     {
         var f = (WinUI.FlipView)s!;
-        if (ChangeEchoSuppressor.ShouldSuppressEcho(f, f.SelectedIndex)) return;
-        (Reconciler.GetElementTag(f) as TemplatedFlipViewElementBase)?.InvokeSelectionChanged(f.SelectedIndex);
+        if (!Reconciler.TryGetReactorState(f, out var state) || state is null) return;
+        if (ChangeEchoSuppressor.ShouldSuppressEcho(state, f.SelectedIndex)) return;
+        (state.Element as TemplatedFlipViewElementBase)?.InvokeSelectionChanged(f.SelectedIndex);
     };
 
     public static readonly ControlDescriptor<TemplatedFlipViewElementBase, WinUI.FlipView> Descriptor =

--- a/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
@@ -280,7 +280,7 @@ internal sealed class ControlledPropEntry<TElement, TControl, TValue, TArgs> : P
         // Issue #207 — single attached-DP read shared by payload lookup,
         // suppression check, and live-element resolution (was three GetValue
         // reads: TryGetControlEventPayload + ShouldSuppress + GetElementTag).
-        if (!Reconciler.TryGetReactorState(fe, out var state) || state is null) return;
+        if (!Reconciler.TryGetReactorState(fe, out var state)) return;
         var payload = Reconciler.TryGetControlEventPayload<
             DescriptorControlledPayload<TElement, TControl, TValue, TArgs>>(state);
 

--- a/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
@@ -277,8 +277,12 @@ internal sealed class ControlledPropEntry<TElement, TControl, TValue, TArgs> : P
     private static readonly EventHandler<TArgs> StaticTrampoline = (sender, args) =>
     {
         var fe = (FrameworkElement)sender!;
+        // Issue #207 — single attached-DP read shared by payload lookup,
+        // suppression check, and live-element resolution (was three GetValue
+        // reads: TryGetControlEventPayload + ShouldSuppress + GetElementTag).
+        if (!Reconciler.TryGetReactorState(fe, out var state) || state is null) return;
         var payload = Reconciler.TryGetControlEventPayload<
-            DescriptorControlledPayload<TElement, TControl, TValue, TArgs>>(fe);
+            DescriptorControlledPayload<TElement, TControl, TValue, TArgs>>(state);
 
         // Counter / setter-scope suppression still wins on this control: an
         // external ReactorBinding.WriteSuppressed token or an ApplySetters
@@ -286,7 +290,7 @@ internal sealed class ControlledPropEntry<TElement, TControl, TValue, TArgs> : P
         // But if a value-diff echo is also armed and THIS suppressed event is
         // that echo (readback matches), drain it here — otherwise the pending
         // flag would strand and swallow the user's next real interaction.
-        if (ChangeEchoSuppressor.ShouldSuppress(fe))
+        if (ChangeEchoSuppressor.ShouldSuppress(state))
         {
             if (payload is { HasExpectedEcho: true } ps && ps.ReadBack is { } rbs)
             {
@@ -301,7 +305,7 @@ internal sealed class ControlledPropEntry<TElement, TControl, TValue, TArgs> : P
             return;
         }
 
-        if (Reconciler.GetElementTag(fe) is not TElement liveEl) return;
+        if (state.Element is not TElement liveEl) return;
         if (payload is null || payload.ReadBack is not { } rb || payload.GetCallback is not { } gc) return;
 
         var current = rb((TControl)fe);

--- a/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
@@ -71,8 +71,9 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
             // (CheckBox/Slider/TextBox/etc.) so the programmatic SelectedIndex
             // writes below in Mount / Update don't echo back into
             // OnSelectedIndexChanged.
-            if (ChangeEchoSuppressor.ShouldSuppress(g)) return;
-            if (Reconciler.GetElementTag(g) is not GridViewElement el) return;
+            if (!Reconciler.TryGetReactorState(g, out var state) || state is null) return;
+            if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            if (state.Element is not GridViewElement el) return;
             el.OnSelectedIndexChanged?.Invoke(g.SelectedIndex);
             if (el.OnSelectionChanged is { } h)
             {

--- a/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
@@ -71,7 +71,7 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
             // (CheckBox/Slider/TextBox/etc.) so the programmatic SelectedIndex
             // writes below in Mount / Update don't echo back into
             // OnSelectedIndexChanged.
-            if (!Reconciler.TryGetReactorState(g, out var state) || state is null) return;
+            if (!Reconciler.TryGetReactorState(g, out var state)) return;
             if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
             if (state.Element is not GridViewElement el) return;
             el.OnSelectedIndexChanged?.Invoke(g.SelectedIndex);

--- a/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
@@ -78,7 +78,7 @@ internal sealed class ListViewHandler : IElementHandler<ListViewElement, WinUI.L
             // looping back through OnSelectedIndexChanged → setIndex →
             // re-render → … which previously caused a 50+-render storm when
             // the callback was bound to UseState.
-            if (!Reconciler.TryGetReactorState(l, out var state) || state is null) return;
+            if (!Reconciler.TryGetReactorState(l, out var state)) return;
             if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
             if (state.Element is not ListViewElement el) return;
             el.OnSelectedIndexChanged?.Invoke(l.SelectedIndex);

--- a/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
@@ -78,8 +78,9 @@ internal sealed class ListViewHandler : IElementHandler<ListViewElement, WinUI.L
             // looping back through OnSelectedIndexChanged → setIndex →
             // re-render → … which previously caused a 50+-render storm when
             // the callback was bound to UseState.
-            if (ChangeEchoSuppressor.ShouldSuppress(l)) return;
-            if (Reconciler.GetElementTag(l) is not ListViewElement el) return;
+            if (!Reconciler.TryGetReactorState(l, out var state) || state is null) return;
+            if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            if (state.Element is not ListViewElement el) return;
             el.OnSelectedIndexChanged?.Invoke(l.SelectedIndex);
             if (el.OnSelectionChanged is { } h)
             {

--- a/src/Reactor/Core/V1Protocol/ReactorBindingT.cs
+++ b/src/Reactor/Core/V1Protocol/ReactorBindingT.cs
@@ -181,8 +181,9 @@ public readonly struct ReactorBinding<TElement> where TElement : Element
             // a free no-op. See §8 / Phase 4 followup: when the echo
             // suppressor is replaced by per-control tolerance / coercion
             // metadata, this drain migrates with it.
-            if (ChangeEchoSuppressor.ShouldSuppress(fe)) return;
-            if (Reconciler.GetElementTag(fe) is TElement el)
+            if (!Reconciler.TryGetReactorState(fe, out var state) || state is null) return;
+            if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            if (state.Element is TElement el)
                 handler(el, args);
         };
         subscribe(fe, trampoline);

--- a/src/Reactor/Core/V1Protocol/ReactorBindingT.cs
+++ b/src/Reactor/Core/V1Protocol/ReactorBindingT.cs
@@ -181,7 +181,7 @@ public readonly struct ReactorBinding<TElement> where TElement : Element
             // a free no-op. See §8 / Phase 4 followup: when the echo
             // suppressor is replaced by per-control tolerance / coercion
             // metadata, this drain migrates with it.
-            if (!Reconciler.TryGetReactorState(fe, out var state) || state is null) return;
+            if (!Reconciler.TryGetReactorState(fe, out var state)) return;
             if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
             if (state.Element is TElement el)
                 handler(el, args);

--- a/src/Reactor/Core/V1Protocol/TemplatedListLifecycle.cs
+++ b/src/Reactor/Core/V1Protocol/TemplatedListLifecycle.cs
@@ -66,8 +66,9 @@ internal static class TemplatedListLifecycle
             // arm BeginSuppress around the SelectedIndex writes below so the
             // synthesized SelectionChanged is dropped here instead of looping
             // back through OnSelectedIndexChanged → setState → re-render.
-            if (ChangeEchoSuppressor.ShouldSuppress(l)) return;
-            if (Reconciler.GetElementTag(l) is not TemplatedListElementBase tel) return;
+            if (!Reconciler.TryGetReactorState(l, out var state) || state is null) return;
+            if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            if (state.Element is not TemplatedListElementBase tel) return;
             tel.InvokeSelectionChanged(l.SelectedIndex);
             if (tel.HasMultiSelectionCallback)
             {
@@ -140,8 +141,9 @@ internal static class TemplatedListLifecycle
         {
             var g = (WinUI.GridView)s!;
             // Issue #495 — see ListView trampoline above.
-            if (ChangeEchoSuppressor.ShouldSuppress(g)) return;
-            if (Reconciler.GetElementTag(g) is not TemplatedListElementBase tel) return;
+            if (!Reconciler.TryGetReactorState(g, out var state) || state is null) return;
+            if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            if (state.Element is not TemplatedListElementBase tel) return;
             tel.InvokeSelectionChanged(g.SelectedIndex);
             if (tel.HasMultiSelectionCallback)
             {
@@ -201,8 +203,9 @@ internal static class TemplatedListLifecycle
         {
             var f = (WinUI.FlipView)s!;
             // Issue #495 — see ListView trampoline above.
-            if (ChangeEchoSuppressor.ShouldSuppress(f)) return;
-            (Reconciler.GetElementTag(f) as TemplatedListElementBase)?.InvokeSelectionChanged(f.SelectedIndex);
+            if (!Reconciler.TryGetReactorState(f, out var state) || state is null) return;
+            if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
+            (state.Element as TemplatedListElementBase)?.InvokeSelectionChanged(f.SelectedIndex);
         };
 
         var selectedIndex = el.GetSelectedIndex();

--- a/src/Reactor/Core/V1Protocol/TemplatedListLifecycle.cs
+++ b/src/Reactor/Core/V1Protocol/TemplatedListLifecycle.cs
@@ -66,7 +66,7 @@ internal static class TemplatedListLifecycle
             // arm BeginSuppress around the SelectedIndex writes below so the
             // synthesized SelectionChanged is dropped here instead of looping
             // back through OnSelectedIndexChanged → setState → re-render.
-            if (!Reconciler.TryGetReactorState(l, out var state) || state is null) return;
+            if (!Reconciler.TryGetReactorState(l, out var state)) return;
             if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
             if (state.Element is not TemplatedListElementBase tel) return;
             tel.InvokeSelectionChanged(l.SelectedIndex);
@@ -141,7 +141,7 @@ internal static class TemplatedListLifecycle
         {
             var g = (WinUI.GridView)s!;
             // Issue #495 — see ListView trampoline above.
-            if (!Reconciler.TryGetReactorState(g, out var state) || state is null) return;
+            if (!Reconciler.TryGetReactorState(g, out var state)) return;
             if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
             if (state.Element is not TemplatedListElementBase tel) return;
             tel.InvokeSelectionChanged(g.SelectedIndex);
@@ -203,7 +203,7 @@ internal static class TemplatedListLifecycle
         {
             var f = (WinUI.FlipView)s!;
             // Issue #495 — see ListView trampoline above.
-            if (!Reconciler.TryGetReactorState(f, out var state) || state is null) return;
+            if (!Reconciler.TryGetReactorState(f, out var state)) return;
             if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
             (state.Element as TemplatedListElementBase)?.InvokeSelectionChanged(f.SelectedIndex);
         };

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
@@ -657,4 +657,63 @@ internal static class EchoSuppressionFixtures
                 calls.Count >= 1 && calls[^1] == false);
         }
     }
+
+    // ── Issue #207: coalesced single ReactorState DP read ─────────────
+    //
+    // The change-event trampolines were collapsed from two attached-DP reads
+    // (ChangeEchoSuppressor.ShouldSuppress + Reconciler.GetElementTag) to one
+    // (Reconciler.TryGetReactorState → state). This fixture pins the two
+    // invariants that the coalescing must preserve on a live control:
+    //   1. TryGetReactorState resolves the SAME live element that GetElementTag
+    //      would — the single read is a faithful substitute for the two.
+    //   2. The end-to-end contract still holds: a real user edit fires the
+    //      callback (dispatch via state.Element works) and a programmatic-write
+    //      echo is still swallowed exactly once (suppression via the state
+    //      overload works).
+
+    internal class TryGetReactorStateCoalescing(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var calls = new List<string>();
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, setPhase) = ctx.UseState(0);
+                var t = phase == 0 ? "initial" : "next";
+                return VStack(
+                    Button("Go_C207", () => setPhase(1)),
+                    TextBox(t, s => calls.Add(s), placeholderText: "c207")
+                );
+            });
+            await Harness.Render();
+            H.Check("Coalesce207_TextBox_MountNoFire", calls.Count == 0);
+
+            var tb = H.FindControl<TextBox>(t => t.PlaceholderText == "c207");
+            H.Check("Coalesce207_TextBox_Found", tb is not null);
+
+            // Invariant 1: the single TryGetReactorState read resolves the same
+            // live element the two-read path (GetElementTag) would have.
+            var resolved = tb is not null
+                && Reconciler.TryGetReactorState(tb, out var state)
+                && state is not null
+                && state.Element is TextBoxElement
+                && ReferenceEquals(state.Element, Reconciler.GetElementTag(tb));
+            H.Check("Coalesce207_TextBox_StateResolvesSameElement", resolved);
+
+            // Invariant 2a: a setState-driven controlled write does not echo a
+            // cross-value call back into the callback (suppression intact).
+            H.ClickButton("Go_C207");
+            await Harness.Render();
+            H.Check("Coalesce207_TextBox_UpdateAppliedValue", tb?.Text == "next");
+            H.Check("Coalesce207_TextBox_NoCrossValueEcho", calls.All(s => s == "next"));
+
+            // Invariant 2b: a real user edit still dispatches the callback.
+            var precedingCount = calls.Count;
+            if (tb is not null) tb.Text = "typed";
+            await Harness.Render();
+            H.Check("Coalesce207_TextBox_UserEditFires",
+                calls.Count > precedingCount && calls[^1] == "typed");
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/EchoSuppressionFixtures.cs
@@ -701,12 +701,16 @@ internal static class EchoSuppressionFixtures
                 && ReferenceEquals(state.Element, Reconciler.GetElementTag(tb));
             H.Check("Coalesce207_TextBox_StateResolvesSameElement", resolved);
 
-            // Invariant 2a: a setState-driven controlled write does not echo a
-            // cross-value call back into the callback (suppression intact).
+            // Invariant 2a: a setState-driven controlled write is swallowed
+            // exactly once — the callback must not fire at all. Snapshot the
+            // count first: asserting the value alone would pass even on a missed
+            // suppression, since the echo readback equals the written value
+            // ("next"), so it would not register as a cross-value call.
+            var preWriteCount = calls.Count;
             H.ClickButton("Go_C207");
             await Harness.Render();
             H.Check("Coalesce207_TextBox_UpdateAppliedValue", tb?.Text == "next");
-            H.Check("Coalesce207_TextBox_NoCrossValueEcho", calls.All(s => s == "next"));
+            H.Check("Coalesce207_TextBox_NoEchoCall", calls.Count == preWriteCount);
 
             // Invariant 2b: a real user edit still dispatches the callback.
             var precedingCount = calls.Count;

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -636,6 +636,8 @@ internal static class SelfTestFixtureRegistry
         "EchoSuppress_PasswordBox",
         "EchoSuppress_TextBox",
         "EchoSuppress_ToggleSplitButton",
+        // Issue #207 — single coalesced ReactorState DP read in change handlers.
+        "EchoSuppress_TryGetReactorStateCoalescing",
         // §8.2 setter-suppression scope — Set(c => c.X = ...) must not echo.
         "SettersScope_ToggleSwitch",
         "SettersScope_Slider",
@@ -2004,6 +2006,7 @@ internal static class SelfTestFixtureRegistry
         "EchoSuppress_PasswordBox" => new EchoSuppressionFixtures.PasswordBoxNoEcho(harness),
         "EchoSuppress_TextBox" => new EchoSuppressionFixtures.TextBoxNoEcho(harness),
         "EchoSuppress_ToggleSplitButton" => new EchoSuppressionFixtures.ToggleSplitButtonNoEcho(harness),
+        "EchoSuppress_TryGetReactorStateCoalescing" => new EchoSuppressionFixtures.TryGetReactorStateCoalescing(harness),
         "SettersScope_ToggleSwitch" => new EchoSuppressionFixtures.SettersScope_ToggleSwitch_NoEcho(harness),
         "SettersScope_Slider" => new EchoSuppressionFixtures.SettersScope_Slider_NoEcho(harness),
         "SettersScope_NumberBox" => new EchoSuppressionFixtures.SettersScope_NumberBox_NoEcho(harness),

--- a/tests/Reactor.Tests/ChangeEchoSuppressorStateTests.cs
+++ b/tests/Reactor.Tests/ChangeEchoSuppressorStateTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Issue #207 — the change-event trampolines were collapsed from two attached-DP
+/// reads (ShouldSuppress + GetElementTag) to one (TryGetReactorState → state).
+/// Suppression now flows through the <see cref="Reconciler.ReactorState"/>-based
+/// overloads of <see cref="ChangeEchoSuppressor"/>. These headless tests pin the
+/// exact decrement-and-suppress semantics those overloads must preserve — the
+/// UIElement overloads simply read the DP once and delegate here, so verifying the
+/// state overload verifies the behavior every trampoline now depends on.
+///
+/// (The FrameworkElement-facing <see cref="Reconciler.TryGetReactorState"/> read and
+/// the end-to-end "callback fires / echo swallowed once" round-trip require a live
+/// WinUI control and are covered by the ReactorStateCoalescing selftest fixture.)
+/// </summary>
+public class ChangeEchoSuppressorStateTests
+{
+    [Fact]
+    public void ShouldSuppress_NoPendingToken_ReturnsFalse()
+    {
+        var state = new Reconciler.ReactorState();
+        Assert.False(ChangeEchoSuppressor.ShouldSuppress(state));
+    }
+
+    [Fact]
+    public void ShouldSuppress_CounterToken_SuppressesOnceThenDecrements()
+    {
+        var state = new Reconciler.ReactorState { EchoSuppressCount = 1 };
+
+        Assert.True(ChangeEchoSuppressor.ShouldSuppress(state));   // consumes the token
+        Assert.Equal(0, state.EchoSuppressCount);
+        Assert.False(ChangeEchoSuppressor.ShouldSuppress(state));  // none left → falls through
+    }
+
+    [Fact]
+    public void ShouldSuppress_MultipleTokens_DecrementOnePerCall()
+    {
+        var state = new Reconciler.ReactorState { EchoSuppressCount = 2 };
+
+        Assert.True(ChangeEchoSuppressor.ShouldSuppress(state));
+        Assert.Equal(1, state.EchoSuppressCount);
+        Assert.True(ChangeEchoSuppressor.ShouldSuppress(state));
+        Assert.Equal(0, state.EchoSuppressCount);
+        Assert.False(ChangeEchoSuppressor.ShouldSuppress(state));
+    }
+
+    [Fact]
+    public void ShouldSuppress_SetterScope_SuppressesWithoutConsumingCounter()
+    {
+        var state = new Reconciler.ReactorState { EchoSuppressScopeDepth = 1, EchoSuppressCount = 1 };
+
+        // Scope wins first and is non-consuming: the counter token survives.
+        Assert.True(ChangeEchoSuppressor.ShouldSuppress(state));
+        Assert.Equal(1, state.EchoSuppressCount);
+        Assert.Equal(1, state.EchoSuppressScopeDepth);
+    }
+
+    [Fact]
+    public void ShouldSuppressEcho_NoArmNoCounter_ReturnsFalse()
+    {
+        var state = new Reconciler.ReactorState();
+        Assert.False(ChangeEchoSuppressor.ShouldSuppressEcho(state, 5));
+    }
+
+    [Fact]
+    public void ShouldSuppressEcho_PendingMatchHit_SuppressesAndConsumesArm()
+    {
+        var state = new Reconciler.ReactorState { PendingEchoMatch = v => Equals(v, 7) };
+
+        Assert.True(ChangeEchoSuppressor.ShouldSuppressEcho(state, 7));
+        Assert.Null(state.PendingEchoMatch);                       // arm consumed
+        Assert.False(ChangeEchoSuppressor.ShouldSuppressEcho(state, 7)); // not re-armed
+    }
+
+    [Fact]
+    public void ShouldSuppressEcho_PendingMatchMiss_FallsThroughAndClearsArm()
+    {
+        var state = new Reconciler.ReactorState { PendingEchoMatch = v => Equals(v, 7) };
+
+        // A real user change superseded the pending write — readback differs.
+        Assert.False(ChangeEchoSuppressor.ShouldSuppressEcho(state, 9));
+        Assert.Null(state.PendingEchoMatch);                       // stale arm cleared
+    }
+
+    [Fact]
+    public void ShouldSuppressEcho_CounterWins_ConsumesTokenAndClearsArm()
+    {
+        var state = new Reconciler.ReactorState
+        {
+            EchoSuppressCount = 1,
+            PendingEchoMatch = _ => true,
+        };
+
+        Assert.True(ChangeEchoSuppressor.ShouldSuppressEcho(state, 123));
+        Assert.Equal(0, state.EchoSuppressCount);                  // counter token consumed
+        Assert.Null(state.PendingEchoMatch);                       // coincident arm cleared
+    }
+
+    [Fact]
+    public void ShouldSuppressEcho_ScopeWins_DoesNotConsumeCounterButClearsArm()
+    {
+        var state = new Reconciler.ReactorState
+        {
+            EchoSuppressScopeDepth = 1,
+            EchoSuppressCount = 1,
+            PendingEchoMatch = _ => true,
+        };
+
+        Assert.True(ChangeEchoSuppressor.ShouldSuppressEcho(state, 123));
+        Assert.Equal(1, state.EchoSuppressCount);                  // scope is non-consuming
+        Assert.Null(state.PendingEchoMatch);                       // arm cleared
+    }
+
+    [Fact]
+    public void StateOverload_MatchesUIElementOverloadContract_ForCounterPath()
+    {
+        // The UIElement overload returns false when no state exists (the no-tag
+        // control case). The state overload models the has-state branch: a fresh
+        // ReactorState with no tokens must not suppress, so a real change event
+        // dispatches through to the user callback.
+        var state = new Reconciler.ReactorState();
+        Assert.False(ChangeEchoSuppressor.ShouldSuppress(state));
+        Assert.False(ChangeEchoSuppressor.ShouldSuppressEcho(state, null));
+    }
+}

--- a/tests/perf_bench/PerfBench.ControlModel/Benches/AllBenches.cs
+++ b/tests/perf_bench/PerfBench.ControlModel/Benches/AllBenches.cs
@@ -878,7 +878,7 @@ public sealed class C207_ChangeHandlerDpRead : IBench
             case BenchVariant.Reactor:
                 // AFTER #207: one GetValue(StateProperty) read per event, shared
                 // by the suppression check and the live-element dispatch.
-                if (!Reconciler.TryGetReactorState(h.Control, out var state) || state is null) return;
+                if (!Reconciler.TryGetReactorState(h.Control, out var state)) return;
                 if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
                 (state.Element as TextBoxElement)?.OnChanged?.Invoke("x");
                 break;

--- a/tests/perf_bench/PerfBench.ControlModel/Benches/AllBenches.cs
+++ b/tests/perf_bench/PerfBench.ControlModel/Benches/AllBenches.cs
@@ -818,6 +818,85 @@ public sealed class OptionalReconcilerUpdateBench : IBench
     private static readonly Action NoOp = static () => { };
 }
 
+/// <summary>
+/// C207 — Issue #207. Change-event trampoline ReactorState DP-read coalescing.
+///
+/// Holds one tagged <see cref="WinUI.TextBox"/> off-tree and runs the
+/// change-handler body N times, isolating the cost difference of the attached-DP
+/// (<c>GetValue(StateProperty)</c>, a COM-interop read) traffic per event:
+///   <list type="bullet">
+///     <item><b>ReactorToday</b> = BEFORE #207 — two DP reads per event
+///       (<c>ChangeEchoSuppressor.ShouldSuppress</c> + <c>Reconciler.GetElementTag</c>).</item>
+///     <item><b>Reactor</b> = AFTER #207 — one DP read per event
+///       (<c>Reconciler.TryGetReactorState</c> → reuse <c>state</c> for both the
+///       suppression check and the live-element dispatch).</item>
+///     <item><b>Direct</b> = floor — callback invoke only, no DP read.</item>
+///   </list>
+/// Encoding both patterns as variants makes this an in-process A/B: a single
+/// build measures the BEFORE and AFTER under identical conditions, so the delta
+/// is exactly the one eliminated <c>GetValue(StateProperty)</c> read per event.
+/// </summary>
+public sealed class C207_ChangeHandlerDpRead : IBench
+{
+    public string Id => "C207";
+    public string Name => "ChangeHandler_DpRead_Coalesce";
+
+    private sealed class Holder
+    {
+        public required WinUI.TextBox Control;
+        public required TextBoxElement Element;
+    }
+
+    // Static sink incremented by the dispatched callback so the JIT cannot
+    // elide the trampoline body as dead code.
+    private static long _sink;
+
+    public void RunOne(BenchVariant variant, BenchContext ctx)
+    {
+        if (ctx.Scratch is not Holder h)
+        {
+            var tb = new WinUI.TextBox();
+            var el = new TextBoxElement(Value: "x", OnChanged: static _ => _sink++);
+            Reconciler.SetElementTag(tb, el);
+            h = new Holder { Control = tb, Element = el };
+            ctx.Scratch = h;
+        }
+
+        switch (variant)
+        {
+            case BenchVariant.Direct:
+                // Floor: dispatch with no attached-DP read at all.
+                h.Element.OnChanged?.Invoke("x");
+                break;
+
+            case BenchVariant.ReactorToday:
+                // BEFORE #207: two GetValue(StateProperty) reads per event.
+                if (ChangeEchoSuppressor.ShouldSuppress(h.Control)) return;
+                (Reconciler.GetElementTag(h.Control) as TextBoxElement)?.OnChanged?.Invoke("x");
+                break;
+
+            case BenchVariant.Reactor:
+                // AFTER #207: one GetValue(StateProperty) read per event, shared
+                // by the suppression check and the live-element dispatch.
+                if (!Reconciler.TryGetReactorState(h.Control, out var state) || state is null) return;
+                if (ChangeEchoSuppressor.ShouldSuppress(state)) return;
+                (state.Element as TextBoxElement)?.OnChanged?.Invoke("x");
+                break;
+        }
+    }
+
+    public void DemoMount(BenchVariant variant, BenchContext ctx)
+    {
+        var stack = new StackPanel { Orientation = Orientation.Vertical };
+        stack.Children.Add(new TextBlock
+        {
+            Text = $"C207 {variant}: change-handler ReactorState DP-read coalescing",
+            FontSize = 16,
+        });
+        ctx.Parent.Children.Add(stack);
+    }
+}
+
 public static class BenchCatalog
 {
     public static IReadOnlyList<IBench> All { get; } = new IBench[]
@@ -837,5 +916,6 @@ public static class BenchCatalog
         new M13_SettersSuppressionScope(),
         new OptionalElementAllocBench(),
         new OptionalReconcilerUpdateBench(),
+        new C207_ChangeHandlerDpRead(),
     };
 }


### PR DESCRIPTION
Closes #207.

## Problem

After PR #205, every change-event trampoline read the `ReactorState` attached DP **twice** per event:

1. `ChangeEchoSuppressor.ShouldSuppress(control)` → `fe.GetValue(ReactorAttached.StateProperty)`
2. immediately after, `Reconciler.GetElementTag(control)` → a second `GetValue(StateProperty)`

Attached-DP reads are COM-interop calls. On hot paths — `TextChanged` per keystroke, `Slider.ValueChanged` during a drag — that is two interop reads per event when one suffices. The generic `ControlledPropEntry` trampoline was even worse: **three** reads (payload + suppress + tag).

## Fix

Collapse the reads into a single `GetValue(StateProperty)` per event, with no behavior change to echo suppression:

- **`Reconciler.TryGetReactorState(FrameworkElement, out ReactorState?)`** — one DP read, returns the state.
- **State-based suppression overloads** that hold the *exact* decrement-and-suppress semantics:
  - `ChangeEchoSuppressor.ShouldSuppress(ReactorState)`
  - `ChangeEchoSuppressor.ShouldSuppressEcho(ReactorState, object?)`
  - The existing `UIElement` overloads now read the DP once and **delegate** to these, so the external contract (and the public `WriteSuppressed` primitive / `ChangeEchoSuppressor`) is untouched.
- **`Reconciler.TryGetControlEventPayload<T>(ReactorState)`** — lets the generic descriptor trampoline reuse the already-read state (3 reads → 1).
- Every change-handler trampoline now reads state once → checks suppression via `state` → dispatches via `state.Element`.

This is an internal hot-path optimization only. The value-diff drain-on-suppress logic in `ControlledPropEntry` (so a stranded pending-echo flag can't swallow the user's next real interaction) is preserved exactly.

## Sites touched

- `Core/V1Protocol/Descriptor/PropEntry.cs` — `ControlledPropEntry.StaticTrampoline` (3 reads → 1)
- `Core/V1Protocol/ReactorBindingT.cs`
- `Core/V1Protocol/Descriptor/Descriptors/`: `GridViewDescriptor`, `ListViewDescriptor`, `TemplatedFlipViewDescriptor`
- `Core/V1Protocol/Handlers/`: `GridViewHandler`, `ListViewHandler`
- `Core/V1Protocol/TemplatedListLifecycle.cs` — ListView / GridView / FlipView
- `Core/Element.cs` — TextBox.TextChanged, NumberBox.ValueChanged, AutoSuggestBox.TextChanged, RichEditBox.TextChanged, Expander.Expanding/Collapsed, ListBox.SelectionChanged, CalendarView.SelectedDatesChanged, ComboBox.SelectionChanged, Pivot.SelectionChanged, SelectorBar.SelectionChanged
- `Core/Element.TabView.cs` — TabView.SelectionChanged
- Helpers added in `Core/Reconciler.cs` and `Core/ChangeEchoSuppressor.cs`

## Measurement

Added an A/B micro-benchmark **C207** to the repo's existing `PerfBench.ControlModel` harness. It holds one tagged `TextBox` off-tree and runs the change-handler body N times under three variants, so BEFORE and AFTER are measured in the **same process under identical conditions**:

| Variant | What it runs | Mean ns/event |
|---|---|---|
| `Direct` | callback invoke only (floor, no DP read) | **22.5** |
| `ReactorToday` | **BEFORE** — `ShouldSuppress(control)` + `GetElementTag(control)` (2 DP reads) | **314.4** |
| `Reactor` | **AFTER** — `TryGetReactorState` → shared `state` (1 DP read) | **181.2** |

**Delta: ~133 ns/event saved (~42% faster); exactly one COM-interop DP read eliminated.** Subtracting the 22.5 ns callback floor, the DP-read cost drops 291.9 ns → 158.7 ns (~46%), i.e. the per-event DP traffic is essentially halved as designed. Allocation is unchanged (gen0 = 0; reported bytes are harness noise).

**Methodology:** `PerfBench.ControlModel.exe --test C207 --variant All --iterations 2000000 --reps 8 --headless` on ARM64, Debug. The absolute win per event is small (as the issue notes); the value is confirming a measurable improvement with **no regression** and no new allocation across the ~24 wiring sites.

## Tests

- **`tests/Reactor.Tests` full suite: 9439 passed, 0 failed, 64 skipped.**
- **All `EchoSuppress` selftests green**, including a new `TryGetReactorStateCoalescing` fixture that asserts (a) `TryGetReactorState` resolves the *same* element as `GetElementTag`, (b) a user edit still fires the callback, and (c) a programmatic echo is still swallowed exactly once.
- New **`ChangeEchoSuppressorStateTests`** (headless xUnit) pin the exact semantics of the state-based `ShouldSuppress`/`ShouldSuppressEcho` overloads (scope is non-consuming, counter decrements once, pending-echo drain). The real-`FrameworkElement` path can't be exercised headlessly, so it's covered by the selftest fixture instead.