### PR TITLE
Fix chart LabelView/TickLabelView a11y peer-subtree leaks (#162)

### DIFF
--- a/docs/_pipeline/templates/charting.md.dt
+++ b/docs/_pipeline/templates/charting.md.dt
@@ -182,16 +182,34 @@ any Element. Each delegate receives the tick's domain value:
 
 | Method | Purpose |
 |--------|---------|
-| `PieChartElement<T>.LabelView(Func<T, PieSliceLayout, Element>)` | Replace the built-in slice text with any Element, anchored on the slice centroid |
-| `ChartElement<T>.XTickLabelView(Func<double, Element>)` | Replace the X-axis tick label, horizontally centered on the tick |
-| `ChartElement<T>.YTickLabelView(Func<double, Element>)` | Replace the Y-axis tick label, right-anchored to the axis edge |
+| `PieChartElement<T>.LabelView(Func<T, PieSliceLayout, Element>, Func<T, string>? name = null, bool interactive = false)` | Replace the built-in slice text with any Element, anchored on the slice centroid |
+| `ChartElement<T>.XTickLabelView(Func<double, Element>, Func<double, string>? name = null, bool interactive = false)` | Replace the X-axis tick label, horizontally centered on the tick |
+| `ChartElement<T>.YTickLabelView(Func<double, Element>, Func<double, string>? name = null, bool interactive = false)` | Replace the Y-axis tick label, right-anchored to the axis edge |
 
-The element you return is auto-anchored — you don't need a known size at
-construction time, and the chart re-positions on layout. It is also rendered
-non-interactive and hidden from the UIA tree, so the chart's structured
-accessibility description (see below) stays canonical. Always keep the
-string `LabelAccessor` (pie) or `DataLabel` (line/bar/area) set when you use
-a `*View` override; that's what screen readers read.
+By default the element you return is rendered non-interactive: the chart
+force-applies `AccessibilityView.Raw` to the **entire realized subtree** (not
+just the outer wrapper) and clears `IsTabStop` on every inner control, so no
+inner peer surfaces to assistive tech and nothing inside the label joins the
+keyboard tab order. The chart's structured accessibility description (see
+below) therefore stays the single source of truth. The element is also
+auto-anchored — you don't need a known size at construction time, and the
+chart re-positions on layout.
+
+Two optional parameters refine this:
+
+- `name` supplies an accessible-name projection for cases where you use a
+  `*View` override **without** a string `LabelAccessor` (pie) / `DataLabel`
+  (line/bar/area). For pie slices the projection feeds the chart's own slice
+  descriptor, so the announced name matches the visible label instead of
+  falling back to `Slice {n}`. For axis ticks it sets `AutomationName` on the
+  realized tick element (ticks have no per-tick descriptor). Prefer the string
+  `LabelAccessor`/`DataLabel` when you have one; reach for `name` only when the
+  visual lives entirely in the `*View`.
+- `interactive: true` is an opt-in escape hatch: it leaves the subtree's peers
+  and tab stops intact so focusable children inside your label remain reachable.
+  When you set it, **you** own the label's accessibility — the chart no longer
+  hides it. Toggling `interactive` at runtime remounts the label so the
+  hide/un-hide takes effect immediately.
 
 ## Chart Accessibility
 

--- a/docs/guide/charting.md
+++ b/docs/guide/charting.md
@@ -350,16 +350,34 @@ LineChart(data, d => d.Month, d => d.Revenue)
 
 | Method | Purpose |
 |--------|---------|
-| `PieChartElement<T>.LabelView(Func<T, PieSliceLayout, Element>)` | Replace the built-in slice text with any Element, anchored on the slice centroid |
-| `ChartElement<T>.XTickLabelView(Func<double, Element>)` | Replace the X-axis tick label, horizontally centered on the tick |
-| `ChartElement<T>.YTickLabelView(Func<double, Element>)` | Replace the Y-axis tick label, right-anchored to the axis edge |
+| `PieChartElement<T>.LabelView(Func<T, PieSliceLayout, Element>, Func<T, string>? name = null, bool interactive = false)` | Replace the built-in slice text with any Element, anchored on the slice centroid |
+| `ChartElement<T>.XTickLabelView(Func<double, Element>, Func<double, string>? name = null, bool interactive = false)` | Replace the X-axis tick label, horizontally centered on the tick |
+| `ChartElement<T>.YTickLabelView(Func<double, Element>, Func<double, string>? name = null, bool interactive = false)` | Replace the Y-axis tick label, right-anchored to the axis edge |
 
-The element you return is auto-anchored — you don't need a known size at
-construction time, and the chart re-positions on layout. It is also rendered
-non-interactive and hidden from the UIA tree, so the chart's structured
-accessibility description (see below) stays canonical. Always keep the
-string `LabelAccessor` (pie) or `DataLabel` (line/bar/area) set when you use
-a `*View` override; that's what screen readers read.
+By default the element you return is rendered non-interactive: the chart
+force-applies `AccessibilityView.Raw` to the **entire realized subtree** (not
+just the outer wrapper) and clears `IsTabStop` on every inner control, so no
+inner peer surfaces to assistive tech and nothing inside the label joins the
+keyboard tab order. The chart's structured accessibility description (see
+below) therefore stays the single source of truth. The element is also
+auto-anchored — you don't need a known size at construction time, and the
+chart re-positions on layout.
+
+Two optional parameters refine this:
+
+- `name` supplies an accessible-name projection for cases where you use a
+  `*View` override **without** a string `LabelAccessor` (pie) / `DataLabel`
+  (line/bar/area). For pie slices the projection feeds the chart's own slice
+  descriptor, so the announced name matches the visible label instead of
+  falling back to `Slice {n}`. For axis ticks it sets `AutomationName` on the
+  realized tick element (ticks have no per-tick descriptor). Prefer the string
+  `LabelAccessor`/`DataLabel` when you have one; reach for `name` only when the
+  visual lives entirely in the `*View`.
+- `interactive: true` is an opt-in escape hatch: it leaves the subtree's peers
+  and tab stops intact so focusable children inside your label remain reachable.
+  When you set it, **you** own the label's accessibility — the chart no longer
+  hides it. Toggling `interactive` at runtime remounts the label so the
+  hide/un-hide takes effect immediately.
 
 ## Chart Accessibility
 

--- a/plugins/reactor/skills/reactor-charts/SKILL.md
+++ b/plugins/reactor/skills/reactor-charts/SKILL.md
@@ -220,12 +220,20 @@ Beyond that, your responsibilities:
   focus should announce category + value. The `IChartAccessibilityData`
   surface drives this; if you turn the chart `Interactive(false)` you lose
   it — keep it on unless there's a reason.
-- **`*View` defaults.** Custom labels are auto-stamped with
-  `IsHitTestVisible=false` and `AccessibilityView=Raw` so they don't
-  duplicate the structured UIA description. **Always** keep the string
-  `LabelAccessor` (PieChart) or `DataLabel` (line/bar/area) set — those
-  feed UIA. Custom visuals augment the visual; they don't replace the
-  accessible description.
+- **`*View` defaults.** Custom labels are non-interactive by default: the
+  chart force-applies `AccessibilityView=Raw` to the **entire realized
+  subtree** (not just the outer wrapper) and clears `IsTabStop` on every inner
+  control, so no inner peer surfaces to UIA and nothing inside the label joins
+  the tab order. Prefer keeping the string `LabelAccessor` (PieChart) or
+  `DataLabel` (line/bar/area) set — those feed UIA. When the visual lives
+  entirely in the `*View`, pass `name:` (a `Func<T,string>` for pie /
+  `Func<double,string>` for ticks) so the accessible name matches the visible
+  label instead of falling back to `Slice {n}`. Set `interactive: true` only
+  when the label has focusable children that must stay reachable — then **you**
+  own its accessibility. Signatures:
+  `LabelView(render, name: null, interactive: false)`,
+  `XTickLabelView(render, name: null, interactive: false)`,
+  `YTickLabelView(render, name: null, interactive: false)`.
 
 ## Common pitfalls — refuse to ship these
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1610,8 +1610,8 @@ Title(string title) → ChartElement<T>
 ToElement() → Element
 Units(string xUnits = null, string yUnits = null) → ChartElement<T>
 Width(double width) → ChartElement<T>
-XTickLabelView(Func<double, Element> render) → ChartElement<T>
-YTickLabelView(Func<double, Element> render) → ChartElement<T>
+XTickLabelView(Func<double, Element> render, Func<double, string> name = null, bool interactive = false) → ChartElement<T>
+YTickLabelView(Func<double, Element> render, Func<double, string> name = null, bool interactive = false) → ChartElement<T>
 
 ### class ChartHandle<T>
 Canvas Canvas { get; }
@@ -5058,7 +5058,7 @@ Description(string description) → PieChartElement<T>
 Height(double height) → PieChartElement<T>
 InnerRadius(double radius) → PieChartElement<T>
 LabelRadiusOffset(double offset) → PieChartElement<T>
-LabelView(Func<T, PieSliceLayout, Element> render) → PieChartElement<T>
+LabelView(Func<T, PieSliceLayout, Element> render, Func<T, string> name = null, bool interactive = false) → PieChartElement<T>
 OnReady(Action<PieChartHandle<T>> callback) → PieChartElement<T>
 PadAngle(double angle) → PieChartElement<T>
 Palette(ChartPalette palette) → PieChartElement<T>

--- a/skills/charts.md
+++ b/skills/charts.md
@@ -229,12 +229,20 @@ Beyond that, your responsibilities:
   focus should announce category + value. The `IChartAccessibilityData`
   surface drives this; if you turn the chart `Interactive(false)` you lose
   it — keep it on unless there's a reason.
-- **`*View` defaults.** Custom labels are auto-stamped with
-  `IsHitTestVisible=false` and `AccessibilityView=Raw` so they don't
-  duplicate the structured UIA description. **Always** keep the string
-  `LabelAccessor` (PieChart) or `DataLabel` (line/bar/area) set — those
-  feed UIA. Custom visuals augment the visual; they don't replace the
-  accessible description.
+- **`*View` defaults.** Custom labels are non-interactive by default: the
+  chart force-applies `AccessibilityView=Raw` to the **entire realized
+  subtree** (not just the outer wrapper) and clears `IsTabStop` on every inner
+  control, so no inner peer surfaces to UIA and nothing inside the label joins
+  the tab order. Prefer keeping the string `LabelAccessor` (PieChart) or
+  `DataLabel` (line/bar/area) set — those feed UIA. When the visual lives
+  entirely in the `*View`, pass `name:` (a `Func<T,string>` for pie /
+  `Func<double,string>` for ticks) so the accessible name matches the visible
+  label instead of falling back to `Slice {n}`. Set `interactive: true` only
+  when the label has focusable children that must stay reachable — then **you**
+  own its accessibility. Signatures:
+  `LabelView(render, name: null, interactive: false)`,
+  `XTickLabelView(render, name: null, interactive: false)`,
+  `YTickLabelView(render, name: null, interactive: false)`.
 
 ## Common pitfalls — refuse to ship these
 

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1610,8 +1610,8 @@ Title(string title) → ChartElement<T>
 ToElement() → Element
 Units(string xUnits = null, string yUnits = null) → ChartElement<T>
 Width(double width) → ChartElement<T>
-XTickLabelView(Func<double, Element> render) → ChartElement<T>
-YTickLabelView(Func<double, Element> render) → ChartElement<T>
+XTickLabelView(Func<double, Element> render, Func<double, string> name = null, bool interactive = false) → ChartElement<T>
+YTickLabelView(Func<double, Element> render, Func<double, string> name = null, bool interactive = false) → ChartElement<T>
 
 ### class ChartHandle<T>
 Canvas Canvas { get; }
@@ -5058,7 +5058,7 @@ Description(string description) → PieChartElement<T>
 Height(double height) → PieChartElement<T>
 InnerRadius(double radius) → PieChartElement<T>
 LabelRadiusOffset(double offset) → PieChartElement<T>
-LabelView(Func<T, PieSliceLayout, Element> render) → PieChartElement<T>
+LabelView(Func<T, PieSliceLayout, Element> render, Func<T, string> name = null, bool interactive = false) → PieChartElement<T>
 OnReady(Action<PieChartHandle<T>> callback) → PieChartElement<T>
 PadAngle(double angle) → PieChartElement<T>
 Palette(ChartPalette palette) → PieChartElement<T>

--- a/src/Reactor.Analyzers/PoolResetSetAnalyzer.cs
+++ b/src/Reactor.Analyzers/PoolResetSetAnalyzer.cs
@@ -47,6 +47,7 @@ public sealed class PoolResetSetAnalyzer : DiagnosticAnalyzer
             { "VerticalAlignment",   "VerticalAlignment" },
             { "Opacity",             "Opacity" },
             { "AccessKey",           "AccessKey" },
+            { "IsTabStop",           "IsTabStop" },
         };
 
     private static readonly LocalizableString Title =

--- a/src/Reactor/Charting/Accessibility/ChartLabelA11y.cs
+++ b/src/Reactor/Charting/Accessibility/ChartLabelA11y.cs
@@ -49,10 +49,25 @@ internal static class ChartLabelA11y
         void OnLoaded(object sender, RoutedEventArgs e)
         {
             fe.Loaded -= OnLoaded;
-            HideSubtree(fe);
+            ApplyDeferredHide(fe);
         }
 
         fe.Loaded += OnLoaded;
+    }
+
+    /// <summary>
+    /// Deferred (<see cref="FrameworkElement.Loaded"/>) arm of <see cref="HideSubtreeOnMount"/>,
+    /// with a stale-handler guard (issue #162 review). If the element was unmounted and
+    /// returned to the pool <em>before it ever loaded</em>, this one-shot handler survives
+    /// into a later reuse. The pool reset restores <c>IsHitTestVisible</c> to <c>true</c> (see
+    /// <c>ElementPool.CleanElement</c>), and an interactive (or unrelated) re-renter never
+    /// re-hides it — so only apply the deferred hide when the element is still in the
+    /// non-interactive hidden state this hook established (<c>IsHitTestVisible == false</c>).
+    /// </summary>
+    internal static void ApplyDeferredHide(FrameworkElement fe)
+    {
+        if (!fe.IsHitTestVisible)
+            HideSubtree(fe);
     }
 
     /// <summary>

--- a/src/Reactor/Charting/Accessibility/ChartLabelA11y.cs
+++ b/src/Reactor/Charting/Accessibility/ChartLabelA11y.cs
@@ -26,6 +26,18 @@ namespace Microsoft.UI.Reactor.Charting.Accessibility;
 /// </summary>
 internal static class ChartLabelA11y
 {
+    // L1 (issue #162 review): a private attached sentinel marking elements whose
+    // deferred (Loaded) hide is still pending. Replaces the old IsHitTestVisible
+    // identity check — which mis-fired when a recycled element happened to carry
+    // IsHitTestVisible=false from an unrelated prior use. AOT/trim-safe (a plain
+    // attached DependencyProperty, no reflection).
+    private static readonly DependencyProperty PendingDeferredHideProperty =
+        DependencyProperty.RegisterAttached(
+            "PendingDeferredHide",
+            typeof(bool),
+            typeof(ChartLabelA11y),
+            new PropertyMetadata(false));
+
     /// <summary>
     /// <c>OnMount</c> hook for a non-interactive custom label / tick element. Blocks
     /// pointer hit-testing and recursively hides the element's subtree from UIA and the
@@ -46,6 +58,10 @@ internal static class ChartLabelA11y
         if (fe.IsLoaded)
             return;
 
+        // Mark the pending hide so the one-shot Loaded handler only acts when this
+        // hook is still the owner of the element's hidden state (see ApplyDeferredHide).
+        MarkPendingDeferredHide(fe);
+
         void OnLoaded(object sender, RoutedEventArgs e)
         {
             fe.Loaded -= OnLoaded;
@@ -56,18 +72,54 @@ internal static class ChartLabelA11y
     }
 
     /// <summary>
+    /// <c>OnUpdate</c> hook for a non-interactive custom label / tick element (issue #162
+    /// review M1). An in-place data/content update can realize <em>new</em> focusable
+    /// descendants; <see cref="HideSubtreeOnMount"/> only fires once (at mount), so those
+    /// would leak back into UIA / the tab order. The element is already loaded on update,
+    /// so a single synchronous re-walk suffices — no deferred <see cref="FrameworkElement.Loaded"/>
+    /// arm is needed.
+    /// </summary>
+    internal static void HideSubtreeOnUpdate(FrameworkElement fe)
+    {
+        fe.IsHitTestVisible = false;
+        HideSubtree(fe);
+    }
+
+    /// <summary>
+    /// Marks <paramref name="fe"/> as having a deferred hide still pending its
+    /// <see cref="FrameworkElement.Loaded"/> event. Internal (not private) so the
+    /// deferred-hide self-test can drive the sentinel directly.
+    /// </summary>
+    internal static void MarkPendingDeferredHide(FrameworkElement fe) =>
+        fe.SetValue(PendingDeferredHideProperty, true);
+
+    /// <summary>
+    /// Clears the deferred-hide sentinel. Wired as an <c>OnUnmount</c> hook on the
+    /// non-interactive chart sites so an element unmounted <em>before it ever loaded</em>
+    /// (its one-shot <see cref="FrameworkElement.Loaded"/> handler still attached) cannot
+    /// later hide a recycled interactive / unrelated renter: with the sentinel cleared,
+    /// the surviving handler's <see cref="ApplyDeferredHide"/> becomes a no-op. Lives on
+    /// the Charting side (not <c>ElementPool</c>) to avoid a Core→Charting layering dependency.
+    /// </summary>
+    internal static void ClearPendingHide(FrameworkElement fe) =>
+        fe.ClearValue(PendingDeferredHideProperty);
+
+    /// <summary>
     /// Deferred (<see cref="FrameworkElement.Loaded"/>) arm of <see cref="HideSubtreeOnMount"/>,
-    /// with a stale-handler guard (issue #162 review). If the element was unmounted and
-    /// returned to the pool <em>before it ever loaded</em>, this one-shot handler survives
-    /// into a later reuse. The pool reset restores <c>IsHitTestVisible</c> to <c>true</c> (see
-    /// <c>ElementPool.CleanElement</c>), and an interactive (or unrelated) re-renter never
-    /// re-hides it — so only apply the deferred hide when the element is still in the
-    /// non-interactive hidden state this hook established (<c>IsHitTestVisible == false</c>).
+    /// with a stale-handler guard (issue #162 review L1). If the element was unmounted and
+    /// returned to the pool <em>before it ever loaded</em>, this one-shot handler can survive
+    /// into a later reuse. Only apply the deferred hide when the pending-hide sentinel this
+    /// hook set is still present — a recycled element that was re-rendered interactive (or for
+    /// an unrelated purpose) has had the sentinel cleared on unmount, so the stale handler
+    /// no-ops. The sentinel is consumed (cleared) once applied.
     /// </summary>
     internal static void ApplyDeferredHide(FrameworkElement fe)
     {
-        if (!fe.IsHitTestVisible)
-            HideSubtree(fe);
+        if (!(bool)fe.GetValue(PendingDeferredHideProperty))
+            return;
+
+        fe.ClearValue(PendingDeferredHideProperty);
+        HideSubtree(fe);
     }
 
     /// <summary>

--- a/src/Reactor/Charting/Accessibility/ChartLabelA11y.cs
+++ b/src/Reactor/Charting/Accessibility/ChartLabelA11y.cs
@@ -1,0 +1,80 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace Microsoft.UI.Reactor.Charting.Accessibility;
+
+/// <summary>
+/// Hides a caller-supplied chart label / axis-tick <see cref="Core.Element"/> and its
+/// <em>entire realized subtree</em> from assistive technology and keyboard focus
+/// traversal, so the chart's own <see cref="IChartAccessibilityData"/> descriptor stays
+/// the single accessible representation of slice / tick data.
+///
+/// <para>
+/// Setting <c>AutomationProperties.AccessibilityView = Raw</c> on only the outer wrapper
+/// the chart applies does <b>not</b> reliably remove inner peers — a caller's
+/// <see cref="Core.Element"/> may be a structured composite (a Reactor
+/// <see cref="Core.Component"/> with focusable children, a <see cref="TextBlock"/>, an
+/// icon, …) whose interior peers still surface to UIA / focus depending on how the
+/// platform composes peer trees under a <c>Raw</c>-marked parent. That produces the
+/// double-announcement and stray-focus-stop problems described in issue #162. Walking
+/// the subtree and force-<c>Raw</c>-ing every descendant FE (plus clearing
+/// <see cref="Control"/>.<c>IsTabStop</c>) removes them from both the UIA tree and the tab order.
+/// </para>
+/// </summary>
+internal static class ChartLabelA11y
+{
+    /// <summary>
+    /// <c>OnMount</c> hook for a non-interactive custom label / tick element. Blocks
+    /// pointer hit-testing and recursively hides the element's subtree from UIA and the
+    /// tab order — once immediately (covers panel children already attached at mount
+    /// time) and again on <see cref="FrameworkElement.Loaded"/> (covers templated-control
+    /// inner peers that only realize after the element enters the live visual tree).
+    /// </summary>
+    internal static void HideSubtreeOnMount(FrameworkElement fe)
+    {
+        fe.IsHitTestVisible = false;
+
+        // Immediate pass: panel children added to a Children collection are visual
+        // children right away, even before the element is loaded.
+        HideSubtree(fe);
+
+        // Deferred pass: a templated Control (Button, etc.) only expands its template —
+        // and therefore its inner peers — once it is loaded and measured. Re-walk then.
+        if (fe.IsLoaded)
+            return;
+
+        void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            fe.Loaded -= OnLoaded;
+            HideSubtree(fe);
+        }
+
+        fe.Loaded += OnLoaded;
+    }
+
+    /// <summary>
+    /// Recursively forces <c>AccessibilityView.Raw</c> on every descendant
+    /// <see cref="FrameworkElement"/> (removing each inner peer from the UIA Content and
+    /// Control views) and clears <see cref="Control"/>.<c>IsTabStop</c> on every descendant
+    /// <see cref="Control"/> (removing inner focusable children from the keyboard tab
+    /// order). Uses only the public <see cref="VisualTreeHelper"/> /
+    /// <see cref="AutomationProperties"/> API — no reflection — so it stays AOT / trim safe.
+    /// </summary>
+    internal static void HideSubtree(DependencyObject root)
+    {
+        if (root is FrameworkElement fe)
+        {
+            AutomationProperties.SetAccessibilityView(fe, AccessibilityView.Raw);
+            if (fe is Control control)
+                control.IsTabStop = false;
+        }
+
+        int count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+            HideSubtree(VisualTreeHelper.GetChild(root, i));
+    }
+}
+

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -90,6 +90,11 @@ public sealed class ChartElement<T> : IChartAccessibilityData
     // position and rendered non-interactive, hidden from the UIA tree.
     private Func<double, Element>? _xTickLabelView;
     private Func<double, Element>? _yTickLabelView;
+    // Optional accessible-name projection + opt-in interactive flag per axis (issue #162).
+    private Func<double, string>? _xTickName;
+    private Func<double, string>? _yTickName;
+    private bool _xTickInteractive;
+    private bool _yTickInteractive;
 
     // Interactive / keyboard navigation fields
     private bool _interactive;
@@ -129,17 +134,53 @@ public sealed class ChartElement<T> : IChartAccessibilityData
 
     /// <summary>
     /// Replaces the built-in numeric X-axis tick label with a caller-supplied <see cref="Element"/>.
-    /// The element is horizontally centered on the tick mark. Rendered non-interactive and hidden
-    /// from the UIA tree (the chart's accessibility data continues to describe axis ticks).
+    /// The element is horizontally centered on the tick mark. By default it is rendered
+    /// non-interactive and its <em>entire</em> realized subtree is hidden from the UIA tree and
+    /// keyboard tab order (the chart's accessibility data continues to describe axis ticks).
     /// </summary>
-    public ChartElement<T> XTickLabelView(Func<double, Element> render) { _xTickLabelView = render; return this; }
+    /// <param name="render">Renders the tick element from the tick value.</param>
+    /// <param name="name">
+    /// Optional accessible-name projection applied as the rendered element's
+    /// <c>AutomationName</c>. Only observable when <paramref name="interactive"/> is
+    /// <see langword="true"/> — non-interactive ticks are hidden from UIA, so the chart's own
+    /// descriptor remains the single source of truth.
+    /// </param>
+    /// <param name="interactive">
+    /// Opt-in escape hatch. When <see langword="true"/>, the chart does <b>not</b> force
+    /// <c>AccessibilityView.Raw</c> / remove the subtree from focus — the caller takes
+    /// responsibility for the tick element's accessibility.
+    /// </param>
+    public ChartElement<T> XTickLabelView(Func<double, Element> render, Func<double, string>? name = null, bool interactive = false)
+    {
+        _xTickLabelView = render;
+        _xTickName = name;
+        _xTickInteractive = interactive;
+        return this;
+    }
 
     /// <summary>
     /// Replaces the built-in numeric Y-axis tick label with a caller-supplied <see cref="Element"/>.
-    /// The element is right-anchored to the axis edge and vertically centered on the tick. Rendered
-    /// non-interactive and hidden from the UIA tree.
+    /// The element is right-anchored to the axis edge and vertically centered on the tick. By
+    /// default it is rendered non-interactive and its <em>entire</em> realized subtree is hidden
+    /// from the UIA tree and keyboard tab order.
     /// </summary>
-    public ChartElement<T> YTickLabelView(Func<double, Element> render) { _yTickLabelView = render; return this; }
+    /// <param name="render">Renders the tick element from the tick value.</param>
+    /// <param name="name">
+    /// Optional accessible-name projection applied as the rendered element's
+    /// <c>AutomationName</c>. Only observable when <paramref name="interactive"/> is
+    /// <see langword="true"/>.
+    /// </param>
+    /// <param name="interactive">
+    /// Opt-in escape hatch. When <see langword="true"/>, the chart does <b>not</b> hide the
+    /// subtree from UIA / focus — the caller owns the tick element's accessibility.
+    /// </param>
+    public ChartElement<T> YTickLabelView(Func<double, Element> render, Func<double, string>? name = null, bool interactive = false)
+    {
+        _yTickLabelView = render;
+        _yTickName = name;
+        _yTickInteractive = interactive;
+        return this;
+    }
 
     /// <summary>Axis unit annotations (e.g., "months", "USD").</summary>
     public ChartElement<T> Units(string? xUnits = null, string? yUnits = null) { _xUnits = xUnits; _yUnits = yUnits; return this; }
@@ -281,7 +322,9 @@ public sealed class ChartElement<T> : IChartAccessibilityData
             [.. _showGrid ? D3Grid(yScale, plotLeft, plotWidth) : [],
              .. RenderData(data, xScale, yScale, plotLeft, plotTop, plotWidth, plotHeight),
              .. _showAxes ? D3Axes(xScale, yScale, plotLeft, plotTop, plotWidth, plotHeight,
-                    xTickLabel: _xTickLabelView, yTickLabel: _yTickLabelView) : []]);
+                    xTickLabel: _xTickLabelView, yTickLabel: _yTickLabelView,
+                    xTickInteractive: _xTickInteractive, yTickInteractive: _yTickInteractive,
+                    xTickName: _xTickName, yTickName: _yTickName) : []]);
 
         if (_onReady is { } cb)
             canvas = canvas.Set(c => cb(new ChartHandle<T>(c)));
@@ -463,6 +506,10 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     // produced from LabelAccessor. The string LabelAccessor is still consulted
     // for accessibility (slice descriptors), so screen-reader summaries keep working.
     private Func<T, PieSliceLayout, Element>? _labelView;
+    // Optional accessible-name projection used when no LabelAccessor/DataLabel is set,
+    // plus opt-in interactive flag (issue #162).
+    private Func<T, string>? _labelName;
+    private bool _labelViewInteractive;
 
     public PieChartElement<T> Width(double width) { _width = width; return this; }
     public PieChartElement<T> Height(double height) { _height = height; return this; }
@@ -505,13 +552,32 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     /// <summary>
     /// Replaces the built-in text label for each slice with a caller-supplied <see cref="Element"/>.
     /// The element is positioned centered on the slice's centroid (it does not need a known size),
-    /// rendered non-interactive by default (no hit-testing), and hidden from the UIA tree so the
-    /// chart's <see cref="IChartAccessibilityData"/> remains the single accessible representation
-    /// of slice data. Set the original string label via the <c>label</c> parameter on
-    /// <see cref="Charts.PieChart{T}"/> or <see cref="DataLabel"/> to keep accessibility metadata
-    /// when overriding the visual.
+    /// rendered non-interactive by default (no hit-testing), and its <em>entire</em> realized
+    /// subtree is hidden from the UIA tree and keyboard tab order so the chart's
+    /// <see cref="IChartAccessibilityData"/> remains the single accessible representation of slice
+    /// data. Set the original string label via the <c>label</c> parameter on
+    /// <see cref="Charts.PieChart{T}"/>, <see cref="DataLabel"/>, or the <paramref name="name"/>
+    /// projection to keep accessibility metadata when overriding the visual.
     /// </summary>
-    public PieChartElement<T> LabelView(Func<T, PieSliceLayout, Element> render) { _labelView = render; return this; }
+    /// <param name="render">Renders the slice label from the data item and its layout.</param>
+    /// <param name="name">
+    /// Optional accessible-name projection. When neither a string <c>label</c> accessor nor
+    /// <see cref="DataLabel"/> is supplied, this becomes the slice's accessible name in the
+    /// chart's descriptor (instead of falling back to <c>"Slice {i+1}"</c>), so screen-reader
+    /// users get the same meaningful label the visual shows.
+    /// </param>
+    /// <param name="interactive">
+    /// Opt-in escape hatch. When <see langword="true"/>, the chart does <b>not</b> force
+    /// <c>AccessibilityView.Raw</c> / remove the subtree from focus — the caller takes
+    /// responsibility for the label element's accessibility.
+    /// </param>
+    public PieChartElement<T> LabelView(Func<T, PieSliceLayout, Element> render, Func<T, string>? name = null, bool interactive = false)
+    {
+        _labelView = render;
+        _labelName = name;
+        _labelViewInteractive = interactive;
+        return this;
+    }
 
     /// <summary>Sets a curated accessible palette (Tier 1).</summary>
     public PieChartElement<T> Palette(Accessibility.ChartPalette palette) { _palette = palette; return this; }
@@ -676,9 +742,18 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
             // caller put on the returned element. ElementModifiers stores a
             // single OnMountAction, so plain `.OnMount(…)` would silently
             // overwrite the caller's hook.
-            return _labelView!(arc.Data, layout)
-                .CenterAt(labelX, labelY)
-                .OnMountAdd(static fe => fe.IsHitTestVisible = false)
+            var labelElement = _labelView!(arc.Data, layout)
+                .CenterAt(labelX, labelY);
+
+            // interactive opt-in (issue #162): caller owns a11y, leave peers intact.
+            if (_labelViewInteractive)
+                return labelElement;
+
+            // Default (issue #162): force-Raw the whole realized subtree and remove
+            // inner focusable children from the tab order, so only the chart's own
+            // descriptor surfaces to UIA / assistive tech.
+            return labelElement
+                .OnMountAdd(Accessibility.ChartLabelA11y.HideSubtreeOnMount)
                 .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
         }).ToArray();
     }
@@ -699,7 +774,7 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
             var points = Data.Select((d, i) =>
             {
                 var value = ValueAccessor(d);
-                var label = LabelAccessor?.Invoke(d) ?? $"Slice {i + 1}";
+                var label = LabelAccessor?.Invoke(d) ?? _labelName?.Invoke(d) ?? $"Slice {i + 1}";
                 string? customLabel = _dataLabel?.Invoke(d, i);
                 return new ChartPointDescriptor(label, value, customLabel);
             }).ToArray();

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -143,7 +143,9 @@ public sealed class ChartElement<T> : IChartAccessibilityData
     /// Optional accessible-name projection applied as the rendered element's
     /// <c>AutomationName</c>. Only observable when <paramref name="interactive"/> is
     /// <see langword="true"/> — non-interactive ticks are hidden from UIA, so the chart's own
-    /// descriptor remains the single source of truth.
+    /// descriptor remains the single source of truth. (Unlike <see cref="PieChartElement{T}.LabelView"/>,
+    /// an axis tick has no per-tick descriptor for the projection to feed, so it never affects a
+    /// hidden tick's accessible name.)
     /// </param>
     /// <param name="interactive">
     /// Opt-in escape hatch. When <see langword="true"/>, the chart does <b>not</b> force
@@ -564,7 +566,11 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     /// Optional accessible-name projection. When neither a string <c>label</c> accessor nor
     /// <see cref="DataLabel"/> is supplied, this becomes the slice's accessible name in the
     /// chart's descriptor (instead of falling back to <c>"Slice {i+1}"</c>), so screen-reader
-    /// users get the same meaningful label the visual shows.
+    /// users get the same meaningful label the visual shows. Note the deliberate asymmetry with
+    /// the axis-tick <c>*TickLabelView(name:)</c> overloads: a pie slice <em>has</em> a per-slice
+    /// descriptor, so <paramref name="name"/> feeds that descriptor even for non-interactive
+    /// labels; an axis tick has no per-tick descriptor, so there the projection only sets
+    /// <c>AutomationName</c> and is observable only when <c>interactive: true</c>.
     /// </param>
     /// <param name="interactive">
     /// Opt-in escape hatch. When <see langword="true"/>, the chart does <b>not</b> force
@@ -743,7 +749,10 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
             // single OnMountAction, so plain `.OnMount(…)` would silently
             // overwrite the caller's hook.
             var labelElement = _labelView!(arc.Data, layout)
-                .CenterAt(labelX, labelY);
+                .CenterAt(labelX, labelY)
+                // Issue #162: key by the interactive flag so toggling it forces a remount
+                // (the hide is a mount-time side effect; in-place update can't undo it).
+                .WithKey($"__pielabel{arc.Index}_{(_labelViewInteractive ? 1 : 0)}");
 
             // interactive opt-in (issue #162): caller owns a11y, leave peers intact.
             if (_labelViewInteractive)

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -760,9 +760,13 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
 
             // Default (issue #162): force-Raw the whole realized subtree and remove
             // inner focusable children from the tab order, so only the chart's own
-            // descriptor surfaces to UIA / assistive tech.
+            // descriptor surfaces to UIA / assistive tech. OnUpdateAdd re-asserts the
+            // hide over descendants realized on a later in-place update (M1); OnUnmountAdd
+            // clears the deferred-hide sentinel so a pre-load unmount can't poison reuse (L1).
             return labelElement
                 .OnMountAdd(Accessibility.ChartLabelA11y.HideSubtreeOnMount)
+                .OnUpdateAdd(Accessibility.ChartLabelA11y.HideSubtreeOnUpdate)
+                .OnUnmountAdd(Accessibility.ChartLabelA11y.ClearPendingHide)
                 .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
         }).ToArray();
     }

--- a/src/Reactor/Charting/D3Charts.cs
+++ b/src/Reactor/Charting/D3Charts.cs
@@ -407,10 +407,25 @@ public static class D3Charts
     /// to the axis edge and vertically centered on the tick. When null, a built-in numeric
     /// <c>TextBlock</c> is rendered.
     /// </param>
+    /// <param name="xTickInteractive">
+    /// When true, the custom X tick element keeps its peers/focus — caller owns a11y (issue #162).
+    /// When false (default), the whole realized subtree is forced to <c>AccessibilityView.Raw</c>
+    /// and removed from the keyboard tab order.
+    /// </param>
+    /// <param name="yTickInteractive">As <paramref name="xTickInteractive"/>, for the Y axis.</param>
+    /// <param name="xTickName">
+    /// Optional accessible-name projection applied as the X tick element's <c>AutomationName</c>.
+    /// Only observable when <paramref name="xTickInteractive"/> is true.
+    /// </param>
+    /// <param name="yTickName">As <paramref name="xTickName"/>, for the Y axis.</param>
     public static Element[] D3Axes(LinearScale xs, LinearScale ys,
         double left, double top, double width, double height, int xTicks = 6, int yTicks = 5,
         Func<double, Element>? xTickLabel = null,
-        Func<double, Element>? yTickLabel = null)
+        Func<double, Element>? yTickLabel = null,
+        bool xTickInteractive = false,
+        bool yTickInteractive = false,
+        Func<double, string>? xTickName = null,
+        Func<double, string>? yTickName = null)
     {
         var ab = ChartAxis;
         double bot = top + height;
@@ -431,11 +446,15 @@ public static class D3Charts
             }
             else
             {
-                elements.Add(xTickLabel(t)
-                    .Canvas(xs.Map(t), bot + 4, anchorX: 0.5, anchorY: 0)
-                    // OnMountAdd preserves the caller's own mount hook, if any.
-                    .OnMountAdd(static fe => fe.IsHitTestVisible = false)
-                    .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw));
+                var el = xTickLabel(t).Canvas(xs.Map(t), bot + 4, anchorX: 0.5, anchorY: 0);
+                if (xTickName is not null)
+                    el = el.AutomationName(xTickName(t));
+                elements.Add(xTickInteractive
+                    ? el
+                    : el
+                        // Default: hide the whole realized subtree from UIA + focus.
+                        .OnMountAdd(Accessibility.ChartLabelA11y.HideSubtreeOnMount)
+                        .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw));
             }
         }
 
@@ -448,11 +467,15 @@ public static class D3Charts
             }
             else
             {
-                elements.Add(yTickLabel(t)
-                    .Canvas(left - 6, ys.Map(t), anchorX: 1.0, anchorY: 0.5)
-                    // OnMountAdd preserves the caller's own mount hook, if any.
-                    .OnMountAdd(static fe => fe.IsHitTestVisible = false)
-                    .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw));
+                var el = yTickLabel(t).Canvas(left - 6, ys.Map(t), anchorX: 1.0, anchorY: 0.5);
+                if (yTickName is not null)
+                    el = el.AutomationName(yTickName(t));
+                elements.Add(yTickInteractive
+                    ? el
+                    : el
+                        // Default: hide the whole realized subtree from UIA + focus.
+                        .OnMountAdd(Accessibility.ChartLabelA11y.HideSubtreeOnMount)
+                        .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw));
             }
         }
 

--- a/src/Reactor/Charting/D3Charts.cs
+++ b/src/Reactor/Charting/D3Charts.cs
@@ -407,25 +407,25 @@ public static class D3Charts
     /// to the axis edge and vertically centered on the tick. When null, a built-in numeric
     /// <c>TextBlock</c> is rendered.
     /// </param>
+    /// <param name="xTickName">
+    /// Optional accessible-name projection applied as the X tick element's <c>AutomationName</c>.
+    /// Only observable when <paramref name="xTickInteractive"/> is true.
+    /// </param>
+    /// <param name="yTickName">As <paramref name="xTickName"/>, for the Y axis.</param>
     /// <param name="xTickInteractive">
     /// When true, the custom X tick element keeps its peers/focus — caller owns a11y (issue #162).
     /// When false (default), the whole realized subtree is forced to <c>AccessibilityView.Raw</c>
     /// and removed from the keyboard tab order.
     /// </param>
     /// <param name="yTickInteractive">As <paramref name="xTickInteractive"/>, for the Y axis.</param>
-    /// <param name="xTickName">
-    /// Optional accessible-name projection applied as the X tick element's <c>AutomationName</c>.
-    /// Only observable when <paramref name="xTickInteractive"/> is true.
-    /// </param>
-    /// <param name="yTickName">As <paramref name="xTickName"/>, for the Y axis.</param>
     public static Element[] D3Axes(LinearScale xs, LinearScale ys,
         double left, double top, double width, double height, int xTicks = 6, int yTicks = 5,
         Func<double, Element>? xTickLabel = null,
         Func<double, Element>? yTickLabel = null,
-        bool xTickInteractive = false,
-        bool yTickInteractive = false,
         Func<double, string>? xTickName = null,
-        Func<double, string>? yTickName = null)
+        Func<double, string>? yTickName = null,
+        bool xTickInteractive = false,
+        bool yTickInteractive = false)
     {
         var ab = ChartAxis;
         double bot = top + height;
@@ -437,6 +437,7 @@ public static class D3Charts
                 .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw),
         };
 
+        int xi = 0;
         foreach (var t in xs.Ticks(xTicks))
         {
             if (xTickLabel is null)
@@ -449,6 +450,9 @@ public static class D3Charts
                 var el = xTickLabel(t).Canvas(xs.Map(t), bot + 4, anchorX: 0.5, anchorY: 0);
                 if (xTickName is not null)
                     el = el.AutomationName(xTickName(t));
+                // Issue #162: key by the interactive flag so toggling it forces a remount
+                // (the hide is a mount-time side effect; in-place update can't undo it).
+                el = el.WithKey($"__xtick{xi}_{(xTickInteractive ? 1 : 0)}");
                 elements.Add(xTickInteractive
                     ? el
                     : el
@@ -456,8 +460,10 @@ public static class D3Charts
                         .OnMountAdd(Accessibility.ChartLabelA11y.HideSubtreeOnMount)
                         .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw));
             }
+            xi++;
         }
 
+        int yi = 0;
         foreach (var t in ys.Ticks(yTicks))
         {
             if (yTickLabel is null)
@@ -470,6 +476,8 @@ public static class D3Charts
                 var el = yTickLabel(t).Canvas(left - 6, ys.Map(t), anchorX: 1.0, anchorY: 0.5);
                 if (yTickName is not null)
                     el = el.AutomationName(yTickName(t));
+                // Issue #162: key by the interactive flag so toggling it forces a remount.
+                el = el.WithKey($"__ytick{yi}_{(yTickInteractive ? 1 : 0)}");
                 elements.Add(yTickInteractive
                     ? el
                     : el
@@ -477,6 +485,7 @@ public static class D3Charts
                         .OnMountAdd(Accessibility.ChartLabelA11y.HideSubtreeOnMount)
                         .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw));
             }
+            yi++;
         }
 
         return elements.ToArray();

--- a/src/Reactor/Charting/D3Charts.cs
+++ b/src/Reactor/Charting/D3Charts.cs
@@ -457,7 +457,11 @@ public static class D3Charts
                     ? el
                     : el
                         // Default: hide the whole realized subtree from UIA + focus.
+                        // OnUpdateAdd re-asserts on in-place update (M1); OnUnmountAdd
+                        // clears the deferred-hide sentinel to keep pool reuse clean (L1).
                         .OnMountAdd(Accessibility.ChartLabelA11y.HideSubtreeOnMount)
+                        .OnUpdateAdd(Accessibility.ChartLabelA11y.HideSubtreeOnUpdate)
+                        .OnUnmountAdd(Accessibility.ChartLabelA11y.ClearPendingHide)
                         .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw));
             }
             xi++;
@@ -482,7 +486,11 @@ public static class D3Charts
                     ? el
                     : el
                         // Default: hide the whole realized subtree from UIA + focus.
+                        // OnUpdateAdd re-asserts on in-place update (M1); OnUnmountAdd
+                        // clears the deferred-hide sentinel to keep pool reuse clean (L1).
                         .OnMountAdd(Accessibility.ChartLabelA11y.HideSubtreeOnMount)
+                        .OnUpdateAdd(Accessibility.ChartLabelA11y.HideSubtreeOnUpdate)
+                        .OnUnmountAdd(Accessibility.ChartLabelA11y.ClearPendingHide)
                         .AccessibilityView(Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw));
             }
             yi++;

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -1025,7 +1025,7 @@ public abstract record Element
     /// Brushes and FontFamily are compared structurally because fluent helpers
     /// (<c>.Background("#color")</c>, <c>.FontFamily("Segoe UI")</c>) allocate
     /// fresh instances on every render even when the underlying values match.
-    /// Ignores OnMountAction (only runs at mount time, not during update).
+    /// Ignores OnMountAction and OnUpdateAction (side-effect hooks, not render state).
     /// </summary>
     internal static bool ModifiersEqual(ElementModifiers? a, ElementModifiers? b)
     {
@@ -1058,6 +1058,7 @@ public abstract record Element
             && a.FontWeight == b.FontWeight
             && FontFamiliesEqual(a.FontFamily, b.FontFamily)
             // Skip OnMountAction — only runs at mount time
+            // Skip OnUpdateAction — side-effect hook, fired each update from ApplyModifiers
             // Skip event handlers — delegate comparison is unreliable, conservative false
             && a.OnSizeChanged is null && b.OnSizeChanged is null
             && a.OnPointerPressed is null && b.OnPointerPressed is null
@@ -1592,6 +1593,11 @@ public record ElementModifiers
     public ElementSoundMode? ElementSoundMode { get; init; }
     public Action<FrameworkElement>? OnMountAction { get; init; }
     public Action<FrameworkElement>? OnUnmountAction { get; init; }
+    // Update-time counterpart to OnMountAction: runs on every in-place update
+    // (oldM is not null) after children have been reconciled. Internal-only — the
+    // framework uses it (chart label a11y, issue #162) to re-assert a side effect
+    // over descendants realized during an update; not yet part of the public DSL.
+    internal Action<FrameworkElement>? OnUpdateAction { get; init; }
 
     // ── Typography (applies to any Control or TextBlock) ────────────
     public FontFamily? FontFamily { get; init; }
@@ -1730,6 +1736,7 @@ public record ElementModifiers
             ElementSoundMode = other.ElementSoundMode ?? ElementSoundMode,
             OnMountAction = other.OnMountAction ?? OnMountAction,
             OnUnmountAction = other.OnUnmountAction ?? OnUnmountAction,
+            OnUpdateAction = other.OnUpdateAction ?? OnUpdateAction,
             FontFamily = other.FontFamily ?? FontFamily,
             FontSize = other.FontSize ?? FontSize,
             FontWeight = other.FontWeight ?? FontWeight,

--- a/src/Reactor/Core/ElementPool.cs
+++ b/src/Reactor/Core/ElementPool.cs
@@ -240,6 +240,14 @@ public sealed class ElementPool : IDisposable
         fe.ClearValue(Microsoft.UI.Xaml.Automation.AutomationProperties.FullDescriptionProperty);
         fe.ClearValue(Microsoft.UI.Xaml.Automation.AutomationProperties.LandmarkTypeProperty);
         fe.ClearValue(Microsoft.UI.Xaml.Automation.AutomationProperties.AccessibilityViewProperty);
+        // Issue #162: chart label/tick subtree-hiding (and any other code path) sets
+        // IsHitTestVisible / IsTabStop imperatively on poolable controls. The pool already
+        // resets AccessibilityView above; it must also reset these two so a control hidden
+        // inside a custom label can't return to the pool non-tabbable / non-hit-testable and
+        // silently poison the next unrelated renter that doesn't re-set them.
+        fe.ClearValue(UIElement.IsHitTestVisibleProperty);
+        if (fe is Control tabStopControl)
+            tabStopControl.ClearValue(Control.IsTabStopProperty);
         fe.ClearValue(Microsoft.UI.Xaml.Automation.AutomationProperties.IsRequiredForFormProperty);
         fe.ClearValue(Microsoft.UI.Xaml.Automation.AutomationProperties.LiveSettingProperty);
         fe.ClearValue(Microsoft.UI.Xaml.Automation.AutomationProperties.PositionInSetProperty);

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -3862,6 +3862,15 @@ public sealed partial class Reconciler : IDisposable
         if (m.OnMountAction is not null && oldM is null)
             m.OnMountAction(fe);
 
+        // OnUpdateAction — the update-time counterpart, run on every in-place
+        // update (oldM is not null) but never at mount. Runs after child
+        // reconciliation (ApplyModifiers is invoked post-dispatch in the update
+        // path), so descendants realized during this update are already in the
+        // visual tree. Chart label a11y uses it to re-hide newly realized
+        // focusable descendants that OnMountAction (mount-only) would miss (#162).
+        if (m.OnUpdateAction is not null && oldM is not null)
+            m.OnUpdateAction(fe);
+
         // OnUnmountAction — captured here (authoritative modifier set) so it fires
         // reliably at teardown regardless of the tagged element's identity. Keep the
         // latest action across re-renders; clear unconditionally when absent so a

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -2434,6 +2434,22 @@ public static partial class ElementExtensions
     }
 
     /// <summary>
+    /// Internal update-time counterpart to <see cref="OnMountAdd"/>: composes an
+    /// action that the reconciler runs on every in-place update (never at mount),
+    /// after children are reconciled. Used by framework code (chart label a11y,
+    /// issue #162) to re-assert a hide over descendants realized on update.
+    /// Not exposed publicly — <see cref="ElementModifiers.OnUpdateAction"/> is internal.
+    /// </summary>
+    internal static T OnUpdateAdd<T>(this T el, Action<FrameworkElement> action) where T : Element
+    {
+        var existing = el.Modifiers?.OnUpdateAction;
+        Action<FrameworkElement> combined = existing is null
+            ? action
+            : fe => { existing(fe); action(fe); };
+        return Modify(el, new ElementModifiers { OnUpdateAction = combined });
+    }
+
+    /// <summary>
     /// Opts a subtree in or out of window drag-from-background hit testing.
     /// Use <c>.Drag(false)</c> on custom interactive regions that should not start a window move.
     /// </summary>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ChartAccessibilityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ChartAccessibilityFixtures.cs
@@ -1546,33 +1546,183 @@ internal static class ChartAccessibilityFixtures
     }
 
     /// <summary>
-    /// Issue #162 review — the deferred (<c>Loaded</c>) hide arm is one-shot and can survive a
-    /// pool round-trip if the element is unmounted before it ever loads. When that recycled FE
-    /// is later re-rented for an interactive (or unrelated) element, the pool reset has restored
-    /// <c>IsHitTestVisible=true</c>, so <c>ApplyDeferredHide</c> must skip — otherwise it would
-    /// wrongly force <c>Raw</c>/<c>IsTabStop=false</c> on the new renter's subtree.
+    /// Issue #162 review L1 — the deferred (<c>Loaded</c>) hide arm is one-shot and can survive a
+    /// pool round-trip if the element is unmounted before it ever loads. The guard is now a private
+    /// attached <em>sentinel</em> set by <c>HideSubtreeOnMount</c> (not an <c>IsHitTestVisible</c>
+    /// identity check, which mis-fired on a recycled element that merely happened to carry
+    /// <c>IsHitTestVisible=false</c>). <c>ApplyDeferredHide</c> must hide only when the sentinel is
+    /// present, and the un-mount path clears it so a stale handler becomes a no-op.
     /// </summary>
     internal class LabelViewDeferredHideStaleGuard(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()
         {
-            // Recycled-FE-now-interactive: IsHitTestVisible restored to true by the pool reset.
-            var interactiveHost = new Button { Content = "stale-guard-probe", IsTabStop = true, IsHitTestVisible = true };
-            ChartLabelA11y.ApplyDeferredHide(interactiveHost);
-            H.Check("ChartA11y_StaleGuard_Skips_TabStopIntact", interactiveHost.IsTabStop);
-            H.Check("ChartA11y_StaleGuard_Skips_NotRaw",
-                AutomationProperties.GetAccessibilityView(interactiveHost) != AccessibilityView.Raw);
+            // Case A — the bug scenario: a recycled FE carries IsHitTestVisible=false from a prior
+            // use but has NO pending-hide sentinel (it's being reused for an interactive/unrelated
+            // element). ApplyDeferredHide must SKIP. The OLD IsHitTestVisible guard would WRONGLY
+            // hide here (red on revert), because it keyed off hit-test state, not ownership.
+            var staleHost = new Button { Content = "stale-guard-probe", IsTabStop = true, IsHitTestVisible = false };
+            ChartLabelA11y.ApplyDeferredHide(staleHost);
+            H.Check("ChartA11y_StaleGuard_NoSentinel_Skips_TabStopIntact", staleHost.IsTabStop);
+            H.Check("ChartA11y_StaleGuard_NoSentinel_Skips_NotRaw",
+                AutomationProperties.GetAccessibilityView(staleHost) != AccessibilityView.Raw);
 
-            // Genuine deferred non-interactive load: HideSubtreeOnMount set IsHitTestVisible=false,
-            // so the deferred arm must still apply.
-            var hiddenHost = new Button { Content = "deferred-hide-probe", IsTabStop = true };
-            hiddenHost.IsHitTestVisible = false;
-            ChartLabelA11y.ApplyDeferredHide(hiddenHost);
-            H.Check("ChartA11y_StaleGuard_Applies_NotTabStop", !hiddenHost.IsTabStop);
-            H.Check("ChartA11y_StaleGuard_Applies_Raw",
-                AutomationProperties.GetAccessibilityView(hiddenHost) == AccessibilityView.Raw);
+            // Case B — genuine pending hide: the sentinel is set (as HideSubtreeOnMount does for an
+            // unloaded element), so ApplyDeferredHide must hide — even though IsHitTestVisible is
+            // TRUE here, which the OLD guard would have SKIPPED (also red on revert). Proves the new
+            // guard keys off the sentinel, not hit-test state.
+            var pendingHost = new Button { Content = "deferred-hide-probe", IsTabStop = true, IsHitTestVisible = true };
+            ChartLabelA11y.MarkPendingDeferredHide(pendingHost);
+            ChartLabelA11y.ApplyDeferredHide(pendingHost);
+            H.Check("ChartA11y_StaleGuard_Sentinel_Applies_NotTabStop", !pendingHost.IsTabStop);
+            H.Check("ChartA11y_StaleGuard_Sentinel_Applies_Raw",
+                AutomationProperties.GetAccessibilityView(pendingHost) == AccessibilityView.Raw);
+
+            // Case C — cleared sentinel (the OnUnmount path ran before Loaded): ApplyDeferredHide
+            // must SKIP, so a pre-load unmount can't hide a later renter.
+            var clearedHost = new Button { Content = "cleared-sentinel-probe", IsTabStop = true, IsHitTestVisible = false };
+            ChartLabelA11y.MarkPendingDeferredHide(clearedHost);
+            ChartLabelA11y.ClearPendingHide(clearedHost);
+            ChartLabelA11y.ApplyDeferredHide(clearedHost);
+            H.Check("ChartA11y_StaleGuard_Cleared_Skips_TabStopIntact", clearedHost.IsTabStop);
+            H.Check("ChartA11y_StaleGuard_Cleared_Skips_NotRaw",
+                AutomationProperties.GetAccessibilityView(clearedHost) != AccessibilityView.Raw);
+
+            // Sentinel is consumed once applied: a second ApplyDeferredHide on the now-hidden
+            // pending host is a no-op (cleared in Case B), so re-applying can't re-hide a control
+            // that has since been reset and reused.
+            pendingHost.IsTabStop = true;
+            ChartLabelA11y.ApplyDeferredHide(pendingHost);
+            H.Check("ChartA11y_StaleGuard_Sentinel_ConsumedAfterApply", pendingHost.IsTabStop);
 
             await Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Issue #162 review M1 — the subtree hide runs at mount; a later <em>in-place</em> data/content
+    /// update that realizes NEW focusable descendants must re-assert the hide (via the
+    /// <c>OnUpdate</c> hook), or those descendants leak back into UIA / the tab order. Keeps the
+    /// label non-interactive (stable key ⇒ in-place update, not remount) and grows the label
+    /// content from <c>VStack(TextBlock)</c> to <c>VStack(TextBlock, Button)</c> on a state toggle;
+    /// the buttons realized on update must be <c>Raw</c> + out of the tab order. Red on revert:
+    /// without the update hook those buttons mount exposed and tabbable.
+    /// </summary>
+    internal class LabelViewUpdateRehide(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            XamlInterop.Register(host.Reconciler);
+            host.Mount(ctx =>
+            {
+                var (expanded, setExpanded) = ctx.UseState(false);
+                return VStack(
+                    Button("ToggleExpanded", () => setExpanded(!expanded)),
+                    Charts.PieChart(NonInteractiveSlices, d => d.Value, d => d.Label)
+                        .Width(360).Height(360)
+                        // Same VStack root + non-interactive ⇒ stable key ⇒ in-place update.
+                        // The Button only appears in the expanded phase, realized on UPDATE.
+                        .LabelView((d, _) => expanded
+                            ? VStack(TextBlock(d.Label), Button("upd-" + d.Label, () => { }))
+                            : VStack(TextBlock(d.Label)))
+                        .ToElement());
+            });
+
+            await Harness.Render();
+
+            // Phase 0 — collapsed: no update-realized buttons yet.
+            var p0 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("upd-"));
+            H.Check("ChartA11y_UpdateRehide_Phase0_NoButtons", p0.Count == 0);
+
+            // Toggle → expanded: the new focusable descendants are mounted on an in-place update.
+            H.ClickButton("ToggleExpanded");
+            await Harness.Render();
+
+            var p1 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("upd-"));
+            H.Check("ChartA11y_UpdateRehide_Phase1_ButtonsRealizedOnUpdate", p1.Count == 2);
+            H.Check("ChartA11y_UpdateRehide_Phase1_NewButtonsRaw",
+                p1.Count == 2 && p1.TrueForAll(b =>
+                    AutomationProperties.GetAccessibilityView(b) == AccessibilityView.Raw));
+            H.Check("ChartA11y_UpdateRehide_Phase1_NewButtonsNotTabStop",
+                p1.Count == 2 && p1.TrueForAll(b => !b.IsTabStop));
+        }
+    }
+
+    private record TickTogglePoint(double X, double Y);
+
+    private static readonly TickTogglePoint[] TickToggleData =
+        [new(0, 10), new(1, 20), new(2, 15)];
+
+    /// <summary>
+    /// Issue #162 review L2 — exercises the Y-tick hide branch and the tick remount-by-interactive
+    /// key for BOTH axes (the existing tick subtree fixture is X-only and static; the toggle fixture
+    /// is pie-only). Composite X and Y tick labels carry a focusable Button; flipping
+    /// <c>interactive</c> at runtime must hide → expose → hide the inner buttons on each axis.
+    /// </summary>
+    internal class TickLabelViewInteractiveToggle(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            XamlInterop.Register(host.Reconciler);
+            host.Mount(ctx =>
+            {
+                var (interactive, setInteractive) = ctx.UseState(false);
+                return VStack(
+                    Button("ToggleTickInteractive", () => setInteractive(!interactive)),
+                    Charts.LineChart(TickToggleData, d => d.X, d => d.Y)
+                        .Width(400).Height(300)
+                        .XTickLabelView(t => VStack(TextBlock("xt" + (int)t), Button("xtb-" + (int)t, () => { })),
+                            interactive: interactive)
+                        .YTickLabelView(t => VStack(TextBlock("yt" + (int)t), Button("ytb-" + (int)t, () => { })),
+                            interactive: interactive)
+                        .ToElement());
+            });
+
+            await Harness.Render();
+
+            // Phase 0 — non-interactive: inner buttons on BOTH axes hidden + out of tab order.
+            var x0 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("xtb-"));
+            var y0 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("ytb-"));
+            H.Check("ChartA11y_TickToggle_Phase0_XMounted", x0.Count > 0);
+            H.Check("ChartA11y_TickToggle_Phase0_YMounted", y0.Count > 0);
+            H.Check("ChartA11y_TickToggle_Phase0_XRaw",
+                x0.Count > 0 && x0.TrueForAll(b => AutomationProperties.GetAccessibilityView(b) == AccessibilityView.Raw));
+            H.Check("ChartA11y_TickToggle_Phase0_XNotTabStop",
+                x0.Count > 0 && x0.TrueForAll(b => !b.IsTabStop));
+            H.Check("ChartA11y_TickToggle_Phase0_YRaw",
+                y0.Count > 0 && y0.TrueForAll(b => AutomationProperties.GetAccessibilityView(b) == AccessibilityView.Raw));
+            H.Check("ChartA11y_TickToggle_Phase0_YNotTabStop",
+                y0.Count > 0 && y0.TrueForAll(b => !b.IsTabStop));
+
+            // Toggle → interactive: keyed remount drops the hide on both axes.
+            H.ClickButton("ToggleTickInteractive");
+            await Harness.Render();
+            var x1 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("xtb-"));
+            var y1 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("ytb-"));
+            H.Check("ChartA11y_TickToggle_Phase1_XTabStop",
+                x1.Count > 0 && x1.TrueForAll(b => b.IsTabStop));
+            H.Check("ChartA11y_TickToggle_Phase1_XNotRaw",
+                x1.Count > 0 && x1.TrueForAll(b => AutomationProperties.GetAccessibilityView(b) != AccessibilityView.Raw));
+            H.Check("ChartA11y_TickToggle_Phase1_YTabStop",
+                y1.Count > 0 && y1.TrueForAll(b => b.IsTabStop));
+            H.Check("ChartA11y_TickToggle_Phase1_YNotRaw",
+                y1.Count > 0 && y1.TrueForAll(b => AutomationProperties.GetAccessibilityView(b) != AccessibilityView.Raw));
+
+            // Toggle back → hidden again on both axes (symmetric).
+            H.ClickButton("ToggleTickInteractive");
+            await Harness.Render();
+            var x2 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("xtb-"));
+            var y2 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("ytb-"));
+            H.Check("ChartA11y_TickToggle_Phase2_XNotTabStop",
+                x2.Count > 0 && x2.TrueForAll(b => !b.IsTabStop));
+            H.Check("ChartA11y_TickToggle_Phase2_XRaw",
+                x2.Count > 0 && x2.TrueForAll(b => AutomationProperties.GetAccessibilityView(b) == AccessibilityView.Raw));
+            H.Check("ChartA11y_TickToggle_Phase2_YNotTabStop",
+                y2.Count > 0 && y2.TrueForAll(b => !b.IsTabStop));
+            H.Check("ChartA11y_TickToggle_Phase2_YRaw",
+                y2.Count > 0 && y2.TrueForAll(b => AutomationProperties.GetAccessibilityView(b) == AccessibilityView.Raw));
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ChartAccessibilityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ChartAccessibilityFixtures.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Reactor.Charting.Accessibility;
 using Microsoft.UI.Reactor.Charting.D3;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Hosting;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Automation.Provider;
@@ -1223,6 +1224,199 @@ internal static class ChartAccessibilityFixtures
             try { point.SetValue("nope"); }
             catch (InvalidOperationException) { setValueThrows = true; }
             H.Check("ChartA11y_PeerProvider_SetValueThrows", setValueThrows);
+
+            await Task.CompletedTask;
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Issue #162 — custom LabelView / TickLabelView peer-subtree hiding
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Composite label component: a focusable child (Button) + a TextBlock, exactly the
+    /// structured peer shape that the issue warns can leak inner peers / focus stops past
+    /// an outer-wrapper-only <c>AccessibilityView.Raw</c>.
+    /// </summary>
+    private sealed class CompositeSliceLabel : Component<string>
+    {
+        public override Element Render() =>
+            VStack(
+                TextBlock(Props),
+                Button("b-" + Props, () => { }));
+    }
+
+    private record A11ySlice(string Label, double Value);
+
+    private static readonly A11ySlice[] NonInteractiveSlices =
+        [new("niA", 30), new("niB", 20)];
+    private static readonly A11ySlice[] InteractiveSlices =
+        [new("intA", 30), new("intB", 20)];
+
+    /// <summary>
+    /// Default (non-interactive) custom <c>LabelView</c>: the chart must force
+    /// <c>AccessibilityView.Raw</c> on the <em>entire</em> realized subtree (so no inner peer
+    /// surfaces to UIA) and clear <c>IsTabStop</c> on inner focusable children (so they leave the
+    /// keyboard tab order). The opt-in <c>interactive: true</c> overload must leave both intact.
+    /// </summary>
+    internal class LabelViewSubtreeA11y(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            XamlInterop.Register(host.Reconciler);
+            host.Mount(ctx =>
+                VStack(
+                    // Reference focusable control the chart never touches — its untouched
+                    // AccessibilityView default + IsTabStop=true anchor the interactive asserts.
+                    Button("RefBtn", () => { }),
+                    Charts.PieChart(NonInteractiveSlices, d => d.Value, d => d.Label)
+                        .Width(360).Height(360)
+                        .LabelView((d, _) => Component<CompositeSliceLabel, string>(d.Label))
+                        .ToElement(),
+                    Charts.PieChart(InteractiveSlices, d => d.Value, d => d.Label)
+                        .Width(360).Height(360)
+                        .LabelView((d, _) => Component<CompositeSliceLabel, string>(d.Label), interactive: true)
+                        .ToElement()));
+
+            await Harness.Render();
+
+            var refBtn = H.FindControl<Button>(b => b.Content is string s && s == "RefBtn");
+            H.Check("ChartA11y_LabelView_RefButtonMounted", refBtn is not null);
+            if (refBtn is null) return;
+            var defaultView = AutomationProperties.GetAccessibilityView(refBtn);
+
+            // ── Non-interactive: subtree must be Raw + out of tab order ──
+            var niButtons = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("b-ni"));
+            H.Check("ChartA11y_LabelView_NonInteractiveButtonsMounted", niButtons.Count == 2);
+            H.Check("ChartA11y_LabelView_NonInteractiveButtonsRaw",
+                niButtons.Count == 2 && niButtons.TrueForAll(b =>
+                    AutomationProperties.GetAccessibilityView(b) == AccessibilityView.Raw));
+            H.Check("ChartA11y_LabelView_NonInteractiveButtonsNotTabStop",
+                niButtons.Count == 2 && niButtons.TrueForAll(b => !b.IsTabStop));
+
+            var niText = H.FindText("niA");
+            H.Check("ChartA11y_LabelView_NonInteractiveTextMounted", niText is not null);
+            H.Check("ChartA11y_LabelView_NonInteractiveTextRaw",
+                niText is not null && AutomationProperties.GetAccessibilityView(niText) == AccessibilityView.Raw);
+
+            // Outer wrapper (the composite host the chart wraps) is hit-test invisible —
+            // pointer-invisibility propagates to the whole subtree — and every ancestor up to
+            // it is Raw, so no inner peer surfaces to UIA.
+            bool hitTestBlocked = false;
+            bool ancestorsAllRaw = true;
+            DependencyObject? node = niText is null
+                ? null
+                : Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(niText);
+            while (node is FrameworkElement feNode)
+            {
+                if (AutomationProperties.GetAccessibilityView(feNode) != AccessibilityView.Raw)
+                    ancestorsAllRaw = false;
+                if (!feNode.IsHitTestVisible)
+                {
+                    hitTestBlocked = true;
+                    break;
+                }
+                node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(feNode);
+            }
+            H.Check("ChartA11y_LabelView_WrapperHitTestInvisible", hitTestBlocked);
+            H.Check("ChartA11y_LabelView_SubtreeAncestorsRaw", ancestorsAllRaw);
+
+            // ── Interactive opt-in: subtree must stay exposed + focusable ──
+            var intButtons = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("b-int"));
+            H.Check("ChartA11y_LabelView_InteractiveButtonsMounted", intButtons.Count == 2);
+            H.Check("ChartA11y_LabelView_InteractiveButtonsTabStop",
+                intButtons.Count == 2 && intButtons.TrueForAll(b => b.IsTabStop));
+            H.Check("ChartA11y_LabelView_InteractiveButtonsNotForcedRaw",
+                intButtons.Count == 2 && intButtons.TrueForAll(b =>
+                    AutomationProperties.GetAccessibilityView(b) == defaultView));
+        }
+    }
+
+    /// <summary>
+    /// Same peer-subtree hiding for the axis-tick path (<c>D3Axes</c> custom tick label):
+    /// a non-interactive composite tick label is fully Raw + out of tab order; the
+    /// <c>interactive: true</c> overload leaves it exposed.
+    /// </summary>
+    internal class TickLabelViewSubtreeA11y(Harness h) : SelfTestFixtureBase(h)
+    {
+        private record P(double X, double Y);
+
+        public override async Task RunAsync()
+        {
+            P[] data = [new(0, 10), new(1, 20), new(2, 15)];
+
+            var host = H.CreateHost();
+            XamlInterop.Register(host.Reconciler);
+            host.Mount(ctx =>
+                VStack(
+                    Button("TickRef", () => { }),
+                    Charts.LineChart(data, d => d.X, d => d.Y)
+                        .Width(360).Height(260)
+                        .XTickLabelView(t => VStack(TextBlock("tx" + (int)t), Button("tb-ni" + (int)t, () => { })))
+                        .ToElement(),
+                    Charts.LineChart(data, d => d.X, d => d.Y)
+                        .Width(360).Height(260)
+                        .XTickLabelView(t => VStack(TextBlock("ix" + (int)t), Button("tb-int" + (int)t, () => { })),
+                            interactive: true)
+                        .ToElement()));
+
+            await Harness.Render();
+
+            var refBtn = H.FindControl<Button>(b => b.Content is string s && s == "TickRef");
+            H.Check("ChartA11y_TickView_RefMounted", refBtn is not null);
+            if (refBtn is null) return;
+            var defaultView = AutomationProperties.GetAccessibilityView(refBtn);
+
+            var niButtons = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("tb-ni"));
+            H.Check("ChartA11y_TickView_NonInteractiveMounted", niButtons.Count > 0);
+            H.Check("ChartA11y_TickView_NonInteractiveRaw",
+                niButtons.Count > 0 && niButtons.TrueForAll(b =>
+                    AutomationProperties.GetAccessibilityView(b) == AccessibilityView.Raw));
+            H.Check("ChartA11y_TickView_NonInteractiveNotTabStop",
+                niButtons.Count > 0 && niButtons.TrueForAll(b => !b.IsTabStop));
+
+            var intButtons = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("tb-int"));
+            H.Check("ChartA11y_TickView_InteractiveMounted", intButtons.Count > 0);
+            H.Check("ChartA11y_TickView_InteractiveTabStop",
+                intButtons.Count > 0 && intButtons.TrueForAll(b => b.IsTabStop));
+            H.Check("ChartA11y_TickView_InteractiveNotForcedRaw",
+                intButtons.Count > 0 && intButtons.TrueForAll(b =>
+                    AutomationProperties.GetAccessibilityView(b) == defaultView));
+        }
+    }
+
+    /// <summary>
+    /// Name projection: a <c>LabelView</c> supplied without a string label / DataLabel must let
+    /// the caller's <c>name</c> projection drive the chart's own descriptor — and therefore the
+    /// realized <see cref="ChartPointProvider"/> accessible name — instead of falling back to
+    /// "Slice N".
+    /// </summary>
+    internal class LabelViewNameProjection(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            string[] browsers = ["Chrome", "Edge", "Firefox"];
+
+            var pie = Charts.PieChart(browsers, _ => 1.0)
+                .Title("Browser share")
+                .LabelView((s, _) => TextBlock(s), name: s => s);
+
+            // Descriptor seam: name projection becomes the slice's accessible label.
+            var points = ((IChartAccessibilityData)pie).Series[0].Points;
+            H.Check("ChartA11y_NameProj_DescriptorMatchesProjection",
+                points.Count == 3 && points[0].XLabel == "Chrome"
+                    && points[1].XLabel == "Edge" && points[2].XLabel == "Firefox");
+            H.Check("ChartA11y_NameProj_NoSliceNFallback",
+                points.All(p => !p.XLabel.StartsWith("Slice ")));
+
+            // Realized peer seam: the same names flow through ChartPointProvider.GetName().
+            var owner = new Border();
+            var peer = new ChartAutomationPeer(owner, (IChartAccessibilityData)pie);
+            var names = peer.GetChildren().OfType<ChartPointProvider>()
+                .Select(p => p.GetName()).ToList();
+            H.Check("ChartA11y_NameProj_PeerNamesUseProjection",
+                names.Any(n => n.Contains("Chrome")) && names.All(n => !n.Contains("Slice ")));
 
             await Task.CompletedTask;
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ChartAccessibilityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ChartAccessibilityFixtures.cs
@@ -1544,4 +1544,35 @@ internal static class ChartAccessibilityFixtures
                 yTicks.Count > 0 && yTicks.TrueForAll(tb => AutomationProperties.GetName(tb) == tb.Text));
         }
     }
+
+    /// <summary>
+    /// Issue #162 review — the deferred (<c>Loaded</c>) hide arm is one-shot and can survive a
+    /// pool round-trip if the element is unmounted before it ever loads. When that recycled FE
+    /// is later re-rented for an interactive (or unrelated) element, the pool reset has restored
+    /// <c>IsHitTestVisible=true</c>, so <c>ApplyDeferredHide</c> must skip — otherwise it would
+    /// wrongly force <c>Raw</c>/<c>IsTabStop=false</c> on the new renter's subtree.
+    /// </summary>
+    internal class LabelViewDeferredHideStaleGuard(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            // Recycled-FE-now-interactive: IsHitTestVisible restored to true by the pool reset.
+            var interactiveHost = new Button { Content = "stale-guard-probe", IsTabStop = true, IsHitTestVisible = true };
+            ChartLabelA11y.ApplyDeferredHide(interactiveHost);
+            H.Check("ChartA11y_StaleGuard_Skips_TabStopIntact", interactiveHost.IsTabStop);
+            H.Check("ChartA11y_StaleGuard_Skips_NotRaw",
+                AutomationProperties.GetAccessibilityView(interactiveHost) != AccessibilityView.Raw);
+
+            // Genuine deferred non-interactive load: HideSubtreeOnMount set IsHitTestVisible=false,
+            // so the deferred arm must still apply.
+            var hiddenHost = new Button { Content = "deferred-hide-probe", IsTabStop = true };
+            hiddenHost.IsHitTestVisible = false;
+            ChartLabelA11y.ApplyDeferredHide(hiddenHost);
+            H.Check("ChartA11y_StaleGuard_Applies_NotTabStop", !hiddenHost.IsTabStop);
+            H.Check("ChartA11y_StaleGuard_Applies_Raw",
+                AutomationProperties.GetAccessibilityView(hiddenHost) == AccessibilityView.Raw);
+
+            await Task.CompletedTask;
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ChartAccessibilityFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ChartAccessibilityFixtures.cs
@@ -1421,4 +1421,127 @@ internal static class ChartAccessibilityFixtures
             await Task.CompletedTask;
         }
     }
+
+    /// <summary>
+    /// Issue #162 H1 — the subtree-hide sets <c>IsTabStop=false</c> / <c>IsHitTestVisible=false</c>
+    /// imperatively on inner controls. Those controls are poolable, so the pool's
+    /// <c>CleanElement</c> must restore both on return — otherwise a hidden inner control would
+    /// poison the next unrelated renter with non-tabbable / non-hit-testable state.
+    /// </summary>
+    internal class LabelViewPoolReset(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var pool = new ElementPool();
+            var btn = new Button { Content = "pool-reset-probe" };
+
+            // Mimic exactly what ChartLabelA11y.HideSubtree does to an inner control.
+            btn.IsTabStop = false;
+            btn.IsHitTestVisible = false;
+            AutomationProperties.SetAccessibilityView(btn, AccessibilityView.Raw);
+
+            pool.Return(btn);
+            var rented = pool.TryRent(typeof(Button)) as Button;
+
+            H.Check("ChartA11y_PoolReset_ReusedInstance", ReferenceEquals(btn, rented));
+            H.Check("ChartA11y_PoolReset_IsTabStopRestored", rented is not null && rented.IsTabStop);
+            H.Check("ChartA11y_PoolReset_IsHitTestVisibleRestored", rented is not null && rented.IsHitTestVisible);
+            H.Check("ChartA11y_PoolReset_AccessibilityViewCleared",
+                rented is not null && AutomationProperties.GetAccessibilityView(rented) != AccessibilityView.Raw);
+
+            await Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Issue #162 H2 — the hide is a mount-time side effect, so toggling <c>interactive</c> at
+    /// runtime must force a remount (the label element is keyed by the flag) for the peers/focus
+    /// to actually hide and un-hide. Combined with the H1 pool reset, flipping the flag yields a
+    /// clean realized control each time.
+    /// </summary>
+    internal class LabelViewInteractiveToggle(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            XamlInterop.Register(host.Reconciler);
+            host.Mount(ctx =>
+            {
+                var (interactive, setInteractive) = ctx.UseState(false);
+                return VStack(
+                    Button("ToggleInteractive", () => setInteractive(!interactive)),
+                    Charts.PieChart(NonInteractiveSlices, d => d.Value, d => d.Label)
+                        .Width(360).Height(360)
+                        .LabelView((d, _) => Component<CompositeSliceLabel, string>(d.Label), interactive: interactive)
+                        .ToElement());
+            });
+
+            await Harness.Render();
+
+            // Phase 0 — non-interactive: inner buttons hidden + out of tab order.
+            var b0 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("b-ni"));
+            H.Check("ChartA11y_Toggle_Phase0_Mounted", b0.Count == 2);
+            H.Check("ChartA11y_Toggle_Phase0_Raw",
+                b0.Count == 2 && b0.TrueForAll(b => AutomationProperties.GetAccessibilityView(b) == AccessibilityView.Raw));
+            H.Check("ChartA11y_Toggle_Phase0_NotTabStop",
+                b0.Count == 2 && b0.TrueForAll(b => !b.IsTabStop));
+
+            // Toggle → interactive: keyed remount drops the hide, so peers/focus come back.
+            H.ClickButton("ToggleInteractive");
+            await Harness.Render();
+            var b1 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("b-ni"));
+            H.Check("ChartA11y_Toggle_Phase1_Mounted", b1.Count == 2);
+            H.Check("ChartA11y_Toggle_Phase1_TabStop",
+                b1.Count == 2 && b1.TrueForAll(b => b.IsTabStop));
+            H.Check("ChartA11y_Toggle_Phase1_NotRaw",
+                b1.Count == 2 && b1.TrueForAll(b => AutomationProperties.GetAccessibilityView(b) != AccessibilityView.Raw));
+
+            // Toggle back → hidden again (proves the transition is symmetric, not one-way).
+            H.ClickButton("ToggleInteractive");
+            await Harness.Render();
+            var b2 = H.FindAllControls<Button>(b => b.Content is string s && s.StartsWith("b-ni"));
+            H.Check("ChartA11y_Toggle_Phase2_NotTabStop",
+                b2.Count == 2 && b2.TrueForAll(b => !b.IsTabStop));
+            H.Check("ChartA11y_Toggle_Phase2_Raw",
+                b2.Count == 2 && b2.TrueForAll(b => AutomationProperties.GetAccessibilityView(b) == AccessibilityView.Raw));
+        }
+    }
+
+    /// <summary>
+    /// Issue #162 M2 — the axis-tick <c>name</c> projection must reach the realized element's
+    /// <c>AutomationName</c> for both the X and Y tick paths (the pie name projection is covered
+    /// separately by <see cref="LabelViewNameProjection"/>).
+    /// </summary>
+    internal class TickLabelViewNameProjection(Harness h) : SelfTestFixtureBase(h)
+    {
+        private record P(double X, double Y);
+
+        public override async Task RunAsync()
+        {
+            P[] data = [new(0, 10), new(1, 20), new(2, 15)];
+
+            var host = H.CreateHost();
+            XamlInterop.Register(host.Reconciler);
+            host.Mount(ctx =>
+                Charts.LineChart(data, d => d.X, d => d.Y)
+                    .Width(400).Height(300)
+                    // Render text and the name projection encode the same value, so an
+                    // applied projection means GetName(tb) == tb.Text.
+                    .XTickLabelView(t => TextBlock("TX" + t), name: t => "TX" + t, interactive: true)
+                    .YTickLabelView(t => TextBlock("TY" + t), name: t => "TY" + t, interactive: true)
+                    .ToElement());
+
+            await Harness.Render();
+
+            var xTicks = H.FindAllControls<TextBlock>(tb => tb.Text != null && tb.Text.StartsWith("TX"));
+            var yTicks = H.FindAllControls<TextBlock>(tb => tb.Text != null && tb.Text.StartsWith("TY"));
+
+            H.Check("ChartA11y_TickName_XTicksMounted", xTicks.Count > 0);
+            H.Check("ChartA11y_TickName_YTicksMounted", yTicks.Count > 0);
+            H.Check("ChartA11y_TickName_XNameMatchesProjection",
+                xTicks.Count > 0 && xTicks.TrueForAll(tb => AutomationProperties.GetName(tb) == tb.Text));
+            H.Check("ChartA11y_TickName_YNameMatchesProjection",
+                yTicks.Count > 0 && yTicks.TrueForAll(tb => AutomationProperties.GetName(tb) == tb.Text));
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -144,6 +144,7 @@ internal static class SelfTestFixtureRegistry
         "ChartA11y_LabelViewPoolReset",
         "ChartA11y_LabelViewInteractiveToggle",
         "ChartA11y_TickLabelViewNameProjection",
+        "ChartA11y_LabelViewDeferredHideStaleGuard",
 
         "MdHtml_HtmlGeneration",
         "MdHtml_HtmlInWebView2",
@@ -1556,6 +1557,7 @@ internal static class SelfTestFixtureRegistry
         "ChartA11y_LabelViewPoolReset" => new ChartAccessibilityFixtures.LabelViewPoolReset(harness),
         "ChartA11y_LabelViewInteractiveToggle" => new ChartAccessibilityFixtures.LabelViewInteractiveToggle(harness),
         "ChartA11y_TickLabelViewNameProjection" => new ChartAccessibilityFixtures.TickLabelViewNameProjection(harness),
+        "ChartA11y_LabelViewDeferredHideStaleGuard" => new ChartAccessibilityFixtures.LabelViewDeferredHideStaleGuard(harness),
 
         "Win2D_Canvas_Mount" => new Win2DCanvasFixtures.CanvasMount(harness),
         "Win2D_AnimatedCanvas_Mount" => new Win2DCanvasFixtures.AnimatedCanvasMount(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -138,6 +138,9 @@ internal static class SelfTestFixtureRegistry
         "ChartA11y_OnDemandAnnounce",
         "ChartA11y_FullIntegration",
         "ChartA11y_AutomationPeerProviderExercise",
+        "ChartA11y_LabelViewSubtreeA11y",
+        "ChartA11y_TickLabelViewSubtreeA11y",
+        "ChartA11y_LabelViewNameProjection",
 
         "MdHtml_HtmlGeneration",
         "MdHtml_HtmlInWebView2",
@@ -1544,6 +1547,9 @@ internal static class SelfTestFixtureRegistry
         "ChartA11y_OnDemandAnnounce" => new ChartAccessibilityFixtures.OnDemandAnnounce(harness),
         "ChartA11y_FullIntegration" => new ChartAccessibilityFixtures.FullIntegration(harness),
         "ChartA11y_AutomationPeerProviderExercise" => new ChartAccessibilityFixtures.AutomationPeerProviderExercise(harness),
+        "ChartA11y_LabelViewSubtreeA11y" => new ChartAccessibilityFixtures.LabelViewSubtreeA11y(harness),
+        "ChartA11y_TickLabelViewSubtreeA11y" => new ChartAccessibilityFixtures.TickLabelViewSubtreeA11y(harness),
+        "ChartA11y_LabelViewNameProjection" => new ChartAccessibilityFixtures.LabelViewNameProjection(harness),
 
         "Win2D_Canvas_Mount" => new Win2DCanvasFixtures.CanvasMount(harness),
         "Win2D_AnimatedCanvas_Mount" => new Win2DCanvasFixtures.AnimatedCanvasMount(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -145,6 +145,8 @@ internal static class SelfTestFixtureRegistry
         "ChartA11y_LabelViewInteractiveToggle",
         "ChartA11y_TickLabelViewNameProjection",
         "ChartA11y_LabelViewDeferredHideStaleGuard",
+        "ChartA11y_LabelViewUpdateRehide",
+        "ChartA11y_TickLabelViewInteractiveToggle",
 
         "MdHtml_HtmlGeneration",
         "MdHtml_HtmlInWebView2",
@@ -1558,6 +1560,8 @@ internal static class SelfTestFixtureRegistry
         "ChartA11y_LabelViewInteractiveToggle" => new ChartAccessibilityFixtures.LabelViewInteractiveToggle(harness),
         "ChartA11y_TickLabelViewNameProjection" => new ChartAccessibilityFixtures.TickLabelViewNameProjection(harness),
         "ChartA11y_LabelViewDeferredHideStaleGuard" => new ChartAccessibilityFixtures.LabelViewDeferredHideStaleGuard(harness),
+        "ChartA11y_LabelViewUpdateRehide" => new ChartAccessibilityFixtures.LabelViewUpdateRehide(harness),
+        "ChartA11y_TickLabelViewInteractiveToggle" => new ChartAccessibilityFixtures.TickLabelViewInteractiveToggle(harness),
 
         "Win2D_Canvas_Mount" => new Win2DCanvasFixtures.CanvasMount(harness),
         "Win2D_AnimatedCanvas_Mount" => new Win2DCanvasFixtures.AnimatedCanvasMount(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -141,6 +141,9 @@ internal static class SelfTestFixtureRegistry
         "ChartA11y_LabelViewSubtreeA11y",
         "ChartA11y_TickLabelViewSubtreeA11y",
         "ChartA11y_LabelViewNameProjection",
+        "ChartA11y_LabelViewPoolReset",
+        "ChartA11y_LabelViewInteractiveToggle",
+        "ChartA11y_TickLabelViewNameProjection",
 
         "MdHtml_HtmlGeneration",
         "MdHtml_HtmlInWebView2",
@@ -1550,6 +1553,9 @@ internal static class SelfTestFixtureRegistry
         "ChartA11y_LabelViewSubtreeA11y" => new ChartAccessibilityFixtures.LabelViewSubtreeA11y(harness),
         "ChartA11y_TickLabelViewSubtreeA11y" => new ChartAccessibilityFixtures.TickLabelViewSubtreeA11y(harness),
         "ChartA11y_LabelViewNameProjection" => new ChartAccessibilityFixtures.LabelViewNameProjection(harness),
+        "ChartA11y_LabelViewPoolReset" => new ChartAccessibilityFixtures.LabelViewPoolReset(harness),
+        "ChartA11y_LabelViewInteractiveToggle" => new ChartAccessibilityFixtures.LabelViewInteractiveToggle(harness),
+        "ChartA11y_TickLabelViewNameProjection" => new ChartAccessibilityFixtures.TickLabelViewNameProjection(harness),
 
         "Win2D_Canvas_Mount" => new Win2DCanvasFixtures.CanvasMount(harness),
         "Win2D_AnimatedCanvas_Mount" => new Win2DCanvasFixtures.AnimatedCanvasMount(harness),

--- a/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/PoolResetSetConsistencyTests.cs
@@ -70,6 +70,13 @@ public class PoolResetSetConsistencyTests
             { "XYFocusDown", "modifier takes ElementRef, not FrameworkElement" },
             { "XYFocusLeft", "modifier takes ElementRef, not FrameworkElement" },
             { "XYFocusRight", "modifier takes ElementRef, not FrameworkElement" },
+
+            // No matching modifier — the framework sets IsHitTestVisible imperatively
+            // (chart label/tick subtree hiding, issue #162) and the pool resets it
+            // alongside IsTabStop. There is deliberately no user-facing .IsHitTestVisible
+            // modifier, so there is nothing to trap; documented here so the reset is
+            // recognized as intentional rather than an oversight.
+            { "IsHitTestVisible", "no modifier; framework-internal, reset for chart-label hiding (#162)" },
         };
 
     [Fact]
@@ -171,7 +178,7 @@ class C
     /// <c>ElementPool.CleanElement</c> — from the method's opening brace up
     /// to (but not including) the <c>switch (fe)</c> that begins type-specific
     /// cleanup. Captures both <c>fe.PROP = ...</c> direct sets and
-    /// <c>fe.ClearValue(FrameworkElement.PROPProperty)</c> calls.
+    /// <c>RECEIVER.ClearValue((FrameworkElement|UIElement|Control).PROPProperty)</c> calls.
     /// </summary>
     private static HashSet<string> ReadResetProperties()
     {
@@ -209,16 +216,23 @@ class C
         var commonBlock = source.Substring(braceStart, switchMatch.Index - braceStart);
 
         // ClearValue() is a method call caught separately by the second regex;
-        // filter it out of the direct-assignment match set. Both regexes use
-        // the captured parameter name so renaming `fe` → `element` keeps working.
+        // filter it out of the direct-assignment match set.
         var escapedParam = Regex.Escape(paramName);
         var directAssignments = Regex.Matches(commonBlock, $@"\b{escapedParam}\.(\w+)\s*=")
             .Cast<Match>()
             .Select(m => m.Groups[1].Value)
             .Where(name => name != "ClearValue");
 
+        // ClearValue(OWNER.PROPProperty) resets. Receiver is `\w+` (not pinned to
+        // the captured param) because some resets run on a narrowed cast — e.g.
+        // `if (fe is Control c) c.ClearValue(Control.IsTabStopProperty)` (issue #162).
+        // The owner is restricted to the DependencyObject base types that actually
+        // back FrameworkElement instance properties (FrameworkElement / UIElement /
+        // Control); this deliberately excludes attached-property owners like
+        // AutomationProperties.* and Layout.FlexPanel.* — those are not per-element
+        // FrameworkElement properties and have never been part of this reset set.
         var clearValueProps = Regex.Matches(commonBlock,
-                $@"\b{escapedParam}\.ClearValue\(\s*FrameworkElement\.(\w+)Property\s*\)")
+                @"\b\w+\.ClearValue\(\s*(?:FrameworkElement|UIElement|Control)\.(\w+)Property\s*\)")
             .Cast<Match>()
             .Select(m => m.Groups[1].Value);
 

--- a/tests/Reactor.Tests/ChartsBuilderTests.cs
+++ b/tests/Reactor.Tests/ChartsBuilderTests.cs
@@ -309,6 +309,61 @@ public class ChartsBuilderTests
     }
 
     [Fact]
+    public void PieChart_LabelView_WithNameAndInteractive_StoresAndReturnsThis()
+    {
+        var pie = Charts.PieChart(new[] { 1.0, 2.0, 3.0 }, v => v);
+        var ret = pie.LabelView((_, _) => Factories.TextBlock("slice"), name: v => $"v{v}", interactive: true);
+        Assert.Same(pie, ret);
+    }
+
+    [Fact]
+    public void LineChart_TickLabelView_WithNameAndInteractive_StoresAndReturnsThis()
+    {
+        var chart = Charts.LineChart(SampleData, d => d.X, d => d.Y);
+        Assert.Same(chart, chart.XTickLabelView(_ => Factories.TextBlock("x"), name: v => $"x{v}", interactive: true));
+        Assert.Same(chart, chart.YTickLabelView(_ => Factories.TextBlock("y"), name: v => $"y{v}", interactive: true));
+    }
+
+    [Fact]
+    public void PieChart_LabelView_NameProjection_FeedsSliceDescriptor_WhenNoLabelAccessor()
+    {
+        // Issue #162 #3: a LabelView without a string label/DataLabel previously fell
+        // back to "Slice {i+1}" for screen-reader users. The name projection threads
+        // into the chart's own ChartPointDescriptor so the accessible name matches the
+        // visible label.
+        var pie = Charts.PieChart(new[] { "Chrome", "Edge", "Firefox" }, _ => 1.0)
+            .LabelView((s, _) => Factories.TextBlock(s), name: s => s);
+
+        var points = ((IChartAccessibilityData)pie).Series[0].Points;
+        Assert.Equal("Chrome", points[0].XLabel);
+        Assert.Equal("Edge", points[1].XLabel);
+        Assert.Equal("Firefox", points[2].XLabel);
+    }
+
+    [Fact]
+    public void PieChart_LabelView_NoNameProjection_FallsBackToSliceN()
+    {
+        var pie = Charts.PieChart(new[] { "Chrome", "Edge" }, _ => 1.0)
+            .LabelView((s, _) => Factories.TextBlock(s));
+
+        var points = ((IChartAccessibilityData)pie).Series[0].Points;
+        Assert.Equal("Slice 1", points[0].XLabel);
+        Assert.Equal("Slice 2", points[1].XLabel);
+    }
+
+    [Fact]
+    public void PieChart_LabelView_StringLabelAccessor_WinsOverNameProjection()
+    {
+        // An explicit string label accessor (3rd PieChart arg) stays authoritative.
+        var pie = Charts.PieChart(new[] { "Chrome", "Edge" }, _ => 1.0, s => $"L:{s}")
+            .LabelView((s, _) => Factories.TextBlock(s), name: s => $"N:{s}");
+
+        var points = ((IChartAccessibilityData)pie).Series[0].Points;
+        Assert.Equal("L:Chrome", points[0].XLabel);
+        Assert.Equal("L:Edge", points[1].XLabel);
+    }
+
+    [Fact]
     public void PieChart_SetColors_EmptyArray_DoesNotStoreEmptyPalette()
     {
         // Empty .SetColors() previously stored an empty palette which would


### PR DESCRIPTION
Closes #162.

## Problem

`PieChartElement<T>.LabelView(Func<T,PieSliceLayout,Element>)` and `ChartElement<T>.{X,Y}TickLabelView(Func<double,Element>)` let callers replace the built-in `TextBlock` at a slice centroid / axis tick with any Reactor `Element` (including a custom `Component`). The stopgap wrapped the returned element with `.AccessibilityView(Raw)` + `IsHitTestVisible=false` on the **outer wrapper only**. `Raw` on the outer wrapper does **not** reliably remove **inner** peers from assistive tech / focus traversal, causing:

1. **Double-announcement** — the chart's own `ChartPointDescriptor` names the slice (e.g. "Slice 5: 12 units"); a user `LabelView` containing the same string produces a second peer that announces it again.
2. **Focusable children** — interactive sub-elements (e.g. a `Button`) in the user's `Element` keep their peers; `IsHitTestVisible=false` blocks pointer hits but not keyboard/focus traversal of inner peers.
3. **DataLabel not auto-fed** — when a caller uses `LabelView` and skips the string `LabelAccessor`/`DataLabel`, the slice's accessible name falls back to `"Slice {i+1}"` even though the visual shows a meaningful label.

## Fix

### 1. Force-Raw the whole realized subtree + remove inner focus
New helper `src/Reactor/Charting/Accessibility/ChartLabelA11y.cs`:
- `HideSubtreeOnMount(fe)` sets `IsHitTestVisible=false` on the outer wrapper, then walks the realized visual tree (immediately **and** again on `Loaded`, to cover templated-control inner peers that only realize after load).
- `HideSubtree(root)` recurses via `VisualTreeHelper`, setting `AutomationProperties.AccessibilityView = Raw` on **every** descendant `FrameworkElement` (removes inner peers from the UIA Content/Control views) and `IsTabStop = false` on **every** descendant `Control` (removes inner focusable children from the keyboard tab order).
- Uses only the public `VisualTreeHelper` / `AutomationProperties` API — **no reflection** — so it stays AOT/trim-safe (the core lib treats AOT/trim warnings as errors).

### 2. Opt-in `interactive: true` escape hatch
`LabelView`, `XTickLabelView`, `YTickLabelView` (and `D3Charts.D3Axes`) gain an optional `interactive` param. When `true`, the chart does **not** force-Raw the subtree or remove focus — the caller takes responsibility for the element's accessibility. Default (`false`) = fully hidden from UIA/focus; the chart's own descriptor is the single source of truth.

### 3. `accessibleName` projection
`LabelView`/`XTickLabelView`/`YTickLabelView` gain an optional `name` projection. For pie slices it threads into the `ChartPointDescriptor` (`LabelAccessor?.Invoke(d) ?? _labelName?.Invoke(d) ?? "Slice {i+1}"`), so the accessible name matches the visible label instead of falling back to "Slice N" when a `LabelView` is supplied without a `DataLabel`/`LabelAccessor`. For ticks it applies `AutomationName`.

API additions are optional params (source-compatible — existing single-arg call sites compile unchanged). `reactor.api.txt` regenerated (both copies).

## Tests

- **6 unit tests** (`tests/Reactor.Tests/ChartsBuilderTests.cs`): overload storage, name-projection threading into the descriptor, "Slice N" fallback, `LabelAccessor` precedence.
- **3 selftest fixtures** (`tests/Reactor.AppTests.Host/SelfTest/Fixtures/ChartAccessibilityFixtures.cs`) that build a real PieChart / Chart with a composite-`Component` `LabelView` containing a focusable `Button` + a `TextBlock`, realize the peer tree, and walk the realized `FrameworkElement` subtree asserting: (a) every inner descendant is `AccessibilityView.Raw` and (b) every inner `Control` is not a tab stop for the default non-interactive case; (c) with `interactive:true` the inner peers/tab-stops are intact; (d) the slice's accessible name equals the `name` projection (not "Slice N") when supplied without a `DataLabel`.
- **Negative-test verified**: temporarily reverting the pie fix to pre-fix behavior makes the subtree-Raw / not-tab-stop assertions fail (4 failures), proving the assertions are real.

Peer-tree assertions are automated at the realized-FE level via the selftest tier; descriptor/name threading is verified both at the builder seam (unit) and via a realized `ChartAutomationPeer` (selftest).

Build clean (core lib + tests, ARM64), all unit + ChartA11y selftests green.

## Coordination note (charting a11y is churning)

Per issue #162, charting a11y is actively churning (#628/#629 A11Y_CHART_011, #633 active-background scope, #498 charting↔scanner decoupling). **This PR keeps changes scoped** to the LabelView/TickLabelView peer-subtree + accessibleName paths. The only shared a11y touch is threading `_labelName` into the existing pie `ChartPointDescriptor` construction in `Charts.cs` (one line, additive fallback) — flagging for merge ordering with any concurrent descriptor/scanner work.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

## Review triage (pr-review follow-up)

Applied the coordinator-triaged pr-review findings on top of the original fix:

- **H1 (high) — pool contamination, fixed systemically.** The subtree-hide sets `IsTabStop=false`/`IsHitTestVisible=false` on poolable inner controls. `ElementPool.CleanElement` now `ClearValue`s `UIElement.IsHitTestVisibleProperty` and (guarded) `Control.IsTabStopProperty` next to the existing `AccessibilityView` reset, so a hidden inner control can't return to the pool non-tabbable / non-hit-testable and poison the next unrelated renter. New selftest `ChartA11y_LabelViewPoolReset` rents → sets both false + Raw → returns → re-rents the same instance and asserts all three reset.
- **H2 (high) — interactive toggle is now update-aware.** The hide is a mount-time side effect, so flipping `interactive` in place couldn't undo it. Pie-label and axis-tick elements are now keyed by the interactive flag (`__pielabel{i}_{0|1}`, `__xtick{i}_{0|1}`, `__ytick{i}_{0|1}`), so toggling forces a remount that re-runs (or skips) the hide. New selftest `ChartA11y_LabelViewInteractiveToggle` toggles at runtime and asserts peers/tab-stops hide → un-hide → re-hide. (Relies on the H1 pool reset for the recycled control to come back clean.)
- **M2 (medium) — tick name coverage.** New selftest `ChartA11y_TickLabelViewNameProjection` exercises both `XTickLabelView`/`YTickLabelView` name projections and asserts the value reaches `AutomationName` on the realized tick element.
- **M3 (medium) — docs.** Updated the `charting.md.dt` template signature table + a11y wording (subtree-Raw + interactive opt-in + name projection) and both chart skill copies (`skills/charts.md`, `plugins/reactor/skills/reactor-charts/SKILL.md`); recompiled `charting.md`.
- **L2 (low) — consistency.** Reordered `D3Axes` params (`name` before `interactive`) to match the fluent builders.
- **L1 (low) — docs.** XML-doc note clarifying the pie `name` feeds the slice descriptor (always) while the tick `name` only sets `AutomationName` (intentional asymmetry).
- **M1 (medium) — accepted as-is.** Kept the clean optional-param signatures rather than adding forwarder overloads. The additions are source-compatible (existing call sites compile unchanged) but technically binary-incompatible; acceptable for this pre-1.0, fast-moving framework.

**Merge-ordering:** the only shared-a11y touch remains the additive `_labelName` fallback in the pie `ChartPointDescriptor` — keep an eye on concurrent #633 descriptor work.

All ChartA11y selftests (incl. 3 new), `ElementPoolOptionalReset` selftests, and `PoolResetSetConsistencyTests` + `ChartsBuilderTests` + `ApiIndexGeneratorTests` unit tests green; core lib + host build clean (ARM64); both `reactor.api.txt` copies identical and current.

---

## Re-review follow-up (2nd pr-review pass)

Implemented the 4 findings from the second pr-review run (0 critical, 0 high, 2 medium, 2 low):

- **M1 (correctness) — re-assert the subtree hide on in-place update.** The non-interactive label/tick hide ran only at mount/`Loaded`, so a later in-place data/content update that realized **new** focusable descendants leaked them back into UIA / the tab order. Added an internal `OnUpdateAction` modifier hook (the update-time counterpart to `OnMountAction`) fired from `Reconciler.ApplyModifiers` when `oldM is not null` — i.e. on every in-place update, **after** child reconciliation — plus an internal `OnUpdateAdd` extension. The 3 non-interactive chart sites now wire `.OnUpdateAdd(HideSubtreeOnUpdate)` to re-walk and re-`Raw`/untab the subtree. Internal-only ⇒ **no public API change**. New selftest `ChartA11y_LabelViewUpdateRehide` grows a label from `VStack(TextBlock)` to `VStack(TextBlock, Button)` on a state toggle (stable key ⇒ in-place update) and asserts the update-realized buttons are `Raw` + not tab stops. **Verified red-on-revert** (buttons still mount but leak when the hook is disabled).
- **M2 (alternative-solution + test-coverage) — track `IsTabStop` in the pool-reset convention.** The new `Control.IsTabStop` pool reset was invisible to `PoolResetSetAnalyzer`/`PoolResetSetConsistencyTests`. Added `IsTabStop` to `TrappedProperties` (it has an `.IsTabStop` modifier) and widened the consistency-test `ClearValue` regex to owner-qualified `(FrameworkElement|UIElement|Control).XProperty` on any receiver, so it now sees both the `UIElement.IsHitTestVisible` and `Control.IsTabStop` resets (the allow-list deliberately keeps `AutomationProperties.*` / `FlexPanel.*` attached-property clears excluded). `IsHitTestVisible` has no modifier → documented in `IntentionallyExcluded`. The table-driven analyzer test auto-covers `IsTabStop`.
- **L1 (correctness) — sentinel-based deferred-hide guard.** Replaced the one-shot `Loaded` arm's `IsHitTestVisible` identity guard (which mis-fired on a recycled element that merely carried `IsHitTestVisible=false`) with a private attached `PendingDeferredHide` sentinel set in `HideSubtreeOnMount` and **cleared on unmount** via `.OnUnmountAdd(ClearPendingHide)` (Charting-side, to avoid a Core→Charting layering dependency). `ApplyDeferredHide` now hides only when the sentinel is present and consumes it. Reworked `ChartA11y_LabelViewDeferredHideStaleGuard` to cover no-sentinel-skips / sentinel-applies / cleared-skips. **Verified red-on-revert** (old guard fails 6/7 cases).
- **L2 (test-coverage) — Y-tick + tick interactive-toggle.** New `ChartA11y_TickLabelViewInteractiveToggle` exercises the previously-uncovered Y-tick hide branch and the tick remount-by-`interactive` key for **both** axes (hide → expose → hide).

**Shared-a11y note (merge ordering):** unchanged from above — the only shared touch remains the additive `_labelName` fallback in the pie `ChartPointDescriptor`; watch vs concurrent #633 descriptor work. No public surface change; both `reactor.api.txt` copies unchanged (verified by `ApiIndexGeneratorTests`). Full unit suite (9523), `PoolResetSet` (28), and all ChartA11y selftests green; core lib + host build clean (ARM64, 0 warnings).