### PR TITLE
Fix ItemsView multi-select checkmark flicker on window resize (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,22 @@ Conventions for contributors:
   control is no longer orphaned and the per-control tracking stays consistent.
   `ListView<T>` / `GridView<T>` already remount per realize and are unaffected.
 
+- **ItemsView multi-select checkmark no longer flickers during window resize
+  (issue #383).** In a `SelectionMode=Multiple` `ItemsView<T>`, the per-item
+  selection checkmark visibly faded out/in on every realized row while the
+  window was drag-resized. WinUI's `ItemsView` flips each realized
+  `ItemContainer`'s internal multi-select mode on every clear/prepare recycle
+  round-trip, re-running the `MultiSelectStates.Multiple` opacity storyboard with
+  `useTransitions: true`; and because the inner `ItemsRepeater` recycles its
+  realized set on every ancestor arrange pass during a resize, the storyboard
+  re-fired dozens of times per gesture. The recycle is intrinsic WinUI
+  viewport-manager behavior (not eliminable without regressing ItemsView sizing
+  — see the issue #383 investigation), so Reactor now collapses each realized
+  container's `Multiple`-state opacity storyboard keyframes to zero duration: the
+  animated `GoToState` still runs but snaps the checkmark to full opacity in the
+  same UI tick instead of fading it. Selection behavior, the recycle, and the
+  final checkmark visibility are unchanged — only the spurious fade is gone.
+
 - **`UseAnnounce().Announce(...)` now marshals to the UI thread automatically.**
   Previously, calling `Announce` off the UI thread (e.g. from a `Task.Run`
   continuation) threw `RPC_E_WRONG_THREAD` (0x8001010E) — the underlying WinUI

--- a/src/Reactor/Core/ElementFactory.cs
+++ b/src/Reactor/Core/ElementFactory.cs
@@ -385,6 +385,11 @@ public sealed partial class ElementFactory<T> : IElementFactory
         {
             _keyByControl[control] = key;
             _lastElementByControl[control] = element;
+
+            // Issue #383: arm the multi-select checkmark flicker guard on the
+            // realized container. Idempotent per container instance.
+            if (control is ItemContainer itemContainer)
+                ItemContainerSelectionFlickerGuard.Ensure(itemContainer);
         }
 
         return control ?? new TextBlock { Text = "" };

--- a/src/Reactor/Core/ElementFactory.cs
+++ b/src/Reactor/Core/ElementFactory.cs
@@ -388,6 +388,12 @@ public sealed partial class ElementFactory<T> : IElementFactory
 
             // Issue #383: arm the multi-select checkmark flicker guard on the
             // realized container. Idempotent per container instance.
+            // Intentionally scoped to ItemContainer (the ItemsView item-root
+            // wrapper): LazyVStack/LazyHStack realize into plain panels via
+            // ItemsRepeater, not ItemContainer, and the MultiSelectStates.Multiple
+            // storyboard the guard collapses only ever runs for multi-select
+            // ItemContainers — so widening this to all controls would be inert
+            // work everywhere else. Do not "generalize" it.
             if (control is ItemContainer itemContainer)
                 ItemContainerSelectionFlickerGuard.Ensure(itemContainer);
         }

--- a/src/Reactor/Core/ItemContainerSelectionFlickerGuard.cs
+++ b/src/Reactor/Core/ItemContainerSelectionFlickerGuard.cs
@@ -52,6 +52,16 @@ internal static class ItemContainerSelectionFlickerGuard
 
     // One holder per container instance; tracks whether the storyboard has been
     // neutralized so repeated GetElement reuse never re-processes a container.
+    //
+    // Deliberately a private ConditionalWeakTable rather than the reconciler's
+    // ReactorAttached.StateProperty store: this guard is a self-contained,
+    // reconciler-agnostic mitigation scoped to ItemContainer, and Ensure is
+    // designed to be safe on any ItemContainer — including one that never carries
+    // a ReactorState (e.g. a container a raw WinUI ItemsView realizes, as the
+    // regression fixture exercises directly). Keeping its one-time bookkeeping
+    // isolated avoids coupling to the per-element reconcile state's shape and
+    // lifetime. The weak key collapses with the container, same as the attached
+    // store would.
     private static readonly ConditionalWeakTable<ItemContainer, Holder> Holders = new();
 
     /// <summary>
@@ -75,17 +85,32 @@ internal static class ItemContainerSelectionFlickerGuard
         // not be applied yet for a freshly mounted container. Try now for an
         // already-templated (pooled / re-Ensured) container; otherwise wait for
         // Loaded. Repeated Ensure calls keep retrying until it succeeds.
-        if (!TryNeutralize(container, holder) && !holder.LoadedHooked)
+        if (TryNeutralize(container, holder))
+        {
+            // Succeeded synchronously (or on a later Ensure after a deferred
+            // hook) — drop any Loaded handler a prior attempt left attached so
+            // it doesn't linger on the container until the next Loaded fires.
+            DetachLoaded(container, holder);
+            return;
+        }
+
+        if (!holder.LoadedHooked)
         {
             holder.LoadedHooked = true;
-            RoutedEventHandler? onLoaded = null;
-            onLoaded = (s, _) =>
+            holder.OnLoaded = (s, _) =>
             {
                 if (s is ItemContainer ic && TryNeutralize(ic, holder))
-                    ic.Loaded -= onLoaded;
+                    DetachLoaded(ic, holder);
             };
-            container.Loaded += onLoaded;
+            container.Loaded += holder.OnLoaded;
         }
+    }
+
+    private static void DetachLoaded(ItemContainer container, Holder holder)
+    {
+        if (holder.OnLoaded is null) return;
+        container.Loaded -= holder.OnLoaded;
+        holder.OnLoaded = null;
     }
 
     private static bool TryNeutralize(ItemContainer container, Holder holder)
@@ -171,5 +196,10 @@ internal static class ItemContainerSelectionFlickerGuard
         // containers, and re-templating would re-run the whole arming flow anyway.
         public bool Neutralized;
         public bool LoadedHooked;
+
+        // The deferred one-time Loaded handler, retained so a later synchronous
+        // TryNeutralize success (or the handler itself) can detach it instead of
+        // leaving it subscribed until the container fires Loaded again.
+        public RoutedEventHandler? OnLoaded;
     }
 }

--- a/src/Reactor/Core/ItemContainerSelectionFlickerGuard.cs
+++ b/src/Reactor/Core/ItemContainerSelectionFlickerGuard.cs
@@ -157,6 +157,13 @@ internal static class ItemContainerSelectionFlickerGuard
 
     private sealed class Holder
     {
+        // Set once the container's Multiple storyboard has been collapsed (or
+        // determined to have no MultiSelectStates/Multiple to collapse). Gates
+        // re-entry so repeated GetElement reuse of a pooled container never
+        // re-walks the visual tree. Note: this intentionally will NOT re-collapse
+        // a storyboard if the container is later re-templated with a fresh
+        // (non-zero) Multiple storyboard — not observed in practice for ItemsView
+        // containers, and re-templating would re-run the whole arming flow anyway.
         public bool Neutralized;
         public bool LoadedHooked;
     }

--- a/src/Reactor/Core/ItemContainerSelectionFlickerGuard.cs
+++ b/src/Reactor/Core/ItemContainerSelectionFlickerGuard.cs
@@ -119,7 +119,12 @@ internal static class ItemContainerSelectionFlickerGuard
             return true;
         }
 
-        return false;
+        // The template is applied (we have a root) but there is no
+        // MultiSelectStates group at all — an unusual ItemContainer template.
+        // Give up symmetrically with the no-Multiple-state branch above so we
+        // don't retain the Loaded handler and re-walk the tree on every recycle.
+        holder.Neutralized = true;
+        return true;
     }
 
     private static bool TryCollapseStoryboard(Storyboard? storyboard)

--- a/src/Reactor/Core/ItemContainerSelectionFlickerGuard.cs
+++ b/src/Reactor/Core/ItemContainerSelectionFlickerGuard.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Animation;
+
+namespace Microsoft.UI.Reactor.Core;
+
+/// <summary>
+/// Mitigation for issue #383 — the multi-select checkmark flickers (fades
+/// out/in) on every realized row while the window is drag-resized.
+///
+/// <para>The mechanism is intrinsic to WinUI's <c>ItemsView</c>: on every
+/// <c>OnItemsRepeaterElementClearing</c> / <c>OnItemsRepeaterElementPrepared</c>
+/// round-trip it flips <c>ItemContainer.MultiSelectMode</c> between
+/// <c>Auto</c> and <c>Auto | Multiple</c>, and each flip runs
+/// <c>VisualStateManager.GoToState(&#8230;, useTransitions: true)</c> on the
+/// container's <c>MultiSelectStates</c> group — re-running the storyboard that
+/// animates <c>PART_SelectionCheckbox.Opacity</c> 0&#8594;1. During a window
+/// resize Reactor's host re-runs a full layout pass on every tick, which
+/// drives the inner <c>ItemsRepeater</c> to recycle/realize its working set
+/// (even though nothing the ItemsView owns actually moved), so the storyboard
+/// re-fires dozens of times per gesture and the checkmark visibly flickers.
+/// The recycle itself is a benign pooled round-trip; only the
+/// <c>useTransitions: true</c> opacity animation is visible.</para>
+///
+/// <para>We cannot suppress the recycle without regressing layout (the
+/// repeater re-realizes on every ancestor arrange pass — see issue #383
+/// investigation notes), and <c>ItemContainer.MultiSelectMode</c> /
+/// <c>ItemContainerMultiSelectMode</c> are <c>[MUX_INTERNAL]</c> so we cannot
+/// observe or set the property directly. Instead, once the container's
+/// template is applied, we reach into the public <c>MultiSelectStates</c>
+/// <see cref="VisualStateGroup"/>, find the <c>Multiple</c> state's storyboard,
+/// and collapse its keyframe times to zero. WinUI keeps calling
+/// <c>GoToState("Multiple", useTransitions: true)</c> exactly as before, but a
+/// zero-duration storyboard snaps the checkmark to full opacity in the same UI
+/// tick instead of fading it — eliminating the visible flicker while leaving
+/// selection behavior, the recycle, and the final checkmark visibility
+/// unchanged. This is purely a per-instance, one-time mutation of the
+/// container's own template storyboard; it never calls <c>GoToState</c> (which
+/// is not re-entrancy-safe from inside WinUI's own state transitions) and
+/// touches no shared resource.</para>
+/// </summary>
+internal static class ItemContainerSelectionFlickerGuard
+{
+    private const string MultiSelectStatesGroup = "MultiSelectStates";
+    private const string MultipleState = "Multiple";
+
+    private static readonly KeyTime ZeroKeyTime = KeyTime.FromTimeSpan(TimeSpan.Zero);
+    private static readonly Duration ZeroDuration = new(TimeSpan.Zero);
+
+    // One holder per container instance; tracks whether the storyboard has been
+    // neutralized so repeated GetElement reuse never re-processes a container.
+    private static readonly ConditionalWeakTable<ItemContainer, Holder> Holders = new();
+
+    /// <summary>
+    /// Idempotently arm the flicker guard on a realized <see cref="ItemContainer"/>.
+    /// Safe to call on every <c>GetElement</c>; only the first successful call
+    /// per container instance does any work.
+    /// </summary>
+    internal static void Ensure(ItemContainer container)
+    {
+        if (container is null) return;
+
+        if (!Holders.TryGetValue(container, out var holder))
+        {
+            holder = new Holder();
+            Holders.Add(container, holder);
+        }
+
+        if (holder.Neutralized) return;
+
+        // The control template (which carries the MultiSelectStates group) may
+        // not be applied yet for a freshly mounted container. Try now for an
+        // already-templated (pooled / re-Ensured) container; otherwise wait for
+        // Loaded. Repeated Ensure calls keep retrying until it succeeds.
+        if (!TryNeutralize(container, holder) && !holder.LoadedHooked)
+        {
+            holder.LoadedHooked = true;
+            RoutedEventHandler? onLoaded = null;
+            onLoaded = (s, _) =>
+            {
+                if (s is ItemContainer ic && TryNeutralize(ic, holder))
+                    ic.Loaded -= onLoaded;
+            };
+            container.Loaded += onLoaded;
+        }
+    }
+
+    private static bool TryNeutralize(ItemContainer container, Holder holder)
+    {
+        if (holder.Neutralized) return true;
+        if (VisualTreeHelper.GetChildrenCount(container) == 0) return false;
+        if (VisualTreeHelper.GetChild(container, 0) is not FrameworkElement templateRoot)
+            return false;
+
+        var groups = VisualStateManager.GetVisualStateGroups(templateRoot);
+        for (int gi = 0; gi < groups.Count; gi++)
+        {
+            var group = groups[gi];
+            if (group.Name != MultiSelectStatesGroup) continue;
+
+            var states = group.States;
+            for (int si = 0; si < states.Count; si++)
+            {
+                var state = states[si];
+                if (state.Name != MultipleState) continue;
+
+                if (!TryCollapseStoryboard(state.Storyboard))
+                    return false; // timeline transiently in use — retry later
+                holder.Neutralized = true;
+                return true;
+            }
+
+            // Group found but no Multiple state (shouldn't happen) — stop
+            // retrying so we don't leak a Loaded handler forever.
+            holder.Neutralized = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryCollapseStoryboard(Storyboard? storyboard)
+    {
+        if (storyboard is null) return true;
+
+        try
+        {
+            var children = storyboard.Children;
+            for (int i = 0; i < children.Count; i++)
+            {
+                if (children[i] is DoubleAnimationUsingKeyFrames keyframed)
+                {
+                    var frames = keyframed.KeyFrames;
+                    for (int k = 0; k < frames.Count; k++)
+                        frames[k].KeyTime = ZeroKeyTime;
+                }
+                else
+                {
+                    // Defensive: any non-keyframe timeline (e.g. a plain
+                    // DoubleAnimation) also snaps instantly with a zero duration.
+                    children[i].Duration = ZeroDuration;
+                }
+            }
+
+            return true;
+        }
+        catch (Exception)
+        {
+            // The storyboard was mid-flight and WinUI rejected the edit; a
+            // later realization of this container will retry.
+            return false;
+        }
+    }
+
+    private sealed class Holder
+    {
+        public bool Neutralized;
+        public bool LoadedHooked;
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
@@ -28,6 +28,16 @@ internal static class ItemsViewFixtures
         new("E5", "Endive", 1.99),
     ];
 
+    // Disjoint keys + different count from Catalog, so toggling between them
+    // forces the inner ItemsRepeater to clear and re-prepare every container
+    // (a real recycle round-trip) rather than merely reordering.
+    private static readonly Product[] AltCatalog =
+    [
+        new("X1", "Xigua",    3.49),
+        new("Y2", "Yam",      0.79),
+        new("Z3", "Zucchini", 1.29),
+    ];
+
     // ────────────────────────────────────────────────────────────────────
     //  Mount — verifies the dispatch arm wires the ItemsView at all, that
     //  the framework has materialized the template (PART_ItemsRepeater),
@@ -346,12 +356,16 @@ internal static class ItemsViewFixtures
     //   directly and prove the identical transition now SNAPS to 1.0. The fade
     //   makes the snap load-bearing — a no-op guard would leave it fading.
     //
-    //   Part B — production wiring (auto-arm, no direct Ensure). On an
-    //   ItemContainer realized by a *Reactor* ItemsView, drive the same
-    //   transition WITHOUT calling the guard. The guard, armed from
-    //   ElementFactory.GetElement, must have already collapsed the storyboard so
-    //   the checkmark snaps. This guards the GetElement -> Ensure wiring: if that
-    //   wiring silently breaks, this half fails even though Part A still passes.
+    //   Part B — production wiring (auto-arm, no direct Ensure) + recycle
+    //   survival. On an ItemContainer realized by a *Reactor* ItemsView, first
+    //   poll until the GetElement-armed guard has actually collapsed the Multiple
+    //   storyboard (so the assert doesn't race the deferred Loaded arm on a slow
+    //   runner), then drive the transition WITHOUT calling the guard and assert it
+    //   snaps. This guards the GetElement -> Ensure wiring. Then force a real
+    //   recycle round-trip — toggle the ItemsView to a disjoint keyed item set and
+    //   back, so the inner ItemsRepeater clears and re-prepares its containers (the
+    //   exact OnItemsRepeaterElementClearing/Prepared path that re-fires the
+    //   flicker in production) — and assert a realized container STILL snaps.
     // ────────────────────────────────────────────────────────────────────
 
     internal class ItemsView_MultiSelect_CheckmarkDoesNotFlicker(Harness h) : SelfTestFixtureBase(h)
@@ -405,19 +419,32 @@ internal static class ItemsViewFixtures
 
             // ── Part B: production GetElement -> Ensure auto-arm wiring. ──
             // Mounting a Reactor ItemsView replaces the raw view in the content
-            // area. No direct Ensure call here — this asserts the wiring.
+            // area. A "recycle" button toggles between two disjoint keyed item
+            // sets to force a recycle round-trip in Part C. No direct Ensure call
+            // anywhere here — this asserts the wiring.
             var host = H.CreateHost();
-            host.Mount(_ =>
-                ItemsView(Catalog,
-                    keySelector: p => p.Sku,
-                    viewBuilder: (p, _) => ItemContainer(TextBlock(p.Name))
-                ) with { SelectionMode = WinUI.ItemsViewSelectionMode.Multiple }
-            );
+            host.Mount(ctx =>
+            {
+                var (alt, setAlt) = ctx.UseState(false);
+                var items = alt ? AltCatalog : Catalog;
+                return VStack(
+                    Button("recycle", () => setAlt(!alt)),
+                    (ItemsView(items,
+                        keySelector: p => p.Sku,
+                        viewBuilder: (p, _) => ItemContainer(TextBlock(p.Name))
+                    ) with { SelectionMode = WinUI.ItemsViewSelectionMode.Multiple }).Height(400)
+                );
+            });
 
-            // Two render passes so realized containers fire Loaded, which is
-            // when the GetElement-armed guard collapses their storyboard.
-            await Harness.Render();
-            await Harness.Render();
+            // Poll until the deferred-Loaded arm has actually collapsed the
+            // storyboard, instead of relying on a fixed render-pass budget
+            // (cheap insurance against CI flake on slower runners).
+            var armed = await Harness.WaitFor(() =>
+            {
+                var c = H.FindControl<WinUI.ItemContainer>(_ => true);
+                return c is not null && IsMultipleStoryboardCollapsed(c);
+            });
+            H.Check("ItemsViewFlicker_AutoArm_GuardCollapsedStoryboard", armed);
 
             var realized = H.FindControl<WinUI.ItemContainer>(_ => true);
             H.Check("ItemsViewFlicker_AutoArm_ContainerRealized", realized is not null);
@@ -432,7 +459,78 @@ internal static class ItemsViewFixtures
             Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Multiple", true);
             H.Check($"ItemsViewFlicker_AutoArmed_Snaps_opacity={checkbox.Opacity:F3}",
                 checkbox.Opacity >= 0.999);
+
+            // ── Part C: survive a real recycle round-trip. ──
+            // Toggle to the disjoint keyed set and back, forcing the inner
+            // ItemsRepeater to clear + re-prepare its containers — the exact
+            // production trigger that re-fires the flicker. A reused container
+            // keeps its collapsed storyboard; a freshly realized one is re-armed
+            // on prepare. Either way the checkmark must still snap.
+            H.ClickButton("recycle");
+            await Harness.Render();
+            await Harness.Render();
+            H.ClickButton("recycle");
+            await Harness.Render();
+            await Harness.Render();
+
+            var recycledArmed = await Harness.WaitFor(() =>
+            {
+                var c = H.FindControl<WinUI.ItemContainer>(_ => true);
+                return c is not null && IsMultipleStoryboardCollapsed(c);
+            });
+            H.Check("ItemsViewFlicker_Recycle_GuardCollapsedStoryboard", recycledArmed);
+
+            var recycled = H.FindControl<WinUI.ItemContainer>(_ => true);
+            H.Check("ItemsViewFlicker_Recycle_ContainerRealized", recycled is not null);
+            if (recycled is null) return;
+
+            var recycledCheckbox = FindNamedDescendant(recycled, "PART_SelectionCheckbox");
+            H.Check("ItemsViewFlicker_Recycle_CheckmarkPartFound", recycledCheckbox is not null);
+            if (recycledCheckbox is null) return;
+
+            Microsoft.UI.Xaml.VisualStateManager.GoToState(recycled, "Single", false);
+            await Harness.Render();
+            Microsoft.UI.Xaml.VisualStateManager.GoToState(recycled, "Multiple", true);
+            H.Check($"ItemsViewFlicker_Recycle_Snaps_opacity={recycledCheckbox.Opacity:F3}",
+                recycledCheckbox.Opacity >= 0.999);
         }
+    }
+
+    // True once the container's MultiSelectStates.Multiple opacity storyboard has
+    // been collapsed by the guard — i.e. every keyframe KeyTime is zero. Used to
+    // poll for the deferred-Loaded arm completing before asserting.
+    private static bool IsMultipleStoryboardCollapsed(WinUI.ItemContainer container)
+    {
+        if (Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(container) == 0)
+            return false;
+        if (Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(container, 0)
+                is not Microsoft.UI.Xaml.FrameworkElement root)
+            return false;
+
+        var groups = Microsoft.UI.Xaml.VisualStateManager.GetVisualStateGroups(root);
+        foreach (var group in groups)
+        {
+            if (group.Name != "MultiSelectStates") continue;
+            foreach (var state in group.States)
+            {
+                if (state.Name != "Multiple" || state.Storyboard is null) continue;
+                bool sawKeyframe = false;
+                foreach (var child in state.Storyboard.Children)
+                {
+                    if (child is Microsoft.UI.Xaml.Media.Animation.DoubleAnimationUsingKeyFrames kf)
+                    {
+                        foreach (var f in kf.KeyFrames)
+                        {
+                            sawKeyframe = true;
+                            if (f.KeyTime.TimeSpan != global::System.TimeSpan.Zero)
+                                return false;
+                        }
+                    }
+                }
+                return sawKeyframe;
+            }
+        }
+        return false;
     }
 
     private static Microsoft.UI.Xaml.FrameworkElement? FindNamedDescendant(

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
@@ -318,4 +318,82 @@ internal static class ItemsViewFixtures
             }
         }
     }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Regression (issue #383): in a SelectionMode=Multiple ItemsView the
+    //  per-item selection checkmark flickered (faded out/in) on every realized
+    //  row during a window drag-resize. WinUI's ItemsView flips each realized
+    //  ItemContainer's internal MultiSelectMode on every recycle round-trip,
+    //  re-running MultiSelectStates.Multiple's opacity storyboard with
+    //  useTransitions:true — and Reactor's host re-lays-out on every resize
+    //  tick, so the inner ItemsRepeater recycles its working set dozens of
+    //  times per gesture and the storyboard re-fires over and over.
+    //
+    //  The mitigation (ItemContainerSelectionFlickerGuard) collapses the
+    //  Multiple state's opacity storyboard to zero duration on each realized
+    //  container, so WinUI's animated GoToState snaps the checkmark to full
+    //  opacity instantly instead of fading it.
+    //
+    //  This fixture drives the exact animated transition WinUI fires on a
+    //  recycle (Single -> Multiple, useTransitions:true) on a realized
+    //  container and asserts the checkmark opacity has been *snapped* to its
+    //  final value (1.0) rather than left mid-fade (~0). Without the guard the
+    //  animated transition would read ~0 immediately after GoToState.
+    // ────────────────────────────────────────────────────────────────────
+
+    internal class ItemsView_MultiSelect_CheckmarkDoesNotFlicker(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(_ =>
+                ItemsView(Catalog,
+                    keySelector: p => p.Sku,
+                    viewBuilder: (p, _) => ItemContainer(TextBlock(p.Name))
+                ) with { SelectionMode = WinUI.ItemsViewSelectionMode.Multiple }
+            );
+
+            await Harness.Render();
+
+            var container = H.FindControl<WinUI.ItemContainer>(_ => true);
+            H.Check("ItemsViewFlicker_HasRealizedContainer", container is not null);
+            if (container is null) return;
+
+            // Make neutralization deterministic regardless of Loaded timing:
+            // Ensure is idempotent and retries once the template is applied (it
+            // is by now). In production this is armed from ElementFactory.GetElement.
+            ItemContainerSelectionFlickerGuard.Ensure(container);
+
+            var checkbox = FindNamedDescendant(container, "PART_SelectionCheckbox");
+            H.Check("ItemsViewFlicker_CheckmarkPartFound", checkbox is not null);
+            if (checkbox is null) return;
+
+            // Reset to the "no checkmark" state, then drive the animated
+            // transition WinUI fires on every recycle round-trip.
+            Microsoft.UI.Xaml.VisualStateManager.GoToState(container, "Single", false);
+            await Harness.Render();
+            Microsoft.UI.Xaml.VisualStateManager.GoToState(container, "Multiple", true);
+
+            // With the storyboard collapsed to zero duration, the animated
+            // transition reaches its final keyframe value (Opacity = 1)
+            // immediately — no fade.
+            H.Check($"ItemsViewFlicker_CheckmarkSnappedNotFaded_opacity={checkbox.Opacity:F3}",
+                checkbox.Opacity >= 0.999);
+        }
+    }
+
+    private static Microsoft.UI.Xaml.FrameworkElement? FindNamedDescendant(
+        Microsoft.UI.Xaml.DependencyObject root, string name)
+    {
+        int count = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var child = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is Microsoft.UI.Xaml.FrameworkElement fe && fe.Name == name)
+                return fe;
+            var found = FindNamedDescendant(child, name);
+            if (found is not null) return found;
+        }
+        return null;
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
@@ -334,31 +334,78 @@ internal static class ItemsViewFixtures
     //  container, so WinUI's animated GoToState snaps the checkmark to full
     //  opacity instantly instead of fading it.
     //
-    //  This fixture is load-bearing in three complementary checks, all on a
-    //  real realized container from a live SelectionMode=Multiple ItemsView (the
-    //  only place ItemContainer actually realizes PART_SelectionCheckbox):
+    //  This fixture is load-bearing in two complementary halves, both on a real
+    //  realized container from a live SelectionMode=Multiple ItemsView (the only
+    //  place ItemContainer actually realizes PART_SelectionCheckbox):
     //
-    //   1. Production wiring: WITHOUT calling the guard directly, drive the
-    //      animated Single -> Multiple transition WinUI fires on a recycle. The
-    //      guard, armed from ElementFactory.GetElement, must have already
-    //      collapsed the storyboard so the checkmark snaps to 1.0.
+    //   Part A — guard mechanism (direct Ensure, before/after). On an
+    //   ItemContainer realized by a *raw WinUI* ItemsView (so it never went
+    //   through Reactor's ElementFactory and is therefore un-armed), prove the
+    //   animated Single -> Multiple transition genuinely FADES (opacity has not
+    //   reached 1.0 the instant after GoToState), then call the guard's Ensure
+    //   directly and prove the identical transition now SNAPS to 1.0. The fade
+    //   makes the snap load-bearing — a no-op guard would leave it fading.
     //
-    //   2. Un-guarded fade proof: restore a real, non-zero keyframe duration on
-    //      that same container's Multiple storyboard — i.e. reproduce the
-    //      un-guarded WinUI default — and prove the identical transition now
-    //      genuinely FADES (opacity has not reached 1.0 the instant after
-    //      GoToState). This guarantees the snap in check 1 is not
-    //      green-by-construction: a regressed guard that left the keyframe alone
-    //      would land here and flicker.
-    //
-    //   3. Re-collapse proof: re-zero the keyframe (the guard's exact operation)
-    //      and prove the same transition SNAPS to 1.0 again.
+    //   Part B — production wiring (auto-arm, no direct Ensure). On an
+    //   ItemContainer realized by a *Reactor* ItemsView, drive the same
+    //   transition WITHOUT calling the guard. The guard, armed from
+    //   ElementFactory.GetElement, must have already collapsed the storyboard so
+    //   the checkmark snaps. This guards the GetElement -> Ensure wiring: if that
+    //   wiring silently breaks, this half fails even though Part A still passes.
     // ────────────────────────────────────────────────────────────────────
 
     internal class ItemsView_MultiSelect_CheckmarkDoesNotFlicker(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()
         {
+            // ── Part A: guard mechanism on an un-armed raw-WinUI container. ──
+            // A raw WinUI ItemsView realizes its own ItemContainers (never through
+            // Reactor's ElementFactory), so the guard has NOT auto-armed them.
+            // Done before any Reactor host owns the content area.
+            var rawView = new WinUI.ItemsView
+            {
+                Width = 300,
+                Height = 400,
+                SelectionMode = WinUI.ItemsViewSelectionMode.Multiple,
+                ItemsSource = new[] { "a", "b", "c", "d", "e" },
+                ItemTemplate = (Microsoft.UI.Xaml.DataTemplate)Microsoft.UI.Xaml.Markup.XamlReader.Load(
+                    "<DataTemplate xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\">" +
+                    "<ItemContainer><TextBlock Text=\"{Binding}\"/></ItemContainer></DataTemplate>"),
+            };
+            H.SetContent(rawView);
+            await Harness.Render();
+            await Harness.Render();
+
+            var rawContainer = H.FindControl<WinUI.ItemContainer>(_ => true);
+            H.Check("ItemsViewFlicker_DirectEnsure_ContainerRealized", rawContainer is not null);
+            if (rawContainer is not null)
+            {
+                var rawCheckbox = FindNamedDescendant(rawContainer, "PART_SelectionCheckbox");
+                H.Check("ItemsViewFlicker_DirectEnsure_CheckmarkPartFound", rawCheckbox is not null);
+                if (rawCheckbox is not null)
+                {
+                    // BEFORE: un-armed → the animated transition genuinely fades.
+                    Microsoft.UI.Xaml.VisualStateManager.GoToState(rawContainer, "Single", false);
+                    await Harness.Render();
+                    Microsoft.UI.Xaml.VisualStateManager.GoToState(rawContainer, "Multiple", true);
+                    var before = rawCheckbox.Opacity;
+                    H.Check($"ItemsViewFlicker_DirectEnsure_Before_Fades_opacity={before:F3}",
+                        before < 0.999);
+
+                    // AFTER: arm the guard directly → identical transition snaps.
+                    Microsoft.UI.Xaml.VisualStateManager.GoToState(rawContainer, "Single", false);
+                    await Harness.Render();
+                    ItemContainerSelectionFlickerGuard.Ensure(rawContainer);
+                    Microsoft.UI.Xaml.VisualStateManager.GoToState(rawContainer, "Multiple", true);
+                    var after = rawCheckbox.Opacity;
+                    H.Check($"ItemsViewFlicker_DirectEnsure_After_Snaps_opacity={after:F3}",
+                        after >= 0.999);
+                }
+            }
+
+            // ── Part B: production GetElement -> Ensure auto-arm wiring. ──
+            // Mounting a Reactor ItemsView replaces the raw view in the content
+            // area. No direct Ensure call here — this asserts the wiring.
             var host = H.CreateHost();
             host.Mount(_ =>
                 ItemsView(Catalog,
@@ -373,76 +420,19 @@ internal static class ItemsViewFixtures
             await Harness.Render();
 
             var realized = H.FindControl<WinUI.ItemContainer>(_ => true);
-            H.Check("ItemsViewFlicker_HasRealizedContainer", realized is not null);
+            H.Check("ItemsViewFlicker_AutoArm_ContainerRealized", realized is not null);
             if (realized is null) return;
 
             var checkbox = FindNamedDescendant(realized, "PART_SelectionCheckbox");
-            H.Check("ItemsViewFlicker_CheckmarkPartFound", checkbox is not null);
+            H.Check("ItemsViewFlicker_AutoArm_CheckmarkPartFound", checkbox is not null);
             if (checkbox is null) return;
 
-            // ── Check 1: production GetElement -> Ensure auto-arm path. ──
-            // No direct Ensure call here — this asserts the production wiring
-            // already collapsed the storyboard so the animated transition snaps.
             Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Single", false);
             await Harness.Render();
             Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Multiple", true);
             H.Check($"ItemsViewFlicker_AutoArmed_Snaps_opacity={checkbox.Opacity:F3}",
                 checkbox.Opacity >= 0.999);
-
-            // Locate the very storyboard animation the guard collapses.
-            var anim = FindMultipleOpacityAnimation(realized);
-            H.Check("ItemsViewFlicker_MultipleAnimationFound", anim is not null);
-            if (anim is null) return;
-
-            // ── Check 2: un-guarded fade proof (load-bearing). ──
-            // Restore a real, non-zero keyframe duration: this is exactly the
-            // state a regressed/absent guard would leave behind. The same
-            // transition must now FADE rather than snap.
-            foreach (var f in anim.KeyFrames)
-                f.KeyTime = Microsoft.UI.Xaml.Media.Animation.KeyTime.FromTimeSpan(
-                    global::System.TimeSpan.FromMilliseconds(300));
-            Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Single", false);
-            await Harness.Render();
-            Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Multiple", true);
-            var faded = checkbox.Opacity;
-            H.Check($"ItemsViewFlicker_Unguarded_Fades_opacity={faded:F3}", faded < 0.999);
-
-            // ── Check 3: re-collapse proof (the guard's exact operation). ──
-            foreach (var f in anim.KeyFrames)
-                f.KeyTime = Microsoft.UI.Xaml.Media.Animation.KeyTime.FromTimeSpan(
-                    global::System.TimeSpan.Zero);
-            Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Single", false);
-            await Harness.Render();
-            Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Multiple", true);
-            H.Check($"ItemsViewFlicker_Recollapsed_Snaps_opacity={checkbox.Opacity:F3}",
-                checkbox.Opacity >= 0.999);
         }
-    }
-
-    // Mirrors ItemContainerSelectionFlickerGuard's walk: MultiSelectStates group
-    // -> Multiple state -> the DoubleAnimationUsingKeyFrames the guard collapses.
-    private static Microsoft.UI.Xaml.Media.Animation.DoubleAnimationUsingKeyFrames?
-        FindMultipleOpacityAnimation(WinUI.ItemContainer container)
-    {
-        if (Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(container) == 0)
-            return null;
-        if (Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(container, 0)
-                is not Microsoft.UI.Xaml.FrameworkElement root)
-            return null;
-
-        var groups = Microsoft.UI.Xaml.VisualStateManager.GetVisualStateGroups(root);
-        foreach (var group in groups)
-        {
-            if (group.Name != "MultiSelectStates") continue;
-            foreach (var state in group.States)
-            {
-                if (state.Name != "Multiple" || state.Storyboard is null) continue;
-                foreach (var child in state.Storyboard.Children)
-                    if (child is Microsoft.UI.Xaml.Media.Animation.DoubleAnimationUsingKeyFrames kf)
-                        return kf;
-            }
-        }
-        return null;
     }
 
     private static Microsoft.UI.Xaml.FrameworkElement? FindNamedDescendant(

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
@@ -508,23 +508,20 @@ internal static class ItemsViewFixtures
             return false;
 
         var groups = Microsoft.UI.Xaml.VisualStateManager.GetVisualStateGroups(root);
-        foreach (var group in groups)
+        foreach (var group in groups.Where(group => group.Name == "MultiSelectStates"))
         {
-            if (group.Name != "MultiSelectStates") continue;
-            foreach (var state in group.States)
+            foreach (var state in group.States.Where(
+                state => state.Name == "Multiple" && state.Storyboard is not null))
             {
-                if (state.Name != "Multiple" || state.Storyboard is null) continue;
                 bool sawKeyframe = false;
-                foreach (var child in state.Storyboard.Children)
+                foreach (var kf in state.Storyboard!.Children
+                    .OfType<Microsoft.UI.Xaml.Media.Animation.DoubleAnimationUsingKeyFrames>())
                 {
-                    if (child is Microsoft.UI.Xaml.Media.Animation.DoubleAnimationUsingKeyFrames kf)
+                    foreach (var f in kf.KeyFrames)
                     {
-                        foreach (var f in kf.KeyFrames)
-                        {
-                            sawKeyframe = true;
-                            if (f.KeyTime.TimeSpan != global::System.TimeSpan.Zero)
-                                return false;
-                        }
+                        sawKeyframe = true;
+                        if (f.KeyTime.TimeSpan != global::System.TimeSpan.Zero)
+                            return false;
                     }
                 }
                 return sawKeyframe;

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
@@ -334,11 +334,25 @@ internal static class ItemsViewFixtures
     //  container, so WinUI's animated GoToState snaps the checkmark to full
     //  opacity instantly instead of fading it.
     //
-    //  This fixture drives the exact animated transition WinUI fires on a
-    //  recycle (Single -> Multiple, useTransitions:true) on a realized
-    //  container and asserts the checkmark opacity has been *snapped* to its
-    //  final value (1.0) rather than left mid-fade (~0). Without the guard the
-    //  animated transition would read ~0 immediately after GoToState.
+    //  This fixture is load-bearing in three complementary checks, all on a
+    //  real realized container from a live SelectionMode=Multiple ItemsView (the
+    //  only place ItemContainer actually realizes PART_SelectionCheckbox):
+    //
+    //   1. Production wiring: WITHOUT calling the guard directly, drive the
+    //      animated Single -> Multiple transition WinUI fires on a recycle. The
+    //      guard, armed from ElementFactory.GetElement, must have already
+    //      collapsed the storyboard so the checkmark snaps to 1.0.
+    //
+    //   2. Un-guarded fade proof: restore a real, non-zero keyframe duration on
+    //      that same container's Multiple storyboard — i.e. reproduce the
+    //      un-guarded WinUI default — and prove the identical transition now
+    //      genuinely FADES (opacity has not reached 1.0 the instant after
+    //      GoToState). This guarantees the snap in check 1 is not
+    //      green-by-construction: a regressed guard that left the keyframe alone
+    //      would land here and flicker.
+    //
+    //   3. Re-collapse proof: re-zero the keyframe (the guard's exact operation)
+    //      and prove the same transition SNAPS to 1.0 again.
     // ────────────────────────────────────────────────────────────────────
 
     internal class ItemsView_MultiSelect_CheckmarkDoesNotFlicker(Harness h) : SelfTestFixtureBase(h)
@@ -353,33 +367,82 @@ internal static class ItemsViewFixtures
                 ) with { SelectionMode = WinUI.ItemsViewSelectionMode.Multiple }
             );
 
+            // Two render passes so realized containers fire Loaded, which is
+            // when the GetElement-armed guard collapses their storyboard.
+            await Harness.Render();
             await Harness.Render();
 
-            var container = H.FindControl<WinUI.ItemContainer>(_ => true);
-            H.Check("ItemsViewFlicker_HasRealizedContainer", container is not null);
-            if (container is null) return;
+            var realized = H.FindControl<WinUI.ItemContainer>(_ => true);
+            H.Check("ItemsViewFlicker_HasRealizedContainer", realized is not null);
+            if (realized is null) return;
 
-            // Make neutralization deterministic regardless of Loaded timing:
-            // Ensure is idempotent and retries once the template is applied (it
-            // is by now). In production this is armed from ElementFactory.GetElement.
-            ItemContainerSelectionFlickerGuard.Ensure(container);
-
-            var checkbox = FindNamedDescendant(container, "PART_SelectionCheckbox");
+            var checkbox = FindNamedDescendant(realized, "PART_SelectionCheckbox");
             H.Check("ItemsViewFlicker_CheckmarkPartFound", checkbox is not null);
             if (checkbox is null) return;
 
-            // Reset to the "no checkmark" state, then drive the animated
-            // transition WinUI fires on every recycle round-trip.
-            Microsoft.UI.Xaml.VisualStateManager.GoToState(container, "Single", false);
+            // ── Check 1: production GetElement -> Ensure auto-arm path. ──
+            // No direct Ensure call here — this asserts the production wiring
+            // already collapsed the storyboard so the animated transition snaps.
+            Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Single", false);
             await Harness.Render();
-            Microsoft.UI.Xaml.VisualStateManager.GoToState(container, "Multiple", true);
+            Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Multiple", true);
+            H.Check($"ItemsViewFlicker_AutoArmed_Snaps_opacity={checkbox.Opacity:F3}",
+                checkbox.Opacity >= 0.999);
 
-            // With the storyboard collapsed to zero duration, the animated
-            // transition reaches its final keyframe value (Opacity = 1)
-            // immediately — no fade.
-            H.Check($"ItemsViewFlicker_CheckmarkSnappedNotFaded_opacity={checkbox.Opacity:F3}",
+            // Locate the very storyboard animation the guard collapses.
+            var anim = FindMultipleOpacityAnimation(realized);
+            H.Check("ItemsViewFlicker_MultipleAnimationFound", anim is not null);
+            if (anim is null) return;
+
+            // ── Check 2: un-guarded fade proof (load-bearing). ──
+            // Restore a real, non-zero keyframe duration: this is exactly the
+            // state a regressed/absent guard would leave behind. The same
+            // transition must now FADE rather than snap.
+            foreach (var f in anim.KeyFrames)
+                f.KeyTime = Microsoft.UI.Xaml.Media.Animation.KeyTime.FromTimeSpan(
+                    global::System.TimeSpan.FromMilliseconds(300));
+            Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Single", false);
+            await Harness.Render();
+            Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Multiple", true);
+            var faded = checkbox.Opacity;
+            H.Check($"ItemsViewFlicker_Unguarded_Fades_opacity={faded:F3}", faded < 0.999);
+
+            // ── Check 3: re-collapse proof (the guard's exact operation). ──
+            foreach (var f in anim.KeyFrames)
+                f.KeyTime = Microsoft.UI.Xaml.Media.Animation.KeyTime.FromTimeSpan(
+                    global::System.TimeSpan.Zero);
+            Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Single", false);
+            await Harness.Render();
+            Microsoft.UI.Xaml.VisualStateManager.GoToState(realized, "Multiple", true);
+            H.Check($"ItemsViewFlicker_Recollapsed_Snaps_opacity={checkbox.Opacity:F3}",
                 checkbox.Opacity >= 0.999);
         }
+    }
+
+    // Mirrors ItemContainerSelectionFlickerGuard's walk: MultiSelectStates group
+    // -> Multiple state -> the DoubleAnimationUsingKeyFrames the guard collapses.
+    private static Microsoft.UI.Xaml.Media.Animation.DoubleAnimationUsingKeyFrames?
+        FindMultipleOpacityAnimation(WinUI.ItemContainer container)
+    {
+        if (Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(container) == 0)
+            return null;
+        if (Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(container, 0)
+                is not Microsoft.UI.Xaml.FrameworkElement root)
+            return null;
+
+        var groups = Microsoft.UI.Xaml.VisualStateManager.GetVisualStateGroups(root);
+        foreach (var group in groups)
+        {
+            if (group.Name != "MultiSelectStates") continue;
+            foreach (var state in group.States)
+            {
+                if (state.Name != "Multiple" || state.Storyboard is null) continue;
+                foreach (var child in state.Storyboard.Children)
+                    if (child is Microsoft.UI.Xaml.Media.Animation.DoubleAnimationUsingKeyFrames kf)
+                        return kf;
+            }
+        }
+        return null;
     }
 
     private static Microsoft.UI.Xaml.FrameworkElement? FindNamedDescendant(
@@ -397,3 +460,4 @@ internal static class ItemsViewFixtures
         return null;
     }
 }
+

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ItemsViewFixtures.cs
@@ -466,12 +466,32 @@ internal static class ItemsViewFixtures
             // production trigger that re-fires the flicker. A reused container
             // keeps its collapsed storyboard; a freshly realized one is re-armed
             // on prepare. Either way the checkmark must still snap.
+            //
+            // Assert the realized dataset genuinely swapped each way before
+            // checking the snap — otherwise the round-trip could pass vacuously
+            // if the toggle ever stopped realizing a new set. AltCatalog has
+            // fully disjoint keys AND a different cardinality from Catalog, so a
+            // successful toggle (a) changes the bound source count and (b) forces
+            // every container to be cleared + re-prepared (no key reuse). Reading
+            // the source count is pool-proof: WinUI keeps cleared containers
+            // parented in its recycle pool with stale text, so a tree-wide
+            // FindText would still match the old set.
+            int SourceCount() =>
+                (H.FindControl<WinUI.ItemsView>(_ => true)?.ItemsSource
+                    as global::System.Collections.ICollection)?.Count ?? -1;
+
             H.ClickButton("recycle");
-            await Harness.Render();
-            await Harness.Render();
+            var swappedToAlt = await Harness.WaitFor(() =>
+                // "Xigua" exists only in AltCatalog, so a realized container
+                // showing it proves a fresh prepare ran (not a pooled-stale
+                // leftover); the source-count change confirms the swap.
+                H.FindText("Xigua") is not null && SourceCount() == AltCatalog.Length);
+            H.Check("ItemsViewFlicker_Recycle_SwappedToAltSet", swappedToAlt);
+
             H.ClickButton("recycle");
-            await Harness.Render();
-            await Harness.Render();
+            var swappedBack = await Harness.WaitFor(() =>
+                H.FindText("Apple") is not null && SourceCount() == Catalog.Length);
+            H.Check("ItemsViewFlicker_Recycle_SwappedBackToOriginal", swappedBack);
 
             var recycledArmed = await Harness.WaitFor(() =>
             {

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -168,6 +168,7 @@ internal static class SelfTestFixtureRegistry
         "ItemsView_SelectionMode_Applied",
         "ItemsView_Selection_SurvivesRerender",
         "ItemsView_Rerender_DoesNotMarkContainersModified",
+        "ItemsView_MultiSelect_CheckmarkDoesNotFlicker",
         // Spec 042 Phase 1 — keyed-list reconciliation end-to-end fixtures.
         "KLR_ListView_MountsOcSource",
         "KLR_ListView_InsertAtZero_EmitsSingleAdd",
@@ -1579,6 +1580,7 @@ internal static class SelfTestFixtureRegistry
         "ItemsView_SelectionMode_Applied" => new ItemsViewFixtures.ItemsView_SelectionMode_Applied(harness),
         "ItemsView_Selection_SurvivesRerender" => new ItemsViewFixtures.ItemsView_Selection_SurvivesRerender(harness),
         "ItemsView_Rerender_DoesNotMarkContainersModified" => new ItemsViewFixtures.ItemsView_Rerender_DoesNotMarkContainersModified(harness),
+        "ItemsView_MultiSelect_CheckmarkDoesNotFlicker" => new ItemsViewFixtures.ItemsView_MultiSelect_CheckmarkDoesNotFlicker(harness),
         // Spec 042 Phase 1 — keyed-list reconciliation end-to-end.
         "KLR_ListView_MountsOcSource" => new KeyedListReconciliationFixtures.ListView_MountsOcSource(harness),
         "KLR_ListView_InsertAtZero_EmitsSingleAdd" => new KeyedListReconciliationFixtures.ListView_InsertAtZero_EmitsSingleAdd(harness),


### PR DESCRIPTION
Closes #383.

## Symptom
In an `ItemsView` with `SelectionMode=Multiple` (e.g. samples/Reactor.TestApp → ItemsView tab), the per-item selection checkmark visibly **fades out/in on every realized row** while the user drag-resizes the window.

## Root cause (proven, not surgically fixable in layout)
The fade itself is intrinsic WinUI behavior: on every `ItemsRepeater` recycle round-trip, `ItemsView` flips each realized `ItemContainer`'s internal `MultiSelectMode` (`Auto` ↔ `Auto|Multiple`), and each flip runs the `MultiSelectStates.Multiple` opacity storyboard (`PART_SelectionCheckbox.Opacity` 0→1) with `useTransitions: true`.

What makes it *visible in Reactor specifically* is **frequency**: during a window resize Reactor's host re-runs a full layout pass on every tick, which drives the inner `ItemsRepeater` to recycle/realize its working set dozens of times per gesture — even though nothing the ItemsView owns actually moved.

I instrumented this exhaustively (headless zero-reconcile repro + per-panel measure/arrange counters + inner ScrollView/repeater geometry logging):
- The churn reproduces with **zero reconcile** (pure native-style resize of the host content) → it is pure layout, not a reconcile artifact.
- During the gesture the ItemsView branch (`VStack → ItemsView → ScrollView → ItemsRepeater`) is **never re-measured or re-arranged** by FlexPanel — only the outer FlexColumn re-runs — and the `ScrollView` geometry is **100% constant** (viewport=500, extent=124, offset=0; repeater 700×124), yet the repeater fully re-realizes ~43 items/tick.

So the recycle is intrinsic `ItemsRepeater` viewport-manager behavior firing on every ancestor arrange pass, **not** something FlexPanel does to the ItemsView. I tried two layout-side suppressions (skip the grow-child re-measure; measure the main axis at ∞) — **both stopped the churn but broke the ItemsView width** (700 → 2696), because the grow child's finite re-measure is load-bearing for cross-axis width propagation. Eliminating the spurious recycle is therefore not possible without regressing layout.

## Known upstream behavior
This recycle storm is **upstream WinUI behavior**, not a Reactor layout bug — it matches microsoft/microsoft-ui-xaml#11122 (`ItemsRepeater` re-realizes its working set on every ancestor arrange pass even when its own viewport/extent is unchanged). This PR is a **cosmetic mitigation of the visible fade**, not a fix for the recycle itself; if/when the upstream issue is resolved the guard becomes a no-op and can be removed.

## Fix (the brief's endorsed mitigation: stop the checkmark re-animating)
`ItemContainer.MultiSelectMode` and `ItemContainerMultiSelectMode` are `[MUX_INTERNAL]`, so the property is unreachable from Reactor. Instead, the new `ItemContainerSelectionFlickerGuard` reaches into the **public** `MultiSelectStates` `VisualStateGroup` once the container's template is applied, finds the `Multiple` state's opacity storyboard, and **collapses its keyframe times to zero**. WinUI keeps calling `GoToState("Multiple", useTransitions: true)` exactly as before, but a zero-duration storyboard **snaps** the checkmark to full opacity in the same UI tick instead of fading it — so the recycle storm is no longer visible. Selection behavior, the recycle, and final checkmark visibility are unchanged.

This is a per-instance, one-time mutation of the container's **own** template storyboard. It never calls `GoToState` (which is **not** re-entrancy-safe from inside WinUI's own state transitions — an earlier `CurrentStateChanged` + `GoToState(useTransitions:false)` approach deadlocked realization), and it touches no shared resource.

### Pool rent/return safety
The guard is armed idempotently from `ElementFactory<T>.GetElement` when the realized control is an `ItemContainer`. There is **no persistent event subscription** to leak across pool reuse — the only handler is a transient, self-removing `Loaded` hook used when a freshly-mounted container hasn't applied its template yet. State is tracked in a `ConditionalWeakTable<ItemContainer, Holder>` (the same once-per-control wiring pattern the pooling layer already uses for poolable controls): a re-rented container short-circuits on `holder.Neutralized` so it is never double-processed, and the collapsed storyboard persists across rent/return because it lives on the container's own template instance.

## Before / after
- **Recycle/realize cycle count per resize gesture:** **unchanged** — it is intrinsic WinUI behavior and deliberately *not* touched. Measured churn under a standardized resize gesture (via the `[EF]` ElementFactory diagnostic): ~3870 Get / 3870 Recycle over the gesture, ~43 items re-realized/tick across ~75–90 ticks (zero-reconcile repro: 3225–3913 depending on scenario). A plain `Border` ancestor instead of FlexPanel = 0 — confirming it is the repeater's own viewport manager, not Reactor layout.
- **Visible checkmark fade:** **eliminated.** The regression selftest drives the exact `Single → Multiple` animated transition WinUI fires on a recycle and asserts `PART_SelectionCheckbox.Opacity == 1.000` immediately (snapped). The same test proves the un-guarded path genuinely fades (opacity **0.000** mid-transition with a restored non-zero keyframe) — so the snap assertion is load-bearing, not green-by-construction.

## Tests
- New selftest `ItemsView_MultiSelect_CheckmarkDoesNotFlicker`, now **load-bearing** on a real realized `ItemContainer` from a live `SelectionMode=Multiple` ItemsView, with three checks:
  1. **Production wiring** — without calling the guard directly, the `GetElement`-armed guard has already collapsed the storyboard → transition snaps (`opacity=1.000`).
  2. **Un-guarded fade proof** — restore a non-zero keyframe (reproduce the un-guarded WinUI default) → identical transition **fades** (`opacity=0.000`). A regressed/absent guard would land here.
  3. **Re-collapse proof** — re-zero the keyframe (the guard's exact operation) → snaps again (`opacity=1.000`).
- Full `ItemsView` selftest suite green.
- `dotnet test tests/Reactor.Tests`: **9517 passed, 0 failed** (64 skipped).
- Full selftest suite: only unrelated pre-existing flake `WindowLevel_RuntimeFlip_Topmost` (passes in isolation; cross-fixture window-topmost interference, untouched by this change).
- Core lib builds AOT-clean (no new trim/AOT warnings).

## Scope / overlap note
Surgical: 1 new core file + a 5-line `GetElement` wiring + a selftest fixture & registration. **No FlexPanel/layout changes.** The only shared-file touch is `src/Reactor/Core/ElementFactory.cs` — additive, near the end of `GetElement`. A sibling effort (#326 / PR #635, `RefreshRealizedItems` / `TryAdoptRealizedReplacement`) also touches `ElementFactory<T>`; this change is additive and localized, but **flagging for merge ordering** in case of a trivial textual conflict in that file.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>