### PR TITLE
perf: eliminate per-diff allocations in ChildReconciler + KeyedListDiff

### DIFF
--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+using System.Collections.Concurrent;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Reactor.Core.Internal;
 using WinUI = Microsoft.UI.Xaml.Controls;
@@ -153,16 +155,43 @@ internal static class ChildReconciler
         int oldLen = oldChildren.Length;
         int newLen = newChildren.Length;
 
+        // Cache the child count once (#37). Both the prefix and suffix loops
+        // only ever Replace (RemoveAt+Insert — count-neutral) or skip, so the
+        // panel count is stable across them. This avoids re-reading the COM
+        // IVector.get_Size on every iteration of the suffix loop.
+        int childCount = children.Count;
+
         // Phase 1: Common prefix
         int prefixLen = 0;
         while (prefixLen < oldLen && prefixLen < newLen &&
                KeyMatch(oldChildren[prefixLen], newChildren[prefixLen]) &&
                reconciler.CanUpdate(oldChildren[prefixLen], newChildren[prefixLen]))
         {
-            // Update in place
-            if (prefixLen < children.Count)
+            var oldEl = oldChildren[prefixLen];
+            var newEl = newChildren[prefixLen];
+
+            // Early skip (#30): when the element is structurally identical we
+            // can avoid the children.Get COM call and the full property diff
+            // inside UpdateChild — exactly mirroring the positional path. The
+            // keyed prefix is the steady-state path for stable lists (e.g. grid
+            // rows whose keys never change), so without this they re-diff every
+            // tick.
+            if (Element.CanSkipUpdate(oldEl, newEl)
+                && !reconciler.ForceRenderThroughWrapper(newEl))
             {
-                var replacement = reconciler.UpdateChild(oldChildren[prefixLen], newChildren[prefixLen], children.Get(prefixLen), requestRerender);
+                reconciler.DebugElementsSkipped++;
+                // Refresh the Tag when the element carries callbacks so the
+                // event trampoline dispatches through the latest closure.
+                if (newEl.HasCallbacks && prefixLen < childCount && children.Get(prefixLen) is FrameworkElement fe)
+                    Reconciler.SetElementTag(fe, newEl);
+                prefixLen++;
+                continue;
+            }
+
+            // Update in place
+            if (prefixLen < childCount)
+            {
+                var replacement = reconciler.UpdateChild(oldEl, newEl, children.Get(prefixLen), requestRerender);
                 if (replacement is not null)
                 {
                     reconciler.UnmountChild(children.Get(prefixLen));
@@ -180,10 +209,26 @@ internal static class ChildReconciler
         {
             // Update in place (from end)
             int oldIdx = oldLen - 1 - suffixLen;
-            int panelIdx = children.Count - 1 - suffixLen;
-            if (panelIdx >= 0 && panelIdx < children.Count)
+            int newIdx = newLen - 1 - suffixLen;
+            var oldEl = oldChildren[oldIdx];
+            var newEl = newChildren[newIdx];
+            int panelIdx = childCount - 1 - suffixLen;
+
+            // Early skip (#30): same fast-path as the prefix loop, applied from
+            // the end of the list.
+            if (Element.CanSkipUpdate(oldEl, newEl)
+                && !reconciler.ForceRenderThroughWrapper(newEl))
             {
-                var replacement = reconciler.UpdateChild(oldChildren[oldIdx], newChildren[newLen - 1 - suffixLen], children.Get(panelIdx), requestRerender);
+                reconciler.DebugElementsSkipped++;
+                if (newEl.HasCallbacks && panelIdx >= 0 && panelIdx < childCount && children.Get(panelIdx) is FrameworkElement fe)
+                    Reconciler.SetElementTag(fe, newEl);
+                suffixLen++;
+                continue;
+            }
+
+            if (panelIdx >= 0 && panelIdx < childCount)
+            {
+                var replacement = reconciler.UpdateChild(oldEl, newEl, children.Get(panelIdx), requestRerender);
                 if (replacement is not null)
                 {
                     reconciler.UnmountChild(children.Get(panelIdx));
@@ -251,126 +296,151 @@ internal static class ChildReconciler
         Action requestRerender,
         AnimationKind? ambientKind)
     {
-        // Build old key → index map
-        var oldKeyMap = new Dictionary<string, int>(oldMidLen);
-        for (int i = 0; i < oldMidLen; i++)
+        // Pool the per-call working buffers (#33). ChildReconciler recurses
+        // via UpdateChild below, so each (re-entrant) call must own distinct
+        // buffers — ArrayPool and the dict pool guarantee that, whereas a
+        // single ThreadStatic scratch would corrupt the outer diff.
+        var intPool = ArrayPool<int>.Shared;
+        var boolPool = ArrayPool<bool>.Shared;
+        var oldKeyMap = RentKeyIndexDict(oldMidLen);
+        var keyToIndex = RentKeyIndexDict(newMidLen);
+        int[] newToOld = intPool.Rent(newMidLen);
+        bool[] matched = boolPool.Rent(oldMidLen);
+        bool[] inLis = boolPool.Rent(newMidLen);
+        try
         {
-            var key = GetKey(oldChildren[oldStart + i], oldStart + i);
-            oldKeyMap[key] = i;
-        }
+            // A rented bool array can carry stale `true` markers; `matched`
+            // must default to false for the unmatched-removal pass below.
+            global::System.Array.Clear(matched, 0, oldMidLen);
 
-        // Map new keys to old indices
-        var newToOld = new int[newMidLen];
-        var matched = new bool[oldMidLen];
-        for (int i = 0; i < newMidLen; i++)
-        {
-            var key = GetKey(newChildren[newStart + i], newStart + i);
-            if (oldKeyMap.TryGetValue(key, out int oldIdx) &&
-                reconciler.CanUpdate(oldChildren[oldStart + oldIdx], newChildren[newStart + i]))
+            // Build old key → index map
+            for (int i = 0; i < oldMidLen; i++)
             {
-                newToOld[i] = oldIdx;
-                matched[oldIdx] = true;
+                var key = GetKey(oldChildren[oldStart + i], oldStart + i);
+                oldKeyMap[key] = i;
             }
-            else
-            {
-                newToOld[i] = -1;
-            }
-        }
 
-        // Compute LIS on newToOld
-        var lisIndices = ComputeLIS(newToOld);
-        var inLIS = new HashSet<int>(lisIndices);
-
-        // Step 1: Remove unmatched old items (reverse order for stable indices)
-        for (int i = oldMidLen - 1; i >= 0; i--)
-        {
-            if (!matched[i])
+            // Map new keys to old indices
+            for (int i = 0; i < newMidLen; i++)
             {
-                int panelIdx = prefixLen + i;
-                if (panelIdx < children.Count)
+                var key = GetKey(newChildren[newStart + i], newStart + i);
+                if (oldKeyMap.TryGetValue(key, out int oldIdx) &&
+                    reconciler.CanUpdate(oldChildren[oldStart + oldIdx], newChildren[newStart + i]))
                 {
-                    reconciler.RemoveChildWithExitTransition(children, panelIdx);
+                    newToOld[i] = oldIdx;
+                    matched[oldIdx] = true;
+                }
+                else
+                {
+                    newToOld[i] = -1;
                 }
             }
-        }
 
-        // Build key→panel-index lookup for O(1) FindItemByOldIndex (CR-011).
-        var keyToIndex = new Dictionary<string, int>();
-        int searchEnd = children.Count - suffixLen;
-        for (int i = prefixLen; i < searchEnd && i < children.Count; i++)
-        {
-            var child = children.Get(i);
-            if (child is FrameworkElement fe && Reconciler.GetElementTag(fe) is Element tagElement)
+            // Compute LIS on newToOld into a pooled membership mask — avoids
+            // the HashSet allocation and the redundant identical-set copy that
+            // the old `new HashSet<int>(ComputeLIS(...))` pair did (#31/#32).
+            ComputeLISInto(newToOld, newMidLen, inLis);
+
+            // Step 1: Remove unmatched old items (reverse order for stable indices)
+            for (int i = oldMidLen - 1; i >= 0; i--)
             {
-                var key = GetKey(tagElement, i);
-                keyToIndex.TryAdd(key, i);
-            }
-        }
-
-        // Step 2: Process new items - insert new, move existing not in LIS
-        for (int i = 0; i < newMidLen; i++)
-        {
-            int targetPanelIdx = prefixLen + i;
-
-            if (newToOld[i] == -1)
-            {
-                var ctrl = reconciler.Mount(newChildren[newStart + i], requestRerender);
-                if (ctrl is not null)
+                if (!matched[i])
                 {
-                    children.Insert(targetPanelIdx, ctrl);
-                    ApplyAmbientEnterIfActive(ctrl, newChildren[newStart + i], ambientKind);
-                }
-            }
-            else if (inLIS.Contains(i))
-            {
-                if (targetPanelIdx < children.Count)
-                {
-                    var replacement = reconciler.UpdateChild(
-                        oldChildren[oldStart + newToOld[i]],
-                        newChildren[newStart + i],
-                        children.Get(targetPanelIdx),
-                        requestRerender);
-                    if (replacement is not null)
+                    int panelIdx = prefixLen + i;
+                    if (panelIdx < children.Count)
                     {
-                        reconciler.UnmountChild(children.Get(targetPanelIdx));
-                        children.Replace(targetPanelIdx, replacement);
+                        reconciler.RemoveChildWithExitTransition(children, panelIdx);
                     }
                 }
             }
-            else
+
+            // Build key→panel-index lookup for O(1) FindItemByOldIndex (CR-011).
+            int searchEnd = children.Count - suffixLen;
+            for (int i = prefixLen; i < searchEnd && i < children.Count; i++)
             {
-                int oldRelIdx = newToOld[i];
-                int oldAbsIdx = oldStart + oldRelIdx;
-                var lookupKey = oldAbsIdx < oldChildren.Length ? GetKey(oldChildren[oldAbsIdx], oldAbsIdx) : null;
-                int currentPos = lookupKey != null && keyToIndex.TryGetValue(lookupKey, out var pos) ? pos : -1;
-                if (currentPos >= 0 && currentPos != targetPanelIdx)
+                var child = children.Get(i);
+                if (child is FrameworkElement fe && Reconciler.GetElementTag(fe) is Element tagElement)
                 {
-                    var movedChild = children.Get(currentPos);
-                    children.Move(currentPos, targetPanelIdx);
-                    // Update lookup: moved element is now at targetPanelIdx.
-                    if (lookupKey != null) keyToIndex[lookupKey] = targetPanelIdx;
-                    // Spec 042 §6 — implicit Offset animation on the moved
-                    // child so the reorder reads visually under an ambient.
-                    // Attach via the existing Composition helper rather
-                    // than the per-element LayoutAnimation modifier (which
-                    // remains the user's per-element opt-in).
-                    if (ambientKind is { } k && movedChild is UIElement movedUi)
-                        ApplyAmbientMove(movedUi, k);
+                    var key = GetKey(tagElement, i);
+                    keyToIndex.TryAdd(key, i);
                 }
-                if (targetPanelIdx < children.Count)
+            }
+
+            // Step 2: Process new items - insert new, move existing not in LIS
+            for (int i = 0; i < newMidLen; i++)
+            {
+                int targetPanelIdx = prefixLen + i;
+
+                if (newToOld[i] == -1)
                 {
-                    var replacement = reconciler.UpdateChild(
-                        oldChildren[oldStart + oldRelIdx],
-                        newChildren[newStart + i],
-                        children.Get(targetPanelIdx),
-                        requestRerender);
-                    if (replacement is not null)
+                    var ctrl = reconciler.Mount(newChildren[newStart + i], requestRerender);
+                    if (ctrl is not null)
                     {
-                        reconciler.UnmountChild(children.Get(targetPanelIdx));
-                        children.Replace(targetPanelIdx, replacement);
+                        children.Insert(targetPanelIdx, ctrl);
+                        ApplyAmbientEnterIfActive(ctrl, newChildren[newStart + i], ambientKind);
+                    }
+                }
+                else if (inLis[i])
+                {
+                    if (targetPanelIdx < children.Count)
+                    {
+                        var replacement = reconciler.UpdateChild(
+                            oldChildren[oldStart + newToOld[i]],
+                            newChildren[newStart + i],
+                            children.Get(targetPanelIdx),
+                            requestRerender);
+                        if (replacement is not null)
+                        {
+                            reconciler.UnmountChild(children.Get(targetPanelIdx));
+                            children.Replace(targetPanelIdx, replacement);
+                        }
+                    }
+                }
+                else
+                {
+                    int oldRelIdx = newToOld[i];
+                    int oldAbsIdx = oldStart + oldRelIdx;
+                    var lookupKey = oldAbsIdx < oldChildren.Length ? GetKey(oldChildren[oldAbsIdx], oldAbsIdx) : null;
+                    int currentPos = lookupKey != null && keyToIndex.TryGetValue(lookupKey, out var pos) ? pos : -1;
+                    if (currentPos >= 0 && currentPos != targetPanelIdx)
+                    {
+                        var movedChild = children.Get(currentPos);
+                        children.Move(currentPos, targetPanelIdx);
+                        // Update lookup: moved element is now at targetPanelIdx.
+                        if (lookupKey != null) keyToIndex[lookupKey] = targetPanelIdx;
+                        // Spec 042 §6 — implicit Offset animation on the moved
+                        // child so the reorder reads visually under an ambient.
+                        // Attach via the existing Composition helper rather
+                        // than the per-element LayoutAnimation modifier (which
+                        // remains the user's per-element opt-in).
+                        if (ambientKind is { } k && movedChild is UIElement movedUi)
+                            ApplyAmbientMove(movedUi, k);
+                    }
+                    if (targetPanelIdx < children.Count)
+                    {
+                        var replacement = reconciler.UpdateChild(
+                            oldChildren[oldStart + oldRelIdx],
+                            newChildren[newStart + i],
+                            children.Get(targetPanelIdx),
+                            requestRerender);
+                        if (replacement is not null)
+                        {
+                            reconciler.UnmountChild(children.Get(targetPanelIdx));
+                            children.Replace(targetPanelIdx, replacement);
+                        }
                     }
                 }
             }
+        }
+        finally
+        {
+            // Clear + return on every exit (including exceptions) so pooled
+            // buffers never leak references or stale markers across frames.
+            ReturnKeyIndexDict(oldKeyMap);
+            ReturnKeyIndexDict(keyToIndex);
+            intPool.Return(newToOld);
+            boolPool.Return(matched, clearArray: true);
+            boolPool.Return(inLis, clearArray: true);
         }
     }
 
@@ -400,81 +470,123 @@ internal static class ChildReconciler
     }
 
     /// <summary>
-    /// Compute Longest Increasing Subsequence.
-    /// Returns indices into the input array that form the LIS.
-    /// Skips entries with value -1 (unmapped items).
-    /// O(n log n) using patience sorting.
+    /// Compute the Longest Increasing Subsequence over the first
+    /// <paramref name="length"/> entries of <paramref name="arr"/>, writing the
+    /// membership mask into <paramref name="inLis"/> (<c>inLis[i] == true</c> iff
+    /// index <c>i</c> participates in the LIS). Entries with value -1 are skipped
+    /// (unmapped items). O(n log n) patience sorting. All working buffers are
+    /// rented from <see cref="ArrayPool{T}"/>, so the hot reconcile path pays no
+    /// per-call heap allocation (#32).
+    /// </summary>
+    internal static void ComputeLISInto(int[] arr, int length, bool[] inLis)
+    {
+        if (length > 0) Array.Clear(inLis, 0, length);
+        if (length == 0) return;
+
+        var pool = ArrayPool<int>.Shared;
+        int[] tails = pool.Rent(length);        // Smallest tail values
+        int[] tailIndices = pool.Rent(length);  // arr indices matching tails
+        int[] predecessors = pool.Rent(length); // back-pointers for reconstruction
+        try
+        {
+            int tailsCount = 0;
+            for (int i = 0; i < length; i++)
+            {
+                if (arr[i] == -1) continue; // Skip unmapped
+
+                int val = arr[i];
+
+                // Binary search for insertion position in tails[0..tailsCount).
+                int lo = 0, hi = tailsCount;
+                while (lo < hi)
+                {
+                    int mid = (lo + hi) / 2;
+                    if (tails[mid] < val) lo = mid + 1;
+                    else hi = mid;
+                }
+
+                // Predecessor is the previous tail's arr-index (read before the
+                // tails[lo] write — index lo-1 is unaffected by it).
+                predecessors[i] = lo > 0 ? tailIndices[lo - 1] : -1;
+
+                if (lo == tailsCount)
+                {
+                    tails[tailsCount] = val;
+                    tailIndices[tailsCount] = i;
+                    tailsCount++;
+                }
+                else
+                {
+                    tails[lo] = val;
+                    tailIndices[lo] = i;
+                }
+            }
+
+            // Backtrack from the last tail to mark LIS membership. Only
+            // non-skipped indices ever enter the chain, so unwritten
+            // predecessor slots for skipped entries are never read.
+            if (tailsCount == 0) return;
+            int idx = tailIndices[tailsCount - 1];
+            while (idx != -1)
+            {
+                inLis[idx] = true;
+                idx = predecessors[idx];
+            }
+        }
+        finally
+        {
+            pool.Return(tails);
+            pool.Return(tailIndices);
+            pool.Return(predecessors);
+        }
+    }
+
+    /// <summary>
+    /// Compute Longest Increasing Subsequence, returning the set of
+    /// participating indices. Convenience wrapper over
+    /// <see cref="ComputeLISInto"/> for tests and set-shaped callers; the hot
+    /// reconcile path uses the allocation-free <see cref="ComputeLISInto"/>.
     /// </summary>
     internal static HashSet<int> ComputeLIS(int[] arr)
     {
-        if (arr.Length == 0) return new HashSet<int>();
-
-        var tails = new List<int>();     // Smallest tail values
-        var tailIndices = new List<int>(); // Indices in arr corresponding to tails
-        var predecessors = new int[arr.Length];
-        Array.Fill(predecessors, -1);
-
-        for (int i = 0; i < arr.Length; i++)
-        {
-            if (arr[i] == -1) continue; // Skip unmapped
-
-            int val = arr[i];
-
-            // Binary search for insertion position
-            int lo = 0, hi = tails.Count;
-            while (lo < hi)
-            {
-                int mid = (lo + hi) / 2;
-                if (tails[mid] < val) lo = mid + 1;
-                else hi = mid;
-            }
-
-            if (lo == tails.Count)
-            {
-                tails.Add(val);
-                tailIndices.Add(i);
-            }
-            else
-            {
-                tails[lo] = val;
-                tailIndices[lo] = i;
-            }
-
-            if (lo > 0)
-                predecessors[i] = tailIndices[lo - 1];
-        }
-
-        // Backtrack to find actual LIS indices
         var result = new HashSet<int>();
-        if (tailIndices.Count == 0) return result;
+        if (arr.Length == 0) return result;
 
-        int idx = tailIndices[^1];
-        while (idx != -1)
+        var pool = ArrayPool<bool>.Shared;
+        bool[] mask = pool.Rent(arr.Length);
+        try
         {
-            result.Add(idx);
-            idx = predecessors[idx];
+            ComputeLISInto(arr, arr.Length, mask);
+            for (int i = 0; i < arr.Length; i++)
+                if (mask[i]) result.Add(i);
         }
-
+        finally
+        {
+            pool.Return(mask, clearArray: true);
+        }
         return result;
     }
 
     private static Element[] Filter(Element[] elements)
     {
-        // Fast path: if no filtering needed, return as-is
-        bool needsFilter = false;
+        // Single count pass; the result array is then sized exactly and filled
+        // in one more pass — no intermediate List + ToArray double-allocation
+        // (#36). The common no-null case still returns the input untouched.
+        int keep = 0;
         for (int i = 0; i < elements.Length; i++)
         {
-            if (elements[i] is null or EmptyElement) { needsFilter = true; break; }
+            if (elements[i] is not null and not EmptyElement) keep++;
         }
-        if (!needsFilter) return elements;
+        if (keep == elements.Length) return elements;
 
-        var result = new List<Element>(elements.Length);
+        var result = new Element[keep];
+        int j = 0;
         for (int i = 0; i < elements.Length; i++)
         {
             if (elements[i] is not null and not EmptyElement)
-                result.Add(elements[i]);
+                result[j++] = elements[i];
         }
-        return result.ToArray();
+        return result;
     }
 
     private static bool HasAnyKeys(Element[] elements)
@@ -493,11 +605,45 @@ internal static class ChildReconciler
         return a.Key == b.Key;
     }
 
+    // Cache the per-Type display name used by the unkeyed GetKey fallback so we
+    // don't reflect over the runtime type on every diff (#38). Explicit keys
+    // are strongly preferred and bypass this path entirely.
+    private static readonly ConcurrentDictionary<Type, string> _typeNameCache = new();
+
     private static string GetKey(Element element, int positionalIndex)
     {
         // Use explicit key if available, otherwise fall back to type+position
         if (element.Key is not null) return element.Key;
-        return $"__pos_{positionalIndex}_{element.GetType().Name}";
+        var typeName = _typeNameCache.GetOrAdd(element.GetType(), static t => t.Name);
+        return $"__pos_{positionalIndex}_{typeName}";
+    }
+
+    // ── Re-entrancy-safe Dictionary&lt;string,int&gt; pool ────────────────────
+    // ReconcileKeyedMiddle needs two transient key→index maps per call, and it
+    // recurses through UpdateChild. A per-thread stack hands each (nested) call
+    // its own instances: rented dicts are not in the pool, so an inner call can
+    // never grab a buffer the outer call is still using. Pool size is capped so
+    // deep trees don't retain an unbounded number of dictionaries.
+    [ThreadStatic] private static Stack<Dictionary<string, int>>? _keyIndexDictPool;
+    private const int KeyIndexDictPoolCap = 16;
+
+    private static Dictionary<string, int> RentKeyIndexDict(int capacity)
+    {
+        var pool = _keyIndexDictPool;
+        if (pool is { Count: > 0 })
+        {
+            var d = pool.Pop();
+            if (capacity > 0) d.EnsureCapacity(capacity);
+            return d;
+        }
+        return new Dictionary<string, int>(capacity > 0 ? capacity : 0, StringComparer.Ordinal);
+    }
+
+    private static void ReturnKeyIndexDict(Dictionary<string, int> dict)
+    {
+        dict.Clear();
+        var pool = _keyIndexDictPool ??= new Stack<Dictionary<string, int>>();
+        if (pool.Count < KeyIndexDictPoolCap) pool.Push(dict);
     }
 
     /// <summary>

--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -434,13 +434,23 @@ internal static class ChildReconciler
         }
         finally
         {
-            // Clear + return on every exit (including exceptions) so pooled
-            // buffers never leak references or stale markers across frames.
+            // Return every pooled buffer on all exits (including exceptions).
+            // The dict pool clears entries on return (ReturnKeyIndexDict), so
+            // element-key references never leak across frames. The bool buffers
+            // hold no references and have their used range fully (re)initialized
+            // before any read — `matched` via the Array.Clear-on-rent above and
+            // `inLis` via ComputeLISInto's own leading clear — so they return
+            // dirty (clearArray:false) and skip an avoidable O(rented-capacity)
+            // wipe on this hot path. `newToOld` (int) is likewise overwritten in
+            // full for [0,newMidLen) before each read, so it too returns without
+            // clearing. (Reference-typed pooled buffers elsewhere — e.g. the
+            // string[]/ReactorRow[] in KeyedListDiff — DO clear, to avoid pinning
+            // objects across frames.)
             ReturnKeyIndexDict(oldKeyMap);
             ReturnKeyIndexDict(keyToIndex);
             intPool.Return(newToOld);
-            boolPool.Return(matched, clearArray: true);
-            boolPool.Return(inLis, clearArray: true);
+            boolPool.Return(matched);
+            boolPool.Return(inLis);
         }
     }
 

--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -303,10 +303,16 @@ internal static class ChildReconciler
         var intPool = ArrayPool<int>.Shared;
         var boolPool = ArrayPool<bool>.Shared;
         var oldKeyMap = RentKeyIndexDict(oldMidLen);
-        var keyToIndex = RentKeyIndexDict(newMidLen);
         int[] newToOld = intPool.Rent(newMidLen);
         bool[] matched = boolPool.Rent(oldMidLen);
         bool[] inLis = boolPool.Rent(newMidLen);
+        // Live panel index of each surviving old item, keyed by old-relative
+        // index (-1 when absent). Replaces the second pooled key→index dict
+        // (#33): positions are tracked here and mutated in lock-step with every
+        // Insert/Move so a survivor's current control is always resolvable
+        // without a COM re-scan — and never patched by a not-yet-reached final
+        // index (bug C1).
+        int[] oldRelToPanel = intPool.Rent(oldMidLen);
         try
         {
             // A rented bool array can carry stale `true` markers; `matched`
@@ -354,7 +360,14 @@ internal static class ChildReconciler
                 }
             }
 
-            // Build key→panel-index lookup for O(1) FindItemByOldIndex (CR-011).
+            // Build the survivor → live-panel-index model by scanning the
+            // realized collection AFTER removals. A live scan (rather than a
+            // computed compaction) is required because
+            // RemoveChildWithExitTransition can DEFER removal under an
+            // exit/ambient transition, leaving the exiting control occupying a
+            // slot for this pass — reading actual positions keeps the model
+            // consistent with the real collection.
+            for (int r = 0; r < oldMidLen; r++) oldRelToPanel[r] = -1;
             int searchEnd = children.Count - suffixLen;
             for (int i = prefixLen; i < searchEnd && i < children.Count; i++)
             {
@@ -362,121 +375,231 @@ internal static class ChildReconciler
                 if (child is FrameworkElement fe && Reconciler.GetElementTag(fe) is Element tagElement)
                 {
                     var key = GetKey(tagElement, i);
-                    keyToIndex.TryAdd(key, i);
+                    if (oldKeyMap.TryGetValue(key, out int oldRel) && matched[oldRel])
+                        oldRelToPanel[oldRel] = i;
                 }
             }
 
-            // Step 2: Process new items - insert new, move existing not in LIS
-            for (int i = 0; i < newMidLen; i++)
-            {
-                int targetPanelIdx = prefixLen + i;
-
-                if (newToOld[i] == -1)
-                {
-                    var ctrl = reconciler.Mount(newChildren[newStart + i], requestRerender);
-                    if (ctrl is not null)
-                    {
-                        children.Insert(targetPanelIdx, ctrl);
-                        ApplyAmbientEnterIfActive(ctrl, newChildren[newStart + i], ambientKind);
-                    }
-                }
-                else if (inLis[i])
-                {
-                    if (targetPanelIdx < children.Count)
-                    {
-                        var replacement = reconciler.UpdateChild(
-                            oldChildren[oldStart + newToOld[i]],
-                            newChildren[newStart + i],
-                            children.Get(targetPanelIdx),
-                            requestRerender);
-                        if (replacement is not null)
-                        {
-                            reconciler.UnmountChild(children.Get(targetPanelIdx));
-                            children.Replace(targetPanelIdx, replacement);
-                        }
-                    }
-                }
-                else
-                {
-                    int oldRelIdx = newToOld[i];
-                    int oldAbsIdx = oldStart + oldRelIdx;
-                    var lookupKey = oldAbsIdx < oldChildren.Length ? GetKey(oldChildren[oldAbsIdx], oldAbsIdx) : null;
-                    int currentPos = lookupKey != null && keyToIndex.TryGetValue(lookupKey, out var pos) ? pos : -1;
-                    if (currentPos >= 0 && currentPos != targetPanelIdx)
-                    {
-                        var movedChild = children.Get(currentPos);
-                        children.Move(currentPos, targetPanelIdx);
-                        // Update lookup: moved element is now at targetPanelIdx.
-                        if (lookupKey != null) keyToIndex[lookupKey] = targetPanelIdx;
-                        // Spec 042 §6 — implicit Offset animation on the moved
-                        // child so the reorder reads visually under an ambient.
-                        // Attach via the existing Composition helper rather
-                        // than the per-element LayoutAnimation modifier (which
-                        // remains the user's per-element opt-in).
-                        if (ambientKind is { } k && movedChild is UIElement movedUi)
-                            ApplyAmbientMove(movedUi, k);
-                    }
-                    if (targetPanelIdx < children.Count)
-                    {
-                        var replacement = reconciler.UpdateChild(
-                            oldChildren[oldStart + oldRelIdx],
-                            newChildren[newStart + i],
-                            children.Get(targetPanelIdx),
-                            requestRerender);
-                        if (replacement is not null)
-                        {
-                            reconciler.UnmountChild(children.Get(targetPanelIdx));
-                            children.Replace(targetPanelIdx, replacement);
-                        }
-                    }
-                }
-            }
+            // Step 2: position + patch via the canonical right-to-left LIS walk.
+            // `initialAnchor` is the start of the suffix (end of the middle);
+            // each item is placed immediately before its already-positioned
+            // right neighbour, and every survivor is patched at its CURRENT live
+            // position resolved from the model — never at a final index the panel
+            // has not yet been rearranged into (bug C1) — with the model kept
+            // exact across every Insert/Move (bug H1).
+            int initialAnchor = children.Count - suffixLen;
+            var sink = new RealKeyedMiddleSink(
+                oldChildren, newChildren, oldStart, newStart,
+                children, reconciler, requestRerender, ambientKind);
+            RunKeyedMiddleCore(ref sink, newToOld, inLis, newMidLen, oldMidLen, initialAnchor, oldRelToPanel);
         }
         finally
         {
             // Return every pooled buffer on all exits (including exceptions).
             // The dict pool clears entries on return (ReturnKeyIndexDict), so
-            // element-key references never leak across frames. The bool buffers
-            // hold no references and have their used range fully (re)initialized
-            // before any read — `matched` via the Array.Clear-on-rent above and
-            // `inLis` via ComputeLISInto's own leading clear — so they return
-            // dirty (clearArray:false) and skip an avoidable O(rented-capacity)
-            // wipe on this hot path. `newToOld` (int) is likewise overwritten in
-            // full for [0,newMidLen) before each read, so it too returns without
-            // clearing. (Reference-typed pooled buffers elsewhere — e.g. the
+            // element-key references never leak across frames. The int/bool
+            // buffers hold no references and have their used range fully
+            // (re)initialized before any read — `matched` via the Array.Clear
+            // above, `inLis` via ComputeLISInto's leading clear, `newToOld`
+            // written in full for [0,newMidLen), and `oldRelToPanel` reset to -1
+            // for [0,oldMidLen) — so they return dirty (clearArray:false) and
+            // skip an avoidable O(rented-capacity) wipe on this hot path.
+            // (Reference-typed pooled buffers elsewhere — e.g. the
             // string[]/ReactorRow[] in KeyedListDiff — DO clear, to avoid pinning
             // objects across frames.)
             ReturnKeyIndexDict(oldKeyMap);
-            ReturnKeyIndexDict(keyToIndex);
             intPool.Return(newToOld);
+            intPool.Return(oldRelToPanel);
             boolPool.Return(matched);
             boolPool.Return(inLis);
         }
     }
 
     /// <summary>
-    /// Find the current position of an item that was originally at a given old index.
-    /// Uses the reconciler's element map to match elements.
+    /// Side-effect surface for <see cref="RunKeyedMiddleCore{TSink}"/>. The
+    /// keyed-middle positioning algorithm is expressed once against this
+    /// interface so the production reconciler (real WinUI Mount/Update/Move) and
+    /// the headless correctness oracle in the test suite drive the identical
+    /// index logic. Implemented as a <c>struct</c> behind a generic constraint
+    /// so the JIT devirtualizes the calls with no boxing on the hot path (and it
+    /// stays AOT/trim-clean — no reflection).
     /// </summary>
-    private static int FindItemByOldIndex(
-        IChildCollection children,
-        Element[] oldElements,
-        int oldIndex,
-        int searchStart,
-        int searchEnd,
-        Reconciler reconciler)
+    internal interface IKeyedMiddleSink
     {
-        for (int i = searchStart; i < searchEnd && i < children.Count; i++)
+        /// <summary>Mount new child <paramref name="newIdx"/> and insert it at
+        /// <paramref name="panelIdx"/>. Returns <c>false</c> when nothing was
+        /// inserted (mount produced no control) so the caller skips the model
+        /// shift.</summary>
+        bool MountInsert(int newIdx, int panelIdx);
+
+        /// <summary>Move the existing control at <paramref name="fromIdx"/> to
+        /// <paramref name="toIdx"/> using final-position semantics (matching
+        /// <see cref="IChildCollection.Move"/>).</summary>
+        void MoveExisting(int fromIdx, int toIdx);
+
+        /// <summary>Patch the surviving control for old-relative index
+        /// <paramref name="oldRelIdx"/> — currently located at
+        /// <paramref name="panelIdx"/> — against new child
+        /// <paramref name="newIdx"/>.</summary>
+        void Patch(int oldRelIdx, int newIdx, int panelIdx);
+    }
+
+    /// <summary>
+    /// Canonical LIS-based keyed reconciliation of the middle section, processed
+    /// right-to-left so each item is positioned immediately before its
+    /// already-placed right neighbour (the live "anchor"). LIS members are left
+    /// in place; only out-of-LIS movers are relocated, giving the minimal move
+    /// count. Every survivor is patched at its CURRENT live position (resolved
+    /// from <paramref name="oldRelToPanel"/>, which is kept exact across every
+    /// structural mutation) rather than a final index the panel has not yet been
+    /// rearranged into — the invariant that fixes the keyed-identity corruption
+    /// (C1) and the stale-index moves (H1).
+    /// </summary>
+    /// <typeparam name="TSink">Concrete sink struct; a generic constraint keeps
+    /// the calls devirtualized and allocation-free.</typeparam>
+    /// <param name="sink">Side-effect surface that applies the mount/move/patch
+    /// operations the walk decides on.</param>
+    /// <param name="newToOld">For each new-middle slot, the old-relative index it
+    /// reuses, or -1 for a freshly-mounted item.</param>
+    /// <param name="inLis">LIS membership mask over <paramref name="newToOld"/>.</param>
+    /// <param name="newMidLen">Number of items in the new middle section.</param>
+    /// <param name="oldMidLen">Number of items in the old middle section.</param>
+    /// <param name="initialAnchor">Live panel index of the start of the suffix
+    /// (end of the middle) — where right-most items are placed.</param>
+    /// <param name="oldRelToPanel">Live panel index of each surviving old item by
+    /// old-relative index (-1 if absent). Mutated in place to stay exact.</param>
+    internal static void RunKeyedMiddleCore<TSink>(
+        ref TSink sink,
+        int[] newToOld, bool[] inLis,
+        int newMidLen, int oldMidLen,
+        int initialAnchor, int[] oldRelToPanel)
+        where TSink : struct, IKeyedMiddleSink
+    {
+        int anchor = initialAnchor;
+        for (int i = newMidLen - 1; i >= 0; i--)
         {
-            var child = children.Get(i);
-            if (child is FrameworkElement fe && Reconciler.GetElementTag(fe) is Element tagElement)
+            int oldRel = newToOld[i];
+            if (oldRel < 0)
             {
-                if (oldIndex < oldElements.Length &&
-                    GetKey(tagElement, -1) == GetKey(oldElements[oldIndex], oldIndex))
-                    return i;
+                // New item: mount + insert immediately before the anchor.
+                if (sink.MountInsert(i, anchor))
+                {
+                    // Insertion at `anchor` shifts every tracked survivor at an
+                    // index >= anchor one slot to the right.
+                    for (int r = 0; r < oldMidLen; r++)
+                        if (oldRelToPanel[r] >= anchor) oldRelToPanel[r]++;
+                    // The new control now occupies `anchor` and is the anchor for
+                    // the next (left) item, so `anchor` itself is unchanged.
+                }
+                continue;
+            }
+
+            int cur = oldRelToPanel[oldRel];
+            if (cur < 0) continue; // Defensive: survivor not realized (skip).
+
+            if (!inLis[i])
+            {
+                // Out-of-LIS mover: relocate immediately before the anchor. With
+                // Move's final-position semantics, the destination is anchor-1
+                // when the control currently sits left of the anchor, else
+                // anchor itself.
+                int to = cur < anchor ? anchor - 1 : anchor;
+                if (cur != to)
+                {
+                    sink.MoveExisting(cur, to);
+                    // Keep the model exact: a Move shifts the half-open range
+                    // between the two endpoints by one slot.
+                    if (cur < to)
+                    {
+                        for (int r = 0; r < oldMidLen; r++)
+                        {
+                            int p = oldRelToPanel[r];
+                            if (p > cur && p <= to) oldRelToPanel[r] = p - 1;
+                        }
+                    }
+                    else
+                    {
+                        for (int r = 0; r < oldMidLen; r++)
+                        {
+                            int p = oldRelToPanel[r];
+                            if (p >= to && p < cur) oldRelToPanel[r] = p + 1;
+                        }
+                    }
+                    oldRelToPanel[oldRel] = to;
+                    cur = to;
+                }
+            }
+
+            sink.Patch(oldRel, i, cur);
+            anchor = cur;
+        }
+    }
+
+    /// <summary>
+    /// Production <see cref="IKeyedMiddleSink"/> — drives real WinUI controls
+    /// through the reconciler. A <c>readonly struct</c> so
+    /// <see cref="RunKeyedMiddleCore{TSink}"/> stays allocation- and
+    /// virtual-dispatch-free.
+    /// </summary>
+    private readonly struct RealKeyedMiddleSink : IKeyedMiddleSink
+    {
+        private readonly Element[] _oldChildren;
+        private readonly Element[] _newChildren;
+        private readonly int _oldStart;
+        private readonly int _newStart;
+        private readonly IChildCollection _children;
+        private readonly Reconciler _reconciler;
+        private readonly Action _requestRerender;
+        private readonly AnimationKind? _ambientKind;
+
+        public RealKeyedMiddleSink(
+            Element[] oldChildren, Element[] newChildren, int oldStart, int newStart,
+            IChildCollection children, Reconciler reconciler, Action requestRerender,
+            AnimationKind? ambientKind)
+        {
+            _oldChildren = oldChildren;
+            _newChildren = newChildren;
+            _oldStart = oldStart;
+            _newStart = newStart;
+            _children = children;
+            _reconciler = reconciler;
+            _requestRerender = requestRerender;
+            _ambientKind = ambientKind;
+        }
+
+        public bool MountInsert(int newIdx, int panelIdx)
+        {
+            var ctrl = _reconciler.Mount(_newChildren[_newStart + newIdx], _requestRerender);
+            if (ctrl is null) return false;
+            _children.Insert(panelIdx, ctrl);
+            ApplyAmbientEnterIfActive(ctrl, _newChildren[_newStart + newIdx], _ambientKind);
+            return true;
+        }
+
+        public void MoveExisting(int fromIdx, int toIdx)
+        {
+            var moved = _children.Get(fromIdx);
+            _children.Move(fromIdx, toIdx);
+            // Spec 042 §6 — implicit Offset animation on the moved child so the
+            // reorder reads visually under an ambient transaction.
+            if (_ambientKind is { } k)
+                ApplyAmbientMove(moved, k);
+        }
+
+        public void Patch(int oldRelIdx, int newIdx, int panelIdx)
+        {
+            if (panelIdx >= _children.Count) return;
+            var replacement = _reconciler.UpdateChild(
+                _oldChildren[_oldStart + oldRelIdx],
+                _newChildren[_newStart + newIdx],
+                _children.Get(panelIdx),
+                _requestRerender);
+            if (replacement is not null)
+            {
+                _reconciler.UnmountChild(_children.Get(panelIdx));
+                _children.Replace(panelIdx, replacement);
             }
         }
-        return -1;
     }
 
     /// <summary>
@@ -629,9 +752,9 @@ internal static class ChildReconciler
     }
 
     // ── Re-entrancy-safe Dictionary&lt;string,int&gt; pool ────────────────────
-    // ReconcileKeyedMiddle needs two transient key→index maps per call, and it
+    // ReconcileKeyedMiddle needs a transient key→index map per call, and it
     // recurses through UpdateChild. A per-thread stack hands each (nested) call
-    // its own instances: rented dicts are not in the pool, so an inner call can
+    // its own instance: rented dicts are not in the pool, so an inner call can
     // never grab a buffer the outer call is still using. Pool size is capped so
     // deep trees don't retain an unbounded number of dictionaries.
     [ThreadStatic] private static Stack<Dictionary<string, int>>? _keyIndexDictPool;

--- a/src/Reactor/Core/Internal/KeyedListDiff.cs
+++ b/src/Reactor/Core/Internal/KeyedListDiff.cs
@@ -208,7 +208,19 @@ internal static class KeyedListDiff
         // steady-state grid case (keys never change) never allocates or scans
         // a dup set. Skip the diff entirely and let the caller's
         // RefreshRealizedContainers handle per-row content reconciliation.
-        if (oldCount == newCount && SequenceEqualOrdinal(state.LastKeys, newKeys, newCount))
+        //
+        // The `ByKey.Count == oldCount` guard keeps this fast path strictly for
+        // the duplicate-free steady state. A prior duplicate bailout leaves
+        // Source/LastKeys still holding the dup keys but ByKey collapsed to
+        // first occurrences (ReactorListState.Reset), so ByKey.Count < oldCount
+        // there. Without the guard an *unchanged* duplicate list would match
+        // LastKeys and return Empty, silently skipping the duplicate
+        // bailout/diagnostic the remarks at the top of this file promise. The
+        // check is O(1) and short-circuits before the O(n) SequenceEqualOrdinal,
+        // so the common unique-key path pays nothing extra.
+        if (oldCount == newCount
+            && state.ByKey.Count == oldCount
+            && SequenceEqualOrdinal(state.LastKeys, newKeys, newCount))
             return DiffStats.Empty;
 
         // ── Fast path 2: empty ↔ empty ─────────────────────────────────

--- a/src/Reactor/Core/Internal/KeyedListDiff.cs
+++ b/src/Reactor/Core/Internal/KeyedListDiff.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.UI.Reactor.Core.Internal;
@@ -42,6 +43,19 @@ namespace Microsoft.UI.Reactor.Core.Internal;
 /// </remarks>
 internal static class KeyedListDiff
 {
+    // Cached sample for the null-key bailout diagnostic so the slow path
+    // doesn't allocate a fresh single-element array every time (#41).
+    private static readonly string[] NullKeySample = { "<null>" };
+
+    // Descending-by-index comparer used to remove doomed rows from the tail
+    // first so earlier OC indices stay stable. Singleton — avoids capturing a
+    // fresh comparison delegate on every diff that has deletions.
+    private sealed class RowIndexDescendingComparer : IComparer<ReactorRow>
+    {
+        public static readonly RowIndexDescendingComparer Instance = new();
+        public int Compare(ReactorRow? a, ReactorRow? b) => b!.Index.CompareTo(a!.Index);
+    }
+
     /// <summary>
     /// Per-diff bookkeeping returned to callers (tests, telemetry, the
     /// Phase 3 animation pipeline) so they can observe the op shape
@@ -118,21 +132,55 @@ internal static class KeyedListDiff
         ArgumentNullException.ThrowIfNull(newItems);
         ArgumentNullException.ThrowIfNull(keySelector);
 
+        int newCount = newItems.Count;
+
+        // Rent the new-keys buffer (#2) rather than allocating a fresh array
+        // every diff. The rented array may be larger than newCount, so the
+        // explicit length is threaded to every consumer below — never
+        // newKeys.Length. The buffer is cleared + returned on every exit
+        // (including exceptions and the early bailouts) via the finally.
+        string[] newKeys = newCount == 0
+            ? global::System.Array.Empty<string>()
+            : ArrayPool<string>.Shared.Rent(newCount);
+        bool rentedKeys = newCount != 0;
+        try
+        {
+            return ApplyCore(state, newItems, keySelector, logger, diagnosticContext, ambient, controlInstance, newKeys, newCount);
+        }
+        finally
+        {
+            if (rentedKeys)
+                ArrayPool<string>.Shared.Return(newKeys, clearArray: true);
+        }
+    }
+
+    /// <summary>
+    /// Core keyed diff over a pre-materialized <paramref name="newKeys"/> buffer
+    /// (valid length <paramref name="newCount"/>; the array may be larger). Split
+    /// out from <see cref="Apply{T}"/> so the rented key buffer is released on
+    /// every exit path via a single try/finally in the caller.
+    /// </summary>
+    private static DiffStats ApplyCore<T>(
+        ReactorListState state,
+        IReadOnlyList<T> newItems,
+        Func<T, int, string> keySelector,
+        ILogger? logger,
+        string? diagnosticContext,
+        AmbientAnimation? ambient,
+        object? controlInstance,
+        string[] newKeys,
+        int newCount)
+    {
         // Resolve the animation intent for this diff once up front. A null
         // result means "no per-container animation work this diff" — every
         // op path below shortcuts on this rather than re-checking the kind.
-        // The contract is symmetric across Insert / Move / Remove so the
-        // user can predict the visual effect from the ambient alone.
         AnimationKind? enterKind = (ambient is { HasEffect: true }) ? ambient.Kind : null;
 
-        int newCount = newItems.Count;
         int oldCount = state.LastKeys.Count;
 
-        // Materialize new keys once. We need this list twice (lockstep walk
-        // and the survivor pass), so paying for one allocation up front is
-        // cheaper than calling keySelector twice and avoids the user-callback
-        // observing each item more than once per diff.
-        string[] newKeys = newCount == 0 ? global::System.Array.Empty<string>() : new string[newCount];
+        // Materialize new keys into the rented buffer. We read them twice
+        // (lockstep walk + survivor pass), so projecting once up front avoids
+        // the user callback observing each item more than once per diff.
         for (int i = 0; i < newCount; i++)
         {
             var k = keySelector(newItems[i], i);
@@ -146,41 +194,44 @@ internal static class KeyedListDiff
                 ReportBailout(
                     controlInstance, diagnosticContext, logger,
                     Microsoft.UI.Reactor.Core.Diagnostics.KeyedListDiagnosticKind.NullKey,
-                    new[] { "<null>" },
+                    NullKeySample,
                     indexHint: i);
                 return Bailout(state, newItems, keySelector);
             }
             newKeys[i] = k;
         }
 
-        // Detect duplicate keys via the same hash set used by the survivor
-        // map below. This costs O(n) on top of the diff but is the only way
-        // to give a useful diagnostic; duplicates inside newKeys would
-        // otherwise silently corrupt the diff (the second occurrence would
-        // never find a survivor because the first one consumed the map entry,
-        // so it would emit an Insert with a duplicate key — and then a later
-        // diff would have two rows with the same key in ByKey).
-        if (HasDuplicates(newKeys))
-        {
-            ReportBailout(
-                controlInstance, diagnosticContext, logger,
-                Microsoft.UI.Reactor.Core.Diagnostics.KeyedListDiagnosticKind.DuplicateKey,
-                CollectDuplicates(newKeys),
-                indexHint: null);
-            return Bailout(state, newItems, keySelector);
-        }
-
-        // ── Fast path 1: no change ─────────────────────────────────────
+        // ── Fast path 1: no change (FLAGSHIP #1) ───────────────────────
         // Most renders don't touch the list shape — Reactor's reducer model
         // means immutable list replacement, but the *contents* (and thus the
-        // keys) usually match. Skip the diff entirely and let the caller's
+        // keys) usually match. This now runs ABOVE the duplicate scan so the
+        // steady-state grid case (keys never change) never allocates or scans
+        // a dup set. Skip the diff entirely and let the caller's
         // RefreshRealizedContainers handle per-row content reconciliation.
-        if (oldCount == newCount && SequenceEqualOrdinal(state.LastKeys, newKeys))
+        if (oldCount == newCount && SequenceEqualOrdinal(state.LastKeys, newKeys, newCount))
             return DiffStats.Empty;
 
         // ── Fast path 2: empty ↔ empty ─────────────────────────────────
         if (oldCount == 0 && newCount == 0)
             return DiffStats.Empty;
+
+        // Detect duplicate keys. Runs after the no-op fast path (#1) so an
+        // unchanged list never pays for it, and reuses the pooled Scratch dict
+        // instead of allocating a HashSet (#11). Duplicates inside newKeys
+        // would otherwise silently corrupt the diff (the second occurrence
+        // would never find a survivor because the first one consumed the map
+        // entry, so it would emit an Insert with a duplicate key — and then a
+        // later diff would have two rows with the same key in ByKey), so they
+        // force a correctness-preserving bailout.
+        if (HasDuplicates(newKeys, newCount, state))
+        {
+            ReportBailout(
+                controlInstance, diagnosticContext, logger,
+                Microsoft.UI.Reactor.Core.Diagnostics.KeyedListDiagnosticKind.DuplicateKey,
+                CollectDuplicates(newKeys, newCount),
+                indexHint: null);
+            return Bailout(state, newItems, keySelector);
+        }
 
         // ── Fast path 3: empty → non-empty (mount-shaped diff) ─────────
         if (oldCount == 0)
@@ -261,52 +312,33 @@ internal static class KeyedListDiff
             return new DiffStats(Inserts: 0, Removes: 1, Moves: 0, Survivors: newCount, Bailout: false);
         }
 
-        // ── Bulk-replace bailout ───────────────────────────────────────
-        // If churn (removed + inserted) exceeds 25% AND the absolute number
-        // of churned ops is large enough that the diff genuinely won't help
-        // animation, fall back to the legacy ItemsSource swap.
-        //
-        // The absolute floor (8 ops) is what keeps small lists from
-        // ever bailing — a 4-item list with Insert+Remove (churn=2) is just
-        // a normal small-list edit; the WinUI delta path animates it
-        // beautifully and we lose nothing by running the general algorithm.
-        //
-        // We approximate churn by counting how many new keys are NOT present
-        // in the old key set. That overcounts "different position same key"
-        // as zero churn (correct), but undercounts deletes — we add the
-        // length delta for that side.
-        state.Scratch.Clear();
-        for (int i = 0; i < oldCount; i++)
-            state.Scratch[state.LastKeys[i]] = null!; // null marker; replaced below
-
-        int additions = 0;
-        int retained = 0;
-        for (int i = 0; i < newCount; i++)
-        {
-            if (state.Scratch.ContainsKey(newKeys[i])) retained++;
-            else additions++;
-        }
-
-        int removals = oldCount - retained;
-        int churn = additions + removals;
-        const int BailoutFloor = 8;
-        // Bailout if (churn / max(oldCount, 1)) > 0.25 AND churn >= floor.
-        // Compute the ratio without floats: churn * 4 > oldCount.
-        if (churn >= BailoutFloor && churn * 4 > global::System.Math.Max(oldCount, 1))
-        {
-            state.Scratch.Clear();
-            return Bailout(state, newItems, keySelector);
-        }
-
         // ── General case: React-style keyed diff ───────────────────────
-        return ApplyGeneral(state, newKeys, enterKind);
+        // The bulk-replace (churn) bailout decision now lives INSIDE
+        // ApplyGeneral (#34): it is computed from the same scratch map the
+        // general walk builds over the post-prefix/suffix diff range, so we
+        // no longer pay a separate O(oldCount) null-marker pre-pass + a second
+        // Scratch.Clear/repopulate. Churn over the diff range is provably
+        // equal to full-range churn because the shared prefix/suffix keys
+        // cancel on both sides (duplicates are already ruled out above).
+        return ApplyGeneral(state, newItems, keySelector, newKeys, newCount, oldCount, enterKind);
     }
 
-    private static DiffStats ApplyGeneral(ReactorListState state, string[] newKeys, AnimationKind? enterKind)
+    /// <summary>
+    /// General keyed diff over the post-prefix/suffix range. Builds the
+    /// survivor map on <see cref="ReactorListState.Scratch"/> once, folds the
+    /// churn-bailout decision into that same map, then emits the minimal
+    /// Insert/Move/Remove op sequence. <paramref name="newKeys"/> is valid for
+    /// <paramref name="newCount"/> entries (the buffer may be larger).
+    /// </summary>
+    private static DiffStats ApplyGeneral<T>(
+        ReactorListState state,
+        IReadOnlyList<T> newItems,
+        Func<T, int, string> keySelector,
+        string[] newKeys,
+        int newCount,
+        int oldCount,
+        AnimationKind? enterKind)
     {
-        int oldCount = state.LastKeys.Count;
-        int newCount = newKeys.Length;
-
         // 1) Lockstep prefix walk — find where the lists first diverge.
         int prefix = 0;
         int sharedFromStart = global::System.Math.Min(oldCount, newCount);
@@ -334,12 +366,32 @@ internal static class KeyedListDiff
         for (int i = prefix; i < oldDiffEnd; i++)
             state.Scratch[state.LastKeys[i]] = state.Source[i];
 
+        // 3a) Bulk-replace bailout (#34, folded in). Count how many new
+        // diff-range keys survive (are present in the old diff-range map);
+        // additions/removals follow without a second populate pass.
+        int retained = 0;
+        for (int i = prefix; i < newDiffEnd; i++)
+            if (state.Scratch.ContainsKey(newKeys[i])) retained++;
+
+        int additions = (newDiffEnd - prefix) - retained;
+        int removals = (oldDiffEnd - prefix) - retained;
+        int churn = additions + removals;
+        const int BailoutFloor = 8;
+        // Bailout if (churn / max(oldCount, 1)) > 0.25 AND churn >= floor.
+        // Compute the ratio without floats: churn * 4 > oldCount.
+        if (churn >= BailoutFloor && churn * 4 > global::System.Math.Max(oldCount, 1))
+        {
+            state.Scratch.Clear();
+            return Bailout(state, newItems, keySelector);
+        }
+
         int inserts = 0;
         int moves = 0;
         int survivors = prefix + suffix;
-        // Collected only when an ambient is active. Null avoids the
-        // allocation in the non-animated (overwhelmingly common) case.
-        List<ReactorRow>? movedRows = enterKind is not null ? new List<ReactorRow>() : null;
+        // Collected lazily — only allocated when an ambient animation is
+        // active AND at least one survivor actually moves (#35). Consumers
+        // treat null as "no moved rows" (they gate on `is { Count: > 0 }`).
+        List<ReactorRow>? movedRows = null;
 
         // 4) Walk new keys in the diff range.
         for (int desired = prefix; desired < newDiffEnd; desired++)
@@ -354,7 +406,8 @@ internal static class KeyedListDiff
                     state.Source.Move(currentIndex, desired);
                     RefreshIndices(state, global::System.Math.Min(desired, currentIndex), global::System.Math.Max(desired, currentIndex));
                     moves++;
-                    movedRows?.Add(survivor);
+                    if (enterKind is not null)
+                        (movedRows ??= new List<ReactorRow>()).Add(survivor);
                 }
                 survivors++;
             }
@@ -370,26 +423,37 @@ internal static class KeyedListDiff
 
         // 5) Whatever remains in the scratch map are removed rows. Remove
         // them in descending OC-index order so earlier indices stay stable.
+        // The doomed buffer is rented from the pool and cleared+returned on
+        // every exit (#3) so it never pins removed rows across frames.
         int removes = state.Scratch.Count;
         if (removes > 0)
         {
-            var doomed = new ReactorRow[removes];
-            int j = 0;
-            foreach (var row in state.Scratch.Values) doomed[j++] = row;
-            global::System.Array.Sort(doomed, static (a, b) => b.Index.CompareTo(a.Index));
-            for (int i = 0; i < removes; i++)
+            ReactorRow[] doomed = ArrayPool<ReactorRow>.Shared.Rent(removes);
+            try
             {
-                state.Source.RemoveAt(doomed[i].Index);
-                state.ByKey.Remove(doomed[i].Key);
+                int j = 0;
+                foreach (var row in state.Scratch.Values) doomed[j++] = row;
+                global::System.Array.Sort(doomed, 0, removes, RowIndexDescendingComparer.Instance);
+                for (int i = 0; i < removes; i++)
+                {
+                    state.Source.RemoveAt(doomed[i].Index);
+                    state.ByKey.Remove(doomed[i].Key);
+                }
+            }
+            finally
+            {
+                ArrayPool<ReactorRow>.Shared.Return(doomed, clearArray: true);
             }
             RefreshIndices(state, 0, state.Source.Count - 1);
         }
 
         state.Scratch.Clear();
 
-        // 6) Sync LastKeys to match the final Source order.
-        state.LastKeys.Clear();
-        for (int i = 0; i < state.Source.Count; i++) state.LastKeys.Add(state.Source[i].Key);
+        // 6) Sync LastKeys to match the final Source order in place (#10),
+        // overwriting shared slots and trimming/extending the tail rather
+        // than Clear()+Add — which would null the whole backing array and
+        // regrow it every diff.
+        SyncLastKeysToSource(state);
 
         return new DiffStats(
             Inserts: inserts,
@@ -398,6 +462,28 @@ internal static class KeyedListDiff
             Survivors: survivors,
             Bailout: false,
             MovedRows: movedRows);
+    }
+
+    /// <summary>
+    /// Overwrites <see cref="ReactorListState.LastKeys"/> to match the current
+    /// <see cref="ReactorListState.Source"/> key order without the full
+    /// Clear()+Add churn. Shared leading slots are overwritten; the tail is
+    /// trimmed or extended as needed. Always leaves LastKeys exactly equal to
+    /// the Source key sequence, so it cannot desync.
+    /// </summary>
+    private static void SyncLastKeysToSource(ReactorListState state)
+    {
+        var lastKeys = state.LastKeys;
+        var source = state.Source;
+        int srcCount = source.Count;
+        int common = global::System.Math.Min(lastKeys.Count, srcCount);
+        for (int i = 0; i < common; i++)
+            lastKeys[i] = source[i].Key;
+        if (lastKeys.Count > srcCount)
+            lastKeys.RemoveRange(srcCount, lastKeys.Count - srcCount);
+        else
+            for (int i = lastKeys.Count; i < srcCount; i++)
+                lastKeys.Add(source[i].Key);
     }
 
     private static void RefreshIndices(ReactorListState state, int fromInclusive, int toInclusive)
@@ -436,28 +522,40 @@ internal static class KeyedListDiff
             Bailout: true);
     }
 
-    private static bool HasDuplicates(string[] keys)
+    private static bool HasDuplicates(string[] keys, int count, ReactorListState state)
     {
-        if (keys.Length < 2) return false;
-        // Small-N optimization: 0/1 already handled, 2..3 is a quick scan.
-        if (keys.Length <= 3)
+        if (count < 2) return false;
+        // Small-N optimization: 0/1 already handled, 2..3 is a quick scan
+        // that never touches the shared scratch dict.
+        if (count <= 3)
         {
-            if (keys.Length == 2) return string.Equals(keys[0], keys[1], global::System.StringComparison.Ordinal);
-            // length == 3
+            if (count == 2) return string.Equals(keys[0], keys[1], global::System.StringComparison.Ordinal);
+            // count == 3
             return string.Equals(keys[0], keys[1], global::System.StringComparison.Ordinal)
                 || string.Equals(keys[0], keys[2], global::System.StringComparison.Ordinal)
                 || string.Equals(keys[1], keys[2], global::System.StringComparison.Ordinal);
         }
-        var seen = new HashSet<string>(keys.Length, global::System.StringComparer.Ordinal);
-        for (int i = 0; i < keys.Length; i++)
-            if (!seen.Add(keys[i])) return true;
+        // Reuse the pooled scratch dict (#11) instead of allocating a fresh
+        // HashSet every diff with 4+ keys. Cleared on entry and on every exit
+        // so it never leaks into the survivor-map build that follows.
+        var scratch = state.Scratch;
+        scratch.Clear();
+        for (int i = 0; i < count; i++)
+        {
+            if (!scratch.TryAdd(keys[i], null!))
+            {
+                scratch.Clear();
+                return true;
+            }
+        }
+        scratch.Clear();
         return false;
     }
 
-    private static bool SequenceEqualOrdinal(List<string> a, string[] b)
+    private static bool SequenceEqualOrdinal(List<string> a, string[] b, int count)
     {
-        if (a.Count != b.Length) return false;
-        for (int i = 0; i < b.Length; i++)
+        if (a.Count != count) return false;
+        for (int i = 0; i < count; i++)
             if (!string.Equals(a[i], b[i], global::System.StringComparison.Ordinal)) return false;
         return true;
     }
@@ -527,15 +625,16 @@ internal static class KeyedListDiff
     // (not every occurrence). For a list with [a, b, a, c, b] returns
     // [a, b] — the dev overlay reader cares about which keys collided,
     // not the per-occurrence count.
-    private static IReadOnlyList<string> CollectDuplicates(string[] keys)
+    private static IReadOnlyList<string> CollectDuplicates(string[] keys, int count)
     {
         // Small set — duplicates in production are rare and the dev surface
-        // caps the displayed list anyway.
+        // caps the displayed list anyway. This is a slow (bailout) path so
+        // the throwaway HashSets are acceptable.
         var seen = new HashSet<string>(global::System.StringComparer.Ordinal);
         var dupes = new HashSet<string>(global::System.StringComparer.Ordinal);
-        foreach (var k in keys)
+        for (int i = 0; i < count; i++)
         {
-            if (!seen.Add(k)) dupes.Add(k);
+            if (!seen.Add(keys[i])) dupes.Add(keys[i]);
         }
         if (dupes.Count == 0) return global::System.Array.Empty<string>();
         var arr = new string[dupes.Count];

--- a/tests/Reactor.Tests/ChildReconcilerKeyedMiddleCoreTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerKeyedMiddleCoreTests.cs
@@ -1,0 +1,397 @@
+using System.Collections.Generic;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Correctness oracle for <see cref="ChildReconciler.RunKeyedMiddleCore{TSink}"/>
+/// — the keyed-middle reorder algorithm that drives which surviving rows move /
+/// insert / patch.
+///
+/// Historically this path was "blocked by the selftest wall" (see
+/// <c>ChildReconcilerReconcileTests.cs</c>): exercising the real
+/// <c>ReconcileKeyedMiddle</c> needs live WinUI controls because
+/// <c>new Border()</c> throws COMException headless. The fix for the keyed
+/// identity bug (C1) / stale-index bug (H1) extracted the pure index logic into
+/// <see cref="ChildReconciler.RunKeyedMiddleCore{TSink}"/> behind an
+/// <see cref="ChildReconciler.IKeyedMiddleSink"/> seam. Production drives it with
+/// a real-WinUI sink; this test drives the SAME method with a headless
+/// <see cref="SimKeyedMiddleSink"/> over a list of identity cells — so the
+/// reorder stepping logic is now unit-testable with exact production parity.
+///
+/// Each cell tracks BOTH which original control occupies a slot (identity) and
+/// which new item's content it was last patched with. The oracle therefore
+/// asserts the two invariants the bugs violated:
+///   • final ORDER + per-key IDENTITY (the right control ends in the right slot);
+///   • per-slot CONTENT (the right control is PATCHED with the right new item —
+///     C1 patched survivors by a not-yet-reached final index, landing content on
+///     the wrong control).
+/// </summary>
+public class ChildReconcilerKeyedMiddleCoreTests
+{
+    // Token spaces keep the four cell kinds distinguishable in assertions.
+    private const int NewBase = 1000;    // new (mounted) item j  -> NewBase + j
+    private const int PrefixBase = 2000; // untouched common-prefix slot k
+    private const int SuffixBase = 3000; // untouched common-suffix slot k
+    private const int Unpatched = -1;    // survivor not yet patched this pass
+
+    private struct Cell
+    {
+        public int Control; // identity: old-relative index, or NewBase+j for new
+        public int Content; // last new-item index patched in (-1 if none)
+    }
+
+    private readonly record struct PatchRecord(int OldRel, int NewIdx, int PanelIdx, int ControlAtPatch);
+
+    /// <summary>
+    /// Headless <see cref="ChildReconciler.IKeyedMiddleSink"/> over a
+    /// <see cref="List{Cell}"/>. Mirrors the real sink's structural mutations
+    /// (Insert / final-position Move / patch-in-place) so it steps through the
+    /// identical core decisions.
+    /// </summary>
+    private struct SimKeyedMiddleSink : ChildReconciler.IKeyedMiddleSink
+    {
+        public List<Cell> Cells;
+        public List<PatchRecord> Patches;
+        public List<(int From, int To)> Moves;
+
+        public bool MountInsert(int newIdx, int panelIdx)
+        {
+            Cells.Insert(panelIdx, new Cell { Control = NewBase + newIdx, Content = newIdx });
+            return true;
+        }
+
+        public void MoveExisting(int fromIdx, int toIdx)
+        {
+            var cell = Cells[fromIdx];
+            Cells.RemoveAt(fromIdx);     // final-position semantics: remove then
+            Cells.Insert(toIdx, cell);   // insert into the post-removal list
+            Moves.Add((fromIdx, toIdx));
+        }
+
+        public void Patch(int oldRelIdx, int newIdx, int panelIdx)
+        {
+            int controlAtPatch = panelIdx >= 0 && panelIdx < Cells.Count ? Cells[panelIdx].Control : int.MinValue;
+            Patches.Add(new PatchRecord(oldRelIdx, newIdx, panelIdx, controlAtPatch));
+            if (panelIdx >= 0 && panelIdx < Cells.Count)
+            {
+                var cell = Cells[panelIdx];
+                cell.Content = newIdx;
+                Cells[panelIdx] = cell;
+            }
+        }
+    }
+
+    private sealed class RunResult
+    {
+        public required List<Cell> Cells;
+        public required List<PatchRecord> Patches;
+        public required List<(int From, int To)> Moves;
+        public required int[] NewToOld;
+        public required int PrefixLen;
+        public required int SuffixLen;
+        public required int NewMidLen;
+    }
+
+    private static string[] Split(string csv) =>
+        csv.Split(',', global::System.StringSplitOptions.RemoveEmptyEntries);
+
+    /// <summary>
+    /// Build the post-Step-1 model exactly as production does — last-wins key
+    /// map, matched survivors compacted in OLD order, LIS via the real
+    /// <see cref="ChildReconciler.ComputeLISInto"/> — then run the REAL core.
+    /// </summary>
+    private static RunResult Run(string[] oldKeys, string[] newKeys, int prefixLen = 0, int suffixLen = 0)
+    {
+        int oldMidLen = oldKeys.Length;
+        int newMidLen = newKeys.Length;
+
+        // newToOld + matched (production semantics: last key wins).
+        var oldKeyMap = new Dictionary<string, int>();
+        for (int i = 0; i < oldMidLen; i++) oldKeyMap[oldKeys[i]] = i;
+
+        var newToOld = new int[newMidLen];
+        var matched = new bool[oldMidLen];
+        for (int j = 0; j < newMidLen; j++)
+        {
+            if (oldKeyMap.TryGetValue(newKeys[j], out int r))
+            {
+                newToOld[j] = r;
+                matched[r] = true;
+            }
+            else
+            {
+                newToOld[j] = -1;
+            }
+        }
+
+        var inLis = new bool[newMidLen];
+        ChildReconciler.ComputeLISInto(newToOld, newMidLen, inLis);
+
+        // Survivors compacted in OLD order → live positions after removal.
+        var oldRelToPanel = new int[oldMidLen];
+        for (int r = 0; r < oldMidLen; r++) oldRelToPanel[r] = -1;
+
+        var cells = new List<Cell>();
+        for (int k = 0; k < prefixLen; k++) cells.Add(new Cell { Control = PrefixBase + k, Content = -2 });
+        int compact = 0;
+        for (int r = 0; r < oldMidLen; r++)
+        {
+            if (matched[r])
+            {
+                oldRelToPanel[r] = prefixLen + compact;
+                cells.Add(new Cell { Control = r, Content = Unpatched });
+                compact++;
+            }
+        }
+        int initialAnchor = prefixLen + compact; // start of suffix / end of middle
+        for (int k = 0; k < suffixLen; k++) cells.Add(new Cell { Control = SuffixBase + k, Content = -2 });
+
+        var sink = new SimKeyedMiddleSink
+        {
+            Cells = cells,
+            Patches = new List<PatchRecord>(),
+            Moves = new List<(int, int)>(),
+        };
+
+        ChildReconciler.RunKeyedMiddleCore(
+            ref sink, newToOld, inLis, newMidLen, oldMidLen, initialAnchor, oldRelToPanel);
+
+        return new RunResult
+        {
+            Cells = sink.Cells,
+            Patches = sink.Patches,
+            Moves = sink.Moves,
+            NewToOld = newToOld,
+            PrefixLen = prefixLen,
+            SuffixLen = suffixLen,
+            NewMidLen = newMidLen,
+        };
+    }
+
+    private static int ExpectedControl(int[] newToOld, int j) =>
+        newToOld[j] >= 0 ? newToOld[j] : NewBase + j;
+
+    /// <summary>Assert all four correctness invariants for a unique-key reorder.</summary>
+    private static void AssertReconciled(string[] oldKeys, string[] newKeys, int prefixLen = 0, int suffixLen = 0)
+    {
+        var r = Run(oldKeys, newKeys, prefixLen, suffixLen);
+
+        // (1) Collection length is exactly prefix + new-middle + suffix.
+        Assert.Equal(prefixLen + r.NewMidLen + suffixLen, r.Cells.Count);
+
+        // (2) Common prefix/suffix slots are never disturbed.
+        for (int k = 0; k < prefixLen; k++)
+            Assert.Equal(PrefixBase + k, r.Cells[k].Control);
+        for (int k = 0; k < suffixLen; k++)
+            Assert.Equal(SuffixBase + k, r.Cells[prefixLen + r.NewMidLen + k].Control);
+
+        // (3) Each middle slot holds the RIGHT control (identity/order) showing
+        //     the RIGHT content (the j-th new item). Content is the C1 teeth.
+        for (int j = 0; j < r.NewMidLen; j++)
+        {
+            var cell = r.Cells[prefixLen + j];
+            Assert.Equal(ExpectedControl(r.NewToOld, j), cell.Control);
+            Assert.Equal(j, cell.Content);
+        }
+
+        // (4) Every patch landed on the survivor it claimed — never the wrong
+        //     control at a not-yet-rearranged index (the direct C1/H1 check).
+        foreach (var p in r.Patches)
+            Assert.Equal(p.OldRel, p.ControlAtPatch);
+    }
+
+    [Theory]
+    [InlineData("", "")]                          // empty → empty
+    [InlineData("", "a,b")]                        // empty → non-empty (all new)
+    [InlineData("a,b", "")]                        // non-empty → empty (all removed)
+    [InlineData("a,b,c", "a,b,c")]                 // no-op (every survivor in LIS)
+    [InlineData("a,b,c", "a,b,c,d")]               // append
+    [InlineData("a,b,c", "d,a,b,c")]               // prepend
+    [InlineData("a,b,c", "a,d,b,c")]               // insert middle
+    [InlineData("a,b,c", "a,d,e,b,c")]             // insert two middle
+    [InlineData("a,b,c,d", "a,c,d")]               // remove middle
+    [InlineData("a,b,c,d", "b,d")]                 // remove two
+    [InlineData("a,b,c,d", "a,c,b,d")]             // adjacent swap
+    [InlineData("a,b,c,d", "b,c,d,a")]             // ROTATION (C1 repro)
+    [InlineData("a,b,c,d", "d,a,b,c")]             // rotation other way
+    [InlineData("a,b,c,d", "d,c,b,a")]             // full reverse
+    [InlineData("a,b,c,d,e", "e,d,c,b,a")]         // reverse 5
+    [InlineData("a,b,c", "c,a,b")]                 // all moved (rotate)
+    [InlineData("a,b,c,d,e,f", "f,a,e,b,d,c")]     // scramble
+    [InlineData("a,b,c,d", "c,d,a,b")]             // block swap
+    [InlineData("a,b,c,d", "e,b,c,f")]             // replace ends, keep middle
+    [InlineData("a,b,c,d", "d,x,b,y,a")]           // moves + inserts mixed
+    public void RunKeyedMiddleCore_PreservesOrderIdentityAndContent(string oldCsv, string newCsv)
+    {
+        AssertReconciled(Split(oldCsv), Split(newCsv));
+    }
+
+    [Theory]
+    [InlineData("a,b,c,d", "b,c,d,a")]             // rotation, offset
+    [InlineData("a,b,c,d", "d,c,b,a")]             // reverse, offset
+    [InlineData("a,b,c", "a,d,b,c")]               // insert middle, offset
+    [InlineData("a,b,c", "x,y")]                   // full replace, offset
+    public void RunKeyedMiddleCore_WithPrefixAndSuffix_OnlyTouchesMiddle(string oldCsv, string newCsv)
+    {
+        AssertReconciled(Split(oldCsv), Split(newCsv), prefixLen: 2, suffixLen: 3);
+    }
+
+    [Fact]
+    public void Rotation_RealCore_PutsBFirst_AndPatchesEachControlWithItsOwnContent()
+    {
+        // [a,b,c,d] → [b,c,d,a]: the exact C1 repro. Post-fix, slot 0 holds the
+        // 'b' control (old-relative index 1) showing the new 'b' content (0).
+        var r = Run(Split("a,b,c,d"), Split("b,c,d,a"));
+
+        Assert.Equal(new[] { 1, 2, 3, 0 }, r.Cells.ConvertAll(c => c.Control).ToArray());
+        Assert.Equal(new[] { 0, 1, 2, 3 }, r.Cells.ConvertAll(c => c.Content).ToArray());
+        Assert.All(r.Patches, p => Assert.Equal(p.OldRel, p.ControlAtPatch));
+        // Minimal moves: only the single non-LIS survivor ('a') relocates.
+        Assert.Single(r.Moves);
+    }
+
+    [Fact]
+    public void Rotation_BuggyPreFixAlgorithm_MisPatchesControls_ProvingTheTestHasTeeth()
+    {
+        // Faithful reproduction of the PRE-FIX Step-2 loop: left-to-right,
+        // survivors patched at their FINAL index (prefixLen + i) against a panel
+        // that is only partially rearranged, with keyToIndex updated only for the
+        // moved key (never shifted on insert). This is exactly the C1/H1 logic.
+        var buggy = RunBuggyPreFix(Split("a,b,c,d"), Split("b,c,d,a"));
+
+        // The buggy walk lands at least one patch on the WRONG control and
+        // produces corrupted per-slot content — both of which AssertReconciled
+        // checks, so the rotation test genuinely has teeth.
+        Assert.Contains(buggy.Patches, p => p.OldRel != p.ControlAtPatch);
+        var content = buggy.Cells.ConvertAll(c => c.Content).ToArray();
+        Assert.NotEqual(new[] { 0, 1, 2, 3 }, content);
+        // Documented symptom: slot 0 shows new item 'c' (index 1), not 'b' (0).
+        Assert.Equal(1, content[0]);
+
+        // And the REAL core never mis-patches on the same input.
+        var real = Run(Split("a,b,c,d"), Split("b,c,d,a"));
+        Assert.All(real.Patches, p => Assert.Equal(p.OldRel, p.ControlAtPatch));
+    }
+
+    [Fact]
+    public void DuplicateNewKeys_DoNotThrow_AndNeverPatchANonSurvivor()
+    {
+        // Duplicate keys are ill-defined (keys must be unique), but the engine
+        // must degrade gracefully: no exception, and every patch still lands on
+        // a genuine surviving control (no wrong-control corruption).
+        var ex = Record.Exception(() =>
+        {
+            var r = Run(Split("a"), Split("a,a"));
+            Assert.All(r.Patches, p => Assert.Equal(p.OldRel, p.ControlAtPatch));
+        });
+        Assert.Null(ex);
+
+        var ex2 = Record.Exception(() =>
+        {
+            var r = Run(Split("a,b"), Split("b,b,a"));
+            Assert.All(r.Patches, p => Assert.Equal(p.OldRel, p.ControlAtPatch));
+        });
+        Assert.Null(ex2);
+    }
+
+    [Fact]
+    public void DuplicateOldKeys_EarlierDuplicateIsTreatedAsRemoved()
+    {
+        // Last-wins key map: with old [a,a,b] → new [a,b], the new 'a' resolves
+        // to the LAST old 'a'; the first 'a' is unmatched (removed in Step 1) and
+        // never appears as a survivor. The two new slots reconcile cleanly.
+        var r = Run(Split("a,a,b"), Split("a,b"));
+        Assert.All(r.Patches, p => Assert.Equal(p.OldRel, p.ControlAtPatch));
+        // Both surviving controls show their new content.
+        Assert.Equal(new[] { 0, 1 }, r.Cells.ConvertAll(c => c.Content).ToArray());
+    }
+
+    // ── Faithful pre-fix (buggy) reproduction — used only to prove teeth ──────
+    private RunResult RunBuggyPreFix(string[] oldKeys, string[] newKeys, int prefixLen = 0, int suffixLen = 0)
+    {
+        int oldMidLen = oldKeys.Length;
+        int newMidLen = newKeys.Length;
+
+        var oldKeyMap = new Dictionary<string, int>();
+        for (int i = 0; i < oldMidLen; i++) oldKeyMap[oldKeys[i]] = i;
+
+        var newToOld = new int[newMidLen];
+        var matched = new bool[oldMidLen];
+        for (int j = 0; j < newMidLen; j++)
+        {
+            if (oldKeyMap.TryGetValue(newKeys[j], out int rr)) { newToOld[j] = rr; matched[rr] = true; }
+            else newToOld[j] = -1;
+        }
+
+        var inLis = new bool[newMidLen];
+        ChildReconciler.ComputeLISInto(newToOld, newMidLen, inLis);
+
+        var cells = new List<Cell>();
+        for (int k = 0; k < prefixLen; k++) cells.Add(new Cell { Control = PrefixBase + k, Content = -2 });
+        for (int r = 0; r < oldMidLen; r++)
+            if (matched[r]) cells.Add(new Cell { Control = r, Content = Unpatched });
+        for (int k = 0; k < suffixLen; k++) cells.Add(new Cell { Control = SuffixBase + k, Content = -2 });
+
+        // keyToIndex built ONCE from the post-removal panel (key → first index),
+        // and only the moved key is rewritten — exactly the stale-index (H1) bug.
+        var keyToIndex = new Dictionary<string, int>();
+        for (int i = prefixLen; i < cells.Count - suffixLen; i++)
+        {
+            int ctrl = cells[i].Control;
+            if (ctrl >= 0 && ctrl < oldMidLen) keyToIndex.TryAdd(oldKeys[ctrl], i);
+        }
+
+        var patches = new List<PatchRecord>();
+        var moves = new List<(int, int)>();
+
+        void PatchAt(int oldRel, int newIdx, int target)
+        {
+            if (target < 0 || target >= cells.Count) return;
+            patches.Add(new PatchRecord(oldRel, newIdx, target, cells[target].Control));
+            var cell = cells[target];
+            cell.Content = newIdx;
+            cells[target] = cell;
+        }
+
+        // Pre-fix Step 2: left-to-right, patch survivor at the FINAL index.
+        for (int i = 0; i < newMidLen; i++)
+        {
+            int target = prefixLen + i;
+            if (newToOld[i] == -1)
+            {
+                cells.Insert(target, new Cell { Control = NewBase + i, Content = i });
+            }
+            else if (inLis[i])
+            {
+                PatchAt(newToOld[i], i, target); // BUG C1: control at `target` is wrong
+            }
+            else
+            {
+                var key = oldKeys[newToOld[i]];
+                int cur = keyToIndex.TryGetValue(key, out int pos) ? pos : -1;
+                if (cur >= 0 && cur != target)
+                {
+                    var cell = cells[cur];
+                    cells.RemoveAt(cur);
+                    cells.Insert(target, cell);
+                    keyToIndex[key] = target; // H1: only the moved key is updated
+                    moves.Add((cur, target));
+                }
+                PatchAt(newToOld[i], i, target);
+            }
+        }
+
+        return new RunResult
+        {
+            Cells = cells,
+            Patches = patches,
+            Moves = moves,
+            NewToOld = newToOld,
+            PrefixLen = prefixLen,
+            SuffixLen = suffixLen,
+            NewMidLen = newMidLen,
+        };
+    }
+}

--- a/tests/Reactor.Tests/ChildReconcilerKeyedSkipTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerKeyedSkipTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Coverage for the keyed prefix/suffix <c>CanSkipUpdate</c> fast-path added by
+/// issue #653 (fix #30). A stable keyed list — e.g. grid rows whose keys never
+/// change between renders — must short-circuit the per-row <c>UpdateChild</c>
+/// COM round-trip exactly like the positional path already does, instead of
+/// re-diffing every row on every tick. Before #30 the keyed prefix/suffix loops
+/// always called <c>UpdateChild</c>; these tests pin the new skip behavior so a
+/// regression that re-introduces the per-row work (or, conversely, wrongly skips
+/// a row that needed updating) is caught.
+///
+/// These exercise the callback-free path, where the skip must avoid touching the
+/// realized control collection entirely — the mock's <c>Get</c> throws, so a
+/// passing test proves no <c>children.Get</c> COM call happened.
+/// </summary>
+public class ChildReconcilerKeyedSkipTests
+{
+    private static readonly Action NoOp = () => { };
+
+    /// <summary>
+    /// Records structural ops and counts <see cref="Get"/> calls; <see cref="Get"/>
+    /// throws because the #30 skip for callback-free rows must never reach a
+    /// realized control (creating one would also throw COMException headless).
+    /// </summary>
+    private sealed class ThrowingGetChildCollection : IChildCollection
+    {
+        private int _count;
+        public List<string> Operations { get; } = new();
+        public int GetCalls { get; private set; }
+
+        public ThrowingGetChildCollection(int count) => _count = count;
+
+        public int Count => _count;
+
+        public UIElement Get(int index)
+        {
+            GetCalls++;
+            throw new InvalidOperationException(
+                $"Get({index}) must not be called when a keyed row is skipped via CanSkipUpdate.");
+        }
+
+        public void Insert(int index, UIElement element) { Operations.Add($"Insert({index})"); _count++; }
+        public void RemoveAt(int index) { Operations.Add($"RemoveAt({index})"); _count--; }
+        public void Move(int oldIndex, int newIndex) => Operations.Add($"Move({oldIndex},{newIndex})");
+        public void Replace(int index, UIElement element) => Operations.Add($"Replace({index})");
+    }
+
+    // Distinct element instances each call (not reference-equal) with identical
+    // key + content, so the skip is driven by structural CanSkipUpdate — the
+    // realistic re-render shape, where every render allocates fresh records.
+    private static Element[] KeyedRows(int count)
+    {
+        var rows = new Element[count];
+        for (int i = 0; i < count; i++)
+            rows[i] = new TextBlockElement($"row-{i}") { Key = $"k{i}" };
+        return rows;
+    }
+
+    [Theory]
+    [InlineData(1)]   // single-row boundary (prefixLen < childCount guard)
+    [InlineData(2)]
+    [InlineData(5)]
+    [InlineData(32)]  // steady-state grid: many stable rows
+    public void Identical_Keyed_List_Skips_Every_Row_With_No_Ops_And_No_ControlAccess(int count)
+    {
+        var oldRows = KeyedRows(count);
+        var newRows = KeyedRows(count);
+        var mock = new ThrowingGetChildCollection(count);
+        var reconciler = new Reconciler();
+
+        ChildReconciler.Reconcile(oldRows, newRows, mock, reconciler, NoOp);
+
+        Assert.Empty(mock.Operations);                    // no insert/move/remove/replace
+        Assert.Equal(0, mock.GetCalls);                   // callback-free rows never touch controls
+        Assert.Equal(count, reconciler.DebugElementsSkipped); // every row hit the #30 fast-path
+    }
+
+    [Fact]
+    public void Repeated_Reconcile_Of_Stable_Keyed_List_Keeps_Skipping()
+    {
+        // Simulates several frames of a grid whose keys/content are unchanged:
+        // each pass must skip all rows and never fall back to UpdateChild.
+        var mock = new ThrowingGetChildCollection(8);
+        var reconciler = new Reconciler();
+        var previous = KeyedRows(8);
+
+        for (int frame = 0; frame < 4; frame++)
+        {
+            var next = KeyedRows(8);
+            ChildReconciler.Reconcile(previous, next, mock, reconciler, NoOp);
+            previous = next;
+        }
+
+        Assert.Empty(mock.Operations);
+        Assert.Equal(0, mock.GetCalls);
+        Assert.Equal(8 * 4, reconciler.DebugElementsSkipped);
+    }
+}

--- a/tests/Reactor.Tests/ChildReconcilerLisIntoTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerLisIntoTests.cs
@@ -30,6 +30,33 @@ public class ChildReconcilerLisIntoTests
         return set;
     }
 
+    // Independent O(n^2) DP reference for the length of the longest STRICTLY
+    // increasing subsequence. Deliberately NOT routed through ComputeLIS /
+    // ComputeLISInto: issue #653 made ComputeLIS a thin wrapper over
+    // ComputeLISInto, so comparing the two against each other is circular and
+    // would mask a bug shared by both. This DP is the non-circular oracle.
+    //
+    // Mirrors ComputeLISInto's contract: entries equal to -1 are "unmapped"
+    // sentinels (a new child with no surviving old match) and are excluded
+    // from the subsequence entirely — see ChildReconciler.ComputeLISInto's
+    // `if (arr[i] == -1) continue;`.
+    private static int BruteForceLisLength(int[] arr)
+    {
+        int n = arr.Length;
+        var dp = new int[n];
+        int best = 0;
+        for (int i = 0; i < n; i++)
+        {
+            if (arr[i] == -1) continue; // unmapped sentinel, never participates
+            dp[i] = 1;
+            for (int j = 0; j < i; j++)
+                if (arr[j] != -1 && arr[j] < arr[i] && dp[j] + 1 > dp[i])
+                    dp[i] = dp[j] + 1;
+            if (dp[i] > best) best = dp[i];
+        }
+        return best;
+    }
+
     [Theory]
     [InlineData(new int[0])]
     [InlineData(new[] { 5 })]
@@ -41,13 +68,28 @@ public class ChildReconcilerLisIntoTests
     [InlineData(new[] { 2, 0, 1, 3 })]
     [InlineData(new[] { 1, 3, 2, 3 })]
     [InlineData(new[] { 5, 1, 4, 2, 3 })]
-    public void ComputeLISInto_Matches_HashSet_Wrapper(int[] arr)
+    public void ComputeLISInto_Selects_Valid_Maximum_Increasing_Subsequence(int[] arr)
     {
-        var expected = ChildReconciler.ComputeLIS(arr);
+        // Non-circular oracle: the returned mask must mark a strictly increasing
+        // subsequence (in index order) whose length equals the true LIS length.
+        // This validates correctness independently of the ComputeLIS wrapper,
+        // and is robust to LIS tie-breaking (any valid maximum-length strictly
+        // increasing subsequence satisfies both properties).
         var mask = MaskFor(arr);
-        var actual = SetFromMask(mask, arr.Length);
 
-        Assert.Equal(expected, actual);
+        int prev = int.MinValue;
+        int count = 0;
+        for (int i = 0; i < arr.Length; i++)
+        {
+            if (!mask[i]) continue;
+            Assert.True(arr[i] > prev,
+                $"selected LIS values must be strictly increasing in index order; " +
+                $"index {i} (value {arr[i]}) breaks it");
+            prev = arr[i];
+            count++;
+        }
+
+        Assert.Equal(BruteForceLisLength(arr), count);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/ChildReconcilerLisIntoTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerLisIntoTests.cs
@@ -82,6 +82,11 @@ public class ChildReconcilerLisIntoTests
         for (int i = 0; i < arr.Length; i++)
         {
             if (!mask[i]) continue;
+            Assert.True(arr[i] != -1,
+                $"LIS selection must never include an unmapped sentinel (arr[i] == -1); " +
+                $"index {i} was selected. ComputeLISInto must skip sentinels entirely — " +
+                $"without this check a buggy impl could swap a real member for a -1 and " +
+                $"still satisfy strictly-increasing + length.");
             Assert.True(arr[i] > prev,
                 $"selected LIS values must be strictly increasing in index order; " +
                 $"index {i} (value {arr[i]}) breaks it");

--- a/tests/Reactor.Tests/ChildReconcilerLisIntoTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerLisIntoTests.cs
@@ -1,0 +1,115 @@
+using System.Buffers;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Tests for <see cref="ChildReconciler.ComputeLISInto"/> — the
+/// allocation-free LIS variant introduced by issue #653 that writes a
+/// membership mask into a caller-supplied (pooled) <c>bool[]</c> instead of
+/// allocating a <see cref="HashSet{T}"/>. These assert it produces exactly the
+/// same membership as the legacy <see cref="ChildReconciler.ComputeLIS"/>
+/// wrapper, clears any stale markers in the supplied mask, and never reads
+/// past <c>length</c> when the mask buffer is larger (the pooled case).
+/// </summary>
+public class ChildReconcilerLisIntoTests
+{
+    private static bool[] MaskFor(int[] arr)
+    {
+        var mask = new bool[arr.Length];
+        ChildReconciler.ComputeLISInto(arr, arr.Length, mask);
+        return mask;
+    }
+
+    private static HashSet<int> SetFromMask(bool[] mask, int length)
+    {
+        var set = new HashSet<int>();
+        for (int i = 0; i < length; i++)
+            if (mask[i]) set.Add(i);
+        return set;
+    }
+
+    [Theory]
+    [InlineData(new int[0])]
+    [InlineData(new[] { 5 })]
+    [InlineData(new[] { 1, 2, 3, 4, 5 })]
+    [InlineData(new[] { 5, 4, 3, 2, 1 })]
+    [InlineData(new[] { -1, 2, -1, 4, -1 })]
+    [InlineData(new[] { -1, -1, -1 })]
+    [InlineData(new[] { 3, 1, 2, 4 })]
+    [InlineData(new[] { 2, 0, 1, 3 })]
+    [InlineData(new[] { 1, 3, 2, 3 })]
+    [InlineData(new[] { 5, 1, 4, 2, 3 })]
+    public void ComputeLISInto_Matches_HashSet_Wrapper(int[] arr)
+    {
+        var expected = ChildReconciler.ComputeLIS(arr);
+        var mask = MaskFor(arr);
+        var actual = SetFromMask(mask, arr.Length);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ComputeLISInto_Clears_Stale_Markers_In_Supplied_Mask()
+    {
+        // A pooled mask can arrive with stale `true` entries. ComputeLISInto
+        // must clear [0,length) so only genuine LIS members remain true.
+        var arr = new[] { 5, 4, 3, 2, 1 }; // LIS is a single element
+        var mask = new bool[arr.Length];
+        for (int i = 0; i < mask.Length; i++) mask[i] = true; // pre-dirty
+
+        ChildReconciler.ComputeLISInto(arr, arr.Length, mask);
+
+        int trues = 0;
+        for (int i = 0; i < arr.Length; i++) if (mask[i]) trues++;
+        Assert.Equal(1, trues); // reverse-sorted ⇒ LIS length 1
+    }
+
+    [Fact]
+    public void ComputeLISInto_Honors_Length_When_Mask_Is_Larger()
+    {
+        // Simulate the hot-path contract: the bool[] comes from ArrayPool and
+        // is larger than `length`. Only [0,length) may be touched/read.
+        int[] arr = { 2, 0, 1, 3 }; // LIS = indices {1,2,3}
+        int length = arr.Length;
+
+        var pool = ArrayPool<bool>.Shared;
+        bool[] mask = pool.Rent(length);
+        try
+        {
+            // Dirty the whole rented buffer including the tail beyond length.
+            for (int i = 0; i < mask.Length; i++) mask[i] = true;
+
+            ChildReconciler.ComputeLISInto(arr, length, mask);
+
+            var actual = SetFromMask(mask, length);
+            Assert.Equal(new HashSet<int> { 1, 2, 3 }, actual);
+        }
+        finally
+        {
+            pool.Return(mask, clearArray: true);
+        }
+    }
+
+    [Fact]
+    public void ComputeLISInto_LargeSequence_With_One_Swap()
+    {
+        var arr = Enumerable.Range(0, 100).ToArray();
+        (arr[50], arr[51]) = (arr[51], arr[50]);
+
+        var mask = MaskFor(arr);
+        int trues = 0;
+        for (int i = 0; i < arr.Length; i++) if (mask[i]) trues++;
+
+        Assert.True(trues >= 99);
+        // Values at LIS positions must be strictly increasing.
+        int prev = int.MinValue;
+        for (int i = 0; i < arr.Length; i++)
+        {
+            if (!mask[i]) continue;
+            Assert.True(arr[i] > prev);
+            prev = arr[i];
+        }
+    }
+}

--- a/tests/Reactor.Tests/Internal/KeyedListDiffPoolingTests.cs
+++ b/tests/Reactor.Tests/Internal/KeyedListDiffPoolingTests.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using System.Collections.Specialized;
 using Microsoft.UI.Reactor.Core.Internal;
 using Xunit;
@@ -8,7 +7,7 @@ namespace Microsoft.UI.Reactor.Tests.Internal;
 /// <summary>
 /// Regression coverage for the per-diff allocation-elimination work
 /// (issue #653): the keyed list diff now rents its working buffers from
-/// <see cref="ArrayPool{T}"/> and reuses <see cref="ReactorListState.Scratch"/>
+/// <see cref="System.Buffers.ArrayPool{T}"/> and reuses <see cref="ReactorListState.Scratch"/>
 /// for the duplicate scan, and the no-op / empty fast paths now run ABOVE the
 /// duplicate check. These tests assert that pooling never corrupts results —
 /// across sequential diffs that share the pool, across interleaved diffs on

--- a/tests/Reactor.Tests/Internal/KeyedListDiffPoolingTests.cs
+++ b/tests/Reactor.Tests/Internal/KeyedListDiffPoolingTests.cs
@@ -304,4 +304,93 @@ public class KeyedListDiffPoolingTests
         // Final state is internally consistent.
         AssertKeysMatch(s, current.ToArray());
     }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Allocation budgets (#1/#2/#11 pooling regression guards — M2)
+    //
+    //  Mirrors the GC.GetAllocatedBytesForCurrentThread warm-up + measured
+    //  pattern used by the other perf-budget tests (#665/#692, DockPerfBudget).
+    //  These FAIL if the per-diff pooling is reverted: the no-op path re-grows a
+    //  `new string[newCount]` (#2) and a HasDuplicates HashSet that now runs
+    //  ABOVE the fast path (#1); the general path re-grows the same, scaled by N.
+    // ────────────────────────────────────────────────────────────────────
+
+    private static readonly Func<Item, int, string> KeyFn = Key;
+
+    [Fact]
+    public void NoOp_SteadyState_Diff_Allocates_Nothing()
+    {
+        // The steady-state grid frame: keys never change. With the no-op fast
+        // path ABOVE the duplicate scan (#1) and the rented newKeys buffer (#2),
+        // an unchanged diff allocates ZERO heap bytes. The Item[] and key
+        // delegate are built ONCE so the loop measures only the diff itself.
+        var keys = new[] { "a", "b", "c", "d", "e", "f", "g", "h" };
+        var s = Seed(keys);
+        var items = Items(keys);
+
+        for (int i = 0; i < 200; i++) // warm: JIT + pool fill + Scratch growth
+        {
+            var st = KeyedListDiff.Apply(s, items, KeyFn);
+            Assert.False(st.AnyOps);
+        }
+
+        const int iterations = 10_000;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iterations; i++)
+            _ = KeyedListDiff.Apply(s, items, KeyFn);
+        var delta = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        // Pooled no-op is 0 B/iter. Allow a tiny constant for CI/JIT noise; a
+        // single reverted `new string[8]` (~88 B) or HasDuplicates HashSet
+        // (hundreds of B) per call would blow far past this.
+        Assert.True(delta < 8L * iterations,
+            $"steady-state no-op diff allocated {delta} B over {iterations} iters " +
+            $"({(double)delta / iterations:F2} B/iter); expected ~0 — pooling (#1/#2) likely reverted");
+    }
+
+    [Fact]
+    public void General_Keyed_Reorder_Diff_Stays_Within_Pooled_Budget()
+    {
+        // A real general-path diff over a large list (128 keys) reordered by a
+        // single adjacent swap each way. The pooled newKeys[128] (#2) and
+        // Scratch-backed duplicate scan (#11) keep per-diff allocation tiny
+        // (just the inherent ObservableCollection move event + movedRows list).
+        // Reverting pooling re-adds a `new string[128]` + a 128-entry HashSet
+        // per diff (several KB), which this budget catches.
+        const int n = 128;
+        var a = new string[n];
+        for (int i = 0; i < n; i++) a[i] = $"k{i}";
+        var b = (string[])a.Clone();
+        (b[0], b[1]) = (b[1], b[0]); // adjacent swap → one move
+
+        var s = Seed(a);
+        var itemsA = Items(a);
+        var itemsB = Items(b);
+
+        for (int i = 0; i < 100; i++) // warm both directions
+        {
+            KeyedListDiff.Apply(s, itemsB, KeyFn);
+            KeyedListDiff.Apply(s, itemsA, KeyFn);
+        }
+
+        const int pairs = 2_000;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < pairs; i++)
+        {
+            KeyedListDiff.Apply(s, itemsB, KeyFn);
+            KeyedListDiff.Apply(s, itemsA, KeyFn);
+        }
+        var delta = GC.GetAllocatedBytesForCurrentThread() - before;
+        long perDiff = delta / (2L * pairs);
+
+        // Generous ceiling vs. the multi-KB-per-diff cost of reverted pooling,
+        // but far below it, so an un-pooled regression at N=128 fails loudly.
+        // Measured steady state is ~72 B/diff (a single ObservableCollection
+        // move event). A 256 B ceiling keeps ~3.5x headroom for runtime variance
+        // while a reverted `new string[128]` (~1 KB) + 128-entry HashSet (several
+        // KB) fails by a wide margin.
+        Assert.True(perDiff < 256,
+            $"general keyed reorder allocated {perDiff} B/diff (N={n}); pooled buffers " +
+            $"(#2 newKeys, #11 Scratch dup-scan) keep this small — likely reverted");
+    }
 }

--- a/tests/Reactor.Tests/Internal/KeyedListDiffPoolingTests.cs
+++ b/tests/Reactor.Tests/Internal/KeyedListDiffPoolingTests.cs
@@ -1,0 +1,307 @@
+using System.Buffers;
+using System.Collections.Specialized;
+using Microsoft.UI.Reactor.Core.Internal;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.Internal;
+
+/// <summary>
+/// Regression coverage for the per-diff allocation-elimination work
+/// (issue #653): the keyed list diff now rents its working buffers from
+/// <see cref="ArrayPool{T}"/> and reuses <see cref="ReactorListState.Scratch"/>
+/// for the duplicate scan, and the no-op / empty fast paths now run ABOVE the
+/// duplicate check. These tests assert that pooling never corrupts results —
+/// across sequential diffs that share the pool, across interleaved diffs on
+/// independent states, and in the rented-buffer-larger-than-count case — and
+/// that correctness (which row moves/inserts/removes) is preserved exactly.
+/// </summary>
+public class KeyedListDiffPoolingTests
+{
+    private sealed record Item(string Id);
+
+    private static string Key(Item i, int _) => i.Id;
+
+    private static ReactorListState Seed(params string[] keys)
+    {
+        var s = new ReactorListState();
+        var seed = new (int Index, string Key)[keys.Length];
+        for (int i = 0; i < keys.Length; i++) seed[i] = (i, keys[i]);
+        s.Reset(seed);
+        return s;
+    }
+
+    private static Item[] Items(params string[] keys)
+    {
+        var arr = new Item[keys.Length];
+        for (int i = 0; i < keys.Length; i++) arr[i] = new Item(keys[i]);
+        return arr;
+    }
+
+    private static void AssertKeysMatch(ReactorListState s, params string[] expected)
+    {
+        Assert.Equal(expected.Length, s.Source.Count);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.Equal(expected[i], s.Source[i].Key);
+            Assert.Equal(i, s.Source[i].Index);
+        }
+        Assert.Equal(expected, s.LastKeys);
+        Assert.Equal(expected.Length, s.ByKey.Count);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  No-op fast path now runs above the duplicate scan (#1)
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NoOp_FastPath_With_Many_Unique_Keys_Emits_Nothing()
+    {
+        // 8 unique keys: previously this allocated/scanned a duplicate HashSet
+        // BEFORE the no-op check. The reorder (#1) must keep it a pure no-op.
+        var keys = new[] { "a", "b", "c", "d", "e", "f", "g", "h" };
+        var s = Seed(keys);
+        var events = new List<NotifyCollectionChangedEventArgs>();
+        s.Source.CollectionChanged += (_, e) => events.Add(e);
+
+        var stats = KeyedListDiff.Apply(s, Items(keys), Key);
+
+        Assert.False(stats.AnyOps);
+        Assert.False(stats.Bailout);
+        Assert.Empty(events);
+        AssertKeysMatch(s, keys);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Rented newKeys buffer may be larger than newCount (#2)
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Large_Then_Small_Diff_Preserves_Correctness_Across_Buffer_Sizes()
+    {
+        // Run diffs whose newCount swings widely so the rented newKeys buffer
+        // is reused at very different sizes. If any code path read
+        // newKeys.Length instead of the threaded newCount, the stale/cleared
+        // tail of a reused (larger) buffer would corrupt the result. The
+        // 64→3 collapse legitimately trips the churn bailout; correctness
+        // (final key order) must hold either way, which is what we assert.
+        var s = Seed();
+
+        var big = new string[64];
+        for (int i = 0; i < big.Length; i++) big[i] = $"k{i}";
+        KeyedListDiff.Apply(s, Items(big), Key);
+        AssertKeysMatch(s, big);
+
+        // Collapse to 3 items — small newCount, large previously-rented buffer.
+        KeyedListDiff.Apply(s, Items("k0", "k1", "k2"), Key);
+        AssertKeysMatch(s, "k0", "k1", "k2");
+
+        // Grow again (general path) to confirm LastKeys sync stayed correct.
+        var stats = KeyedListDiff.Apply(s, Items("k0", "z", "k1", "k2", "w"), Key);
+        Assert.False(stats.Bailout);
+        AssertKeysMatch(s, "k0", "z", "k1", "k2", "w");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Pooled `doomed` buffer for removals (#3) — non-contiguous removes
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Multiple_NonContiguous_Removes_From_Middle_Are_Correct()
+    {
+        // [a,b,c,d,e] → [a,c,e]: prefix 'a', suffix 'e', remove b and d (non
+        // contiguous indices 1 and 3). Exercises the rented doomed[] sorted
+        // descending so RemoveAt keeps earlier indices stable.
+        var s = Seed("a", "b", "c", "d", "e");
+        var rowA = s.ByKey["a"];
+        var rowC = s.ByKey["c"];
+        var rowE = s.ByKey["e"];
+
+        var stats = KeyedListDiff.Apply(s, Items("a", "c", "e"), Key);
+
+        Assert.False(stats.Bailout);
+        Assert.Equal(0, stats.Inserts);
+        Assert.Equal(2, stats.Removes);
+        AssertKeysMatch(s, "a", "c", "e");
+        // Survivors keep identity (proves we removed the right rows).
+        Assert.Same(rowA, s.Source[0]);
+        Assert.Same(rowC, s.Source[1]);
+        Assert.Same(rowE, s.Source[2]);
+        Assert.False(s.ByKey.ContainsKey("b"));
+        Assert.False(s.ByKey.ContainsKey("d"));
+    }
+
+    [Fact]
+    public void Many_Removes_Below_Floor_Use_Pooled_Doomed_Buffer()
+    {
+        // [a,b,c,d,e,f,g] → [a,g]: prefix 'a', suffix 'g', 5 middle removes.
+        // churn = 5 < floor(8) so the general path runs (no bailout), driving
+        // the rented doomed buffer with 5 entries.
+        var s = Seed("a", "b", "c", "d", "e", "f", "g");
+        var stats = KeyedListDiff.Apply(s, Items("a", "g"), Key);
+
+        Assert.False(stats.Bailout);
+        Assert.Equal(5, stats.Removes);
+        AssertKeysMatch(s, "a", "g");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Churn bailout (#34) still correct with a non-empty prefix AND suffix
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Churn_Bailout_Counts_FullRange_Even_With_Shared_Prefix_And_Suffix()
+    {
+        // Stable 5-key prefix + stable 5-key suffix, middle 10 fully replaced.
+        // Diff-range churn (10 add + 10 remove = 20) must equal full-range
+        // churn so the >25% + floor(8) bailout still triggers.
+        var old = new List<string>();
+        var @new = new List<string>();
+        for (int i = 0; i < 5; i++) { old.Add($"p{i}"); @new.Add($"p{i}"); }      // prefix
+        for (int i = 0; i < 10; i++) { old.Add($"m{i}"); @new.Add($"n{i}"); }     // churned middle
+        for (int i = 0; i < 5; i++) { old.Add($"s{i}"); @new.Add($"s{i}"); }      // suffix
+
+        var s = Seed(old.ToArray());
+        var stats = KeyedListDiff.Apply(s, Items(@new.ToArray()), Key);
+
+        Assert.True(stats.Bailout);
+        // Reset still produced a coherent collection in the new order.
+        AssertKeysMatch(s, @new.ToArray());
+    }
+
+    [Fact]
+    public void Stable_Prefix_Suffix_With_Small_Middle_Churn_Does_Not_Bail()
+    {
+        // Same shape but only a 1-key middle change — well under the floor, so
+        // the general diff runs and the merged churn calc must NOT over-count.
+        var old = new List<string>();
+        var @new = new List<string>();
+        for (int i = 0; i < 5; i++) { old.Add($"p{i}"); @new.Add($"p{i}"); }
+        old.Add("mid"); @new.Add("MID");
+        for (int i = 0; i < 5; i++) { old.Add($"s{i}"); @new.Add($"s{i}"); }
+
+        var s = Seed(old.ToArray());
+        var stats = KeyedListDiff.Apply(s, Items(@new.ToArray()), Key);
+
+        Assert.False(stats.Bailout);
+        AssertKeysMatch(s, @new.ToArray());
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Scratch reuse for the duplicate scan (#11) must not leak (clean diff
+    //  after a duplicate bailout on the SAME state)
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Duplicate_Bailout_Then_Reset_Through_Empty_Recovers_Cleanly()
+    {
+        // A duplicate-key diff bails out via Reset, which (by design — see
+        // ReactorListState.Reset) tolerates the duplicate and leaves LastKeys
+        // holding it. The supported recovery is a structural reset; here we go
+        // through the empty list (Fast path 4) and then re-mount a clean unique
+        // list. This proves the duplicate scan's reuse of state.Scratch (#11)
+        // left no residue that survives a bailout + rebuild.
+        var s = Seed("a", "b", "c");
+        var dup = KeyedListDiff.Apply(s, Items("a", "b", "c", "d", "a"), Key);
+        Assert.True(dup.Bailout);
+
+        KeyedListDiff.Apply(s, Items(), Key); // clear to empty (Fast path 4)
+
+        var clean = KeyedListDiff.Apply(s, Items("a", "b", "c", "d", "e"), Key);
+        Assert.False(clean.Bailout);
+        AssertKeysMatch(s, "a", "b", "c", "d", "e");
+    }
+
+    [Fact]
+    public void Duplicate_In_FourPlus_Keys_Still_Detected_Via_Scratch()
+    {
+        // 4+ keys takes the Scratch-backed dup path (not the <=3 inline scan).
+        var s = Seed("a", "b", "c", "d");
+        var stats = KeyedListDiff.Apply(s, Items("a", "b", "c", "d", "b"), Key);
+        Assert.True(stats.Bailout);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Pool sharing: interleaved diffs on independent states
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Interleaved_Diffs_On_Independent_States_Do_Not_Cross_Contaminate()
+    {
+        var s1 = Seed("a", "b", "c", "d", "e");
+        var s2 = Seed("v", "w", "x", "y", "z");
+
+        for (int round = 0; round < 25; round++)
+        {
+            // s1: rotate left by one each round.
+            var k1 = new[] { "b", "c", "d", "e", "a" };
+            KeyedListDiff.Apply(s1, Items(k1), Key);
+            AssertKeysMatch(s1, k1);
+
+            // s2: reverse each round (toggles back and forth).
+            var k2 = new[] { "z", "y", "x", "w", "v" };
+            KeyedListDiff.Apply(s2, Items(k2), Key);
+            AssertKeysMatch(s2, k2);
+
+            // restore both so the next round starts from the seed order.
+            KeyedListDiff.Apply(s1, Items("a", "b", "c", "d", "e"), Key);
+            KeyedListDiff.Apply(s2, Items("v", "w", "x", "y", "z"), Key);
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Randomized stress — the pooled diff must equal a trivial oracle
+    //  (Source order == applied key list) on every step, with survivor
+    //  identity preserved for keys that persist across a step.
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Randomized_Sequence_Of_Diffs_Always_Matches_Oracle()
+    {
+        var rng = new Random(20240613);
+        var universe = new string[40];
+        for (int i = 0; i < universe.Length; i++) universe[i] = $"u{i}";
+
+        var s = Seed();
+        var current = new List<string>();
+
+        for (int step = 0; step < 400; step++)
+        {
+            // Build a random subset of the universe in a random order. Always
+            // unique keys (no dup/null) so we stay on the structural path.
+            int take = rng.Next(0, universe.Length + 1);
+            var pool = new List<string>(universe);
+            var next = new List<string>(take);
+            for (int i = 0; i < take; i++)
+            {
+                int idx = rng.Next(pool.Count);
+                next.Add(pool[idx]);
+                pool.RemoveAt(idx);
+            }
+
+            // Capture survivor rows (keys present before AND after) to assert
+            // identity stability through the diff.
+            var survivorsBefore = new Dictionary<string, ReactorRow>();
+            foreach (var k in next)
+                if (s.ByKey.TryGetValue(k, out var row)) survivorsBefore[k] = row;
+
+            var stats = KeyedListDiff.Apply(s, Items(next.ToArray()), Key);
+
+            // Oracle: the Source must always equal exactly the applied list.
+            AssertKeysMatch(s, next.ToArray());
+
+            // When the diff did NOT bail, survivor ReactorRow identity must be
+            // preserved (WinUI relies on this). A bailout (Reset) legitimately
+            // rebuilds rows, so only check identity on the non-bailout path.
+            if (!stats.Bailout)
+            {
+                foreach (var (k, beforeRow) in survivorsBefore)
+                    Assert.Same(beforeRow, s.ByKey[k]);
+            }
+
+            current = next;
+        }
+
+        // Final state is internally consistent.
+        AssertKeysMatch(s, current.ToArray());
+    }
+}

--- a/tests/Reactor.Tests/Internal/KeyedListDiffTests.cs
+++ b/tests/Reactor.Tests/Internal/KeyedListDiffTests.cs
@@ -365,6 +365,36 @@ public class KeyedListDiffTests
     }
 
     [Fact]
+    public void Apply_Unchanged_Duplicate_List_Re_Bails_Instead_Of_NoOp_FastPath()
+    {
+        // Regression for the #657 review (#1/#4): the no-op fast path runs ABOVE
+        // the duplicate scan, so it is gated on `ByKey.Count == oldCount`. A list
+        // that is UNCHANGED yet already holds duplicate keys — the state a prior
+        // duplicate bailout leaves behind, since ReactorListState.Reset preserves
+        // the dups in Source/LastKeys but ByKey collapses to first occurrences —
+        // must NOT short-circuit to Empty. It has to re-take the duplicate
+        // bailout so the keyed diff never runs in an invalid duplicate state.
+        var s = Seed("a", "b", "c");
+
+        // 1) First diff with a duplicate → bailout. State now carries the dup:
+        //    LastKeys = [a,b,c,a] (count 4), ByKey = {a,b,c} (count 3).
+        var first = KeyedListDiff.Apply(s, Items("a", "b", "c", "a"), Key);
+        Assert.True(first.Bailout);
+        Assert.Equal(4, s.LastKeys.Count);
+        Assert.Equal(3, s.ByKey.Count); // duplicate collapsed in ByKey
+
+        // 2) Re-apply the IDENTICAL duplicate list. oldCount(4) == newCount(4)
+        //    and LastKeys matches, so WITHOUT the ByKey.Count guard this would
+        //    hit the no-op fast path and return Empty (Bailout == false), leaving
+        //    the duplicate state unhandled. The guard forces the bailout again.
+        var second = KeyedListDiff.Apply(s, Items("a", "b", "c", "a"), Key);
+        Assert.True(second.Bailout,
+            "an unchanged duplicate list must re-take the duplicate bailout, not " +
+            "the no-op fast path (the ByKey.Count == oldCount guard enforces this)");
+        Assert.Equal(4, s.Source.Count);
+    }
+
+    [Fact]
     public void Apply_Null_Key_Triggers_Bailout()
     {
         var s = Seed("a", "b");


### PR DESCRIPTION
Closes #653

## What

Two things in the keyed list-diff path:

1. **Eliminates per-diff allocations** and restores the missing fast-path on the keyed prefix/suffix loops — a top Diff-gap contributor on the data-grid stress workload (StocksGrid), where stable grid rows go through the keyed path and re-diff every tick. (Confirmed **−30.8% keyed-list allocation / −32.3% Gen0** on the stress workload.)
2. **Fixes a pre-existing keyed-identity correctness bug** in `ReconcileKeyedMiddle` (C1/H1, see below) surfaced during review, and adds the reorder-oracle coverage that was previously disabled.

Scope is limited to `src/Reactor/Core/ChildReconciler.cs` and `src/Reactor/Core/Internal/KeyedListDiff.cs` (+ tests).

## Correctness fix — keyed-middle reorder identity (C1/H1)

> **Behavior note:** the allocation/fast-path work below preserves diff behavior exactly. This section is the one **intentional** behavior change — it *fixes* incorrect reorder behavior; for inputs that were already correct (the common steady-state grid: no-op / append / in-LIS rows) output is unchanged.

- **C1 (critical):** the old Step-2 loop patched the surviving control at its *final* panel index (`children.Get(prefixLen + i)`) while the panel was only partially rearranged, so on a reorder a survivor could be patched against the **wrong control** — e.g. rotation `[a,b,c,d] → [b,c,d,a]` rendered `c` at slot 0 and scrambled keyed identity (focus/animation/state landed on the wrong row).
- **H1 (high):** `keyToIndex` was built once and only the moved key rewritten, leaving shifted siblings mis-indexed after an insert/move.
- **Fix:** the index logic is extracted into `RunKeyedMiddleCore<TSink>` behind a struct-generic `IKeyedMiddleSink` seam (devirtualized, AOT-clean), and the left-to-right loop is replaced with the canonical **right-to-left LIS walk**. Each item is positioned immediately before its already-placed right neighbour; LIS members stay put and only out-of-LIS movers relocate (minimal moves). Every survivor is patched at its **current live position**, resolved from a pooled `oldRelToPanel` int[] that is mutated in lock-step with every Insert/Move so it stays exact — fixing C1 and H1 together. The production `RealKeyedMiddleSink` drives the identical Mount/Move/UpdateChild/Unmount/ambient behavior as before. `oldRelToPanel` also replaces the second pooled key→index dict (one fewer rented dict per call).

## ChildReconciler.cs (allocation/fast-path)
- **[flagship] Keyed prefix/suffix `CanSkipUpdate` early-exit (#30):** mirror the positional path's structural-skip so stable keyed rows avoid the `children.Get` COM call + full property diff every tick. Includes the `ForceRenderThroughWrapper` guard and the callback-Tag refresh.
- **Cache `children.Count` (#37):** stop re-reading the COM `IVector.get_Size` per suffix iteration.
- **Allocation-free LIS (#31/#32):** replace the `HashSet<int>`-returning `ComputeLIS` (which was copied into a 2nd identical set) with `ComputeLISInto(arr, length, bool[] mask)`; `tails`/`tailIndices`/`predecessors` come from `ArrayPool`. A thin `ComputeLIS(int[])` wrapper is kept for existing tests.
- **Pool `ReconcileKeyedMiddle` buffers (#33):** `newToOld`/`matched`/`inLis`/`oldRelToPanel` from `ArrayPool`; the key→index dict from a re-entrancy-safe `[ThreadStatic]` pool. Cleared + returned on every exit (incl. exceptions).
- **`Filter` (#36):** count-pass + single `Element[]` fill instead of `List` + `ToArray`.
- **`GetKey` (#38):** cache `Type.Name` via `ConcurrentDictionary`.

## KeyedListDiff.cs
- **[flagship] No-op/empty fast paths above the duplicate scan (#1):** the steady-state grid case (keys unchanged) no longer allocates/scans a dup set before the `SequenceEqual` fast path. The no-op path is gated on `ByKey.Count == oldCount` (O(1)) so an *unchanged duplicate* list (left by a prior duplicate bailout) still re-takes the bailout instead of short-circuiting to Empty.
- **[flagship] Rent `newKeys` from `ArrayPool<string>` (#2):** an explicit `newCount` is threaded everywhere (the rented array may be larger); returned `clearArray:true` in a `finally` via an `Apply`/`ApplyCore` split.
- **Fold churn-bailout into `ApplyGeneral` (#34):** computed from the same post-prefix/suffix scratch map the general walk already builds (diff-range churn ≡ full-range churn), removing the O(2n) null-marker pre-pass + second populate.
- **Pool the `doomed` `ReactorRow[]` (#3)**, lazy `movedRows` (#35), in-place `SyncLastKeysToSource` instead of `Clear()`+`Add` (#10), `HasDuplicates` reuses `state.Scratch` for 4+ keys (#11), cached null-key diagnostic sample (#41).

## Tests
New coverage in `tests/Reactor.Tests`:
- **Keyed-middle reorder oracle** (`ChildReconcilerKeyedMiddleCoreTests`): a headless `SimKeyedMiddleSink` drives the *same* `RunKeyedMiddleCore` over identity cells (exact production parity, no live-WinUI selftest wall), with a 4-invariant oracle (length, prefix/suffix untouched, per-slot identity+content, every patch hits its claimed survivor) across rotation, full reverse, scramble, block-swap, inserts/removes/duplicates and prefix/suffix offsets. A faithful pre-fix reproduction proves the rotation regression test has teeth (the buggy walk corrupts `content[0]` and mis-patches; the real core is clean).
- **Allocation budgets** (`KeyedListDiffPoolingTests`): two `GC.GetAllocatedBytesForCurrentThread` budgets — no-op steady-state diff = **0 B/iter**, 128-key reorder = **~72 B/diff** — that fail if the pooling (#1/#2/#11) is reverted.
- **Duplicate-guard regression** (`KeyedListDiffTests`): an unchanged duplicate list re-bails (verified to fail without the `ByKey.Count` guard).
- **LIS bool-mask** (`ChildReconcilerLisIntoTests`): independent brute-force DP oracle (non-circular), clears stale markers, honors `length` on an oversized pooled mask, and asserts selection never includes a `-1` sentinel.
- Plus the existing pooled-buffer non-corruption suite (rented-buffer-larger-than-count, interleaved independent states, randomized stress vs. oracle with survivor-identity checks, pooled `doomed` removes, churn with shared prefix **and** suffix, `Scratch` reuse across a dup bailout).

## Validation
- `dotnet test tests/Reactor.Tests` — **9843 passed, 0 failed, 64 skipped**.
- `dotnet build src/Reactor` `-c Release` — **0 warnings, 0 errors** (core lib promotes AOT/trim warnings to errors).
- Perf re-confirmed via `/perf`: **−30.8% [−31.0, −30.6] keyed-list allocation, −32.3% Gen0**, keyed reconcile/rps within-noise.