### PR TITLE
Warn when HStack/VStack collapses in a Grid Auto track (#345)

### DIFF
--- a/docs/_pipeline/templates/layout.md.dt
+++ b/docs/_pipeline/templates/layout.md.dt
@@ -336,6 +336,46 @@ measurements — predictable enough for trivial cases, surprising for
 anything dynamic. Pick one per axis. See
 [flex-layout](flex-layout.md) for when each shape is right.
 
+### `HStack`/`VStack` in a `Grid` `Auto` track collapses to nothing
+
+```csharp
+// Don't:
+Grid(
+    columns: [GridSize.Auto, GridSize.Star()],
+    rows: [GridSize.Star()],
+    HStack(SaveButton(), CancelButton()).Grid(column: 0))  // row vanishes — measures 0×0
+```
+
+A `Grid` `Auto` track measures its content with **infinite** available
+space on that axis. A `StackPanel` (`HStack`/`VStack`) measures its
+children sequentially and accumulates their desired size — so any child
+that relies on *stretch* sizing reports `0`, the stack accumulates `0`,
+and the whole column (or row) silently collapses to `0×0`. The action
+row just disappears with no error.
+
+Wrapping the stack in a `Border` does **not** help — the `Border` sizes
+to its `0`-sized child. The real fixes are:
+
+- Use a `Star` track (`GridSize.Star()`) so the cell hands the stack a
+  finite width to stretch into, **or**
+- Set an explicit `.Width(...)` (for `HStack`) / `.Height(...)` (for
+  `VStack`) on the stack, **or**
+- Give the stack's children explicit sizes so they don't depend on
+  stretch.
+
+```csharp
+// Do:
+Grid(
+    columns: [GridSize.Star(), GridSize.Star()],   // Star, not Auto
+    rows: [GridSize.Star()],
+    HStack(SaveButton(), CancelButton()).Grid(column: 0))
+```
+
+Reactor surfaces this footgun at debug time: when
+`ReactorFeatureFlags.WarnLayoutFootguns` is set (always on in `DEBUG`
+builds), the reconciler emits a one-time warning naming the offending
+stack and its `Auto` track so you don't have to bisect the collapse.
+
 ## Tips
 
 **Start with VStack.** Most screens are a vertical stack of sections.

--- a/docs/_pipeline/templates/layout.md.dt
+++ b/docs/_pipeline/templates/layout.md.dt
@@ -359,9 +359,9 @@ to its `0`-sized child. The real fixes are:
 - Use a `Star` track (`GridSize.Star()`) so the cell hands the stack a
   finite width to stretch into, **or**
 - Set an explicit `.Width(...)` (for `HStack`) / `.Height(...)` (for
-  `VStack`) on the stack, **or**
-- Give the stack's children explicit sizes so they don't depend on
-  stretch.
+  `VStack`) — or a `.MinWidth(...)` / `.MinHeight(...)` — on the stack, **or**
+- Give the stack's children explicit (or minimum) sizes so they don't
+  depend on stretch.
 
 ```csharp
 // Do:

--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -574,6 +574,46 @@ measurements — predictable enough for trivial cases, surprising for
 anything dynamic. Pick one per axis. See
 [flex-layout](flex-layout.md) for when each shape is right.
 
+### `HStack`/`VStack` in a `Grid` `Auto` track collapses to nothing
+
+```csharp
+// Don't:
+Grid(
+    columns: [GridSize.Auto, GridSize.Star()],
+    rows: [GridSize.Star()],
+    HStack(SaveButton(), CancelButton()).Grid(column: 0))  // row vanishes — measures 0×0
+```
+
+A `Grid` `Auto` track measures its content with **infinite** available
+space on that axis. A `StackPanel` (`HStack`/`VStack`) measures its
+children sequentially and accumulates their desired size — so any child
+that relies on *stretch* sizing reports `0`, the stack accumulates `0`,
+and the whole column (or row) silently collapses to `0×0`. The action
+row just disappears with no error.
+
+Wrapping the stack in a `Border` does **not** help — the `Border` sizes
+to its `0`-sized child. The real fixes are:
+
+- Use a `Star` track (`GridSize.Star()`) so the cell hands the stack a
+  finite width to stretch into, **or**
+- Set an explicit `.Width(...)` (for `HStack`) / `.Height(...)` (for
+  `VStack`) on the stack, **or**
+- Give the stack's children explicit sizes so they don't depend on
+  stretch.
+
+```csharp
+// Do:
+Grid(
+    columns: [GridSize.Star(), GridSize.Star()],   // Star, not Auto
+    rows: [GridSize.Star()],
+    HStack(SaveButton(), CancelButton()).Grid(column: 0))
+```
+
+Reactor surfaces this footgun at debug time: when
+`ReactorFeatureFlags.WarnLayoutFootguns` is set (always on in `DEBUG`
+builds), the reconciler emits a one-time warning naming the offending
+stack and its `Auto` track so you don't have to bisect the collapse.
+
 ## Tips
 
 **Start with VStack.** Most screens are a vertical stack of sections.

--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -597,9 +597,9 @@ to its `0`-sized child. The real fixes are:
 - Use a `Star` track (`GridSize.Star()`) so the cell hands the stack a
   finite width to stretch into, **or**
 - Set an explicit `.Width(...)` (for `HStack`) / `.Height(...)` (for
-  `VStack`) on the stack, **or**
-- Give the stack's children explicit sizes so they don't depend on
-  stretch.
+  `VStack`) — or a `.MinWidth(...)` / `.MinHeight(...)` — on the stack, **or**
+- Give the stack's children explicit (or minimum) sizes so they don't
+  depend on stretch.
 
 ```csharp
 // Do:

--- a/src/Reactor/Core/ReactorFeatureFlags.cs
+++ b/src/Reactor/Core/ReactorFeatureFlags.cs
@@ -54,7 +54,7 @@ public static class ReactorFeatureFlags
     public static bool HighlightReconcileChanges { get; set; }
 
     /// <summary>
-    /// When true, the reconciler emits a one-time diagnostic warning at first mount
+    /// When true, the reconciler emits a one-time diagnostic warning — at mount and on update —
     /// for layout "footguns" that silently collapse to <c>0×0</c> — most notably an
     ///     <c>HStack</c>/<c>VStack</c> placed in a <c>Grid</c> <see cref="GridSize.Auto"/>
     /// track with no explicit size and no explicitly-sized children (issue #345). The
@@ -64,9 +64,13 @@ public static class ReactorFeatureFlags
     /// <remarks>
     /// <para>Default: <c>false</c>. In <c>DEBUG</c> builds the detection is always on
     /// regardless of this flag — the flag is the opt-in switch for <c>Release</c>
-    /// builds. When off in <c>Release</c> the detection call is elided to a single
-    /// flag read per <c>Grid</c> mount, so it is effectively free.</para>
-    /// <para>Each distinct offending placement warns at most once per process; see
+    /// builds. When off in <c>Release</c> the detection call site is gated by a single
+    /// read of this flag per mounted/updated element (the detector then no-ops for any
+    /// non-<c>Grid</c> element), so it is effectively free.</para>
+    /// <para>The detector runs on both the mount and update reconcile paths, so a warning can
+    /// appear after a state-driven layout change (e.g. a column flipped to <c>Auto</c> or an
+    /// explicit size removed), not just on first render. Each distinct offending placement warns at
+    /// most once per process; see
     /// <see cref="Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector"/>.</para>
     /// </remarks>
     public static bool WarnLayoutFootguns { get; set; }

--- a/src/Reactor/Core/ReactorFeatureFlags.cs
+++ b/src/Reactor/Core/ReactorFeatureFlags.cs
@@ -57,21 +57,19 @@ public static class ReactorFeatureFlags
     /// When true, the reconciler emits a one-time diagnostic warning — at mount and on update —
     /// for layout "footguns" that silently collapse to <c>0×0</c> — most notably an
     ///     <c>HStack</c>/<c>VStack</c> placed in a <c>Grid</c> <see cref="GridSize.Auto"/>
-    /// track with no explicit size and no explicitly-sized children (issue #345). The
-    /// warning is routed through
-    /// <see cref="Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector"/> (and <c>Debug.WriteLine</c>).
+    /// track with no explicit size and no explicitly-sized children (issue #345). Each warning is
+    /// written to <c>Debug.WriteLine</c>.
     /// </summary>
     /// <remarks>
     /// <para>Default: <c>false</c>. In <c>DEBUG</c> builds the detection is always on
     /// regardless of this flag — the flag is the opt-in switch for <c>Release</c>
     /// builds. When off in <c>Release</c> the detection call site is gated by a single
-    /// read of this flag per mounted/updated element (the detector then no-ops for any
+    /// read of this flag per mounted/updated element (the check then no-ops for any
     /// non-<c>Grid</c> element), so it is effectively free.</para>
-    /// <para>The detector runs on both the mount and update reconcile paths, so a warning can
+    /// <para>Detection runs on both the mount and update reconcile paths, so a warning can
     /// appear after a state-driven layout change (e.g. a column flipped to <c>Auto</c> or an
     /// explicit size removed), not just on first render. Each distinct offending placement warns at
-    /// most once per process; see
-    /// <see cref="Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector"/>.</para>
+    /// most once per process.</para>
     /// </remarks>
     public static bool WarnLayoutFootguns { get; set; }
 }

--- a/src/Reactor/Core/ReactorFeatureFlags.cs
+++ b/src/Reactor/Core/ReactorFeatureFlags.cs
@@ -52,4 +52,22 @@ public static class ReactorFeatureFlags
     /// the reconciler skips all collection work so there is zero overhead.
     /// </remarks>
     public static bool HighlightReconcileChanges { get; set; }
+
+    /// <summary>
+    /// When true, the reconciler emits a one-time diagnostic warning at first mount
+    /// for layout "footguns" that silently collapse to <c>0×0</c> — most notably an
+    ///     <c>HStack</c>/<c>VStack</c> placed in a <c>Grid</c> <see cref="GridSize.Auto"/>
+    /// track with no explicit size and no explicitly-sized children (issue #345). The
+    /// warning is routed through
+    /// <see cref="Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector"/> (and <c>Debug.WriteLine</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>Default: <c>false</c>. In <c>DEBUG</c> builds the detection is always on
+    /// regardless of this flag — the flag is the opt-in switch for <c>Release</c>
+    /// builds. When off in <c>Release</c> the detection call is elided to a single
+    /// flag read per <c>Grid</c> mount, so it is effectively free.</para>
+    /// <para>Each distinct offending placement warns at most once per process; see
+    /// <see cref="Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector"/>.</para>
+    /// </remarks>
+    public static bool WarnLayoutFootguns { get; set; }
 }

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -108,6 +108,11 @@ public sealed partial class Reconciler
                 _highlightMounted.Add(control);
         }
 
+        // Issue #345 — one-time debug warning for HStack/VStack collapsing to 0×0 inside a
+        // Grid Auto track. Gated so Release builds with the flag off pay a single flag read.
+        if (global::Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector.AlwaysOnInDebug || ReactorFeatureFlags.WarnLayoutFootguns)
+            global::Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector.Inspect(element);
+
         // Apply inline modifiers after mounting
         if (modifiers is not null && control is FrameworkElement fe)
             ApplyModifiers(fe, modifiers, requestRerender);

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -109,6 +109,15 @@ public sealed partial class Reconciler
         }
         DebugUIElementsModified++;
 
+        // Issue #345 — re-run the Grid Auto-track stack collapse check on update so dynamic,
+        // state-driven placements that a static analyzer cannot see still warn: a `columns:`
+        // collection computed to Auto, a state change that moves an HStack into an Auto track, or
+        // an explicit size being dropped on an already-mounted stack. We are past the
+        // structural-equality short-circuit above, so this only runs when something actually
+        // changed; the emit-once dedup keyed on element identity prevents repeat spam.
+        if (global::Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector.AlwaysOnInDebug || ReactorFeatureFlags.WarnLayoutFootguns)
+            global::Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector.Inspect(newEl);
+
         // Push context values onto scope before processing children
         var ctxValues = newEl.ContextValues;
         int ctxCount = 0;

--- a/src/Reactor/Diagnostics/LayoutFootgunDetector.cs
+++ b/src/Reactor/Diagnostics/LayoutFootgunDetector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Microsoft.UI.Reactor.Core;
 using WinUI = Microsoft.UI.Xaml.Controls;
 
@@ -22,15 +23,18 @@ namespace Microsoft.UI.Reactor.Diagnostics;
 /// <para>
 /// Reactor can detect it because it holds the declarative tree: it can correlate "an <c>HStack</c>
 /// was just placed at <c>Grid</c> column N" with "column N's track is <c>Auto</c>". This detector
-/// runs at first mount (see <c>Reconciler.Mount</c>) and emits a one-time warning when <b>all</b>
+/// runs at mount <em>and</em> update (see <c>Reconciler.Mount</c> / <c>Reconciler.Update</c>, so a
+/// dynamic track or size change can still be caught) and emits a one-time warning when <b>all</b>
 /// of the following hold for a stack child:
 /// </para>
 /// <list type="bullet">
 ///   <item>it lands in a <c>Grid</c> track that is <c>Auto</c> on the stacking axis (column for
 ///   <c>HStack</c>, row for <c>VStack</c>),</item>
 ///   <item>neither the stack nor any single-child wrapper (e.g. a <c>Border</c>) around it carries
-///   an explicit size on that axis, and</item>
-///   <item>none of the stack's first-generation children carry an explicit size on that axis.</item>
+///   an explicit size on that axis (a fixed <c>Width</c>/<c>Height</c> or a <c>MinWidth</c>/
+///   <c>MinHeight</c>, both of which clamp the Measure pass), and</item>
+///   <item>none of the stack's first-generation children carry an explicit size (fixed or minimum)
+///   on that axis.</item>
 /// </list>
 /// <para>
 /// Detection is gated by <see cref="ReactorFeatureFlags.WarnLayoutFootguns"/> (always on in
@@ -92,11 +96,8 @@ internal static class LayoutFootgunDetector
         var columns = grid.Definition?.Columns;
         var rows = grid.Definition?.Rows;
 
-        foreach (var child in children)
+        foreach (var child in children.Where(static c => c is not null))
         {
-            if (child is null)
-                continue;
-
             // Walk down through single-child wrappers (e.g. Border) to the stack, accumulating any
             // explicit size seen along the way. Wrapping a collapsing stack in a Border does NOT
             // fix the collapse (the Border sizes to its 0-sized child), so we keep descending.
@@ -109,8 +110,11 @@ internal static class LayoutFootgunDetector
             {
                 locationKey ??= current.Key;
                 var mods = current.Modifiers;
-                if (mods?.Width is not null) chainHasWidth = true;
-                if (mods?.Height is not null) chainHasHeight = true;
+                // MinWidth/MinHeight clamp the desired size during Measure too, so an explicit
+                // minimum on the stack (or any wrapper) prevents the stretch→0 collapse just like
+                // a fixed Width/Height does. Treat both as an explicit size to avoid false warnings.
+                if (mods?.Width is not null || mods?.MinWidth is not null) chainHasWidth = true;
+                if (mods?.Height is not null || mods?.MinHeight is not null) chainHasHeight = true;
 
                 if (current is StackElement stack)
                 {
@@ -171,20 +175,12 @@ internal static class LayoutFootgunDetector
     }
 
     private static bool AnyChildHasExplicitWidth(Element[] children)
-    {
-        foreach (var c in children)
-            if (c?.Modifiers?.Width is not null)
-                return true;
-        return false;
-    }
+        // MinWidth also prevents the stretch→0 desired-size case during Measure, so it counts.
+        => children.Any(static c => c?.Modifiers?.Width is not null || c?.Modifiers?.MinWidth is not null);
 
     private static bool AnyChildHasExplicitHeight(Element[] children)
-    {
-        foreach (var c in children)
-            if (c?.Modifiers?.Height is not null)
-                return true;
-        return false;
-    }
+        // MinHeight also clamps the desired size during Measure, so it counts as an explicit size.
+        => children.Any(static c => c?.Modifiers?.Height is not null || c?.Modifiers?.MinHeight is not null);
 
     private static bool TrackIsAuto(string[]? tracks, int index)
     {
@@ -195,15 +191,18 @@ internal static class LayoutFootgunDetector
     }
 
     /// <summary>
-    /// Builds the emit-once dedup key for an offending placement. Keyed on element identity
-    /// (the author-supplied <see cref="Element.Key"/> when present) or, for unkeyed elements, on
-    /// the stack type plus its concrete grid placement (row/column). This keeps two <em>distinct</em>
-    /// offending placements that merely share a stack type + track from collapsing into a single
-    /// warning, while staying stable across re-renders (records produce fresh-but-equal instances).
+    /// Builds the emit-once dedup key for an offending placement. The key always encodes the stack
+    /// type plus its concrete grid placement (row/column); the author-supplied
+    /// <see cref="Element.Key"/> is appended as an extra discriminator when present. Because
+    /// <see cref="Element.Key"/> uniqueness is only guaranteed among siblings, keying on it alone
+    /// could wrongly collapse distinct offenders (the same key reused under different grids, or a
+    /// keyed stack that moves to a new row/column). Including the placement keeps each distinct
+    /// position warning once while staying stable across re-renders (records produce
+    /// fresh-but-equal instances).
     /// </summary>
     private static string BuildDedupKey(string stackName, int row, int col, string? locationKey)
         => locationKey is { Length: > 0 }
-            ? $"key:{locationKey}"
+            ? string.Format(CultureInfo.InvariantCulture, "{0}@r{1}c{2}|key:{3}", stackName, row, col, locationKey)
             : string.Format(CultureInfo.InvariantCulture, "{0}@r{1}c{2}", stackName, row, col);
 
     private static string BuildMessage(string stackName, bool axisIsColumn, int index, string? locationKey)

--- a/src/Reactor/Diagnostics/LayoutFootgunDetector.cs
+++ b/src/Reactor/Diagnostics/LayoutFootgunDetector.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.UI.Reactor.Core;
+using WinUI = Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.UI.Reactor.Diagnostics;
+
+/// <summary>
+/// Debug-time detector for the <c>HStack</c>/<c>VStack</c>-in-a-<c>Grid</c>-<c>Auto</c>-track
+/// layout footgun (issue #345).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <c>StackPanel</c> placed in a <c>Grid</c> <see cref="GridSize.Auto"/> track measures its
+/// children with <em>infinite</em> available space on the stacking axis. Children that rely on
+/// stretch sizing (no explicit size) therefore report a desired size of <c>0</c>, the stack
+/// accumulates <c>0</c>, and the whole row/column silently collapses to <c>0×0</c>. This is
+/// generic XAML measure semantics — not a Reactor reconciler bug — but the failure is invisible:
+/// the developer just sees their content vanish.
+/// </para>
+/// <para>
+/// Reactor can detect it because it holds the declarative tree: it can correlate "an <c>HStack</c>
+/// was just placed at <c>Grid</c> column N" with "column N's track is <c>Auto</c>". This detector
+/// runs at first mount (see <c>Reconciler.Mount</c>) and emits a one-time warning when <b>all</b>
+/// of the following hold for a stack child:
+/// </para>
+/// <list type="bullet">
+///   <item>it lands in a <c>Grid</c> track that is <c>Auto</c> on the stacking axis (column for
+///   <c>HStack</c>, row for <c>VStack</c>),</item>
+///   <item>neither the stack nor any single-child wrapper (e.g. a <c>Border</c>) around it carries
+///   an explicit size on that axis, and</item>
+///   <item>none of the stack's first-generation children carry an explicit size on that axis.</item>
+/// </list>
+/// <para>
+/// Detection is gated by <see cref="ReactorFeatureFlags.WarnLayoutFootguns"/> (always on in
+/// <c>DEBUG</c>); each distinct placement warns at most once per process. The detection only
+/// inspects the immutable element tree (modifier chain + grid definition) — it never reads back
+/// realized control dimensions, so it stays cheap and side-effect free.
+/// </para>
+/// </remarks>
+public static class LayoutFootgunDetector
+{
+    /// <summary>
+    /// <c>true</c> when compiled in a <c>DEBUG</c> configuration. A compile-time constant so the
+    /// JIT can fold the call-site guard away entirely in <c>Release</c> builds.
+    /// </summary>
+    internal const bool AlwaysOnInDebug =
+#if DEBUG
+        true;
+#else
+        false;
+#endif
+
+    /// <summary>
+    /// Optional diagnostic sink. When set, each warning message is delivered here (in addition to
+    /// the <c>Debug</c> channel). Used by tests and devtools surfaces to observe
+    /// warnings without scraping the debug channel.
+    /// </summary>
+#pragma warning disable CS0649 // Assigned via InternalsVisibleTo (tests / devtools), never inside this assembly.
+    internal static Action<string>? Sink;
+#pragma warning restore CS0649
+
+    private static readonly HashSet<string> s_warned = new(StringComparer.Ordinal);
+    private static readonly object s_gate = new();
+
+    /// <summary>
+    /// Inspects a freshly mounted element for the Grid-<c>Auto</c>-track stack footgun and emits a
+    /// one-time warning if it matches. A no-op for non-<see cref="GridElement"/> elements and when
+    /// detection is disabled (Release build with the flag off).
+    /// </summary>
+    internal static void Inspect(Element element)
+    {
+        if (!(AlwaysOnInDebug || ReactorFeatureFlags.WarnLayoutFootguns))
+            return;
+        if (element is not GridElement grid)
+            return;
+
+        InspectGrid(grid);
+    }
+
+    /// <summary>
+    /// Core detection over a <see cref="GridElement"/>. Exposed to tests; callers on the mount hot
+    /// path should go through <see cref="Inspect"/> so the enable check is honored.
+    /// </summary>
+    internal static void InspectGrid(GridElement grid)
+    {
+        var children = grid.Children;
+        if (children is null || children.Length == 0)
+            return;
+
+        var columns = grid.Definition?.Columns;
+        var rows = grid.Definition?.Rows;
+
+        foreach (var child in children)
+        {
+            if (child is null)
+                continue;
+
+            // Walk down through single-child wrappers (e.g. Border) to the stack, accumulating any
+            // explicit size seen along the way. Wrapping a collapsing stack in a Border does NOT
+            // fix the collapse (the Border sizes to its 0-sized child), so we keep descending.
+            var current = child;
+            bool chainHasWidth = false;
+            bool chainHasHeight = false;
+            string? locationKey = null;
+
+            while (true)
+            {
+                locationKey ??= current.Key;
+                var mods = current.Modifiers;
+                if (mods?.Width is not null) chainHasWidth = true;
+                if (mods?.Height is not null) chainHasHeight = true;
+
+                if (current is StackElement stack)
+                {
+                    InspectStack(grid, child, stack, columns, rows, chainHasWidth, chainHasHeight, locationKey);
+                    break;
+                }
+
+                if (current is BorderElement { Child: { } inner })
+                {
+                    current = inner;
+                    continue;
+                }
+
+                // Any other leaf/wrapper: not a stack we model — leave it alone.
+                break;
+            }
+        }
+    }
+
+    private static void InspectStack(
+        GridElement grid,
+        Element gridChild,
+        StackElement stack,
+        string[]? columns,
+        string[]? rows,
+        bool chainHasWidth,
+        bool chainHasHeight,
+        string? locationKey)
+    {
+        var stackChildren = stack.Children;
+        if (stackChildren is null || stackChildren.Length == 0)
+            return; // An empty stack collapsing to 0 is expected, not a footgun.
+
+        bool horizontal = stack.Orientation == WinUI.Orientation.Horizontal;
+
+        var placement = gridChild.GetAttached<GridAttached>();
+        int row = placement?.Row ?? 0;
+        int col = placement?.Column ?? 0;
+
+        if (horizontal)
+        {
+            if (!TrackIsAuto(columns, col)) return;
+            if (chainHasWidth) return;
+            if (AnyChildHasExplicitWidth(stackChildren)) return;
+            Emit(BuildMessage("HStack", axisIsColumn: true, index: col, locationKey: locationKey));
+        }
+        else
+        {
+            if (!TrackIsAuto(rows, row)) return;
+            if (chainHasHeight) return;
+            if (AnyChildHasExplicitHeight(stackChildren)) return;
+            Emit(BuildMessage("VStack", axisIsColumn: false, index: row, locationKey: locationKey));
+        }
+    }
+
+    private static bool AnyChildHasExplicitWidth(Element[] children)
+    {
+        foreach (var c in children)
+            if (c?.Modifiers?.Width is not null)
+                return true;
+        return false;
+    }
+
+    private static bool AnyChildHasExplicitHeight(Element[] children)
+    {
+        foreach (var c in children)
+            if (c?.Modifiers?.Height is not null)
+                return true;
+        return false;
+    }
+
+    private static bool TrackIsAuto(string[]? tracks, int index)
+    {
+        if (tracks is null || index < 0 || index >= tracks.Length)
+            return false;
+        var track = tracks[index];
+        return track is not null && string.Equals(track.Trim(), "Auto", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string BuildMessage(string stackName, bool axisIsColumn, int index, string? locationKey)
+    {
+        string axis = axisIsColumn ? "column" : "row";
+        string sizeModifier = axisIsColumn ? "Width" : "Height";
+        string starTrack = axisIsColumn ? "Star (\"*\") column" : "Star (\"*\") row";
+        string location = locationKey is { Length: > 0 } ? $" (key: \"{locationKey}\")" : string.Empty;
+
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "[Reactor] {0}{1} is in Grid {2} {3} (Auto) with no explicit {4} and no explicitly-sized " +
+            "children. The measure pass may return 0\u00d70 (collapsed). Use a {5} or set .{4}(...) on the {0}.",
+            stackName, location, axis, index, sizeModifier, starTrack);
+    }
+
+    private static void Emit(string message)
+    {
+        lock (s_gate)
+        {
+            if (!s_warned.Add(message))
+                return;
+        }
+
+        Sink?.Invoke(message);
+        global::System.Diagnostics.Debug.WriteLine(message);
+    }
+
+    /// <summary>
+    /// Clears the emit-once dedup set. Test-only hook so each test observes warnings
+    /// independently; not part of the supported API surface.
+    /// </summary>
+    internal static void ResetForTests()
+    {
+        lock (s_gate)
+        {
+            s_warned.Clear();
+        }
+    }
+}

--- a/src/Reactor/Diagnostics/LayoutFootgunDetector.cs
+++ b/src/Reactor/Diagnostics/LayoutFootgunDetector.cs
@@ -199,6 +199,13 @@ internal static class LayoutFootgunDetector
     /// keyed stack that moves to a new row/column). Including the placement keeps each distinct
     /// position warning once while staying stable across re-renders (records produce
     /// fresh-but-equal instances).
+    /// <para>
+    /// Known limitation: the dedup set is process-global and the element tree carries no parent
+    /// pointer, so two <em>unkeyed</em> offenders that share the same stack type and row/column but
+    /// live in <em>different</em> Grids hash to the same key — only the first warns. This is an
+    /// accepted tradeoff for a DEBUG-only diagnostic; assign distinct <see cref="Element.Key"/>s
+    /// (e.g. via <c>.WithKey(...)</c>) to the stacks to surface every offender.
+    /// </para>
     /// </summary>
     private static string BuildDedupKey(string stackName, int row, int col, string? locationKey)
         => locationKey is { Length: > 0 }
@@ -209,14 +216,16 @@ internal static class LayoutFootgunDetector
     {
         string axis = axisIsColumn ? "column" : "row";
         string sizeModifier = axisIsColumn ? "Width" : "Height";
+        string minSizeModifier = axisIsColumn ? "MinWidth" : "MinHeight";
         string starTrack = axisIsColumn ? "Star (\"*\") column" : "Star (\"*\") row";
         string location = locationKey is { Length: > 0 } ? $" (key: \"{locationKey}\")" : string.Empty;
 
         return string.Format(
             CultureInfo.InvariantCulture,
             "[Reactor] {0}{1} is in Grid {2} {3} (Auto) with no explicit {4} and no explicitly-sized " +
-            "children. The measure pass may return 0\u00d70 (collapsed). Use a {5} or set .{4}(...) on the {0}.",
-            stackName, location, axis, index, sizeModifier, starTrack);
+            "children. The measure pass may return 0\u00d70 (collapsed). Fix it by using a {5}, setting " +
+            ".{4}(...) or .{6}(...) on the {0}, or giving a child an explicit size.",
+            stackName, location, axis, index, sizeModifier, starTrack, minSizeModifier);
     }
 
     private static void Emit(string dedupKey, string message)

--- a/src/Reactor/Diagnostics/LayoutFootgunDetector.cs
+++ b/src/Reactor/Diagnostics/LayoutFootgunDetector.cs
@@ -39,7 +39,7 @@ namespace Microsoft.UI.Reactor.Diagnostics;
 /// realized control dimensions, so it stays cheap and side-effect free.
 /// </para>
 /// </remarks>
-public static class LayoutFootgunDetector
+internal static class LayoutFootgunDetector
 {
     /// <summary>
     /// <c>true</c> when compiled in a <c>DEBUG</c> configuration. A compile-time constant so the
@@ -155,14 +155,18 @@ public static class LayoutFootgunDetector
             if (!TrackIsAuto(columns, col)) return;
             if (chainHasWidth) return;
             if (AnyChildHasExplicitWidth(stackChildren)) return;
-            Emit(BuildMessage("HStack", axisIsColumn: true, index: col, locationKey: locationKey));
+            Emit(
+                BuildDedupKey("HStack", row, col, locationKey),
+                BuildMessage("HStack", axisIsColumn: true, index: col, locationKey: locationKey));
         }
         else
         {
             if (!TrackIsAuto(rows, row)) return;
             if (chainHasHeight) return;
             if (AnyChildHasExplicitHeight(stackChildren)) return;
-            Emit(BuildMessage("VStack", axisIsColumn: false, index: row, locationKey: locationKey));
+            Emit(
+                BuildDedupKey("VStack", row, col, locationKey),
+                BuildMessage("VStack", axisIsColumn: false, index: row, locationKey: locationKey));
         }
     }
 
@@ -190,6 +194,18 @@ public static class LayoutFootgunDetector
         return track is not null && string.Equals(track.Trim(), "Auto", StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Builds the emit-once dedup key for an offending placement. Keyed on element identity
+    /// (the author-supplied <see cref="Element.Key"/> when present) or, for unkeyed elements, on
+    /// the stack type plus its concrete grid placement (row/column). This keeps two <em>distinct</em>
+    /// offending placements that merely share a stack type + track from collapsing into a single
+    /// warning, while staying stable across re-renders (records produce fresh-but-equal instances).
+    /// </summary>
+    private static string BuildDedupKey(string stackName, int row, int col, string? locationKey)
+        => locationKey is { Length: > 0 }
+            ? $"key:{locationKey}"
+            : string.Format(CultureInfo.InvariantCulture, "{0}@r{1}c{2}", stackName, row, col);
+
     private static string BuildMessage(string stackName, bool axisIsColumn, int index, string? locationKey)
     {
         string axis = axisIsColumn ? "column" : "row";
@@ -204,11 +220,11 @@ public static class LayoutFootgunDetector
             stackName, location, axis, index, sizeModifier, starTrack);
     }
 
-    private static void Emit(string message)
+    private static void Emit(string dedupKey, string message)
     {
         lock (s_gate)
         {
-            if (!s_warned.Add(message))
+            if (!s_warned.Add(dedupKey))
                 return;
         }
 

--- a/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
+++ b/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Diagnostics;
+using Xunit;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Issue #345 — debug-time warning when an <c>HStack</c>/<c>VStack</c> is placed in a
+/// <c>Grid</c> <c>Auto</c> track with no explicit size and no explicitly-sized children
+/// (the silent 0×0 collapse footgun).
+///
+/// <para>These tests drive <see cref="LayoutFootgunDetector.InspectGrid"/> directly against
+/// the element tree — no WinUI control mount is required, so they stay in the headless unit
+/// tier.</para>
+/// </summary>
+public sealed class LayoutFootgunDetectorTests : IDisposable
+{
+    private readonly List<string> _warnings = new();
+
+    public LayoutFootgunDetectorTests()
+    {
+        LayoutFootgunDetector.ResetForTests();
+        LayoutFootgunDetector.Sink = _warnings.Add;
+    }
+
+    public void Dispose()
+    {
+        LayoutFootgunDetector.Sink = null;
+        LayoutFootgunDetector.ResetForTests();
+    }
+
+    // ── Should warn ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BareHStack_InAutoColumn_NoExplicitSize_Warns()
+    {
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A"), TextBlock("B")).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        var msg = Assert.Single(_warnings);
+        Assert.Contains("HStack", msg);
+        Assert.Contains("column 0 (Auto)", msg);
+    }
+
+    [Fact]
+    public void BorderWrappedHStack_InAutoColumn_StillWarns()
+    {
+        // Wrapping in a Border does NOT fix the collapse (the Border sizes to its 0-sized child).
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            Border(HStack(TextBlock("A"), TextBlock("B"))).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        var msg = Assert.Single(_warnings);
+        Assert.Contains("HStack", msg);
+    }
+
+    [Fact]
+    public void VStack_InAutoRow_NoExplicitSize_Warns()
+    {
+        var grid = Grid(
+            columns: new[] { GridSize.Star() },
+            rows: new[] { GridSize.Star(), GridSize.Auto },
+            VStack(TextBlock("A"), TextBlock("B")).Grid(row: 1, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        var msg = Assert.Single(_warnings);
+        Assert.Contains("VStack", msg);
+        Assert.Contains("row 1 (Auto)", msg);
+    }
+
+    // ── Should NOT warn ────────────────────────────────────────────────────
+
+    [Fact]
+    public void HStack_InStarColumn_DoesNotWarn()
+    {
+        var grid = Grid(
+            columns: new[] { GridSize.Star(), GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A"), TextBlock("B")).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void HStack_InAutoColumn_WithExplicitWidth_DoesNotWarn()
+    {
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A"), TextBlock("B")).Width(200).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void HStack_InAutoColumn_WithExplicitlySizedChild_DoesNotWarn()
+    {
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A").Width(120), TextBlock("B")).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void BorderWrappedHStack_BorderHasExplicitWidth_DoesNotWarn()
+    {
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            Border(HStack(TextBlock("A"), TextBlock("B"))).Width(200).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void HStack_InAutoRow_StarColumn_DoesNotWarn()
+    {
+        // A horizontal stack only collapses on its main (horizontal) axis. An Auto *row*
+        // with a Star column does not trigger the HStack width-collapse footgun.
+        var grid = Grid(
+            columns: new[] { GridSize.Star() },
+            rows: new[] { GridSize.Auto },
+            HStack(TextBlock("A"), TextBlock("B")).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void EmptyHStack_InAutoColumn_DoesNotWarn()
+    {
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack().Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    // ── Emit-once ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SameOffendingPlacement_WarnsOnlyOnce_AcrossRenders()
+    {
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A"), TextBlock("B")).Grid(row: 0, column: 0));
+
+        // Simulate two render/mount passes of the same logical placement.
+        LayoutFootgunDetector.InspectGrid(grid);
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Single(_warnings);
+    }
+}

--- a/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
+++ b/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
@@ -169,6 +169,48 @@ public sealed class LayoutFootgunDetectorTests : IDisposable
     }
 
     [Fact]
+    public void VStack_InAutoRow_WithExplicitHeight_DoesNotWarn()
+    {
+        var grid = Grid(
+            columns: new[] { GridSize.Star() },
+            rows: new[] { GridSize.Star(), GridSize.Auto },
+            VStack(TextBlock("A"), TextBlock("B")).Height(120).Grid(row: 1, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void VStack_InAutoRow_WithExplicitlySizedChild_DoesNotWarn()
+    {
+        // Mirrors the horizontal child-Width case: a child's explicit Height keeps the column from
+        // collapsing, so AnyChildHasExplicitHeight must suppress the warning.
+        var grid = Grid(
+            columns: new[] { GridSize.Star() },
+            rows: new[] { GridSize.Star(), GridSize.Auto },
+            VStack(TextBlock("A").Height(60), TextBlock("B")).Grid(row: 1, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void VStack_InAutoRow_WithChildMinHeight_DoesNotWarn()
+    {
+        // A child's MinHeight clamps the Measure pass too — mirrors the horizontal child-MinWidth case.
+        var grid = Grid(
+            columns: new[] { GridSize.Star() },
+            rows: new[] { GridSize.Star(), GridSize.Auto },
+            VStack(TextBlock("A").MinHeight(40), TextBlock("B")).Grid(row: 1, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
     public void BorderWrappedHStack_BorderHasExplicitWidth_DoesNotWarn()
     {
         var grid = Grid(
@@ -203,6 +245,22 @@ public sealed class LayoutFootgunDetectorTests : IDisposable
             columns: new[] { GridSize.Auto, GridSize.Star() },
             rows: new[] { GridSize.Star() },
             HStack().Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void NonStackChild_InAutoColumn_DoesNotWarn()
+    {
+        // A non-stack element (here a bare TextBlock) placed directly in an Auto track is not the
+        // footgun the detector models — InspectGrid must leave it alone (the "not a stack we model"
+        // branch), so a regression that warned on every TextBlock/Button in an Auto track is caught.
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            TextBlock("A").Grid(row: 0, column: 0));
 
         LayoutFootgunDetector.InspectGrid(grid);
 
@@ -304,6 +362,23 @@ public sealed class LayoutFootgunDetectorTests : IDisposable
             rows: new[] { GridSize.Star(), GridSize.Star() },
             HStack(TextBlock("A")).WithKey("row").Grid(row: 0, column: 0),
             HStack(TextBlock("B")).WithKey("row").Grid(row: 1, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Equal(2, _warnings.Count);
+    }
+
+    [Fact]
+    public void TwoKeyedOffenders_SameCell_DifferentKeys_BothWarn()
+    {
+        // Two HStacks in the SAME Auto cell (row 0, column 0) with different keys. They share stack
+        // type and placement, so without the author-key discriminator in the dedup key they would
+        // collapse to one warning — this pins that `.WithKey(...)` keeps distinct offenders distinct.
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A")).WithKey("first").Grid(row: 0, column: 0),
+            HStack(TextBlock("B")).WithKey("second").Grid(row: 0, column: 0));
 
         LayoutFootgunDetector.InspectGrid(grid);
 

--- a/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
+++ b/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
@@ -177,4 +177,100 @@ public sealed class LayoutFootgunDetectorTests : IDisposable
 
         Assert.Single(_warnings);
     }
+
+    // ── Update path (dynamic / state-driven placements) ────────────────────
+
+    [Fact]
+    public void HStack_StarColumn_ThenFlippedToAuto_WarnsAfterFlip()
+    {
+        // Models a state-driven `columns:` change on an already-mounted Grid: the first render is
+        // safe (Star), a later render flips the track to Auto. The runtime warning's whole point
+        // over a static analyzer is catching this dynamic case — the detector must fire on the
+        // second pass. Goes through Inspect() so the DEBUG/flag gate + `is GridElement` filter run.
+        var keyedHStack = HStack(TextBlock("A"), TextBlock("B")).WithKey("toolbar").Grid(row: 0, column: 0);
+
+        var safe = Grid(
+            columns: new[] { GridSize.Star(), GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            keyedHStack);
+        LayoutFootgunDetector.Inspect(safe);
+        Assert.Empty(_warnings);
+
+        var collapsing = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            keyedHStack);
+        LayoutFootgunDetector.Inspect(collapsing);
+
+        var msg = Assert.Single(_warnings);
+        Assert.Contains("column 0 (Auto)", msg);
+    }
+
+    [Fact]
+    public void HStack_ExplicitWidth_ThenWidthRemoved_WarnsAfterRemoval()
+    {
+        // Models the explicit size being dropped on a re-render (e.g. a conditional .Width()).
+        var sized = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A"), TextBlock("B")).WithKey("toolbar").Width(200).Grid(row: 0, column: 0));
+        LayoutFootgunDetector.Inspect(sized);
+        Assert.Empty(_warnings);
+
+        var unsized = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A"), TextBlock("B")).WithKey("toolbar").Grid(row: 0, column: 0));
+        LayoutFootgunDetector.Inspect(unsized);
+
+        Assert.Single(_warnings);
+    }
+
+    // ── Dedup keyed on identity, not message (L1) ──────────────────────────
+
+    [Fact]
+    public void TwoDistinctOffenders_SameStackTypeAndTrackIndex_BothWarn()
+    {
+        // Two different HStacks both land in column 0 (Auto) but at different rows. They are
+        // distinct offending placements and must each warn — dedup keys on element identity /
+        // grid position, not on the (identical) message text.
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star(), GridSize.Star() },
+            HStack(TextBlock("A")).Grid(row: 0, column: 0),
+            HStack(TextBlock("B")).Grid(row: 1, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Equal(2, _warnings.Count);
+    }
+
+    // ── Hook wiring: gate + `is GridElement` filter + Sink (L4) ────────────
+
+    [Fact]
+    public void Inspect_NonGridElement_DoesNotWarn()
+    {
+        // The Reconciler calls Inspect() on every mounted/updated element; only GridElement should
+        // be considered. A bare HStack (not inside a Grid) must be ignored by the `is GridElement`
+        // filter even though it is a stack.
+        LayoutFootgunDetector.Inspect(HStack(TextBlock("A"), TextBlock("B")));
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void Inspect_OffendingGridElement_RoutesThroughGateAndSink()
+    {
+        // Exercises the exact entry point the Reconciler Mount/Update tail calls: the DEBUG/flag
+        // gate is satisfied (tests run under DEBUG), the `is GridElement` filter passes, and the
+        // warning reaches the Sink — pinning the hook wiring, not just InspectGrid() detection.
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A"), TextBlock("B")).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.Inspect(grid);
+
+        Assert.Single(_warnings);
+    }
 }

--- a/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
+++ b/tests/Reactor.Tests/LayoutFootgunDetectorTests.cs
@@ -16,12 +16,18 @@ namespace Microsoft.UI.Reactor.Tests;
 /// the element tree — no WinUI control mount is required, so they stay in the headless unit
 /// tier.</para>
 /// </summary>
+[Collection("LayoutFootgunDetector")]
 public sealed class LayoutFootgunDetectorTests : IDisposable
 {
     private readonly List<string> _warnings = new();
+    private readonly bool _originalFlag;
 
     public LayoutFootgunDetectorTests()
     {
+        // Enable the flag explicitly rather than relying on DEBUG-always-on, so the tests behave
+        // identically under Release configurations.
+        _originalFlag = ReactorFeatureFlags.WarnLayoutFootguns;
+        ReactorFeatureFlags.WarnLayoutFootguns = true;
         LayoutFootgunDetector.ResetForTests();
         LayoutFootgunDetector.Sink = _warnings.Add;
     }
@@ -30,6 +36,7 @@ public sealed class LayoutFootgunDetectorTests : IDisposable
     {
         LayoutFootgunDetector.Sink = null;
         LayoutFootgunDetector.ResetForTests();
+        ReactorFeatureFlags.WarnLayoutFootguns = _originalFlag;
     }
 
     // ── Should warn ────────────────────────────────────────────────────────
@@ -114,6 +121,47 @@ public sealed class LayoutFootgunDetectorTests : IDisposable
             columns: new[] { GridSize.Auto, GridSize.Star() },
             rows: new[] { GridSize.Star() },
             HStack(TextBlock("A").Width(120), TextBlock("B")).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void HStack_InAutoColumn_WithMinWidth_DoesNotWarn()
+    {
+        // MinWidth clamps the Measure pass, so the stack cannot collapse to 0 — no warning.
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A"), TextBlock("B")).MinWidth(80).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void HStack_InAutoColumn_WithChildMinWidth_DoesNotWarn()
+    {
+        // A child's MinWidth also prevents the stretch→0 desired-size case during Measure.
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star() },
+            HStack(TextBlock("A").MinWidth(40), TextBlock("B")).Grid(row: 0, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Empty(_warnings);
+    }
+
+    [Fact]
+    public void VStack_InAutoRow_WithMinHeight_DoesNotWarn()
+    {
+        var grid = Grid(
+            columns: new[] { GridSize.Star() },
+            rows: new[] { GridSize.Star(), GridSize.Auto },
+            VStack(TextBlock("A"), TextBlock("B")).MinHeight(50).Grid(row: 1, column: 0));
 
         LayoutFootgunDetector.InspectGrid(grid);
 
@@ -245,7 +293,22 @@ public sealed class LayoutFootgunDetectorTests : IDisposable
         Assert.Equal(2, _warnings.Count);
     }
 
-    // ── Hook wiring: gate + `is GridElement` filter + Sink (L4) ────────────
+    [Fact]
+    public void TwoOffenders_ReusingSameKeyAtDifferentPlacements_BothWarn()
+    {
+        // Element.Key uniqueness is only guaranteed among siblings, so the same key can legitimately
+        // appear at distinct grid placements. Each is a distinct offender and must warn — the dedup
+        // key folds in the grid placement, not just the author key.
+        var grid = Grid(
+            columns: new[] { GridSize.Auto, GridSize.Star() },
+            rows: new[] { GridSize.Star(), GridSize.Star() },
+            HStack(TextBlock("A")).WithKey("row").Grid(row: 0, column: 0),
+            HStack(TextBlock("B")).WithKey("row").Grid(row: 1, column: 0));
+
+        LayoutFootgunDetector.InspectGrid(grid);
+
+        Assert.Equal(2, _warnings.Count);
+    }
 
     [Fact]
     public void Inspect_NonGridElement_DoesNotWarn()

--- a/tests/Reactor.Tests/TestIsolationCollections.cs
+++ b/tests/Reactor.Tests/TestIsolationCollections.cs
@@ -49,3 +49,14 @@ public sealed class JumpListGlobalsCollection { }
 /// </summary>
 [CollectionDefinition("HotReload", DisableParallelization = true)]
 public sealed class HotReloadCollection { }
+
+/// <summary>
+/// xUnit collection marker for tests that mutate process-wide
+/// <see cref="Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector"/> state — the diagnostic
+/// <c>Sink</c>, the emit-once dedup set (<c>ResetForTests()</c>), and
+/// <see cref="Microsoft.UI.Reactor.Core.ReactorFeatureFlags.WarnLayoutFootguns"/>. These statics
+/// are global to the test process, so the tests must run exclusively to avoid cross-test
+/// interference.
+/// </summary>
+[CollectionDefinition("LayoutFootgunDetector", DisableParallelization = true)]
+public sealed class LayoutFootgunDetectorCollection { }


### PR DESCRIPTION
Closes #345.

## Problem

`HStack(...).Grid(column: N)` placed in a `GridSize.Auto` column silently
collapses to `0×0` when its children rely on stretch sizing. This is generic
XAML measure semantics (a `Grid` `Auto` track measures content with infinite
available space; a `StackPanel` accumulates child desired width, which is `0`
for stretch children) — **not** a Reactor reconciler bug. But the failure is
invisible: the action row just vanishes with no signal, and bisecting it costs
hours. Reactor can detect it because it holds the declarative tree and can
correlate "an `HStack` was just placed at Grid column N" with "column N is
`Auto`".

## Solution

A debug-time, emit-once runtime warning (issue's chosen option).

- **New flag** `ReactorFeatureFlags.WarnLayoutFootguns` — default `false`, but
  **always on in `DEBUG`** builds (the flag is the opt-in switch for Release).
  When off in Release the detection is elided to a single flag read per Grid
  mount, so it's effectively free.
- **New detector** `Microsoft.UI.Reactor.Diagnostics.LayoutFootgunDetector`,
  invoked from `Reconciler.Mount` for `GridElement` mounts. It inspects the
  immutable element tree only (grid `Definition`, child `GridAttached`,
  `Modifiers.Width/Height`, `StackElement.Orientation/Children`) — it never
  reads back realized control dimensions.
- **Detection conditions** (all must hold): a stack-style child (`HStack`/
  `VStack`, including ones wrapped in a `Border`) lands in a Grid track that is
  `Auto` on its stacking axis (column for `HStack`, row for `VStack`); neither
  the stack nor any wrapper carries an explicit size on that axis; and none of
  the stack's first-generation children carry an explicit size on that axis.
  Wrapping in a `Border` does **not** suppress the warning (the Border sizes to
  its `0`-sized child — matching the real-world behavior).
- **Emit-once**: each distinct offending placement warns at most once per
  process. Warnings route through a testable `Sink` plus `Debug.WriteLine`.

The message is actionable, e.g.:

```
[Reactor] HStack is in Grid column 0 (Auto) with no explicit Width and no
explicitly-sized children. The measure pass may return 0×0 (collapsed). Use a
Star ("*") column or set .Width(...) on the HStack.
```

## Docs

Added an `HStack`/`VStack`-in-`Grid`-`Auto`-track footgun note to the layout
guide's **Common Mistakes** section (edited the
`docs/_pipeline/templates/layout.md.dt` template and recompiled via
`mur docs compile`).

## Tests

10 new headless xUnit tests in `tests/Reactor.Tests/LayoutFootgunDetectorTests.cs`:
bare HStack-in-Auto-column warns; Border-wrapped warns; VStack-in-Auto-row
warns; Star column / explicit `.Width` / explicitly-sized child / empty stack /
HStack-in-Auto-row-with-Star-column do **not** warn; and emit-once (inspect
twice → one warning). Full suite green (9527 passed).

## Scope note

The complementary Roslyn analyzer mentioned in the issue (for literal
`HStack(...).Grid(col)` cases) is deferred as a follow-up — the runtime warning
already covers dynamic column collections, which the analyzer cannot.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>