### PR TITLE
perf(dsl): lift Command to a typed property on Button and friends, drop per-render Setters alloc (#153)

### DIFF
--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1435,6 +1435,7 @@ ToString() → string
 ### record ButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
+Command Command { get; init; }
 Element ContentElement { get; init; }
 bool IsDisabledFocusable { get; init; }
 bool IsEnabled { get; init; }
@@ -3562,6 +3563,7 @@ new(string message)
 ### record HyperlinkButtonElement
 new(string Content, Uri NavigateUri = null, Action OnClick = null)
 Action OnClick { get; init; }
+Command Command { get; init; }
 Uri NavigateUri { get; init; }
 string Content { get; init; }
 Deconstruct(ref string Content, ref Uri NavigateUri, ref Action OnClick) → void
@@ -5736,6 +5738,7 @@ long TotalRenders { get; init; }
 ### record RepeatButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
+Command Command { get; init; }
 int Delay { get; init; }
 int Interval { get; init; }
 string Label { get; init; }
@@ -6255,6 +6258,7 @@ ToString() → string
 ### record SplitButtonElement
 new(string Label, Action OnClick = null, Element Flyout = null)
 Action OnClick { get; init; }
+Command Command { get; init; }
 Element Flyout { get; init; }
 string Label { get; init; }
 Deconstruct(ref string Label, ref Action OnClick, ref Element Flyout) → void
@@ -6823,6 +6827,7 @@ ToString() → string
 new(string Label, bool IsChecked = false, Action<bool> OnIsCheckedChanged = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Action<bool?> OnCheckedStateChanged { get; init; }
+Command Command { get; init; }
 bool IsChecked { get; init; }
 bool IsThreeState { get; init; }
 bool? CheckedState { get; init; }
@@ -6851,6 +6856,7 @@ ToString() → string
 ### record ToggleSplitButtonElement
 new(string Label, Optional<bool> IsChecked = null, Action<bool> OnIsCheckedChanged = null, Element Flyout = null)
 Action<bool> OnIsCheckedChanged { get; init; }
+Command Command { get; init; }
 Element Flyout { get; init; }
 Optional<bool> IsChecked { get; init; }
 string Label { get; init; }

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1435,7 +1435,7 @@ ToString() → string
 ### record ButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 Element ContentElement { get; init; }
 bool IsDisabledFocusable { get; init; }
 bool IsEnabled { get; init; }
@@ -3563,7 +3563,7 @@ new(string message)
 ### record HyperlinkButtonElement
 new(string Content, Uri NavigateUri = null, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 Uri NavigateUri { get; init; }
 string Content { get; init; }
 Deconstruct(ref string Content, ref Uri NavigateUri, ref Action OnClick) → void
@@ -5738,7 +5738,7 @@ long TotalRenders { get; init; }
 ### record RepeatButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 int Delay { get; init; }
 int Interval { get; init; }
 string Label { get; init; }
@@ -6258,7 +6258,7 @@ ToString() → string
 ### record SplitButtonElement
 new(string Label, Action OnClick = null, Element Flyout = null)
 Action OnClick { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 Element Flyout { get; init; }
 string Label { get; init; }
 Deconstruct(ref string Label, ref Action OnClick, ref Element Flyout) → void
@@ -6827,7 +6827,7 @@ ToString() → string
 new(string Label, bool IsChecked = false, Action<bool> OnIsCheckedChanged = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Action<bool?> OnCheckedStateChanged { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 bool IsChecked { get; init; }
 bool IsThreeState { get; init; }
 bool? CheckedState { get; init; }
@@ -6856,7 +6856,7 @@ ToString() → string
 ### record ToggleSplitButtonElement
 new(string Label, Optional<bool> IsChecked = null, Action<bool> OnIsCheckedChanged = null, Element Flyout = null)
 Action<bool> OnIsCheckedChanged { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 Element Flyout { get; init; }
 Optional<bool> IsChecked { get; init; }
 string Label { get; init; }

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1435,6 +1435,7 @@ ToString() → string
 ### record ButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
+Command Command { get; init; }
 Element ContentElement { get; init; }
 bool IsDisabledFocusable { get; init; }
 bool IsEnabled { get; init; }
@@ -3562,6 +3563,7 @@ new(string message)
 ### record HyperlinkButtonElement
 new(string Content, Uri NavigateUri = null, Action OnClick = null)
 Action OnClick { get; init; }
+Command Command { get; init; }
 Uri NavigateUri { get; init; }
 string Content { get; init; }
 Deconstruct(ref string Content, ref Uri NavigateUri, ref Action OnClick) → void
@@ -5736,6 +5738,7 @@ long TotalRenders { get; init; }
 ### record RepeatButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
+Command Command { get; init; }
 int Delay { get; init; }
 int Interval { get; init; }
 string Label { get; init; }
@@ -6255,6 +6258,7 @@ ToString() → string
 ### record SplitButtonElement
 new(string Label, Action OnClick = null, Element Flyout = null)
 Action OnClick { get; init; }
+Command Command { get; init; }
 Element Flyout { get; init; }
 string Label { get; init; }
 Deconstruct(ref string Label, ref Action OnClick, ref Element Flyout) → void
@@ -6823,6 +6827,7 @@ ToString() → string
 new(string Label, bool IsChecked = false, Action<bool> OnIsCheckedChanged = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Action<bool?> OnCheckedStateChanged { get; init; }
+Command Command { get; init; }
 bool IsChecked { get; init; }
 bool IsThreeState { get; init; }
 bool? CheckedState { get; init; }
@@ -6851,6 +6856,7 @@ ToString() → string
 ### record ToggleSplitButtonElement
 new(string Label, Optional<bool> IsChecked = null, Action<bool> OnIsCheckedChanged = null, Element Flyout = null)
 Action<bool> OnIsCheckedChanged { get; init; }
+Command Command { get; init; }
 Element Flyout { get; init; }
 Optional<bool> IsChecked { get; init; }
 string Label { get; init; }

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1435,7 +1435,7 @@ ToString() → string
 ### record ButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 Element ContentElement { get; init; }
 bool IsDisabledFocusable { get; init; }
 bool IsEnabled { get; init; }
@@ -3563,7 +3563,7 @@ new(string message)
 ### record HyperlinkButtonElement
 new(string Content, Uri NavigateUri = null, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 Uri NavigateUri { get; init; }
 string Content { get; init; }
 Deconstruct(ref string Content, ref Uri NavigateUri, ref Action OnClick) → void
@@ -5738,7 +5738,7 @@ long TotalRenders { get; init; }
 ### record RepeatButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 int Delay { get; init; }
 int Interval { get; init; }
 string Label { get; init; }
@@ -6258,7 +6258,7 @@ ToString() → string
 ### record SplitButtonElement
 new(string Label, Action OnClick = null, Element Flyout = null)
 Action OnClick { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 Element Flyout { get; init; }
 string Label { get; init; }
 Deconstruct(ref string Label, ref Action OnClick, ref Element Flyout) → void
@@ -6827,7 +6827,7 @@ ToString() → string
 new(string Label, bool IsChecked = false, Action<bool> OnIsCheckedChanged = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Action<bool?> OnCheckedStateChanged { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 bool IsChecked { get; init; }
 bool IsThreeState { get; init; }
 bool? CheckedState { get; init; }
@@ -6856,7 +6856,7 @@ ToString() → string
 ### record ToggleSplitButtonElement
 new(string Label, Optional<bool> IsChecked = null, Action<bool> OnIsCheckedChanged = null, Element Flyout = null)
 Action<bool> OnIsCheckedChanged { get; init; }
-Command Command { get; init; }
+Command Command { get; }
 Element Flyout { get; init; }
 Optional<bool> IsChecked { get; init; }
 string Label { get; init; }

--- a/src/Reactor/Core/CommandBindings.cs
+++ b/src/Reactor/Core/CommandBindings.cs
@@ -8,11 +8,14 @@ namespace Microsoft.UI.Reactor.Core;
 
 /// <summary>
 /// Shared binding helpers for wiring a <see cref="Command"/> into command-capable
-/// WinUI controls (<see cref="ButtonBase"/> derivatives, <see cref="SwipeItem"/>, …).
-/// Keeps the per-control factory overloads thin: apply label/onClick at construction
-/// time and defer Description / Icon / Accelerator / AccessKey to a mount-time setter
-/// so per-site overrides (e.g. <c>.AccessKey("X")</c> after <c>.Command(cmd)</c>) win
-/// via the normal modifier-after-command ordering.
+/// WinUI controls (<see cref="ButtonBase"/> derivatives, <see cref="SplitButton"/>, …).
+/// Keeps the per-control factory overloads thin: the factory/modifier wires label +
+/// click and stores the command on the element's typed <c>Command</c> property; the
+/// reconciler applies its Description / Icon / Accelerator / AccessKey / enabled metadata
+/// field-aware through the <see cref="OneWayCommand{TElement,TControl}"/> descriptor entry
+/// (issue #153). Raw <c>.Set(...)</c> setters run after every descriptor prop, so an explicit
+/// <c>.Set(b =&gt; b.AccessKey = "X")</c> overrides command-derived metadata regardless of where
+/// it appears in the fluent chain — the documented "<c>.Set</c> wins / applied last" rule.
 /// </summary>
 internal static class CommandBindings
 {
@@ -117,6 +120,32 @@ internal static class CommandBindings
         if (cmd.Execute is not null) cmd.Execute();
         else if (cmd.ExecuteAsync is not null) _ = cmd.ExecuteAsync();
     }
+
+    /// <summary>
+    /// Registers the typed <see cref="Command"/> descriptor entry shared by every
+    /// command-capable button element (issue #153). On mount it applies
+    /// <see cref="ApplyButtonBaseCommon"/>; on update it re-applies only when a rendered
+    /// command field changed (delegate fields ignored via
+    /// <see cref="CommandModuloDelegatesComparer"/>). Pass <paramref name="applyIsEnabled"/>=false
+    /// when the element already drives <see cref="Control.IsEnabled"/> through its own descriptor
+    /// prop (e.g. <see cref="ButtonElement"/>'s <c>IsDisabledFocusable</c>-coerced entry), so the
+    /// command apply does not clobber that coercion.
+    /// </summary>
+    internal static global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<TElement, TControl> OneWayCommand<TElement, TControl>(
+        this global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<TElement, TControl> d,
+        Func<TElement, Command?> getCommand,
+        bool applyIsEnabled = true)
+        where TElement : Element
+        where TControl : Control, new()
+        => applyIsEnabled
+            ? d.OneWay<Command?>(
+                getCommand,
+                static (c, cmd) => { if (cmd is not null) ApplyButtonBaseCommon(c, cmd, applyIsEnabled: true); },
+                CommandModuloDelegatesComparer.Instance)
+            : d.OneWay<Command?>(
+                getCommand,
+                static (c, cmd) => { if (cmd is not null) ApplyButtonBaseCommon(c, cmd, applyIsEnabled: false); },
+                CommandModuloDelegatesComparer.Instance);
 
     /// <summary>
     /// Structural equality for two <see cref="Command"/> values that <b>ignores</b> the

--- a/src/Reactor/Core/CommandBindings.cs
+++ b/src/Reactor/Core/CommandBindings.cs
@@ -117,4 +117,41 @@ internal static class CommandBindings
         if (cmd.Execute is not null) cmd.Execute();
         else if (cmd.ExecuteAsync is not null) _ = cmd.ExecuteAsync();
     }
+
+    /// <summary>
+    /// Structural equality for two <see cref="Command"/> values that <b>ignores</b> the
+    /// <see cref="Command.Execute"/> / <see cref="Command.ExecuteAsync"/> delegate fields
+    /// (issue #153, same rationale as #151). Dispatch goes through the click trampoline,
+    /// which reads the latest <see cref="Command"/> off the element Tag at invoke time, so
+    /// delegate identity is irrelevant to dispatch correctness — only the rendered metadata
+    /// (label, enabled state, tooltip, accelerator, access key) determines whether the
+    /// command-applied control state must be re-written. Two commands that differ only in
+    /// their delegates therefore produce identical visuals and can skip reconcile entirely.
+    /// </summary>
+    internal static bool CommandsEqual(Command? a, Command? b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+        return a.Label == b.Label
+            && a.CanExecute == b.CanExecute
+            && a.IsExecuting == b.IsExecuting
+            && a.Description == b.Description
+            && a.AccessKey == b.AccessKey
+            && Equals(a.Icon, b.Icon)
+            && Equals(a.Accelerator, b.Accelerator);
+    }
+
+    /// <summary>
+    /// <see cref="IEqualityComparer{T}"/> wrapper over <see cref="CommandsEqual"/> for the
+    /// descriptor's <c>OneWay&lt;Command?&gt;</c> diff: the command-apply entry only re-runs
+    /// <see cref="ApplyButtonBaseCommon"/> when the command changed in a rendered field, never
+    /// when only its delegates changed across renders.
+    /// </summary>
+    internal sealed class CommandModuloDelegatesComparer : IEqualityComparer<Command?>
+    {
+        internal static readonly CommandModuloDelegatesComparer Instance = new();
+        public bool Equals(Command? a, Command? b) => CommandsEqual(a, b);
+        public int GetHashCode(Command? c) =>
+            c is null ? 0 : global::System.HashCode.Combine(c.Label, c.CanExecute, c.IsExecuting, c.Description, c.AccessKey);
+    }
 }

--- a/src/Reactor/Core/CommandBindings.cs
+++ b/src/Reactor/Core/CommandBindings.cs
@@ -111,6 +111,28 @@ internal static class CommandBindings
     private static readonly ConditionalWeakTable<Control, KeyboardAccelerator> _commandAccelerators = new();
 
     /// <summary>
+    /// Clears the metadata a prior <see cref="Command"/> applied to <paramref name="btn"/> when the
+    /// element's command transitions to <c>null</c> — either an in-place re-render (e.g.
+    /// <c>Button(cmd)</c> → <c>Button("x")</c>) or a pooled control rented for a command-less button.
+    /// Without this, the previously-set tooltip / UIA HelpText, AccessKey, command-added
+    /// <see cref="KeyboardAccelerator"/>, and placement mode would stick on the live control (issue
+    /// #153, PR review). <see cref="Control.IsEnabled"/> is intentionally NOT reset: the element's
+    /// own IsEnabled descriptor prop drives it.
+    /// </summary>
+    internal static void ClearButtonCommandMetadata(Control btn)
+    {
+        ToolTipService.SetToolTip(btn, null);
+        btn.ClearValue(Microsoft.UI.Xaml.Automation.AutomationProperties.HelpTextProperty);
+        btn.AccessKey = "";
+        if (_commandAccelerators.TryGetValue(btn, out var prior))
+        {
+            btn.KeyboardAccelerators.Remove(prior);
+            _commandAccelerators.Remove(btn);
+        }
+        btn.ClearValue(UIElement.KeyboardAcceleratorPlacementModeProperty);
+    }
+
+    /// <summary>
     /// Invokes <see cref="Command.Execute"/> or fires-and-forgets
     /// <see cref="Command.ExecuteAsync"/>. Used by factory overloads that need to
     /// wire a click handler from a bare <see cref="Command"/>.
@@ -126,10 +148,13 @@ internal static class CommandBindings
     /// command-capable button element (issue #153). On mount it applies
     /// <see cref="ApplyButtonBaseCommon"/>; on update it re-applies only when a rendered
     /// command field changed (delegate fields ignored via
-    /// <see cref="CommandModuloDelegatesComparer"/>). Pass <paramref name="applyIsEnabled"/>=false
-    /// when the element already drives <see cref="Control.IsEnabled"/> through its own descriptor
-    /// prop (e.g. <see cref="ButtonElement"/>'s <c>IsDisabledFocusable</c>-coerced entry), so the
-    /// command apply does not clobber that coercion.
+    /// <see cref="CommandModuloDelegatesComparer"/>). When the command transitions to <c>null</c>
+    /// (in-place re-render or a pooled control reused without a command) the setter clears the
+    /// stale command metadata via <see cref="ClearButtonCommandMetadata"/>. Pass
+    /// <paramref name="applyIsEnabled"/>=false when the element already drives
+    /// <see cref="Control.IsEnabled"/> through its own descriptor prop (e.g.
+    /// <see cref="ButtonElement"/>'s <c>IsDisabledFocusable</c>-coerced entry), so the command apply
+    /// does not clobber that coercion.
     /// </summary>
     internal static global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<TElement, TControl> OneWayCommand<TElement, TControl>(
         this global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<TElement, TControl> d,
@@ -140,11 +165,11 @@ internal static class CommandBindings
         => applyIsEnabled
             ? d.OneWay<Command?>(
                 getCommand,
-                static (c, cmd) => { if (cmd is not null) ApplyButtonBaseCommon(c, cmd, applyIsEnabled: true); },
+                static (c, cmd) => { if (cmd is not null) ApplyButtonBaseCommon(c, cmd, applyIsEnabled: true); else ClearButtonCommandMetadata(c); },
                 CommandModuloDelegatesComparer.Instance)
             : d.OneWay<Command?>(
                 getCommand,
-                static (c, cmd) => { if (cmd is not null) ApplyButtonBaseCommon(c, cmd, applyIsEnabled: false); },
+                static (c, cmd) => { if (cmd is not null) ApplyButtonBaseCommon(c, cmd, applyIsEnabled: false); else ClearButtonCommandMetadata(c); },
                 CommandModuloDelegatesComparer.Instance);
 
     /// <summary>

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -407,6 +407,23 @@ public abstract record Element
                 && CommandBindings.CommandsEqual(ta.Command, tb.Command)
                 && ReferenceEquals(ta.Setters, tb.Setters),
 
+            // issue #153 (L1) — extend the command fast-path arm to Split / ToggleSplit so all six
+            // command-capable buttons memoize consistently. Flyout uses reference-equality (matches
+            // the descriptor's ElementReferenceComparer); null == null lets flyout-less command split
+            // buttons fast-path too.
+            (SplitButtonElement sa, SplitButtonElement sb) =>
+                sa.Label == sb.Label
+                && ReferenceEquals(sa.Flyout, sb.Flyout)
+                && CommandBindings.CommandsEqual(sa.Command, sb.Command)
+                && ReferenceEquals(sa.Setters, sb.Setters),
+
+            (ToggleSplitButtonElement tsa, ToggleSplitButtonElement tsb) =>
+                tsa.Label == tsb.Label
+                && tsa.IsChecked == tsb.IsChecked
+                && ReferenceEquals(tsa.Flyout, tsb.Flyout)
+                && CommandBindings.CommandsEqual(tsa.Command, tsb.Command)
+                && ReferenceEquals(tsa.Setters, tsb.Setters),
+
             (SliderElement sa, SliderElement sb) =>
                 sa.Value == sb.Value
                 && sa.Min == sb.Min
@@ -2524,11 +2541,15 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
     public Element? ContentElement { get; init; }
     /// <summary>
     /// The <see cref="Command"/> bound to this button via the <c>Button(Command)</c> factory
-    /// or the <c>.Command()</c> modifier. Lifted to a typed property (issue #153) so the
-    /// reconciler compares it field-aware in <see cref="Element.ShallowEquals"/> and applies
-    /// its metadata through a descriptor entry — no per-render <see cref="Setters"/> lambda.
+    /// or the <c>.Command()</c> modifier (issue #153). Carries the command so the reconciler can
+    /// compare it field-aware in <see cref="Element.ShallowEquals"/> and apply its metadata through
+    /// a descriptor entry — no per-render <see cref="Setters"/> lambda. The <c>init</c> accessor is
+    /// <c>internal</c> on purpose: this property only carries command <em>metadata</em>; the click
+    /// trampoline (<c>Execute</c>) and the coerced <c>IsEnabled</c> wiring live in the factory /
+    /// modifier, so the supported way to bind a command is <c>Button(cmd)</c> / <c>.Command(cmd)</c>,
+    /// not a direct <c>new ButtonElement { Command = cmd }</c> (which would not invoke the command).
     /// </summary>
-    public Command? Command { get; init; }
+    public Command? Command { get; internal init; }
     internal Action<WinUI.Button>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnClick is not null;
 
@@ -2586,10 +2607,7 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
             // drives the control (gated on !IsDisabledFocusable), so the command must not
             // clobber the disabled-focusable coercion. Re-applied only when the Command
             // changes in a rendered field (delegates ignored — CommandModuloDelegatesComparer).
-            .OneWay<Command?>(
-                get:      static e => e.Command,
-                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd, applyIsEnabled: false); },
-                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
+            .OneWayCommand(static e => e.Command, applyIsEnabled: false);
     }
 }
 
@@ -2598,17 +2616,14 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record HyperlinkButtonElement(string Content, Uri? NavigateUri = null, Action? OnClick = null) : Element
 {
-    /// <summary>The <see cref="Command"/> bound via <c>HyperlinkButton(Command)</c> / <c>.Command()</c> (issue #153).</summary>
-    public Command? Command { get; init; }
+    /// <summary>The command metadata bound via <c>HyperlinkButton(Command)</c> / <c>.Command()</c> (issue #153). <c>internal init</c>: bind via the factory/modifier, not direct record init. See <see cref="ButtonElement.Command"/>.</summary>
+    public Command? Command { get; internal init; }
     internal Action<WinUI.HyperlinkButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnClick is not null;
 
     private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<HyperlinkButtonElement, WinUI.HyperlinkButton> Customize(
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<HyperlinkButtonElement, WinUI.HyperlinkButton> d)
-        => d.OneWay<Command?>(  // issue #153 — command metadata + IsEnabled applied field-aware
-                get:      static e => e.Command,
-                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd); },
-                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
+        => d.OneWayCommand(static e => e.Command);  // issue #153 — command metadata + IsEnabled applied field-aware
 }
 
 [global::Microsoft.UI.Reactor.Wrappers.GenerateReactorDescriptor(typeof(WinPrim.RepeatButton))]  // spec 058 §15 (P5.4)
@@ -2618,17 +2633,14 @@ public partial record RepeatButtonElement(string Label, Action? OnClick = null) 
 {
     public int Delay { get; init; } = 250;
     public int Interval { get; init; } = 50;
-    /// <summary>The <see cref="Command"/> bound via <c>RepeatButton(Command)</c> / <c>.Command()</c> (issue #153).</summary>
-    public Command? Command { get; init; }
+    /// <summary>The command metadata bound via <c>RepeatButton(Command)</c> / <c>.Command()</c> (issue #153). <c>internal init</c>: bind via the factory/modifier, not direct record init. See <see cref="ButtonElement.Command"/>.</summary>
+    public Command? Command { get; internal init; }
     internal Action<WinPrim.RepeatButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnClick is not null;
 
     private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<RepeatButtonElement, WinPrim.RepeatButton> Customize(
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<RepeatButtonElement, WinPrim.RepeatButton> d)
-        => d.OneWay<Command?>(  // issue #153 — command metadata + IsEnabled applied field-aware
-                get:      static e => e.Command,
-                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd); },
-                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
+        => d.OneWayCommand(static e => e.Command);  // issue #153 — command metadata + IsEnabled applied field-aware
 }
 
 // Spec 058 §15 (P5.22) — Label→Content ([WrapAlias]). IsThreeState/IsChecked/CheckedState +
@@ -2654,8 +2666,8 @@ public partial record ToggleButtonElement(string Label, bool IsChecked = false, 
     public bool? CheckedState { get; init; }
     /// <summary>Three-state change handler. Receives <c>null</c> for indeterminate.</summary>
     public Action<bool?>? OnCheckedStateChanged { get; init; }
-    /// <summary>The <see cref="Command"/> bound via <c>ToggleButton(Command)</c> / <c>.Command()</c> (issue #153).</summary>
-    public Command? Command { get; init; }
+    /// <summary>The command metadata bound via <c>ToggleButton(Command)</c> / <c>.Command()</c> (issue #153). <c>internal init</c>: bind via the factory/modifier, not direct record init. See <see cref="ButtonElement.Command"/>.</summary>
+    public Command? Command { get; internal init; }
     internal Action<WinPrim.ToggleButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnIsCheckedChanged is not null || OnCheckedStateChanged is not null;
 
@@ -2681,10 +2693,7 @@ public partial record ToggleButtonElement(string Label, bool IsChecked = false, 
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
                 setSlot:          static (p, h) => p.ClickTrampoline = h)
-            .OneWay<Command?>(  // issue #153 — command metadata + IsEnabled applied field-aware
-                get:      static e => e.Command,
-                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd); },
-                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
+            .OneWayCommand(static e => e.Command);  // issue #153 — command metadata + IsEnabled applied field-aware
 }
 
 // Spec 058 §15 (P5.22) — Label→Content ([WrapAlias], which also suppresses the auto content slot
@@ -2715,8 +2724,8 @@ public partial record DropDownButtonElement(string Label, Element? Flyout = null
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record SplitButtonElement(string Label, Action? OnClick = null, Element? Flyout = null) : Element
 {
-    /// <summary>The <see cref="Command"/> bound via <c>SplitButton(Command)</c> (issue #153).</summary>
-    public Command? Command { get; init; }
+    /// <summary>The command metadata bound via <c>SplitButton(Command)</c> / <c>.Command()</c> (issue #153). <c>internal init</c>: bind via the factory/modifier, not direct record init. See <see cref="ButtonElement.Command"/>.</summary>
+    public Command? Command { get; internal init; }
     internal Action<WinUI.SplitButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnClick is not null;
 
@@ -2736,10 +2745,7 @@ public partial record SplitButtonElement(string Label, Action? OnClick = null, E
                 set:         static (c, v, rec, rr) => c.Flyout = rec.CreateFlyoutForDescriptor(v, rr),
                 shouldWrite: static e => e.Flyout is not null,
                 comparer:    global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors.ElementReferenceComparer.Instance)
-            .OneWay<Command?>(  // issue #153 — command metadata + IsEnabled applied field-aware
-                get:      static e => e.Command,
-                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd); },
-                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
+            .OneWayCommand(static e => e.Command);  // issue #153 — command metadata + IsEnabled applied field-aware
 }
 
 // Spec 058 §15 (P5.22) — Label→Content ([WrapAlias], suppresses the auto content slot). IsChecked
@@ -2752,8 +2758,8 @@ public partial record SplitButtonElement(string Label, Action? OnClick = null, E
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record ToggleSplitButtonElement(string Label, Optional<bool> IsChecked = default, Action<bool>? OnIsCheckedChanged = null, Element? Flyout = null) : Element
 {
-    /// <summary>The <see cref="Command"/> bound via <c>ToggleSplitButton(Command)</c> (issue #153).</summary>
-    public Command? Command { get; init; }
+    /// <summary>The command metadata bound via <c>ToggleSplitButton(Command)</c> / <c>.Command()</c> (issue #153). <c>internal init</c>: bind via the factory/modifier, not direct record init. See <see cref="ButtonElement.Command"/>.</summary>
+    public Command? Command { get; internal init; }
     internal Action<WinUI.ToggleSplitButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnIsCheckedChanged is not null;
 
@@ -2771,10 +2777,7 @@ public partial record ToggleSplitButtonElement(string Label, Optional<bool> IsCh
                 set:         static (c, v, rec, rr) => c.Flyout = rec.CreateFlyoutForDescriptor(v, rr),
                 shouldWrite: static e => e.Flyout is not null,
                 comparer:    global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors.ElementReferenceComparer.Instance)
-            .OneWay<Command?>(  // issue #153 — command metadata + IsEnabled applied field-aware
-                get:      static e => e.Command,
-                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd); },
-                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
+            .OneWayCommand(static e => e.Command);  // issue #153 — command metadata + IsEnabled applied field-aware
 }
 
 // ════════════════════════════════════════════════════════════════════════

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -385,22 +385,26 @@ public abstract record Element
                 ba.Label == bb.Label
                 && ba.IsEnabled == bb.IsEnabled
                 && ba.ContentElement is null && bb.ContentElement is null
+                && CommandBindings.CommandsEqual(ba.Command, bb.Command)
                 && ReferenceEquals(ba.Setters, bb.Setters),
 
             (HyperlinkButtonElement ha, HyperlinkButtonElement hb) =>
                 ha.Content == hb.Content
                 && ha.NavigateUri == hb.NavigateUri
+                && CommandBindings.CommandsEqual(ha.Command, hb.Command)
                 && ReferenceEquals(ha.Setters, hb.Setters),
 
             (RepeatButtonElement ra, RepeatButtonElement rb) =>
                 ra.Label == rb.Label
                 && ra.Delay == rb.Delay
                 && ra.Interval == rb.Interval
+                && CommandBindings.CommandsEqual(ra.Command, rb.Command)
                 && ReferenceEquals(ra.Setters, rb.Setters),
 
             (ToggleButtonElement ta, ToggleButtonElement tb) =>
                 ta.Label == tb.Label
                 && ta.IsChecked == tb.IsChecked
+                && CommandBindings.CommandsEqual(ta.Command, tb.Command)
                 && ReferenceEquals(ta.Setters, tb.Setters),
 
             (SliderElement sa, SliderElement sb) =>
@@ -2501,6 +2505,7 @@ public record RichTextInlineUIContainer : RichTextInline
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("Label")]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("IsEnabled")]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("IsDisabledFocusable")]
+[global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record ButtonElement(string Label, Action? OnClick = null) : Element
 {
     public bool IsEnabled { get; init; } = true;
@@ -2517,6 +2522,13 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
     /// </summary>
     public bool IsDisabledFocusable { get; init; }
     public Element? ContentElement { get; init; }
+    /// <summary>
+    /// The <see cref="Command"/> bound to this button via the <c>Button(Command)</c> factory
+    /// or the <c>.Command()</c> modifier. Lifted to a typed property (issue #153) so the
+    /// reconciler compares it field-aware in <see cref="Element.ShallowEquals"/> and applies
+    /// its metadata through a descriptor entry — no per-render <see cref="Setters"/> lambda.
+    /// </summary>
+    public Command? Command { get; init; }
     internal Action<WinUI.Button>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnClick is not null;
 
@@ -2568,26 +2580,55 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
                 callbackPresent:  static e => e.OnClick,
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
-                setSlot:          static (p, h) => p.ClickTrampoline = h);
+                setSlot:          static (p, h) => p.ClickTrampoline = h)
+            // issue #153 — command metadata (tooltip / accelerator / access key) applied
+            // field-aware. applyIsEnabled:false: the IsEnabled OneWayConditional above already
+            // drives the control (gated on !IsDisabledFocusable), so the command must not
+            // clobber the disabled-focusable coercion. Re-applied only when the Command
+            // changes in a rendered field (delegates ignored — CommandModuloDelegatesComparer).
+            .OneWay<Command?>(
+                get:      static e => e.Command,
+                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd, applyIsEnabled: false); },
+                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
     }
 }
 
 [global::Microsoft.UI.Reactor.Wrappers.GenerateReactorDescriptor(typeof(WinUI.HyperlinkButton))]  // spec 058 §15 (P5.4)
 [global::Microsoft.UI.Reactor.Wrappers.WrapAlias("Content", "Content")]  // Content as value (not child slot)
+[global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record HyperlinkButtonElement(string Content, Uri? NavigateUri = null, Action? OnClick = null) : Element
 {
+    /// <summary>The <see cref="Command"/> bound via <c>HyperlinkButton(Command)</c> / <c>.Command()</c> (issue #153).</summary>
+    public Command? Command { get; init; }
     internal Action<WinUI.HyperlinkButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnClick is not null;
+
+    private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<HyperlinkButtonElement, WinUI.HyperlinkButton> Customize(
+        global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<HyperlinkButtonElement, WinUI.HyperlinkButton> d)
+        => d.OneWay<Command?>(  // issue #153 — command metadata + IsEnabled applied field-aware
+                get:      static e => e.Command,
+                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd); },
+                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
 }
 
 [global::Microsoft.UI.Reactor.Wrappers.GenerateReactorDescriptor(typeof(WinPrim.RepeatButton))]  // spec 058 §15 (P5.4)
 [global::Microsoft.UI.Reactor.Wrappers.WrapAlias("Label", "Content")]
+[global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record RepeatButtonElement(string Label, Action? OnClick = null) : Element
 {
     public int Delay { get; init; } = 250;
     public int Interval { get; init; } = 50;
+    /// <summary>The <see cref="Command"/> bound via <c>RepeatButton(Command)</c> / <c>.Command()</c> (issue #153).</summary>
+    public Command? Command { get; init; }
     internal Action<WinPrim.RepeatButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnClick is not null;
+
+    private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<RepeatButtonElement, WinPrim.RepeatButton> Customize(
+        global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<RepeatButtonElement, WinPrim.RepeatButton> d)
+        => d.OneWay<Command?>(  // issue #153 — command metadata + IsEnabled applied field-aware
+                get:      static e => e.Command,
+                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd); },
+                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
 }
 
 // Spec 058 §15 (P5.22) — Label→Content ([WrapAlias]). IsThreeState/IsChecked/CheckedState +
@@ -2599,6 +2640,7 @@ public partial record RepeatButtonElement(string Label, Action? OnClick = null) 
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("IsThreeState")]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("IsChecked")]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("CheckedState")]
+[global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record ToggleButtonElement(string Label, bool IsChecked = false, Action<bool>? OnIsCheckedChanged = null) : Element
 {
     /// <summary>
@@ -2612,6 +2654,8 @@ public partial record ToggleButtonElement(string Label, bool IsChecked = false, 
     public bool? CheckedState { get; init; }
     /// <summary>Three-state change handler. Receives <c>null</c> for indeterminate.</summary>
     public Action<bool?>? OnCheckedStateChanged { get; init; }
+    /// <summary>The <see cref="Command"/> bound via <c>ToggleButton(Command)</c> / <c>.Command()</c> (issue #153).</summary>
+    public Command? Command { get; init; }
     internal Action<WinPrim.ToggleButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnIsCheckedChanged is not null || OnCheckedStateChanged is not null;
 
@@ -2636,7 +2680,11 @@ public partial record ToggleButtonElement(string Label, bool IsChecked = false, 
                 callbackPresent:  static e => (Delegate?)e.OnIsCheckedChanged ?? e.OnCheckedStateChanged,
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
-                setSlot:          static (p, h) => p.ClickTrampoline = h);
+                setSlot:          static (p, h) => p.ClickTrampoline = h)
+            .OneWay<Command?>(  // issue #153 — command metadata + IsEnabled applied field-aware
+                get:      static e => e.Command,
+                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd); },
+                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
 }
 
 // Spec 058 §15 (P5.22) — Label→Content ([WrapAlias], which also suppresses the auto content slot
@@ -2664,8 +2712,11 @@ public partial record DropDownButtonElement(string Label, Element? Flyout = null
 [global::Microsoft.UI.Reactor.Wrappers.GenerateReactorDescriptor(typeof(WinUI.SplitButton), Exclude = new[] { "Click" })]
 [global::Microsoft.UI.Reactor.Wrappers.WrapAlias("Label", "Content")]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("Flyout")]
+[global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record SplitButtonElement(string Label, Action? OnClick = null, Element? Flyout = null) : Element
 {
+    /// <summary>The <see cref="Command"/> bound via <c>SplitButton(Command)</c> (issue #153).</summary>
+    public Command? Command { get; init; }
     internal Action<WinUI.SplitButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnClick is not null;
 
@@ -2684,7 +2735,11 @@ public partial record SplitButtonElement(string Label, Action? OnClick = null, E
                 get:         static e => e.Flyout,
                 set:         static (c, v, rec, rr) => c.Flyout = rec.CreateFlyoutForDescriptor(v, rr),
                 shouldWrite: static e => e.Flyout is not null,
-                comparer:    global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors.ElementReferenceComparer.Instance);
+                comparer:    global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors.ElementReferenceComparer.Instance)
+            .OneWay<Command?>(  // issue #153 — command metadata + IsEnabled applied field-aware
+                get:      static e => e.Command,
+                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd); },
+                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
 }
 
 // Spec 058 §15 (P5.22) — Label→Content ([WrapAlias], suppresses the auto content slot). IsChecked
@@ -2694,8 +2749,11 @@ public partial record SplitButtonElement(string Label, Action? OnClick = null, E
 [global::Microsoft.UI.Reactor.Wrappers.WrapAlias("Label", "Content")]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("IsChecked")]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("Flyout")]
+[global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record ToggleSplitButtonElement(string Label, Optional<bool> IsChecked = default, Action<bool>? OnIsCheckedChanged = null, Element? Flyout = null) : Element
 {
+    /// <summary>The <see cref="Command"/> bound via <c>ToggleSplitButton(Command)</c> (issue #153).</summary>
+    public Command? Command { get; init; }
     internal Action<WinUI.ToggleSplitButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnIsCheckedChanged is not null;
 
@@ -2712,7 +2770,11 @@ public partial record ToggleSplitButtonElement(string Label, Optional<bool> IsCh
                 get:         static e => e.Flyout,
                 set:         static (c, v, rec, rr) => c.Flyout = rec.CreateFlyoutForDescriptor(v, rr),
                 shouldWrite: static e => e.Flyout is not null,
-                comparer:    global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors.ElementReferenceComparer.Instance);
+                comparer:    global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.Descriptors.ElementReferenceComparer.Instance)
+            .OneWay<Command?>(  // issue #153 — command metadata + IsEnabled applied field-aware
+                get:      static e => e.Command,
+                set:      static (c, cmd) => { if (cmd is not null) CommandBindings.ApplyButtonBaseCommon(c, cmd); },
+                comparer: CommandBindings.CommandModuloDelegatesComparer.Instance);
 }
 
 // ════════════════════════════════════════════════════════════════════════

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -162,22 +162,17 @@ public static partial class Factories
 
     /// <summary>
     /// Creates a Button driven by a Command. Maps Label → Content, Execute → Click,
-    /// IsEnabled → IsEnabled. Description / Accelerator / AccessKey are wired via
-    /// a Setter so per-site overrides win via the normal modifier ordering — e.g.
-    /// <c>Button(saveCommand).IsEnabled(canSave)</c> or
-    /// <c>.Set(b =&gt; b.FlowDirection = FlowDirection.RightToLeft)</c>.
+    /// IsEnabled → IsEnabled. Description / Accelerator / AccessKey are applied by the
+    /// reconciler from the typed <see cref="ButtonElement.Command"/> property (issue #153),
+    /// so no per-render Setters array or lambda is allocated and the reconciler can
+    /// fast-path command-bound buttons whose Command is unchanged across renders.
     /// </summary>
     public static ButtonElement Button(Core.Command command)
     {
         return new ButtonElement(command.Label, () => Core.CommandBindings.Invoke(command))
         {
             IsEnabled = command.IsEnabled,
-            // applyIsEnabled: false — the record IsEnabled prop above drives the control
-            // through ButtonElement's descriptor, which gates IsEnabled on !IsDisabledFocusable
-            // and coerces a disabled-focusable button back to IsEnabled=true. Writing IsEnabled
-            // from the setter too would override that coercion and drop a disabled-command +
-            // .IsDisabledFocusable() button out of the tab order. (issue #133, PR review)
-            Setters = [b => Core.CommandBindings.ApplyButtonBaseCommon(b, command, applyIsEnabled: false)],
+            Command = command,
         };
     }
 
@@ -198,7 +193,7 @@ public static partial class Factories
     {
         return new HyperlinkButtonElement(command.Label, null, () => Core.CommandBindings.Invoke(command))
         {
-            Setters = [b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+            Command = command,
         };
     }
 
@@ -212,7 +207,7 @@ public static partial class Factories
     {
         return new RepeatButtonElement(command.Label, () => Core.CommandBindings.Invoke(command))
         {
-            Setters = [b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+            Command = command,
         };
     }
 
@@ -230,7 +225,7 @@ public static partial class Factories
     {
         return new ToggleButtonElement(command.Label, isChecked, _ => Core.CommandBindings.Invoke(command))
         {
-            Setters = [b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+            Command = command,
         };
     }
 
@@ -261,7 +256,7 @@ public static partial class Factories
     {
         return new SplitButtonElement(command.Label, () => Core.CommandBindings.Invoke(command), flyout)
         {
-            Setters = [b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+            Command = command,
         };
     }
 
@@ -281,7 +276,7 @@ public static partial class Factories
     {
         return new ToggleSplitButtonElement(command.Label, isChecked, _ => Core.CommandBindings.Invoke(command), flyout)
         {
-            Setters = [b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+            Command = command,
         };
     }
 

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -990,31 +990,31 @@ public static partial class ElementExtensions
     // (Description / Accelerator / AccessKey) onto an already-built clickable
     // element. This closes the custom-content gap: the Button(Command) factory
     // only accepts a vanilla label, so icon-plus-label buttons previously had to
-    // re-thread `.IsEnabled(command.IsEnabled)` by hand. The CommandBindings
-    // setter runs on every reconcile pass, so IsEnabled is re-applied whenever the
-    // command's state flips (e.g. UseCommand toggling IsExecuting) — not captured
+    // re-thread `.IsEnabled(command.IsEnabled)` by hand. Issue #153 lifts Command to
+    // a typed property: the reconciler applies the command metadata field-aware from
+    // that property (no per-render Setters lambda), and re-applies IsEnabled whenever
+    // the command's state flips (e.g. UseCommand toggling IsExecuting) — not captured
     // once at construction. Place `.Command(cmd)` before per-site overrides so the
     // usual modifier-after-command ordering still lets later calls win.
 
     /// <summary>
     /// Binds a <see cref="Core.Command"/> to a custom-content <see cref="ButtonElement"/>:
     /// wires Execute → Click, applies <see cref="Core.Command.IsEnabled"/> (re-applied on
-    /// every update), and flows Description / Accelerator / AccessKey via a setter. Pairs
-    /// with <c>Button(content)</c> so icon-plus-label buttons auto-disable like the
-    /// <c>Button(Command)</c> factory. (issue #133)
+    /// every update), and flows Description / Accelerator / AccessKey via the typed
+    /// <see cref="ButtonElement.Command"/> property. Pairs with <c>Button(content)</c> so
+    /// icon-plus-label buttons auto-disable like the <c>Button(Command)</c> factory.
+    /// (issue #133, lifted to a typed property in issue #153)
     /// </summary>
     public static ButtonElement Command(this ButtonElement el, Core.Command command) =>
         el with
         {
             OnClick = () => Core.CommandBindings.Invoke(command),
             IsEnabled = command.IsEnabled,
-            // applyIsEnabled: false — the record IsEnabled prop above already drives the
-            // control through ButtonElement's descriptor, which gates IsEnabled on
-            // !IsDisabledFocusable and coerces a disabled-focusable button back to
-            // IsEnabled=true. Writing IsEnabled from the setter too would override that
-            // coercion and silently drop a disabled-command + .IsDisabledFocusable() button
-            // out of the tab order. (issue #133, PR review M1)
-            Setters = [.. el.Setters, b => Core.CommandBindings.ApplyButtonBaseCommon(b, command, applyIsEnabled: false)],
+            // issue #153 — Command lifted to a typed property; the reconciler applies its
+            // metadata field-aware (applyIsEnabled:false, since the IsEnabled prop above already
+            // drives the control through ButtonElement's !IsDisabledFocusable-gated descriptor).
+            // No per-render Setters lambda. (supersedes the #133 setter wiring)
+            Command = command,
         };
 
     /// <summary>
@@ -1025,7 +1025,7 @@ public static partial class ElementExtensions
         el with
         {
             OnClick = () => Core.CommandBindings.Invoke(command),
-            Setters = [.. el.Setters, b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+            Command = command,  // issue #153 — typed property, no per-render Setters lambda
         };
 
     /// <summary>
@@ -1036,7 +1036,7 @@ public static partial class ElementExtensions
         el with
         {
             OnClick = () => Core.CommandBindings.Invoke(command),
-            Setters = [.. el.Setters, b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+            Command = command,  // issue #153 — typed property, no per-render Setters lambda
         };
 
     /// <summary>
@@ -1048,7 +1048,7 @@ public static partial class ElementExtensions
         el with
         {
             OnIsCheckedChanged = _ => Core.CommandBindings.Invoke(command),
-            Setters = [.. el.Setters, b => Core.CommandBindings.ApplyButtonBaseCommon(b, command)],
+            Command = command,  // issue #153 — typed property, no per-render Setters lambda
         };
 
     /// <summary>

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -994,8 +994,10 @@ public static partial class ElementExtensions
     // a typed property: the reconciler applies the command metadata field-aware from
     // that property (no per-render Setters lambda), and re-applies IsEnabled whenever
     // the command's state flips (e.g. UseCommand toggling IsExecuting) — not captured
-    // once at construction. Place `.Command(cmd)` before per-site overrides so the
-    // usual modifier-after-command ordering still lets later calls win.
+    // once at construction. Raw `.Set(...)` setters always run after every descriptor
+    // prop (the documented "Setters apply last / win" rule, spec 058), so an explicit
+    // `.Set(b => b.AccessKey = "X")` overrides command-derived metadata regardless of
+    // where it sits in the chain.
 
     /// <summary>
     /// Binds a <see cref="Core.Command"/> to a custom-content <see cref="ButtonElement"/>:
@@ -1003,6 +1005,9 @@ public static partial class ElementExtensions
     /// every update), and flows Description / Accelerator / AccessKey via the typed
     /// <see cref="ButtonElement.Command"/> property. Pairs with <c>Button(content)</c> so
     /// icon-plus-label buttons auto-disable like the <c>Button(Command)</c> factory.
+    /// A raw <c>.Set(...)</c> setter runs after the command metadata and therefore overrides
+    /// it (e.g. <c>.Command(cmd).Set(b =&gt; b.AccessKey = "X")</c> — or the reverse order — both
+    /// resolve AccessKey to "X").
     /// (issue #133, lifted to a typed property in issue #153)
     /// </summary>
     public static ButtonElement Command(this ButtonElement el, Core.Command command) =>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -385,4 +385,107 @@ internal static class CommandingCoverageFixtures
                 && ReferenceEquals(btn2.KeyboardAccelerators[0], accel0));
         }
     }
+
+    /// <summary>
+    /// Issue #153 (M1) precedence pin: a raw <c>.Set(...)</c> setter applies after the typed
+    /// Command's descriptor metadata, so it overrides command-derived metadata regardless of where
+    /// it sits in the fluent chain. Both <c>.Set(...).Command(cmd)</c> and <c>.Command(cmd).Set(...)</c>
+    /// must resolve AccessKey to the Setter's value (the documented "Setters apply last / win" rule).
+    /// </summary>
+    internal class BoundButtonSetterOverridesCommandMetadata(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var cmd = new Command { Label = "Save", Execute = () => { }, AccessKey = "S" };
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                // Setter before .Command — Setter must still win (applied last).
+                Button("setThenCmd").Set(b => b.AccessKey = "X").Command(cmd),
+                // .Command before Setter — Setter wins (normal chain order).
+                Button("cmdThenSet").Command(cmd).Set(b => b.AccessKey = "Y")));
+            await Harness.Render();
+
+            var setThenCmd = H.FindControl<Button>(b => (b.Content as string) == "setThenCmd");
+            var cmdThenSet = H.FindControl<Button>(b => (b.Content as string) == "cmdThenSet");
+            H.Check("Precedence_SetThenCmd_Mounted", setThenCmd is not null);
+            H.Check("Precedence_SetThenCmd_SetterWins", setThenCmd is not null && setThenCmd.AccessKey == "X");
+            H.Check("Precedence_CmdThenSet_Mounted", cmdThenSet is not null);
+            H.Check("Precedence_CmdThenSet_SetterWins", cmdThenSet is not null && cmdThenSet.AccessKey == "Y");
+        }
+    }
+
+    /// <summary>
+    /// Issue #153 (M3): the <c>SplitButton(Command)</c> typed property is applied by a descriptor
+    /// entry; when the bound command changes across a re-render, the command metadata (AccessKey,
+    /// IsEnabled) must update on the reused live control. Mirrors
+    /// <see cref="BoundButtonCommandChangeUpdatesMetadata"/>.
+    /// </summary>
+    internal class BoundSplitButtonCommandChangeUpdatesMetadata(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (flipped, setFlipped) = ctx.UseState(false);
+                var cmd = flipped
+                    ? new Command { Label = "Save", Execute = () => { }, AccessKey = "D", CanExecute = false }
+                    : new Command { Label = "Save", Execute = () => { }, AccessKey = "S", CanExecute = true };
+                return VStack(
+                    Button("flipSplitCmd", () => setFlipped(true)),
+                    SplitButton(cmd).Set(b => b.Name = "splitCmdChangeBtn"));
+            });
+            await Harness.Render();
+
+            var sb = H.FindControl<SplitButton>(b => b.Name == "splitCmdChangeBtn");
+            H.Check("SplitCmdChange_Mounted", sb is not null);
+            H.Check("SplitCmdChange_InitialAccessKey", sb is not null && sb.AccessKey == "S");
+            H.Check("SplitCmdChange_InitiallyEnabled", sb is not null && sb.IsEnabled);
+
+            H.ClickButton("flipSplitCmd");
+            await Harness.Render();
+
+            var sb2 = H.FindControl<SplitButton>(b => b.Name == "splitCmdChangeBtn");
+            H.Check("SplitCmdChange_Reused", ReferenceEquals(sb, sb2));
+            H.Check("SplitCmdChange_AccessKeyUpdated", sb2 is not null && sb2.AccessKey == "D");
+            H.Check("SplitCmdChange_DisabledAfterUpdate", sb2 is not null && !sb2.IsEnabled);
+        }
+    }
+
+    /// <summary>
+    /// Issue #153 (M3): same live command-change reapply check as
+    /// <see cref="BoundSplitButtonCommandChangeUpdatesMetadata"/>, for <c>ToggleSplitButton(Command)</c>.
+    /// </summary>
+    internal class BoundToggleSplitButtonCommandChangeUpdatesMetadata(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (flipped, setFlipped) = ctx.UseState(false);
+                var cmd = flipped
+                    ? new Command { Label = "Pin", Execute = () => { }, AccessKey = "D", CanExecute = false }
+                    : new Command { Label = "Pin", Execute = () => { }, AccessKey = "S", CanExecute = true };
+                return VStack(
+                    Button("flipToggleSplitCmd", () => setFlipped(true)),
+                    ToggleSplitButton(cmd).Set(b => b.Name = "toggleSplitCmdChangeBtn"));
+            });
+            await Harness.Render();
+
+            var tsb = H.FindControl<ToggleSplitButton>(b => b.Name == "toggleSplitCmdChangeBtn");
+            H.Check("ToggleSplitCmdChange_Mounted", tsb is not null);
+            H.Check("ToggleSplitCmdChange_InitialAccessKey", tsb is not null && tsb.AccessKey == "S");
+            H.Check("ToggleSplitCmdChange_InitiallyEnabled", tsb is not null && tsb.IsEnabled);
+
+            H.ClickButton("flipToggleSplitCmd");
+            await Harness.Render();
+
+            var tsb2 = H.FindControl<ToggleSplitButton>(b => b.Name == "toggleSplitCmdChangeBtn");
+            H.Check("ToggleSplitCmdChange_Reused", ReferenceEquals(tsb, tsb2));
+            H.Check("ToggleSplitCmdChange_AccessKeyUpdated", tsb2 is not null && tsb2.AccessKey == "D");
+            H.Check("ToggleSplitCmdChange_DisabledAfterUpdate", tsb2 is not null && !tsb2.IsEnabled);
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -163,12 +163,14 @@ internal static class CommandingCoverageFixtures
     }
 
     /// <summary>
-    /// PR review M2: the HyperlinkButton / RepeatButton / ToggleButton <c>.Command()</c>
-    /// paths apply IsEnabled solely through the appended <c>ApplyButtonBaseCommon</c>
-    /// setter (they have no record IsEnabled prop like ButtonElement). Each fresh
-    /// <c>.Command()</c> render allocates a new Setters array, so the reconciler re-runs
-    /// the setter and re-applies IsEnabled. Mount each, flip CanExecute across a re-render,
-    /// and assert the reused live control becomes disabled.
+    /// The HyperlinkButton / RepeatButton / ToggleButton <c>.Command()</c> paths apply
+    /// IsEnabled solely through the command-apply descriptor entry (they have no record
+    /// IsEnabled prop like ButtonElement). When the bound command's <c>CanExecute</c> flips
+    /// across a re-render, <see cref="Command"/> is no longer structurally equal modulo
+    /// delegates, so the reconciler runs Update and the <c>OneWay&lt;Command?&gt;</c> entry
+    /// re-applies <c>ApplyButtonBaseCommon</c> (issue #153 — typed Command property; replaces
+    /// the per-render Setters array that previously forced the re-run). Mount each, flip
+    /// CanExecute across a re-render, and assert the reused live control becomes disabled.
     /// </summary>
     internal class HyperlinkButtonCommandReappliesIsEnabledOnUpdate(Harness h) : SelfTestFixtureBase(h)
     {
@@ -296,6 +298,91 @@ internal static class CommandingCoverageFixtures
             H.Check("CmdDfRev_Mounted", btn is not null);
             H.Check("CmdDfRev_StaysFocusable", btn is not null && btn.IsEnabled);
             H.Check("CmdDfRev_Dimmed", btn is not null && global::System.Math.Abs(btn.Opacity - 0.4) < 0.001);
+        }
+    }
+
+    /// <summary>
+    /// Issue #153: the <c>Button(Command)</c> factory lowers Command to a typed property,
+    /// applied by a descriptor entry. When the bound command changes across a re-render, the
+    /// command metadata (AccessKey, IsEnabled) must update on the reused live control.
+    /// </summary>
+    internal class BoundButtonCommandChangeUpdatesMetadata(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (flipped, setFlipped) = ctx.UseState(false);
+                var cmd = flipped
+                    ? new Command { Label = "Open", Execute = () => { }, AccessKey = "D", CanExecute = false }
+                    : new Command { Label = "Open", Execute = () => { }, AccessKey = "S", CanExecute = true };
+                return VStack(
+                    Button("flipCmd", () => setFlipped(true)),
+                    Button(cmd).Set(b => b.Name = "cmdChangeBtn"));
+            });
+            await Harness.Render();
+
+            var btn = H.FindControl<Button>(b => b.Name == "cmdChangeBtn");
+            H.Check("CmdChange_Mounted", btn is not null);
+            H.Check("CmdChange_InitialAccessKey", btn is not null && btn.AccessKey == "S");
+            H.Check("CmdChange_InitiallyEnabled", btn is not null && btn.IsEnabled);
+
+            H.ClickButton("flipCmd");
+            await Harness.Render();
+
+            var btn2 = H.FindControl<Button>(b => b.Name == "cmdChangeBtn");
+            H.Check("CmdChange_Reused", ReferenceEquals(btn, btn2));
+            H.Check("CmdChange_AccessKeyUpdated", btn2 is not null && btn2.AccessKey == "D");
+            H.Check("CmdChange_DisabledAfterUpdate", btn2 is not null && !btn2.IsEnabled);
+        }
+    }
+
+    /// <summary>
+    /// Issue #153 fast-path proof: when a command-bound button re-renders with a Command that
+    /// is structurally equal modulo its Execute/ExecuteAsync delegates (a fresh instance each
+    /// render with identical rendered fields but a new closure), <see cref="Element.ShallowEquals"/>
+    /// returns true and the reconciler skips the command-apply entry entirely. Observable proof:
+    /// <c>ApplyButtonBaseCommon</c> removes+re-adds a NEW <c>KeyboardAccelerator</c> instance when
+    /// it runs, so a reference-equal accelerator across the re-render proves it did NOT run.
+    /// </summary>
+    internal class BoundButtonUnchangedCommandSkipsReapply(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (n, setN) = ctx.UseState(0);
+                // Fresh Command each render: identical rendered fields, brand-new Execute
+                // delegate. Structurally equal modulo delegates ⇒ ShallowEquals fast-paths.
+                var cmd = new Command
+                {
+                    Label = "Open",
+                    Execute = () => { },
+                    Accelerator = new KeyboardAcceleratorData(
+                        global::Windows.System.VirtualKey.O, global::Windows.System.VirtualKeyModifiers.Control),
+                    Description = "Open a file",
+                };
+                return VStack(
+                    Button("bumpFastPath", () => setN(n + 1)),
+                    Button(cmd));  // no .Set — a fresh Setters array each render would defeat ShallowEquals
+            });
+            await Harness.Render();
+
+            var btn = H.FindControl<Button>(b => (b.Content as string) == "Open");
+            H.Check("FastPath_Mounted", btn is not null && btn.KeyboardAccelerators.Count == 1);
+            var accel0 = btn?.KeyboardAccelerators.Count == 1 ? btn.KeyboardAccelerators[0] : null;
+
+            H.ClickButton("bumpFastPath");
+            await Harness.Render();
+
+            var btn2 = H.FindControl<Button>(b => (b.Content as string) == "Open");
+            H.Check("FastPath_Reused", ReferenceEquals(btn, btn2));
+            H.Check("FastPath_SkippedReapply",
+                btn2 is not null && accel0 is not null
+                && btn2.KeyboardAccelerators.Count == 1
+                && ReferenceEquals(btn2.KeyboardAccelerators[0], accel0));
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -372,7 +372,7 @@ internal static class CommandingCoverageFixtures
 
             var btn = H.FindControl<Button>(b => (b.Content as string) == "Open");
             H.Check("FastPath_Mounted", btn is not null && btn.KeyboardAccelerators.Count == 1);
-            var accel0 = btn?.KeyboardAccelerators.Count == 1 ? btn.KeyboardAccelerators[0] : null;
+            var accel0 = btn is { KeyboardAccelerators.Count: 1 } ? btn.KeyboardAccelerators[0] : null;
 
             H.ClickButton("bumpFastPath");
             await Harness.Render();
@@ -486,6 +486,53 @@ internal static class CommandingCoverageFixtures
             H.Check("ToggleSplitCmdChange_Reused", ReferenceEquals(tsb, tsb2));
             H.Check("ToggleSplitCmdChange_AccessKeyUpdated", tsb2 is not null && tsb2.AccessKey == "D");
             H.Check("ToggleSplitCmdChange_DisabledAfterUpdate", tsb2 is not null && !tsb2.IsEnabled);
+        }
+    }
+
+    /// <summary>
+    /// Issue #153 (PR review): when a command-bound button is re-rendered <em>without</em> a Command
+    /// (the typed Command transitions to null on the reused live control), the descriptor's command
+    /// entry must clear the stale command metadata — tooltip / UIA HelpText, AccessKey, and the
+    /// command-added <see cref="KeyboardAccelerator"/> — rather than leaving it stuck.
+    /// </summary>
+    internal class BoundButtonCommandClearedWhenRemoved(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (removed, setRemoved) = ctx.UseState(false);
+                return VStack(
+                    Button("removeCmd", () => setRemoved(true)),
+                    removed
+                        ? Button("Open").Set(b => b.Name = "cmdClearBtn")
+                        : Button(new Command
+                        {
+                            Label = "Open",
+                            Execute = () => { },
+                            AccessKey = "S",
+                            Accelerator = new KeyboardAcceleratorData(
+                                global::Windows.System.VirtualKey.O, global::Windows.System.VirtualKeyModifiers.Control),
+                            Description = "Open a file",
+                        }).Set(b => b.Name = "cmdClearBtn"));
+            });
+            await Harness.Render();
+
+            var btn = H.FindControl<Button>(b => b.Name == "cmdClearBtn");
+            H.Check("CmdClear_Mounted", btn is not null);
+            H.Check("CmdClear_InitialAccessKey", btn is not null && btn.AccessKey == "S");
+            H.Check("CmdClear_InitialAccelerator", btn is not null && btn.KeyboardAccelerators.Count == 1);
+            H.Check("CmdClear_InitialToolTip", btn is not null && ToolTipService.GetToolTip(btn) is not null);
+
+            H.ClickButton("removeCmd");
+            await Harness.Render();
+
+            var btn2 = H.FindControl<Button>(b => b.Name == "cmdClearBtn");
+            H.Check("CmdClear_Reused", ReferenceEquals(btn, btn2));
+            H.Check("CmdClear_AccessKeyCleared", btn2 is not null && string.IsNullOrEmpty(btn2.AccessKey));
+            H.Check("CmdClear_AcceleratorCleared", btn2 is not null && btn2.KeyboardAccelerators.Count == 0);
+            H.Check("CmdClear_ToolTipCleared", btn2 is not null && ToolTipService.GetToolTip(btn2) is null);
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -854,6 +854,8 @@ internal static class SelfTestFixtureRegistry
         "Commanding_ToggleButtonCommandReappliesIsEnabledOnUpdate",
         "Commanding_CommandDisabledFocusableStaysFocusable",
         "Commanding_CommandDisabledFocusableStaysFocusableReverseOrder",
+        "Commanding_BoundButtonCommandChangeUpdatesMetadata",
+        "Commanding_BoundButtonUnchangedCommandSkipsReapply",
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag",
@@ -2243,6 +2245,8 @@ internal static class SelfTestFixtureRegistry
         "Commanding_ToggleButtonCommandReappliesIsEnabledOnUpdate" => new CommandingCoverageFixtures.ToggleButtonCommandReappliesIsEnabledOnUpdate(harness),
         "Commanding_CommandDisabledFocusableStaysFocusable" => new CommandingCoverageFixtures.CommandDisabledFocusableStaysFocusable(harness),
         "Commanding_CommandDisabledFocusableStaysFocusableReverseOrder" => new CommandingCoverageFixtures.CommandDisabledFocusableStaysFocusableReverseOrder(harness),
+        "Commanding_BoundButtonCommandChangeUpdatesMetadata" => new CommandingCoverageFixtures.BoundButtonCommandChangeUpdatesMetadata(harness),
+        "Commanding_BoundButtonUnchangedCommandSkipsReapply" => new CommandingCoverageFixtures.BoundButtonUnchangedCommandSkipsReapply(harness),
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag" => new DragDropFixtures.OnDragStartAutoSetsCanDrag(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -856,6 +856,9 @@ internal static class SelfTestFixtureRegistry
         "Commanding_CommandDisabledFocusableStaysFocusableReverseOrder",
         "Commanding_BoundButtonCommandChangeUpdatesMetadata",
         "Commanding_BoundButtonUnchangedCommandSkipsReapply",
+        "Commanding_BoundButtonSetterOverridesCommandMetadata",
+        "Commanding_BoundSplitButtonCommandChangeUpdatesMetadata",
+        "Commanding_BoundToggleSplitButtonCommandChangeUpdatesMetadata",
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag",
@@ -2247,6 +2250,9 @@ internal static class SelfTestFixtureRegistry
         "Commanding_CommandDisabledFocusableStaysFocusableReverseOrder" => new CommandingCoverageFixtures.CommandDisabledFocusableStaysFocusableReverseOrder(harness),
         "Commanding_BoundButtonCommandChangeUpdatesMetadata" => new CommandingCoverageFixtures.BoundButtonCommandChangeUpdatesMetadata(harness),
         "Commanding_BoundButtonUnchangedCommandSkipsReapply" => new CommandingCoverageFixtures.BoundButtonUnchangedCommandSkipsReapply(harness),
+        "Commanding_BoundButtonSetterOverridesCommandMetadata" => new CommandingCoverageFixtures.BoundButtonSetterOverridesCommandMetadata(harness),
+        "Commanding_BoundSplitButtonCommandChangeUpdatesMetadata" => new CommandingCoverageFixtures.BoundSplitButtonCommandChangeUpdatesMetadata(harness),
+        "Commanding_BoundToggleSplitButtonCommandChangeUpdatesMetadata" => new CommandingCoverageFixtures.BoundToggleSplitButtonCommandChangeUpdatesMetadata(harness),
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag" => new DragDropFixtures.OnDragStartAutoSetsCanDrag(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -859,6 +859,7 @@ internal static class SelfTestFixtureRegistry
         "Commanding_BoundButtonSetterOverridesCommandMetadata",
         "Commanding_BoundSplitButtonCommandChangeUpdatesMetadata",
         "Commanding_BoundToggleSplitButtonCommandChangeUpdatesMetadata",
+        "Commanding_BoundButtonCommandClearedWhenRemoved",
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag",
@@ -2253,6 +2254,7 @@ internal static class SelfTestFixtureRegistry
         "Commanding_BoundButtonSetterOverridesCommandMetadata" => new CommandingCoverageFixtures.BoundButtonSetterOverridesCommandMetadata(harness),
         "Commanding_BoundSplitButtonCommandChangeUpdatesMetadata" => new CommandingCoverageFixtures.BoundSplitButtonCommandChangeUpdatesMetadata(harness),
         "Commanding_BoundToggleSplitButtonCommandChangeUpdatesMetadata" => new CommandingCoverageFixtures.BoundToggleSplitButtonCommandChangeUpdatesMetadata(harness),
+        "Commanding_BoundButtonCommandClearedWhenRemoved" => new CommandingCoverageFixtures.BoundButtonCommandClearedWhenRemoved(harness),
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag" => new DragDropFixtures.OnDragStartAutoSetsCanDrag(harness),

--- a/tests/Reactor.Tests/CommandTypedPropertyTests.cs
+++ b/tests/Reactor.Tests/CommandTypedPropertyTests.cs
@@ -1,0 +1,303 @@
+using Microsoft.UI.Reactor.Core;
+using Windows.System;
+using static Microsoft.UI.Reactor.Factories;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Issue #153 — Command is lifted to a typed <c>Command?</c> record property on the
+/// command-capable button elements (Button, HyperlinkButton, RepeatButton, ToggleButton,
+/// SplitButton, ToggleSplitButton). The command factories no longer allocate a per-render
+/// <c>Setters</c> array + lambda, and <see cref="Element.ShallowEquals"/> fast-paths
+/// command-bound buttons whose Command is unchanged (reference-equal OR structurally equal
+/// modulo the Execute/ExecuteAsync delegates).
+///
+/// These are pure C# record tests — no WinUI thread required. Live mount/update behaviour is
+/// covered by the Commanding selftest fixtures (CommandingCoverageFixtures.cs).
+/// </summary>
+public class CommandTypedPropertyTests
+{
+    private static Command MakeCmd(Action? execute = null) => new()
+    {
+        Label = "Save",
+        Execute = execute ?? (() => { }),
+        Icon = new SymbolIconData("Save"),
+        Accelerator = new KeyboardAcceleratorData(VirtualKey.S, VirtualKeyModifiers.Control),
+        AccessKey = "S",
+        Description = "Save the file",
+    };
+
+    // ════════════════════════════════════════════════════════════════
+    //  (a) Command factories allocate NO Setters array
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Button_Command_AllocatesNoSetters()
+    {
+        var cmd = MakeCmd();
+        var el = Button(cmd);
+        Assert.Empty(el.Setters);
+        Assert.Same(cmd, el.Command);
+    }
+
+    [Fact]
+    public void HyperlinkButton_Command_AllocatesNoSetters()
+    {
+        var cmd = MakeCmd();
+        var el = HyperlinkButton(cmd);
+        Assert.Empty(el.Setters);
+        Assert.Same(cmd, el.Command);
+    }
+
+    [Fact]
+    public void RepeatButton_Command_AllocatesNoSetters()
+    {
+        var cmd = MakeCmd();
+        var el = RepeatButton(cmd);
+        Assert.Empty(el.Setters);
+        Assert.Same(cmd, el.Command);
+    }
+
+    [Fact]
+    public void ToggleButton_Command_AllocatesNoSetters()
+    {
+        var cmd = MakeCmd();
+        var el = ToggleButton(cmd);
+        Assert.Empty(el.Setters);
+        Assert.Same(cmd, el.Command);
+    }
+
+    [Fact]
+    public void SplitButton_Command_AllocatesNoSetters()
+    {
+        var cmd = MakeCmd();
+        var el = SplitButton(cmd);
+        Assert.Empty(el.Setters);
+        Assert.Same(cmd, el.Command);
+    }
+
+    [Fact]
+    public void ToggleSplitButton_Command_AllocatesNoSetters()
+    {
+        var cmd = MakeCmd();
+        var el = ToggleSplitButton(cmd);
+        Assert.Empty(el.Setters);
+        Assert.Same(cmd, el.Command);
+    }
+
+    [Fact]
+    public void Command_Factories_ShareReferenceEqualEmptySetters()
+    {
+        // Array.Empty<T>() is reference-shared, so the ShallowEquals
+        // ReferenceEquals(Setters, Setters) guard stays true across two
+        // command-bound buttons that carry no extra setters.
+        var cmd = MakeCmd();
+        var a = Button(cmd);
+        var b = Button(cmd);
+        Assert.Same(a.Setters, b.Setters);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  (b) ShallowEquals fast-paths unchanged commands
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ShallowEquals_True_When_Command_ReferenceEqual()
+    {
+        var cmd = MakeCmd();
+        Assert.True(Element.ShallowEquals(Button(cmd), Button(cmd)));
+        Assert.True(Element.ShallowEquals(HyperlinkButton(cmd), HyperlinkButton(cmd)));
+        Assert.True(Element.ShallowEquals(RepeatButton(cmd), RepeatButton(cmd)));
+        Assert.True(Element.ShallowEquals(ToggleButton(cmd), ToggleButton(cmd)));
+    }
+
+    [Fact]
+    public void ShallowEquals_True_When_Command_StructurallyEqual_ModuloDelegates()
+    {
+        // Two distinct Command instances with identical rendered metadata but
+        // DIFFERENT Execute delegates — the per-render closure case. ShallowEquals
+        // must still fast-path because the rendered fields are unchanged.
+        int x = 0, y = 0;
+        var cmdA = MakeCmd(() => x++);
+        var cmdB = MakeCmd(() => y++);
+        Assert.NotSame(cmdA, cmdB);
+        Assert.NotSame(cmdA.Execute, cmdB.Execute);
+
+        Assert.True(Element.ShallowEquals(Button(cmdA), Button(cmdB)));
+        Assert.True(Element.ShallowEquals(HyperlinkButton(cmdA), HyperlinkButton(cmdB)));
+        Assert.True(Element.ShallowEquals(RepeatButton(cmdA), RepeatButton(cmdB)));
+        Assert.True(Element.ShallowEquals(ToggleButton(cmdA), ToggleButton(cmdB)));
+    }
+
+    [Fact]
+    public void ShallowEquals_True_When_Command_StructurallyEqual_ModuloAsyncDelegate()
+    {
+        var cmdA = new Command { Label = "Run", ExecuteAsync = async () => { await Task.Yield(); } };
+        var cmdB = new Command { Label = "Run", ExecuteAsync = async () => { await Task.Delay(1); } };
+        Assert.NotSame(cmdA.ExecuteAsync, cmdB.ExecuteAsync);
+        Assert.True(Element.ShallowEquals(Button(cmdA), Button(cmdB)));
+    }
+
+    [Fact]
+    public void ShallowEquals_False_When_Command_Label_Differs()
+    {
+        var cmdA = MakeCmd();
+        var cmdB = cmdA with { Label = "Save As" };
+        // Label also flows to the Button content, so this would be unequal anyway —
+        // assert specifically through the command compare with matching content.
+        Assert.False(Element.ShallowEquals(Button(cmdA), Button(cmdB)));
+    }
+
+    [Fact]
+    public void ShallowEquals_False_When_Command_AccessKey_Differs()
+    {
+        // AccessKey does NOT flow to a record field — only to the typed Command —
+        // so this isolates the CommandsEqual contribution.
+        var cmdA = MakeCmd();
+        var cmdB = cmdA with { AccessKey = "X" };
+        Assert.False(Element.ShallowEquals(Button(cmdA), Button(cmdB)));
+        Assert.False(Element.ShallowEquals(HyperlinkButton(cmdA), HyperlinkButton(cmdB)));
+        Assert.False(Element.ShallowEquals(RepeatButton(cmdA), RepeatButton(cmdB)));
+        Assert.False(Element.ShallowEquals(ToggleButton(cmdA), ToggleButton(cmdB)));
+    }
+
+    [Fact]
+    public void ShallowEquals_False_When_Command_Description_Differs()
+    {
+        var cmdA = MakeCmd();
+        var cmdB = cmdA with { Description = "Different tooltip" };
+        Assert.False(Element.ShallowEquals(Button(cmdA), Button(cmdB)));
+    }
+
+    [Fact]
+    public void ShallowEquals_False_When_Command_CanExecute_Differs()
+    {
+        var cmdA = MakeCmd();
+        var cmdB = cmdA with { CanExecute = false };
+        Assert.False(Element.ShallowEquals(Button(cmdA), Button(cmdB)));
+    }
+
+    [Fact]
+    public void ShallowEquals_False_When_OneSideHasNoCommand()
+    {
+        var cmd = MakeCmd();
+        var withCmd = Button(cmd);
+        var noCmd = Button("Save");
+        Assert.False(Element.ShallowEquals(withCmd, noCmd));
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  CommandsEqual unit semantics (internal, via InternalsVisibleTo)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void CommandsEqual_IgnoresExecuteDelegates()
+    {
+        var a = MakeCmd(() => { });
+        var b = MakeCmd(() => { });
+        Assert.True(CommandBindings.CommandsEqual(a, b));
+    }
+
+    [Fact]
+    public void CommandsEqual_BothNull_True_OneNull_False()
+    {
+        Assert.True(CommandBindings.CommandsEqual(null, null));
+        Assert.False(CommandBindings.CommandsEqual(MakeCmd(), null));
+        Assert.False(CommandBindings.CommandsEqual(null, MakeCmd()));
+    }
+
+    [Fact]
+    public void CommandsEqual_ComparesAcceleratorAndIcon()
+    {
+        var a = MakeCmd();
+        var diffAccel = a with { Accelerator = new KeyboardAcceleratorData(VirtualKey.X, VirtualKeyModifiers.Control) };
+        var diffIcon = a with { Icon = new SymbolIconData("Open") };
+        Assert.False(CommandBindings.CommandsEqual(a, diffAccel));
+        Assert.False(CommandBindings.CommandsEqual(a, diffIcon));
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  (d) Clicking still invokes the command (sync + async)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Button_Command_OnClick_Invokes_Sync_Execute()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "Go", Execute = () => count++ };
+        var el = Button(cmd);
+        Assert.NotNull(el.OnClick);
+        el.OnClick!();
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task Button_Command_OnClick_Invokes_Async_Execute()
+    {
+        var tcs = new TaskCompletionSource();
+        var cmd = new Command
+        {
+            Label = "Go",
+            ExecuteAsync = () => { tcs.SetResult(); return Task.CompletedTask; },
+        };
+        var el = Button(cmd);
+        Assert.NotNull(el.OnClick);
+        el.OnClick!();
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.True(tcs.Task.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public void ToggleButton_Command_Toggle_Invokes_Execute()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "T", Execute = () => count++ };
+        var el = ToggleButton(cmd);
+        Assert.NotNull(el.OnIsCheckedChanged);
+        el.OnIsCheckedChanged!(true);
+        el.OnIsCheckedChanged!(false);
+        Assert.Equal(2, count); // fires on every toggle (Option A)
+    }
+
+    [Fact]
+    public void SplitButton_Command_OnClick_Invokes_Execute()
+    {
+        int count = 0;
+        var cmd = new Command { Label = "S", Execute = () => count++ };
+        var el = SplitButton(cmd);
+        Assert.NotNull(el.OnClick);
+        el.OnClick!();
+        Assert.Equal(1, count);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Allocation budget — per-construct bytes stay well under the
+    //  pre-#153 baseline (≈264 B; the Setters array + closure was ≈88 B).
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Button_Command_PerConstruct_Allocation_UnderBudget()
+    {
+        var cmd = MakeCmd();
+
+        // Warm-up: JIT the factory + GC.GetAllocatedBytesForCurrentThread path.
+        for (int i = 0; i < 1000; i++)
+            GC.KeepAlive(Button(cmd));
+
+        const int N = 50_000;
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < N; i++)
+            GC.KeepAlive(Button(cmd));
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        double perConstruct = (after - before) / (double)N;
+
+        // The pre-#153 factory allocated ≈264 B/construct (record + Setters array +
+        // lambda closure). After lifting Command to a typed property the Setters
+        // array/closure (≈88 B) is gone. Use a generous CI-jitter ceiling that still
+        // catches a regression that reintroduces a per-render array/closure.
+        Assert.True(perConstruct < 220,
+            $"Button(command) per-construct allocation regressed: {perConstruct:F1} B (expected < 220 B).");
+    }
+}

--- a/tests/Reactor.Tests/CommandTypedPropertyTests.cs
+++ b/tests/Reactor.Tests/CommandTypedPropertyTests.cs
@@ -187,6 +187,32 @@ public class CommandTypedPropertyTests
         Assert.False(Element.ShallowEquals(withCmd, noCmd));
     }
 
+    // issue #153 (L1) — Split / ToggleSplit fast-path the command arm too, so all six
+    // command-capable buttons memoize consistently.
+    [Fact]
+    public void ShallowEquals_True_For_Split_And_ToggleSplit_When_Command_Unchanged()
+    {
+        var cmd = MakeCmd();
+        // reference-equal command
+        Assert.True(Element.ShallowEquals(SplitButton(cmd), SplitButton(cmd)));
+        Assert.True(Element.ShallowEquals(ToggleSplitButton(cmd), ToggleSplitButton(cmd)));
+
+        // structurally-equal-modulo-delegates (fresh Execute closure each render)
+        var cmdA = MakeCmd() with { Execute = () => { } };
+        var cmdB = MakeCmd() with { Execute = () => { } };
+        Assert.True(Element.ShallowEquals(SplitButton(cmdA), SplitButton(cmdB)));
+        Assert.True(Element.ShallowEquals(ToggleSplitButton(cmdA), ToggleSplitButton(cmdB)));
+    }
+
+    [Fact]
+    public void ShallowEquals_False_For_Split_And_ToggleSplit_When_Command_AccessKey_Differs()
+    {
+        var cmdA = MakeCmd();
+        var cmdB = cmdA with { AccessKey = "X" };
+        Assert.False(Element.ShallowEquals(SplitButton(cmdA), SplitButton(cmdB)));
+        Assert.False(Element.ShallowEquals(ToggleSplitButton(cmdA), ToggleSplitButton(cmdB)));
+    }
+
     // ════════════════════════════════════════════════════════════════
     //  CommandsEqual unit semantics (internal, via InternalsVisibleTo)
     // ════════════════════════════════════════════════════════════════

--- a/tests/Reactor.Tests/Elements/CommandModifierTests.cs
+++ b/tests/Reactor.Tests/Elements/CommandModifierTests.cs
@@ -47,16 +47,18 @@ public class CommandModifierTests
     }
 
     [Fact]
-    public void Command_Appends_CommandBindings_Setter()
+    public void Command_Sets_Typed_Command_Without_Appending_Setter()
     {
         var cmd = new Command { Label = "Run", Execute = () => { } };
 
         var before = Button(TextBlock("Run"));
         var after = before.Command(cmd);
 
-        // The ApplyButtonBaseCommon setter is appended; it runs on every reconcile
-        // pass (mount AND update) which is what re-applies IsEnabled to the control.
-        Assert.Equal(before.Setters.Length + 1, after.Setters.Length);
+        // issue #153 — the modifier lifts Command to a typed property instead of
+        // appending a per-render Setters lambda. The reconciler applies the command's
+        // metadata field-aware from the typed Command property.
+        Assert.Equal(before.Setters.Length, after.Setters.Length);
+        Assert.Same(cmd, after.Command);
     }
 
     // ── (b) IsEnabled is re-applied on update when command flips ─────
@@ -77,18 +79,26 @@ public class CommandModifierTests
     }
 
     [Fact]
-    public void Command_Produces_Fresh_Setters_So_Reconciler_Reapplies()
+    public void Command_Modifier_Reapplies_On_Change_Via_Typed_Property()
     {
-        // Element equality short-circuits Update when Setters are reference-equal
-        // (see Element.cs ButtonElement equality). Each .Command() render allocates a
-        // fresh Setters array, so the reconciler never skips re-applying the command's
-        // IsEnabled — the crux of the bug, where the custom-content path captured state once.
-        var cmd = new Command { Label = "Run", Execute = () => { } };
+        // issue #153 — the modifier no longer allocates a fresh Setters array each
+        // render (the per-render ApplyButtonBaseCommon lambda is gone). Re-application
+        // on update is driven by the typed Command property + the descriptor's
+        // modulo-delegates comparer: a changed command (e.g. a CanExecute flip) is not
+        // ShallowEqual, so the reconciler still re-applies IsEnabled. (For custom-content
+        // buttons ContentElement is non-null, which already forces ShallowEquals false.)
+        var enabled = new Command { Label = "Run", Execute = () => { }, CanExecute = true };
+        var disabled = new Command { Label = "Run", Execute = () => { }, CanExecute = false };
 
-        var first = Button(TextBlock("Run")).Command(cmd);
-        var second = Button(TextBlock("Run")).Command(cmd);
+        var first = Button(TextBlock("Run")).Command(enabled);
+        var second = Button(TextBlock("Run")).Command(disabled);
 
-        Assert.False(ReferenceEquals(first.Setters, second.Setters));
+        // The modifier does not allocate fresh Setters (both share Array.Empty).
+        Assert.Same(first.Setters, second.Setters);
+        // A flipped command is not ShallowEqual, so the reconciler re-applies the effects.
+        Assert.False(Element.ShallowEquals(first, second));
+        Assert.True(first.IsEnabled);
+        Assert.False(second.IsEnabled);
     }
 
     // ── (c) Clicking invokes the command ────────────────────────────


### PR DESCRIPTION
## What & why

`Button(Command)` (and the other command-bound button factories) lowered a `Command` into:

```csharp
Setters = [b => CommandBindings.ApplyButtonBaseCommon(b, command)]
```

That lambda **+ array** was freshly allocated **every render** and is opaque to `Element.ShallowEquals`, so the reconciler rejected the fast-path on every command-bound button on every reconcile and re-ran `ApplyButtonBaseCommon` needlessly. This is the perf bug described in #153 ("Option C" of #151's callbacks-as-data theme).

This PR lifts `Command` to a first-class **typed property**, parallel to `OnClick`.

## The change

- New typed property `public Command? Command { get; init; }` on the six command-capable element records: **ButtonElement, HyperlinkButtonElement, RepeatButtonElement, ToggleButtonElement, SplitButtonElement, ToggleSplitButtonElement**.
  - `[WrapManual("Command")]` keeps the source-generator from colliding with WinUI `ButtonBase.Command` (ICommand) and forces the `Customize` hook to be emitted.
- The command factories (`Button(cmd)` … `ToggleSplitButton(cmd)`) and the `.Command()` fluent modifiers now set `Command = command` — **no `Setters` array, no per-render lambda**.
- The reconciler applies command metadata (label / enabled / tooltip / accelerator / access-key) through a descriptor `OneWay<Command?>` entry that calls `ApplyButtonBaseCommon` field-aware. `Button` uses `applyIsEnabled:false` (its `IsEnabled` record prop already drives the control through the `!IsDisabledFocusable`-gated descriptor, so the command must not clobber the disabled-focusable coercion); the other five use the default `applyIsEnabled:true`.
- New `CommandBindings.CommandsEqual(Command?, Command?)` + `CommandModuloDelegatesComparer` compare a `Command` by its **rendered** fields (Label/CanExecute/IsExecuting/Description/AccessKey/Icon/Accelerator) and **ignore** the `Execute`/`ExecuteAsync` delegates — same rationale as #151. Wired into:
  - `Element.ShallowEquals` (Button/Hyperlink/Repeat/Toggle cases) → reference-equal **or** structurally-equal-modulo-delegates commands now skip reconcile entirely.
  - the descriptor's `OneWay` comparer → even when an element does reconcile, `ApplyButtonBaseCommon` only re-runs when a rendered command field actually changed.

## Measurement (required deliverable)

Methodology: `GC.GetAllocatedBytesForCurrentThread()` around `N` constructions of `Button(cmd)` (warm-up first), plus `Element.ShallowEquals(Button(cmd), Button(cmd))` and `Setters.Length`.

| Metric | Before | After |
|---|---:|---:|
| Per-construct allocation | **264 B** | **176 B** |
| `Setters.Length` | 1 | **0** |
| `ShallowEquals` fast-path (unchanged cmd) | **False** | **True** |

The ~88 B/construct delta is exactly the `Setters` array + the captured-command closure. A CI-jitter-tolerant allocation-budget test (`< 220 B`) guards against reintroducing a per-render array/closure.

Live proof of the reconciler skip: the new `Commanding_BoundButtonUnchangedCommandSkipsReapply` selftest mounts a command-bound `Button` with a keyboard accelerator, re-renders with a **fresh** `Command` instance each render (identical fields, new `Execute` closure), and asserts the live `KeyboardAccelerator` **instance is reference-equal** across the re-render — which can only happen if `ApplyButtonBaseCommon` did **not** run (it removes+re-adds a new accelerator when it does).

## Tests

- New `tests/Reactor.Tests/CommandTypedPropertyTests.cs` (23 facts): no-Setters-alloc for all 6 factories; `ShallowEquals` true across renders (reference-equal **and** structurally-equal-modulo-(sync/async)-delegates) and false when a metadata field differs (Label/AccessKey/Description/CanExecute); `CommandsEqual` semantics; click invokes Execute (sync) and ExecuteAsync (async); toggle fires on each toggle; split-button primary click; allocation-budget fact.
- Updated `CommandModifierTests` two cases that asserted the old Setters-append behaviour to assert the new typed-property path.
- New selftests `Commanding_BoundButtonCommandChangeUpdatesMetadata` (AccessKey/IsEnabled update on the reused live control when the command changes) and `Commanding_BoundButtonUnchangedCommandSkipsReapply` (fast-path proof above).
- Regenerated `skills/reactor.api.txt` (+ the plugin mirror) for the 6 new public `Command` properties.

Status: `dotnet test tests/Reactor.Tests` → **9497 passed, 64 skipped, 0 failed**. All `Commanding` selftests pass (live WinUI window). Built `-p:Platform=x64` (the canonical/CI platform; this ARM64 box has a pre-existing XAML-compiler/perf_bench issue unrelated to this change).

## Coordination

- **#133 / PR #625** added the `.Command()` fluent modifier for custom-content buttons and the `applyIsEnabled` flag on `ApplyButtonBaseCommon`. This PR builds on both: the `.Command()` modifiers now set the **typed** `Command` property (superseding the per-render setter wiring) and reuse the same `applyIsEnabled` semantics. Custom-content buttons keep their existing re-apply guarantee (non-null `ContentElement` already forces `ShallowEquals` false, so they always reconcile and the descriptor re-applies on change).
- **#151** (parallel session) also touches `Element.ShallowEquals`. The change here is intentionally minimal and localized to adding `CommandsEqual(...)` to the four button cases, to keep the two PRs merging cleanly.

Closes #153.
