### PR TITLE
Make UseNavigation thread-safe by default (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,4 +321,19 @@ Conventions for contributors:
   `TryEnqueue`; the UI-thread fast path stays a single `HasThreadAccess` check.
   (issue #130)
 
+- **`UseNavigation` mutators are now thread-safe by default (issue #234).**
+  `NavigationHandle<TRoute>`'s `Navigate`, `GoBack`, `GoForward`, `Replace`,
+  `Reset`, `PopTo`, and `SetState` previously mutated the back/forward stacks
+  with no thread guard, so calling them off the UI thread (from a `Task.Run`,
+  a timer, or after `await … ConfigureAwait(false)`) could corrupt the stacks
+  or silently drop the navigation. Each mutator now auto-marshals the whole
+  operation onto the handle's captured UI dispatcher — completing the
+  thread-safety-by-default story that #212 started for `UseState` / `UseReducer`
+  — via the shared `UIThreadMarshal` gate. The UI-thread fast path stays a
+  single thread-id compare with zero allocation. When no dispatcher is available
+  (headless / unit-test contexts) or it has shut down, the off-thread call throws
+  a loud `InvalidOperationException` instead of corrupting state. On the UI thread
+  behavior is unchanged. The `RenderContext` setter marshal and the navigation
+  gate now share one `UIThreadMarshal.EnqueueOrThrow` implementation.
+
 ### Security

--- a/docs/_pipeline/templates/navigation.md.dt
+++ b/docs/_pipeline/templates/navigation.md.dt
@@ -404,9 +404,16 @@ class Shell : Component
 ```
 
 The handle is bound to the dispatcher of the component that created
-it. Calling `Nav.Navigate(...)` from a background timer or an event
-handler captured in a closure that outlives the page is a silent
-no-op when the bound dispatcher has shut down. Use
+it. As of issue #234 the mutators (`Navigate`, `GoBack`, `GoForward`,
+`Replace`, `Reset`, `PopTo`, `SetState`) are **thread-safe by default**:
+calling `Nav.Navigate(...)` from a background timer or a closure that
+runs off the UI thread auto-marshals the navigation onto that captured
+dispatcher — mirroring the `UseState` / `UseReducer` contract (see
+[Threading and Dispatch](threading-and-dispatch.md)). If the dispatcher
+was never captured, or has already shut down, the call throws
+`InvalidOperationException` loudly rather than silently corrupting the
+back/forward stacks. Stashing the handle in a `static` is still a smell
+— it outlives the page and leaks the dispatcher it captured — so prefer
 `UseNavigation<TRoute>()` (no initial value) in a descendant component
 to access the same handle via context, or pass the handle through
 [Context](context.md) explicitly.

--- a/docs/_pipeline/templates/threading-and-dispatch.md.dt
+++ b/docs/_pipeline/templates/threading-and-dispatch.md.dt
@@ -45,6 +45,7 @@ UI thread.
 | `Component.Render()` | UI thread | `RenderContext.BeginRender` captures `_uiThreadId`; reconciler invokes on the dispatcher |
 | `setX(...)` / `updateX(...)` from `UseState` / `UseReducer` | Any thread | `MarshalIfOffUIThread` in `RenderContext.cs` |
 | `setX(...)` with `threadSafe: true` | Any thread | per-cell `lock` in `ValueHookState<T>`; no marshal hop |
+| `NavigationHandle` mutators (`Navigate` / `GoBack` / `GoForward` / `Replace` / `Reset` / `PopTo` / `SetState`) from `UseNavigation` | Any thread | `UIThreadMarshal` gate in `NavigationHandle.cs` (auto-marshal; shares `EnqueueOrThrow` with `MarshalIfOffUIThread`) |
 | `UseEffect` body | UI thread | `RenderContext.FlushEffects` runs on the dispatcher |
 | `UseEffect` cleanup | UI thread | same dispatcher as flush |
 | `Reconciler.Reconcile` | UI thread | host calls it from a dispatcher continuation |
@@ -82,6 +83,18 @@ The two failure modes throw immediately rather than swallow:
   loud throw beats a state cell that mysteriously stops advancing
   near window close. Cancel background producers in your effect
   cleanup so they stop before the window closes.
+
+The same machinery now covers `UseNavigation` (issue #234). A
+`NavigationHandle<TRoute>` captures the UI thread id when it is created,
+and its mutators — `Navigate`, `GoBack`, `GoForward`, `Replace`,
+`Reset`, `PopTo`, and `SetState` — auto-marshal the whole operation onto
+that dispatcher when called off-thread, throwing the same two failure
+modes above when no live dispatcher is available. Both paths share one
+`UIThreadMarshal.EnqueueOrThrow` implementation, so the setter marshal
+and the navigation gate stay behaviourally identical. The `bool` the
+mutators return reports whether the operation was *scheduled*, not
+whether the navigation ultimately succeeded — off-thread callers must
+not treat `true` as confirmation that the stack changed.
 
 ## The trampoline guard for non-setter mutators
 

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -760,9 +760,16 @@ class Shell : Component
 ```
 
 The handle is bound to the dispatcher of the component that created
-it. Calling `Nav.Navigate(...)` from a background timer or an event
-handler captured in a closure that outlives the page is a silent
-no-op when the bound dispatcher has shut down. Use
+it. As of issue #234 the mutators (`Navigate`, `GoBack`, `GoForward`,
+`Replace`, `Reset`, `PopTo`, `SetState`) are **thread-safe by default**:
+calling `Nav.Navigate(...)` from a background timer or a closure that
+runs off the UI thread auto-marshals the navigation onto that captured
+dispatcher — mirroring the `UseState` / `UseReducer` contract (see
+[Threading and Dispatch](threading-and-dispatch.md)). If the dispatcher
+was never captured, or has already shut down, the call throws
+`InvalidOperationException` loudly rather than silently corrupting the
+back/forward stacks. Stashing the handle in a `static` is still a smell
+— it outlives the page and leaks the dispatcher it captured — so prefer
 `UseNavigation<TRoute>()` (no initial value) in a descendant component
 to access the same handle via context, or pass the handle through
 [Context](context.md) explicitly.

--- a/docs/guide/threading-and-dispatch.md
+++ b/docs/guide/threading-and-dispatch.md
@@ -35,6 +35,7 @@ UI thread.
 | `Component.Render()` | UI thread | `RenderContext.BeginRender` captures `_uiThreadId`; reconciler invokes on the dispatcher |
 | `setX(...)` / `updateX(...)` from `UseState` / `UseReducer` | Any thread | `MarshalIfOffUIThread` in `RenderContext.cs` |
 | `setX(...)` with `threadSafe: true` | Any thread | per-cell `lock` in `ValueHookState<T>`; no marshal hop |
+| `NavigationHandle` mutators (`Navigate` / `GoBack` / `GoForward` / `Replace` / `Reset` / `PopTo` / `SetState`) from `UseNavigation` | Any thread | `UIThreadMarshal` gate in `NavigationHandle.cs` (auto-marshal; shares `EnqueueOrThrow` with `MarshalIfOffUIThread`) |
 | `UseEffect` body | UI thread | `RenderContext.FlushEffects` runs on the dispatcher |
 | `UseEffect` cleanup | UI thread | same dispatcher as flush |
 | `Reconciler.Reconcile` | UI thread | host calls it from a dispatcher continuation |
@@ -102,6 +103,18 @@ The two failure modes throw immediately rather than swallow:
   near window close. Cancel background producers in your effect
   cleanup so they stop before the window closes.
 
+The same machinery now covers `UseNavigation` (issue #234). A
+`NavigationHandle<TRoute>` captures the UI thread id when it is created,
+and its mutators — `Navigate`, `GoBack`, `GoForward`, `Replace`,
+`Reset`, `PopTo`, and `SetState` — auto-marshal the whole operation onto
+that dispatcher when called off-thread, throwing the same two failure
+modes above when no live dispatcher is available. Both paths share one
+`UIThreadMarshal.EnqueueOrThrow` implementation, so the setter marshal
+and the navigation gate stay behaviourally identical. The `bool` the
+mutators return reports whether the operation was *scheduled*, not
+whether the navigation ultimately succeeded — off-thread callers must
+not treat `true` as confirmation that the stack changed.
+
 ## The trampoline guard for non-setter mutators
 
 Setters reach the UI thread via auto-marshal. Other mutators — opening
@@ -167,6 +180,19 @@ internal static bool ShouldSuppress(UIElement control)
     if (control is not FrameworkElement fe) return false;
     if (fe.GetValue(Reconciler.ReactorAttached.StateProperty) is not Reconciler.ReactorState state)
         return false;
+    return ShouldSuppress(state);
+}
+
+/// <summary>
+/// Issue #207 — suppression check for trampolines that already hold the
+/// control's <see cref="Reconciler.ReactorState"/> (read once via
+/// <see cref="Reconciler.TryGetReactorState"/>). Identical decrement-and-
+/// suppress semantics to <see cref="ShouldSuppress(UIElement)"/>; the
+/// UIElement overload delegates here after a single attached-DP read so a
+/// change handler pays one DP read instead of two.
+/// </summary>
+internal static bool ShouldSuppress(Reconciler.ReactorState state)
+{
     // §8.2 — setter-suppression scope: drop the echo without consuming a
     // counter token. The scope wraps ApplySetters, where the engine can't
     // predict which value-bearing DPs the user's `.Set(...)` will write.

--- a/plugins/reactor/skills/reactor-navigation/SKILL.md
+++ b/plugins/reactor/skills/reactor-navigation/SKILL.md
@@ -275,3 +275,30 @@ navigation stack automatically.
    against unsaved-changes navigation.
 6. **Don't forget `backStackFactory` in deep links.** Without it, GoBack
    does nothing after a deep-linked entry.
+
+## Threading
+
+`UseNavigation` mutators are **thread-safe by default** (issue #234). The
+handle captures the UI thread when it is created, so calling `Navigate`,
+`GoBack`, `GoForward`, `Replace`, `Reset`, `PopTo`, or `SetState` from a
+`Task.Run`, a timer, or after `await … ConfigureAwait(false)` auto-marshals
+the operation back onto the captured dispatcher — no `threadSafe:` flag and
+no manual `DispatcherQueue.TryEnqueue` needed:
+
+```csharp
+await Task.Run(async () => {
+    var result = await LoadAsync();
+    nav.Navigate(Route.Detail, result); // marshals onto the UI thread automatically
+});
+```
+
+This mirrors the `UseState` / `UseReducer` contract. Two caveats:
+
+- **No live dispatcher → loud throw.** Off-thread calls in a headless or
+  unit-test context (no `ReactorApp.UIDispatcher`), or after the dispatcher
+  has shut down, throw `InvalidOperationException` instead of silently
+  corrupting the back/forward stacks. On the UI thread the call runs inline.
+- **Off-thread `bool` means "scheduled", not "navigated".** When a mutator
+  marshals, its return value reports that the operation was *enqueued*, not
+  that the navigation ultimately succeeded. Don't branch on it from a
+  background thread.

--- a/plugins/reactor/skills/reactor-navigation/SKILL.md
+++ b/plugins/reactor/skills/reactor-navigation/SKILL.md
@@ -287,8 +287,8 @@ no manual `DispatcherQueue.TryEnqueue` needed:
 
 ```csharp
 await Task.Run(async () => {
-    var result = await LoadAsync();
-    nav.Navigate(Route.Detail, result); // marshals onto the UI thread automatically
+    var itemId = await LoadItemIdAsync();
+    nav.Navigate(new Route.Details(itemId)); // marshals onto the UI thread automatically
 });
 ```
 

--- a/skills/navigation.md
+++ b/skills/navigation.md
@@ -275,3 +275,30 @@ navigation stack automatically.
    against unsaved-changes navigation.
 6. **Don't forget `backStackFactory` in deep links.** Without it, GoBack
    does nothing after a deep-linked entry.
+
+## Threading
+
+`UseNavigation` mutators are **thread-safe by default** (issue #234). The
+handle captures the UI thread when it is created, so calling `Navigate`,
+`GoBack`, `GoForward`, `Replace`, `Reset`, `PopTo`, or `SetState` from a
+`Task.Run`, a timer, or after `await … ConfigureAwait(false)` auto-marshals
+the operation back onto the captured dispatcher — no `threadSafe:` flag and
+no manual `DispatcherQueue.TryEnqueue` needed:
+
+```csharp
+await Task.Run(async () => {
+    var result = await LoadAsync();
+    nav.Navigate(Route.Detail, result); // marshals onto the UI thread automatically
+});
+```
+
+This mirrors the `UseState` / `UseReducer` contract. Two caveats:
+
+- **No live dispatcher → loud throw.** Off-thread calls in a headless or
+  unit-test context (no `ReactorApp.UIDispatcher`), or after the dispatcher
+  has shut down, throw `InvalidOperationException` instead of silently
+  corrupting the back/forward stacks. On the UI thread the call runs inline.
+- **Off-thread `bool` means "scheduled", not "navigated".** When a mutator
+  marshals, its return value reports that the operation was *enqueued*, not
+  that the navigation ultimately succeeded. Don't branch on it from a
+  background thread.

--- a/skills/navigation.md
+++ b/skills/navigation.md
@@ -287,8 +287,8 @@ no manual `DispatcherQueue.TryEnqueue` needed:
 
 ```csharp
 await Task.Run(async () => {
-    var result = await LoadAsync();
-    nav.Navigate(Route.Detail, result); // marshals onto the UI thread automatically
+    var itemId = await LoadItemIdAsync();
+    nav.Navigate(new Route.Details(itemId)); // marshals onto the UI thread automatically
 });
 ```
 

--- a/src/Reactor/Core/Navigation/NavigationHandle.cs
+++ b/src/Reactor/Core/Navigation/NavigationHandle.cs
@@ -358,6 +358,12 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
         // throwing later on the UI dispatcher where the caller can't observe it.
         if (state.Current is null)
             throw new ArgumentException("Navigation state must include a non-null Current route.", nameof(state));
+        // RestoreState calls AddRange on both lists; a null list would otherwise throw deep on
+        // the UI dispatcher after marshaling, where the caller can't observe it. Validate here.
+        if (state.BackStack is null)
+            throw new ArgumentException("Navigation state must include a non-null BackStack.", nameof(state));
+        if (state.ForwardStack is null)
+            throw new ArgumentException("Navigation state must include a non-null ForwardStack.", nameof(state));
         if (IsOffUIThread && MarshalOff(nameof(SetState), () => SetState(state))) return;
 
         var previous = _stack.Current;

--- a/src/Reactor/Core/Navigation/NavigationHandle.cs
+++ b/src/Reactor/Core/Navigation/NavigationHandle.cs
@@ -77,7 +77,10 @@ internal interface INavigationHandle
 /// rather than corrupting the back/forward stacks. The bool-returning mutators
 /// return <see langword="true"/> when an off-thread call is accepted and
 /// scheduled; the actual guard/empty-stack outcome is then resolved on the UI
-/// thread.</para>
+/// thread. Off-thread callers must therefore not treat that <see langword="true"/>
+/// as confirmation that the navigation actually happened &#8212; only that it was
+/// scheduled. (On the UI thread the bool keeps its original meaning: whether the
+/// navigation succeeded.)</para>
 /// </remarks>
 public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : notnull
 {
@@ -306,9 +309,12 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     public void SetState(NavigationState<TRoute> state)
     {
         ArgumentNullException.ThrowIfNull(state);
-        if (IsOffUIThread && MarshalOff(nameof(SetState), () => SetState(state))) return;
+        // Validate the state shape up front, on the caller's thread, so an invalid
+        // snapshot fails fast at the call site rather than being marshaled and only
+        // throwing later on the UI dispatcher where the caller can't observe it.
         if (state.Current is null)
             throw new ArgumentException("Navigation state must include a non-null Current route.", nameof(state));
+        if (IsOffUIThread && MarshalOff(nameof(SetState), () => SetState(state))) return;
 
         var previous = _stack.Current;
         _stack.RestoreState(state.BackStack, state.Current, state.ForwardStack);

--- a/src/Reactor/Core/Navigation/NavigationHandle.cs
+++ b/src/Reactor/Core/Navigation/NavigationHandle.cs
@@ -164,6 +164,13 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     /// Navigate to a new route. By default pushes the current route onto the back stack.
     /// If <see cref="NavigateOptions.PushToBackStack"/> is false, replaces the current route instead.
     /// </summary>
+    /// <returns>
+    /// On the UI thread, <see langword="true"/> if the navigation succeeded, or
+    /// <see langword="false"/> if a guard cancelled it. When called off the UI thread,
+    /// <see langword="true"/> means the call was marshaled and scheduled onto the UI
+    /// dispatcher &#8212; not that it succeeded; the real outcome is resolved later on the
+    /// UI thread (see the type-level thread-safety remarks).
+    /// </returns>
     public bool Navigate(TRoute route, NavigateOptions? options = null)
     {
         if (IsOffUIThread && MarshalOff(nameof(Navigate), () => Navigate(route, options))) return true;
@@ -200,8 +207,15 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     }
 
     /// <summary>
-    /// Go back to the previous route. Returns false if back stack is empty or guard cancels.
+    /// Go back to the previous route.
     /// </summary>
+    /// <returns>
+    /// On the UI thread, <see langword="true"/> if navigation succeeded, or
+    /// <see langword="false"/> if the back stack is empty or a guard cancelled it. When
+    /// called off the UI thread, <see langword="true"/> means the call was marshaled and
+    /// scheduled onto the UI dispatcher &#8212; not that it succeeded; the empty-stack/guard
+    /// outcome is resolved later on the UI thread (see the type-level thread-safety remarks).
+    /// </returns>
     public bool GoBack()
     {
         if (IsOffUIThread && MarshalOff(nameof(GoBack), () => GoBack())) return true;
@@ -216,8 +230,15 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     }
 
     /// <summary>
-    /// Go forward to the next route in the forward stack. Returns false if forward stack is empty or guard cancels.
+    /// Go forward to the next route in the forward stack.
     /// </summary>
+    /// <returns>
+    /// On the UI thread, <see langword="true"/> if navigation succeeded, or
+    /// <see langword="false"/> if the forward stack is empty or a guard cancelled it. When
+    /// called off the UI thread, <see langword="true"/> means the call was marshaled and
+    /// scheduled onto the UI dispatcher &#8212; not that it succeeded; the empty-stack/guard
+    /// outcome is resolved later on the UI thread (see the type-level thread-safety remarks).
+    /// </returns>
     public bool GoForward()
     {
         if (IsOffUIThread && MarshalOff(nameof(GoForward), () => GoForward())) return true;
@@ -234,6 +255,13 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     /// <summary>
     /// Replace the current route without modifying back/forward stacks.
     /// </summary>
+    /// <returns>
+    /// On the UI thread, <see langword="true"/> if the route was replaced, or
+    /// <see langword="false"/> if a guard cancelled it. When called off the UI thread,
+    /// <see langword="true"/> means the call was marshaled and scheduled onto the UI
+    /// dispatcher &#8212; not that it succeeded; the real outcome is resolved later on the
+    /// UI thread (see the type-level thread-safety remarks).
+    /// </returns>
     public bool Replace(TRoute route)
     {
         if (IsOffUIThread && MarshalOff(nameof(Replace), () => Replace(route))) return true;
@@ -250,6 +278,13 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     /// <summary>
     /// Reset the entire stack to a single root route. Clears back and forward stacks.
     /// </summary>
+    /// <returns>
+    /// On the UI thread, <see langword="true"/> if the stack was reset, or
+    /// <see langword="false"/> if a guard cancelled it. When called off the UI thread,
+    /// <see langword="true"/> means the call was marshaled and scheduled onto the UI
+    /// dispatcher &#8212; not that it succeeded; the real outcome is resolved later on the
+    /// UI thread (see the type-level thread-safety remarks).
+    /// </returns>
     public bool Reset(TRoute route)
     {
         if (IsOffUIThread && MarshalOff(nameof(Reset), () => Reset(route))) return true;
@@ -265,8 +300,14 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
 
     /// <summary>
     /// Pop entries from the back stack until the predicate matches.
-    /// Returns false if no match or guard cancels.
     /// </summary>
+    /// <returns>
+    /// On the UI thread, <see langword="true"/> if a matching entry was popped to, or
+    /// <see langword="false"/> if no back-stack entry matches the predicate or a guard
+    /// cancelled it. When called off the UI thread, <see langword="true"/> means the call
+    /// was marshaled and scheduled onto the UI dispatcher &#8212; not that it succeeded; the
+    /// real outcome is resolved later on the UI thread (see the type-level thread-safety remarks).
+    /// </returns>
     public bool PopTo(Func<TRoute, bool> predicate)
     {
         if (IsOffUIThread && MarshalOff(nameof(PopTo), () => PopTo(predicate))) return true;

--- a/src/Reactor/Core/Navigation/NavigationHandle.cs
+++ b/src/Reactor/Core/Navigation/NavigationHandle.cs
@@ -62,14 +62,43 @@ internal interface INavigationHandle
 /// Public API for controlling navigation. Wraps a <see cref="NavigationStack{TRoute}"/>
 /// with a safe, read-heavy interface. Obtained via <c>UseNavigation</c> hook.
 /// </summary>
+/// <remarks>
+/// <para><b>Thread safety (issue #234).</b> The mutating methods
+/// (<see cref="Navigate"/>, <see cref="GoBack"/>, <see cref="GoForward"/>,
+/// <see cref="Replace"/>, <see cref="Reset"/>, <see cref="PopTo"/>,
+/// <see cref="SetState"/>) are thread-safe by default. When called from the UI
+/// thread the cost is a single thread-id compare. When called off-thread (e.g.
+/// from <c>Task.Run</c> or after <c>await … ConfigureAwait(false)</c>) the whole
+/// mutation &#8212; stack edit, <see cref="Navigated"/>/<c>RouteChanged</c>
+/// events, and the component re-render &#8212; is auto-marshaled onto the captured
+/// UI dispatcher, mirroring the <c>UseState</c>/<c>UseReducer</c> contract from
+/// issue #212. If no UI dispatcher is available (unit-test / headless contexts)
+/// an off-thread call throws <see cref="InvalidOperationException"/> loudly
+/// rather than corrupting the back/forward stacks. The bool-returning mutators
+/// return <see langword="true"/> when an off-thread call is accepted and
+/// scheduled; the actual guard/empty-stack outcome is then resolved on the UI
+/// thread.</para>
+/// </remarks>
 public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : notnull
 {
     private readonly NavigationStack<TRoute> _stack;
+
+    // Captured at construction. UseNavigation creates the handle during render on
+    // the UI thread, so this is the render/UI thread id used by the marshal gate.
+    private readonly int _uiThreadId = global::System.Environment.CurrentManagedThreadId;
 
     internal NavigationHandle(NavigationStack<TRoute> stack)
     {
         _stack = stack;
     }
+
+    // True when the caller is off the UI thread captured at construction. Kept as a
+    // tiny helper so the per-mutator gate reads cleanly; the marshaling closure is
+    // only allocated when this returns true (see UIThreadMarshal remarks).
+    private bool IsOffUIThread => Core.UIThreadMarshal.IsOffUIThread(_uiThreadId);
+
+    private bool MarshalOff(string operation, global::System.Action work)
+        => Core.UIThreadMarshal.MarshalOffUIThread(_uiThreadId, $"NavigationHandle.{operation}", work);
 
     /// <summary>
     /// Non-generic route change notification for NavigationHost.
@@ -131,6 +160,8 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     /// </summary>
     public bool Navigate(TRoute route, NavigateOptions? options = null)
     {
+        if (IsOffUIThread && MarshalOff(nameof(Navigate), () => Navigate(route, options))) return true;
+
         var previous = _stack.Current;
         _pendingTransitionOverride = options?.Transition;
         bool success;
@@ -167,6 +198,8 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     /// </summary>
     public bool GoBack()
     {
+        if (IsOffUIThread && MarshalOff(nameof(GoBack), () => GoBack())) return true;
+
         var previous = _stack.Current;
         if (!_stack.Pop())
             return false;
@@ -181,6 +214,8 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     /// </summary>
     public bool GoForward()
     {
+        if (IsOffUIThread && MarshalOff(nameof(GoForward), () => GoForward())) return true;
+
         var previous = _stack.Current;
         if (!_stack.Forward())
             return false;
@@ -195,6 +230,8 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     /// </summary>
     public bool Replace(TRoute route)
     {
+        if (IsOffUIThread && MarshalOff(nameof(Replace), () => Replace(route))) return true;
+
         var previous = _stack.Current;
         if (!_stack.Replace(route))
             return false;
@@ -209,6 +246,8 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     /// </summary>
     public bool Reset(TRoute route)
     {
+        if (IsOffUIThread && MarshalOff(nameof(Reset), () => Reset(route))) return true;
+
         var previous = _stack.Current;
         if (!_stack.Reset(route))
             return false;
@@ -224,6 +263,8 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     /// </summary>
     public bool PopTo(Func<TRoute, bool> predicate)
     {
+        if (IsOffUIThread && MarshalOff(nameof(PopTo), () => PopTo(predicate))) return true;
+
         var previous = _stack.Current;
         if (!_stack.PopTo(predicate))
             return false;
@@ -265,6 +306,7 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
     public void SetState(NavigationState<TRoute> state)
     {
         ArgumentNullException.ThrowIfNull(state);
+        if (IsOffUIThread && MarshalOff(nameof(SetState), () => SetState(state))) return;
         if (state.Current is null)
             throw new ArgumentException("Navigation state must include a non-null Current route.", nameof(state));
 

--- a/src/Reactor/Core/Navigation/NavigationHandle.cs
+++ b/src/Reactor/Core/Navigation/NavigationHandle.cs
@@ -364,7 +364,17 @@ public sealed class NavigationHandle<TRoute> : INavigationHandle where TRoute : 
             throw new ArgumentException("Navigation state must include a non-null BackStack.", nameof(state));
         if (state.ForwardStack is null)
             throw new ArgumentException("Navigation state must include a non-null ForwardStack.", nameof(state));
-        if (IsOffUIThread && MarshalOff(nameof(SetState), () => SetState(state))) return;
+        if (IsOffUIThread)
+        {
+            // Freeze the caller-supplied lists into arrays before the dispatcher hop. The
+            // marshaled restore runs later on the UI thread; without this copy a caller could
+            // mutate their original List<T> in the meantime and the applied history would no
+            // longer match the snapshot validated here. Symmetric with GetState, which hands
+            // out arrays so a snapshot can't alias — or be aliased into — the live stack.
+            var frozen = new NavigationState<TRoute>(
+                state.BackStack.ToArray(), state.Current, state.ForwardStack.ToArray());
+            if (MarshalOff(nameof(SetState), () => SetState(frozen))) return;
+        }
 
         var previous = _stack.Current;
         _stack.RestoreState(state.BackStack, state.Current, state.ForwardStack);

--- a/src/Reactor/Core/Navigation/NavigationHandle.cs
+++ b/src/Reactor/Core/Navigation/NavigationHandle.cs
@@ -72,9 +72,12 @@ internal interface INavigationHandle
 /// mutation &#8212; stack edit, <see cref="Navigated"/>/<c>RouteChanged</c>
 /// events, and the component re-render &#8212; is auto-marshaled onto the captured
 /// UI dispatcher, mirroring the <c>UseState</c>/<c>UseReducer</c> contract from
-/// issue #212. If no UI dispatcher is available (unit-test / headless contexts)
-/// an off-thread call throws <see cref="InvalidOperationException"/> loudly
-/// rather than corrupting the back/forward stacks. The bool-returning mutators
+/// issue #212. An off-thread call throws <see cref="InvalidOperationException"/>
+/// loudly &#8212; rather than corrupting the back/forward stacks &#8212; in two
+/// cases: when no UI dispatcher is available (unit-test / headless contexts), and
+/// when the captured dispatcher refuses the enqueue (its <c>TryEnqueue</c> returns
+/// <see langword="false"/>, e.g. once it has begun shutting down near window
+/// close). The bool-returning mutators
 /// return <see langword="true"/> when an off-thread call is accepted and
 /// scheduled; the actual guard/empty-stack outcome is then resolved on the UI
 /// thread. Off-thread callers must therefore not treat that <see langword="true"/>

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -54,32 +54,32 @@ public sealed class RenderContext
         if (Environment.CurrentManagedThreadId == _uiThreadId) return false;
         // </snippet:ui-thread-invariant>
 
+        // Off-thread: funnel through the shared marshal-or-throw primitive so this
+        // and NavigationHandle's mutator gate (issue #234) share one implementation.
+        // The exact diagnostic wording — including the "threadSafe: true" remedy — is
+        // preserved here because callers/tests depend on it.
         var dq = Microsoft.UI.Reactor.ReactorApp.UIDispatcher;
-        if (dq is null)
-        {
-            // Test/headless context with no captured UI dispatcher AND off-thread.
-            // The legacy [Conditional("DEBUG")] assert at this spot swallowed silently
-            // in RELEASE; surface loudly in both flavors so the call is visible.
-            throw new InvalidOperationException(
+        return UIThreadMarshal.EnqueueOrThrow(
+            dq is null ? null : w => dq.TryEnqueue(() => w()),
+            work,
+            () =>
+                // Test/headless context with no captured UI dispatcher AND off-thread.
+                // The legacy [Conditional("DEBUG")] assert at this spot swallowed silently
+                // in RELEASE; surface loudly in both flavors so the call is visible.
                 $"{hookName} setter was called from thread {Environment.CurrentManagedThreadId}, " +
                 $"but the captured UI thread is {_uiThreadId}, and no UI dispatcher is " +
                 $"available to marshal the call. Run the setter on the UI thread, " +
-                $"or pass threadSafe: true to the hook.");
-        }
-        // TryEnqueue returns false when the dispatcher has begun shutting down
-        // (queue closed, owning thread exiting). Silently swallowing that case
-        // would lose the state update with no diagnostic; throw so the caller
-        // sees the same loud failure mode as the no-dispatcher path.
-        if (!dq.TryEnqueue(() => work()))
-        {
-            throw new InvalidOperationException(
+                $"or pass threadSafe: true to the hook.",
+            () =>
+                // TryEnqueue returns false when the dispatcher has begun shutting down
+                // (queue closed, owning thread exiting). Silently swallowing that case
+                // would lose the state update with no diagnostic; throw so the caller
+                // sees the same loud failure mode as the no-dispatcher path.
                 $"{hookName} setter was called from thread {Environment.CurrentManagedThreadId}, " +
                 $"but the UI dispatcher refused the marshaled call (TryEnqueue returned " +
                 $"false — typically because the dispatcher is shutting down). The state " +
                 $"update was dropped. Stop scheduling background setters past window/app " +
                 $"shutdown (cancel the producing task in the effect cleanup).");
-        }
-        return true;
     }
 
     /// <summary>

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -60,7 +60,7 @@ public sealed class RenderContext
         // preserved here because callers/tests depend on it.
         var dq = Microsoft.UI.Reactor.ReactorApp.UIDispatcher;
         return UIThreadMarshal.EnqueueOrThrow(
-            dq is null ? null : w => dq.TryEnqueue(() => w()),
+            dq is null ? null : w => dq.TryEnqueue(w.Invoke),
             work,
             () =>
                 // Test/headless context with no captured UI dispatcher AND off-thread.

--- a/src/Reactor/Core/UIThreadMarshal.cs
+++ b/src/Reactor/Core/UIThreadMarshal.cs
@@ -1,0 +1,94 @@
+namespace Microsoft.UI.Reactor.Core;
+
+/// <summary>
+/// Shared UI-thread marshaling gate for hook mutators that run off the render
+/// thread. Mirrors the auto-marshal contract introduced for <c>UseState</c> /
+/// <c>UseReducer</c> in issue #212 (see <see cref="RenderContext"/>'s private
+/// <c>MarshalIfOffUIThread</c>) so the rest of the hook surface can stay
+/// thread-safe-by-default without each call site reimplementing the same
+/// thread-id check + dispatcher hop.
+/// </summary>
+/// <remarks>
+/// The design goal (issue #234) is that authors should not have to predict upfront
+/// whether a mutation will originate off-thread. The intended call shape keeps the
+/// UI-thread fast path allocation-free:
+/// <code>
+/// if (UIThreadMarshal.IsOffUIThread(_uiThreadId)
+///     &amp;&amp; UIThreadMarshal.MarshalOffUIThread(_uiThreadId, "Op", () => Op(...)))
+///     return; // scheduled on the UI dispatcher
+/// // ... inline body runs on the UI thread ...
+/// </code>
+/// Because the closure is the argument to <see cref="MarshalOffUIThread"/> on the
+/// right of <c>&amp;&amp;</c>, it is only allocated when <see cref="IsOffUIThread"/>
+/// is <see langword="true"/>. On the UI thread the gate is a single
+/// <see cref="Environment.CurrentManagedThreadId"/> read plus an
+/// <see langword="int"/> compare (~1&#8211;2&#160;ns, zero allocation), so the
+/// common case stays lock-light. Only the genuinely off-thread path pays for a
+/// marshal closure + dispatcher enqueue.
+/// </remarks>
+internal static class UIThreadMarshal
+{
+    /// <summary>
+    /// Fast UI-thread check. Returns <see langword="true"/> when the caller is NOT
+    /// on the thread identified by <paramref name="uiThreadId"/> (the render/UI
+    /// thread captured when the owning hook handle was created).
+    /// </summary>
+    public static bool IsOffUIThread(int uiThreadId)
+        => global::System.Environment.CurrentManagedThreadId != uiThreadId;
+
+    /// <summary>
+    /// Marshals <paramref name="work"/> onto the captured UI dispatcher. Call this
+    /// only once <see cref="IsOffUIThread"/> has confirmed the caller is off-thread
+    /// (the short-circuit pattern in the type remarks keeps the closure off the hot
+    /// path). Always returns <see langword="true"/> when the work is scheduled, so
+    /// callers can write
+    /// <c>if (IsOffUIThread(id) &amp;&amp; MarshalOffUIThread(...)) return;</c>.
+    /// <para>
+    /// When no <see cref="Microsoft.UI.Reactor.ReactorApp.UIDispatcher"/> has been
+    /// captured (unit-test / headless contexts) or when the dispatcher has already
+    /// begun shutting down, this throws <see cref="InvalidOperationException"/>
+    /// instead of silently racing the reconciler or dropping the mutation &#8212;
+    /// closing the same silent-failure gap #212 closed for state setters.
+    /// </para>
+    /// </summary>
+    /// <param name="uiThreadId">
+    /// The managed thread id captured on the render/UI thread (used only in the
+    /// thrown diagnostic message).
+    /// </param>
+    /// <param name="operation">
+    /// Human-readable name of the mutating operation, used in the thrown message.
+    /// </param>
+    /// <param name="work">
+    /// The mutation to re-invoke on the UI dispatcher. The caller makes this
+    /// idempotent by simply re-calling the same public method (which re-enters the
+    /// gate and falls through inline on the UI thread).
+    /// </param>
+    public static bool MarshalOffUIThread(int uiThreadId, string operation, global::System.Action work)
+    {
+        var dq = Microsoft.UI.Reactor.ReactorApp.UIDispatcher;
+        int callerThreadId = global::System.Environment.CurrentManagedThreadId;
+        if (dq is null)
+        {
+            throw new global::System.InvalidOperationException(
+                $"{operation} was called from thread {callerThreadId}, " +
+                $"but the captured UI thread is {uiThreadId}, and no UI dispatcher is " +
+                $"available to marshal the call. Invoke it on the UI thread.");
+        }
+
+        // TryEnqueue returns false once the dispatcher has begun shutting down
+        // (queue closed, owning thread exiting). Silently swallowing that would
+        // lose the mutation with no diagnostic; throw so the caller sees the same
+        // loud failure mode as the no-dispatcher path.
+        if (!dq.TryEnqueue(() => work()))
+        {
+            throw new global::System.InvalidOperationException(
+                $"{operation} was called from thread {callerThreadId}, " +
+                $"but the UI dispatcher refused the marshaled call (TryEnqueue returned " +
+                $"false — typically because the dispatcher is shutting down). The mutation " +
+                $"was dropped. Cancel background work in effect cleanup before window/app " +
+                $"shutdown.");
+        }
+
+        return true;
+    }
+}

--- a/src/Reactor/Core/UIThreadMarshal.cs
+++ b/src/Reactor/Core/UIThreadMarshal.cs
@@ -37,6 +37,55 @@ internal static class UIThreadMarshal
         => global::System.Environment.CurrentManagedThreadId != uiThreadId;
 
     /// <summary>
+    /// Shared off-thread dispatch primitive: enqueues <paramref name="work"/> via
+    /// <paramref name="tryEnqueue"/>, or throws a caller-supplied diagnostic when no
+    /// dispatcher is available (<paramref name="tryEnqueue"/> is <see langword="null"/>)
+    /// or the dispatcher refuses the enqueue (<paramref name="tryEnqueue"/> returns
+    /// <see langword="false"/>). Both <see cref="RenderContext"/>'s hook-setter
+    /// marshal and <c>NavigationHandle&lt;TRoute&gt;</c>'s mutator gate funnel
+    /// through this single implementation so the marshal-or-throw contract from
+    /// issue #212 has exactly one copy. The caller is responsible for the UI-thread
+    /// fast-path check BEFORE calling this (this method assumes it is already
+    /// off-thread). The message factories are only invoked on the throwing paths, so
+    /// the successful-enqueue path allocates no message strings.
+    /// </summary>
+    /// <param name="tryEnqueue">
+    /// Posts the work onto the captured UI dispatcher and returns whether it was
+    /// accepted; <see langword="null"/> when no dispatcher has been captured.
+    /// </param>
+    /// <param name="work">The mutation to run on the UI thread.</param>
+    /// <param name="onNoDispatcher">
+    /// Builds the exception message thrown when no dispatcher is available.
+    /// </param>
+    /// <param name="onRefused">
+    /// Builds the exception message thrown when the dispatcher refuses the enqueue.
+    /// </param>
+    public static bool EnqueueOrThrow(
+        global::System.Func<global::System.Action, bool>? tryEnqueue,
+        global::System.Action work,
+        global::System.Func<string> onNoDispatcher,
+        global::System.Func<string> onRefused)
+    {
+        if (tryEnqueue is null)
+        {
+            // Test/headless context with no captured UI dispatcher AND off-thread.
+            // Surface loudly instead of silently racing the reconciler.
+            throw new global::System.InvalidOperationException(onNoDispatcher());
+        }
+
+        // TryEnqueue returns false once the dispatcher has begun shutting down
+        // (queue closed, owning thread exiting). Silently swallowing that would
+        // lose the mutation with no diagnostic; throw so the caller sees the same
+        // loud failure mode as the no-dispatcher path.
+        if (!tryEnqueue(work))
+        {
+            throw new global::System.InvalidOperationException(onRefused());
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Marshals <paramref name="work"/> onto the captured UI dispatcher. Call this
     /// only once <see cref="IsOffUIThread"/> has confirmed the caller is off-thread
     /// (the short-circuit pattern in the type remarks keeps the closure off the hot
@@ -66,29 +115,24 @@ internal static class UIThreadMarshal
     public static bool MarshalOffUIThread(int uiThreadId, string operation, global::System.Action work)
     {
         var dq = Microsoft.UI.Reactor.ReactorApp.UIDispatcher;
-        int callerThreadId = global::System.Environment.CurrentManagedThreadId;
-        if (dq is null)
-        {
-            throw new global::System.InvalidOperationException(
-                $"{operation} was called from thread {callerThreadId}, " +
-                $"but the captured UI thread is {uiThreadId}, and no UI dispatcher is " +
-                $"available to marshal the call. Invoke it on the UI thread.");
-        }
-
-        // TryEnqueue returns false once the dispatcher has begun shutting down
-        // (queue closed, owning thread exiting). Silently swallowing that would
-        // lose the mutation with no diagnostic; throw so the caller sees the same
-        // loud failure mode as the no-dispatcher path.
-        if (!dq.TryEnqueue(() => work()))
-        {
-            throw new global::System.InvalidOperationException(
-                $"{operation} was called from thread {callerThreadId}, " +
-                $"but the UI dispatcher refused the marshaled call (TryEnqueue returned " +
-                $"false — typically because the dispatcher is shutting down). The mutation " +
-                $"was dropped. Cancel background work in effect cleanup before window/app " +
-                $"shutdown.");
-        }
-
-        return true;
+        return EnqueueOrThrow(
+            dq is null ? null : w => dq.TryEnqueue(() => w()),
+            work,
+            () =>
+            {
+                int callerThreadId = global::System.Environment.CurrentManagedThreadId;
+                return $"{operation} was called from thread {callerThreadId}, " +
+                    $"but the captured UI thread is {uiThreadId}, and no UI dispatcher is " +
+                    $"available to marshal the call. Invoke it on the UI thread.";
+            },
+            () =>
+            {
+                int callerThreadId = global::System.Environment.CurrentManagedThreadId;
+                return $"{operation} was called from thread {callerThreadId}, " +
+                    $"but the UI dispatcher refused the marshaled call (TryEnqueue returned " +
+                    $"false — typically because the dispatcher is shutting down). The mutation " +
+                    $"was dropped. Cancel background work in effect cleanup before window/app " +
+                    $"shutdown.";
+            });
     }
 }

--- a/src/Reactor/Core/UIThreadMarshal.cs
+++ b/src/Reactor/Core/UIThreadMarshal.cs
@@ -116,7 +116,7 @@ internal static class UIThreadMarshal
     {
         var dq = Microsoft.UI.Reactor.ReactorApp.UIDispatcher;
         return EnqueueOrThrow(
-            dq is null ? null : w => dq.TryEnqueue(() => w()),
+            dq is null ? null : w => dq.TryEnqueue(w.Invoke),
             work,
             () =>
             {

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
@@ -206,4 +206,73 @@ internal static class ThreadSafeNavigationFixtures
             for (int i = 0; i < 4; i++) await Harness.Render();
         }
     }
+
+    /// <summary>
+    /// Regression for the off-thread <c>SetState</c> snapshot-aliasing race (issue #234
+    /// review): <c>NavigationState&lt;TRoute&gt;</c> accepts arbitrary <c>IReadOnlyList</c>
+    /// stacks, so a caller can hand in a live <c>List&lt;T&gt;</c>. The off-thread call
+    /// marshals the restore onto the dispatcher and returns immediately; if the caller then
+    /// mutates that original list before the dispatcher runs, the applied history must still
+    /// match the snapshot validated at call time — <c>SetState</c> freezes the stacks into
+    /// arrays before the hop. This fixture corrupts the caller's lists inside the marshal
+    /// window and asserts the restored state is the call-time snapshot, not the corruption.
+    /// </summary>
+    internal class SetStateOffThreadFreezesSnapshot(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            NavigationHandle<NavRoute>? nav = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var handle = ctx.UseNavigation(NavRoute.Home);
+                nav = handle;
+                return TextBlock($"Route: {handle.CurrentRoute}");
+            });
+
+            await Harness.Render();
+
+            // Caller-owned MUTABLE lists handed to SetState as the snapshot's stacks.
+            var backStack = new List<NavRoute> { NavRoute.Home };
+            var forwardStack = new List<NavRoute> { NavRoute.Settings };
+            var snapshot = new NavigationState<NavRoute>(
+                BackStack: backStack, Current: NavRoute.Detail, ForwardStack: forwardStack);
+
+            // Off the UI thread: call SetState (which marshals the restore), then immediately
+            // corrupt the caller's lists BEFORE the dispatcher applies it. The freeze happens
+            // synchronously inside SetState, so these mutations must not leak into the restore.
+            var done = new TaskCompletionSource();
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    nav!.SetState(snapshot);
+                    backStack.Clear();
+                    backStack.Add(NavRoute.Settings);
+                    forwardStack.Clear();
+                    done.TrySetResult();
+                }
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+                {
+                    done.TrySetException(ex);
+                }
+            });
+
+            var winner = await Task.WhenAny(done.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            H.Check("NavFreeze_Completed", winner == done.Task);
+            if (winner == done.Task) await done.Task;
+
+            // Drain the marshaled restore + the rerender it requests.
+            for (int i = 0; i < 4; i++) await Harness.Render();
+
+            // The applied history matches the call-time snapshot, not the corrupted lists.
+            H.Check("NavFreeze_Current", nav!.CurrentRoute.Equals(NavRoute.Detail));
+            H.Check("NavFreeze_BackStack",
+                nav!.BackStack.Count == 1 && nav.BackStack[0].Equals(NavRoute.Home));
+            H.Check("NavFreeze_ForwardStack",
+                nav!.ForwardStack.Count == 1 && nav.ForwardStack[0].Equals(NavRoute.Settings));
+            H.Check("NavFreeze_Rerendered", H.FindText("Route: Detail") is not null);
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
@@ -52,11 +52,12 @@ internal static class ThreadSafeNavigationFixtures
                     nav!.Navigate(NavRoute.Detail);
                     done.TrySetResult();
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
                 {
-                    // Forward ANY failure (not only the marshal's InvalidOperationException)
-                    // so an unexpected exception surfaces on `await done.Task` with its real
-                    // stack trace instead of hanging the fixture until the 10s timeout.
+                    // Forward ANY recoverable failure (not only the marshal's InvalidOperationException)
+                    // so an unexpected exception surfaces on `await done.Task` with its real stack trace
+                    // instead of hanging the fixture until the 10s timeout. The filter excludes only
+                    // process-fatal exceptions, matching the house style in src/Reactor.
                     done.TrySetException(ex);
                 }
             });
@@ -84,9 +85,9 @@ internal static class ThreadSafeNavigationFixtures
                     nav!.Replace(NavRoute.Settings);
                     done2.TrySetResult();
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
                 {
-                    // Surface any unexpected failure immediately (see note above).
+                    // Surface any recoverable failure immediately (see note above).
                     done2.TrySetException(ex);
                 }
             });
@@ -188,10 +189,11 @@ internal static class ThreadSafeNavigationFixtures
                     mutate();
                     done.TrySetResult();
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
                 {
-                    // Forward ANY failure so an unexpected exception (e.g. a setup regression)
-                    // surfaces on `await done.Task` instead of hanging to the 10s timeout.
+                    // Forward ANY recoverable failure so an unexpected exception (e.g. a setup
+                    // regression) surfaces on `await done.Task` instead of hanging to the 10s
+                    // timeout. The filter excludes only process-fatal exceptions (house style).
                     done.TrySetException(ex);
                 }
             });

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
@@ -100,4 +100,102 @@ internal static class ThreadSafeNavigationFixtures
             H.Check("NavMarshal_ReplaceRerendered", H.FindText("Route: Settings") is not null);
         }
     }
+
+    /// <summary>
+    /// Companion to <see cref="NavigateOffThreadMarshals"/> that drives the <em>remaining</em>
+    /// thread-safe mutators &#8212; <c>GoBack</c>, <c>GoForward</c>, <c>PopTo</c>, <c>Reset</c>,
+    /// and <c>SetState</c> &#8212; off the UI thread under a real pumped <c>DispatcherQueue</c>.
+    /// Each one's marshal gate is mechanically identical, but proving the happy path
+    /// end-to-end (store mutates + component re-renders) for every mutator closes the
+    /// coverage gap left by only exercising Navigate/Replace.
+    /// </summary>
+    internal class MutatorsOffThreadMarshal(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            NavigationHandle<NavRoute>? nav = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var handle = ctx.UseNavigation(NavRoute.Home);
+                nav = handle;
+                return TextBlock($"Route: {handle.CurrentRoute}");
+            });
+
+            await Harness.Render();
+
+            // Build a back stack on the UI thread: Home -> Detail -> Settings.
+            nav!.Navigate(NavRoute.Detail);
+            nav!.Navigate(NavRoute.Settings);
+            for (int i = 0; i < 2; i++) await Harness.Render();
+            H.Check("NavMutators_Setup",
+                nav!.CurrentRoute.Equals(NavRoute.Settings) && nav.BackStack.Count == 2);
+
+            // GoBack off-thread: current rewinds to Detail, Settings moves to forward stack.
+            await RunOffThread("GoBack", () => nav!.GoBack());
+            H.Check("NavMutators_GoBackCurrent", nav!.CurrentRoute.Equals(NavRoute.Detail));
+            H.Check("NavMutators_GoBackForward", nav!.CanGoForward);
+            H.Check("NavMutators_GoBackRerendered", H.FindText("Route: Detail") is not null);
+
+            // GoForward off-thread: current advances back to Settings.
+            await RunOffThread("GoForward", () => nav!.GoForward());
+            H.Check("NavMutators_GoForwardCurrent", nav!.CurrentRoute.Equals(NavRoute.Settings));
+            H.Check("NavMutators_GoForwardRerendered", H.FindText("Route: Settings") is not null);
+
+            // PopTo off-thread: pop back to Home, draining the back stack.
+            await RunOffThread("PopTo", () => nav!.PopTo(r => r == NavRoute.Home));
+            H.Check("NavMutators_PopToCurrent", nav!.CurrentRoute.Equals(NavRoute.Home));
+            H.Check("NavMutators_PopToBackEmpty", nav!.BackStack.Count == 0);
+            H.Check("NavMutators_PopToRerendered", H.FindText("Route: Home") is not null);
+
+            // Rebuild a back entry, then Reset off-thread: single root, both stacks cleared.
+            nav!.Navigate(NavRoute.Detail);
+            await Harness.Render();
+            await RunOffThread("Reset", () => nav!.Reset(NavRoute.Settings));
+            H.Check("NavMutators_ResetCurrent", nav!.CurrentRoute.Equals(NavRoute.Settings));
+            H.Check("NavMutators_ResetCleared", nav!.BackStack.Count == 0 && !nav.CanGoForward);
+            H.Check("NavMutators_ResetRerendered", H.FindText("Route: Settings") is not null);
+
+            // SetState off-thread: restore a captured snapshot wholesale.
+            var snapshot = new NavigationState<NavRoute>(
+                BackStack: new[] { NavRoute.Home },
+                Current: NavRoute.Detail,
+                ForwardStack: new[] { NavRoute.Settings });
+            await RunOffThread("SetState", () => nav!.SetState(snapshot));
+            H.Check("NavMutators_SetStateCurrent", nav!.CurrentRoute.Equals(NavRoute.Detail));
+            H.Check("NavMutators_SetStateBackStack",
+                nav!.BackStack.Count == 1 && nav.BackStack[0].Equals(NavRoute.Home));
+            H.Check("NavMutators_SetStateForwardStack",
+                nav!.ForwardStack.Count == 1 && nav.ForwardStack[0].Equals(NavRoute.Settings));
+            H.Check("NavMutators_SetStateRerendered", H.FindText("Route: Detail") is not null);
+        }
+
+        // Runs a mutator from a background Task.Run, waits for it to be accepted (the
+        // off-thread call returns once the work is scheduled), then pumps the dispatcher
+        // so the marshaled mutation + the rerender it requests actually apply.
+        private async Task RunOffThread(string label, Action mutate)
+        {
+            var done = new TaskCompletionSource();
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    mutate();
+                    done.TrySetResult();
+                }
+                catch (InvalidOperationException ex)
+                {
+                    done.TrySetException(ex);
+                }
+            });
+
+            var winner = await Task.WhenAny(done.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            H.Check($"NavMutators_{label}Completed", winner == done.Task);
+            if (winner == done.Task) await done.Task; // surface any captured exception
+
+            // Drain the marshaled mutation + the rerender it requests.
+            for (int i = 0; i < 4; i++) await Harness.Render();
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
@@ -52,7 +52,7 @@ internal static class ThreadSafeNavigationFixtures
                     nav!.Navigate(NavRoute.Detail);
                     done.TrySetResult();
                 }
-                catch (Exception ex)
+                catch (InvalidOperationException ex)
                 {
                     done.TrySetException(ex);
                 }
@@ -81,7 +81,7 @@ internal static class ThreadSafeNavigationFixtures
                     nav!.Replace(NavRoute.Settings);
                     done2.TrySetResult();
                 }
-                catch (Exception ex)
+                catch (InvalidOperationException ex)
                 {
                     done2.TrySetException(ex);
                 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
@@ -1,0 +1,103 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Navigation;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Selfhost tests for issue #234: <c>NavigationHandle&lt;TRoute&gt;</c> mutators
+/// invoked off the UI thread must auto-marshal onto the captured dispatcher and
+/// apply correctly. The unit tests in <c>ThreadSafeNavigationTests</c> only prove
+/// off-thread <em>rejection</em> when no dispatcher exists; these fixtures drive a
+/// real pumped WinUI <c>DispatcherQueue</c> and assert the happy path end-to-end —
+/// the store ends in the right state and the component actually re-renders.
+/// </summary>
+internal static class ThreadSafeNavigationFixtures
+{
+    private enum NavRoute { Home, Detail, Settings }
+
+    /// <summary>
+    /// Mounts a component with <c>UseNavigation</c>, then calls <c>Navigate</c> and
+    /// <c>Replace</c> from a background <c>Task.Run</c>. Verifies the navigation
+    /// marshals onto the UI thread, the back/forward stacks end in the right state,
+    /// and the bound component re-renders to reflect the new route.
+    /// </summary>
+    internal class NavigateOffThreadMarshals(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            NavigationHandle<NavRoute>? nav = null;
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var handle = ctx.UseNavigation(NavRoute.Home);
+                nav = handle;
+                return TextBlock($"Route: {handle.CurrentRoute}");
+            });
+
+            await Harness.Render();
+            H.Check("NavMarshal_Initial", H.FindText("Route: Home") is not null);
+
+            // Navigate from a background thread — the exact #234 scenario that used
+            // to mutate the List<T> backing store off-thread with no protection.
+            var done = new TaskCompletionSource();
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    nav!.Navigate(NavRoute.Detail);
+                    done.TrySetResult();
+                }
+                catch (Exception ex)
+                {
+                    done.TrySetException(ex);
+                }
+            });
+
+            var winner = await Task.WhenAny(done.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            H.Check("NavMarshal_NavigateCompleted", winner == done.Task);
+            if (winner == done.Task) await done.Task; // surface any captured exception
+
+            // Drain the marshaled mutation + the rerender it requests.
+            for (int i = 0; i < 4; i++) await Harness.Render();
+
+            // The store ended in the right state: current advanced, Home pushed.
+            H.Check("NavMarshal_NavigateCurrent", nav!.CurrentRoute.Equals(NavRoute.Detail));
+            H.Check("NavMarshal_NavigateBackStack",
+                nav!.BackStack.Count == 1 && nav.BackStack[0].Equals(NavRoute.Home));
+            // ...and the rerender actually fired (not just the store mutated).
+            H.Check("NavMarshal_NavigateRerendered", H.FindText("Route: Detail") is not null);
+
+            // Replace from a background thread — a second mutator end-to-end.
+            var done2 = new TaskCompletionSource();
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    nav!.Replace(NavRoute.Settings);
+                    done2.TrySetResult();
+                }
+                catch (Exception ex)
+                {
+                    done2.TrySetException(ex);
+                }
+            });
+
+            var winner2 = await Task.WhenAny(done2.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            H.Check("NavMarshal_ReplaceCompleted", winner2 == done2.Task);
+            if (winner2 == done2.Task) await done2.Task;
+
+            for (int i = 0; i < 4; i++) await Harness.Render();
+
+            // Replace swaps current without growing the back stack.
+            H.Check("NavMarshal_ReplaceCurrent", nav!.CurrentRoute.Equals(NavRoute.Settings));
+            H.Check("NavMarshal_ReplaceBackStack",
+                nav!.BackStack.Count == 1 && nav.BackStack[0].Equals(NavRoute.Home));
+            H.Check("NavMarshal_ReplaceRerendered", H.FindText("Route: Settings") is not null);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ThreadSafeNavigationFixtures.cs
@@ -52,8 +52,11 @@ internal static class ThreadSafeNavigationFixtures
                     nav!.Navigate(NavRoute.Detail);
                     done.TrySetResult();
                 }
-                catch (InvalidOperationException ex)
+                catch (Exception ex)
                 {
+                    // Forward ANY failure (not only the marshal's InvalidOperationException)
+                    // so an unexpected exception surfaces on `await done.Task` with its real
+                    // stack trace instead of hanging the fixture until the 10s timeout.
                     done.TrySetException(ex);
                 }
             });
@@ -81,8 +84,9 @@ internal static class ThreadSafeNavigationFixtures
                     nav!.Replace(NavRoute.Settings);
                     done2.TrySetResult();
                 }
-                catch (InvalidOperationException ex)
+                catch (Exception ex)
                 {
+                    // Surface any unexpected failure immediately (see note above).
                     done2.TrySetException(ex);
                 }
             });
@@ -184,8 +188,10 @@ internal static class ThreadSafeNavigationFixtures
                     mutate();
                     done.TrySetResult();
                 }
-                catch (InvalidOperationException ex)
+                catch (Exception ex)
                 {
+                    // Forward ANY failure so an unexpected exception (e.g. a setup regression)
+                    // surfaces on `await done.Task` instead of hanging to the 10s timeout.
                     done.TrySetException(ex);
                 }
             });

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -437,6 +437,7 @@ internal static class SelfTestFixtureRegistry
         // Thread-safe navigation (#234) — off-thread marshal on a real dispatcher
         "ThreadSafeNav_NavigateOffThreadMarshals",
         "ThreadSafeNav_MutatorsOffThreadMarshal",
+        "ThreadSafeNav_SetStateOffThreadFreezesSnapshot",
         // Animation system — Curve & Easing
         "Curve_RecordEquality",
         "Curve_PresetValues",
@@ -1829,6 +1830,7 @@ internal static class SelfTestFixtureRegistry
         "ThreadSafe_NonThreadSafeAutoMarshal" => new ThreadSafeHookFixtures.NonThreadSafeAutoMarshal(harness),
         "ThreadSafeNav_NavigateOffThreadMarshals" => new ThreadSafeNavigationFixtures.NavigateOffThreadMarshals(harness),
         "ThreadSafeNav_MutatorsOffThreadMarshal" => new ThreadSafeNavigationFixtures.MutatorsOffThreadMarshal(harness),
+        "ThreadSafeNav_SetStateOffThreadFreezesSnapshot" => new ThreadSafeNavigationFixtures.SetStateOffThreadFreezesSnapshot(harness),
         // Animation system — Curve & Easing
         "Curve_RecordEquality" => new CurveTests.RecordEquality(harness),
         "Curve_PresetValues" => new CurveTests.PresetValues(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -434,6 +434,8 @@ internal static class SelfTestFixtureRegistry
         "ThreadSafe_RenderCoalescing",
         "ThreadSafe_RenderCoalescingDispatcherBatch",
         "ThreadSafe_NonThreadSafeAutoMarshal",
+        // Thread-safe navigation (#234) — off-thread marshal on a real dispatcher
+        "ThreadSafeNav_NavigateOffThreadMarshals",
         // Animation system — Curve & Easing
         "Curve_RecordEquality",
         "Curve_PresetValues",
@@ -1824,6 +1826,7 @@ internal static class SelfTestFixtureRegistry
         "ThreadSafe_RenderCoalescing" => new ThreadSafeHookFixtures.RenderCoalescing(harness),
         "ThreadSafe_RenderCoalescingDispatcherBatch" => new ThreadSafeHookFixtures.RenderCoalescingDispatcherBatch(harness),
         "ThreadSafe_NonThreadSafeAutoMarshal" => new ThreadSafeHookFixtures.NonThreadSafeAutoMarshal(harness),
+        "ThreadSafeNav_NavigateOffThreadMarshals" => new ThreadSafeNavigationFixtures.NavigateOffThreadMarshals(harness),
         // Animation system — Curve & Easing
         "Curve_RecordEquality" => new CurveTests.RecordEquality(harness),
         "Curve_PresetValues" => new CurveTests.PresetValues(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -436,6 +436,7 @@ internal static class SelfTestFixtureRegistry
         "ThreadSafe_NonThreadSafeAutoMarshal",
         // Thread-safe navigation (#234) — off-thread marshal on a real dispatcher
         "ThreadSafeNav_NavigateOffThreadMarshals",
+        "ThreadSafeNav_MutatorsOffThreadMarshal",
         // Animation system — Curve & Easing
         "Curve_RecordEquality",
         "Curve_PresetValues",
@@ -1827,6 +1828,7 @@ internal static class SelfTestFixtureRegistry
         "ThreadSafe_RenderCoalescingDispatcherBatch" => new ThreadSafeHookFixtures.RenderCoalescingDispatcherBatch(harness),
         "ThreadSafe_NonThreadSafeAutoMarshal" => new ThreadSafeHookFixtures.NonThreadSafeAutoMarshal(harness),
         "ThreadSafeNav_NavigateOffThreadMarshals" => new ThreadSafeNavigationFixtures.NavigateOffThreadMarshals(harness),
+        "ThreadSafeNav_MutatorsOffThreadMarshal" => new ThreadSafeNavigationFixtures.MutatorsOffThreadMarshal(harness),
         // Animation system — Curve & Easing
         "Curve_RecordEquality" => new CurveTests.RecordEquality(harness),
         "Curve_PresetValues" => new CurveTests.PresetValues(harness),

--- a/tests/Reactor.Tests/ThreadSafeNavigationTests.cs
+++ b/tests/Reactor.Tests/ThreadSafeNavigationTests.cs
@@ -220,4 +220,80 @@ public class ThreadSafeNavigationTests
         Assert.False(nav.CanGoBack);
         Assert.False(nav.CanGoForward);
     }
+
+    // ════════════════════════════════════════════════════════════════
+    //  SetState validates the snapshot shape up front (M7 fail-fast)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void SetState_OffThread_NullCurrent_Throws_ArgumentException_Synchronously()
+    {
+        var nav = MakeHandle(new Home());
+        var bad = new NavigationState<Route>(
+            BackStack: Array.Empty<Route>(),
+            Current: null!,
+            ForwardStack: Array.Empty<Route>());
+
+        // The Current-null check runs BEFORE the marshal gate, so an off-thread caller
+        // gets an ArgumentException at the call site — NOT an InvalidOperationException
+        // raised later on the dispatcher (which the caller could never observe), and
+        // NOT a swallowed marshal. ArgumentException must win the race against the gate.
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await Task.Run(() => nav.SetState(bad), TestContext.Current.CancellationToken);
+        }).Result;
+        Assert.IsNotType<InvalidOperationException>(ex);
+        Assert.Equal("state", ex.ParamName);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  UIThreadMarshal.EnqueueOrThrow — the shared marshal primitive (M8/M9)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void EnqueueOrThrow_NullDispatcher_Throws_NoDispatcher_Message()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            UIThreadMarshal.EnqueueOrThrow(
+                tryEnqueue: null,
+                work: () => { },
+                onNoDispatcher: () => "NO-DISPATCHER",
+                onRefused: () => "REFUSED"));
+
+        Assert.Equal("NO-DISPATCHER", ex.Message);
+    }
+
+    [Fact]
+    public void EnqueueOrThrow_DispatcherRefuses_Throws_Refused_Message()
+    {
+        // tryEnqueue returns false — the dispatcher-shutting-down branch that was
+        // previously unreachable from a unit test (only the null-dispatcher branch
+        // was hit). This covers the TryEnqueue == false failure mode end-to-end.
+        bool enqueueCalled = false;
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            UIThreadMarshal.EnqueueOrThrow(
+                tryEnqueue: _ => { enqueueCalled = true; return false; },
+                work: () => { },
+                onNoDispatcher: () => "NO-DISPATCHER",
+                onRefused: () => "REFUSED"));
+
+        Assert.True(enqueueCalled);
+        Assert.Equal("REFUSED", ex.Message);
+    }
+
+    [Fact]
+    public void EnqueueOrThrow_DispatcherAccepts_Returns_True_And_Posts_Work()
+    {
+        Action? posted = null;
+        var work = new Action(() => { });
+
+        bool result = UIThreadMarshal.EnqueueOrThrow(
+            tryEnqueue: w => { posted = w; return true; },
+            work: work,
+            onNoDispatcher: () => "NO-DISPATCHER",
+            onRefused: () => "REFUSED");
+
+        Assert.True(result);
+        Assert.Same(work, posted); // the exact work delegate is handed to the dispatcher
+    }
 }

--- a/tests/Reactor.Tests/ThreadSafeNavigationTests.cs
+++ b/tests/Reactor.Tests/ThreadSafeNavigationTests.cs
@@ -1,0 +1,223 @@
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Navigation;
+using Xunit;
+
+#pragma warning disable xUnit1031 // These tests deliberately use blocking (.Result/.Wait/WaitAll)
+                                  // to drive UI-thread + background-thread interaction patterns.
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Cross-thread tests for <see cref="NavigationHandle{TRoute}"/> mutators (issue #234).
+///
+/// Mirrors the <c>UseState</c>/<c>UseReducer</c> cross-thread tests added for #212:
+/// the navigation hook is now thread-safe by default. On the UI thread the mutators
+/// behave exactly as before; off-thread they auto-marshal onto the captured UI
+/// dispatcher, and when no dispatcher is available (this headless unit-test context)
+/// they throw a loud, actionable exception INSTEAD of corrupting the back/forward
+/// stacks or silently dropping the navigation.
+/// </summary>
+public class ThreadSafeNavigationTests
+{
+    private abstract record Route;
+    private sealed record Home : Route;
+    private sealed record Detail(int Id) : Route;
+    private sealed record Settings : Route;
+
+    private static NavigationHandle<Route> MakeHandle(Route initial)
+    {
+        // Build the handle through the real hook so its captured UI thread id is the
+        // render thread — exactly how a component obtains it via UseNavigation.
+        var ctx = new RenderContext();
+        ctx.BeginRender(() => { });
+        return ctx.UseNavigation<Route>(initial);
+    }
+
+    private static InvalidOperationException AssertOffThreadThrows(Action call)
+    {
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await Task.Run(call, TestContext.Current.CancellationToken);
+        }).Result;
+        // The message names the operation and the missing-dispatcher remedy.
+        Assert.Contains("NavigationHandle.", ex.Message);
+        Assert.Contains("no UI dispatcher", ex.Message);
+        return ex;
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Off-thread, no dispatcher: each mutator throws loudly (#234)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Navigate_OffThread_NoDispatcher_Throws_And_Leaves_Stack_Untouched()
+    {
+        var nav = MakeHandle(new Home());
+
+        AssertOffThreadThrows(() => nav.Navigate(new Detail(1)));
+
+        // No partial mutation: the stack is exactly as it started.
+        Assert.IsType<Home>(nav.CurrentRoute);
+        Assert.Equal(1, nav.Depth);
+        Assert.False(nav.CanGoBack);
+        Assert.False(nav.CanGoForward);
+    }
+
+    [Fact]
+    public void GoBack_OffThread_NoDispatcher_Throws_And_Leaves_Stack_Untouched()
+    {
+        var nav = MakeHandle(new Home());
+        nav.Navigate(new Detail(1)); // on UI thread — sets up a back entry
+        Assert.True(nav.CanGoBack);
+
+        AssertOffThreadThrows(() => nav.GoBack());
+
+        Assert.IsType<Detail>(nav.CurrentRoute);
+        Assert.True(nav.CanGoBack);
+        Assert.False(nav.CanGoForward);
+        Assert.Equal(2, nav.Depth);
+    }
+
+    [Fact]
+    public void GoForward_OffThread_NoDispatcher_Throws_And_Leaves_Stack_Untouched()
+    {
+        var nav = MakeHandle(new Home());
+        nav.Navigate(new Detail(1));
+        nav.GoBack(); // now CanGoForward
+        Assert.True(nav.CanGoForward);
+
+        AssertOffThreadThrows(() => nav.GoForward());
+
+        Assert.IsType<Home>(nav.CurrentRoute);
+        Assert.True(nav.CanGoForward);
+    }
+
+    [Fact]
+    public void Replace_OffThread_NoDispatcher_Throws_And_Leaves_Stack_Untouched()
+    {
+        var nav = MakeHandle(new Home());
+
+        AssertOffThreadThrows(() => nav.Replace(new Settings()));
+
+        Assert.IsType<Home>(nav.CurrentRoute);
+        Assert.Equal(1, nav.Depth);
+    }
+
+    [Fact]
+    public void Reset_OffThread_NoDispatcher_Throws_And_Leaves_Stack_Untouched()
+    {
+        var nav = MakeHandle(new Home());
+        nav.Navigate(new Detail(1));
+        nav.Navigate(new Detail(2));
+
+        AssertOffThreadThrows(() => nav.Reset(new Settings()));
+
+        Assert.IsType<Detail>(nav.CurrentRoute);
+        Assert.Equal(new Detail(2), nav.CurrentRoute);
+        Assert.Equal(3, nav.Depth);
+    }
+
+    [Fact]
+    public void PopTo_OffThread_NoDispatcher_Throws_And_Leaves_Stack_Untouched()
+    {
+        var nav = MakeHandle(new Home());
+        nav.Navigate(new Detail(1));
+        nav.Navigate(new Detail(2));
+
+        AssertOffThreadThrows(() => nav.PopTo(r => r is Home));
+
+        Assert.Equal(new Detail(2), nav.CurrentRoute);
+        Assert.Equal(3, nav.Depth);
+    }
+
+    [Fact]
+    public void SetState_OffThread_NoDispatcher_Throws_And_Leaves_Stack_Untouched()
+    {
+        var nav = MakeHandle(new Home());
+        var snapshot = new NavigationState<Route>(
+            BackStack: new Route[] { new Home(), new Detail(1) },
+            Current: new Detail(2),
+            ForwardStack: Array.Empty<Route>());
+
+        AssertOffThreadThrows(() => nav.SetState(snapshot));
+
+        Assert.IsType<Home>(nav.CurrentRoute);
+        Assert.Equal(1, nav.Depth);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  UI thread: behavior is unchanged (the gate is a no-op fast path)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Mutators_On_UI_Thread_Behave_Normally()
+    {
+        var nav = MakeHandle(new Home());
+
+        Assert.True(nav.Navigate(new Detail(1)));
+        Assert.Equal(new Detail(1), nav.CurrentRoute);
+
+        Assert.True(nav.Replace(new Detail(2)));
+        Assert.Equal(new Detail(2), nav.CurrentRoute);
+
+        Assert.True(nav.GoBack());
+        Assert.IsType<Home>(nav.CurrentRoute);
+
+        Assert.True(nav.GoForward());
+        Assert.Equal(new Detail(2), nav.CurrentRoute);
+
+        Assert.True(nav.Reset(new Settings()));
+        Assert.IsType<Settings>(nav.CurrentRoute);
+        Assert.False(nav.CanGoBack);
+        Assert.False(nav.CanGoForward);
+    }
+
+    [Fact]
+    public void Navigate_On_UI_Thread_Fires_Rerender()
+    {
+        var ctx = new RenderContext();
+        int rerenders = 0;
+        ctx.BeginRender(() => rerenders++);
+        var nav = ctx.UseNavigation<Route>(new Home());
+
+        nav.Navigate(new Detail(1));
+
+        Assert.True(rerenders >= 1);
+        Assert.Equal(new Detail(1), nav.CurrentRoute);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Concurrency: many off-thread writers cannot corrupt the stack
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Concurrent_OffThread_Writers_All_Rejected_No_Corruption()
+    {
+        var nav = MakeHandle(new Home());
+
+        // 32 background writers all attempt to mutate concurrently. With no
+        // dispatcher every attempt must throw at the gate BEFORE touching the
+        // stack — so none of them can interleave a List<T> mutation.
+        var tasks = Enumerable.Range(0, 32).Select(i => Task.Run(() =>
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                switch (i % 4)
+                {
+                    case 0: nav.Navigate(new Detail(i)); break;
+                    case 1: nav.Replace(new Detail(i)); break;
+                    case 2: nav.Reset(new Detail(i)); break;
+                    default: nav.GoBack(); break;
+                }
+            });
+        }, TestContext.Current.CancellationToken)).ToArray();
+
+        Task.WaitAll(tasks, TestContext.Current.CancellationToken);
+
+        // The stack is pristine — exactly the initial single-entry Home stack.
+        Assert.IsType<Home>(nav.CurrentRoute);
+        Assert.Equal(1, nav.Depth);
+        Assert.False(nav.CanGoBack);
+        Assert.False(nav.CanGoForward);
+    }
+}

--- a/tests/Reactor.Tests/ThreadSafeNavigationTests.cs
+++ b/tests/Reactor.Tests/ThreadSafeNavigationTests.cs
@@ -246,9 +246,42 @@ public class ThreadSafeNavigationTests
         Assert.Equal("state", ex.ParamName);
     }
 
-    // ════════════════════════════════════════════════════════════════
-    //  UIThreadMarshal.EnqueueOrThrow — the shared marshal primitive (M8/M9)
-    // ════════════════════════════════════════════════════════════════
+    [Fact]
+    public void SetState_OffThread_NullBackStack_Throws_ArgumentException_Synchronously()
+    {
+        var nav = MakeHandle(new Home());
+        var bad = new NavigationState<Route>(
+            BackStack: null!,
+            Current: new Home(),
+            ForwardStack: Array.Empty<Route>());
+
+        // Like the Current check, BackStack is validated BEFORE the marshal gate so a null
+        // list fails fast at the call site rather than throwing later inside RestoreState's
+        // AddRange on the UI dispatcher, where an off-thread caller could never observe it.
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await Task.Run(() => nav.SetState(bad), TestContext.Current.CancellationToken);
+        }).Result;
+        Assert.IsNotType<InvalidOperationException>(ex);
+        Assert.Equal("state", ex.ParamName);
+    }
+
+    [Fact]
+    public void SetState_OffThread_NullForwardStack_Throws_ArgumentException_Synchronously()
+    {
+        var nav = MakeHandle(new Home());
+        var bad = new NavigationState<Route>(
+            BackStack: Array.Empty<Route>(),
+            Current: new Home(),
+            ForwardStack: null!);
+
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await Task.Run(() => nav.SetState(bad), TestContext.Current.CancellationToken);
+        }).Result;
+        Assert.IsNotType<InvalidOperationException>(ex);
+        Assert.Equal("state", ex.ParamName);
+    }
 
     [Fact]
     public void EnqueueOrThrow_NullDispatcher_Throws_NoDispatcher_Message()


### PR DESCRIPTION
Closes #234.

## What & why

Issue #234 tracks bringing **the rest** of the hooks up to the thread-safety-by-default standard that #212 established for `UseState`/`UseReducer` (per @codemonkeychris: *"UseState and UseReducer were fixed for #212, this issue would track the rest of the hooks"*). The maintainer's position is *safety over raw performance* — authors should not have to predict upfront whether a value will be updated off-thread.

After auditing every hook in `src/Reactor/Core` and `src/Reactor/Hooks`, the **single genuine remaining gap** is `UseNavigation`. Its `NavigationHandle<TRoute>` mutators (`Navigate`, `GoBack`, `GoForward`, `Replace`, `Reset`, `PopTo`, `SetState`) mutated the internal back/forward `List<T>` stores with **no protection**, so an off-thread call (from `Task.Run`, a timer, or after `await … ConfigureAwait(false)`) could corrupt the stacks or silently lose the navigation. Every other hook was already safe (see audit below).

## The #212 pattern this mirrors

#212 used **marshal-or-throw**, not always-lock:
- UI-thread fast path = a single thread-id compare → run inline.
- Off-thread = enqueue the work onto the captured UI dispatcher (`ReactorApp.UIDispatcher.TryEnqueue`); throw `InvalidOperationException` loudly if no dispatcher is available or the queue refuses (shutdown), instead of silently racing the reconciler.

This PR reproduces that contract:
- New internal helper `src/Reactor/Core/UIThreadMarshal.cs` (`IsOffUIThread` + `MarshalOffUIThread`) so the rest of the hook surface can share one gate.
- `NavigationHandle` captures the render/UI thread id at construction and gates each mutator:
  ```csharp
  if (IsOffUIThread && MarshalOff(nameof(Navigate), () => Navigate(route, options))) return true;
  ```
  The short-circuit (`IsOffUIThread && …`) keeps the marshaling closure **off** the UI-thread fast path — so navigation's hot path allocates *less* than the #212 state hooks.

## Lock-cost / fast-path measurement (the maintainer explicitly cares)

Micro-benchmark on the UI-thread fast path (ARM64, Release):

| Path | ns/op | alloc |
|---|---|---|
| Gate (thread-id read + compare) | **~1.16 ns** delta | 0 bytes |
| `NavigationHandle.Replace` (full) | 20.9 ns | 32 bytes (inherent nav-entry work; gate adds none) |
| `UseState` default setter (#212 reference) | 71 ns | 120 bytes |

The gate cost on the common (UI-thread) case is **~1 ns and zero allocation** — well within the "tolerable" bar. Navigation's fast path is lighter than the existing #212 state hooks.

## Breaking?

**Non-breaking.** The gate is additive; on-thread behavior is byte-for-byte identical. The only behavior change is on the *previously broken* off-thread path: it now marshals (just works) or throws a clear, actionable exception instead of corrupting state. The bool-returning mutators return `true` when an off-thread call is *scheduled* (documented in the XML docs).

## Audit — why only UseNavigation needed changes

- `UseState` / `UseReducer` / `UsePersisted` — ✅ done in #212.
- `UseObservable*` / `UseCollection` — ✅ route through the default `UseReducer` `forceRender`, which auto-marshals.
- `UseResource` / `UseMutation` / `UseInfiniteResource` — ✅ self-marshal via `IHookDispatcher` + `threadSafe:true` reducer.
- `UseCommand` — ✅ `UseState(threadSafe:true)`.
- `UseMemo` / `UseCallback` / `UseContext` / `UseEffect` — render-phase only, no off-thread setter.
- `UseRef` — React-parity escape hatch, never schedules a render (left as-is, by design).
- Theme/motion hooks — WinRT `UISettings` events fire off-thread, but rerender already marshals + the field writes are atomic (left as-is to avoid shutdown-crash risk from a throwing marshal).
- **`UseNavigation` → `NavigationHandle`** — ❌ the gap this PR fixes.

`RenderContext.MarshalIfOffUIThread` (the #212 mechanism) was unified with the new `UIThreadMarshal` (M8): both now funnel through `UIThreadMarshal.EnqueueOrThrow`, so there is a single marshal implementation rather than two near-identical copies. #212's `UseState`/`UseReducer` cross-thread tests stay green after the refactor (the exact exception wording, incl. `threadSafe: true`, is preserved via lazy message factories).

## Tests

- New `tests/Reactor.Tests/ThreadSafeNavigationTests.cs`: every mutator off-thread-with-no-dispatcher throws + leaves the stack untouched (no partial mutation); UI-thread mutators behave normally; rerender fires; a 32-task concurrent off-thread test; M7 `SetState` null-`Current` fail-fast; the `UIThreadMarshal.EnqueueOrThrow` null/refused/accept primitive cases.
- Selftests on a real pumped `DispatcherQueue`: `NavigateOffThreadMarshals` (Navigate/Replace) + `MutatorsOffThreadMarshal` (GoBack/GoForward/PopTo/Reset/SetState) prove off-thread calls marshal + apply + re-render end-to-end.
- Full `Reactor.Tests` suite green (the only failure under full-suite load is the pre-existing unrelated `CompilationLoaderTests` cold-load timing flake, which passes in isolation).

---

## Review follow-ups (after the initial description)

A second `pr-review` pass produced no critical/high findings; the actionable items landed as follow-up commits:

- **Test coverage:** added a `MutatorsOffThreadMarshal` selftest that drives `GoBack`/`GoForward`/`PopTo`/`Reset`/`SetState` off-thread on a **real pumped `DispatcherQueue`** (the original M10 fixture only exercised `Navigate`/`Replace`). Every mutator now has real-dispatcher happy-path coverage, not just the off-thread-rejection path.
- **API docs:** each bool-returning mutator now has a `<returns>` documenting that an off-thread `true` means *scheduled*, not *succeeded* (the UI-thread meaning is unchanged).
- **Heads-up — benign generated-doc churn:** the `docs/guide/threading-and-dispatch.md` diff includes ~13 lines of an unrelated `ShouldSuppress(Reconciler.ReactorState)` overload (issue #207). That is **not** a change in this PR — `mur docs compile` re-extracted the current snippet from `src/Reactor/Core/ChangeEchoSuppressor.cs` (whose source is not touched here; an earlier PR landed the overload without recompiling docs). Flagged so reviewers aren't surprised; the generated content is correct.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>