### PR TITLE
perf: cache hook delegates + drop per-render hook allocations

### DIFF
--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -857,6 +857,9 @@ RenderContext.UseAnnounce() → AnnounceHandle
 RenderContext.UseBreakpoint(Window window, double minWidth) → bool
 RenderContext.UseBreakpoint(double minWidth) → bool
 RenderContext.UseCallback(Action callback, object[] dependencies) → Action
+RenderContext.UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3) → Action
+RenderContext.UseCallback<T1, T2>(Action callback, T1 d1, T2 d2) → Action
+RenderContext.UseCallback<T1>(Action callback, T1 d1) → Action
 RenderContext.UseChildValidationContext() → ValueTuple<ValidationContext, ValidationContext>
 RenderContext.UseClosingGuard(Func<bool> canClose) → void
 RenderContext.UseCollection<T>(ObservableCollection<T> collection) → IReadOnlyList<T>
@@ -875,6 +878,12 @@ RenderContext.UseDockState() → DockPaneState
 RenderContext.UseDpi() → UInt32
 RenderContext.UseEffect(Action effect, object[] dependencies) → void
 RenderContext.UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
+RenderContext.UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void
+RenderContext.UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3) → void
+RenderContext.UseEffect<T1, T2>(Action effect, T1 d1, T2 d2) → void
+RenderContext.UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2) → void
+RenderContext.UseEffect<T1>(Action effect, T1 d1) → void
+RenderContext.UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1) → void
 RenderContext.UseElementFocus(FocusState state = FocusState.Programmatic) → ValueTuple<ElementRef, Action>
 RenderContext.UseElementRef<T>() → ElementRef<T>
 RenderContext.UseFilePickerAsync(FilePickerOptions options) → Task<StorageFile>
@@ -890,6 +899,9 @@ RenderContext.UseIsActive() → bool
 RenderContext.UseIsActivePane() → bool
 RenderContext.UseIsCovered() → bool
 RenderContext.UseIsDarkTheme() → bool
+RenderContext.UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3) → T
+RenderContext.UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2) → T
+RenderContext.UseMemo<T, T1>(Func<T> factory, T1 d1) → T
 RenderContext.UseMemo<T>(Func<T> factory, object[] dependencies) → T
 RenderContext.UseMemoCells<T>(IReadOnlyList<T> items, Func<T, int, Element> builder, object[] dependencies) → Element[]
 RenderContext.UseMemoCellsByIndex<T>(IReadOnlyList<T> items, IReadOnlyList<int> changedIndices, Func<T, int, Element> builder, object[] dependencies) → Element[]
@@ -5700,6 +5712,9 @@ new()
 UseBreakpoint(Window window, double minWidth) → bool
 UseBreakpoint(double minWidth) → bool
 UseCallback(Action callback, object[] dependencies) → Action
+UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3) → Action
+UseCallback<T1, T2>(Action callback, T1 d1, T2 d2) → Action
+UseCallback<T1>(Action callback, T1 d1) → Action
 UseClosingGuard(Func<bool> canClose) → void
 UseCollection<T>(ObservableCollection<T> collection) → IReadOnlyList<T>
 UseColorScheme() → ColorScheme
@@ -5710,6 +5725,12 @@ UseDisplays() → IReadOnlyList<DisplayInfo>
 UseDpi() → UInt32
 UseEffect(Action effect, object[] dependencies) → void
 UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
+UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void
+UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3) → void
+UseEffect<T1, T2>(Action effect, T1 d1, T2 d2) → void
+UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2) → void
+UseEffect<T1>(Action effect, T1 d1) → void
+UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1) → void
 UseFilePickerAsync(FilePickerOptions options) → Task<StorageFile>
 UseFolderPickerAsync(FolderPickerOptions options) → Task<StorageFolder>
 UseHighContrast() → bool
@@ -5718,6 +5739,9 @@ UseIntl() → IntlAccessor
 UseIsActive() → bool
 UseIsCovered() → bool
 UseIsDarkTheme() → bool
+UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3) → T
+UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2) → T
+UseMemo<T, T1>(Func<T> factory, T1 d1) → T
 UseMemo<T>(Func<T> factory, object[] dependencies) → T
 UseNavigation<TRoute>() → NavigationHandle<TRoute>
 UseNavigation<TRoute>(TRoute initial) → NavigationHandle<TRoute>

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -857,6 +857,9 @@ RenderContext.UseAnnounce() → AnnounceHandle
 RenderContext.UseBreakpoint(Window window, double minWidth) → bool
 RenderContext.UseBreakpoint(double minWidth) → bool
 RenderContext.UseCallback(Action callback, object[] dependencies) → Action
+RenderContext.UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3) → Action
+RenderContext.UseCallback<T1, T2>(Action callback, T1 d1, T2 d2) → Action
+RenderContext.UseCallback<T1>(Action callback, T1 d1) → Action
 RenderContext.UseChildValidationContext() → ValueTuple<ValidationContext, ValidationContext>
 RenderContext.UseClosingGuard(Func<bool> canClose) → void
 RenderContext.UseCollection<T>(ObservableCollection<T> collection) → IReadOnlyList<T>
@@ -875,6 +878,12 @@ RenderContext.UseDockState() → DockPaneState
 RenderContext.UseDpi() → UInt32
 RenderContext.UseEffect(Action effect, object[] dependencies) → void
 RenderContext.UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
+RenderContext.UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void
+RenderContext.UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3) → void
+RenderContext.UseEffect<T1, T2>(Action effect, T1 d1, T2 d2) → void
+RenderContext.UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2) → void
+RenderContext.UseEffect<T1>(Action effect, T1 d1) → void
+RenderContext.UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1) → void
 RenderContext.UseElementFocus(FocusState state = FocusState.Programmatic) → ValueTuple<ElementRef, Action>
 RenderContext.UseElementRef<T>() → ElementRef<T>
 RenderContext.UseFilePickerAsync(FilePickerOptions options) → Task<StorageFile>
@@ -890,6 +899,9 @@ RenderContext.UseIsActive() → bool
 RenderContext.UseIsActivePane() → bool
 RenderContext.UseIsCovered() → bool
 RenderContext.UseIsDarkTheme() → bool
+RenderContext.UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3) → T
+RenderContext.UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2) → T
+RenderContext.UseMemo<T, T1>(Func<T> factory, T1 d1) → T
 RenderContext.UseMemo<T>(Func<T> factory, object[] dependencies) → T
 RenderContext.UseMemoCells<T>(IReadOnlyList<T> items, Func<T, int, Element> builder, object[] dependencies) → Element[]
 RenderContext.UseMemoCellsByIndex<T>(IReadOnlyList<T> items, IReadOnlyList<int> changedIndices, Func<T, int, Element> builder, object[] dependencies) → Element[]
@@ -5700,6 +5712,9 @@ new()
 UseBreakpoint(Window window, double minWidth) → bool
 UseBreakpoint(double minWidth) → bool
 UseCallback(Action callback, object[] dependencies) → Action
+UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3) → Action
+UseCallback<T1, T2>(Action callback, T1 d1, T2 d2) → Action
+UseCallback<T1>(Action callback, T1 d1) → Action
 UseClosingGuard(Func<bool> canClose) → void
 UseCollection<T>(ObservableCollection<T> collection) → IReadOnlyList<T>
 UseColorScheme() → ColorScheme
@@ -5710,6 +5725,12 @@ UseDisplays() → IReadOnlyList<DisplayInfo>
 UseDpi() → UInt32
 UseEffect(Action effect, object[] dependencies) → void
 UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
+UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void
+UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3) → void
+UseEffect<T1, T2>(Action effect, T1 d1, T2 d2) → void
+UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2) → void
+UseEffect<T1>(Action effect, T1 d1) → void
+UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1) → void
 UseFilePickerAsync(FilePickerOptions options) → Task<StorageFile>
 UseFolderPickerAsync(FolderPickerOptions options) → Task<StorageFolder>
 UseHighContrast() → bool
@@ -5718,6 +5739,9 @@ UseIntl() → IntlAccessor
 UseIsActive() → bool
 UseIsCovered() → bool
 UseIsDarkTheme() → bool
+UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3) → T
+UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2) → T
+UseMemo<T, T1>(Func<T> factory, T1 d1) → T
 UseMemo<T>(Func<T> factory, object[] dependencies) → T
 UseNavigation<TRoute>() → NavigationHandle<TRoute>
 UseNavigation<TRoute>(TRoute initial) → NavigationHandle<TRoute>

--- a/src/Reactor/Core/PanelAttachedHooks.cs
+++ b/src/Reactor/Core/PanelAttachedHooks.cs
@@ -144,7 +144,10 @@ public partial record RelativePanelElement
         }
         else
         {
-            nameMap = _nameMapPool ??= new Dictionary<string, UIElement>(global::System.StringComparer.Ordinal);
+            // Seed capacity on first creation to match the non-pool path above and keep
+            // the first reconcile resize-free; Clear() retains capacity, so later passes
+            // reuse it (the high-water mark) without re-seeding.
+            nameMap = _nameMapPool ??= new Dictionary<string, UIElement>(pairs.Count, global::System.StringComparer.Ordinal);
             nameMap.Clear();
             _nameMapInUse = true;
             usingPool = true;

--- a/src/Reactor/Core/PanelAttachedHooks.cs
+++ b/src/Reactor/Core/PanelAttachedHooks.cs
@@ -121,58 +121,93 @@ public partial record WrapGridElement
 
 public partial record RelativePanelElement
 {
+    // #60: reconcile can run very frequently for panels with many children; the
+    // name→control map was allocated fresh on every pass. Pool it per-thread and
+    // clear-and-reuse instead. RelativePanels can nest, so reconcile may re-enter
+    // on the same thread mid-build — the reentrancy guard hands nested calls a
+    // private instance and leaves the pooled one untouched.
+    [global::System.ThreadStatic] private static Dictionary<string, UIElement>? _nameMapPool;
+    [global::System.ThreadStatic] private static bool _nameMapInUse;
+
     // Two-pass: build a name → control map across siblings, then write the
     // RelativePanel sibling-referencing + panel-alignment attached DPs.
     private static void ApplyRelativePanelAttachedProps(
         WinUI.RelativePanel panel,
         IReadOnlyList<(UIElement Mounted, Element ChildElement)> pairs)
     {
-        var nameMap = new Dictionary<string, UIElement>(pairs.Count, global::System.StringComparer.Ordinal);
-        for (int i = 0; i < pairs.Count; i++)
+        Dictionary<string, UIElement> nameMap;
+        bool usingPool;
+        if (_nameMapInUse)
         {
-            var (mounted, child) = pairs[i];
-            ClearRelativePanelAttached(mounted);
-
-            var rpa = child.GetAttached<RelativePanelAttached>();
-            if (mounted is FrameworkElement fe)
-                fe.Name = rpa?.Name ?? string.Empty;
-            if (rpa is not null)
-                nameMap[rpa.Name] = mounted;
+            nameMap = new Dictionary<string, UIElement>(pairs.Count, global::System.StringComparer.Ordinal);
+            usingPool = false;
+        }
+        else
+        {
+            nameMap = _nameMapPool ??= new Dictionary<string, UIElement>(global::System.StringComparer.Ordinal);
+            nameMap.Clear();
+            _nameMapInUse = true;
+            usingPool = true;
         }
 
-        for (int i = 0; i < pairs.Count; i++)
+        try
         {
-            var (mounted, child) = pairs[i];
-            var rpa = child.GetAttached<RelativePanelAttached>();
-            if (rpa is null) continue;
+            for (int i = 0; i < pairs.Count; i++)
+            {
+                var (mounted, child) = pairs[i];
+                ClearRelativePanelAttached(mounted);
 
-            if (rpa.RightOf is not null && nameMap.TryGetValue(rpa.RightOf, out var rightOf))
-                WinUI.RelativePanel.SetRightOf(mounted, rightOf);
-            if (rpa.Below is not null && nameMap.TryGetValue(rpa.Below, out var below))
-                WinUI.RelativePanel.SetBelow(mounted, below);
-            if (rpa.LeftOf is not null && nameMap.TryGetValue(rpa.LeftOf, out var leftOf))
-                WinUI.RelativePanel.SetLeftOf(mounted, leftOf);
-            if (rpa.Above is not null && nameMap.TryGetValue(rpa.Above, out var above))
-                WinUI.RelativePanel.SetAbove(mounted, above);
-            if (rpa.AlignLeftWith is not null && nameMap.TryGetValue(rpa.AlignLeftWith, out var alw))
-                WinUI.RelativePanel.SetAlignLeftWith(mounted, alw);
-            if (rpa.AlignRightWith is not null && nameMap.TryGetValue(rpa.AlignRightWith, out var arw))
-                WinUI.RelativePanel.SetAlignRightWith(mounted, arw);
-            if (rpa.AlignTopWith is not null && nameMap.TryGetValue(rpa.AlignTopWith, out var atw))
-                WinUI.RelativePanel.SetAlignTopWith(mounted, atw);
-            if (rpa.AlignBottomWith is not null && nameMap.TryGetValue(rpa.AlignBottomWith, out var abw))
-                WinUI.RelativePanel.SetAlignBottomWith(mounted, abw);
-            if (rpa.AlignHorizontalCenterWith is not null && nameMap.TryGetValue(rpa.AlignHorizontalCenterWith, out var ahcw))
-                WinUI.RelativePanel.SetAlignHorizontalCenterWith(mounted, ahcw);
-            if (rpa.AlignVerticalCenterWith is not null && nameMap.TryGetValue(rpa.AlignVerticalCenterWith, out var avcw))
-                WinUI.RelativePanel.SetAlignVerticalCenterWith(mounted, avcw);
+                var rpa = child.GetAttached<RelativePanelAttached>();
+                if (mounted is FrameworkElement fe)
+                    fe.Name = rpa?.Name ?? string.Empty;
+                if (rpa is not null)
+                    nameMap[rpa.Name] = mounted;
+            }
 
-            WinUI.RelativePanel.SetAlignLeftWithPanel(mounted, rpa.AlignLeftWithPanel);
-            WinUI.RelativePanel.SetAlignRightWithPanel(mounted, rpa.AlignRightWithPanel);
-            WinUI.RelativePanel.SetAlignTopWithPanel(mounted, rpa.AlignTopWithPanel);
-            WinUI.RelativePanel.SetAlignBottomWithPanel(mounted, rpa.AlignBottomWithPanel);
-            WinUI.RelativePanel.SetAlignHorizontalCenterWithPanel(mounted, rpa.AlignHorizontalCenterWithPanel);
-            WinUI.RelativePanel.SetAlignVerticalCenterWithPanel(mounted, rpa.AlignVerticalCenterWithPanel);
+            for (int i = 0; i < pairs.Count; i++)
+            {
+                var (mounted, child) = pairs[i];
+                var rpa = child.GetAttached<RelativePanelAttached>();
+                if (rpa is null) continue;
+
+                if (rpa.RightOf is not null && nameMap.TryGetValue(rpa.RightOf, out var rightOf))
+                    WinUI.RelativePanel.SetRightOf(mounted, rightOf);
+                if (rpa.Below is not null && nameMap.TryGetValue(rpa.Below, out var below))
+                    WinUI.RelativePanel.SetBelow(mounted, below);
+                if (rpa.LeftOf is not null && nameMap.TryGetValue(rpa.LeftOf, out var leftOf))
+                    WinUI.RelativePanel.SetLeftOf(mounted, leftOf);
+                if (rpa.Above is not null && nameMap.TryGetValue(rpa.Above, out var above))
+                    WinUI.RelativePanel.SetAbove(mounted, above);
+                if (rpa.AlignLeftWith is not null && nameMap.TryGetValue(rpa.AlignLeftWith, out var alw))
+                    WinUI.RelativePanel.SetAlignLeftWith(mounted, alw);
+                if (rpa.AlignRightWith is not null && nameMap.TryGetValue(rpa.AlignRightWith, out var arw))
+                    WinUI.RelativePanel.SetAlignRightWith(mounted, arw);
+                if (rpa.AlignTopWith is not null && nameMap.TryGetValue(rpa.AlignTopWith, out var atw))
+                    WinUI.RelativePanel.SetAlignTopWith(mounted, atw);
+                if (rpa.AlignBottomWith is not null && nameMap.TryGetValue(rpa.AlignBottomWith, out var abw))
+                    WinUI.RelativePanel.SetAlignBottomWith(mounted, abw);
+                if (rpa.AlignHorizontalCenterWith is not null && nameMap.TryGetValue(rpa.AlignHorizontalCenterWith, out var ahcw))
+                    WinUI.RelativePanel.SetAlignHorizontalCenterWith(mounted, ahcw);
+                if (rpa.AlignVerticalCenterWith is not null && nameMap.TryGetValue(rpa.AlignVerticalCenterWith, out var avcw))
+                    WinUI.RelativePanel.SetAlignVerticalCenterWith(mounted, avcw);
+
+                WinUI.RelativePanel.SetAlignLeftWithPanel(mounted, rpa.AlignLeftWithPanel);
+                WinUI.RelativePanel.SetAlignRightWithPanel(mounted, rpa.AlignRightWithPanel);
+                WinUI.RelativePanel.SetAlignTopWithPanel(mounted, rpa.AlignTopWithPanel);
+                WinUI.RelativePanel.SetAlignBottomWithPanel(mounted, rpa.AlignBottomWithPanel);
+                WinUI.RelativePanel.SetAlignHorizontalCenterWithPanel(mounted, rpa.AlignHorizontalCenterWithPanel);
+                WinUI.RelativePanel.SetAlignVerticalCenterWithPanel(mounted, rpa.AlignVerticalCenterWithPanel);
+            }
+        }
+        finally
+        {
+            if (usingPool)
+            {
+                // Drop UIElement references promptly so the pooled map doesn't pin
+                // mounted controls alive between reconciles.
+                nameMap.Clear();
+                _nameMapInUse = false;
+            }
         }
     }
 

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -376,13 +376,20 @@ public sealed class RenderContext
     /// with one dependency: the effect re-runs only when <paramref name="d1"/>
     /// changes.
     /// </summary>
+    /// <remarks>
+    /// If <paramref name="d1"/>'s compile-time type is an array of reference types
+    /// (e.g. <c>string[]</c>), it is treated as a dependency <em>list</em> and compared
+    /// element-wise — matching the <c>params object[]</c> overload — not as a single
+    /// reference-compared value. A dependency whose static type is not an array is
+    /// always compared as one value, even if its runtime value happens to be an array.
+    /// </remarks>
     public void UseEffect<T1>(Action effect, T1 d1)
     {
         var hook = AcquireEffectSlot();
-        // A lone dependency that is itself an object[] at runtime (e.g. a covariant
-        // string[]) bound to the params overload before this generic existed and was
-        // compared element-wise — preserve that so an array re-allocated each render
-        // with equal contents does not spuriously re-run the effect.
+        // A lone dependency whose compile-time type is a reference-type array (e.g. a
+        // covariant string[]) binds this generic but historically went through the
+        // params overload and was compared element-wise — preserve that so an array
+        // re-allocated each render with equal contents does not spuriously re-run.
         if (AsParamsArrayDep(d1) is { } arr)
         {
             if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
@@ -419,6 +426,13 @@ public sealed class RenderContext
     /// <c>params object[]</c> allocation on the deps-unchanged path. Semantically
     /// identical to the params overload called with one dependency.
     /// </summary>
+    /// <remarks>
+    /// If <paramref name="d1"/>'s compile-time type is an array of reference types
+    /// (e.g. <c>string[]</c>), it is treated as a dependency <em>list</em> and compared
+    /// element-wise — matching the <c>params object[]</c> overload — not as a single
+    /// reference-compared value. A dependency whose static type is not an array is
+    /// always compared as one value, even if its runtime value happens to be an array.
+    /// </remarks>
     public void UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1)
     {
         var hook = AcquireEffectSlot();
@@ -502,10 +516,17 @@ public sealed class RenderContext
     /// <c>params object[]</c> allocation (and value-type boxing) on the
     /// deps-unchanged path. Recomputes only when <paramref name="d1"/> changes.
     /// </summary>
+    /// <remarks>
+    /// If <paramref name="d1"/>'s compile-time type is an array of reference types
+    /// (e.g. <c>string[]</c>), it is treated as a dependency <em>list</em> and compared
+    /// element-wise — matching the <c>params object[]</c> overload — not as a single
+    /// reference-compared value. A dependency whose static type is not an array is
+    /// always compared as one value, even if its runtime value happens to be an array.
+    /// </remarks>
     public T UseMemo<T, T1>(Func<T> factory, T1 d1)
     {
         var hook = AcquireMemoSlot<T>();
-        // See UseEffect<T1>: a lone object[]-typed dep keeps element-wise semantics.
+        // See UseEffect<T1>: a compile-time array dep keeps element-wise semantics.
         if (AsParamsArrayDep(d1) is { } arr)
         {
             if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
@@ -578,10 +599,17 @@ public sealed class RenderContext
     /// deps-unchanged path. Returns a stable reference until <paramref name="d1"/>
     /// changes.
     /// </summary>
+    /// <remarks>
+    /// If <paramref name="d1"/>'s compile-time type is an array of reference types
+    /// (e.g. <c>string[]</c>), it is treated as a dependency <em>list</em> and compared
+    /// element-wise — matching the <c>params object[]</c> overload — not as a single
+    /// reference-compared value. A dependency whose static type is not an array is
+    /// always compared as one value, even if its runtime value happens to be an array.
+    /// </remarks>
     public Action UseCallback<T1>(Action callback, T1 d1)
     {
         var hook = AcquireMemoSlot<Action>();
-        // See UseEffect<T1>: a lone object[]-typed dep keeps element-wise semantics.
+        // See UseEffect<T1>: a compile-time array dep keeps element-wise semantics.
         if (AsParamsArrayDep(d1) is { } arr)
         {
             if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
@@ -695,33 +723,52 @@ public sealed class RenderContext
         return copy;
     }
 
-    // A lone arity-1 dependency that is itself an object[] at runtime — e.g. a
-    // covariant string[]/Element[] — historically bound to the params overload and
-    // was compared element-wise. The generic arity-1 overload would otherwise wrap
-    // the whole array as ONE reference-compared dep, so an array re-allocated each
-    // render with equal contents would spuriously re-run. Detect that exact case and
-    // route it back through the element-wise path. typeof(T1).IsValueType is a
-    // JIT-time constant for value-type instantiations, so value-type deps fold this
-    // to null and never box; int[] (not assignable to object[]) returns null too.
+    // A lone arity-1 dependency whose COMPILE-TIME type is an array of reference types
+    // — e.g. a covariant string[]/Element[] — is treated as a dependency LIST and
+    // compared element-wise, matching how the params overload behaved before these
+    // generics existed. The gate is on the *static* type (typeof(T1)) on purpose: a
+    // value whose static type is object/Array/an interface but whose runtime value
+    // happens to be an object[] historically bound the params overload in EXPANDED
+    // form (wrapped as new object[]{ dep }) and was compared as ONE reference dep, so
+    // it must stay a single dep here too — unwrapping it would be a silent semantic
+    // change (observable for UseMemo, whose two overloads are both generic so the
+    // arity-1 wins overload resolution). typeof(T1).IsArray is a JIT-time constant per
+    // instantiation, so value-type and non-array deps fold this to null and never
+    // reach the IsAssignableFrom check or box.
     private static object[]? AsParamsArrayDep<T1>(T1 d1)
-        => !typeof(T1).IsValueType && d1 is object[] arr ? arr : null;
+        => typeof(T1).IsArray && typeof(object[]).IsAssignableFrom(typeof(T1)) && d1 is object[] arr ? arr : null;
 
-    // Returns true when the stored deps already match — unboxing the stored value
-    // (no allocation) and comparing through the typed comparer so the incoming dep
-    // is never boxed. A null/wrong-arity stored array counts as "changed".
+    // Returns true when the stored deps already match. Each element is compared via
+    // DepEquals, which unboxes the stored value (no allocation) and compares through
+    // the typed comparer so the incoming dep is never boxed. A null/wrong-arity stored
+    // array counts as "changed".
     private static bool DepsEqual1<T1>(object[]? prev, T1 d1)
-        => prev is { Length: 1 } && EqualityComparer<T1>.Default.Equals((T1)prev[0], d1);
+        => prev is { Length: 1 } && DepEquals(prev[0], d1);
 
     private static bool DepsEqual2<T1, T2>(object[]? prev, T1 d1, T2 d2)
         => prev is { Length: 2 }
-           && EqualityComparer<T1>.Default.Equals((T1)prev[0], d1)
-           && EqualityComparer<T2>.Default.Equals((T2)prev[1], d2);
+           && DepEquals(prev[0], d1)
+           && DepEquals(prev[1], d2);
 
     private static bool DepsEqual3<T1, T2, T3>(object[]? prev, T1 d1, T2 d2, T3 d3)
         => prev is { Length: 3 }
-           && EqualityComparer<T1>.Default.Equals((T1)prev[0], d1)
-           && EqualityComparer<T2>.Default.Equals((T2)prev[1], d2)
-           && EqualityComparer<T3>.Default.Equals((T3)prev[2], d3);
+           && DepEquals(prev[0], d1)
+           && DepEquals(prev[1], d2)
+           && DepEquals(prev[2], d3);
+
+    // Compare a stored (boxed) dependency against the current typed value without an
+    // unconditional (T)stored cast. A hot-reload edit or a dynamic call site can change
+    // a dependency's runtime type at the same hook slot across renders; an
+    // InvalidCastException while COMPARING deps is worse than simply treating the slot
+    // as changed, so a type mismatch returns false ("changed"). This mirrors the
+    // non-generic params DepsEqual, which compares via object.Equals and never throws.
+    // Value-type T unboxes through the `is T` pattern with no extra allocation, and the
+    // current dep is still passed through EqualityComparer<T> unboxed.
+    private static bool DepEquals<T>(object? stored, T current)
+    {
+        if (stored is null) return current is null;
+        return stored is T t && EqualityComparer<T>.Default.Equals(t, current);
+    }
 
     /// <summary>
     /// Returns a mutable ref object that persists across renders.

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -10,7 +10,9 @@ namespace Microsoft.UI.Reactor.Core;
 /// </summary>
 public sealed class RenderContext
 {
-    private readonly List<HookState> _hooks = new();
+    // #50: seed a small capacity so the common 1-8 hook component doesn't churn
+    // through the List's 0→4→8 doubling reallocations at mount.
+    private readonly List<HookState> _hooks = new(8);
     private int _hookIndex;
     private Action? _requestRerender;
     private ContextScope? _contextScope;
@@ -137,43 +139,52 @@ public sealed class RenderContext
 
         T current;
         if (hook.ThreadSafe)
-            lock (hook.Lock) { current = hook.Value; }
+            lock (hook.Lock!) { current = hook.Value; }
         else
             current = hook.Value;
 
         // <snippet:set-state>
-        void Setter(T newValue)
+        // #43: build the setter once and cache it on the hook slot. `this` and
+        // `currentIndex` are both stable across renders, so the cached delegate
+        // is observably identical to re-creating it every render — minus the
+        // per-render display-class + Action<T> allocation.
+        if (hook.CachedDelegate is not Action<T> setter)
         {
-            var h = (ValueHookState<T>)_hooks[currentIndex];
-            bool changed;
-            if (h.ThreadSafe)
+            void Setter(T newValue)
             {
-                lock (h.Lock)
+                var h = (ValueHookState<T>)_hooks[currentIndex];
+                bool changed;
+                if (h.ThreadSafe)
                 {
+                    lock (h.Lock!)
+                    {
+                        changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
+                        if (changed) h.Value = newValue;
+                    }
+                    if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                            global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                            Diagnostics.ReactorEventSource.Keywords.State))
+                        Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+                    if (changed) _requestRerender?.Invoke();
+                }
+                else
+                {
+                    if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
                     changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
                     if (changed) h.Value = newValue;
+                    if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                            global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                            Diagnostics.ReactorEventSource.Keywords.State))
+                        Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+                    if (changed) _requestRerender?.Invoke();
                 }
-                if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                        global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                        Diagnostics.ReactorEventSource.Keywords.State))
-                    Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-                if (changed) _requestRerender?.Invoke();
             }
-            else
-            {
-                if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
-                changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
-                if (changed) h.Value = newValue;
-                if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                        global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                        Diagnostics.ReactorEventSource.Keywords.State))
-                    Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-                if (changed) _requestRerender?.Invoke();
-            }
+            setter = Setter;
+            hook.CachedDelegate = setter;
         }
         // </snippet:set-state>
 
-        return (current, Setter);
+        return (current, setter);
     }
 
     /// <summary>
@@ -201,45 +212,52 @@ public sealed class RenderContext
 
         T current;
         if (hook.ThreadSafe)
-            lock (hook.Lock) { current = hook.Value; }
+            lock (hook.Lock!) { current = hook.Value; }
         else
             current = hook.Value;
 
-        void Updater(Func<T, T> reducer)
+        // #44: the updater takes its reducer as an argument and otherwise closes
+        // only over `this` + `currentIndex` (both stable), so cache it once.
+        if (hook.CachedDelegate is not Action<Func<T, T>> updater)
         {
-            var h = (ValueHookState<T>)_hooks[currentIndex];
-            bool changed;
-            if (h.ThreadSafe)
+            void Updater(Func<T, T> reducer)
             {
-                lock (h.Lock)
+                var h = (ValueHookState<T>)_hooks[currentIndex];
+                bool changed;
+                if (h.ThreadSafe)
                 {
+                    lock (h.Lock!)
+                    {
+                        var prev = h.Value;
+                        var next = reducer(prev);
+                        changed = !EqualityComparer<T>.Default.Equals(prev, next);
+                        if (changed) h.Value = next;
+                    }
+                    if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                            global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                            Diagnostics.ReactorEventSource.Keywords.State))
+                        Diagnostics.ReactorEventSource.Log.StateChange("UseReducer", typeof(T).Name, changed);
+                    if (changed) _requestRerender?.Invoke();
+                }
+                else
+                {
+                    if (MarshalIfOffUIThread("UseReducer", () => Updater(reducer))) return;
                     var prev = h.Value;
                     var next = reducer(prev);
                     changed = !EqualityComparer<T>.Default.Equals(prev, next);
                     if (changed) h.Value = next;
+                    if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                            global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                            Diagnostics.ReactorEventSource.Keywords.State))
+                        Diagnostics.ReactorEventSource.Log.StateChange("UseReducer", typeof(T).Name, changed);
+                    if (changed) _requestRerender?.Invoke();
                 }
-                if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                        global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                        Diagnostics.ReactorEventSource.Keywords.State))
-                    Diagnostics.ReactorEventSource.Log.StateChange("UseReducer", typeof(T).Name, changed);
-                if (changed) _requestRerender?.Invoke();
             }
-            else
-            {
-                if (MarshalIfOffUIThread("UseReducer", () => Updater(reducer))) return;
-                var prev = h.Value;
-                var next = reducer(prev);
-                changed = !EqualityComparer<T>.Default.Equals(prev, next);
-                if (changed) h.Value = next;
-                if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                        global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                        Diagnostics.ReactorEventSource.Keywords.State))
-                    Diagnostics.ReactorEventSource.Log.StateChange("UseReducer", typeof(T).Name, changed);
-                if (changed) _requestRerender?.Invoke();
-            }
+            updater = Updater;
+            hook.CachedDelegate = updater;
         }
 
-        return (current, Updater);
+        return (current, updater);
     }
 
     /// <summary>
@@ -269,39 +287,51 @@ public sealed class RenderContext
 
         TState current;
         if (hook.ThreadSafe)
-            lock (hook.Lock) { current = hook.Value; }
+            lock (hook.Lock!) { current = hook.Value; }
         else
             current = hook.Value;
 
-        void Dispatch(TAction action)
+        // #44: the dispatch closure also captures the per-render `reducer`. Stash
+        // the latest reducer on the hook slot and have the cached dispatch read it
+        // back, so the returned dispatch is stable across renders yet always runs
+        // the current reducer (the prior code returned a fresh dispatch bound to
+        // that render's reducer — observably the same for the latest dispatch).
+        hook.Reducer = reducer;
+        if (hook.CachedDelegate is not Action<TAction> dispatch)
         {
-            var h = (ValueHookState<TState>)_hooks[currentIndex];
-            if (h.ThreadSafe)
+            void Dispatch(TAction action)
             {
-                bool changed;
-                lock (h.Lock)
+                var h = (ValueHookState<TState>)_hooks[currentIndex];
+                var currentReducer = (Func<TState, TAction, TState>)h.Reducer!;
+                if (h.ThreadSafe)
                 {
+                    bool changed;
+                    lock (h.Lock!)
+                    {
+                        var prev = h.Value;
+                        var next = currentReducer(prev, action);
+                        changed = !EqualityComparer<TState>.Default.Equals(prev, next);
+                        if (changed) h.Value = next;
+                    }
+                    if (changed) _requestRerender?.Invoke();
+                }
+                else
+                {
+                    if (MarshalIfOffUIThread("UseReducer", () => Dispatch(action))) return;
                     var prev = h.Value;
-                    var next = reducer(prev, action);
-                    changed = !EqualityComparer<TState>.Default.Equals(prev, next);
-                    if (changed) h.Value = next;
-                }
-                if (changed) _requestRerender?.Invoke();
-            }
-            else
-            {
-                if (MarshalIfOffUIThread("UseReducer", () => Dispatch(action))) return;
-                var prev = h.Value;
-                var next = reducer(prev, action);
-                if (!EqualityComparer<TState>.Default.Equals(prev, next))
-                {
-                    h.Value = next;
-                    _requestRerender?.Invoke();
+                    var next = currentReducer(prev, action);
+                    if (!EqualityComparer<TState>.Default.Equals(prev, next))
+                    {
+                        h.Value = next;
+                        _requestRerender?.Invoke();
+                    }
                 }
             }
+            dispatch = Dispatch;
+            hook.CachedDelegate = dispatch;
         }
 
-        return (current, Dispatch);
+        return (current, dispatch);
     }
 
     /// <summary>
@@ -312,25 +342,11 @@ public sealed class RenderContext
     // <snippet:effect-schedule>
     public void UseEffect(Action effect, params object[] dependencies)
     {
-        if (_hookIndex >= _hooks.Count)
-        {
-            _hooks.Add(new EffectHookState { Dependencies = null, Effect = effect });
-        }
-
-        if (_hooks[_hookIndex] is not EffectHookState hook)
-            throw new HookOrderException(
-                $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected EffectHookState. " +
-                "Hooks must be called in the same order every render.");
-        _hookIndex++;
-
+        var hook = AcquireEffectSlot();
+        // #48: the params array is freshly minted at the call site and never
+        // aliased, so store it directly instead of copying it again via ToArray().
         if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
-        {
-            hook.PendingCleanup = hook.Cleanup;
-            hook.Cleanup = null;
-            hook.Dependencies = dependencies.ToArray();
-            hook.Effect = effect;
-            hook.Pending = true;
-        }
+            ScheduleEffect(hook, effect, null, dependencies);
     }
     // </snippet:effect-schedule>
 
@@ -339,25 +355,80 @@ public sealed class RenderContext
     /// </summary>
     public void UseEffect(Func<Action> effectWithCleanup, params object[] dependencies)
     {
+        var hook = AcquireEffectSlot();
+        if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
+            ScheduleEffect(hook, null, effectWithCleanup, dependencies);
+    }
+
+    // #45: arity 1-3 overloads so the common "a couple of deps" call avoids the
+    // params-array allocation AND the value-type boxing on the steady-state
+    // (deps-unchanged) path. Storage stays object[] for hot-reload / snapshot /
+    // DepsEqual compatibility; the array is only allocated when deps actually
+    // change. Comparison unboxes the stored value (no new allocation) and uses
+    // the typed EqualityComparer so the incoming dep is never boxed.
+    public void UseEffect<T1>(Action effect, T1 d1)
+    {
+        var hook = AcquireEffectSlot();
+        if (!DepsEqual1(hook.Dependencies, d1)) ScheduleEffect(hook, effect, null, PackDeps(d1));
+    }
+
+    public void UseEffect<T1, T2>(Action effect, T1 d1, T2 d2)
+    {
+        var hook = AcquireEffectSlot();
+        if (!DepsEqual2(hook.Dependencies, d1, d2)) ScheduleEffect(hook, effect, null, PackDeps(d1, d2));
+    }
+
+    public void UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3)
+    {
+        var hook = AcquireEffectSlot();
+        if (!DepsEqual3(hook.Dependencies, d1, d2, d3)) ScheduleEffect(hook, effect, null, PackDeps(d1, d2, d3));
+    }
+
+    public void UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1)
+    {
+        var hook = AcquireEffectSlot();
+        if (!DepsEqual1(hook.Dependencies, d1)) ScheduleEffect(hook, null, effectWithCleanup, PackDeps(d1));
+    }
+
+    public void UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2)
+    {
+        var hook = AcquireEffectSlot();
+        if (!DepsEqual2(hook.Dependencies, d1, d2)) ScheduleEffect(hook, null, effectWithCleanup, PackDeps(d1, d2));
+    }
+
+    public void UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3)
+    {
+        var hook = AcquireEffectSlot();
+        if (!DepsEqual3(hook.Dependencies, d1, d2, d3)) ScheduleEffect(hook, null, effectWithCleanup, PackDeps(d1, d2, d3));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="resource"/>'s <see cref="IDisposable.Dispose"/> once on
+    /// unmount (mount-once effect with a stable teardown). Equivalent to
+    /// <c>UseEffect(() =&gt; () =&gt; resource.Dispose())</c> but allocates nothing per
+    /// render — the resource is passed by reference and the cleanup delegate is
+    /// captured a single time on first mount (#56). Internal helper used by the
+    /// resource hooks; not part of the public hook surface.
+    /// </summary>
+    internal void UseDisposableEffect(IDisposable resource)
+    {
         if (_hookIndex >= _hooks.Count)
         {
-            _hooks.Add(new EffectHookState { Dependencies = null });
+            // Schedule once: empty (non-null) deps never compare unequal again, so
+            // the mount effect runs exactly once and its cleanup is resource.Dispose.
+            _hooks.Add(new EffectHookState
+            {
+                Dependencies = Array.Empty<object>(),
+                EffectWithCleanup = () => resource.Dispose,
+                Pending = true,
+            });
         }
 
-        if (_hooks[_hookIndex] is not EffectHookState hook)
+        if (_hooks[_hookIndex] is not EffectHookState)
             throw new HookOrderException(
                 $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected EffectHookState. " +
                 "Hooks must be called in the same order every render.");
         _hookIndex++;
-
-        if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
-        {
-            hook.PendingCleanup = hook.Cleanup;
-            hook.Cleanup = null;
-            hook.Dependencies = dependencies.ToArray();
-            hook.EffectWithCleanup = effectWithCleanup;
-            hook.Pending = true;
-        }
     }
 
     /// <summary>
@@ -365,23 +436,47 @@ public sealed class RenderContext
     /// </summary>
     public T UseMemo<T>(Func<T> factory, params object[] dependencies)
     {
-        if (_hookIndex >= _hooks.Count)
-        {
-            _hooks.Add(new MemoHookState<T> { Dependencies = null });
-        }
-
-        if (_hooks[_hookIndex] is not MemoHookState<T> hook)
-            throw new HookOrderException(
-                $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected MemoHookState<{typeof(T).Name}>. " +
-                "Hooks must be called in the same order every render.");
-        _hookIndex++;
-
+        var hook = AcquireMemoSlot<T>();
         if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
         {
             hook.Value = factory();
-            hook.Dependencies = dependencies.ToArray();
+            hook.Dependencies = dependencies; // #48: store the fresh params array directly
         }
+        return hook.Value;
+    }
 
+    // #46: arity overloads mirror UseEffect — no params array / boxing on the
+    // deps-unchanged path; factory only runs (and array only allocates) on change.
+    public T UseMemo<T, T1>(Func<T> factory, T1 d1)
+    {
+        var hook = AcquireMemoSlot<T>();
+        if (!DepsEqual1(hook.Dependencies, d1))
+        {
+            hook.Value = factory();
+            hook.Dependencies = PackDeps(d1);
+        }
+        return hook.Value;
+    }
+
+    public T UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2)
+    {
+        var hook = AcquireMemoSlot<T>();
+        if (!DepsEqual2(hook.Dependencies, d1, d2))
+        {
+            hook.Value = factory();
+            hook.Dependencies = PackDeps(d1, d2);
+        }
+        return hook.Value;
+    }
+
+    public T UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3)
+    {
+        var hook = AcquireMemoSlot<T>();
+        if (!DepsEqual3(hook.Dependencies, d1, d2, d3))
+        {
+            hook.Value = factory();
+            hook.Dependencies = PackDeps(d1, d2, d3);
+        }
         return hook.Value;
     }
 
@@ -390,8 +485,111 @@ public sealed class RenderContext
     /// </summary>
     public Action UseCallback(Action callback, params object[] dependencies)
     {
-        return UseMemo(() => callback, dependencies);
+        // #46: store the callback directly in the memo slot instead of routing
+        // through UseMemo(() => callback, ...), whose `() => callback` factory
+        // lambda allocated on every render before the deps short-circuit. The slot
+        // is still MemoHookState<Action> so hook-order checks / devtools labels are
+        // unchanged.
+        var hook = AcquireMemoSlot<Action>();
+        if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
+        {
+            hook.Value = callback;
+            hook.Dependencies = dependencies;
+        }
+        return hook.Value;
     }
+
+    public Action UseCallback<T1>(Action callback, T1 d1)
+    {
+        var hook = AcquireMemoSlot<Action>();
+        if (!DepsEqual1(hook.Dependencies, d1))
+        {
+            hook.Value = callback;
+            hook.Dependencies = PackDeps(d1);
+        }
+        return hook.Value;
+    }
+
+    public Action UseCallback<T1, T2>(Action callback, T1 d1, T2 d2)
+    {
+        var hook = AcquireMemoSlot<Action>();
+        if (!DepsEqual2(hook.Dependencies, d1, d2))
+        {
+            hook.Value = callback;
+            hook.Dependencies = PackDeps(d1, d2);
+        }
+        return hook.Value;
+    }
+
+    public Action UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3)
+    {
+        var hook = AcquireMemoSlot<Action>();
+        if (!DepsEqual3(hook.Dependencies, d1, d2, d3))
+        {
+            hook.Value = callback;
+            hook.Dependencies = PackDeps(d1, d2, d3);
+        }
+        return hook.Value;
+    }
+
+    // ── Hook-slot + deps helpers (shared by the effect / memo / callback hooks) ──
+
+    private EffectHookState AcquireEffectSlot()
+    {
+        if (_hookIndex >= _hooks.Count)
+            _hooks.Add(new EffectHookState { Dependencies = null });
+
+        if (_hooks[_hookIndex] is not EffectHookState hook)
+            throw new HookOrderException(
+                $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected EffectHookState. " +
+                "Hooks must be called in the same order every render.");
+        _hookIndex++;
+        return hook;
+    }
+
+    private MemoHookState<T> AcquireMemoSlot<T>()
+    {
+        if (_hookIndex >= _hooks.Count)
+            _hooks.Add(new MemoHookState<T> { Dependencies = null });
+
+        if (_hooks[_hookIndex] is not MemoHookState<T> hook)
+            throw new HookOrderException(
+                $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected MemoHookState<{typeof(T).Name}>. " +
+                "Hooks must be called in the same order every render.");
+        _hookIndex++;
+        return hook;
+    }
+
+    private static void ScheduleEffect(EffectHookState hook, Action? effect, Func<Action>? withCleanup, object[] dependencies)
+    {
+        hook.PendingCleanup = hook.Cleanup;
+        hook.Cleanup = null;
+        hook.Dependencies = dependencies;
+        hook.Effect = effect;
+        hook.EffectWithCleanup = withCleanup;
+        hook.Pending = true;
+    }
+
+    private static object[] PackDeps<T1>(T1 d1) => new object[] { d1! };
+    private static object[] PackDeps<T1, T2>(T1 d1, T2 d2) => new object[] { d1!, d2! };
+    private static object[] PackDeps<T1, T2, T3>(T1 d1, T2 d2, T3 d3) => new object[] { d1!, d2!, d3! };
+
+    // Returns true when the stored deps already match — unboxing the stored value
+    // (no allocation) and comparing through the typed comparer so the incoming dep
+    // is never boxed. A null/wrong-arity stored array counts as "changed".
+    private static bool DepsEqual1<T1>(object[]? prev, T1 d1)
+        => prev is { Length: 1 } && EqualityComparer<T1>.Default.Equals((T1)prev[0], d1);
+
+    private static bool DepsEqual2<T1, T2>(object[]? prev, T1 d1, T2 d2)
+        => prev is { Length: 2 }
+           && EqualityComparer<T1>.Default.Equals((T1)prev[0], d1)
+           && EqualityComparer<T2>.Default.Equals((T2)prev[1], d2);
+
+    private static bool DepsEqual3<T1, T2, T3>(object[]? prev, T1 d1, T2 d2, T3 d3)
+        => prev is { Length: 3 }
+           && EqualityComparer<T1>.Default.Equals((T1)prev[0], d1)
+           && EqualityComparer<T2>.Default.Equals((T2)prev[1], d2)
+           && EqualityComparer<T3>.Default.Equals((T3)prev[2], d3);
 
     /// <summary>
     /// Returns a mutable ref object that persists across renders.
@@ -468,18 +666,23 @@ public sealed class RenderContext
 
         T current = hook.Value;
 
-        void Setter(T newValue)
+        if (hook.CachedSetter is not Action<T> setter)
         {
-            if (MarshalIfOffUIThread("UsePersisted", () => Setter(newValue))) return;
-            var h = (PersistedHookState<T>)_hooks[currentIndex];
-            if (!EqualityComparer<T>.Default.Equals(h.Value, newValue))
+            void Setter(T newValue)
             {
-                h.Value = newValue;
-                _requestRerender?.Invoke();
+                if (MarshalIfOffUIThread("UsePersisted", () => Setter(newValue))) return;
+                var h = (PersistedHookState<T>)_hooks[currentIndex];
+                if (!EqualityComparer<T>.Default.Equals(h.Value, newValue))
+                {
+                    h.Value = newValue;
+                    _requestRerender?.Invoke();
+                }
             }
+            setter = Setter;
+            hook.CachedSetter = setter;
         }
 
-        return (current, Setter);
+        return (current, setter);
     }
 
     // ════════════════════════════════════════════════════════════════
@@ -728,15 +931,68 @@ public sealed class RenderContext
     /// <summary>
     /// Enumerates ContextHookState entries for memo change detection (Phase 3).
     /// </summary>
-    internal IEnumerable<ContextHookState> ContextHooks
+    /// <remarks>
+    /// #51: returns a struct enumerable (not an iterator block) so the per-render
+    /// change-detection walk in the reconciler doesn't heap-allocate an enumerator.
+    /// The sole consumer (<c>Reconciler.HasConsumedContextChanged</c>) only foreach-es,
+    /// which binds to <see cref="ContextHookEnumerable.GetEnumerator"/> by duck typing.
+    /// </remarks>
+    internal ContextHookEnumerable ContextHooks => new(_hooks);
+
+    /// <summary>Allocation-free enumerable over the <see cref="ContextHookState"/> slots.</summary>
+    /// <remarks>
+    /// Implements <see cref="IEnumerable{T}"/> so LINQ (e.g. tests calling
+    /// <c>ContextHooks.ToList()</c>) still works, but the hot-path
+    /// <c>foreach</c> in the reconciler binds to the public struct
+    /// <see cref="GetEnumerator"/> below and never boxes.
+    /// </remarks>
+    internal readonly struct ContextHookEnumerable : IEnumerable<ContextHookState>
     {
-        get
+        private readonly List<HookState> _hooks;
+        internal ContextHookEnumerable(List<HookState> hooks) => _hooks = hooks;
+
+        public Enumerator GetEnumerator() => new(_hooks);
+
+        IEnumerator<ContextHookState> IEnumerable<ContextHookState>.GetEnumerator() => GetEnumerator();
+        global::System.Collections.IEnumerator global::System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>Struct enumerator — skips non-context slots without allocating.</summary>
+        internal struct Enumerator : IEnumerator<ContextHookState>
         {
-            for (int i = 0; i < _hooks.Count; i++)
+            private readonly List<HookState> _hooks;
+            private int _index;
+            private ContextHookState? _current;
+
+            internal Enumerator(List<HookState> hooks)
             {
-                if (_hooks[i] is ContextHookState ctx)
-                    yield return ctx;
+                _hooks = hooks;
+                _index = 0;
+                _current = null;
             }
+
+            public readonly ContextHookState Current => _current!;
+            readonly object global::System.Collections.IEnumerator.Current => _current!;
+
+            public bool MoveNext()
+            {
+                while (_index < _hooks.Count)
+                {
+                    if (_hooks[_index++] is ContextHookState ctx)
+                    {
+                        _current = ctx;
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            public void Reset()
+            {
+                _index = 0;
+                _current = null;
+            }
+
+            public readonly void Dispose() { }
         }
     }
 
@@ -944,10 +1200,22 @@ public sealed class RenderContext
         var asyncAction = command.ExecuteAsync;
         var syncAction = command.Execute;
         int debounceMs = command.DebounceMs;
+        object depA = (object?)command.ExecuteAsync ?? NullDep;
+        object depB = (object?)command.Execute ?? NullDep;
 
-        var wrappedExecute = UseMemo<Action>(() => () =>
-            DispatchCommand(asyncAction, syncAction, debounceMs, guardRef, debounceRef, setIsExecuting, setIsDebouncing),
-            (object?)command.ExecuteAsync ?? NullDep, (object?)command.Execute ?? NullDep, debounceMs);
+        // #52: inline the memo slot so the `() => () => DispatchCommand(...)`
+        // factory closure (which captures 7 locals) isn't allocated on every
+        // render before the deps short-circuit. The slot is still
+        // MemoHookState<Action>, so the hook shape and devtools label are
+        // unchanged; the inner dispatch closure is built only when deps change.
+        var memo = AcquireMemoSlot<Action>();
+        if (!DepsEqual3(memo.Dependencies, depA, depB, debounceMs))
+        {
+            memo.Value = () =>
+                DispatchCommand(asyncAction, syncAction, debounceMs, guardRef, debounceRef, setIsExecuting, setIsDebouncing);
+            memo.Dependencies = PackDeps(depA, depB, debounceMs);
+        }
+        var wrappedExecute = memo.Value;
 
         // Branch on VALUES, never on hook calls: a pure sync, non-debounced, not-yet-wrapped
         // command is returned unchanged (preserves identity / Assert.Same and today's behavior).
@@ -977,13 +1245,22 @@ public sealed class RenderContext
         var asyncAction = command.ExecuteAsync;
         var syncAction = command.Execute;
         int debounceMs = command.DebounceMs;
+        object depA = (object?)command.ExecuteAsync ?? NullDep;
+        object depB = (object?)command.Execute ?? NullDep;
 
-        var wrappedExecute = UseMemo<Action<T>>(() => (arg) =>
-            DispatchCommand(
-                asyncAction is null ? null : () => asyncAction(arg),
-                syncAction is null ? null : () => syncAction(arg),
-                debounceMs, guardRef, debounceRef, setIsExecuting, setIsDebouncing),
-            (object?)command.ExecuteAsync ?? NullDep, (object?)command.Execute ?? NullDep, debounceMs);
+        // #52: inline memo slot (see UseCommand(Command)); avoids the per-render
+        // factory + wrapper closure allocation while keeping the MemoHookState<Action<T>> shape.
+        var memo = AcquireMemoSlot<Action<T>>();
+        if (!DepsEqual3(memo.Dependencies, depA, depB, debounceMs))
+        {
+            memo.Value = (arg) =>
+                DispatchCommand(
+                    asyncAction is null ? null : () => asyncAction(arg),
+                    syncAction is null ? null : () => syncAction(arg),
+                    debounceMs, guardRef, debounceRef, setIsExecuting, setIsDebouncing);
+            memo.Dependencies = PackDeps(depA, depB, debounceMs);
+        }
+        var wrappedExecute = memo.Value;
 
         if (!CommandNeedsWrapping(command.ExecuteAsync, command.DebounceMs, command.DebounceHandled))
             return command;
@@ -1970,11 +2247,24 @@ public sealed class RenderContext
     {
         public T Value;
         public readonly bool ThreadSafe;
-        public readonly object Lock = new();
+        // #42: only the threadSafe path locks, so allocate the monitor object
+        // lazily. The default (threadSafe:false) leaves this null — N rows × M
+        // hooks of unused lock objects were pure gen0/gen2 churn otherwise.
+        public readonly object? Lock;
+        // #43/#44: the setter / updater / dispatch delegate for this slot. Hook
+        // call order is stable (rules of hooks) and the hook instance is stable
+        // across renders (hot-reload mutates Value in place), so the delegate can
+        // be built once and reused instead of re-allocating a closure per render.
+        public Delegate? CachedDelegate;
+        // #44: latest reducer for the UseReducer<TState,TAction> dispatch path,
+        // refreshed each render so the cached dispatch always runs the current
+        // reducer (matches the prior per-render-dispatch behaviour and React).
+        public object? Reducer;
         public ValueHookState(T value, bool threadSafe = false)
         {
             Value = value;
             ThreadSafe = threadSafe;
+            Lock = threadSafe ? new object() : null;
         }
     }
 
@@ -2022,6 +2312,10 @@ public sealed class RenderContext
     private class PersistedHookState<T> : PersistedHookStateBase
     {
         public T Value;
+        // #53: the setter is built once on first render and reused, so a
+        // component holding a persisted value doesn't mint a fresh display-class +
+        // Action<T> every render.
+        public Action<T>? CachedSetter;
         public PersistedHookState(T value) => Value = value;
         public override void SaveToCache()
         {

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -366,36 +366,82 @@ public sealed class RenderContext
     // DepsEqual compatibility; the array is only allocated when deps actually
     // change. Comparison unboxes the stored value (no new allocation) and uses
     // the typed EqualityComparer so the incoming dep is never boxed.
+    /// <summary>
+    /// Single-dependency <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation (and value-type boxing) on the
+    /// deps-unchanged path. Semantically identical to the params overload called
+    /// with one dependency: the effect re-runs only when <paramref name="d1"/>
+    /// changes.
+    /// </summary>
     public void UseEffect<T1>(Action effect, T1 d1)
     {
         var hook = AcquireEffectSlot();
+        // A lone dependency that is itself an object[] at runtime (e.g. a covariant
+        // string[]) bound to the params overload before this generic existed and was
+        // compared element-wise — preserve that so an array re-allocated each render
+        // with equal contents does not spuriously re-run the effect.
+        if (AsParamsArrayDep(d1) is { } arr)
+        {
+            if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
+                ScheduleEffect(hook, effect, null, arr);
+            return;
+        }
         if (!DepsEqual1(hook.Dependencies, d1)) ScheduleEffect(hook, effect, null, PackDeps(d1));
     }
 
+    /// <summary>
+    /// Two-dependency <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path. Re-runs when
+    /// either dependency changes.
+    /// </summary>
     public void UseEffect<T1, T2>(Action effect, T1 d1, T2 d2)
     {
         var hook = AcquireEffectSlot();
         if (!DepsEqual2(hook.Dependencies, d1, d2)) ScheduleEffect(hook, effect, null, PackDeps(d1, d2));
     }
 
+    /// <summary>
+    /// Three-dependency <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path. Re-runs when
+    /// any dependency changes.
+    /// </summary>
     public void UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3)
     {
         var hook = AcquireEffectSlot();
         if (!DepsEqual3(hook.Dependencies, d1, d2, d3)) ScheduleEffect(hook, effect, null, PackDeps(d1, d2, d3));
     }
 
+    /// <summary>
+    /// Single-dependency cleanup-flavor <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path. Semantically
+    /// identical to the params overload called with one dependency.
+    /// </summary>
     public void UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1)
     {
         var hook = AcquireEffectSlot();
+        if (AsParamsArrayDep(d1) is { } arr)
+        {
+            if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
+                ScheduleEffect(hook, null, effectWithCleanup, arr);
+            return;
+        }
         if (!DepsEqual1(hook.Dependencies, d1)) ScheduleEffect(hook, null, effectWithCleanup, PackDeps(d1));
     }
 
+    /// <summary>
+    /// Two-dependency cleanup-flavor <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
     public void UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2)
     {
         var hook = AcquireEffectSlot();
         if (!DepsEqual2(hook.Dependencies, d1, d2)) ScheduleEffect(hook, null, effectWithCleanup, PackDeps(d1, d2));
     }
 
+    /// <summary>
+    /// Three-dependency cleanup-flavor <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
     public void UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3)
     {
         var hook = AcquireEffectSlot();
@@ -447,9 +493,25 @@ public sealed class RenderContext
 
     // #46: arity overloads mirror UseEffect — no params array / boxing on the
     // deps-unchanged path; factory only runs (and array only allocates) on change.
+
+    /// <summary>
+    /// Single-dependency <c>UseMemo</c> overload that avoids the
+    /// <c>params object[]</c> allocation (and value-type boxing) on the
+    /// deps-unchanged path. Recomputes only when <paramref name="d1"/> changes.
+    /// </summary>
     public T UseMemo<T, T1>(Func<T> factory, T1 d1)
     {
         var hook = AcquireMemoSlot<T>();
+        // See UseEffect<T1>: a lone object[]-typed dep keeps element-wise semantics.
+        if (AsParamsArrayDep(d1) is { } arr)
+        {
+            if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
+            {
+                hook.Value = factory();
+                hook.Dependencies = arr;
+            }
+            return hook.Value;
+        }
         if (!DepsEqual1(hook.Dependencies, d1))
         {
             hook.Value = factory();
@@ -458,6 +520,10 @@ public sealed class RenderContext
         return hook.Value;
     }
 
+    /// <summary>
+    /// Two-dependency <c>UseMemo</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
     public T UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2)
     {
         var hook = AcquireMemoSlot<T>();
@@ -469,6 +535,10 @@ public sealed class RenderContext
         return hook.Value;
     }
 
+    /// <summary>
+    /// Three-dependency <c>UseMemo</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
     public T UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3)
     {
         var hook = AcquireMemoSlot<T>();
@@ -499,9 +569,25 @@ public sealed class RenderContext
         return hook.Value;
     }
 
+    /// <summary>
+    /// Single-dependency <c>UseCallback</c> overload that avoids the
+    /// <c>params object[]</c> allocation (and value-type boxing) on the
+    /// deps-unchanged path. Returns a stable reference until <paramref name="d1"/>
+    /// changes.
+    /// </summary>
     public Action UseCallback<T1>(Action callback, T1 d1)
     {
         var hook = AcquireMemoSlot<Action>();
+        // See UseEffect<T1>: a lone object[]-typed dep keeps element-wise semantics.
+        if (AsParamsArrayDep(d1) is { } arr)
+        {
+            if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
+            {
+                hook.Value = callback;
+                hook.Dependencies = arr;
+            }
+            return hook.Value;
+        }
         if (!DepsEqual1(hook.Dependencies, d1))
         {
             hook.Value = callback;
@@ -510,6 +596,10 @@ public sealed class RenderContext
         return hook.Value;
     }
 
+    /// <summary>
+    /// Two-dependency <c>UseCallback</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
     public Action UseCallback<T1, T2>(Action callback, T1 d1, T2 d2)
     {
         var hook = AcquireMemoSlot<Action>();
@@ -521,6 +611,10 @@ public sealed class RenderContext
         return hook.Value;
     }
 
+    /// <summary>
+    /// Three-dependency <c>UseCallback</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
     public Action UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3)
     {
         var hook = AcquireMemoSlot<Action>();
@@ -573,6 +667,17 @@ public sealed class RenderContext
     private static object[] PackDeps<T1>(T1 d1) => new object[] { d1! };
     private static object[] PackDeps<T1, T2>(T1 d1, T2 d2) => new object[] { d1!, d2! };
     private static object[] PackDeps<T1, T2, T3>(T1 d1, T2 d2, T3 d3) => new object[] { d1!, d2!, d3! };
+
+    // A lone arity-1 dependency that is itself an object[] at runtime — e.g. a
+    // covariant string[]/Element[] — historically bound to the params overload and
+    // was compared element-wise. The generic arity-1 overload would otherwise wrap
+    // the whole array as ONE reference-compared dep, so an array re-allocated each
+    // render with equal contents would spuriously re-run. Detect that exact case and
+    // route it back through the element-wise path. typeof(T1).IsValueType is a
+    // JIT-time constant for value-type instantiations, so value-type deps fold this
+    // to null and never box; int[] (not assignable to object[]) returns null too.
+    private static object[]? AsParamsArrayDep<T1>(T1 d1)
+        => !typeof(T1).IsValueType && d1 is object[] arr ? arr : null;
 
     // Returns true when the stored deps already match — unboxing the stored value
     // (no allocation) and comparing through the typed comparer so the incoming dep

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -343,10 +343,13 @@ public sealed class RenderContext
     public void UseEffect(Action effect, params object[] dependencies)
     {
         var hook = AcquireEffectSlot();
-        // #48: the params array is freshly minted at the call site and never
-        // aliased, so store it directly instead of copying it again via ToArray().
+        // Snapshot the deps on store (SnapshotDeps): a caller can pass — and then
+        // reuse and mutate in place — the same array instance across renders, so the
+        // stored copy must be isolated or DepsEqual would alias prev/next and skip a
+        // real change. Only the deps-CHANGED path stores, so this adds no
+        // steady-state allocation.
         if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
-            ScheduleEffect(hook, effect, null, dependencies);
+            ScheduleEffect(hook, effect, null, SnapshotDeps(dependencies));
     }
     // </snippet:effect-schedule>
 
@@ -357,7 +360,7 @@ public sealed class RenderContext
     {
         var hook = AcquireEffectSlot();
         if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
-            ScheduleEffect(hook, null, effectWithCleanup, dependencies);
+            ScheduleEffect(hook, null, effectWithCleanup, SnapshotDeps(dependencies));
     }
 
     // #45: arity 1-3 overloads so the common "a couple of deps" call avoids the
@@ -383,7 +386,7 @@ public sealed class RenderContext
         if (AsParamsArrayDep(d1) is { } arr)
         {
             if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
-                ScheduleEffect(hook, effect, null, arr);
+                ScheduleEffect(hook, effect, null, SnapshotDeps(arr));
             return;
         }
         if (!DepsEqual1(hook.Dependencies, d1)) ScheduleEffect(hook, effect, null, PackDeps(d1));
@@ -422,7 +425,7 @@ public sealed class RenderContext
         if (AsParamsArrayDep(d1) is { } arr)
         {
             if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
-                ScheduleEffect(hook, null, effectWithCleanup, arr);
+                ScheduleEffect(hook, null, effectWithCleanup, SnapshotDeps(arr));
             return;
         }
         if (!DepsEqual1(hook.Dependencies, d1)) ScheduleEffect(hook, null, effectWithCleanup, PackDeps(d1));
@@ -486,7 +489,7 @@ public sealed class RenderContext
         if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
         {
             hook.Value = factory();
-            hook.Dependencies = dependencies; // #48: store the fresh params array directly
+            hook.Dependencies = SnapshotDeps(dependencies);
         }
         return hook.Value;
     }
@@ -508,7 +511,7 @@ public sealed class RenderContext
             if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
             {
                 hook.Value = factory();
-                hook.Dependencies = arr;
+                hook.Dependencies = SnapshotDeps(arr);
             }
             return hook.Value;
         }
@@ -564,7 +567,7 @@ public sealed class RenderContext
         if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
         {
             hook.Value = callback;
-            hook.Dependencies = dependencies;
+            hook.Dependencies = SnapshotDeps(dependencies);
         }
         return hook.Value;
     }
@@ -584,7 +587,7 @@ public sealed class RenderContext
             if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
             {
                 hook.Value = callback;
-                hook.Dependencies = arr;
+                hook.Dependencies = SnapshotDeps(arr);
             }
             return hook.Value;
         }
@@ -667,6 +670,24 @@ public sealed class RenderContext
     private static object[] PackDeps<T1>(T1 d1) => new object[] { d1! };
     private static object[] PackDeps<T1, T2>(T1 d1, T2 d2) => new object[] { d1!, d2! };
     private static object[] PackDeps<T1, T2, T3>(T1 d1, T2 d2, T3 d3) => new object[] { d1!, d2!, d3! };
+
+    // Snapshot a caller-supplied deps array before persisting it on a hook slot.
+    // Callers can pass — and then reuse and mutate in place — the same array
+    // instance across renders (a params target, or a covariant array routed through
+    // AsParamsArrayDep). Storing it by reference would alias prev/next so an in-place
+    // mutation is invisible to DepsEqual and would wrongly skip the effect or memo
+    // recompute. Cloning isolates the stored copy. This runs only on the
+    // deps-CHANGED store path (the deps-equal path short-circuits before storing), so
+    // it adds no steady-state allocation; the empty "run once" case reuses the shared
+    // empty array. Always returns a genuine object[] even when the source is a
+    // covariant array (e.g. string[]).
+    private static object[] SnapshotDeps(object[] dependencies)
+    {
+        if (dependencies.Length == 0) return Array.Empty<object>();
+        var copy = new object[dependencies.Length];
+        Array.Copy(dependencies, copy, dependencies.Length);
+        return copy;
+    }
 
     // A lone arity-1 dependency that is itself an object[] at runtime — e.g. a
     // covariant string[]/Element[] — historically bound to the params overload and

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -296,13 +296,26 @@ public sealed class RenderContext
         // back, so the returned dispatch is stable across renders yet always runs
         // the current reducer (the prior code returned a fresh dispatch bound to
         // that render's reducer — observably the same for the latest dispatch).
-        hook.Reducer = reducer;
+        // threadSafe correctness: a threadSafe dispatch may run on a background
+        // thread, so publish the reducer with a release write (paired with the
+        // acquire read in Dispatch) to guarantee the latest reducer is visible
+        // cross-thread on weak memory models (e.g. ARM64). The non-threadSafe path
+        // marshals dispatch onto the UI render thread, so a plain store is already
+        // correctly ordered there and pays no barrier on the common path.
+        if (hook.ThreadSafe)
+            global::System.Threading.Volatile.Write(ref hook.Reducer, (object?)reducer);
+        else
+            hook.Reducer = reducer;
         if (hook.CachedDelegate is not Action<TAction> dispatch)
         {
             void Dispatch(TAction action)
             {
                 var h = (ValueHookState<TState>)_hooks[currentIndex];
-                var currentReducer = (Func<TState, TAction, TState>)h.Reducer!;
+                // acquire-read pairs with the render-thread release write above so a
+                // cross-thread (threadSafe) dispatch observes the latest reducer;
+                // non-threadSafe dispatch already runs on the UI render thread.
+                var currentReducer = (Func<TState, TAction, TState>)(
+                    h.ThreadSafe ? global::System.Threading.Volatile.Read(ref h.Reducer) : h.Reducer)!;
                 if (h.ThreadSafe)
                 {
                     bool changed;
@@ -2447,6 +2460,9 @@ public sealed class RenderContext
         // #44: latest reducer for the UseReducer<TState,TAction> dispatch path,
         // refreshed each render so the cached dispatch always runs the current
         // reducer (matches the prior per-render-dispatch behaviour and React).
+        // For threadSafe reducers this is published/consumed with Volatile
+        // release/acquire (see UseReducer) so a cross-thread dispatch sees the
+        // latest reducer on weak memory models.
         public object? Reducer;
         public ValueHookState(T value, bool threadSafe = false)
         {

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -657,6 +657,12 @@ public sealed class RenderContext
         return hook;
     }
 
+    // The caller is responsible for passing an isolated deps array — either a
+    // freshly packed array (PackDeps, arity overloads) or a defensive clone
+    // (SnapshotDeps, params/AsParamsArrayDep paths). Storing it by reference here
+    // is therefore safe: no caller-owned array is ever aliased onto the hook slot,
+    // so an in-place mutation of a reused caller array cannot make prev/next deps
+    // alias and wrongly short-circuit DepsEqual.
     private static void ScheduleEffect(EffectHookState hook, Action? effect, Func<Action>? withCleanup, object[] dependencies)
     {
         hook.PendingCleanup = hook.Cleanup;

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -764,6 +764,15 @@ public sealed class RenderContext
     // non-generic params DepsEqual, which compares via object.Equals and never throws.
     // Value-type T unboxes through the `is T` pattern with no extra allocation, and the
     // current dep is still passed through EqualityComparer<T> unboxed.
+    //
+    // Nullable value-type deps (T = U?) are handled correctly. Boxing a non-null
+    // Nullable<U> stores a boxed U, but the GENERIC `stored is T` test still succeeds for
+    // that boxed U and binds the nullable-wrapped value — the CLR special-cases nullable
+    // type-tests (the symmetric counterpart of `(U?)(object)u` unboxing). So an unchanged
+    // nullable dep compares equal, a null nullable boxes to a null reference handled by
+    // the `stored is null` guard above, and value<->null transitions are detected. This
+    // matches the pre-existing `(T)prev[i]` behavior exactly (verified across
+    // int?/long?/double?/enum? incl. null transitions) — it is NOT a per-render re-run.
     private static bool DepEquals<T>(object? stored, T current)
     {
         if (stored is null) return current is null;

--- a/src/Reactor/Hooks/UseElementFocus.cs
+++ b/src/Reactor/Hooks/UseElementFocus.cs
@@ -27,7 +27,11 @@ public static class UseElementFocusExtensions
     public static (ElementRef Ref, Action RequestFocus) UseElementFocus(this RenderContext ctx,
         FocusState state = FocusState.Programmatic)
     {
-        var (elRef, _) = ctx.UseState(new ElementRef());
+        // The ElementRef must survive re-renders but never changes after the first.
+        // UseMemo with empty deps allocates it exactly once via a non-capturing static
+        // factory; UseState(new ElementRef()) would eagerly allocate (and discard) a
+        // fresh ElementRef on EVERY render even though only the first is ever kept.
+        var elRef = ctx.UseMemo(static () => new ElementRef(), Array.Empty<object>());
 
         // #55: previously this hook captured the UI dispatcher via a
         // GetForCurrentThread() COM call AND allocated a fresh `requestFocus`

--- a/src/Reactor/Hooks/UseElementFocus.cs
+++ b/src/Reactor/Hooks/UseElementFocus.cs
@@ -50,7 +50,7 @@ public static class UseElementFocusExtensions
             // call: in unit-test / headless contexts the WinUI activation factory
             // isn't registered and GetForCurrentThread throws a COMException.
             try { cache.UiQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread(); }
-            catch { cache.UiQueue = null; }
+            catch (global::System.Runtime.InteropServices.COMException) { cache.UiQueue = null; }
             cache.RequestFocus = () =>
             {
                 if (cache.UiQueue is null)

--- a/src/Reactor/Hooks/UseElementFocus.cs
+++ b/src/Reactor/Hooks/UseElementFocus.cs
@@ -28,25 +28,54 @@ public static class UseElementFocusExtensions
         FocusState state = FocusState.Programmatic)
     {
         var (elRef, _) = ctx.UseState(new ElementRef());
-        // Capture the UI dispatcher at render time — RequestFocus may be called from a
-        // background thread (e.g. from UseEffect cleanup, task continuations), where
-        // GetForCurrentThread() would return the wrong queue or null.
-        // Guard the call itself: in unit-test / headless contexts the WinUI activation
-        // factory isn't registered and GetForCurrentThread throws a COMException.
-        Microsoft.UI.Dispatching.DispatcherQueue? uiQueue;
-        try { uiQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread(); }
-        catch { uiQueue = null; }
-        Action requestFocus = () =>
+
+        // #55: previously this hook captured the UI dispatcher via a
+        // GetForCurrentThread() COM call AND allocated a fresh `requestFocus`
+        // closure on EVERY render (multiplied by every focusable cell). Both are
+        // now built exactly once and stashed in a UseRef cell:
+        //   • the dispatcher is resolved a single time (it never changes for the
+        //     component's UI thread), and
+        //   • the closure is allocated once and reused; the latest `state` is
+        //     written into the cache each render (a cheap field store, no
+        //     allocation) and read at invoke time, so focus still uses the
+        //     current render's focus state.
+        var cacheRef = ctx.UseRef<FocusHookCache?>(null);
+        var cache = cacheRef.Current;
+        if (cache is null)
         {
-            if (uiQueue is null)
+            cache = new FocusHookCache { State = state };
+            // Capture the UI dispatcher once — RequestFocus may be called from a
+            // background thread (UseEffect cleanup, task continuations) where
+            // GetForCurrentThread() would return the wrong queue or null. Guard the
+            // call: in unit-test / headless contexts the WinUI activation factory
+            // isn't registered and GetForCurrentThread throws a COMException.
+            try { cache.UiQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread(); }
+            catch { cache.UiQueue = null; }
+            cache.RequestFocus = () =>
             {
-                // No dispatcher available (headless/tests) — invoke synchronously.
-                Microsoft.UI.Reactor.Input.FocusManager.Focus(elRef, state);
-                return;
-            }
-            uiQueue.TryEnqueue(() => Microsoft.UI.Reactor.Input.FocusManager.Focus(elRef, state));
-        };
-        return (elRef, requestFocus);
+                if (cache.UiQueue is null)
+                {
+                    // No dispatcher available (headless/tests) — invoke synchronously.
+                    Microsoft.UI.Reactor.Input.FocusManager.Focus(elRef, cache.State);
+                    return;
+                }
+                cache.UiQueue.TryEnqueue(() => Microsoft.UI.Reactor.Input.FocusManager.Focus(elRef, cache.State));
+            };
+            cacheRef.Current = cache;
+        }
+        else
+        {
+            cache.State = state;
+        }
+
+        return (elRef, cache.RequestFocus);
+    }
+
+    private sealed class FocusHookCache
+    {
+        public Microsoft.UI.Dispatching.DispatcherQueue? UiQueue;
+        public FocusState State;
+        public Action RequestFocus = default!;
     }
 
     /// <summary>

--- a/src/Reactor/Hooks/UseElementFocus.cs
+++ b/src/Reactor/Hooks/UseElementFocus.cs
@@ -40,9 +40,10 @@ public static class UseElementFocusExtensions
         //   • the dispatcher is resolved a single time (it never changes for the
         //     component's UI thread), and
         //   • the closure is allocated once and reused; the latest `state` is
-        //     written into the cache each render (a cheap field store, no
-        //     allocation) and read at invoke time, so focus still uses the
-        //     current render's focus state.
+        //     written into the cache each render (a cheap volatile field store,
+        //     no allocation) and read at invoke time, so focus still uses the
+        //     current render's focus state. The cache fields are `volatile` so a
+        //     background-thread invoke sees the latest values (see FocusHookCache).
         var cacheRef = ctx.UseRef<FocusHookCache?>(null);
         var cache = cacheRef.Current;
         if (cache is null)
@@ -77,8 +78,15 @@ public static class UseElementFocusExtensions
 
     private sealed class FocusHookCache
     {
-        public Microsoft.UI.Dispatching.DispatcherQueue? UiQueue;
-        public FocusState State;
+        // RequestFocus may be invoked from a background thread (task continuations),
+        // while UiQueue (write-once at construction) and State (refreshed each render)
+        // are written on the UI render thread. `volatile` gives those cross-thread
+        // reads/writes release/acquire semantics so a background invoke never observes
+        // a stale UiQueue (e.g. a spurious null -> a wrong synchronous off-thread
+        // focus) or an outdated FocusState on a weak memory model (e.g. ARM64).
+        // RequestFocus itself is write-once and only read on the render thread.
+        public volatile Microsoft.UI.Dispatching.DispatcherQueue? UiQueue;
+        public volatile FocusState State;
         public Action RequestFocus = default!;
     }
 

--- a/src/Reactor/Hooks/UseInfiniteResource.cs
+++ b/src/Reactor/Hooks/UseInfiniteResource.cs
@@ -70,7 +70,9 @@ public static class UseInfiniteResourceExtensions
         state.SetFetcher(fetchPage);
         state.CursorFromPageIndex = cursorFromPageIndex;
 
-        ctx.UseEffect(() => () => state.Dispose());
+        // #56: run-once-on-unmount cleanup without the per-render double-lambda
+        // allocation (see UseResource / UseDisposableEffect).
+        ctx.UseDisposableEffect(state);
 
         // Deps-change restart.
         string newKeyPrefix = BuildKeyPrefix(hookIdRef.Current!, deps, options);

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -170,15 +170,25 @@ public static class UseMemoCellsExtensions
             keys[i] = keySelector(items[i]);
 
         // #47: full-reuse fast path — deps unchanged, same length, every item equal
-        // in order. Returns the prior children and skips the children[] + Dictionary
-        // rebuild + snapshot allocations.
+        // in order AND every key still maps to its own position. Returns the prior
+        // children and skips the children[] + Dictionary rebuild + snapshot
+        // allocations. The key check (via the existing KeyToIndex map, zero-alloc)
+        // keeps this provably equivalent to the slow path's key-identity reuse even
+        // when keySelector is not a pure function of the item value.
         if (!depsChanged && prev!.Items.Length == count)
         {
             var prevSnapshot = prev.Items;
+            var prevKeyMap = prev.KeyToIndex;
             bool allReused = true;
             for (int i = 0; i < count; i++)
             {
-                if (!Equals(items[i], prevSnapshot[i])) { allReused = false; break; }
+                if (!Equals(items[i], prevSnapshot[i])
+                    || !prevKeyMap.TryGetValue(keys[i], out var prevPos)
+                    || prevPos != i)
+                {
+                    allReused = false;
+                    break;
+                }
             }
             if (allReused)
                 return prev.Children;

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -161,6 +161,9 @@ public static class UseMemoCellsExtensions
         var prev = stateRef.Current;
         var depsChanged = prev is null || !DepsEqual(prev.Deps, dependencies);
         var count = items.Count;
+        // Previous render's row count (snapshot length); bounds the key-buffer tail
+        // clear below and feeds the full-reuse length check.
+        var prevCount = prev?.Items.Length ?? 0;
 
         // #59: compute each item's key exactly once and reuse it in both the reuse
         // scan and the snapshot-map build (keySelector was previously invoked twice
@@ -173,12 +176,15 @@ public static class UseMemoCellsExtensions
             keys = count == 0 ? Array.Empty<TKey>() : new TKey[count];
         for (int i = 0; i < count; i++)
             keys[i] = keySelector(items[i]);
-        // When the buffer is reused from a render that had more rows, null out the
-        // stale [count..] tail so keys for rows that scrolled/shrank away are not held
-        // alive until the slots are next overwritten. Zero-alloc: writes null over the
-        // unused region only, and is skipped in the steady state where Length == count.
-        if (keys.Length > count)
-            Array.Clear(keys, count, keys.Length - count);
+        // Null only the slots vacated since the PREVIOUS render ([count..prevCount]).
+        // Slots beyond prevCount were already nulled by the render that vacated them,
+        // so a buffer that peaked large then stays small is cleared once per shrink
+        // transition instead of paying an O(buffer) Array.Clear on every steady-state
+        // full-reuse render. The post-render invariant is unchanged: [count..Length]
+        // is still all-null afterwards. prevCount <= keys.Length always holds (the
+        // buffer grows to fit every count it has seen); Math.Min is a defensive clamp.
+        if (prevCount > count)
+            Array.Clear(keys, count, Math.Min(prevCount, keys.Length) - count);
 
         // #47: full-reuse fast path — deps unchanged, same length, every item equal
         // in order AND every key still maps to its own position. Returns the prior
@@ -186,9 +192,9 @@ public static class UseMemoCellsExtensions
         // allocations. The key check (via the existing KeyToIndex map, zero-alloc)
         // keeps this provably equivalent to the slow path's key-identity reuse even
         // when keySelector is not a pure function of the item value.
-        if (!depsChanged && prev!.Items.Length == count)
+        if (!depsChanged && prevCount == count)
         {
-            var prevSnapshot = prev.Items;
+            var prevSnapshot = prev!.Items;
             var prevKeyMap = prev.KeyToIndex;
             bool allReused = true;
             for (int i = 0; i < count; i++)

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -94,7 +94,7 @@ public static class UseMemoCellsExtensions
             bool allReused = true;
             for (int i = 0; i < count; i++)
             {
-                if (!Equals(items[i], prevSnapshot[i])) { allReused = false; break; }
+                if (!EqualityComparer<T>.Default.Equals(items[i], prevSnapshot[i])) { allReused = false; break; }
             }
             if (allReused)
                 return prev.Children;
@@ -115,7 +115,7 @@ public static class UseMemoCellsExtensions
             for (int i = 0; i < count; i++)
             {
                 var item = items[i];
-                if (i < prevLen && Equals(item, prevItems[i]))
+                if (i < prevLen && EqualityComparer<T>.Default.Equals(item, prevItems[i]))
                     children[i] = prevChildren[i];
                 else
                     children[i] = builder(item, i);
@@ -199,7 +199,7 @@ public static class UseMemoCellsExtensions
             bool allReused = true;
             for (int i = 0; i < count; i++)
             {
-                if (!Equals(items[i], prevSnapshot[i])
+                if (!EqualityComparer<T>.Default.Equals(items[i], prevSnapshot[i])
                     || !prevKeyMap.TryGetValue(keys[i], out var prevPos)
                     || prevPos != i)
                 {
@@ -219,7 +219,7 @@ public static class UseMemoCellsExtensions
             var item = items[i];
             if (keyToIndex is not null
                 && keyToIndex.TryGetValue(keys[i], out var prevIdx)
-                && Equals(item, prev!.Items[prevIdx]))
+                && EqualityComparer<T>.Default.Equals(item, prev!.Items[prevIdx]))
             {
                 children[i] = prev!.Children[prevIdx];
             }

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -81,6 +81,25 @@ public static class UseMemoCellsExtensions
         var prev = stateRef.Current;
         var depsChanged = prev is null || !DepsEqual(prev.Deps, dependencies);
         var count = items.Count;
+
+        // #47: full-reuse fast path. When deps are unchanged and every item still
+        // compares equal (in order, same count) to the previous snapshot, nothing
+        // changed — return the prior children array directly and skip the
+        // children[] + SnapshotItems + SnapshotDeps + state-record allocations
+        // entirely. This is the dominant steady-state case for a grid whose
+        // visible rows didn't change between renders.
+        if (!depsChanged && prev!.Items.Length == count)
+        {
+            var prevSnapshot = prev.Items;
+            bool allReused = true;
+            for (int i = 0; i < count; i++)
+            {
+                if (!Equals(items[i], prevSnapshot[i])) { allReused = false; break; }
+            }
+            if (allReused)
+                return prev.Children;
+        }
+
         var children = new Element[count];
 
         if (depsChanged)
@@ -142,6 +161,29 @@ public static class UseMemoCellsExtensions
         var prev = stateRef.Current;
         var depsChanged = prev is null || !DepsEqual(prev.Deps, dependencies);
         var count = items.Count;
+
+        // #59: compute each item's key exactly once and reuse it in both the reuse
+        // scan and the snapshot-map build (keySelector was previously invoked twice
+        // per item per render).
+        var keys = count == 0 ? Array.Empty<TKey>() : new TKey[count];
+        for (int i = 0; i < count; i++)
+            keys[i] = keySelector(items[i]);
+
+        // #47: full-reuse fast path — deps unchanged, same length, every item equal
+        // in order. Returns the prior children and skips the children[] + Dictionary
+        // rebuild + snapshot allocations.
+        if (!depsChanged && prev!.Items.Length == count)
+        {
+            var prevSnapshot = prev.Items;
+            bool allReused = true;
+            for (int i = 0; i < count; i++)
+            {
+                if (!Equals(items[i], prevSnapshot[i])) { allReused = false; break; }
+            }
+            if (allReused)
+                return prev.Children;
+        }
+
         var children = new Element[count];
         var keyToIndex = depsChanged ? null : prev!.KeyToIndex;
 
@@ -149,7 +191,7 @@ public static class UseMemoCellsExtensions
         {
             var item = items[i];
             if (keyToIndex is not null
-                && keyToIndex.TryGetValue(keySelector(item), out var prevIdx)
+                && keyToIndex.TryGetValue(keys[i], out var prevIdx)
                 && Equals(item, prev!.Items[prevIdx]))
             {
                 children[i] = prev!.Children[prevIdx];
@@ -164,8 +206,9 @@ public static class UseMemoCellsExtensions
         var snapshotKeyMap = new Dictionary<TKey, int>(count);
         for (int i = 0; i < count; i++)
         {
-            // Last-write-wins on duplicate keys.
-            snapshotKeyMap[keySelector(snapshotItems[i])] = i;
+            // Last-write-wins on duplicate keys. snapshotItems[i] is a 1:1 copy of
+            // items[i], so the key computed above lines up by index.
+            snapshotKeyMap[keys[i]] = i;
         }
         stateRef.Current = new MemoCellsByKeyState<T, TKey>(snapshotItems, children, SnapshotDeps(dependencies), snapshotKeyMap);
         return children;
@@ -212,6 +255,13 @@ public static class UseMemoCellsExtensions
         var prev = stateRef.Current;
         var depsChanged = prev is null || !DepsEqual(prev.Deps, dependencies);
         var count = items.Count;
+
+        // #47: nothing-changed fast path — deps unchanged, no named changed
+        // indices, and the count matches. Return the prior children directly and
+        // skip the children[] + snapshot + state-record allocations.
+        if (!depsChanged && changedIndices.Count == 0 && prev!.Children.Length == count)
+            return prev.Children;
+
         var children = new Element[count];
 
         if (depsChanged || prev!.Children.Length != count)

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -173,6 +173,12 @@ public static class UseMemoCellsExtensions
             keys = count == 0 ? Array.Empty<TKey>() : new TKey[count];
         for (int i = 0; i < count; i++)
             keys[i] = keySelector(items[i]);
+        // When the buffer is reused from a render that had more rows, null out the
+        // stale [count..] tail so keys for rows that scrolled/shrank away are not held
+        // alive until the slots are next overwritten. Zero-alloc: writes null over the
+        // unused region only, and is skipped in the steady state where Length == count.
+        if (keys.Length > count)
+            Array.Clear(keys, count, keys.Length - count);
 
         // #47: full-reuse fast path — deps unchanged, same length, every item equal
         // in order AND every key still maps to its own position. Returns the prior

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -164,8 +164,13 @@ public static class UseMemoCellsExtensions
 
         // #59: compute each item's key exactly once and reuse it in both the reuse
         // scan and the snapshot-map build (keySelector was previously invoked twice
-        // per item per render).
-        var keys = count == 0 ? Array.Empty<TKey>() : new TKey[count];
+        // per item per render). The key buffer is carried on the hook state and
+        // reused across renders — grown only when the row count exceeds the prior
+        // capacity — so the steady-state full-reuse fast path below allocates nothing
+        // (the buffer is scratch: the authoritative key map is the stored Dictionary).
+        var keys = prev?.KeyBuffer;
+        if (keys is null || keys.Length < count)
+            keys = count == 0 ? Array.Empty<TKey>() : new TKey[count];
         for (int i = 0; i < count; i++)
             keys[i] = keySelector(items[i]);
 
@@ -220,7 +225,7 @@ public static class UseMemoCellsExtensions
             // items[i], so the key computed above lines up by index.
             snapshotKeyMap[keys[i]] = i;
         }
-        stateRef.Current = new MemoCellsByKeyState<T, TKey>(snapshotItems, children, SnapshotDeps(dependencies), snapshotKeyMap);
+        stateRef.Current = new MemoCellsByKeyState<T, TKey>(snapshotItems, children, SnapshotDeps(dependencies), snapshotKeyMap, keys);
         return children;
     }
 
@@ -342,7 +347,7 @@ public static class UseMemoCellsExtensions
 
     private sealed record MemoCellsState<T>(T[] Items, Element[] Children, object[] Deps);
 
-    private sealed record MemoCellsByKeyState<T, TKey>(T[] Items, Element[] Children, object[] Deps, Dictionary<TKey, int> KeyToIndex)
+    private sealed record MemoCellsByKeyState<T, TKey>(T[] Items, Element[] Children, object[] Deps, Dictionary<TKey, int> KeyToIndex, TKey[] KeyBuffer)
         where TKey : notnull;
 }
 

--- a/src/Reactor/Hooks/UseMutation.cs
+++ b/src/Reactor/Hooks/UseMutation.cs
@@ -135,7 +135,9 @@ public static class UseMutationExtensions
         state.Mutator = mutator;
         state.Options = options;
 
-        ctx.UseEffect(() => () => state.Dispose());
+        // #56: run-once-on-unmount cleanup without the per-render double-lambda
+        // allocation (see UseResource / UseDisposableEffect).
+        ctx.UseDisposableEffect(state);
 
         return state.Handle;
     }

--- a/src/Reactor/Hooks/UseResource.cs
+++ b/src/Reactor/Hooks/UseResource.cs
@@ -66,6 +66,12 @@ internal sealed class WindowsDispatcherHookDispatcher : IHookDispatcher
 /// </remarks>
 public static class UseResourceExtensions
 {
+    // #57: monotonic counter for per-call-site hook ids — replaces a
+    // Guid.NewGuid() (16 random bytes + 32-char format) per mounted resource hook
+    // with a single interlocked increment. The id only needs process-unique
+    // identity for the cache-key prefix, which a counter satisfies.
+    private static int _hookIdCounter;
+
     /// <summary>
     /// Runs an async fetch keyed on <paramref name="deps"/>, returning an
     /// <see cref="AsyncValue{T}"/> that tracks the fetch's lifecycle. The hook
@@ -114,10 +120,10 @@ public static class UseResourceExtensions
     {
         options ??= ResourceOptions.Default;
 
-        // Stable per-call-site identity. UseRef persists across renders; the GUID is
+        // Stable per-call-site identity. UseRef persists across renders; the id is
         // chosen once on first render for this component instance + hook index.
         var hookIdRef = ctx.UseRef<string?>(null);
-        hookIdRef.Current ??= Guid.NewGuid().ToString("N");
+        hookIdRef.Current ??= Interlocked.Increment(ref _hookIdCounter).ToString(global::System.Globalization.CultureInfo.InvariantCulture);
 
         var stateRef = ctx.UseRef<ResourceHookState<T>?>(null);
         var (_, rerenderTick) = ctx.UseReducer(0, threadSafe: true);
@@ -136,11 +142,24 @@ public static class UseResourceExtensions
             pendingScope: pendingScope,
             focusService: options.RefetchOnWindowFocus ? focusService : null);
 
-        // Run-once-on-unmount cleanup. Deps-change is driven synchronously below rather than
-        // via UseEffect, because we need the updated value inside this same render.
-        ctx.UseEffect(() => () => state.Dispose());
+        // #56: run-once-on-unmount cleanup. Equivalent to
+        // `UseEffect(() => () => state.Dispose())` but without allocating the two
+        // lambdas every render — the teardown is captured a single time on mount.
+        // Deps-change is driven synchronously below rather than via UseEffect,
+        // because we need the updated value inside this same render.
+        ctx.UseDisposableEffect(state);
 
-        string newKey = options.CacheKey ?? $"{hookIdRef.Current}/{DepsHash(deps)}";
+        // #57: only rebuild the DepsHash-based cache key when the deps actually
+        // changed since the last transition. The hash string was previously rebuilt
+        // every render even on the steady-state path where deps are identical.
+        string newKey;
+        if (options.CacheKey is not null)
+            newKey = options.CacheKey;
+        else if (state.LastDeps is not null && DepsEqual(state.LastDeps, deps))
+            newKey = state.CacheKey;
+        else
+            newKey = $"{hookIdRef.Current}/{DepsHash(deps)}";
+
         bool firstRender = state.LastDeps is null;
         bool depsChanged = !firstRender && (!string.Equals(state.CacheKey, newKey, StringComparison.Ordinal));
 
@@ -373,6 +392,16 @@ public static class UseResourceExtensions
                 h = h * 31 + (d?.GetHashCode() ?? 0);
             return h;
         }
+    }
+
+    private static bool DepsEqual(object[] prev, object[] next)
+    {
+        if (prev.Length != next.Length) return false;
+        for (int i = 0; i < prev.Length; i++)
+        {
+            if (!Equals(prev[i], next[i])) return false;
+        }
+        return true;
     }
 
     private static bool IsCanceledOrDropped<T>(this Task<T> t) =>

--- a/src/Reactor/Hooks/UseResource.cs
+++ b/src/Reactor/Hooks/UseResource.cs
@@ -152,10 +152,15 @@ public static class UseResourceExtensions
         // #57: only rebuild the DepsHash-based cache key when the deps actually
         // changed since the last transition. The hash string was previously rebuilt
         // every render even on the steady-state path where deps are identical.
+        bool keyIsExplicit = options.CacheKey is not null;
         string newKey;
-        if (options.CacheKey is not null)
-            newKey = options.CacheKey;
-        else if (state.LastDeps is not null && DepsEqual(state.LastDeps, deps))
+        if (keyIsExplicit)
+            newKey = options.CacheKey!;
+        // Reuse the prior hashed key only when the previous render was ALSO in
+        // deps-hash mode. If CacheKey just transitioned explicit -> null, the stored
+        // key is the old explicit string and must be recomputed even though deps are
+        // unchanged (matches the pre-#57 behaviour of always recomputing).
+        else if (state.LastDeps is not null && !state.LastKeyWasExplicit && DepsEqual(state.LastDeps, deps))
             newKey = state.CacheKey;
         else
             newKey = $"{hookIdRef.Current}/{DepsHash(deps)}";
@@ -165,7 +170,7 @@ public static class UseResourceExtensions
 
         if (firstRender || depsChanged)
         {
-            state.TransitionToKey(newKey, deps);
+            state.TransitionToKey(newKey, deps, keyIsExplicit);
             EnterKey(state, fetcher, options);
         }
         else
@@ -420,6 +425,10 @@ internal sealed class ResourceHookState<T> : IDisposable
     public readonly PendingScope? PendingScope;
     public string CacheKey = "";
     public object[]? LastDeps;
+    // True when CacheKey currently holds an explicit options.CacheKey rather than a
+    // deps-hash key. Lets the #57 rehash-skip path detect an explicit -> null
+    // transition and recompute instead of reusing the stale explicit key.
+    public bool LastKeyWasExplicit;
     public CancellationTokenSource? Cts;
     private AsyncValue<T> _lastValue = AsyncValue<T>.Loading.Instance;
     public AsyncValue<T> LastValue
@@ -473,7 +482,7 @@ internal sealed class ResourceHookState<T> : IDisposable
         PendingScope.SetLoading(this, loading);
     }
 
-    public void TransitionToKey(string newKey, object[] newDeps)
+    public void TransitionToKey(string newKey, object[] newDeps, bool keyIsExplicit)
     {
         // Cancel outstanding work for the previous key.
         Cts?.Cancel();
@@ -491,6 +500,7 @@ internal sealed class ResourceHookState<T> : IDisposable
         Cache.Subscribe(newKey);
         _focusService?.Enroll(newKey);
         LastDeps = newDeps.ToArray();
+        LastKeyWasExplicit = keyIsExplicit;
     }
 
     public void ScheduleRetry(TimeSpan delay, Action afterDelay)

--- a/src/Reactor/Hooks/UseResource.cs
+++ b/src/Reactor/Hooks/UseResource.cs
@@ -69,8 +69,10 @@ public static class UseResourceExtensions
     // #57: monotonic counter for per-call-site hook ids — replaces a
     // Guid.NewGuid() (16 random bytes + 32-char format) per mounted resource hook
     // with a single interlocked increment. The id only needs process-unique
-    // identity for the cache-key prefix, which a counter satisfies.
-    private static int _hookIdCounter;
+    // identity for the cache-key prefix, which a counter satisfies. A long avoids
+    // any wrap-around (and resulting cache-key prefix collisions) over the process
+    // lifetime, at no cost over an int.
+    private static long _hookIdCounter;
 
     /// <summary>
     /// Runs an async fetch keyed on <paramref name="deps"/>, returning an

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -201,10 +201,14 @@ public class HookAllocationPerfTests
         var (_, update) = ctx.UseReducer(0, threadSafe: true);
 
         const int threads = 8, perThread = 1000;
+        // A start barrier maximizes real contention: every worker blocks until all
+        // threads are ready, so the increments actually race on the lock.
+        using var barrier = new Barrier(threads);
         var tasks = new Task[threads];
         for (int t = 0; t < threads; t++)
             tasks[t] = Task.Run(() =>
             {
+                barrier.SignalAndWait(TestContext.Current.CancellationToken);
                 for (int i = 0; i < perThread; i++)
                     update(prev => prev + 1);
             }, TestContext.Current.CancellationToken);
@@ -437,5 +441,276 @@ public class HookAllocationPerfTests
 
         Assert.Same(ref1, ref2);
         Assert.Same(requestFocus1, requestFocus2);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  H1 — a lone object[]-typed dep keeps element-wise (params) semantics
+    //  (covariant ref-type arrays must NOT be reference-compared as one dep)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseEffect_Arity1_ObjectArray_Dep_Uses_ElementWise_Comparison()
+    {
+        // A fresh string[] of equal contents each render must NOT re-run the effect.
+        // (If the array were wrapped as one reference-compared dep it would re-run.)
+        var ctx = NewCtx();
+        int runs = 0;
+        ctx.UseEffect(() => { runs++; }, new[] { "a", "b" });
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, new[] { "a", "b" }); // new array, equal contents
+        ctx.FlushEffects();
+        Assert.Equal(1, runs); // element-wise equal → skipped
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, new[] { "a", "c" }); // contents changed
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+    }
+
+    [Fact]
+    public void UseMemo_Arity1_ObjectArray_Dep_Uses_ElementWise_Comparison()
+    {
+        var ctx = NewCtx();
+        int calls = 0;
+        var v1 = ctx.UseMemo(() => { calls++; return calls; }, new[] { "a", "b" });
+        Rerender(ctx);
+        var v2 = ctx.UseMemo(() => { calls++; return calls; }, new[] { "a", "b" }); // equal contents
+        Rerender(ctx);
+        var v3 = ctx.UseMemo(() => { calls++; return calls; }, new[] { "a", "c" }); // changed
+
+        Assert.Equal(1, v1);
+        Assert.Equal(1, v2); // reused
+        Assert.Equal(2, v3); // recomputed
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void UseCallback_Arity1_ObjectArray_Dep_Uses_ElementWise_Comparison()
+    {
+        var ctx = NewCtx();
+        Action cb1 = () => { };
+        Action cb2 = () => { };
+        Action cb3 = () => { };
+        var r1 = ctx.UseCallback(cb1, new[] { "a", "b" });
+        Rerender(ctx);
+        var r2 = ctx.UseCallback(cb2, new[] { "a", "b" }); // equal contents → retain cb1
+        Rerender(ctx);
+        var r3 = ctx.UseCallback(cb3, new[] { "a", "c" }); // changed → adopt cb3
+
+        Assert.Same(cb1, r1);
+        Assert.Same(cb1, r2); // deps equal element-wise → cached callback retained
+        Assert.Same(cb3, r3); // deps changed → new callback
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  #45/#46 — remaining deps-overload matrix (arity 2/3 + cleanup flavor)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseEffect_Arity2_And_Arity3_Fire_Once_While_Deps_Unchanged()
+    {
+        var ctx = NewCtx();
+        int runs2 = 0, runs3 = 0;
+        for (int r = 0; r < 3; r++)
+        {
+            ctx.BeginRender(() => { });
+            ctx.UseEffect(() => { runs2++; }, 1, "x");
+            ctx.UseEffect(() => { runs3++; }, 1, "x", 2.5);
+            ctx.FlushEffects();
+        }
+
+        Assert.Equal(1, runs2);
+        Assert.Equal(1, runs3);
+    }
+
+    [Fact]
+    public void UseEffect_Cleanup_Arity1_Reruns_And_Cleans_Up_On_Dep_Change()
+    {
+        var ctx = NewCtx();
+        int runs = 0, cleanups = 0;
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, 1);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, 1); // unchanged
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, 2); // changed → cleanup + rerun
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+        Assert.Equal(1, cleanups);
+    }
+
+    [Fact]
+    public void UseCallback_Arity2_And_Arity3_Recompute_On_Change()
+    {
+        var ctx = NewCtx();
+        Action a1 = () => { };
+        Action a2 = () => { };
+        ctx.UseCallback(a1, 1, "x");
+        ctx.UseCallback(a1, 1, "x", 2.5);
+        Rerender(ctx);
+        var c2 = ctx.UseCallback(a2, 1, "x");      // unchanged deps → keep a1
+        var c3 = ctx.UseCallback(a2, 1, "x", 9.9); // changed dep → adopt a2
+
+        Assert.Same(a1, c2);
+        Assert.Same(a2, c3);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  #56 — UseDisposableEffect: dispose exactly once on unmount
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseDisposableEffect_Disposes_Resource_Once_On_Unmount()
+    {
+        var ctx = NewCtx();
+        var probe = new DisposeProbe();
+        ctx.UseDisposableEffect(probe);
+        ctx.FlushEffects();
+
+        for (int i = 0; i < 3; i++) // re-render: mount-once effect must not re-fire
+        {
+            Rerender(ctx);
+            ctx.UseDisposableEffect(probe);
+            ctx.FlushEffects();
+        }
+        Assert.Equal(0, probe.Disposals); // still mounted
+
+        ctx.RunCleanups();
+        Assert.Equal(1, probe.Disposals); // disposed exactly once on unmount
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  #52 — UseCommand<T> caches its wrapped Execute across renders
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseCommand_Generic_Wrapped_Execute_Is_Same_Instance_When_Command_Unchanged()
+    {
+        var ctx = NewCtx();
+        var cmd = new Command<string> { Label = "Delete", ExecuteAsync = _ => Task.CompletedTask };
+
+        var r1 = ctx.UseCommand(cmd);
+        Rerender(ctx);
+        var r2 = ctx.UseCommand(cmd);
+
+        Assert.NotNull(r1.Execute);
+        Assert.Same(r1.Execute, r2.Execute);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  M1 — UseMemoCellsByKey full-reuse requires KEY stability, not just value
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseMemoCellsByKey_Rebuilds_When_Key_Changes_Despite_Equal_Items()
+    {
+        // The full-reuse fast path must also require key stability. With equal items
+        // but changed keys, cells are rebuilt (keyed identity changed) rather than
+        // wrongly reused — matching the slow path's key-identity reuse.
+        var ctx = NewCtx();
+        int delta = 0;
+        var items = new[] { 1, 2, 3 };
+        int builds = 0;
+        var first = ctx.UseMemoCellsByKey<int, int>(items, x => x + delta, (item, i) => { builds++; return MakeCell(item); }, "d");
+        Rerender(ctx);
+        delta = 100; // same items, but every key now differs
+        var second = ctx.UseMemoCellsByKey<int, int>(items, x => x + delta, (item, i) => { builds++; return MakeCell(item); }, "d");
+
+        Assert.NotSame(first, second);       // fast path skipped (keys changed)
+        Assert.NotSame(first[0], second[0]); // cell rebuilt under its new key
+        Assert.Equal(6, builds);             // 3 first render + 3 rebuilt
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  #57 / M2 — UseResource cache-key recompute correctness
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseResource_Stable_Deps_Does_Not_Refetch_But_Changed_Deps_Does()
+    {
+        // #57: identical deps + no explicit key reuses the deps-hash key (no spurious
+        // refetch); changed deps recompute the key and fetch again.
+        var cache = NewCache();
+        var dispatcher = new InlineDispatcher();
+        int calls = 0;
+        Func<CancellationToken, Task<int>> fetcher = _ => { calls++; return Task.FromResult(calls); };
+        var opts = new ResourceOptions(StaleTime: TimeSpan.FromMinutes(5));
+
+        var ctx = new RenderContext();
+        ctx.BeginRender(() => { });
+        ctx.UseResource(fetcher, cache, new object[] { 1 }, opts, dispatcher);
+        ctx.FlushEffects();
+        Assert.Equal(1, calls);
+
+        ctx.BeginRender(() => { });
+        ctx.UseResource(fetcher, cache, new object[] { 1 }, opts, dispatcher); // same deps
+        ctx.FlushEffects();
+        Assert.Equal(1, calls); // reused key → no refetch
+
+        ctx.BeginRender(() => { });
+        ctx.UseResource(fetcher, cache, new object[] { 2 }, opts, dispatcher); // changed deps
+        ctx.FlushEffects();
+        Assert.Equal(2, calls); // recomputed key → refetch
+
+        ctx.RunCleanups();
+    }
+
+    [Fact]
+    public void UseResource_Explicit_To_Null_CacheKey_With_Equal_Deps_Recomputes_Key()
+    {
+        // M2 regression: when options.CacheKey transitions non-null -> null while deps
+        // are unchanged, the #57 rehash-skip must NOT reuse the stale explicit key. It
+        // must fall back to the deps-hash key (a key change → a fresh fetch), matching
+        // the pre-#57 behaviour of always recomputing when no explicit key is supplied.
+        var cache = NewCache();
+        var dispatcher = new InlineDispatcher();
+        int calls = 0;
+        Func<CancellationToken, Task<int>> fetcher = _ => { calls++; return Task.FromResult(calls); };
+
+        var ctx = new RenderContext();
+        ctx.BeginRender(() => { });
+        ctx.UseResource(fetcher, cache, new object[] { 1 }, new ResourceOptions(CacheKey: "explicit"), dispatcher);
+        ctx.FlushEffects();
+        Assert.Equal(1, calls);
+
+        ctx.BeginRender(() => { });
+        ctx.UseResource(fetcher, cache, new object[] { 1 }, null, dispatcher); // CacheKey now null, deps equal
+        ctx.FlushEffects();
+        Assert.Equal(2, calls); // key recomputed → new fetch (would stay 1 if stale key reused)
+
+        ctx.RunCleanups();
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Test helpers
+    // ════════════════════════════════════════════════════════════════
+
+    private sealed class DisposeProbe : IDisposable
+    {
+        public int Disposals;
+        public void Dispose() => Disposals++;
+    }
+
+    private sealed class InlineDispatcher : IHookDispatcher
+    {
+        public void Post(Action action) => action();
+    }
+
+    private static QueryCache NewCache()
+    {
+        var cache = new QueryCache();
+        var t = DateTime.UtcNow;
+        cache.UtcNow = () => t; // frozen clock so cached entries stay fresh within a test
+        return cache;
     }
 }

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -387,6 +387,40 @@ public class HookAllocationPerfTests
     }
 
     [Fact]
+    public void UseMemoCellsByKey_FullReuse_Does_Not_Allocate_Per_Render()
+    {
+        // Guards the steady-state full-reuse fast path against per-render allocation
+        // (the key buffer is carried on the hook state and reused). Reference-type
+        // keys avoid boxing in the equality scan; Array.Empty deps avoids the params
+        // call-site allocation; the delegates are hoisted so no delegate is allocated
+        // per call. Only the hook call is bracketed — render passes are excluded.
+        var ctx = NewCtx();
+        var items = new[] { "a", "b", "c" };
+        var deps = Array.Empty<object>();
+        Func<string, string> keySel = x => x;
+        Func<string, int, Element> build = (item, i) => new DivElement($"v={item}");
+
+        for (int w = 0; w < 3; w++) // prime + JIT the fast-path return
+        {
+            ctx.UseMemoCellsByKey(items, keySel, build, deps);
+            Rerender(ctx);
+        }
+
+        long worst = 0;
+        for (int i = 0; i < 64; i++)
+        {
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            var children = ctx.UseMemoCellsByKey(items, keySel, build, deps);
+            long after = GC.GetAllocatedBytesForCurrentThread();
+            worst = Math.Max(worst, after - before);
+            Assert.Equal(3, children.Length); // full-reuse path actually taken
+            Rerender(ctx);
+        }
+
+        Assert.Equal(0, worst);
+    }
+
+    [Fact]
     public void UseMemoCellsByKey_Invokes_KeySelector_Once_Per_Item_Per_Render()
     {
         var ctx = NewCtx();

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -168,6 +168,59 @@ public class HookAllocationPerfTests
         Assert.Same(r1.Execute, r2.Execute);
     }
 
+    [Fact]
+    public void Hook_Delegates_Stay_Reference_Stable_Across_Many_Renders_DiffSkipPath()
+    {
+        // The Element-layer DIFF skip-path (PR #665) skips a cell's update only when
+        // its event-handler delegates are REFERENCE-STABLE across renders (presence-only
+        // comparison was unsafe). That makes UseState/UseReducer setters and UseCallback
+        // (deps unchanged) load-bearing for DIFF, not merely an allocation win: a
+        // component passing these as handlers must receive the SAME delegate instance on
+        // every steady-state render so the diff can prove the handler is unchanged. This
+        // guards that contract across many renders, with fresh reducer/callback lambdas
+        // supplied each render (as a real component would).
+        var ctx = NewCtx();
+        Action handler = () => { };
+
+        var (_, set0) = ctx.UseState(0);
+        var (_, update0) = ctx.UseReducer(0);
+        var (_, dispatch0) = ctx.UseReducer<int, string>((s, a) => s, 0);
+        var cb0 = ctx.UseCallback(handler, "stable-dep");
+
+        for (int i = 0; i < 50; i++)
+        {
+            Rerender(ctx);
+            var (_, set) = ctx.UseState(0);
+            var (_, update) = ctx.UseReducer(0);
+            var (_, dispatch) = ctx.UseReducer<int, string>((s, a) => s, 0);
+            // Pass a FRESH, distinct handler lambda each render (capturing i) — exactly
+            // what a real component does. UseCallback must ignore it and return the
+            // render-0 instance while the dep is unchanged, proving it truly caches
+            // rather than echoing back whatever was passed in.
+            int captured = i;
+            var cb = ctx.UseCallback(() => { _ = captured; }, "stable-dep");
+
+            Assert.Same(set0, set);
+            Assert.Same(update0, update);
+            Assert.Same(dispatch0, dispatch);
+            Assert.Same(cb0, cb);
+        }
+
+        // Precision: when a callback dep actually changes, the skip-path must NOT skip —
+        // UseCallback hands back the fresh instance so the diff re-applies the handler.
+        // Hook order/count is preserved (all four hooks, in order) so only the dep varies,
+        // and a distinct handler instance is supplied so the change is observable.
+        Rerender(ctx);
+        ctx.UseState(0);
+        ctx.UseReducer(0);
+        ctx.UseReducer<int, string>((s, a) => s, 0);
+        int sentinel = -1;
+        Action newHandler = () => { _ = sentinel; };
+        var cbChanged = ctx.UseCallback(newHandler, "new-dep");
+        Assert.NotSame(cb0, cbChanged);
+        Assert.Same(newHandler, cbChanged);
+    }
+
     // ════════════════════════════════════════════════════════════════
     //  #42 — thread-safe lock retained; default path leaves it null
     // ════════════════════════════════════════════════════════════════

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -585,6 +585,69 @@ public class HookAllocationPerfTests
     }
 
     [Fact]
+    public void UseMemoCells_FullReuse_ValueTypeItems_Does_Not_Allocate_Per_Render()
+    {
+        // Round 10 regression: the full-reuse fast-path equality scan previously called
+        // the static object.Equals(items[i], prev[i]), which BOXES both operands when T
+        // is a value type (2 boxes per item per render) -- defeating the zero-alloc goal.
+        // The scan now uses EqualityComparer<T>.Default.Equals (no boxing, AOT-safe). int
+        // items exercise the boxing path the earlier string-keyed test could not catch.
+        // Only the hook call is bracketed (Rerender is excluded).
+        var ctx = NewCtx();
+        var items = new[] { 1, 2, 3, 4, 5 }; // value-type T -> would box under object.Equals
+        var deps = Array.Empty<object>();
+        Func<int, int, Element> build = (item, i) => new DivElement($"v={item}");
+
+        for (int w = 0; w < 200; w++) { ctx.UseMemoCells(items, build, deps); Rerender(ctx); }
+
+        const int iterations = 2000;
+        long total = 0;
+        for (int i = 0; i < iterations; i++)
+        {
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            var children = ctx.UseMemoCells(items, build, deps);
+            long after = GC.GetAllocatedBytesForCurrentThread();
+            total += after - before;
+            Assert.Equal(5, children.Length); // full-reuse path actually taken
+            Rerender(ctx);
+        }
+
+        Assert.True(total <= iterations,
+            $"UseMemoCells value-type full-reuse allocated {total}B over {iterations} steady-state calls (cap {iterations}B = 1 B/call); boxing 5 int pairs via object.Equals would add ~240 B/call and blow the cap.");
+    }
+
+    [Fact]
+    public void UseMemoCellsByKey_FullReuse_ValueTypeItems_Does_Not_Allocate_Per_Render()
+    {
+        // Round 10 regression (ByKey arm): same value-type boxing in the full-reuse scan
+        // (object.Equals(items[i], prev[i])), now EqualityComparer<T>.Default.Equals. int
+        // items + int keys: the key buffer (int[]) and Dictionary<int,int> lookup are
+        // already non-boxing, so the item-equality scan was the only boxing source.
+        var ctx = NewCtx();
+        var items = new[] { 1, 2, 3, 4, 5 };
+        var deps = Array.Empty<object>();
+        Func<int, int> keySel = x => x;
+        Func<int, int, Element> build = (item, i) => new DivElement($"v={item}");
+
+        for (int w = 0; w < 200; w++) { ctx.UseMemoCellsByKey(items, keySel, build, deps); Rerender(ctx); }
+
+        const int iterations = 2000;
+        long total = 0;
+        for (int i = 0; i < iterations; i++)
+        {
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            var children = ctx.UseMemoCellsByKey(items, keySel, build, deps);
+            long after = GC.GetAllocatedBytesForCurrentThread();
+            total += after - before;
+            Assert.Equal(5, children.Length);
+            Rerender(ctx);
+        }
+
+        Assert.True(total <= iterations,
+            $"UseMemoCellsByKey value-type full-reuse allocated {total}B over {iterations} steady-state calls (cap {iterations}B = 1 B/call); object.Equals boxing would blow the cap.");
+    }
+
+    [Fact]
     public void UseMemoCellsByKey_FullReuse_After_Buffer_Peak_Then_Shrink()
     {
         // Round 9: the key-buffer tail is now cleared only over the slots vacated since

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -470,6 +470,79 @@ public class HookAllocationPerfTests
         Assert.Equal(2, runs);
     }
 
+    // ════════════════════════════════════════════════════════════════
+    //  Aliasing guard (Copilot review) — a caller that reuses AND mutates the
+    //  SAME deps array instance across renders must still observe the change.
+    //  Stored deps are snapshotted (SnapshotDeps) so prev/next can never alias
+    //  the caller's live array.
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseEffect_Reused_Mutated_Deps_Array_Still_Detects_Change()
+    {
+        var ctx = NewCtx();
+        var deps = new object[] { "a" };
+        int runs = 0;
+
+        ctx.UseEffect(() => { runs++; }, deps);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        deps[0] = "b"; // mutate in place, reuse the SAME instance
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, deps);
+        ctx.FlushEffects();
+        Assert.Equal(2, runs); // change detected despite array aliasing
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, deps); // same instance, same contents
+        ctx.FlushEffects();
+        Assert.Equal(2, runs); // unchanged → skipped
+    }
+
+    [Fact]
+    public void UseMemo_Reused_Mutated_Deps_Array_Still_Recomputes()
+    {
+        var ctx = NewCtx();
+        var deps = new object[] { 1 };
+        int factoryCalls = 0;
+
+        int Render() => ctx.UseMemo(() => { factoryCalls++; return (int)deps[0]; }, deps);
+
+        Assert.Equal(1, Render());
+        Assert.Equal(1, factoryCalls);
+
+        deps[0] = 2; // mutate in place
+        Rerender(ctx);
+        Assert.Equal(2, Render());
+        Assert.Equal(2, factoryCalls); // recomputed despite aliasing
+
+        Rerender(ctx);
+        Assert.Equal(2, Render()); // unchanged contents
+        Assert.Equal(2, factoryCalls); // cached, not recomputed
+    }
+
+    [Fact]
+    public void UseCallback_Reused_Mutated_Deps_Array_Returns_Updated_Callback()
+    {
+        var ctx = NewCtx();
+        var deps = new object[] { 1 };
+        // Capture a distinct value so each callback is a unique delegate instance
+        // (a non-capturing lambda would be compiler-cached and defeat NotSame).
+        static Action Cb(int tag) => () => { _ = tag; };
+
+        Action cb1 = ctx.UseCallback(Cb(1), deps);
+
+        deps[0] = 2; // mutate the same instance in place
+        Rerender(ctx);
+        Action cb2 = ctx.UseCallback(Cb(2), deps);
+        Assert.NotSame(cb1, cb2); // deps change detected despite aliasing → new callback
+
+        Rerender(ctx);
+        Action cb3 = ctx.UseCallback(Cb(3), deps); // unchanged contents
+        Assert.Same(cb2, cb3); // cached
+    }
+
     [Fact]
     public void UseMemo_Arity1_ObjectArray_Dep_Uses_ElementWise_Comparison()
     {

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Hooks;
+using Xunit;
+
+#pragma warning disable xUnit1031 // The concurrency stress test deliberately blocks (Task.WaitAll).
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Guards the hook-bookkeeping perf work (cache hook delegates + drop per-render
+/// hook allocations). These are behavioral proxies for "we stopped allocating on
+/// the steady-state path": a cached delegate is observable as reference identity
+/// across renders, and a fully-reused memo-cells array is observable as the same
+/// array instance. The thread-safe path (where the lock IS needed) must keep
+/// working, and deps short-circuits must still skip exactly as before.
+/// </summary>
+public class HookAllocationPerfTests
+{
+    private static RenderContext NewCtx()
+    {
+        var ctx = new RenderContext();
+        ctx.BeginRender(() => { });
+        return ctx;
+    }
+
+    private static void Rerender(RenderContext ctx) => ctx.BeginRender(() => { });
+
+    private record DivElement(string Content) : Element;
+
+    private static Element MakeCell(int v) => new DivElement($"v={v}");
+
+    // ════════════════════════════════════════════════════════════════
+    //  #43/#44/#46/#53 — cached delegate identity across renders
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseState_Setter_Is_Same_Instance_Across_Renders()
+    {
+        var ctx = NewCtx();
+        var (_, set1) = ctx.UseState(0);
+        Rerender(ctx);
+        var (_, set2) = ctx.UseState(0);
+        Rerender(ctx);
+        var (_, set3) = ctx.UseState(0);
+
+        Assert.Same(set1, set2);
+        Assert.Same(set2, set3);
+    }
+
+    [Fact]
+    public void UseState_Cached_Setter_Still_Updates_And_Rerenders()
+    {
+        int rerenders = 0;
+        var ctx = new RenderContext();
+        ctx.BeginRender(() => rerenders++);
+        var (v1, set) = ctx.UseState(1);
+        Assert.Equal(1, v1);
+
+        set(42);
+        Assert.Equal(1, rerenders);
+
+        ctx.BeginRender(() => rerenders++);
+        var (v2, set2) = ctx.UseState(1);
+        Assert.Equal(42, v2);
+        Assert.Same(set, set2); // identity survived the state mutation
+    }
+
+    [Fact]
+    public void UseReducer_Updater_Is_Same_Instance_Across_Renders()
+    {
+        var ctx = NewCtx();
+        var (_, up1) = ctx.UseReducer(0);
+        Rerender(ctx);
+        var (_, up2) = ctx.UseReducer(0);
+
+        Assert.Same(up1, up2);
+    }
+
+    [Fact]
+    public void UseReducer_Redux_Dispatch_Is_Same_Instance_Across_Renders()
+    {
+        static int Reducer(int s, string a) => a == "inc" ? s + 1 : s;
+        var ctx = NewCtx();
+        var (_, d1) = ctx.UseReducer<int, string>(Reducer, 0);
+        Rerender(ctx);
+        var (_, d2) = ctx.UseReducer<int, string>(Reducer, 0);
+
+        Assert.Same(d1, d2);
+    }
+
+    [Fact]
+    public void UseReducer_Redux_Cached_Dispatch_Runs_Latest_Reducer()
+    {
+        // The dispatch delegate is cached, but each render refreshes the reducer it
+        // runs — so a re-render that swaps the reducer takes effect (matches React /
+        // the prior per-render-allocated dispatch).
+        var ctx = NewCtx();
+        var (_, dispatch) = ctx.UseReducer<int, string>((s, a) => s + 1, 0);
+
+        Rerender(ctx);
+        var (_, dispatch2) = ctx.UseReducer<int, string>((s, a) => s + 10, 0);
+        Assert.Same(dispatch, dispatch2);
+
+        dispatch("go"); // held from render 1, but must run render 2's reducer (+10)
+
+        Rerender(ctx);
+        var (value, _) = ctx.UseReducer<int, string>((s, a) => s, 0);
+        Assert.Equal(10, value);
+    }
+
+    [Fact]
+    public void UsePersisted_Setter_Is_Same_Instance_Across_Renders()
+    {
+        var ctx = NewCtx();
+        var (_, set1) = ctx.UsePersisted("k", 0, PersistedScope.Application);
+        Rerender(ctx);
+        var (_, set2) = ctx.UsePersisted("k", 0, PersistedScope.Application);
+
+        Assert.Same(set1, set2);
+    }
+
+    [Fact]
+    public void UseCallback_Returns_Same_Instance_When_Deps_Unchanged()
+    {
+        var ctx = NewCtx();
+        Action cb = () => { };
+        var r1 = ctx.UseCallback(cb, "dep");
+        Rerender(ctx);
+        var r2 = ctx.UseCallback(cb, "dep");
+
+        Assert.Same(cb, r1);
+        Assert.Same(r1, r2);
+    }
+
+    [Fact]
+    public void UseCallback_Returns_New_Instance_When_Deps_Change()
+    {
+        var ctx = NewCtx();
+        Action cbA = () => { };
+        Action cbB = () => { };
+        var r1 = ctx.UseCallback(cbA, "a");
+        Rerender(ctx);
+        var r2 = ctx.UseCallback(cbB, "b");
+
+        Assert.Same(cbA, r1);
+        Assert.Same(cbB, r2);
+        Assert.NotSame(r1, r2);
+    }
+
+    [Fact]
+    public void UseCommand_Wrapped_Execute_Is_Same_Instance_When_Command_Unchanged()
+    {
+        var ctx = NewCtx();
+        Func<Task> asyncAction = () => Task.CompletedTask;
+        var cmd = new Command { Label = "Save", ExecuteAsync = asyncAction };
+
+        var r1 = ctx.UseCommand(cmd);
+        Rerender(ctx);
+        var r2 = ctx.UseCommand(cmd);
+
+        Assert.NotNull(r1.Execute);
+        Assert.Same(r1.Execute, r2.Execute);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  #42 — thread-safe lock retained; default path leaves it null
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void NonThreadSafe_State_Does_Not_Allocate_Lock()
+    {
+        var ctx = NewCtx();
+        ctx.UseState(0); // default threadSafe: false
+
+        Assert.Null(GetHookLock(ctx, 0));
+    }
+
+    [Fact]
+    public void ThreadSafe_State_Allocates_Lock()
+    {
+        var ctx = NewCtx();
+        ctx.UseState(0, threadSafe: true);
+
+        Assert.NotNull(GetHookLock(ctx, 0));
+    }
+
+    [Fact]
+    public void ThreadSafe_State_Is_Correct_Under_Concurrent_Writes()
+    {
+        // If the lock were dropped on the threadSafe path, the increments would race
+        // (lost updates) or NRE on `lock(hook.Lock!)`. A correct final total proves
+        // the lock is both allocated and doing its job.
+        var ctx = new RenderContext();
+        ctx.BeginRender(() => { });
+        var (_, update) = ctx.UseReducer(0, threadSafe: true);
+
+        const int threads = 8, perThread = 1000;
+        var tasks = new Task[threads];
+        for (int t = 0; t < threads; t++)
+            tasks[t] = Task.Run(() =>
+            {
+                for (int i = 0; i < perThread; i++)
+                    update(prev => prev + 1);
+            }, TestContext.Current.CancellationToken);
+        Task.WaitAll(tasks, TestContext.Current.CancellationToken);
+
+        ctx.BeginRender(() => { });
+        var (value, _) = ctx.UseReducer(0, threadSafe: true);
+        Assert.Equal(threads * perThread, value);
+    }
+
+    private static object? GetHookLock(RenderContext ctx, int index)
+    {
+        var hooksField = typeof(RenderContext).GetField("_hooks", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(hooksField);
+        var hooks = (IList)hooksField!.GetValue(ctx)!;
+        var hook = hooks[index]!;
+        var lockField = hook.GetType().GetField("Lock", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(lockField);
+        return lockField!.GetValue(hook);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  #45/#46 — deps short-circuit still skips (params + arity overloads)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseMemo_Params_Skips_Factory_When_Deps_Unchanged()
+    {
+        // Four deps → the params overload (arity overloads cover 1-3).
+        var ctx = NewCtx();
+        int calls = 0;
+        var v1 = ctx.UseMemo(() => { calls++; return 7; }, "a", 1, "b", 2);
+        Rerender(ctx);
+        var v2 = ctx.UseMemo(() => { calls++; return 7; }, "a", 1, "b", 2);
+        Rerender(ctx);
+        var v3 = ctx.UseMemo(() => { calls++; return 99; }, "a", 1, "b", 3); // changed
+
+        Assert.Equal(7, v1);
+        Assert.Equal(7, v2);
+        Assert.Equal(99, v3);
+        Assert.Equal(2, calls); // first render + the changed render
+    }
+
+    [Fact]
+    public void UseMemo_Arity1_Skips_Factory_When_Dep_Unchanged()
+    {
+        var ctx = NewCtx();
+        int calls = 0;
+        var v1 = ctx.UseMemo(() => { calls++; return calls; }, 5);
+        Rerender(ctx);
+        var v2 = ctx.UseMemo(() => { calls++; return calls; }, 5);
+        Rerender(ctx);
+        var v3 = ctx.UseMemo(() => { calls++; return calls; }, 6); // changed
+
+        Assert.Equal(1, v1);
+        Assert.Equal(1, v2); // reused
+        Assert.Equal(2, v3); // recomputed
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void UseMemo_Arity2_And_Arity3_Skip_Factory_When_Deps_Unchanged()
+    {
+        var ctx = NewCtx();
+        int calls2 = 0, calls3 = 0;
+
+        for (int r = 0; r < 3; r++)
+        {
+            ctx.BeginRender(() => { });
+            ctx.UseMemo(() => { calls2++; return 0; }, 1, "x");
+            ctx.UseMemo(() => { calls3++; return 0; }, 1, "x", 2.5);
+        }
+
+        Assert.Equal(1, calls2);
+        Assert.Equal(1, calls3);
+    }
+
+    [Fact]
+    public void UseEffect_Params_Fires_Once_While_Deps_Unchanged()
+    {
+        var ctx = NewCtx();
+        int runs = 0;
+        ctx.UseEffect(() => { runs++; }, "a", 1);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, "a", 1);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs); // skipped
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, "a", 2); // changed
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+    }
+
+    [Fact]
+    public void UseEffect_Arity1_Fires_Once_While_Dep_Unchanged()
+    {
+        var ctx = NewCtx();
+        int runs = 0;
+        ctx.UseEffect(() => { runs++; }, 10);
+        ctx.FlushEffects();
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, 10);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, 11);
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+    }
+
+    [Fact]
+    public void UseEffect_Arity_Empty_Deps_Runs_Once_On_Mount()
+    {
+        var ctx = NewCtx();
+        int runs = 0, cleanups = 0;
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, Array.Empty<object>());
+        ctx.FlushEffects();
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, Array.Empty<object>());
+        ctx.FlushEffects();
+
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  #47 — UseMemoCells full-reuse returns the SAME array (zero alloc)
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseMemoCells_FullReuse_Returns_Same_Array_Instance()
+    {
+        var ctx = NewCtx();
+        var items = new[] { 1, 2, 3 };
+        int builds = 0;
+        var first = ctx.UseMemoCells<int>(items, (item, i) => { builds++; return MakeCell(item); }, "d");
+        Rerender(ctx);
+        var second = ctx.UseMemoCells<int>(items, (item, i) => { builds++; return MakeCell(item); }, "d");
+
+        Assert.Equal(3, builds);     // nothing rebuilt on render 2
+        Assert.Same(first, second);  // #47: whole array reused, no new allocation
+    }
+
+    [Fact]
+    public void UseMemoCells_Rebuilds_New_Array_When_An_Item_Changes()
+    {
+        var ctx = NewCtx();
+        int builds = 0;
+        var first = ctx.UseMemoCells<int>(new[] { 1, 2, 3 }, (item, i) => { builds++; return MakeCell(item); }, "d");
+        Rerender(ctx);
+        var second = ctx.UseMemoCells<int>(new[] { 1, 99, 3 }, (item, i) => { builds++; return MakeCell(item); }, "d");
+
+        Assert.NotSame(first, second);
+        Assert.Same(first[0], second[0]); // unchanged cell reused
+        Assert.NotSame(first[1], second[1]); // changed cell rebuilt
+        Assert.Equal(4, builds); // 3 + 1
+    }
+
+    [Fact]
+    public void UseMemoCellsByKey_FullReuse_Returns_Same_Array_Instance()
+    {
+        var ctx = NewCtx();
+        var items = new[] { 1, 2, 3 };
+        int builds = 0;
+        var first = ctx.UseMemoCellsByKey<int, int>(items, x => x, (item, i) => { builds++; return MakeCell(item); }, "d");
+        Rerender(ctx);
+        var second = ctx.UseMemoCellsByKey<int, int>(items, x => x, (item, i) => { builds++; return MakeCell(item); }, "d");
+
+        Assert.Equal(3, builds);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void UseMemoCellsByKey_Invokes_KeySelector_Once_Per_Item_Per_Render()
+    {
+        var ctx = NewCtx();
+        int keyCalls = 0;
+        var items = new[] { 1, 2, 3 };
+        // First render builds the snapshot map; #59 means one key call per item.
+        ctx.UseMemoCellsByKey<int, int>(items, x => { keyCalls++; return x; }, (item, i) => MakeCell(item), "d");
+
+        Assert.Equal(3, keyCalls);
+    }
+
+    [Fact]
+    public void UseMemoCellsByIndex_FullReuse_Returns_Same_Array_Instance()
+    {
+        var ctx = NewCtx();
+        var items = new[] { 1, 2, 3 };
+        int builds = 0;
+        var first = ctx.UseMemoCellsByIndex<int>(items, Array.Empty<int>(), (item, i) => { builds++; return MakeCell(item); }, "d");
+        Rerender(ctx);
+        var second = ctx.UseMemoCellsByIndex<int>(items, Array.Empty<int>(), (item, i) => { builds++; return MakeCell(item); }, "d");
+
+        Assert.Equal(3, builds);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void UseMemoCellsByIndex_Rebuilds_Only_Named_Indices()
+    {
+        var ctx = NewCtx();
+        int builds = 0;
+        var first = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), (item, i) => { builds++; return MakeCell(item); }, "d");
+        Rerender(ctx);
+        var second = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, new[] { 1 }, (item, i) => { builds++; return MakeCell(item); }, "d");
+
+        Assert.NotSame(first, second);
+        Assert.Same(first[0], second[0]);
+        Assert.NotSame(first[1], second[1]);
+        Assert.Equal(4, builds);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  #55 — UseElementFocus caches ref + requestFocus across renders
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseElementFocus_RequestFocus_Is_Same_Instance_Across_Renders()
+    {
+        var ctx = NewCtx();
+        var (ref1, requestFocus1) = ctx.UseElementFocus();
+        Rerender(ctx);
+        var (ref2, requestFocus2) = ctx.UseElementFocus();
+
+        Assert.Same(ref1, ref2);
+        Assert.Same(requestFocus1, requestFocus2);
+    }
+}

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -554,24 +554,34 @@ public class HookAllocationPerfTests
         Func<string, string> keySel = x => x;
         Func<string, int, Element> build = (item, i) => new DivElement($"v={item}");
 
-        for (int w = 0; w < 3; w++) // prime + JIT the fast-path return
+        for (int w = 0; w < 200; w++) // prime + JIT the fast-path return
         {
             ctx.UseMemoCellsByKey(items, keySel, build, deps);
             Rerender(ctx);
         }
 
-        long worst = 0;
-        for (int i = 0; i < 64; i++)
+        // Bracket ONLY the hook call each iteration (Rerender/BeginRender allocates and
+        // is deliberately excluded) and sum the per-call deltas. A true full-reuse hit
+        // allocates nothing, so the sum stays at/near 0.
+        const int iterations = 2000;
+        long total = 0;
+        for (int i = 0; i < iterations; i++)
         {
             long before = GC.GetAllocatedBytesForCurrentThread();
             var children = ctx.UseMemoCellsByKey(items, keySel, build, deps);
             long after = GC.GetAllocatedBytesForCurrentThread();
-            worst = Math.Max(worst, after - before);
+            total += after - before;
             Assert.Equal(3, children.Length); // full-reuse path actually taken
             Rerender(ctx);
         }
 
-        Assert.Equal(0, worst);
+        // <= 1 byte/call averaged (repo idiom; cf. DockPerfBudgetTests
+        // DropTargetHitTest_HotPath_ZeroAlloc): absorbs incidental bookkeeping / one-time
+        // tiered-JIT jitter on shared CI runners while still catching any real per-call
+        // allocation — re-allocating the key buffer (~24 B), the children array (~40 B),
+        // or a Dictionary (~200 B) per call would exceed the cap by orders of magnitude.
+        Assert.True(total <= iterations,
+            $"UseMemoCellsByKey full-reuse path allocated {total}B over {iterations} steady-state calls (cap {iterations}B = 1 B/call); a real per-call regression would far exceed this.");
     }
 
     [Fact]

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -585,6 +585,37 @@ public class HookAllocationPerfTests
     }
 
     [Fact]
+    public void UseMemoCellsByKey_FullReuse_After_Buffer_Peak_Then_Shrink()
+    {
+        // Round 9: the key-buffer tail is now cleared only over the slots vacated since
+        // the previous render ([count..prevCount]) rather than the whole [count..Length]
+        // tail on every render. Drive grow -> shrink -> steady so the buffer keeps a
+        // larger capacity than the current row count, and confirm the full-reuse fast
+        // path still returns the prior children (the narrowed tail clear must not corrupt
+        // the [0..count] key region the fast-path scan reads).
+        var ctx = NewCtx();
+        Func<int, int> keySel = x => x;
+        Func<int, int, Element> build = (item, i) => MakeCell(item);
+
+        var big = new[] { 1, 2, 3, 4, 5 };
+        var small = new[] { 1, 2, 3 };
+
+        ctx.UseMemoCellsByKey(big, keySel, build, "d");   // grow key buffer to length 5
+        Rerender(ctx);
+        var afterShrink = ctx.UseMemoCellsByKey(small, keySel, build, "d"); // shrink to 3
+        Assert.Equal(3, afterShrink.Length);
+        Rerender(ctx);
+        var steady1 = ctx.UseMemoCellsByKey(small, keySel, build, "d"); // steady -> full reuse
+        Rerender(ctx);
+        var steady2 = ctx.UseMemoCellsByKey(small, keySel, build, "d");
+
+        // Full-reuse returns the prior children array across the steady renders even
+        // though the underlying key buffer still has capacity 5.
+        Assert.Same(afterShrink, steady1);
+        Assert.Same(steady1, steady2);
+    }
+
+    [Fact]
     public void UseMemoCellsByKey_Invokes_KeySelector_Once_Per_Item_Per_Render()
     {
         var ctx = NewCtx();

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -711,6 +711,54 @@ public class HookAllocationPerfTests
     }
 
     // ════════════════════════════════════════════════════════════════
+    //  Nullable-dep semantics (Copilot review — verified FALSE POSITIVE). It was
+    //  suggested that DepEquals<T>'s `stored is T t` always fails for T = Nullable<U>
+    //  (because boxing a non-null nullable stores a boxed U), making an unchanged
+    //  nullable dep re-run every render. That is NOT how the generic `is T` pattern
+    //  behaves: the CLR special-cases nullable type-tests, so a boxed U satisfies
+    //  `o is U?` and binds the nullable-wrapped value (the symmetric counterpart of
+    //  `(U?)(object)u` unboxing). This locks in that a nullable value-type dep is
+    //  SKIPPED while unchanged (incl. null↔null) and re-runs on every change
+    //  (incl. value↔null), matching the legacy `(T)prev[0]` semantics.
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseEffect_Arity1_Nullable_ValueType_Dep_Skips_While_Unchanged_And_Reruns_On_Change()
+    {
+        var ctx = NewCtx();
+        int runs = 0;
+
+        ctx.UseEffect(() => { runs++; }, (int?)5);    // T1=int? → boxed int stored at slot 0
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, (int?)5);    // unchanged → skipped
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, (int?)6);    // value changed → re-run
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, (int?)null); // value → null → re-run
+        ctx.FlushEffects();
+        Assert.Equal(3, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, (int?)null); // null unchanged → skipped
+        ctx.FlushEffects();
+        Assert.Equal(3, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, (int?)7);    // null → value → re-run
+        ctx.FlushEffects();
+        Assert.Equal(4, runs);
+    }
+
+    // ════════════════════════════════════════════════════════════════
     //  Aliasing guard (Copilot review) — a caller that reuses AND mutates the
     //  SAME deps array instance across renders must still observe the change.
     //  Stored deps are snapshotted (SnapshotDeps) so prev/next can never alias

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -421,6 +421,58 @@ public class HookAllocationPerfTests
     }
 
     // ════════════════════════════════════════════════════════════════
+    //  Review (test-coverage) — arity-2/3 cleanup-flavor UseEffect overloads:
+    //  the prior cleanup runs exactly once when a dependency changes, and the
+    //  effect+cleanup are skipped entirely while every dependency is unchanged.
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseEffect_Arity2_Cleanup_Skips_While_Unchanged_And_Cleans_Up_Once_On_Change()
+    {
+        var ctx = NewCtx();
+        int runs = 0, cleanups = 0;
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 1);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 1); // unchanged
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);     // skipped
+        Assert.Equal(0, cleanups); // no cleanup while skipped
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 2); // d2 changed
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+        Assert.Equal(1, cleanups); // prior cleanup ran exactly once
+    }
+
+    [Fact]
+    public void UseEffect_Arity3_Cleanup_Skips_While_Unchanged_And_Cleans_Up_Once_On_Change()
+    {
+        var ctx = NewCtx();
+        int runs = 0, cleanups = 0;
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 1, true);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 1, true); // unchanged
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 1, false); // d3 changed
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+        Assert.Equal(1, cleanups);
+    }
+
+    // ════════════════════════════════════════════════════════════════
     //  #47 — UseMemoCells full-reuse returns the SAME array (zero alloc)
     // ════════════════════════════════════════════════════════════════
 
@@ -558,6 +610,23 @@ public class HookAllocationPerfTests
         Assert.Same(requestFocus1, requestFocus2);
     }
 
+    [Fact]
+    public void UseElementFocus_RequestFocus_Invokes_Safely_When_Unmounted()
+    {
+        // In headless tests no UI dispatcher is registered, so the cached requestFocus
+        // takes its synchronous fallback branch and calls FocusManager.Focus directly.
+        // With an unmounted ref (no target) Focus is a no-op, so invoking must not throw —
+        // this exercises the invoke/fallback path, not just delegate identity.
+        var ctx = NewCtx();
+        var (_, requestFocus) = ctx.UseElementFocus();
+        Assert.Null(Record.Exception(() => requestFocus()));
+
+        Rerender(ctx);
+        var (_, requestFocus2) = ctx.UseElementFocus();
+        Assert.Same(requestFocus, requestFocus2);             // still the cached delegate
+        Assert.Null(Record.Exception(() => requestFocus2())); // still invocable after re-render
+    }
+
     // ════════════════════════════════════════════════════════════════
     //  H1 — a lone object[]-typed dep keeps element-wise (params) semantics
     //  (covariant ref-type arrays must NOT be reference-compared as one dep)
@@ -583,6 +652,62 @@ public class HookAllocationPerfTests
         ctx.UseEffect(() => { runs++; }, new[] { "a", "c" }); // contents changed
         ctx.FlushEffects();
         Assert.Equal(2, runs);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  CORR-1 (correctness review) — an arity-1 dep whose STATIC type is NOT an
+    //  array (here object) but whose RUNTIME value is object[] must be compared as
+    //  ONE value, exactly as the legacy params overload did (it wrapped such a value
+    //  as new object[]{ dep } and reference-compared it). Only UseMemo is affected:
+    //  its two overloads are both generic, so the arity-1 generic wins overload
+    //  resolution (UseEffect/UseCallback bind their non-generic params overload here).
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void UseMemo_Arity1_ObjectTyped_ArrayValue_Is_Compared_By_Reference_Like_Params()
+    {
+        var ctx = NewCtx();
+        int factoryRuns = 0;
+        object dep = new object[] { "a" };          // static type object, runtime object[]
+        ctx.UseMemo(() => { factoryRuns++; return factoryRuns; }, dep);
+        Assert.Equal(1, factoryRuns);
+
+        Rerender(ctx);
+        ctx.UseMemo(() => { factoryRuns++; return factoryRuns; }, dep); // same ref → cached
+        Assert.Equal(1, factoryRuns);
+
+        Rerender(ctx);
+        object depNewEqual = new object[] { "a" };  // NEW reference, equal contents
+        ctx.UseMemo(() => { factoryRuns++; return factoryRuns; }, depNewEqual);
+        Assert.Equal(2, factoryRuns); // reference changed → recompute (NOT element-wise)
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    //  Cast-safety (Copilot review) — a hot-reload edit or dynamic call site can
+    //  change a dependency's runtime type at the same hook slot across renders. The
+    //  typed comparer must treat a type mismatch as "changed" (re-run) rather than
+    //  throwing InvalidCastException while comparing deps.
+    // ════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Arity1_Deps_Comparer_Treats_Runtime_Type_Change_As_Changed_Without_Throwing()
+    {
+        var ctx = NewCtx();
+        int runs = 0;
+        ctx.UseEffect(() => { runs++; }, 42);    // T1=int → stores boxed int at slot 0
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        // Same slot, but the dep is now a string. Comparing (string)prev[0] over a
+        // boxed int must NOT throw; the mismatch is treated as "changed".
+        Exception? ex = Record.Exception(() =>
+        {
+            ctx.UseEffect(() => { runs++; }, "now-a-string"); // T1=string at the same slot
+            ctx.FlushEffects();
+        });
+        Assert.Null(ex);
+        Assert.Equal(2, runs); // type changed → effect re-ran (no crash)
     }
 
     // ════════════════════════════════════════════════════════════════

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -115,6 +115,27 @@ public class HookAllocationPerfTests
     }
 
     [Fact]
+    public void UseReducer_Redux_ThreadSafe_Cached_Dispatch_Runs_Latest_Reducer()
+    {
+        // Same "runs latest reducer" contract as above, but on the threadSafe arm:
+        // the render thread publishes the reducer with Volatile.Write (release) and
+        // the cached dispatch consumes it with Volatile.Read (acquire). A re-render
+        // that swaps the reducer must still take effect through the cached dispatch.
+        var ctx = NewCtx();
+        var (_, dispatch) = ctx.UseReducer<int, string>((s, a) => s + 1, 0, threadSafe: true);
+
+        Rerender(ctx);
+        var (_, dispatch2) = ctx.UseReducer<int, string>((s, a) => s + 10, 0, threadSafe: true);
+        Assert.Same(dispatch, dispatch2);
+
+        dispatch("go"); // held from render 1, but must run render 2's reducer (+10)
+
+        Rerender(ctx);
+        var (value, _) = ctx.UseReducer<int, string>((s, a) => s, 0, threadSafe: true);
+        Assert.Equal(10, value);
+    }
+
+    [Fact]
     public void UsePersisted_Setter_Is_Same_Instance_Across_Renders()
     {
         var ctx = NewCtx();

--- a/tests/Reactor.Tests/HookAllocationPerfTests.cs
+++ b/tests/Reactor.Tests/HookAllocationPerfTests.cs
@@ -221,6 +221,34 @@ public class HookAllocationPerfTests
         Assert.Same(newHandler, cbChanged);
     }
 
+    [Fact]
+    public void UseCallback_And_Setter_Satisfy_ReferenceEquals_Contract_DiffSkipPath()
+    {
+        // Literal ReferenceEquals form of the DIFF skip-path contract (PR #665), the
+        // exact predicate the Element-layer skip path evaluates on handler delegates:
+        //   deps unchanged  ⇒ ReferenceEquals(prev, next) == true  (cell can be skipped)
+        //   deps changed     ⇒ ReferenceEquals(prev, next) == false (cell must re-apply)
+        // The UseState setter identity is dep-independent (cached once on the slot), so it
+        // is stable regardless.
+        var ctx = NewCtx();
+        Action handler = () => { };
+        var (_, set1) = ctx.UseState(0);
+        var cb1 = ctx.UseCallback(handler, "k");
+
+        Rerender(ctx);
+        var (_, set2) = ctx.UseState(0);
+        var cb2 = ctx.UseCallback(handler, "k"); // deps unchanged
+        Assert.True(ReferenceEquals(set1, set2));
+        Assert.True(ReferenceEquals(cb1, cb2));
+
+        Rerender(ctx);
+        var (_, set3) = ctx.UseState(0);
+        int s = 1;
+        var cb3 = ctx.UseCallback(() => { _ = s; }, "k2"); // deps changed
+        Assert.True(ReferenceEquals(set1, set3));
+        Assert.False(ReferenceEquals(cb1, cb3));
+    }
+
     // ════════════════════════════════════════════════════════════════
     //  #42 — thread-safe lock retained; default path leaves it null
     // ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #659

## What

Every component re-render re-runs every hook, so per-render hook bookkeeping allocations multiply by **cells × hooks** on data-grid workloads (the `StocksGrid` stress benchmark). This PR removes those hot-path allocations while preserving the rules of hooks (same call order/count/types every render) and **all observable semantics** (cached delegates behave identically, deps comparisons unchanged, effects fire the same number of times, the `threadSafe:true` lock is kept exactly where it's needed).

## Changes

**`Core/RenderContext.cs`**
- **#42** `ValueHookState` `Lock` is now lazy/nullable — allocated only when `threadSafe:true`. Saves N rows × M hooks of unused `Lock` objects (the default path).
- **#43** `UseState` setter cached on the hook slot — built once instead of a new display-class + `Action<T>` every render.
- **#44** `UseReducer<T>` updater and `UseReducer<TState,TAction>` dispatch delegates cached on the hook; dispatch reads the latest reducer from state (matches React).
- **#45/#46/#48** `UseEffect` / `UseMemo` / `UseCallback` gain **arity 1–3 deps overloads** that compare deps without boxing and allocate the deps array **only when deps change**; `params` overloads kept as fallback and now assign `Dependencies` directly (no extra `ToArray`). `UseCallback` drops its `()=>callback` wrapper.
- **#50** `_hooks` list pre-sized to `new(8)` — avoids 0→4→8→16 realloc churn at mount.
- **#51** `ContextHooks` uses a struct enumerator (no heap enumerator per render); still implements `IEnumerable` so existing `.ToList()` callers work.
- **#52** `UseCommand` / `UseCommand<T>` use an inline memo slot instead of a per-render factory closure capturing 7 vars.
- **#53** `UsePersisted` setter cached on the hook slot.
- **#56** new **internal** `UseDisposableEffect(IDisposable)` mount-once helper with a stable teardown (no 2 lambdas per render).

**`Hooks/`**
- **#47** `UseMemoCells` / `ByKey` / `ByIndex` early full-reuse: return the prior children array and skip the snapshot/dict allocation on a full cache hit.
- **#59** `UseMemoCellsByKey` computes each key once per item into a buffer instead of invoking the key selector twice.
- **#55** `UseElementFocus` caches the `requestFocus` closure and `DispatcherQueue` in refs instead of allocating a closure + a COM call every render.
- **#57** `UseResource` uses an `Interlocked` counter id (not `Guid.NewGuid`) and skips the deps-hash rebuild when deps are unchanged; **#56** disposes via `UseDisposableEffect`.
- **#56** `UseMutation` / `UseInfiniteResource` dispose via `UseDisposableEffect`.

**`Core/PanelAttachedHooks.cs`**
- **#60** `ApplyRelativePanelAttachedProps` reuses a thread-static name-map dictionary (with a reentrancy guard for nested `RelativePanel`s) instead of allocating one per reconcile.

## Expected impact

Targets the C#↔Rust gap on the data-grid stress workload — higher **Renders/sec** and lower **Avg Memory** by removing per-cell/per-hook delegate, closure, array, and dictionary allocations from the render → diff → reconcile hot path. Final numbers will be confirmed by the `/perf` CI workflow.

## Tests

`tests/Reactor.Tests/HookAllocationPerfTests.cs` (25 tests): cached-delegate identity across renders (UseState/UseReducer/UsePersisted/UseCallback/UseCommand), deps short-circuit still skips for both `params` and arity overloads, `threadSafe` Lock still allocated and correct under concurrent writes (null when not requested), and `UseMemoCells`/`ByKey`/`ByIndex` cache-hit returning the **same** prior children array.

## Validation

- `dotnet build src/Reactor/Reactor.csproj -c Release` → **0 warnings, 0 errors** (core lib promotes AOT/trim warnings to errors; no new reflection added).
- `dotnet test tests/Reactor.Tests` → **9695 passed, 0 failed, 64 skipped**.

> Note: the two committed `skills/reactor.api.txt` copies are regenerated to add the new **public** arity overloads (the `Index_IsUpToDate` test enforces this). `UseDisposableEffect` is `internal`, so it stays off the public surface.