### PR TITLE
CI: stage WebView2 Core DLL so the /perf Rust column runs (fix #674)

### DIFF
--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -147,10 +147,13 @@ Two tables plus footnotes:
   [`microsoft/windows-rs`](https://github.com/microsoft/windows-rs) `reactor_perf`
   harness (a port of this workload), pinned in CI to a known-good commit. Because
   that harness is built self-contained (its `build.rs` is patched to
-  `windows_reactor_setup::as_self_contained()`), the Windows App SDK runtime DLLs
-  must sit next to `test_reactor_perf.exe` at process start — `Stage-RustRuntime`
-  in `Run-PerfBenchmark.ps1` stages and verifies them explicitly so a silent
-  staging miss can't surface as a `0xC0000135` load failure (issue #674). It is
+  `windows_reactor_setup::as_self_contained()`), the DLLs its embedded
+  `app.manifest` declares must sit next to `test_reactor_perf.exe` at process start —
+  `Stage-RustRuntime` in `Run-PerfBenchmark.ps1` stages and verifies them explicitly:
+  both the Windows App SDK runtime MSIX payload and `Microsoft.Web.WebView2.Core.dll`
+  (a manifest-declared SxS file that ships in the separate `Microsoft.Web.WebView2`
+  package, mirroring upstream `deploy_webview2`), so a silent staging miss can't
+  surface as a `0xC0000135` load failure (issue #674). It is
   best-effort: if the Rust build, staging, or run fails the column reads `n/a` and
   the PR-vs-`main` comparison is unaffected. The WinUI3 column is the local
   `StressPerf.Direct` build.

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -492,7 +492,7 @@ function Stage-RustRuntime {
         } else {
             # List exactly what's missing — MSIX payload files by name plus any required core /
             # SxS file (e.g. the WebView2 Core DLL) — so a partial stage is diagnosable from the log.
-            $missing = @(@($notCopied | ForEach-Object Name) + @($coreMissing) | Where-Object { $_ } | Select-Object -Unique)
+            $missing = @(@($notCopied | ForEach-Object { $_.Name }) + @($coreMissing) | Where-Object { $_ } | Select-Object -Unique)
             Write-Log "  runtime staging incomplete (copied $staged; missing: $($missing -join ', ')) — Rust column may read n/a (#674)" 'Yellow'
         }
     } catch {

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -287,7 +287,9 @@ function Stage-RustRuntime {
        layout: nupkg -> (strip leading dir) -> MSIX\win10-<arch>\...2.msix -> extract
        -> copy the root *.dll / *.pri next to the exe. We copy the full runtime DLL set
        (a superset of the crate's runtime.txt allow-list) so every manifest-referenced
-       file is present. #>
+       file is present. The embedded manifest also declares Microsoft.Web.WebView2.Core.dll,
+       which ships in the SEPARATE Microsoft.Web.WebView2 package (not the runtime MSIX), so we
+       stage it too — mirroring upstream windows_reactor_setup::deploy_webview2. #>
     param([string]$ExeDir, [string]$Platform)
 
     $arch = if ($Platform -match 'arm64') { 'arm64' } else { 'x64' }
@@ -300,7 +302,7 @@ function Stage-RustRuntime {
     # manifest-referenced file has been verified next to the exe — and we still re-check the
     # core set when the marker is present, so an external wipe can't leave a stale marker
     # pointing at a now-broken exe.
-    $required = @('microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll')
+    $required = @('microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll', 'Microsoft.Web.WebView2.Core.dll')
     $sentinel = 'microsoft.ui.xaml.dll'
     $marker = Join-Path $ExeDir '.perfci-runtime-staged'
     if (Test-Path $marker) {
@@ -420,6 +422,51 @@ function Stage-RustRuntime {
             Where-Object { $_.Extension -in '.dll', '.pri' } |
             ForEach-Object { try { Copy-Item -LiteralPath $_.FullName -Destination $ExeDir -Force; $staged++ } catch {} }
 
+        # 5. Stage the WebView2 Core DLL (issue #674). The embedded app.manifest declares
+        #    Microsoft.Web.WebView2.Core.dll as a load-time SxS <file>, but unlike the other
+        #    16 manifest files it does NOT ship in the WinAppSDK runtime MSIX — it lives in the
+        #    SEPARATE Microsoft.Web.WebView2 package. The runtime copy above can never produce
+        #    it, so the loader faults with 0xC0000135 at process start. Mirror upstream
+        #    windows_reactor_setup::deploy_webview2 (reactor-setup/src/lib.rs @ the pinned
+        #    RUST_REF): stage Microsoft.Web.WebView2 <ver> and copy its
+        #    win-<arch>/native_uap/Microsoft.Web.WebView2.Core.dll next to the exe, reusing the
+        #    same shared windows-reactor-setup cache + self-healing (evict truncated nupkg /
+        #    partial extract) as the runtime above.
+        $wpkg = 'Microsoft.Web.WebView2'; $wver = '1.0.4022.49'; $wdll = 'Microsoft.Web.WebView2.Core.dll'
+        $wnupkg = Join-Path $cache "$wpkg.$wver.nupkg"
+        if ((Test-Path $wnupkg) -and (Get-Item $wnupkg).Length -lt 1MB) {
+            Remove-Item $wnupkg -Force -ErrorAction SilentlyContinue
+        }
+        if (-not (Test-Path $wnupkg)) {
+            $wurl = "https://www.nuget.org/api/v2/package/$wpkg/$wver"
+            $wcurl = Join-Path $env:SystemRoot 'System32\curl.exe'
+            Write-Log "  staging WebView2 Core DLL for Rust harness: downloading $wpkg $wver" 'DarkGray'
+            if (Test-Path $wcurl) { & $wcurl -s -L -o $wnupkg $wurl }
+            else { Invoke-WebRequest -Uri $wurl -OutFile $wnupkg }
+        }
+        if ((Test-Path $wnupkg) -and (Get-Item $wnupkg).Length -ge 1MB) {
+            $wextract = Join-Path $cache "$wpkg-$wver"
+            $wsrc = Join-Path $wextract "win-$arch\native_uap\$wdll"
+            if (-not (Test-Path $wsrc)) {
+                # Clear any prior partial extract, then re-extract fresh (strip the leading
+                # package dir, matching upstream stage_pkg's --strip-components=1).
+                if (Test-Path $wextract) { Remove-Item $wextract -Recurse -Force -ErrorAction SilentlyContinue }
+                $null = New-Item -ItemType Directory -Force -Path $wextract -ErrorAction SilentlyContinue
+                & $tar -xf $wnupkg -C $wextract --strip-components=1
+            }
+            if (Test-Path $wsrc) {
+                try { Copy-Item -LiteralPath $wsrc -Destination $ExeDir -Force; $staged++ } catch {}
+            } else {
+                # The package extracted but lacks the expected DLL (corrupt/partial): evict the
+                # nupkg so the next run re-downloads instead of looping on a bad artifact.
+                Remove-Item $wnupkg -Force -ErrorAction SilentlyContinue
+                Write-Log "  WebView2 Core DLL not found in package after extract — Rust column may read n/a (#674)" 'Yellow'
+            }
+        } else {
+            if (Test-Path $wnupkg) { Remove-Item $wnupkg -Force -ErrorAction SilentlyContinue }
+            Write-Log "  WebView2 package unavailable — Rust column may read n/a (#674)" 'Yellow'
+        }
+
         # Verify completeness against the actual MSIX payload for this package version (not
         # just one sentinel): every runtime file we copied (.dll AND .pri) from the MSIX root
         # must now sit next to the exe, and the required core DLL set must be present — so a
@@ -433,7 +480,10 @@ function Stage-RustRuntime {
             Set-Content -LiteralPath $marker -Value (Get-Date -Format o) -ErrorAction SilentlyContinue
             Write-Log "  staged $staged WinAppSDK runtime file(s) next to test_reactor_perf.exe (self-contained)" 'Green'
         } else {
-            Write-Log "  runtime staging incomplete (copied $staged; $($notCopied.Count) file(s) missing) — Rust column may read n/a (#674)" 'Yellow'
+            # List exactly what's missing — MSIX payload files by name plus any required core /
+            # SxS file (e.g. the WebView2 Core DLL) — so a partial stage is diagnosable from the log.
+            $missing = @(@($notCopied | ForEach-Object Name) + @($coreMissing) | Where-Object { $_ } | Select-Object -Unique)
+            Write-Log "  runtime staging incomplete (copied $staged; missing: $($missing -join ', ')) — Rust column may read n/a (#674)" 'Yellow'
         }
     } catch {
         Write-Log "  Rust runtime staging failed ($($_.Exception.Message)) — Rust column may read n/a (#674)" 'Yellow'

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -462,13 +462,15 @@ function Stage-RustRuntime {
             if ($wok -and (Test-Path $wsrc)) {
                 try { Copy-Item -LiteralPath $wsrc -Destination $ExeDir -Force; $staged++ } catch {}
             } else {
-                # The package lacks the expected DLL, or tar failed on a truncated-but->1MB nupkg
-                # (partial/corrupt extract): evict the nupkg AND clear the partial extract so the
-                # next run re-downloads a fresh copy instead of staging a broken Core.dll and
-                # writing the completion marker over it.
+                # Either tar failed on a truncated-but->1MB nupkg (partial/corrupt extract) or the
+                # package extracted cleanly but genuinely lacks the DLL. Either way evict the nupkg
+                # AND clear the partial extract so the next run re-downloads a fresh copy instead of
+                # staging a broken Core.dll and writing the completion marker over it — but log the
+                # two causes distinctly so a tar failure isn't misread as a missing-from-package.
                 Remove-Item $wnupkg -Force -ErrorAction SilentlyContinue
                 Remove-Item $wextract -Recurse -Force -ErrorAction SilentlyContinue
-                Write-Log "  WebView2 Core DLL not staged (missing or corrupt extract) — Rust column may read n/a (#674)" 'Yellow'
+                $wwhy = if (-not $wok) { 'extract failed (tar exit nonzero)' } else { 'DLL absent from package' }
+                Write-Log "  WebView2 Core DLL not staged ($wwhy) — Rust column may read n/a (#674)" 'Yellow'
             }
         } else {
             if (Test-Path $wnupkg) { Remove-Item $wnupkg -Force -ErrorAction SilentlyContinue }
@@ -486,7 +488,7 @@ function Stage-RustRuntime {
             # Completion marker: written only now that staging is fully verified, so a later
             # call can trust it and skip re-staging (a partial stage never reaches here).
             Set-Content -LiteralPath $marker -Value (Get-Date -Format o) -ErrorAction SilentlyContinue
-            Write-Log "  staged $staged WinAppSDK runtime file(s) next to test_reactor_perf.exe (self-contained)" 'Green'
+            Write-Log "  staged $staged self-contained file(s) next to test_reactor_perf.exe (WinAppSDK runtime + WebView2 Core)" 'Green'
         } else {
             # List exactly what's missing — MSIX payload files by name plus any required core /
             # SxS file (e.g. the WebView2 Core DLL) — so a partial stage is diagnosable from the log.

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -447,20 +447,28 @@ function Stage-RustRuntime {
         if ((Test-Path $wnupkg) -and (Get-Item $wnupkg).Length -ge 1MB) {
             $wextract = Join-Path $cache "$wpkg-$wver"
             $wsrc = Join-Path $wextract "win-$arch\native_uap\$wdll"
+            $wok = $true
             if (-not (Test-Path $wsrc)) {
                 # Clear any prior partial extract, then re-extract fresh (strip the leading
                 # package dir, matching upstream stage_pkg's --strip-components=1).
                 if (Test-Path $wextract) { Remove-Item $wextract -Recurse -Force -ErrorAction SilentlyContinue }
                 $null = New-Item -ItemType Directory -Force -Path $wextract -ErrorAction SilentlyContinue
                 & $tar -xf $wnupkg -C $wextract --strip-components=1
+                # A truncated nupkg that still cleared the coarse 1MB gate can make tar emit a
+                # partial/corrupt Core.dll that Test-Path alone would accept. Mirror the
+                # runtime-MSIX guard above: require a clean tar exit before trusting the extract.
+                if ($LASTEXITCODE -ne 0) { $wok = $false }
             }
-            if (Test-Path $wsrc) {
+            if ($wok -and (Test-Path $wsrc)) {
                 try { Copy-Item -LiteralPath $wsrc -Destination $ExeDir -Force; $staged++ } catch {}
             } else {
-                # The package extracted but lacks the expected DLL (corrupt/partial): evict the
-                # nupkg so the next run re-downloads instead of looping on a bad artifact.
+                # The package lacks the expected DLL, or tar failed on a truncated-but->1MB nupkg
+                # (partial/corrupt extract): evict the nupkg AND clear the partial extract so the
+                # next run re-downloads a fresh copy instead of staging a broken Core.dll and
+                # writing the completion marker over it.
                 Remove-Item $wnupkg -Force -ErrorAction SilentlyContinue
-                Write-Log "  WebView2 Core DLL not found in package after extract — Rust column may read n/a (#674)" 'Yellow'
+                Remove-Item $wextract -Recurse -Force -ErrorAction SilentlyContinue
+                Write-Log "  WebView2 Core DLL not staged (missing or corrupt extract) — Rust column may read n/a (#674)" 'Yellow'
             }
         } else {
             if (Test-Path $wnupkg) { Remove-Item $wnupkg -Force -ErrorAction SilentlyContinue }

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -153,7 +153,7 @@ $exeDir = Join-Path ([IO.Path]::GetTempPath()) 'perfci-rust-exedir'
 if (Test-Path $exeDir) { Remove-Item $exeDir -Recurse -Force }
 $null = New-Item -ItemType Directory -Force $exeDir | Out-Null
 Set-Content -LiteralPath (Join-Path $exeDir '.perfci-runtime-staged') -Value 'x' -NoNewline
-foreach ($f in 'microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll') {
+foreach ($f in 'microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll', 'Microsoft.Web.WebView2.Core.dll') {
     Set-Content -LiteralPath (Join-Path $exeDir $f) -Value 'x' -NoNewline
 }
 $global:LogLines.Clear()
@@ -196,6 +196,28 @@ Assert-True (@($global:LogLines | Where-Object { $_ -match 'already staged' }).C
 Assert-True (-not (Test-Path $marker3)) `
     '[stage] stale marker (core DLLs missing) -> marker deleted before restage'
 Remove-Item $exeDir3 -Recurse -Force -ErrorAction SilentlyContinue
+
+# (4) marker + the WinAppSDK core DLLs present but the WebView2 Core DLL MISSING -> the stage
+# is incomplete (WebView2 is a manifest-required SxS file that ships in a SEPARATE package), so
+# the gate must treat the marker as stale, drop it, and NOT early-return. Force the tar probe to
+# miss so it bails network-free right after the gate.
+$exeDir4 = Join-Path ([IO.Path]::GetTempPath()) 'perfci-rust-exedir4'
+if (Test-Path $exeDir4) { Remove-Item $exeDir4 -Recurse -Force }
+$null = New-Item -ItemType Directory -Force $exeDir4 | Out-Null
+$marker4 = Join-Path $exeDir4 '.perfci-runtime-staged'
+Set-Content -LiteralPath $marker4 -Value 'x' -NoNewline
+foreach ($f in 'microsoft.ui.xaml.dll', 'Microsoft.WindowsAppRuntime.dll') {
+    Set-Content -LiteralPath (Join-Path $exeDir4 $f) -Value 'x' -NoNewline
+}
+$savedSysRoot = $env:SystemRoot
+$env:SystemRoot = [IO.Path]::GetTempPath()
+$global:LogLines.Clear()
+try { Stage-RustRuntime -ExeDir $exeDir4 -Platform 'x64' } finally { $env:SystemRoot = $savedSysRoot }
+Assert-True (@($global:LogLines | Where-Object { $_ -match 'already staged' }).Count -eq 0) `
+    '[stage] WebView2 Core DLL missing -> does NOT early-return (WebView2 is required)'
+Assert-True (-not (Test-Path $marker4)) `
+    '[stage] WebView2 Core DLL missing -> stale marker dropped before restage'
+Remove-Item $exeDir4 -Recurse -Force -ErrorAction SilentlyContinue
 
 # cleanup
 foreach ($d in @($baseTree, $prTree, $OutDir, $exeDir)) {


### PR DESCRIPTION
## Problem

The `/perf` Rust cross-framework column reads **n/a** even though the crate builds fine. On the live re-run that validated the merged gate fix (#677), the C# legs all computed but the Rust column was still empty:

- Live comment: [`/perf` on PR #656](https://github.com/microsoft/microsoft-ui-reactor/pull/656#issuecomment-4804542412) — Rust column = `n/a`.
- [Run 28211304020](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/28211304020): `test_reactor_perf` reports `Finished release`, then every run exits `0xC0000135` (`STATUS_DLL_NOT_FOUND`) instantly with 0-byte stdout/stderr.

This is issue #674.

## Root cause

The workflow patches the harness `build.rs` to `windows_reactor_setup::as_self_contained()`, which **embeds an `app.manifest`** declaring **17 load-time side-by-side `<asmv3:file>` dependencies**. The Windows loader resolves every manifest `<file>` from the activation context at *process start* — a single missing one faults with `0xC0000135` before any app code runs (hence the instant exit + empty output).

`Stage-RustRuntime` already copies the WinAppSDK runtime DLLs from the runtime MSIX, which covers **16 of the 17**. The 17th — **`Microsoft.Web.WebView2.Core.dll`** — does **not** ship in the WinAppSDK runtime MSIX; it lives in the **separate `Microsoft.Web.WebView2` NuGet package**. Upstream stages it via `deploy_webview2()`; our PowerShell backstop never fetched it.

Proven offline against the pinned `RUST_REF` (`ef02ee6f…`): diffing the 17 manifest `<file>` names against the staged set leaves exactly one gap — `Microsoft.Web.WebView2.Core.dll`.

## Fix

Port upstream `windows_reactor_setup::deploy_webview2` (`crates/libs/reactor-setup/src/lib.rs` @ the pinned `RUST_REF`) into `Stage-RustRuntime`:

- Download `Microsoft.Web.WebView2` **1.0.4022.49** (upstream's pinned `WEBVIEW2_VER`) into the shared `windows-reactor-setup` cache.
- Extract (`--strip-components=1`, matching upstream `stage_pkg`) and copy `win-<arch>/native_uap/Microsoft.Web.WebView2.Core.dll` next to `test_reactor_perf.exe`.
- Reuse the same evict-on-truncated / clear-partial-extract self-healing as the runtime staging.
- Add the WebView2 Core DLL to the `$required` set, so the completion marker is only written (and only trusted on the idempotent early-return) once it is present — a pre-fix warm cache is detected as stale and re-staged.

### Why it's safe

- CI/build-script + docs only — no framework runtime code.
- The Rust leg is `continue-on-error` / non-blocking: the four C# target metrics (PR vs `main`) compute regardless, so this lands after #677 with no risk to the gate.
- It mirrors the upstream-supported self-contained recipe exactly, so the staged DLL set matches what the embedded manifest expects.

## Validation

- `RunPerfBenchmark.Tests.ps1`: **21/21** (added a test asserting a missing WebView2 Core DLL invalidates the completion marker), under both `-File` and dot-source.
- `PerfLib.Tests.ps1`: **61/61**, both invocations.
- Offline download/extract/copy repro: `Microsoft.Web.WebView2.Core.dll` (855,944 bytes, x64) lands next to the exe; warm-cache re-run does not re-download.

**Final acceptance** is a live `/perf` re-run on a PR (e.g. comment `/perf` on #656) by a maintainer — confirm the Rust column populates instead of `n/a`.

Refs #661, #662, #674; follows up merged #677.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
