### PR TITLE
docs: clone to a short path on Windows to avoid MAX_PATH build failures (#678)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,19 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 > **Package version:** All projects reference `Microsoft.WindowsAppSDK` **2.0.1** (public NuGet). The version is centralized in `Directory.Build.props` — update it there to change the version for every project at once.
 
+> **Clone to a short path (Windows):** Clone into a short root directory such as
+> `C:\src\` (for example `C:\src\microsoft-ui-reactor`) rather than a deeply
+> nested or OneDrive-synced folder. The Windows App SDK XAML markup compiler
+> (`XamlCompiler.exe`) and resource indexer (`MakePri.exe`) are 32-bit tools with
+> no long-path support, so when the repository sits on a long path a project's
+> generated `obj`/`bin` output can exceed the Windows 260-character `MAX_PATH`
+> limit and the build fails with errors such as `MSB3073`, `PRI210`, or
+> `APPX0002`. This is most common on ARM64 dev boxes, where these tools run under
+> x86 emulation. Enabling `git config --global core.longpaths true` lets Git
+> itself check out long paths, but the Windows App SDK build tools still require
+> the short checkout path. See
+> [issue #678](https://github.com/microsoft/microsoft-ui-reactor/issues/678).
+
 ---
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ cd MyApp
 dotnet run -p:Platform=x64
 ```
 
+> ⚠️ **Clone to a short path**: Clone into a short root directory such as
+> `C:\src\` (e.g. `C:\src\microsoft-ui-reactor`), not a deeply nested or
+> OneDrive-synced folder. The Windows App SDK's XAML and resource compilers are
+> 32-bit tools with no long-path support, so a long checkout path can push a
+> project's generated `obj`/`bin` output past the Windows 260-character
+> `MAX_PATH` limit and break the build (`MSB3073` / `PRI210`) — most often on
+> ARM64 dev boxes, where those tools run under emulation. See
+> [#678](https://github.com/microsoft/microsoft-ui-reactor/issues/678).
+
 > ⚠️ **Platform flag required**: Always build with an explicit platform:
 > `dotnet build -p:Platform=x64` (or `ARM64`). Omitting `-p:Platform=...`
 > causes `WindowsAppSDKSelfContained` errors. This applies to `dotnet build`,


### PR DESCRIPTION
## Summary

Documents that the repo should be cloned to a **short path** on Windows to avoid `MAX_PATH` build failures. **Docs-only** — no build-configuration or source changes (README.md + CONTRIBUTING.md, +22 lines).

## Background (issue #678)

On Windows, the Windows App SDK's XAML markup compiler (`XamlCompiler.exe`) and resource indexer (`MakePri.exe`) are 32-bit tools with no long-path support. When the repository is cloned to a long path (a deeply nested or OneDrive-synced folder), a project's generated `obj`/`bin` **output** paths can exceed the Windows 260-character `MAX_PATH` limit and the build fails — e.g. `MSB3073` (XAML markup compile) or `PRI210`/`APPX0002` (resource indexer). This is most visible on **ARM64 dev boxes**, where those tools run under x86 emulation, and it reproduces on a pristine `main` checkout (pre-existing; not a regression). It does **not** affect x64 CI or the `/perf` gate, which build from short paths.

## What changed

- **README.md** (Quick start) — a short ⚠️ callout at the `git clone` step.
- **CONTRIBUTING.md** (Prerequisites) — a fuller note with the error signatures and a `core.longpaths` clarification (it lets Git check out long paths, but the WinUI App SDK build tools still require the short checkout path).

## Why docs instead of a build-config change

An earlier revision of this PR redirected each project's `obj`/`bin` to a short `%LOCALAPPDATA%` path on ARM64 hosts. Per maintainer preference that approach was dropped in favor of this documentation note: the failure is a dev-box ergonomics issue (clone location) rather than a product/CI defect, and cloning to a short path avoids it entirely without adding build machinery.

## Validation

Docs-only; no build impact. The guidance is verified empirically — relocating an affected checkout to a short root (e.g. `C:\src\`) makes the same toolchain build successfully on this ARM64 box.

Closes #678.