### PR TITLE
fix(a11y): scope A11Y_CHART_011 to active background, promote to warning (#633)

### DIFF
--- a/docs/_pipeline/templates/charting.md.dt
+++ b/docs/_pipeline/templates/charting.md.dt
@@ -217,6 +217,9 @@ annotations, and `.Interactive()` for keyboard navigation:
 | `.OnPointInvoke(handler)` | Callback when Enter/Space pressed on a point |
 | `.AlternateView(element)` | Toggle between chart and data table (T key) |
 | `.Palette(palette)` | Curated colorblind-safe palette |
+| `.SeriesColors(colors)` | Custom series colors (scanner-validated) |
+| `.RawColors(colors)` | Raw series colors — escape hatch, no validation (Tier 4) |
+| `.ChartBackground(color)` | Declare the rendered background so palette-contrast (A11Y_CHART_011) is checked against that single active background (warning) instead of either fixed light/dark background (info) |
 | `.SeriesShapes(shapes)` | Marker shapes for double-encoding |
 | `.SeriesDashes(dashes)` | Dash patterns for double-encoding |
 

--- a/docs/guide/charting.md
+++ b/docs/guide/charting.md
@@ -427,6 +427,9 @@ class AccessibleChartDemo : Component
 | `.OnPointInvoke(handler)` | Callback when Enter/Space pressed on a point |
 | `.AlternateView(element)` | Toggle between chart and data table (T key) |
 | `.Palette(palette)` | Curated colorblind-safe palette |
+| `.SeriesColors(colors)` | Custom series colors (scanner-validated) |
+| `.RawColors(colors)` | Raw series colors — escape hatch, no validation (Tier 4) |
+| `.ChartBackground(color)` | Declare the rendered background so palette-contrast (A11Y_CHART_011) is checked against that single active background (warning) instead of either fixed light/dark background (info) |
 | `.SeriesShapes(shapes)` | Marker shapes for double-encoding |
 | `.SeriesDashes(dashes)` | Dash patterns for double-encoding |
 

--- a/docs/specs/026-charting-accessibility-design.md
+++ b/docs/specs/026-charting-accessibility-design.md
@@ -746,6 +746,9 @@ Force graph physics is decorative; accessibility ships as structure, not motion.
 .Palette(ChartPalette)                  // Tier 1 — curated, pre-vetted (default: OkabeIto)
 .SeriesColors(params Color[])           // Tier 3 — scanner-validated raw colors
 .RawColors(params Color[])              // Tier 4 — unchecked escape hatch (A11Y_CHART_012)
+.ChartBackground(Color)                 // declare rendered background → scopes A11Y_CHART_011
+                                        //   to that single active background (warning) instead
+                                        //   of either fixed light/dark background (info)
 ChartPalette.Harden(Color[])            // utility — returns nearest safe palette + diffs
 
 // Escape hatches (scanner warns on each)

--- a/docs/specs/026-charting-accessibility-design.md
+++ b/docs/specs/026-charting-accessibility-design.md
@@ -557,7 +557,7 @@ LineChart(...).SeriesColors(
 Checks run:
 
 - Pairwise WCAG non-text contrast (every series vs. every other) ≥ 3:1.
-- Each series vs. `ChartBackground` (light or dark) ≥ 3:1.
+- Each series vs. `ChartBackground` — the declared active background when `.ChartBackground(...)` is set, otherwise both fixed light/dark backgrounds — ≥ 3:1.
 - Pairwise ΔE ≥ 10 under deuteranopia, protanopia, tritanopia simulation.
 
 Violations emit scanner rules `A11Y_CHART_009`–`011` (see Layer 8) with the offending hex
@@ -653,7 +653,7 @@ JSON shape as existing A11Y_001–008:
 | `A11Y_CHART_007` | `.AnnounceEveryFrame()` used — floods live region | Remove; defaults are debounced for a reason. |
 | `A11Y_CHART_009` | Custom palette fails pairwise WCAG 3:1 non-text contrast | Run `ChartPalette.Harden(...)` — fix suggestion embeds hardened hex values. |
 | `A11Y_CHART_010` | Custom palette fails colorblind simulation (ΔE < 10 under deut/prot/trit) | Same: hardened alternative provided inline. |
-| `A11Y_CHART_011` | Custom palette would fail 3:1 contrast against `ChartBackground` (light or dark) | Informational (the static scanner is theme-agnostic and cannot know the active background, so it flags either-theme risk without blocking). Hardened alternative adjusts lightness away from the failing background. |
+| `A11Y_CHART_011` | Custom palette fails 3:1 contrast against the chart background. Scoped to the active background when the author declares `.ChartBackground(...)`, otherwise checked against `ChartBackground` (light or dark). | **Severity is conditional** (issue #633): a `warning` when a representative background is declared (the check is scoped to that single active background, so the failure is real and not noisy); `info` when no background is declared (the static scanner is theme-agnostic and cannot know the active background, so it flags either-theme risk without blocking to avoid alert fatigue). Hardened alternative adjusts lightness away from the failing background. |
 | `A11Y_CHART_012` | `.RawColors()` escape hatch used | Informational; no blocking. Recorded for audit. Consider moving to `.Palette()` or `.SeriesColors()`. |
 
 *(A11Y_CHART_008 for a missing data-table fallback is intentionally absent: the fallback is

--- a/plugins/reactor/skills/reactor-charts/SKILL.md
+++ b/plugins/reactor/skills/reactor-charts/SKILL.md
@@ -72,7 +72,8 @@ Common fluent knobs (chain-call any subset):
 .Fill("#50C878")                                  // bars / area / pie slice baseline
 .ShowGrid(true).ShowAxes(true)
 .DataLabel((point, idx) => $"{point.Revenue:C}")  // string label per point
-.Palette(ChartPalette.Categorical)                // pie color palette
+.Palette(ChartPalette.Categorical)                // Tier 1 curated palette (a11y-scanned)
+.ChartBackground("#1E1E1E")                        // declare active bg → scopes A11Y_CHART_011
 ```
 
 `AxisLabel` text and `Title` are reserved for *labeling the chart*, not
@@ -212,6 +213,20 @@ Beyond that, your responsibilities:
   for text labels. The default chart palette meets this against the
   framework's surface tokens; if you override with `.Stroke("#…")` /
   `.Fill("#…")`, check contrast against `Theme.SurfaceBackground`.
+- **Custom colors & the scanner.** Three tiers, in order of safety:
+  `.Palette(ChartPalette.Categorical)` (Tier 1, curated) and `.SeriesColors(…)`
+  (Tier 3, your own colors) are both contrast-checked by the a11y scanner
+  (`A11Y_CHART_011`). `.RawColors(…)` (Tier 4) is an escape hatch that bypasses
+  the check and itself trips the `A11Y_CHART_012` info. Colors set via the
+  low-level `.SetColors(…)` are **not** seen by the scanner — use
+  `.Palette` / `.SeriesColors` for scanner-visible palettes.
+- **Declare the background you render on.** `A11Y_CHART_011` is theme-agnostic
+  by default, so it can only flag a custom color against *either* fixed
+  light/dark background as an `info`. Call `.ChartBackground("#1E1E1E")` (also
+  takes a `D3Color` or `Windows.UI.Color`) to scope the check to the single
+  background the chart actually renders on — the finding becomes an actionable
+  `warning` with a real, contrast-hardened fix, and palettes that are fine on
+  their actual background stop being flagged.
 - **Screen-reader fallback.** UIA structured data is good but not enough
   for screen-reader-only users — a hidden, expandable data table next to
   the chart is the pattern Tenon and the W3C WAI accessibility guidance

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1581,7 +1581,9 @@ new()
 AlternateView(Element view) → ChartElement<T>
 AnnounceEveryFrame() → ChartElement<T>
 AxisLabel(ChartAxisType axis, string label) → ChartElement<T>
+ChartBackground(Color background) → ChartElement<T>
 ChartBackground(D3Color background) → ChartElement<T>
+ChartBackground(string background) → ChartElement<T>
 ColorOnly() → ChartElement<T>
 DataLabel(Func<T, int, string> labeller) → ChartElement<T>
 Description(string description) → ChartElement<T>
@@ -5054,7 +5056,9 @@ ToString() → string
 ### class PieChartElement<T>
 new()
 AlternateView(Element view) → PieChartElement<T>
+ChartBackground(Color background) → PieChartElement<T>
 ChartBackground(D3Color background) → PieChartElement<T>
+ChartBackground(string background) → PieChartElement<T>
 ColorOnly() → PieChartElement<T>
 DataLabel(Func<T, int, string> labeller) → PieChartElement<T>
 Description(string description) → PieChartElement<T>

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1581,6 +1581,7 @@ new()
 AlternateView(Element view) → ChartElement<T>
 AnnounceEveryFrame() → ChartElement<T>
 AxisLabel(ChartAxisType axis, string label) → ChartElement<T>
+ChartBackground(D3Color background) → ChartElement<T>
 ColorOnly() → ChartElement<T>
 DataLabel(Func<T, int, string> labeller) → ChartElement<T>
 Description(string description) → ChartElement<T>
@@ -3544,6 +3545,7 @@ ToString() → string
 
 ### class HardenOptions
 new()
+D3Color? Background { get; init; }
 double MinBackgroundContrast { get; init; }
 double MinColorblindDeltaE { get; init; }
 double MinPairwiseContrast { get; init; }
@@ -5052,6 +5054,7 @@ ToString() → string
 ### class PieChartElement<T>
 new()
 AlternateView(Element view) → PieChartElement<T>
+ChartBackground(D3Color background) → PieChartElement<T>
 ColorOnly() → PieChartElement<T>
 DataLabel(Func<T, int, string> labeller) → PieChartElement<T>
 Description(string description) → PieChartElement<T>

--- a/skills/charts.md
+++ b/skills/charts.md
@@ -81,7 +81,8 @@ Common fluent knobs (chain-call any subset):
 .Fill("#50C878")                                  // bars / area / pie slice baseline
 .ShowGrid(true).ShowAxes(true)
 .DataLabel((point, idx) => $"{point.Revenue:C}")  // string label per point
-.Palette(ChartPalette.Categorical)                // pie color palette
+.Palette(ChartPalette.Categorical)                // Tier 1 curated palette (a11y-scanned)
+.ChartBackground("#1E1E1E")                        // declare active bg → scopes A11Y_CHART_011
 ```
 
 `AxisLabel` text and `Title` are reserved for *labeling the chart*, not
@@ -221,6 +222,20 @@ Beyond that, your responsibilities:
   for text labels. The default chart palette meets this against the
   framework's surface tokens; if you override with `.Stroke("#…")` /
   `.Fill("#…")`, check contrast against `Theme.SurfaceBackground`.
+- **Custom colors & the scanner.** Three tiers, in order of safety:
+  `.Palette(ChartPalette.Categorical)` (Tier 1, curated) and `.SeriesColors(…)`
+  (Tier 3, your own colors) are both contrast-checked by the a11y scanner
+  (`A11Y_CHART_011`). `.RawColors(…)` (Tier 4) is an escape hatch that bypasses
+  the check and itself trips the `A11Y_CHART_012` info. Colors set via the
+  low-level `.SetColors(…)` are **not** seen by the scanner — use
+  `.Palette` / `.SeriesColors` for scanner-visible palettes.
+- **Declare the background you render on.** `A11Y_CHART_011` is theme-agnostic
+  by default, so it can only flag a custom color against *either* fixed
+  light/dark background as an `info`. Call `.ChartBackground("#1E1E1E")` (also
+  takes a `D3Color` or `Windows.UI.Color`) to scope the check to the single
+  background the chart actually renders on — the finding becomes an actionable
+  `warning` with a real, contrast-hardened fix, and palettes that are fine on
+  their actual background stop being flagged.
 - **Screen-reader fallback.** UIA structured data is good but not enough
   for screen-reader-only users — a hidden, expandable data table next to
   the chart is the pattern Tenon and the W3C WAI accessibility guidance

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1581,7 +1581,9 @@ new()
 AlternateView(Element view) → ChartElement<T>
 AnnounceEveryFrame() → ChartElement<T>
 AxisLabel(ChartAxisType axis, string label) → ChartElement<T>
+ChartBackground(Color background) → ChartElement<T>
 ChartBackground(D3Color background) → ChartElement<T>
+ChartBackground(string background) → ChartElement<T>
 ColorOnly() → ChartElement<T>
 DataLabel(Func<T, int, string> labeller) → ChartElement<T>
 Description(string description) → ChartElement<T>
@@ -5054,7 +5056,9 @@ ToString() → string
 ### class PieChartElement<T>
 new()
 AlternateView(Element view) → PieChartElement<T>
+ChartBackground(Color background) → PieChartElement<T>
 ChartBackground(D3Color background) → PieChartElement<T>
+ChartBackground(string background) → PieChartElement<T>
 ColorOnly() → PieChartElement<T>
 DataLabel(Func<T, int, string> labeller) → PieChartElement<T>
 Description(string description) → PieChartElement<T>

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1581,6 +1581,7 @@ new()
 AlternateView(Element view) → ChartElement<T>
 AnnounceEveryFrame() → ChartElement<T>
 AxisLabel(ChartAxisType axis, string label) → ChartElement<T>
+ChartBackground(D3Color background) → ChartElement<T>
 ColorOnly() → ChartElement<T>
 DataLabel(Func<T, int, string> labeller) → ChartElement<T>
 Description(string description) → ChartElement<T>
@@ -3544,6 +3545,7 @@ ToString() → string
 
 ### class HardenOptions
 new()
+D3Color? Background { get; init; }
 double MinBackgroundContrast { get; init; }
 double MinColorblindDeltaE { get; init; }
 double MinPairwiseContrast { get; init; }
@@ -5052,6 +5054,7 @@ ToString() → string
 ### class PieChartElement<T>
 new()
 AlternateView(Element view) → PieChartElement<T>
+ChartBackground(D3Color background) → PieChartElement<T>
 ColorOnly() → PieChartElement<T>
 DataLabel(Func<T, int, string> labeller) → PieChartElement<T>
 Description(string description) → PieChartElement<T>

--- a/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
@@ -318,9 +318,22 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
             double contrast = ChartPalette.ContrastRatio(palette[i], activeBg);
             if (contrast >= 3.0) continue;
 
-            var hardenResult = ChartPalette.Harden(
-                Enumerable.Range(0, palette.Count).Select(k => palette[k]).ToArray(),
-                new HardenOptions { Background = activeBg });
+            var original = Enumerable.Range(0, palette.Count).Select(k => palette[k]).ToArray();
+            var hardened = ChartPalette.Harden(original, new HardenOptions { Background = activeBg }).Palette;
+
+            // Only offer the hardened palette as a concrete fix when it ACTUALLY changed
+            // AND every color now clears 3:1 against the active background. The pairwise
+            // distinguishability guard can legitimately leave a color un-nudged; echoing the
+            // unchanged (still-failing) palette back as the "fix" would reintroduce the
+            // bad-fix-suggestion defect of #628/#629 (issue #633 M1). Fall back to a textual
+            // instruction when we cannot prove the suggestion is real.
+            bool changed = Enumerable.Range(0, Math.Min(hardened.Count, original.Length))
+                .Any(k => !string.Equals(hardened[k].ToHex(), original[k].ToHex(), StringComparison.OrdinalIgnoreCase));
+            bool allPass = hardened.Count == original.Length
+                && Enumerable.Range(0, hardened.Count).All(k => ChartPalette.ContrastRatio(hardened[k], activeBg) >= 3.0);
+            string suggestedValue = changed && allPass
+                ? string.Join(", ", hardened.Colors.Select(c => c.ToHex()))
+                : $"Adjust palette colors to ≥3:1 contrast against {activeBg.ToHex()}";
 
             findings.Add(new A11yDiagnostic
             {
@@ -334,7 +347,7 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                 Fix = new A11yFixSuggestion
                 {
                     Modifier = "SeriesColors",
-                    SuggestedValue = string.Join(", ", hardenResult.Palette.Colors.Select(c => c.ToHex())),
+                    SuggestedValue = suggestedValue,
                     CodeSnippet = "Adjust color lightness to ensure ≥3:1 contrast against the chart background",
                 },
                 Context = ctx.BuildContext(canvas),

--- a/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
@@ -233,7 +233,7 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
     /// the check is scoped to that single active background and emitted as a <c>warning</c>
     /// (the palette is only penalized for a background it actually renders on). Otherwise the
     /// scanner is theme-agnostic and cannot know the active theme, so it flags failure against
-    /// *either* fixed background as an <c>info</c> finding to avoid alert fatigue (issue #633).
+    /// <c>either</c> fixed background as an <c>info</c> finding to avoid alert fatigue (issue #633).
     /// </summary>
     private static void CheckChartPaletteBackground(CanvasElement canvas, ChartA11yData cd, IScanContext ctx, List<A11yDiagnostic> findings)
     {

--- a/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
@@ -227,10 +227,23 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
         }
     }
 
-    /// <summary>A11Y_CHART_011: Custom palette would fail background contrast (informational — the scanner cannot know the active theme).</summary>
+    /// <summary>
+    /// A11Y_CHART_011: Custom palette fails contrast against the chart background.
+    /// When the author declares a representative background via <c>.ChartBackground(...)</c>,
+    /// the check is scoped to that single active background and emitted as a <c>warning</c>
+    /// (the palette is only penalized for a background it actually renders on). Otherwise the
+    /// scanner is theme-agnostic and cannot know the active theme, so it flags failure against
+    /// *either* fixed background as an <c>info</c> finding to avoid alert fatigue (issue #633).
+    /// </summary>
     private static void CheckChartPaletteBackground(CanvasElement canvas, ChartA11yData cd, IScanContext ctx, List<A11yDiagnostic> findings)
     {
         if (cd.CustomPalette is not { } palette) return;
+
+        if (cd.ChartBackground is { } activeBg)
+        {
+            CheckChartPaletteAgainstKnownBackground(canvas, cd, palette, activeBg, ctx, findings);
+            return;
+        }
 
         var lightBg = new D3Color(255, 255, 255);
         var darkBg = new D3Color(32, 32, 32);
@@ -254,8 +267,9 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
             // know which theme is actually active. A color flagged here only fails if
             // the chart renders on the matching background — hence this is emitted as
             // an informational finding, not a warning, to avoid alert fatigue on
-            // palettes that are fine for the theme they actually run under. See the
-            // "scope to active background" follow-up tracked for spec 026.
+            // palettes that are fine for the theme they actually run under. Authors can
+            // declare .ChartBackground(...) to scope this to the active background and
+            // promote it to a warning (issue #633).
             if (failsLight || failsDark)
             {
                 var hardenResult = ChartPalette.Harden(
@@ -286,6 +300,46 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                 });
                 return;
             }
+        }
+    }
+
+    /// <summary>
+    /// A11Y_CHART_011 scoped to a single author-declared background (issue #633): each palette
+    /// color is checked against that one active background, the false positives that forced the
+    /// info downgrade are gone, so a real failure is emitted as a <c>warning</c>. The fix
+    /// suggestion hardens the palette toward that same background so it is a genuine remediation.
+    /// </summary>
+    private static void CheckChartPaletteAgainstKnownBackground(
+        CanvasElement canvas, ChartA11yData cd, ChartPalette palette, D3Color activeBg,
+        IScanContext ctx, List<A11yDiagnostic> findings)
+    {
+        for (int i = 0; i < palette.Count; i++)
+        {
+            double contrast = ChartPalette.ContrastRatio(palette[i], activeBg);
+            if (contrast >= 3.0) continue;
+
+            var hardenResult = ChartPalette.Harden(
+                Enumerable.Range(0, palette.Count).Select(k => palette[k]).ToArray(),
+                new HardenOptions { Background = activeBg });
+
+            findings.Add(new A11yDiagnostic
+            {
+                Id = "A11Y_CHART_011",
+                Severity = "warning",
+                Message = $"Custom palette: color {i} fails 3:1 contrast ({contrast:F1}:1) against the chart background {activeBg.ToHex()}",
+                WcagCriterion = "1.4.11",
+                ElementType = "CanvasElement (Chart)",
+                AutomationId = ctx.GetAutomationId(canvas),
+                ComponentType = ctx.CurrentComponent,
+                Fix = new A11yFixSuggestion
+                {
+                    Modifier = "SeriesColors",
+                    SuggestedValue = string.Join(", ", hardenResult.Palette.Colors.Select(c => c.ToHex())),
+                    CodeSnippet = "Adjust color lightness to ensure ≥3:1 contrast against the chart background",
+                },
+                Context = ctx.BuildContext(canvas),
+            });
+            return;
         }
     }
 

--- a/src/Reactor/Charting/Accessibility/ChartPalette.cs
+++ b/src/Reactor/Charting/Accessibility/ChartPalette.cs
@@ -70,7 +70,7 @@ public sealed class HardenOptions
     /// <summary>
     /// Representative background the palette will actually render on. When set, the
     /// background-contrast pass scopes its check (and direction-aware nudge) to this single
-    /// active background instead of hardening against *both* the fixed light and dark
+    /// active background instead of hardening against <c>both</c> the fixed light and dark
     /// backgrounds. Mirrors A11Y_CHART_011's active-background scoping (issue #633). Null
     /// keeps the theme-agnostic both-backgrounds behavior.
     /// </summary>

--- a/src/Reactor/Charting/Accessibility/ChartPalette.cs
+++ b/src/Reactor/Charting/Accessibility/ChartPalette.cs
@@ -73,6 +73,10 @@ public sealed class HardenOptions
     /// active background instead of hardening against <c>both</c> the fixed light and dark
     /// backgrounds. Mirrors A11Y_CHART_011's active-background scoping (issue #633). Null
     /// keeps the theme-agnostic both-backgrounds behavior.
+    /// <para>Opacity is ignored: contrast cannot be evaluated against a semi-transparent
+    /// background without knowing what is behind it, so any alpha is dropped to opaque RGB
+    /// inside <see cref="ChartPalette.Harden"/> (matching the
+    /// <c>.ChartBackground(...)</c> DSL modifier).</para>
     /// </summary>
     public D3.D3Color? Background { get; init; }
 
@@ -293,7 +297,7 @@ public sealed class ChartPalette
             // contrast against *either* fixed background, so the set is {light, dark}.
             // Both cases share this one path.
             var backgrounds = opts.Background is { } activeBg
-                ? new[] { activeBg }
+                ? new[] { new D3.D3Color(activeBg.R, activeBg.G, activeBg.B) }
                 : new[] { new D3.D3Color(255, 255, 255), new D3.D3Color(32, 32, 32) };
             for (int i = 0; i < adjusted.Length; i++)
             {

--- a/src/Reactor/Charting/Accessibility/ChartPalette.cs
+++ b/src/Reactor/Charting/Accessibility/ChartPalette.cs
@@ -286,51 +286,45 @@ public sealed class ChartPalette
                 }
             }
 
-            // Check each color vs the background(s). When the caller declares a single
-            // representative background (issue #633), scope the check and the nudge to
-            // THAT background only — a palette is only penalized for a background it will
+            // Check each color against the background(s) it must remain legible on. When
+            // the caller declares a single representative background (issue #633), the set
+            // is just {active} — a palette is only penalized for a background it will
             // actually render on. Otherwise the palette is theme-agnostic and must clear
-            // contrast against *either* fixed background.
-            var lightBg = new D3.D3Color(255, 255, 255);
-            var darkBg = new D3.D3Color(32, 32, 32);
+            // contrast against *either* fixed background, so the set is {light, dark}.
+            // Both cases share this one path.
+            var backgrounds = opts.Background is { } activeBg
+                ? new[] { activeBg }
+                : new[] { new D3.D3Color(255, 255, 255), new D3.D3Color(32, 32, 32) };
             for (int i = 0; i < adjusted.Length; i++)
             {
-                bool darken;
-                if (opts.Background is { } activeBg)
+                // Target the worst (lowest-contrast) background this color currently fails.
+                D3.D3Color? worst = null;
+                double worstContrast = double.MaxValue;
+                foreach (var bg in backgrounds)
                 {
-                    if (ContrastRatio(adjusted[i], activeBg) >= opts.MinBackgroundContrast) continue;
-
-                    // Move the color away from the background's lightness: darken when the
-                    // color is no lighter than the background, lighten when it is lighter.
-                    darken = RelativeLuminance(adjusted[i]) <= RelativeLuminance(activeBg);
+                    double contrast = ContrastRatio(adjusted[i], bg);
+                    if (contrast < opts.MinBackgroundContrast && contrast < worstContrast)
+                    {
+                        worstContrast = contrast;
+                        worst = bg;
+                    }
                 }
-                else
-                {
-                    double lightContrast = ContrastRatio(adjusted[i], lightBg);
-                    double darkContrast = ContrastRatio(adjusted[i], darkBg);
-                    bool failsLight = lightContrast < opts.MinBackgroundContrast;
-                    bool failsDark = darkContrast < opts.MinBackgroundContrast;
-                    // A color need only contrast against whichever background is active, so
-                    // harden when it fails against *either* (matching the A11Y_CHART_011
-                    // detection rule). The adjustment is direction-aware: a near-white color
-                    // that fails the light background must get darker, and a near-black color
-                    // that fails the dark background must get lighter.
-                    if (!failsLight && !failsDark) continue;
+                if (worst is not { } targetBg) continue;
 
-                    // At the default 3:1 threshold failsLight and failsDark are mutually
-                    // exclusive, but MinBackgroundContrast is configurable: a high threshold
-                    // (e.g. >~4:1) lets a mid-tone fail against *both* fixed backgrounds. In
-                    // that case darkening improves light contrast while lightening improves
-                    // dark contrast, so move toward the worse (lower) of the two ratios to
-                    // maximize the attainable minimum rather than always darkening.
-                    darken = failsLight && failsDark
-                        ? lightContrast <= darkContrast
-                        : failsLight;
-                }
-
+                // Pick the nudge direction by *attainable* contrast, not by comparing the
+                // color's luminance to the background's: darkening can never satisfy a
+                // near-black background (you cannot get darker than black) and lightening
+                // can never satisfy a near-white one, so a fixed luminance-ordering rule
+                // would pick an impossible direction and echo a still-failing color back
+                // (issue #633 M2 — the same bad-fix-suggestion class as #628/#629). Build
+                // both candidates and keep whichever raises contrast against the target
+                // background the most.
                 var (l, c, h) = RgbToLch(adjusted[i]);
-                l = darken ? Math.Max(5, l - 15) : Math.Min(95, l + 15);
-                var candidate = LchToRgb(l, c, h);
+                var darker = LchToRgb(Math.Max(5, l - 15), c, h);
+                var lighter = LchToRgb(Math.Min(95, l + 15), c, h);
+                var candidate = ContrastRatio(lighter, targetBg) >= ContrastRatio(darker, targetBg)
+                    ? lighter
+                    : darker;
 
                 // Series distinguishability takes priority: a color and its background
                 // both being legible is impossible to guarantee for every theme when

--- a/src/Reactor/Charting/Accessibility/ChartPalette.cs
+++ b/src/Reactor/Charting/Accessibility/ChartPalette.cs
@@ -67,6 +67,15 @@ public sealed class HardenOptions
     /// <summary>Minimum contrast ratio of each color against the background. Default 3.0.</summary>
     public double MinBackgroundContrast { get; init; } = 3.0;
 
+    /// <summary>
+    /// Representative background the palette will actually render on. When set, the
+    /// background-contrast pass scopes its check (and direction-aware nudge) to this single
+    /// active background instead of hardening against *both* the fixed light and dark
+    /// backgrounds. Mirrors A11Y_CHART_011's active-background scoping (issue #633). Null
+    /// keeps the theme-agnostic both-backgrounds behavior.
+    /// </summary>
+    public D3.D3Color? Background { get; init; }
+
     /// <summary>Maximum number of adjustment passes. Default 8.</summary>
     public int MaxPasses { get; init; } = 8;
 }
@@ -277,31 +286,47 @@ public sealed class ChartPalette
                 }
             }
 
-            // Check each color vs light and dark backgrounds
+            // Check each color vs the background(s). When the caller declares a single
+            // representative background (issue #633), scope the check and the nudge to
+            // THAT background only — a palette is only penalized for a background it will
+            // actually render on. Otherwise the palette is theme-agnostic and must clear
+            // contrast against *either* fixed background.
             var lightBg = new D3.D3Color(255, 255, 255);
             var darkBg = new D3.D3Color(32, 32, 32);
             for (int i = 0; i < adjusted.Length; i++)
             {
-                double lightContrast = ContrastRatio(adjusted[i], lightBg);
-                double darkContrast = ContrastRatio(adjusted[i], darkBg);
-                bool failsLight = lightContrast < opts.MinBackgroundContrast;
-                bool failsDark = darkContrast < opts.MinBackgroundContrast;
-                // A color need only contrast against whichever background is active, so
-                // harden when it fails against *either* (matching the A11Y_CHART_011
-                // detection rule). The adjustment is direction-aware: a near-white color
-                // that fails the light background must get darker, and a near-black color
-                // that fails the dark background must get lighter.
-                if (!failsLight && !failsDark) continue;
+                bool darken;
+                if (opts.Background is { } activeBg)
+                {
+                    if (ContrastRatio(adjusted[i], activeBg) >= opts.MinBackgroundContrast) continue;
 
-                // At the default 3:1 threshold failsLight and failsDark are mutually
-                // exclusive, but MinBackgroundContrast is configurable: a high threshold
-                // (e.g. >~4:1) lets a mid-tone fail against *both* fixed backgrounds. In
-                // that case darkening improves light contrast while lightening improves
-                // dark contrast, so move toward the worse (lower) of the two ratios to
-                // maximize the attainable minimum rather than always darkening.
-                bool darken = failsLight && failsDark
-                    ? lightContrast <= darkContrast
-                    : failsLight;
+                    // Move the color away from the background's lightness: darken when the
+                    // color is no lighter than the background, lighten when it is lighter.
+                    darken = RelativeLuminance(adjusted[i]) <= RelativeLuminance(activeBg);
+                }
+                else
+                {
+                    double lightContrast = ContrastRatio(adjusted[i], lightBg);
+                    double darkContrast = ContrastRatio(adjusted[i], darkBg);
+                    bool failsLight = lightContrast < opts.MinBackgroundContrast;
+                    bool failsDark = darkContrast < opts.MinBackgroundContrast;
+                    // A color need only contrast against whichever background is active, so
+                    // harden when it fails against *either* (matching the A11Y_CHART_011
+                    // detection rule). The adjustment is direction-aware: a near-white color
+                    // that fails the light background must get darker, and a near-black color
+                    // that fails the dark background must get lighter.
+                    if (!failsLight && !failsDark) continue;
+
+                    // At the default 3:1 threshold failsLight and failsDark are mutually
+                    // exclusive, but MinBackgroundContrast is configurable: a high threshold
+                    // (e.g. >~4:1) lets a mid-tone fail against *both* fixed backgrounds. In
+                    // that case darkening improves light contrast while lightening improves
+                    // dark contrast, so move toward the worse (lower) of the two ratios to
+                    // maximize the attainable minimum rather than always darkening.
+                    darken = failsLight && failsDark
+                        ? lightContrast <= darkContrast
+                        : failsLight;
+                }
 
                 var (l, c, h) = RgbToLch(adjusted[i]);
                 l = darken ? Math.Max(5, l - 15) : Math.Min(95, l + 15);

--- a/src/Reactor/Charting/Accessibility/IChartAccessibilityData.cs
+++ b/src/Reactor/Charting/Accessibility/IChartAccessibilityData.cs
@@ -123,4 +123,14 @@ internal sealed record ChartA11yData(IChartAccessibilityData Data)
 
     /// <summary>Custom focus indicator color, if any — scanner validates 3:1 contrast (A11Y_CHART_006).</summary>
     public global::Windows.UI.Color? CustomFocusColor { get; init; }
+
+    /// <summary>
+    /// Author-declared representative background the chart actually renders on, if any
+    /// (set via <c>.ChartBackground(...)</c>). When present, the theme-agnostic scanner
+    /// can scope A11Y_CHART_011's palette contrast check to this single active background
+    /// (promoting it to a <c>warning</c>) instead of flagging failure against *either*
+    /// fixed background (<c>info</c>). Left null for theme-agnostic charts that may render
+    /// on any background.
+    /// </summary>
+    public D3.D3Color? ChartBackground { get; init; }
 }

--- a/src/Reactor/Charting/Accessibility/IChartAccessibilityData.cs
+++ b/src/Reactor/Charting/Accessibility/IChartAccessibilityData.cs
@@ -128,7 +128,7 @@ internal sealed record ChartA11yData(IChartAccessibilityData Data)
     /// Author-declared representative background the chart actually renders on, if any
     /// (set via <c>.ChartBackground(...)</c>). When present, the theme-agnostic scanner
     /// can scope A11Y_CHART_011's palette contrast check to this single active background
-    /// (promoting it to a <c>warning</c>) instead of flagging failure against *either*
+    /// (promoting it to a <c>warning</c>) instead of flagging failure against <c>either</c>
     /// fixed background (<c>info</c>). Left null for theme-agnostic charts that may render
     /// on any background.
     /// </summary>

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -170,8 +170,11 @@ public sealed class ChartElement<T> : IChartAccessibilityData
     /// contrast check to this single active background (a <c>warning</c>) instead of flagging
     /// failure against either fixed light/dark background (an <c>info</c>). Omit for charts
     /// that may render on any background.
+    /// <para>The stored value is normalized to opaque RGB: contrast math
+    /// (<see cref="Accessibility.ChartPalette.ContrastRatio"/>) cannot evaluate a semi-transparent
+    /// background without knowing what is behind it, so any alpha is dropped.</para>
     /// </summary>
-    public ChartElement<T> ChartBackground(D3.D3Color background) { _chartBackground = background; return this; }
+    public ChartElement<T> ChartBackground(D3.D3Color background) { _chartBackground = new D3.D3Color(background.R, background.G, background.B); return this; }
 
     /// <summary>
     /// <inheritdoc cref="ChartBackground(D3.D3Color)"/> Parses a CSS color string (hex, rgb(), hsl(), or named).
@@ -557,8 +560,11 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     /// <para><b>Note:</b> only a scanner-visible palette (set via <see cref="Palette(Accessibility.ChartPalette)"/>)
     /// is contrast-checked against this background. Colors set via <c>.SetColors(...)</c> are
     /// not seen by the scanner.</para>
+    /// <para>The stored value is normalized to opaque RGB: contrast math
+    /// (<see cref="Accessibility.ChartPalette.ContrastRatio"/>) cannot evaluate a semi-transparent
+    /// background without knowing what is behind it, so any alpha is dropped.</para>
     /// </summary>
-    public PieChartElement<T> ChartBackground(D3Color background) { _chartBackground = background; return this; }
+    public PieChartElement<T> ChartBackground(D3Color background) { _chartBackground = new D3Color(background.R, background.G, background.B); return this; }
 
     /// <summary>
     /// <inheritdoc cref="ChartBackground(D3Color)"/> Parses a CSS color string (hex, rgb(), hsl(), or named).

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -667,6 +667,11 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
             ChartBackground = _chartBackground,
         });
 
+    // Test-only seam (InternalsVisibleTo Reactor.Tests): mirrors ChartElement<T>'s seam so unit
+    // tests can pin PieChartElement<T>'s own .ChartBackground(...) → ChartA11yData wiring without
+    // building the chart's D3Canvas, which constructs a SolidColorBrush and therefore needs WinUI COM.
+    internal Core.CanvasElement AttachChartDataForTest(Core.CanvasElement canvas) => AttachChartData(canvas);
+
     // Non-finite offsets would propagate NaN/Infinity into Canvas.Left/Top and
     // can crash WinUI layout — treat them as 0 to match how Width/Height/InnerRadius
     // are normalized in BuildElement.

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -80,6 +80,7 @@ public sealed class ChartElement<T> : IChartAccessibilityData
     private Accessibility.ChartPalette? _palette;
     private bool _colorOnly;
     private bool _rawColors;
+    private D3.D3Color? _chartBackground;
     private Accessibility.MarkerShape[]? _seriesShapes;
     private Accessibility.DashStyle[]? _seriesDashes;
 
@@ -162,6 +163,15 @@ public sealed class ChartElement<T> : IChartAccessibilityData
 
     /// <summary>Sets raw series colors — escape hatch with no validation (Tier 4). Triggers scanner warning A11Y_CHART_012.</summary>
     public ChartElement<T> RawColors(params D3.D3Color[] colors) { _palette = Accessibility.ChartPalette.FromRaw(colors); _rawColors = true; return this; }
+
+    /// <summary>
+    /// Declares the representative background color the chart actually renders on.
+    /// Lets the theme-agnostic accessibility scanner scope A11Y_CHART_011's custom-palette
+    /// contrast check to this single active background (a <c>warning</c>) instead of flagging
+    /// failure against either fixed light/dark background (an <c>info</c>). Omit for charts
+    /// that may render on any background.
+    /// </summary>
+    public ChartElement<T> ChartBackground(D3.D3Color background) { _chartBackground = background; return this; }
 
     /// <summary>Disables shape/dash double-encoding — color is sole series differentiator. Triggers scanner warning A11Y_CHART_004.</summary>
     public ChartElement<T> ColorOnly() { _colorOnly = true; return this; }
@@ -314,6 +324,7 @@ public sealed class ChartElement<T> : IChartAccessibilityData
             IsTightHitTest = _tightHitTest,
             CustomFocusColor = _customFocusColor,
             IsAnnounceEveryFrame = _announceEveryFrame,
+            ChartBackground = _chartBackground,
         });
 
     private Element[] RenderData(IReadOnlyList<T> data, LinearScale xScale, LinearScale yScale,
@@ -458,6 +469,7 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     // Double-encoding / palette fields
     private Accessibility.ChartPalette? _palette;
     private bool _colorOnly;
+    private D3Color? _chartBackground;
 
     // Custom label rendering — when set, replaces the built-in TextBlock label
     // produced from LabelAccessor. The string LabelAccessor is still consulted
@@ -515,6 +527,15 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
 
     /// <summary>Sets a curated accessible palette (Tier 1).</summary>
     public PieChartElement<T> Palette(Accessibility.ChartPalette palette) { _palette = palette; return this; }
+
+    /// <summary>
+    /// Declares the representative background color the chart actually renders on.
+    /// Lets the theme-agnostic accessibility scanner scope A11Y_CHART_011's custom-palette
+    /// contrast check to this single active background (a <c>warning</c>) instead of flagging
+    /// failure against either fixed light/dark background (an <c>info</c>). Omit for charts
+    /// that may render on any background.
+    /// </summary>
+    public PieChartElement<T> ChartBackground(D3Color background) { _chartBackground = background; return this; }
 
     /// <summary>Disables shape/dash double-encoding. Triggers scanner warning A11Y_CHART_004.</summary>
     public PieChartElement<T> ColorOnly() { _colorOnly = true; return this; }
@@ -603,6 +624,7 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
         {
             IsColorOnly = _colorOnly,
             CustomPalette = _palette,
+            ChartBackground = _chartBackground,
         });
 
     // Non-finite offsets would propagate NaN/Infinity into Canvas.Left/Top and

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -173,6 +173,17 @@ public sealed class ChartElement<T> : IChartAccessibilityData
     /// </summary>
     public ChartElement<T> ChartBackground(D3.D3Color background) { _chartBackground = background; return this; }
 
+    /// <summary>
+    /// <inheritdoc cref="ChartBackground(D3.D3Color)"/> Parses a CSS color string (hex, rgb(), hsl(), or named).
+    /// </summary>
+    public ChartElement<T> ChartBackground(string background) => ChartBackground(D3Color.Parse(background));
+
+    /// <summary>
+    /// <inheritdoc cref="ChartBackground(D3.D3Color)"/> Accepts a <see cref="global::Windows.UI.Color"/>.
+    /// </summary>
+    public ChartElement<T> ChartBackground(global::Windows.UI.Color background)
+        => ChartBackground(new D3.D3Color(background.R, background.G, background.B, background.A / 255.0));
+
     /// <summary>Disables shape/dash double-encoding — color is sole series differentiator. Triggers scanner warning A11Y_CHART_004.</summary>
     public ChartElement<T> ColorOnly() { _colorOnly = true; return this; }
 
@@ -326,6 +337,12 @@ public sealed class ChartElement<T> : IChartAccessibilityData
             IsAnnounceEveryFrame = _announceEveryFrame,
             ChartBackground = _chartBackground,
         });
+
+    // Test-only seam (InternalsVisibleTo Reactor.Tests): drives the real AttachChartData
+    // wiring against a caller-supplied canvas so unit tests can pin the accessibility
+    // metadata flow (e.g. .ChartBackground(...)) without building the chart's D3Canvas,
+    // which constructs a SolidColorBrush and therefore needs WinUI COM.
+    internal Core.CanvasElement AttachChartDataForTest(Core.CanvasElement canvas) => AttachChartData(canvas);
 
     private Element[] RenderData(IReadOnlyList<T> data, LinearScale xScale, LinearScale yScale,
         double plotLeft, double plotTop, double plotWidth, double plotHeight)
@@ -494,6 +511,9 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     /// the override and restores the default palette — we deliberately don't store an
     /// empty palette because every downstream consumer would have to mod-by-zero
     /// guard, and "no colors" isn't a meaningful render state.
+    /// <para><b>Accessibility note:</b> colors set via <c>.SetColors(...)</c> are NOT seen by
+    /// the a11y scanner, so A11Y_CHART_011 contrast checks do not run on them. Use
+    /// <see cref="Palette(Accessibility.ChartPalette)"/> for a scanner-visible palette.</para>
     /// </summary>
     public PieChartElement<T> SetColors(params D3Color[] colors)
     {
@@ -534,8 +554,22 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     /// contrast check to this single active background (a <c>warning</c>) instead of flagging
     /// failure against either fixed light/dark background (an <c>info</c>). Omit for charts
     /// that may render on any background.
+    /// <para><b>Note:</b> only a scanner-visible palette (set via <see cref="Palette(Accessibility.ChartPalette)"/>)
+    /// is contrast-checked against this background. Colors set via <c>.SetColors(...)</c> are
+    /// not seen by the scanner.</para>
     /// </summary>
     public PieChartElement<T> ChartBackground(D3Color background) { _chartBackground = background; return this; }
+
+    /// <summary>
+    /// <inheritdoc cref="ChartBackground(D3Color)"/> Parses a CSS color string (hex, rgb(), hsl(), or named).
+    /// </summary>
+    public PieChartElement<T> ChartBackground(string background) => ChartBackground(D3Color.Parse(background));
+
+    /// <summary>
+    /// <inheritdoc cref="ChartBackground(D3Color)"/> Accepts a <see cref="global::Windows.UI.Color"/>.
+    /// </summary>
+    public PieChartElement<T> ChartBackground(global::Windows.UI.Color background)
+        => ChartBackground(new D3Color(background.R, background.G, background.B, background.A / 255.0));
 
     /// <summary>Disables shape/dash double-encoding. Triggers scanner warning A11Y_CHART_004.</summary>
     public PieChartElement<T> ColorOnly() { _colorOnly = true; return this; }

--- a/tests/Reactor.Tests/D3/ChartPaletteTests.cs
+++ b/tests/Reactor.Tests/D3/ChartPaletteTests.cs
@@ -95,6 +95,45 @@ public class ChartPaletteTests
     }
 
     [Fact]
+    public void Harden_KnownBackground_OutputPassesThatBackground()
+    {
+        // When HardenOptions.Background declares the active background (issue #633), the
+        // background pass is scoped to THAT single background and the nudge is direction-aware.
+        // A near-white color that fails the light background must be hardened so it ACTUALLY
+        // clears 3:1 against light — proving the scoped fix suggestion is a real remediation,
+        // not an echo of the failing color (mirrors the #629 OutputPasses guard).
+        var lightBg = new D3Color(255, 255, 255);
+        var nearWhite = new D3Color(255, 255, 200);
+        Assert.True(ChartPalette.ContrastRatio(nearWhite, lightBg) < 3.0);
+
+        var hardened = ChartPalette.Harden(
+            new[] { nearWhite },
+            new HardenOptions { Background = lightBg });
+        Assert.True(
+            ChartPalette.ContrastRatio(hardened.Palette[0], lightBg) >= 3.0,
+            $"Hardened near-white {hardened.Palette[0].ToHex()} still fails light bg " +
+            $"({ChartPalette.ContrastRatio(hardened.Palette[0], lightBg):F2}:1)");
+    }
+
+    [Fact]
+    public void Harden_KnownBackground_LeavesColorPassingThatBackgroundUnchanged()
+    {
+        // The same near-white color PASSES the dark (32,32,32) background. Scoping Harden to
+        // the dark background must not touch it — a palette is only adjusted for the background
+        // it actually renders on (issue #633).
+        var darkBg = new D3Color(32, 32, 32);
+        var nearWhite = new D3Color(255, 255, 200);
+        Assert.True(ChartPalette.ContrastRatio(nearWhite, darkBg) >= 3.0);
+
+        var hardened = ChartPalette.Harden(
+            new[] { nearWhite },
+            new HardenOptions { Background = darkBg });
+        Assert.Equal(nearWhite.R, hardened.Palette[0].R);
+        Assert.Equal(nearWhite.G, hardened.Palette[0].G);
+        Assert.Equal(nearWhite.B, hardened.Palette[0].B);
+    }
+
+    [Fact]
     public void Harden_FailsBothBackgrounds_ImprovesWorseSide()
     {
         // When MinBackgroundContrast is raised, a mid-tone can fail the minimum

--- a/tests/Reactor.Tests/D3/ChartPaletteTests.cs
+++ b/tests/Reactor.Tests/D3/ChartPaletteTests.cs
@@ -134,6 +134,28 @@ public class ChartPaletteTests
     }
 
     [Fact]
+    public void Harden_KnownDarkBackground_NearBlack_OutputPassesThatBackground()
+    {
+        // A near-black color fails 3:1 against the dark #202020 background. Scoping Harden to
+        // that dark background MUST lighten it so it actually clears 3:1 — darkening can never
+        // satisfy a near-black background (you can't get darker than black), so a luminance-
+        // ordering direction rule would echo a still-failing color (issue #633 M2 — the same
+        // bad-fix-suggestion class as #628/#629). This is the load-bearing guard: it fails
+        // against the pre-M2 darken-only nudge.
+        var darkBg = new D3Color(32, 32, 32);
+        var nearBlack = new D3Color(28, 28, 28);
+        Assert.True(ChartPalette.ContrastRatio(nearBlack, darkBg) < 3.0);
+
+        var hardened = ChartPalette.Harden(
+            new[] { nearBlack },
+            new HardenOptions { Background = darkBg });
+        Assert.True(
+            ChartPalette.ContrastRatio(hardened.Palette[0], darkBg) >= 3.0,
+            $"Hardened near-black {hardened.Palette[0].ToHex()} still fails dark bg " +
+            $"({ChartPalette.ContrastRatio(hardened.Palette[0], darkBg):F2}:1)");
+    }
+
+    [Fact]
     public void Harden_FailsBothBackgrounds_ImprovesWorseSide()
     {
         // When MinBackgroundContrast is raised, a mid-tone can fail the minimum

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -336,6 +336,60 @@ public class ChartScannerRuleTests
     }
 
     [Fact]
+    public void A11Y_CHART_011_KnownDarkBackground_FailingColor_FiresWarningWithRealFix()
+    {
+        // A near-black series fails 3:1 against the dark #202020 background it actually renders
+        // on, so the scanner fires a WARNING (issue #633 M4). Critically, the suggested fix must
+        // be a REAL remediation — colors that genuinely clear 3:1 against that dark background —
+        // not an echo of the still-failing near-black color. Darkening can never satisfy a
+        // near-black background, so a direction rule that always darkens would echo a failing
+        // color (the #628/#629 bad-fix-suggestion defect class, #633 M2). This assertion fails
+        // against the pre-M2 darken-only Harden, so it is the load-bearing guard.
+        var darkBg = new D3Color(32, 32, 32);
+        var palette = ChartPalette.FromColors(new D3Color(28, 28, 28));
+        var canvas = MakeChartCanvas(
+            chartData: DataWithSeries(name: "Revenue"),
+            customPalette: palette,
+            chartBackground: darkBg);
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+        Assert.Equal("warning", finding.Severity);
+
+        // The fix's suggested value must parse to a palette whose every color clears 3:1
+        // against the active dark background (M1 + M2 together: a verified, non-echo fix).
+        var fixedColors = finding.Fix!.SuggestedValue!
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Select(D3Color.Parse)
+            .ToArray();
+        Assert.NotEmpty(fixedColors);
+        Assert.All(fixedColors, c => Assert.True(
+            ChartPalette.ContrastRatio(c, darkBg) >= 3.0,
+            $"Suggested color {c.ToHex()} still fails 3:1 against dark background {darkBg.ToHex()}"));
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_ChartBackgroundDslModifier_FlowsIntoScan()
+    {
+        // Drives the actual .ChartBackground(...) DSL modifier (string overload) through the
+        // real AttachChartData wiring into ChartA11yData, then scans — pinning the modifier→
+        // attach path itself rather than setting ChartA11yData.ChartBackground directly via
+        // MakeChartCanvas (issue #633 L1; also exercises the L2 string→D3Color overload). We
+        // attach to a bare CanvasElement to stay headless: the real D3Canvas builds a
+        // SolidColorBrush and would need WinUI COM.
+        var chart = Charts.LineChart(Array.Empty<DataPoint>(), d => d.X, d => d.Y)
+            .SeriesColors(new D3Color(255, 255, 200)) // near-white: fails the light background
+            .ChartBackground("#FFFFFF");              // string overload → light (255,255,255)
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+        Assert.Equal("warning", finding.Severity);
+    }
+
+    [Fact]
     public void A11Y_CHART_012_RawColors_EmittedAsInfo()
     {
         var canvas = MakeChartCanvas(

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -36,7 +36,8 @@ public class ChartScannerRuleTests
         bool isKeyboardDisabled = false,
         bool isTightHitTest = false,
         global::Windows.UI.Color? customFocusColor = null,
-        bool isAnnounceEveryFrame = false)
+        bool isAnnounceEveryFrame = false,
+        D3Color? chartBackground = null)
     {
         var canvas = new CanvasElement([])
         {
@@ -56,6 +57,7 @@ public class ChartScannerRuleTests
                 IsTightHitTest = isTightHitTest,
                 CustomFocusColor = customFocusColor,
                 IsAnnounceEveryFrame = isAnnounceEveryFrame,
+                ChartBackground = chartBackground,
             });
         }
 
@@ -277,7 +279,61 @@ public class ChartScannerRuleTests
         Assert.DoesNotContain(findings, f => f.Id == "A11Y_CHART_011");
     }
 
-    // ── A11Y_CHART_012: RawColors escape hatch ──────────────────────
+    // ── A11Y_CHART_011: active-background scoping (issue #633) ───────
+
+    [Fact]
+    public void A11Y_CHART_011_KnownLightBackground_FailingColor_FiresWarning()
+    {
+        // Near-white yellow fails 3:1 against the light (255,255,255) background. When the
+        // author declares .ChartBackground(light), the scanner knows the palette actually
+        // renders on that background, so the failure is real and is promoted from info to a
+        // WARNING (the false positives that forced the info downgrade are gone — issue #633).
+        var palette = ChartPalette.FromColors(new D3Color(255, 255, 200));
+        var canvas = MakeChartCanvas(
+            chartData: DataWithSeries(name: "Revenue"),
+            customPalette: palette,
+            chartBackground: new D3Color(255, 255, 255));
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+        Assert.Equal("warning", finding.Severity);
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_KnownDarkBackground_LightColor_DoesNotFire()
+    {
+        // The SAME near-white palette passes 3:1 against the dark (32,32,32) background. With
+        // the background scoped to dark, the color is legible on the background it actually
+        // renders on, so the rule must NOT fire — a palette is only penalized for a background
+        // it will actually render on (issue #633). Under the old both-backgrounds OR behavior
+        // this same palette would have produced an info finding.
+        var palette = ChartPalette.FromColors(new D3Color(255, 255, 200));
+        var canvas = MakeChartCanvas(
+            chartData: DataWithSeries(name: "Revenue"),
+            customPalette: palette,
+            chartBackground: new D3Color(32, 32, 32));
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        Assert.DoesNotContain(findings, f => f.Id == "A11Y_CHART_011");
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_NoDeclaredBackground_KeepsInfoBothBackgroundsBehavior()
+    {
+        // Without a declared background the scanner stays theme-agnostic: it flags the
+        // near-white color against EITHER fixed background and keeps the INFO severity so the
+        // alert-fatigue mitigation from #629 is preserved for charts that don't opt in. Pinning
+        // the severity guards the unknown-background path from silently regressing (issue #633).
+        var palette = ChartPalette.FromColors(new D3Color(255, 255, 200));
+        var canvas = MakeChartCanvas(chartData: DataWithSeries(name: "Revenue"), customPalette: palette);
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+        Assert.Equal("info", finding.Severity);
+    }
 
     [Fact]
     public void A11Y_CHART_012_RawColors_EmittedAsInfo()

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -390,6 +390,27 @@ public class ChartScannerRuleTests
     }
 
     [Fact]
+    public void ChartBackground_NormalizesToOpaqueRgb()
+    {
+        // Contrast math (ChartPalette.ContrastRatio/RelativeLuminance) ignores opacity — a
+        // semi-transparent background can't be evaluated without knowing what's behind it. So
+        // .ChartBackground(...) must drop alpha and store opaque RGB regardless of overload,
+        // rather than persisting a misleading alpha (PR #638 review). Drive a translucent
+        // Windows.UI.Color through the real modifier and assert the attached value is opaque.
+        var translucent = global::Windows.UI.Color.FromArgb(0x80, 0x20, 0x20, 0x20);
+        var chart = Charts.LineChart(Array.Empty<DataPoint>(), d => d.X, d => d.Y)
+            .ChartBackground(translucent);
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+
+        var bg = canvas.GetAttached<ChartA11yData>()!.ChartBackground;
+        Assert.NotNull(bg);
+        Assert.Equal(1.0, bg!.Value.Opacity);
+        Assert.Equal(0x20, bg.Value.R);
+        Assert.Equal(0x20, bg.Value.G);
+        Assert.Equal(0x20, bg.Value.B);
+    }
+
+    [Fact]
     public void A11Y_CHART_012_RawColors_EmittedAsInfo()
     {
         var canvas = MakeChartCanvas(

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -402,12 +402,74 @@ public class ChartScannerRuleTests
             .ChartBackground(translucent);
         var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
 
-        var bg = canvas.GetAttached<ChartA11yData>()!.ChartBackground;
-        Assert.NotNull(bg);
-        Assert.Equal(1.0, bg!.Value.Opacity);
-        Assert.Equal(0x20, bg.Value.R);
-        Assert.Equal(0x20, bg.Value.G);
-        Assert.Equal(0x20, bg.Value.B);
+        // Assert.IsType narrows the nullable ChartBackground to a non-null D3Color in one step,
+        // so the subsequent reads don't dereference a nullable value type (CodeQL r3461264777).
+        var bg = Assert.IsType<D3Color>(canvas.GetAttached<ChartA11yData>()!.ChartBackground);
+        Assert.Equal(1.0, bg.Opacity);
+        Assert.Equal(0x20, bg.R);
+        Assert.Equal(0x20, bg.G);
+        Assert.Equal(0x20, bg.B);
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_PieChart_ChartBackgroundDslModifier_FlowsIntoScan()
+    {
+        // H1: PieChartElement<T> has its OWN .ChartBackground(...) overloads, _chartBackground
+        // field, and AttachChartData path — separate from ChartElement<T>. Pin that the Pie
+        // modifier wiring also scopes A11Y_CHART_011 to the declared background and promotes it
+        // to a warning (issue #633 / PR #638 review). A near-white palette fails the declared
+        // light background. Headless: attach to a bare CanvasElement to skip the D3Canvas/
+        // SolidColorBrush WinUI COM path, exactly as the ChartElement<T> DSL test does.
+        var palette = ChartPalette.FromColors(new D3Color(255, 255, 200));
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .Palette(palette)
+            .ChartBackground("#FFFFFF");
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+        Assert.Equal("warning", finding.Severity);
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_KnownBackground_PairwiseGuardBlocksFix_FallsBackToTextualHint()
+    {
+        // M2: when the contrast-improving nudge would collide with another series, the pairwise-
+        // distinguishability guard skips it, so Harden cannot produce a fully-passing palette. The
+        // fix must then fall back to a TEXTUAL instruction rather than echoing the still-failing
+        // palette as a "fix" (the #628/#629 bad-suggestion defect class this whole arc closes).
+        //
+        // Provable construction: on the dark #202020 background, color0 #2b2b2b (near-black) fails
+        // 3:1 and can only clear it by LIGHTENING. color1 #888888 already passes #202020, so the
+        // background pass never moves it. But any color light enough to clear #202020 (relative
+        // luminance ≳ 0.14, gray ≈ 111) sits within 3:1 of color1 (luminance ≈ 0.25); the only
+        // escape — lightening all the way past color1 to ≈ gray 237 — requires crossing a band
+        // (gray ≈ 66..237) where every incremental candidate is pairwise-blocked. color0 is
+        // therefore trapped failing the background, so no real hardened palette exists and the
+        // suggestion must be the textual fallback.
+        var bg = new D3Color(32, 32, 32);
+        var palette = ChartPalette.FromColors(new D3Color(0x2b, 0x2b, 0x2b), new D3Color(0x88, 0x88, 0x88));
+        var canvas = MakeChartCanvas(
+            chartData: DataWithSeries(name: "Revenue"),
+            customPalette: palette,
+            chartBackground: bg);
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+
+        // Detection/severity stay correct: a real failure against the declared background → warning.
+        Assert.Equal("warning", finding.Severity);
+
+        // The fix is NOT an echo: because Harden could not prove a fully-passing palette under the
+        // pairwise guard, the suggestion is the TEXTUAL fallback arm (starts with the instruction
+        // phrase), never the hex-list arm (string.Join of palette colors). It may name the active
+        // background hex (#202020), but it must not echo the still-failing palette color #2b2b2b.
+        Assert.NotNull(finding.Fix);
+        var suggested = finding.Fix!.SuggestedValue ?? "";
+        Assert.StartsWith("Adjust palette colors", suggested);
+        Assert.DoesNotContain("2b2b2b", suggested.ToLowerInvariant());
     }
 
     [Fact]


### PR DESCRIPTION
Closes #633. Builds on the merged PR #629 (#628) — no stacking required since #629 is already in `main`.

## Problem

`A11Y_CHART_011` flags custom palette colors that fail WCAG 3:1 non-text contrast against the chart background. The accessibility scanner is a static, theme-agnostic tree walk (decoupled from core charting in #498), so at scan time it could not know the chart's effective background. #629 made the rule reachable by switching the dead `&&` to `||` (fail vs *either* fixed background), but under OR it fires on essentially every reasonable multi-color palette (a near-white series fails light; a near-black series fails dark) — alert fatigue. As interim mitigation #629 downgraded the rule from `warning` to `info`.

## Approach: author-declared `ChartBackground` (option i)

I made the representative background **knowable** via an opt-in author signal rather than re-coupling the scanner to host theming (which would violate #498). A new `.ChartBackground(D3Color)` DSL modifier flows into the existing `ChartA11yData` attached-metadata record — the same out-of-band channel chart elements already use for `CustomPalette`, `IsColorOnly`, `CustomFocusColor`, etc. The theme-aware-`IScanContext` alternative (option ii) was rejected: it would force the decoupled scanner to become theme-aware, re-coupling it to core charting.

## Changes

**Detection** (`ChartAccessibilityChecker.cs`)
- When `ChartBackground` is declared, each palette color is checked against **that single active background** and a real failure is emitted as a **`warning`** (the false positives that forced the `info` downgrade are gone for this path).
- When no background is declared, the existing **both-backgrounds OR** behavior is preserved at **`info`** severity, so theme-agnostic charts keep the #629 alert-fatigue mitigation.
- The hardened palette is only offered as a concrete fix when it **actually changed AND every color clears 3:1** against the active background; otherwise a textual instruction is emitted (no echo of a still-failing palette).

**Remediation** (`ChartPalette.cs`)
- `HardenOptions` gains a `D3Color? Background`. The background pass is unified around a single **checked-background set** — `{active}` when known, `{light, dark}` otherwise — and the nudge direction is chosen by **attainable contrast**: both ±LCH-lightness candidates are built and whichever raises contrast against the worst-failing background is kept. This fixes the dark-background echo (darkening can never satisfy a near-black background). The series-distinguishability (pairwise) guard from #629 is preserved.

**DSL** (`Charts.cs`)
- `.ChartBackground(D3Color)` on `ChartElement<T>` and `PieChartElement<T>`, plus `string` and `Windows.UI.Color` overloads (converting to `D3Color` internally) for parity with `.FocusColor`/`.Stroke`/`.Fill`.
- XML-doc note on `.SetColors(...)` / `PieChart.ChartBackground(...)` that `.SetColors` colors are **not** seen by the a11y scanner (use `.Palette(...)` for a scanner-visible palette).

**Docs** (`docs/specs/026-charting-accessibility-design.md`, `docs/_pipeline/templates/charting.md.dt`)
- Spec rule table + "Checks run" + API Summary updated for active-background scoping and the conditional severity.
- Charting guide accessibility-modifiers table gains `.ChartBackground`, `.SeriesColors`, `.RawColors` (edited the `.md.dt` template, recompiled the guide).

**Tests** (`ChartScannerRuleTests.cs`, `ChartPaletteTests.cs`)
- Light palette + declared light bg → fires `warning` (severity pinned).
- Same palette + declared dark bg → does **not** fire (legible on its actual bg).
- No declared bg → keeps `info` both-backgrounds behavior (severity pinned).
- **Near-black palette on declared dark `#202020` → fires `warning` AND the suggested fix actually clears ≥3:1 against the dark bg** (scanner + palette tests; the palette test fails against the pre-fix darken-only nudge — load-bearing guard for the M2 fix).
- `Harden` with a known background produces a palette that actually clears 3:1, and leaves an already-passing color untouched.
- End-to-end test driving the real `.ChartBackground(...)` DSL modifier through `AttachChartData` into the scan.

## Follow-up

- **#645** — `PieChartElement` stores `.SetColors()` colors in `_colorPalette` (render-only, not scanner-visible) separately from `.Palette()`'s `_palette` (scanner-visible). This pre-existing asymmetry is documented here but deliberately left unfixed (out of scope / behavioral-change risk); #645 tracks unifying the two.

## Verification

- `dotnet build src/Reactor` (ARM64) → clean, 0 warnings / 0 errors.
- `dotnet test tests/Reactor.Tests --filter "ChartScannerRuleTests|ChartPaletteTests"` → **64 passed, 0 failed**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>