### PR TITLE
test(selftest): gate docking effect-count asserts on body realization (#445)

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/NativeDockingReliabilityFixture.cs
@@ -219,10 +219,18 @@ internal static class NativeDockingReliabilityFixtures
             host.Mount(_ => managerEl);
             await Harness.Render();
 
-            H.Check("Reliability_Effect_MountedOnce", mountedCount == 1);
-            H.Check("Reliability_Effect_NoCleanupBeforeClose", cleanupCount == 0);
+            // Pump until the pane body realizes behind the TabView content
+            // presenter BEFORE probing the mount/cleanup counters. The
+            // nested component's OnMount effect — which increments
+            // mountedCount — only fires once the body is committed, and on
+            // the NativeAOT dispatcher-timing window that realization can
+            // land a wave later than Harness.Render drains. Gating the count
+            // asserts on the body sentinel closes the residual cascade where
+            // Reliability_Effect_MountedOnce probes a count of 0.
             H.Check("Reliability_Effect_BodyRendered",
                 await Harness.WaitFor(() => H.FindText("effect-body-p1") is not null));
+            H.Check("Reliability_Effect_MountedOnce", mountedCount == 1);
+            H.Check("Reliability_Effect_NoCleanupBeforeClose", cleanupCount == 0);
 
             var model = DockHostModelBridge.Get(managerEl);
             H.Check("Reliability_Effect_BridgeYieldsModel", model is not null);


### PR DESCRIPTION
## Summary

Closes #445.

Residual NativeAOT selftest flake in the `NativeDocking_*` fixtures. PR #442 (drain dispatcher after `UpdateLayout` in `Harness.Render`) cut the flake rate dramatically, and the later #502/#510 sweep generalized the per-fixture pump-until pattern into `Harness.WaitFor`. Five of the six fixtures flagged in #445 already place their `WaitFor` sentinel guard before their first realized-content assert.

The lone gap was **`NativeDocking_Reliability_UseEffectCleanup_BodyRemovedOnPaneClose`**: it probed `mountedCount == 1` / `cleanupCount == 0` *before* its `effect-body-p1` `WaitFor` guard. The nested component's `UseEffect` `OnMount` (which increments `mountedCount`) only fires once the pane body is committed behind the `TabView` content presenter. On the AOT dispatcher-timing window that realization can land a wave later than a single `Harness.Render` drains, cascading `Reliability_Effect_MountedOnce` against a count of `0`.

## Change

Reorder so the bounded pump-until body-realization guard runs **first**, matching the defense-in-depth pattern the other five NativeDocking fixtures already use. Test-side only — no framework source touched.

## Validation

- All 48 `NativeDocking_*` selftest fixtures pass, including the reordered fixture (`Reliability_Effect_BodyRendered` → `MountedOnce` → `NoCleanupBeforeClose` all `ok`).
- Focused flake loop: **30/30 clean** runs of the full NativeDocking selftest set on ARM64 (standard/non-AOT path — NativeAOT `link.exe` is unavailable on ARM64). Zero `not ok` across all runs.

Why the bounded pump also closes the AOT timing window: `Harness.WaitFor` re-queries the live tree after each `Harness.Render` pass until the sentinel resolves, so the count probe waits for the component's actual realization+effect regardless of whether the deferred `TabViewItem.ContentPresenter` realization was posted at Normal/Low/post-Loaded priority. The loop is bounded (25 passes) so a genuinely broken fixture still fails fast rather than hanging.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>