### PR TITLE
feat(reconciler): public echo-suppression extension point for custom value controls (#206)

### DIFF
--- a/docs/_pipeline/templates/extending-reactor-controls.md.dt
+++ b/docs/_pipeline/templates/extending-reactor-controls.md.dt
@@ -448,10 +448,15 @@ supported, RCW-safe public extension point** for custom value-bearing
 controls — you never touch the framework's internal echo suppressor
 (issue #206). The controlled-control contract is: pair exactly one
 `WriteSuppressed` with exactly one programmatic write, and gate it on
-an equality check (`if (oldEl.Value != newEl.Value && ctrl.Value !=
-newEl.Value)`) so the suppression token is always consumed by the
-engine-provoked echo and never strands to swallow the user's next real
-edit. A worked, external-assembly proof of exactly this lives in
+a live readback check (`if (ctrl.Value != newEl.Value)`) — comparing
+the control's *current* value against the rendered value, exactly as
+the engine's `ControlledPropEntry.Update` does. Gating on the live
+readback (rather than `oldEl.Value != newEl.Value`) means the write
+also fires when the control has drifted from the rendered value even
+though the element is unchanged — snapping drift back — while still
+ensuring the suppression token is consumed by the engine-provoked echo
+and never strands to swallow the user's next real edit. A worked,
+external-assembly proof of exactly this lives in
 [`tests/external_proof/`](https://github.com/microsoft/microsoft-ui-reactor/tree/main/tests/external_proof)
 (`GaugeHandler` — a Slider-shaped `double Value` control authored
 against the public surface only).

--- a/docs/_pipeline/templates/extending-reactor-controls.md.dt
+++ b/docs/_pipeline/templates/extending-reactor-controls.md.dt
@@ -442,6 +442,20 @@ with `binding.WriteSuppressed(() => ctrl.Value = newValue)`.
 Forgetting it is the single most common cause of "the value snaps
 back when I edit it" bugs.
 
+`WriteSuppressed` (`ReactorBinding.WriteSuppressed`, and the
+per-binding `ctx.BindFor(ctrl, el).WriteSuppressed(...)`) is **the
+supported, RCW-safe public extension point** for custom value-bearing
+controls — you never touch the framework's internal echo suppressor
+(issue #206). The controlled-control contract is: pair exactly one
+`WriteSuppressed` with exactly one programmatic write, and gate it on
+an equality check (`if (oldEl.Value != newEl.Value && ctrl.Value !=
+newEl.Value)`) so the suppression token is always consumed by the
+engine-provoked echo and never strands to swallow the user's next real
+edit. A worked, external-assembly proof of exactly this lives in
+[`tests/external_proof/`](https://github.com/microsoft/microsoft-ui-reactor/tree/main/tests/external_proof)
+(`GaugeHandler` — a Slider-shaped `double Value` control authored
+against the public surface only).
+
 **Stashing per-control state on the descriptor / handler.** The
 descriptor and the handler instance are registered once per host.
 Per-control state needs to live on the **control** — either on the

--- a/docs/guide/extending-reactor-controls.md
+++ b/docs/guide/extending-reactor-controls.md
@@ -559,6 +559,20 @@ with `binding.WriteSuppressed(() => ctrl.Value = newValue)`.
 Forgetting it is the single most common cause of "the value snaps
 back when I edit it" bugs.
 
+`WriteSuppressed` (`ReactorBinding.WriteSuppressed`, and the
+per-binding `ctx.BindFor(ctrl, el).WriteSuppressed(...)`) is **the
+supported, RCW-safe public extension point** for custom value-bearing
+controls — you never touch the framework's internal echo suppressor
+(issue #206). The controlled-control contract is: pair exactly one
+`WriteSuppressed` with exactly one programmatic write, and gate it on
+an equality check (`if (oldEl.Value != newEl.Value && ctrl.Value !=
+newEl.Value)`) so the suppression token is always consumed by the
+engine-provoked echo and never strands to swallow the user's next real
+edit. A worked, external-assembly proof of exactly this lives in
+[`tests/external_proof/`](https://github.com/microsoft/microsoft-ui-reactor/tree/main/tests/external_proof)
+(`GaugeHandler` — a Slider-shaped `double Value` control authored
+against the public surface only).
+
 **Stashing per-control state on the descriptor / handler.** The
 descriptor and the handler instance are registered once per host.
 Per-control state needs to live on the **control** — either on the

--- a/docs/guide/extending-reactor-controls.md
+++ b/docs/guide/extending-reactor-controls.md
@@ -565,10 +565,15 @@ supported, RCW-safe public extension point** for custom value-bearing
 controls — you never touch the framework's internal echo suppressor
 (issue #206). The controlled-control contract is: pair exactly one
 `WriteSuppressed` with exactly one programmatic write, and gate it on
-an equality check (`if (oldEl.Value != newEl.Value && ctrl.Value !=
-newEl.Value)`) so the suppression token is always consumed by the
-engine-provoked echo and never strands to swallow the user's next real
-edit. A worked, external-assembly proof of exactly this lives in
+a live readback check (`if (ctrl.Value != newEl.Value)`) — comparing
+the control's *current* value against the rendered value, exactly as
+the engine's `ControlledPropEntry.Update` does. Gating on the live
+readback (rather than `oldEl.Value != newEl.Value`) means the write
+also fires when the control has drifted from the rendered value even
+though the element is unchanged — snapping drift back — while still
+ensuring the suppression token is consumed by the engine-provoked echo
+and never strands to swallow the user's next real edit. A worked,
+external-assembly proof of exactly this lives in
 [`tests/external_proof/`](https://github.com/microsoft/microsoft-ui-reactor/tree/main/tests/external_proof)
 (`GaugeHandler` — a Slider-shaped `double Value` control authored
 against the public surface only).

--- a/src/Reactor/Core/ChangeEchoSuppressor.cs
+++ b/src/Reactor/Core/ChangeEchoSuppressor.cs
@@ -5,6 +5,18 @@ namespace Microsoft.UI.Reactor.Core;
 /// <summary>
 /// Per-control "suppress next change event" counter used by the reconciler.
 ///
+/// <para><b>Custom-control authors: do NOT use this type directly.</b> It is
+/// <c>internal</c> by design (issue #206). The supported, RCW-safe PUBLIC entry
+/// point is <see cref="ReactorBinding"/>'s <c>WriteSuppressed</c> method
+/// (and the per-binding wrapper
+/// <see cref="V1Protocol.ReactorBinding{TElement}"/>,
+/// reached in a handler via <c>ctx.BindFor(ctrl, el).WriteSuppressed(...)</c>),
+/// or — for descriptor
+/// authors — the <c>.Controlled</c> / <c>.HandCodedControlled</c> opt-ins,
+/// which wrap this primitive for you. Those surfaces were deliberately kept as
+/// the only public path so the storage mechanism below can evolve without
+/// breaking external controls.</para>
+///
 /// Background — why this exists:
 ///   A Reactor Update handler that writes a value-bearing DP (<c>cp.Color = ...</c>,
 ///   <c>nb.Value = ...</c>, <c>ts.IsOn = ...</c>) synthesizes a ValueChanged /

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -777,8 +777,12 @@ public sealed partial class Reconciler : IDisposable
     /// from the <c>update</c> callback. Use the supported public primitive
     /// <see cref="ReactorBinding"/>'s
     /// <c>WriteSuppressed</c> method — wrap the programmatic write, gate it on an
-    /// equality check, and pair it 1:1 with the write. Prefer <see cref="RegisterHandler{TElement,TControl}"/>
-    /// + <see cref="V1Protocol.IElementHandler{TElement,TControl}"/> for new
+    /// equality check, and pair it 1:1 with the write. For new controls prefer
+    /// the V1 path: a <see cref="V1Protocol.Descriptor.ControlDescriptor{TElement,TControl}"/>
+    /// (the primary, descriptor-first authoring shape — its <c>.Controlled</c> /
+    /// <c>.HandCodedControlled</c> handle echo suppression for you), or a
+    /// hand-coded <see cref="V1Protocol.IElementHandler{TElement,TControl}"/> via
+    /// <see cref="RegisterHandler{TElement,TControl}"/> only for irregular
     /// controls (its <see cref="V1Protocol.ReactorBinding{TElement}"/> wraps the
     /// same primitive). See <c>docs/guide/extending-reactor-controls.md</c>
     /// (issue #206).

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -771,6 +771,18 @@ public sealed partial class Reconciler : IDisposable
     /// (throw on duplicate, no base-class fallback, no open generics) tightens
     /// previously-undefined behavior; it does not change the shape of this API.
     /// </summary>
+    /// <remarks>
+    /// A value-bearing custom control (one that raises the same change event for
+    /// a programmatic write as for a user edit) must suppress its own write echo
+    /// from the <c>update</c> callback. Use the supported public primitive
+    /// <see cref="ReactorBinding"/>'s
+    /// <c>WriteSuppressed</c> method — wrap the programmatic write, gate it on an
+    /// equality check, and pair it 1:1 with the write. Prefer <see cref="RegisterHandler{TElement,TControl}"/>
+    /// + <see cref="V1Protocol.IElementHandler{TElement,TControl}"/> for new
+    /// controls (its <see cref="V1Protocol.ReactorBinding{TElement}"/> wraps the
+    /// same primitive). See <c>docs/guide/extending-reactor-controls.md</c>
+    /// (issue #206).
+    /// </remarks>
     public void RegisterType<TElement, TControl>(
         Func<Reconciler, TElement, Action, TControl> mount,
         Func<Reconciler, TElement, TElement, TControl, Action, UIElement?> update,
@@ -826,6 +838,16 @@ public sealed partial class Reconciler : IDisposable
     /// (including across registries) and on open-generic element types
     /// (spec §13 Q17).
     /// </summary>
+    /// <remarks>
+    /// Value-bearing handlers (a control whose programmatic property write
+    /// raises the same change event as a user edit) must suppress their own
+    /// write echo with the supported public primitive
+    /// <see cref="V1Protocol.ReactorBinding{TElement}"/>'s <c>WriteSuppressed</c>
+    /// method (or the static <see cref="ReactorBinding"/>); descriptor authors get it
+    /// via <c>.Controlled</c> / <c>.HandCodedControlled</c>. See
+    /// <see cref="V1Protocol.IElementHandler{TElement,TControl}"/> and
+    /// <c>docs/guide/extending-reactor-controls.md</c> (issue #206).
+    /// </remarks>
     public void RegisterHandler<TElement, TControl>(V1Protocol.IElementHandler<TElement, TControl> handler)
         where TElement : Element
         where TControl : UIElement

--- a/src/Reactor/Core/V1Protocol/ControlRegistry.cs
+++ b/src/Reactor/Core/V1Protocol/ControlRegistry.cs
@@ -75,6 +75,17 @@ public static class ControlRegistry
     /// the call site. A capturing lambda is functionally correct but
     /// allocates a closure on every <c>Reg&lt;&gt;.Init</c> / cctor run,
     /// undoing the cost-model claim in spec §9.</para>
+    ///
+    /// <para><b>Echo suppression for value-bearing controls (issue #206).</b> A
+    /// custom <see cref="IElementHandler{TElement,TControl}"/> registered here
+    /// that writes a value-bearing property in <c>Update</c> must guard that
+    /// write with the supported public primitive
+    /// <see cref="ReactorBinding{TElement}"/>'s <c>WriteSuppressed</c> method
+    /// (or the static <see cref="Microsoft.UI.Reactor.Core.ReactorBinding"/>) so
+    /// the control's own echo does not flow back as a spurious user edit. Never
+    /// reach into the internal <c>ChangeEchoSuppressor</c>. Descriptor authors
+    /// get this through <c>.Controlled</c> / <c>.HandCodedControlled</c>. See
+    /// <c>docs/guide/extending-reactor-controls.md</c>.</para>
     /// </summary>
     /// <typeparam name="TElement">The element record type the handler
     /// dispatches against. Used as the dispatch key (<see cref="Type"/>).</typeparam>

--- a/src/Reactor/Core/V1Protocol/Descriptor/ControlDescriptor.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/ControlDescriptor.cs
@@ -34,6 +34,17 @@ public delegate void AfterChildrenMountCallback<TElement, TControl>(
 /// decision matrix determines which surface ships as the primary author
 /// path. See <c>docs/specs/047-extensible-control-model.md</c> §13 Q1.</para>
 ///
+/// <para><b>Echo suppression (issue #206).</b> A <c>.Controlled</c> /
+/// <c>.HandCodedControlled</c> entry suppresses the echo of its own
+/// programmatic write automatically — the interpreter wraps the write in the
+/// public <see cref="Microsoft.UI.Reactor.Core.ReactorBinding"/> <c>WriteSuppressed</c> primitive
+/// (or arms a value-diff predicate when <c>valueDiffEcho</c> is set),
+/// so a framework-driven write never echoes back into the user's
+/// <c>OnChanged</c> callback. Descriptor authors therefore never touch the
+/// suppressor directly; hand-coded <see cref="IElementHandler{TElement,TControl}"/>
+/// authors call <c>WriteSuppressed</c> themselves. See
+/// <c>docs/guide/extending-reactor-controls.md</c>.</para>
+///
 /// <para><b>Fluent author pattern:</b>
 /// <code>
 /// public record ToggleSwitchElement(Optional&lt;bool&gt; IsOn = default) : Element;

--- a/src/Reactor/Core/V1Protocol/IElementHandler.cs
+++ b/src/Reactor/Core/V1Protocol/IElementHandler.cs
@@ -18,6 +18,21 @@ namespace Microsoft.UI.Reactor.Core.V1Protocol;
 /// should avoid allocations in <see cref="Mount"/> / <see cref="Update"/>
 /// bodies; the <c>ref struct</c> context types are allocation-free by
 /// construction.</para>
+///
+/// <para><b>Echo suppression for value-bearing controls (issue #206).</b> If
+/// the control raises the same change event for a programmatic property write
+/// as it does for a user edit, a write from <see cref="Update"/> would echo
+/// back through the trampoline into the owning component's <c>OnChanged</c>
+/// state setter — indistinguishable from real input. Guard every programmatic
+/// controlled-value write with the supported, RCW-safe public primitive
+/// <see cref="ReactorBinding{TElement}"/>'s <c>WriteSuppressed</c> method
+/// (or the static <see cref="Microsoft.UI.Reactor.Core.ReactorBinding"/>):
+/// <c>ctx.BindFor(ctrl, newEl).WriteSuppressed(() =&gt; ctrl.Value = newEl.Value)</c>.
+/// Pair it 1:1 with the write and gate it on an equality check so the token is
+/// always consumed by the engine-provoked echo. Descriptor authors get this for
+/// free through <c>.Controlled</c> / <c>.HandCodedControlled</c>. Never reach
+/// into the internal <c>ChangeEchoSuppressor</c>. See
+/// <c>docs/guide/extending-reactor-controls.md</c>.</para>
 /// </summary>
 // <snippet:handler-contract>
 public interface IElementHandler<TElement, TControl>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047ExternalProofFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047ExternalProofFixtures.cs
@@ -130,6 +130,62 @@ internal static class Spec047ExternalProofFixtures
     }
 
     // ────────────────────────────────────────────────────────────────────
+    //  Issue #206 — Slider-shaped (numeric) value-bearing control proving the
+    //  PUBLIC echo-suppression surface is sufficient for a custom control:
+    //
+    //   - Framework-driven reconcile write (handler Update → WriteSuppressed)
+    //     does NOT fire the user's OnValueChanged callback.
+    //   - A genuine user edit (direct setter, outside the suppression scope)
+    //     DOES fire the callback exactly once.
+    //
+    //  GaugeHandler lives in the external Reactor.External.TestControl assembly
+    //  and touches no Reactor internals — only the public WriteSuppressed /
+    //  BindFor / RentControl surface.
+    // ────────────────────────────────────────────────────────────────────
+
+    internal class GaugeWriteSuppressedEcho(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int fireCount = 0;
+            var host = H.CreateHost();
+
+            host.Mount(ctx =>
+            {
+                var (value, setValue) = ctx.UseState(1.0);
+                return VStack(
+                    Gauge.Of(value, v => { fireCount++; setValue(v); }),
+                    Button("Reconcile", () => setValue(2.0))
+                );
+            });
+
+            await Harness.Render();
+            var gc = H.FindControl<GaugeControl>(_ => true);
+            H.Check("ExtProof_Gauge_WriteSuppressed_Mounted", gc is not null);
+            H.Check("ExtProof_Gauge_InitialValue", gc?.Value == 1.0);
+
+            // Framework-driven reconcile — handler's Update writes Value via
+            // WriteSuppressed. The callback must NOT fire (no spurious echo).
+            int beforeReconcile = fireCount;
+            H.ClickButton("Reconcile");
+            await Harness.Render();
+            H.Check("ExtProof_Gauge_WriteSuppressed_NoEchoOnReconcile",
+                fireCount == beforeReconcile);
+            gc = H.FindControl<GaugeControl>(_ => true);
+            H.Check("ExtProof_Gauge_WriteSuppressed_ReconcileApplied",
+                gc?.Value == 2.0);
+
+            // Genuine user edit — direct write OUTSIDE the suppression scope.
+            // The callback must fire exactly once.
+            int beforeUser = fireCount;
+            if (gc is not null) gc.Value = 5.0;
+            await Harness.Render();
+            H.Check("ExtProof_Gauge_WriteSuppressed_FiresOnUserEdit",
+                fireCount == beforeUser + 1);
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     //  Modifier chain — .Margin / .Width / ... applied by the engine's
     //  modifier pipeline (V1-independent, but worth proving on a non-
     //  built-in element type).

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047ExternalProofFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047ExternalProofFixtures.cs
@@ -176,12 +176,27 @@ internal static class Spec047ExternalProofFixtures
                 gc?.Value == 2.0);
 
             // Genuine user edit — direct write OUTSIDE the suppression scope.
-            // The callback must fire exactly once.
+            // The callback must fire exactly once. This also sets up the
+            // coincident-reconcile case: the callback's setValue drives a
+            // re-render where newEl.Value == ctrl.Value already (oldEl.Value !=
+            // newEl.Value, but the control is in sync), so the handler's
+            // readback-gated Update performs NO write and arms NO suppression
+            // token.
             int beforeUser = fireCount;
             if (gc is not null) gc.Value = 5.0;
             await Harness.Render();
             H.Check("ExtProof_Gauge_WriteSuppressed_FiresOnUserEdit",
                 fireCount == beforeUser + 1);
+
+            // Token-stranding pin — if the coincident reconcile above had armed
+            // a stray suppression token, the NEXT real user edit would be
+            // swallowed. Assert it still fires exactly once.
+            int beforeSecond = fireCount;
+            gc = H.FindControl<GaugeControl>(_ => true);
+            if (gc is not null) gc.Value = 7.0;
+            await Harness.Render();
+            H.Check("ExtProof_Gauge_WriteSuppressed_NoStrandedTokenAfterCoincident",
+                fireCount == beforeSecond + 1);
         }
     }
 

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1299,6 +1299,7 @@ internal static class SelfTestFixtureRegistry
         // surface is sufficient for external authors.
         "Spec047ExternalProof_Marquee_MountUpdate",
         "Spec047ExternalProof_Marquee_WriteSuppressed",
+        "Spec047ExternalProof_Gauge_WriteSuppressed",
         "Spec047ExternalProof_Marquee_ModifierChain",
         "Spec047ExternalProof_Marquee_SetterChain",
         "Spec047ExternalProof_Marquee_PoolRent",
@@ -2666,6 +2667,7 @@ internal static class SelfTestFixtureRegistry
         // Spec 047 §14 Phase 1 (1.16) — external-assembly proof fixtures.
         "Spec047ExternalProof_Marquee_MountUpdate" => new Spec047ExternalProofFixtures.MarqueeMountUpdate(harness),
         "Spec047ExternalProof_Marquee_WriteSuppressed" => new Spec047ExternalProofFixtures.MarqueeWriteSuppressedEcho(harness),
+        "Spec047ExternalProof_Gauge_WriteSuppressed" => new Spec047ExternalProofFixtures.GaugeWriteSuppressedEcho(harness),
         "Spec047ExternalProof_Marquee_ModifierChain" => new Spec047ExternalProofFixtures.MarqueeModifierChain(harness),
         "Spec047ExternalProof_Marquee_SetterChain" => new Spec047ExternalProofFixtures.MarqueeSetterChain(harness),
         "Spec047ExternalProof_Marquee_PoolRent" => new Spec047ExternalProofFixtures.MarqueePoolRentReturn(harness),

--- a/tests/external_proof/Reactor.External.TestControl.Tests/GaugeHandlerSelftests.cs
+++ b/tests/external_proof/Reactor.External.TestControl.Tests/GaugeHandlerSelftests.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Core.V1Protocol;
+using Xunit;
+
+namespace Reactor.External.TestControl.Tests;
+
+/// <summary>
+/// Issue #206 — hermetic (no-dispatcher) proof that the external Slider-shaped
+/// <see cref="GaugeHandler"/> registers through the public extension path. The
+/// live echo-suppression proof (user edit fires, framework write does not)
+/// requires a real WinUI dispatcher and lives in
+/// <c>Reactor.AppTests.Host</c> as
+/// <c>Spec047ExternalProofFixtures.GaugeWriteSuppressedEcho</c>.
+///
+/// <para>The very fact that this file compiles — with no
+/// <c>InternalsVisibleTo</c> from Reactor.dll into this assembly — is the
+/// proof that <see cref="ReactorBinding{TElement}.WriteSuppressed"/> and the
+/// rest of the value-control surface are sufficient from outside the
+/// framework.</para>
+/// </summary>
+public class GaugeHandlerSelftests
+{
+    [Fact]
+    public void RegisterHandler_Succeeds_ForExternalValueControl()
+    {
+        var reconciler = new Reconciler();
+        reconciler.RegisterHandler<GaugeElement, GaugeControl>(new GaugeHandler());
+        // No exception — the external value-bearing handler is accepted.
+    }
+
+    [Fact]
+    public void RegisterHandler_Twice_Throws()
+    {
+        var reconciler = new Reconciler();
+        reconciler.RegisterHandler<GaugeElement, GaugeControl>(new GaugeHandler());
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            reconciler.RegisterHandler<GaugeElement, GaugeControl>(new GaugeHandler()));
+
+        Assert.Contains("GaugeElement", ex.Message);
+    }
+
+    [Fact(Skip = "Requires WinUI dispatcher; lives in AppTests.Host fixture Spec047ExternalProof_Gauge_WriteSuppressed")]
+    public void Gauge_WriteSuppressed_NumericEchoSuppressed()
+    {
+        // See Spec047ExternalProofFixtures.GaugeWriteSuppressedEcho — a numeric
+        // (Slider-shaped) value-bearing control suppressing its own write echo
+        // through the public surface only.
+    }
+}

--- a/tests/external_proof/Reactor.External.TestControl/Gauge.cs
+++ b/tests/external_proof/Reactor.External.TestControl/Gauge.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.UI.Reactor.Core.V1Protocol;
+
+namespace Reactor.External.TestControl;
+
+/// <summary>
+/// Issue #206 — public construction holder for the external
+/// <see cref="GaugeElement"/>. Its static constructor registers
+/// <see cref="GaugeHandler"/> against the global <see cref="ControlRegistry"/>,
+/// and <see cref="Of(double)"/> is the only path to a <see cref="GaugeElement"/>
+/// (the element's primary constructor is <c>internal</c>) — so dispatch and
+/// trim-reachability both follow <c>Gauge → cctor → GaugeHandler →
+/// GaugeControl</c>. Mirrors the <see cref="Marquee"/> shape.
+/// </summary>
+public static class Gauge
+{
+    static Gauge() =>
+        ControlRegistry.Register<GaugeElement, GaugeControl>(static () => new GaugeHandler());
+
+    /// <summary>Sole public construction path for <see cref="GaugeElement"/>.</summary>
+    public static GaugeElement Of(double value) => new(value);
+
+    /// <summary>Construct a <see cref="GaugeElement"/> with an
+    /// <see cref="GaugeElement.OnValueChanged"/> callback.</summary>
+    public static GaugeElement Of(double value, Action<double> onValueChanged) =>
+        new(value, onValueChanged);
+}

--- a/tests/external_proof/Reactor.External.TestControl/GaugeControl.cs
+++ b/tests/external_proof/Reactor.External.TestControl/GaugeControl.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Reactor.External.TestControl;
+
+/// <summary>
+/// Issue #206 — a Slider-shaped external WinUI control authored outside
+/// Reactor.dll. Carries one numeric value-bearing prop (<see cref="Value"/>)
+/// and one CLR change event (<see cref="ValueChanged"/>). It mirrors the
+/// canonical value-bearing shape the issue calls out (<c>Slider.Value</c> /
+/// <c>NumberBox.Value</c>): a programmatic write to <see cref="Value"/> raises
+/// <see cref="ValueChanged"/> exactly as a user edit would, so the V1 handler
+/// must suppress its own write echo through the public
+/// <c>ReactorBinding.WriteSuppressed</c> primitive.
+/// </summary>
+public sealed partial class GaugeControl : UserControl
+{
+    private readonly TextBlock _text;
+    private double _value;
+
+    public GaugeControl()
+    {
+        _text = new TextBlock();
+        Content = _text;
+    }
+
+    /// <summary>Numeric value-bearing property. The setter fires
+    /// <see cref="ValueChanged"/> only when the value actually changes,
+    /// so a no-op programmatic write never echoes and the suppression token
+    /// is always consumed by a real change.</summary>
+    public double Value
+    {
+        get => _value;
+        set
+        {
+            if (_value == value) return;
+            _value = value;
+            _text.Text = value.ToString();
+            ValueChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>Fires whenever <see cref="Value"/> actually changes
+    /// (user-initiated or programmatic). The V1 handler subscribes via
+    /// <c>BindFor.OnCustomEvent</c> and relies on <c>WriteSuppressed</c>
+    /// to drop the echo from its own programmatic writes.</summary>
+    public event EventHandler? ValueChanged;
+}

--- a/tests/external_proof/Reactor.External.TestControl/GaugeControl.cs
+++ b/tests/external_proof/Reactor.External.TestControl/GaugeControl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Reactor.External.TestControl;
@@ -33,7 +34,9 @@ public sealed partial class GaugeControl : UserControl
         get => _value;
         set
         {
-            if (_value == value) return;
+            // EqualityComparer (not ==) so NaN == NaN holds and a repeated
+            // NaN write is a genuine no-op rather than a phantom change.
+            if (EqualityComparer<double>.Default.Equals(_value, value)) return;
             _value = value;
             _text.Text = value.ToString();
             ValueChanged?.Invoke(this, EventArgs.Empty);

--- a/tests/external_proof/Reactor.External.TestControl/GaugeElement.cs
+++ b/tests/external_proof/Reactor.External.TestControl/GaugeElement.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.UI.Reactor.Core;
+
+namespace Reactor.External.TestControl;
+
+/// <summary>
+/// Issue #206 — element record for the external <see cref="GaugeControl"/>.
+/// Carries the numeric value-bearing <see cref="Value"/> prop, the
+/// <see cref="OnValueChanged"/> callback, and a <see cref="Setters"/> array.
+/// Construction is funnelled through <see cref="Gauge.Of(double)"/> (the
+/// primary constructor is <c>internal</c>) so the static cctor that registers
+/// <see cref="GaugeHandler"/> always runs before the element can be mounted —
+/// the same trim-reachability discipline as <see cref="MarqueeElement"/>.
+/// </summary>
+public sealed record GaugeElement : Element
+{
+    public double Value { get; init; }
+    public Action<double>? OnValueChanged { get; init; }
+    public Action<GaugeControl>[] Setters { get; init; } = Array.Empty<Action<GaugeControl>>();
+
+    internal GaugeElement(double value, Action<double>? onValueChanged = null)
+    {
+        Value = value;
+        OnValueChanged = onValueChanged;
+    }
+}

--- a/tests/external_proof/Reactor.External.TestControl/GaugeHandler.cs
+++ b/tests/external_proof/Reactor.External.TestControl/GaugeHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.UI.Reactor.Core.V1Protocol;
 
 namespace Reactor.External.TestControl;
@@ -19,9 +20,11 @@ namespace Reactor.External.TestControl;
 /// </list>
 ///
 /// <para><b>Controlled-control contract.</b> The programmatic write in
-/// <see cref="Update"/> is (1) gated on an equality check so it only runs when
-/// the value actually changed, and (2) wrapped in <c>WriteSuppressed</c> 1:1 —
-/// so the engine-synthesized <see cref="GaugeControl.ValueChanged"/> consumes
+/// <see cref="Update"/> is (1) gated on a readback-vs-target equality check
+/// (<c>ctrl.Value</c> vs <c>newEl.Value</c>) so it only runs when the live
+/// control actually differs from the rendered value — which also snaps back
+/// native drift — and (2) wrapped in <c>WriteSuppressed</c> 1:1 — so the
+/// engine-synthesized <see cref="GaugeControl.ValueChanged"/> consumes
 /// exactly one suppression token and never reaches the user's
 /// <see cref="GaugeElement.OnValueChanged"/>. A genuine user edit (outside the
 /// suppression scope) leaves no token and flows through to the callback.</para>
@@ -36,7 +39,7 @@ public sealed class GaugeHandler : IElementHandler<GaugeElement, GaugeControl>
         // Bare initial write — the ValueChanged subscription is wired below,
         // so the synchronous setter event has no trampoline yet. Suppression
         // at mount would leak a token that drains the next real event.
-        if (ctrl.Value != el.Value)
+        if (!EqualityComparer<double>.Default.Equals(ctrl.Value, el.Value))
             ctrl.Value = el.Value;
 
         bind.OnCustomEvent<EventArgs>(
@@ -50,10 +53,13 @@ public sealed class GaugeHandler : IElementHandler<GaugeElement, GaugeControl>
 
     public void Update(UpdateContext ctx, GaugeElement oldEl, GaugeElement newEl, GaugeControl ctrl)
     {
-        // Controlled-value write: equality-gated AND echo-suppressed. This is
-        // the entire public-surface contract issue #206 asks custom-control
-        // authors to follow.
-        if (oldEl.Value != newEl.Value && ctrl.Value != newEl.Value)
+        // Controlled-value write: gated on the live control readback (NOT the
+        // old element) so the handler also snaps back any native-control drift
+        // when the rendered value is unchanged — mirroring the descriptor
+        // .Controlled path. The write is echo-suppressed 1:1. This is the entire
+        // public-surface contract issue #206 asks custom-control authors to
+        // follow.
+        if (!EqualityComparer<double>.Default.Equals(ctrl.Value, newEl.Value))
             ctx.BindFor(ctrl, newEl).WriteSuppressed(() => ctrl.Value = newEl.Value);
         ctx.ApplySetters(newEl.Setters, ctrl);
     }

--- a/tests/external_proof/Reactor.External.TestControl/GaugeHandler.cs
+++ b/tests/external_proof/Reactor.External.TestControl/GaugeHandler.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.UI.Reactor.Core.V1Protocol;
+
+namespace Reactor.External.TestControl;
+
+/// <summary>
+/// Issue #206 — external V1 handler for a Slider-shaped value-bearing control,
+/// authored against the public Reactor surface ONLY (no
+/// <c>InternalsVisibleTo</c> from Reactor.dll). It is the worked proof that a
+/// third-party custom value control can suppress the echo from its own
+/// programmatic write with nothing but the public primitives:
+/// <list type="bullet">
+///   <item><see cref="MountContext.RentControl"/> — pool/allocate.</item>
+///   <item><see cref="MountContext.BindFor"/> +
+///         <see cref="ReactorBinding{TElement}.OnCustomEvent"/> — subscribe the
+///         change event with trampoline-refresh.</item>
+///   <item><see cref="ReactorBinding{TElement}.WriteSuppressed"/> — suppress the
+///         echo of the handler's own programmatic <c>Value</c> write.</item>
+/// </list>
+///
+/// <para><b>Controlled-control contract.</b> The programmatic write in
+/// <see cref="Update"/> is (1) gated on an equality check so it only runs when
+/// the value actually changed, and (2) wrapped in <c>WriteSuppressed</c> 1:1 —
+/// so the engine-synthesized <see cref="GaugeControl.ValueChanged"/> consumes
+/// exactly one suppression token and never reaches the user's
+/// <see cref="GaugeElement.OnValueChanged"/>. A genuine user edit (outside the
+/// suppression scope) leaves no token and flows through to the callback.</para>
+/// </summary>
+public sealed class GaugeHandler : IElementHandler<GaugeElement, GaugeControl>
+{
+    public GaugeControl Mount(MountContext ctx, GaugeElement el)
+    {
+        var ctrl = ctx.RentControl<GaugeControl>();
+        var bind = ctx.BindFor(ctrl, el);
+
+        // Bare initial write — the ValueChanged subscription is wired below,
+        // so the synchronous setter event has no trampoline yet. Suppression
+        // at mount would leak a token that drains the next real event.
+        if (ctrl.Value != el.Value)
+            ctrl.Value = el.Value;
+
+        bind.OnCustomEvent<EventArgs>(
+            subscribe:   (c, h) => ((GaugeControl)c).ValueChanged += new EventHandler(h),
+            unsubscribe: (c, h) => ((GaugeControl)c).ValueChanged -= new EventHandler(h),
+            handler:     (cur, _) => cur.OnValueChanged?.Invoke(ctrl.Value));
+
+        ctx.ApplySetters(el.Setters, ctrl);
+        return ctrl;
+    }
+
+    public void Update(UpdateContext ctx, GaugeElement oldEl, GaugeElement newEl, GaugeControl ctrl)
+    {
+        // Controlled-value write: equality-gated AND echo-suppressed. This is
+        // the entire public-surface contract issue #206 asks custom-control
+        // authors to follow.
+        if (oldEl.Value != newEl.Value && ctrl.Value != newEl.Value)
+            ctx.BindFor(ctrl, newEl).WriteSuppressed(() => ctrl.Value = newEl.Value);
+        ctx.ApplySetters(newEl.Setters, ctrl);
+    }
+
+    /// <summary>Leaf — value-bearing control with no child slot.</summary>
+    public ChildrenStrategy<GaugeElement, GaugeControl>? Children => null;
+}


### PR DESCRIPTION
## What & why

Closes #206 — "Expose `ChangeEchoSuppressor` as a public extension point for custom controls."

The issue asks for a first-class, RCW-safe way for custom-control authors to suppress the change-event **echo** that their own programmatic property writes trigger (a `Slider.Value = x` from `Update` synthesizes a `ValueChanged` that looks identical to user input and writes back into the owning component's state setter).

### Adapting the stale issue to the current architecture

The issue was written against the **pre-spec-047** model:
- it references `Reconciler.RegisterType<TElement,TControl>(mount, update, unmount)` as the extension point, and
- proposes flipping `internal static ChangeEchoSuppressor` (`BeginSuppress`/`ShouldSuppress(UIElement)`) to `public`.

Since then the repo moved to the spec-047 V1 protocol (`IElementHandler` / `ControlDescriptor` registered via `RegisterHandler`), and PR #626 (#207) reshaped `ChangeEchoSuppressor` to be `ReactorState`-keyed with `ShouldSuppress(ReactorState)` overloads and the value-diff `ShouldSuppressEcho` arm.

Crucially, **the RCW-safe public primitive the issue wanted already exists today**:

| Need | Public surface (already shipped) |
|---|---|
| Suppress a hand-coded handler's own write echo | `ReactorBinding.WriteSuppressed(UIElement, Action)` and the per-binding `ctx.BindFor(ctrl, el).WriteSuppressed(() => …)` |
| Suppress a descriptor's controlled-value write echo | `.Controlled<TValue,TArgs>(…)` / `.HandCodedControlled(… valueDiffEcho)` (the interpreter wraps the write for you) |
| Register a custom control | `Reconciler.RegisterHandler` / `RegisterType` / `ControlRegistry.Register` |

So the right minimal answer is **option (a): no new public API.** `ChangeEchoSuppressor` stays `internal` by design — `WriteSuppressed` is the single supported primitive, and exposing the raw suppress-counter would be a redundant, easier-to-misuse surface (you can leak/strand a token). This realizes the issue's *intent* (no rolling your own CWT, no reflecting into internals) through today's primitives.

### What this PR actually changes

**1. Discoverability (the issue's items 3 & 4) — XML-doc cross-links only, no behavior change, no new API.** An author who lands on a registration entry point now sees echo suppression exists:
- `Reconciler.RegisterHandler`, `Reconciler.RegisterType`
- `IElementHandler<TElement,TControl>`
- `ControlDescriptor<TElement,TControl>`
- a redirect note on the internal `ChangeEchoSuppressor` pointing authors to the public `WriteSuppressed` (and explaining *why* it's kept internal).

**2. Documented the controlled-control contract** in `docs/guide/extending-reactor-controls.md` (template + regenerated output): pair exactly one `WriteSuppressed` with one programmatic write, and equality-gate it (`if (oldEl.Value != newEl.Value && ctrl.Value != newEl.Value)`) so the token is always consumed by the engine-provoked echo and never strands to swallow the user's next real edit.

**3. Canonical numeric value-bearing pinning test (the core validation of the issue).** A new Slider-shaped `Gauge` (`double Value` + `ValueChanged`) external control in `tests/external_proof/Reactor.External.TestControl/`, authored against the **public surface only** (no `InternalsVisibleTo` from `Reactor.dll`), registered through the public path. The live selftest `Spec047ExternalProof_Gauge_WriteSuppressed` asserts:
- a framework-driven reconcile write (handler `Update` → `WriteSuppressed`) does **not** fire the user's `OnValueChanged`, and
- a genuine user edit (outside the suppression scope) **does** fire it exactly once.

This both proves the public surface is sufficient (the issue's whole point) and pins it. (The pre-existing `Marquee` proof covers the same contract for a string-valued control; `Gauge` adds the canonical numeric/`Value` shape the issue calls out.)

### Out of scope
Per the issue, the higher-level generic `WireControlledChangeHandler(...)` helper is intentionally **not** built.

## Test status
- `dotnet test tests/Reactor.Tests` → **9474 passed, 0 failed**, 64 skipped.
- Echo-suppression selftests (`--filter "Echo"`) → **20 fixtures, 0 failures**, including the new `Spec047ExternalProof_Gauge_WriteSuppressed`.
- External hermetic proof tests → **6 passed, 0 failed** (incl. `Gauge` public-`RegisterHandler` registration).
- `src/Reactor/Reactor.csproj` (strict trim/AOT-as-errors) → **0 warnings, 0 errors** (ARM64).
- Docs recompiled via `mur docs compile`; no `PublicAPI.*.txt` baselines exist and no new public members were added, so no analyzer baseline update is required.