### PR TITLE
Fix #647: multi-window teardown ACCESS_VIOLATION (0xC0000005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,6 +316,26 @@ Conventions for contributors:
 
 ### Fixed
 
+- **Multi-window teardown no longer faults with an `ACCESS_VIOLATION`
+  (issue #647).** Closing a docking tear-off floating preview window could
+  terminate the process with `0xC0000005` deep in the WinUI backdrop interop —
+  an unmanaged fault no `try`/`catch` can trap — corrupting the lifecycle of
+  windows opened later in the same process. Root cause: a transient auxiliary
+  window (e.g. a docking tear-off) could be elected the fallback `PrimaryWindow`,
+  so closing it fired `ShutdownPolicy.OnPrimaryWindowClosed` →
+  `Application.Exit()`, tearing down every still-open window mid-process; a
+  surviving host then wrote `Window.SystemBackdrop` on one of those torn-down
+  surfaces. Three reinforcing fixes (spec 036, spec 045): docking floating
+  windows opt out of primary election via `ExcludeFromShutdownPolicy`, and the
+  single election helper that runs on both initial registration and
+  unregister re-election never promotes an excluded window — so an auxiliary
+  window can neither become *nor remain* primary, and `PrimaryWindow` goes
+  `null` rather than to an excluded window when no eligible window remains;
+  `BackdropApplier` records torn-down surfaces in a process-wide closed-window
+  registry and skips every `SystemBackdrop` write (both `Apply` and `Reset`) on
+  them; and `ReactorWindow.Close()` is now idempotent — a redundant or
+  owner-cascade close performs the native close exactly once instead of
+  re-entering native teardown.
 - **TitleBar in a non-content-extended window no longer corrupts the heap on
   close (issue #537).** A window whose `WindowSpec` set
   `ExtendsContentIntoTitleBar = false` while its content still rendered a

--- a/docs/_pipeline/templates/windows.md.dt
+++ b/docs/_pipeline/templates/windows.md.dt
@@ -44,9 +44,10 @@ Caveats:
   cascade is already tearing the window down) performs the native close exactly
   once. A redundant close is a safe no-op, so converging teardown paths can't
   re-enter native window destruction.
-- `ReactorApp.PrimaryWindow` is the first opened window; shutdown policy decides
-  whether closing it exits the process. Auxiliary windows that opt out of the
-  shutdown policy — notably docking tear-off floating windows — are excluded
+- `ReactorApp.PrimaryWindow` is the first *eligible* opened window; shutdown
+  policy decides whether closing it exits the process. Auxiliary windows that
+  opt out of the shutdown policy — notably docking tear-off floating windows —
+  are excluded
   from primary election: they can never become the fallback primary, and they
   are never promoted to primary when the real primary closes (re-election skips
   them, leaving `PrimaryWindow` `null` if only excluded windows remain). This

--- a/docs/_pipeline/templates/windows.md.dt
+++ b/docs/_pipeline/templates/windows.md.dt
@@ -40,8 +40,18 @@ settings.Close();
 Caveats:
 
 - `Close`, `Show`, `Hide`, `Activate`, `Update`, and mutators are UI-thread only.
+- `Close()` is idempotent: calling it more than once (or while an owner-close
+  cascade is already tearing the window down) performs the native close exactly
+  once. A redundant close is a safe no-op, so converging teardown paths can't
+  re-enter native window destruction.
 - `ReactorApp.PrimaryWindow` is the first opened window; shutdown policy decides
-  whether closing it exits the process.
+  whether closing it exits the process. Auxiliary windows that opt out of the
+  shutdown policy — notably docking tear-off floating windows — are excluded
+  from primary election: they can never become the fallback primary, and they
+  are never promoted to primary when the real primary closes (re-election skips
+  them, leaving `PrimaryWindow` `null` if only excluded windows remain). This
+  keeps closing a transient floating window from firing
+  `OnPrimaryWindowClosed` and exiting the app.
 - `UseWindow()` returns the owning `ReactorWindow` inside a window component and
   `null` outside one (for example tray flyouts).
 
@@ -341,6 +351,11 @@ lets a component declaratively own a secondary window's existence; tray icons us
 | `OnPrimaryWindowClosed` *(default)* | The primary window closes |
 | `OnLastSurfaceClosed` | The last window and the last tray icon both close |
 | `Explicit` | Never automatically; call `ReactorApp.Exit()` |
+
+Under `OnPrimaryWindowClosed`, only the elected `PrimaryWindow` triggers the
+exit. Auxiliary windows that opt out of the shutdown policy (such as docking
+tear-off floating windows) are never elected primary, so closing one of them
+never exits the app even when it is the last *visible* window.
 
 ## Tips
 

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -36,9 +36,10 @@ Caveats:
   cascade is already tearing the window down) performs the native close exactly
   once. A redundant close is a safe no-op, so converging teardown paths can't
   re-enter native window destruction.
-- `ReactorApp.PrimaryWindow` is the first opened window; shutdown policy decides
-  whether closing it exits the process. Auxiliary windows that opt out of the
-  shutdown policy — notably docking tear-off floating windows — are excluded
+- `ReactorApp.PrimaryWindow` is the first *eligible* opened window; shutdown
+  policy decides whether closing it exits the process. Auxiliary windows that
+  opt out of the shutdown policy — notably docking tear-off floating windows —
+  are excluded
   from primary election: they can never become the fallback primary, and they
   are never promoted to primary when the real primary closes (re-election skips
   them, leaving `PrimaryWindow` `null` if only excluded windows remain). This

--- a/docs/guide/windows.md
+++ b/docs/guide/windows.md
@@ -32,8 +32,18 @@ settings.Close();
 Caveats:
 
 - `Close`, `Show`, `Hide`, `Activate`, `Update`, and mutators are UI-thread only.
+- `Close()` is idempotent: calling it more than once (or while an owner-close
+  cascade is already tearing the window down) performs the native close exactly
+  once. A redundant close is a safe no-op, so converging teardown paths can't
+  re-enter native window destruction.
 - `ReactorApp.PrimaryWindow` is the first opened window; shutdown policy decides
-  whether closing it exits the process.
+  whether closing it exits the process. Auxiliary windows that opt out of the
+  shutdown policy — notably docking tear-off floating windows — are excluded
+  from primary election: they can never become the fallback primary, and they
+  are never promoted to primary when the real primary closes (re-election skips
+  them, leaving `PrimaryWindow` `null` if only excluded windows remain). This
+  keeps closing a transient floating window from firing
+  `OnPrimaryWindowClosed` and exiting the app.
 - `UseWindow()` returns the owning `ReactorWindow` inside a window component and
   `null` outside one (for example tray flyouts).
 
@@ -361,6 +371,11 @@ static class Startup
 | `OnPrimaryWindowClosed` *(default)* | The primary window closes |
 | `OnLastSurfaceClosed` | The last window and the last tray icon both close |
 | `Explicit` | Never automatically; call `ReactorApp.Exit()` |
+
+Under `OnPrimaryWindowClosed`, only the elected `PrimaryWindow` triggers the
+exit. Auxiliary windows that opt out of the shutdown policy (such as docking
+tear-off floating windows) are never elected primary, so closing one of them
+never exits the app even when it is the last *visible* window.
 
 ## Tips
 

--- a/docs/specs/036-window-design.md
+++ b/docs/specs/036-window-design.md
@@ -499,6 +499,33 @@ only that the selected `ShutdownPolicy` permits the resulting state.
 - `Closing` (new) fires *before* `Window.Close()` is honored, so
   `UseClosingGuard` can cancel.
 
+### 6.4 Multi-window teardown safety (issue #647)
+
+Three invariants make sequential and overlapping window teardown safe in a
+single process — they prevent a torn-down window from re-entering native
+teardown and faulting later windows with an `ACCESS_VIOLATION` (0xC0000005)
+in the shared WinUI backdrop interop:
+
+- **Primary election excludes auxiliary windows.** Windows that opt out of the
+  shutdown policy (`ExcludeFromShutdownPolicy` — docking tear-off floating
+  windows set this) are never elected `PrimaryWindow`. Both election sites
+  (initial registration and unregister re-election) run through one shared
+  helper, so an excluded window can neither *become* primary nor be *promoted*
+  to primary when the real primary closes; `PrimaryWindow` becomes `null`
+  rather than an excluded window when no eligible window remains. This stops a
+  transient floating window from triggering `OnPrimaryWindowClosed` →
+  `Application.Exit()` and tearing down every open window mid-process.
+- **`Close()` is idempotent.** The native window close fires exactly once; a
+  redundant `Close()` or an owner-close cascade that reaches an
+  already-closing window is a guarded no-op rather than a second native
+  teardown.
+- **Backdrop writes are gated on a closed-window registry.** `BackdropApplier`
+  records every window whose `Closed` has fired in a process-wide
+  (weak-keyed) registry and skips all `SystemBackdrop` writes on those windows
+  — on both the render-pass `Apply` and on `Reset` — including from a freshly
+  constructed applier on a reused window. Writing `SystemBackdrop` on a
+  torn-down surface is the operation that faults.
+
 ## §7 Hooks
 
 ```csharp

--- a/docs/specs/045-docking-windows-design.md
+++ b/docs/specs/045-docking-windows-design.md
@@ -728,6 +728,19 @@ A dockable window opens like any other window (`ReactorApp.OpenWindow(spec, ...)
 - If `DefaultHostId` is set and a `DockHost` with that id is currently mounted, the window opens *adopted* (no HWND created until tear-out).
 - Otherwise, it opens *floating* (top-level HWND, no host).
 
+Floating docking windows are **excluded from primary election** (issue #647).
+They open through the core window entry point with
+`ExcludeFromShutdownPolicy: true`, so a transient tear-off preview window is
+never elected `ReactorApp.PrimaryWindow` — neither on open nor by re-election
+when the real primary later closes. Without this, closing a tear-off under the
+default `OnPrimaryWindowClosed` policy would fire `Application.Exit()` and tear
+down every open window mid-process, after which a surviving host writing
+`Window.SystemBackdrop` on a torn-down surface faults with an
+`ACCESS_VIOLATION` (0xC0000005) in the shared WinUI backdrop interop. The
+companion `Window.Close()` idempotency and `BackdropApplier` closed-window
+registry (spec 036 §6.4) close the same teardown hazard for converging close
+paths.
+
 Tray-icon flyout windows (per spec 036 §11) can host a `DockHost` in their content — meaning tray flyouts can present dockable content. This is the "tray icon + dock = seamless" integration the user described.
 
 ### 6.4 DockHost as a Reactor element

--- a/src/Reactor/Docking/Native/DockFloatingWindow.cs
+++ b/src/Reactor/Docking/Native/DockFloatingWindow.cs
@@ -138,10 +138,20 @@ public static class DockFloatingWindow
         // by the host's dispatcher loop after OpenWindow returns, so
         // the holder is always populated by the time it's read.
         var windowHolder = new ReactorWindow?[] { null };
-        var window = ReactorApp.OpenWindow(spec, _ =>
-            new Microsoft.UI.Reactor.Core.ComponentElement<DockFloatingWindowProps>(
-                typeof(DockFloatingWindowComponent),
-                new DockFloatingWindowProps(pane, windowHolder, manager)));
+        var window = ReactorApp.OpenWindowCore(
+            spec,
+            rootFactory: null,
+            renderFunc: _ =>
+                new Microsoft.UI.Reactor.Core.ComponentElement<DockFloatingWindowProps>(
+                    typeof(DockFloatingWindowComponent),
+                    new DockFloatingWindowProps(pane, windowHolder, manager)),
+            configure: null,
+            // Spec 045 — a tear-off floating window is an auxiliary docking
+            // surface. It must never be elected the app's primary window, so
+            // closing it (e.g. dock-back, last-tab-close) cannot trigger
+            // ShutdownPolicy.OnPrimaryWindowClosed and tear the whole app down.
+            // (issue #647)
+            excludeFromShutdownPolicy: true);
         windowHolder[0] = window;
         DockFloatingTracker.Register(window);
         DockFloatingTracker.RegisterEntry(window, pane, spec.Width, spec.Height);

--- a/src/Reactor/Hosting/BackdropApplier.cs
+++ b/src/Reactor/Hosting/BackdropApplier.cs
@@ -21,6 +21,32 @@ namespace Microsoft.UI.Reactor.Hosting;
 /// </remarks>
 internal sealed class BackdropApplier
 {
+    // Windows whose native surface has been torn down (Window.Closed has fired).
+    // Writing Window.SystemBackdrop on such a window faults with an
+    // ACCESS_VIOLATION (0xC0000005) deep in the WinUI backdrop interop — an
+    // unmanaged fault no try/catch can trap — and the WinUI backdrop machinery
+    // is global, so the corruption takes down later windows in the same process
+    // too. A window can outlive its native surface in two ways that reach a
+    // BackdropApplier: an app-driven Application.Exit() that tears down every
+    // open window mid-process, and a test harness that reuses one Window object
+    // across many hosts. Tracked process-wide (keyed weakly on the Window so a
+    // genuinely collected window doesn't leak) and consulted before every
+    // SystemBackdrop write. (issue #647)
+    private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<Window, object> s_closedWindows = new();
+    private static readonly object s_closedMarker = new();
+
+    /// <summary>
+    /// Record that <paramref name="window"/>'s native surface has been torn down
+    /// (its <c>Closed</c> event fired), so no <see cref="BackdropApplier"/> — including
+    /// one created later for a reused window — writes <c>SystemBackdrop</c> on it
+    /// again. Idempotent. (issue #647)
+    /// </summary>
+    internal static void MarkWindowClosed(Window? window)
+    {
+        if (window is null) return;
+        s_closedWindows.AddOrUpdate(window, s_closedMarker);
+    }
+
     private readonly Window? _window;
 
     // Last-applied state — used so the host's per-render apply pass is a no-op
@@ -41,6 +67,10 @@ internal sealed class BackdropApplier
     {
         _window = window;
     }
+
+    // True once the owning window's native surface has been torn down — see
+    // s_closedWindows. SystemBackdrop writes are skipped from here on. (issue #647)
+    private bool WindowSurfaceGone => _window is not null && s_closedWindows.TryGetValue(_window, out _);
 
     /// <summary>
     /// Sets the window-level default backdrop. Used by
@@ -81,6 +111,12 @@ internal sealed class BackdropApplier
             }
             return false;
         }
+
+        // The window's native surface has been torn down (e.g. Application.Exit
+        // closed it, or the harness is reusing a closed Window). Writing
+        // SystemBackdrop now AVs (0xC0000005) — skip it. (issue #647)
+        if (WindowSurfaceGone)
+            return false;
 
         var nextKind = choice?.Kind;
         var nextFactory = choice?.Factory;
@@ -131,17 +167,31 @@ internal sealed class BackdropApplier
     /// Clears the backdrop and resets internal state. Called by the host on dispose
     /// so subsequent non-Reactor hosts on the same window see a clean slate.
     /// </summary>
-    public void Reset()
+    /// <param name="windowClosed">
+    /// When <c>true</c> the owning window has already been closed/destroyed. The
+    /// <c>Window.SystemBackdrop</c> write is then skipped (in addition to the
+    /// process-wide closed-window guard): touching <c>set_SystemBackdrop</c> on a
+    /// torn-down window faults with an <c>ACCESS_VIOLATION</c> (0xC0000005) — an
+    /// unmanaged fault the surrounding <c>try/catch</c> cannot trap — and corrupts
+    /// the WinUI backdrop interop for windows opened later in the same process.
+    /// Clearing the backdrop on a window that is going away is pointless anyway.
+    /// The internal last-applied state is still reset so a reused applier starts
+    /// clean. (issue #647)
+    /// </param>
+    public void Reset(bool windowClosed = false)
     {
         if (_window is null)
         {
             _hasApplied = false;
             return;
         }
-        try { _window.SystemBackdrop = null; }
-        catch (global::System.Exception ex)
+        if (!windowClosed && !WindowSurfaceGone)
         {
-            Debug.WriteLine($"[Reactor] Backdrop reset failed: {ex.GetType().Name}: {ex.Message}");
+            try { _window.SystemBackdrop = null; }
+            catch (global::System.Exception ex)
+            {
+                Debug.WriteLine($"[Reactor] Backdrop reset failed: {ex.GetType().Name}: {ex.Message}");
+            }
         }
         _lastKind = null;
         _lastFactory = null;

--- a/src/Reactor/Hosting/BackdropApplier.cs
+++ b/src/Reactor/Hosting/BackdropApplier.cs
@@ -189,6 +189,9 @@ internal sealed class BackdropApplier
         {
             try { _window.SystemBackdrop = null; }
             catch (global::System.Exception ex)
+                when (ex is global::System.ObjectDisposedException
+                    or global::System.InvalidOperationException
+                    or global::System.ArgumentException)
             {
                 Debug.WriteLine($"[Reactor] Backdrop reset failed: {ex.GetType().Name}: {ex.Message}");
             }

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -477,13 +477,15 @@ public static partial class ReactorApp
         WindowSpec spec,
         Func<Component>? rootFactory,
         Func<RenderContext, Element>? renderFunc,
-        Action<ReactorHost>? configure)
+        Action<ReactorHost>? configure,
+        bool excludeFromShutdownPolicy = false)
     {
         Console.Error.WriteLine("[embed:trace] OpenWindowCore enter (embed=" + (spec.Embed is not null) + ")");
         ReactorWindow window;
         try
         {
             window = new ReactorWindow(spec);
+            window.ExcludeFromShutdownPolicy = excludeFromShutdownPolicy;
             Console.Error.WriteLine("[embed:trace] OpenWindowCore: ReactorWindow ctor ok");
         }
         catch (Exception ex)
@@ -587,7 +589,11 @@ public static partial class ReactorApp
         next[^1] = window;
         Volatile.Write(ref _windows, next);
 
-        if (PrimaryWindow is null)
+        // An auxiliary window (e.g. a docking tear-off floating window) must
+        // never become the fallback primary: closing it would otherwise fire
+        // ShutdownPolicy.OnPrimaryWindowClosed and tear the whole app down, even
+        // though it is just a transient docking surface. (issue #647)
+        if (PrimaryWindow is null && !window.ExcludeFromShutdownPolicy)
             PrimaryWindow = window;
 
         ReactorDisplay.RegisterWindowMonitor(window, window.MessageMonitor);

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -607,15 +607,8 @@ public static partial class ReactorApp
     // opted out via ExcludeFromShutdownPolicy. Returns null when only auxiliary
     // windows remain. Shared by initial registration and unregister re-election
     // so the two election sites cannot drift apart. (issue #647)
-    private static ReactorWindow? ElectPrimaryWindow(ReactorWindow[] candidates)
-    {
-        foreach (var candidate in candidates)
-        {
-            if (!candidate.ExcludeFromShutdownPolicy)
-                return candidate;
-        }
-        return null;
-    }
+    private static ReactorWindow? ElectPrimaryWindow(ReactorWindow[] candidates) =>
+        Array.Find(candidates, static c => !c.ExcludeFromShutdownPolicy);
 
     // Copy-on-write remove. Idempotent — removing an already-removed window
     // (Phase 1 path runs Dispose → close cascade twice in some failure modes)

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -593,13 +593,28 @@ public static partial class ReactorApp
         // never become the fallback primary: closing it would otherwise fire
         // ShutdownPolicy.OnPrimaryWindowClosed and tear the whole app down, even
         // though it is just a transient docking surface. (issue #647)
-        if (PrimaryWindow is null && !window.ExcludeFromShutdownPolicy)
-            PrimaryWindow = window;
+        if (PrimaryWindow is null)
+            PrimaryWindow = ElectPrimaryWindow(next);
 
         ReactorDisplay.RegisterWindowMonitor(window, window.MessageMonitor);
 
         try { WindowOpened?.Invoke(null, window); }
         catch (Exception ex) { global::System.Diagnostics.Debug.WriteLine($"[Reactor] WindowOpened threw: {ex.Message}"); }
+    }
+
+    // Pick the first window eligible to be the application's PrimaryWindow,
+    // skipping auxiliary windows (e.g. docking tear-off floating windows) that
+    // opted out via ExcludeFromShutdownPolicy. Returns null when only auxiliary
+    // windows remain. Shared by initial registration and unregister re-election
+    // so the two election sites cannot drift apart. (issue #647)
+    private static ReactorWindow? ElectPrimaryWindow(ReactorWindow[] candidates)
+    {
+        foreach (var candidate in candidates)
+        {
+            if (!candidate.ExcludeFromShutdownPolicy)
+                return candidate;
+        }
+        return null;
     }
 
     // Copy-on-write remove. Idempotent — removing an already-removed window
@@ -618,10 +633,15 @@ public static partial class ReactorApp
 
         // Capture whether this window was the primary BEFORE we re-elect, so
         // ShutdownPolicy.OnPrimaryWindowClosed can distinguish "primary just
-        // died" from "secondary closed while primary still alive."
+        // died" from "secondary closed while primary still alive." Re-election
+        // goes through the same ElectPrimaryWindow helper as initial
+        // registration so an excluded auxiliary window (e.g. a docking tear-off)
+        // can never be promoted to primary on the unregister path either, which
+        // would re-introduce the exact OnPrimaryWindowClosed teardown #647
+        // closes. (issue #647)
         bool wasPrimary = ReferenceEquals(PrimaryWindow, window);
         if (wasPrimary)
-            PrimaryWindow = next.Length > 0 ? next[0] : null;
+            PrimaryWindow = ElectPrimaryWindow(next);
 
         ReactorDisplay.UnregisterWindowMonitor(window);
 

--- a/src/Reactor/Hosting/ReactorHost.cs
+++ b/src/Reactor/Hosting/ReactorHost.cs
@@ -41,6 +41,13 @@ public sealed class ReactorHost : IDisposable
     private FrameworkElement? _themeListenerElement;
     private volatile bool _disposed;
 
+    // Set when the owning window has raised Closed — i.e. the native window is
+    // being torn down. Drives BackdropApplier.Reset so it does NOT write
+    // Window.SystemBackdrop on an already-destroyed window, which AVs
+    // (0xC0000005) and corrupts the WinUI backdrop interop for later windows in
+    // the same process. (issue #647)
+    private bool _windowClosed;
+
     // Spec 033 §6 — declarative SystemBackdrop modifier on the root tree.
     // Owned for the host's lifetime; reset on dispose so a non-Reactor
     // window-reuse path returns to a clean slate.
@@ -231,7 +238,18 @@ public sealed class ReactorHost : IDisposable
 
         // Stop the render loop when the window closes — background threads
         // may still call setState after this, but RequestRender will bail out.
-        _closedHandler = (_, _) => Dispose();
+        // Mark the window's native surface gone BEFORE disposing so neither this
+        // host's Reset nor any host later created on a reused Window writes
+        // SystemBackdrop on it — that AVs (0xC0000005) and corrupts the WinUI
+        // backdrop interop for the rest of the process. This handler is wired in
+        // the host ctor, before ReactorWindow.OnNativeClosed, so the guard is set
+        // ahead of any teardown that reaches a SystemBackdrop write. (issue #647)
+        _closedHandler = (_, _) =>
+        {
+            _windowClosed = true;
+            BackdropApplier.MarkWindowClosed(_window);
+            Dispose();
+        };
         _window.Closed += _closedHandler;
     }
 
@@ -899,8 +917,11 @@ public sealed class ReactorHost : IDisposable
         _funcContext?.RunCleanups();
 
         // Clear the SystemBackdrop so a window-reuse path returns to the WinUI
-        // default. Best effort — disposed hosts may already be torn down.
-        try { _backdropApplier.Reset(); } catch { /* best effort */ }
+        // default. Skip the actual window write when the window has already been
+        // closed/destroyed — touching set_SystemBackdrop on a torn-down window
+        // AVs (0xC0000005) and corrupts the backdrop interop for later windows.
+        // Best effort either way. (issue #647)
+        try { _backdropApplier.Reset(_windowClosed); } catch { /* best effort */ }
 
         _reconciler.Dispose();
         _rootComponent = null;

--- a/src/Reactor/Hosting/ReactorHost.cs
+++ b/src/Reactor/Hosting/ReactorHost.cs
@@ -923,6 +923,7 @@ public sealed class ReactorHost : IDisposable
         // Best effort either way. (issue #647)
         try { _backdropApplier.Reset(_windowClosed); }
         catch (global::System.Exception ex)
+            when (ex is not global::System.OutOfMemoryException and not global::System.StackOverflowException)
         {
             Debug.WriteLine($"[Reactor] backdrop reset on dispose failed (best effort): {ex.GetType().Name}: {ex.Message}");
         }

--- a/src/Reactor/Hosting/ReactorHost.cs
+++ b/src/Reactor/Hosting/ReactorHost.cs
@@ -921,7 +921,11 @@ public sealed class ReactorHost : IDisposable
         // closed/destroyed — touching set_SystemBackdrop on a torn-down window
         // AVs (0xC0000005) and corrupts the backdrop interop for later windows.
         // Best effort either way. (issue #647)
-        try { _backdropApplier.Reset(_windowClosed); } catch { /* best effort */ }
+        try { _backdropApplier.Reset(_windowClosed); }
+        catch (global::System.Exception ex)
+        {
+            Debug.WriteLine($"[Reactor] backdrop reset on dispose failed (best effort): {ex.GetType().Name}: {ex.Message}");
+        }
 
         _reconciler.Dispose();
         _rootComponent = null;

--- a/src/Reactor/Hosting/ReactorWindow.cs
+++ b/src/Reactor/Hosting/ReactorWindow.cs
@@ -99,6 +99,14 @@ public sealed class ReactorWindow : IDisposable
     private DipPositionSnapshot _position = new(0, 0);
     private int _stateValue; // backing storage for State (cast WindowState <-> int)
     private bool _disposed;
+    // Issue #647 — latched the first time the native Window.Close() is requested
+    // for this window, on any path (programmatic Close, the owner-close cascade,
+    // or ReactorApp exit). A second native close on an already-closing/closed
+    // window re-enters native teardown and faults with an ACCESS_VIOLATION
+    // (0xC0000005), poisoning later windows in the same process. All native
+    // closes route through CloseNativeWindowOnce so the underlying Window.Close()
+    // happens at most once.
+    private bool _nativeCloseRequested;
     private bool _userResized; // Phase 2: once true we no longer overwrite size on DPI events.
     private bool _firstDpiApplied;
     private bool _persistenceRestoreAttempted;
@@ -143,6 +151,15 @@ public sealed class ReactorWindow : IDisposable
     internal WindowMessageMonitor MessageMonitor => _messageMonitor;
 
     internal nint Hwnd => _hwnd;
+
+    /// <summary>
+    /// When <c>true</c>, this window is an auxiliary surface (e.g. a docking
+    /// tear-off floating window) that must never be elected the application's
+    /// <see cref="ReactorApp.PrimaryWindow"/> and so never drives the
+    /// <see cref="ShutdownPolicy.OnPrimaryWindowClosed"/> shutdown when it
+    /// closes. Set once at open time. (issue #647)
+    /// </summary>
+    internal bool ExcludeFromShutdownPolicy { get; set; }
 
     /// <summary>The <see cref="ReactorHost"/> driving this window's render loop.</summary>
     public ReactorHost Host => _host;
@@ -1400,7 +1417,7 @@ public sealed class ReactorWindow : IDisposable
                 // safe to tear down here, before the native close, mirroring
                 // ReactorWindow.Close(). Idempotent. (#537)
                 child.PrepareTitleBarTreeForClose();
-                try { child._window.Close(); }
+                try { child.CloseNativeWindowOnce(); }
                 // Iteration sibling-independence (spec 044 §6.7.3): one
                 // failing child must not abort the cascade across its
                 // siblings. The Window.Close call also re-enters the child's
@@ -1823,6 +1840,22 @@ public sealed class ReactorWindow : IDisposable
         // owned descendants that likewise never see their own AppWindow.Closing.
         // Idempotent. (issue #537)
         PrepareTitleBarTreeForClose();
+        CloseNativeWindowOnce();
+    }
+
+    /// <summary>
+    /// Request the underlying native <see cref="Window.Close"/> at most once for
+    /// this window, regardless of how many close paths converge on it
+    /// (programmatic <see cref="Close"/>, the owner-close cascade, the
+    /// <c>ReactorApp</c> exit prep). A redundant native close on a window whose
+    /// teardown has already started re-enters native destroy and faults with an
+    /// <c>ACCESS_VIOLATION</c> (0xC0000005) that corrupts later windows in the
+    /// process — the multi-window batch teardown crash this guards. (issue #647)
+    /// </summary>
+    private void CloseNativeWindowOnce()
+    {
+        if (_disposed || _nativeCloseRequested) return;
+        _nativeCloseRequested = true;
         try { _window.Close(); }
         catch (COMException ex) when (HResults.IsTeardownReentry(ex.HResult))
         { DiagnosticLog.SwallowedError(LogCategory.Hosting, "ReactorWindow.Close", ex); }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowLifecycleHardeningFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowLifecycleHardeningFixtures.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Hosting;
@@ -62,10 +63,15 @@ internal static class WindowLifecycleHardeningFixtures
 
     private static async Task CloseAndSettle(params ReactorWindow?[] windows)
     {
-        foreach (var win in windows)
+        foreach (var win in windows.Where(static w => w is not null))
         {
-            if (win is null) continue;
-            try { win.Close(); } catch { }
+            try { win!.Close(); }
+            catch (global::System.Exception ex)
+                when (ex is global::System.InvalidOperationException
+                    or global::System.Runtime.InteropServices.COMException)
+            {
+                global::System.Diagnostics.Debug.WriteLine($"[selftest] CloseAndSettle best-effort close failed: {ex.GetType().Name}: {ex.Message}");
+            }
         }
         await Task.Delay(80);
         await Harness.Render(30);
@@ -193,7 +199,13 @@ internal static class WindowLifecycleHardeningFixtures
             }
             finally
             {
-                try { window.Close(); } catch { }
+                try { window.Close(); }
+                catch (global::System.Exception ex)
+                    when (ex is global::System.InvalidOperationException
+                        or global::System.Runtime.InteropServices.COMException)
+                {
+                    global::System.Diagnostics.Debug.WriteLine($"[selftest] BackdropSkipsClosedWindow cleanup close failed: {ex.GetType().Name}: {ex.Message}");
+                }
                 await Harness.Render(20);
             }
         }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowLifecycleHardeningFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/WindowLifecycleHardeningFixtures.cs
@@ -1,0 +1,245 @@
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Hosting;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Spec 036/045 — multi-window teardown hardening regression fixtures for
+/// issue #647. They lock in the three invariants the framework fix established:
+/// <list type="bullet">
+/// <item>An auxiliary window (e.g. a docking tear-off floating window) excluded
+/// via <c>ExcludeFromShutdownPolicy</c> can never become <em>nor remain</em>
+/// (via unregister re-election) the application's <c>PrimaryWindow</c>.</item>
+/// <item><c>BackdropApplier</c> never writes <c>SystemBackdrop</c> on a window
+/// whose native surface has been torn down — the process-wide closed-window
+/// registry gates both <c>Apply</c> and <c>Reset</c>.</item>
+/// <item><c>ReactorWindow.Close()</c> is idempotent: a redundant or
+/// owner-cascade close performs the native close exactly once.</item>
+/// </list>
+/// </summary>
+internal static class WindowLifecycleHardeningFixtures
+{
+    private static void EnsureUIDispatcher()
+    {
+        if (ReactorApp.UIDispatcher is null)
+            ReactorApp.UIDispatcher = DispatcherQueue.GetForCurrentThread();
+        // These fixtures intentionally close windows that may be the elected
+        // PrimaryWindow; Explicit keeps OnPrimaryWindowClosed from exiting the
+        // shared self-test host process mid-batch.
+        ReactorApp.ShutdownPolicy = ShutdownPolicy.Explicit;
+    }
+
+    private sealed class StubComponent : Component
+    {
+        public override Element Render() => TextBlock("ok");
+    }
+
+    private static async Task<ReactorWindow> OpenAndSettle(WindowSpec spec)
+    {
+        var win = ReactorApp.OpenWindow(spec, () => new StubComponent());
+        await win.Host.WaitForIdleAsync();
+        await Harness.Render(50);
+        return win;
+    }
+
+    private static async Task<ReactorWindow> OpenExcludedAndSettle(WindowSpec spec)
+    {
+        // Mirrors how a docking tear-off floating window registers: opened through
+        // the core entry point with excludeFromShutdownPolicy: true so it opts out
+        // of primary election. (DockFloatingWindow.cs)
+        var win = ReactorApp.OpenWindowCore(
+            spec,
+            rootFactory: () => new StubComponent(),
+            renderFunc: null,
+            configure: null,
+            excludeFromShutdownPolicy: true);
+        await win.Host.WaitForIdleAsync();
+        await Harness.Render(50);
+        return win;
+    }
+
+    private static async Task CloseAndSettle(params ReactorWindow?[] windows)
+    {
+        foreach (var win in windows)
+        {
+            if (win is null) continue;
+            try { win.Close(); } catch { }
+        }
+        await Task.Delay(80);
+        await Harness.Render(30);
+    }
+
+    private static WindowSpec Spec(string title) => new()
+    {
+        Title = title,
+        Width = 220,
+        Height = 150,
+        StartPosition = WindowStartPosition.Manual,
+        ManualPosition = (120, 120),
+    };
+
+    /// <summary>
+    /// H1 — an excluded auxiliary window can neither become nor remain the
+    /// PrimaryWindow. Drives the unregister re-election path specifically (M1's
+    /// regression guard): with [primary1, aux(excluded), primary2] registered,
+    /// closing primary1 must re-elect primary2 (skipping aux, i.e. NOT next[0]),
+    /// and closing primary2 must leave PrimaryWindow null — never the aux.
+    /// </summary>
+    internal class PrimaryElectionExcludesAuxiliary(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            EnsureUIDispatcher();
+
+            // Clean slate so a closed window left primary by an earlier fixture
+            // doesn't mask the election under test.
+            ReactorApp.PrimaryWindow = null;
+
+            ReactorWindow? primary1 = null, aux = null, primary2 = null;
+            try
+            {
+                primary1 = await OpenAndSettle(Spec("Election Primary 1"));
+                H.Check("Election_PrimaryElectedOnOpen",
+                    ReferenceEquals(ReactorApp.PrimaryWindow, primary1));
+
+                aux = await OpenExcludedAndSettle(Spec("Election Aux (excluded)"));
+                H.Check("Election_AuxIsExcluded", aux.ExcludeFromShutdownPolicy);
+                // Opening the excluded window must not displace the real primary.
+                H.Check("Election_AuxDoesNotBecomePrimary",
+                    ReferenceEquals(ReactorApp.PrimaryWindow, primary1));
+
+                // Registered AFTER aux, so aux sits before primary2 in the window
+                // array — re-election picking next[0] would (wrongly) pick aux.
+                primary2 = await OpenAndSettle(Spec("Election Primary 2"));
+
+                // Close the real primary: re-election must skip the excluded aux
+                // and land on primary2, not the array head (aux).
+                await CloseAndSettle(primary1);
+                bool reelected = await Harness.WaitFor(
+                    () => ReferenceEquals(ReactorApp.PrimaryWindow, primary2),
+                    maxPasses: 25, perPassMs: 20);
+                H.Check("Election_ReelectsNonExcludedNotAux", reelected);
+                H.Check("Election_ExcludedNeverReelectedPrimary",
+                    !ReferenceEquals(ReactorApp.PrimaryWindow, aux));
+                primary1 = null;
+
+                // Close the remaining real primary: only the excluded aux is left,
+                // so PrimaryWindow must go null — never the aux.
+                await CloseAndSettle(primary2);
+                bool wentNull = await Harness.WaitFor(
+                    () => ReactorApp.PrimaryWindow is null,
+                    maxPasses: 25, perPassMs: 20);
+                H.Check("Election_NullWhenOnlyExcludedRemains", wentNull);
+                H.Check("Election_ExcludedNeverPromotedOnLastClose",
+                    !ReferenceEquals(ReactorApp.PrimaryWindow, aux));
+                primary2 = null;
+            }
+            finally
+            {
+                await CloseAndSettle(primary1, aux, primary2);
+                ReactorApp.PrimaryWindow = null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// M2 — the BackdropApplier closed-window registry suppresses every
+    /// SystemBackdrop write once a window is marked closed, on both Apply and
+    /// Reset, and across a freshly constructed applier (proving it is the
+    /// process-wide registry, not per-instance last-applied state, doing the
+    /// skip — and not an exception swallow, since no setter is reached).
+    /// </summary>
+    internal class BackdropSkipsClosedWindow(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            EnsureUIDispatcher();
+
+            var window = new Microsoft.UI.Xaml.Window();
+            try
+            {
+                var applier = new BackdropApplier(window);
+
+                // Live window: Apply writes and reports a change.
+                bool liveApplied = applier.Apply(BackdropChoice.Of(BackdropKind.Mica));
+                H.Check("Backdrop_LiveApplyWrites",
+                    liveApplied && window.SystemBackdrop is not null);
+                var backdropWhileLive = window.SystemBackdrop;
+
+                // Surface torn down — record it in the process-wide registry.
+                BackdropApplier.MarkWindowClosed(window);
+
+                // A genuinely different kind WOULD write, so a skip here can only be
+                // the registry guard (it short-circuits before the no-change bail).
+                bool appliedAfterClose = applier.Apply(BackdropChoice.Of(BackdropKind.DesktopAcrylic));
+                H.Check("Backdrop_ApplySkippedAfterClose", !appliedAfterClose);
+                H.Check("Backdrop_SurfaceUnchangedAfterClose",
+                    ReferenceEquals(window.SystemBackdrop, backdropWhileLive));
+
+                // A fresh applier (mirrors a later host on the same reused, already
+                // closed window) is gated too — proves it's the registry, not the
+                // first applier's instance state.
+                var freshApplier = new BackdropApplier(window);
+                bool freshApplied = freshApplier.Apply(BackdropChoice.Of(BackdropKind.Mica));
+                H.Check("Backdrop_FreshApplierAlsoSkips", !freshApplied);
+
+                // Reset (windowClosed:false) must still skip the SystemBackdrop=null
+                // clear via the registry guard — that write is the one that AVs.
+                freshApplier.Reset();
+                H.Check("Backdrop_ResetSkipsClearAfterClose",
+                    window.SystemBackdrop is not null);
+            }
+            finally
+            {
+                try { window.Close(); } catch { }
+                await Harness.Render(20);
+            }
+        }
+    }
+
+    /// <summary>
+    /// M3 — ReactorWindow.Close() is idempotent. Two converging close calls on
+    /// one window fire the native Window.Closed exactly once; a second native
+    /// close would re-enter teardown and AV (#647). The process stays healthy:
+    /// a window opened afterward mounts content normally.
+    /// </summary>
+    internal class NativeCloseIsIdempotent(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            EnsureUIDispatcher();
+
+            ReactorWindow? win2 = null;
+            try
+            {
+                var win = await OpenAndSettle(Spec("CloseOnce Target"));
+
+                int closedCount = 0;
+                win.NativeWindow.Closed += (_, _) => closedCount++;
+
+                // Two converging programmatic close paths against the same window.
+                // The second must be a guarded no-op.
+                win.Close();
+                win.Close();
+
+                await Harness.WaitFor(() => closedCount >= 1, maxPasses: 25, perPassMs: 20);
+                await Task.Delay(60);
+                H.Check("CloseOnce_NativeClosedFiredExactlyOnce", closedCount == 1);
+
+                // Process is still healthy after the double close: a new window
+                // opens and mounts its content.
+                win2 = await OpenAndSettle(Spec("CloseOnce HealthCheck"));
+                H.Check("CloseOnce_SubsequentWindowOpens", win2.Host is not null);
+                H.Check("CloseOnce_SubsequentWindowRendersContent",
+                    win2.NativeWindow.Content is not null);
+            }
+            finally
+            {
+                await CloseAndSettle(win2);
+                ReactorApp.PrimaryWindow = null;
+            }
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1088,6 +1088,10 @@ internal static class SelfTestFixtureRegistry
         "WindowStyle_ToolWindowExStyleRemoved",
         "SizeToContent_MinMaxInfoSuite",
         "UseSpec054Hooks_Suite",
+        // Spec 036/045 — issue #647 multi-window teardown hardening regression.
+        "Window647_PrimaryElectionExcludesAuxiliary",
+        "Window647_BackdropSkipsClosedWindow",
+        "Window647_NativeCloseIsIdempotent",
         // Spec 045 §2.19 — Phase-1 wrapper-based Docking_* smoke fixtures
         // were retired with the XAML wrapper at the §2.29 review gate.
         // NativeDocking_* below covers the same surface against the P2
@@ -2494,6 +2498,10 @@ internal static class SelfTestFixtureRegistry
         "FilePicker_InitializesWithWindow" => new Phase7WindowingFixtures.FilePickerInitializesWithWindow(harness),
         "FilePicker_ThrowsOffUiThread" => new Phase7WindowingFixtures.FilePickerThrowsOffUiThread(harness),
         "UseSpec054Hooks_Suite" => new Phase7WindowingFixtures.UseSpec054HooksSuite(harness),
+        // Spec 036/045 — issue #647 multi-window teardown hardening regression.
+        "Window647_PrimaryElectionExcludesAuxiliary" => new WindowLifecycleHardeningFixtures.PrimaryElectionExcludesAuxiliary(harness),
+        "Window647_BackdropSkipsClosedWindow" => new WindowLifecycleHardeningFixtures.BackdropSkipsClosedWindow(harness),
+        "Window647_NativeCloseIsIdempotent" => new WindowLifecycleHardeningFixtures.NativeCloseIsIdempotent(harness),
         // Spec 045 §2.19 — Phase-1 DockingSmokeFixtures retired alongside
         // the XAML wrapper unhooking. NativeDockingSmokeFixtures (below)
         // covers the same mount/update/unmount surface against the P2


### PR DESCRIPTION
Closes #647.

## Root cause

This is the **0xC0000005 ACCESS_VIOLATION** multi-window teardown bug (distinct from the already-fixed #537 / #642 `0xC0000374` WinUI `TitleBar` heap corruption — the dock floating window uses `ExtendsContentIntoTitleBar=true` and does not render that control, so #537 is structurally inapplicable).

Two native re-entrancy hazards combined to fault and poison later windows in the same process (all selftests run sequentially in **one** Host process):

1. **Spurious app teardown via primary-window election.** The `NativeDockingTearOff` batch opens a tear-off floating preview window through `ReactorApp`. In that isolated batch nothing else is registered with `ReactorApp`, so `RegisterWindow` elected the *floating preview* as the fallback `PrimaryWindow`. When T04 closed it, `ShutdownPolicy.OnPrimaryWindowClosed` (the default) fired → `SafeExit` → `Application.Exit()`, which synchronously tore down **every** open window mid-batch — including the harness's shared `Window` reused by every fixture.

2. **`SystemBackdrop` write on a dead window.** The next fixture (T05) reused that now-natively-destroyed shared window and its mount wrote `Window.SystemBackdrop`, which faults with an **unmanaged `ACCESS_VIOLATION` (0xC0000005)** deep in the WinUI backdrop interop — a fault no `try/catch` can trap. `BackdropApplier.Reset()` had the same hazard: it unconditionally nulled `_window.SystemBackdrop` even when the window/AppWindow was already torn down.

A redundant second native `Window.Close()` (programmatic close + owner-close cascade + app-exit prep converging on one window) is the same class of re-entry hazard.

## What changed

- **`ReactorWindow`** — all native closes route through a new `CloseNativeWindowOnce()` guarded by `_nativeCloseRequested`, so the underlying `Window.Close()` happens **at most once** regardless of how many close paths converge (programmatic `Close`, owner-close cascade, app exit). `Dispose()` was already idempotent (`_disposed` latch). Adds internal `ExcludeFromShutdownPolicy`.
- **`BackdropApplier`** — a process-wide closed-window registry (`ConditionalWeakTable<Window, object>`, weak-keyed so collected windows don't leak), marked when a window's `Closed` fires, consulted before **every** `SystemBackdrop` write in both `Apply()` and `Reset()`. `Reset(bool windowClosed = false)` skips the AV-prone `set_SystemBackdrop` on a torn-down window. This is the genuine, defense-in-depth fix for the documented `set_SystemBackdrop` AV path.
- **`ReactorHost`** — marks the window closed in the registry on `Window.Closed` (the handler is wired in the host ctor, *before* `ReactorWindow.OnNativeClosed`, so the guard is set ahead of any teardown), and passes `windowClosed` to `Reset()`.
- **`ReactorApp` / `DockFloatingWindow`** — docking tear-off floating windows open with `ExcludeFromShutdownPolicy=true`, so they are never elected `PrimaryWindow` and closing one cannot trigger `OnPrimaryWindowClosed` and tear the whole app down. In real apps the main window registers first, so this is a no-op there; it only corrects the abnormal case where a transient docking surface would otherwise become primary.

## Applied pr-review findings

The five pr-review findings raised against the original fix are now applied:

- **M1 (correctness / api-ergonomics) — unified primary election.** The unregister re-election path could re-elect an excluded tear-off as primary after the real primary closed, re-introducing the exact invariant this PR establishes. Both election sites (initial registration **and** unregister re-election) now route through a single `ElectPrimaryWindow` helper that returns the first non-`ExcludeFromShutdownPolicy` window, else `null` — so the two sites cannot drift apart and an excluded window can neither *become* nor *remain* primary.
- **H1 (test-coverage) — election-exclusion selftest.** `Window647_PrimaryElectionExcludesAuxiliary` opens a real primary + an excluded tear-off + a second real primary, closes the first primary and asserts re-election picks the *non-excluded* window (not the array head), then closes the last real primary and asserts `PrimaryWindow` goes `null` rather than the excluded aux. This is M1's regression guard.
- **M2 (test-coverage) — backdrop closed-window registry selftest.** `Window647_BackdropSkipsClosedWindow` applies a live backdrop, marks the window closed, then asserts both `Apply` (different kind) and `Reset` skip the `SystemBackdrop` write — including via a freshly constructed applier, proving it is the process-wide registry (not per-instance last-applied state, and not an exception swallow) doing the skip.
- **M3 (test-coverage) — idempotent native close selftest.** `Window647_NativeCloseIsIdempotent` drives two converging `Close()` calls at one window, asserts the native `Window.Closed` fires exactly once, then opens and renders another window to confirm the process stays healthy.
- **L1 (docs).** Specs 036 (new §6.4) and 045 document that docking floating windows are excluded from primary election / `OnPrimaryWindowClosed` and that `Window.Close()` is idempotent; `docs/guide/windows.md` (+ its `.md.dt` template) gained the same caveats; CHANGELOG `[Unreleased] ### Fixed` has a #647 entry.

## Red → green evidence (ARM64, one process)

```
dotnet build tests\Reactor.AppTests.Host -p:Platform=ARM64 -m:1
dotnet run --project tests\Reactor.AppTests.Host -p:Platform=ARM64 --no-build -- --self-test --filter "NativeDockingTearOff"
```

| | Result |
|---|---|
| **Before** | T01–T04 pass, process dies at **T05 mount** — exit `-1073741819` (0xC0000005) in `BackdropApplier.Apply → set_SystemBackdrop` |
| **After** | **exit 0**, `# Total failures: 0`, T01 through T14 all green |

New regression fixtures (`--filter "Window647"`): **exit 0**, all three green. Full selftest suite (ARM64): **`# Total failures: 0`** — the cross-fixture poisoning is gone (previously the AV killed the process mid-suite).

## Known issue (not introduced here, tracked separately)

A residual **process-exit** (final-shutdown) native AV remains **only** when the *entire* selftest suite runs together: every test reports pass (`# Total failures: 0`) and the TAP summary prints, then the process faults during final teardown after all fixtures have completed. It does **not** reproduce in any subset I ran (the `NativeDockingTearOff` batch, the new `Window647` fixtures, `Window`, `AspectRatio`, and other windowing subsets all exit 0), and it is independent of this change (the same shutdown-time fault behavior predates this PR). It is a separate, pre-existing final-shutdown issue, out of scope for #647, and is tracked as its own follow-up in **#680**. Reviewers should expect the full-suite run to print `0 failures` and then exit non-zero for this reason.

## Notes

- The `T08b/T12b/T12c` test-side double-close guards mentioned in the issue **do not exist on this branch** (searched — no matches), so there is nothing to remove. Now that the framework makes redundant native close idempotent, any such test-side guards would be unnecessary going forward.
- Pre-existing, unrelated and not touched here: a `WindowLevel_RuntimeFlip_Topmost` flake and `perf_bench` XAML failures.
- Native `link.exe` fails on ARM64, so no full NativeAOT link was run; selftests run fine.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
