### PR TITLE
feat(core): add Callbacks&lt;T&gt; to keep delegate props out of memo comparison (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ Conventions for contributors:
 
 ### Added
 
+- **`Callbacks<T>` — keep delegate props out of memo comparison (issue #151).**
+  An opt-in, always-equal wrapper record (`Equals` returns `true`, `GetHashCode`
+  returns `0`) for the delegate (callback) portion of a component's props. Because
+  `Component<TProps>.ShouldUpdate` memoizes on `!Equals(oldProps, newProps)` and
+  `Action`/`Func` fields compare by reference, a parent passing freshly-allocated
+  callbacks each render forced the child to re-render even when no data changed.
+  Declaring `Callbacks<MyCallbacks> Cb` on the props record excludes the callbacks
+  slot from equality, so only data fields drive re-renders — replacing the old
+  hand-written `Equals`/`GetHashCode` workaround. The reconciler still refreshes the
+  child's live `Props` on a memo-skip, so handlers reading `Props.Cb.Value.OnX` at
+  dispatch time always invoke the current delegate, never a stale one.
+
 - New optional package `Microsoft.UI.Reactor.Devtools` for the `--devtools` runtime surface (spec 051 Phase 2).
 
 - **Hot reload: tree-wide hook-order recovery (spec 049 §5, Phase 1).**

--- a/docs/_pipeline/templates/components.md.dt
+++ b/docs/_pipeline/templates/components.md.dt
@@ -129,6 +129,48 @@ For propless `Component`, `ShouldUpdate()` returns `false` by default,
 meaning the component only re-renders from its own state changes. Override
 and return `true` to re-render whenever the parent re-renders.
 
+## Callback props and memoization
+
+Memoization compares props with `Equals()`. For records that is a
+field-by-field compare, and **delegate fields (`Action`/`Func`) compare by
+reference**. A parent almost always passes a freshly-allocated callback (a
+lambda or local function) on every render, so a child whose props carry an
+inline `Action` field compares unequal *every* render and re-renders even
+when no observable data changed:
+
+```csharp
+// Re-renders on every parent render — OnChanged is a fresh delegate each time.
+record StepProps(StepModel Step, Action<string> OnChanged);
+```
+
+Wrap the callbacks in `Callbacks<T>` so their identity is excluded from the
+memo comparison. `Callbacks<T>` is an always-equal record (`Equals` returns
+`true`, `GetHashCode` returns `0`), so the owning record's auto-generated
+equality treats the callbacks slot as always-equal — only the data fields
+drive the re-render decision:
+
+```csharp
+record StepCallbacks(Action<string> OnChanged, Action OnRun);
+
+// Only Step drives re-render now; the callbacks slot is ignored by memo.
+record StepProps(StepModel Step, Callbacks<StepCallbacks> Cb);
+
+// Construct it — the payload converts implicitly:
+new StepProps(step, new StepCallbacks(onChanged, onRun));
+```
+
+This replaces the old workaround of hand-writing `Equals`/`GetHashCode` on
+every props record (listing only the data fields), which was ~10 lines of
+boilerplate per record and a silent stale-UI bug if you forgot a field.
+
+**Read callbacks live at dispatch time.** When the reconciler skips a child's
+re-render because the data is unchanged, it still refreshes the child's
+`Props` with the latest values, so a handler that reads
+`Props.Cb.Value.OnChanged` *at event time* always invokes the current
+delegate — never a memoized-stale one. Do read the callback off `Props` when
+the event fires; don't capture `Props.Cb.Value.OnChanged` into a local at
+render time and hold onto it.
+
 ## Function Components
 
 Not everything needs a class. Use `Memo` for lightweight inline components

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -172,6 +172,48 @@ For propless `Component`, `ShouldUpdate()` returns `false` by default,
 meaning the component only re-renders from its own state changes. Override
 and return `true` to re-render whenever the parent re-renders.
 
+## Callback props and memoization
+
+Memoization compares props with `Equals()`. For records that is a
+field-by-field compare, and **delegate fields (`Action`/`Func`) compare by
+reference**. A parent almost always passes a freshly-allocated callback (a
+lambda or local function) on every render, so a child whose props carry an
+inline `Action` field compares unequal *every* render and re-renders even
+when no observable data changed:
+
+```csharp
+// Re-renders on every parent render — OnChanged is a fresh delegate each time.
+record StepProps(StepModel Step, Action<string> OnChanged);
+```
+
+Wrap the callbacks in `Callbacks<T>` so their identity is excluded from the
+memo comparison. `Callbacks<T>` is an always-equal record (`Equals` returns
+`true`, `GetHashCode` returns `0`), so the owning record's auto-generated
+equality treats the callbacks slot as always-equal — only the data fields
+drive the re-render decision:
+
+```csharp
+record StepCallbacks(Action<string> OnChanged, Action OnRun);
+
+// Only Step drives re-render now; the callbacks slot is ignored by memo.
+record StepProps(StepModel Step, Callbacks<StepCallbacks> Cb);
+
+// Construct it — the payload converts implicitly:
+new StepProps(step, new StepCallbacks(onChanged, onRun));
+```
+
+This replaces the old workaround of hand-writing `Equals`/`GetHashCode` on
+every props record (listing only the data fields), which was ~10 lines of
+boilerplate per record and a silent stale-UI bug if you forgot a field.
+
+**Read callbacks live at dispatch time.** When the reconciler skips a child's
+re-render because the data is unchanged, it still refreshes the child's
+`Props` with the latest values, so a handler that reads
+`Props.Cb.Value.OnChanged` *at event time* always invokes the current
+delegate — never a memoized-stale one. Do read the callback off `Props` when
+the event fires; don't capture `Props.Cb.Value.OnChanged` into a local at
+render time and hold onto it.
+
 ## Function Components
 
 Not everything needs a class. Use `Memo` for lightweight inline components

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1514,6 +1514,15 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### record Callbacks<T>
+new(T Value)
+T Value { get; init; }
+Deconstruct(ref T Value) → void
+Equals(Callbacks<T> other) → bool
+Equals(object obj) → bool
+GetHashCode() → int
+ToString() → string
+
 ### record CanvasAttached
 new(double Left = 0, double Top = 0)
 double AnchorX { get; init; }

--- a/samples/apps/demo-script-tool/App/Components/DemoPromptPanel.cs
+++ b/samples/apps/demo-script-tool/App/Components/DemoPromptPanel.cs
@@ -3,24 +3,18 @@ using static Microsoft.UI.Reactor.Factories;
 
 namespace DemoScriptTool.App.Components;
 
+/// <summary>
+/// The demo-prompt callbacks, wrapped in <see cref="Callbacks{T}"/> so their
+/// per-render delegate identity never re-renders the panel (issue #151). Only
+/// <see cref="DemoPromptPanelProps.Model"/> drives the memo decision.
+/// </summary>
+public sealed record DemoPromptPanelCallbacks(
+    System.Action<string> OnPromptChanged,
+    System.Action<string> OnTitleChanged);
+
 public sealed record DemoPromptPanelProps(
     DemoScriptModel Model,
-    System.Action<string> OnPromptChanged,
-    System.Action<string> OnTitleChanged)
-{
-    // Manual Equals: callback delegates are excluded from memo equality. They
-    // get a fresh delegate identity each parent render. SAFETY CONTRACT: when
-    // memo decides "skip render", Reactor does NOT refresh Props on the child,
-    // so the child continues to dispatch through the *prior* delegates. That's
-    // only safe when the callbacks' captured state doesn't change between
-    // renders, OR any state they capture is reflected in one of the data
-    // fields below. Both hold today: callbacks close over `model` (UseRef-
-    // stable identity); Model changes flow via reference identity below.
-    // Framework-level fix tracked at #151.
-    public bool Equals(DemoPromptPanelProps? other) =>
-        other is not null && ReferenceEquals(Model, other.Model);
-    public override int GetHashCode() => Model.GetHashCode();
-}
+    Callbacks<DemoPromptPanelCallbacks> Cb);
 
 /// <summary>
 /// Top-of-body region binding to <c>## Demo Prompt</c>. The text-area writes
@@ -51,7 +45,7 @@ public sealed class DemoPromptPanel : Component<DemoPromptPanelProps>
         var titleField = (TextBox(title, v =>
         {
             setTitle(v);
-            Props.OnTitleChanged(v);
+            Props.Cb.Value.OnTitleChanged(v);
         }, placeholderText: "Demo title (rendered as # heading in demo-script.md)")
             with { AcceptsReturn = false })
             .FontSize(18)
@@ -61,7 +55,7 @@ public sealed class DemoPromptPanel : Component<DemoPromptPanelProps>
         var promptField = (TextBox(prompt, v =>
         {
             setPrompt(v);
-            Props.OnPromptChanged(v);
+            Props.Cb.Value.OnPromptChanged(v);
         }, placeholderText: "Describe the demo: tech stack, single-file vs multi-file, audience level, constraints…")
             with { AcceptsReturn = true, TextWrapping = TextWrapping.Wrap })
             .MinHeight(96)

--- a/samples/apps/demo-script-tool/App/Components/StepCard.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepCard.cs
@@ -6,39 +6,27 @@ using static Microsoft.UI.Reactor.Factories;
 
 namespace DemoScriptTool.App.Components;
 
-public sealed record StepCardProps(
-    StepModel Step,
-    StepModel? PriorStep,
-    int TotalSteps,
-    bool IsGenerating,
+/// <summary>
+/// The per-card callbacks, grouped so they ride along in props inside a
+/// <see cref="Callbacks{T}"/> wrapper (issue #151). The wrapper is always-equal,
+/// so these freshly-allocated delegates never force the card to re-render — only
+/// the data fields on <see cref="StepCardProps"/> drive the memo decision. Read
+/// them live off <c>Props.Cb.Value</c> at dispatch time.
+/// </summary>
+public sealed record StepCardCallbacks(
     Action<int, string> OnPromptChanged,
     Action<int, string> OnTitleChanged,
     Action<StepModel> OnRun,
     Action<StepModel> OnCopyDelta,
     Action<StepModel> OnDelete,
-    Action<StepModel> OnRegenFromHere)
-{
-    // Manual Equals: callback delegates are excluded from memo equality. They
-    // get a fresh delegate identity each parent render (local functions in
-    // DemoScriptShell.Render), and including them here would re-render every
-    // card on every shell render. SAFETY CONTRACT: when memo decides "skip
-    // render", Reactor does NOT refresh Props on the child, so the child
-    // continues to dispatch through the *prior* delegates. That's only safe
-    // when the callbacks' captured state doesn't change between renders, OR
-    // when any state they capture is also reflected in one of the data
-    // fields below (so a meaningful change forces a refresh). Both hold for
-    // these callbacks today: they close over `model` (UseRef-stable identity)
-    // and per-step actions; per-step state changes show up via Step / PriorStep
-    // identity. Framework-level fix tracked at #151.
-    public bool Equals(StepCardProps? other) =>
-        other is not null
-        && ReferenceEquals(Step, other.Step)
-        && ReferenceEquals(PriorStep, other.PriorStep)
-        && TotalSteps == other.TotalSteps
-        && IsGenerating == other.IsGenerating;
-    public override int GetHashCode() =>
-        HashCode.Combine(Step, PriorStep, TotalSteps, IsGenerating);
-}
+    Action<StepModel> OnRegenFromHere);
+
+public sealed record StepCardProps(
+    StepModel Step,
+    StepModel? PriorStep,
+    int TotalSteps,
+    bool IsGenerating,
+    Callbacks<StepCardCallbacks> Cb);
 
 /// <summary>
 /// One step rendered as a three-column card: prompt | code | actions
@@ -116,7 +104,7 @@ public sealed class StepCard : Component<StepCardProps>
                 v =>
                 {
                     setLocalPrompt(v);
-                    Props.OnPromptChanged(step.Number, v);
+                    Props.Cb.Value.OnPromptChanged(step.Number, v);
                 },
                 placeholderText: "What should this step do?")
                 with { AcceptsReturn = true, TextWrapping = TextWrapping.Wrap })
@@ -222,7 +210,7 @@ public sealed class StepCard : Component<StepCardProps>
             CanExecute = canRun,
             ExecuteAsync = async () =>
             {
-                Props.OnRun(step);
+                Props.Cb.Value.OnRun(step);
                 await Task.Delay(1500).ConfigureAwait(false);
             },
         });
@@ -239,7 +227,7 @@ public sealed class StepCard : Component<StepCardProps>
         {
             Label = "Re-gen",
             CanExecute = !Props.IsGenerating,
-            Execute = () => Props.OnRegenFromHere(step),
+            Execute = () => Props.Cb.Value.OnRegenFromHere(step),
         };
 
         var toggleCmd = new Command
@@ -253,13 +241,13 @@ public sealed class StepCard : Component<StepCardProps>
         {
             Label = "Copy notes",
             CanExecute = hasDelta,
-            Execute = () => Props.OnCopyDelta(step),
+            Execute = () => Props.Cb.Value.OnCopyDelta(step),
         };
 
         var deleteCmd = new Command
         {
             Label = "Delete",
-            Execute = () => Props.OnDelete(step),
+            Execute = () => Props.Cb.Value.OnDelete(step),
         };
 
         var actions = VStack(6,
@@ -295,7 +283,7 @@ public sealed class StepCard : Component<StepCardProps>
                 v =>
                 {
                     setLocalTitle(v);
-                    Props.OnTitleChanged(step.Number, v);
+                    Props.Cb.Value.OnTitleChanged(step.Number, v);
                 },
                 placeholderText: "Step title")
                 with { AcceptsReturn = false })

--- a/samples/apps/demo-script-tool/App/Components/StepsPanel.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepsPanel.cs
@@ -38,11 +38,15 @@ public sealed class StepsPanel : Component<StepsPanelProps>
         var (_, setRevision) = UseState(0, threadSafe: true);
         var counterRef = UseRef(0);
 
-        // Read the live callbacks bundle off Props at render time (issue #151);
-        // forwarding them per-card is cheap because StepCard wraps them in a
-        // Callbacks<T> too, so the fresh per-render delegate identity is ignored
-        // by the card's memo check.
-        var cb = Props.Cb.Value;
+        // Forward callbacks as dispatch-time trampolines that read Props.Cb.Value
+        // *at invoke time* (issue #151) — never capture the bundle into a render-time
+        // local and bake those delegates into commands/child props. When this panel
+        // memo-skips, the reconciler refreshes its live Props but does NOT re-render,
+        // so any baked delegate would go stale; a trampoline that closes over `this`
+        // and reads Props.Cb.Value on invoke always dispatches the current delegate.
+        // The fresh per-render trampoline identity is free: the Add Command lives on
+        // this panel, and StepCard wraps its callbacks in a Callbacks<T> too, so the
+        // identity is ignored by the card's memo check.
 
         // StepsChanged only — the steps panel cares about Add/Remove, not about
         // typing in the demo title/prompt (which would otherwise re-render every
@@ -59,7 +63,7 @@ public sealed class StepsPanel : Component<StepsPanelProps>
         var addStepCmd = new Command
         {
             Label = "Add step",
-            Execute = cb.OnAddStep,
+            Execute = () => Props.Cb.Value.OnAddStep(),
             Icon = SymbolIcon("Add"),
             Description = "Append a new empty step at the end of the script",
             Accelerator = Accelerator(Windows.System.VirtualKey.Enter,
@@ -94,8 +98,12 @@ public sealed class StepsPanel : Component<StepsPanelProps>
                 steps.Count,
                 Props.IsGenerating,
                 new StepCardCallbacks(
-                    cb.OnPromptChanged, cb.OnTitleChanged, cb.OnRun, cb.OnCopyDelta, cb.OnDeleteStep,
-                    cb.OnRegenFromStep))))
+                    (n, v) => Props.Cb.Value.OnPromptChanged(n, v),
+                    (n, v) => Props.Cb.Value.OnTitleChanged(n, v),
+                    step => Props.Cb.Value.OnRun(step),
+                    step => Props.Cb.Value.OnCopyDelta(step),
+                    step => Props.Cb.Value.OnDeleteStep(step),
+                    step => Props.Cb.Value.OnRegenFromStep(step)))))
             .Append(addButton)
             .ToArray();
 

--- a/samples/apps/demo-script-tool/App/Components/StepsPanel.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepsPanel.cs
@@ -6,33 +6,25 @@ using static Microsoft.UI.Reactor.Factories;
 
 namespace DemoScriptTool.App.Components;
 
-public sealed record StepsPanelProps(
-    DemoScriptModel Model,
-    bool IsGenerating,
+/// <summary>
+/// The panel-level callbacks, wrapped in <see cref="Callbacks{T}"/> so their
+/// per-render delegate identity never re-renders the panel (issue #151). Only
+/// <see cref="StepsPanelProps.Model"/> / <see cref="StepsPanelProps.IsGenerating"/>
+/// drive the memo decision.
+/// </summary>
+public sealed record StepsPanelCallbacks(
     Action<int, string> OnPromptChanged,
     Action<int, string> OnTitleChanged,
     Action<StepModel> OnRun,
     Action<StepModel> OnCopyDelta,
     Action OnAddStep,
     Action<StepModel> OnDeleteStep,
-    Action<StepModel> OnRegenFromStep)
-{
-    // Manual Equals: callback delegates are excluded from memo equality. They
-    // get a fresh delegate identity each parent render (local functions in
-    // DemoScriptShell.Render). SAFETY CONTRACT: when memo decides "skip render",
-    // Reactor does NOT refresh Props on the child, so the child continues to
-    // dispatch through the *prior* delegates. That's only safe when the
-    // callbacks' captured state doesn't change between renders, OR any state
-    // they capture is reflected in one of the data fields below. Both hold
-    // today: callbacks close over `model` (UseRef-stable identity) and
-    // observable Model changes show up via reference identity. Framework-level
-    // fix tracked at #151.
-    public bool Equals(StepsPanelProps? other) =>
-        other is not null
-        && ReferenceEquals(Model, other.Model)
-        && IsGenerating == other.IsGenerating;
-    public override int GetHashCode() => HashCode.Combine(Model, IsGenerating);
-}
+    Action<StepModel> OnRegenFromStep);
+
+public sealed record StepsPanelProps(
+    DemoScriptModel Model,
+    bool IsGenerating,
+    Callbacks<StepsPanelCallbacks> Cb);
 
 /// <summary>
 /// Vertical scroller of <see cref="StepCard"/> instances keyed by step number.
@@ -45,6 +37,12 @@ public sealed class StepsPanel : Component<StepsPanelProps>
     {
         var (_, setRevision) = UseState(0, threadSafe: true);
         var counterRef = UseRef(0);
+
+        // Read the live callbacks bundle off Props at render time (issue #151);
+        // forwarding them per-card is cheap because StepCard wraps them in a
+        // Callbacks<T> too, so the fresh per-render delegate identity is ignored
+        // by the card's memo check.
+        var cb = Props.Cb.Value;
 
         // StepsChanged only — the steps panel cares about Add/Remove, not about
         // typing in the demo title/prompt (which would otherwise re-render every
@@ -61,7 +59,7 @@ public sealed class StepsPanel : Component<StepsPanelProps>
         var addStepCmd = new Command
         {
             Label = "Add step",
-            Execute = Props.OnAddStep,
+            Execute = cb.OnAddStep,
             Icon = SymbolIcon("Add"),
             Description = "Append a new empty step at the end of the script",
             Accelerator = Accelerator(Windows.System.VirtualKey.Enter,
@@ -95,8 +93,9 @@ public sealed class StepsPanel : Component<StepsPanelProps>
                 idx > 0 ? steps[idx - 1] : null,
                 steps.Count,
                 Props.IsGenerating,
-                Props.OnPromptChanged, Props.OnTitleChanged, Props.OnRun, Props.OnCopyDelta, Props.OnDeleteStep,
-                Props.OnRegenFromStep)))
+                new StepCardCallbacks(
+                    cb.OnPromptChanged, cb.OnTitleChanged, cb.OnRun, cb.OnCopyDelta, cb.OnDeleteStep,
+                    cb.OnRegenFromStep))))
             .Append(addButton)
             .ToArray();
 

--- a/samples/apps/demo-script-tool/App/DemoScriptShell.cs
+++ b/samples/apps/demo-script-tool/App/DemoScriptShell.cs
@@ -650,11 +650,12 @@ public sealed class DemoScriptShell : Component
                     ? InlineBanner.Render($"demo-script.md parse error — {parseError}", BannerKind.Error)
                     : Empty()),
             Component<DemoPromptPanel, DemoPromptPanelProps>(
-                new DemoPromptPanelProps(model, OnDemoPromptChanged, OnDemoTitleChanged))
+                new DemoPromptPanelProps(model, new DemoPromptPanelCallbacks(OnDemoPromptChanged, OnDemoTitleChanged)))
                 .Margin(0, banner is null && parseError is null ? 0 : 12, 0, 0),
             (parseError is null
                 ? (Element)Component<StepsPanel, StepsPanelProps>(
-                    new StepsPanelProps(model, isGenerating, OnPromptChanged, OnTitleChanged, OnRunStep, OnCopyDelta, OnAddStep, OnDeleteStep, OnRegenFromStep))
+                    new StepsPanelProps(model, isGenerating, new StepsPanelCallbacks(
+                        OnPromptChanged, OnTitleChanged, OnRunStep, OnCopyDelta, OnAddStep, OnDeleteStep, OnRegenFromStep)))
                     .Flex(grow: 1, basis: 0)
                 : Empty()))
             with { RowGap = 0 })

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1514,6 +1514,15 @@ Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string
 
+### record Callbacks<T>
+new(T Value)
+T Value { get; init; }
+Deconstruct(ref T Value) → void
+Equals(Callbacks<T> other) → bool
+Equals(object obj) → bool
+GetHashCode() → int
+ToString() → string
+
 ### record CanvasAttached
 new(double Left = 0, double Top = 0)
 double AnchorX { get; init; }

--- a/src/Reactor/Core/Callbacks.cs
+++ b/src/Reactor/Core/Callbacks.cs
@@ -1,0 +1,83 @@
+namespace Microsoft.UI.Reactor.Core;
+
+/// <summary>
+/// An opt-in, always-equal wrapper for the delegate (callback) portion of a
+/// component's props, so callback identity never forces a re-render.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Component{TProps}"/> memoizes against <c>!Equals(oldProps, newProps)</c>
+/// in its <c>ShouldUpdate</c> method. For <c>record</c> props that is a field-by-field
+/// compare, and <c>Action</c>/<c>Func</c> delegate fields
+/// compare by <em>reference</em>. A parent typically passes a freshly-allocated delegate
+/// (a lambda or local function) on every render, so a child's props compare unequal and
+/// the child re-renders even though no observable data changed.
+/// </para>
+/// <para>
+/// Historically apps worked around this by hand-writing <c>Equals</c>/<c>GetHashCode</c>
+/// on every props record, listing only the data fields — ~10 lines each, with a silent
+/// stale-UI bug if you forgot a field. Wrap the callbacks in <see cref="Callbacks{T}"/>
+/// instead: its <see cref="Equals(Callbacks{T})"/> is constant <c>true</c> and
+/// <see cref="GetHashCode"/> is constant <c>0</c>, so the outer record's auto-generated
+/// equality treats the callbacks slot as always-equal — data fields still drive the memo
+/// decision, callbacks never do.
+/// </para>
+/// <code>
+/// public sealed record StepCardCallbacks(
+///     Action&lt;int, string&gt; OnPromptChanged,
+///     Action&lt;StepModel&gt; OnRun);
+///
+/// public sealed record StepCardProps(
+///     StepModel Step,
+///     bool IsGenerating,
+///     Callbacks&lt;StepCardCallbacks&gt; Cb);   // ← no manual Equals needed
+/// </code>
+/// <para>
+/// <strong>Stale-delegate guarantee.</strong> "Always-equal for diffing" must not mean
+/// "stale delegate at invoke". When the reconciler skips a child's re-render because the
+/// data is unchanged, it still refreshes the child's <see cref="Component{TProps}.Props"/>
+/// with the latest props (see <c>Reconciler.ReconcileComponent</c>). So a handler that
+/// reads <c>Props.Cb.Value.OnRun</c> <em>live</em> at event time always invokes the
+/// <em>current</em> delegate, never the memoized one. Read callbacks off <c>Props</c> at
+/// dispatch time — do not capture <c>Props.Cb.Value.OnRun</c> into a local at render time.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">
+/// The payload carrying the callbacks. Usually a small record (or a single delegate)
+/// holding only <c>Action</c>/<c>Func</c> delegate members.
+/// </typeparam>
+/// <param name="Value">The wrapped callbacks payload. Read it live at dispatch time.</param>
+public sealed record Callbacks<T>(T Value)
+{
+    /// <summary>
+    /// Always returns <c>true</c> for any non-null peer: two <see cref="Callbacks{T}"/>
+    /// instances are considered equal regardless of the delegates they carry, so callback
+    /// identity is excluded from the owning record's memo comparison.
+    /// </summary>
+    public bool Equals(Callbacks<T>? other) => other is not null;
+
+    /// <summary>
+    /// Always returns <c>0</c> so the always-equal contract is consistent with hashing
+    /// (equal values must hash equally).
+    /// </summary>
+    public override int GetHashCode() => 0;
+
+    /// <summary>
+    /// Wraps a callbacks payload so it can be assigned directly to a
+    /// <see cref="Callbacks{T}"/> props field without calling the constructor.
+    /// </summary>
+    public static implicit operator Callbacks<T>(T value) => new(value);
+}
+
+/// <summary>
+/// Factory helpers for <see cref="Callbacks{T}"/> that allow the payload type to be
+/// inferred at the call site.
+/// </summary>
+public static class Callbacks
+{
+    /// <summary>
+    /// Creates a <see cref="Callbacks{T}"/> wrapper with <typeparamref name="T"/> inferred
+    /// from <paramref name="value"/>.
+    /// </summary>
+    public static Callbacks<T> Of<T>(T value) => new(value);
+}

--- a/src/Reactor/Core/Callbacks.cs
+++ b/src/Reactor/Core/Callbacks.cs
@@ -64,20 +64,9 @@ public sealed record Callbacks<T>(T Value)
 
     /// <summary>
     /// Wraps a callbacks payload so it can be assigned directly to a
-    /// <see cref="Callbacks{T}"/> props field without calling the constructor.
+    /// <see cref="Callbacks{T}"/> props field without calling the constructor — the
+    /// payload type is inferred from the target field, so authors just write
+    /// <c>new StepProps(step, new StepCallbacks(...))</c>.
     /// </summary>
     public static implicit operator Callbacks<T>(T value) => new(value);
-}
-
-/// <summary>
-/// Factory helpers for <see cref="Callbacks{T}"/> that allow the payload type to be
-/// inferred at the call site.
-/// </summary>
-public static class Callbacks
-{
-    /// <summary>
-    /// Creates a <see cref="Callbacks{T}"/> wrapper with <typeparamref name="T"/> inferred
-    /// from <paramref name="value"/>.
-    /// </summary>
-    public static Callbacks<T> Of<T>(T value) => new(value);
 }

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -1602,6 +1602,23 @@ public sealed partial class Reconciler : IDisposable
             {
                 // Still update the element reference (modifiers may have changed on the ComponentElement itself)
                 node.Element = newEl;
+
+                // Stale-delegate guard (issue #151): even though we skip re-rendering,
+                // refresh the live Props on the instance so any handler that reads
+                // Props.X at *dispatch* time invokes the CURRENT delegate rather than the
+                // one captured when the child last rendered. This is what makes an
+                // always-equal callbacks slot (Callbacks<T>) safe: data fields drive the
+                // memo decision, but the latest callbacks are still reachable off Props.
+                // Mirrors the leaf-level Tag-trampoline refresh (Element.cs HasCallbacks).
+                // The skipped data fields are equal by construction, so refreshing them is
+                // a no-op for the rendered subtree; only the excluded slots (callbacks)
+                // actually change. PreviousProps is kept in sync as the next baseline.
+                if (node.Component is IPropsReceiver skipReceiver
+                    && newEl is ComponentElement skipCompEl && skipCompEl.Props is not null)
+                {
+                    skipReceiver.SetProps(skipCompEl.Props);
+                    node.PreviousProps = skipCompEl.Props;
+                }
                 return;
             }
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CallbacksMemoSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CallbacksMemoSkipFixtures.cs
@@ -24,15 +24,22 @@ internal static class CallbacksMemoSkipFixtures
 {
     private sealed record ChildCallbacks(Action OnTap);
 
-    private sealed record MemoChildProps(string Data, Callbacks<ChildCallbacks> Cb);
+    // A reference-stable render tally the parent owns and the child writes to. It is
+    // a data prop, but its identity never changes across renders (same instance), so
+    // it compares reference-equal and never drives a re-render — it just lets the test
+    // observe how many times the child actually rendered, without static mutable state.
+    private sealed class RenderTally
+    {
+        public int Count;
+    }
+
+    private sealed record MemoChildProps(string Data, RenderTally Tally, Callbacks<ChildCallbacks> Cb);
 
     private sealed class MemoChild : Component<MemoChildProps>
     {
-        public static int RenderCount;
-
         public override Element Render()
         {
-            RenderCount++;
+            Props.Tally.Count++;
             return VStack(
                 TextBlock($"child-data:{Props.Data}"),
                 // Reads the live callback off Props at *dispatch* time — the button
@@ -44,14 +51,14 @@ internal static class CallbacksMemoSkipFixtures
 
     /// <summary>
     /// Parent bumps a counter that its child-callback closes over, while the child's
-    /// data stays constant. The child must memo-skip (RenderCount stays 1) yet, when
-    /// tapped, fire the delegate that captured the latest counter value.
+    /// data stays constant. The child must memo-skip (tally stays 1) yet, when tapped,
+    /// fire the delegate that captured the latest counter value.
     /// </summary>
     internal class SkipRefreshesLiveDelegate(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()
         {
-            MemoChild.RenderCount = 0;
+            var tally = new RenderTally();
 
             var host = H.CreateHost();
             host.Mount(ctx =>
@@ -68,18 +75,18 @@ internal static class CallbacksMemoSkipFixtures
                     TextBlock($"fired:{fired}"),
                     Button("BumpTick", () => setTick(tick + 1)),
                     Component<MemoChild, MemoChildProps>(
-                        new MemoChildProps("constant", childCb)));
+                        new MemoChildProps("constant", tally, childCb)));
             });
 
             await Harness.Render();
-            H.Check("MemoSkip_ChildRenderedOnce", MemoChild.RenderCount == 1);
+            H.Check("MemoSkip_ChildRenderedOnce", tally.Count == 1);
             H.Check("MemoSkip_FiredInitial", H.FindText("fired:-1") is not null);
 
             // Parent re-renders with a NEW delegate (captures tick=1); child data is
             // unchanged so the real reconciler memo-skips the child render...
             H.ClickButton("BumpTick");
             await Harness.Render();
-            H.Check("MemoSkip_ChildDidNotReRender", MemoChild.RenderCount == 1);
+            H.Check("MemoSkip_ChildDidNotReRender", tally.Count == 1);
 
             // ...but dispatching from the (un-re-rendered) child must invoke the
             // CURRENT delegate (tick=1 → fired:1), proving the skip branch refreshed

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CallbacksMemoSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CallbacksMemoSkipFixtures.cs
@@ -1,0 +1,93 @@
+using System;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Issue #151 end-to-end proof through the REAL reconciler. When a child's data
+/// is unchanged but the parent passes a freshly-allocated callback (wrapped in
+/// <see cref="Callbacks{T}"/>), <c>Reconciler.ReconcileComponent</c> memo-skips the
+/// child render — yet its skip branch still refreshes the child's live
+/// <see cref="Component{TProps}.Props"/>. So a handler that reads
+/// <c>Props.Cb.Value</c> at dispatch time invokes the CURRENT delegate, never a
+/// memoized-stale one.
+///
+/// Unlike the headless <c>CallbacksMemoTests</c> (which drive the production
+/// primitives <c>IPropsComparable.CompareProps</c> / <c>IPropsReceiver.SetProps</c>
+/// directly), this fixture mounts a live parent/child tree and exercises the actual
+/// skip branch wired into the reconciler.
+/// </summary>
+internal static class CallbacksMemoSkipFixtures
+{
+    private sealed record ChildCallbacks(Action OnTap);
+
+    private sealed record MemoChildProps(string Data, Callbacks<ChildCallbacks> Cb);
+
+    private sealed class MemoChild : Component<MemoChildProps>
+    {
+        public static int RenderCount;
+
+        public override Element Render()
+        {
+            RenderCount++;
+            return VStack(
+                TextBlock($"child-data:{Props.Data}"),
+                // Reads the live callback off Props at *dispatch* time — the button
+                // element is built once (the child memo-skips on later reconciles),
+                // but its handler resolves Props.Cb.Value when the click fires.
+                Button("ChildTap", () => Props.Cb.Value.OnTap()));
+        }
+    }
+
+    /// <summary>
+    /// Parent bumps a counter that its child-callback closes over, while the child's
+    /// data stays constant. The child must memo-skip (RenderCount stays 1) yet, when
+    /// tapped, fire the delegate that captured the latest counter value.
+    /// </summary>
+    internal class SkipRefreshesLiveDelegate(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            MemoChild.RenderCount = 0;
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (tick, setTick) = ctx.UseState(0);
+                var (fired, setFired) = ctx.UseState(-1);
+
+                // Fresh delegate every parent render, capturing the CURRENT tick.
+                // The child's data is constant, so the child memo-skips — the only
+                // thing that changes across renders is this excluded callbacks slot.
+                var childCb = new ChildCallbacks(() => setFired(tick));
+
+                return VStack(
+                    TextBlock($"fired:{fired}"),
+                    Button("BumpTick", () => setTick(tick + 1)),
+                    Component<MemoChild, MemoChildProps>(
+                        new MemoChildProps("constant", childCb)));
+            });
+
+            await Harness.Render();
+            H.Check("MemoSkip_ChildRenderedOnce", MemoChild.RenderCount == 1);
+            H.Check("MemoSkip_FiredInitial", H.FindText("fired:-1") is not null);
+
+            // Parent re-renders with a NEW delegate (captures tick=1); child data is
+            // unchanged so the real reconciler memo-skips the child render...
+            H.ClickButton("BumpTick");
+            await Harness.Render();
+            H.Check("MemoSkip_ChildDidNotReRender", MemoChild.RenderCount == 1);
+
+            // ...but dispatching from the (un-re-rendered) child must invoke the
+            // CURRENT delegate (tick=1 → fired:1), proving the skip branch refreshed
+            // the child's live Props. A stale delegate would yield fired:0.
+            H.ClickButton("ChildTap");
+            await Harness.Render();
+            H.Check("MemoSkip_CurrentDelegateInvoked", H.FindText("fired:1") is not null);
+            H.Check("MemoSkip_StaleDelegateNotInvoked", H.FindText("fired:0") is null);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -359,6 +359,7 @@ internal static class SelfTestFixtureRegistry
         "ComponentHook_UseWindowSize",
         "ComponentHook_UseBreakpoint",
         "ComponentHook_MultipleComponents",
+        "ComponentMemo_SkipRefreshesLiveDelegate",
         "HotReload_ChildHookOrderRecovery",
         "HotReload_ComponentMigratesState",
         // DSL and extension tests
@@ -1740,6 +1741,7 @@ internal static class SelfTestFixtureRegistry
         "ComponentHook_UseWindowSize" => new ComponentHookFixtures.UseWindowSizeHook(harness),
         "ComponentHook_UseBreakpoint" => new ComponentHookFixtures.UseBreakpointHook(harness),
         "ComponentHook_MultipleComponents" => new ComponentHookFixtures.MultipleComponents(harness),
+        "ComponentMemo_SkipRefreshesLiveDelegate" => new CallbacksMemoSkipFixtures.SkipRefreshesLiveDelegate(harness),
         "HotReload_ChildHookOrderRecovery" => new HotReloadRecoveryFixtures.ChildRecoversAndSiblingStateSurvives(harness),
         "HotReload_ComponentMigratesState" => new HotReloadComponentMigrationFixtures.MigratesPreservingState(harness),
         // DSL and extension tests

--- a/tests/Reactor.Tests/CallbacksMemoTests.cs
+++ b/tests/Reactor.Tests/CallbacksMemoTests.cs
@@ -80,15 +80,6 @@ public class CallbacksMemoTests
     }
 
     [Fact]
-    public void Callbacks_Factory_Of_Infers_Type()
-    {
-        var payload = new Cbs(() => { });
-        var wrapped = Callbacks.Of(payload);
-        Assert.IsType<Callbacks<Cbs>>(wrapped);
-        Assert.Same(payload, wrapped.Value);
-    }
-
-    [Fact]
     public void Owning_Record_Equality_Ignores_Callbacks_Slot()
     {
         // Same data, totally different callbacks => records are equal.

--- a/tests/Reactor.Tests/CallbacksMemoTests.cs
+++ b/tests/Reactor.Tests/CallbacksMemoTests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Tests for issue #151: keeping delegate props out of memo comparison via the
+/// opt-in <see cref="Callbacks{T}"/> wrapper, plus the reconciler's stale-delegate
+/// guard (live Props refresh on a memo-skip).
+///
+/// These are headless: they exercise the production memo gate
+/// (<see cref="IPropsComparable.CompareProps"/> → <c>Component&lt;TProps&gt;.ShouldUpdate</c>)
+/// and the production props-refresh primitive (<see cref="IPropsReceiver.SetProps"/>) —
+/// the same two pieces the reconciler wires together in <c>ReconcileComponent</c>.
+/// </summary>
+public class CallbacksMemoTests
+{
+    // ── Test payloads / props / components ───────────────────────
+
+    private sealed record Cbs(Action OnTap, Action<string>? OnText = null);
+
+    // AFTER: callbacks ride along inside a Callbacks<T> wrapper.
+    private sealed record WrappedProps(int Data, Callbacks<Cbs> Cb);
+
+    // BEFORE: the old shape with an inline delegate field that compares by reference.
+    private sealed record InlineProps(int Data, Action OnTap);
+
+    private sealed class WrappedComp : Component<WrappedProps>
+    {
+        public override Element Render() => new TextBlockElement($"data={Props.Data}");
+
+        // A handler that reads the live callback off Props at *dispatch* time.
+        public void Dispatch() => Props.Cb.Value.OnTap();
+    }
+
+    private sealed class InlineComp : Component<InlineProps>
+    {
+        public override Element Render() => new TextBlockElement($"data={Props.Data}");
+    }
+
+    // Mirrors the reconciler's memo gate: true => re-render, false => skip.
+    private static bool Gate(Component comp, object? oldProps, object? newProps)
+        => ((IPropsComparable)comp).CompareProps(oldProps, newProps);
+
+    // ── Callbacks<T> semantics ───────────────────────────────────
+
+    [Fact]
+    public void Callbacks_Equals_Is_Always_True_Regardless_Of_Payload()
+    {
+        var a = new Callbacks<Cbs>(new Cbs(() => { }));
+        var b = new Callbacks<Cbs>(new Cbs(() => { })); // different delegates entirely
+        Assert.True(a.Equals(b));
+        Assert.True(b.Equals(a));
+        Assert.True(a == b);
+    }
+
+    [Fact]
+    public void Callbacks_GetHashCode_Is_Always_Zero()
+    {
+        Assert.Equal(0, new Callbacks<Cbs>(new Cbs(() => { })).GetHashCode());
+        Assert.Equal(0, new Callbacks<Action>(() => { }).GetHashCode());
+    }
+
+    [Fact]
+    public void Callbacks_Value_Returns_The_Wrapped_Payload()
+    {
+        var payload = new Cbs(() => { });
+        var wrapped = new Callbacks<Cbs>(payload);
+        Assert.Same(payload, wrapped.Value);
+    }
+
+    [Fact]
+    public void Callbacks_Implicit_Conversion_From_Payload()
+    {
+        var payload = new Cbs(() => { });
+        Callbacks<Cbs> wrapped = payload; // implicit
+        Assert.Same(payload, wrapped.Value);
+    }
+
+    [Fact]
+    public void Callbacks_Factory_Of_Infers_Type()
+    {
+        var payload = new Cbs(() => { });
+        var wrapped = Callbacks.Of(payload);
+        Assert.IsType<Callbacks<Cbs>>(wrapped);
+        Assert.Same(payload, wrapped.Value);
+    }
+
+    [Fact]
+    public void Owning_Record_Equality_Ignores_Callbacks_Slot()
+    {
+        // Same data, totally different callbacks => records are equal.
+        var p1 = new WrappedProps(1, new Cbs(() => { }));
+        var p2 = new WrappedProps(1, new Cbs(() => { }));
+        Assert.Equal(p1, p2);
+
+        // Different data => not equal (data still drives equality).
+        var p3 = new WrappedProps(2, p1.Cb);
+        Assert.NotEqual(p1, p3);
+    }
+
+    // ── (a) No re-render when only a callback delegate's identity changes ──
+
+    [Fact]
+    public void Skips_Render_When_Only_Callback_Identity_Changes()
+    {
+        var comp = new WrappedComp();
+        var oldProps = new WrappedProps(7, new Cbs(() => { }));
+        var newProps = new WrappedProps(7, new Cbs(() => { })); // fresh delegate, same data
+
+        // Gate returns false => reconciler skips the re-render.
+        Assert.False(Gate(comp, oldProps, newProps));
+    }
+
+    // ── (b) Re-renders when data changes ─────────────────────────
+
+    [Fact]
+    public void Re_Renders_When_Data_Changes()
+    {
+        var comp = new WrappedComp();
+        var cb = new Callbacks<Cbs>(new Cbs(() => { }));
+        var oldProps = new WrappedProps(7, cb);
+        var newProps = new WrappedProps(8, cb); // same callbacks, different data
+
+        Assert.True(Gate(comp, oldProps, newProps));
+    }
+
+    // ── (c) Stale-delegate guard: latest delegate is invoked, not the memoized one ──
+
+    [Fact]
+    public void Skip_Refreshes_Live_Props_So_Current_Delegate_Is_Invoked()
+    {
+        var comp = new WrappedComp();
+
+        int firstCalls = 0, secondCalls = 0;
+        var firstProps = new WrappedProps(5, new Cbs(() => firstCalls++));
+        var secondProps = new WrappedProps(5, new Cbs(() => secondCalls++)); // new delegate, same data
+
+        // Initial mount-equivalent: props are set on the instance.
+        ((IPropsReceiver)comp).SetProps(firstProps);
+
+        // Reconcile with new props: data unchanged, only the callback identity
+        // differs, so the gate skips the re-render...
+        bool reRender = Gate(comp, firstProps, secondProps);
+        Assert.False(reRender);
+
+        // ...but the reconciler's skip path (issue #151) still refreshes the live
+        // Props so the CURRENT delegate dispatches. This mirrors the SetProps call
+        // in Reconciler.ReconcileComponent's skipRender branch.
+        ((IPropsReceiver)comp).SetProps(secondProps);
+
+        comp.Dispatch();
+
+        Assert.Equal(0, firstCalls);  // stale delegate NOT invoked
+        Assert.Equal(1, secondCalls); // current delegate invoked
+    }
+
+    [Fact]
+    public void Without_The_Refresh_The_Stale_Delegate_Would_Be_Invoked()
+    {
+        // Documents WHY the reconciler refresh is load-bearing: an always-equal
+        // callbacks slot without a Props refresh on skip would dispatch the stale
+        // delegate. (This is the buggy behavior the #151 fix prevents.)
+        var comp = new WrappedComp();
+
+        int firstCalls = 0, secondCalls = 0;
+        var firstProps = new WrappedProps(5, new Cbs(() => firstCalls++));
+        var secondProps = new WrappedProps(5, new Cbs(() => secondCalls++));
+
+        ((IPropsReceiver)comp).SetProps(firstProps);
+        Assert.False(Gate(comp, firstProps, secondProps));
+        // NOTE: deliberately NOT refreshing Props here.
+
+        comp.Dispatch();
+
+        Assert.Equal(1, firstCalls);  // stale delegate invoked — the hazard
+        Assert.Equal(0, secondCalls);
+    }
+
+    // ── Headless render-count bench: 9-of-9 → 1-of-9 ─────────────
+
+    [Fact]
+    public void RenderCount_Bench_Nine_Children_One_Mutates()
+    {
+        const int childCount = 9;
+        const int mutatedIndex = 3;
+
+        // Build the "previous render" prop set: child i has data=i and its own delegate.
+        var oldInline = new InlineProps[childCount];
+        var oldWrapped = new WrappedProps[childCount];
+        for (int i = 0; i < childCount; i++)
+        {
+            int captured = i;
+            oldInline[i] = new InlineProps(captured, () => { _ = captured; });
+            oldWrapped[i] = new WrappedProps(captured, new Cbs(() => { _ = captured; }));
+        }
+
+        // Build the "next render" prop set: the parent re-renders, allocating FRESH
+        // delegates for every child (as lambdas/local functions always do), and only
+        // child #mutatedIndex's data actually changes.
+        var newInline = new InlineProps[childCount];
+        var newWrapped = new WrappedProps[childCount];
+        for (int i = 0; i < childCount; i++)
+        {
+            int data = i == mutatedIndex ? 100 + i : i;
+            int captured = i;
+            newInline[i] = new InlineProps(data, () => { _ = captured; }); // fresh delegate
+            newWrapped[i] = new WrappedProps(data, new Cbs(() => { _ = captured; })); // fresh delegate
+        }
+
+        var inlineComp = new InlineComp();
+        var wrappedComp = new WrappedComp();
+
+        int inlineRerenders = 0, wrappedRerenders = 0;
+        for (int i = 0; i < childCount; i++)
+        {
+            if (Gate(inlineComp, oldInline[i], newInline[i])) inlineRerenders++;
+            if (Gate(wrappedComp, oldWrapped[i], newWrapped[i])) wrappedRerenders++;
+        }
+
+        // BEFORE (inline delegate field): every child re-renders because each got a
+        // fresh delegate identity — 9 of 9.
+        Assert.Equal(childCount, inlineRerenders);
+
+        // AFTER (Callbacks<T> wrapper): only the child whose data changed re-renders —
+        // 1 of 9.
+        Assert.Equal(1, wrappedRerenders);
+    }
+}


### PR DESCRIPTION
Closes #151.

## Problem

`Component<TProps>.ShouldUpdate` defaults to `!Equals(oldProps, newProps)`. For record props that is a field-by-field compare, and **delegate fields (`Action`/`Func`) compare by reference**. Parents pass a freshly-allocated callback (lambda / local function) on every render, so a child's props compare unequal → the child re-renders even when no observable data changed.

Apps worked around this by hand-writing `Equals`/`GetHashCode` on every props record that carried a delegate, listing only the data fields — ~10 lines each, and a **silent stale-UI bug** if you forgot to add a new data field.

## Decision: Option B (`Callbacks<T>` wrapper)

The issue offered two acceptable approaches (reflection and source-gen were off the table):

- **Option A — `Component<TData, TCallbacks>`**: split props into a memoized data record and a callbacks slot. More type-safe, but a larger API shift: a new base class plus two records on every component, and a migration for every existing single-`TProps` component.
- **Option B — `Callbacks<T>` always-equal wrapper** ✅ *chosen*: a one-line opt-in. Wrap the callbacks; the owning record keeps its auto-generated equality and the callbacks slot is simply ignored by the compare. Composes with existing single-`TProps` components, no new base class, incremental adoption.

Option B is the smaller, lower-churn change that fits the framework's existing `Component<TProps>` + record-props design. (Option C — first-class `Command` on element types — is orthogonal and handled separately in #153.)

```csharp
public sealed record Callbacks<T>(T Value)
{
    public bool Equals(Callbacks<T>? other) => other is not null; // always equal
    public override int GetHashCode() => 0;
    public static implicit operator Callbacks<T>(T value) => new(value);
}
```

### API shape

```csharp
record StepCallbacks(Action<string> OnChanged, Action OnRun);
record StepProps(StepModel Step, Callbacks<StepCallbacks> Cb);   // no manual Equals

new StepProps(step, new StepCallbacks(onChanged, onRun));         // implicit wrap
// read live at dispatch time: Props.Cb.Value.OnRun()
```

Also ships `Callbacks.Of(payload)` for type inference at the call site.

## Stale-delegate correctness guarantee (the critical guard)

"Always-equal for diffing" must **not** mean "stale delegate at invoke." Before this change, when memo skipped a child's re-render the reconciler did **not** refresh `Props` on the instance — so an always-equal callbacks slot would have dispatched the *prior* delegate.

Fix: `Reconciler.ReconcileComponent`'s `skipRender` branch now refreshes the live `Props` (and `PreviousProps`) on the instance even when it skips the render. Because handlers read `Props.Cb.Value.X` **live at event time** (Props is an instance property), the **current** delegate is always the one invoked. This mirrors the leaf-level Tag-trampoline refresh already documented in `Element.cs`. The skipped data fields are equal by construction, so refreshing them is a no-op for the rendered subtree; only the excluded callbacks slot actually changes.

Two tests pin this down: one proves the current delegate is invoked after a skip, and a contrast test documents the stale-delegate hazard that the refresh prevents.

## Measurement (headless render-count)

The bench mirrors the issue's repro shape — a parent holding N child components whose props carry a callback, mutating exactly one child's data while (as always) every child gets a fresh delegate identity. It counts how many children the production memo gate (`IPropsComparable.CompareProps` → `Component<TProps>.ShouldUpdate`) decides to re-render:

| Props shape | Children re-rendered when 1 of 9 data fields changes |
|---|---|
| **Before** — inline `Action` field | **9 of 9** (every child got a fresh delegate identity) |
| **After** — `Callbacks<T>` wrapper | **1 of 9** (only the child whose data changed) |

`CallbacksMemoTests.RenderCount_Bench_Nine_Children_One_Mutates` asserts exactly `9 → 1`. This directly maps to the profile in the issue (89 `StepCard.Render` invocations driven by callback-identity churn).

## Tests

`tests/Reactor.Tests/CallbacksMemoTests.cs` — 11 headless tests, all green:
- (a) **no** re-render when only a callback delegate's identity changes
- (b) re-render when data changes
- (c) latest delegate invoked after a skip (stale-delegate guard) + a contrast test showing the hazard without the refresh
- `Callbacks<T>` semantics (always-equal, `GetHashCode` 0, `.Value`, implicit conversion, `Callbacks.Of`)
- owning-record equality ignores the callbacks slot
- the 9 → 1 render-count bench

`dotnet test tests/Reactor.Tests` → **9485 passed, 0 failed, 64 skipped** (`-p:Platform=ARM64 -m:1` on this box).

## Sample migration ("Done when")

Removed all **three** manual `Equals`/`GetHashCode` overrides in `demo-script-tool` (`StepCardProps`, `StepsPanelProps`, `DemoPromptPanelProps`) and converted them to grouped `*Callbacks` records wrapped in `Callbacks<T>`. The sample builds clean.

## Docs

New **"Callback props and memoization"** section in `docs/guide/components.md` (edited the `.md.dt` template + `mur docs compile`), covering the wrapper, the implicit-conversion construction, and the read-callbacks-live-at-dispatch-time rule.

## Notes / overlap
- Non-breaking and opt-in: equality semantics for existing props records are unchanged unless they adopt `Callbacks<T>`.
- The reconciler refresh also retroactively closes the documented stale-delegate hazard for the old manual-`Equals` pattern.
- Nearby code overlap with #153 (lifts `Command` to a typed property, Option C) — orthogonal; this change stays localized to memoization.


---

## pr-review follow-up (commit `3ad88446`)

Ran the multi-dimension `pr-review` skill on this PR and applied all four findings (no auto-apply during review; these were applied deliberately after triage):

- **M2 — sample foot-gun (api-ergonomics / correctness / alternative-solution).** `StepsPanel` was capturing the callbacks bundle into a render-time local (`var cb = Props.Cb.Value`) and baking those delegates into the Add `Command` and the forwarded `StepCardCallbacks`. On a panel memo-skip those baked delegates could go stale — the exact hazard the new docs warn about, in the reference sample. Now it forwards **dispatch-time trampolines** (`Execute = () => Props.Cb.Value.OnAddStep()`, `(n,v) => Props.Cb.Value.OnPromptChanged(n,v)`, …) that read `Props.Cb.Value` live at invoke time.
- **M3 — real-reconciler coverage (test-coverage).** The headless `CallbacksMemoTests` simulate the gate via `CompareProps` + `SetProps`; they don't drive the actual reconciler skip branch. Added a selftest fixture **`ComponentMemo_SkipRefreshesLiveDelegate`** that mounts a live parent/child tree, lets the **real** `Reconciler` memo-skip the child (`RenderCount` stays 1), then dispatches from the child and asserts the **current** delegate runs (`fired:1`, never `fired:0`) — proving the production live-Props refresh, not just the primitives. All 5 TAP checks pass.
- **M1 — changelog.** Added a `CHANGELOG` `[Unreleased] > Added` entry for `Callbacks<T>`.
- **L1 — YAGNI.** Dropped the redundant `Callbacks.Of` factory (kept only the implicit operator) and removed its unit test.

Updated counts after this commit: `CallbacksMemoTests` = **10 headless tests** (`Callbacks.Of` test removed) + the new **`ComponentMemo_SkipRefreshesLiveDelegate`** selftest; full `dotnet test tests/Reactor.Tests` → **9484 passed, 0 failed, 64 skipped**; selftest fixture → **5/5 checks pass**.

security and packaging dimensions came back clean (reflection-free / NativeAOT-safe; both `reactor.api.txt` copies already covered by the existing agentkit pack entries).