### PR TITLE
fix(a11y): make A11Y_CHART_011 background-contrast rule reachable (#628)

### DIFF
--- a/docs/specs/026-charting-accessibility-design.md
+++ b/docs/specs/026-charting-accessibility-design.md
@@ -653,7 +653,7 @@ JSON shape as existing A11Y_001–008:
 | `A11Y_CHART_007` | `.AnnounceEveryFrame()` used — floods live region | Remove; defaults are debounced for a reason. |
 | `A11Y_CHART_009` | Custom palette fails pairwise WCAG 3:1 non-text contrast | Run `ChartPalette.Harden(...)` — fix suggestion embeds hardened hex values. |
 | `A11Y_CHART_010` | Custom palette fails colorblind simulation (ΔE < 10 under deut/prot/trit) | Same: hardened alternative provided inline. |
-| `A11Y_CHART_011` | Custom palette fails 3:1 contrast against `ChartBackground` (light or dark) | Hardened alternative adjusts lightness away from background. |
+| `A11Y_CHART_011` | Custom palette would fail 3:1 contrast against `ChartBackground` (light or dark) | Informational (the static scanner is theme-agnostic and cannot know the active background, so it flags either-theme risk without blocking). Hardened alternative adjusts lightness away from the failing background. |
 | `A11Y_CHART_012` | `.RawColors()` escape hatch used | Informational; no blocking. Recorded for audit. Consider moving to `.Palette()` or `.SeriesColors()`. |
 
 *(A11Y_CHART_008 for a missing data-table fallback is intentionally absent: the fallback is

--- a/docs/specs/026-charting-accessibility-design.md
+++ b/docs/specs/026-charting-accessibility-design.md
@@ -557,7 +557,7 @@ LineChart(...).SeriesColors(
 Checks run:
 
 - Pairwise WCAG non-text contrast (every series vs. every other) ≥ 3:1.
-- Each series vs. `ChartBackground` (both light and dark) ≥ 3:1.
+- Each series vs. `ChartBackground` (light or dark) ≥ 3:1.
 - Pairwise ΔE ≥ 10 under deuteranopia, protanopia, tritanopia simulation.
 
 Violations emit scanner rules `A11Y_CHART_009`–`011` (see Layer 8) with the offending hex

--- a/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
@@ -227,7 +227,7 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
         }
     }
 
-    /// <summary>A11Y_CHART_011: Custom palette fails background contrast.</summary>
+    /// <summary>A11Y_CHART_011: Custom palette would fail background contrast (informational — the scanner cannot know the active theme).</summary>
     private static void CheckChartPaletteBackground(CanvasElement canvas, ChartA11yData cd, IScanContext ctx, List<A11yDiagnostic> findings)
     {
         if (cd.CustomPalette is not { } palette) return;
@@ -248,6 +248,14 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
             // against *either* the light or dark background (per spec 026). Requiring
             // failure against both is mathematically unreachable: a color light enough
             // to fail vs white can never also be dark enough to fail vs near-black.
+            //
+            // The scanner is a static, theme-agnostic tree walk (issue #498) and has
+            // no access to the chart's effective rendered background, so it cannot
+            // know which theme is actually active. A color flagged here only fails if
+            // the chart renders on the matching background — hence this is emitted as
+            // an informational finding, not a warning, to avoid alert fatigue on
+            // palettes that are fine for the theme they actually run under. See the
+            // "scope to active background" follow-up tracked for spec 026.
             if (failsLight || failsDark)
             {
                 var hardenResult = ChartPalette.Harden(
@@ -256,14 +264,14 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                 // failsLight and failsDark are mutually exclusive: a color light enough
                 // to fail vs white can never also be dark enough to fail vs near-black.
                 string failedBackground = failsLight
-                    ? $"the light ({lightContrast:F1}:1) background"
-                    : $"the dark ({darkContrast:F1}:1) background";
+                    ? $"a light ({lightContrast:F1}:1) background"
+                    : $"a dark ({darkContrast:F1}:1) background";
 
                 findings.Add(new A11yDiagnostic
                 {
                     Id = "A11Y_CHART_011",
-                    Severity = "warning",
-                    Message = $"Custom palette: color {i} fails 3:1 background contrast on {failedBackground}",
+                    Severity = "info",
+                    Message = $"Custom palette: color {i} would fail 3:1 contrast if rendered on {failedBackground}",
                     WcagCriterion = "1.4.11",
                     ElementType = "CanvasElement (Chart)",
                     AutomationId = ctx.GetAutomationId(canvas),

--- a/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
@@ -240,16 +240,30 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
             double lightContrast = ChartPalette.ContrastRatio(palette[i], lightBg);
             double darkContrast = ChartPalette.ContrastRatio(palette[i], darkBg);
 
-            if (lightContrast < 3.0 && darkContrast < 3.0)
+            bool failsLight = lightContrast < 3.0;
+            bool failsDark = darkContrast < 3.0;
+
+            // A theme-agnostic chart palette must render legibly under whichever
+            // background is active, so a color is flagged when it fails 3:1 contrast
+            // against *either* the light or dark background (per spec 026). Requiring
+            // failure against both is mathematically unreachable: a color light enough
+            // to fail vs white can never also be dark enough to fail vs near-black.
+            if (failsLight || failsDark)
             {
                 var hardenResult = ChartPalette.Harden(
                     Enumerable.Range(0, palette.Count).Select(k => palette[k]).ToArray());
+
+                string failedBackgrounds = failsLight && failsDark
+                    ? $"both light ({lightContrast:F1}:1) and dark ({darkContrast:F1}:1) backgrounds"
+                    : failsLight
+                        ? $"the light ({lightContrast:F1}:1) background"
+                        : $"the dark ({darkContrast:F1}:1) background";
 
                 findings.Add(new A11yDiagnostic
                 {
                     Id = "A11Y_CHART_011",
                     Severity = "warning",
-                    Message = $"Custom palette: color {i} fails background contrast on both light ({lightContrast:F1}:1) and dark ({darkContrast:F1}:1) backgrounds",
+                    Message = $"Custom palette: color {i} fails 3:1 background contrast on {failedBackgrounds}",
                     WcagCriterion = "1.4.11",
                     ElementType = "CanvasElement (Chart)",
                     AutomationId = ctx.GetAutomationId(canvas),

--- a/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
@@ -253,17 +253,17 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                 var hardenResult = ChartPalette.Harden(
                     Enumerable.Range(0, palette.Count).Select(k => palette[k]).ToArray());
 
-                string failedBackgrounds = failsLight && failsDark
-                    ? $"both light ({lightContrast:F1}:1) and dark ({darkContrast:F1}:1) backgrounds"
-                    : failsLight
-                        ? $"the light ({lightContrast:F1}:1) background"
-                        : $"the dark ({darkContrast:F1}:1) background";
+                // failsLight and failsDark are mutually exclusive: a color light enough
+                // to fail vs white can never also be dark enough to fail vs near-black.
+                string failedBackground = failsLight
+                    ? $"the light ({lightContrast:F1}:1) background"
+                    : $"the dark ({darkContrast:F1}:1) background";
 
                 findings.Add(new A11yDiagnostic
                 {
                     Id = "A11Y_CHART_011",
                     Severity = "warning",
-                    Message = $"Custom palette: color {i} fails 3:1 background contrast on {failedBackgrounds}",
+                    Message = $"Custom palette: color {i} fails 3:1 background contrast on {failedBackground}",
                     WcagCriterion = "1.4.11",
                     ElementType = "CanvasElement (Chart)",
                     AutomationId = ctx.GetAutomationId(canvas),

--- a/src/Reactor/Charting/Accessibility/ChartPalette.cs
+++ b/src/Reactor/Charting/Accessibility/ChartPalette.cs
@@ -293,8 +293,18 @@ public sealed class ChartPalette
                 // that fails the dark background must get lighter.
                 if (!failsLight && !failsDark) continue;
 
+                // At the default 3:1 threshold failsLight and failsDark are mutually
+                // exclusive, but MinBackgroundContrast is configurable: a high threshold
+                // (e.g. >~4:1) lets a mid-tone fail against *both* fixed backgrounds. In
+                // that case darkening improves light contrast while lightening improves
+                // dark contrast, so move toward the worse (lower) of the two ratios to
+                // maximize the attainable minimum rather than always darkening.
+                bool darken = failsLight && failsDark
+                    ? lightContrast <= darkContrast
+                    : failsLight;
+
                 var (l, c, h) = RgbToLch(adjusted[i]);
-                l = failsLight ? Math.Max(5, l - 15) : Math.Min(95, l + 15);
+                l = darken ? Math.Max(5, l - 15) : Math.Min(95, l + 15);
                 var candidate = LchToRgb(l, c, h);
 
                 // Series distinguishability takes priority: a color and its background

--- a/src/Reactor/Charting/Accessibility/ChartPalette.cs
+++ b/src/Reactor/Charting/Accessibility/ChartPalette.cs
@@ -284,15 +284,39 @@ public sealed class ChartPalette
             {
                 double lightContrast = ContrastRatio(adjusted[i], lightBg);
                 double darkContrast = ContrastRatio(adjusted[i], darkBg);
-                if (lightContrast < opts.MinBackgroundContrast && darkContrast < opts.MinBackgroundContrast)
+                bool failsLight = lightContrast < opts.MinBackgroundContrast;
+                bool failsDark = darkContrast < opts.MinBackgroundContrast;
+                // A color need only contrast against whichever background is active, so
+                // harden when it fails against *either* (matching the A11Y_CHART_011
+                // detection rule). The adjustment is direction-aware: a near-white color
+                // that fails the light background must get darker, and a near-black color
+                // that fails the dark background must get lighter.
+                if (!failsLight && !failsDark) continue;
+
+                var (l, c, h) = RgbToLch(adjusted[i]);
+                l = failsLight ? Math.Max(5, l - 15) : Math.Min(95, l + 15);
+                var candidate = LchToRgb(l, c, h);
+
+                // Series distinguishability takes priority: a color and its background
+                // both being legible is impossible to guarantee for every theme when
+                // colors must also stay ≥3:1 apart from each other. Only apply the
+                // background nudge when it does not push this color below the pairwise
+                // minimum against any other series.
+                bool breaksPairwise = false;
+                for (int k = 0; k < adjusted.Length; k++)
                 {
-                    // Push away from mid-lightness
-                    var (l, c, h) = RgbToLch(adjusted[i]);
-                    l = l < 50 ? Math.Max(5, l - 15) : Math.Min(95, l + 15);
-                    adjusted[i] = LchToRgb(l, c, h);
-                    passChanged = true;
-                    changed = true;
+                    if (k == i) continue;
+                    if (ContrastRatio(candidate, adjusted[k]) < opts.MinPairwiseContrast)
+                    {
+                        breaksPairwise = true;
+                        break;
+                    }
                 }
+                if (breaksPairwise) continue;
+
+                adjusted[i] = candidate;
+                passChanged = true;
+                changed = true;
             }
 
             if (!passChanged) break;

--- a/tests/Reactor.Tests/D3/ChartPaletteTests.cs
+++ b/tests/Reactor.Tests/D3/ChartPaletteTests.cs
@@ -94,8 +94,40 @@ public class ChartPaletteTests
             $"({ChartPalette.ContrastRatio(hardenedBlack.Palette[0], darkBg):F2}:1)");
     }
 
-    // ── Harden: colorblind-unsafe palette ───────────────────────────
+    [Fact]
+    public void Harden_FailsBothBackgrounds_ImprovesWorseSide()
+    {
+        // When MinBackgroundContrast is raised, a mid-tone can fail the minimum
+        // against BOTH the light (255,255,255) and dark (32,32,32) fixed backgrounds
+        // at once. Darkening improves light contrast while lightening improves dark
+        // contrast, so the nudge must move toward the worse (lower) of the two ratios
+        // to maximize the attainable minimum — not blindly darken (PR #629 review).
+        var lightBg = new D3Color(255, 255, 255);
+        var darkBg = new D3Color(32, 32, 32);
+        var midTone = new D3Color(128, 128, 128);
 
+        double inLight = ChartPalette.ContrastRatio(midTone, lightBg);
+        double inDark = ChartPalette.ContrastRatio(midTone, darkBg);
+
+        var opts = new HardenOptions { MinBackgroundContrast = 4.5, MaxPasses = 1 };
+        Assert.True(inLight < opts.MinBackgroundContrast && inDark < opts.MinBackgroundContrast,
+            $"mid-tone should fail both backgrounds at this threshold (light {inLight:F2}, dark {inDark:F2})");
+
+        var result = ChartPalette.Harden(new[] { midTone }, opts);
+        var outColor = result.Palette[0];
+        double outLight = ChartPalette.ContrastRatio(outColor, lightBg);
+        double outDark = ChartPalette.ContrastRatio(outColor, darkBg);
+
+        // The worse of the two sides before hardening must improve, not regress.
+        if (inLight <= inDark)
+            Assert.True(outLight > inLight,
+                $"worse (light) side should improve: {inLight:F2} -> {outLight:F2}");
+        else
+            Assert.True(outDark > inDark,
+                $"worse (dark) side should improve: {inDark:F2} -> {outDark:F2}");
+    }
+
+    // ── Harden: colorblind-unsafe palette ───────────────────────────
     [Fact]
     public void Harden_ColorblindUnsafe_OutputImproved()
     {

--- a/tests/Reactor.Tests/D3/ChartPaletteTests.cs
+++ b/tests/Reactor.Tests/D3/ChartPaletteTests.cs
@@ -64,6 +64,36 @@ public class ChartPaletteTests
         }
     }
 
+    // ── Harden: failing background contrast ─────────────────────────
+
+    [Fact]
+    public void Harden_FailingBackgroundContrast_OutputPasses()
+    {
+        // A near-white color fails 3:1 against the light (255,255,255) background;
+        // a near-black color fails against the dark (32,32,32) background. Harden
+        // must adjust each so it clears 3:1 against the background it failed —
+        // proving the A11Y_CHART_011 fix suggestion is a real remediation, not a
+        // no-op that echoes the failing color back (issue #628).
+        var lightBg = new D3Color(255, 255, 255);
+        var darkBg = new D3Color(32, 32, 32);
+
+        var nearWhite = new D3Color(255, 255, 200);
+        Assert.True(ChartPalette.ContrastRatio(nearWhite, lightBg) < 3.0);
+        var hardenedWhite = ChartPalette.Harden(new[] { nearWhite });
+        Assert.True(
+            ChartPalette.ContrastRatio(hardenedWhite.Palette[0], lightBg) >= 3.0,
+            $"Hardened near-white {hardenedWhite.Palette[0].ToHex()} still fails light bg " +
+            $"({ChartPalette.ContrastRatio(hardenedWhite.Palette[0], lightBg):F2}:1)");
+
+        var nearBlack = new D3Color(28, 28, 28);
+        Assert.True(ChartPalette.ContrastRatio(nearBlack, darkBg) < 3.0);
+        var hardenedBlack = ChartPalette.Harden(new[] { nearBlack });
+        Assert.True(
+            ChartPalette.ContrastRatio(hardenedBlack.Palette[0], darkBg) >= 3.0,
+            $"Hardened near-black {hardenedBlack.Palette[0].ToHex()} still fails dark bg " +
+            $"({ChartPalette.ContrastRatio(hardenedBlack.Palette[0], darkBg):F2}:1)");
+    }
+
     // ── Harden: colorblind-unsafe palette ───────────────────────────
 
     [Fact]
@@ -94,11 +124,14 @@ public class ChartPaletteTests
     [Fact]
     public void Harden_AlreadySafe_PassedWithoutChanges()
     {
-        // Black and white — maximum contrast
+        // A single mid-tone gray needs no pairwise/colorblind separation and keeps
+        // ≥3:1 against both the light (255,255,255) and dark (32,32,32) backgrounds,
+        // so it is already safe. (Pure black/white are NOT background-safe — white is
+        // illegible on a light background and black on a dark one — so a multi-color
+        // palette spread for pairwise contrast can never satisfy every background.)
         var input = new D3Color[]
         {
-            new(0, 0, 0),
-            new(255, 255, 255),
+            new(128, 128, 128),
         };
 
         var result = ChartPalette.Harden(input);

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -234,14 +234,43 @@ public class ChartScannerRuleTests
     // ── A11Y_CHART_011: Background contrast ─────────────────────────
 
     [Fact]
-    public void A11Y_CHART_011_VeryLightColor_FailsDark_PassesLight()
+    public void A11Y_CHART_011_VeryLightColor_FailsLightBackground()
     {
+        // Near-white yellow has ~1:1 contrast against the light (255,255,255)
+        // background, so it fails the 3:1 minimum on the light theme and must be
+        // flagged. Asserting the specific rule ID guards against the rule silently
+        // becoming unreachable again (see issue #628).
         var palette = ChartPalette.FromColors(new D3Color(255, 255, 200));
         var canvas = MakeChartCanvas(chartData: DataWithSeries(name: "Revenue"), customPalette: palette);
         var tree = VStack(canvas);
 
         var findings = AccessibilityScanner.Scan(tree);
-        // Light yellow passes against dark bg (good contrast), so _011 should not fire
+        Assert.Contains(findings, f => f.Id == "A11Y_CHART_011");
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_VeryDarkColor_FailsDarkBackground()
+    {
+        // Near-black color has ~1:1 contrast against the dark (32,32,32)
+        // background, so it fails on the dark theme and must be flagged.
+        var palette = ChartPalette.FromColors(new D3Color(28, 28, 28));
+        var canvas = MakeChartCanvas(chartData: DataWithSeries(name: "Revenue"), customPalette: palette);
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        Assert.Contains(findings, f => f.Id == "A11Y_CHART_011");
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_MidToneColor_PassesBothBackgrounds()
+    {
+        // A mid-tone gray keeps ≥3:1 contrast against both the light and dark
+        // backgrounds, so the rule should not fire.
+        var palette = ChartPalette.FromColors(new D3Color(128, 128, 128));
+        var canvas = MakeChartCanvas(chartData: DataWithSeries(name: "Revenue"), customPalette: palette);
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
         Assert.DoesNotContain(findings, f => f.Id == "A11Y_CHART_011");
     }
 

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -237,15 +237,18 @@ public class ChartScannerRuleTests
     public void A11Y_CHART_011_VeryLightColor_FailsLightBackground()
     {
         // Near-white yellow has ~1:1 contrast against the light (255,255,255)
-        // background, so it fails the 3:1 minimum on the light theme and must be
-        // flagged. Asserting the specific rule ID guards against the rule silently
-        // becoming unreachable again (see issue #628).
+        // background, so it would fail the 3:1 minimum if rendered on a light theme
+        // and must be flagged. Asserting the specific rule ID guards against the rule
+        // silently becoming unreachable again (see issue #628). The finding is
+        // informational, not a warning: the scanner is theme-agnostic and cannot know
+        // which background the chart actually renders on (avoids alert fatigue).
         var palette = ChartPalette.FromColors(new D3Color(255, 255, 200));
         var canvas = MakeChartCanvas(chartData: DataWithSeries(name: "Revenue"), customPalette: palette);
         var tree = VStack(canvas);
 
         var findings = AccessibilityScanner.Scan(tree);
-        Assert.Contains(findings, f => f.Id == "A11Y_CHART_011");
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+        Assert.Equal("info", finding.Severity);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #628. The chart accessibility rule **`A11Y_CHART_011`** (custom-palette background contrast) was a dead rule — no input could trigger it.

## Root cause

`CheckChartPaletteBackground` flagged a palette color only when it failed 3:1 contrast against **both** backgrounds simultaneously:

```csharp
if (lightContrast < 3.0 && darkContrast < 3.0)   // unreachable
```

That `&&` is mathematically unreachable. Failing the light background `(255,255,255)` requires relative luminance `Lc > 0.30`; failing the dark background `(32,32,32)` requires `Lc < 0.14`. No single color satisfies both, so the rule never fired and its test could only assert *absence*.

## Decision: fix (AND → OR), not remove

A background-contrast check is genuinely useful, and **spec 026** documents the intent as "fails 3:1 contrast against `ChartBackground` (**light or dark**)". A theme-agnostic palette must read against whichever background is active, so a color that fails *either* extreme should be flagged. The checker tests a fixed light/dark pair (it doesn't know the runtime-active theme), so the correct combinator is OR.

## Scoping decision: active background is *not* knowable → keep OR, downgrade to informational

A follow-up review raised a real alert-fatigue concern: under OR, `A11Y_CHART_011` fires on essentially every reasonable multi-color palette (a near-white series fails the light bg; a near-black series fails the dark bg), so a noisy `warning` would get blanket-suppressed — barely better than the dead rule.

I investigated whether the check could instead be scoped to the chart's **active/representative background** (which would be both more correct and non-noisy):

- `IScanContext` exposes no theme / `ForcedColors` / host-background context.
- `ChartA11yData` / `IChartAccessibilityData` carry no background.
- The chart canvas is `Transparent`; there is no author-declared `ChartBackground` property.
- The scanner is a **static, theme-agnostic tree walk** (`AccessibilityScanner.Scan(tree)`), decoupled from core charting in #498.

**Conclusion: the active background is genuinely not knowable at scan time.** So I kept the OR fix (the honest answer) but **downgraded `A11Y_CHART_011` from `warning` to `info`** and reworded the message to make its conditional ("if rendered on a light/dark background") nature explicit. The "scope to the active background" design improvement is tracked as a follow-up in #633, where the rule can be promoted back to `warning` once the background becomes knowable.

## Changes

**Detection**
- `ChartAccessibilityChecker.cs` — condition `&&` → `||`; the diagnostic message reports which background actually failed instead of always claiming "both" (the dead `failsLight && failsDark` "both" arm was removed — a single color can't fail both). Severity downgraded to `info`; message reworded to "would fail 3:1 contrast if rendered on …".

**Remediation (PR-review follow-up)**
- `ChartPalette.cs` — `Harden`'s background pass had the *identical* unreachable `&&`, so the fix suggestion echoed the failing color back unchanged. The pass now fires on `failsLight || failsDark` with a **direction-aware** nudge (darken a near-white color failing the light bg; lighten a near-black color failing the dark bg). Series distinguishability takes priority: the nudge is skipped when it would drop a color below the pairwise 3:1 minimum, since a spread theme-agnostic palette can't satisfy every background *and* pairwise contrast at once.

**Docs**
- `docs/specs/026-charting-accessibility-design.md` — reworded "(both light and dark)" → "(light or dark)" and noted the rule is informational (theme-agnostic scanner) in the rule table.

**Tests** (`ChartScannerRuleTests.cs`, `ChartPaletteTests.cs`)
- Replaced the absence-only `_011` test with 2 positive cases (light color fails light bg — also asserts `info` severity; dark color fails dark bg) + 1 negative (mid-tone passes both).
- Added `Harden_FailingBackgroundContrast_OutputPasses` — asserts the hardened color **actually clears 3:1** against the background it failed (the guard proving the remediation is not a no-op).
- Updated `Harden_AlreadySafe` to a single mid-tone color, since pure black/white are not background-safe under the corrected semantics.

## Verification

- `dotnet build src/Reactor` → clean (0 warnings, 0 errors)
- `dotnet test tests/Reactor.Tests --filter "ChartScannerRuleTests|ChartPaletteTests"` → **55 passed, 0 failed**

## Follow-up

- #633 — scope `A11Y_CHART_011` to the active/representative background (would eliminate the false positives that motivated the `info` downgrade, allowing promotion back to `warning`).

Closes #628.