### PR TITLE
fix(virtualization): propagate LazyStack keySelector to row Element.Key (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,26 @@ Conventions for contributors:
 
 ### Fixed
 
+- **Virtualized rows now reset per-item component state on recycle when keyed
+  (issue #326).** `LazyVStack` / `LazyHStack` / `ItemsRepeater<T>` / `ItemsView<T>`
+  now propagate the `keySelector` projection onto each realized row's top-level
+  `Element.Key`. Post-#324 the ItemsRepeater recycle path reuses a realized
+  inner `Component<T>` across logical items as you scroll, which carried that
+  component's `UseState` / `UseEffect` state from one item to another (e.g. an
+  editor row left "dirty" for item 5 stayed dirty when its container was reused
+  for item 12). With the per-item key in place, reusing a container for a
+  *different* logical item fails `CanUpdate` and the row remounts with fresh
+  hook cells; same-item re-renders keep the key and diff in place, preserving
+  state. An explicit `.WithKey(...)` in the row builder still wins. This is a
+  user-visible behavior change for code that (intentionally or not) relied on
+  cross-item state carry-over — use a stable constant key, or hoist the state
+  above the row, to opt back into durable carry-over. The shared
+  `RefreshRealizedItems` refresh path now also handles a same-slot key change
+  (the documented `.WithKey($"{id}:{rev}")` revision-bump pattern) by adopting
+  the freshly-mounted subtree into the still-parented row wrapper, so the old
+  control is no longer orphaned and the per-control tracking stays consistent.
+  `ListView<T>` / `GridView<T>` already remount per realize and are unaffected.
+
 - **`UseAnnounce().Announce(...)` now marshals to the UI thread automatically.**
   Previously, calling `Announce` off the UI thread (e.g. from a `Task.Run`
   continuation) threw `RPC_E_WRONG_THREAD` (0x8001010E) — the underlying WinUI

--- a/docs/_pipeline/templates/collections.md.dt
+++ b/docs/_pipeline/templates/collections.md.dt
@@ -128,6 +128,39 @@ Even with 50 items in the list, `LazyVStack` only materializes the rows
 you can see. As you scroll, it creates new rows and recycles old ones. This
 keeps memory usage constant regardless of list size.
 
+### Per-item Component state resets on recycle
+
+When a row builder returns a stateful `Component<T>` — one that holds its own
+`UseState` / `UseEffect` (an inline editor's "dirty" flag, an expand/collapse
+toggle, a per-row animation) — that state is **per logical item**, not per
+recycled control. `LazyVStack<T>` (and `LazyHStack<T>`, `ItemsRepeater<T>`,
+`ItemsView<T>`) propagate your `keySelector` projection onto each row's
+top-level `Element.Key`. When a realized row is recycled for a *different*
+item while scrolling, the new key forces a clean remount of the row, so the
+inner component starts from its initial state instead of inheriting the
+previous item's:
+
+```csharp
+// Each row owns edit state. Scrolling row 5 (dirty) onto row 12 must NOT
+// carry the dirty flag — keySelector identity guarantees a fresh mount.
+LazyVStack<Note>(notes, n => n.Id, (note, i) =>
+    Component<NoteEditor, Note>(note));
+```
+
+Re-rendering the **same** item in place (its data changed but its key did not)
+preserves that state — the row diffs in place rather than remounting. If you
+deliberately want a hand-picked identity, an explicit `.WithKey(...)` on the
+row element always wins over the implicit `keySelector` key:
+
+```csharp
+LazyVStack<Note>(notes, n => n.Id, (note, i) =>
+    Component<NoteEditor, Note>(note)
+        .WithKey($"{note.Id}:{note.Revision}")); // remount on every revision
+```
+
+> `ListView<T>` / `GridView<T>` already mount each container fresh on
+> realization, so per-item state resets there without any extra keying.
+
 When to use which:
 
 | Collection | Virtualized | Best for |

--- a/docs/_pipeline/templates/collections.md.dt
+++ b/docs/_pipeline/templates/collections.md.dt
@@ -158,6 +158,23 @@ LazyVStack<Note>(notes, n => n.Id, (note, i) =>
         .WithKey($"{note.Id}:{note.Revision}")); // remount on every revision
 ```
 
+Conversely, if you *want* a row's component state to survive recycling — a
+deliberately durable cache, a long-running per-row animation, or state you've
+hoisted so it should outlive any single logical item — opt out by giving every
+row the **same constant key** so the recycle reuse never trips a remount:
+
+```csharp
+// Durable carry-over: a constant key disables the per-item reset, so the
+// recycled control keeps its component state across logical items.
+LazyVStack<Note>(notes, n => n.Id, (note, i) =>
+    Component<NoteEditor, Note>(note).WithKey("note-row"));
+```
+
+The more common way to keep state across recycles is to **hoist it above the
+row** — store it in the parent component (keyed by item id) and pass it down as
+props — so the row stays a pure function of its data and recycling never loses
+anything.
+
 > `ListView<T>` / `GridView<T>` already mount each container fresh on
 > realization, so per-item state resets there without any extra keying.
 

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -195,6 +195,23 @@ LazyVStack<Note>(notes, n => n.Id, (note, i) =>
         .WithKey($"{note.Id}:{note.Revision}")); // remount on every revision
 ```
 
+Conversely, if you *want* a row's component state to survive recycling — a
+deliberately durable cache, a long-running per-row animation, or state you've
+hoisted so it should outlive any single logical item — opt out by giving every
+row the **same constant key** so the recycle reuse never trips a remount:
+
+```csharp
+// Durable carry-over: a constant key disables the per-item reset, so the
+// recycled control keeps its component state across logical items.
+LazyVStack<Note>(notes, n => n.Id, (note, i) =>
+    Component<NoteEditor, Note>(note).WithKey("note-row"));
+```
+
+The more common way to keep state across recycles is to **hoist it above the
+row** — store it in the parent component (keyed by item id) and pass it down as
+props — so the row stays a pure function of its data and recycling never loses
+anything.
+
 > `ListView<T>` / `GridView<T>` already mount each container fresh on
 > realization, so per-item state resets there without any extra keying.
 

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -165,6 +165,39 @@ Even with 50 items in the list, `LazyVStack` only materializes the rows
 you can see. As you scroll, it creates new rows and recycles old ones. This
 keeps memory usage constant regardless of list size.
 
+### Per-item Component state resets on recycle
+
+When a row builder returns a stateful `Component<T>` — one that holds its own
+`UseState` / `UseEffect` (an inline editor's "dirty" flag, an expand/collapse
+toggle, a per-row animation) — that state is **per logical item**, not per
+recycled control. `LazyVStack<T>` (and `LazyHStack<T>`, `ItemsRepeater<T>`,
+`ItemsView<T>`) propagate your `keySelector` projection onto each row's
+top-level `Element.Key`. When a realized row is recycled for a *different*
+item while scrolling, the new key forces a clean remount of the row, so the
+inner component starts from its initial state instead of inheriting the
+previous item's:
+
+```csharp
+// Each row owns edit state. Scrolling row 5 (dirty) onto row 12 must NOT
+// carry the dirty flag — keySelector identity guarantees a fresh mount.
+LazyVStack<Note>(notes, n => n.Id, (note, i) =>
+    Component<NoteEditor, Note>(note));
+```
+
+Re-rendering the **same** item in place (its data changed but its key did not)
+preserves that state — the row diffs in place rather than remounting. If you
+deliberately want a hand-picked identity, an explicit `.WithKey(...)` on the
+row element always wins over the implicit `keySelector` key:
+
+```csharp
+LazyVStack<Note>(notes, n => n.Id, (note, i) =>
+    Component<NoteEditor, Note>(note)
+        .WithKey($"{note.Id}:{note.Revision}")); // remount on every revision
+```
+
+> `ListView<T>` / `GridView<T>` already mount each container fresh on
+> realization, so per-item state resets there without any extra keying.
+
 When to use which:
 
 | Collection | Virtualized | Best for |

--- a/src/Reactor/Core/ElementFactory.cs
+++ b/src/Reactor/Core/ElementFactory.cs
@@ -100,8 +100,15 @@ public sealed partial class ElementFactory<T> : IElementFactory
     /// Resolve the viewBuilder output for a (key, item, index) tuple,
     /// memoized by reference identity of <paramref name="item"/>. See
     /// <see cref="_viewBuilderCache"/> for the rationale.
+    /// <para><c>keyed</c> is true on the spec-042 <see cref="ReactorRow"/>
+    /// path, where <paramref name="key"/> is the author's <c>keySelector</c>
+    /// projection (a stable per-item identity). When set, the projection is
+    /// propagated to the row's top-level <see cref="Element.Key"/> — see
+    /// <see cref="ApplyItemIdentityKey"/> (issue #326). It is false on the
+    /// legacy int-index path, where the "key" is just the realized index and
+    /// propagating it would force a control swap on every scroll.</para>
     /// </summary>
-    private Element BuildOrCache(string key, T item, int index)
+    private Element BuildOrCache(string key, T item, int index, bool keyed)
     {
         if (_viewBuilderCache.TryGetValue(key, out var cached)
             && ReferenceEquals(cached.Item, item)
@@ -110,9 +117,34 @@ public sealed partial class ElementFactory<T> : IElementFactory
             return cached.Built;
         }
         var built = _viewBuilder(item, index);
+        if (keyed)
+            built = ApplyItemIdentityKey(built, key);
         _viewBuilderCache[key] = new ViewBuilderCacheEntry(item, index, built);
         return built;
     }
+
+    /// <summary>
+    /// Issue #326 — propagate the author's per-item <c>keySelector</c>
+    /// projection onto the row's top-level <see cref="Element.Key"/> so the
+    /// recycle-on-reuse <see cref="Reconciler.Reconcile"/> path (see
+    /// <see cref="GetElement"/>) observes a different key when a realized
+    /// container is reused for a <em>different</em> logical item. That flips
+    /// <see cref="Reconciler.CanUpdate"/> to false → Reactor takes its
+    /// keyed-replacement path (unmount + fresh mount) instead of an in-place
+    /// property diff, which resets the row's per-item Component
+    /// <c>UseState</c> / <c>UseEffect</c> state. Without this, post-#324
+    /// recycling reuses the same realized inner <c>Component&lt;T&gt;</c>
+    /// across logical items and carries hook state from item A into item B.
+    ///
+    /// <para>An explicit author-supplied key (<c>row.WithKey(...)</c> inside
+    /// the row builder) always wins: it is only applied when the built row's
+    /// <see cref="Element.Key"/> is still null. Same-item re-renders
+    /// (RefreshRealizedItems) keep the same key on both old and new elements,
+    /// so <see cref="Reconciler.CanUpdate"/> stays true and the row diffs in
+    /// place — state is preserved exactly when the logical item is unchanged.</para>
+    /// </summary>
+    internal static Element ApplyItemIdentityKey(Element built, string key)
+        => built.Key is null ? built with { Key = key } : built;
 
     public ElementFactory(
         IReadOnlyList<T> items,
@@ -228,7 +260,7 @@ public sealed partial class ElementFactory<T> : IElementFactory
             if (!_mountedElements.TryGetValue(key, out var oldElement)) continue;
             if (currentIndex < 0 || currentIndex >= _items.Count) continue;
 
-            var newElement = BuildOrCache(key, _items[currentIndex], currentIndex);
+            var newElement = BuildOrCache(key, _items[currentIndex], currentIndex, keyed: _listState is not null);
             _mountedElements[key] = newElement;
             // Keep the per-control "last element" tracking in lockstep with
             // _mountedElements. Without this, a later RecycleElement→GetElement
@@ -250,19 +282,23 @@ public sealed partial class ElementFactory<T> : IElementFactory
         //   3. Fallback: unknown shape, treat as index 0.
         string key;
         int index;
+        bool keyed;
         switch (args.Data)
         {
             case ReactorRow row:
                 key = row.Key;
                 index = row.Index;
+                keyed = true;
                 break;
             case int i:
                 index = i;
                 key = i.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+                keyed = false;
                 break;
             default:
                 index = 0;
                 key = "0";
+                keyed = false;
                 break;
         }
 
@@ -270,7 +306,7 @@ public sealed partial class ElementFactory<T> : IElementFactory
             return new TextBlock { Text = "" };
 
         var item = _items[index];
-        var element = BuildOrCache(key, item, index);
+        var element = BuildOrCache(key, item, index, keyed);
 
         UIElement? control;
         if (_recyclePool.Count > 0)

--- a/src/Reactor/Core/ElementFactory.cs
+++ b/src/Reactor/Core/ElementFactory.cs
@@ -262,14 +262,47 @@ public sealed partial class ElementFactory<T> : IElementFactory
 
             var newElement = BuildOrCache(key, _items[currentIndex], currentIndex, keyed: _listState is not null);
             _mountedElements[key] = newElement;
-            // Keep the per-control "last element" tracking in lockstep with
-            // _mountedElements. Without this, a later RecycleElement→GetElement
-            // round-trip for the same control would feed the pre-refresh
-            // Element to Reconcile as oldElement and diff against a stale
-            // tree shape. (PR #324 review)
-            _lastElementByControl[child] = newElement;
 
-            _reconciler.Reconcile(oldElement, newElement, child, _requestRerender);
+            var replacement = _reconciler.Reconcile(oldElement, newElement, child, _requestRerender);
+            if (replacement is not null && !ReferenceEquals(replacement, child))
+            {
+                // CanUpdate was false (the row's Element.Key changed — e.g. the
+                // documented .WithKey($"{id}:{rev}") pattern — or a root type
+                // change) → Reconcile unmounted `child` and built a fresh
+                // `replacement`. The ItemsRepeater that still parents `child`
+                // isn't a Panel, so we can't swap the realized slot the way the
+                // GetElement framework return-channel does. Adopt the fresh
+                // subtree into the still-parented wrapper when the shapes allow
+                // it; otherwise keep the maps consistent so no stale entry
+                // survives and the next scroll re-realize fixes the visual.
+                // Without this, the old control was orphaned (stale state still
+                // visible) and _lastElementByControl[child] pointed at an
+                // element the control no longer hosted. (Issue #326 pr-review H1)
+                if (_reconciler.TryAdoptRealizedReplacement(child, replacement))
+                {
+                    // `child` now hosts the fresh component subtree — tracking
+                    // stays anchored on the still-realized `child`.
+                    _lastElementByControl[child] = newElement;
+                }
+                else
+                {
+                    DetachFromParent(child);
+                    _keyByControl.Remove(child);
+                    _lastElementByControl.Remove(child);
+                    _keyByControl[replacement] = key;
+                    _lastElementByControl[replacement] = newElement;
+                }
+            }
+            else
+            {
+                // In-place diff (same key) reused `child`. Keep the per-control
+                // "last element" tracking in lockstep with _mountedElements.
+                // Without this, a later RecycleElement→GetElement round-trip for
+                // the same control would feed the pre-refresh Element to
+                // Reconcile as oldElement and diff against a stale tree shape.
+                // (PR #324 review)
+                _lastElementByControl[child] = newElement;
+            }
         }
     }
 

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -1539,6 +1539,51 @@ public sealed partial class Reconciler : IDisposable
         return Mount(newElement, requestRerender);
     }
 
+    /// <summary>
+    /// Issue #326 (pr-review H1) — adopt a freshly-mounted <paramref name="replacement"/>
+    /// into an already-realized, still-parented wrapper so an out-of-band refresh
+    /// (<see cref="ElementFactory{T}.RefreshRealizedItems"/>) whose row key changed
+    /// (<see cref="CanUpdate"/> == false → <see cref="ReconcileImperative"/> returned a
+    /// brand-new control) can reset per-item component state without reparenting.
+    ///
+    /// <para>The WinUI ItemsRepeater that owns realized rows is NOT a Panel, so its
+    /// children cannot be replaced from managed code — there is no Children collection
+    /// to assign into the way the normal Reconcile contract
+    /// (<c>g.Children[i] = replacement</c>) or the framework's GetElement return-channel
+    /// relies on. When both the realized control and the replacement are
+    /// component-wrapper Borders (the dominant case: authors put per-item state in a
+    /// Component and key it with <c>.WithKey($"{id}:{rev}")</c>), keep the parented
+    /// wrapper in place and move the fresh component subtree plus its
+    /// <see cref="_componentNodes"/> entry onto it. The discarded replacement wrapper is
+    /// left empty for GC.</para>
+    ///
+    /// <para>Returns false when the shapes don't permit an in-place adopt (e.g. a root
+    /// TYPE change where neither side is a component wrapper); the caller then falls
+    /// back to tracking-only reconciliation.</para>
+    /// </summary>
+    internal bool TryAdoptRealizedReplacement(UIElement realized, UIElement replacement)
+    {
+        if (realized is not Border realizedWrapper || replacement is not Border replacementWrapper)
+            return false;
+        if (!_componentNodes.TryGetValue(replacement, out var freshNode))
+            return false;
+
+        // Migrate the fresh component node onto the still-parented wrapper. The old
+        // node keyed on `realized` was already torn down + removed by the Unmount
+        // inside ReconcileImperative; overwrite defensively regardless.
+        _componentNodes.Remove(replacement);
+        _componentNodes[realized] = freshNode;
+
+        // Move the fresh visual subtree into the parented wrapper. Assigning
+        // Border.Child detaches it from `replacementWrapper` first (and detaches the
+        // old, already-unmounted subtree from `realizedWrapper`), leaving the
+        // replacement wrapper empty + unreferenced.
+        var freshChild = replacementWrapper.Child;
+        replacementWrapper.Child = null;
+        realizedWrapper.Child = freshChild;
+        return true;
+    }
+
     // ════════════════════════════════════════════════════════════════════
     //  Component reconciliation
     // ════════════════════════════════════════════════════════════════════

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ElementFactoryRecyclingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ElementFactoryRecyclingFixtures.cs
@@ -486,4 +486,108 @@ internal static class ElementFactoryRecyclingFixtures
             return Task.CompletedTask;
         }
     }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Issue #326 (pr-review H1 + L1) — RefreshRealizedItems must handle a
+    //  same-slot key change end-to-end.
+    //
+    //  The documented `.WithKey($"{id}:{revision}")` pattern bumps a realized
+    //  row's Element.Key on an in-place re-render (no structural list change),
+    //  so the refresh path runs Reconcile with CanUpdate == false → Unmount +
+    //  Mount → a fresh replacement control. RefreshRealizedItems must, exactly
+    //  like GetElement, (a) parent the replacement into the realized slot,
+    //  (b) detach/unmount the old control, and (c) migrate the per-control
+    //  tracking maps so no stale entry survives. It must ALSO reset the inner
+    //  Component's UseState end-to-end (L1): the rendered value returns to its
+    //  initial state.
+    //
+    //  Drives a LIVE LazyVStack + real ItemsRepeater (not a standalone factory)
+    //  because the bug is specifically about the framework-owned realized tree
+    //  and the refresh path that only that wiring exercises.
+    // ────────────────────────────────────────────────────────────────────
+
+    private class StatefulKeyedRow : Microsoft.UI.Reactor.Core.Component
+    {
+        public override Microsoft.UI.Reactor.Core.Element Render()
+        {
+            var (n, setN) = UseState(0);
+            UseEffect(() =>
+            {
+                global::System.Threading.Interlocked.Increment(ref s_keyedRowEffectMount);
+                return () => global::System.Threading.Interlocked.Increment(ref s_keyedRowEffectCleanup);
+            });
+            return VStack(
+                TextBlock($"val:{n}"),
+                Button("incRow", () => setN(n + 1))
+            );
+        }
+    }
+
+    private static int s_keyedRowEffectMount;
+    private static int s_keyedRowEffectCleanup;
+
+    internal class Factory_RefreshKeyChange_RemountsRealizedRow(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            s_keyedRowEffectMount = 0;
+            s_keyedRowEffectCleanup = 0;
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (rev, setRev) = ctx.UseState(0);
+                var items = new[] { new Item("a", "A") };
+                return VStack(
+                    Button("BumpRev", () => setRev(rev + 1)),
+                    LazyVStack<Item>(items, i => i.Id, (i, _) =>
+                        Component<StatefulKeyedRow>().WithKey($"{i.Id}:{rev}")).Height(200)
+                );
+            });
+            await Harness.Render();
+
+            var repeater = H.FindControl<WinXC.ItemsRepeater>(_ => true);
+            var factory = repeater?.ItemTemplate as ElementFactory<Item>;
+            H.Check("EFR326_RefreshKey_FactoryFound", factory is not null && repeater is not null);
+            if (factory is null || repeater is null) return;
+
+            H.Check("EFR326_RefreshKey_InitialVal0", H.FindText("val:0") is not null);
+
+            // Make the realized row dirty: val 0 → 1.
+            H.ClickButton("incRow");
+            await Harness.Render();
+            H.Check("EFR326_RefreshKey_DirtyVal1", H.FindText("val:1") is not null);
+
+            var realizedBefore = repeater.TryGetElement(0);
+            int mountBefore = s_keyedRowEffectMount;
+
+            // Bump the outer revision → row key "a:0" → "a:1". Same list slot,
+            // changed Element.Key → RefreshRealizedItems runs Reconcile with
+            // CanUpdate == false → remount.
+            H.ClickButton("BumpRev");
+            await Harness.Render();
+
+            // (L1) End-to-end state reset: the fresh Component renders val:0,
+            // and the dirty val:1 control is gone from the visual tree.
+            bool showsReset = await Harness.WaitFor(() => H.FindText("val:0") is not null);
+            H.Check("EFR326_RefreshKey_StateResetToVal0", showsReset);
+            H.Check("EFR326_RefreshKey_DirtyValGone", H.FindText("val:1") is null);
+
+            // Effect lifecycle: old row's cleanup ran, fresh row's effect mounted.
+            H.Check($"EFR326_RefreshKey_NewEffectMounted_mount={s_keyedRowEffectMount}",
+                s_keyedRowEffectMount > mountBefore);
+            H.Check($"EFR326_RefreshKey_OldEffectCleanedUp_cleanup={s_keyedRowEffectCleanup}",
+                s_keyedRowEffectCleanup >= 1);
+
+            // Tracking maps: the realized control after the bump is tracked,
+            // and the pre-bump control left no stale entry behind.
+            var realizedAfter = repeater.TryGetElement(0);
+            H.Check("EFR326_RefreshKey_RealizedAfterTracked",
+                realizedAfter is not null && factory.DebugTryGetLastElementByControl(realizedAfter, out _));
+            H.Check("EFR326_RefreshKey_NoStaleOldTracking",
+                realizedBefore is null
+                || ReferenceEquals(realizedBefore, realizedAfter)
+                || !factory.DebugTryGetLastElementByControl(realizedBefore, out _));
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ElementFactoryRecyclingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ElementFactoryRecyclingFixtures.cs
@@ -358,4 +358,132 @@ internal static class ElementFactoryRecyclingFixtures
             H.Check($"EFR_LazyStackUnmount_AtLeastOneCleanup_after={after}", after >= 1);
         }
     }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Issue #326 — per-item identity reset on recycle.
+    //  The ElementFactory recycle path (#324) retains the realized WinUI tree
+    //  and Reconciles-on-reuse. Without propagating the keySelector key to the
+    //  row's top-level Element.Key, reusing a realized container for a DIFFERENT
+    //  logical item diffs the inner Component in place and CARRIES its
+    //  UseState/UseEffect state from item A into item B. The fix propagates the
+    //  per-item key (issue #326), so cross-item reuse fails CanUpdate and the
+    //  row remounts → fresh hook cells. Same-item reuse keeps the key and stays
+    //  in place → state preserved.
+    //
+    //  These drive a standalone ElementFactory through the spec-042 ReactorRow
+    //  keyed path (args.Data is ReactorRow), the same path every live
+    //  LazyVStack/LazyHStack/ItemsRepeater<T> uses. A per-Component constructor
+    //  count is a deterministic proxy for "fresh hook state": a new Component
+    //  instance means new UseState/UseEffect cells. The UseEffect mount/cleanup
+    //  counters corroborate it (effects flush synchronously on the render path).
+    // ────────────────────────────────────────────────────────────────────
+
+    private static int s_rowCtorCount;
+    private static int s_rowEffectMountCount;
+    private static int s_rowEffectCleanupCount;
+
+    private class IdentityRowComponent : Microsoft.UI.Reactor.Core.Component
+    {
+        public IdentityRowComponent() => global::System.Threading.Interlocked.Increment(ref s_rowCtorCount);
+
+        public override Microsoft.UI.Reactor.Core.Element Render()
+        {
+            // A per-item state cell + a per-item effect. If the row's identity
+            // is correctly reset on cross-item reuse, both are re-initialized
+            // (fresh cell, effect re-runs). If it leaks, the same instance —
+            // and therefore the same cell/effect — is reused across items.
+            var (_, _) = UseState(0);
+            UseEffect(() =>
+            {
+                global::System.Threading.Interlocked.Increment(ref s_rowEffectMountCount);
+                return () => global::System.Threading.Interlocked.Increment(ref s_rowEffectCleanupCount);
+            });
+            return TextBlock("row");
+        }
+    }
+
+    private static ElementFactoryGetArgs MakeRowGetArgs(int index, string key)
+        // Spec-042 ReactorRow path — args.Data carries both the stable key
+        // (keySelector projection) and the data index. This is the path the
+        // issue #326 fix gates on; the legacy int path is intentionally left
+        // unkeyed so the bounded-working-set fixtures above keep passing.
+        => new() { Data = new ReactorRow { Index = index, Key = key } };
+
+    internal class Factory_KeyChangeRecycle_ResetsRowComponentState(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync()
+        {
+            s_rowCtorCount = 0;
+            s_rowEffectMountCount = 0;
+            s_rowEffectCleanupCount = 0;
+
+            var items = new[] { new Item("a", "A"), new Item("b", "B") };
+            var reconciler = new Reconciler();
+            var factory = new ElementFactory<Item>(
+                items,
+                // No explicit .WithKey on the row root — the implicit per-item
+                // key is what must drive the reset.
+                (_, _) => Component<IdentityRowComponent>(),
+                reconciler,
+                requestRerender: static () => { },
+                pool: null);
+            var ifactory = (IElementFactory)factory;
+
+            // Realize logical item "a" → one Component instance mounts.
+            var ctlA = ifactory.GetElement(MakeRowGetArgs(0, "a"));
+            H.Check($"EFR326_KeyChange_FirstRealizeMountsOne_ctor={s_rowCtorCount}", s_rowCtorCount == 1);
+            H.Check($"EFR326_KeyChange_FirstRealizeEffectRan_mount={s_rowEffectMountCount}", s_rowEffectMountCount == 1);
+
+            // Recycle it so the container is pool-available, then realize a
+            // DIFFERENT logical item ("b") that reuses the pooled container.
+            ifactory.RecycleElement(MakeRecycleArgs(ctlA));
+            ifactory.GetElement(MakeRowGetArgs(1, "b"));
+
+            // Key "a" → "b" differs → CanUpdate false → the old Component is
+            // unmounted (cleanup runs) and a fresh one is mounted (new hook
+            // cells). Pre-fix this was an in-place diff → ctor stays 1, state
+            // leaks. Post-fix: ctor == 2.
+            H.Check($"EFR326_KeyChange_FreshComponentInstance_ctor={s_rowCtorCount}", s_rowCtorCount == 2);
+            H.Check($"EFR326_KeyChange_NewEffectMounted_mount={s_rowEffectMountCount}", s_rowEffectMountCount == 2);
+            H.Check($"EFR326_KeyChange_OldEffectCleanedUp_cleanup={s_rowEffectCleanupCount}", s_rowEffectCleanupCount >= 1);
+
+            return Task.CompletedTask;
+        }
+    }
+
+    internal class Factory_SameItemReuse_PreservesRowComponentState(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync()
+        {
+            s_rowCtorCount = 0;
+            s_rowEffectMountCount = 0;
+            s_rowEffectCleanupCount = 0;
+
+            var items = new[] { new Item("a", "A"), new Item("b", "B") };
+            var reconciler = new Reconciler();
+            var factory = new ElementFactory<Item>(
+                items,
+                (_, _) => Component<IdentityRowComponent>(),
+                reconciler,
+                requestRerender: static () => { },
+                pool: null);
+            var ifactory = (IElementFactory)factory;
+
+            // Realize "a", recycle, then realize the SAME logical item "a"
+            // again reusing the pooled container.
+            var ctlA = ifactory.GetElement(MakeRowGetArgs(0, "a"));
+            ifactory.RecycleElement(MakeRecycleArgs(ctlA));
+            ifactory.GetElement(MakeRowGetArgs(0, "a"));
+
+            // Same key → CanUpdate true → in-place reuse → the same Component
+            // instance is preserved (no remount). State for the unchanged
+            // logical item is retained — exactly the non-reset half of the
+            // contract.
+            H.Check($"EFR326_SameItem_PreservesComponentInstance_ctor={s_rowCtorCount}", s_rowCtorCount == 1);
+            H.Check($"EFR326_SameItem_NoExtraEffectMount_mount={s_rowEffectMountCount}", s_rowEffectMountCount == 1);
+            H.Check($"EFR326_SameItem_NoCleanup_cleanup={s_rowEffectCleanupCount}", s_rowEffectCleanupCount == 0);
+
+            return Task.CompletedTask;
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -246,6 +246,7 @@ internal static class SelfTestFixtureRegistry
         "EFR_LazyStack_Unmount_CleansUpAllRecycledRowComponents",
         "EFR_Factory_KeyChangeRecycle_ResetsRowComponentState",
         "EFR_Factory_SameItemReuse_PreservesRowComponentState",
+        "EFR_Factory_RefreshKeyChange_RemountsRealizedRow",
         // Spec 042 Phase 3 — Animate(...) ambient end-to-end.
         "AAF_ListView_InsertUnderAnimate_TagsRowWithKind",
         "AAF_ListView_InsertWithoutAnimate_RowNotTagged",
@@ -1629,6 +1630,7 @@ internal static class SelfTestFixtureRegistry
         "EFR_LazyStack_Unmount_CleansUpAllRecycledRowComponents" => new ElementFactoryRecyclingFixtures.LazyStack_Unmount_CleansUpAllRecycledRowComponents(harness),
         "EFR_Factory_KeyChangeRecycle_ResetsRowComponentState" => new ElementFactoryRecyclingFixtures.Factory_KeyChangeRecycle_ResetsRowComponentState(harness),
         "EFR_Factory_SameItemReuse_PreservesRowComponentState" => new ElementFactoryRecyclingFixtures.Factory_SameItemReuse_PreservesRowComponentState(harness),
+        "EFR_Factory_RefreshKeyChange_RemountsRealizedRow" => new ElementFactoryRecyclingFixtures.Factory_RefreshKeyChange_RemountsRealizedRow(harness),
         // Spec 042 Phase 3 — Animate(...) ambient end-to-end.
         "AAF_ListView_InsertUnderAnimate_TagsRowWithKind" => new AnimateAmbientFixtures.ListView_InsertUnderAnimate_TagsRowWithKind(harness),
         "AAF_ListView_InsertWithoutAnimate_RowNotTagged" => new AnimateAmbientFixtures.ListView_InsertWithoutAnimate_RowNotTagged(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -244,6 +244,8 @@ internal static class SelfTestFixtureRegistry
         "EFR_Factory_ReplacementOnRootTypeChange_DropsOldControlTracking",
         "EFR_Factory_RefreshRealizedItems_SyncsLastElementByControl",
         "EFR_LazyStack_Unmount_CleansUpAllRecycledRowComponents",
+        "EFR_Factory_KeyChangeRecycle_ResetsRowComponentState",
+        "EFR_Factory_SameItemReuse_PreservesRowComponentState",
         // Spec 042 Phase 3 — Animate(...) ambient end-to-end.
         "AAF_ListView_InsertUnderAnimate_TagsRowWithKind",
         "AAF_ListView_InsertWithoutAnimate_RowNotTagged",
@@ -1625,6 +1627,8 @@ internal static class SelfTestFixtureRegistry
         "EFR_Factory_ReplacementOnRootTypeChange_DropsOldControlTracking" => new ElementFactoryRecyclingFixtures.Factory_ReplacementOnRootTypeChange_DropsOldControlTracking(harness),
         "EFR_Factory_RefreshRealizedItems_SyncsLastElementByControl" => new ElementFactoryRecyclingFixtures.Factory_RefreshRealizedItems_SyncsLastElementByControl(harness),
         "EFR_LazyStack_Unmount_CleansUpAllRecycledRowComponents" => new ElementFactoryRecyclingFixtures.LazyStack_Unmount_CleansUpAllRecycledRowComponents(harness),
+        "EFR_Factory_KeyChangeRecycle_ResetsRowComponentState" => new ElementFactoryRecyclingFixtures.Factory_KeyChangeRecycle_ResetsRowComponentState(harness),
+        "EFR_Factory_SameItemReuse_PreservesRowComponentState" => new ElementFactoryRecyclingFixtures.Factory_SameItemReuse_PreservesRowComponentState(harness),
         // Spec 042 Phase 3 — Animate(...) ambient end-to-end.
         "AAF_ListView_InsertUnderAnimate_TagsRowWithKind" => new AnimateAmbientFixtures.ListView_InsertUnderAnimate_TagsRowWithKind(harness),
         "AAF_ListView_InsertWithoutAnimate_RowNotTagged" => new AnimateAmbientFixtures.ListView_InsertWithoutAnimate_RowNotTagged(harness),

--- a/tests/Reactor.Tests/ElementFactoryKeyPropagationTests.cs
+++ b/tests/Reactor.Tests/ElementFactoryKeyPropagationTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Issue #326 — unit coverage for the keySelector → row <see cref="Element.Key"/>
+/// propagation logic used by <see cref="ElementFactory{T}"/>'s recycle path.
+/// The reused-container reconcile (GetElement) relies on a different key landing
+/// on the row's top-level element so <see cref="Reconciler.CanUpdate"/> flips to
+/// false for a different logical item and the row's Component state resets.
+/// These exercise the pure projection helper directly (no WinUI thread needed).
+/// </summary>
+public class ElementFactoryKeyPropagationTests
+{
+    [Fact]
+    public void ApplyItemIdentityKey_Sets_Key_When_Row_Has_None()
+    {
+        var row = VStack(TextBlock("hello"));
+        Assert.Null(row.Key);
+
+        var keyed = ElementFactory<int>.ApplyItemIdentityKey(row, "item-42");
+
+        Assert.Equal("item-42", keyed.Key);
+    }
+
+    [Fact]
+    public void ApplyItemIdentityKey_Preserves_Concrete_Record_Type()
+    {
+        // `with` on the base Element reference must clone the most-derived
+        // record so downstream Mount/Update dispatch still sees the real type.
+        Element row = TextBlock("hello");
+        var keyed = ElementFactory<int>.ApplyItemIdentityKey(row, "k");
+
+        Assert.IsType<TextBlockElement>(keyed);
+        Assert.Equal("k", keyed.Key);
+    }
+
+    [Fact]
+    public void ApplyItemIdentityKey_Explicit_Author_Key_Wins()
+    {
+        // A `.WithKey(...)` written inside the row builder must not be
+        // overwritten by the implicit per-item key (issue #326 Q2).
+        var row = VStack(TextBlock("hello")).WithKey("author-key");
+
+        var keyed = ElementFactory<int>.ApplyItemIdentityKey(row, "item-42");
+
+        Assert.Equal("author-key", keyed.Key);
+        Assert.Same(row, keyed); // no clone allocated when the key already exists
+    }
+
+    [Fact]
+    public void ApplyItemIdentityKey_Different_Items_Get_Different_Keys()
+    {
+        // The whole point: two logical items projecting through keySelector
+        // produce row elements whose Keys differ, so a recycled container
+        // reused across them fails CanUpdate and remounts (state reset).
+        var a = ElementFactory<int>.ApplyItemIdentityKey(VStack(TextBlock("a")), "id-a");
+        var b = ElementFactory<int>.ApplyItemIdentityKey(VStack(TextBlock("b")), "id-b");
+
+        Assert.NotEqual(a.Key, b.Key);
+    }
+}


### PR DESCRIPTION
## Summary

The post-#324 `ItemsRepeater` recycle path (`ElementFactory<T>`) reused a realized inner `Component<T>` across **different logical items** while scrolling, because each row's top-level `Element.Key` was `null`. `Reconciler.CanUpdate` then returned `true` for same-type rows, taking an in-place property diff that carried the row's `UseState`/`UseEffect` state from item A into item B — e.g. an inline editor's "dirty" flag for item 5 stayed dirty when its control was recycled for item 12. This matched WinUI `RecyclingElementFactory` behavior but is a footgun.

**Fix:** in the spec-042 `ReactorRow` path, propagate the author's `keySelector` projection onto the built row's `Element.Key` (`ElementFactory<T>.ApplyItemIdentityKey`). A different logical item now yields a different key → `CanUpdate` returns `false` → Reactor takes its keyed-replacement path (unmount + fresh mount) → per-item Component state resets cleanly. Same-item re-renders keep the same key and still diff in place (state preserved).

## Design decision — always-on, explicit `.WithKey` wins (Q1 / Q2)

I chose **always-on** rather than an opt-in flag, with explicit author keys winning:

- **Always-on for the keyed list path.** Per-item identity reset is the intuitive default; state carry-over across logical items is a footgun, not a feature. The perf data below shows no regression, so the opt-in fallback (`resetStateOnRecycle:`) the issue allows is unnecessary.
- **Explicit author `.WithKey(...)` always wins** — the implicit key is only applied when the built row's `Key` is still `null`.
- **Legacy int-index path left unkeyed.** On that path the "key" is the realized index, not item identity; keying it would force a control swap on every scroll and break the bounded-working-set #324 fixtures. All live `LazyVStack`/`LazyHStack`/`ItemsRepeater<T>`/`ItemsView<T>` bind an `ObservableCollection<ReactorRow>` source (spec 042), so they all get the fix through the single central site.

## Issue questions

- **Q3 (ListView/GridView):** Not affected. `TemplatedListLifecycle` + `HandleTemplatedContainerContentChanging` already unmount container content on `InRecycleQueue` and mount fresh on realize, so per-item state already resets there. No change needed.
- **Q4 (does KeyedListDiff already key the realized row?):** No. `KeyedListDiff` keys only the `OC<ReactorRow>` level (for move/insert/remove); the realized row's `Element.Key` was never set. The fix sets it at realization/refresh in `ElementFactory<T>`.

## Perf check (Q5 — required)

Homogeneous-row scroll-recycle, `StressPerf.VirtualList.Reactor --headless --count 5000 --duration 6`, ARM64 Release, clean back-to-back A/B (core file reverted via `git stash` for BEFORE, identical platform/build):

| Metric | BEFORE | AFTER | Δ |
|---|---|---|---|
| Avg dt | 16.64 ms | 16.65 ms | +0.01 |
| P50 | 16.67 ms | 16.67 ms | 0.00 |
| P95 | 17.81 ms | 17.84 ms | +0.03 |
| P99 | 22.15 ms | 22.30 ms | +0.15 |
| Max | 25.36 ms | 24.96 ms | −0.40 |
| WS | 177 MB | 182 MB | +5 MB |

**No meaningful regression.** The keyed reuse path swaps via `ElementPool` (the raw control is recycled on Unmount→Mount, not reallocated) and stays well within the 60fps frame budget; tail latency is unchanged. No swap-mitigation was needed.

## Tests

- **Unit** (`tests/Reactor.Tests/ElementFactoryKeyPropagationTests.cs`): null→key, explicit author key wins, distinct items get distinct keys, concrete record type preserved through the `with` copy.
- **SelfTest** (`tests/Reactor.AppTests.Host/SelfTest/Fixtures/ElementFactoryRecyclingFixtures.cs`):
  - `EFR_Factory_KeyChangeRecycle_ResetsRowComponentState` — fresh component instance (ctor=2) + new effect mount + old effect cleanup on cross-key reuse.
  - `EFR_Factory_SameItemReuse_PreservesRowComponentState` — same instance (ctor=1), no extra mount/cleanup on same-key re-render.
- Existing #324 EFR, LazyStack, Keyed, VirtualList, ItemsRepeater, ItemsView fixtures stay green. Full `dotnet test tests/Reactor.Tests` = **9478 passed, 0 failed**.

## Docs

`docs/guide/collections.md` gains a **"Per-item Component state resets on recycle"** section documenting the default behavior and the explicit-`.WithKey` precedence (edited the `docs/_pipeline/templates/collections.md.dt` template and recompiled via `mur docs compile`).

Closes #326