### PR TITLE
feat(command): add declarative DebounceMs to Command (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ Conventions for contributors:
 
 ### Added
 
+- **Command debouncing: `Command.DebounceMs` (issue #136).**
+  Commands can declare a leading-edge debounce window via `DebounceMs` (default
+  `0` = off) to absorb double-clicks without reaching for `Task.Delay`. When
+  routed through `UseCommand`, the first fire is accepted and any subsequent fire
+  within the window is dropped; `IsDebouncing` drives `IsEnabled = false` so the
+  bound control visibly disables and then re-enables when the window elapses. For
+  async commands the disabled window is the longer of the lambda's lifetime
+  (`IsExecuting`) and `DebounceMs`. Debounce state lives in the `UseCommand` hook
+  store, so a raw `new Command { DebounceMs = … }` bound directly (not through
+  `UseCommand`) is inert. `UseCommand` now consumes a stable hook shape regardless
+  of the command's sync/async/debounce shape.
+
 - New optional package `Microsoft.UI.Reactor.Devtools` for the `--devtools` runtime surface (spec 051 Phase 2).
 
 - **Hot reload: tree-wide hook-order recovery (spec 049 §5, Phase 1).**

--- a/docs/_pipeline/templates/commanding.md.dt
+++ b/docs/_pipeline/templates/commanding.md.dt
@@ -58,11 +58,13 @@ do not set them individually on each control.
 | `ExecuteAsync` | `Func<Task>?` | Async action — pair with [`UseCommand`](hooks.md) for tracking. |
 | `CanExecute` | `bool` (default `true`) | Whether the action can run right now. |
 | `IsExecuting` | `bool` | Managed by `UseCommand` while async work is in flight. |
+| `DebounceMs` | `int` (default `0`) | Leading-edge debounce window in ms. `0` = off. Realized by `UseCommand`. |
+| `IsDebouncing` | `bool` | Managed by `UseCommand` while inside the `DebounceMs` window. |
 | `Icon` | `IconData?` | `SymbolIcon(name)`, `FontIcon(...)`, or `BitmapIcon(uri)`. |
 | `Description` | `string?` | Tooltip / accessibility description. |
 | `Accelerator` | `KeyboardAcceleratorData?` | Keyboard binding (`Accelerator(VirtualKey.S, Control)`). |
 | `AccessKey` | `string?` | Single-character Alt-prefix shortcut for menu items. |
-| `IsEnabled` | `bool` (computed) | `CanExecute && !IsExecuting` — what every surface reads. |
+| `IsEnabled` | `bool` (computed) | `CanExecute && !IsExecuting && !IsDebouncing` — what every surface reads. |
 
 `Command<T>` exposes the same members with `Execute: Action<T>?` and
 `ExecuteAsync: Func<T, Task>?` — the action receives an argument from
@@ -173,6 +175,59 @@ the await completes. Hoist the `Command` to the navigation root and
 the behavior is correct; recreate it per page (via
 [`UseMemo`](hooks.md) keyed on page identity) when you want
 per-surface isolation.
+<!-- /ai:caveat -->
+
+## Debouncing double-clicks: `DebounceMs`
+
+`IsExecuting` tracks the lifetime of an `ExecuteAsync` lambda — great
+when there's real async work to wait on. But the common "stop the
+double-click from re-firing the same action" case has no async work to
+track: the action is synchronous (spawn a process, kick off a parent
+re-render) and returns instantly, so `IsExecuting` blinks for
+microseconds and the second click slips through. The historical
+workaround was to wrap the sync action in `ExecuteAsync` purely to slip
+in a `Task.Delay`, leaving magic numbers in the source.
+
+`DebounceMs` is the framework-owned replacement. It applies a
+**leading-edge** debounce: the first fire is accepted, every subsequent
+fire within `DebounceMs` of it is dropped, and `IsEnabled` reports
+`false` for the duration so the bound control visibly disables and then
+re-enables when the window elapses.
+
+```csharp
+// Sync action + framework-managed debounce — no fake async, no Task.Delay.
+var runCmd = UseCommand(new Command
+{
+    Label = "Run",
+    Execute = () => RunStep(step),
+    DebounceMs = 1500,
+});
+
+// Async action — IsExecuting still tracks the lambda; DebounceMs keeps the
+// button disabled past the lambda's return (the disabled window is the
+// longer of the two).
+var regenCmd = UseCommand(new Command
+{
+    Label = "Re-gen",
+    ExecuteAsync = () => { RegenFromHere(step); return Task.CompletedTask; },
+    DebounceMs = 250,
+});
+```
+
+<!-- ai:caveat -->
+**`DebounceMs` requires `UseCommand`.** The debounce window and its
+re-enable timer are persistent state, and a plain `Command` record is
+immutable and reconstructed on every render — it has nowhere to keep
+that state. `UseCommand` stores it in the component's hook table (the
+same place it keeps the async re-entrance guard), so always route a
+debounced command through `UseCommand`. A raw
+`new Command { DebounceMs = … }` that is bound directly (never passed to
+`UseCommand`) does **not** debounce.
+
+Debounce is **leading-edge and fixed-duration** by design — fire first,
+then ignore. Trailing-edge "wait for the input to settle, then fire
+once" debounce (search-as-you-type) is a different concept and is not
+what `DebounceMs` provides.
 <!-- /ai:caveat -->
 
 ## Parameterized commands

--- a/docs/guide/commanding.md
+++ b/docs/guide/commanding.md
@@ -70,11 +70,13 @@ do not set them individually on each control.
 | `ExecuteAsync` | `Func<Task>?` | Async action — pair with [`UseCommand`](hooks.md) for tracking. |
 | `CanExecute` | `bool` (default `true`) | Whether the action can run right now. |
 | `IsExecuting` | `bool` | Managed by `UseCommand` while async work is in flight. |
+| `DebounceMs` | `int` (default `0`) | Leading-edge debounce window in ms. `0` = off. Realized by `UseCommand`. |
+| `IsDebouncing` | `bool` | Managed by `UseCommand` while inside the `DebounceMs` window. |
 | `Icon` | `IconData?` | `SymbolIcon(name)`, `FontIcon(...)`, or `BitmapIcon(uri)`. |
 | `Description` | `string?` | Tooltip / accessibility description. |
 | `Accelerator` | `KeyboardAcceleratorData?` | Keyboard binding (`Accelerator(VirtualKey.S, Control)`). |
 | `AccessKey` | `string?` | Single-character Alt-prefix shortcut for menu items. |
-| `IsEnabled` | `bool` (computed) | `CanExecute && !IsExecuting` — what every surface reads. |
+| `IsEnabled` | `bool` (computed) | `CanExecute && !IsExecuting && !IsDebouncing` — what every surface reads. |
 
 `Command<T>` exposes the same members with `Execute: Action<T>?` and
 `ExecuteAsync: Func<T, Task>?` — the action receives an argument from
@@ -294,6 +296,56 @@ class AsyncWithProgressExample : Component
 > the behavior is correct; recreate it per page (via
 > [`UseMemo`](hooks.md) keyed on page identity) when you want
 > per-surface isolation.
+
+## Debouncing double-clicks: `DebounceMs`
+
+`IsExecuting` tracks the lifetime of an `ExecuteAsync` lambda — great
+when there's real async work to wait on. But the common "stop the
+double-click from re-firing the same action" case has no async work to
+track: the action is synchronous (spawn a process, kick off a parent
+re-render) and returns instantly, so `IsExecuting` blinks for
+microseconds and the second click slips through. The historical
+workaround was to wrap the sync action in `ExecuteAsync` purely to slip
+in a `Task.Delay`, leaving magic numbers in the source.
+
+`DebounceMs` is the framework-owned replacement. It applies a
+**leading-edge** debounce: the first fire is accepted, every subsequent
+fire within `DebounceMs` of it is dropped, and `IsEnabled` reports
+`false` for the duration so the bound control visibly disables and then
+re-enables when the window elapses.
+
+```csharp
+// Sync action + framework-managed debounce — no fake async, no Task.Delay.
+var runCmd = UseCommand(new Command
+{
+    Label = "Run",
+    Execute = () => RunStep(step),
+    DebounceMs = 1500,
+});
+
+// Async action — IsExecuting still tracks the lambda; DebounceMs keeps the
+// button disabled past the lambda's return (the disabled window is the
+// longer of the two).
+var regenCmd = UseCommand(new Command
+{
+    Label = "Re-gen",
+    ExecuteAsync = () => { RegenFromHere(step); return Task.CompletedTask; },
+    DebounceMs = 250,
+});
+```
+
+> **Caveat:** `DebounceMs` requires `UseCommand`. The debounce window and
+> its re-enable timer are persistent state, and a plain `Command` record
+> is immutable and reconstructed on every render — it has nowhere to keep
+> that state. `UseCommand` stores it in the component's hook table (the
+> same place it keeps the async re-entrance guard), so always route a
+> debounced command through `UseCommand`. A raw
+> `new Command { DebounceMs = … }` that is bound directly (never passed to
+> `UseCommand`) does **not** debounce. Debounce is **leading-edge and
+> fixed-duration** by design — fire first, then ignore. Trailing-edge
+> "wait for the input to settle, then fire once" debounce
+> (search-as-you-type) is a different concept and is not what `DebounceMs`
+> provides.
 
 ## Parameterized commands
 

--- a/docs/guide/reference/hooks/UseCommand.md
+++ b/docs/guide/reference/hooks/UseCommand.md
@@ -7,9 +7,16 @@ _cref_: `M:Microsoft.UI.Reactor.Core.RenderContext.UseCommand(Microsoft.UI.React
 
 ## Summary
 
-Processes a Command for use in a component. For sync-only commands, returns
-the command unchanged (no hook slots consumed). For async commands, wraps ExecuteAsync
-with automatic IsExecuting tracking and re-entrance guards. The returned command
-always has a sync Execute action and ExecuteAsync = null.
+Processes a Command for use in a component. Always consumes a stable hook shape
+(independent of whether the command is sync/async or debounced), so a command at a
+given call site can flip between sync↔async or DebounceMs 0↔N across renders without
+reordering hook slots. For a pure sync command with no DebounceMs the original command
+is returned unchanged (identity preserved). For async commands, wraps ExecuteAsync with
+automatic IsExecuting tracking and re-entrance guards. When DebounceMs > 0, wraps the
+dispatch with a leading-edge debounce so a fire within the window is dropped and
+IsDebouncing (hence IsEnabled = false) disables the bound control until the window
+elapses. The returned command has a sync Execute action, ExecuteAsync = null, and
+preserves the authored DebounceMs value (re-passing it through UseCommand is a no-op —
+debounce is never applied twice).
 
 

--- a/plugins/reactor/skills/reactor-commanding/SKILL.md
+++ b/plugins/reactor/skills/reactor-commanding/SKILL.md
@@ -29,8 +29,9 @@ var save = new Command
     Description = "Save the document",               // tooltip + a11y
     Accelerator = Accelerator(VirtualKey.S, VirtualKeyModifiers.Control),
     AccessKey = "S",                                 // Alt+key
+    DebounceMs = 0,                                  // >0 = leading-edge debounce (needs UseCommand)
 };
-// Computed: IsEnabled = CanExecute && !IsExecuting
+// Computed: IsEnabled = CanExecute && !IsExecuting && !IsDebouncing
 ```
 
 `Command<T>` is identical but `Execute`/`ExecuteAsync` receive a typed
@@ -126,6 +127,14 @@ class Editor : Component
 - Consumes 2 hook slots; re-entrance guard ignores clicks while executing.
 - `IsExecuting` resets to false even if `ExecuteAsync` throws.
 - Call unconditionally — don't wrap in `if`.
+- `DebounceMs > 0` adds **leading-edge** debounce: the first fire runs,
+  re-fires within the window are dropped, and `IsEnabled` is false for the
+  duration so the button auto-disables then re-enables. Replaces the
+  `Task.Delay`-to-absorb-double-clicks workaround. Needs `UseCommand` to
+  persist the window — a raw `new Command { DebounceMs = … }` bound
+  directly does **not** debounce. Works on sync `Execute` too (stays on the
+  UI thread; no `Task.Run` hop). For async commands the disabled window is
+  the longer of the lambda lifetime and `DebounceMs`.
 
 ## CommandHost — keyboard-scoped accelerators
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1812,8 +1812,10 @@ Func<Task> ExecuteAsync { get; init; }
 IconData Icon { get; init; }
 KeyboardAcceleratorData Accelerator { get; init; }
 bool CanExecute { get; init; }
+bool IsDebouncing { get; init; }
 bool IsEnabled { get; }
 bool IsExecuting { get; init; }
+int DebounceMs { get; init; }
 string AccessKey { get; init; }
 string Description { get; init; }
 string Label { get; init; }
@@ -1828,8 +1830,10 @@ Func<T, Task> ExecuteAsync { get; init; }
 IconData Icon { get; init; }
 KeyboardAcceleratorData Accelerator { get; init; }
 bool CanExecute { get; init; }
+bool IsDebouncing { get; init; }
 bool IsEnabled { get; }
 bool IsExecuting { get; init; }
+int DebounceMs { get; init; }
 string AccessKey { get; init; }
 string Description { get; init; }
 string Label { get; init; }

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1812,7 +1812,7 @@ Func<Task> ExecuteAsync { get; init; }
 IconData Icon { get; init; }
 KeyboardAcceleratorData Accelerator { get; init; }
 bool CanExecute { get; init; }
-bool IsDebouncing { get; init; }
+bool IsDebouncing { get; }
 bool IsEnabled { get; }
 bool IsExecuting { get; init; }
 int DebounceMs { get; init; }
@@ -1830,7 +1830,7 @@ Func<T, Task> ExecuteAsync { get; init; }
 IconData Icon { get; init; }
 KeyboardAcceleratorData Accelerator { get; init; }
 bool CanExecute { get; init; }
-bool IsDebouncing { get; init; }
+bool IsDebouncing { get; }
 bool IsEnabled { get; }
 bool IsExecuting { get; init; }
 int DebounceMs { get; init; }

--- a/samples/apps/demo-script-tool/App/Components/StepCard.cs
+++ b/samples/apps/demo-script-tool/App/Components/StepCard.cs
@@ -210,37 +210,32 @@ public sealed class StepCard : Component<StepCardProps>
         // synchronous launcher that flips IsExecuting=true while the action
         // is in flight and back to false on completion — Command.IsEnabled
         // honors that flag, so the button auto-disables for the duration.
-        // - Run: wraps a Task.Delay so the visible disable lasts long enough
-        //   to absorb double-clicks (the spawn itself returns instantly).
-        // - Re-gen: tiny delay so the IsExecuting window overlaps with the
-        //   shell flipping Props.IsGenerating to true on the next render —
-        //   without this the button could re-enable for a frame in between.
+        // - Run: spawning the step exe returns instantly, so there's no async
+        //   work to track. DebounceMs=1500 gives the framework-owned
+        //   leading-edge debounce: the click fires once, the button disables
+        //   for 1.5s, and the rapid re-clicks are dropped (issue #136). No
+        //   more Task.Delay padding a fake async window.
+        // - Re-gen: DebounceMs=250 bridges the gap until the shell flips
+        //   Props.IsGenerating=true on the next render — without it the button
+        //   could re-enable for a frame in between. Sync Execute keeps
+        //   OnRegenFromHere on the UI thread (UseCommand only hops to a
+        //   threadpool thread for ExecuteAsync — see framework #130).
         // - Show / Copy / Delete: plain sync Commands; instant.
         var runCmd = UseCommand(new Command
         {
             Label = "Run",
             CanExecute = canRun,
-            ExecuteAsync = async () =>
-            {
-                Props.OnRun(step);
-                await Task.Delay(1500).ConfigureAwait(false);
-            },
+            Execute = () => Props.OnRun(step),
+            DebounceMs = 1500,
         });
 
-        // Plain sync Command (no UseCommand). UseCommand's Task.Run wrapper
-        // would put OnRegenFromHere on a threadpool thread, which made the
-        // shell's announce.Announce throw RPC_E_WRONG_THREAD on the
-        // FrameworkElementAutomationPeer call (the exact issue tracked by
-        // framework #130). The 250 ms IsExecuting bridge is no longer needed
-        // either — the shell's lastRegenClickRef debounce (200 ms) covers
-        // the same multi-fire window without crossing threads, and
-        // Props.IsGenerating disables the button on the next render.
-        var regenCmd = new Command
+        var regenCmd = UseCommand(new Command
         {
             Label = "Re-gen",
             CanExecute = !Props.IsGenerating,
             Execute = () => Props.OnRegenFromHere(step),
-        };
+            DebounceMs = 250,
+        });
 
         var toggleCmd = new Command
         {

--- a/samples/apps/demo-script-tool/App/DemoScriptShell.cs
+++ b/samples/apps/demo-script-tool/App/DemoScriptShell.cs
@@ -62,17 +62,6 @@ public sealed class DemoScriptShell : Component
         var watcherRef = UseRef<DemoScriptWatcher?>(null);
         var generationCtsRef = UseRef<CancellationTokenSource?>(null);
         var saveDebounceRef = UseRef<CancellationTokenSource?>(null);
-        // Last-click-fired timestamp guards against Generate / Re-gen / etc.
-        // entry handlers running multiple times per user click. We've observed
-        // (logged at SessionLog) the OnGenerateAll handler firing 3+ times
-        // within 1 ms of a single click — which previously kicked off a run
-        // and then immediately cancelled it. Until the framework-level cause
-        // is found (suspected leaky button click subscription across
-        // re-renders, see PoolableWireFlags + EnsureButtonWiring) a cheap
-        // 200 ms debounce stops the immediate-cancel symptom without changing
-        // the user's perceived behavior on legitimate clicks.
-        var lastGenerateClickRef = UseRef<long>(0);
-        var lastRegenClickRef = UseRef<long>(0);
         // SHA-256 of the bytes of our most recent save (or load). When the
         // file watcher fires for a write WE just made, the disk hash equals
         // this value and we suppress the reload — otherwise our own debounced
@@ -328,15 +317,7 @@ public sealed class DemoScriptShell : Component
         void OnGenerateAll() => SafeClickHandler("OnGenerateAll", OnGenerateAllCore);
         void OnGenerateAllCore()
         {
-            var now = Environment.TickCount64;
-            var delta = now - lastGenerateClickRef.Current;
-            SessionLog.Write($"[Shell] OnGenerateAll projectRoot='{projectRoot ?? "(null)"}' ctsCurrent={(generationCtsRef.Current is null ? "null" : "non-null")} isGenerating={isGenerating} steps={model.Steps.Count} sinceLastClick={delta}ms");
-            if (lastGenerateClickRef.Current != 0 && delta < 200)
-            {
-                SessionLog.Write($"[Shell] OnGenerateAll → debounce drop ({delta}ms since last invocation)");
-                return;
-            }
-            lastGenerateClickRef.Current = now;
+            SessionLog.Write($"[Shell] OnGenerateAll projectRoot='{projectRoot ?? "(null)"}' ctsCurrent={(generationCtsRef.Current is null ? "null" : "non-null")} isGenerating={isGenerating} steps={model.Steps.Count}");
             if (projectRoot is null)
             {
                 _status.ShowToast("Open a folder first (Ctrl+O).", StatusSeverity.Warning);
@@ -422,15 +403,7 @@ public sealed class DemoScriptShell : Component
         void OnRegenFromStep(StepModel step) => SafeClickHandler($"OnRegenFromStep(step={step.Number})", () => OnRegenFromStepCore(step));
         void OnRegenFromStepCore(StepModel step)
         {
-            var now = Environment.TickCount64;
-            var delta = now - lastRegenClickRef.Current;
-            SessionLog.Write($"[Shell] OnRegenFromStep step={step.Number} '{step.Title}' projectRoot='{projectRoot ?? "(null)"}' ctsCurrent={(generationCtsRef.Current is null ? "null" : "non-null")} isGenerating={isGenerating} sinceLastClick={delta}ms");
-            if (lastRegenClickRef.Current != 0 && delta < 200)
-            {
-                SessionLog.Write($"[Shell] OnRegenFromStep → debounce drop ({delta}ms since last invocation)");
-                return;
-            }
-            lastRegenClickRef.Current = now;
+            SessionLog.Write($"[Shell] OnRegenFromStep step={step.Number} '{step.Title}' projectRoot='{projectRoot ?? "(null)"}' ctsCurrent={(generationCtsRef.Current is null ? "null" : "non-null")} isGenerating={isGenerating}");
             if (projectRoot is null)
             {
                 _status.ShowToast("Open a folder first.", StatusSeverity.Warning);
@@ -542,14 +515,21 @@ public sealed class DemoScriptShell : Component
             Icon = SymbolIcon("OpenLocal"),
             Accelerator = Accelerator(VirtualKey.O, VirtualKeyModifiers.Control),
         };
-        var generateCmd = new Command
+        // Generate / Cancel toggle. DebounceMs=200 (via UseCommand) is the
+        // framework-owned leading-edge debounce that replaces the hand-rolled
+        // Environment.TickCount64 guard we used to keep in OnGenerateAllCore:
+        // it drops the duplicate fires of a single click (the multi-fire
+        // symptom of a leaky click subscription, framework #114) while letting
+        // legitimate clicks through.
+        var generateCmd = UseCommand(new Command
         {
             Label = isGenerating ? "Cancel" : "Generate All",
             Execute = OnGenerateAll,
             CanExecute = projectRoot is not null,
             Icon = SymbolIcon(isGenerating ? "Stop" : "Play"),
             Accelerator = Accelerator(VirtualKey.G, VirtualKeyModifiers.Control),
-        };
+            DebounceMs = 200,
+        });
         var exportCmd = new Command
         {
             Label = "Export Speaker Notes",

--- a/samples/apps/demo-script-tool/App/DemoScriptShell.cs
+++ b/samples/apps/demo-script-tool/App/DemoScriptShell.cs
@@ -520,7 +520,12 @@ public sealed class DemoScriptShell : Component
         // Environment.TickCount64 guard we used to keep in OnGenerateAllCore:
         // it drops the duplicate fires of a single click (the multi-fire
         // symptom of a leaky click subscription, framework #114) while letting
-        // legitimate clicks through.
+        // legitimate clicks through. The 200ms window also briefly disables the
+        // button after it relabels to "Cancel" — this is intentional: it's
+        // exactly the duplicate fire that would otherwise instantly cancel the
+        // generation the first click just started. 200ms is well below human
+        // double-click-then-deliberately-cancel timing, so a real cancel is
+        // unaffected.
         var generateCmd = UseCommand(new Command
         {
             Label = isGenerating ? "Cancel" : "Generate All",

--- a/skills/commanding.md
+++ b/skills/commanding.md
@@ -29,8 +29,9 @@ var save = new Command
     Description = "Save the document",               // tooltip + a11y
     Accelerator = Accelerator(VirtualKey.S, VirtualKeyModifiers.Control),
     AccessKey = "S",                                 // Alt+key
+    DebounceMs = 0,                                  // >0 = leading-edge debounce (needs UseCommand)
 };
-// Computed: IsEnabled = CanExecute && !IsExecuting
+// Computed: IsEnabled = CanExecute && !IsExecuting && !IsDebouncing
 ```
 
 `Command<T>` is identical but `Execute`/`ExecuteAsync` receive a typed
@@ -126,6 +127,14 @@ class Editor : Component
 - Consumes 2 hook slots; re-entrance guard ignores clicks while executing.
 - `IsExecuting` resets to false even if `ExecuteAsync` throws.
 - Call unconditionally — don't wrap in `if`.
+- `DebounceMs > 0` adds **leading-edge** debounce: the first fire runs,
+  re-fires within the window are dropped, and `IsEnabled` is false for the
+  duration so the button auto-disables then re-enables. Replaces the
+  `Task.Delay`-to-absorb-double-clicks workaround. Needs `UseCommand` to
+  persist the window — a raw `new Command { DebounceMs = … }` bound
+  directly does **not** debounce. Works on sync `Execute` too (stays on the
+  UI thread; no `Task.Run` hop). For async commands the disabled window is
+  the longer of the lambda lifetime and `DebounceMs`.
 
 ## CommandHost — keyboard-scoped accelerators
 

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1812,8 +1812,10 @@ Func<Task> ExecuteAsync { get; init; }
 IconData Icon { get; init; }
 KeyboardAcceleratorData Accelerator { get; init; }
 bool CanExecute { get; init; }
+bool IsDebouncing { get; init; }
 bool IsEnabled { get; }
 bool IsExecuting { get; init; }
+int DebounceMs { get; init; }
 string AccessKey { get; init; }
 string Description { get; init; }
 string Label { get; init; }
@@ -1828,8 +1830,10 @@ Func<T, Task> ExecuteAsync { get; init; }
 IconData Icon { get; init; }
 KeyboardAcceleratorData Accelerator { get; init; }
 bool CanExecute { get; init; }
+bool IsDebouncing { get; init; }
 bool IsEnabled { get; }
 bool IsExecuting { get; init; }
+int DebounceMs { get; init; }
 string AccessKey { get; init; }
 string Description { get; init; }
 string Label { get; init; }

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1812,7 +1812,7 @@ Func<Task> ExecuteAsync { get; init; }
 IconData Icon { get; init; }
 KeyboardAcceleratorData Accelerator { get; init; }
 bool CanExecute { get; init; }
-bool IsDebouncing { get; init; }
+bool IsDebouncing { get; }
 bool IsEnabled { get; }
 bool IsExecuting { get; init; }
 int DebounceMs { get; init; }
@@ -1830,7 +1830,7 @@ Func<T, Task> ExecuteAsync { get; init; }
 IconData Icon { get; init; }
 KeyboardAcceleratorData Accelerator { get; init; }
 bool CanExecute { get; init; }
-bool IsDebouncing { get; init; }
+bool IsDebouncing { get; }
 bool IsEnabled { get; }
 bool IsExecuting { get; init; }
 int DebounceMs { get; init; }

--- a/src/Reactor/Core/Command.cs
+++ b/src/Reactor/Core/Command.cs
@@ -27,6 +27,36 @@ public sealed record Command
     /// Managed by <see cref="RenderContext.UseCommand"/>.</summary>
     public bool IsExecuting { get; init; }
 
+    /// <summary>
+    /// Leading-edge debounce window, in milliseconds. <c>0</c> (the default) disables
+    /// debouncing and preserves the un-debounced behavior exactly.
+    /// <para>
+    /// When &gt; 0 and the command is processed through <see cref="RenderContext.UseCommand"/>,
+    /// the first fire is accepted and any subsequent fire within <c>DebounceMs</c> of it is
+    /// dropped (a no-op). For the duration of the window <see cref="IsDebouncing"/> is true,
+    /// so <see cref="IsEnabled"/> reports false and the bound control visibly disables, then
+    /// re-enables when the window elapses. This is the framework-owned replacement for the
+    /// "wrap a sync action in <c>Task.Delay</c> to absorb double-clicks" pattern (issue #136).
+    /// </para>
+    /// <para>
+    /// For async commands, <see cref="IsExecuting"/> already tracks the lambda's lifetime;
+    /// <c>DebounceMs</c> is the time-based generalization that keeps the disabled window open
+    /// past the lambda's return (the effective disabled window is the longer of the two).
+    /// </para>
+    /// <para>
+    /// The debounce state (last-fire window + re-enable timer) lives in the
+    /// <see cref="RenderContext.UseCommand"/> hook's backing store, which persists across
+    /// renders. A raw <c>new Command { DebounceMs = … }</c> that is NOT routed through
+    /// <see cref="RenderContext.UseCommand"/> has nowhere to persist that state and therefore
+    /// does NOT debounce — always wrap a debounced command with <c>UseCommand</c>.
+    /// </para>
+    /// </summary>
+    public int DebounceMs { get; init; }
+
+    /// <summary>Whether the command is currently inside its leading-edge debounce window.
+    /// Managed by <see cref="RenderContext.UseCommand"/> when <see cref="DebounceMs"/> &gt; 0.</summary>
+    public bool IsDebouncing { get; init; }
+
     /// <summary>Icon to display alongside the command.</summary>
     public IconData? Icon { get; init; }
 
@@ -39,8 +69,9 @@ public sealed record Command
     /// <summary>Access key (Alt+key) for this command.</summary>
     public string? AccessKey { get; init; }
 
-    /// <summary>Computed: the command is enabled only when it can execute and is not currently executing.</summary>
-    public bool IsEnabled => CanExecute && !IsExecuting;
+    /// <summary>Computed: the command is enabled only when it can execute, is not currently
+    /// executing, and is not inside its leading-edge debounce window.</summary>
+    public bool IsEnabled => CanExecute && !IsExecuting && !IsDebouncing;
 }
 
 /// <summary>
@@ -67,6 +98,20 @@ public sealed record Command<T>
     /// <summary>Whether the command is currently executing an async operation.</summary>
     public bool IsExecuting { get; init; }
 
+    /// <summary>
+    /// Leading-edge debounce window, in milliseconds. <c>0</c> (the default) disables
+    /// debouncing. When &gt; 0 and the command is processed through
+    /// <see cref="RenderContext.UseCommand{T}"/>, the first fire is accepted and any
+    /// subsequent fire within the window is dropped, with <see cref="IsDebouncing"/> (and
+    /// therefore <see cref="IsEnabled"/>=false) reflecting the window so the bound control
+    /// disables. See <see cref="Command.DebounceMs"/> for the full contract (issue #136).
+    /// </summary>
+    public int DebounceMs { get; init; }
+
+    /// <summary>Whether the command is currently inside its leading-edge debounce window.
+    /// Managed by <see cref="RenderContext.UseCommand{T}"/> when <see cref="DebounceMs"/> &gt; 0.</summary>
+    public bool IsDebouncing { get; init; }
+
     /// <summary>Icon to display alongside the command.</summary>
     public IconData? Icon { get; init; }
 
@@ -79,6 +124,7 @@ public sealed record Command<T>
     /// <summary>Access key (Alt+key) for this command.</summary>
     public string? AccessKey { get; init; }
 
-    /// <summary>Computed: the command is enabled only when it can execute and is not currently executing.</summary>
-    public bool IsEnabled => CanExecute && !IsExecuting;
+    /// <summary>Computed: the command is enabled only when it can execute, is not currently
+    /// executing, and is not inside its leading-edge debounce window.</summary>
+    public bool IsEnabled => CanExecute && !IsExecuting && !IsDebouncing;
 }

--- a/src/Reactor/Core/Command.cs
+++ b/src/Reactor/Core/Command.cs
@@ -44,18 +44,28 @@ public sealed record Command
     /// past the lambda's return (the effective disabled window is the longer of the two).
     /// </para>
     /// <para>
-    /// The debounce state (last-fire window + re-enable timer) lives in the
-    /// <see cref="RenderContext.UseCommand"/> hook's backing store, which persists across
-    /// renders. A raw <c>new Command { DebounceMs = … }</c> that is NOT routed through
-    /// <see cref="RenderContext.UseCommand"/> has nowhere to persist that state and therefore
-    /// does NOT debounce — always wrap a debounced command with <c>UseCommand</c>.
+    /// <b>DebounceMs only works through <see cref="RenderContext.UseCommand"/>.</b> The debounce
+    /// state (last-fire window + re-enable timer) lives in the <c>UseCommand</c> hook's backing
+    /// store, which is the only place that persists across renders (the <see cref="Command"/>
+    /// record itself is reconstructed every render). A raw <c>new Command { DebounceMs = … }</c>
+    /// bound directly to a control — without being passed through <c>UseCommand</c> — has nowhere
+    /// to persist that state and is therefore <b>inert: it does NOT debounce</b>. Always wrap a
+    /// debounced command with <c>UseCommand</c>:
+    /// <code>var run = UseCommand(new Command { Label = "Run", Execute = Run, DebounceMs = 1500 });</code>
     /// </para>
     /// </summary>
     public int DebounceMs { get; init; }
 
     /// <summary>Whether the command is currently inside its leading-edge debounce window.
-    /// Managed by <see cref="RenderContext.UseCommand"/> when <see cref="DebounceMs"/> &gt; 0.</summary>
-    public bool IsDebouncing { get; init; }
+    /// This is framework-managed state set by <see cref="RenderContext.UseCommand"/> when
+    /// <see cref="DebounceMs"/> &gt; 0; it is read-only to app authors (internal init).</summary>
+    public bool IsDebouncing { get; internal init; }
+
+    /// <summary>Internal marker: set when <see cref="RenderContext.UseCommand"/> has already
+    /// wrapped this command's execution (debounce + IsExecuting tracking). Re-passing an
+    /// already-handled command through <c>UseCommand</c> is a passthrough, so debounce is never
+    /// applied twice. Not part of the public surface.</summary>
+    internal bool DebounceHandled { get; init; }
 
     /// <summary>Icon to display alongside the command.</summary>
     public IconData? Icon { get; init; }
@@ -104,13 +114,22 @@ public sealed record Command<T>
     /// <see cref="RenderContext.UseCommand{T}"/>, the first fire is accepted and any
     /// subsequent fire within the window is dropped, with <see cref="IsDebouncing"/> (and
     /// therefore <see cref="IsEnabled"/>=false) reflecting the window so the bound control
-    /// disables. See <see cref="Command.DebounceMs"/> for the full contract (issue #136).
+    /// disables. <b>Like <see cref="Command.DebounceMs"/>, this only works through
+    /// <see cref="RenderContext.UseCommand{T}"/></b> — a raw <c>new Command&lt;T&gt; { DebounceMs = … }</c>
+    /// bound directly is inert and does not debounce. See <see cref="Command.DebounceMs"/> for
+    /// the full contract (issue #136).
     /// </summary>
     public int DebounceMs { get; init; }
 
     /// <summary>Whether the command is currently inside its leading-edge debounce window.
-    /// Managed by <see cref="RenderContext.UseCommand{T}"/> when <see cref="DebounceMs"/> &gt; 0.</summary>
-    public bool IsDebouncing { get; init; }
+    /// Framework-managed state set by <see cref="RenderContext.UseCommand{T}"/> when
+    /// <see cref="DebounceMs"/> &gt; 0; read-only to app authors (internal init).</summary>
+    public bool IsDebouncing { get; internal init; }
+
+    /// <summary>Internal marker: set when <see cref="RenderContext.UseCommand{T}"/> has already
+    /// wrapped this command's execution, so debounce is never applied twice on a re-passed
+    /// command. Not part of the public surface.</summary>
+    internal bool DebounceHandled { get; init; }
 
     /// <summary>Icon to display alongside the command.</summary>
     public IconData? Icon { get; init; }

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -16,6 +16,13 @@ public sealed class RenderContext
     private ContextScope? _contextScope;
     private int _uiThreadId;
 
+    /// <summary>
+    /// Time source used by time-based hooks (currently <see cref="UseCommand(Command)"/>'s
+    /// <see cref="Command.DebounceMs"/> window). Defaults to <see cref="TimeProvider.System"/>;
+    /// tests inject a fake provider so debounce timing isn't wall-clock-flaky.
+    /// </summary>
+    internal global::System.TimeProvider TimeProvider { get; set; } = global::System.TimeProvider.System;
+
     internal void BeginRender(Action requestRerender)
     {
         _hookIndex = 0;
@@ -915,87 +922,191 @@ public sealed class RenderContext
     // ════════════════════════════════════════════════════════════════
 
     /// <summary>
-    /// Processes a Command for use in a component. For sync-only commands, returns
-    /// the command unchanged (no hook slots consumed). For async commands, wraps ExecuteAsync
-    /// with automatic IsExecuting tracking and re-entrance guards. The returned command
-    /// always has a sync Execute action and ExecuteAsync = null.
+    /// Processes a Command for use in a component. For sync-only commands with no
+    /// <see cref="Command.DebounceMs"/>, returns the command unchanged (no hook slots consumed).
+    /// For async commands, wraps ExecuteAsync with automatic IsExecuting tracking and re-entrance
+    /// guards. When <see cref="Command.DebounceMs"/> &gt; 0, wraps the dispatch with a leading-edge
+    /// debounce: a fire within the window of the prior accepted fire is dropped and
+    /// <see cref="Command.IsDebouncing"/> (hence <see cref="Command.IsEnabled"/>=false) reflects
+    /// the window so the bound control disables, re-enabling when the window elapses. The returned
+    /// command always has a sync Execute action, ExecuteAsync = null, and DebounceMs = 0 (consumed).
     /// </summary>
     public Command UseCommand(Command command)
     {
-        // Sync-only commands pass through unchanged — no hooks consumed
-        if (command.ExecuteAsync is null)
+        bool needsDebounce = command.DebounceMs > 0;
+
+        // Sync-only, no debounce → passthrough unchanged (no hooks consumed).
+        if (command.ExecuteAsync is null && !needsDebounce)
             return command;
 
         var (isExecuting, setIsExecuting) = UseState(false, threadSafe: true);
+        var (isDebouncing, setIsDebouncing) = UseState(false, threadSafe: true);
         var guardRef = UseRef(false);
+        var debounceRef = UseRef<DebounceSlot?>(null);
         var asyncAction = command.ExecuteAsync;
+        var syncAction = command.Execute;
+        int debounceMs = command.DebounceMs;
 
         var wrappedExecute = UseMemo<Action>(() => () =>
         {
-            // Re-entrance guard using ref for live value (not stale closure capture)
-            if (guardRef.Current) return;
-            guardRef.Current = true;
-            setIsExecuting(true);
-            // try/finally — NOT try/catch. The user's command throw becomes a
-            // faulted Task; the framework's reentry-guard and IsExecuting
-            // state still get restored. We deliberately let the exception
-            // surface via Task.UnobservedTaskException rather than swallowing,
-            // so a buggy command is visible to the developer (matches the
-            // dispose / lifecycle policy elsewhere — don't hide user bugs).
-            _ = Task.Run(async () =>
+            if (asyncAction is not null)
             {
-                try
+                // Re-entrance guard using ref for live value (not stale closure capture).
+                // Checked BEFORE arming the debounce window so a fire blocked because the
+                // async action is still running doesn't re-arm the window for nothing.
+                if (guardRef.Current) return;
+                if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return;
+                guardRef.Current = true;
+                setIsExecuting(true);
+                // try/finally — NOT try/catch. The user's command throw becomes a
+                // faulted Task; the framework's reentry-guard and IsExecuting
+                // state still get restored. We deliberately let the exception
+                // surface via Task.UnobservedTaskException rather than swallowing,
+                // so a buggy command is visible to the developer (matches the
+                // dispose / lifecycle policy elsewhere — don't hide user bugs).
+                _ = Task.Run(async () =>
                 {
-                    await asyncAction();
-                }
-                finally
-                {
-                    guardRef.Current = false;
-                    setIsExecuting(false);
-                }
-            });
-        }, command.ExecuteAsync);
+                    try
+                    {
+                        await asyncAction();
+                    }
+                    finally
+                    {
+                        guardRef.Current = false;
+                        setIsExecuting(false);
+                    }
+                });
+            }
+            else
+            {
+                // Sync command + debounce: dispatch stays synchronous (no Task.Run hop),
+                // so the action keeps running on the UI thread.
+                if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return;
+                syncAction?.Invoke();
+            }
+        }, (object?)command.ExecuteAsync ?? NullDep, (object?)command.Execute ?? NullDep, debounceMs);
 
-        return command with { Execute = wrappedExecute, ExecuteAsync = null, IsExecuting = isExecuting };
+        return command with
+        {
+            Execute = wrappedExecute,
+            ExecuteAsync = null,
+            IsExecuting = isExecuting,
+            IsDebouncing = isDebouncing,
+            DebounceMs = 0,
+        };
     }
 
     /// <summary>
-    /// Processes a parameterized Command for use in a component. For sync-only commands,
-    /// returns unchanged. For async commands, wraps ExecuteAsync with IsExecuting tracking
-    /// and re-entrance guards.
+    /// Processes a parameterized Command for use in a component. For sync-only commands with no
+    /// <see cref="Command{T}.DebounceMs"/>, returns unchanged. For async commands, wraps
+    /// ExecuteAsync with IsExecuting tracking and re-entrance guards. When
+    /// <see cref="Command{T}.DebounceMs"/> &gt; 0, applies the same leading-edge debounce as the
+    /// non-generic <see cref="UseCommand(Command)"/>.
     /// </summary>
     public Command<T> UseCommand<T>(Command<T> command)
     {
-        if (command.ExecuteAsync is null)
+        bool needsDebounce = command.DebounceMs > 0;
+
+        if (command.ExecuteAsync is null && !needsDebounce)
             return command;
 
         var (isExecuting, setIsExecuting) = UseState(false, threadSafe: true);
+        var (isDebouncing, setIsDebouncing) = UseState(false, threadSafe: true);
         var guardRef = UseRef(false);
+        var debounceRef = UseRef<DebounceSlot?>(null);
         var asyncAction = command.ExecuteAsync;
+        var syncAction = command.Execute;
+        int debounceMs = command.DebounceMs;
 
         var wrappedExecute = UseMemo<Action<T>>(() => (arg) =>
         {
-            // Re-entrance guard using ref for live value (not stale closure capture)
-            if (guardRef.Current) return;
-            guardRef.Current = true;
-            setIsExecuting(true);
-            // try/finally — same shape as the non-generic UseCommand above.
-            // Cleanup runs; user throw surfaces via Task.UnobservedTaskException.
-            _ = Task.Run(async () =>
+            if (asyncAction is not null)
             {
-                try
+                // Re-entrance guard using ref for live value (not stale closure capture).
+                if (guardRef.Current) return;
+                if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return;
+                guardRef.Current = true;
+                setIsExecuting(true);
+                // try/finally — same shape as the non-generic UseCommand above.
+                // Cleanup runs; user throw surfaces via Task.UnobservedTaskException.
+                _ = Task.Run(async () =>
                 {
-                    await asyncAction(arg);
-                }
-                finally
-                {
-                    guardRef.Current = false;
-                    setIsExecuting(false);
-                }
-            });
-        }, command.ExecuteAsync);
+                    try
+                    {
+                        await asyncAction(arg);
+                    }
+                    finally
+                    {
+                        guardRef.Current = false;
+                        setIsExecuting(false);
+                    }
+                });
+            }
+            else
+            {
+                if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return;
+                syncAction?.Invoke(arg);
+            }
+        }, (object?)command.ExecuteAsync ?? NullDep, (object?)command.Execute ?? NullDep, debounceMs);
 
-        return command with { Execute = wrappedExecute, ExecuteAsync = null, IsExecuting = isExecuting };
+        return command with
+        {
+            Execute = wrappedExecute,
+            ExecuteAsync = null,
+            IsExecuting = isExecuting,
+            IsDebouncing = isDebouncing,
+            DebounceMs = 0,
+        };
+    }
+
+    /// <summary>
+    /// Per-command leading-edge debounce state: the in-window flag plus the one-shot
+    /// re-enable timer. Lives in a <see cref="UseRef{T}"/> slot so it persists across renders
+    /// (the <see cref="Command"/> record itself is reconstructed every render).
+    /// </summary>
+    private sealed class DebounceSlot
+    {
+        public readonly object Gate = new();
+        public bool InWindow;
+        public global::System.Threading.ITimer? Timer;
+    }
+
+    /// <summary>Stable non-null stand-in for a null delegate in a <see cref="UseMemo{T}"/>
+    /// dependency array (keeps the comparison meaningful without tripping nullable warnings).</summary>
+    private static readonly object NullDep = new();
+
+    /// <summary>
+    /// Leading-edge gate. Returns true if this fire is accepted (window was open); arms the
+    /// window for <paramref name="debounceMs"/> and schedules a re-enable that clears
+    /// <see cref="DebounceSlot.InWindow"/> and re-renders so the control comes back. Returns
+    /// false if a prior accepted fire is still inside its window (drop this fire).
+    /// </summary>
+    private bool TryEnterDebounceWindow(int debounceMs, Ref<DebounceSlot?> slotRef, Action<bool> setIsDebouncing)
+    {
+        if (debounceMs <= 0) return true;
+
+        var slot = slotRef.Current ??= new DebounceSlot();
+        global::System.Threading.ITimer? prior;
+        lock (slot.Gate)
+        {
+            if (slot.InWindow) return false;
+            slot.InWindow = true;
+            prior = slot.Timer;
+        }
+        // setState is threadSafe:true → safe to call from the timer callback thread too.
+        setIsDebouncing(true);
+        var timer = TimeProvider.CreateTimer(
+            _ =>
+            {
+                lock (slot.Gate) { slot.InWindow = false; }
+                setIsDebouncing(false);
+            },
+            null,
+            TimeSpan.FromMilliseconds(debounceMs),
+            global::System.Threading.Timeout.InfiniteTimeSpan);
+        lock (slot.Gate) { slot.Timer = timer; }
+        prior?.Dispose();
+        return true;
     }
 
     // ════════════════════════════════════════════════════════════════

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -1133,7 +1133,9 @@ public sealed class RenderContext
             // here and the InWindow check, so the control can't be left wrongly enabled.
             setIsDebouncing(true);
         }
-        // Dispose the previous (already-fired, inert) timer outside the lock.
+        // Defensive: the re-enable callback now disposes its own timer when it clears the window,
+        // so by the time we re-arm (InWindow was false) slot.Timer is normally already null. Keep
+        // this as belt-and-suspenders in case a prior timer was left installed (e.g. epoch races).
         prior?.Dispose();
 
         var timer = TimeProvider.CreateTimer(
@@ -1148,6 +1150,12 @@ public sealed class RenderContext
                     if (slot.Epoch != epoch || !slot.InWindow) return;
                     slot.InWindow = false;
                     setIsDebouncing(false);
+                    // Dispose this now-inert one-shot timer immediately (atomic with the clear, so
+                    // slot.Timer is still us) rather than retaining it until the next accepted fire
+                    // or unmount — otherwise a fire-once debounced command on a long-lived component
+                    // would keep a dead timer object alive indefinitely.
+                    slot.Timer?.Dispose();
+                    slot.Timer = null;
                 }
             },
             null,

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -922,69 +922,37 @@ public sealed class RenderContext
     // ════════════════════════════════════════════════════════════════
 
     /// <summary>
-    /// Processes a Command for use in a component. For sync-only commands with no
-    /// <see cref="Command.DebounceMs"/>, returns the command unchanged (no hook slots consumed).
-    /// For async commands, wraps ExecuteAsync with automatic IsExecuting tracking and re-entrance
-    /// guards. When <see cref="Command.DebounceMs"/> &gt; 0, wraps the dispatch with a leading-edge
-    /// debounce: a fire within the window of the prior accepted fire is dropped and
+    /// Processes a Command for use in a component. Always consumes a <b>stable hook shape</b>
+    /// (independent of whether the command is sync/async or debounced), so a command at a given
+    /// call site can flip between sync↔async or <see cref="Command.DebounceMs"/> 0↔N across
+    /// renders without ever reordering hook slots. For a pure sync command with no
+    /// <see cref="Command.DebounceMs"/> the original command is returned unchanged (identity
+    /// preserved). For async commands, wraps ExecuteAsync with automatic IsExecuting tracking and
+    /// re-entrance guards. When <see cref="Command.DebounceMs"/> &gt; 0, wraps the dispatch with a
+    /// leading-edge debounce: a fire within the window of the prior accepted fire is dropped and
     /// <see cref="Command.IsDebouncing"/> (hence <see cref="Command.IsEnabled"/>=false) reflects
     /// the window so the bound control disables, re-enabling when the window elapses. The returned
-    /// command always has a sync Execute action, ExecuteAsync = null, and DebounceMs = 0 (consumed).
+    /// command has a sync Execute action, ExecuteAsync = null, and preserves the authored
+    /// DebounceMs value (re-passing it through UseCommand is a no-op — debounce is never applied
+    /// twice).
     /// </summary>
     public Command UseCommand(Command command)
     {
-        bool needsDebounce = command.DebounceMs > 0;
+        var (guardRef, debounceRef, isExecuting, setIsExecuting, isDebouncing, setIsDebouncing)
+            = UseCommandState();
 
-        // Sync-only, no debounce → passthrough unchanged (no hooks consumed).
-        if (command.ExecuteAsync is null && !needsDebounce)
-            return command;
-
-        var (isExecuting, setIsExecuting) = UseState(false, threadSafe: true);
-        var (isDebouncing, setIsDebouncing) = UseState(false, threadSafe: true);
-        var guardRef = UseRef(false);
-        var debounceRef = UseRef<DebounceSlot?>(null);
         var asyncAction = command.ExecuteAsync;
         var syncAction = command.Execute;
         int debounceMs = command.DebounceMs;
 
         var wrappedExecute = UseMemo<Action>(() => () =>
-        {
-            if (asyncAction is not null)
-            {
-                // Re-entrance guard using ref for live value (not stale closure capture).
-                // Checked BEFORE arming the debounce window so a fire blocked because the
-                // async action is still running doesn't re-arm the window for nothing.
-                if (guardRef.Current) return;
-                if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return;
-                guardRef.Current = true;
-                setIsExecuting(true);
-                // try/finally — NOT try/catch. The user's command throw becomes a
-                // faulted Task; the framework's reentry-guard and IsExecuting
-                // state still get restored. We deliberately let the exception
-                // surface via Task.UnobservedTaskException rather than swallowing,
-                // so a buggy command is visible to the developer (matches the
-                // dispose / lifecycle policy elsewhere — don't hide user bugs).
-                _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        await asyncAction();
-                    }
-                    finally
-                    {
-                        guardRef.Current = false;
-                        setIsExecuting(false);
-                    }
-                });
-            }
-            else
-            {
-                // Sync command + debounce: dispatch stays synchronous (no Task.Run hop),
-                // so the action keeps running on the UI thread.
-                if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return;
-                syncAction?.Invoke();
-            }
-        }, (object?)command.ExecuteAsync ?? NullDep, (object?)command.Execute ?? NullDep, debounceMs);
+            DispatchCommand(asyncAction, syncAction, debounceMs, guardRef, debounceRef, setIsExecuting, setIsDebouncing),
+            (object?)command.ExecuteAsync ?? NullDep, (object?)command.Execute ?? NullDep, debounceMs);
+
+        // Branch on VALUES, never on hook calls: a pure sync, non-debounced, not-yet-wrapped
+        // command is returned unchanged (preserves identity / Assert.Same and today's behavior).
+        if (!CommandNeedsWrapping(command.ExecuteAsync, command.DebounceMs, command.DebounceHandled))
+            return command;
 
         return command with
         {
@@ -992,62 +960,33 @@ public sealed class RenderContext
             ExecuteAsync = null,
             IsExecuting = isExecuting,
             IsDebouncing = isDebouncing,
-            DebounceMs = 0,
+            DebounceHandled = true,
         };
     }
 
     /// <summary>
-    /// Processes a parameterized Command for use in a component. For sync-only commands with no
-    /// <see cref="Command{T}.DebounceMs"/>, returns unchanged. For async commands, wraps
-    /// ExecuteAsync with IsExecuting tracking and re-entrance guards. When
-    /// <see cref="Command{T}.DebounceMs"/> &gt; 0, applies the same leading-edge debounce as the
-    /// non-generic <see cref="UseCommand(Command)"/>.
+    /// Processes a parameterized Command for use in a component. Consumes the same
+    /// <b>stable hook shape</b> as the non-generic <see cref="UseCommand(Command)"/> and applies
+    /// the same async tracking and leading-edge <see cref="Command{T}.DebounceMs"/> debounce.
     /// </summary>
     public Command<T> UseCommand<T>(Command<T> command)
     {
-        bool needsDebounce = command.DebounceMs > 0;
+        var (guardRef, debounceRef, isExecuting, setIsExecuting, isDebouncing, setIsDebouncing)
+            = UseCommandState();
 
-        if (command.ExecuteAsync is null && !needsDebounce)
-            return command;
-
-        var (isExecuting, setIsExecuting) = UseState(false, threadSafe: true);
-        var (isDebouncing, setIsDebouncing) = UseState(false, threadSafe: true);
-        var guardRef = UseRef(false);
-        var debounceRef = UseRef<DebounceSlot?>(null);
         var asyncAction = command.ExecuteAsync;
         var syncAction = command.Execute;
         int debounceMs = command.DebounceMs;
 
         var wrappedExecute = UseMemo<Action<T>>(() => (arg) =>
-        {
-            if (asyncAction is not null)
-            {
-                // Re-entrance guard using ref for live value (not stale closure capture).
-                if (guardRef.Current) return;
-                if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return;
-                guardRef.Current = true;
-                setIsExecuting(true);
-                // try/finally — same shape as the non-generic UseCommand above.
-                // Cleanup runs; user throw surfaces via Task.UnobservedTaskException.
-                _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        await asyncAction(arg);
-                    }
-                    finally
-                    {
-                        guardRef.Current = false;
-                        setIsExecuting(false);
-                    }
-                });
-            }
-            else
-            {
-                if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return;
-                syncAction?.Invoke(arg);
-            }
-        }, (object?)command.ExecuteAsync ?? NullDep, (object?)command.Execute ?? NullDep, debounceMs);
+            DispatchCommand(
+                asyncAction is null ? null : () => asyncAction(arg),
+                syncAction is null ? null : () => syncAction(arg),
+                debounceMs, guardRef, debounceRef, setIsExecuting, setIsDebouncing),
+            (object?)command.ExecuteAsync ?? NullDep, (object?)command.Execute ?? NullDep, debounceMs);
+
+        if (!CommandNeedsWrapping(command.ExecuteAsync, command.DebounceMs, command.DebounceHandled))
+            return command;
 
         return command with
         {
@@ -1055,19 +994,113 @@ public sealed class RenderContext
             ExecuteAsync = null,
             IsExecuting = isExecuting,
             IsDebouncing = isDebouncing,
-            DebounceMs = 0,
+            DebounceHandled = true,
         };
     }
 
+    /// <summary>A command's execution needs wrapping when it is async, or it declares a debounce
+    /// window that <see cref="UseCommand(Command)"/> hasn't already consumed. Pure sync,
+    /// non-debounced commands (and already-wrapped commands) pass through untouched.</summary>
+    private static bool CommandNeedsWrapping(object? executeAsync, int debounceMs, bool debounceHandled)
+        => !debounceHandled && (executeAsync is not null || debounceMs > 0);
+
     /// <summary>
-    /// Per-command leading-edge debounce state: the in-window flag plus the one-shot
-    /// re-enable timer. Lives in a <see cref="UseRef{T}"/> slot so it persists across renders
-    /// (the <see cref="Command"/> record itself is reconstructed every render).
+    /// Allocates the stable hook shape shared by both <see cref="UseCommand(Command)"/> overloads:
+    /// the IsExecuting / IsDebouncing state, the re-entrance guard and debounce-slot refs, and an
+    /// unmount effect that disposes any live re-enable timer so it cannot fire
+    /// <c>setIsDebouncing</c> / request a re-render against a torn-down context. These hooks are
+    /// allocated unconditionally so the hook order is identical regardless of the command's shape.
+    /// </summary>
+    private (Ref<bool> GuardRef, Ref<DebounceSlot?> DebounceRef,
+             bool IsExecuting, Action<bool> SetIsExecuting,
+             bool IsDebouncing, Action<bool> SetIsDebouncing) UseCommandState()
+    {
+        var (isExecuting, setIsExecuting) = UseState(false, threadSafe: true);
+        var (isDebouncing, setIsDebouncing) = UseState(false, threadSafe: true);
+        var guardRef = UseRef(false);
+        var debounceRef = UseRef<DebounceSlot?>(null);
+
+        // Mount-once effect: on unmount, dispose the live re-enable timer (if any) so a pending
+        // window can't fire its callback against a context that no longer exists.
+        UseEffect(() => () =>
+        {
+            var slot = debounceRef.Current;
+            if (slot is null) return;
+            global::System.Threading.ITimer? timer;
+            lock (slot.Gate)
+            {
+                timer = slot.Timer;
+                slot.Timer = null;
+                slot.InWindow = false;
+            }
+            timer?.Dispose();
+        });
+
+        return (guardRef, debounceRef, isExecuting, setIsExecuting, isDebouncing, setIsDebouncing);
+    }
+
+    /// <summary>
+    /// Shared dispatch core for both <see cref="UseCommand(Command)"/> overloads. Applies the
+    /// re-entrance guard (async only, checked BEFORE arming the window so a fire blocked because
+    /// the async action is still running doesn't arm the window for nothing) and the leading-edge
+    /// debounce, then runs the action. Returns true if the fire was accepted.
+    /// </summary>
+    private bool DispatchCommand(
+        Func<Task>? asyncAction,
+        Action? syncAction,
+        int debounceMs,
+        Ref<bool> guardRef,
+        Ref<DebounceSlot?> debounceRef,
+        Action<bool> setIsExecuting,
+        Action<bool> setIsDebouncing)
+    {
+        if (asyncAction is not null)
+        {
+            // Re-entrance guard using ref for live value (not stale closure capture).
+            if (guardRef.Current) return false;
+            if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return false;
+            guardRef.Current = true;
+            setIsExecuting(true);
+            // try/finally — NOT try/catch. The user's command throw becomes a faulted Task; the
+            // framework's reentry-guard and IsExecuting state still get restored. We deliberately
+            // let the exception surface via Task.UnobservedTaskException rather than swallowing,
+            // so a buggy command is visible to the developer (matches the dispose / lifecycle
+            // policy elsewhere — don't hide user bugs).
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await asyncAction();
+                }
+                finally
+                {
+                    guardRef.Current = false;
+                    setIsExecuting(false);
+                }
+            });
+            return true;
+        }
+
+        // Sync command + debounce: dispatch stays synchronous (no Task.Run hop), so the action
+        // keeps running on the UI thread.
+        if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return false;
+        syncAction?.Invoke();
+        return true;
+    }
+
+    /// <summary>
+    /// Per-command leading-edge debounce state: the in-window flag, an epoch token, and the
+    /// one-shot re-enable timer. Lives in a <see cref="UseRef{T}"/> slot so it persists across
+    /// renders (the <see cref="Command"/> record itself is reconstructed every render).
     /// </summary>
     private sealed class DebounceSlot
     {
         public readonly object Gate = new();
         public bool InWindow;
+        /// <summary>Incremented for every accepted fire. The re-enable timer captures the epoch
+        /// it was created for and only clears the window if it still owns the current epoch — so a
+        /// stale timer (a newer accepted fire already re-armed the window) is a no-op.</summary>
+        public long Epoch;
         public global::System.Threading.ITimer? Timer;
     }
 
@@ -1087,25 +1120,48 @@ public sealed class RenderContext
 
         var slot = slotRef.Current ??= new DebounceSlot();
         global::System.Threading.ITimer? prior;
+        long epoch;
         lock (slot.Gate)
         {
             if (slot.InWindow) return false;
             slot.InWindow = true;
+            epoch = ++slot.Epoch;
             prior = slot.Timer;
+            slot.Timer = null;
+            // setIsDebouncing(true) is called under the gate so it is atomic with arming the
+            // window: a stale timer's setIsDebouncing(false) (below) can never interleave between
+            // here and the InWindow check, so the control can't be left wrongly enabled.
+            setIsDebouncing(true);
         }
-        // setState is threadSafe:true → safe to call from the timer callback thread too.
-        setIsDebouncing(true);
+        // Dispose the previous (already-fired, inert) timer outside the lock.
+        prior?.Dispose();
+
         var timer = TimeProvider.CreateTimer(
             _ =>
             {
-                lock (slot.Gate) { slot.InWindow = false; }
-                setIsDebouncing(false);
+                lock (slot.Gate)
+                {
+                    // Only the timer that still owns the current epoch may clear the window.
+                    // A stale timer whose window was superseded by a newer accepted fire is a
+                    // no-op. setIsDebouncing(false) runs under the gate so it is atomic with the
+                    // clear and cannot race a concurrent accepted fire's setIsDebouncing(true).
+                    if (slot.Epoch != epoch || !slot.InWindow) return;
+                    slot.InWindow = false;
+                    setIsDebouncing(false);
+                }
             },
             null,
             TimeSpan.FromMilliseconds(debounceMs),
             global::System.Threading.Timeout.InfiniteTimeSpan);
-        lock (slot.Gate) { slot.Timer = timer; }
-        prior?.Dispose();
+
+        lock (slot.Gate)
+        {
+            // Install only if we still own the window; otherwise this timer is already stale.
+            if (slot.Epoch == epoch)
+                slot.Timer = timer;
+            else
+                timer.Dispose();
+        }
         return true;
     }
 

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -1011,13 +1011,13 @@ public sealed class RenderContext
     /// <c>setIsDebouncing</c> / request a re-render against a torn-down context. These hooks are
     /// allocated unconditionally so the hook order is identical regardless of the command's shape.
     /// </summary>
-    private (Ref<bool> GuardRef, Ref<DebounceSlot?> DebounceRef,
+    private (Ref<AsyncReentryGuard?> GuardRef, Ref<DebounceSlot?> DebounceRef,
              bool IsExecuting, Action<bool> SetIsExecuting,
              bool IsDebouncing, Action<bool> SetIsDebouncing) UseCommandState()
     {
         var (isExecuting, setIsExecuting) = UseState(false, threadSafe: true);
         var (isDebouncing, setIsDebouncing) = UseState(false, threadSafe: true);
-        var guardRef = UseRef(false);
+        var guardRef = UseRef<AsyncReentryGuard?>(null);
         var debounceRef = UseRef<DebounceSlot?>(null);
 
         // Mount-once effect: on unmount, dispose the live re-enable timer (if any) so a pending
@@ -1049,17 +1049,26 @@ public sealed class RenderContext
         Func<Task>? asyncAction,
         Action? syncAction,
         int debounceMs,
-        Ref<bool> guardRef,
+        Ref<AsyncReentryGuard?> guardRef,
         Ref<DebounceSlot?> debounceRef,
         Action<bool> setIsExecuting,
         Action<bool> setIsDebouncing)
     {
         if (asyncAction is not null)
         {
-            // Re-entrance guard using ref for live value (not stale closure capture).
-            if (guardRef.Current) return false;
-            if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing)) return false;
-            guardRef.Current = true;
+            var guard = guardRef.Current ??= new AsyncReentryGuard();
+            // Atomic test-and-set re-entrance guard, checked BEFORE arming the window so a fire
+            // blocked because the async action is still running doesn't arm the window for nothing.
+            // The guard is acquired here (the dispatcher/UI thread) and released in the Task.Run
+            // finally (a threadpool thread); Interlocked.CompareExchange + Volatile.Write give the
+            // cross-thread release proper visibility, so the next invoke always observes a completed
+            // action's release (a plain field could in principle read a stale "busy").
+            if (global::System.Threading.Interlocked.CompareExchange(ref guard.Busy, 1, 0) != 0) return false;
+            if (!TryEnterDebounceWindow(debounceMs, debounceRef, setIsDebouncing))
+            {
+                global::System.Threading.Volatile.Write(ref guard.Busy, 0);
+                return false;
+            }
             setIsExecuting(true);
             // try/finally — NOT try/catch. The user's command throw becomes a faulted Task; the
             // framework's reentry-guard and IsExecuting state still get restored. We deliberately
@@ -1074,7 +1083,7 @@ public sealed class RenderContext
                 }
                 finally
                 {
-                    guardRef.Current = false;
+                    global::System.Threading.Volatile.Write(ref guard.Busy, 0);
                     setIsExecuting(false);
                 }
             });
@@ -1089,14 +1098,20 @@ public sealed class RenderContext
     }
 
     /// <summary>
-    /// Per-command leading-edge debounce state: the in-window flag, an epoch token, and the
-    /// one-shot re-enable timer. Lives in a <see cref="UseRef{T}"/> slot so it persists across
-    /// renders (the <see cref="Command"/> record itself is reconstructed every render).
+    /// Per-command leading-edge debounce state: the in-window flag, the absolute window deadline,
+    /// an epoch token, and the one-shot re-enable timer. Lives in a <see cref="UseRef{T}"/> slot so
+    /// it persists across renders (the <see cref="Command"/> record itself is reconstructed every
+    /// render).
     /// </summary>
     private sealed class DebounceSlot
     {
         public readonly object Gate = new();
         public bool InWindow;
+        /// <summary>Absolute time (per the context's <see cref="TimeProvider"/>) at which the
+        /// current window expires. Acceptance is decided against this deadline rather than purely on
+        /// <see cref="InWindow"/>, so a delayed re-enable timer callback can never drop a fire that
+        /// is genuinely past <c>DebounceMs</c>.</summary>
+        public DateTimeOffset WindowEndsAt;
         /// <summary>Incremented for every accepted fire. The re-enable timer captures the epoch
         /// it was created for and only clears the window if it still owns the current epoch — so a
         /// stale timer (a newer accepted fire already re-armed the window) is a no-op.</summary>
@@ -1104,27 +1119,47 @@ public sealed class RenderContext
         public global::System.Threading.ITimer? Timer;
     }
 
+    /// <summary>Atomic re-entrance guard for an async command's in-flight window. Stored in a
+    /// <see cref="UseRef{T}"/> slot; <see cref="Busy"/> is mutated via <c>Interlocked</c>/
+    /// <c>Volatile</c> because it is acquired on the dispatcher thread and released on the Task.Run
+    /// worker thread.</summary>
+    private sealed class AsyncReentryGuard
+    {
+        public int Busy;
+    }
+
     /// <summary>Stable non-null stand-in for a null delegate in a <see cref="UseMemo{T}"/>
     /// dependency array (keeps the comparison meaningful without tripping nullable warnings).</summary>
     private static readonly object NullDep = new();
 
     /// <summary>
-    /// Leading-edge gate. Returns true if this fire is accepted (window was open); arms the
-    /// window for <paramref name="debounceMs"/> and schedules a re-enable that clears
+    /// Leading-edge gate. Returns true if this fire is accepted; arms the window for
+    /// <paramref name="debounceMs"/> and schedules a re-enable that clears
     /// <see cref="DebounceSlot.InWindow"/> and re-renders so the control comes back. Returns
-    /// false if a prior accepted fire is still inside its window (drop this fire).
+    /// false only while a prior accepted fire is genuinely still inside its window.
+    /// <para>Acceptance is <b>time-based</b>: it is decided against the absolute
+    /// <see cref="DebounceSlot.WindowEndsAt"/> deadline (via the injected <see cref="TimeProvider"/>),
+    /// not purely on the <see cref="DebounceSlot.InWindow"/> flag. The one-shot timer only exists to
+    /// trigger the re-render/re-enable; if it is delayed (threadpool starvation/suspension) a fire
+    /// arriving after the deadline is still accepted and re-arms, honoring the fixed-duration
+    /// semantics rather than dropping until the callback eventually runs.</para>
     /// </summary>
     private bool TryEnterDebounceWindow(int debounceMs, Ref<DebounceSlot?> slotRef, Action<bool> setIsDebouncing)
     {
         if (debounceMs <= 0) return true;
 
         var slot = slotRef.Current ??= new DebounceSlot();
+        var now = TimeProvider.GetUtcNow();
         global::System.Threading.ITimer? prior;
         long epoch;
         lock (slot.Gate)
         {
-            if (slot.InWindow) return false;
+            // Drop only while we are genuinely still inside the window. If the re-enable timer
+            // callback is delayed past the deadline, InWindow may still be set — but the window has
+            // logically expired, so fall through and accept + re-arm rather than wrongly drop.
+            if (slot.InWindow && now < slot.WindowEndsAt) return false;
             slot.InWindow = true;
+            slot.WindowEndsAt = now + TimeSpan.FromMilliseconds(debounceMs);
             epoch = ++slot.Epoch;
             prior = slot.Timer;
             slot.Timer = null;
@@ -1133,9 +1168,8 @@ public sealed class RenderContext
             // here and the InWindow check, so the control can't be left wrongly enabled.
             setIsDebouncing(true);
         }
-        // Defensive: the re-enable callback now disposes its own timer when it clears the window,
-        // so by the time we re-arm (InWindow was false) slot.Timer is normally already null. Keep
-        // this as belt-and-suspenders in case a prior timer was left installed (e.g. epoch races).
+        // Dispose the superseded timer (the re-enable callback normally disposes its own when it
+        // clears the window, so on a clean re-arm this is already null; covers the expiry/race path).
         prior?.Dispose();
 
         var timer = TimeProvider.CreateTimer(

--- a/tests/Reactor.Tests/CommandDebounceTests.cs
+++ b/tests/Reactor.Tests/CommandDebounceTests.cs
@@ -96,7 +96,7 @@ public class CommandDebounceTests
     public async Task Async_Command_DebounceMs_Extends_Window_Past_Lambda_Return()
     {
         var time = new FakeTimeProvider();
-        var stateChanged = new SemaphoreSlim(0);
+        using var stateChanged = new SemaphoreSlim(0);
         var ctx = new RenderContext { TimeProvider = time };
         ctx.BeginRender(() => stateChanged.Release());
 
@@ -205,7 +205,7 @@ public class CommandDebounceTests
     public async Task Parameterized_Async_Command_Debounces_And_Forwards_Arg()
     {
         var time = new FakeTimeProvider();
-        var stateChanged = new SemaphoreSlim(0);
+        using var stateChanged = new SemaphoreSlim(0);
         var ctx = new RenderContext { TimeProvider = time };
         ctx.BeginRender(() => stateChanged.Release());
 
@@ -254,7 +254,7 @@ public class CommandDebounceTests
         ctx.BeginRender(() => { });
 
         int runs = 0;
-        var started = new SemaphoreSlim(0);
+        using var started = new SemaphoreSlim(0);
         var release = new TaskCompletionSource();
         var cmd = new Command
         {
@@ -355,11 +355,12 @@ public class CommandDebounceTests
 
         for (int i = 0; i < 5; i++)
         {
-            result.Execute!();                              // arm window i (prior fired timer disposed)
-            Assert.Equal(1, time.ActiveTimerCount);
-            time.Advance(TimeSpan.FromMilliseconds(100));   // window elapses
+            result.Execute!();                              // arm window i
+            Assert.Equal(1, time.ActiveTimerCount);         // exactly one live timer
+            time.Advance(TimeSpan.FromMilliseconds(100));   // window elapses → timer fires
+            Assert.Equal(0, time.ActiveTimerCount);         // fired timer disposes itself, not retained
         }
-        Assert.Equal(1, time.ActiveTimerCount);             // never accumulates
+        Assert.Equal(0, time.ActiveTimerCount);             // never accumulates
 
         ctx.RunCleanups();
         Assert.Equal(0, time.ActiveTimerCount);

--- a/tests/Reactor.Tests/CommandDebounceTests.cs
+++ b/tests/Reactor.Tests/CommandDebounceTests.cs
@@ -196,4 +196,172 @@ public class CommandDebounceTests
         result.Execute!("c");            // accepted
         Assert.Equal(new[] { "a", "c" }, args);
     }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Parameterized async + debounce (L3)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Parameterized_Async_Command_Debounces_And_Forwards_Arg()
+    {
+        var time = new FakeTimeProvider();
+        var stateChanged = new SemaphoreSlim(0);
+        var ctx = new RenderContext { TimeProvider = time };
+        ctx.BeginRender(() => stateChanged.Release());
+
+        var seen = new List<string>();
+        var cmd = new Command<string>
+        {
+            Label = "Delete",
+            ExecuteAsync = arg => { lock (seen) seen.Add(arg); return Task.CompletedTask; },
+            DebounceMs = 300,
+        };
+
+        var result = ctx.UseCommand(cmd);
+
+        result.Execute!("a");   // accepted, forwards "a"
+        // Releases: IsDebouncing=true, IsExecuting=true, then IsExecuting=false (task completes).
+        for (int i = 0; i < 3; i++)
+            await stateChanged.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        result.Execute!("b");   // within window → dropped (guard already cleared, window holds)
+        lock (seen) Assert.Equal(new[] { "a" }, seen);
+
+        ctx.BeginRender(() => stateChanged.Release());
+        var during = ctx.UseCommand(cmd);
+        Assert.True(during.IsDebouncing);
+        Assert.False(during.IsEnabled);
+
+        time.Advance(TimeSpan.FromMilliseconds(300));   // window elapses → IsDebouncing=false
+        await stateChanged.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        result.Execute!("c");   // accepted, forwards "c"
+        for (int i = 0; i < 3; i++)
+            await stateChanged.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        lock (seen) Assert.Equal(new[] { "a", "c" }, seen);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Long-running async: window elapses but the lambda is still running, so a
+    //  second fire is dropped by the re-entrance guard (M5)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task LongRunning_Async_Second_Fire_After_Window_Is_Dropped_By_Guard()
+    {
+        var time = new FakeTimeProvider();
+        var ctx = new RenderContext { TimeProvider = time };
+        ctx.BeginRender(() => { });
+
+        int runs = 0;
+        var started = new SemaphoreSlim(0);
+        var release = new TaskCompletionSource();
+        var cmd = new Command
+        {
+            Label = "x",
+            ExecuteAsync = async () => { Interlocked.Increment(ref runs); started.Release(); await release.Task; },
+            DebounceMs = 100,
+        };
+
+        var result = ctx.UseCommand(cmd);
+
+        result.Execute!();
+        await started.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.Equal(1, Volatile.Read(ref runs));
+
+        // Debounce window elapses, but the async lambda is still running → the command stays
+        // disabled via the re-entrance guard and a fresh fire is dropped, not re-armed.
+        time.Advance(TimeSpan.FromMilliseconds(100));
+        result.Execute!();
+        Assert.Equal(1, Volatile.Read(ref runs));
+
+        // Let the lambda finish; the guard clears and a subsequent fire is accepted.
+        release.SetResult();
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (Volatile.Read(ref runs) >= 2) break;
+            result.Execute!();
+            await Task.Delay(15, TestContext.Current.CancellationToken);
+        }
+        Assert.Equal(2, Volatile.Read(ref runs));
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Stable hook shape (H1): a command at one call site can flip
+    //  sync↔async and DebounceMs 0↔N across renders without reordering hooks
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseCommand_Consumes_Stable_Hook_Shape_Across_Command_Shape_Changes()
+    {
+        var time = new FakeTimeProvider();
+        var ctx = new RenderContext { TimeProvider = time };
+
+        // Render 1: pure sync, no debounce. A UseState AFTER UseCommand lands at some slot.
+        ctx.BeginRender(() => { });
+        ctx.UseCommand(new Command { Label = "x", Execute = () => { } });
+        var (v1, set1) = ctx.UseState(42);
+        Assert.Equal(42, v1);
+        set1(99);
+
+        // Render 2: async + debounce at the SAME call site. If UseCommand consumed a different
+        // number of hook slots, the trailing UseState would shift and throw or misbind.
+        ctx.BeginRender(() => { });
+        ctx.UseCommand(new Command { Label = "x", ExecuteAsync = () => Task.CompletedTask, DebounceMs = 250 });
+        var (v2, _) = ctx.UseState(42);
+        Assert.Equal(99, v2);   // state preserved → slots didn't move
+
+        // Render 3: back to pure sync, no debounce.
+        ctx.BeginRender(() => { });
+        ctx.UseCommand(new Command { Label = "x", Execute = () => { } });
+        var (v3, _) = ctx.UseState(42);
+        Assert.Equal(99, v3);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Timer lifecycle (M7 / M8): the re-enable timer is disposed on unmount
+    //  and re-arming a window never leaks timers
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Debounce_Timer_Is_Disposed_On_Unmount()
+    {
+        var time = new FakeTimeProvider();
+        var ctx = new RenderContext { TimeProvider = time };
+        ctx.BeginRender(() => { });
+        var cmd = new Command { Label = "x", Execute = () => { }, DebounceMs = 1000 };
+
+        var result = ctx.UseCommand(cmd);
+        ctx.FlushEffects();          // register the unmount cleanup effect
+
+        result.Execute!();           // arms a window → one live timer
+        Assert.Equal(1, time.ActiveTimerCount);
+
+        ctx.RunCleanups();           // unmount → cleanup disposes the live timer
+        Assert.Equal(0, time.ActiveTimerCount);
+    }
+
+    [Fact]
+    public void Reentering_Window_Does_Not_Leak_Timers()
+    {
+        var time = new FakeTimeProvider();
+        var ctx = new RenderContext { TimeProvider = time };
+        ctx.BeginRender(() => { });
+        var cmd = new Command { Label = "x", Execute = () => { }, DebounceMs = 100 };
+
+        var result = ctx.UseCommand(cmd);
+        ctx.FlushEffects();
+
+        for (int i = 0; i < 5; i++)
+        {
+            result.Execute!();                              // arm window i (prior fired timer disposed)
+            Assert.Equal(1, time.ActiveTimerCount);
+            time.Advance(TimeSpan.FromMilliseconds(100));   // window elapses
+        }
+        Assert.Equal(1, time.ActiveTimerCount);             // never accumulates
+
+        ctx.RunCleanups();
+        Assert.Equal(0, time.ActiveTimerCount);
+    }
 }

--- a/tests/Reactor.Tests/CommandDebounceTests.cs
+++ b/tests/Reactor.Tests/CommandDebounceTests.cs
@@ -365,4 +365,37 @@ public class CommandDebounceTests
         ctx.RunCleanups();
         Assert.Equal(0, time.ActiveTimerCount);
     }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Time-based acceptance: a fire after DebounceMs has elapsed is accepted
+    //  even if the re-enable timer callback is delayed (threadpool starvation),
+    //  honoring the fixed-duration semantics instead of dropping until the
+    //  callback runs.
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Fire_After_Deadline_Is_Accepted_Even_If_Timer_Callback_Is_Delayed()
+    {
+        var time = new FakeTimeProvider();
+        var ctx = CreateContext(time);
+        int fires = 0;
+        var cmd = new Command { Label = "Run", Execute = () => fires++, DebounceMs = 1000 };
+
+        var result = ctx.UseCommand(cmd);
+
+        result.Execute!();                 // accepted, window armed for 1000ms
+        Assert.Equal(1, fires);
+
+        // Advance the clock PAST the deadline but DON'T let the re-enable timer fire (simulates the
+        // callback being delayed under load). The window flag is still set, but it has logically
+        // expired — a fire now must be accepted, not dropped.
+        time.AdvanceWithoutFiring(TimeSpan.FromMilliseconds(1001));
+        result.Execute!();
+        Assert.Equal(2, fires);
+
+        // And a fire still inside the freshly re-armed window is dropped as usual.
+        time.AdvanceWithoutFiring(TimeSpan.FromMilliseconds(500));
+        result.Execute!();
+        Assert.Equal(2, fires);
+    }
 }

--- a/tests/Reactor.Tests/CommandDebounceTests.cs
+++ b/tests/Reactor.Tests/CommandDebounceTests.cs
@@ -1,0 +1,199 @@
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Tests for the leading-edge <see cref="Command.DebounceMs"/> debounce realized by
+/// <see cref="RenderContext.UseCommand(Command)"/> (issue #136). Timing is driven by an
+/// injected <see cref="FakeTimeProvider"/> so the window assertions aren't wall-clock-flaky.
+/// </summary>
+[Collection("UnobservedTaskException")]
+public class CommandDebounceTests
+{
+    private static RenderContext CreateContext(FakeTimeProvider time)
+    {
+        var ctx = new RenderContext { TimeProvider = time };
+        ctx.BeginRender(() => { });
+        return ctx;
+    }
+
+    private static void Rerender(RenderContext ctx)
+    {
+        ctx.BeginRender(() => { });
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  (a) second invoke within the window is dropped
+    //  (b) an invoke after the window elapses is accepted
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Second_Invoke_Within_Window_Is_Dropped_Then_Accepted_After()
+    {
+        var time = new FakeTimeProvider();
+        var ctx = CreateContext(time);
+        int fires = 0;
+        var cmd = new Command { Label = "Run", Execute = () => fires++, DebounceMs = 1500 };
+
+        var result = ctx.UseCommand(cmd);
+
+        result.Execute!();                 // accepted
+        Assert.Equal(1, fires);
+
+        result.Execute!();                 // within window → dropped
+        time.Advance(TimeSpan.FromMilliseconds(500));
+        result.Execute!();                 // still within window → dropped
+        Assert.Equal(1, fires);
+
+        time.Advance(TimeSpan.FromMilliseconds(1000)); // window (1500ms) elapses → timer clears it
+        result.Execute!();                 // accepted again
+        Assert.Equal(2, fires);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  (c) IsEnabled is false during the window and true after
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void IsEnabled_Is_False_During_Window_And_True_After()
+    {
+        var time = new FakeTimeProvider();
+        var ctx = CreateContext(time);
+        var cmd = new Command { Label = "Run", Execute = () => { }, DebounceMs = 1000 };
+
+        var result = ctx.UseCommand(cmd);
+        Assert.True(result.IsEnabled);
+        Assert.False(result.IsDebouncing);
+
+        result.Execute!();
+
+        // Re-render to observe the debouncing state flowing through.
+        Rerender(ctx);
+        var during = ctx.UseCommand(cmd);
+        Assert.True(during.IsDebouncing);
+        Assert.False(during.IsEnabled);
+
+        // Not yet elapsed — still disabled.
+        time.Advance(TimeSpan.FromMilliseconds(999));
+        Rerender(ctx);
+        var stillDuring = ctx.UseCommand(cmd);
+        Assert.False(stillDuring.IsEnabled);
+
+        // Window elapses → timer fires → re-enabled.
+        time.Advance(TimeSpan.FromMilliseconds(1));
+        Rerender(ctx);
+        var after = ctx.UseCommand(cmd);
+        Assert.False(after.IsDebouncing);
+        Assert.True(after.IsEnabled);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  (d) async commands keep DebounceMs extending the window past lambda return
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Async_Command_DebounceMs_Extends_Window_Past_Lambda_Return()
+    {
+        var time = new FakeTimeProvider();
+        var stateChanged = new SemaphoreSlim(0);
+        var ctx = new RenderContext { TimeProvider = time };
+        ctx.BeginRender(() => stateChanged.Release());
+
+        var cmd = new Command
+        {
+            Label = "Re-gen",
+            ExecuteAsync = () => Task.CompletedTask, // returns immediately
+            DebounceMs = 250,
+        };
+
+        var result = ctx.UseCommand(cmd);
+        result.Execute!();
+
+        // The synchronous part sets IsDebouncing=true (1st release) and IsExecuting=true (2nd),
+        // and the immediately-completing task resets IsExecuting=false (3rd release).
+        for (int i = 0; i < 3; i++)
+            await stateChanged.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // Lambda already returned (IsExecuting back to false) but the debounce window holds
+        // the command disabled.
+        ctx.BeginRender(() => stateChanged.Release());
+        var during = ctx.UseCommand(cmd);
+        Assert.False(during.IsExecuting);
+        Assert.True(during.IsDebouncing);
+        Assert.False(during.IsEnabled);
+
+        // Elapse the debounce window → re-enabled.
+        time.Advance(TimeSpan.FromMilliseconds(250));
+        await stateChanged.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Rerender(ctx);
+        var after = ctx.UseCommand(cmd);
+        Assert.False(after.IsDebouncing);
+        Assert.True(after.IsEnabled);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  (e) DebounceMs = 0 preserves today's behavior exactly
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void DebounceMs_Zero_Sync_Command_Passes_Through_Unchanged()
+    {
+        var time = new FakeTimeProvider();
+        var ctx = CreateContext(time);
+        var original = new Command { Label = "Cut", Execute = () => { } }; // DebounceMs defaults to 0
+
+        var result = ctx.UseCommand(original);
+
+        Assert.Same(original, result);
+    }
+
+    [Fact]
+    public void DebounceMs_Zero_Sync_Command_Never_Disables()
+    {
+        var time = new FakeTimeProvider();
+        var ctx = CreateContext(time);
+        int fires = 0;
+        var cmd = new Command { Label = "Cut", Execute = () => fires++, DebounceMs = 0 };
+
+        var result = ctx.UseCommand(cmd);
+
+        result.Execute!();
+        result.Execute!();
+        result.Execute!();
+        Assert.Equal(3, fires);          // no fire is dropped
+        Assert.True(result.IsEnabled);   // never disables
+    }
+
+    [Fact]
+    public void Default_DebounceMs_Is_Zero()
+    {
+        var cmd = new Command { Label = "x", Execute = () => { } };
+        Assert.Equal(0, cmd.DebounceMs);
+        Assert.False(cmd.IsDebouncing);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Parameterized command debounce
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parameterized_Sync_Command_Debounces()
+    {
+        var time = new FakeTimeProvider();
+        var ctx = CreateContext(time);
+        var args = new List<string>();
+        var cmd = new Command<string> { Label = "Delete", Execute = args.Add, DebounceMs = 500 };
+
+        var result = ctx.UseCommand(cmd);
+
+        result.Execute!("a");            // accepted
+        result.Execute!("b");            // dropped (within window)
+        Assert.Equal(new[] { "a" }, args);
+
+        time.Advance(TimeSpan.FromMilliseconds(500));
+        result.Execute!("c");            // accepted
+        Assert.Equal(new[] { "a", "c" }, args);
+    }
+}

--- a/tests/Reactor.Tests/FakeTimeProvider.cs
+++ b/tests/Reactor.Tests/FakeTimeProvider.cs
@@ -1,0 +1,104 @@
+using System.Threading;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Minimal controllable <see cref="TimeProvider"/> for tests: time only moves when
+/// <see cref="Advance"/> is called, and one-shot timers created via <see cref="CreateTimer"/>
+/// fire synchronously inside <see cref="Advance"/> once their due time is reached. Enough to
+/// drive the <see cref="Microsoft.UI.Reactor.Core.Command.DebounceMs"/> window deterministically
+/// without depending on the wall clock.
+/// </summary>
+internal sealed class FakeTimeProvider : TimeProvider
+{
+    private readonly object _gate = new();
+    private DateTimeOffset _now;
+    private readonly List<FakeTimer> _timers = new();
+
+    public FakeTimeProvider(DateTimeOffset? start = null)
+    {
+        _now = start ?? DateTimeOffset.UnixEpoch;
+    }
+
+    public override DateTimeOffset GetUtcNow()
+    {
+        lock (_gate) return _now;
+    }
+
+    /// <summary>Moves the clock forward and fires any timers that come due.</summary>
+    public void Advance(TimeSpan delta)
+    {
+        FakeTimer[] due;
+        lock (_gate)
+        {
+            _now += delta;
+            due = _timers.Where(t => t.IsDue(_now)).ToArray();
+        }
+        // Fire outside the lock — callbacks may schedule/dispose timers.
+        foreach (var t in due) t.Fire();
+    }
+
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        var timer = new FakeTimer(this, callback, state);
+        lock (_gate)
+        {
+            _timers.Add(timer);
+            timer.Schedule(_now, dueTime, period);
+        }
+        return timer;
+    }
+
+    private void Remove(FakeTimer timer)
+    {
+        lock (_gate) _timers.Remove(timer);
+    }
+
+    private sealed class FakeTimer : ITimer
+    {
+        private readonly FakeTimeProvider _owner;
+        private readonly TimerCallback _callback;
+        private readonly object? _state;
+        private DateTimeOffset? _fireAt;
+        private TimeSpan _period;
+
+        public FakeTimer(FakeTimeProvider owner, TimerCallback callback, object? state)
+        {
+            _owner = owner;
+            _callback = callback;
+            _state = state;
+        }
+
+        public void Schedule(DateTimeOffset now, TimeSpan dueTime, TimeSpan period)
+        {
+            _period = period;
+            _fireAt = dueTime == Timeout.InfiniteTimeSpan ? null : now + dueTime;
+        }
+
+        public bool IsDue(DateTimeOffset now) => _fireAt is { } at && at <= now;
+
+        public void Fire()
+        {
+            // One-shot unless a finite period was supplied (not used by the debounce path).
+            if (_period == Timeout.InfiniteTimeSpan || _period <= TimeSpan.Zero)
+                _fireAt = null;
+            else
+                _fireAt = (_fireAt ?? _owner.GetUtcNow()) + _period;
+            _callback(_state);
+        }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            Schedule(_owner.GetUtcNow(), dueTime, period);
+            return true;
+        }
+
+        public void Dispose() => _owner.Remove(this);
+
+        public ValueTask DisposeAsync()
+        {
+            _owner.Remove(this);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Reactor.Tests/FakeTimeProvider.cs
+++ b/tests/Reactor.Tests/FakeTimeProvider.cs
@@ -87,10 +87,9 @@ internal sealed class FakeTimeProvider : TimeProvider
         public void Fire()
         {
             // One-shot unless a finite period was supplied (not used by the debounce path).
-            if (_period == Timeout.InfiniteTimeSpan || _period <= TimeSpan.Zero)
-                _fireAt = null;
-            else
-                _fireAt = (_fireAt ?? _owner.GetUtcNow()) + _period;
+            _fireAt = _period == Timeout.InfiniteTimeSpan || _period <= TimeSpan.Zero
+                ? null
+                : (_fireAt ?? _owner.GetUtcNow()) + _period;
             _callback(_state);
         }
 

--- a/tests/Reactor.Tests/FakeTimeProvider.cs
+++ b/tests/Reactor.Tests/FakeTimeProvider.cs
@@ -45,6 +45,14 @@ internal sealed class FakeTimeProvider : TimeProvider
         foreach (var t in due) t.Fire();
     }
 
+    /// <summary>Moves the clock forward WITHOUT firing any due timers — simulates a re-enable
+    /// timer callback delayed past its deadline (threadpool starvation/suspension), so tests can
+    /// prove acceptance is time-based rather than purely timer-callback-driven.</summary>
+    public void AdvanceWithoutFiring(TimeSpan delta)
+    {
+        lock (_gate) _now += delta;
+    }
+
     public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
     {
         var timer = new FakeTimer(this, callback, state);

--- a/tests/Reactor.Tests/FakeTimeProvider.cs
+++ b/tests/Reactor.Tests/FakeTimeProvider.cs
@@ -25,6 +25,13 @@ internal sealed class FakeTimeProvider : TimeProvider
         lock (_gate) return _now;
     }
 
+    /// <summary>Number of timers created but not yet disposed — lets tests assert the debounce
+    /// path disposes its re-enable timers (on unmount and when re-arming a window).</summary>
+    public int ActiveTimerCount
+    {
+        get { lock (_gate) return _timers.Count; }
+    }
+
     /// <summary>Moves the clock forward and fires any timers that come due.</summary>
     public void Advance(TimeSpan delta)
     {


### PR DESCRIPTION
Closes #136.

## What

Adds a declarative leading-edge **`DebounceMs`** to `Command` / `Command<T>` so apps stop wrapping a sync action in `ExecuteAsync` purely to slip in a `Task.Delay` that absorbs double-clicks. The framework owns the click and the command, so it owns the debounce.

```csharp
// Before — fake-async + magic number:
UseCommand(new Command { Label = "Run", ExecuteAsync = async () => { OnRun(step); await Task.Delay(1500); } });

// After — declarative:
UseCommand(new Command { Label = "Run", Execute = () => OnRun(step), DebounceMs = 1500 });
```

## Semantics (leading-edge, fixed-duration)

- First fire is **accepted**; any subsequent fire within `DebounceMs` of the prior accepted fire is **dropped** (no-op).
- During the window the command reports **`IsEnabled == false`** via a new `IsDebouncing` dimension (`IsEnabled = CanExecute && !IsExecuting && !IsDebouncing`), so the bound control visibly disables and then **re-enables** when the window elapses (a timer triggers the re-render).
- **Async commands:** `IsExecuting` still tracks the lambda's lifetime; `DebounceMs` keeps the button disabled *past* the lambda's return. The effective disabled window is `max(lambda lifetime, DebounceMs)`.
- **Sync commands:** dispatch stays synchronous (no `Task.Run` hop), so the action keeps running on the UI thread.
- `DebounceMs = 0` (default) preserves today's behavior **exactly** (sync no-debounce commands still pass through `UseCommand` returning the same instance — `Assert.Same`).

Trailing-edge / search-as-you-type debounce is explicitly **out of scope** (different control, different concept).

## Where the debounce state lives

A plain `Command` record is immutable and reconstructed every render, so the last-fire window and the re-enable timer can't live on it. They live in **`UseCommand`'s hook backing store** (the same place that already holds the async re-entrance guard). Timing is driven by an **injectable `TimeProvider`** on `RenderContext` (`TimeProvider.System` by default) so unit tests are deterministic rather than wall-clock-flaky.

### Stable hook shape (review H1)

`UseCommand` now allocates the **same hooks unconditionally** every render, regardless of whether the command is sync/async or has `DebounceMs` 0 or N: a shared `UseCommandState()` helper consumes the `isExecuting`/`isDebouncing` `UseState`, the guard/debounce `UseRef`s, and an unmount-cleanup `UseEffect`. The sync/async/debounce decision (`CommandNeedsWrapping`) then branches only on those hook **values** to decide whether to return the raw command or a wrapped one — never the hook **calls**. A command that flips sync↔async or `DebounceMs` 0↔N at the same call site can no longer reorder hook slots (this also narrows the pre-existing sync↔async hook-shape hazard).

### Raw-vs-`UseCommand` contract

`DebounceMs` is realized **by `UseCommand`**. A raw `new Command { DebounceMs = … }` that is bound directly (never routed through `UseCommand`) has nowhere to persist the window and therefore **does not debounce** — it is inert. This is documented loudly on the `DebounceMs` XML doc, in `docs/guide/reference/hooks/UseCommand.md`, `docs/guide/commanding.md`, and the commanding skills. `CommandBindings.Invoke` stays a pure dispatcher. The wrapped command returned by `UseCommand` keeps its **authored** `DebounceMs` (the public property no longer lies); an internal `DebounceHandled` flag prevents a re-passed wrapped command from double-debouncing. A proper analyzer/diagnostic for the inert raw case is tracked as follow-up #636.

## Sample cleanup (demo-script-tool)

Removed the three reinvented double-click workarounds the issue cites:

- `StepCard.cs` **Run** — `Task.Delay(1500)` padding → `DebounceMs = 1500`.
- `StepCard.cs` **Re-gen** — 250 ms `IsExecuting` bridge → sync `Execute` + `DebounceMs = 250` (stays on the UI thread, avoiding the `RPC_E_WRONG_THREAD` foot-gun that previously forced a raw sync command).
- `DemoScriptShell.cs` **Generate/Re-gen** — the hand-rolled `Environment.TickCount64` + 200 ms guards → `generateCmd` gets `DebounceMs = 200` via `UseCommand`; the per-step Re-gen is covered by `StepCard`'s `DebounceMs = 250`. The intentional 200 ms Cancel-disable is documented inline (it drops the duplicate fire that would otherwise instantly cancel a just-started generation).

## Tests

`tests/Reactor.Tests/CommandDebounceTests.cs` (+ a minimal `FakeTimeProvider`) prove:

- (a) a second invoke within `DebounceMs` is dropped;
- (b) an invoke after the window elapses is accepted;
- (c) `IsEnabled` is false during the window and true after;
- (d) async commands keep `DebounceMs` extending the disabled window past lambda return;
- (e) `DebounceMs = 0` preserves prior behavior (sync passthrough `Assert.Same`, no drops, never disables);
- default-is-zero and parameterized `Command<T>` debounce;
- **stable hook shape** across sync↔async / DebounceMs 0↔N at one call site (review H1);
- the re-enable timer is **disposed on unmount** (review M7);
- re-entering the window does not **leak timers** / a stale timer can't re-enable a fresh window (review M8);
- a long-running async command's second fire after the window is still dropped by the in-flight guard (review M5);
- `Command<T>` async + `DebounceMs` forwards its argument (review L3).

`dotnet test tests/Reactor.Tests` → **9486 passed, 0 failed, 64 skipped**. The `demo-script-tool` sample and `src/Reactor` build clean (ARM64). No selftest added: the `FakeTimeProvider` unit tests already assert the `IsEnabled` disable/re-enable flow deterministically, whereas a live-control selftest would depend on wall-clock timing.

## Review triage applied

This PR incorporates the multi-dimensional `pr-review` triage:

- **H1** — `UseCommand` consumes a stable hook shape (above).
- **M6** — wrapped command keeps authored `DebounceMs`; double-debounce guarded by internal `DebounceHandled` flag.
- **M7** — re-enable `ITimer` disposed on unmount via `UseEffect` cleanup.
- **M8** — generation/epoch token (checked under the gate lock) blocks stale-timer re-enable.
- **L1** — `IsDebouncing` is internal-init (framework-managed).
- **L2** — generic/non-generic `UseCommand` overloads share `DispatchCommand()` / `UseCommandState()`.
- **M1/M2/M4** — CHANGELOG entry, `UseCommand.md` reference, loud `DebounceMs` XML docs; analyzer follow-up #636.
- **M3/M5/L3** — sample 200 ms behavior pinned + the coverage tests above.

## Overlap note

#153 (lifting `Command` to a typed property on button elements) and PR #625 / #133 (`.Command()` modifier) also touch the `Command` type and `CommandBindings`. This change is deliberately localized to the `Command` record + the `UseCommand` invoke path and should merge cleanly alongside them.