### PR TITLE
perf: Yoga layout-cache guards + inline per-node arrays

### DIFF
--- a/src/Reactor/Yoga/AlgorithmUtils.cs
+++ b/src/Reactor/Yoga/AlgorithmUtils.cs
@@ -398,6 +398,37 @@ internal static class FlexLineHelper
         s_listPool.Push(list);
     }
 
+    // AI-HINT (perf #144): FlexLine is allocated once per flex line per frame.
+    // Pool the object together with its ItemsInFlow list (the list travels with
+    // the FlexLine across rent/return cycles, so it is NOT drawn from s_listPool).
+    // A FlexLine is used entirely within one per-line loop iteration in
+    // CalculateLayoutImpl and is never stored beyond it, so returning it at the
+    // loop tail is safe. Recursive layout of children rents distinct FlexLines
+    // (LIFO stack), so no aliasing.
+    [ThreadStatic]
+    private static Stack<FlexLine>? s_flexLinePool;
+
+    internal static FlexLine RentFlexLine()
+    {
+        var pool = s_flexLinePool ??= new Stack<FlexLine>();
+        if (pool.Count > 0)
+        {
+            var line = pool.Pop();
+            line.ItemsInFlow.Clear();
+            line.SizeConsumed = 0;
+            line.NumberOfAutoMargins = 0;
+            line.Layout = default;
+            return line;
+        }
+        return new FlexLine();
+    }
+
+    internal static void ReturnFlexLine(FlexLine line)
+    {
+        var pool = s_flexLinePool ??= new Stack<FlexLine>();
+        pool.Push(line);
+    }
+
     /// <summary>
     /// Calculates where a line starting at a given child index should break.
     /// Assumes all children have their computedFlexBasis computed.
@@ -408,7 +439,8 @@ internal static class FlexLineHelper
         ref int childIndex, int lineCount,
         List<YogaNode> layoutChildren)
     {
-        var itemsInFlow = RentList();
+        var line = RentFlexLine();
+        var itemsInFlow = line.ItemsInFlow;
         float sizeConsumed = 0;
         float totalFlexGrowFactors = 0;
         float totalFlexShrinkScaledFactors = 0;
@@ -472,16 +504,13 @@ internal static class FlexLineHelper
         if (totalFlexShrinkScaledFactors > 0 && totalFlexShrinkScaledFactors < 1)
             totalFlexShrinkScaledFactors = 1;
 
-        return new FlexLine
+        line.SizeConsumed = sizeConsumed;
+        line.NumberOfAutoMargins = numberOfAutoMargins;
+        line.Layout = new FlexLineRunningLayout
         {
-            ItemsInFlow = itemsInFlow,
-            SizeConsumed = sizeConsumed,
-            NumberOfAutoMargins = numberOfAutoMargins,
-            Layout = new FlexLineRunningLayout
-            {
-                TotalFlexGrowFactors = totalFlexGrowFactors,
-                TotalFlexShrinkScaledFactors = totalFlexShrinkScaledFactors,
-            }
+            TotalFlexGrowFactors = totalFlexGrowFactors,
+            TotalFlexShrinkScaledFactors = totalFlexShrinkScaledFactors,
         };
+        return line;
     }
 }

--- a/src/Reactor/Yoga/AlgorithmUtils.cs
+++ b/src/Reactor/Yoga/AlgorithmUtils.cs
@@ -405,26 +405,26 @@ internal static class FlexLineHelper
     // CalculateLayoutImpl and is never stored beyond it, so returning it at the
     // loop tail is safe. Recursive layout of children rents distinct FlexLines
     // (LIFO stack), so no aliasing.
+    // The line is reset on RETURN (not on rent), matching ReturnList's
+    // clear-before-pool contract: ItemsInFlow holds YogaNode references that
+    // reach whole UI subtrees, so clearing on return keeps the thread-static
+    // pool from pinning that memory between layout passes. The only way into the
+    // pool is ReturnFlexLine, so a popped line is always clean at rent time.
     [ThreadStatic]
     private static Stack<FlexLine>? s_flexLinePool;
 
     internal static FlexLine RentFlexLine()
     {
         var pool = s_flexLinePool ??= new Stack<FlexLine>();
-        if (pool.Count > 0)
-        {
-            var line = pool.Pop();
-            line.ItemsInFlow.Clear();
-            line.SizeConsumed = 0;
-            line.NumberOfAutoMargins = 0;
-            line.Layout = default;
-            return line;
-        }
-        return new FlexLine();
+        return pool.Count > 0 ? pool.Pop() : new FlexLine();
     }
 
     internal static void ReturnFlexLine(FlexLine line)
     {
+        line.ItemsInFlow.Clear();
+        line.SizeConsumed = 0;
+        line.NumberOfAutoMargins = 0;
+        line.Layout = default;
         var pool = s_flexLinePool ??= new Stack<FlexLine>();
         pool.Push(line);
     }

--- a/src/Reactor/Yoga/AlgorithmUtils.cs
+++ b/src/Reactor/Yoga/AlgorithmUtils.cs
@@ -283,9 +283,13 @@ internal static class PixelGridHelper
                 - RoundValueToPixelGrid(absoluteNodeTop, pointScaleFactor, false, textRounding));
         }
 
-        foreach (var child in node.Children)
+        // #145: iterate by index via ChildCount/GetChild instead of foreach over
+        // the IReadOnlyList Children (which boxes List<T>.Enumerator per node).
+        // Note: this rounds ALL children (no Display.Contents flattening), matching
+        // the original traversal.
+        for (int i = 0; i < node.ChildCount; i++)
         {
-            RoundLayoutResultsToPixelGrid(child, absoluteNodeLeft, absoluteNodeTop);
+            RoundLayoutResultsToPixelGrid(node.GetChild(i), absoluteNodeLeft, absoluteNodeTop);
         }
     }
 

--- a/src/Reactor/Yoga/FlexPanel.cs
+++ b/src/Reactor/Yoga/FlexPanel.cs
@@ -762,11 +762,16 @@ public partial class FlexPanel : Panel
         var minWidthExplicit = GetMinWidth(el);
         var minHeightExplicit = GetMinHeight(el);
 
-        node.Style.FlexGrow = (float)grow;
-        node.Style.FlexShrink = (float)shrink;
-        node.Style.FlexBasis = double.IsNaN(basis) ? YogaValue.Auto : YogaValue.Point((float)basis);
-        node.Style.AlignSelf = alignSelf;
-        node.Style.PositionType = position;
+        // Route through the YogaNode setters (not node.Style.X directly) so the
+        // equality-guarded setters (#138) dirty the node only on a real change.
+        // Writing node.Style.X directly would bypass dirty tracking and, now
+        // that Width/Height/Margin no longer unconditionally dirty, could leave
+        // a changed flex item stale.
+        node.FlexGrow = (float)grow;
+        node.FlexShrink = (float)shrink;
+        node.FlexBasis = double.IsNaN(basis) ? YogaValue.Auto : YogaValue.Point((float)basis);
+        node.AlignSelf = alignSelf;
+        node.PositionType = position;
 
         // ── CSS Flexbox §4.5 automatic minimum size ──
         // Compute effective MinWidth / MinHeight per CSS spec:
@@ -787,16 +792,16 @@ public partial class FlexPanel : Panel
             el, axisIsMain: !mainAxisIsRow,
             explicitMin: minHeightExplicit, basis: basis, isWidth: false);
 
-        // Position insets
+        // Position insets (via SetPosition so the guarded setter dirties only on change)
         var left = GetLeft(el);
         var top = GetTop(el);
         var right = GetRight(el);
         var bottom = GetBottom(el);
 
-        node.Style.Position[(int)YogaEdge.Left] = double.IsNaN(left) ? YogaValue.Undefined : YogaValue.Point((float)left);
-        node.Style.Position[(int)YogaEdge.Top] = double.IsNaN(top) ? YogaValue.Undefined : YogaValue.Point((float)top);
-        node.Style.Position[(int)YogaEdge.Right] = double.IsNaN(right) ? YogaValue.Undefined : YogaValue.Point((float)right);
-        node.Style.Position[(int)YogaEdge.Bottom] = double.IsNaN(bottom) ? YogaValue.Undefined : YogaValue.Point((float)bottom);
+        node.SetPosition(YogaEdge.Left, double.IsNaN(left) ? YogaValue.Undefined : YogaValue.Point((float)left));
+        node.SetPosition(YogaEdge.Top, double.IsNaN(top) ? YogaValue.Undefined : YogaValue.Point((float)top));
+        node.SetPosition(YogaEdge.Right, double.IsNaN(right) ? YogaValue.Undefined : YogaValue.Point((float)right));
+        node.SetPosition(YogaEdge.Bottom, double.IsNaN(bottom) ? YogaValue.Undefined : YogaValue.Point((float)bottom));
 
         // If the child has explicit Width/Height set, pass them to Yoga
         if (el is FrameworkElement fe)

--- a/src/Reactor/Yoga/FlexPanel.cs
+++ b/src/Reactor/Yoga/FlexPanel.cs
@@ -32,6 +32,23 @@ public partial class FlexPanel : Panel
     private readonly HashSet<UIElement> _syncCurrentChildren = new();
     private readonly List<UIElement> _syncToRemove = new();
 
+    // AI-HINT (perf #147): per-child cache of the last-read attached-property
+    // values (Grow/Shrink/Basis/AlignSelf/Position/FlexMin*/insets). Reading
+    // an attached DP via GetValue boxes the double/enum; for a large grid that
+    // is ~11 boxed allocations per child per MeasureOverride. Attached DPs can
+    // only change through the property system, which raises
+    // OnChildPropertyChanged — so the cache is invalidated there (and on
+    // add/remove). FrameworkElement Width/Height/Margin/Visibility are NOT
+    // cached: they change without our callback, so they are re-read each pass.
+    private readonly Dictionary<UIElement, AttachedProps> _attachedCache = new();
+
+    private struct AttachedProps
+    {
+        public double Grow, Shrink, Basis, MinWidth, MinHeight, Left, Top, Right, Bottom;
+        public FlexAlign AlignSelf;
+        public FlexPositionType Position;
+    }
+
     public FlexPanel()
     {
         _rootNode = new YogaNode(_yogaConfig);
@@ -62,6 +79,7 @@ public partial class FlexPanel : Panel
         foreach (var node in _nodeCache.Values)
             _rootNode.RemoveChild(node);
         _nodeCache.Clear();
+        _attachedCache.Clear();
     }
 
     // ── Container dependency properties ──
@@ -258,7 +276,12 @@ public partial class FlexPanel : Panel
     private static void OnChildPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is UIElement el && Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(el) is FlexPanel panel)
+        {
+            // Invalidate the cached attached-property snapshot for this child so
+            // the next sync re-reads the changed value (#147).
+            panel._attachedCache.Remove(el);
             panel.InvalidateMeasure();
+        }
     }
 
     // ── Layout ──
@@ -619,6 +642,7 @@ public partial class FlexPanel : Panel
             if (_nodeCache.TryGetValue(el, out var node))
                 _rootNode.RemoveChild(node);
             _nodeCache.Remove(el);
+            _attachedCache.Remove(el);
         }
 
         // Ensure each child has a YogaNode at the correct index
@@ -754,13 +778,36 @@ public partial class FlexPanel : Panel
 
     private void ApplyAttachedProperties(UIElement el, YogaNode node)
     {
-        var grow = GetGrow(el);
-        var shrink = GetShrink(el);
-        var basis = GetBasis(el);
-        var alignSelf = GetAlignSelf(el);
-        var position = GetPosition(el);
-        var minWidthExplicit = GetMinWidth(el);
-        var minHeightExplicit = GetMinHeight(el);
+        // Read attached properties from the per-child cache (#147); only the
+        // first sync after a change boxes the GetValue results. The cache is
+        // invalidated in OnChildPropertyChanged / on add/remove, so a missing
+        // entry means the values may have changed and must be re-read.
+        if (!_attachedCache.TryGetValue(el, out var ap))
+        {
+            ap = new AttachedProps
+            {
+                Grow = GetGrow(el),
+                Shrink = GetShrink(el),
+                Basis = GetBasis(el),
+                AlignSelf = GetAlignSelf(el),
+                Position = GetPosition(el),
+                MinWidth = GetMinWidth(el),
+                MinHeight = GetMinHeight(el),
+                Left = GetLeft(el),
+                Top = GetTop(el),
+                Right = GetRight(el),
+                Bottom = GetBottom(el),
+            };
+            _attachedCache[el] = ap;
+        }
+
+        var grow = ap.Grow;
+        var shrink = ap.Shrink;
+        var basis = ap.Basis;
+        var alignSelf = ap.AlignSelf;
+        var position = ap.Position;
+        var minWidthExplicit = ap.MinWidth;
+        var minHeightExplicit = ap.MinHeight;
 
         // Route through the YogaNode setters (not node.Style.X directly) so the
         // equality-guarded setters (#138) dirty the node only on a real change.
@@ -793,10 +840,10 @@ public partial class FlexPanel : Panel
             explicitMin: minHeightExplicit, basis: basis, isWidth: false);
 
         // Position insets (via SetPosition so the guarded setter dirties only on change)
-        var left = GetLeft(el);
-        var top = GetTop(el);
-        var right = GetRight(el);
-        var bottom = GetBottom(el);
+        var left = ap.Left;
+        var top = ap.Top;
+        var right = ap.Right;
+        var bottom = ap.Bottom;
 
         node.SetPosition(YogaEdge.Left, double.IsNaN(left) ? YogaValue.Undefined : YogaValue.Point((float)left));
         node.SetPosition(YogaEdge.Top, double.IsNaN(top) ? YogaValue.Undefined : YogaValue.Point((float)top));

--- a/src/Reactor/Yoga/FlexPanel.cs
+++ b/src/Reactor/Yoga/FlexPanel.cs
@@ -8,6 +8,7 @@
 // are synced to Yoga nodes in SyncYogaTree(). MeasureFunc bridge lets Yoga call
 // back into WinUI Measure for leaf children that need intrinsic sizing.
 
+using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Reactor.Layout;
@@ -37,10 +38,20 @@ public partial class FlexPanel : Panel
     // an attached DP via GetValue boxes the double/enum; for a large grid that
     // is ~11 boxed allocations per child per MeasureOverride. Attached DPs can
     // only change through the property system, which raises
-    // OnChildPropertyChanged — so the cache is invalidated there (and on
-    // add/remove). FrameworkElement Width/Height/Margin/Visibility are NOT
-    // cached: they change without our callback, so they are re-read each pass.
+    // OnChildPropertyChanged — which drops the child's entry while it is parented
+    // to this panel; the SyncYogaTree sweep drops entries for removed children.
+    // FrameworkElement Width/Height/Margin/Visibility are NOT cached: they change
+    // without our callback, so they are re-read each pass.
     private readonly Dictionary<UIElement, AttachedProps> _attachedCache = new();
+
+    // AI-HINT (perf #147 correctness): an attached DP can change while a child is
+    // detached from its panel (e.g. removed, re-styled, then re-added before the
+    // next measure). OnChildPropertyChanged then cannot reach the owning panel to
+    // drop its cache entry, so the child is flagged here instead; the next
+    // ApplyAttachedProperties re-reads it rather than trusting a stale snapshot.
+    // Static + weak-keyed: shared across panels, no per-panel state, no leak.
+    private static readonly ConditionalWeakTable<UIElement, object> s_detachedAttachedDirty = new();
+    private static readonly object s_detachedDirtyMarker = new();
 
     private struct AttachedProps
     {
@@ -275,12 +286,22 @@ public partial class FlexPanel : Panel
 
     private static void OnChildPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is UIElement el && Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(el) is FlexPanel panel)
+        if (d is not UIElement el)
+            return;
+
+        if (Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(el) is FlexPanel panel)
         {
             // Invalidate the cached attached-property snapshot for this child so
             // the next sync re-reads the changed value (#147).
             panel._attachedCache.Remove(el);
             panel.InvalidateMeasure();
+        }
+        else
+        {
+            // Detached (or not yet parented): we cannot reach the owning panel's
+            // cache, so flag the element. The next ApplyAttachedProperties (after
+            // it is (re-)added) re-reads it instead of using a stale entry (#147).
+            s_detachedAttachedDirty.AddOrUpdate(el, s_detachedDirtyMarker);
         }
     }
 
@@ -780,10 +801,19 @@ public partial class FlexPanel : Panel
     {
         // Read attached properties from the per-child cache (#147); only the
         // first sync after a change boxes the GetValue results. The cache is
-        // invalidated in OnChildPropertyChanged / on add/remove, so a missing
-        // entry means the values may have changed and must be re-read.
-        if (!_attachedCache.TryGetValue(el, out var ap))
+        // invalidated in OnChildPropertyChanged (while the child is parented) and
+        // by the SyncYogaTree removal sweep; a change made while the child was
+        // detached is flagged in s_detachedAttachedDirty and honored here. A
+        // missing or invalidated entry means the values must be re-read.
+        bool hit = _attachedCache.TryGetValue(el, out var ap);
+        if (hit && s_detachedAttachedDirty.TryGetValue(el, out _))
         {
+            // Snapshot was invalidated while the child was detached from a panel.
+            hit = false;
+        }
+        if (!hit)
+        {
+            s_detachedAttachedDirty.Remove(el);
             ap = new AttachedProps
             {
                 Grow = GetGrow(el),

--- a/src/Reactor/Yoga/LayoutResults.cs
+++ b/src/Reactor/Yoga/LayoutResults.cs
@@ -53,29 +53,46 @@ internal sealed class LayoutResults
     public FlexLayoutDirection LastOwnerDirection = FlexLayoutDirection.Inherit;
 
     public uint NextCachedMeasurementsIndex;
-    public readonly CachedMeasurement[] CachedMeasurements = new CachedMeasurement[MaxCachedMeasurements];
+
+    // Inline fixed-size buffer (#142): replaces a CachedMeasurement[8] heap
+    // array. Exposed as a ref-returning property so existing in-place element
+    // mutation (CachedMeasurements[idx].AvailableWidth = ...) is unchanged.
+    private CachedMeasurementArray _cachedMeasurements;
+    public ref CachedMeasurementArray CachedMeasurements => ref _cachedMeasurements;
     public CachedMeasurement CachedLayout;
 
     // Direction and overflow
     private FlexLayoutDirection _direction = FlexLayoutDirection.Inherit;
     private bool _hadOverflow;
 
-    // Dimensions
-    private readonly float[] _dimensions = { float.NaN, float.NaN };
-    private readonly float[] _measuredDimensions = { float.NaN, float.NaN };
-    private readonly float[] _rawDimensions = { float.NaN, float.NaN };
+    // Dimensions / edges stored inline (#142) instead of 7 separate float[]
+    // arrays. For a ~200-node tree this removes ~1400 GC objects (7 arrays/node)
+    // — a major part of the Yoga memory gap vs the C++ original's inline members.
+    private Float2 _dimensions;
+    private Float2 _measuredDimensions;
+    private Float2 _rawDimensions;
 
     // Position, margin, border, padding (indexed by PhysicalEdge: Left=0, Top=1, Right=2, Bottom=3)
-    private readonly float[] _position = new float[4];
-    private readonly float[] _margin = new float[4];
-    private readonly float[] _border = new float[4];
-    private readonly float[] _padding = new float[4];
+    private Float4 _position;
+    private Float4 _margin;
+    private Float4 _border;
+    private Float4 _padding;
 
     public LayoutResults()
     {
+        // CachedMeasurement's field initializers (the -1 sentinels) only run via
+        // its constructor, NOT for default-initialized inline-array elements, so
+        // seed each slot explicitly to preserve the previous array behavior.
         for (int i = 0; i < MaxCachedMeasurements; i++)
-            CachedMeasurements[i] = new CachedMeasurement();
+            _cachedMeasurements[i] = new CachedMeasurement();
         CachedLayout = new CachedMeasurement();
+
+        // The _dimensions family historically defaulted to NaN (the float[]
+        // initializers); _position/_margin/_border/_padding defaulted to 0,
+        // which matches a zero-initialized inline buffer (no seeding needed).
+        _dimensions[0] = float.NaN; _dimensions[1] = float.NaN;
+        _measuredDimensions[0] = float.NaN; _measuredDimensions[1] = float.NaN;
+        _rawDimensions[0] = float.NaN; _rawDimensions[1] = float.NaN;
     }
 
     public FlexLayoutDirection Direction
@@ -132,13 +149,16 @@ internal sealed class LayoutResults
         _rawDimensions[0] = float.NaN;
         _rawDimensions[1] = float.NaN;
 
-        Array.Clear(_position);
-        Array.Clear(_margin);
-        Array.Clear(_border);
-        Array.Clear(_padding);
+        for (int i = 0; i < 4; i++)
+        {
+            _position[i] = 0;
+            _margin[i] = 0;
+            _border[i] = 0;
+            _padding[i] = 0;
+        }
 
         for (int i = 0; i < MaxCachedMeasurements; i++)
-            CachedMeasurements[i] = new CachedMeasurement();
+            _cachedMeasurements[i] = new CachedMeasurement();
         CachedLayout = new CachedMeasurement();
     }
 
@@ -170,4 +190,33 @@ internal sealed class LayoutResults
 
         return true;
     }
+}
+
+// AI-HINT (perf #142): fixed-size inline buffers embedded directly in the
+// LayoutResults heap object, replacing 7 float[] arrays + a CachedMeasurement[8]
+// per node. For a ~200-node tree that removes ~1600 GC objects — a dominant
+// part of the Yoga memory gap vs the C++ original (which uses inline members).
+// InlineArray is a C# 12 feature: element access is compiler-generated and
+// fully AOT/trim safe (no reflection, no Unsafe). Each struct has exactly one
+// instance field, as InlineArray requires.
+
+/// <summary>Inline buffer of 2 floats (YogaDimension: Width=0, Height=1).</summary>
+[global::System.Runtime.CompilerServices.InlineArray(2)]
+internal struct Float2
+{
+    private float _element0;
+}
+
+/// <summary>Inline buffer of 4 floats (YogaPhysicalEdge: Left=0..Bottom=3).</summary>
+[global::System.Runtime.CompilerServices.InlineArray(4)]
+internal struct Float4
+{
+    private float _element0;
+}
+
+/// <summary>Inline buffer of <see cref="LayoutResults.MaxCachedMeasurements"/> (8) cached measurements.</summary>
+[global::System.Runtime.CompilerServices.InlineArray(8)]
+internal struct CachedMeasurementArray
+{
+    private CachedMeasurement _element0;
 }

--- a/src/Reactor/Yoga/YogaAlgorithm.cs
+++ b/src/Reactor/Yoga/YogaAlgorithm.cs
@@ -428,8 +428,10 @@ internal static class YogaAlgorithm
         float crossAxisGap = node.Style.ComputeGapForAxis(crossAxis, availableInnerCrossDim);
         float maxLineMainDim = 0;
 
-        // Build the list of layout children once for iteration
-        var layoutChildren = new List<YogaNode>();
+        // Build the list of layout children once for iteration.
+        // Rented from the per-thread pool (#141) to avoid a per-container List
+        // allocation each frame; returned at the single method exit below.
+        var layoutChildren = FlexLineHelper.RentList();
         node.CollectLayoutChildren(layoutChildren);
 
         while (startOfLineIndex < layoutChildren.Count)
@@ -898,6 +900,8 @@ internal static class YogaAlgorithm
                     0.0f, 0.0f, availableInnerWidth, availableInnerHeight);
             }
         }
+
+        FlexLineHelper.ReturnList(layoutChildren);
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -1332,7 +1336,8 @@ internal static class YogaAlgorithm
     {
         float totalOuterFlexBasis = 0.0f;
         YogaNode? singleFlexChild = null;
-        var children = new List<YogaNode>();
+        // Rented from the per-thread pool (#141); returned at the single exit.
+        var children = FlexLineHelper.RentList();
         node.CollectLayoutChildren(children);
         var sizingModeMainDim = FlexDirectionHelper.IsRow(mainAxis) ? widthSizingMode : heightSizingMode;
 
@@ -1394,6 +1399,7 @@ internal static class YogaAlgorithm
                 child.Style.ComputeMarginForAxis(mainAxis, availableInnerWidth);
         }
 
+        FlexLineHelper.ReturnList(children);
         return totalOuterFlexBasis;
     }
 

--- a/src/Reactor/Yoga/YogaAlgorithm.cs
+++ b/src/Reactor/Yoga/YogaAlgorithm.cs
@@ -982,9 +982,22 @@ internal static class YogaAlgorithm
 
         if (useResolvedFlexBasis)
         {
+            // AI-HINT (perf #138): invalidate the resolved flex-basis cache by
+            // layout generation, not only under WebFlexBasis. FlexPanel runs each
+            // nested panel as its own Yoga tree and measures a child across several
+            // top-level CalculateLayout calls within a single WinUI layout — e.g. a
+            // min-content probe (undefined main axis → basis measured from CONTENT)
+            // followed by the definite-main-axis pass (where an explicit
+            // `flex-basis: 0` must apply). Before the #138 setter guards, FlexPanel
+            // re-dirtied every child each pass, which reset ComputedFlexBasis to NaN
+            // (see YogaNode.MarkDirtyAndPropagate) and forced this recompute. The
+            // guards intentionally stop that re-dirtying so the layout cache can hit
+            // across frames; the per-generation check below restores the same basis
+            // freshness without re-dirtying the root. Without it the stale
+            // content-measured basis from the probe leaks into the definite pass and
+            // breaks flex-grow distribution (basis 0 items grow from min-content).
             if (YogaFloat.IsUndefined(child.Layout.ComputedFlexBasis) ||
-                (child.Config.IsExperimentalFeatureEnabled(YogaExperimentalFeature.WebFlexBasis) &&
-                 child.Layout.ComputedFlexBasisGeneration != generationCount))
+                child.Layout.ComputedFlexBasisGeneration != generationCount)
             {
                 float paddingAndBorder = BoundAxisHelper.PaddingAndBorderForAxis(child, mainAxis, direction, ownerWidth);
                 child.SetLayoutComputedFlexBasis(YogaFloat.MaxOrDefined(resolvedFlexBasis, paddingAndBorder));

--- a/src/Reactor/Yoga/YogaAlgorithm.cs
+++ b/src/Reactor/Yoga/YogaAlgorithm.cs
@@ -434,6 +434,13 @@ internal static class YogaAlgorithm
         var layoutChildren = FlexLineHelper.RentList();
         node.CollectLayoutChildren(layoutChildren);
 
+        // #148: baseline-ness depends only on this node's FlexDirection /
+        // AlignItems and its children's AlignSelf / PositionType — all invariant
+        // within a single layout pass. Compute it ONCE here instead of per flex
+        // line inside JustifyMainAxis (and again at STEP 8). No cross-frame cache,
+        // so no invalidation hazard.
+        bool isNodeBaselineLayout = BaselineHelper.IsBaselineLayout(node);
+
         while (startOfLineIndex < layoutChildren.Count)
         {
             int currentIndex = startOfLineIndex;
@@ -510,7 +517,7 @@ internal static class YogaAlgorithm
                 sizingModeMainDim, sizingModeCrossDim,
                 mainAxisOwnerSize, ownerWidth,
                 availableInnerMainDim, availableInnerCrossDim, availableInnerWidth,
-                performLayout);
+                performLayout, isNodeBaselineLayout);
 
             float containerCrossAxis = availableInnerCrossDim;
             if (sizingModeCrossDim == SizingMode.MaxContent || sizingModeCrossDim == SizingMode.FitContent)
@@ -636,7 +643,7 @@ internal static class YogaAlgorithm
         }
 
         // STEP 8: MULTI-LINE CONTENT ALIGNMENT
-        if (performLayout && (isNodeFlexWrap || BaselineHelper.IsBaselineLayout(node)))
+        if (performLayout && (isNodeFlexWrap || isNodeBaselineLayout))
         {
             float leadPerLine = 0;
             float currentLead = leadingPaddingAndBorderCross;
@@ -1678,7 +1685,7 @@ internal static class YogaAlgorithm
         SizingMode sizingModeMainDim, SizingMode sizingModeCrossDim,
         float mainAxisOwnerSize, float ownerWidth,
         float availableInnerMainDim, float availableInnerCrossDim,
-        float availableInnerWidth, bool performLayout)
+        float availableInnerWidth, bool performLayout, bool isNodeBaselineLayout)
     {
         var style = node.Style;
 
@@ -1745,7 +1752,6 @@ internal static class YogaAlgorithm
 
         float maxAscentForCurrentLine = 0;
         float maxDescentForCurrentLine = 0;
-        bool isNodeBaselineLayout = BaselineHelper.IsBaselineLayout(node);
         bool isMainAxisRow = FlexDirectionHelper.IsRow(mainAxis);
 
         for (int ci = 0; ci < flexLine.ItemsInFlow.Count; ci++)

--- a/src/Reactor/Yoga/YogaAlgorithm.cs
+++ b/src/Reactor/Yoga/YogaAlgorithm.cs
@@ -638,7 +638,7 @@ internal static class YogaAlgorithm
             float appliedCrossGap = lineCount != 0 ? crossAxisGap : 0.0f;
             totalLineCrossDim += flexLine.Layout.CrossDim + appliedCrossGap;
             maxLineMainDim = YogaFloat.MaxOrDefined(maxLineMainDim, flexLine.Layout.MainDim);
-            FlexLineHelper.ReturnList(flexLine.ItemsInFlow);
+            FlexLineHelper.ReturnFlexLine(flexLine);
             lineCount++;
         }
 

--- a/src/Reactor/Yoga/YogaNode.cs
+++ b/src/Reactor/Yoga/YogaNode.cs
@@ -196,7 +196,13 @@ internal sealed class YogaNode
 
         public Enumerator GetEnumerator() => new Enumerator(_node);
 
-        public struct Enumerator
+        // AI-HINT (perf #145): implements IDisposable so a foreach that breaks
+        // out early (e.g. baseline detection in AlgorithmUtils) while a
+        // Display.Contents subtree is mid-drain still releases the fallback
+        // iterator's captured references. foreach emits a finally-Dispose for a
+        // struct enumerator that implements IDisposable as a non-boxing
+        // constrained call, so the common (no-inner) path stays allocation-free.
+        public struct Enumerator : IDisposable
         {
             private readonly List<YogaNode> _children;
             private int _index;
@@ -223,6 +229,7 @@ internal sealed class YogaNode
                         _current = _inner.Current;
                         return true;
                     }
+                    _inner.Dispose();
                     _inner = null;
                 }
 
@@ -237,6 +244,7 @@ internal sealed class YogaNode
                             _current = _inner.Current;
                             return true;
                         }
+                        _inner.Dispose();
                         _inner = null;
                         continue;
                     }
@@ -244,6 +252,12 @@ internal sealed class YogaNode
                     return true;
                 }
                 return false;
+            }
+
+            public void Dispose()
+            {
+                _inner?.Dispose();
+                _inner = null;
             }
         }
     }

--- a/src/Reactor/Yoga/YogaNode.cs
+++ b/src/Reactor/Yoga/YogaNode.cs
@@ -157,18 +157,93 @@ internal sealed class YogaNode
     /// Display.None children are NOT skipped here; the algorithm handles them explicitly.
     /// Ported from yoga/node/LayoutableChildren.h
     /// </summary>
-    internal IEnumerable<YogaNode> GetLayoutChildren()
+    /// <remarks>
+    /// AI-HINT (perf #145): returns a value-type <see cref="LayoutChildren"/> so
+    /// the common (no Display.Contents) case iterates <c>_children</c> by index
+    /// with ZERO heap allocations — a <c>yield</c> iterator allocates a
+    /// state-machine enumerator on every call, and these are hot per-frame paths
+    /// (baseline, trailing positions, wrap-reverse, pixel rounding). The rare
+    /// Display.Contents subtree still falls back to the allocating iterator.
+    /// </remarks>
+    internal LayoutChildren GetLayoutChildren() => new LayoutChildren(this);
+
+    // Allocating fallback used only to flatten a Display.Contents subtree.
+    private IEnumerable<YogaNode> EnumerateLayoutChildrenContents()
     {
         foreach (var child in _children)
         {
             if (child._style.Display == YogaDisplay.Contents)
             {
-                foreach (var grandchild in child.GetLayoutChildren())
+                foreach (var grandchild in child.EnumerateLayoutChildrenContents())
                     yield return grandchild;
             }
             else
             {
                 yield return child;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Allocation-free enumerable over a node's layoutable children (see
+    /// <see cref="GetLayoutChildren"/>). Nested in <see cref="YogaNode"/> so the
+    /// struct enumerator can read the private <c>_children</c> / <c>_style</c>.
+    /// </summary>
+    internal readonly struct LayoutChildren
+    {
+        private readonly YogaNode _node;
+        internal LayoutChildren(YogaNode node) => _node = node;
+
+        public Enumerator GetEnumerator() => new Enumerator(_node);
+
+        public struct Enumerator
+        {
+            private readonly List<YogaNode> _children;
+            private int _index;
+            private IEnumerator<YogaNode>? _inner;
+            private YogaNode _current;
+
+            internal Enumerator(YogaNode node)
+            {
+                _children = node._children;
+                _index = 0;
+                _inner = null;
+                _current = null!;
+            }
+
+            public readonly YogaNode Current => _current;
+
+            public bool MoveNext()
+            {
+                // Drain an in-progress Display.Contents subtree first.
+                if (_inner != null)
+                {
+                    if (_inner.MoveNext())
+                    {
+                        _current = _inner.Current;
+                        return true;
+                    }
+                    _inner = null;
+                }
+
+                while (_index < _children.Count)
+                {
+                    var child = _children[_index++];
+                    if (child._style.Display == YogaDisplay.Contents)
+                    {
+                        _inner = child.EnumerateLayoutChildrenContents().GetEnumerator();
+                        if (_inner.MoveNext())
+                        {
+                            _current = _inner.Current;
+                            return true;
+                        }
+                        _inner = null;
+                        continue;
+                    }
+                    _current = child;
+                    return true;
+                }
+                return false;
             }
         }
     }

--- a/src/Reactor/Yoga/YogaNode.cs
+++ b/src/Reactor/Yoga/YogaNode.cs
@@ -212,13 +212,20 @@ internal sealed class YogaNode
 
     // ── Public style property accessors ──
 
-    public FlexDirection FlexDirection { get => _style.FlexDirection; set { _style.FlexDirection = value; MarkDirtyAndPropagate(); } }
-    public FlexJustify JustifyContent { get => _style.JustifyContent; set { _style.JustifyContent = value; MarkDirtyAndPropagate(); } }
-    public FlexAlign AlignItems { get => _style.AlignItems; set { _style.AlignItems = value; MarkDirtyAndPropagate(); } }
-    public FlexAlign AlignSelf { get => _style.AlignSelf; set { _style.AlignSelf = value; MarkDirtyAndPropagate(); } }
-    public FlexAlign AlignContent { get => _style.AlignContent; set { _style.AlignContent = value; MarkDirtyAndPropagate(); } }
-    public FlexWrap FlexWrap { get => _style.FlexWrap; set { _style.FlexWrap = value; MarkDirtyAndPropagate(); } }
-    public FlexPositionType PositionType { get => _style.PositionType; set { _style.PositionType = value; MarkDirtyAndPropagate(); } }
+    // AI-HINT (perf #138): every setter guards with an equality check before
+    // dirtying. FlexPanel re-applies the same container/child style every
+    // MeasureOverride; without these guards the root + every cell are
+    // re-dirtied each frame and the Yoga layout cache NEVER hits. The guards
+    // mirror upstream Yoga's updateStyle, which only dirties on a real change.
+    // YogaValue is a record struct whose == treats two Undefined (NaN) values
+    // as equal; raw floats use float.Equals so NaN==NaN is also a no-op.
+    public FlexDirection FlexDirection { get => _style.FlexDirection; set { if (_style.FlexDirection == value) return; _style.FlexDirection = value; MarkDirtyAndPropagate(); } }
+    public FlexJustify JustifyContent { get => _style.JustifyContent; set { if (_style.JustifyContent == value) return; _style.JustifyContent = value; MarkDirtyAndPropagate(); } }
+    public FlexAlign AlignItems { get => _style.AlignItems; set { if (_style.AlignItems == value) return; _style.AlignItems = value; MarkDirtyAndPropagate(); } }
+    public FlexAlign AlignSelf { get => _style.AlignSelf; set { if (_style.AlignSelf == value) return; _style.AlignSelf = value; MarkDirtyAndPropagate(); } }
+    public FlexAlign AlignContent { get => _style.AlignContent; set { if (_style.AlignContent == value) return; _style.AlignContent = value; MarkDirtyAndPropagate(); } }
+    public FlexWrap FlexWrap { get => _style.FlexWrap; set { if (_style.FlexWrap == value) return; _style.FlexWrap = value; MarkDirtyAndPropagate(); } }
+    public FlexPositionType PositionType { get => _style.PositionType; set { if (_style.PositionType == value) return; _style.PositionType = value; MarkDirtyAndPropagate(); } }
     public YogaDisplay Display
     {
         get => _style.Display;
@@ -226,22 +233,23 @@ internal sealed class YogaNode
         {
             if (value == YogaDisplay.Grid)
                 throw new NotImplementedException("Grid layout is not yet implemented in this C# port of Yoga.");
+            if (_style.Display == value) return;
             _style.Display = value;
             MarkDirtyAndPropagate();
         }
     }
-    public YogaOverflow Overflow { get => _style.Overflow; set { _style.Overflow = value; MarkDirtyAndPropagate(); } }
+    public YogaOverflow Overflow { get => _style.Overflow; set { if (_style.Overflow == value) return; _style.Overflow = value; MarkDirtyAndPropagate(); } }
 
-    public float FlexGrow { get => _style.FlexGrow; set { _style.FlexGrow = value; MarkDirtyAndPropagate(); } }
-    public float FlexShrink { get => _style.FlexShrink; set { _style.FlexShrink = value; MarkDirtyAndPropagate(); } }
-    public YogaValue FlexBasis { get => _style.FlexBasis; set { _style.FlexBasis = value; MarkDirtyAndPropagate(); } }
+    public float FlexGrow { get => _style.FlexGrow; set { if (_style.FlexGrow.Equals(value)) return; _style.FlexGrow = value; MarkDirtyAndPropagate(); } }
+    public float FlexShrink { get => _style.FlexShrink; set { if (_style.FlexShrink.Equals(value)) return; _style.FlexShrink = value; MarkDirtyAndPropagate(); } }
+    public YogaValue FlexBasis { get => _style.FlexBasis; set { if (_style.FlexBasis == value) return; _style.FlexBasis = value; MarkDirtyAndPropagate(); } }
 
-    public YogaValue Width { get => _style.Dimensions[(int)YogaDimension.Width]; set { _style.Dimensions[(int)YogaDimension.Width] = value; MarkDirtyAndPropagate(); } }
-    public YogaValue Height { get => _style.Dimensions[(int)YogaDimension.Height]; set { _style.Dimensions[(int)YogaDimension.Height] = value; MarkDirtyAndPropagate(); } }
-    public YogaValue MinWidth { get => _style.MinDimensions[(int)YogaDimension.Width]; set { _style.MinDimensions[(int)YogaDimension.Width] = value; MarkDirtyAndPropagate(); } }
-    public YogaValue MinHeight { get => _style.MinDimensions[(int)YogaDimension.Height]; set { _style.MinDimensions[(int)YogaDimension.Height] = value; MarkDirtyAndPropagate(); } }
-    public YogaValue MaxWidth { get => _style.MaxDimensions[(int)YogaDimension.Width]; set { _style.MaxDimensions[(int)YogaDimension.Width] = value; MarkDirtyAndPropagate(); } }
-    public YogaValue MaxHeight { get => _style.MaxDimensions[(int)YogaDimension.Height]; set { _style.MaxDimensions[(int)YogaDimension.Height] = value; MarkDirtyAndPropagate(); } }
+    public YogaValue Width { get => _style.Dimensions[(int)YogaDimension.Width]; set { if (_style.Dimensions[(int)YogaDimension.Width] == value) return; _style.Dimensions[(int)YogaDimension.Width] = value; MarkDirtyAndPropagate(); } }
+    public YogaValue Height { get => _style.Dimensions[(int)YogaDimension.Height]; set { if (_style.Dimensions[(int)YogaDimension.Height] == value) return; _style.Dimensions[(int)YogaDimension.Height] = value; MarkDirtyAndPropagate(); } }
+    public YogaValue MinWidth { get => _style.MinDimensions[(int)YogaDimension.Width]; set { if (_style.MinDimensions[(int)YogaDimension.Width] == value) return; _style.MinDimensions[(int)YogaDimension.Width] = value; MarkDirtyAndPropagate(); } }
+    public YogaValue MinHeight { get => _style.MinDimensions[(int)YogaDimension.Height]; set { if (_style.MinDimensions[(int)YogaDimension.Height] == value) return; _style.MinDimensions[(int)YogaDimension.Height] = value; MarkDirtyAndPropagate(); } }
+    public YogaValue MaxWidth { get => _style.MaxDimensions[(int)YogaDimension.Width]; set { if (_style.MaxDimensions[(int)YogaDimension.Width] == value) return; _style.MaxDimensions[(int)YogaDimension.Width] = value; MarkDirtyAndPropagate(); } }
+    public YogaValue MaxHeight { get => _style.MaxDimensions[(int)YogaDimension.Height]; set { if (_style.MaxDimensions[(int)YogaDimension.Height] == value) return; _style.MaxDimensions[(int)YogaDimension.Height] = value; MarkDirtyAndPropagate(); } }
 
     public float AspectRatio
     {
@@ -249,17 +257,19 @@ internal sealed class YogaNode
         set
         {
             // Degenerate aspect ratios act as auto
-            _style.AspectRatio = (value == 0 || float.IsInfinity(value)) ? float.NaN : value;
+            float normalized = (value == 0 || float.IsInfinity(value)) ? float.NaN : value;
+            if (_style.AspectRatio.Equals(normalized)) return;
+            _style.AspectRatio = normalized;
             MarkDirtyAndPropagate();
         }
     }
 
-    public void SetMargin(YogaEdge edge, YogaValue value) { _style.Margin[(int)edge] = value; MarkDirtyAndPropagate(); }
-    public void SetPadding(YogaEdge edge, YogaValue value) { _style.Padding[(int)edge] = value; MarkDirtyAndPropagate(); }
-    public void SetBorder(YogaEdge edge, float value) { _style.Border[(int)edge] = YogaValue.Point(value); MarkDirtyAndPropagate(); }
-    public void SetPosition(YogaEdge edge, YogaValue value) { _style.Position[(int)edge] = value; MarkDirtyAndPropagate(); }
-    public void SetGap(YogaGutter gutter, float value) { _style.Gap[(int)gutter] = YogaValue.Point(value); MarkDirtyAndPropagate(); }
-    public void SetGap(YogaGutter gutter, YogaValue value) { _style.Gap[(int)gutter] = value; MarkDirtyAndPropagate(); }
+    public void SetMargin(YogaEdge edge, YogaValue value) { if (_style.Margin[(int)edge] == value) return; _style.Margin[(int)edge] = value; MarkDirtyAndPropagate(); }
+    public void SetPadding(YogaEdge edge, YogaValue value) { if (_style.Padding[(int)edge] == value) return; _style.Padding[(int)edge] = value; MarkDirtyAndPropagate(); }
+    public void SetBorder(YogaEdge edge, float value) { var v = YogaValue.Point(value); if (_style.Border[(int)edge] == v) return; _style.Border[(int)edge] = v; MarkDirtyAndPropagate(); }
+    public void SetPosition(YogaEdge edge, YogaValue value) { if (_style.Position[(int)edge] == value) return; _style.Position[(int)edge] = value; MarkDirtyAndPropagate(); }
+    public void SetGap(YogaGutter gutter, float value) { var v = YogaValue.Point(value); if (_style.Gap[(int)gutter] == v) return; _style.Gap[(int)gutter] = v; MarkDirtyAndPropagate(); }
+    public void SetGap(YogaGutter gutter, YogaValue value) { if (_style.Gap[(int)gutter] == value) return; _style.Gap[(int)gutter] = value; MarkDirtyAndPropagate(); }
 
     // ── Measure/baseline callbacks ──
 

--- a/src/Reactor/Yoga/YogaStyle.cs
+++ b/src/Reactor/Yoga/YogaStyle.cs
@@ -43,31 +43,56 @@ internal sealed class YogaStyle
     public float FlexShrink = float.NaN;
     public YogaValue FlexBasis = YogaValue.Auto;
 
-    // Edge-indexed arrays (indexed by YogaEdge: Left=0..All=8)
-    public readonly YogaValue[] Margin = CreateUndefinedEdges();
-    public readonly YogaValue[] Position = CreateUndefinedEdges();
-    public readonly YogaValue[] Padding = CreateUndefinedEdges();
-    public readonly YogaValue[] Border = CreateUndefinedEdges();
+    // Edge / gutter / dimension values are stored inline (see #143 InlineArray
+    // structs at the bottom of this file) instead of 8 separate YogaValue[]
+    // arrays. Exposed as ref-returning properties so existing indexer reads and
+    // writes (style.Margin[i], style.Position[i] = v) keep working unchanged.
+    private EdgeValues _margin;
+    private EdgeValues _position;
+    private EdgeValues _padding;
+    private EdgeValues _border;
+    private GutterValues _gap;            // Column=0, Row=1, All=2
+    private DimensionValues _dimensions;  // Width=0, Height=1
+    private DimensionValues _minDimensions;
+    private DimensionValues _maxDimensions;
 
-    // Gutter-indexed array (Column=0, Row=1, All=2)
-    public readonly YogaValue[] Gap = new YogaValue[3]
-    {
-        YogaValue.Undefined, YogaValue.Undefined, YogaValue.Undefined
-    };
+    // Edge-indexed values (indexed by YogaEdge: Left=0..All=8)
+    public ref EdgeValues Margin => ref _margin;
+    public ref EdgeValues Position => ref _position;
+    public ref EdgeValues Padding => ref _padding;
+    public ref EdgeValues Border => ref _border;
 
-    // Dimension-indexed arrays (Width=0, Height=1)
-    public readonly YogaValue[] Dimensions = new YogaValue[2]
+    // Gutter-indexed values (Column=0, Row=1, All=2)
+    public ref GutterValues Gap => ref _gap;
+
+    // Dimension-indexed values (Width=0, Height=1)
+    public ref DimensionValues Dimensions => ref _dimensions;
+    public ref DimensionValues MinDimensions => ref _minDimensions;
+    public ref DimensionValues MaxDimensions => ref _maxDimensions;
+
+    public YogaStyle()
     {
-        YogaValue.Auto, YogaValue.Auto
-    };
-    public readonly YogaValue[] MinDimensions = new YogaValue[2]
-    {
-        YogaValue.Undefined, YogaValue.Undefined
-    };
-    public readonly YogaValue[] MaxDimensions = new YogaValue[2]
-    {
-        YogaValue.Undefined, YogaValue.Undefined
-    };
+        // Explicitly seed the inline buffers to match the historic array
+        // initializers. default(YogaValue) is (0, Undefined) — NOT the
+        // (NaN, Undefined) sentinel — so leaving them zero-initialized would
+        // subtly change == and Resolve() behavior. Dimensions default to Auto.
+        for (int i = 0; i < 9; i++)
+        {
+            _margin[i] = YogaValue.Undefined;
+            _position[i] = YogaValue.Undefined;
+            _padding[i] = YogaValue.Undefined;
+            _border[i] = YogaValue.Undefined;
+        }
+        _gap[0] = YogaValue.Undefined;
+        _gap[1] = YogaValue.Undefined;
+        _gap[2] = YogaValue.Undefined;
+        _dimensions[0] = YogaValue.Auto;
+        _dimensions[1] = YogaValue.Auto;
+        _minDimensions[0] = YogaValue.Undefined;
+        _minDimensions[1] = YogaValue.Undefined;
+        _maxDimensions[0] = YogaValue.Undefined;
+        _maxDimensions[1] = YogaValue.Undefined;
+    }
 
     // Aspect ratio (NaN = undefined)
     private float _aspectRatio = float.NaN;
@@ -90,30 +115,22 @@ internal sealed class YogaStyle
         }
     }
 
-    private static YogaValue[] CreateUndefinedEdges()
-    {
-        var arr = new YogaValue[9];
-        for (int i = 0; i < 9; i++)
-            arr[i] = YogaValue.Undefined;
-        return arr;
-    }
-
     // ── Edge computation (resolves Start/End/Horizontal/Vertical/All fallbacks) ──
 
     public YogaValue ComputeColumnGap()
     {
-        var col = Gap[(int)YogaGutter.Column];
-        return col.IsDefined ? col : Gap[(int)YogaGutter.All];
+        var col = _gap[(int)YogaGutter.Column];
+        return col.IsDefined ? col : _gap[(int)YogaGutter.All];
     }
 
     public YogaValue ComputeRowGap()
     {
-        var row = Gap[(int)YogaGutter.Row];
-        return row.IsDefined ? row : Gap[(int)YogaGutter.All];
+        var row = _gap[(int)YogaGutter.Row];
+        return row.IsDefined ? row : _gap[(int)YogaGutter.All];
     }
 
     /// <summary>Resolve the left edge value considering Start/End/Left/Horizontal/All fallbacks.</summary>
-    private YogaValue ComputeLeftEdge(YogaValue[] edges, FlexLayoutDirection layoutDirection)
+    private static YogaValue ComputeLeftEdge(ReadOnlySpan<YogaValue> edges, FlexLayoutDirection layoutDirection)
     {
         if (layoutDirection == FlexLayoutDirection.LTR && edges[(int)YogaEdge.Start].IsDefined)
             return edges[(int)YogaEdge.Start];
@@ -126,14 +143,14 @@ internal sealed class YogaStyle
         return edges[(int)YogaEdge.All];
     }
 
-    private YogaValue ComputeTopEdge(YogaValue[] edges)
+    private static YogaValue ComputeTopEdge(ReadOnlySpan<YogaValue> edges)
     {
         if (edges[(int)YogaEdge.Top].IsDefined) return edges[(int)YogaEdge.Top];
         if (edges[(int)YogaEdge.Vertical].IsDefined) return edges[(int)YogaEdge.Vertical];
         return edges[(int)YogaEdge.All];
     }
 
-    private YogaValue ComputeRightEdge(YogaValue[] edges, FlexLayoutDirection layoutDirection)
+    private static YogaValue ComputeRightEdge(ReadOnlySpan<YogaValue> edges, FlexLayoutDirection layoutDirection)
     {
         if (layoutDirection == FlexLayoutDirection.LTR && edges[(int)YogaEdge.End].IsDefined)
             return edges[(int)YogaEdge.End];
@@ -146,14 +163,14 @@ internal sealed class YogaStyle
         return edges[(int)YogaEdge.All];
     }
 
-    private YogaValue ComputeBottomEdge(YogaValue[] edges)
+    private static YogaValue ComputeBottomEdge(ReadOnlySpan<YogaValue> edges)
     {
         if (edges[(int)YogaEdge.Bottom].IsDefined) return edges[(int)YogaEdge.Bottom];
         if (edges[(int)YogaEdge.Vertical].IsDefined) return edges[(int)YogaEdge.Vertical];
         return edges[(int)YogaEdge.All];
     }
 
-    private YogaValue ComputeEdge(YogaValue[] edges, YogaPhysicalEdge edge, FlexLayoutDirection direction)
+    private static YogaValue ComputeEdge(ReadOnlySpan<YogaValue> edges, YogaPhysicalEdge edge, FlexLayoutDirection direction)
     {
         return edge switch
         {
@@ -168,32 +185,32 @@ internal sealed class YogaStyle
     // ── Position queries ──
 
     public YogaValue ComputePosition(YogaPhysicalEdge edge, FlexLayoutDirection direction)
-        => ComputeEdge(Position, edge, direction);
+        => ComputeEdge(_position, edge, direction);
 
     public YogaValue ComputeMargin(YogaPhysicalEdge edge, FlexLayoutDirection direction)
-        => ComputeEdge(Margin, edge, direction);
+        => ComputeEdge(_margin, edge, direction);
 
     public YogaValue ComputePadding(YogaPhysicalEdge edge, FlexLayoutDirection direction)
-        => ComputeEdge(Padding, edge, direction);
+        => ComputeEdge(_padding, edge, direction);
 
     public YogaValue ComputeBorder(YogaPhysicalEdge edge, FlexLayoutDirection direction)
-        => ComputeEdge(Border, edge, direction);
+        => ComputeEdge(_border, edge, direction);
 
     // ── Inset queries ──
 
     public bool HorizontalInsetsDefined =>
-        Position[(int)YogaEdge.Left].IsDefined ||
-        Position[(int)YogaEdge.Right].IsDefined ||
-        Position[(int)YogaEdge.All].IsDefined ||
-        Position[(int)YogaEdge.Horizontal].IsDefined ||
-        Position[(int)YogaEdge.Start].IsDefined ||
-        Position[(int)YogaEdge.End].IsDefined;
+        _position[(int)YogaEdge.Left].IsDefined ||
+        _position[(int)YogaEdge.Right].IsDefined ||
+        _position[(int)YogaEdge.All].IsDefined ||
+        _position[(int)YogaEdge.Horizontal].IsDefined ||
+        _position[(int)YogaEdge.Start].IsDefined ||
+        _position[(int)YogaEdge.End].IsDefined;
 
     public bool VerticalInsetsDefined =>
-        Position[(int)YogaEdge.Top].IsDefined ||
-        Position[(int)YogaEdge.Bottom].IsDefined ||
-        Position[(int)YogaEdge.All].IsDefined ||
-        Position[(int)YogaEdge.Vertical].IsDefined;
+        _position[(int)YogaEdge.Top].IsDefined ||
+        _position[(int)YogaEdge.Bottom].IsDefined ||
+        _position[(int)YogaEdge.All].IsDefined ||
+        _position[(int)YogaEdge.Vertical].IsDefined;
 
     // ── Flex-direction-aware computed values ──
 
@@ -328,7 +345,7 @@ internal sealed class YogaStyle
 
     public float ResolvedMinDimension(FlexLayoutDirection direction, YogaDimension axis, float referenceLength, float ownerWidth)
     {
-        float value = MinDimensions[(int)axis].Resolve(referenceLength);
+        float value = _minDimensions[(int)axis].Resolve(referenceLength);
         if (BoxSizing == YogaBoxSizing.BorderBox)
             return value;
 
@@ -341,7 +358,7 @@ internal sealed class YogaStyle
 
     public float ResolvedMaxDimension(FlexLayoutDirection direction, YogaDimension axis, float referenceLength, float ownerWidth)
     {
-        float value = MaxDimensions[(int)axis].Resolve(referenceLength);
+        float value = _maxDimensions[(int)axis].Resolve(referenceLength);
         if (BoxSizing == YogaBoxSizing.BorderBox)
             return value;
 
@@ -350,4 +367,36 @@ internal sealed class YogaStyle
         float pb = YogaFloat.IsDefined(paddingAndBorder) ? paddingAndBorder : 0;
         return value + pb;
     }
+}
+
+// AI-HINT (perf #143): fixed-size inline value buffers embedded directly in the
+// YogaStyle heap object. These replace 8 separate YogaValue[] arrays per node —
+// for a ~200-node tree that removes ~1600 GC objects (a dominant Yoga memory
+// regression vs the C++ original, which uses inline members). InlineArray is a
+// first-class C# 12 feature: indexing is compiler-generated and fully AOT/trim
+// safe (no reflection, no Unsafe). Each struct has exactly one instance field,
+// as InlineArray requires. They are explicitly initialized in the YogaStyle
+// constructor (default(YogaValue) is (0, Undefined), not the (NaN, Undefined)
+// sentinel — and dimensions default to Auto), so == and Resolve() semantics
+// stay byte-identical to the previous arrays.
+
+/// <summary>Edge-indexed inline buffer (YogaEdge: Left=0 .. All=8).</summary>
+[global::System.Runtime.CompilerServices.InlineArray(9)]
+internal struct EdgeValues
+{
+    private YogaValue _element0;
+}
+
+/// <summary>Gutter-indexed inline buffer (Column=0, Row=1, All=2).</summary>
+[global::System.Runtime.CompilerServices.InlineArray(3)]
+internal struct GutterValues
+{
+    private YogaValue _element0;
+}
+
+/// <summary>Dimension-indexed inline buffer (Width=0, Height=1).</summary>
+[global::System.Runtime.CompilerServices.InlineArray(2)]
+internal struct DimensionValues
+{
+    private YogaValue _element0;
 }

--- a/tests/Reactor.Tests/YogaEdgeCaseTests.cs
+++ b/tests/Reactor.Tests/YogaEdgeCaseTests.cs
@@ -1316,4 +1316,59 @@ public class YogaEdgeCaseTests
         // Cache hit ⇒ measure function not invoked again.
         Assert.Equal(callsAfterFirst, measureCalls);
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // 7. Flex-basis cache invalidation across layout generations (#138 follow-up)
+    //    The equality guards stop FlexPanel re-dirtying stable children every
+    //    MeasureOverride, so a child's resolved flex-basis must be invalidated
+    //    per layout generation rather than relying on the dirty flag. Without
+    //    that, a flex-basis:0 grow item measured at content during an
+    //    undefined-main-axis pass leaks that content size into a later
+    //    definite-width pass and mis-distributes the grow space. The 704
+    //    single-generation Yoga fixtures never exercise this; only a repeated
+    //    (multi-generation) layout of the same un-dirtied tree does.
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void FlexBasis_StaleAcrossGenerations_RecomputedOnDefinitePass()
+    {
+        // Two flex-grow children with flex-basis:0 in a row, content width 50
+        // each (via measure function). In a definite 600px row the basis:0 grow
+        // split 1:2 must be 200 / 400 — the content size must NOT enter the base.
+        var config = new YogaConfig();
+        var root = new YogaNode(config);
+        root.FlexDirection = FlexDirection.Row;
+        root.Height = YogaValue.Point(50f);
+
+        var child0 = new YogaNode(config);
+        child0.FlexGrow = 1f;
+        child0.FlexShrink = 0f;
+        child0.FlexBasis = YogaValue.Point(0f);
+        child0.MeasureFunction = (n, w, wm, h, hm) => new YogaSize(50f, 10f);
+        root.InsertChild(child0, 0);
+
+        var child1 = new YogaNode(config);
+        child1.FlexGrow = 2f;
+        child1.FlexShrink = 0f;
+        child1.FlexBasis = YogaValue.Point(0f);
+        child1.MeasureFunction = (n, w, wm, h, hm) => new YogaSize(50f, 10f);
+        root.InsertChild(child1, 1);
+
+        // Generation 1: undefined main axis (no root width, undefined available
+        // width). flex-basis:0 is not applied in an indefinite main axis, so the
+        // children are measured at content and each ComputedFlexBasis becomes 50.
+        root.CalculateLayout(float.NaN, 50f, FlexLayoutDirection.LTR);
+
+        // Generation 2: definite 600px main axis. Only the root constraint
+        // changed (what FlexPanel does each frame); the children were never
+        // re-dirtied, so their stale gen-1 content basis must be invalidated by
+        // layout generation, not by the dirty flag.
+        root.Width = YogaValue.Point(600f);
+        root.CalculateLayout(600f, 50f, FlexLayoutDirection.LTR);
+
+        // flex-basis:0 grow 1:2 across 600px ⇒ 200 / 400.
+        // A leaked content basis (50 each) would instead give ~217 / 383.
+        Assert.Equal(200f, child0.LayoutWidth);
+        Assert.Equal(400f, child1.LayoutWidth);
+    }
 }

--- a/tests/Reactor.Tests/YogaEdgeCaseTests.cs
+++ b/tests/Reactor.Tests/YogaEdgeCaseTests.cs
@@ -1178,4 +1178,142 @@ public class YogaEdgeCaseTests
         node.HasNewLayout = false;
         Assert.False(node.HasNewLayout);
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // 6. Setter equality guards (#138 — layout cache enablement)
+    //    A setter assigned its current value must NOT re-dirty the node, so
+    //    FlexPanel's per-frame re-apply of stable style does not defeat the
+    //    Yoga layout cache. A genuine change must still dirty.
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Setter_SameValue_DoesNotMarkDirty()
+    {
+        var node = new YogaNode();
+        // Prime each input to a known value, then clear the dirty flag.
+        node.FlexDirection = FlexDirection.Row;
+        node.JustifyContent = FlexJustify.Center;
+        node.AlignItems = FlexAlign.Center;
+        node.FlexGrow = 1f;
+        node.FlexShrink = 0f;
+        node.FlexBasis = YogaValue.Point(50f);
+        node.Width = YogaValue.Point(100f);
+        node.Height = YogaValue.Percent(50f);
+        node.MinWidth = YogaValue.Point(10f);
+        node.MaxHeight = YogaValue.Point(200f);
+        node.AspectRatio = 1.5f;
+        node.SetMargin(YogaEdge.Left, YogaValue.Point(8f));
+        node.SetPadding(YogaEdge.Top, YogaValue.Point(4f));
+        node.SetBorder(YogaEdge.Right, 2f);
+        node.SetPosition(YogaEdge.Bottom, YogaValue.Point(3f));
+        node.SetGap(YogaGutter.Row, 6f);
+        node.SetDirty(false);
+        Assert.False(node.IsDirty);
+
+        // Re-assign every input its current value — none should dirty.
+        node.FlexDirection = FlexDirection.Row;
+        node.JustifyContent = FlexJustify.Center;
+        node.AlignItems = FlexAlign.Center;
+        node.FlexGrow = 1f;
+        node.FlexShrink = 0f;
+        node.FlexBasis = YogaValue.Point(50f);
+        node.Width = YogaValue.Point(100f);
+        node.Height = YogaValue.Percent(50f);
+        node.MinWidth = YogaValue.Point(10f);
+        node.MaxHeight = YogaValue.Point(200f);
+        node.AspectRatio = 1.5f;
+        node.SetMargin(YogaEdge.Left, YogaValue.Point(8f));
+        node.SetPadding(YogaEdge.Top, YogaValue.Point(4f));
+        node.SetBorder(YogaEdge.Right, 2f);
+        node.SetPosition(YogaEdge.Bottom, YogaValue.Point(3f));
+        node.SetGap(YogaGutter.Row, 6f);
+
+        Assert.False(node.IsDirty);
+    }
+
+    [Fact]
+    public void Setter_UndefinedToUndefined_DoesNotMarkDirty()
+    {
+        // YogaValue.Undefined carries a NaN payload; the record-struct == must
+        // treat two Undefined values as equal so re-applying Undefined (e.g. a
+        // child with no margin) does not dirty.
+        var node = new YogaNode();
+        node.SetMargin(YogaEdge.Left, YogaValue.Undefined);
+        node.Width = YogaValue.Auto;
+        node.SetDirty(false);
+
+        node.SetMargin(YogaEdge.Left, YogaValue.Undefined);
+        node.Width = YogaValue.Auto;
+
+        Assert.False(node.IsDirty);
+    }
+
+    [Theory]
+    [InlineData("flexDirection")]
+    [InlineData("justify")]
+    [InlineData("width")]
+    [InlineData("flexGrow")]
+    [InlineData("margin")]
+    [InlineData("gap")]
+    [InlineData("display")]
+    public void Setter_RealChange_MarksDirty(string which)
+    {
+        var node = new YogaNode();
+        node.FlexDirection = FlexDirection.Row;
+        node.JustifyContent = FlexJustify.Center;
+        node.Width = YogaValue.Point(100f);
+        node.FlexGrow = 1f;
+        node.SetMargin(YogaEdge.Left, YogaValue.Point(8f));
+        node.SetGap(YogaGutter.Row, 6f);
+        node.Display = YogaDisplay.Flex;
+        node.SetDirty(false);
+        Assert.False(node.IsDirty);
+
+        switch (which)
+        {
+            case "flexDirection": node.FlexDirection = FlexDirection.Column; break;
+            case "justify": node.JustifyContent = FlexJustify.FlexEnd; break;
+            case "width": node.Width = YogaValue.Point(101f); break;
+            case "flexGrow": node.FlexGrow = 2f; break;
+            case "margin": node.SetMargin(YogaEdge.Left, YogaValue.Point(9f)); break;
+            case "gap": node.SetGap(YogaGutter.Row, 7f); break;
+            case "display": node.Display = YogaDisplay.None; break;
+        }
+
+        Assert.True(node.IsDirty);
+    }
+
+    [Fact]
+    public void Setter_SameValue_KeepsLayoutCacheHot()
+    {
+        // End-to-end: after a layout, re-assigning identical style must not
+        // re-dirty, so the next layout reuses the cache instead of recomputing.
+        // Observable: the child's measure function is NOT invoked again.
+        var config = new YogaConfig();
+        var root = new YogaNode(config);
+        root.Width = YogaValue.Point(200f);
+        root.Height = YogaValue.Point(100f);
+        root.FlexDirection = FlexDirection.Row;
+
+        int measureCalls = 0;
+        var child = new YogaNode(config);
+        child.MeasureFunction = (n, w, wm, h, hm) => { measureCalls++; return new YogaSize(20f, 10f); };
+        root.InsertChild(child, 0);
+
+        root.CalculateLayout(200f, 100f, FlexLayoutDirection.LTR);
+        int callsAfterFirst = measureCalls;
+        Assert.True(callsAfterFirst > 0);
+
+        // Re-apply identical container style (what FlexPanel does every
+        // MeasureOverride). With the equality guards this must not dirty.
+        root.FlexDirection = FlexDirection.Row;
+        root.Width = YogaValue.Point(200f);
+        root.Height = YogaValue.Point(100f);
+        Assert.False(root.IsDirty);
+        Assert.False(child.IsDirty);
+
+        root.CalculateLayout(200f, 100f, FlexLayoutDirection.LTR);
+        // Cache hit ⇒ measure function not invoked again.
+        Assert.Equal(callsAfterFirst, measureCalls);
+    }
 }

--- a/tests/Reactor.Tests/YogaEdgeCaseTests.cs
+++ b/tests/Reactor.Tests/YogaEdgeCaseTests.cs
@@ -1203,7 +1203,7 @@ public class YogaEdgeCaseTests
     }
 
     // ════════════════════════════════════════════════════════════════════
-    // 6. Setter equality guards (#138 — layout cache enablement)
+    // 13. Setter equality guards (#138 — layout cache enablement)
     //    A setter assigned its current value must NOT re-dirty the node, so
     //    FlexPanel's per-frame re-apply of stable style does not defeat the
     //    Yoga layout cache. A genuine change must still dirty.
@@ -1369,7 +1369,7 @@ public class YogaEdgeCaseTests
     }
 
     // ════════════════════════════════════════════════════════════════════
-    // 7. Flex-basis cache invalidation across layout generations (#138 follow-up)
+    // 14. Flex-basis cache invalidation across layout generations (#138 follow-up)
     //    The equality guards stop FlexPanel re-dirtying stable children every
     //    MeasureOverride, so a child's resolved flex-basis must be invalidated
     //    per layout generation rather than relying on the dirty flag. Without

--- a/tests/Reactor.Tests/YogaEdgeCaseTests.cs
+++ b/tests/Reactor.Tests/YogaEdgeCaseTests.cs
@@ -1110,6 +1110,29 @@ public class YogaEdgeCaseTests
         Assert.Empty(list2);
     }
 
+    [Fact]
+    public void FlexLineHelper_RentAndReturnFlexLine_ReusesAndResets()
+    {
+        var line1 = FlexLineHelper.RentFlexLine();
+        line1.ItemsInFlow.Add(new YogaNode());
+        line1.SizeConsumed = 42f;
+        line1.NumberOfAutoMargins = 3;
+        line1.Layout.MainDim = 7f;
+        line1.Layout.CrossDim = 9f;
+        FlexLineHelper.ReturnFlexLine(line1);
+
+        var line2 = FlexLineHelper.RentFlexLine();
+        // The pooled FlexLine is reused AND fully reset on return (#144), so no
+        // stale scalar state or pinned YogaNode references leak across layout
+        // passes (the ItemsInFlow refs reach whole UI subtrees).
+        Assert.Same(line1, line2);
+        Assert.Empty(line2.ItemsInFlow);
+        Assert.Equal(0f, line2.SizeConsumed);
+        Assert.Equal(0, line2.NumberOfAutoMargins);
+        Assert.Equal(0f, line2.Layout.MainDim);
+        Assert.Equal(0f, line2.Layout.CrossDim);
+    }
+
     // ════════════════════════════════════════════════════════════════════
     // 12. Additional layout integration tests for edge cases
     // ════════════════════════════════════════════════════════════════════
@@ -1253,6 +1276,7 @@ public class YogaEdgeCaseTests
     [InlineData("justify")]
     [InlineData("width")]
     [InlineData("flexGrow")]
+    [InlineData("aspectRatio")]
     [InlineData("margin")]
     [InlineData("gap")]
     [InlineData("display")]
@@ -1263,6 +1287,7 @@ public class YogaEdgeCaseTests
         node.JustifyContent = FlexJustify.Center;
         node.Width = YogaValue.Point(100f);
         node.FlexGrow = 1f;
+        node.AspectRatio = 1.5f;
         node.SetMargin(YogaEdge.Left, YogaValue.Point(8f));
         node.SetGap(YogaGutter.Row, 6f);
         node.Display = YogaDisplay.Flex;
@@ -1275,11 +1300,37 @@ public class YogaEdgeCaseTests
             case "justify": node.JustifyContent = FlexJustify.FlexEnd; break;
             case "width": node.Width = YogaValue.Point(101f); break;
             case "flexGrow": node.FlexGrow = 2f; break;
+            case "aspectRatio": node.AspectRatio = 2.0f; break;
             case "margin": node.SetMargin(YogaEdge.Left, YogaValue.Point(9f)); break;
             case "gap": node.SetGap(YogaGutter.Row, 7f); break;
             case "display": node.Display = YogaDisplay.None; break;
         }
 
+        Assert.True(node.IsDirty);
+    }
+
+    [Fact]
+    public void Setter_AspectRatio_DegenerateNormalizesToAuto()
+    {
+        // AspectRatio normalizes degenerate inputs (0 or Infinity) to NaN ("auto"),
+        // and the .Equals guard must treat NaN==NaN as a no-op so re-applying a
+        // degenerate ratio each frame does not dirty (which would defeat the layout
+        // cache). A genuine ratio change must still dirty.
+        var node = new YogaNode();
+        node.AspectRatio = 1.5f;
+        node.SetDirty(false);
+
+        // 1.5 -> 0 is a real change (0 normalizes to auto/NaN): must dirty.
+        node.AspectRatio = 0f;
+        Assert.True(node.IsDirty);
+
+        // 0 -> +Infinity: both normalize to NaN, so NaN==NaN must be a no-op.
+        node.SetDirty(false);
+        node.AspectRatio = float.PositiveInfinity;
+        Assert.False(node.IsDirty);
+
+        // NaN ("auto") -> a real ratio: must dirty.
+        node.AspectRatio = 2.0f;
         Assert.True(node.IsDirty);
     }
 


### PR DESCRIPTION
Closes #658

## Summary

Targets the Yoga layout engine (`src/Reactor/Yoga/` only) — implicated in both the **Renders/sec** gap (layout cache never hit → full re-layout every frame) and the **~1.5x Memory** gap (per-node arrays where the C++ original uses inline members) on the StocksGrid data-grid stress workload.

## Fixes

**Flagship — renders (layout cache):**
- **#138** `YogaNode` setter equality guards (`if (current == value) return;`) on `FlexDirection`/`Justify`/`Align`/`Width`/`Height`/`Min`/margins/… so `SetRootConstraints` + `ApplyAttachedProperties` re-setting unchanged values each frame no longer re-dirties the root. This is what lets the frame-level layout cache actually hit for stable cells. Unit tests assert no-op sets don't dirty and real changes do (incl. the `AspectRatio` degenerate-`0`/`Infinity`→`auto` normalization).

**Flagship — memory:**
- **#142** `LayoutResults`: 7 separate `float[]` + `CachedMeasurement[]` per node → inline `Float2`/`Float4`/cached-measurement storage via `[InlineArray]` (`Unsafe.Add` indexing, AOT-safe). Public accessors unchanged.
- **#143** `YogaStyle`: 8 separate `YogaValue[]` arrays per instance → one inline fixed-layout edge struct via `[InlineArray]` + `ref` indexer.

**Supporting allocations / boxing:**
- **#147** `FlexPanel` caches last-seen attached-DP values per child; pushes only on change (removes 9N boxing GetValue/SetValue per frame). The cache is invalidated when a DP changes while the child is parented (`OnChildPropertyChanged`), by the `SyncYogaTree` removal sweep, and — for a DP changed while the child is *detached* and re-added before the next measure — via a static weak-keyed dirty flag consulted on cache hit.
- **#141** `YogaAlgorithm` rents the `layoutChildren`/children lists from a pool and threads them down (removes 2N list allocs/frame).
- **#144** `FlexLine` pooled (no per-line heap alloc per frame); reset-on-return is unit-tested so no stale scalars or pinned `YogaNode` refs leak across passes.
- **#145** allocation-free layout-children iteration (no `yield` enumerator / boxed `List.Enumerator` in hot paths). The `Display.Contents` fallback enumerator is disposed (struct `Enumerator : IDisposable`).
- **#148** `IsBaselineLayout` computed once per layout pass instead of per flex line.

**Regression fix (caught by Flex selftest):**
- The #138 guards stopped FlexPanel re-dirtying every child each `MeasureOverride`; that re-dirty used to reset `Layout.ComputedFlexBasis = NaN`. `ComputeFlexBasisForChild` only recomputed a cached basis when it was `NaN` (or under the off-by-default `WebFlexBasis` flag), so a child first measured in a min-content probe (undefined main axis → basis from **content**) reused that stale content-basis in the later definite-width pass where `flex-basis:0` must apply — breaking flex-grow distribution in nested `FlexPanel`s. **Fix:** invalidate the resolved-basis cache when `ComputedFlexBasisGeneration` differs from the current generation, regardless of `WebFlexBasis`. Each top-level `CalculateLayout` bumps the generation, so this restores the old always-fresh basis **without** re-dirtying the root (the layout cache still hits).

## Deferred (intentionally, for correctness)
- **#139** aggressive skip-clean-children — the per-child min-content re-measure is load-bearing; #138 (no MarkDirty spam) + #147 (no boxing) already remove the bulk of the per-frame cost.
- **#140** `ComputeMinContent` re-measure — load-bearing: content changes don't otherwise dirty the node. Removing it would drop genuine relayouts.
- **#146** `LayoutResults.Reset` — dead code (no callers); the GC concern is superseded by #142 making `CachedMeasurement` a struct.

## Validation
- **Yoga fixtures** (`--filter ~Yoga`): **708 passed, 0 failed**, 46 skipped — encode Yoga's reference behavior; all preserved.
- **Full `tests/Reactor.Tests`**: **9684 passed, 0 failed**, 64 skipped.
- **Flex selftest** (`--self-test --filter Flex`): **0 failures**, including the two nested flex-grow fixtures the regression fix restores.
- **`dotnet build src/Reactor/Reactor.csproj -c Release`**: core `Reactor.dll` builds with **0 warnings / 0 errors** (the core lib treats AOT/trim warnings as errors, so the `InlineArray`/`Unsafe`/`ConditionalWeakTable` usage is confirmed AOT-safe).

Layout correctness is paramount — no fixture numeric results changed.