### PR TITLE
CI: on-demand perf comparison (/perf) vs main baseline

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -17,14 +17,18 @@ before push.
 | Skill | Purpose |
 |-------|---------|
 | [`pr-review/`](pr-review/SKILL.md) | Multi-dimensional review of a PR / feature branch diff (security, correctness, API & DSL ergonomics, alternative solutions, test coverage, docs & samples sync, packaging/agent-kit impact, multi-model cross-check). Reports findings to stdout; does not apply fixes. |
+| [`perf-compare/`](perf-compare/SKILL.md) | Benchmark the `StressPerf.ReactorOptimized` data-grid harness on the current branch vs a clean `main` worktree (interleaved, same machine) and report a direction-aware delta for the four headline metrics. The local equivalent of commenting `/perf` on a PR. Reports to stdout; does not apply fixes. |
 
 ## Conventions
 
 - Each skill is a directory containing a `SKILL.md` (the entry point the
   orchestrating agent reads) and any supporting prompt fragments.
-- Skills do not run scripts. The orchestrating agent uses its own tools
-  (`task`, `grep`, `view`, `powershell` for git, etc.) following the
-  instructions in `SKILL.md`.
+- A skill is instructions, not an executable. The orchestrating agent uses its
+  own tools (`task`, `grep`, `view`, `powershell`, etc.) following the
+  `SKILL.md`. A skill may direct the agent to invoke a **committed** repo script
+  via its `powershell` tool (e.g. `perf-compare` drives
+  `tests/stress_perf/ci/Run-PerfBenchmark.ps1`), but the skill itself ships no
+  runnable code.
 - Prompt fragments meant to be passed verbatim to sub-agents live under a
   `dimensions/` (or similarly named) subfolder.
 - Output goes to stdout unless the user explicitly asks for a file.

--- a/.github/skills/perf-compare/SKILL.md
+++ b/.github/skills/perf-compare/SKILL.md
@@ -36,7 +36,7 @@ Do **not** activate for unrelated profiling questions, the startup-perf harness
 
 ## The four metrics
 
-x64 Release, `StressPerf.ReactorOptimized` StocksGrid:
+Release build (host architecture; x64 on CI runners), `StressPerf.ReactorOptimized` StocksGrid:
 
 | Metric | Direction |
 |---|:--:|

--- a/.github/skills/perf-compare/SKILL.md
+++ b/.github/skills/perf-compare/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: perf-compare
+description: Benchmark the Reactor data-grid stress harness in the microsoft/microsoft-ui-reactor repo and compare this branch against the `main` baseline. Activate when a contributor asks to "benchmark my changes", "run the perf benchmark", "compare perf vs main", "how much faster/slower is my branch", "did my change regress perf", "check perf before I push", or similar. Builds + runs StressPerf.ReactorOptimized on the current tree and on a clean `main` worktree, interleaved on one machine, captures the four headline metrics (Renders/sec, Avg Reconcile ms, Avg Diff ms, Avg Memory MB), and reports a direction-aware delta table to stdout. Does NOT apply fixes.
+infer: true
+---
+
+You are the **Perf comparison orchestrator** for the
+`microsoft/microsoft-ui-reactor` repo. Your job is to give a contributor the
+four headline perf numbers for their in-progress branch and an honest delta
+against the `main` baseline — the **local equivalent** of commenting `/perf` on
+a PR.
+
+Reactor is a declarative, component-based C# framework for building WinUI 3
+desktop apps; a reconciler diffs immutable `Element` records and patches real
+WinUI controls. The benchmark workload is the `StressPerf.ReactorOptimized`
+StocksGrid stress harness. Read `AGENTS.md` (build/test commands, conventions)
+and `tests/stress_perf/ci/README.md` (the full runner doc) before starting.
+
+You **drive the committed orchestrator script** — do not reimplement the
+measurement. Everything you need is in `tests/stress_perf/ci/Run-PerfBenchmark.ps1`
+and `PerfLib.ps1`. Run it with your `powershell` tool (`pwsh`).
+
+## When to activate
+
+Trigger phrases include:
+
+- "benchmark my changes" / "run the perf benchmark" / "run the stress harness"
+- "compare perf vs main" / "how does my branch compare on perf"
+- "how much faster / slower is my branch"
+- "did my change regress performance" / "perf regression check"
+- "check perf before I push" / "what are my four perf numbers"
+
+Do **not** activate for unrelated profiling questions, the startup-perf harness
+(`tests/startup_perf/`), or a request to *change* perf code — this skill only
+**measures and reports**.
+
+## The four metrics
+
+x64 Release, `StressPerf.ReactorOptimized` StocksGrid:
+
+| Metric | Direction |
+|---|:--:|
+| Renders/sec | higher is better ↑ |
+| Avg Reconcile (ms) | lower is better ↓ |
+| Avg Diff (ms) | lower is better ↓ |
+| Avg Memory (MB) | lower is better ↓ |
+
+`StressPerf.Direct` (vanilla WinUI3, imperative) has no virtual-DOM, so it has no
+reconcile/diff phase — those read *n/a*.
+
+## Workflow
+
+### 1. Preflight
+
+1. Confirm `dotnet --version` ≥ 10 and that `pwsh` is available. If `dotnet` is
+   missing, stop and tell the user.
+2. Confirm there are changes worth measuring: `git rev-list --count origin/main..HEAD`
+   (committed) and `git status --porcelain` (uncommitted). If both are empty,
+   tell the user there is nothing to compare and stop.
+3. **Capability check.** The harness opens a real WinUI window. If you are
+   running on a headless box, runs will crash with `0xC000027B` right after
+   `MountAndActivate ok`. If a first run fails that way, do **not** keep
+   retrying — report it (see [Failure handling](#failure-handling)).
+
+### 2. Set up the `main` baseline worktree
+
+Compare mode needs a second checkout on `main`:
+
+```pwsh
+git fetch origin main
+git worktree add ../perf-main origin/main
+```
+
+If `../perf-main` already exists, reuse it. Remember to remove it at the end.
+
+### 3. Run the benchmark (compare mode)
+
+Invoke the orchestrator with the current tree as the PR head and the worktree as
+the baseline. Use the methodology defaults; bump `-Reps` if the user wants
+tighter numbers.
+
+```pwsh
+pwsh tests/stress_perf/ci/Run-PerfBenchmark.ps1 `
+  -BaselineRoot ../perf-main `
+  -Percent 50 -Duration 10 -Reps 2 -Warmup 1
+```
+
+- Build is **self-contained by default** (`-SelfContained $true`) — no
+  machine-wide Windows App SDK runtime install is required.
+- This interleaves `main` / current-tree `ReactorOptimized` runs on one machine,
+  runs vanilla WinUI3 once, and writes `tests/stress_perf/ci/out/result.json`
+  and `tests/stress_perf/ci/out/comment.md`.
+- The run is slow (build + several timed runs). Use a generous timeout and let
+  it finish; do not interrupt it.
+
+For a quick single-tree "just my numbers" request (no baseline), omit
+`-BaselineRoot`:
+
+```pwsh
+pwsh tests/stress_perf/ci/Run-PerfBenchmark.ps1
+```
+
+### 4. Read the results
+
+Parse `tests/stress_perf/ci/out/result.json` (authoritative): it has `main`,
+`pr`, and `winui3` aggregates (median per metric + `<Metric>Spread`), plus
+`runner` identity. `comment.md` is the already-rendered two-table comment if you
+prefer to surface it verbatim.
+
+Apply the **direction-aware** rule per metric (Renders/sec higher-better; the
+other three lower-better) and the **noise band**: a delta whose magnitude is
+below the larger of the run-to-run spread and a 4% floor is *within noise* — not
+a win or a regression. (`PerfLib.ps1`'s `Get-PerfDelta` already encodes this; the
+numbers in `result.json` reflect it.)
+
+### 5. Report to stdout
+
+Print a concise report — do **not** edit code, do **not** post anything to
+GitHub (that is the `/perf` workflow's job). Format:
+
+```
+Perf comparison — <branch> vs main  (median of <Reps>, <Warmup> warmup)
+Runner: <CPU> · <cores> cores · <RAM> GB
+
+Metric                 main      PR       Δ        Status
+Renders/sec ↑          <m>       <p>      <+/-x%>  <improvement|regression|within noise>
+Avg Reconcile (ms) ↓   <m>       <p>      <+/-x%>  ...
+Avg Diff (ms) ↓        <m>       <p>      <+/-x%>  ...
+Avg Memory (MB) ↓      <m>       <p>      <+/-x%>  ...
+
+Cross-framework (same workload): vanilla WinUI3 <…> · Rust windows-reactor <ref> · Reactor (PR) <…>
+
+Note: absolute numbers are machine-dependent — trust the Δ vs main. Memory is the noisiest metric.
+```
+
+Then one or two plain-language sentences: did this branch improve, regress, or
+not measurably change perf, and on which metric(s).
+
+### 6. Clean up
+
+Remove the baseline worktree you created:
+
+```pwsh
+git worktree remove ../perf-main
+```
+
+## Failure handling
+
+- **`0xC000027B` / no metrics produced.** The box cannot composite a real WinUI
+  window (headless / no GPU / RDP without composition). The build and runtime
+  are fine. Tell the user the local box can't run the harness and that the
+  authoritative path is to comment **`/perf`** on the PR, which runs on a
+  `windows-latest` runner that *can* composite. Do not loop on retries.
+- **Build failure.** Surface the real `dotnet` error from
+  `tests/stress_perf/ci/out/build-*.log`; do not guess.
+- **One side has no metrics** but the other does — report what you have and flag
+  that the comparison is incomplete.
+
+## Rules the orchestrator must enforce
+
+- **Measure, don't fix.** Never edit framework or harness code from this skill.
+- **Don't post to GitHub.** Local stdout only; the sticky PR comment is owned by
+  `.github/workflows/perf-compare.yml`.
+- **Drive the committed script.** Use `Run-PerfBenchmark.ps1` / `PerfLib.ps1` —
+  do not hand-roll a parallel measurement.
+- **Same-runner A/B only.** Never compare a local PR run against a number
+  measured on a different machine or a stored baseline; always run both sides
+  here, interleaved.
+- **Honor the noise band.** Do not call a sub-noise delta an improvement or a
+  regression.
+- **Trust the delta, not the absolutes**, and say so in the report.
+
+## Relationship to `/perf` and the startup harness
+
+- This skill is the **local** equivalent of the `/perf` PR workflow
+  (`.github/workflows/perf-compare.yml`); both use the same scripts and render
+  the same comparison. Use this before pushing; use `/perf` for the
+  reviewer-visible comment on the PR.
+- It is unrelated to the **startup** perf harness under `tests/startup_perf/`
+  (ETW/WPR TTFP/TTI measurement) — do not invoke that here.

--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -1,0 +1,170 @@
+# On-demand perf comparison: comment `/perf` on a PR to benchmark its head
+# against the `main` baseline and post a sticky comparison comment.
+#
+# ── How to use ───────────────────────────────────────────────────────────────
+#   • Comment `/perf` on any open PR (must be an OWNER / MEMBER / COLLABORATOR).
+#   • Or run it manually: Actions ▸ "Perf comparison" ▸ Run workflow ▸ pr_number.
+#
+# It builds StressPerf.ReactorOptimized (the StocksGrid data-grid stress harness)
+# on the PR head and on `main`, runs them INTERLEAVED on the same runner, and
+# posts/updates one sticky comment with four metrics:
+#
+#   Renders/sec       higher is better
+#   Avg Reconcile ms  lower is better
+#   Avg Diff ms       lower is better
+#   Avg Memory MB     lower is better
+#
+# Each metric shows main, PR, a signed Δ%, and an improvement/regression/within-
+# noise status. A second table cross-references vanilla WinUI3 (StressPerf.Direct,
+# measured live) and the Rust `windows-reactor` snapshot (static reference).
+#
+# ── Why `issue_comment` (not a label) ────────────────────────────────────────
+# `issue_comment` always runs the workflow from the DEFAULT branch. Once this
+# lands on `main` it therefore works on every already-open PR with no rebase —
+# which is exactly what a fleet of in-flight perf PRs needs. The trade-off is
+# that the privileged (write-token) workflow builds and runs PR-authored harness
+# code, so triggering is restricted to trusted comment authors via
+# `author_association` (OWNER / MEMBER / COLLABORATOR). The perf scripts and the
+# `main` baseline come from the trusted default branch, never the PR.
+#
+# Local equivalent + script docs: tests/stress_perf/ci/README.md
+name: Perf comparison
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to benchmark against main
+        required: true
+        type: string
+
+# One in-flight run per PR; a newer /perf supersedes an older one.
+concurrency:
+  group: perf-compare-${{ github.event.issue.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read         # checkout
+  pull-requests: write   # post/update the comparison comment
+  issues: write          # PR conversation comments use the issues API
+
+jobs:
+  perf:
+    name: Benchmark PR vs main
+    # Gate: manual dispatch, OR a `/perf` comment on a PR from a trusted author.
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request != null &&
+         startsWith(github.event.comment.body, '/perf') &&
+         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      }}
+    runs-on: windows-latest
+    timeout-minutes: 40
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      # Acknowledge the trigger so the author knows it was picked up.
+      - name: React to /perf comment
+        if: github.event_name == 'issue_comment'
+        continue-on-error: true
+        run: gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
+
+      # Trusted checkout: the default branch carries the perf scripts + the main
+      # baseline. fetch-depth: 0 so we can resolve origin/main and PR head SHAs.
+      - name: Checkout default branch (trusted scripts + main baseline)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: 10.0.x
+
+      # Resolve the PR number + head SHA. PR head is fetched via refs/pull/N/head
+      # so forks work too. The PR head lives in its own worktree; the workspace
+      # root stays on the trusted main baseline.
+      - name: Resolve PR + create PR worktree
+        id: resolve
+        shell: pwsh
+        run: |
+          $pr = if ('${{ github.event_name }}' -eq 'workflow_dispatch') { '${{ github.event.inputs.pr_number }}' } else { '${{ github.event.issue.number }}' }
+          if (-not $pr) { throw 'Could not resolve a PR number.' }
+          Write-Host "PR #$pr"
+          git fetch --no-tags --force origin "pull/$pr/head" 2>&1 | Out-Host
+          $headSha = (git rev-parse FETCH_HEAD).Trim()
+          $baseSha = (git rev-parse origin/main).Trim()
+          $prTree  = Join-Path $env:RUNNER_TEMP 'pr-tree'
+          if (Test-Path $prTree) { git worktree remove --force $prTree 2>&1 | Out-Host }
+          git worktree add --force --detach $prTree $headSha 2>&1 | Out-Host
+          "pr_number=$pr"        | Out-File $env:GITHUB_OUTPUT -Append
+          "head_sha=$headSha"    | Out-File $env:GITHUB_OUTPUT -Append
+          "base_sha=$baseSha"    | Out-File $env:GITHUB_OUTPUT -Append
+          "pr_tree=$prTree"      | Out-File $env:GITHUB_OUTPUT -Append
+          Write-Host "head=$headSha base=$baseSha tree=$prTree"
+
+      # Build (self-contained, so no machine-wide WinApp runtime install — same
+      # hermetic trick the WinUI selftests job uses) + run interleaved + render
+      # the sticky comment to perf-out/comment.md. continue-on-error so a flaky
+      # run still posts a comment (with a NOTE) instead of failing silently.
+      - name: Run perf benchmark (PR vs main)
+        id: bench
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          ./tests/stress_perf/ci/Run-PerfBenchmark.ps1 `
+            -Root '${{ steps.resolve.outputs.pr_tree }}' `
+            -BaselineRoot '${{ github.workspace }}' `
+            -Percent 50 -Duration 10 -Reps 2 -Warmup 1 `
+            -HeadSha '${{ steps.resolve.outputs.head_sha }}' `
+            -BaseSha '${{ steps.resolve.outputs.base_sha }}' `
+            -RunUrl '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' `
+            -OutDir '${{ github.workspace }}/perf-out'
+
+      - name: Upload perf logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: perf-logs
+          path: perf-out
+          if-no-files-found: warn
+          retention-days: 14
+
+      # Post or update-in-place the sticky comment (hidden marker lookup). Always
+      # runs; synthesizes a failure comment if the benchmark produced none.
+      - name: Post / update sticky comment
+        if: always()
+        shell: pwsh
+        run: |
+          $marker = '<!-- reactor-perf-compare -->'
+          $pr = '${{ steps.resolve.outputs.pr_number }}'
+          if (-not $pr) { Write-Host 'No PR number; nothing to comment on.'; exit 0 }
+          $file = '${{ github.workspace }}/perf-out/comment.md'
+          if (-not (Test-Path $file)) {
+            $runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            $body = "$marker`n## ⚡ Reactor perf comparison`n`n> [!CAUTION]`n> The perf benchmark did not produce results (build or harness launch failed). See the [run log]($runUrl) and the ``perf-logs`` artifact.`n"
+            Set-Content -LiteralPath $file -Value $body -Encoding UTF8
+          }
+          $existing = gh api "repos/$env:GH_REPO/issues/$pr/comments" --paginate --jq "[.[] | select(.body | startswith(""$marker""))][0].id"
+          if ($existing) {
+            Write-Host "Updating existing comment $existing"
+            gh api -X PATCH "repos/$env:GH_REPO/issues/comments/$existing" -F "body=@$file" | Out-Null
+          } else {
+            Write-Host 'Creating new sticky comment'
+            gh api "repos/$env:GH_REPO/issues/$pr/comments" -F "body=@$file" | Out-Null
+          }
+
+      # Surface a red check if the benchmark itself failed (comment still posted).
+      - name: Reflect benchmark status
+        if: always()
+        shell: pwsh
+        run: |
+          if ('${{ steps.bench.outcome }}' -ne 'success') {
+            throw 'Perf benchmark step failed or returned non-zero — see the comparison comment and the perf-logs artifact.'
+          }
+          Write-Host 'Perf benchmark completed successfully.'

--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -15,17 +15,27 @@
 #   Avg Memory MB     lower is better
 #
 # Each metric shows main, PR, a signed Δ%, and an improvement/regression/within-
-# noise status. A second table cross-references vanilla WinUI3 (StressPerf.Direct,
-# measured live) and the Rust `windows-reactor` snapshot (static reference).
+# noise status. A second table cross-references vanilla WinUI3 (StressPerf.Direct)
+# and the Rust `windows-reactor` port (test_reactor_perf from microsoft/windows-rs)
+# — both built and measured live on the same runner.
 #
 # ── Why `issue_comment` (not a label) ────────────────────────────────────────
-# `issue_comment` always runs the workflow from the DEFAULT branch. Once this
-# lands on `main` it therefore works on every already-open PR with no rebase —
-# which is exactly what a fleet of in-flight perf PRs needs. The trade-off is
-# that the privileged (write-token) workflow builds and runs PR-authored harness
-# code, so triggering is restricted to trusted comment authors via
-# `author_association` (OWNER / MEMBER / COLLABORATOR). The perf scripts and the
-# `main` baseline come from the trusted default branch, never the PR.
+# `issue_comment` always runs the workflow from the DEFAULT branch, so the perf
+# scripts + `main` baseline always come from trusted `main`, never the PR. Once
+# this lands on `main`, the /perf logic itself works on every already-open PR
+# without touching its branch.
+#
+# One caveat: a PR head opened BEFORE this gate merged won't carry the self-
+# contained build knob (`PerfCiSelfContained`, added here), so its harness may
+# fail to launch on a runner without the WinAppSDK runtime. Rebasing the PR onto
+# `main` (which the in-flight perf fleet does once this merges) fixes that. See
+# tests/stress_perf/ci/README.md.
+#
+# Because the privileged (write-token) job builds + runs PR-authored harness
+# code, it is hardened: triggering is restricted to trusted comment authors via
+# `author_association` (OWNER / MEMBER / COLLABORATOR); the PR checkout uses
+# `persist-credentials: false`; and the GitHub token is scoped to the react +
+# comment steps only — never the build/benchmark step that runs PR code.
 #
 # Local equivalent + script docs: tests/stress_perf/ci/README.md
 name: Perf comparison
@@ -63,16 +73,23 @@ jobs:
          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
       }}
     runs-on: windows-latest
-    timeout-minutes: 40
+    # 60 (not 40): the Rust cross-framework leg cold-builds the windows-rs port.
+    timeout-minutes: 60
     env:
-      GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
+      # Pinned microsoft/windows-rs commit whose `test_reactor_perf` crate backs
+      # the Rust column (a port of this harness — same StocksGrid + CLI). Refresh
+      # deliberately; a moving ref would make the Rust numbers non-comparable.
+      RUST_REF: ef02ee6f600e75540653c505b8dbb6821e82c694
     steps:
       # Acknowledge the trigger so the author knows it was picked up.
       - name: React to /perf comment
         if: github.event_name == 'issue_comment'
         continue-on-error: true
-        run: gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: gh api "repos/$env:GH_REPO/issues/comments/$env:COMMENT_ID/reactions" -f content=eyes
 
       # Trusted checkout: the default branch carries the perf scripts + the main
       # baseline. fetch-depth: 0 so we can resolve origin/main and PR head SHAs.
@@ -80,51 +97,108 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # PR-authored harness code runs later in this job; don't leave a usable
+          # git credential on disk for it. The public PR head fetches anonymously.
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: 10.0.x
 
+      # Cheap guard: validate PerfLib's pure parser + delta math before spending
+      # ~30 min benchmarking. Also runs standalone in perf-lib-tests.yml on PRs.
+      - name: Test PerfLib (parser + delta math)
+        shell: pwsh
+        run: ./tests/stress_perf/ci/PerfLib.Tests.ps1
+
       # Resolve the PR number + head SHA. PR head is fetched via refs/pull/N/head
       # so forks work too. The PR head lives in its own worktree; the workspace
-      # root stays on the trusted main baseline.
+      # root stays on the trusted main baseline. The PR number is validated to be
+      # digits-only (it reaches a shell) and event context is passed via env, so
+      # a crafted PR number / comment can't be injected into the script body.
       - name: Resolve PR + create PR worktree
         id: resolve
         shell: pwsh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PR: ${{ github.event.inputs.pr_number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          $pr = if ('${{ github.event_name }}' -eq 'workflow_dispatch') { '${{ github.event.inputs.pr_number }}' } else { '${{ github.event.issue.number }}' }
-          if (-not $pr) { throw 'Could not resolve a PR number.' }
+          $pr = if ($env:EVENT_NAME -eq 'workflow_dispatch') { $env:DISPATCH_PR } else { $env:ISSUE_NUMBER }
+          if ($pr -notmatch '^\d+$') { throw "Could not resolve a valid PR number (got '$pr')." }
           Write-Host "PR #$pr"
+          # Public repo: the PR head (incl. forks) fetches anonymously, so this
+          # step needs no token — keeping it token-free shrinks the attack surface.
           git fetch --no-tags --force origin "pull/$pr/head" 2>&1 | Out-Host
           $headSha = (git rev-parse FETCH_HEAD).Trim()
           $baseSha = (git rev-parse origin/main).Trim()
           $prTree  = Join-Path $env:RUNNER_TEMP 'pr-tree'
           if (Test-Path $prTree) { git worktree remove --force $prTree 2>&1 | Out-Host }
           git worktree add --force --detach $prTree $headSha 2>&1 | Out-Host
-          "pr_number=$pr"        | Out-File $env:GITHUB_OUTPUT -Append
-          "head_sha=$headSha"    | Out-File $env:GITHUB_OUTPUT -Append
-          "base_sha=$baseSha"    | Out-File $env:GITHUB_OUTPUT -Append
-          "pr_tree=$prTree"      | Out-File $env:GITHUB_OUTPUT -Append
+          "pr_number=$pr"     | Out-File $env:GITHUB_OUTPUT -Append
+          "head_sha=$headSha" | Out-File $env:GITHUB_OUTPUT -Append
+          "base_sha=$baseSha" | Out-File $env:GITHUB_OUTPUT -Append
+          "pr_tree=$prTree"   | Out-File $env:GITHUB_OUTPUT -Append
           Write-Host "head=$headSha base=$baseSha tree=$prTree"
+
+      # Clone the pinned windows-rs and flip its perf harness to self-contained so
+      # the Rust column needs no machine-wide WinAppSDK runtime (mirrors the C#
+      # self-contained trick). Best-effort: on any failure the rust_repo output is
+      # empty and the Rust column reads n/a — the C# comparison is unaffected.
+      - name: Prepare Rust harness (windows-rs port)
+        id: rust
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $dir = Join-Path $env:RUNNER_TEMP 'windows-rs'
+          if (Test-Path $dir) { Remove-Item $dir -Recurse -Force }
+          New-Item -ItemType Directory -Path $dir | Out-Null
+          git -C $dir init -q
+          git -C $dir remote add origin https://github.com/microsoft/windows-rs
+          git -C $dir fetch --depth 1 origin $env:RUST_REF 2>&1 | Out-Host
+          git -C $dir checkout -q FETCH_HEAD
+          $buildRs = Join-Path $dir 'crates/tests/libs/reactor_perf/build.rs'
+          if (-not (Test-Path $buildRs)) { throw "reactor_perf/build.rs missing in windows-rs@$env:RUST_REF" }
+          # as_self_contained() is the upstream-supported, benchmark-neutral setup
+          # used by the windows-rs reactor samples (see docs/crates/windows-reactor-setup.md).
+          Set-Content -LiteralPath $buildRs -Value 'fn main() { windows_reactor_setup::as_self_contained(); }' -Encoding UTF8
+          "rust_repo=$dir" | Out-File $env:GITHUB_OUTPUT -Append
+          Write-Host "Rust harness ready at $dir"
+
+      - name: Cache Rust build
+        if: steps.rust.outcome == 'success'
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: ${{ runner.temp }}/windows-rs
 
       # Build (self-contained, so no machine-wide WinApp runtime install — same
       # hermetic trick the WinUI selftests job uses) + run interleaved + render
       # the sticky comment to perf-out/comment.md. continue-on-error so a flaky
       # run still posts a comment (with a NOTE) instead of failing silently.
+      # All context flows in via env (never interpolated into the script body).
       - name: Run perf benchmark (PR vs main)
         id: bench
         continue-on-error: true
         shell: pwsh
+        env:
+          PR_TREE: ${{ steps.resolve.outputs.pr_tree }}
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+          BASE_SHA: ${{ steps.resolve.outputs.base_sha }}
+          RUST_REPO: ${{ steps.rust.outputs.rust_repo }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OUT_DIR: ${{ github.workspace }}/perf-out
         run: |
           ./tests/stress_perf/ci/Run-PerfBenchmark.ps1 `
-            -Root '${{ steps.resolve.outputs.pr_tree }}' `
-            -BaselineRoot '${{ github.workspace }}' `
+            -Root $env:PR_TREE `
+            -BaselineRoot $env:GITHUB_WORKSPACE `
             -Percent 50 -Duration 10 -Reps 2 -Warmup 1 `
-            -HeadSha '${{ steps.resolve.outputs.head_sha }}' `
-            -BaseSha '${{ steps.resolve.outputs.base_sha }}' `
-            -RunUrl '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' `
-            -OutDir '${{ github.workspace }}/perf-out'
+            -RustRepo "$env:RUST_REPO" `
+            -DefenderExclude `
+            -HeadSha $env:HEAD_SHA `
+            -BaseSha $env:BASE_SHA `
+            -RunUrl $env:RUN_URL `
+            -OutDir $env:OUT_DIR
 
       - name: Upload perf logs
         if: always()
@@ -140,14 +214,19 @@ jobs:
       - name: Post / update sticky comment
         if: always()
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          WORKSPACE: ${{ github.workspace }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           $marker = '<!-- reactor-perf-compare -->'
-          $pr = '${{ steps.resolve.outputs.pr_number }}'
+          $pr = $env:PR_NUMBER
           if (-not $pr) { Write-Host 'No PR number; nothing to comment on.'; exit 0 }
-          $file = '${{ github.workspace }}/perf-out/comment.md'
+          $file = Join-Path $env:WORKSPACE 'perf-out/comment.md'
           if (-not (Test-Path $file)) {
-            $runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-            $body = "$marker`n## ⚡ Reactor perf comparison`n`n> [!CAUTION]`n> The perf benchmark did not produce results (build or harness launch failed). See the [run log]($runUrl) and the ``perf-logs`` artifact.`n"
+            New-Item -ItemType Directory -Force -Path (Split-Path $file) | Out-Null
+            $body = "$marker`n## ⚡ Reactor perf comparison`n`n> [!CAUTION]`n> The perf benchmark did not produce results (build or harness launch failed). See the [run log]($env:RUN_URL) and the ``perf-logs`` artifact.`n"
             Set-Content -LiteralPath $file -Value $body -Encoding UTF8
           }
           $existing = gh api "repos/$env:GH_REPO/issues/$pr/comments" --paginate --jq "[.[] | select(.body | startswith(""$marker""))][0].id"
@@ -163,8 +242,10 @@ jobs:
       - name: Reflect benchmark status
         if: always()
         shell: pwsh
+        env:
+          BENCH_OUTCOME: ${{ steps.bench.outcome }}
         run: |
-          if ('${{ steps.bench.outcome }}' -ne 'success') {
+          if ($env:BENCH_OUTCOME -ne 'success') {
             throw 'Perf benchmark step failed or returned non-zero — see the comparison comment and the perf-logs artifact.'
           }
           Write-Host 'Perf benchmark completed successfully.'

--- a/.github/workflows/perf-lib-tests.yml
+++ b/.github/workflows/perf-lib-tests.yml
@@ -1,0 +1,39 @@
+# Fast, headless unit tests for PerfLib.ps1 — the pure parser / median / delta /
+# comment-renderer that backs the /perf comparison workflow (perf-compare.yml).
+# No WinUI harness and no external test framework, so this runs on a cheap Linux
+# runner in seconds and guards the parsing + formatting logic on every change
+# under tests/stress_perf/ci/**.
+#
+# perf-compare.yml runs these same assertions before it spends ~30 min
+# benchmarking; this standalone job gives PR authors fast feedback without
+# needing a full `/perf` run.
+name: Perf lib tests
+
+on:
+  push:
+    paths:
+      - 'tests/stress_perf/ci/**'
+      - '.github/workflows/perf-lib-tests.yml'
+  pull_request:
+    paths:
+      - 'tests/stress_perf/ci/**'
+      - '.github/workflows/perf-lib-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  perflib:
+    name: PerfLib parser + delta math
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # pwsh (PowerShell 7) is preinstalled on the GitHub-hosted Ubuntu runner.
+      # PerfLib.Tests.ps1 exits non-zero on any failed assertion.
+      - name: Run PerfLib unit tests
+        shell: pwsh
+        run: ./tests/stress_perf/ci/PerfLib.Tests.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,8 @@ tests/stress_perf/dwm-attribution.log
 tests/stress_perf/attr-*.csv
 tests/stress_perf/sweep-results/
 tests/stress_perf/sweep_results.csv
+# perf-compare (/perf) runner output: logs, result.json, comment.md.
+tests/stress_perf/ci/out/
 # Per-frame CSV captures under baselines/ — only summary.md / summary.csv are tracked.
 tests/stress_perf/baselines/**/*.frames.csv
 tests/stress_perf/baselines/**/per-rep.csv

--- a/tests/stress_perf/StressPerf.Direct/MainWindow.cs
+++ b/tests/stress_perf/StressPerf.Direct/MainWindow.cs
@@ -170,8 +170,8 @@ public sealed class MainWindow : Window
         _tickCount++;
         if (_reportClock.Elapsed.TotalSeconds >= 1.0 && _tickCount > 0)
         {
-            File.AppendAllText(@"C:\temp\direct_perf_phases.log",
-                $"PERF [{_tickCount} ticks]: mutate={_mutateSum / _tickCount:F2}ms  propSet={_propSetSum / _tickCount:F2}ms  total={(_mutateSum + _propSetSum) / _tickCount:F2}ms\n");
+            try { File.AppendAllText(@"C:\temp\direct_perf_phases.log",
+                $"PERF [{_tickCount} ticks]: mutate={_mutateSum / _tickCount:F2}ms  propSet={_propSetSum / _tickCount:F2}ms  total={(_mutateSum + _propSetSum) / _tickCount:F2}ms\n"); } catch { }
             _mutateSum = 0; _propSetSum = 0; _tickCount = 0;
             _reportClock.Restart();
         }

--- a/tests/stress_perf/StressPerf.Direct/MainWindow.cs
+++ b/tests/stress_perf/StressPerf.Direct/MainWindow.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -18,12 +17,6 @@ public sealed class MainWindow : Window
     private readonly PerfTracker _perf = new();
     private readonly CliOptions _options;
     private readonly TextBlock[] _cells = new TextBlock[StockDataSource.TotalItems];
-
-    // Phase timing
-    private readonly Stopwatch _phaseSw = new();
-    private double _mutateSum, _propSetSum;
-    private int _tickCount;
-    private readonly Stopwatch _reportClock = Stopwatch.StartNew();
 
     private DispatcherTimer? _updateTimer;
     private DispatcherTimer? _shutdownTimer;
@@ -143,12 +136,9 @@ public sealed class MainWindow : Window
     {
         _perf.BeginUpdate();
 
-        _phaseSw.Restart();
         double pct = _percentSlider!.Value;
         var changed = _source.Update(pct);
-        double mutateMs = _phaseSw.Elapsed.TotalMilliseconds;
 
-        _phaseSw.Restart();
         // Direct update: set TextBlock properties for changed items only
         var items = _source.Items;
         foreach (int idx in changed)
@@ -158,23 +148,11 @@ public sealed class MainWindow : Window
             tb.Text = StockDataSource.FormatCell(in item);
             tb.Foreground = item.IsUp ? GreenBrush : RedBrush;
         }
-        double propSetMs = _phaseSw.Elapsed.TotalMilliseconds;
 
         _perf.EndUpdate();
         // For imperative WinUI variants a "render" = one tick that finished
         // patching cell properties on the live tree. Cross-variant cmp.
         _perf.RecordRender();
-
-        _mutateSum += mutateMs;
-        _propSetSum += propSetMs;
-        _tickCount++;
-        if (_reportClock.Elapsed.TotalSeconds >= 1.0 && _tickCount > 0)
-        {
-            try { File.AppendAllText(@"C:\temp\direct_perf_phases.log",
-                $"PERF [{_tickCount} ticks]: mutate={_mutateSum / _tickCount:F2}ms  propSet={_propSetSum / _tickCount:F2}ms  total={(_mutateSum + _propSetSum) / _tickCount:F2}ms\n"); } catch { }
-            _mutateSum = 0; _propSetSum = 0; _tickCount = 0;
-            _reportClock.Restart();
-        }
 
         // Update stats display
         _fpsText!.Text = $"FPS: {_perf.CurrentFps:F0}";

--- a/tests/stress_perf/StressPerf.Direct/StressPerf.Direct.csproj
+++ b/tests/stress_perf/StressPerf.Direct/StressPerf.Direct.csproj
@@ -12,6 +12,19 @@
     <DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
   </PropertyGroup>
 
+  <!--
+    Built self-contained (-p:PerfCiSelfContained=true) by the perf-comparison CI so
+    the vanilla-WinUI3 baseline carries its own Windows App SDK runtime and needs no
+    machine-wide install on the runner. Scoped here so it never flows into the
+    referenced StressPerf.Shared class library. See the matching note in
+    StressPerf.ReactorOptimized.csproj and .github/workflows/perf-compare.yml.
+  -->
+  <PropertyGroup Condition="'$(PerfCiSelfContained)' == 'true'">
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' != 'ARM64'">win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>

--- a/tests/stress_perf/StressPerf.ReactorOptimized/Program.cs
+++ b/tests/stress_perf/StressPerf.ReactorOptimized/Program.cs
@@ -155,7 +155,15 @@ class StockGridApp : Component
             {
                 setRunning(false);
                 shutdownTimer.Stop();
-                perfRef.Current!.WriteReportFile(AppName, CliOpts.Percent);
+                var perf = perfRef.Current!;
+                perf.WriteReportFile(AppName, CliOpts.Percent);
+                if (CliOpts.Json)
+                {
+                    perf.WriteMetricsJsonFile(AppName, CliOpts.Percent);
+                    // Echo a single marked line so log scrapers have a fallback
+                    // to the {AppName}.metrics.json file written next to the exe.
+                    Console.WriteLine("REACTOR_PERF_JSON " + perf.GetMetricsJson(AppName, CliOpts.Percent));
+                }
                 Application.Current.Exit();
             };
             shutdownTimer.Start();

--- a/tests/stress_perf/StressPerf.ReactorOptimized/StressPerf.ReactorOptimized.csproj
+++ b/tests/stress_perf/StressPerf.ReactorOptimized/StressPerf.ReactorOptimized.csproj
@@ -12,6 +12,22 @@
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 
+  <!--
+    On-demand perf-comparison CI (.github/workflows/perf-compare.yml) builds this
+    harness with -p:PerfCiSelfContained=true so it carries its own Windows App SDK
+    runtime and needs NO machine-wide runtime install on the GitHub-hosted runner —
+    the same hermetic trick the WinUI selftest hosts use to open real windows in CI.
+    Scoped to THIS executable (rather than a global -p:WindowsAppSDKSelfContained)
+    so the flag never flows into the referenced class libraries (Reactor.csproj /
+    StressPerf.Shared), which reject self-contained packaging. Run-PerfBenchmark.ps1
+    passes it by default; pass -SelfContained:$false to build framework-dependent.
+  -->
+  <PropertyGroup Condition="'$(PerfCiSelfContained)' == 'true'">
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' != 'ARM64'">win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>

--- a/tests/stress_perf/StressPerf.Shared/CliOptions.cs
+++ b/tests/stress_perf/StressPerf.Shared/CliOptions.cs
@@ -6,6 +6,15 @@ public sealed class CliOptions
     public int DurationSeconds { get; set; } = 10;
     public bool Headless { get; set; }
 
+    /// <summary>
+    /// When set (via <c>--json</c>), the harness also writes a machine-readable
+    /// <c>{AppName}.metrics.json</c> next to the executable and echoes a single
+    /// <c>REACTOR_PERF_JSON {…}</c> line to the console. Used by the on-demand
+    /// perf-comparison CI workflow (.github/workflows/perf-compare.yml) to parse
+    /// the four headline metrics without scraping the human-readable report.
+    /// </summary>
+    public bool Json { get; set; }
+
     public static CliOptions Parse(string[] args)
     {
         var opts = new CliOptions();
@@ -21,6 +30,9 @@ public sealed class CliOptions
                     break;
                 case "--headless":
                     opts.Headless = true;
+                    break;
+                case "--json":
+                    opts.Json = true;
                     break;
             }
         }

--- a/tests/stress_perf/StressPerf.Shared/CliOptions.cs
+++ b/tests/stress_perf/StressPerf.Shared/CliOptions.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace StressPerf.Shared;
 
 public sealed class CliOptions
@@ -23,10 +25,10 @@ public sealed class CliOptions
             switch (args[i])
             {
                 case "--percent" when i + 1 < args.Length:
-                    opts.Percent = double.Parse(args[++i]);
+                    opts.Percent = double.Parse(args[++i], CultureInfo.InvariantCulture);
                     break;
                 case "--duration" when i + 1 < args.Length:
-                    opts.DurationSeconds = int.Parse(args[++i]);
+                    opts.DurationSeconds = int.Parse(args[++i], CultureInfo.InvariantCulture);
                     break;
                 case "--headless":
                     opts.Headless = true;

--- a/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
+++ b/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 
 namespace StressPerf.Shared;
@@ -151,5 +152,64 @@ public sealed class PerfTracker
         }
         var csvPath = Path.Combine(AppContext.BaseDirectory, $"{appName}.samples.csv");
         File.WriteAllText(csvPath, csv.ToString());
+    }
+
+    // ── Machine-readable metrics (CI) ────────────────────────────────────────
+    // The on-demand perf-comparison workflow parses these four headline numbers
+    // to diff a PR against the main baseline. Renders/sec is "higher is better";
+    // the three latency/memory figures are "lower is better". Kept here (rather
+    // than scraped from GetReport) so CI never has to depend on the exact prose
+    // layout of the human report, and so missing phase samples surface as 0
+    // rather than an absent line. See .github/workflows/perf-compare.yml.
+
+    /// <summary>Average reconcile cost (ms) across all recorded render passes, or 0.</summary>
+    public double AvgReconcileMs => _reconcileTimeSamples.Count > 0 ? _reconcileTimeSamples.Average() : 0.0;
+
+    /// <summary>Average diff/patch cost (ms) across all recorded render passes, or 0.</summary>
+    public double AvgDiffMs => _diffPatchSamples.Count > 0 ? _diffPatchSamples.Average() : 0.0;
+
+    /// <summary>Average sampled working set in MB, or 0 when no samples were taken.</summary>
+    public double AvgMemoryMB => _memorySamples.Count > 0 ? _memorySamples.Average() / (1024.0 * 1024.0) : 0.0;
+
+    /// <summary>
+    /// Throughput proxy: total renders divided by measured wall-clock seconds.
+    /// Mirrors the methodology's <c>Total Renders / Duration</c> (METHODOLOGY.md,
+    /// "easy mode") since both use the same <see cref="ElapsedSeconds"/> clock.
+    /// </summary>
+    public double RendersPerSec => ElapsedSeconds > 0 ? _renderCount / ElapsedSeconds : 0.0;
+
+    /// <summary>
+    /// Compact, single-line, culture-invariant JSON with the four headline
+    /// metrics plus context. Built by hand (no serializer) to stay trivially
+    /// AOT/trim-safe for this PublishAot harness.
+    /// </summary>
+    public string GetMetricsJson(string appName, double percent)
+    {
+        static string F(double v) => v.ToString("0.####", CultureInfo.InvariantCulture);
+        var sb = new StringBuilder();
+        sb.Append('{');
+        sb.Append("\"app\":\"").Append(appName).Append("\",");
+        sb.Append("\"percent\":").Append(F(percent)).Append(',');
+        sb.Append("\"durationSeconds\":").Append(F(ElapsedSeconds)).Append(',');
+        sb.Append("\"rendersPerSec\":").Append(F(RendersPerSec)).Append(',');
+        sb.Append("\"totalRenders\":").Append(_renderCount.ToString(CultureInfo.InvariantCulture)).Append(',');
+        sb.Append("\"avgReconcileMs\":").Append(F(AvgReconcileMs)).Append(',');
+        sb.Append("\"avgDiffMs\":").Append(F(AvgDiffMs)).Append(',');
+        sb.Append("\"avgMemoryMB\":").Append(F(AvgMemoryMB)).Append(',');
+        sb.Append("\"avgFps\":").Append(F(_fpsSamples.Count > 0 ? _fpsSamples.Average() : 0.0)).Append(',');
+        sb.Append("\"sampleCount\":").Append(_fpsSamples.Count.ToString(CultureInfo.InvariantCulture));
+        sb.Append('}');
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Write the machine-readable metrics to <c>{appName}.metrics.json</c> next
+    /// to the executable (alongside the human report written by
+    /// <see cref="WriteReportFile"/>).
+    /// </summary>
+    public void WriteMetricsJsonFile(string appName, double percent)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, $"{appName}.metrics.json");
+        File.WriteAllText(path, GetMetricsJson(appName, percent));
     }
 }

--- a/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
+++ b/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
@@ -232,10 +232,12 @@ public sealed class PerfTracker
     /// </summary>
     public void WriteMetricsJsonFile(string appName, double percent)
     {
-        // GetFileName() strips any directory/rooted segment so a stray appName
-        // can't redirect the write or make Path.Combine drop BaseDirectory.
+        // GetFileName() strips any directory/rooted segment, and Path.Join (not
+        // Path.Combine) concatenates without rooted-path reset semantics, so a
+        // stray appName can't redirect the write or drop BaseDirectory.
         var safeAppName = Path.GetFileName(appName);
-        var path = Path.Combine(AppContext.BaseDirectory, $"{safeAppName}.metrics.json");
+        var fileName = $"{safeAppName}.metrics.json";
+        var path = Path.Join(AppContext.BaseDirectory, fileName);
         File.WriteAllText(path, GetMetricsJson(appName, percent));
     }
 }

--- a/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
+++ b/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
@@ -209,7 +209,10 @@ public sealed class PerfTracker
     /// </summary>
     public void WriteMetricsJsonFile(string appName, double percent)
     {
-        var path = Path.Combine(AppContext.BaseDirectory, $"{appName}.metrics.json");
+        // GetFileName() strips any directory/rooted segment so a stray appName
+        // can't redirect the write or make Path.Combine drop BaseDirectory.
+        var safeAppName = Path.GetFileName(appName);
+        var path = Path.Combine(AppContext.BaseDirectory, $"{safeAppName}.metrics.json");
         File.WriteAllText(path, GetMetricsJson(appName, percent));
     }
 }

--- a/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
+++ b/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
@@ -186,9 +186,32 @@ public sealed class PerfTracker
     public string GetMetricsJson(string appName, double percent)
     {
         static string F(double v) => v.ToString("0.####", CultureInfo.InvariantCulture);
+        // Minimal JSON string escaping for the one string field (appName) so the
+        // hand-built JSON stays valid even if a name ever carries a quote /
+        // backslash / control char. The numbers are culture-invariant already.
+        static string J(string s)
+        {
+            var b = new StringBuilder(s.Length + 2);
+            foreach (char c in s)
+            {
+                switch (c)
+                {
+                    case '"': b.Append("\\\""); break;
+                    case '\\': b.Append("\\\\"); break;
+                    case '\n': b.Append("\\n"); break;
+                    case '\r': b.Append("\\r"); break;
+                    case '\t': b.Append("\\t"); break;
+                    default:
+                        if (c < ' ') b.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                        else b.Append(c);
+                        break;
+                }
+            }
+            return b.ToString();
+        }
         var sb = new StringBuilder();
         sb.Append('{');
-        sb.Append("\"app\":\"").Append(appName).Append("\",");
+        sb.Append("\"app\":\"").Append(J(appName)).Append("\",");
         sb.Append("\"percent\":").Append(F(percent)).Append(',');
         sb.Append("\"durationSeconds\":").Append(F(ElapsedSeconds)).Append(',');
         sb.Append("\"rendersPerSec\":").Append(F(RendersPerSec)).Append(',');

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -1,0 +1,223 @@
+<#
+.SYNOPSIS
+    Dependency-free unit tests for PerfLib.ps1 (the pure parser/median/delta/
+    renderer used by the /perf comparison workflow).
+
+.DESCRIPTION
+    Runs headless with no WinUI harness and no external test framework, so it is
+    safe on any runner (it is wired into .github/workflows/perf-lib-tests.yml on
+    changes under tests/stress_perf/ci/**). Exits non-zero if any assertion fails.
+
+    Run locally:  pwsh tests/stress_perf/ci/PerfLib.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'PerfLib.ps1')
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -eq $Actual) {
+        $script:Pass++
+    } else {
+        $script:Fail++
+        $script:Failures.Add("$Message`n    expected: [$Expected]`n    actual:   [$Actual]")
+    }
+}
+
+function Assert-Null {
+    param($Actual, [string]$Message)
+    if ($null -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: <null>`n    actual:   [$Actual]") }
+}
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add($Message) }
+}
+
+function Assert-Match {
+    param([string]$Haystack, [string]$Needle, [string]$Message)
+    if ($Haystack -like "*$Needle*") { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    missing substring: [$Needle]") }
+}
+
+# ── Get-PerfMedian ───────────────────────────────────────────────────────────
+Assert-Equal 2   (Get-PerfMedian @(3, 1, 2))        'median odd'
+Assert-Equal 2.5 (Get-PerfMedian @(1, 2, 3, 4))     'median even'
+Assert-Equal 5   (Get-PerfMedian @(5))              'median single'
+Assert-Null      (Get-PerfMedian @())               'median empty -> null'
+Assert-Equal 4   (Get-PerfMedian @(4, $null, 4))    'median ignores nulls'
+
+# ── Get-PerfRelativeSpreadPct ────────────────────────────────────────────────
+Assert-Equal 0    (Get-PerfRelativeSpreadPct @(10, 10)) 'spread identical -> 0'
+Assert-Equal 18.2 (Get-PerfRelativeSpreadPct @(10, 12)) 'spread (2/11)%'
+Assert-Equal 0    (Get-PerfRelativeSpreadPct @(7))      'spread single -> 0'
+Assert-Equal 0    (Get-PerfRelativeSpreadPct @())       'spread empty -> 0'
+
+# ── ConvertTo-PerfDouble ─────────────────────────────────────────────────────
+Assert-Equal 8.7 (ConvertTo-PerfDouble '8.70')  'parse invariant decimal'
+Assert-Equal 8.7 (ConvertTo-PerfDouble '8,70')  'parse comma-decimal culture'
+Assert-Equal 12  (ConvertTo-PerfDouble '  12 ') 'parse trims whitespace'
+Assert-Null      (ConvertTo-PerfDouble '')      'parse empty -> null'
+Assert-Null      (ConvertTo-PerfDouble 'abc')   'parse junk -> null'
+
+# ── Get-PerfDelta (direction-aware + noise band) ─────────────────────────────
+$d = Get-PerfDelta -Baseline 10 -Candidate 12 -LowerIsBetter $false
+Assert-Equal 20      $d.DeltaPct 'higher-better +20% delta'
+Assert-Equal 'better' $d.Status  'higher-better improvement status'
+Assert-True  $d.Improved         'higher-better improved flag'
+
+$d = Get-PerfDelta -Baseline 10 -Candidate 8 -LowerIsBetter $false
+Assert-Equal 'worse' $d.Status 'higher-better regression status'
+
+$d = Get-PerfDelta -Baseline 10 -Candidate 8 -LowerIsBetter $true
+Assert-Equal 'better' $d.Status 'lower-better improvement status'
+
+$d = Get-PerfDelta -Baseline 10 -Candidate 12 -LowerIsBetter $true
+Assert-Equal 'worse' $d.Status 'lower-better regression status'
+
+$d = Get-PerfDelta -Baseline 10 -Candidate 10.2 -LowerIsBetter $false
+Assert-Equal 'noise' $d.Status 'small delta within 4% floor -> noise'
+
+# Spread wider than the 4% floor widens the band, so +20% can still be noise.
+$d = Get-PerfDelta -Baseline 10 -Candidate 12 -LowerIsBetter $false -SpreadPct 25
+Assert-Equal 'noise' $d.Status 'delta below spread band -> noise'
+
+$d = Get-PerfDelta -Baseline $null -Candidate 12 -LowerIsBetter $false
+Assert-Equal 'na' $d.Status 'null baseline -> na'
+Assert-Null  $d.DeltaPct    'null baseline -> null delta'
+
+$d = Get-PerfDelta -Baseline 0 -Candidate 12 -LowerIsBetter $false
+Assert-Equal 'na' $d.Status 'zero baseline -> na'
+
+# ── Format-PerfNumber / Format-PerfDeltaCell ─────────────────────────────────
+Assert-Equal 'n/a'   (Format-PerfNumber $null 1) 'format null -> n/a'
+Assert-Equal '8.70'  (Format-PerfNumber 8.7 2)   'format 2 digits invariant'
+Assert-Equal '+20.0%' (Format-PerfDeltaCell ([pscustomobject]@{ DeltaPct = 20.0 })) 'delta cell signs positive'
+Assert-Equal '-5.0%'  (Format-PerfDeltaCell ([pscustomobject]@{ DeltaPct = -5.0 })) 'delta cell signs negative'
+Assert-Equal '—'      (Format-PerfDeltaCell ([pscustomobject]@{ DeltaPct = $null })) 'delta cell na -> dash'
+
+# ── Get-PerfStatusGlyph (status color coding) ────────────────────────────────
+Assert-Equal "$([char]0x2705) improvement"             (Get-PerfStatusGlyph 'better') 'better -> check + improvement'
+Assert-Equal "$([char]0x26A0)$([char]0xFE0F) regression" (Get-PerfStatusGlyph 'worse')  'worse -> warning + regression'
+Assert-Equal "$([char]0x2248) within noise"            (Get-PerfStatusGlyph 'noise')  'noise -> approx + within noise'
+
+# ── Read-HarnessMetrics ──────────────────────────────────────────────────────
+$tmp = Join-Path ([IO.Path]::GetTempPath()) ("perflib-tests-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+    # C# Reactor-style report.txt (declarative: has reconcile + diff).
+    $csReport = @"
+StressPerf.ReactorOptimized report
+Total Renders: 1234
+Duration: 10.0 s
+Avg Reconcile: 5.50 ms
+Avg Diff: 2.20 ms
+Avg Memory: 210.0 MB
+"@
+    Set-Content -LiteralPath (Join-Path $tmp 'StressPerf.ReactorOptimized.report.txt') -Value $csReport -Encoding UTF8
+    $m = Read-HarnessMetrics -Directory $tmp -AppName 'StressPerf.ReactorOptimized'
+    Assert-Equal 'report' $m.Source        'C# report parsed from report.txt'
+    Assert-Equal 123.4 $m.RendersPerSec    'C# renders/sec = total/duration'
+    Assert-Equal 5.5   $m.AvgReconcileMs   'C# reconcile'
+    Assert-Equal 2.2   $m.AvgDiffMs        'C# diff'
+    Assert-Equal 210   $m.AvgMemoryMB      'C# memory'
+
+    # Rust port report.txt: indented Avg Diff, "Duration: 10.0s" (no space), and
+    # a Renders/sec: line the parser ignores in favour of Total/Duration.
+    $rustReport = @"
+StressPerf.Reactor (windows-reactor) report
+Renders/sec: 8.70
+Avg Reconcile: 7.90 ms
+  Avg Diff: 7.10 ms
+Avg Memory: 190.0 MB
+Total Renders: 87
+Duration: 10.0s
+"@
+    Set-Content -LiteralPath (Join-Path $tmp 'StressPerf.Reactor.report.txt') -Value $rustReport -Encoding UTF8
+    $r = Read-HarnessMetrics -Directory $tmp -AppName 'StressPerf.Reactor'
+    Assert-Equal 'report' $r.Source       'Rust report parsed from report.txt'
+    Assert-Equal 8.7  $r.RendersPerSec    'Rust renders/sec = 87/10'
+    Assert-Equal 7.9  $r.AvgReconcileMs   'Rust reconcile'
+    Assert-Equal 7.1  $r.AvgDiffMs        'Rust diff (indented line still matched)'
+    Assert-Equal 190  $r.AvgMemoryMB      'Rust memory'
+
+    # metrics.json takes precedence over report.txt when both exist.
+    $json = '{"app":"StressPerf.ReactorOptimized","percent":50,"durationSeconds":10,"rendersPerSec":99.9,"totalRenders":999,"avgReconcileMs":1.1,"avgDiffMs":2.2,"avgMemoryMB":150.5,"avgFps":60,"sampleCount":5}'
+    Set-Content -LiteralPath (Join-Path $tmp 'StressPerf.ReactorOptimized.metrics.json') -Value $json -Encoding UTF8
+    $j = Read-HarnessMetrics -Directory $tmp -AppName 'StressPerf.ReactorOptimized'
+    Assert-Equal 'json' $j.Source         'metrics.json wins over report.txt'
+    Assert-Equal 99.9 $j.RendersPerSec    'json renders/sec'
+    Assert-Equal 150.5 $j.AvgMemoryMB     'json memory'
+
+    # Imperative WinUI3 (StressPerf.Direct): no reconcile/diff lines -> n/a.
+    $directReport = @"
+StressPerf.Direct report
+Total Renders: 500
+Duration: 10.0 s
+Avg Memory: 205.0 MB
+"@
+    Set-Content -LiteralPath (Join-Path $tmp 'StressPerf.Direct.report.txt') -Value $directReport -Encoding UTF8
+    $w = Read-HarnessMetrics -Directory $tmp -AppName 'StressPerf.Direct'
+    Assert-Equal 50 $w.RendersPerSec      'Direct renders/sec'
+    Assert-Null  $w.AvgReconcileMs        'Direct reconcile -> n/a'
+    Assert-Null  $w.AvgDiffMs             'Direct diff -> n/a'
+
+    # Nothing on disk -> source 'none'.
+    $none = Read-HarnessMetrics -Directory $tmp -AppName 'Nope.Missing'
+    Assert-Equal 'none' $none.Source      'missing files -> none'
+}
+finally {
+    Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ── Format-PerfComment (renderer smoke) ──────────────────────────────────────
+$mainRuns = @(
+    [pscustomobject]@{ RendersPerSec = 10; AvgReconcileMs = 5; AvgDiffMs = 2; AvgMemoryMB = 200; TotalRenders = 100; DurationSeconds = 10 }
+    [pscustomobject]@{ RendersPerSec = 10; AvgReconcileMs = 5; AvgDiffMs = 2; AvgMemoryMB = 200; TotalRenders = 100; DurationSeconds = 10 }
+)
+$prRuns = @(
+    [pscustomobject]@{ RendersPerSec = 12; AvgReconcileMs = 4; AvgDiffMs = 1.8; AvgMemoryMB = 195; TotalRenders = 120; DurationSeconds = 10 }
+    [pscustomobject]@{ RendersPerSec = 12; AvgReconcileMs = 4; AvgDiffMs = 1.8; AvgMemoryMB = 195; TotalRenders = 120; DurationSeconds = 10 }
+)
+$main = Measure-PerfRuns -Runs $mainRuns
+$pr = Measure-PerfRuns -Runs $prRuns
+$winui3 = Measure-PerfRuns -Runs @([pscustomobject]@{ RendersPerSec = 9; AvgReconcileMs = $null; AvgDiffMs = $null; AvgMemoryMB = 220; TotalRenders = 90; DurationSeconds = 10 })
+$rust = Measure-PerfRuns -Runs @([pscustomobject]@{ RendersPerSec = 8.5; AvgReconcileMs = 7.5; AvgDiffMs = 6.9; AvgMemoryMB = 188; TotalRenders = 85; DurationSeconds = 10 })
+$ctx = @{ Percent = 50; Duration = 10; Reps = 2; Warmup = 1; HeadSha = 'abcdef1234'; BaseSha = '1234567890'; Cpu = 'Test CPU'; Cores = 4; MemoryGB = 16; Timestamp = '2025-01-01T00:00:00Z' }
+
+# With a live Rust measurement.
+$comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Rust $rust -Context $ctx
+Assert-Match $comment '<!-- reactor-perf-compare -->' 'comment carries the sticky marker'
+Assert-Match $comment 'Regression vs'                 'comment has regression table'
+Assert-Match $comment 'Cross-framework reference'     'comment has cross-framework table'
+Assert-Match $comment 'live on this runner'           'rust footnote = measured live'
+Assert-Match $comment 'improvement'                   'renders/sec improvement glyph present'
+Assert-Match $comment 'x64 Release'                   'methodology falls back to x64 when Platform absent'
+
+# Platform threads through to the methodology line (and the missing-key fallback
+# above must not throw under Set-StrictMode -Version Latest).
+$armCtx = $ctx.Clone(); $armCtx['Platform'] = 'ARM64'
+$armComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -Context $armCtx
+Assert-Match $armComment 'ARM64 Release' 'methodology reflects -Platform ARM64'
+
+# Rust absent -> column n/a, footnote says not run, and it must not throw.
+$noRust = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -Context $ctx
+Assert-Match $noRust 'Not run'  'rust footnote = not run when null'
+Assert-Match $noRust 'n/a'      'n/a cells rendered when winui3 + rust null'
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+Write-Host ""
+if ($script:Fail -gt 0) {
+    Write-Host "FAILED: $($script:Fail) / $($script:Pass + $script:Fail) assertions" -ForegroundColor Red
+    foreach ($f in $script:Failures) { Write-Host "  ✗ $f" -ForegroundColor Red }
+    exit 1
+}
+Write-Host "PASSED: all $($script:Pass) assertions" -ForegroundColor Green
+exit 0

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -156,6 +156,23 @@ Duration: 10.0s
     Assert-Equal 99.9 $j.RendersPerSec    'json renders/sec'
     Assert-Equal 150.5 $j.AvgMemoryMB     'json memory'
 
+    # A metrics.json with a null required field is rejected -> fall back to
+    # report.txt, instead of coercing the null to 0 and reporting it.
+    $badJson = '{"app":"StressPerf.Partial","percent":50,"durationSeconds":10,"rendersPerSec":null,"totalRenders":999,"avgReconcileMs":1.1,"avgDiffMs":2.2,"avgMemoryMB":150.5}'
+    $partialReport = @"
+StressPerf.Partial report
+Total Renders: 400
+Duration: 10.0 s
+Avg Reconcile: 5.0 ms
+Avg Diff: 3.0 ms
+Avg Memory: 180.0 MB
+"@
+    Set-Content -LiteralPath (Join-Path $tmp 'StressPerf.Partial.metrics.json') -Value $badJson -Encoding UTF8
+    Set-Content -LiteralPath (Join-Path $tmp 'StressPerf.Partial.report.txt') -Value $partialReport -Encoding UTF8
+    $p = Read-HarnessMetrics -Directory $tmp -AppName 'StressPerf.Partial' -WarningAction SilentlyContinue
+    Assert-Equal 'report' $p.Source       'null json field -> fall back to report.txt'
+    Assert-Equal 40 $p.RendersPerSec      'fallback renders/sec from report (400/10)'
+
     # Imperative WinUI3 (StressPerf.Direct): no reconcile/diff lines -> n/a.
     $directReport = @"
 StressPerf.Direct report

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -98,14 +98,28 @@ function Read-HarnessMetrics {
     if (Test-Path -LiteralPath $jsonPath) {
         try {
             $j = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json
-            $result.RendersPerSec   = [double]$j.rendersPerSec
-            $result.AvgReconcileMs  = [double]$j.avgReconcileMs
-            $result.AvgDiffMs       = [double]$j.avgDiffMs
-            $result.AvgMemoryMB     = [double]$j.avgMemoryMB
-            $result.TotalRenders    = [int]$j.totalRenders
-            $result.DurationSeconds = [double]$j.durationSeconds
-            $result.Source          = 'json'
-            return $result
+            # Every field below is always emitted by GetMetricsJson, so a missing
+            # or null one means a partial write or a schema mismatch. Reject the
+            # JSON and fall back to report.txt rather than coerce null -> 0 and
+            # surface a misleading metric / delta.
+            $required = 'rendersPerSec', 'avgReconcileMs', 'avgDiffMs', 'avgMemoryMB', 'totalRenders', 'durationSeconds'
+            $missing = @($required | Where-Object {
+                    $p = $j.PSObject.Properties[$_]
+                    (-not $p) -or ($null -eq $p.Value)
+                })
+            if ($missing.Count -gt 0) {
+                Write-Warning "Read-HarnessMetrics: '$jsonPath' is missing/null field(s): $($missing -join ', '); falling back to report.txt."
+            }
+            else {
+                $result.RendersPerSec   = [double]$j.rendersPerSec
+                $result.AvgReconcileMs  = [double]$j.avgReconcileMs
+                $result.AvgDiffMs       = [double]$j.avgDiffMs
+                $result.AvgMemoryMB     = [double]$j.avgMemoryMB
+                $result.TotalRenders    = [int]$j.totalRenders
+                $result.DurationSeconds = [double]$j.durationSeconds
+                $result.Source          = 'json'
+                return $result
+            }
         }
         catch {
             Write-Warning "Read-HarnessMetrics: '$jsonPath' is not valid JSON ($($_.Exception.Message)); falling back to report.txt."

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -15,7 +15,7 @@
       Get-PerfDelta             signed %, direction-aware, with a noise band.
       Format-PerfComment        the sticky two-table markdown comment.
 
-    The four headline metrics (x64 Release, StocksGrid workload):
+    The four headline metrics (Release build, StocksGrid workload):
       Renders/sec      higher is better
       Avg Reconcile ms lower is better
       Avg Diff ms      lower is better
@@ -26,20 +26,6 @@ Set-StrictMode -Version Latest
 
 # Hidden marker used to find + update-in-place the sticky PR comment.
 $script:PerfCommentMarker = '<!-- reactor-perf-compare -->'
-
-# Point-in-time Rust reference snapshot, cited from microsoft/windows-rs
-# docs/crates/windows-reactor.md (Performance notes → "Comparing against the
-# C# reactor"). Measured on a DIFFERENT machine (x64 Release, --percent 50
-# --duration 10, median of two runs, 80x60 grid vs the C# harness's 70x70), so
-# these are indicative cross-language reference values, NOT a runner-local
-# measurement. Refresh if the upstream snapshot changes.
-$script:RustReference = [pscustomobject]@{
-    RendersPerSec  = 8.7
-    AvgReconcileMs = 7.9
-    AvgDiffMs      = 7.1
-    AvgMemoryMB    = 190.0
-}
-$script:RustReferenceUrl = 'https://github.com/microsoft/windows-rs/blob/master/docs/crates/windows-reactor.md#performance-notes'
 
 # Headline metric table spec, shared by the comment renderer.
 $script:PerfMetricSpec = @(
@@ -251,6 +237,8 @@ function Format-PerfComment {
     .PARAMETER Main       Aggregated baseline metrics (Measure-PerfRuns output).
     .PARAMETER Pr         Aggregated PR-head metrics.
     .PARAMETER WinUI3     Aggregated vanilla-WinUI3 (StressPerf.Direct) metrics, or $null.
+    .PARAMETER Rust       Aggregated Rust windows-reactor (test_reactor_perf) metrics
+                          measured live on this runner, or $null when not run.
     .PARAMETER Context    Hashtable: Percent, Duration, Reps, Warmup, BaseSha, HeadSha,
                           Runner, Cpu, Cores, MemoryGB, RunUrl, Timestamp, Note.
     #>
@@ -258,6 +246,7 @@ function Format-PerfComment {
         [Parameter(Mandatory)][pscustomobject]$Main,
         [Parameter(Mandatory)][pscustomobject]$Pr,
         [AllowNull()][pscustomobject]$WinUI3,
+        [AllowNull()][pscustomobject]$Rust,
         [Parameter(Mandatory)][hashtable]$Context
     )
 
@@ -268,8 +257,9 @@ function Format-PerfComment {
     & $add $script:PerfCommentMarker
     & $add "## $([char]0x26A1) Reactor perf comparison"
     & $add ''
+    $plat = if ($Context.ContainsKey('Platform') -and $Context.Platform) { $Context.Platform } else { 'x64' }
     $methodology = "**Workload:** ``StressPerf.ReactorOptimized`` StocksGrid &middot; " +
-        "``--percent $($Context.Percent) --duration $($Context.Duration)`` &middot; x64 Release &middot; " +
+        "``--percent $($Context.Percent) --duration $($Context.Duration)`` &middot; $plat Release &middot; " +
         "median of $($Context.Reps) runs ($($Context.Warmup) warmup dropped) &middot; " +
         "PR head and ``main`` built and run **interleaved on the same runner**."
     & $add $methodology
@@ -302,10 +292,11 @@ function Format-PerfComment {
     & $add '|---|--:|--:|--:|'
     foreach ($m in $script:PerfMetricSpec) {
         $w = if ($null -ne $WinUI3) { $WinUI3.($m.Key) } else { $null }
+        $r = if ($null -ne $Rust) { $Rust.($m.Key) } else { $null }
         $row = '| {0} {1} | {2} | {3} | {4} |' -f `
             $m.Label, $m.Arrow, `
             (Format-PerfNumber $w $m.Digits), `
-            (Format-PerfNumber $script:RustReference.($m.Key) $m.Digits), `
+            (Format-PerfNumber $r $m.Digits), `
             (Format-PerfNumber $Pr.($m.Key) $m.Digits)
         & $add $row
     }
@@ -313,9 +304,14 @@ function Format-PerfComment {
 
     # ── Footnotes ────────────────────────────────────────────────────────────
     $up = [char]0x2191; $down = [char]0x2193
+    $rustNote = if ($null -ne $Rust) {
+        'Built from source and measured **live on this runner**.'
+    } else {
+        '*Not run* on this runner (Rust toolchain/checkout unavailable or the Rust leg failed) — its cells read *n/a*.'
+    }
     & $add "<sub>$up higher is better &middot; $down lower is better. **Within noise** = |Δ| below the larger of the run-to-run spread and a 4% floor; treat as no measurable change.</sub>"
     & $add "<sub>$([char]0x00B9) vanilla WinUI3 = ``StressPerf.Direct`` (imperative; no virtual-DOM, so it has no reconcile/diff phase — those cells read *n/a*). Measured live on this runner.</sub>"
-    & $add "<sub>$([char]0x00B2) Rust = point-in-time snapshot from [microsoft/windows-rs ``windows-reactor.md``]($script:RustReferenceUrl) (different machine, x64 Release, ``--percent 50 --duration 10``, median of 2, 80&times;60 grid). Cross-language reference only — **not** measured on this runner.</sub>"
+    & $add "<sub>$([char]0x00B2) Rust = ``test_reactor_perf`` from [microsoft/windows-rs](https://github.com/microsoft/windows-rs/tree/master/crates/tests/libs/reactor_perf) — a port of this harness (same StocksGrid, same ``--percent``/``--duration`` CLI). $rustNote</sub>"
     & $add "<sub>Absolute numbers are runner-dependent — trust the **Δ vs main**, not the absolute values. Memory (working set) is the noisiest metric.</sub>"
 
     $ctxBits = @()

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -1,0 +1,344 @@
+<#
+.SYNOPSIS
+    Pure, dot-source-able helpers for the on-demand /perf comparison workflow
+    (.github/workflows/perf-compare.yml).
+
+.DESCRIPTION
+    These functions have no side effects beyond Write-Warning so they can be
+    unit-tested locally without running a WinUI harness:
+
+      Read-HarnessMetrics       parse one run's {AppName}.metrics.json (preferred)
+                                or fall back to {AppName}.report.txt.
+      Get-PerfMedian            median of a numeric sample.
+      Get-PerfRelativeSpreadPct (max-min)/|median| as a percent — run-to-run noise.
+      Measure-PerfRuns          median + spread across N per-run metric objects.
+      Get-PerfDelta             signed %, direction-aware, with a noise band.
+      Format-PerfComment        the sticky two-table markdown comment.
+
+    The four headline metrics (x64 Release, StocksGrid workload):
+      Renders/sec      higher is better
+      Avg Reconcile ms lower is better
+      Avg Diff ms      lower is better
+      Avg Memory MB    lower is better
+#>
+
+Set-StrictMode -Version Latest
+
+# Hidden marker used to find + update-in-place the sticky PR comment.
+$script:PerfCommentMarker = '<!-- reactor-perf-compare -->'
+
+# Point-in-time Rust reference snapshot, cited from microsoft/windows-rs
+# docs/crates/windows-reactor.md (Performance notes → "Comparing against the
+# C# reactor"). Measured on a DIFFERENT machine (x64 Release, --percent 50
+# --duration 10, median of two runs, 80x60 grid vs the C# harness's 70x70), so
+# these are indicative cross-language reference values, NOT a runner-local
+# measurement. Refresh if the upstream snapshot changes.
+$script:RustReference = [pscustomobject]@{
+    RendersPerSec  = 8.7
+    AvgReconcileMs = 7.9
+    AvgDiffMs      = 7.1
+    AvgMemoryMB    = 190.0
+}
+$script:RustReferenceUrl = 'https://github.com/microsoft/windows-rs/blob/master/docs/crates/windows-reactor.md#performance-notes'
+
+# Headline metric table spec, shared by the comment renderer.
+$script:PerfMetricSpec = @(
+    [pscustomobject]@{ Key = 'RendersPerSec';  Label = 'Renders/sec';       LowerIsBetter = $false; Digits = 2; Arrow = [char]0x2191 } # up
+    [pscustomobject]@{ Key = 'AvgReconcileMs'; Label = 'Avg Reconcile (ms)'; LowerIsBetter = $true;  Digits = 1; Arrow = [char]0x2193 } # down
+    [pscustomobject]@{ Key = 'AvgDiffMs';      Label = 'Avg Diff (ms)';      LowerIsBetter = $true;  Digits = 1; Arrow = [char]0x2193 }
+    [pscustomobject]@{ Key = 'AvgMemoryMB';    Label = 'Avg Memory (MB)';    LowerIsBetter = $true;  Digits = 1; Arrow = [char]0x2193 }
+)
+
+function ConvertTo-PerfDouble {
+    <#
+    .SYNOPSIS Culture-tolerant parse of a captured numeric string, or $null.
+    #>
+    param([string]$Raw)
+    if ([string]::IsNullOrWhiteSpace($Raw)) { return $null }
+    # Harness report numbers carry no thousands separators, so a comma can only
+    # be a decimal separator emitted under a comma-decimal culture — normalise it.
+    $norm = ($Raw.Trim() -replace ',', '.')
+    [double]$val = 0
+    $ok = [double]::TryParse(
+        $norm,
+        [System.Globalization.NumberStyles]::Float,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [ref]$val)
+    if ($ok) { return $val }
+    return $null
+}
+
+function Get-PerfReportField {
+    param([string]$Text, [string]$Pattern, [switch]$AsInt)
+    $m = [regex]::Match($Text, $Pattern)
+    if (-not $m.Success) { return $null }
+    $val = ConvertTo-PerfDouble $m.Groups[1].Value
+    if ($null -eq $val) { return $null }
+    if ($AsInt) { return [int][math]::Round($val) }
+    return $val
+}
+
+function Read-HarnessMetrics {
+    <#
+    .SYNOPSIS
+        Normalised metrics for one harness run. Prefers {AppName}.metrics.json
+        (emitted by --json); falls back to {AppName}.report.txt regex parsing
+        for harness builds/variants that predate --json (e.g. StressPerf.Direct).
+    .OUTPUTS
+        PSCustomObject with RendersPerSec, AvgReconcileMs, AvgDiffMs,
+        AvgMemoryMB, TotalRenders, DurationSeconds (any of which may be $null
+        when not applicable), and Source ('json' | 'report' | 'none').
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Directory,
+        [Parameter(Mandatory)][string]$AppName
+    )
+
+    $result = [pscustomobject]@{
+        AppName         = $AppName
+        RendersPerSec   = $null
+        AvgReconcileMs  = $null
+        AvgDiffMs       = $null
+        AvgMemoryMB     = $null
+        TotalRenders    = $null
+        DurationSeconds = $null
+        Source          = 'none'
+    }
+
+    $jsonPath   = Join-Path $Directory ("{0}.metrics.json" -f $AppName)
+    $reportPath = Join-Path $Directory ("{0}.report.txt" -f $AppName)
+
+    if (Test-Path -LiteralPath $jsonPath) {
+        try {
+            $j = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json
+            $result.RendersPerSec   = [double]$j.rendersPerSec
+            $result.AvgReconcileMs  = [double]$j.avgReconcileMs
+            $result.AvgDiffMs       = [double]$j.avgDiffMs
+            $result.AvgMemoryMB     = [double]$j.avgMemoryMB
+            $result.TotalRenders    = [int]$j.totalRenders
+            $result.DurationSeconds = [double]$j.durationSeconds
+            $result.Source          = 'json'
+            return $result
+        }
+        catch {
+            Write-Warning "Read-HarnessMetrics: '$jsonPath' is not valid JSON ($($_.Exception.Message)); falling back to report.txt."
+        }
+    }
+
+    if (-not (Test-Path -LiteralPath $reportPath)) {
+        Write-Warning "Read-HarnessMetrics: no metrics.json or report.txt for '$AppName' in '$Directory'."
+        return $result
+    }
+
+    $text = Get-Content -LiteralPath $reportPath -Raw
+    $result.Source          = 'report'
+    $result.TotalRenders    = Get-PerfReportField $text 'Total Renders:\s*([0-9][0-9.,]*)' -AsInt
+    $result.DurationSeconds = Get-PerfReportField $text 'Duration:\s*([0-9][0-9.,]*)\s*s'
+    # Reconcile / Diff lines only exist for declarative (Reactor) variants;
+    # imperative WinUI3 (StressPerf.Direct) omits them -> stay $null (n/a).
+    $result.AvgReconcileMs  = Get-PerfReportField $text 'Avg Reconcile:\s*([0-9][0-9.,]*)\s*ms'
+    $result.AvgDiffMs       = Get-PerfReportField $text 'Avg Diff:\s*([0-9][0-9.,]*)\s*ms'
+    $result.AvgMemoryMB     = Get-PerfReportField $text 'Avg Memory:\s*([0-9][0-9.,]*)\s*MB'
+
+    if ($null -ne $result.TotalRenders -and $null -ne $result.DurationSeconds -and $result.DurationSeconds -gt 0) {
+        $result.RendersPerSec = [math]::Round($result.TotalRenders / $result.DurationSeconds, 4)
+    }
+    return $result
+}
+
+function Get-PerfMedian {
+    param([Parameter(ValueFromPipeline)][AllowNull()][double[]]$Values)
+    $v = @($Values | Where-Object { $null -ne $_ })
+    if ($v.Count -eq 0) { return $null }
+    $sorted = @($v | Sort-Object)
+    $n = $sorted.Count
+    if ($n % 2 -eq 1) { return [double]$sorted[[int][math]::Floor($n / 2)] }
+    return ([double]$sorted[$n / 2 - 1] + [double]$sorted[$n / 2]) / 2.0
+}
+
+function Get-PerfRelativeSpreadPct {
+    <#
+    .SYNOPSIS Run-to-run dispersion (max-min)/|median| as a percent. 0 for <2 samples.
+    #>
+    param([AllowNull()][double[]]$Values)
+    $v = @($Values | Where-Object { $null -ne $_ })
+    if ($v.Count -lt 2) { return 0.0 }
+    $min = ($v | Measure-Object -Minimum).Minimum
+    $max = ($v | Measure-Object -Maximum).Maximum
+    $med = Get-PerfMedian $v
+    if ($null -eq $med -or $med -eq 0) { return 0.0 }
+    return [math]::Round((($max - $min) / [math]::Abs($med)) * 100.0, 1)
+}
+
+function Measure-PerfRuns {
+    <#
+    .SYNOPSIS
+        Collapse N per-run metric objects (from Read-HarnessMetrics) into a
+        single object carrying the median of each metric plus a "<Key>Spread"
+        relative-dispersion percent.
+    #>
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Runs)
+
+    $keys = 'RendersPerSec', 'AvgReconcileMs', 'AvgDiffMs', 'AvgMemoryMB', 'TotalRenders', 'DurationSeconds'
+    $agg = [ordered]@{ RunCount = @($Runs).Count }
+    foreach ($k in $keys) {
+        $vals = @($Runs | ForEach-Object { $_.$k } | Where-Object { $null -ne $_ } | ForEach-Object { [double]$_ })
+        $agg[$k] = Get-PerfMedian $vals
+        $agg["${k}Spread"] = Get-PerfRelativeSpreadPct $vals
+    }
+    return [pscustomobject]$agg
+}
+
+function Get-PerfDelta {
+    <#
+    .SYNOPSIS
+        Signed percent change of Candidate vs Baseline, direction-aware, with a
+        noise band. Status is one of: better | worse | noise | na.
+    .PARAMETER NoiseFloorPct
+        Absolute floor for the "within noise" band (default 4%).
+    .PARAMETER SpreadPct
+        Run-to-run dispersion for this metric; the effective noise band is
+        max(NoiseFloorPct, SpreadPct).
+    #>
+    param(
+        [AllowNull()]$Baseline,
+        [AllowNull()]$Candidate,
+        [Parameter(Mandatory)][bool]$LowerIsBetter,
+        [double]$NoiseFloorPct = 4.0,
+        [double]$SpreadPct = 0.0
+    )
+    if ($null -eq $Baseline -or $null -eq $Candidate -or [double]$Baseline -eq 0) {
+        return [pscustomobject]@{ DeltaPct = $null; Status = 'na'; Improved = $null }
+    }
+    $b = [double]$Baseline
+    $c = [double]$Candidate
+    $deltaPct = (($c - $b) / [math]::Abs($b)) * 100.0
+    $improved = if ($LowerIsBetter) { $deltaPct -lt 0 } else { $deltaPct -gt 0 }
+    $band = [math]::Max($NoiseFloorPct, $SpreadPct)
+    $status = if ([math]::Abs($deltaPct) -lt $band) { 'noise' } elseif ($improved) { 'better' } else { 'worse' }
+    return [pscustomobject]@{ DeltaPct = [math]::Round($deltaPct, 1); Status = $status; Improved = $improved }
+}
+
+function Format-PerfNumber {
+    param([AllowNull()]$Value, [int]$Digits = 1)
+    if ($null -eq $Value) { return 'n/a' }
+    return ([math]::Round([double]$Value, $Digits)).ToString("0.$('0' * $Digits)", [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+function Format-PerfDeltaCell {
+    param([pscustomobject]$Delta)
+    if ($null -eq $Delta.DeltaPct) { return '—' }
+    $s = ('{0:+0.0;-0.0;0.0}' -f $Delta.DeltaPct)
+    return "$s%"
+}
+
+function Get-PerfStatusGlyph {
+    param([string]$Status)
+    switch ($Status) {
+        'better' { return [char]0x2705 + ' improvement' }                       # checkmark
+        'worse'  { return [char]0x26A0 + [char]0xFE0F + ' regression' }          # warning
+        'noise'  { return [char]0x2248 + ' within noise' }                       # almost-equal
+        default  { return '—' }
+    }
+}
+
+function Format-PerfComment {
+    <#
+    .SYNOPSIS
+        Render the sticky two-table comparison comment (markdown), prefixed with
+        the hidden marker used for update-in-place.
+    .PARAMETER Main       Aggregated baseline metrics (Measure-PerfRuns output).
+    .PARAMETER Pr         Aggregated PR-head metrics.
+    .PARAMETER WinUI3     Aggregated vanilla-WinUI3 (StressPerf.Direct) metrics, or $null.
+    .PARAMETER Context    Hashtable: Percent, Duration, Reps, Warmup, BaseSha, HeadSha,
+                          Runner, Cpu, Cores, MemoryGB, RunUrl, Timestamp, Note.
+    #>
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Main,
+        [Parameter(Mandatory)][pscustomobject]$Pr,
+        [AllowNull()][pscustomobject]$WinUI3,
+        [Parameter(Mandatory)][hashtable]$Context
+    )
+
+    $nl = "`n"
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $add = { param($t) $lines.Add($t) }
+
+    & $add $script:PerfCommentMarker
+    & $add "## $([char]0x26A1) Reactor perf comparison"
+    & $add ''
+    $methodology = "**Workload:** ``StressPerf.ReactorOptimized`` StocksGrid &middot; " +
+        "``--percent $($Context.Percent) --duration $($Context.Duration)`` &middot; x64 Release &middot; " +
+        "median of $($Context.Reps) runs ($($Context.Warmup) warmup dropped) &middot; " +
+        "PR head and ``main`` built and run **interleaved on the same runner**."
+    & $add $methodology
+    & $add ''
+
+    # ── Table 1: regression vs main ──────────────────────────────────────────
+    & $add "### Regression vs ``main`` baseline"
+    & $add ''
+    & $add '| Metric | `main` (baseline) | This PR | Δ | Status |'
+    & $add '|---|--:|--:|--:|:--|'
+    foreach ($m in $script:PerfMetricSpec) {
+        $bVal = $Main.($m.Key)
+        $pVal = $Pr.($m.Key)
+        $spread = [math]::Max([double]$Main."$($m.Key)Spread", [double]$Pr."$($m.Key)Spread")
+        $delta = Get-PerfDelta -Baseline $bVal -Candidate $pVal -LowerIsBetter $m.LowerIsBetter -SpreadPct $spread
+        $row = '| {0} {1} | {2} | {3} | {4} | {5} |' -f `
+            $m.Label, $m.Arrow, `
+            (Format-PerfNumber $bVal $m.Digits), `
+            (Format-PerfNumber $pVal $m.Digits), `
+            (Format-PerfDeltaCell $delta), `
+            (Get-PerfStatusGlyph $delta.Status)
+        & $add $row
+    }
+    & $add ''
+
+    # ── Table 2: cross-framework reference ───────────────────────────────────
+    & $add "### Cross-framework reference (same StocksGrid workload)"
+    & $add ''
+    & $add ('| Metric | vanilla WinUI3{0} | Rust `windows-reactor`{1} | Reactor (this PR) |' -f [char]0x00B9, [char]0x00B2)
+    & $add '|---|--:|--:|--:|'
+    foreach ($m in $script:PerfMetricSpec) {
+        $w = if ($null -ne $WinUI3) { $WinUI3.($m.Key) } else { $null }
+        $row = '| {0} {1} | {2} | {3} | {4} |' -f `
+            $m.Label, $m.Arrow, `
+            (Format-PerfNumber $w $m.Digits), `
+            (Format-PerfNumber $script:RustReference.($m.Key) $m.Digits), `
+            (Format-PerfNumber $Pr.($m.Key) $m.Digits)
+        & $add $row
+    }
+    & $add ''
+
+    # ── Footnotes ────────────────────────────────────────────────────────────
+    $up = [char]0x2191; $down = [char]0x2193
+    & $add "<sub>$up higher is better &middot; $down lower is better. **Within noise** = |Δ| below the larger of the run-to-run spread and a 4% floor; treat as no measurable change.</sub>"
+    & $add "<sub>$([char]0x00B9) vanilla WinUI3 = ``StressPerf.Direct`` (imperative; no virtual-DOM, so it has no reconcile/diff phase — those cells read *n/a*). Measured live on this runner.</sub>"
+    & $add "<sub>$([char]0x00B2) Rust = point-in-time snapshot from [microsoft/windows-rs ``windows-reactor.md``]($script:RustReferenceUrl) (different machine, x64 Release, ``--percent 50 --duration 10``, median of 2, 80&times;60 grid). Cross-language reference only — **not** measured on this runner.</sub>"
+    & $add "<sub>Absolute numbers are runner-dependent — trust the **Δ vs main**, not the absolute values. Memory (working set) is the noisiest metric.</sub>"
+
+    $ctxBits = @()
+    if ($Context.ContainsKey('Cpu') -and $Context.Cpu)       { $ctxBits += "CPU: $($Context.Cpu)" }
+    if ($Context.ContainsKey('Cores') -and $Context.Cores)   { $ctxBits += "$($Context.Cores) logical cores" }
+    if ($Context.ContainsKey('MemoryGB') -and $Context.MemoryGB) { $ctxBits += "$($Context.MemoryGB) GB RAM" }
+    if ($Context.ContainsKey('Runner') -and $Context.Runner) { $ctxBits += "runner: $($Context.Runner)" }
+    if ($ctxBits.Count -gt 0) { & $add ("<sub>Runner: " + ($ctxBits -join ' &middot; ') + ".</sub>") }
+
+    $shaBits = @()
+    if ($Context.ContainsKey('HeadSha') -and $Context.HeadSha) { $shaBits += "PR ``$($Context.HeadSha)``" }
+    if ($Context.ContainsKey('BaseSha') -and $Context.BaseSha) { $shaBits += "main ``$($Context.BaseSha)``" }
+    $genLine = "<sub>Generated by ``.github/workflows/perf-compare.yml``"
+    if ($shaBits.Count -gt 0) { $genLine += ' &middot; ' + ($shaBits -join ' vs ') }
+    if ($Context.ContainsKey('Timestamp') -and $Context.Timestamp) { $genLine += " &middot; $($Context.Timestamp)" }
+    if ($Context.ContainsKey('RunUrl') -and $Context.RunUrl) { $genLine += " &middot; [run log]($($Context.RunUrl))" }
+    $genLine += '.</sub>'
+    & $add $genLine
+
+    if ($Context.ContainsKey('Note') -and $Context.Note) {
+        & $add ''
+        & $add "> [!NOTE]$nl> $($Context.Note)"
+    }
+
+    return ($lines -join $nl)
+}

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -17,7 +17,7 @@ PowerShell entry point powers two things:
 
 ## The four metrics
 
-Measured on the `StressPerf.ReactorOptimized` StocksGrid workload, x64 Release:
+Measured on the `StressPerf.ReactorOptimized` StocksGrid workload (Release, built for the host architecture — x64 on the CI runner):
 
 | Metric | Meaning | Direction |
 |---|---|:--:|
@@ -41,6 +41,10 @@ reconcile/diff phase — those cells read *n/a*.
   property), the same hermetic trick the WinUI selftest hosts use, so the
   bundled runtime ships next to the exe. Pass `-SelfContained:$false` to use a
   machine-wide runtime instead.
+- **Any architecture.** The harness builds for your **host architecture** by
+  default (`x64` or `ARM64`), so it runs natively. This matters on ARM64 boxes:
+  an x64 build there runs under emulation and crashes WinUI composition with a
+  stowed exception (`0xC000027B`). Override with `-Platform x64|ARM64` if needed.
 
 ## Run it locally
 
@@ -52,8 +56,9 @@ pwsh tests/stress_perf/ci/Run-PerfBenchmark.ps1
 
 Builds + runs `StressPerf.ReactorOptimized` **and** `StressPerf.Direct`
 (vanilla WinUI3) in the current checkout, prints a console table, and writes
-`tests/stress_perf/ci/out/result.json`. The table also shows the static Rust
-`windows-reactor` reference column for context.
+`tests/stress_perf/ci/out/result.json`. Both build for your host architecture.
+Add a live Rust `windows-reactor` column with `-RustRepo <windows-rs checkout>`
+(see [Parameters](#parameters)).
 
 ### A/B against a clean `main` baseline
 
@@ -80,15 +85,18 @@ git worktree remove ../main
 | `-Reps` | `2` | Measured runs whose **median** is reported (methodology "median of two"). Bump for tighter numbers. |
 | `-Warmup` | `1` | Leading runs discarded before the measured `Reps`. |
 | `-Apps` | `ReactorOptimized,Direct` | Single-tree mode only: which harnesses to run. |
+| `-Platform` | host arch | Target architecture (`x64` or `ARM64`). Defaults to your machine's native arch so the WinUI harness runs without emulation. |
 | `-SelfContained` | `$true` | Build with the bundled WinApp runtime (no machine-wide install). |
 | `-SkipBuild` | off | Reuse existing binaries (skip `dotnet build`). |
 | `-PinAffinity` | off | Pin each run to one CPU core (can hurt on small runners). |
+| `-RustRepo` | _(unset)_ | Path to a [`microsoft/windows-rs`](https://github.com/microsoft/windows-rs) checkout. Builds + runs its `reactor_perf` harness to add a **live** Rust column (best-effort). |
+| `-DefenderExclude` | off | Add a temporary Defender exclusion on the output tree (removed afterward). CI-only; opt-in locally. |
 | `-OutDir` | `ci/out` | Where logs, `result.json` and `comment.md` land. |
 | `-HeadSha` / `-BaseSha` / `-RunUrl` | _(empty)_ | Context echoed into the comment footer (compare mode). |
 
 ### Outputs
 
-- **Console table** — median per metric, per app, plus the Rust reference column.
+- **Console table** — median per metric, per app (plus a live Rust column when `-RustRepo` is set).
 - **`out/result.json`** — machine-readable medians + run-to-run spread + runner identity.
 - **`out/comment.md`** _(compare mode only)_ — the rendered sticky comment.
 - **`out/*.log`** — per-build and per-run stdout/stderr for debugging.
@@ -120,12 +128,13 @@ Two tables plus footnotes:
   noise`). "Within noise" means `|Δ|` is below the larger of the run-to-run
   spread and a 4% floor — treat it as no measurable change.
 - **Cross-framework reference** — `vanilla WinUI3 | Rust windows-reactor |
-  Reactor (this PR)` on the same StocksGrid workload. The Rust column is a
-  **static** point-in-time snapshot cited from
-  [`microsoft/windows-rs` `windows-reactor.md`](https://github.com/microsoft/windows-rs/blob/master/docs/crates/windows-reactor.md#performance-notes)
-  (different machine, x64 Release, `--percent 50 --duration 10`, median of 2,
-  80×60 grid) — a cross-language reference, **not** a runner-local measurement.
-  The WinUI3 column **is** measured live on the runner.
+  Reactor (this PR)` on the same StocksGrid workload, **all measured live on the
+  same runner**. The Rust column builds and runs the
+  [`microsoft/windows-rs`](https://github.com/microsoft/windows-rs) `reactor_perf`
+  harness (a port of this workload), pinned in CI to a known-good commit. It is
+  best-effort: if the Rust build or run fails the column reads `n/a` and the
+  PR-vs-`main` comparison is unaffected. The WinUI3 column is the local
+  `StressPerf.Direct` build.
 
 ## Variance: trust the delta, not the absolutes
 
@@ -155,18 +164,21 @@ For the steadiest local numbers: close other apps, stay on AC power, and bump
 | File | Role |
 |---|---|
 | [`Run-PerfBenchmark.ps1`](Run-PerfBenchmark.ps1) | Orchestrator — build, run, interleave, render. Used by both the workflow and humans. |
-| [`PerfLib.ps1`](PerfLib.ps1) | Pure, side-effect-free helpers (parse, median, spread, direction-aware delta, comment renderer). Holds the Rust reference constants + comment marker. |
+| [`PerfLib.ps1`](PerfLib.ps1) | Pure, side-effect-free helpers (parse, median, spread, direction-aware delta, comment renderer) + the sticky-comment marker. |
 
 ## Troubleshooting
 
 - **Run crashes with `0xC000027B` right after "MountAndActivate ok".** That is a
-  stowed XAML/compositor exception: the box cannot composite a real WinUI window
-  (headless server, no GPU/desktop session, or an RDP session without
-  composition). The **build and runtime are fine** — `windows-latest` CI runners
-  composite XAML correctly (the selftest/E2E jobs prove it). Run locally from an
-  interactive desktop session.
-- **`exe … not found`.** The self-contained build nests the exe under a RID
-  folder (`bin\x64\Release\<tfm>\win-x64\`); the script finds it recursively. If
-  it is genuinely missing, check the `out/build-*.log` for the real `dotnet`
-  error.
+  stowed XAML/compositor exception. Most often the box cannot composite a real
+  WinUI window (headless server, no GPU/desktop session, or an RDP session
+  without composition) — run from an interactive desktop session. **On an ARM64
+  machine** it also happens when an **x64** harness runs under emulation; the
+  runner builds for your host architecture by default (so ARM64 runs natively),
+  but if you forced `-Platform x64` on ARM64, drop it or pass `-Platform ARM64`.
+  The build and runtime are otherwise fine — `windows-latest` CI runners
+  composite XAML correctly (the selftest/E2E jobs prove it).
+- **`exe … not found`.** The self-contained build nests the exe under an arch +
+  RID folder (`bin\<arch>\Release\<tfm>\win-<arch>\`); the script finds it
+  recursively. If it is genuinely missing, check the `out/build-*.log` for the
+  real `dotnet` error.
 - **Scripts won't parse.** Use `pwsh` (PowerShell 7+), not `powershell.exe` 5.1.

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -1,0 +1,172 @@
+# Perf comparison (`/perf`) — CI workflow + local runner
+
+On-demand benchmarking for the Reactor data-grid stress harness. The same
+PowerShell entry point powers two things:
+
+- **In CI** — comment **`/perf`** on a pull request and
+  [`.github/workflows/perf-compare.yml`](../../../.github/workflows/perf-compare.yml)
+  builds the harness on the **PR head** and on **`main`**, runs them
+  interleaved on one runner, and posts a sticky comparison comment.
+- **Locally** — run [`Run-PerfBenchmark.ps1`](Run-PerfBenchmark.ps1) yourself to
+  get your four numbers (and an optional A/B against a clean `main` worktree)
+  before you ever push.
+
+> There is also a Copilot skill — [`perf-compare`](../../../.github/skills/perf-compare/SKILL.md) —
+> that drives the local runner for you. Just ask Copilot to "benchmark my perf
+> changes vs main".
+
+## The four metrics
+
+Measured on the `StressPerf.ReactorOptimized` StocksGrid workload, x64 Release:
+
+| Metric | Meaning | Direction |
+|---|---|:--:|
+| **Renders/sec** | `Total Renders` ÷ `Duration` — render throughput | higher is better ↑ |
+| **Avg Reconcile (ms)** | mean reconcile-phase time per render | lower is better ↓ |
+| **Avg Diff (ms)** | mean element-tree diff time per render | lower is better ↓ |
+| **Avg Memory (MB)** | mean working set during the measured window | lower is better ↓ |
+
+Imperative WinUI3 (`StressPerf.Direct`) has no virtual-DOM, so it has **no**
+reconcile/diff phase — those cells read *n/a*.
+
+## Prerequisites
+
+- **Windows** with a real interactive desktop session (the harness opens a real
+  WinUI window — see [Troubleshooting](#troubleshooting)).
+- **.NET 10 SDK** (`dotnet --version` ≥ 10).
+- **PowerShell 7+** (`pwsh`). The scripts use pwsh-7 syntax (`??`, `(if …)`
+  sub-expressions) and will not run under Windows PowerShell 5.1.
+- **No Windows App SDK runtime install needed.** The runner builds the harness
+  with `WindowsAppSDKSelfContained=true` (via the gated `-p:PerfCiSelfContained=true`
+  property), the same hermetic trick the WinUI selftest hosts use, so the
+  bundled runtime ships next to the exe. Pass `-SelfContained:$false` to use a
+  machine-wide runtime instead.
+
+## Run it locally
+
+### Quick: my four numbers right now
+
+```pwsh
+pwsh tests/stress_perf/ci/Run-PerfBenchmark.ps1
+```
+
+Builds + runs `StressPerf.ReactorOptimized` **and** `StressPerf.Direct`
+(vanilla WinUI3) in the current checkout, prints a console table, and writes
+`tests/stress_perf/ci/out/result.json`. The table also shows the static Rust
+`windows-reactor` reference column for context.
+
+### A/B against a clean `main` baseline
+
+Create a worktree on `main`, then point `-BaselineRoot` at it. This switches the
+script into **compare mode**: it interleaves the PR-tree and main-tree
+`ReactorOptimized` runs on the same machine, runs WinUI3 once, and renders the
+exact sticky comment (`out/comment.md`) the CI workflow would post.
+
+```pwsh
+git worktree add ../main origin/main
+pwsh tests/stress_perf/ci/Run-PerfBenchmark.ps1 -BaselineRoot ../main -Reps 3
+# when done:
+git worktree remove ../main
+```
+
+### Parameters
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `-Root` | repo root | Checkout to build + run (the **PR head** in compare mode). |
+| `-BaselineRoot` | _(unset)_ | A second checkout (the **`main`** baseline). Setting it enables **compare mode** and renders `comment.md`. |
+| `-Percent` | `50` | Fraction of grid cells mutated per tick (methodology default). |
+| `-Duration` | `10` | Measured seconds per run (methodology default). |
+| `-Reps` | `2` | Measured runs whose **median** is reported (methodology "median of two"). Bump for tighter numbers. |
+| `-Warmup` | `1` | Leading runs discarded before the measured `Reps`. |
+| `-Apps` | `ReactorOptimized,Direct` | Single-tree mode only: which harnesses to run. |
+| `-SelfContained` | `$true` | Build with the bundled WinApp runtime (no machine-wide install). |
+| `-SkipBuild` | off | Reuse existing binaries (skip `dotnet build`). |
+| `-PinAffinity` | off | Pin each run to one CPU core (can hurt on small runners). |
+| `-OutDir` | `ci/out` | Where logs, `result.json` and `comment.md` land. |
+| `-HeadSha` / `-BaseSha` / `-RunUrl` | _(empty)_ | Context echoed into the comment footer (compare mode). |
+
+### Outputs
+
+- **Console table** — median per metric, per app, plus the Rust reference column.
+- **`out/result.json`** — machine-readable medians + run-to-run spread + runner identity.
+- **`out/comment.md`** _(compare mode only)_ — the rendered sticky comment.
+- **`out/*.log`** — per-build and per-run stdout/stderr for debugging.
+
+## How `/perf` works in CI
+
+1. A trusted author (**OWNER / MEMBER / COLLABORATOR**, checked via
+   `github.event.comment.author_association`) comments **`/perf`** on a PR.
+   `workflow_dispatch` with a `pr_number` input is also supported for manual runs.
+2. The workflow runs from the **default branch** (that is how `issue_comment`
+   behaves), so once this is on `main` it works on **every already-open PR with
+   no rebase** — important while a fleet of perf PRs is in flight.
+3. It checks out the default branch (trusted perf scripts + the `main` baseline),
+   sets up .NET 10, fetches the PR head via `refs/pull/N/head` into a worktree
+   (so forks work), then runs `Run-PerfBenchmark.ps1` in compare mode.
+4. It posts — or **updates in place** on re-runs, via the hidden
+   `<!-- reactor-perf-compare -->` marker — one sticky comment.
+
+Only the harness *code* comes from the PR; the perf scripts and the `main`
+baseline always come from the trusted default branch. The `author_association`
+gate is the security control, because the job has a write token.
+
+### The comment
+
+Two tables plus footnotes:
+
+- **Regression vs `main`** — `Metric | main | This PR | Δ% | Status`, where
+  Status is direction-aware (`✅ improvement` / `⚠️ regression` / `≈ within
+  noise`). "Within noise" means `|Δ|` is below the larger of the run-to-run
+  spread and a 4% floor — treat it as no measurable change.
+- **Cross-framework reference** — `vanilla WinUI3 | Rust windows-reactor |
+  Reactor (this PR)` on the same StocksGrid workload. The Rust column is a
+  **static** point-in-time snapshot cited from
+  [`microsoft/windows-rs` `windows-reactor.md`](https://github.com/microsoft/windows-rs/blob/master/docs/crates/windows-reactor.md#performance-notes)
+  (different machine, x64 Release, `--percent 50 --duration 10`, median of 2,
+  80×60 grid) — a cross-language reference, **not** a runner-local measurement.
+  The WinUI3 column **is** measured live on the runner.
+
+## Variance: trust the delta, not the absolutes
+
+GitHub-hosted runners are shared and heterogeneous — absolute numbers drift
+between runs and machines. We do not own them, so the design leans on
+**relative** measurement and several mitigations:
+
+- **Same-runner A/B** — PR and `main` are built and measured on the *same*
+  machine in the *same* job, so machine-class differences cancel.
+- **Interleaving** — runs alternate `main, PR, main, PR, …` so slow time
+  windows hit both sides roughly equally.
+- **Warm-up discard + median of N** — the first run(s) are dropped; the median
+  rejects single-run outliers.
+- **Noise band** — a delta smaller than the larger of the measured run-to-run
+  spread and a 4% floor is reported as *within noise*, not a win/regression.
+- **Process priority + power plan** — runs use High priority and a
+  high-performance power plan (restored afterward), with a best-effort Defender
+  exclusion on the output tree.
+- **Runner identity** — CPU / cores / RAM are recorded in the comment so the
+  absolute numbers are read in context.
+
+For the steadiest local numbers: close other apps, stay on AC power, and bump
+`-Reps` (e.g. `-Reps 5`).
+
+## Files here
+
+| File | Role |
+|---|---|
+| [`Run-PerfBenchmark.ps1`](Run-PerfBenchmark.ps1) | Orchestrator — build, run, interleave, render. Used by both the workflow and humans. |
+| [`PerfLib.ps1`](PerfLib.ps1) | Pure, side-effect-free helpers (parse, median, spread, direction-aware delta, comment renderer). Holds the Rust reference constants + comment marker. |
+
+## Troubleshooting
+
+- **Run crashes with `0xC000027B` right after "MountAndActivate ok".** That is a
+  stowed XAML/compositor exception: the box cannot composite a real WinUI window
+  (headless server, no GPU/desktop session, or an RDP session without
+  composition). The **build and runtime are fine** — `windows-latest` CI runners
+  composite XAML correctly (the selftest/E2E jobs prove it). Run locally from an
+  interactive desktop session.
+- **`exe … not found`.** The self-contained build nests the exe under a RID
+  folder (`bin\x64\Release\<tfm>\win-x64\`); the script finds it recursively. If
+  it is genuinely missing, check the `out/build-*.log` for the real `dotnet`
+  error.
+- **Scripts won't parse.** Use `pwsh` (PowerShell 7+), not `powershell.exe` 5.1.

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -1,0 +1,318 @@
+<#
+.SYNOPSIS
+    Build + run the StressPerf WinUI harnesses, capture the four headline perf
+    metrics, and (in compare mode) render the sticky PR-comparison comment.
+
+.DESCRIPTION
+    Used both locally (developers) and by .github/workflows/perf-compare.yml.
+
+    Two modes, auto-selected:
+
+      * Local / single-tree (no -BaselineRoot): builds and runs the requested
+        harness(es) in -Root, prints a results table to the console, and writes
+        result.json. Good for "what are my four numbers right now, and how do
+        they line up against vanilla WinUI3 and the Rust reference?".
+
+      * Compare (with -BaselineRoot): builds + runs StressPerf.ReactorOptimized
+        in BOTH trees, INTERLEAVED on the same machine (main, PR, main, PR, ...)
+        to cancel time-correlated drift, plus vanilla WinUI3 once, then renders
+        the two-table sticky comment to comment.md for the workflow to post.
+
+    Variance mitigations (we don't own CI runners): same-runner A/B, interleaved
+    reps, warm-up discard, median of N, a noise band on the deltas (PerfLib),
+    High process priority, a high-performance power plan for the duration, and a
+    best-effort Defender exclusion on the output dir. Runner identity (CPU /
+    cores / RAM) is recorded in the comment so absolute numbers are interpreted
+    in context — trust the delta, not the absolutes.
+
+.PARAMETER Root
+    Checkout to build + run (the PR head in compare mode). Defaults to the repo
+    root inferred from this script's location.
+
+.PARAMETER BaselineRoot
+    Second checkout (the `main` baseline). When set, the script runs in compare
+    mode and renders comment.md.
+
+.PARAMETER Percent
+    Fraction of grid cells mutated per tick. Methodology default 50.
+
+.PARAMETER Duration
+    Measured seconds per run. Methodology default 10.
+
+.PARAMETER Reps
+    Measured runs whose median is reported (default 2 — methodology "median of
+    two"). Bump locally for tighter numbers.
+
+.PARAMETER Warmup
+    Leading runs discarded before the Reps measured runs (default 1).
+
+.PARAMETER Apps
+    Which harnesses to run in single-tree mode: ReactorOptimized, Direct.
+    Ignored in compare mode (which always does ReactorOptimized both sides +
+    Direct once for the WinUI3 column).
+
+.PARAMETER OutDir
+    Where logs, comment.md and result.json land. Defaults to ci\out next to this
+    script.
+
+.PARAMETER SkipBuild
+    Reuse existing binaries (skip dotnet build).
+
+.PARAMETER PinAffinity
+    Pin each harness to a single CPU core (opt-in; can hurt on busy 2-core
+    runners, off by default).
+
+.PARAMETER HeadSha / BaseSha / RunUrl
+    Context echoed into the comment footer (compare mode).
+
+.EXAMPLE
+    # Local: my four numbers + cross-framework reference
+    pwsh tests/stress_perf/ci/Run-PerfBenchmark.ps1
+
+.EXAMPLE
+    # Local A/B vs a clean main worktree
+    git worktree add ../main origin/main
+    pwsh tests/stress_perf/ci/Run-PerfBenchmark.ps1 -BaselineRoot ../main -Reps 3
+#>
+[CmdletBinding()]
+param(
+    [string]$Root,
+    [string]$BaselineRoot = '',
+    [double]$Percent = 50,
+    [int]$Duration = 10,
+    [int]$Reps = 2,
+    [int]$Warmup = 1,
+    [ValidateSet('ReactorOptimized', 'Direct')]
+    [string[]]$Apps = @('ReactorOptimized', 'Direct'),
+    [string]$OutDir,
+    [switch]$SkipBuild,
+    [bool]$SelfContained = $true,
+    [switch]$PinAffinity,
+    [string]$HeadSha = '',
+    [string]$BaseSha = '',
+    [string]$RunUrl = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'PerfLib.ps1')
+
+if (-not $Root)   { $Root = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path }
+if (-not $OutDir) { $OutDir = Join-Path $PSScriptRoot 'out' }
+$Root = (Resolve-Path $Root).Path
+if ($BaselineRoot) { $BaselineRoot = (Resolve-Path $BaselineRoot).Path }
+New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
+
+$Compare = [bool]$BaselineRoot
+$tfmGuess = 'net10.0-windows10.0.22621.0'
+
+$AppRegistry = @{
+    ReactorOptimized = @{ AppName = 'StressPerf.ReactorOptimized'; ProjectRel = 'tests\stress_perf\StressPerf.ReactorOptimized\StressPerf.ReactorOptimized.csproj' }
+    Direct           = @{ AppName = 'StressPerf.Direct';           ProjectRel = 'tests\stress_perf\StressPerf.Direct\StressPerf.Direct.csproj' }
+}
+
+function Write-Log {
+    param([string]$Message, [string]$Color = 'Gray')
+    $ts = (Get-Date).ToString('HH:mm:ss')
+    Write-Host "[$ts] $Message" -ForegroundColor $Color
+}
+
+function Get-RunnerInfo {
+    $info = [ordered]@{ Cpu = ''; Cores = [Environment]::ProcessorCount; MemoryGB = ''; Runner = $env:RUNNER_NAME }
+    try { $info.Cpu = (Get-CimInstance Win32_Processor -ErrorAction Stop | Select-Object -First 1).Name.Trim() } catch {}
+    try { $info.MemoryGB = [math]::Round((Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory / 1GB) } catch {}
+    return [pscustomobject]$info
+}
+
+function Resolve-HarnessExe {
+    param([string]$TreeRoot, [hashtable]$AppMeta)
+    $projDir = Split-Path (Join-Path $TreeRoot $AppMeta.ProjectRel)
+    $binRoot = Join-Path $projDir 'bin\x64\Release'
+    if (-not (Test-Path $binRoot)) { return $null }
+    $exe = Get-ChildItem -Path $binRoot -Recurse -Filter ("{0}.exe" -f $AppMeta.AppName) -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($exe) { return $exe.FullName }
+    return $null
+}
+
+function Build-Harness {
+    param([string]$TreeRoot, [hashtable]$AppMeta)
+    $proj = Join-Path $TreeRoot $AppMeta.ProjectRel
+    if (-not (Test-Path $proj)) { throw "Project not found: $proj" }
+    Write-Log "build $($AppMeta.AppName)  [$TreeRoot]" 'Cyan'
+    $log = Join-Path $OutDir ("build-{0}-{1}.log" -f $AppMeta.AppName, ([IO.Path]::GetFileName($TreeRoot)))
+    $buildArgs = @($proj, '-c', 'Release', '-p:Platform=x64', '--nologo')
+    if ($SelfContained) { $buildArgs += '-p:PerfCiSelfContained=true' }
+    & dotnet build @buildArgs 2>&1 | Tee-Object -FilePath $log | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host (Get-Content $log -Raw) -ForegroundColor DarkRed
+        throw "dotnet build failed for $($AppMeta.AppName) in $TreeRoot (see $log)"
+    }
+}
+
+function Invoke-OneRun {
+    <# Run the harness once; return a metric object (Read-HarnessMetrics) or $null. #>
+    param([string]$Exe, [hashtable]$AppMeta, [int]$Index, [string]$Tag)
+
+    $exeDir = Split-Path $Exe
+    foreach ($ext in 'metrics.json', 'report.txt', 'samples.csv') {
+        $p = Join-Path $exeDir ("{0}.{1}" -f $AppMeta.AppName, $ext)
+        if (Test-Path $p) { Remove-Item $p -Force -ErrorAction SilentlyContinue }
+    }
+
+    $stdout = Join-Path $OutDir ("run-{0}-{1}-{2}.out.log" -f $AppMeta.AppName, $Tag, $Index)
+    $stderr = Join-Path $OutDir ("run-{0}-{1}-{2}.err.log" -f $AppMeta.AppName, $Tag, $Index)
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    $harnessArgs = @('--headless', '--percent', $Percent.ToString($inv), '--duration', $Duration.ToString($inv), '--json')
+    $timeoutSec = $Duration + 90
+
+    Write-Log ("  run [{0} #{1}] {2} --percent {3} --duration {4}" -f $Tag, $Index, $AppMeta.AppName, $Percent, $Duration)
+    $proc = Start-Process -FilePath $Exe -ArgumentList $harnessArgs -PassThru `
+        -RedirectStandardOutput $stdout -RedirectStandardError $stderr -WindowStyle Hidden
+    try {
+        $proc.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::High
+        if ($PinAffinity) { $proc.ProcessorAffinity = [IntPtr]([int]($Index % [Environment]::ProcessorCount) -bor 1) }
+    } catch {}
+
+    if (-not $proc.WaitForExit($timeoutSec * 1000)) {
+        Write-Log "  TIMEOUT after ${timeoutSec}s — killing $($AppMeta.AppName)" 'Yellow'
+        try { $proc.Kill($true) } catch { try { $proc.Kill() } catch {} }
+        Start-Sleep -Seconds 2
+    }
+
+    $metrics = Read-HarnessMetrics -Directory $exeDir -AppName $AppMeta.AppName
+    if ($metrics.Source -eq 'none') {
+        Write-Log "  no metrics for $($AppMeta.AppName) run #$Index (exit=$($proc.ExitCode)). stderr tail:" 'Yellow'
+        if (Test-Path $stderr) { Get-Content $stderr -Tail 8 | ForEach-Object { Write-Host "      $_" -ForegroundColor DarkYellow } }
+        return $null
+    }
+    Write-Log ("  -> renders/sec={0}  reconcile={1}  diff={2}  mem={3}  ({4})" -f `
+        (Format-PerfNumber $metrics.RendersPerSec 2), (Format-PerfNumber $metrics.AvgReconcileMs 1), `
+        (Format-PerfNumber $metrics.AvgDiffMs 1), (Format-PerfNumber $metrics.AvgMemoryMB 1), $metrics.Source) 'DarkGray'
+    return $metrics
+}
+
+function Measure-Sequential {
+    param([string]$Exe, [hashtable]$AppMeta, [string]$Tag)
+    $runs = @()
+    for ($i = 1; $i -le ($Warmup + $Reps); $i++) {
+        $m = Invoke-OneRun -Exe $Exe -AppMeta $AppMeta -Index $i -Tag $Tag
+        if ($i -le $Warmup) { Write-Log "  (warmup #$i discarded)" 'DarkGray'; continue }
+        if ($m) { $runs += $m }
+    }
+    return , $runs
+}
+
+# ── Power plan + Defender (best-effort, restored on exit) ────────────────────
+$prevScheme = $null
+try {
+    $active = (& powercfg /getactivescheme) 2>$null
+    if ($active -match '([0-9a-fA-F-]{36})') { $prevScheme = $Matches[1] }
+    & powercfg /setactive SCHEME_MIN 2>$null | Out-Null   # High performance
+    Write-Log "power plan -> High performance (was $prevScheme)" 'DarkGray'
+} catch { Write-Log "power plan unchanged ($_)" 'DarkGray' }
+try { Add-MpPreference -ExclusionPath $Root -ErrorAction Stop; Write-Log "Defender exclusion added for $Root" 'DarkGray' } catch {}
+
+$runner = Get-RunnerInfo
+Write-Log ("runner: {0} | {1} cores | {2} GB | {3}" -f $runner.Cpu, $runner.Cores, $runner.MemoryGB, ($runner.Runner ?? 'local')) 'Cyan'
+Write-Log ("mode: {0} | percent={1} duration={2} reps={3} warmup={4}" -f ($(if ($Compare) { 'COMPARE' } else { 'LOCAL' })), $Percent, $Duration, $Reps, $Warmup) 'Cyan'
+
+$exit = 0
+try {
+    if ($Compare) {
+        # ---- Compare mode: interleaved ReactorOptimized A/B + WinUI3 once -----
+        $ro = $AppRegistry.ReactorOptimized
+        $direct = $AppRegistry.Direct
+
+        if (-not $SkipBuild) {
+            Build-Harness -TreeRoot $BaselineRoot -AppMeta $ro
+            Build-Harness -TreeRoot $Root -AppMeta $ro
+            Build-Harness -TreeRoot $Root -AppMeta $direct
+        }
+        $mainExe = Resolve-HarnessExe -TreeRoot $BaselineRoot -AppMeta $ro
+        $prExe = Resolve-HarnessExe -TreeRoot $Root -AppMeta $ro
+        $directExe = Resolve-HarnessExe -TreeRoot $Root -AppMeta $direct
+        if (-not $mainExe) { throw "main ReactorOptimized exe not found under $BaselineRoot" }
+        if (-not $prExe) { throw "PR ReactorOptimized exe not found under $Root" }
+
+        Write-Log "interleaving main/PR ReactorOptimized ($($Warmup) warmup + $($Reps) measured each)" 'Green'
+        $mainRuns = @(); $prRuns = @()
+        for ($i = 1; $i -le ($Warmup + $Reps); $i++) {
+            $mm = Invoke-OneRun -Exe $mainExe -AppMeta $ro -Index $i -Tag 'main'
+            $pm = Invoke-OneRun -Exe $prExe -AppMeta $ro -Index $i -Tag 'pr'
+            if ($i -le $Warmup) { Write-Log "  (warmup pair #$i discarded)" 'DarkGray'; continue }
+            if ($mm) { $mainRuns += $mm }
+            if ($pm) { $prRuns += $pm }
+        }
+
+        $winRuns = @()
+        if ($directExe) {
+            Write-Log "vanilla WinUI3 (StressPerf.Direct)" 'Green'
+            $winRuns = Measure-Sequential -Exe $directExe -AppMeta $direct -Tag 'winui3'
+        } else {
+            Write-Log "StressPerf.Direct exe not found — WinUI3 column will read n/a" 'Yellow'
+        }
+
+        $main = Measure-PerfRuns -Runs $mainRuns
+        $pr = Measure-PerfRuns -Runs $prRuns
+        $winui3 = if ($winRuns.Count) { Measure-PerfRuns -Runs $winRuns } else { $null }
+
+        $note = $null
+        if ($prRuns.Count -eq 0 -or $mainRuns.Count -eq 0) {
+            $note = 'One or both of the main/PR ReactorOptimized runs produced no metrics — the harness may have failed to open a window on this runner. See the workflow run log and the uploaded ``perf-logs`` artifact.'
+            $exit = 1
+        }
+
+        $ctx = @{
+            Percent = $Percent; Duration = $Duration; Reps = $Reps; Warmup = $Warmup
+            BaseSha = (if ($BaseSha) { $BaseSha.Substring(0, [Math]::Min(7, $BaseSha.Length)) } else { '' })
+            HeadSha = (if ($HeadSha) { $HeadSha.Substring(0, [Math]::Min(7, $HeadSha.Length)) } else { '' })
+            Runner = $runner.Runner; Cpu = $runner.Cpu; Cores = $runner.Cores; MemoryGB = $runner.MemoryGB
+            RunUrl = $RunUrl; Timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'); Note = $note
+        }
+        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Context $ctx
+        $commentPath = Join-Path $OutDir 'comment.md'
+        Set-Content -LiteralPath $commentPath -Value $comment -Encoding UTF8
+        Write-Log "comment.md written -> $commentPath" 'Green'
+
+        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; runner = $runner; context = $ctx }
+        $result | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutDir 'result.json') -Encoding UTF8
+
+        Write-Host "`n----- comment.md -----" -ForegroundColor DarkGray
+        Write-Host $comment
+    }
+    else {
+        # ---- Local single-tree mode ------------------------------------------
+        $aggs = [ordered]@{}
+        foreach ($key in $Apps) {
+            $meta = $AppRegistry[$key]
+            if (-not $SkipBuild) { Build-Harness -TreeRoot $Root -AppMeta $meta }
+            $exe = Resolve-HarnessExe -TreeRoot $Root -AppMeta $meta
+            if (-not $exe) { Write-Log "exe for $key not found — skipping" 'Yellow'; continue }
+            $runs = Measure-Sequential -Exe $exe -AppMeta $meta -Tag $key
+            $aggs[$key] = Measure-PerfRuns -Runs $runs
+        }
+
+        Write-Host ""
+        Write-Host "==== Perf results (median of $Reps, $Warmup warmup) ====" -ForegroundColor Green
+        $rows = foreach ($m in $script:PerfMetricSpec) {
+            $row = [ordered]@{ Metric = ("{0} {1}" -f $m.Label, $(if ($m.LowerIsBetter) { '(lower better)' } else { '(higher better)' })) }
+            foreach ($key in $aggs.Keys) { $row[$key] = Format-PerfNumber $aggs[$key].($m.Key) $m.Digits }
+            $row['Rust(ref)'] = Format-PerfNumber $script:RustReference.($m.Key) $m.Digits
+            [pscustomobject]$row
+        }
+        $rows | Format-Table -AutoSize | Out-String | Write-Host
+        Write-Host "Rust(ref): point-in-time windows-reactor snapshot (different machine) — indicative only." -ForegroundColor DarkGray
+
+        $result = [pscustomobject]@{ apps = $aggs; runner = $runner; rustReference = $script:RustReference }
+        $result | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutDir 'result.json') -Encoding UTF8
+        Write-Log "result.json written -> $(Join-Path $OutDir 'result.json')" 'Green'
+    }
+}
+finally {
+    if ($prevScheme) { try { & powercfg /setactive $prevScheme 2>$null | Out-Null; Write-Log "power plan restored -> $prevScheme" 'DarkGray' } catch {} }
+    try { Remove-MpPreference -ExclusionPath $Root -ErrorAction SilentlyContinue } catch {}
+}
+
+exit $exit

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -20,10 +20,15 @@
 
     Variance mitigations (we don't own CI runners): same-runner A/B, interleaved
     reps, warm-up discard, median of N, a noise band on the deltas (PerfLib),
-    High process priority, a high-performance power plan for the duration, and a
-    best-effort Defender exclusion on the output dir. Runner identity (CPU /
-    cores / RAM) is recorded in the comment so absolute numbers are interpreted
-    in context — trust the delta, not the absolutes.
+    High process priority, a high-performance power plan for the duration, and an
+    opt-in Defender exclusion (-DefenderExclude). Runner identity (CPU / cores /
+    RAM) is recorded in the comment so absolute numbers are interpreted in
+    context — trust the delta, not the absolutes.
+
+    The Rust `windows-reactor` cross-framework column is measured live when
+    -RustRepo points at a microsoft/windows-rs checkout (its `test_reactor_perf`
+    crate is a port of this harness with the same CLI + report). Without it, the
+    Rust column reads n/a.
 
 .PARAMETER Root
     Checkout to build + run (the PR head in compare mode). Defaults to the repo
@@ -58,12 +63,39 @@
 .PARAMETER SkipBuild
     Reuse existing binaries (skip dotnet build).
 
+.PARAMETER SelfContained
+    Build the harness self-contained (WindowsAppSDKSelfContained=true + the
+    matching win-x64 / win-arm64 RID) so no machine-wide Windows App SDK runtime
+    install is needed. Default $true. Disable with -SelfContained:$false.
+
+.PARAMETER Platform
+    Target architecture (x64 or ARM64). Defaults to the host's native
+    architecture, so an ARM64 box builds and runs the harness natively instead
+    of x64-under-emulation — emulated WinUI composition crashes with a stowed
+    exception (0xC000027B). GitHub-hosted runners are x64, so CI builds x64.
+
 .PARAMETER PinAffinity
     Pin each harness to a single CPU core (opt-in; can hurt on busy 2-core
     runners, off by default).
 
-.PARAMETER HeadSha / BaseSha / RunUrl
-    Context echoed into the comment footer (compare mode).
+.PARAMETER RustRepo
+    Path to a microsoft/windows-rs checkout. When set, the script builds + runs
+    its `test_reactor_perf` crate (cargo, release) and fills the Rust
+    cross-framework column with a live measurement. Omit to leave it n/a.
+
+.PARAMETER DefenderExclude
+    Opt in to a best-effort Microsoft Defender exclusion on -Root for the run
+    (restored on exit). Off by default; intended for ephemeral CI runners, not
+    developer machines.
+
+.PARAMETER HeadSha
+    PR head SHA echoed into the comment footer (compare mode).
+
+.PARAMETER BaseSha
+    Baseline (`main`) SHA echoed into the comment footer (compare mode).
+
+.PARAMETER RunUrl
+    Workflow run URL linked in the comment footer (compare mode).
 
 .EXAMPLE
     # Local: my four numbers + cross-framework reference
@@ -73,6 +105,10 @@
     # Local A/B vs a clean main worktree
     git worktree add ../main origin/main
     pwsh tests/stress_perf/ci/Run-PerfBenchmark.ps1 -BaselineRoot ../main -Reps 3
+
+.EXAMPLE
+    # Local A/B + a live Rust column from a windows-rs checkout
+    pwsh tests/stress_perf/ci/Run-PerfBenchmark.ps1 -BaselineRoot ../main -RustRepo ../windows-rs
 #>
 [CmdletBinding()]
 param(
@@ -87,7 +123,11 @@ param(
     [string]$OutDir,
     [switch]$SkipBuild,
     [bool]$SelfContained = $true,
+    [ValidateSet('x64', 'ARM64')]
+    [string]$Platform = $(if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'ARM64' } else { 'x64' }),
     [switch]$PinAffinity,
+    [string]$RustRepo = '',
+    [switch]$DefenderExclude,
     [string]$HeadSha = '',
     [string]$BaseSha = '',
     [string]$RunUrl = ''
@@ -128,10 +168,17 @@ function Get-RunnerInfo {
 function Resolve-HarnessExe {
     param([string]$TreeRoot, [hashtable]$AppMeta)
     $projDir = Split-Path (Join-Path $TreeRoot $AppMeta.ProjectRel)
-    $binRoot = Join-Path $projDir 'bin\x64\Release'
+    $binRoot = Join-Path $projDir "bin\$Platform\Release"
     if (-not (Test-Path $binRoot)) { return $null }
-    $exe = Get-ChildItem -Path $binRoot -Recurse -Filter ("{0}.exe" -f $AppMeta.AppName) -ErrorAction SilentlyContinue |
-        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    $candidates = @(Get-ChildItem -Path $binRoot -Recurse -Filter ("{0}.exe" -f $AppMeta.AppName) -ErrorAction SilentlyContinue)
+    if ($SelfContained) {
+        # Prefer the RID-specific (self-contained) output; a stale framework-dependent
+        # exe from an earlier build can otherwise win on LastWriteTime and fail to launch.
+        $ridDir = if ($Platform -eq 'ARM64') { 'win-arm64' } else { 'win-x64' }
+        $rid = @($candidates | Where-Object { $_.FullName -match "\\$ridDir\\" })
+        if ($rid.Count) { $candidates = $rid }
+    }
+    $exe = $candidates | Sort-Object LastWriteTime -Descending | Select-Object -First 1
     if ($exe) { return $exe.FullName }
     return $null
 }
@@ -142,7 +189,7 @@ function Build-Harness {
     if (-not (Test-Path $proj)) { throw "Project not found: $proj" }
     Write-Log "build $($AppMeta.AppName)  [$TreeRoot]" 'Cyan'
     $log = Join-Path $OutDir ("build-{0}-{1}.log" -f $AppMeta.AppName, ([IO.Path]::GetFileName($TreeRoot)))
-    $buildArgs = @($proj, '-c', 'Release', '-p:Platform=x64', '--nologo')
+    $buildArgs = @($proj, '-c', 'Release', "-p:Platform=$Platform", '--nologo')
     if ($SelfContained) { $buildArgs += '-p:PerfCiSelfContained=true' }
     & dotnet build @buildArgs 2>&1 | Tee-Object -FilePath $log | Out-Null
     if ($LASTEXITCODE -ne 0) {
@@ -151,9 +198,59 @@ function Build-Harness {
     }
 }
 
+function Build-RustHarness {
+    <# Build the windows-rs `test_reactor_perf` crate (release) for the Rust column.
+       Bounded by -TimeoutSec so a slow/stuck cargo build can never consume the
+       whole job or starve the C# comparison (the Rust leg is best-effort). #>
+    param([string]$RepoRoot, [int]$TimeoutSec = 1500)
+    Write-Log "build Rust test_reactor_perf  [$RepoRoot] (timeout ${TimeoutSec}s)" 'Cyan'
+    $log = Join-Path $OutDir 'build-rust.out.log'
+    $err = Join-Path $OutDir 'build-rust.err.log'
+    $p = Start-Process -FilePath 'cargo' -ArgumentList @('build', '--release', '-p', 'test_reactor_perf') `
+        -WorkingDirectory $RepoRoot -PassThru -NoNewWindow `
+        -RedirectStandardOutput $log -RedirectStandardError $err
+    if (-not $p.WaitForExit($TimeoutSec * 1000)) {
+        try { $p.Kill($true) } catch { try { $p.Kill() } catch {} }
+        throw "cargo build for test_reactor_perf exceeded ${TimeoutSec}s — aborted"
+    }
+    if ($p.ExitCode -ne 0) {
+        if (Test-Path $err) { Write-Host (Get-Content $err -Raw) -ForegroundColor DarkRed }
+        throw "cargo build failed for test_reactor_perf in $RepoRoot (exit=$($p.ExitCode); see $log / $err)"
+    }
+}
+
+function Resolve-RustExe {
+    param([string]$RepoRoot)
+    $exe = Join-Path $RepoRoot 'target\release\test_reactor_perf.exe'
+    if (Test-Path $exe) { return (Resolve-Path $exe).Path }
+    return $null
+}
+
+function Invoke-RustLeg {
+    <# Build + run the windows-rs `test_reactor_perf` crate for the Rust column.
+       Best-effort: any failure logs a warning and yields $null (column reads n/a). #>
+    if (-not $RustRepo) { return $null }
+    if (-not (Test-Path $RustRepo)) { Write-Log "RustRepo '$RustRepo' not found — Rust column n/a" 'Yellow'; return $null }
+    try {
+        if (-not $SkipBuild) { Build-RustHarness -RepoRoot $RustRepo }
+        $rustExe = Resolve-RustExe -RepoRoot $RustRepo
+        if (-not $rustExe) { Write-Log "test_reactor_perf.exe not found after build — Rust column n/a" 'Yellow'; return $null }
+        Write-Log "Rust windows-reactor (test_reactor_perf)" 'Green'
+        # The Rust port writes StressPerf.Reactor.report.txt next to its exe and has
+        # no --json mode, so run with -NoJson and read the report.
+        $rustRuns = Measure-Sequential -Exe $rustExe -AppMeta @{ AppName = 'StressPerf.Reactor' } -Tag 'rust' -NoJson
+        if ($rustRuns.Count) { return Measure-PerfRuns -Runs $rustRuns }
+        Write-Log "Rust harness produced no metrics — Rust column n/a" 'Yellow'
+        return $null
+    } catch {
+        Write-Log "Rust leg failed ($($_.Exception.Message)) — Rust column n/a" 'Yellow'
+        return $null
+    }
+}
+
 function Invoke-OneRun {
     <# Run the harness once; return a metric object (Read-HarnessMetrics) or $null. #>
-    param([string]$Exe, [hashtable]$AppMeta, [int]$Index, [string]$Tag)
+    param([string]$Exe, [hashtable]$AppMeta, [int]$Index, [string]$Tag, [switch]$NoJson)
 
     $exeDir = Split-Path $Exe
     foreach ($ext in 'metrics.json', 'report.txt', 'samples.csv') {
@@ -164,7 +261,9 @@ function Invoke-OneRun {
     $stdout = Join-Path $OutDir ("run-{0}-{1}-{2}.out.log" -f $AppMeta.AppName, $Tag, $Index)
     $stderr = Join-Path $OutDir ("run-{0}-{1}-{2}.err.log" -f $AppMeta.AppName, $Tag, $Index)
     $inv = [System.Globalization.CultureInfo]::InvariantCulture
-    $harnessArgs = @('--headless', '--percent', $Percent.ToString($inv), '--duration', $Duration.ToString($inv), '--json')
+    # The Rust port has no --json mode; it always writes report.txt. C# harnesses get --json.
+    $harnessArgs = @('--headless', '--percent', $Percent.ToString($inv), '--duration', $Duration.ToString($inv))
+    if (-not $NoJson) { $harnessArgs += '--json' }
     $timeoutSec = $Duration + 90
 
     Write-Log ("  run [{0} #{1}] {2} --percent {3} --duration {4}" -f $Tag, $Index, $AppMeta.AppName, $Percent, $Duration)
@@ -172,7 +271,7 @@ function Invoke-OneRun {
         -RedirectStandardOutput $stdout -RedirectStandardError $stderr -WindowStyle Hidden
     try {
         $proc.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::High
-        if ($PinAffinity) { $proc.ProcessorAffinity = [IntPtr]([int]($Index % [Environment]::ProcessorCount) -bor 1) }
+        if ($PinAffinity) { $proc.ProcessorAffinity = [IntPtr]([int64]1 -shl (($Index - 1) % [Environment]::ProcessorCount)) }
     } catch {}
 
     if (-not $proc.WaitForExit($timeoutSec * 1000)) {
@@ -194,10 +293,10 @@ function Invoke-OneRun {
 }
 
 function Measure-Sequential {
-    param([string]$Exe, [hashtable]$AppMeta, [string]$Tag)
+    param([string]$Exe, [hashtable]$AppMeta, [string]$Tag, [switch]$NoJson)
     $runs = @()
     for ($i = 1; $i -le ($Warmup + $Reps); $i++) {
-        $m = Invoke-OneRun -Exe $Exe -AppMeta $AppMeta -Index $i -Tag $Tag
+        $m = Invoke-OneRun -Exe $Exe -AppMeta $AppMeta -Index $i -Tag $Tag -NoJson:$NoJson
         if ($i -le $Warmup) { Write-Log "  (warmup #$i discarded)" 'DarkGray'; continue }
         if ($m) { $runs += $m }
     }
@@ -212,11 +311,14 @@ try {
     & powercfg /setactive SCHEME_MIN 2>$null | Out-Null   # High performance
     Write-Log "power plan -> High performance (was $prevScheme)" 'DarkGray'
 } catch { Write-Log "power plan unchanged ($_)" 'DarkGray' }
-try { Add-MpPreference -ExclusionPath $Root -ErrorAction Stop; Write-Log "Defender exclusion added for $Root" 'DarkGray' } catch {}
+if ($DefenderExclude) {
+    try { Add-MpPreference -ExclusionPath $Root -ErrorAction Stop; Write-Log "Defender exclusion added for $Root" 'DarkGray' }
+    catch { Write-Log "Defender exclusion skipped ($_)" 'DarkGray' }
+}
 
 $runner = Get-RunnerInfo
 Write-Log ("runner: {0} | {1} cores | {2} GB | {3}" -f $runner.Cpu, $runner.Cores, $runner.MemoryGB, ($runner.Runner ?? 'local')) 'Cyan'
-Write-Log ("mode: {0} | percent={1} duration={2} reps={3} warmup={4}" -f ($(if ($Compare) { 'COMPARE' } else { 'LOCAL' })), $Percent, $Duration, $Reps, $Warmup) 'Cyan'
+Write-Log ("mode: {0} | platform={1} | percent={2} duration={3} reps={4} warmup={5}" -f ($(if ($Compare) { 'COMPARE' } else { 'LOCAL' })), $Platform, $Percent, $Duration, $Reps, $Warmup) 'Cyan'
 
 $exit = 0
 try {
@@ -254,6 +356,8 @@ try {
             Write-Log "StressPerf.Direct exe not found — WinUI3 column will read n/a" 'Yellow'
         }
 
+        $rust = Invoke-RustLeg
+
         $main = Measure-PerfRuns -Runs $mainRuns
         $pr = Measure-PerfRuns -Runs $prRuns
         $winui3 = if ($winRuns.Count) { Measure-PerfRuns -Runs $winRuns } else { $null }
@@ -263,20 +367,31 @@ try {
             $note = 'One or both of the main/PR ReactorOptimized runs produced no metrics — the harness may have failed to open a window on this runner. See the workflow run log and the uploaded ``perf-logs`` artifact.'
             $exit = 1
         }
+        else {
+            $short = @()
+            if ($mainRuns.Count -lt $Reps) { $short += "main $($mainRuns.Count)/$Reps" }
+            if ($prRuns.Count -lt $Reps) { $short += "PR $($prRuns.Count)/$Reps" }
+            if ($short.Count) {
+                $note = "Some measured runs produced no metrics ($($short -join ', ')); the reported median uses fewer than $Reps samples, so treat the delta with extra caution. See the uploaded ``perf-logs`` artifact."
+                $exit = 1
+            }
+        }
 
         $ctx = @{
             Percent = $Percent; Duration = $Duration; Reps = $Reps; Warmup = $Warmup
-            BaseSha = (if ($BaseSha) { $BaseSha.Substring(0, [Math]::Min(7, $BaseSha.Length)) } else { '' })
-            HeadSha = (if ($HeadSha) { $HeadSha.Substring(0, [Math]::Min(7, $HeadSha.Length)) } else { '' })
+            Platform = $Platform
+            MainSamples = $mainRuns.Count; PrSamples = $prRuns.Count
+            BaseSha = $(if ($BaseSha) { $BaseSha.Substring(0, [Math]::Min(7, $BaseSha.Length)) } else { '' })
+            HeadSha = $(if ($HeadSha) { $HeadSha.Substring(0, [Math]::Min(7, $HeadSha.Length)) } else { '' })
             Runner = $runner.Runner; Cpu = $runner.Cpu; Cores = $runner.Cores; MemoryGB = $runner.MemoryGB
             RunUrl = $RunUrl; Timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'); Note = $note
         }
-        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Context $ctx
+        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Rust $rust -Context $ctx
         $commentPath = Join-Path $OutDir 'comment.md'
         Set-Content -LiteralPath $commentPath -Value $comment -Encoding UTF8
         Write-Log "comment.md written -> $commentPath" 'Green'
 
-        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; runner = $runner; context = $ctx }
+        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; rust = $rust; runner = $runner; context = $ctx }
         $result | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutDir 'result.json') -Encoding UTF8
 
         Write-Host "`n----- comment.md -----" -ForegroundColor DarkGray
@@ -294,25 +409,28 @@ try {
             $aggs[$key] = Measure-PerfRuns -Runs $runs
         }
 
+        $rust = Invoke-RustLeg
+        if ($rust) { $aggs['Rust'] = $rust }
+
         Write-Host ""
-        Write-Host "==== Perf results (median of $Reps, $Warmup warmup) ====" -ForegroundColor Green
+        Write-Host "==== Perf results ($Platform, median of $Reps, $Warmup warmup) ====" -ForegroundColor Green
         $rows = foreach ($m in $script:PerfMetricSpec) {
             $row = [ordered]@{ Metric = ("{0} {1}" -f $m.Label, $(if ($m.LowerIsBetter) { '(lower better)' } else { '(higher better)' })) }
             foreach ($key in $aggs.Keys) { $row[$key] = Format-PerfNumber $aggs[$key].($m.Key) $m.Digits }
-            $row['Rust(ref)'] = Format-PerfNumber $script:RustReference.($m.Key) $m.Digits
             [pscustomobject]$row
         }
         $rows | Format-Table -AutoSize | Out-String | Write-Host
-        Write-Host "Rust(ref): point-in-time windows-reactor snapshot (different machine) — indicative only." -ForegroundColor DarkGray
+        if ($RustRepo -and -not $rust) { Write-Host "Rust column n/a — see warnings above." -ForegroundColor DarkGray }
+        elseif (-not $RustRepo) { Write-Host "Tip: pass -RustRepo <windows-rs checkout> to add a live Rust column." -ForegroundColor DarkGray }
 
-        $result = [pscustomobject]@{ apps = $aggs; runner = $runner; rustReference = $script:RustReference }
+        $result = [pscustomobject]@{ apps = $aggs; runner = $runner }
         $result | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutDir 'result.json') -Encoding UTF8
         Write-Log "result.json written -> $(Join-Path $OutDir 'result.json')" 'Green'
     }
 }
 finally {
     if ($prevScheme) { try { & powercfg /setactive $prevScheme 2>$null | Out-Null; Write-Log "power plan restored -> $prevScheme" 'DarkGray' } catch {} }
-    try { Remove-MpPreference -ExclusionPath $Root -ErrorAction SilentlyContinue } catch {}
+    if ($DefenderExclude) { try { Remove-MpPreference -ExclusionPath $Root -ErrorAction SilentlyContinue } catch {} }
 }
 
 exit $exit


### PR DESCRIPTION
Closes #661

> [!IMPORTANT]
> **Review/merge this FIRST.** It's the linchpin for the in-flight fleet of perf PRs. Because the trigger is `issue_comment` (which always runs from the **default branch**), once this is on `main` the `/perf` command works on **every already-open PR with no rebase**.

## What this adds

Comment **`/perf`** on a PR → a `windows-latest` job builds the `StressPerf.ReactorOptimized` StocksGrid harness on the **PR head** and on **`main`**, runs them **interleaved on the same runner**, and posts a sticky comparison comment (updated in place on re-runs via a hidden marker).

### The four metrics (x64 Release)

| Metric | Direction |
|---|:--:|
| **Renders/sec** | higher is better ↑ |
| **Avg Reconcile (ms)** | lower is better ↓ |
| **Avg Diff (ms)** | lower is better ↓ |
| **Avg Memory (MB)** | lower is better ↓ |

The comment has two tables: **Regression vs `main`** (signed Δ%, ✅ improvement / ⚠️ regression / ≈ within-noise) and a **Cross-framework reference** (vanilla WinUI3 measured live + a static Rust `windows-reactor` snapshot + this PR).

## Usage

- **`/perf`** on a PR (must be OWNER / MEMBER / COLLABORATOR — the job has a write token and builds PR code, so triggering is gated by `author_association`; the perf scripts and the `main` baseline always come from the trusted default branch).
- Manual: **Actions ▸ Perf comparison ▸ Run workflow ▸ `pr_number`**.
- **Locally** (before you push): `pwsh tests/stress_perf/ci/Run-PerfBenchmark.ps1` for your numbers, or A/B against a clean `main` worktree — see [`tests/stress_perf/ci/README.md`](tests/stress_perf/ci/README.md). There's also a **`perf-compare` Copilot skill** that drives it.

## Files

- **`.github/workflows/perf-compare.yml`** — the `/perf` workflow (`issue_comment` + `workflow_dispatch`). `contents: read`, `pull-requests: write`, `issues: write`. Heavily logged, `continue-on-error` on the bench step so a flaky run still posts a comment, artifact upload of all logs.
- **`tests/stress_perf/ci/PerfLib.ps1`** — pure parse/median/spread/direction-aware-delta/comment-render helpers (no WinUI dependency, locally testable).
- **`tests/stress_perf/ci/Run-PerfBenchmark.ps1`** — orchestrator used by both the workflow and humans (local single-tree mode + CI compare mode).
- **`tests/stress_perf/ci/README.md`** — local-run docs + metric semantics + variance notes.
- **`.github/skills/perf-compare/SKILL.md`** (+ skills README row) — Copilot skill mirroring `pr-review`.
- **Harness `--json`** (`CliOptions.cs`, `PerfTracker.cs`, `ReactorOptimized/Program.cs`) — opt-in machine-readable `{App}.metrics.json` + a `REACTOR_PERF_JSON` echo. Parser falls back to `report.txt`, so PR heads predating this still work.
- **`StressPerf.*.csproj`** — gated `PerfCiSelfContained` property → self-contained build (bundled WinApp runtime, **no machine-wide install on the runner**, the same trick the selftests use). Scoped so it never flows into the referenced class libraries.
- **`StressPerf.Direct/MainWindow.cs`** — wrap the `C:\temp` phase-log append in `try/catch` so it can't crash the WinUI3 baseline on a runner without `C:\temp`.

## Reducing runner variability (we don't own the runners)

Same-runner interleaved A/B (machine-class differences cancel), warmup discard + median-of-N, a direction-aware noise band (`|Δ|` below max(run-to-run spread, 4% floor) = "within noise"), High process priority + a high-performance power plan, and runner identity recorded in the comment. **Trust the Δ vs `main`, not the absolute numbers.**

## Validation

- ✅ `actionlint` clean on the workflow; YAML structure verified.
- ✅ `PerfLib.ps1` parser/renderer validated against constructed harness outputs (json + report.txt fallback paths, direction-aware deltas, noise band).
- ✅ The **exact CI build path** — `dotnet build … -c Release -p:Platform=x64 -p:PerfCiSelfContained=true` for both `StressPerf.ReactorOptimized` and `StressPerf.Direct` — builds **green (0 errors)**.

> [!NOTE]
> **Build caveat (does not affect CI).** The harness opens a real WinUI window. I verified the build and parser, but could not run the harness end-to-end on this dev box: it's **ARM64** and can't composite XAML (`0xC000027B` after `MountAndActivate ok`). `windows-latest` runners (x64) composite fine — the selftest/E2E jobs prove it — so the benchmark runs there. Likewise, a full `dotnet build Reactor.slnx -c Release` on this ARM64 box fails only in 4 **unrelated** XAML-markup projects (`InteractivePool.*`, `StructuralSharing.*`) due to a `XamlCompiler.exe` ARM64-emulation flake — those reference none of my changes, and the solution builds on x64 CI. The workflow is defensive: build/launch/parse failures post a clear comment and upload a `perf-logs` artifact rather than failing silently.