### PR TITLE
Enable AOT for The BlankReactorMSIX app used in K2 Perf

### DIFF
--- a/tests/startup_perf/BlankReactorMsix/BlankReactor.csproj
+++ b/tests/startup_perf/BlankReactorMsix/BlankReactor.csproj
@@ -62,9 +62,17 @@
     -->
     <SelfContained>true</SelfContained>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
-    <!-- AOT off: the shared EventSource tracing helper relies on EventSource.Write()
-         over [EventData] payloads, which NativeAOT trims and turns into zero ETW events. -->
-    <PublishAot>false</PublishAot>
+    <PublishAot>true</PublishAot>
+    <!--
+      NativeAOT defaults the EventSourceSupport feature switch to false, which
+      no-ops *all* EventSource code (IsEnabled() returns false, WriteEvent is
+      trimmed) and emits zero ETW events — even from the manifest-based,
+      WriteEvent-over-primitives BenchmarkTracing helper. Opt back in so both
+      BenchmarkSyntheticApps and Microsoft-UI-Reactor providers emit under AOT.
+      (The helper already avoids EventSource.Write()/[EventData] structs, which
+      NativeAOT trims separately; that rewrite is necessary but not sufficient.)
+    -->
+    <EventSourceSupport>true</EventSourceSupport>
     <AppxBundle>Never</AppxBundle>
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>

--- a/tests/startup_perf/Common/BenchmarkTracing.cs
+++ b/tests/startup_perf/Common/BenchmarkTracing.cs
@@ -5,7 +5,7 @@ using System.Threading;
 namespace BenchmarkCommon;
 
 // Manifest-based EventSource using WriteEvent() with primitive parameters.
-// AOT-safe: no reflection, no [EventData] structs.
+// AOT-safe: avoids EventSource.Write() + [EventData] payload reflection; works under NativeAOT when EventSourceSupport is enabled.
 //
 // Provider GUID + event names + AppName payload field match -lift exactly.
 // Method names match the event names the run_startup_bench.ps1 parser and

--- a/tests/startup_perf/Common/BenchmarkTracing.cs
+++ b/tests/startup_perf/Common/BenchmarkTracing.cs
@@ -4,14 +4,15 @@ using System.Threading;
 
 namespace BenchmarkCommon;
 
-// Self-describing TraceLogging via EventSource.Write(). Event names ride
-// along with each event so tracerpt can resolve them without a manifest
-// (matches how the C++ TraceLoggingProvider macros emit, so RNW and our
-// C# variants render identically in WPA / tracerpt).
+// Manifest-based EventSource using WriteEvent() with primitive parameters.
+// AOT-safe: no reflection, no [EventData] structs.
 //
 // Provider GUID + event names + AppName payload field match -lift exactly.
-// Note: requires PublishAot=false. With NativeAOT, the Write() reflection
-// path over [EventData] structs is trimmed and no events are emitted.
+// Method names match the event names the run_startup_bench.ps1 parser and
+// -lift Regions XML expect (wWinMainEntry, XamlAppLoaded, etc.).
+//
+// Previous implementation used EventSource.Write() with [EventData] structs
+// which NativeAOT trims — producing zero ETW events under PublishAot=true.
 [EventSource(Name = "BenchmarkSyntheticApps", Guid = "FD80D616-E92B-4B2B-9BED-131ADA36A8FD")]
 internal sealed class BenchmarkTracing : EventSource
 {
@@ -20,37 +21,36 @@ internal sealed class BenchmarkTracing : EventSource
     private string _appName = "Unknown";
     private long _seq;
 
-    private static readonly EventSourceOptions s_infoMeasures = new()
-    {
-        Level = EventLevel.Informational,
-        Keywords = (EventKeywords)0x0000400000000000 // MICROSOFT_KEYWORD_MEASURES (bit 46)
-    };
+    private const EventKeywords MeasuresKeyword = (EventKeywords)0x0000400000000000; // MICROSOFT_KEYWORD_MEASURES (bit 46)
 
     [NonEvent]
     public void SetAppName(string appName) => _appName = appName ?? "Unknown";
 
-    [NonEvent] public void TraceWinMainEntry() => Write("wWinMainEntry", s_infoMeasures, new TracePayload(_appName, NextSeq(), Pid()));
-    [NonEvent] public void TraceXamlAppLoaded() => Write("XamlAppLoaded", s_infoMeasures, new TracePayload(_appName, NextSeq(), Pid()));
-    [NonEvent] public void TraceWindowLoaded() => Write("WindowLoaded", s_infoMeasures, new TracePayload(_appName, NextSeq(), Pid()));
-    [NonEvent] public void TraceFirstRender() => Write("FirstRender", s_infoMeasures, new TracePayload(_appName, NextSeq(), Pid()));
-    [NonEvent] public void TraceFirstIdle() => Write("FirstIdle", s_infoMeasures, new TracePayload(_appName, NextSeq(), Pid()));
-    [NonEvent] public void TraceProcessStop() => Write("ProcessStop", s_infoMeasures, new TracePayload(_appName, NextSeq(), Pid()));
+    [NonEvent] public void TraceWinMainEntry() => wWinMainEntry(_appName, NextSeq(), Pid());
+    [NonEvent] public void TraceXamlAppLoaded() => XamlAppLoaded(_appName, NextSeq(), Pid());
+    [NonEvent] public void TraceWindowLoaded() => WindowLoaded(_appName, NextSeq(), Pid());
+    [NonEvent] public void TraceFirstRender() => FirstRender(_appName, NextSeq(), Pid());
+    [NonEvent] public void TraceFirstIdle() => FirstIdle(_appName, NextSeq(), Pid());
+    [NonEvent] public void TraceProcessStop() => ProcessStop(_appName, NextSeq(), Pid());
+
+    [Event(1, Level = EventLevel.Informational, Keywords = MeasuresKeyword)]
+    private void wWinMainEntry(string AppName, long Seq, int Pid) => WriteEvent(1, AppName, Seq, Pid);
+
+    [Event(2, Level = EventLevel.Informational, Keywords = MeasuresKeyword)]
+    private void XamlAppLoaded(string AppName, long Seq, int Pid) => WriteEvent(2, AppName, Seq, Pid);
+
+    [Event(3, Level = EventLevel.Informational, Keywords = MeasuresKeyword)]
+    private void WindowLoaded(string AppName, long Seq, int Pid) => WriteEvent(3, AppName, Seq, Pid);
+
+    [Event(4, Level = EventLevel.Informational, Keywords = MeasuresKeyword)]
+    private void FirstRender(string AppName, long Seq, int Pid) => WriteEvent(4, AppName, Seq, Pid);
+
+    [Event(5, Level = EventLevel.Informational, Keywords = MeasuresKeyword)]
+    private void FirstIdle(string AppName, long Seq, int Pid) => WriteEvent(5, AppName, Seq, Pid);
+
+    [Event(6, Level = EventLevel.Informational, Keywords = MeasuresKeyword)]
+    private void ProcessStop(string AppName, long Seq, int Pid) => WriteEvent(6, AppName, Seq, Pid);
 
     private long NextSeq() => Interlocked.Increment(ref _seq) - 1;
     private static int Pid() => Environment.ProcessId;
-
-    [EventData]
-    private struct TracePayload
-    {
-        public string AppName { get; set; }
-        public long Seq { get; set; }
-        public int Pid { get; set; }
-
-        public TracePayload(string appName, long seq, int pid)
-        {
-            AppName = appName;
-            Seq = seq;
-            Pid = pid;
-        }
-    }
 }

--- a/tests/startup_perf/README.md
+++ b/tests/startup_perf/README.md
@@ -149,9 +149,8 @@ What this gives us:
 ## Methodology notes
 
 - **PublishAot is on for BlankReactorMsix only**
-  (`<PublishAot>true</PublishAot>`). `BenchmarkTracing` uses manifest-based
-  `WriteEvent()` with primitive parameters — no `[EventData]` structs, no
-  reflection — so ETW events emit correctly under NativeAOT. BlankReactor
+  (`<PublishAot>true</PublishAot>`, plus `<EventSourceSupport>true</EventSourceSupport>` for NativeAOT ETW). `BenchmarkTracing` uses manifest-based
+  `WriteEvent()` with primitive parameters — no `[EventData]` structs / `EventSource.Write()` payload reflection — so ETW events emit correctly under NativeAOT. BlankReactor
   (unpackaged) and BlankWinUI3 keep AOT off by default (flip them if you
   want an AOT run of those variants).
   Non-AOT C# adds ~70–100 ms of CLR bootstrap cost vs.

--- a/tests/startup_perf/README.md
+++ b/tests/startup_perf/README.md
@@ -148,10 +148,13 @@ What this gives us:
 
 ## Methodology notes
 
-- **PublishAot is off** (`<PublishAot>false</PublishAot>` in both C#
-  csprojs). NativeAOT trims the `EventSource` subclass even when events
-  are declared via manifest-style `[Event]` attributes, producing zero
-  ETW emissions. Non-AOT C# adds ~70–100 ms of CLR bootstrap cost vs.
+- **PublishAot is on for BlankReactorMsix only**
+  (`<PublishAot>true</PublishAot>`). `BenchmarkTracing` uses manifest-based
+  `WriteEvent()` with primitive parameters — no `[EventData]` structs, no
+  reflection — so ETW events emit correctly under NativeAOT. BlankReactor
+  (unpackaged) and BlankWinUI3 keep AOT off by default (flip them if you
+  want an AOT run of those variants).
+  Non-AOT C# adds ~70–100 ms of CLR bootstrap cost vs.
   -lift's pure C++ WinUI 3 baseline. Relative comparisons inside this
   repo (BlankWinUI3 vs. BlankReactor vs. BlankRNW) are still
   apples-to-apples; the C++ RNW host doesn't pay this cost (Hermes
@@ -162,10 +165,10 @@ What this gives us:
   cache-cold outlier; the script reports median over N runs so this
   doesn't skew results.
 
-- **Self-describing TraceLogging.** C# uses `EventSource.Write()` with
-  an `[EventData]` payload struct, the same pattern -lift's
-  `Common/BenchmarkTracing.cs` uses, so tracerpt resolves event names
-  and payload fields without an installed manifest. RNW uses C++
+- **Manifest-based EventSource.** C# uses `WriteEvent()` with `[Event]`
+  attributes and primitive parameters. Method names match the event names
+  the run_startup_bench.ps1 parser and -lift Regions XML expect
+  (`wWinMainEntry`, `XamlAppLoaded`, etc.). RNW uses C++
   `TraceLoggingProvider` macros directly.
 
 - **What to expect on the same hardware as -lift's README.** -lift


### PR DESCRIPTION
<!--
Thanks for contributing to Reactor! A few notes before you open this PR:

- Link the issue or spec this PR addresses (Fixes #..., Implements docs/specs/0XX-...).
- Keep the change focused. Smaller, well-scoped PRs land faster.
- Include tests. See CONTRIBUTING.md for the unit / selftest / e2e split.
- Run `dotnet build Reactor.slnx` and `dotnet test tests/Reactor.Tests` locally.
- First-time contributors: the Microsoft CLA bot will comment automatically; sign once and you're set.
-->

## Summary

Rebuilt the MSIX pkg with AOT true.
Made changes to ETW tracer so that AOT app events can be emitted.

## Linked issue / spec

<!-- Fixes #...  /  Implements docs/specs/0XX-...  /  Part of #... -->

## Test plan

<!-- Bulleted list of how this was verified. Examples:
- [ ] Added unit tests in tests/Reactor.Tests/...
- [ ] Added selftest fixture in tests/Reactor.AppTests.Host/SelfTest/Fixtures/...
- [ ] Ran `dotnet test tests/Reactor.Tests`
- [ ] Manually ran `dotnet run --project samples/Reactor.TestApp`
-->

## Risk / breaking changes

<!-- Any public-API change, behavior shift, or perf-sensitive path? Flag it here. -->
