### PR TITLE
perf: devirtualize per-prop diff dispatch in V1 descriptor

### DIFF
--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -5270,6 +5270,7 @@ GetHashCode() → int
 ToString() → string
 
 ### class PropEntry<TElement, TControl>
+bool Subscribes { get; }
 EnsureSubscribed(ReactorBinding<TElement> binding, TControl ctrl, TElement el) → void
 Mount(TControl ctrl, TElement el) → void
 Mount(ref MountContext ctx, TControl ctrl, TElement el) → void

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -5270,6 +5270,7 @@ GetHashCode() → int
 ToString() → string
 
 ### class PropEntry<TElement, TControl>
+bool Subscribes { get; }
 EnsureSubscribed(ReactorBinding<TElement> binding, TControl ctrl, TElement el) → void
 Mount(TControl ctrl, TElement el) → void
 Mount(ref MountContext ctx, TControl ctrl, TElement el) → void

--- a/src/Reactor/Core/V1Protocol/Descriptor/DescriptorHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/DescriptorHandler.cs
@@ -47,10 +47,45 @@ public class DescriptorHandler<TElement, TControl> : IElementHandler<TElement, T
 {
     private readonly ControlDescriptor<TElement, TControl> _descriptor;
 
+    // Issue #117 — the per-prop loop ran over IReadOnlyList, paying an
+    // interface-indexer dispatch per prop per cell. Snapshot the descriptor's
+    // property list into concrete arrays once (the descriptor is a process-wide
+    // singleton built before this handler is constructed, so the list is final)
+    // and iterate those instead. _updateEntries holds every entry in declared
+    // order (drives Mount/Update writes); _subscribeEntries is the small subset
+    // (Issue #114) whose EnsureSubscribed override actually wires something —
+    // typically empty (e.g. a grid cell's TextBlock) or 1-3 entries.
+    private readonly PropEntry<TElement, TControl>[] _updateEntries;
+    private readonly PropEntry<TElement, TControl>[] _subscribeEntries;
+
     public DescriptorHandler(ControlDescriptor<TElement, TControl> descriptor)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
         _descriptor = descriptor;
+
+        var properties = descriptor.Properties;
+        var update = new PropEntry<TElement, TControl>[properties.Count];
+        int subscribeCount = 0;
+        for (int i = 0; i < properties.Count; i++)
+        {
+            var entry = properties[i];
+            update[i] = entry;
+            if (entry.Subscribes) subscribeCount++;
+        }
+
+        _updateEntries = update;
+        if (subscribeCount == 0)
+        {
+            _subscribeEntries = Array.Empty<PropEntry<TElement, TControl>>();
+        }
+        else
+        {
+            var subscribe = new PropEntry<TElement, TControl>[subscribeCount];
+            int s = 0;
+            for (int i = 0; i < update.Length; i++)
+                if (update[i].Subscribes) subscribe[s++] = update[i];
+            _subscribeEntries = subscribe;
+        }
     }
 
     /// <summary>The descriptor this handler interprets. Exposed for tests
@@ -112,14 +147,24 @@ public class DescriptorHandler<TElement, TControl> : IElementHandler<TElement, T
         // context-carrying overload so OneWayBridged entries can reach the
         // reconciler/rerender helpers; existing entries forward to the
         // parameterless overload via the virtual default on PropEntry.
-        var props = _descriptor.Properties;
-        for (int i = 0; i < props.Count; i++)
-            props[i].Mount(in ctx, ctrl, el);
+        // Issue #117 — iterate the concrete array (no interface-indexer dispatch).
+        var entries = _updateEntries;
+        for (int i = 0; i < entries.Length; i++)
+            entries[i].Mount(in ctx, ctrl, el);
 
-        // Phase 2: subscribe controlled entries.
-        var binding = ctx.BindFor(ctrl, el);
-        for (int i = 0; i < props.Count; i++)
-            props[i].EnsureSubscribed(binding, ctrl, el);
+        // Phase 2: subscribe controlled entries. Issue #114 — only the entries
+        // that actually wire subscriptions are visited, and when there are none
+        // (the dominant grid-cell case) BindFor is skipped entirely. BindFor's
+        // only side effect is resetting the reference-slot thread-static, which
+        // is consumed solely by reference entries — themselves subscribers — so
+        // skipping it when the subset is empty changes no observable behavior.
+        var subscribers = _subscribeEntries;
+        if (subscribers.Length > 0)
+        {
+            var binding = ctx.BindFor(ctrl, el);
+            for (int i = 0; i < subscribers.Length; i++)
+                subscribers[i].EnsureSubscribed(binding, ctrl, el);
+        }
 
         var getSetters = _descriptor.GetSetters;
         if (getSetters is not null)
@@ -145,8 +190,6 @@ public class DescriptorHandler<TElement, TControl> : IElementHandler<TElement, T
         else if (_descriptor.Children is IItemsBinderStrategy binder && ctrl is FrameworkElement feBinder)
             binder.Bind(feBinder, oldEl, newEl, ctx.Reconciler, ctx.RequestRerender, isMount: false);
 
-        var props = _descriptor.Properties;
-
         // Spec 050: wire trampolines BEFORE the prop Update loop so a
         // controlled write that triggers a DEFERRED change event (TextBox /
         // PasswordBox / NumberBox / AutoSuggest / RichEdit text writes,
@@ -156,12 +199,24 @@ public class DescriptorHandler<TElement, TControl> : IElementHandler<TElement, T
         // ShouldSuppress on, so the token sat at +1 and swallowed the user's
         // next real input. The per-entry CWT gate (slot-is-null) makes the
         // steady-state no-op case cheap.
-        var binding = ctx.BindFor(ctrl, newEl);
-        for (int i = 0; i < props.Count; i++)
-            props[i].EnsureSubscribed(binding, ctrl, newEl);
+        //
+        // Issue #114 — visit only the subscribe subset, and skip BindFor when
+        // there are none (e.g. a grid cell of OneWay-only TextBlocks). This is
+        // the dominant per-cell-per-frame saving: most entries are no-op
+        // EnsureSubscribed overrides that previously paid a vtable dispatch on
+        // every Update.
+        var subscribers = _subscribeEntries;
+        if (subscribers.Length > 0)
+        {
+            var binding = ctx.BindFor(ctrl, newEl);
+            for (int i = 0; i < subscribers.Length; i++)
+                subscribers[i].EnsureSubscribed(binding, ctrl, newEl);
+        }
 
-        for (int i = 0; i < props.Count; i++)
-            props[i].Update(in ctx, ctrl, oldEl, newEl);
+        // Issue #117 — iterate the concrete array (no interface-indexer dispatch).
+        var entries = _updateEntries;
+        for (int i = 0; i < entries.Length; i++)
+            entries[i].Update(in ctx, ctrl, oldEl, newEl);
 
         var getSetters = _descriptor.GetSetters;
         if (getSetters is not null)

--- a/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
@@ -94,7 +94,8 @@ public abstract class PropEntry<TElement, TControl>
     /// to <c>false</c> (the base <see cref="EnsureSubscribed"/> is a no-op);
     /// every entry type that overrides <see cref="EnsureSubscribed"/> overrides
     /// this to <c>true</c>. A reflection-backed test
-    /// (<c>PropEntrySubscribesDiscriminatorTests</c>) guards that invariant.</summary>
+    /// (<c>PropEntryDiffDispatchTests.Subscribes_OverrideMatches_EnsureSubscribedOverride_ForEveryEntry</c>)
+    /// guards that invariant.</summary>
     public virtual bool Subscribes => false;
 }
 
@@ -591,6 +592,14 @@ internal sealed class ReferenceListPropEntry<TElement, TControl, TTarget> : Prop
     // (FrameworkElements) between calls.
     [ThreadStatic] private static List<Microsoft.UI.Reactor.Input.ElementRef>? s_scratchCells;
 
+    // Lazily allocate the per-thread scratch through a static helper so the
+    // [ThreadStatic] write doesn't happen inside the instance EnsureSubscribed body
+    // (CodeQL cs/static-field-written-by-instance) while keeping the per-thread
+    // reuse. The list is always empty on return: freshly allocated, or drained by
+    // the previous call's finally below.
+    private static List<Microsoft.UI.Reactor.Input.ElementRef> RentScratchCells()
+        => s_scratchCells ??= new List<Microsoft.UI.Reactor.Input.ElementRef>();
+
     public ReferenceListPropEntry(
         Func<TElement, IReadOnlyList<Microsoft.UI.Reactor.Input.ElementRef<TTarget>>?> get,
         Action<TControl, IReadOnlyList<TTarget>> apply,
@@ -619,8 +628,7 @@ internal sealed class ReferenceListPropEntry<TElement, TControl, TTarget> : Prop
         TElement el)
     {
         var refs = _get(el);
-        var cells = s_scratchCells ??= new List<Microsoft.UI.Reactor.Input.ElementRef>();
-        cells.Clear();
+        var cells = RentScratchCells();
         try
         {
             if (refs is not null)
@@ -1246,6 +1254,26 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
     [ThreadStatic] private static HashSet<TKey>? s_scratchPresentKeys;
     [ThreadStatic] private static IEqualityComparer<TKey>? s_scratchComparer;
 
+    // Rent the per-thread scratch sets through a static helper so the
+    // [ThreadStatic] writes don't happen inside the instance Update body (CodeQL
+    // cs/static-field-written-by-instance) while keeping the per-thread reuse.
+    // Rebuilds both sets when the active entry's key comparer differs from the one
+    // the current sets were created with, so a custom-comparer entry never diffs
+    // with another entry's comparer (#119). Both sets are empty on return: freshly
+    // allocated, or drained by the previous call's finally.
+    private static (HashSet<TKey> NewKeys, HashSet<TKey> PresentKeys) RentScratchSets(IEqualityComparer<TKey> keyComparer)
+    {
+        var newKeys = s_scratchNewKeys;
+        var presentKeys = s_scratchPresentKeys;
+        if (newKeys is null || presentKeys is null || !ReferenceEquals(s_scratchComparer, keyComparer))
+        {
+            newKeys = s_scratchNewKeys = new HashSet<TKey>(keyComparer);
+            presentKeys = s_scratchPresentKeys = new HashSet<TKey>(keyComparer);
+            s_scratchComparer = keyComparer;
+        }
+        return (newKeys, presentKeys);
+    }
+
     public CollectionDiffControlledPropEntry(
         Func<TElement, IReadOnlyList<TItem>> get,
         Func<TControl, IList<TItem>> getVector,
@@ -1286,17 +1314,9 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
         // Fast path: same items, no work.
         if (ReferenceEquals(oldItems, newItems)) return;
 
-        // Acquire the per-thread scratch sets. Rebuild them when the active entry's
-        // key comparer differs from the one the current sets were created with, so a
-        // custom-comparer entry never diffs with another entry's comparer (#119).
-        var newKeys = s_scratchNewKeys;
-        var presentKeys = s_scratchPresentKeys;
-        if (newKeys is null || presentKeys is null || !ReferenceEquals(s_scratchComparer, _keyComparer))
-        {
-            newKeys = s_scratchNewKeys = new HashSet<TKey>(_keyComparer);
-            presentKeys = s_scratchPresentKeys = new HashSet<TKey>(_keyComparer);
-            s_scratchComparer = _keyComparer;
-        }
+        // Rent the per-thread scratch sets (rebuilt if this entry's key comparer
+        // differs from the one they were created with — see RentScratchSets).
+        var (newKeys, presentKeys) = RentScratchSets(_keyComparer);
 
         try
         {

--- a/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
@@ -1,7 +1,25 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml;
 
 namespace Microsoft.UI.Reactor.Core.V1Protocol.Descriptor;
+
+/// <summary>Issue #115 — devirtualized value comparison for descriptor prop
+/// entries. Entries store their comparer as a <em>nullable</em>
+/// <see cref="IEqualityComparer{T}"/> where <c>null</c> means "use the default
+/// comparer". When it is null this calls <see cref="EqualityComparer{T}.Default"/>'s
+/// <c>Equals</c> directly — a JIT intrinsic the runtime can devirtualize and
+/// inline for value-type <c>TValue</c> (the dominant grid case,
+/// ~300k compares/sec). A custom comparer (non-null) is honored through the
+/// interface call exactly as before, so no comparison behavior changes.</summary>
+internal static class PropValueComparison
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool ValuesEqual<TValue>(IEqualityComparer<TValue>? comparer, TValue x, TValue y)
+        => comparer is null
+            ? EqualityComparer<TValue>.Default.Equals(x, y)
+            : comparer.Equals(x, y);
+}
 
 /// <summary>
 /// Spec 047 §6 / §14 Phase 2 (Q1 spike) — base class for descriptor entries
@@ -65,6 +83,19 @@ public abstract class PropEntry<TElement, TControl>
         ReactorBinding<TElement> binding,
         TControl ctrl,
         TElement el) { }
+
+    /// <summary>Issue #114 — does this entry's <see cref="EnsureSubscribed"/>
+    /// do real work? The interpreter
+    /// (<see cref="DescriptorHandler{TElement,TControl}"/>) partitions entries
+    /// into an all-entries update list and a (typically 1-3 element) subscribe
+    /// subset using this flag, so the per-Update subscribe pass iterates only
+    /// the entries that actually wire/refresh a subscription instead of paying
+    /// a megamorphic no-op virtual call on every prop of every cell. Defaults
+    /// to <c>false</c> (the base <see cref="EnsureSubscribed"/> is a no-op);
+    /// every entry type that overrides <see cref="EnsureSubscribed"/> overrides
+    /// this to <c>true</c>. A reflection-backed test
+    /// (<c>PropEntrySubscribesDiscriminatorTests</c>) guards that invariant.</summary>
+    public virtual bool Subscribes => false;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -79,7 +110,7 @@ internal sealed class OneWayPropEntry<TElement, TControl, TValue> : PropEntry<TE
 {
     private readonly Func<TElement, TValue> _get;
     private readonly Action<TControl, TValue> _set;
-    private readonly IEqualityComparer<TValue> _comparer;
+    private readonly IEqualityComparer<TValue>? _comparer;
 
     public OneWayPropEntry(
         Func<TElement, TValue> get,
@@ -88,7 +119,7 @@ internal sealed class OneWayPropEntry<TElement, TControl, TValue> : PropEntry<TE
     {
         _get = get;
         _set = set;
-        _comparer = comparer ?? EqualityComparer<TValue>.Default;
+        _comparer = comparer;
     }
 
     public override void Mount(TControl ctrl, TElement el) => _set(ctrl, _get(el));
@@ -96,7 +127,7 @@ internal sealed class OneWayPropEntry<TElement, TControl, TValue> : PropEntry<TE
     public override void Update(TControl ctrl, TElement oldEl, TElement newEl)
     {
         var nv = _get(newEl);
-        if (!_comparer.Equals(_get(oldEl), nv))
+        if (!PropValueComparison.ValuesEqual(_comparer, _get(oldEl), nv))
             _set(ctrl, nv);
     }
 }
@@ -111,7 +142,7 @@ internal sealed class OneWayClearValuePropEntry<TElement, TControl, TValue> : Pr
     private readonly Func<TElement, Optional<TValue>> _get;
     private readonly Action<TControl, TValue> _set;
     private readonly DependencyProperty _dp;
-    private readonly IEqualityComparer<TValue> _comparer;
+    private readonly IEqualityComparer<TValue>? _comparer;
 
     public OneWayClearValuePropEntry(
         Func<TElement, Optional<TValue>> get,
@@ -122,7 +153,7 @@ internal sealed class OneWayClearValuePropEntry<TElement, TControl, TValue> : Pr
         _get = get;
         _set = set;
         _dp = dp;
-        _comparer = comparer ?? EqualityComparer<TValue>.Default;
+        _comparer = comparer;
     }
 
     public override void Mount(TControl ctrl, TElement el)
@@ -152,7 +183,7 @@ internal sealed class OneWayClearValuePropEntry<TElement, TControl, TValue> : Pr
             return;
         }
 
-        if (!ovOpt.HasValue || !_comparer.Equals(ovOpt.Value, nvOpt.Value))
+        if (!ovOpt.HasValue || !PropValueComparison.ValuesEqual(_comparer, ovOpt.Value, nvOpt.Value))
             _set(ctrl, nvOpt.Value);
     }
 }
@@ -169,7 +200,7 @@ internal sealed class OneWayConditionalPropEntry<TElement, TControl, TValue> : P
     private readonly Func<TElement, TValue> _get;
     private readonly Action<TControl, TValue> _set;
     private readonly Func<TElement, bool> _shouldWrite;
-    private readonly IEqualityComparer<TValue> _comparer;
+    private readonly IEqualityComparer<TValue>? _comparer;
 
     public OneWayConditionalPropEntry(
         Func<TElement, TValue> get,
@@ -180,7 +211,7 @@ internal sealed class OneWayConditionalPropEntry<TElement, TControl, TValue> : P
         _get = get;
         _set = set;
         _shouldWrite = shouldWrite;
-        _comparer = comparer ?? EqualityComparer<TValue>.Default;
+        _comparer = comparer;
     }
 
     public override void Mount(TControl ctrl, TElement el)
@@ -194,7 +225,7 @@ internal sealed class OneWayConditionalPropEntry<TElement, TControl, TValue> : P
         var nv = _get(newEl);
         // Re-write when the predicate flips from false to true OR the value
         // genuinely changed. Don't try to be clever about the old element.
-        if (!_shouldWrite(oldEl) || !_comparer.Equals(_get(oldEl), nv))
+        if (!_shouldWrite(oldEl) || !PropValueComparison.ValuesEqual(_comparer, _get(oldEl), nv))
             _set(ctrl, nv);
     }
 }
@@ -269,7 +300,7 @@ internal sealed class ControlledPropEntry<TElement, TControl, TValue, TArgs> : P
     private readonly Action<FrameworkElement, EventHandler<TArgs>> _unsubscribe;
     private readonly Func<TElement, Action<TValue>?> _getCallback;
     private readonly Func<TControl, TValue> _readBack;
-    private readonly IEqualityComparer<TValue> _comparer;
+    private readonly IEqualityComparer<TValue>? _comparer;
 
     // Static trampoline — closes over the closed generic's TElement /
     // TControl / TValue / TArgs but captures no per-instance state.
@@ -343,7 +374,7 @@ internal sealed class ControlledPropEntry<TElement, TControl, TValue, TArgs> : P
         _unsubscribe = unsubscribe;
         _getCallback = getCallback;
         _readBack = readBack;
-        _comparer = comparer ?? EqualityComparer<TValue>.Default;
+        _comparer = comparer;
     }
 
     public override void Mount(TControl ctrl, TElement el)
@@ -366,7 +397,7 @@ internal sealed class ControlledPropEntry<TElement, TControl, TValue, TArgs> : P
         var vOpt = _get(el);
         if (!vOpt.HasValue) return;
         var v = vOpt.Value;
-        if (!_comparer.Equals(_readBack(ctrl), v))
+        if (!PropValueComparison.ValuesEqual(_comparer, _readBack(ctrl), v))
             _set(ctrl, v);
     }
 
@@ -379,7 +410,7 @@ internal sealed class ControlledPropEntry<TElement, TControl, TValue, TArgs> : P
         // Spec 047 §8 echo-suppression contract: write ONLY when the control has
         // drifted from the element's authority. A no-drift write raises no event,
         // so arming would strand the pending flag (the §8 cross-state echo class).
-        if (_comparer.Equals(current, nv))
+        if (PropValueComparison.ValuesEqual(_comparer, current, nv))
             return;
 
         // §8 value-diff echo suppression (PoC) for the controlled fast path: arm
@@ -403,6 +434,8 @@ internal sealed class ControlledPropEntry<TElement, TControl, TValue, TArgs> : P
 
         _set(ctrl, nv);
     }
+
+    public override bool Subscribes => true;
 
     public override void EnsureSubscribed(
         ReactorBinding<TElement> binding,
@@ -465,6 +498,8 @@ internal sealed class ReferencePropEntry<TElement, TControl, TTarget> : PropEntr
         // Cell changes drive writes; ref-instance swaps are handled by EnsureSubscribed.
     }
 
+    public override bool Subscribes => true;
+
     public override void EnsureSubscribed(
         ReactorBinding<TElement> binding,
         TControl ctrl,
@@ -515,6 +550,8 @@ internal sealed class UntypedReferencePropEntry<TElement, TControl> : PropEntry<
         // Cell changes drive writes; ref-instance swaps are handled by EnsureSubscribed.
     }
 
+    public override bool Subscribes => true;
+
     public override void EnsureSubscribed(
         ReactorBinding<TElement> binding,
         TControl ctrl,
@@ -544,6 +581,14 @@ internal sealed class ReferenceListPropEntry<TElement, TControl, TTarget> : Prop
     private readonly Action<TControl, IReadOnlyList<TTarget>> _apply;
     private readonly int _slot;
 
+    // Issue #120 — per-thread reusable scratch for the cells projection built on
+    // every EnsureSubscribed (this entry re-evaluates each Update to detect
+    // ref-list add/remove/reorder). WireReferenceListEdge copies the list into
+    // its own edge state synchronously and does not retain it, so a cleared-on-
+    // use thread-static buffer removes the per-Update allocation without racing
+    // across windows (same rationale as CollectionDiff's scratch above).
+    [ThreadStatic] private static List<Microsoft.UI.Reactor.Input.ElementRef>? s_scratchCells;
+
     public ReferenceListPropEntry(
         Func<TElement, IReadOnlyList<Microsoft.UI.Reactor.Input.ElementRef<TTarget>>?> get,
         Action<TControl, IReadOnlyList<TTarget>> apply,
@@ -564,16 +609,18 @@ internal sealed class ReferenceListPropEntry<TElement, TControl, TTarget> : Prop
         // Cell changes drive writes; ref-list add/remove/order changes are handled by EnsureSubscribed.
     }
 
+    public override bool Subscribes => true;
+
     public override void EnsureSubscribed(
         ReactorBinding<TElement> binding,
         TControl ctrl,
         TElement el)
     {
         var refs = _get(el);
-        List<Microsoft.UI.Reactor.Input.ElementRef>? cells = null;
+        var cells = s_scratchCells ??= new List<Microsoft.UI.Reactor.Input.ElementRef>();
+        cells.Clear();
         if (refs is not null)
         {
-            cells = new(refs.Count);
             foreach (var r in refs)
                 if (r is not null)
                     cells.Add(r.Inner);
@@ -695,7 +742,7 @@ internal sealed class HandCodedControlledPropEntry<TElement, TControl, TPayload,
     private readonly TDelegate _trampoline;
     private readonly Func<TPayload, bool> _slotIsNull;
     private readonly Action<TPayload, TDelegate> _setSlot;
-    private readonly IEqualityComparer<TValue> _comparer;
+    private readonly IEqualityComparer<TValue>? _comparer;
     private readonly bool _valueDiffEcho;
 
     public HandCodedControlledPropEntry(
@@ -718,7 +765,7 @@ internal sealed class HandCodedControlledPropEntry<TElement, TControl, TPayload,
         _trampoline = trampoline;
         _slotIsNull = slotIsNull;
         _setSlot = setSlot;
-        _comparer = comparer ?? EqualityComparer<TValue>.Default;
+        _comparer = comparer;
         _valueDiffEcho = valueDiffEcho;
     }
 
@@ -733,7 +780,7 @@ internal sealed class HandCodedControlledPropEntry<TElement, TControl, TPayload,
         var vOpt = _get(el);
         if (!vOpt.HasValue) return;
         var v = vOpt.Value;
-        if (!_comparer.Equals(_readBack(ctrl), v))
+        if (!PropValueComparison.ValuesEqual(_comparer, _readBack(ctrl), v))
             _set(ctrl, v);
     }
 
@@ -746,7 +793,7 @@ internal sealed class HandCodedControlledPropEntry<TElement, TControl, TPayload,
         // Spec 047 §8: suppress-write only on real drift (see ControlledPropEntry).
         // The prior `oldEl != newEl` disjunct stranded the suppress token on the
         // standard controlled round-trip and swallowed the next real user event.
-        if (_comparer.Equals(current, nv))
+        if (PropValueComparison.ValuesEqual(_comparer, current, nv))
             return;
 
         // §8 value-diff (opt-in via valueDiffEcho): arm the per-control expected
@@ -761,7 +808,7 @@ internal sealed class HandCodedControlledPropEntry<TElement, TControl, TPayload,
             if (_getCallback(newEl) is not null)
             {
                 var expected = nv;
-                var cmp = _comparer;
+                var cmp = _comparer ?? EqualityComparer<TValue>.Default;
                 ChangeEchoSuppressor.ArmExpectedEcho(
                     ctrl, rb => cmp.Equals(rb is TValue tv ? tv : default!, expected));
             }
@@ -770,7 +817,7 @@ internal sealed class HandCodedControlledPropEntry<TElement, TControl, TPayload,
             // dropped the write, the synchronous echo never fired to consume the
             // arm. Clear it so it can't strand and swallow a later real event
             // whose readback happens to equal the never-applied value.
-            if (!_comparer.Equals(_readBack(ctrl), nv))
+            if (!PropValueComparison.ValuesEqual(_comparer, _readBack(ctrl), nv))
                 ChangeEchoSuppressor.ClearExpectedEcho(ctrl);
         }
         else
@@ -778,6 +825,8 @@ internal sealed class HandCodedControlledPropEntry<TElement, TControl, TPayload,
             ReactorBinding.WriteSuppressed(ctrl, () => _set(ctrl, nv));
         }
     }
+
+    public override bool Subscribes => true;
 
     public override void EnsureSubscribed(
         ReactorBinding<TElement> binding,
@@ -832,6 +881,8 @@ internal sealed class HandCodedEventPropEntry<TElement, TControl, TPayload, TDel
 
     public override void Update(TControl ctrl, TElement oldEl, TElement newEl) { /* no DP write */ }
 
+    public override bool Subscribes => true;
+
     public override void EnsureSubscribed(
         ReactorBinding<TElement> binding,
         TControl ctrl,
@@ -862,7 +913,7 @@ internal sealed class CoercingOneWayPropEntry<TElement, TControl, TValue> : Prop
     private readonly Func<TElement, TValue> _get;
     private readonly Action<TControl, TValue> _set;
     private readonly Func<TControl, TValue, bool> _coercesController;
-    private readonly IEqualityComparer<TValue> _comparer;
+    private readonly IEqualityComparer<TValue>? _comparer;
 
     public CoercingOneWayPropEntry(
         Func<TElement, TValue> get,
@@ -873,7 +924,7 @@ internal sealed class CoercingOneWayPropEntry<TElement, TControl, TValue> : Prop
         _get = get;
         _set = set;
         _coercesController = coercesController;
-        _comparer = comparer ?? EqualityComparer<TValue>.Default;
+        _comparer = comparer;
     }
 
     public override void Mount(TControl ctrl, TElement el)
@@ -887,7 +938,7 @@ internal sealed class CoercingOneWayPropEntry<TElement, TControl, TValue> : Prop
     public override void Update(TControl ctrl, TElement oldEl, TElement newEl)
     {
         var nv = _get(newEl);
-        if (_comparer.Equals(_get(oldEl), nv)) return;
+        if (PropValueComparison.ValuesEqual(_comparer, _get(oldEl), nv)) return;
 
         if (_coercesController(ctrl, nv))
             ReactorBinding.WriteSuppressed(ctrl, () => _set(ctrl, nv));
@@ -995,7 +1046,7 @@ internal sealed class OneWayBridgedPropEntry<TElement, TControl, TValue> : PropE
     private readonly Func<TElement, TValue> _get;
     private readonly OneWayBridgedSetter<TControl, TValue> _set;
     private readonly Func<TElement, bool> _shouldWrite;
-    private readonly IEqualityComparer<TValue> _comparer;
+    private readonly IEqualityComparer<TValue>? _comparer;
 
     public OneWayBridgedPropEntry(
         Func<TElement, TValue> get,
@@ -1006,7 +1057,7 @@ internal sealed class OneWayBridgedPropEntry<TElement, TControl, TValue> : PropE
         _get = get;
         _set = set;
         _shouldWrite = shouldWrite;
-        _comparer = comparer ?? EqualityComparer<TValue>.Default;
+        _comparer = comparer;
     }
 
     // Parameterless overloads — unreachable; the bridged entry only goes
@@ -1029,7 +1080,7 @@ internal sealed class OneWayBridgedPropEntry<TElement, TControl, TValue> : PropE
     {
         if (!_shouldWrite(newEl)) return;
         var nv = _get(newEl);
-        if (!_shouldWrite(oldEl) || !_comparer.Equals(_get(oldEl), nv))
+        if (!_shouldWrite(oldEl) || !PropValueComparison.ValuesEqual(_comparer, _get(oldEl), nv))
             _set(ctrl, nv, ctx.Reconciler, ctx.RequestRerender);
     }
 }
@@ -1109,6 +1160,8 @@ internal sealed class ImmediatePropEntry<TElement, TControl, TPayload> : PropEnt
     public override void Mount(TControl ctrl, TElement el) { /* no DP write */ }
     public override void Update(TControl ctrl, TElement oldEl, TElement newEl) { /* no DP write */ }
 
+    public override bool Subscribes => true;
+
     public override void EnsureSubscribed(
         ReactorBinding<TElement> binding,
         TControl ctrl,
@@ -1161,6 +1214,21 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
     private readonly Action<TPayload, TDelegate> _setSlot;
     private readonly IEqualityComparer<TKey> _keyComparer;
 
+    // Issue #119 — per-thread reusable scratch sets for the Update diff. This
+    // entry is a process-wide singleton shared by every control of its type, so
+    // (mirroring the reconciler's own [ThreadStatic] scratch, and supporting a
+    // component that owns a separate DispatcherQueue/UI thread) the scratch is
+    // thread-static rather than an instance field: each UI thread keeps its own
+    // cleared-on-use sets. That removes the two per-Update HashSet allocations
+    // (CalendarView.SelectedDates and peers rebuild their list every render)
+    // with no cross-window race. Each Update fully drains both sets before it
+    // returns, so reuse within a thread is safe. (Two CollectionDiff entries
+    // with an identical closed generic on one control would share these — the
+    // same accepted collision caveat as DescriptorControlledPayload above; the
+    // handler still runs entries sequentially, so each drains before the next.)
+    [ThreadStatic] private static HashSet<TKey>? s_scratchNewKeys;
+    [ThreadStatic] private static HashSet<TKey>? s_scratchPresentKeys;
+
     public CollectionDiffControlledPropEntry(
         Func<TElement, IReadOnlyList<TItem>> get,
         Func<TControl, IList<TItem>> getVector,
@@ -1202,7 +1270,8 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
         if (ReferenceEquals(oldItems, newItems)) return;
 
         // Build new key set; track which old indices are still present.
-        var newKeys = new HashSet<TKey>(newItems.Count, _keyComparer);
+        var newKeys = s_scratchNewKeys ??= new HashSet<TKey>(_keyComparer);
+        newKeys.Clear();
         for (int i = 0; i < newItems.Count; i++) newKeys.Add(_key(newItems[i]));
 
         var vec = _getVector(ctrl);
@@ -1217,7 +1286,8 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
         }
 
         // Add items that aren't already present.
-        var presentKeys = new HashSet<TKey>(vec.Count, _keyComparer);
+        var presentKeys = s_scratchPresentKeys ??= new HashSet<TKey>(_keyComparer);
+        presentKeys.Clear();
         for (int i = 0; i < vec.Count; i++) presentKeys.Add(_key(vec[i]));
         for (int i = 0; i < newItems.Count; i++)
         {
@@ -1225,6 +1295,8 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
             if (presentKeys.Add(k)) vec.Add(newItems[i]);
         }
     }
+
+    public override bool Subscribes => true;
 
     public override void EnsureSubscribed(
         ReactorBinding<TElement> binding,

--- a/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
@@ -586,7 +586,9 @@ internal sealed class ReferenceListPropEntry<TElement, TControl, TTarget> : Prop
     // ref-list add/remove/reorder). WireReferenceListEdge copies the list into
     // its own edge state synchronously and does not retain it, so a cleared-on-
     // use thread-static buffer removes the per-Update allocation without racing
-    // across windows (same rationale as CollectionDiff's scratch above).
+    // across windows (same rationale as CollectionDiff's scratch above). The
+    // buffer is drained in a finally so it never retains cell references
+    // (FrameworkElements) between calls.
     [ThreadStatic] private static List<Microsoft.UI.Reactor.Input.ElementRef>? s_scratchCells;
 
     public ReferenceListPropEntry(
@@ -619,19 +621,28 @@ internal sealed class ReferenceListPropEntry<TElement, TControl, TTarget> : Prop
         var refs = _get(el);
         var cells = s_scratchCells ??= new List<Microsoft.UI.Reactor.Input.ElementRef>();
         cells.Clear();
-        if (refs is not null)
+        try
         {
-            foreach (var r in refs)
-                if (r is not null)
-                    cells.Add(r.Inner);
-        }
+            if (refs is not null)
+            {
+                foreach (var r in refs)
+                    if (r is not null)
+                        cells.Add(r.Inner);
+            }
 
-        Reconciler.WireReferenceListEdge(
-            ctrl,
-            _slot,
-            cells,
-            c => ApplyResolved((TControl)c, el),
-            clearTarget: c => _apply((TControl)c, Array.Empty<TTarget>()));
+            Reconciler.WireReferenceListEdge(
+                ctrl,
+                _slot,
+                cells,
+                c => ApplyResolved((TControl)c, el),
+                clearTarget: c => _apply((TControl)c, Array.Empty<TTarget>()));
+        }
+        finally
+        {
+            // WireReferenceListEdge copies synchronously; drop the cell references
+            // (FrameworkElements) so the scratch doesn't retain them between calls.
+            cells.Clear();
+        }
     }
 
     private void ApplyResolved(TControl ctrl, TElement el)
@@ -1219,15 +1230,21 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
     // (mirroring the reconciler's own [ThreadStatic] scratch, and supporting a
     // component that owns a separate DispatcherQueue/UI thread) the scratch is
     // thread-static rather than an instance field: each UI thread keeps its own
-    // cleared-on-use sets. That removes the two per-Update HashSet allocations
+    // sets. That removes the two per-Update HashSet allocations
     // (CalendarView.SelectedDates and peers rebuild their list every render)
-    // with no cross-window race. Each Update fully drains both sets before it
-    // returns, so reuse within a thread is safe. (Two CollectionDiff entries
-    // with an identical closed generic on one control would share these — the
-    // same accepted collision caveat as DescriptorControlledPayload above; the
-    // handler still runs entries sequentially, so each drains before the next.)
+    // with no cross-window race. Each Update drains both sets in a finally before
+    // it returns, so reuse within a thread always starts clean.
+    //
+    // The sets hash by _keyComparer, which is per entry instance. Two CollectionDiff
+    // entries of the same closed generic on one thread share these sets but may
+    // carry different comparers, so s_scratchComparer records the comparer the
+    // current sets were built with and the sets are rebuilt when a differing
+    // comparer runs — never diffing with another entry's comparer. (The handler
+    // runs entries sequentially and the finally drains before the next entry, so
+    // the only rebuild cost is a genuine comparer change, not normal alternation.)
     [ThreadStatic] private static HashSet<TKey>? s_scratchNewKeys;
     [ThreadStatic] private static HashSet<TKey>? s_scratchPresentKeys;
+    [ThreadStatic] private static IEqualityComparer<TKey>? s_scratchComparer;
 
     public CollectionDiffControlledPropEntry(
         Func<TElement, IReadOnlyList<TItem>> get,
@@ -1269,30 +1286,47 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
         // Fast path: same items, no work.
         if (ReferenceEquals(oldItems, newItems)) return;
 
-        // Build new key set; track which old indices are still present.
-        var newKeys = s_scratchNewKeys ??= new HashSet<TKey>(_keyComparer);
-        newKeys.Clear();
-        for (int i = 0; i < newItems.Count; i++) newKeys.Add(_key(newItems[i]));
-
-        var vec = _getVector(ctrl);
-        ChangeEchoSuppressor.BeginSuppress(ctrl);
-
-        // Remove items not in newKeys, in descending index order so earlier
-        // indices stay stable.
-        for (int i = vec.Count - 1; i >= 0; i--)
+        // Acquire the per-thread scratch sets. Rebuild them when the active entry's
+        // key comparer differs from the one the current sets were created with, so a
+        // custom-comparer entry never diffs with another entry's comparer (#119).
+        var newKeys = s_scratchNewKeys;
+        var presentKeys = s_scratchPresentKeys;
+        if (newKeys is null || presentKeys is null || !ReferenceEquals(s_scratchComparer, _keyComparer))
         {
-            if (!newKeys.Contains(_key(vec[i])))
-                vec.RemoveAt(i);
+            newKeys = s_scratchNewKeys = new HashSet<TKey>(_keyComparer);
+            presentKeys = s_scratchPresentKeys = new HashSet<TKey>(_keyComparer);
+            s_scratchComparer = _keyComparer;
         }
 
-        // Add items that aren't already present.
-        var presentKeys = s_scratchPresentKeys ??= new HashSet<TKey>(_keyComparer);
-        presentKeys.Clear();
-        for (int i = 0; i < vec.Count; i++) presentKeys.Add(_key(vec[i]));
-        for (int i = 0; i < newItems.Count; i++)
+        try
         {
-            var k = _key(newItems[i]);
-            if (presentKeys.Add(k)) vec.Add(newItems[i]);
+            // Build new key set; track which old indices are still present.
+            for (int i = 0; i < newItems.Count; i++) newKeys.Add(_key(newItems[i]));
+
+            var vec = _getVector(ctrl);
+            ChangeEchoSuppressor.BeginSuppress(ctrl);
+
+            // Remove items not in newKeys, in descending index order so earlier
+            // indices stay stable.
+            for (int i = vec.Count - 1; i >= 0; i--)
+            {
+                if (!newKeys.Contains(_key(vec[i])))
+                    vec.RemoveAt(i);
+            }
+
+            // Add items that aren't already present.
+            for (int i = 0; i < vec.Count; i++) presentKeys.Add(_key(vec[i]));
+            for (int i = 0; i < newItems.Count; i++)
+            {
+                var k = _key(newItems[i]);
+                if (presentKeys.Add(k)) vec.Add(newItems[i]);
+            }
+        }
+        finally
+        {
+            // Drain before returning so the next reuse on this thread starts clean.
+            newKeys.Clear();
+            presentKeys.Clear();
         }
     }
 

--- a/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
@@ -95,7 +95,13 @@ public abstract class PropEntry<TElement, TControl>
     /// every entry type that overrides <see cref="EnsureSubscribed"/> overrides
     /// this to <c>true</c>. A reflection-backed test
     /// (<c>PropEntryDiffDispatchTests.Subscribes_OverrideMatches_EnsureSubscribedOverride_ForEveryEntry</c>)
-    /// guards that invariant.</summary>
+    /// guards that invariant.
+    /// <para><b>Note for subclassers:</b> the base is a deliberate <c>false</c> so the
+    /// dominant no-op entries (e.g. <c>OneWay</c>) stay out of the subscribe subset.
+    /// If you derive from <see cref="PropEntry{TElement,TControl}"/> and override
+    /// <see cref="EnsureSubscribed"/> to do real wiring, you <b>must</b> also override
+    /// this to return <c>true</c> — otherwise the interpreter omits your entry from the
+    /// subscribe pass and your subscription is silently never wired.</para></summary>
     public virtual bool Subscribes => false;
 }
 
@@ -591,14 +597,36 @@ internal sealed class ReferenceListPropEntry<TElement, TControl, TTarget> : Prop
     // buffer is drained in a finally so it never retains cell references
     // (FrameworkElements) between calls.
     [ThreadStatic] private static List<Microsoft.UI.Reactor.Input.ElementRef>? s_scratchCells;
+    [ThreadStatic] private static bool s_scratchCellsInUse;
 
-    // Lazily allocate the per-thread scratch through a static helper so the
-    // [ThreadStatic] write doesn't happen inside the instance EnsureSubscribed body
-    // (CodeQL cs/static-field-written-by-instance) while keeping the per-thread
-    // reuse. The list is always empty on return: freshly allocated, or drained by
-    // the previous call's finally below.
-    private static List<Microsoft.UI.Reactor.Input.ElementRef> RentScratchCells()
-        => s_scratchCells ??= new List<Microsoft.UI.Reactor.Input.ElementRef>();
+    // Rent the per-thread scratch through a static helper so the [ThreadStatic]
+    // write doesn't happen inside the instance EnsureSubscribed body (CodeQL
+    // cs/static-field-written-by-instance) while keeping the per-thread reuse.
+    //
+    // Reentrancy: like CollectionDiff's scratch above, if a synchronous nested
+    // rerender re-enters EnsureSubscribed on this thread while the shared list is
+    // still in use, `Rented` is false and the caller gets a fresh per-call list
+    // (the pre-#120 always-allocate behavior) so the in-flight outer projection is
+    // never corrupted. The list is empty on return either way. Always pair with
+    // ReturnScratchCells in a finally.
+    private static (List<Microsoft.UI.Reactor.Input.ElementRef> Cells, bool Rented) RentScratchCells()
+    {
+        if (s_scratchCellsInUse)
+            return (new List<Microsoft.UI.Reactor.Input.ElementRef>(), false);
+        var cells = s_scratchCells ??= new List<Microsoft.UI.Reactor.Input.ElementRef>();
+        s_scratchCellsInUse = true;
+        return (cells, true);
+    }
+
+    private static void ReturnScratchCells(List<Microsoft.UI.Reactor.Input.ElementRef> cells, bool rented)
+    {
+        // Fresh per-call lists from the reentrant path are just dropped to GC.
+        if (!rented) return;
+        // WireReferenceListEdge copies synchronously; drop the cell references
+        // (FrameworkElements) so the shared scratch doesn't retain them between calls.
+        cells.Clear();
+        s_scratchCellsInUse = false;
+    }
 
     public ReferenceListPropEntry(
         Func<TElement, IReadOnlyList<Microsoft.UI.Reactor.Input.ElementRef<TTarget>>?> get,
@@ -628,7 +656,7 @@ internal sealed class ReferenceListPropEntry<TElement, TControl, TTarget> : Prop
         TElement el)
     {
         var refs = _get(el);
-        var cells = RentScratchCells();
+        var (cells, rented) = RentScratchCells();
         try
         {
             if (refs is not null)
@@ -647,9 +675,7 @@ internal sealed class ReferenceListPropEntry<TElement, TControl, TTarget> : Prop
         }
         finally
         {
-            // WireReferenceListEdge copies synchronously; drop the cell references
-            // (FrameworkElements) so the scratch doesn't retain them between calls.
-            cells.Clear();
+            ReturnScratchCells(cells, rented);
         }
     }
 
@@ -1253,16 +1279,30 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
     [ThreadStatic] private static HashSet<TKey>? s_scratchNewKeys;
     [ThreadStatic] private static HashSet<TKey>? s_scratchPresentKeys;
     [ThreadStatic] private static IEqualityComparer<TKey>? s_scratchComparer;
+    [ThreadStatic] private static bool s_scratchInUse;
 
     // Rent the per-thread scratch sets through a static helper so the
     // [ThreadStatic] writes don't happen inside the instance Update body (CodeQL
     // cs/static-field-written-by-instance) while keeping the per-thread reuse.
+    //
     // Rebuilds both sets when the active entry's key comparer differs from the one
     // the current sets were created with, so a custom-comparer entry never diffs
-    // with another entry's comparer (#119). Both sets are empty on return: freshly
-    // allocated, or drained by the previous call's finally.
-    private static (HashSet<TKey> NewKeys, HashSet<TKey> PresentKeys) RentScratchSets(IEqualityComparer<TKey> keyComparer)
+    // with another entry's comparer (#119).
+    //
+    // Reentrancy: a CollectionDiff mutation can echo synchronously (a leaked
+    // SelectedDates change → user callback → inline rerender) and re-enter Update
+    // on this thread for the same closed generic while the shared sets are still
+    // populated. When that happens `Rented` is false and the caller gets fresh
+    // per-call sets — restoring the pre-#119 always-allocate behavior for that rare
+    // path so the in-flight outer diff is never corrupted; the shared scratch and
+    // comparer sentinel are left untouched. The common (non-reentrant) path keeps
+    // the allocation-free shared scratch. Always pair this with ReturnScratchSets
+    // in a finally.
+    private static (HashSet<TKey> NewKeys, HashSet<TKey> PresentKeys, bool Rented) RentScratchSets(IEqualityComparer<TKey> keyComparer)
     {
+        if (s_scratchInUse)
+            return (new HashSet<TKey>(keyComparer), new HashSet<TKey>(keyComparer), false);
+
         var newKeys = s_scratchNewKeys;
         var presentKeys = s_scratchPresentKeys;
         if (newKeys is null || presentKeys is null || !ReferenceEquals(s_scratchComparer, keyComparer))
@@ -1271,7 +1311,19 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
             presentKeys = s_scratchPresentKeys = new HashSet<TKey>(keyComparer);
             s_scratchComparer = keyComparer;
         }
-        return (newKeys, presentKeys);
+        s_scratchInUse = true;
+        return (newKeys, presentKeys, true);
+    }
+
+    private static void ReturnScratchSets(HashSet<TKey> newKeys, HashSet<TKey> presentKeys, bool rented)
+    {
+        // Fresh per-call sets from the reentrant path are just dropped to GC.
+        if (!rented) return;
+        // Drain the shared scratch so the next reuse on this thread starts clean,
+        // then release it for the next (non-nested) caller.
+        newKeys.Clear();
+        presentKeys.Clear();
+        s_scratchInUse = false;
     }
 
     public CollectionDiffControlledPropEntry(
@@ -1315,8 +1367,8 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
         if (ReferenceEquals(oldItems, newItems)) return;
 
         // Rent the per-thread scratch sets (rebuilt if this entry's key comparer
-        // differs from the one they were created with — see RentScratchSets).
-        var (newKeys, presentKeys) = RentScratchSets(_keyComparer);
+        // differs; fresh per-call if a nested rerender re-entered — see RentScratchSets).
+        var (newKeys, presentKeys, rented) = RentScratchSets(_keyComparer);
 
         try
         {
@@ -1344,9 +1396,7 @@ internal sealed class CollectionDiffControlledPropEntry<TElement, TControl, TPay
         }
         finally
         {
-            // Drain before returning so the next reuse on this thread starts clean.
-            newKeys.Clear();
-            presentKeys.Clear();
+            ReturnScratchSets(newKeys, presentKeys, rented);
         }
     }
 

--- a/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
+++ b/src/Reactor/Core/V1Protocol/Descriptor/PropEntry.cs
@@ -428,7 +428,7 @@ internal sealed class ControlledPropEntry<TElement, TControl, TValue, TArgs> : P
             {
                 payload.ExpectedEcho = nv;
                 payload.HasExpectedEcho = true;
-                payload.EchoComparer = _comparer;
+                payload.EchoComparer = _comparer ?? EqualityComparer<TValue>.Default;
             }
         }
 

--- a/tests/Reactor.Tests/PropEntryDiffDispatchTests.cs
+++ b/tests/Reactor.Tests/PropEntryDiffDispatchTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Core.V1Protocol;
 using Microsoft.UI.Reactor.Core.V1Protocol.Descriptor;
 using WinUI = Microsoft.UI.Xaml.Controls;
 using Xunit;
@@ -206,6 +207,38 @@ public class PropEntryDiffDispatchTests
         Assert.Empty(GetPrivateArray(handler, "_subscribeEntries"));
     }
 
+    // #114: when the subscribe subset is empty, handler.Update skips BindFor and the
+    // subscribe loop entirely. This guards that the *update* loop still runs every
+    // OneWay entry in that path — i.e. the BindFor skip never gates the prop writes.
+    [Fact]
+    public void DescriptorHandler_Update_StillWritesOneWayEntries_WhenSubscribeSubsetEmpty()
+    {
+        int aWrites = 0, bWrites = 0;
+        int aLast = -1, bLast = -1;
+        var descriptor = new ControlDescriptor<IntElement, WinUI.TextBlock>()
+            .OneWay(e => e.Value, (c, v) => { aWrites++; aLast = v; })
+            .OneWay(e => e.Value + 100, (c, v) => { bWrites++; bLast = v; });
+
+        var handler = new DescriptorHandler<IntElement, WinUI.TextBlock>(descriptor);
+        Assert.Empty(GetPrivateArray(handler, "_subscribeEntries"));
+
+        var reconciler = new Reconciler();
+        var ctx = new UpdateContext(reconciler, static () => { });
+
+        // Changed value → both OneWay entries write. ctrl is null; the recording
+        // setters ignore it (headless — no live control needed for OneWay writes).
+        handler.Update(ctx, new IntElement(1), new IntElement(2), null!);
+        Assert.Equal(1, aWrites);
+        Assert.Equal(2, aLast);
+        Assert.Equal(1, bWrites);
+        Assert.Equal(102, bLast);
+
+        // Unchanged value → both skip (proves the writes are real diffs, not unconditional).
+        handler.Update(ctx, new IntElement(2), new IntElement(2), null!);
+        Assert.Equal(1, aWrites);
+        Assert.Equal(1, bWrites);
+    }
+
     // ── #119: CollectionDiff scratch reuse stays correct across updates ──────
 
     [Fact]
@@ -242,8 +275,31 @@ public class PropEntryDiffDispatchTests
         Assert.Equal(new[] { 1, 2, 3 }, backing);
     }
 
+    // #119: two CollectionDiff entries of the SAME closed generic share the
+    // thread-static scratch sets, but each must diff with its OWN key comparer.
+    // Guards the s_scratchComparer sentinel that rebuilds the sets when a
+    // differing comparer runs (a leaked comparer would corrupt the diff).
+    [Fact]
+    public void CollectionDiff_PerEntryKeyComparer_NotLeakedAcrossSharedScratch()
+    {
+        // Run the parity entry first so the shared scratch is built with ParityComparer.
+        // Target [4], new items [2]: under parity 2 ≡ 4, so 4 stays and 2 is not added.
+        var parityBacking = new List<int> { 4 };
+        var parityEntry = MakeCollectionDiffEntry(_ => parityBacking, ParityComparer.Instance);
+        parityEntry.Update(null!, new ItemsElement(new[] { 4 }), new ItemsElement(new[] { 2 }));
+        Assert.Equal(new[] { 4 }, parityBacking);
+
+        // Now a DEFAULT-comparer entry. If the scratch leaked ParityComparer, this would
+        // wrongly keep [4]; with the per-entry rebuild it diffs with default equality:
+        // 2 ≠ 4, so 4 is removed and 2 is added.
+        var defaultBacking = new List<int> { 4 };
+        var defaultEntry = MakeCollectionDiffEntry(_ => defaultBacking);
+        defaultEntry.Update(null!, new ItemsElement(new[] { 4 }), new ItemsElement(new[] { 2 }));
+        Assert.Equal(new[] { 2 }, defaultBacking);
+    }
+
     private static CollectionDiffControlledPropEntry<ItemsElement, WinUI.CalendarView, DummyPayload, int, int, Action>
-        MakeCollectionDiffEntry(Func<WinUI.CalendarView, IList<int>> getVector)
+        MakeCollectionDiffEntry(Func<WinUI.CalendarView, IList<int>> getVector, IEqualityComparer<int>? keyComparer = null)
         => new(
             get: e => e.Items,
             getVector: getVector,
@@ -252,7 +308,8 @@ public class PropEntryDiffDispatchTests
             callbackPresent: e => null,
             trampoline: () => { },
             slotIsNull: p => true,
-            setSlot: (p, d) => { });
+            setSlot: (p, d) => { },
+            keyComparer: keyComparer);
 
     private static Array GetPrivateArray(object owner, string field)
     {

--- a/tests/Reactor.Tests/PropEntryDiffDispatchTests.cs
+++ b/tests/Reactor.Tests/PropEntryDiffDispatchTests.cs
@@ -298,6 +298,69 @@ public class PropEntryDiffDispatchTests
         Assert.Equal(new[] { 2 }, defaultBacking);
     }
 
+    // C2: if a lambda throws mid-diff, the finally (ReturnScratchSets) must still
+    // drain the shared scratch so the NEXT diff on this thread starts clean — a
+    // leaked newKeys set would let removed items wrongly survive.
+    [Fact]
+    public void CollectionDiff_ScratchDrainedAfterException_NoStaleKeyLeak()
+    {
+        var backing = new List<int> { 1, 2, 3 };
+        int getVectorCalls = 0;
+        var entry = MakeCollectionDiffEntry(_ =>
+        {
+            getVectorCalls++;
+            // Throw on the first diff, AFTER newKeys {1,2} has been populated.
+            if (getVectorCalls == 1) throw new InvalidOperationException("boom");
+            return backing;
+        });
+
+        // Update 1: builds newKeys {1,2}, then getVector throws → finally must drain.
+        Assert.Throws<InvalidOperationException>(() =>
+            entry.Update(null!, new ItemsElement(new[] { 1, 2 }), new ItemsElement(new[] { 1, 2 })));
+
+        // Update 2: vec [1,2,3] -> [3]. If {1,2} leaked into newKeys, keys 1 and 2 would
+        // be treated as still-wanted and never removed (wrong result [1,2,3]); a clean
+        // drain removes them, leaving [3].
+        entry.Update(null!, new ItemsElement(new[] { 1, 2, 3 }), new ItemsElement(new[] { 3 }));
+        Assert.Equal(new[] { 3 }, backing);
+    }
+
+    // FINDING A (reentrancy): a CollectionDiff mutation can echo synchronously and
+    // re-enter Update on the same thread + closed generic while the outer diff still
+    // holds the shared scratch. The in-use guard must hand the nested call FRESH sets
+    // so it neither pollutes nor drains the outer's populated newKeys.
+    [Fact]
+    public void CollectionDiff_NestedReentrantUpdate_DoesNotCorruptOuterDiff()
+    {
+        var outerVec = new RecordingList(new[] { 1, 2, 3 });
+        var innerBacking = new List<int> { 10, 20 };
+        var innerEntry = MakeCollectionDiffEntry(_ => innerBacking);
+
+        bool reentered = false;
+        var outerEntry = MakeCollectionDiffEntry(_ =>
+        {
+            if (!reentered)
+            {
+                reentered = true;
+                // Nested diff on a DIFFERENT entry of the SAME closed generic — it shares
+                // the thread-static scratch with the outer call that is mid-flight.
+                innerEntry.Update(null!, new ItemsElement(new[] { 10, 20 }), new ItemsElement(new[] { 20, 30 }));
+            }
+            return outerVec;
+        });
+
+        // Outer [1,2,3] -> [2,3,4]: a correct diff drops only key 1 and appends key 4
+        // (exactly 1 RemoveAt + 1 Add). Without the guard the nested call drains the
+        // outer's newKeys in its finally, so the outer instead removes all three and
+        // re-adds three — same final state, but 4 extra WinUI mutations (and echo churn).
+        outerEntry.Update(null!, new ItemsElement(new[] { 1, 2, 3 }), new ItemsElement(new[] { 2, 3, 4 }));
+
+        Assert.Equal(new[] { 20, 30 }, innerBacking);       // nested diff correct
+        Assert.Equal(new[] { 2, 3, 4 }, outerVec.Snapshot); // outer final state correct
+        Assert.Equal(1, outerVec.Removes);                  // minimal churn — proves newKeys survived
+        Assert.Equal(1, outerVec.Adds);
+    }
+
     private static CollectionDiffControlledPropEntry<ItemsElement, WinUI.CalendarView, DummyPayload, int, int, Action>
         MakeCollectionDiffEntry(Func<WinUI.CalendarView, IList<int>> getVector, IEqualityComparer<int>? keyComparer = null)
         => new(
@@ -327,5 +390,33 @@ public class PropEntryDiffDispatchTests
             toCheck = toCheck.BaseType;
         }
         return false;
+    }
+
+    // IList<int> that counts Add/RemoveAt so a test can assert how much a diff churned
+    // the target vector (used by the reentrancy test, where the corruption shows up as
+    // extra mutations rather than a different final state).
+    private sealed class RecordingList : IList<int>
+    {
+        private readonly List<int> _inner;
+        public int Removes;
+        public int Adds;
+
+        public RecordingList(IEnumerable<int> items) => _inner = new List<int>(items);
+
+        public IReadOnlyList<int> Snapshot => _inner;
+
+        public int this[int index] { get => _inner[index]; set => _inner[index] = value; }
+        public int Count => _inner.Count;
+        public bool IsReadOnly => false;
+        public void Add(int item) { Adds++; _inner.Add(item); }
+        public void RemoveAt(int index) { Removes++; _inner.RemoveAt(index); }
+        public void Clear() => _inner.Clear();
+        public bool Contains(int item) => _inner.Contains(item);
+        public void CopyTo(int[] array, int arrayIndex) => _inner.CopyTo(array, arrayIndex);
+        public int IndexOf(int item) => _inner.IndexOf(item);
+        public void Insert(int index, int item) => _inner.Insert(index, item);
+        public bool Remove(int item) => _inner.Remove(item);
+        public IEnumerator<int> GetEnumerator() => _inner.GetEnumerator();
+        global::System.Collections.IEnumerator global::System.Collections.IEnumerable.GetEnumerator() => _inner.GetEnumerator();
     }
 }

--- a/tests/Reactor.Tests/PropEntryDiffDispatchTests.cs
+++ b/tests/Reactor.Tests/PropEntryDiffDispatchTests.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Core.V1Protocol.Descriptor;
+using WinUI = Microsoft.UI.Xaml.Controls;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+// Perf: devirtualize per-prop diff dispatch in V1 descriptor (issues #114/#115/#117/#119/#120).
+// These are headless tests — they never instantiate a live WinUI control (which throws
+// COMException in the test host). Real control *types* are used only as generic arguments;
+// the "control" argument passed to entries is null and the recording set/get/vector lambdas
+// ignore it. This mirrors the existing RichTextBlockDescriptorTests pattern.
+public class PropEntryDiffDispatchTests
+{
+    private sealed record IntElement(int Value) : Element;
+
+    private sealed record ItemsElement(IReadOnlyList<int> Items) : Element;
+
+    private sealed class DummyPayload { }
+
+    // Treats two ints as equal iff they have the same parity. Lets us prove a custom
+    // comparer's behavior is honored (and not silently replaced by the default).
+    private sealed class ParityComparer : IEqualityComparer<int>
+    {
+        public static readonly ParityComparer Instance = new();
+        public bool Equals(int x, int y) => (x & 1) == (y & 1);
+        public int GetHashCode(int obj) => obj & 1;
+    }
+
+    // ── #115: comparer devirtualization helper ──────────────────────────────
+
+    [Fact]
+    public void ValuesEqual_NullComparer_MatchesDefaultForValueTypes()
+    {
+        Assert.True(PropValueComparison.ValuesEqual<int>(null, 5, 5));
+        Assert.False(PropValueComparison.ValuesEqual<int>(null, 5, 6));
+        Assert.Equal(EqualityComparer<int>.Default.Equals(5, 5), PropValueComparison.ValuesEqual<int>(null, 5, 5));
+        Assert.Equal(EqualityComparer<int>.Default.Equals(5, 6), PropValueComparison.ValuesEqual<int>(null, 5, 6));
+
+        var a = new DateTime(2024, 1, 1);
+        var b = new DateTime(2024, 1, 1);
+        var c = new DateTime(2025, 6, 30);
+        Assert.True(PropValueComparison.ValuesEqual<DateTime>(null, a, b));
+        Assert.False(PropValueComparison.ValuesEqual<DateTime>(null, a, c));
+    }
+
+    [Fact]
+    public void ValuesEqual_NullComparer_MatchesDefaultForReferenceTypes()
+    {
+        Assert.True(PropValueComparison.ValuesEqual<string>(null, "abc", "abc"));
+        Assert.False(PropValueComparison.ValuesEqual<string>(null, "abc", "xyz"));
+        Assert.True(PropValueComparison.ValuesEqual<string?>(null, null, null));
+        Assert.False(PropValueComparison.ValuesEqual<string?>(null, "abc", null));
+    }
+
+    [Fact]
+    public void ValuesEqual_CustomComparer_IsHonored()
+    {
+        // Parity comparer: 2 and 4 are "equal", 2 and 3 are not.
+        Assert.True(PropValueComparison.ValuesEqual(ParityComparer.Instance, 2, 4));
+        Assert.False(PropValueComparison.ValuesEqual(ParityComparer.Instance, 2, 3));
+        // The default comparer would disagree on 2 vs 4 — proves we didn't fall back to it.
+        Assert.NotEqual(EqualityComparer<int>.Default.Equals(2, 4), PropValueComparison.ValuesEqual(ParityComparer.Instance, 2, 4));
+    }
+
+    // ── #115/#117: OneWay write-vs-skip still correct after devirtualization ──
+
+    [Fact]
+    public void OneWay_DefaultComparer_WritesOnChange_SkipsWhenEqual()
+    {
+        int writes = 0;
+        int last = -1;
+        var entry = new OneWayPropEntry<IntElement, WinUI.TextBlock, int>(
+            e => e.Value,
+            (c, v) => { writes++; last = v; });
+
+        // changed → write
+        entry.Update(null!, new IntElement(1), new IntElement(2));
+        Assert.Equal(1, writes);
+        Assert.Equal(2, last);
+
+        // unchanged → skip
+        entry.Update(null!, new IntElement(2), new IntElement(2));
+        Assert.Equal(1, writes);
+    }
+
+    [Fact]
+    public void OneWay_Mount_AlwaysWrites()
+    {
+        int writes = 0;
+        int last = -1;
+        var entry = new OneWayPropEntry<IntElement, WinUI.TextBlock, int>(
+            e => e.Value,
+            (c, v) => { writes++; last = v; });
+
+        entry.Mount(null!, new IntElement(7));
+        Assert.Equal(1, writes);
+        Assert.Equal(7, last);
+    }
+
+    [Fact]
+    public void OneWay_CustomComparer_IsHonoredForWriteDecision()
+    {
+        int writes = 0;
+        var entry = new OneWayPropEntry<IntElement, WinUI.TextBlock, int>(
+            e => e.Value,
+            (c, v) => writes++,
+            ParityComparer.Instance);
+
+        // 2 -> 4: parity-equal, so NO write (default comparer would have written).
+        entry.Update(null!, new IntElement(2), new IntElement(4));
+        Assert.Equal(0, writes);
+
+        // 2 -> 3: parity differs, so write.
+        entry.Update(null!, new IntElement(2), new IntElement(3));
+        Assert.Equal(1, writes);
+    }
+
+    // ── #114: Subscribes discriminator ──────────────────────────────────────
+
+    [Fact]
+    public void Subscribes_IsFalse_ForNonSubscribingEntry()
+    {
+        var entry = new OneWayPropEntry<IntElement, WinUI.TextBlock, int>(e => e.Value, (c, v) => { });
+        Assert.False(entry.Subscribes);
+    }
+
+    [Fact]
+    public void Subscribes_IsTrue_ForSubscribingEntry()
+    {
+        var entry = new ReferencePropEntry<IntElement, WinUI.ToggleSwitch, WinUI.ToggleSwitch>(
+            e => null, (c, t) => { }, slot: 0);
+        Assert.True(entry.Subscribes);
+    }
+
+    // Robustness guard: every PropEntry subtype must override Subscribes IFF it
+    // overrides EnsureSubscribed. A future entry that wires a subscription but
+    // forgets to set Subscribes=true would be silently dropped from the subscribe
+    // partition; this test fails loudly in that case.
+    [Fact]
+    public void Subscribes_OverrideMatches_EnsureSubscribedOverride_ForEveryEntry()
+    {
+        var baseOpen = typeof(PropEntry<,>);
+        var entryTypes = baseOpen.Assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && IsSubclassOfRawGeneric(baseOpen, t))
+            .ToList();
+
+        Assert.NotEmpty(entryTypes);
+
+        foreach (var t in entryTypes)
+        {
+            var ensure = t.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .Single(m => m.Name == "EnsureSubscribed");
+            bool overridesEnsure = ensure.DeclaringType == t;
+
+            var subscribesGetter = t.GetProperty("Subscribes")!.GetGetMethod()!;
+            bool overridesSubscribes = subscribesGetter.DeclaringType == t;
+
+            Assert.True(
+                overridesEnsure == overridesSubscribes,
+                $"{t.Name}: overrides EnsureSubscribed={overridesEnsure} but overrides Subscribes={overridesSubscribes}. " +
+                "Any entry that overrides EnsureSubscribed must also override Subscribes => true.");
+        }
+    }
+
+    // ── #114/#117: DescriptorHandler partitions entries correctly ────────────
+
+    [Fact]
+    public void DescriptorHandler_PartitionsUpdateAndSubscribeEntries()
+    {
+        var descriptor = new ControlDescriptor<IntElement, WinUI.ToggleSwitch>()
+            .OneWay(e => e.Value, (c, v) => { })
+            .Initial(e => e.Value, (c, v) => { })
+            .Reference<WinUI.ToggleSwitch>(e => null, (c, t) => { })
+            .OneWay(e => e.Value, (c, v) => { });
+
+        var handler = new DescriptorHandler<IntElement, WinUI.ToggleSwitch>(descriptor);
+
+        var update = GetPrivateArray(handler, "_updateEntries");
+        var subscribe = GetPrivateArray(handler, "_subscribeEntries");
+
+        // _updateEntries: all four entries, in declaration order, same instances as Properties.
+        Assert.Equal(4, update.Length);
+        Assert.True(descriptor.Properties.SequenceEqual(update.Cast<PropEntry<IntElement, WinUI.ToggleSwitch>>()));
+
+        // _subscribeEntries: only the single reference entry (the one that overrides EnsureSubscribed).
+        var single = Assert.Single(subscribe)!;
+        Assert.StartsWith("ReferencePropEntry", single.GetType().Name, StringComparison.Ordinal);
+        Assert.True(((PropEntry<IntElement, WinUI.ToggleSwitch>)single).Subscribes);
+    }
+
+    [Fact]
+    public void DescriptorHandler_EmptySubscribeSubset_WhenNoSubscribingEntries()
+    {
+        var descriptor = new ControlDescriptor<IntElement, WinUI.ToggleSwitch>()
+            .OneWay(e => e.Value, (c, v) => { })
+            .OneWay(e => e.Value, (c, v) => { });
+
+        var handler = new DescriptorHandler<IntElement, WinUI.ToggleSwitch>(descriptor);
+
+        Assert.Equal(2, GetPrivateArray(handler, "_updateEntries").Length);
+        Assert.Empty(GetPrivateArray(handler, "_subscribeEntries"));
+    }
+
+    // ── #119: CollectionDiff scratch reuse stays correct across updates ──────
+
+    [Fact]
+    public void CollectionDiff_ReusedScratch_ProducesCorrectDiffAcrossUpdates()
+    {
+        var backing = new List<int> { 1, 2, 3 };
+        var entry = MakeCollectionDiffEntry(_ => backing);
+
+        // [1,2,3] -> [2,3,4]: drop 1, keep 2/3, add 4.
+        entry.Update(null!, new ItemsElement(new[] { 1, 2, 3 }), new ItemsElement(new[] { 2, 3, 4 }));
+        Assert.Equal(new[] { 2, 3, 4 }, backing);
+
+        // [2,3,4] -> [5]: if the scratch key sets weren't cleared between updates,
+        // stale keys {2,3,4} would survive and suppress the removals — proving reuse is clean.
+        entry.Update(null!, new ItemsElement(new[] { 2, 3, 4 }), new ItemsElement(new[] { 5 }));
+        Assert.Equal(new[] { 5 }, backing);
+
+        // [5] -> []: clears everything.
+        entry.Update(null!, new ItemsElement(new[] { 5 }), new ItemsElement(Array.Empty<int>()));
+        Assert.Empty(backing);
+    }
+
+    [Fact]
+    public void CollectionDiff_ReferenceEqualItems_IsNoOp()
+    {
+        var backing = new List<int> { 1, 2, 3 };
+        var entry = MakeCollectionDiffEntry(_ => backing);
+
+        var items = (IReadOnlyList<int>)new[] { 9, 9, 9 };
+        var el = new ItemsElement(items);
+        entry.Update(null!, el, el);
+
+        // Same item-list reference on both sides → fast path, backing untouched.
+        Assert.Equal(new[] { 1, 2, 3 }, backing);
+    }
+
+    private static CollectionDiffControlledPropEntry<ItemsElement, WinUI.CalendarView, DummyPayload, int, int, Action>
+        MakeCollectionDiffEntry(Func<WinUI.CalendarView, IList<int>> getVector)
+        => new(
+            get: e => e.Items,
+            getVector: getVector,
+            key: i => i,
+            subscribe: (c, d) => { },
+            callbackPresent: e => null,
+            trampoline: () => { },
+            slotIsNull: p => true,
+            setSlot: (p, d) => { });
+
+    private static Array GetPrivateArray(object owner, string field)
+    {
+        var f = owner.GetType().GetField(field, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(f);
+        return Assert.IsAssignableFrom<Array>(f!.GetValue(owner));
+    }
+
+    private static bool IsSubclassOfRawGeneric(Type generic, Type? toCheck)
+    {
+        while (toCheck is not null && toCheck != typeof(object))
+        {
+            var cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
+            if (generic == cur) return true;
+            toCheck = toCheck.BaseType;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Closes #655

## What

Devirtualizes the V1 descriptor per-prop diff dispatch — the machinery that runs hundreds of thousands of comparisons/sec on the data-grid stress workload. Scope is the two diff-machinery files plus tests; behavior is preserved exactly for every descriptor-based control.

| # | Fix |
|---|-----|
| #115 | Value comparers stored nullable (`null` = default); all compares routed through an `AggressiveInlining` `PropValueComparison.ValuesEqual` helper that calls `EqualityComparer<T>.Default.Equals` directly (JIT devirtualizes + inlines for value types). Custom comparers still honored via the interface call. |
| #114 | New `PropEntry.Subscribes` discriminator; handler partitions entries into `_updateEntries` (all) + `_subscribeEntries` (small subset). Per-Update subscribe pass visits only the subset and skips `BindFor` + the loop entirely when empty (the OneWay-only grid-cell case). |
| #117 | `Properties` snapshotted into concrete `PropEntry[]` arrays in the handler ctor; Mount/Update iterate the arrays (no interface-indexer dispatch). |
| #119 | `[ThreadStatic]` cleared-on-use scratch `HashSet`s in `CollectionDiffControlledPropEntry.Update` (−2 allocs/update). |
| #120 | `ReferenceListPropEntry` moved into the subscribe subset; `[ThreadStatic]` scratch cells list removes its per-Update allocation. |

#118 is deferred — its fix needs `ControlDescriptor.cs`/`Element.cs` (out of scope); the entry still gets the #115 devirtualization.

## Behavior preservation

The reference entries deliberately re-evaluate `EnsureSubscribed` every Update (ref add/remove/reorder detection), so a "skip after first wire" flag would be unsafe — only the empty-subset skip is used. Skipping `BindFor` when there are no subscribers is safe: its sole side effect (resetting the reference-slot thread-static) is consumed exclusively by reference entries, which are themselves subscribers. Scratch state is `[ThreadStatic]` (not instance fields) because entries are process-wide singletons shared across controls and Reactor supports multiple UI threads/windows.

## Validation

- `dotnet build src/Reactor` (Release) — clean, 0 warnings/0 errors.
- `dotnet test tests/Reactor.Tests` (Release) — **9683 passed, 0 failed**, incl. 13 new `PropEntryDiffDispatchTests` (write-on-change / skip-on-equal for default + custom comparer; comparer helper vs `EqualityComparer<T>.Default`; `Subscribes` discriminator + a reflection invariant guarding "overrides `EnsureSubscribed` ⇔ overrides `Subscribes`"; handler `_updateEntries`/`_subscribeEntries` partitioning; collection-diff scratch reuse across updates).
- Live WinUI selftests: ToggleSwitch controlled family (echo suppression, value-diff, subscription wire/fire) and the `RealRef` reference-edge torture suite (scalar/list refs, keyed reorder a11y ordering, pool-reuse wire-exactly-once, no subscriber leaks) — **0 failures**.

Perf numbers will be confirmed via `/perf` once that workflow merges. The two `reactor.api.txt` files are regenerated by the build's API-index tool to include the new public `PropEntry.Subscribes` member.