### PR TITLE
CI: skip framework-dependent bootstrapper in self-contained /perf Rust harness (fix #674 0xC0000135)

### DIFF
--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -163,6 +163,30 @@ jobs:
           # as_self_contained() is the upstream-supported, benchmark-neutral setup
           # used by the windows-rs reactor samples (see docs/crates/windows-reactor-setup.md).
           Set-Content -LiteralPath $buildRs -Value 'fn main() { windows_reactor_setup::as_self_contained(); }' -Encoding UTF8
+          # The harness main() unconditionally calls bootstrap() (MddBootstrapInitialize2)
+          # to locate a *machine-wide* WinAppSDK runtime. as_self_contained() never stages
+          # the framework-dependent bootstrapper, so on the runtime-less runner the exe
+          # carries an unsatisfiable load-time import -> 0xC0000135 (DLL-not-found), exits
+          # instantly with 0-byte output, and the watchdog reports n/a. (Even if the
+          # bootstrap DLL were staged, MddBootstrapInitialize2 fail-fasts headless with no
+          # machine-wide package -> 0xC0000602.) Self-contained apps don't need it: the
+          # embedded reg-free manifest activates the runtime app-local. Neutralize the one
+          # call so the self-contained harness launches. Benchmark-neutral (it only changes
+          # runtime discovery, not the measured StockGrid workload) and best-effort: warn,
+          # don't fail, if upstream ever drops the line.
+          $mainRs = Join-Path $dir 'crates/tests/libs/reactor_perf/src/main.rs'
+          if (Test-Path $mainRs) {
+            $src = Get-Content -LiteralPath $mainRs -Raw
+            $patched = [regex]::Replace($src, '(?m)^(?<indent>[ \t]*)bootstrap\(\)\?;', '${indent}// bootstrap()?; // perf CI self-contained: reg-free manifest provides the runtime app-local; the framework-dependent bootstrapper is not staged and would fail with no machine-wide WinAppSDK runtime')
+            if ($patched -ne $src) {
+              Set-Content -LiteralPath $mainRs -Value $patched -Encoding UTF8 -NoNewline
+              Write-Host "Patched main.rs: neutralized bootstrap() for the self-contained run"
+            } else {
+              Write-Warning "main.rs: bootstrap() call not found (upstream may have changed) - Rust column may read n/a"
+            }
+          } else {
+            Write-Warning "reactor_perf/src/main.rs missing in windows-rs@$env:RUST_REF - Rust column may read n/a"
+          }
           "rust_repo=$dir" | Out-File $env:GITHUB_OUTPUT -Append
           Write-Host "Rust harness ready at $dir"
 

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -146,16 +146,27 @@ Two tables plus footnotes:
   same runner**. The Rust column builds and runs the
   [`microsoft/windows-rs`](https://github.com/microsoft/windows-rs) `reactor_perf`
   harness (a port of this workload), pinned in CI to a known-good commit. Because
-  that harness is built self-contained (its `build.rs` is patched to
-  `windows_reactor_setup::as_self_contained()`), the DLLs its embedded
-  `app.manifest` declares must sit next to `test_reactor_perf.exe` at process start —
-  `Stage-RustRuntime` in `Run-PerfBenchmark.ps1` stages and verifies them explicitly:
-  both the Windows App SDK runtime MSIX payload and `Microsoft.Web.WebView2.Core.dll`
-  (a manifest-declared SxS file that ships in the separate `Microsoft.Web.WebView2`
-  package, mirroring upstream `deploy_webview2`), so a silent staging miss can't
-  surface as a `0xC0000135` load failure (issue #674). It is
-  best-effort: if the Rust build, staging, or run fails the column reads `n/a` and
-  the PR-vs-`main` comparison is unaffected. The WinUI3 column is the local
+  that harness is built self-contained, two things are patched into the pinned
+  checkout before it builds: its `build.rs` is set to
+  `windows_reactor_setup::as_self_contained()`, and the single `bootstrap()` call
+  in its `main()` is commented out. The second patch matters as much as the first:
+  the harness `main()` otherwise calls the framework-dependent Windows App SDK
+  bootstrapper (`MddBootstrapInitialize2`) to locate a *machine-wide* runtime —
+  which a self-contained app neither needs nor finds on the runtime-less runner.
+  That call adds an unsatisfiable load-time import on
+  `Microsoft.WindowsAppRuntime.Bootstrap.dll` (which `as_self_contained()` does not
+  stage), so the exe dies at load with `0xC0000135` (DLL-not-found) and 0-byte
+  output — exactly the failure first seen in issue #674. (Even if that DLL were
+  staged, the bootstrapper fail-fasts headless with no machine-wide package —
+  `0xC0000602`.) Dropping the call removes the import; the embedded `app.manifest`
+  then activates the runtime app-local (reg-free). The DLLs that manifest declares
+  must still sit next to `test_reactor_perf.exe` at process start, so
+  `Stage-RustRuntime` in `Run-PerfBenchmark.ps1` stages and verifies them
+  explicitly: both the Windows App SDK runtime MSIX payload and
+  `Microsoft.Web.WebView2.Core.dll` (a manifest-declared SxS file that ships in the
+  separate `Microsoft.Web.WebView2` package, mirroring upstream `deploy_webview2`).
+  It is best-effort: if the Rust build, staging, or run fails the column reads `n/a`
+  and the PR-vs-`main` comparison is unaffected. The WinUI3 column is the local
   `StressPerf.Direct` build.
 
 ## Variance: trust the delta, not the absolutes
@@ -203,4 +214,13 @@ For the steadiest local numbers: close other apps, stay on AC power, and bump
   RID folder (`bin\<arch>\Release\<tfm>\win-<arch>\`); the script finds it
   recursively. If it is genuinely missing, check the `out/build-*.log` for the
   real `dotnet` error.
+- **Rust column reads `n/a` with the harness exiting `0xC0000135`.** The
+  self-contained `test_reactor_perf.exe` must not import the framework-dependent
+  Windows App SDK bootstrapper. The workflow patches the harness `main()` to skip
+  its `bootstrap()` call (alongside the `build.rs` → `as_self_contained()` patch);
+  if upstream `windows-rs` moves that call and the patch's regex stops matching,
+  the bootstrapper's load-time import on `Microsoft.WindowsAppRuntime.Bootstrap.dll`
+  returns — and on the runtime-less runner the loader fails with `0xC0000135`. The
+  "Prepare Rust harness" step logs a warning when the `main()` patch finds no match;
+  re-point the regex at the relocated call. See issue #674.
 - **Scripts won't parse.** Use `pwsh` (PowerShell 7+), not `powershell.exe` 5.1.


### PR DESCRIPTION
## Summary

The on-demand `/perf` workflow's cross-framework **Rust column still read `n/a`**, with `test_reactor_perf.exe` exiting `0xC0000135` (DLL-not-found) at launch — even after the self-contained build (#662) and WebView2 Core staging (#689) fixes. This PR fixes the remaining root cause so the Rust column produces live numbers.

This is **CI/build-script + docs only** — no framework runtime code is touched.

## Root cause (reproduced locally, hermetically)

I reproduced the runner failure on a local box with `PATH` scrubbed to `System32` only (so a machine-wide Windows App SDK runtime cannot mask missing app-local DLLs), mirroring the GitHub `windows-latest` runner which has no machine-wide WinAppSDK runtime:

- The windows-rs `reactor_perf` harness `main()` **unconditionally calls `bootstrap()`** (`MddBootstrapInitialize2`) to locate a **machine-wide** Windows App SDK runtime.
- `windows_reactor_setup::as_self_contained()` (which the workflow already patches `build.rs` to call) **never stages the framework-dependent bootstrapper** — only `as_framework_dependent` calls `copy_bootstrap_to`.
- So the self-contained exe carries an **unsatisfiable load-time PE import** on `Microsoft.WindowsAppRuntime.Bootstrap.dll` (confirmed with `dumpbin /imports`). On the runtime-less runner the loader fails **before `main` runs** → `0xC0000135`, instant exit, 0-byte stdout/stderr → the 100s watchdog reports `n/a`.
- **Second layer:** even if that DLL is staged, `MddBootstrapInitialize2(..., OnNoMatch_ShowUI | ...)` looks for a machine-wide framework package and **fail-fasts headless** (`0xC0000602`) when none is present. So staging the DLL is *necessary-but-insufficient* — the bootstrap **call** itself must be neutralized. (This is why #689's staging alone didn't fix it.)

`MddBootstrapInitialize2`'s own documentation: *"Self-contained apps do not need to call this."* The harness's embedded reg-free `app.manifest` activates the runtime app-local.

## The fix

In the workflow's **"Prepare Rust harness"** step, alongside the existing `build.rs` → `as_self_contained()` patch, comment out the single `bootstrap()?;` call in the cloned harness `main.rs`:

```powershell
$patched = [regex]::Replace($src, '(?m)^(?<indent>[ \t]*)bootstrap\(\)\?;', '${indent}// bootstrap()?; // ...')
```

**Why it's safe:**
- **Benchmark-neutral.** `main()`'s `bootstrap()` is deployment-mode setup (runtime *discovery*), not the measured StocksGrid workload. Removing it is directly analogous to the existing `build.rs` `as_self_contained()` patch and does not affect the four target metrics.
- **Best-effort.** If upstream ever moves the call so the regex stops matching, the step logs a warning and the column reads `n/a` — it never fails the job, and the PR-vs-`main` **C# comparison is entirely unaffected** (the Rust leg is `continue-on-error`).
- **`Stage-RustRuntime` is unchanged** — the runtime MSIX payload + `Microsoft.Web.WebView2.Core.dll` (manifest-declared SxS) are still staged app-local; this fix removes the *need* for the bootstrapper, it doesn't change staging.

## Local verification

Applying the **exact** workflow patches (`build.rs` + `main.rs` regex) to the pinned `windows-rs` checkout, rebuilding, and running hermetically:

- ✅ `dumpbin` confirms the `Microsoft.WindowsAppRuntime.Bootstrap.dll` import is **gone** from the rebuilt exe.
- ✅ Hermetic, `PATH`-scrubbed run → **exit 0 with full metrics** (Renders/sec, Reconcile, Diff, Memory).
- ✅ Loaded-module snapshot: all WinAppSDK DLLs resolve from the **app-local staging dir** (zero from `C:\Program Files\WindowsApps`) — proving the fix is genuinely runtime-independent, not masked by my box's installed runtime.
- ✅ Regex unit-validated: matches exactly one call site, preserves indentation, idempotent, leaves no bare `bootstrap()?;`.

I also confirmed the **before** state: the unpatched exit is `0xC0000135` (matching the runner), and the DLL-staged-but-call-present exit is `0xC0000602` (the fail-fast), exactly as the root-cause analysis predicts.

## Validation run locally

- `tests/stress_perf/ci/PerfLib.Tests.ps1` → **61/61** ✅
- `tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1` → **21/21** ✅
- Workflow YAML parses ✅; the step's embedded PowerShell AST parses with **0 errors** ✅

> Note: the local `dotnet build Reactor.slnx -c Release` surfaces a pre-existing, unrelated ARM64-dev-box XAML markup-compiler failure (issue #678, fixed by the separate open PR #684 — `XamlCompiler.exe` MSB3073 on long paths). It does not occur on x64 `windows-latest` CI runners and is independent of this YAML+docs change (neither file is an MSBuild compiler input).

## Final acceptance test

This can only be **fully** validated by a **live `/perf` re-run on a pre-gate PR** (e.g. comment `/perf` on #656). A maintainer should run that as the final acceptance step; the local hermetic repro + module-path proof above are the strongest evidence achievable off-runner.

## Refs

- Fixes the `0xC0000135` symptom tracked in #674 (auto-closed by #689, but the bug persisted on the live re-run).
- Builds on #662 (self-contained harness), #677 (csproj overlay), #689 (WebView2 Core staging).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>