### PR TITLE
CI: make /perf work on pre-gate PRs (self-contained C# overlay) + fix Rust column (#674)

### DIFF
--- a/.github/workflows/perf-lib-tests.yml
+++ b/.github/workflows/perf-lib-tests.yml
@@ -37,3 +37,10 @@ jobs:
       - name: Run PerfLib unit tests
         shell: pwsh
         run: ./tests/stress_perf/ci/PerfLib.Tests.ps1
+
+      # Covers the testable branching in the orchestrator script itself: the
+      # compare-mode .csproj overlay/restore guarantees and the Stage-RustRuntime
+      # idempotency gate. Headless, cross-platform, no network.
+      - name: Run Run-PerfBenchmark unit tests
+        shell: pwsh
+        run: ./tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -112,22 +112,26 @@ git worktree remove ../main
    promise even for PRs opened *before* the gate landed (whose tree predates the
    self-contained csproj block), `Run-PerfBenchmark.ps1` overlays the harness
    `.csproj` from the trusted baseline over the PR tree's copy before building
-   (compare mode only) — see below.
+   (compare mode only), restoring it afterwards — see below.
 3. It checks out the default branch (trusted perf scripts + the `main` baseline),
    sets up .NET 10, fetches the PR head via `refs/pull/N/head` into a worktree
    (so forks work), then runs `Run-PerfBenchmark.ps1` in compare mode.
 4. It posts — or **updates in place** on re-runs, via the hidden
    `<!-- reactor-perf-compare -->` marker — one sticky comment.
 
-Only the harness *code under measurement* comes from the PR — i.e. `src/Reactor/`,
-which the harness compiles via its relative `ProjectReference`. The perf scripts,
-the `main` baseline, **and the harness `.csproj` build recipe** (fixed test
-scaffolding, including the `PerfCiSelfContained` self-contained knob) all come
-from the trusted default branch: in compare mode `Build-Harness` copies each
-harness `.csproj` from the baseline tree over the PR tree's copy before building,
-so the self-contained build works regardless of how old the PR is. The
-`author_association` gate is the security control, because the job has a write
-token.
+In compare mode the PR tree supplies everything it normally would — `src/Reactor/`
+(the code under measurement) **and** the harness/workload sources under
+`tests/stress_perf/` — *except* the harness `.csproj` build recipe, which
+`Build-Harness` overlays from the trusted baseline tree for the duration of the
+build and then restores. That `.csproj` is fixed test scaffolding (the StocksGrid
+build recipe, including the `PerfCiSelfContained` self-contained knob), not a
+perf-sensitive input; sourcing only it from baseline guarantees the self-contained
+build works regardless of how old the PR is, while the PR's actual `src/Reactor/`
+change is still compiled in via the harness's relative `ProjectReference`. (A PR
+that deliberately edits the harness *sources* still has those changes measured —
+only the project file comes from baseline.) The perf scripts and the `main`
+baseline also come from the trusted default branch. The `author_association` gate
+is the security control, because the job has a write token.
 
 ### The comment
 

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -145,9 +145,14 @@ Two tables plus footnotes:
   Reactor (this PR)` on the same StocksGrid workload, **all measured live on the
   same runner**. The Rust column builds and runs the
   [`microsoft/windows-rs`](https://github.com/microsoft/windows-rs) `reactor_perf`
-  harness (a port of this workload), pinned in CI to a known-good commit. It is
-  best-effort: if the Rust build or run fails the column reads `n/a` and the
-  PR-vs-`main` comparison is unaffected. The WinUI3 column is the local
+  harness (a port of this workload), pinned in CI to a known-good commit. Because
+  that harness is built self-contained (its `build.rs` is patched to
+  `windows_reactor_setup::as_self_contained()`), the Windows App SDK runtime DLLs
+  must sit next to `test_reactor_perf.exe` at process start — `Stage-RustRuntime`
+  in `Run-PerfBenchmark.ps1` stages and verifies them explicitly so a silent
+  staging miss can't surface as a `0xC0000135` load failure (issue #674). It is
+  best-effort: if the Rust build, staging, or run fails the column reads `n/a` and
+  the PR-vs-`main` comparison is unaffected. The WinUI3 column is the local
   `StressPerf.Direct` build.
 
 ## Variance: trust the delta, not the absolutes

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -108,16 +108,26 @@ git worktree remove ../main
    `workflow_dispatch` with a `pr_number` input is also supported for manual runs.
 2. The workflow runs from the **default branch** (that is how `issue_comment`
    behaves), so once this is on `main` it works on **every already-open PR with
-   no rebase** — important while a fleet of perf PRs is in flight.
+   no rebase** — important while a fleet of perf PRs is in flight. To honour that
+   promise even for PRs opened *before* the gate landed (whose tree predates the
+   self-contained csproj block), `Run-PerfBenchmark.ps1` overlays the harness
+   `.csproj` from the trusted baseline over the PR tree's copy before building
+   (compare mode only) — see below.
 3. It checks out the default branch (trusted perf scripts + the `main` baseline),
    sets up .NET 10, fetches the PR head via `refs/pull/N/head` into a worktree
    (so forks work), then runs `Run-PerfBenchmark.ps1` in compare mode.
 4. It posts — or **updates in place** on re-runs, via the hidden
    `<!-- reactor-perf-compare -->` marker — one sticky comment.
 
-Only the harness *code* comes from the PR; the perf scripts and the `main`
-baseline always come from the trusted default branch. The `author_association`
-gate is the security control, because the job has a write token.
+Only the harness *code under measurement* comes from the PR — i.e. `src/Reactor/`,
+which the harness compiles via its relative `ProjectReference`. The perf scripts,
+the `main` baseline, **and the harness `.csproj` build recipe** (fixed test
+scaffolding, including the `PerfCiSelfContained` self-contained knob) all come
+from the trusted default branch: in compare mode `Build-Harness` copies each
+harness `.csproj` from the baseline tree over the PR tree's copy before building,
+so the self-contained build works regardless of how old the PR is. The
+`author_association` gate is the security control, because the job has a write
+token.
 
 ### The comment
 

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -321,14 +321,20 @@ function Stage-RustRuntime {
         $base = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { $env:TEMP }
         $cache = Join-Path $base 'windows-reactor-setup\temp'
 
-        # 1. Locate the runtime nupkg. Prefer the one the build script already
-        #    downloaded (auto-syncs with the crate's pinned RUNTIME_VER); else fetch
-        #    the version this crate revision expects.
+        # 1. Locate the runtime nupkg. Prefer one already in the shared windows-reactor-setup
+        #    cache (auto-syncs with the crate's pinned RUNTIME_VER); if several versions linger
+        #    there (e.g. local experimentation), pick the highest *version* — never the largest
+        #    file, which is arbitrary and could stage a mismatched runtime and reintroduce
+        #    0xC0000135. Else download the pinned version.
         $pkg = 'Microsoft.WindowsAppSDK.Runtime'; $ver = '2.1.3'
         $nupkg = $null
         if (Test-Path $cache) {
             $nupkg = Get-ChildItem $cache -Filter "$pkg.*.nupkg" -File -ErrorAction SilentlyContinue |
-                Sort-Object Length -Descending | Select-Object -First 1 -ExpandProperty FullName
+                Sort-Object @{ Expression = {
+                    $p = [version]'0.0'
+                    try { [void][version]::TryParse($_.BaseName.Substring($pkg.Length + 1), [ref]$p) } catch {}
+                    $p } } -Descending |
+                Select-Object -First 1 -ExpandProperty FullName
         }
         if (-not $nupkg) {
             $null = New-Item -ItemType Directory -Force -Path $cache -ErrorAction SilentlyContinue
@@ -344,9 +350,11 @@ function Stage-RustRuntime {
             return
         }
 
-        # 2. Extract the nupkg (strip the leading 'tools/'-style component, matching
-        #    upstream) so the MSIX lands at MSIX\win10-<arch>\...
-        $extract = Join-Path $cache 'perfci-runtime-extract'
+        # 2. Extract the nupkg (strip the leading 'tools/'-style component, matching upstream)
+        #    so the MSIX lands at MSIX\win10-<arch>\... Key the extract dir by the selected
+        #    nupkg name (version) so a different version selected later cannot reuse a stale
+        #    cross-version MSIX payload from a stable path.
+        $extract = Join-Path $cache ("perfci-runtime-extract-" + [IO.Path]::GetFileNameWithoutExtension($nupkg))
         $msix = Join-Path $extract "MSIX\win10-$arch\Microsoft.WindowsAppRuntime.2.msix"
         if (-not (Test-Path $msix)) {
             $null = New-Item -ItemType Directory -Force -Path $extract -ErrorAction SilentlyContinue
@@ -378,11 +386,12 @@ function Stage-RustRuntime {
             Where-Object { $_.Extension -in '.dll', '.pri' } |
             ForEach-Object { try { Copy-Item -LiteralPath $_.FullName -Destination $ExeDir -Force; $staged++ } catch {} }
 
-        # Verify completeness against the actual MSIX payload for this package version
-        # (not just one sentinel): every runtime DLL from the MSIX root must now sit next
-        # to the exe, and the required core set must be present.
-        $srcDlls = @(Get-ChildItem $msixOut -File -ErrorAction SilentlyContinue | Where-Object { $_.Extension -eq '.dll' })
-        $notCopied = @($srcDlls | Where-Object { -not (Test-Path (Join-Path $ExeDir $_.Name)) })
+        # Verify completeness against the actual MSIX payload for this package version (not
+        # just one sentinel): every runtime file we copied (.dll AND .pri) from the MSIX root
+        # must now sit next to the exe, and the required core DLL set must be present — so a
+        # swallowed .pri copy failure also blocks the completion marker.
+        $srcFiles = @(Get-ChildItem $msixOut -File -ErrorAction SilentlyContinue | Where-Object { $_.Extension -in '.dll', '.pri' })
+        $notCopied = @($srcFiles | Where-Object { -not (Test-Path (Join-Path $ExeDir $_.Name)) })
         $coreMissing = @($required | Where-Object { -not (Test-Path (Join-Path $ExeDir $_)) })
         if ($notCopied.Count -eq 0 -and $coreMissing.Count -eq 0) {
             # Completion marker: written only now that staging is fully verified, so a later

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -321,14 +321,18 @@ function Stage-RustRuntime {
         $base = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { $env:TEMP }
         $cache = Join-Path $base 'windows-reactor-setup\temp'
 
-        # 1. Locate the runtime nupkg. Prefer one already in the shared windows-reactor-setup
-        #    cache (auto-syncs with the crate's pinned RUNTIME_VER); if several versions linger
-        #    there (e.g. local experimentation), pick the highest *version* — never the largest
-        #    file, which is arbitrary and could stage a mismatched runtime and reintroduce
-        #    0xC0000135. Else download the pinned version.
+        # 1. Locate the runtime nupkg. Prefer the pinned version ($pkg.$ver.nupkg) when it is
+        #    already cached, so runs are reproducible and match the version this script would
+        #    otherwise download. Only if the pinned copy is absent but other versions linger in
+        #    the shared windows-reactor-setup cache (e.g. local experimentation) fall back to
+        #    the highest *version* — never the largest file, which is arbitrary and could stage
+        #    a mismatched runtime and reintroduce 0xC0000135. Else download the pinned version.
         $pkg = 'Microsoft.WindowsAppSDK.Runtime'; $ver = '2.1.3'
         $nupkg = $null
-        if (Test-Path $cache) {
+        $pinned = Join-Path $cache "$pkg.$ver.nupkg"
+        if (Test-Path $pinned) {
+            $nupkg = $pinned
+        } elseif (Test-Path $cache) {
             $nupkg = Get-ChildItem $cache -Filter "$pkg.*.nupkg" -File -ErrorAction SilentlyContinue |
                 Sort-Object @{ Expression = {
                     $p = [version]'0.0'
@@ -338,7 +342,7 @@ function Stage-RustRuntime {
         }
         if (-not $nupkg) {
             $null = New-Item -ItemType Directory -Force -Path $cache -ErrorAction SilentlyContinue
-            $nupkg = Join-Path $cache "$pkg.$ver.nupkg"
+            $nupkg = $pinned
             $url = "https://www.nuget.org/api/v2/package/$pkg/$ver"
             Write-Log "  staging WinAppSDK runtime for Rust harness: downloading $pkg $ver" 'DarkGray'
             $curl = Join-Path $env:SystemRoot 'System32\curl.exe'
@@ -399,7 +403,7 @@ function Stage-RustRuntime {
             Set-Content -LiteralPath $marker -Value (Get-Date -Format o) -ErrorAction SilentlyContinue
             Write-Log "  staged $staged WinAppSDK runtime file(s) next to test_reactor_perf.exe (self-contained)" 'Green'
         } else {
-            Write-Log "  runtime staging incomplete (copied $staged; $($notCopied.Count) DLL(s) missing) — Rust column may read n/a (#674)" 'Yellow'
+            Write-Log "  runtime staging incomplete (copied $staged; $($notCopied.Count) file(s) missing) — Rust column may read n/a (#674)" 'Yellow'
         }
     } catch {
         Write-Log "  Rust runtime staging failed ($($_.Exception.Message)) — Rust column may read n/a (#674)" 'Yellow'

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -380,6 +380,11 @@ function Stage-RustRuntime {
         $null = New-Item -ItemType Directory -Force -Path $msixOut -ErrorAction SilentlyContinue
         & $tar -xf $msix -C $msixOut
         if ($LASTEXITCODE -ne 0 -or -not (Test-Path (Join-Path $msixOut $sentinel))) {
+            # The MSIX itself is corrupt/partial (a truncated nupkg extract can yield a bad
+            # .msix that tar -xf still "produces"). Evict the cached $msix so the next call's
+            # step 2 — which skips re-extract while $msix exists — is forced to re-extract a
+            # fresh MSIX from the nupkg instead of looping forever on the poisoned cache.
+            Remove-Item $msix -Force -ErrorAction SilentlyContinue
             Write-Log "  runtime MSIX extraction failed/incomplete — Rust column may read n/a (#674)" 'Yellow'
             return
         }

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -348,11 +348,19 @@ function Stage-RustRuntime {
             return
         }
 
-        # 3. Extract the per-arch MSIX (its root holds the runtime DLLs + .pri).
+        # 3. Extract the per-arch MSIX (its root holds the runtime DLLs + .pri). We only
+        #    reach here when the completion marker is absent, so the cached scratch dir is
+        #    untrusted: clear any prior (possibly partial) payload and re-extract fresh, then
+        #    require BOTH a clean tar exit and the sentinel before trusting $msixOut as the
+        #    completeness source below — a partial/stale extraction must never feed the
+        #    verification and write the marker from an incomplete payload.
         $msixOut = Join-Path $extract ".msix_extract-$arch"
-        if (-not (Test-Path (Join-Path $msixOut $sentinel))) {
-            $null = New-Item -ItemType Directory -Force -Path $msixOut -ErrorAction SilentlyContinue
-            & $tar -xf $msix -C $msixOut
+        if (Test-Path $msixOut) { Remove-Item $msixOut -Recurse -Force -ErrorAction SilentlyContinue }
+        $null = New-Item -ItemType Directory -Force -Path $msixOut -ErrorAction SilentlyContinue
+        & $tar -xf $msix -C $msixOut
+        if ($LASTEXITCODE -ne 0 -or -not (Test-Path (Join-Path $msixOut $sentinel))) {
+            Write-Log "  runtime MSIX extraction failed/incomplete — Rust column may read n/a (#674)" 'Yellow'
+            return
         }
 
         # 4. Copy the runtime DLLs + resource indices next to the exe.

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -291,14 +291,18 @@ function Stage-RustRuntime {
     param([string]$ExeDir, [string]$Platform)
 
     $arch = if ($Platform -match 'arm64') { 'arm64' } else { 'x64' }
-    # Verify a REQUIRED SET, not a single sentinel: a prior *partial* stage could leave
-    # one runtime DLL present while others are missing, which still faults the loader at
-    # process start. Both of these are always in the self-contained runtime MSIX and are
-    # referenced by the embedded SxS manifest.
+    # Idempotency is gated on a positive completion marker that we write ONLY after a
+    # full, verified stage (below) — NOT on the presence of a subset of DLLs. The per-file
+    # copy loop intentionally swallows errors, so a prior *partial* stage could leave a few
+    # runtime DLLs present while others are missing, which still faults the loader at
+    # process start; keying the early-return on a DLL subset would wrongly short-circuit
+    # that incomplete state and never finish staging. The marker only exists once every
+    # manifest-referenced file has been verified next to the exe.
     $required = @('microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll')
     $sentinel = 'microsoft.ui.xaml.dll'
-    if (-not ($required | Where-Object { -not (Test-Path (Join-Path $ExeDir $_)) })) {
-        Write-Log "  Rust runtime already staged next to exe (required DLLs present)" 'DarkGray'
+    $marker = Join-Path $ExeDir '.perfci-runtime-staged'
+    if (Test-Path $marker) {
+        Write-Log "  Rust runtime already staged next to exe (completion marker present)" 'DarkGray'
         return
     }
 
@@ -364,6 +368,9 @@ function Stage-RustRuntime {
         $notCopied = @($srcDlls | Where-Object { -not (Test-Path (Join-Path $ExeDir $_.Name)) })
         $coreMissing = @($required | Where-Object { -not (Test-Path (Join-Path $ExeDir $_)) })
         if ($notCopied.Count -eq 0 -and $coreMissing.Count -eq 0) {
+            # Completion marker: written only now that staging is fully verified, so a later
+            # call can trust it and skip re-staging (a partial stage never reaches here).
+            Set-Content -LiteralPath $marker -Value (Get-Date -Format o) -ErrorAction SilentlyContinue
             Write-Log "  staged $staged WinAppSDK runtime file(s) next to test_reactor_perf.exe (self-contained)" 'Green'
         } else {
             Write-Log "  runtime staging incomplete (copied $staged; $($notCopied.Count) DLL(s) missing) — Rust column may read n/a (#674)" 'Yellow'

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -188,6 +188,27 @@ function Build-Harness {
     $proj = Join-Path $TreeRoot $AppMeta.ProjectRel
     if (-not (Test-Path $proj)) { throw "Project not found: $proj" }
     Write-Log "build $($AppMeta.AppName)  [$TreeRoot]" 'Cyan'
+
+    # Compare mode only: overlay the harness .csproj from the trusted baseline tree
+    # over the PR tree's copy before building. The harness csproj is fixed test
+    # scaffolding — the build recipe for the StocksGrid workload, including the
+    # PerfCiSelfContained self-contained knob — NOT the code under measurement. The
+    # PR's actual perf change lives in src/Reactor/, which the harness still compiles
+    # via its relative ProjectReference into the PR tree, so overlaying only the
+    # csproj is fair. This guarantees the self-contained build block is present even
+    # for PRs opened before the gate landed (whose tree predates that csproj block),
+    # so /perf needs no rebase. Never runs in local single-tree mode ($BaselineRoot
+    # empty) or when building the baseline itself ($TreeRoot -eq $BaselineRoot).
+    if ($BaselineRoot -and ($TreeRoot -ne $BaselineRoot)) {
+        $trusted = Join-Path $BaselineRoot $AppMeta.ProjectRel
+        if (Test-Path $trusted) {
+            Copy-Item -LiteralPath $trusted -Destination $proj -Force
+            Write-Log "  overlaid trusted csproj (self-contained knob) from baseline" 'DarkGray'
+        } else {
+            Write-Log "  trusted csproj not found in baseline ($trusted) — using PR tree copy" 'Yellow'
+        }
+    }
+
     $log = Join-Path $OutDir ("build-{0}-{1}.log" -f $AppMeta.AppName, ([IO.Path]::GetFileName($TreeRoot)))
     $buildArgs = @($proj, '-c', 'Release', "-p:Platform=$Platform", '--nologo')
     if ($SelfContained) { $buildArgs += '-p:PerfCiSelfContained=true' }

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -297,13 +297,22 @@ function Stage-RustRuntime {
     # runtime DLLs present while others are missing, which still faults the loader at
     # process start; keying the early-return on a DLL subset would wrongly short-circuit
     # that incomplete state and never finish staging. The marker only exists once every
-    # manifest-referenced file has been verified next to the exe.
+    # manifest-referenced file has been verified next to the exe — and we still re-check the
+    # core set when the marker is present, so an external wipe can't leave a stale marker
+    # pointing at a now-broken exe.
     $required = @('microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll')
     $sentinel = 'microsoft.ui.xaml.dll'
     $marker = Join-Path $ExeDir '.perfci-runtime-staged'
     if (Test-Path $marker) {
-        Write-Log "  Rust runtime already staged next to exe (completion marker present)" 'DarkGray'
-        return
+        if (-not ($required | Where-Object { -not (Test-Path (Join-Path $ExeDir $_)) })) {
+            Write-Log "  Rust runtime already staged next to exe (completion marker present)" 'DarkGray'
+            return
+        }
+        # Marker survived but a core DLL was removed (external cleanup / partial dir wipe):
+        # the marker is stale and must not short-circuit into a broken exe — drop it and
+        # fall through to a full restage.
+        Write-Log "  stale Rust runtime marker (core DLL missing) — re-staging" 'Yellow'
+        Remove-Item $marker -Force -ErrorAction SilentlyContinue
     }
 
     try {

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -291,9 +291,14 @@ function Stage-RustRuntime {
     param([string]$ExeDir, [string]$Platform)
 
     $arch = if ($Platform -match 'arm64') { 'arm64' } else { 'x64' }
+    # Verify a REQUIRED SET, not a single sentinel: a prior *partial* stage could leave
+    # one runtime DLL present while others are missing, which still faults the loader at
+    # process start. Both of these are always in the self-contained runtime MSIX and are
+    # referenced by the embedded SxS manifest.
+    $required = @('microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll')
     $sentinel = 'microsoft.ui.xaml.dll'
-    if (Test-Path (Join-Path $ExeDir $sentinel)) {
-        Write-Log "  Rust runtime already staged next to exe ($sentinel present)" 'DarkGray'
+    if (-not ($required | Where-Object { -not (Test-Path (Join-Path $ExeDir $_)) })) {
+        Write-Log "  Rust runtime already staged next to exe (required DLLs present)" 'DarkGray'
         return
     }
 
@@ -352,10 +357,16 @@ function Stage-RustRuntime {
             Where-Object { $_.Extension -in '.dll', '.pri' } |
             ForEach-Object { try { Copy-Item -LiteralPath $_.FullName -Destination $ExeDir -Force; $staged++ } catch {} }
 
-        if (Test-Path (Join-Path $ExeDir $sentinel)) {
+        # Verify completeness against the actual MSIX payload for this package version
+        # (not just one sentinel): every runtime DLL from the MSIX root must now sit next
+        # to the exe, and the required core set must be present.
+        $srcDlls = @(Get-ChildItem $msixOut -File -ErrorAction SilentlyContinue | Where-Object { $_.Extension -eq '.dll' })
+        $notCopied = @($srcDlls | Where-Object { -not (Test-Path (Join-Path $ExeDir $_.Name)) })
+        $coreMissing = @($required | Where-Object { -not (Test-Path (Join-Path $ExeDir $_)) })
+        if ($notCopied.Count -eq 0 -and $coreMissing.Count -eq 0) {
             Write-Log "  staged $staged WinAppSDK runtime file(s) next to test_reactor_perf.exe (self-contained)" 'Green'
         } else {
-            Write-Log "  runtime staging copied $staged file(s) but $sentinel is missing — Rust column may read n/a (#674)" 'Yellow'
+            Write-Log "  runtime staging incomplete (copied $staged; $($notCopied.Count) DLL(s) missing) — Rust column may read n/a (#674)" 'Yellow'
         }
     } catch {
         Write-Log "  Rust runtime staging failed ($($_.Exception.Message)) — Rust column may read n/a (#674)" 'Yellow'

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -366,13 +366,31 @@ function Stage-RustRuntime {
         #    nupkg name (version) so a different version selected later cannot reuse a stale
         #    cross-version MSIX payload from a stable path.
         $extract = Join-Path $cache ("perfci-runtime-extract-" + [IO.Path]::GetFileNameWithoutExtension($nupkg))
-        $msix = Join-Path $extract "MSIX\win10-$arch\Microsoft.WindowsAppRuntime.2.msix"
-        if (-not (Test-Path $msix)) {
+        $msixDir = Join-Path $extract "MSIX\win10-$arch"
+        # Resolve the per-arch framework MSIX. 2.x ships Microsoft.WindowsAppRuntime.2.msix
+        # (the '2' is the stable WinAppSDK API-contract major, identical across 2.1.3/2.10/…),
+        # so that exact name is the fast path. Only if it is absent — e.g. the non-pinned
+        # fallback above selected a cached package from a future major whose framework MSIX is
+        # numbered differently (…\Microsoft.WindowsAppRuntime.N.msix) — glob for the framework
+        # MSIX by its stable stem so a valid runtime still stages instead of failing outright.
+        # The glob is scoped to the 'Microsoft.WindowsAppRuntime.<major>.msix' shape (no embedded
+        # dot after the stem) so it can't pick an unrelated package (DDLM/Singleton) that lacks
+        # the runtime DLLs.
+        $resolveMsix = {
+            $exact = Join-Path $msixDir 'Microsoft.WindowsAppRuntime.2.msix'
+            if (Test-Path $exact) { return $exact }
+            Get-ChildItem -Path $msixDir -Filter 'Microsoft.WindowsAppRuntime.*.msix' -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -match '^Microsoft\.WindowsAppRuntime\.\d+\.msix$' } |
+                Select-Object -First 1 -ExpandProperty FullName
+        }
+        $msix = & $resolveMsix
+        if (-not $msix) {
             $null = New-Item -ItemType Directory -Force -Path $extract -ErrorAction SilentlyContinue
             & $tar -xf $nupkg -C $extract --strip-components=1
+            $msix = & $resolveMsix
         }
-        if (-not (Test-Path $msix)) {
-            Write-Log "  runtime MSIX not found after extract ($msix) — Rust column may read n/a (#674)" 'Yellow'
+        if (-not $msix -or -not (Test-Path $msix)) {
+            Write-Log "  runtime MSIX not found after extract ($msixDir) — Rust column may read n/a (#674)" 'Yellow'
             return
         }
 

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -190,18 +190,25 @@ function Build-Harness {
     Write-Log "build $($AppMeta.AppName)  [$TreeRoot]" 'Cyan'
 
     # Compare mode only: overlay the harness .csproj from the trusted baseline tree
-    # over the PR tree's copy before building. The harness csproj is fixed test
-    # scaffolding — the build recipe for the StocksGrid workload, including the
-    # PerfCiSelfContained self-contained knob — NOT the code under measurement. The
-    # PR's actual perf change lives in src/Reactor/, which the harness still compiles
-    # via its relative ProjectReference into the PR tree, so overlaying only the
-    # csproj is fair. This guarantees the self-contained build block is present even
-    # for PRs opened before the gate landed (whose tree predates that csproj block),
-    # so /perf needs no rebase. Never runs in local single-tree mode ($BaselineRoot
-    # empty) or when building the baseline itself ($TreeRoot -eq $BaselineRoot).
+    # over the PR tree's copy for the duration of the build, then restore it. The
+    # harness csproj is fixed test scaffolding — the build recipe for the StocksGrid
+    # workload, including the PerfCiSelfContained self-contained knob — NOT the code
+    # under measurement. The PR's actual perf change lives in src/Reactor/, which the
+    # harness still compiles via its relative ProjectReference into the PR tree, so
+    # overlaying only the csproj is fair. This guarantees the self-contained build
+    # block is present even for PRs opened before the gate landed (whose tree predates
+    # that csproj block), so /perf needs no rebase. The overlay is build-scoped: the
+    # original csproj is restored in the finally below, so the checkout is never left
+    # modified — important for local compare runs against a developer's own worktree,
+    # and it keeps repeated runs deterministic. Never runs in local single-tree mode
+    # ($BaselineRoot empty) or when building the baseline itself ($TreeRoot -eq
+    # $BaselineRoot).
+    $overlayBackup = $null
     if ($BaselineRoot -and ($TreeRoot -ne $BaselineRoot)) {
         $trusted = Join-Path $BaselineRoot $AppMeta.ProjectRel
         if (Test-Path $trusted) {
+            $overlayBackup = "$proj.perfci-orig"
+            Copy-Item -LiteralPath $proj -Destination $overlayBackup -Force
             Copy-Item -LiteralPath $trusted -Destination $proj -Force
             Write-Log "  overlaid trusted csproj (self-contained knob) from baseline" 'DarkGray'
         } else {
@@ -209,13 +216,21 @@ function Build-Harness {
         }
     }
 
-    $log = Join-Path $OutDir ("build-{0}-{1}.log" -f $AppMeta.AppName, ([IO.Path]::GetFileName($TreeRoot)))
-    $buildArgs = @($proj, '-c', 'Release', "-p:Platform=$Platform", '--nologo')
-    if ($SelfContained) { $buildArgs += '-p:PerfCiSelfContained=true' }
-    & dotnet build @buildArgs 2>&1 | Tee-Object -FilePath $log | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host (Get-Content $log -Raw) -ForegroundColor DarkRed
-        throw "dotnet build failed for $($AppMeta.AppName) in $TreeRoot (see $log)"
+    try {
+        $log = Join-Path $OutDir ("build-{0}-{1}.log" -f $AppMeta.AppName, ([IO.Path]::GetFileName($TreeRoot)))
+        $buildArgs = @($proj, '-c', 'Release', "-p:Platform=$Platform", '--nologo')
+        if ($SelfContained) { $buildArgs += '-p:PerfCiSelfContained=true' }
+        & dotnet build @buildArgs 2>&1 | Tee-Object -FilePath $log | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host (Get-Content $log -Raw) -ForegroundColor DarkRed
+            throw "dotnet build failed for $($AppMeta.AppName) in $TreeRoot (see $log)"
+        }
+    } finally {
+        if ($overlayBackup -and (Test-Path $overlayBackup)) {
+            Copy-Item -LiteralPath $overlayBackup -Destination $proj -Force
+            Remove-Item -LiteralPath $overlayBackup -Force -ErrorAction SilentlyContinue
+            Write-Log "  restored original PR csproj (overlay is build-scoped)" 'DarkGray'
+        }
     }
 }
 

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -350,6 +350,13 @@ function Stage-RustRuntime {
             else { Invoke-WebRequest -Uri $url -OutFile $nupkg }
         }
         if (-not $nupkg -or -not (Test-Path $nupkg) -or (Get-Item $nupkg).Length -lt 1MB) {
+            # A truncated/partial nupkg (failed download or corrupt cache entry) would be
+            # preferred again next run via the pinned-cache fast path above, permanently
+            # poisoning the cache and pinning the Rust leg at n/a. Evict it so the next
+            # invocation re-downloads (or falls back to another cached version) instead of
+            # looping on a bad artifact — the top of the same self-healing chain applied to
+            # $msix and $msixOut below.
+            if ($nupkg -and (Test-Path $nupkg)) { Remove-Item $nupkg -Force -ErrorAction SilentlyContinue }
             Write-Log "  WinAppSDK runtime nupkg unavailable — Rust column may read n/a (#674)" 'Yellow'
             return
         }

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -268,6 +268,100 @@ function Resolve-RustExe {
     return $null
 }
 
+function Stage-RustRuntime {
+    <# Stage the Windows App SDK self-contained runtime DLLs next to the Rust
+       test_reactor_perf.exe, with hard verification + loud logging (issue #674).
+
+       The crate's build.rs is patched to windows_reactor_setup::as_self_contained(),
+       which embeds an app.manifest that declares the WinAppSDK runtime DLLs as SxS
+       <file> entries — so the loader requires those DLLs *next to the exe at process
+       start*. as_self_contained() also tries to copy them there during `cargo build`,
+       but every download/extract/copy step in the upstream helper swallows its error
+       (`let _ = ...` / `.ok()`), so a single transient runner hiccup leaves ZERO DLLs
+       staged while the build still "Finishes". The exe then dies at load with
+       0xC0000135 (STATUS_DLL_NOT_FOUND) and 0-byte stdout/stderr, and the Rust column
+       reads n/a. This re-does the staging explicitly and verifies the result.
+
+       Best-effort: any failure here only leaves the Rust column n/a — the C# legs are
+       self-contained independently of this and are unaffected. Mirrors the upstream
+       layout: nupkg -> (strip leading dir) -> MSIX\win10-<arch>\...2.msix -> extract
+       -> copy the root *.dll / *.pri next to the exe. We copy the full runtime DLL set
+       (a superset of the crate's runtime.txt allow-list) so every manifest-referenced
+       file is present. #>
+    param([string]$ExeDir, [string]$Platform)
+
+    $arch = if ($Platform -match 'arm64') { 'arm64' } else { 'x64' }
+    $sentinel = 'microsoft.ui.xaml.dll'
+    if (Test-Path (Join-Path $ExeDir $sentinel)) {
+        Write-Log "  Rust runtime already staged next to exe ($sentinel present)" 'DarkGray'
+        return
+    }
+
+    try {
+        $tar = Join-Path $env:SystemRoot 'System32\tar.exe'
+        if (-not (Test-Path $tar)) { Write-Log "  System32\tar.exe not found — cannot stage Rust runtime (#674)" 'Yellow'; return }
+        $base = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { $env:TEMP }
+        $cache = Join-Path $base 'windows-reactor-setup\temp'
+
+        # 1. Locate the runtime nupkg. Prefer the one the build script already
+        #    downloaded (auto-syncs with the crate's pinned RUNTIME_VER); else fetch
+        #    the version this crate revision expects.
+        $pkg = 'Microsoft.WindowsAppSDK.Runtime'; $ver = '2.1.3'
+        $nupkg = $null
+        if (Test-Path $cache) {
+            $nupkg = Get-ChildItem $cache -Filter "$pkg.*.nupkg" -File -ErrorAction SilentlyContinue |
+                Sort-Object Length -Descending | Select-Object -First 1 -ExpandProperty FullName
+        }
+        if (-not $nupkg) {
+            $null = New-Item -ItemType Directory -Force -Path $cache -ErrorAction SilentlyContinue
+            $nupkg = Join-Path $cache "$pkg.$ver.nupkg"
+            $url = "https://www.nuget.org/api/v2/package/$pkg/$ver"
+            Write-Log "  staging WinAppSDK runtime for Rust harness: downloading $pkg $ver" 'DarkGray'
+            $curl = Join-Path $env:SystemRoot 'System32\curl.exe'
+            if (Test-Path $curl) { & $curl -s -L -o $nupkg $url }
+            else { Invoke-WebRequest -Uri $url -OutFile $nupkg }
+        }
+        if (-not $nupkg -or -not (Test-Path $nupkg) -or (Get-Item $nupkg).Length -lt 1MB) {
+            Write-Log "  WinAppSDK runtime nupkg unavailable — Rust column may read n/a (#674)" 'Yellow'
+            return
+        }
+
+        # 2. Extract the nupkg (strip the leading 'tools/'-style component, matching
+        #    upstream) so the MSIX lands at MSIX\win10-<arch>\...
+        $extract = Join-Path $cache 'perfci-runtime-extract'
+        $msix = Join-Path $extract "MSIX\win10-$arch\Microsoft.WindowsAppRuntime.2.msix"
+        if (-not (Test-Path $msix)) {
+            $null = New-Item -ItemType Directory -Force -Path $extract -ErrorAction SilentlyContinue
+            & $tar -xf $nupkg -C $extract --strip-components=1
+        }
+        if (-not (Test-Path $msix)) {
+            Write-Log "  runtime MSIX not found after extract ($msix) — Rust column may read n/a (#674)" 'Yellow'
+            return
+        }
+
+        # 3. Extract the per-arch MSIX (its root holds the runtime DLLs + .pri).
+        $msixOut = Join-Path $extract ".msix_extract-$arch"
+        if (-not (Test-Path (Join-Path $msixOut $sentinel))) {
+            $null = New-Item -ItemType Directory -Force -Path $msixOut -ErrorAction SilentlyContinue
+            & $tar -xf $msix -C $msixOut
+        }
+
+        # 4. Copy the runtime DLLs + resource indices next to the exe.
+        $staged = 0
+        Get-ChildItem $msixOut -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Extension -in '.dll', '.pri' } |
+            ForEach-Object { try { Copy-Item -LiteralPath $_.FullName -Destination $ExeDir -Force; $staged++ } catch {} }
+
+        if (Test-Path (Join-Path $ExeDir $sentinel)) {
+            Write-Log "  staged $staged WinAppSDK runtime file(s) next to test_reactor_perf.exe (self-contained)" 'Green'
+        } else {
+            Write-Log "  runtime staging copied $staged file(s) but $sentinel is missing — Rust column may read n/a (#674)" 'Yellow'
+        }
+    } catch {
+        Write-Log "  Rust runtime staging failed ($($_.Exception.Message)) — Rust column may read n/a (#674)" 'Yellow'
+    }
+}
+
 function Invoke-RustLeg {
     <# Build + run the windows-rs `test_reactor_perf` crate for the Rust column.
        Best-effort: any failure logs a warning and yields $null (column reads n/a). #>
@@ -277,6 +371,7 @@ function Invoke-RustLeg {
         if (-not $SkipBuild) { Build-RustHarness -RepoRoot $RustRepo }
         $rustExe = Resolve-RustExe -RepoRoot $RustRepo
         if (-not $rustExe) { Write-Log "test_reactor_perf.exe not found after build — Rust column n/a" 'Yellow'; return $null }
+        Stage-RustRuntime -ExeDir (Split-Path $rustExe) -Platform $Platform
         Write-Log "Rust windows-reactor (test_reactor_perf)" 'Green'
         # The Rust port writes StressPerf.Reactor.report.txt next to its exe and has
         # no --json mode, so run with -NoJson and read the report.

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -203,20 +203,26 @@ function Build-Harness {
     # and it keeps repeated runs deterministic. Never runs in local single-tree mode
     # ($BaselineRoot empty) or when building the baseline itself ($TreeRoot -eq
     # $BaselineRoot).
+    # $overlayBackup is set only AFTER the backup file is successfully written, and the
+    # overlay itself lives inside the try below. That ordering keeps the "checkout is
+    # never left modified" guarantee even if a Copy-Item throws mid-overlay: the finally
+    # restores from (and removes) the backup whenever it exists, so a failed trusted copy
+    # can't orphan a *.perfci-orig file or leave the PR csproj swapped out.
     $overlayBackup = $null
-    if ($BaselineRoot -and ($TreeRoot -ne $BaselineRoot)) {
-        $trusted = Join-Path $BaselineRoot $AppMeta.ProjectRel
-        if (Test-Path $trusted) {
-            $overlayBackup = "$proj.perfci-orig"
-            Copy-Item -LiteralPath $proj -Destination $overlayBackup -Force
-            Copy-Item -LiteralPath $trusted -Destination $proj -Force
-            Write-Log "  overlaid trusted csproj (self-contained knob) from baseline" 'DarkGray'
-        } else {
-            Write-Log "  trusted csproj not found in baseline ($trusted) — using PR tree copy" 'Yellow'
-        }
-    }
-
     try {
+        if ($BaselineRoot -and ($TreeRoot -ne $BaselineRoot)) {
+            $trusted = Join-Path $BaselineRoot $AppMeta.ProjectRel
+            if (Test-Path $trusted) {
+                $bak = "$proj.perfci-orig"
+                Copy-Item -LiteralPath $proj -Destination $bak -Force
+                $overlayBackup = $bak
+                Copy-Item -LiteralPath $trusted -Destination $proj -Force
+                Write-Log "  overlaid trusted csproj (self-contained knob) from baseline" 'DarkGray'
+            } else {
+                Write-Log "  trusted csproj not found in baseline ($trusted) — using PR tree copy" 'Yellow'
+            }
+        }
+
         $log = Join-Path $OutDir ("build-{0}-{1}.log" -f $AppMeta.AppName, ([IO.Path]::GetFileName($TreeRoot)))
         $buildArgs = @($proj, '-c', 'Release', "-p:Platform=$Platform", '--nologo')
         if ($SelfContained) { $buildArgs += '-p:PerfCiSelfContained=true' }

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -1,0 +1,163 @@
+<#
+.SYNOPSIS
+    Dependency-free unit tests for the testable functions in Run-PerfBenchmark.ps1
+    (the /perf benchmark orchestrator): the compare-mode .csproj overlay in
+    Build-Harness and the required-set idempotency gate in Stage-RustRuntime.
+
+.DESCRIPTION
+    Run-PerfBenchmark.ps1 isn't dot-sourceable (it has a param block + a main run
+    flow), so each function under test is extracted via the PowerShell AST and
+    defined in isolation with `dotnet` / the runtime download stubbed out. Runs
+    headless and cross-platform with no WinUI harness and no network, so it is safe
+    on the cheap Linux runner in .github/workflows/perf-lib-tests.yml. Exits
+    non-zero if any assertion fails.
+
+    The full Stage-RustRuntime download/extract/copy path is Windows + network +
+    MSIX-extraction bound; it is validated by the live `/perf` run (the stated
+    final acceptance for #674), not here. This file covers the pure branching that
+    does NOT need a runner: the overlay/restore guarantees and the staging
+    idempotency gate.
+
+    Run locally:  pwsh tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { $script:Pass++ } else { $script:Fail++; $script:Failures.Add($Message) }
+}
+
+# --- Extract the functions under test from the orchestrator script. ---
+$scriptPath = Join-Path $PSScriptRoot 'Run-PerfBenchmark.ps1'
+$src = Get-Content $scriptPath -Raw
+$ast = [System.Management.Automation.Language.Parser]::ParseInput($src, [ref]$null, [ref]$null)
+function Get-Func([string]$name) {
+    $f = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $name }, $true) |
+        Select-Object -First 1
+    if (-not $f) { throw "$name not found in Run-PerfBenchmark.ps1" }
+    $f.Extent.Text
+}
+
+$global:LogLines = [System.Collections.Generic.List[string]]::new()
+function Write-Log { param($Message, $Color) $global:LogLines.Add([string]$Message) }
+# Stub `dotnet`: record the .csproj content the build actually saw, honor a forced exit code.
+function dotnet { $global:SAW = Get-Content $args[1] -Raw; $global:LASTEXITCODE = $global:ForceExit }
+
+Invoke-Expression (Get-Func 'Build-Harness')
+Invoke-Expression (Get-Func 'Stage-RustRuntime')
+
+# ===========================================================================
+#  Build-Harness — compare-mode .csproj overlay / restore
+# ===========================================================================
+# Script-scope inputs Build-Harness reads.
+$Platform = 'x64'; $SelfContained = $true
+$OutDir = Join-Path ([IO.Path]::GetTempPath()) 'perfci-bh-out'
+$null = New-Item -ItemType Directory -Force $OutDir | Out-Null
+
+$meta = @{ AppName = 'RO'; ProjectRel = [IO.Path]::Combine('h', 'app.csproj') }
+$baseTree = Join-Path ([IO.Path]::GetTempPath()) 'perfci-bh-base'
+$prTree   = Join-Path ([IO.Path]::GetTempPath()) 'perfci-bh-pr'
+$prCsproj = Join-Path $prTree $meta.ProjectRel
+
+function New-Tree([string]$root, [string]$content) {
+    if (Test-Path $root) { Remove-Item $root -Recurse -Force }
+    $proj = Join-Path $root $meta.ProjectRel
+    $null = New-Item -ItemType Directory -Force (Split-Path $proj) | Out-Null
+    Set-Content -LiteralPath $proj -Value $content -NoNewline
+}
+
+# 1. compare mode, PR tree, trusted present -> build sees TRUSTED; PR tree restored; no leftover.
+$global:ForceExit = 0
+New-Tree $baseTree 'TRUSTED'; New-Tree $prTree 'PRORIG'
+$BaselineRoot = $baseTree
+Build-Harness -TreeRoot $prTree -AppMeta $meta
+Assert-True ($global:SAW -eq 'TRUSTED')                  '[1] compare/PR: build saw trusted csproj'
+Assert-True ((Get-Content $prCsproj -Raw) -eq 'PRORIG')  '[1] compare/PR: PR csproj restored'
+Assert-True (-not (Test-Path "$prCsproj.perfci-orig"))   '[1] compare/PR: no backup leftover'
+
+# 2. compare mode, building the BASELINE itself -> no overlay, no backup.
+New-Tree $baseTree 'TRUSTED'
+$BaselineRoot = $baseTree
+Build-Harness -TreeRoot $baseTree -AppMeta $meta
+$baseCsproj = Join-Path $baseTree $meta.ProjectRel
+Assert-True ($global:SAW -eq 'TRUSTED')                  '[2] baseline-self: build saw own csproj'
+Assert-True (-not (Test-Path "$baseCsproj.perfci-orig")) '[2] baseline-self: no backup created'
+
+# 3. local single-tree mode ($BaselineRoot empty) -> no overlay.
+New-Tree $prTree 'PRORIG'
+$BaselineRoot = ''
+Build-Harness -TreeRoot $prTree -AppMeta $meta
+Assert-True ($global:SAW -eq 'PRORIG')                   '[3] local: build saw PR csproj (no overlay)'
+Assert-True ((Get-Content $prCsproj -Raw) -eq 'PRORIG')  '[3] local: PR csproj unchanged'
+
+# 4. compare mode, PR tree, trusted MISSING -> graceful fallback, PR untouched.
+New-Tree $prTree 'PRORIG'
+if (Test-Path $baseTree) { Remove-Item $baseTree -Recurse -Force }
+$null = New-Item -ItemType Directory -Force $baseTree | Out-Null
+$BaselineRoot = $baseTree
+Build-Harness -TreeRoot $prTree -AppMeta $meta
+Assert-True ($global:SAW -eq 'PRORIG')                   '[4] trusted-missing: fallback to PR csproj'
+Assert-True ((Get-Content $prCsproj -Raw) -eq 'PRORIG')  '[4] trusted-missing: PR csproj untouched'
+
+# 5. compare mode, build FAILS -> throws, but finally restores + removes backup.
+$global:ForceExit = 1
+New-Tree $baseTree 'TRUSTED'; New-Tree $prTree 'PRORIG'
+$BaselineRoot = $baseTree
+$threw = $false
+try { Build-Harness -TreeRoot $prTree -AppMeta $meta } catch { $threw = $true }
+Assert-True $threw                                       '[5] build-fails: Build-Harness threw'
+Assert-True ((Get-Content $prCsproj -Raw) -eq 'PRORIG')  '[5] build-fails: PR csproj restored'
+Assert-True (-not (Test-Path "$prCsproj.perfci-orig"))   '[5] build-fails: no backup leftover'
+
+# 6. compare mode, the trusted overlay Copy-Item THROWS after the backup is created ->
+#    finally must still restore from backup and remove it (the new cleanup guarantee).
+$global:ForceExit = 0
+New-Tree $baseTree 'TRUSTED'; New-Tree $prTree 'PRORIG'
+$BaselineRoot = $baseTree
+# Shadow Copy-Item so ONLY the overlay copy (source in the baseline tree) fails; the
+# backup-create copy and the finally restore copy (source = *.perfci-orig) still work.
+function Copy-Item {
+    param([string]$LiteralPath, [string]$Destination, [switch]$Force)
+    if ($LiteralPath -like '*perfci-bh-base*') { throw 'simulated overlay copy failure' }
+    Microsoft.PowerShell.Management\Copy-Item -LiteralPath $LiteralPath -Destination $Destination -Force:$Force
+}
+$threw6 = $false
+try { Build-Harness -TreeRoot $prTree -AppMeta $meta } catch { $threw6 = $true }
+Remove-Item function:Copy-Item
+Assert-True $threw6                                      '[6] overlay-throws: Build-Harness rethrew'
+Assert-True ((Get-Content $prCsproj -Raw) -eq 'PRORIG')  '[6] overlay-throws: PR csproj restored'
+Assert-True (-not (Test-Path "$prCsproj.perfci-orig"))   '[6] overlay-throws: no backup leftover'
+
+# ===========================================================================
+#  Stage-RustRuntime — required-set idempotency gate (network-free)
+# ===========================================================================
+# When the full required runtime set is already staged next to the exe, the
+# function must early-return before any download/extract. A single sentinel must
+# NOT be enough (a partial prior stage would still fault the loader at start).
+$exeDir = Join-Path ([IO.Path]::GetTempPath()) 'perfci-rust-exedir'
+if (Test-Path $exeDir) { Remove-Item $exeDir -Recurse -Force }
+$null = New-Item -ItemType Directory -Force $exeDir | Out-Null
+foreach ($f in 'microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll') {
+    Set-Content -LiteralPath (Join-Path $exeDir $f) -Value 'x' -NoNewline
+}
+$global:LogLines.Clear()
+Stage-RustRuntime -ExeDir $exeDir -Platform 'x64'
+Assert-True (@($global:LogLines | Where-Object { $_ -match 'already staged' }).Count -ge 1) `
+    '[stage] full required set present -> idempotent early-return (no download)'
+
+# cleanup
+foreach ($d in @($baseTree, $prTree, $OutDir, $exeDir)) {
+    if (Test-Path $d) { Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue }
+}
+
+Write-Host ""
+if ($script:Fail -gt 0) {
+    Write-Host "Run-PerfBenchmark tests: $script:Pass passed, $script:Fail FAILED" -ForegroundColor Red
+    $script:Failures | ForEach-Object { Write-Host "  FAIL: $_" -ForegroundColor Red }
+    exit 1
+}
+Write-Host "PASSED: all $script:Pass assertions" -ForegroundColor Green

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -144,22 +144,27 @@ Assert-True (-not (Test-Path "$prCsproj.perfci-orig"))   '[6] overlay-throws: no
 # ===========================================================================
 #  Stage-RustRuntime — completion-marker idempotency gate (network-free)
 # ===========================================================================
-# Idempotency is keyed on a completion marker written only after a fully verified
-# stage. When the marker is present the function must early-return before any
-# download/extract/tar.
+# Early-return requires BOTH the completion marker AND the core DLLs present next to the
+# exe. The marker is written only after a fully verified stage (so a partial stage can't
+# set it); the core-DLL re-check guards against the marker surviving an external wipe.
+
+# (1) marker + core DLLs present -> early-return before any download/extract/tar.
 $exeDir = Join-Path ([IO.Path]::GetTempPath()) 'perfci-rust-exedir'
 if (Test-Path $exeDir) { Remove-Item $exeDir -Recurse -Force }
 $null = New-Item -ItemType Directory -Force $exeDir | Out-Null
 Set-Content -LiteralPath (Join-Path $exeDir '.perfci-runtime-staged') -Value 'x' -NoNewline
+foreach ($f in 'microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll') {
+    Set-Content -LiteralPath (Join-Path $exeDir $f) -Value 'x' -NoNewline
+}
 $global:LogLines.Clear()
 Stage-RustRuntime -ExeDir $exeDir -Platform 'x64'
 Assert-True (@($global:LogLines | Where-Object { $_ -match 'already staged' }).Count -ge 1) `
-    '[stage] completion marker present -> idempotent early-return (no download)'
+    '[stage] marker + core DLLs present -> idempotent early-return (no download)'
 
-# A *subset* of runtime DLLs present but NO completion marker must NOT early-return — a
-# partial prior stage has to be allowed to finish. Point SystemRoot at a dir with no
-# System32\tar.exe so the function bails network-free right after the marker check on any
-# OS, and assert it never logged 'already staged' (i.e. the DLL subset did not satisfy it).
+# (2) a DLL subset present but NO marker must NOT early-return — a partial prior stage has
+# to be allowed to finish. Point SystemRoot at a dir with no System32\tar.exe so the
+# function bails network-free right after the gate on any OS, and assert it never logged
+# 'already staged' (i.e. the DLL subset did not satisfy the gate).
 $exeDir2 = Join-Path ([IO.Path]::GetTempPath()) 'perfci-rust-exedir2'
 if (Test-Path $exeDir2) { Remove-Item $exeDir2 -Recurse -Force }
 $null = New-Item -ItemType Directory -Force $exeDir2 | Out-Null
@@ -174,6 +179,24 @@ Assert-True (@($global:LogLines | Where-Object { $_ -match 'already staged' }).C
     '[stage] DLL subset without marker -> does NOT early-return (no false idempotency)'
 Remove-Item $exeDir2 -Recurse -Force -ErrorAction SilentlyContinue
 
+# (3) marker present but the core DLLs were externally removed -> the marker is stale: the
+# function must delete it and NOT early-return (it falls through to restage). Force the tar
+# probe to miss so it bails network-free after dropping the marker.
+$exeDir3 = Join-Path ([IO.Path]::GetTempPath()) 'perfci-rust-exedir3'
+if (Test-Path $exeDir3) { Remove-Item $exeDir3 -Recurse -Force }
+$null = New-Item -ItemType Directory -Force $exeDir3 | Out-Null
+$marker3 = Join-Path $exeDir3 '.perfci-runtime-staged'
+Set-Content -LiteralPath $marker3 -Value 'x' -NoNewline
+$savedSysRoot = $env:SystemRoot
+$env:SystemRoot = [IO.Path]::GetTempPath()
+$global:LogLines.Clear()
+try { Stage-RustRuntime -ExeDir $exeDir3 -Platform 'x64' } finally { $env:SystemRoot = $savedSysRoot }
+Assert-True (@($global:LogLines | Where-Object { $_ -match 'already staged' }).Count -eq 0) `
+    '[stage] stale marker (core DLLs missing) -> does NOT early-return'
+Assert-True (-not (Test-Path $marker3)) `
+    '[stage] stale marker (core DLLs missing) -> marker deleted before restage'
+Remove-Item $exeDir3 -Recurse -Force -ErrorAction SilentlyContinue
+
 # cleanup
 foreach ($d in @($baseTree, $prTree, $OutDir, $exeDir)) {
     if (Test-Path $d) { Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue }
@@ -186,3 +209,9 @@ if ($script:Fail -gt 0) {
     exit 1
 }
 Write-Host "PASSED: all $script:Pass assertions" -ForegroundColor Green
+# Explicit success exit: the perf-lib-tests workflow invokes this via `pwsh -Command
+# ". '<script>'"` (dot-source), under which a non-zero $LASTEXITCODE left over from the
+# stubbed `dotnet` build-failure scenario leaks into the process exit code on Linux even
+# though every assertion passed. Pin the exit code to the test result. (Mirrors
+# PerfLib.Tests.ps1.)
+exit 0

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -34,7 +34,16 @@ function Assert-True {
 # --- Extract the functions under test from the orchestrator script. ---
 $scriptPath = Join-Path $PSScriptRoot 'Run-PerfBenchmark.ps1'
 $src = Get-Content $scriptPath -Raw
-$ast = [System.Management.Automation.Language.Parser]::ParseInput($src, [ref]$null, [ref]$null)
+# Capture parse errors instead of discarding them: a syntax error in the orchestrator
+# script makes every extracted function extent unreliable, so fail fast and let CI flag
+# the broken script rather than silently testing garbage.
+$parseTokens = $null; $parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseInput($src, [ref]$parseTokens, [ref]$parseErrors)
+if ($parseErrors -and $parseErrors.Count -gt 0) {
+    Write-Host "Run-PerfBenchmark.ps1 has $($parseErrors.Count) parse error(s):" -ForegroundColor Red
+    $parseErrors | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" -ForegroundColor Red }
+    exit 1
+}
 function Get-Func([string]$name) {
     $f = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $name }, $true) |
         Select-Object -First 1
@@ -133,21 +142,37 @@ Assert-True ((Get-Content $prCsproj -Raw) -eq 'PRORIG')  '[6] overlay-throws: PR
 Assert-True (-not (Test-Path "$prCsproj.perfci-orig"))   '[6] overlay-throws: no backup leftover'
 
 # ===========================================================================
-#  Stage-RustRuntime — required-set idempotency gate (network-free)
+#  Stage-RustRuntime — completion-marker idempotency gate (network-free)
 # ===========================================================================
-# When the full required runtime set is already staged next to the exe, the
-# function must early-return before any download/extract. A single sentinel must
-# NOT be enough (a partial prior stage would still fault the loader at start).
+# Idempotency is keyed on a completion marker written only after a fully verified
+# stage. When the marker is present the function must early-return before any
+# download/extract/tar.
 $exeDir = Join-Path ([IO.Path]::GetTempPath()) 'perfci-rust-exedir'
 if (Test-Path $exeDir) { Remove-Item $exeDir -Recurse -Force }
 $null = New-Item -ItemType Directory -Force $exeDir | Out-Null
-foreach ($f in 'microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll') {
-    Set-Content -LiteralPath (Join-Path $exeDir $f) -Value 'x' -NoNewline
-}
+Set-Content -LiteralPath (Join-Path $exeDir '.perfci-runtime-staged') -Value 'x' -NoNewline
 $global:LogLines.Clear()
 Stage-RustRuntime -ExeDir $exeDir -Platform 'x64'
 Assert-True (@($global:LogLines | Where-Object { $_ -match 'already staged' }).Count -ge 1) `
-    '[stage] full required set present -> idempotent early-return (no download)'
+    '[stage] completion marker present -> idempotent early-return (no download)'
+
+# A *subset* of runtime DLLs present but NO completion marker must NOT early-return — a
+# partial prior stage has to be allowed to finish. Point SystemRoot at a dir with no
+# System32\tar.exe so the function bails network-free right after the marker check on any
+# OS, and assert it never logged 'already staged' (i.e. the DLL subset did not satisfy it).
+$exeDir2 = Join-Path ([IO.Path]::GetTempPath()) 'perfci-rust-exedir2'
+if (Test-Path $exeDir2) { Remove-Item $exeDir2 -Recurse -Force }
+$null = New-Item -ItemType Directory -Force $exeDir2 | Out-Null
+foreach ($f in 'microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll') {
+    Set-Content -LiteralPath (Join-Path $exeDir2 $f) -Value 'x' -NoNewline
+}
+$savedSysRoot = $env:SystemRoot
+$env:SystemRoot = [IO.Path]::GetTempPath()
+$global:LogLines.Clear()
+try { Stage-RustRuntime -ExeDir $exeDir2 -Platform 'x64' } finally { $env:SystemRoot = $savedSysRoot }
+Assert-True (@($global:LogLines | Where-Object { $_ -match 'already staged' }).Count -eq 0) `
+    '[stage] DLL subset without marker -> does NOT early-return (no false idempotency)'
+Remove-Item $exeDir2 -Recurse -Force -ErrorAction SilentlyContinue
 
 # cleanup
 foreach ($d in @($baseTree, $prTree, $OutDir, $exeDir)) {


### PR DESCRIPTION
## Problem

The on-demand `/perf` gate (added by #662, issue #661) benchmarks a PR's `src/Reactor/` against the trusted `main` baseline by building the StressPerf WinUI harnesses **self-contained**, so they launch on a `windows-latest` runner that has no machine-wide Windows App SDK runtime.

Two defects broke the first live run ([run 28202538748](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/28202538748), against #656):

1. **Self-contained build is a no-op on pre-gate PRs.** The self-contained knob is a `PropertyGroup` that #662 *added to each harness `.csproj`*. Any PR opened **before #662 merged** (the entire in-flight fleet) has a tree that predates that block, so `-p:PerfCiSelfContained=true` does nothing → the harness builds framework-dependent → on the runner it can't find the WinAppSDK runtime → hangs in the bootstrapper (0-byte output) → the 100s watchdog kills it → no PR metrics → red check + an all-n/a comparison comment. This defeats the gate's core promise: *works on every already-open PR with no rebase.*

2. **Rust column fails with `0xC0000135` (#674).** The workflow patches the windows-rs `test_reactor_perf` crate to `as_self_contained()`, which embeds a side-by-side manifest requiring the WinAppSDK runtime DLLs next to the exe at process start — but upstream stages those DLLs with all errors swallowed (`let _ = …`), so a single runner hiccup stages **zero** DLLs while the crate still "Finishes" → every run exits `0xC0000135` (DLL-not-found) → no metrics → n/a column.

## Fix

**(1) Compare-mode harness `.csproj` overlay** — `Build-Harness` in `Run-PerfBenchmark.ps1`. When building a PR tree in compare mode (`$BaselineRoot` set and `$TreeRoot -ne $BaselineRoot`), back up the PR's harness `.csproj`, overlay the trusted baseline copy (which always carries the self-contained block) for the build, then restore the original. The harness `.csproj` is fixed test scaffolding — the build recipe for the StocksGrid workload — **not** the code under measurement: the PR's actual perf change in `src/Reactor/` is still compiled via the harness's relative `ProjectReference` into the PR tree, and the PR's harness *sources* still come from the PR checkout. So the overlay is fair and makes the self-contained build present regardless of PR age, with **no rebase**. It is build-scoped and side-effect-free: the original is restored even if the build (or the overlay copy itself) throws, so a developer's worktree is never left modified and repeated runs are deterministic.

  Scoping note: we deliberately do **not** pass `-p:WindowsAppSDKSelfContained=true` globally on the command line — it would flow into the referenced class libraries (`Reactor.csproj`, `StressPerf.Shared`), which reject self-contained packaging. The csproj scopes the flag to the executable; the overlay preserves that scoping.

**(2) Rust runtime DLL staging (#674)** — new `Stage-RustRuntime` in `Run-PerfBenchmark.ps1`, called from `Invoke-RustLeg` after the crate builds. It explicitly stages the WinAppSDK runtime DLLs next to `test_reactor_perf.exe` (reusing the build-script's own cached runtime nupkg when present, else downloading the pinned `Microsoft.WindowsAppSDK.Runtime` package over HTTPS from nuget.org), so the embedded side-by-side manifest resolves at process start. It verifies a **required set** of DLLs and completeness against the actual MSIX payload (not a single sentinel), so a partial prior stage can't read as "done." Unlike upstream's silent staging, a failure is logged; the Rust leg stays `continue-on-error` (non-blocking for the four C# metrics).

## Review feedback addressed
- **Overlay left the tree modified** → overlay is now build-scoped (backup + restore in `finally`).
- **README overstated provenance** → reworded: in compare mode the PR supplies `src/Reactor/` *and* the harness sources; only the `.csproj` build recipe is normalized from the baseline and restored after the build, so a PR that edits harness sources still has those changes measured.
- **Backup orphaned if the overlay copy throws** → overlay moved inside the try/finally and the backup marker is set only after the backup file exists, so the `finally` always restores and removes it.
- **`Invoke-WebRequest -UseBasicParsing`** → dropped (no-op/compat-only in pwsh 7).
- **Single-sentinel staging check** → `Stage-RustRuntime` now verifies a required DLL set + completeness vs. the MSIX payload (a partial stage no longer faults the loader silently).
- **Rust staging undocumented** → CI README now describes the staging + best-effort `n/a` fallback.

## Review process
Ran the repo's `pr-review` skill (8 dimensions + a multi-model cross-check). Correctness, docs, and test-coverage findings are fixed above + below. Two security findings (no checksum/signature on the runtime download; archive extraction not path-validated) were **downgraded by the multi-model cross-check to medium/low** and accepted as defense-in-depth: the fetch is a **pinned** package over **HTTPS** from the **canonical nuget.org** the whole repo already restores from, on an **ephemeral** `windows-latest` runner, extracted via Windows `tar`/libarchive into fresh temp dirs, feeding only the **non-blocking** Rust column.

## Validation
- `pwsh tests/stress_perf/ci/PerfLib.Tests.ps1` → **61/61**.
- `pwsh tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1` → **16/16** (new committed test, wired into `perf-lib-tests.yml`): overlay only for PR trees in compare mode; never local/baseline; tree restored on build-failure **and** overlay-copy-failure; graceful when the trusted csproj is missing; staging idempotency gate.
- `Stage-RustRuntime` exercised end-to-end (x64 + arm64) out-of-band: stages `microsoft.ui.xaml.dll` + `Microsoft.WindowsAppRuntime.dll`, idempotent.
- `Run-PerfBenchmark.ps1` parses clean; StressPerf ARM64 build OK.

**Final acceptance is a live `/perf` re-run on a pre-gate PR** (e.g. comment `/perf` on #656 after this lands) — a maintainer should run it. Local validation cannot reproduce the `windows-latest` no-runtime environment.

Refs #661, #662. Fixes #674.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>