### PR TITLE
perf(/perf): allocation metric + paired-CI statistics for perf-compare

### DIFF
--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -216,7 +216,7 @@ jobs:
           ./tests/stress_perf/ci/Run-PerfBenchmark.ps1 `
             -Root $env:PR_TREE `
             -BaselineRoot $env:GITHUB_WORKSPACE `
-            -Percent 50 -Duration 10 -Reps 2 -Warmup 1 `
+            -Percent 50 -Duration 10 -Reps 12 -Warmup 2 -PinAffinity `
             -RustRepo "$env:RUST_REPO" `
             -DefenderExclude `
             -HeadSha $env:HEAD_SHA `

--- a/tests/stress_perf/METHODOLOGY.md
+++ b/tests/stress_perf/METHODOLOGY.md
@@ -192,6 +192,34 @@ delta from the loaded run is per-content cost. The published baseline
 report's RN row mostly reflects engine-baseline — note that explicitly
 when comparing.
 
+## Allocation: `Alloc/render` + Gen0/1/2 (C# variants)
+
+Each C# `PerfTracker` also brackets the measured render loop with
+`GC.GetTotalAllocatedBytes()` and `GC.CollectionCount(0/1/2)`, snapshotted on the
+first render (so process-startup allocations are excluded) and read again at
+report time. Every `*.report.txt` now carries three extra lines:
+
+```
+Alloc/render: <managed bytes allocated per render>
+GC Gen0/1/2: <gen0> / <gen1> / <gen2>      (collections during the run)
+Gen0/Krender: <gen0 collections per 1,000 renders>
+```
+
+These are the **sensitive signal for allocation-reduction work**: the mean-ms and
+working-set figures barely move when a PR removes per-render allocations, but
+`Alloc/render` and `Gen0/Krender` track it directly. The `/perf` CI harness
+parses these and reports a Reactor `main`-vs-PR allocation table with the same
+paired 95%-CI gating as the timing metrics — see
+[`ci/README.md`](ci/README.md#the-comment). They are C#-only (no Rust/RN
+equivalent is collected) and absent in a harness built before the metric landed.
+
+> **Statistical gating note.** The `/perf` comparison reports the **median of 12
+> paired runs** per side and flags a metric as a win/regression only when the
+> **95% confidence interval of the paired delta excludes 0** — not a fixed
+> percentage floor. A 2-run median cannot resolve the ~1–3% deltas these PRs
+> target; its run-to-run swing is larger than the effect. Full rationale in
+> [`ci/README.md`](ci/README.md#variance-trust-the-delta-not-the-absolutes).
+
 ## Don'ts (so we don't redo this analysis)
 
 1. **Don't trust `CompositionTarget.Rendering` for "FPS."** It's UI-thread-

--- a/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
+++ b/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
@@ -40,6 +40,19 @@ public sealed class PerfTracker
     private int _startGen1;
     private int _startGen2;
 
+    // End snapshot of the cumulative GC counters, frozen exactly once — the first
+    // time a report/JSON is produced or an allocation property is read — and
+    // BEFORE any report-string building. Because GetTotalAllocatedBytes/
+    // CollectionCount are process-wide cumulative counters, freezing them up front
+    // keeps allocations from report/JSON generation itself out of the measured
+    // window and guarantees report.txt and metrics.json report identical figures.
+    private bool _allocEndCaptured;
+    private long _endAllocBytes;
+    private int _endGen0;
+    private int _endGen1;
+    private int _endGen2;
+    private int _endRenderCount;
+
     public double CurrentFps => _currentFps;
     public double LastUpdateMs => _lastUpdateMs;
     public long CurrentMemoryMB => Process.GetCurrentProcess().WorkingSet64 / (1024 * 1024);
@@ -101,6 +114,31 @@ public sealed class PerfTracker
         _renderCount++;
     }
 
+    /// <summary>
+    /// Freeze the end-of-measurement allocation/GC counters exactly once, before
+    /// any report or JSON string is built. Idempotent: the first call wins, so
+    /// every consumer (report.txt, metrics.json, direct property reads) sees the
+    /// same numbers and string-building allocations never leak into the window.
+    /// No-op until the first render has set the baseline.
+    /// </summary>
+    private void CaptureFinalSnapshot()
+    {
+        if (_allocEndCaptured || !_allocBaselineCaptured) return;
+        _endAllocBytes = GC.GetTotalAllocatedBytes();
+        _endGen0 = GC.CollectionCount(0);
+        _endGen1 = GC.CollectionCount(1);
+        _endGen2 = GC.CollectionCount(2);
+        _endRenderCount = _renderCount;
+        _allocEndCaptured = true;
+    }
+
+    // Renders fully inside the allocation window. The baseline is captured during
+    // the FIRST RecordRender, so that render's own allocations sit in the baseline
+    // and only renders 2..N contribute to the measured delta. Normalising the
+    // delta by (N-1) keeps numerator and denominator over the same window and
+    // avoids a small systematic downward bias.
+    private int AllocWindowRenders => _allocEndCaptured ? Math.Max(0, _endRenderCount - 1) : 0;
+
     public int TotalRenders => _renderCount;
 
     /// <summary>
@@ -121,6 +159,10 @@ public sealed class PerfTracker
     public string GetReport(string appName, double percent)
     {
         if (_fpsSamples.Count == 0) return "No data collected.";
+
+        // Freeze the allocation/GC end-counters before building any report string
+        // so report generation's own allocations never enter the measured window.
+        CaptureFinalSnapshot();
 
         var sb = new StringBuilder();
         sb.AppendLine($"=== {appName} ===");
@@ -216,27 +258,41 @@ public sealed class PerfTracker
     /// Mean managed bytes allocated per recorded render across the measurement
     /// window (first render → report time), or 0. Lower is better. This is the
     /// metric allocation-reduction PRs move directly; the mean-ms and working-set
-    /// figures are largely insensitive to allocation churn. See METHODOLOGY.md.
+    /// figures are largely insensitive to allocation churn. Reads the frozen
+    /// end-snapshot and normalises by renders-since-baseline. See METHODOLOGY.md.
     /// </summary>
-    public double AllocBytesPerRender =>
-        _allocBaselineCaptured && _renderCount > 0
-            ? (GC.GetTotalAllocatedBytes() - _startAllocBytes) / (double)_renderCount
-            : 0.0;
+    public double AllocBytesPerRender
+    {
+        get
+        {
+            CaptureFinalSnapshot();
+            int n = AllocWindowRenders;
+            return n > 0 ? (_endAllocBytes - _startAllocBytes) / (double)n : 0.0;
+        }
+    }
 
     /// <summary>Gen0 garbage collections during the measurement window, or 0.</summary>
-    public int Gen0Collections => _allocBaselineCaptured ? GC.CollectionCount(0) - _startGen0 : 0;
+    public int Gen0Collections { get { CaptureFinalSnapshot(); return _allocEndCaptured ? _endGen0 - _startGen0 : 0; } }
 
     /// <summary>Gen1 garbage collections during the measurement window, or 0.</summary>
-    public int Gen1Collections => _allocBaselineCaptured ? GC.CollectionCount(1) - _startGen1 : 0;
+    public int Gen1Collections { get { CaptureFinalSnapshot(); return _allocEndCaptured ? _endGen1 - _startGen1 : 0; } }
 
     /// <summary>Gen2 garbage collections during the measurement window, or 0.</summary>
-    public int Gen2Collections => _allocBaselineCaptured ? GC.CollectionCount(2) - _startGen2 : 0;
+    public int Gen2Collections { get { CaptureFinalSnapshot(); return _allocEndCaptured ? _endGen2 - _startGen2 : 0; } }
 
     /// <summary>
     /// Gen0 collections per 1,000 renders (render-rate-normalised so it is
     /// comparable across runs of differing length), or 0. Lower is better.
+    /// Normalised by renders-since-baseline to match the collection window.
     /// </summary>
-    public double Gen0PerKRenders => _renderCount > 0 ? Gen0Collections * 1000.0 / _renderCount : 0.0;
+    public double Gen0PerKRenders
+    {
+        get
+        {
+            int n = AllocWindowRenders;
+            return n > 0 ? Gen0Collections * 1000.0 / n : 0.0;
+        }
+    }
 
     /// <summary>
     /// Compact, single-line, culture-invariant JSON with the four headline
@@ -269,6 +325,10 @@ public sealed class PerfTracker
             }
             return b.ToString();
         }
+        // Freeze the allocation/GC end-counters before building the JSON so the
+        // payload's own allocations never enter the measured window (and so this
+        // matches report.txt exactly when both are written).
+        CaptureFinalSnapshot();
         var sb = new StringBuilder();
         sb.Append('{');
         sb.Append("\"app\":\"").Append(J(appName)).Append("\",");

--- a/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
+++ b/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
@@ -26,6 +26,20 @@ public sealed class PerfTracker
     // increment when the reconcile completes via RecordPhases.
     private int _renderCount;
 
+    // Managed-allocation accounting for the render loop. The baseline is captured
+    // lazily on the FIRST recorded render (see RecordRender) so app-startup
+    // allocations (XAML load, first layout) are excluded and we measure the
+    // steady-state per-render cost. These are process-wide cumulative counters
+    // (GC.GetTotalAllocatedBytes / GC.CollectionCount) — AOT/trim-safe and
+    // require no changes to the Reactor host being measured. Allocation-reduction
+    // PRs move these directly, while the mean-ms / working-set metrics are largely
+    // blind to them. See METHODOLOGY.md.
+    private bool _allocBaselineCaptured;
+    private long _startAllocBytes;
+    private int _startGen0;
+    private int _startGen1;
+    private int _startGen2;
+
     public double CurrentFps => _currentFps;
     public double LastUpdateMs => _lastUpdateMs;
     public long CurrentMemoryMB => Process.GetCurrentProcess().WorkingSet64 / (1024 * 1024);
@@ -71,7 +85,21 @@ public sealed class PerfTracker
     /// <see cref="RecordPhases"/> fires from the reconcile-complete callback.
     /// See METHODOLOGY.md.
     /// </summary>
-    public void RecordRender() => _renderCount++;
+    public void RecordRender()
+    {
+        // Capture the allocation baseline on the first render so per-render
+        // allocation figures reflect the steady-state render loop, not one-time
+        // app startup. Cheap, AOT-safe, and identical for every variant.
+        if (!_allocBaselineCaptured)
+        {
+            _allocBaselineCaptured = true;
+            _startAllocBytes = GC.GetTotalAllocatedBytes();
+            _startGen0 = GC.CollectionCount(0);
+            _startGen1 = GC.CollectionCount(1);
+            _startGen2 = GC.CollectionCount(2);
+        }
+        _renderCount++;
+    }
 
     public int TotalRenders => _renderCount;
 
@@ -130,6 +158,12 @@ public sealed class PerfTracker
         }
         sb.AppendLine($"Avg Memory:  {_memorySamples.Average() / (1024 * 1024):F1} MB");
         sb.AppendLine($"Peak Memory: {_memorySamples.Max() / (1024 * 1024):F1} MB");
+        // Allocation accounting (steady-state render loop; baseline = first render).
+        // Lower is better. The mean-ms / working-set metrics above are largely blind
+        // to allocation-reduction changes, so these are the sensitive signal for them.
+        sb.AppendLine($"Alloc/render: {AllocBytesPerRender:F0} bytes");
+        sb.AppendLine($"GC Gen0/1/2: {Gen0Collections} / {Gen1Collections} / {Gen2Collections}");
+        sb.AppendLine($"Gen0/Krender: {Gen0PerKRenders:F2}");
         return sb.ToString();
     }
 
@@ -179,6 +213,32 @@ public sealed class PerfTracker
     public double RendersPerSec => ElapsedSeconds > 0 ? _renderCount / ElapsedSeconds : 0.0;
 
     /// <summary>
+    /// Mean managed bytes allocated per recorded render across the measurement
+    /// window (first render → report time), or 0. Lower is better. This is the
+    /// metric allocation-reduction PRs move directly; the mean-ms and working-set
+    /// figures are largely insensitive to allocation churn. See METHODOLOGY.md.
+    /// </summary>
+    public double AllocBytesPerRender =>
+        _allocBaselineCaptured && _renderCount > 0
+            ? (GC.GetTotalAllocatedBytes() - _startAllocBytes) / (double)_renderCount
+            : 0.0;
+
+    /// <summary>Gen0 garbage collections during the measurement window, or 0.</summary>
+    public int Gen0Collections => _allocBaselineCaptured ? GC.CollectionCount(0) - _startGen0 : 0;
+
+    /// <summary>Gen1 garbage collections during the measurement window, or 0.</summary>
+    public int Gen1Collections => _allocBaselineCaptured ? GC.CollectionCount(1) - _startGen1 : 0;
+
+    /// <summary>Gen2 garbage collections during the measurement window, or 0.</summary>
+    public int Gen2Collections => _allocBaselineCaptured ? GC.CollectionCount(2) - _startGen2 : 0;
+
+    /// <summary>
+    /// Gen0 collections per 1,000 renders (render-rate-normalised so it is
+    /// comparable across runs of differing length), or 0. Lower is better.
+    /// </summary>
+    public double Gen0PerKRenders => _renderCount > 0 ? Gen0Collections * 1000.0 / _renderCount : 0.0;
+
+    /// <summary>
     /// Compact, single-line, culture-invariant JSON with the four headline
     /// metrics plus context. Built by hand (no serializer) to stay trivially
     /// AOT/trim-safe for this PublishAot harness.
@@ -219,6 +279,11 @@ public sealed class PerfTracker
         sb.Append("\"avgReconcileMs\":").Append(F(AvgReconcileMs)).Append(',');
         sb.Append("\"avgDiffMs\":").Append(F(AvgDiffMs)).Append(',');
         sb.Append("\"avgMemoryMB\":").Append(F(AvgMemoryMB)).Append(',');
+        sb.Append("\"allocBytesPerRender\":").Append(F(AllocBytesPerRender)).Append(',');
+        sb.Append("\"gen0\":").Append(Gen0Collections.ToString(CultureInfo.InvariantCulture)).Append(',');
+        sb.Append("\"gen1\":").Append(Gen1Collections.ToString(CultureInfo.InvariantCulture)).Append(',');
+        sb.Append("\"gen2\":").Append(Gen2Collections.ToString(CultureInfo.InvariantCulture)).Append(',');
+        sb.Append("\"gen0PerKRenders\":").Append(F(Gen0PerKRenders)).Append(',');
         sb.Append("\"avgFps\":").Append(F(_fpsSamples.Count > 0 ? _fpsSamples.Average() : 0.0)).Append(',');
         sb.Append("\"sampleCount\":").Append(_fpsSamples.Count.ToString(CultureInfo.InvariantCulture));
         sb.Append('}');

--- a/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
+++ b/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
@@ -289,6 +289,7 @@ public sealed class PerfTracker
     {
         get
         {
+            CaptureFinalSnapshot();
             int n = AllocWindowRenders;
             return n > 0 ? Gen0Collections * 1000.0 / n : 0.0;
         }

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -229,8 +229,156 @@ $noRust = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -Cont
 Assert-Match $noRust 'Not run'  'rust footnote = not run when null'
 Assert-Match $noRust 'n/a'      'n/a cells rendered when winui3 + rust null'
 
-# ── Summary ──────────────────────────────────────────────────────────────────
-Write-Host ""
+# ── Get-StudentTCritical (95% two-sided t-table) ─────────────────────────────
+Assert-Equal 12.706 (Get-StudentTCritical -Df 1)  't critical df=1'
+Assert-Equal 2.201  (Get-StudentTCritical -Df 11) 't critical df=11'
+Assert-Equal 2.042  (Get-StudentTCritical -Df 30) 't critical df=30 (table edge)'
+Assert-Equal 2.0    (Get-StudentTCritical -Df 45) 't critical df 31..60 -> 2.000'
+Assert-Equal 1.98   (Get-StudentTCritical -Df 90) 't critical df 61..120 -> 1.980'
+Assert-Equal 1.96   (Get-StudentTCritical -Df 500) 't critical df>120 -> 1.960 (z)'
+Assert-True ([double]::IsNaN((Get-StudentTCritical -Df 0))) 't critical df<1 -> NaN'
+
+# ── Get-PerfPairedDeltaStats (paired CI over per-iteration deltas) ────────────
+# A clear, low-variance ~5% reduction: the 95% CI must exclude 0.
+$bImp = @(100, 102, 98, 101, 99, 100, 103, 97, 99, 101)
+$cImp = @(95,  96,  93, 95,  94, 95,  97,  92, 94, 96)
+$sImp = Get-PerfPairedDeltaStats -BaselineSamples $bImp -CandidateSamples $cImp
+Assert-Equal 10 $sImp.N                          'paired N = 10 valid pairs'
+Assert-True ($sImp.MeanPct -lt 0)                'paired mean delta is negative (improvement)'
+Assert-True ($sImp.CiHighPct -lt 0)              'paired improvement CI excludes 0 (high < 0)'
+
+# Pure jitter around the baseline: the CI must straddle 0.
+$bN = @(100, 102, 98, 101, 99, 100, 103, 97, 99, 101)
+$cN = @(101, 99, 100, 98, 102, 99, 101, 100, 98, 102)
+$sN = Get-PerfPairedDeltaStats -BaselineSamples $bN -CandidateSamples $cN
+Assert-True (($sN.CiLowPct -lt 0) -and ($sN.CiHighPct -gt 0)) 'noise CI includes 0'
+
+# Nulls (a dropped/failed run on either side) are skipped, not zipped as zero.
+$bNull = @(100, $null, 98, 101)
+$cNull = @(95, 96, $null, 95)
+$sNull = Get-PerfPairedDeltaStats -BaselineSamples $bNull -CandidateSamples $cNull
+Assert-Equal 2 $sNull.N                          'paired stats skips null-containing pairs (2 valid)'
+
+# Fewer than 2 valid pairs -> null (a CI needs >= 2).
+Assert-Null (Get-PerfPairedDeltaStats -BaselineSamples @(100) -CandidateSamples @(95)) 'one pair -> null'
+Assert-Null (Get-PerfPairedDeltaStats -BaselineSamples $null -CandidateSamples $null)  'null samples -> null'
+Assert-Null (Get-PerfPairedDeltaStats -BaselineSamples @(0, 0) -CandidateSamples @(5, 5)) 'zero baselines skipped -> null'
+
+# ── Get-PerfDelta with samples (CI-excludes-0 replaces the 4% floor) ──────────
+# A ~2% improvement that the OLD 4% floor would have buried as "noise", now
+# resolved as a real improvement because the paired CI excludes 0.
+$bSmall = @(100, 100.5, 99.5, 100, 100.2, 99.8, 100.1, 99.9, 100.3, 99.7)
+$cSmall = @(98,  98.4,  97.6, 98,  98.2,  97.8, 98.1,  97.9, 98.3,  97.7)
+$dSmall = Get-PerfDelta -Baseline 100 -Candidate 98 -LowerIsBetter $true -BaselineSamples $bSmall -CandidateSamples $cSmall
+Assert-Equal 'better' $dSmall.Status   'sub-4% improvement resolved via CI (was noise under floor)'
+Assert-True  ($null -ne $dSmall.CiLowPct) 'sample delta carries CiLowPct'
+Assert-Equal 10 $dSmall.N              'sample delta carries N'
+
+# Genuine jitter with samples -> noise even though the point delta is non-trivial.
+$dNoise = Get-PerfDelta -Baseline 100 -Candidate 100 -LowerIsBetter $true -BaselineSamples $bN -CandidateSamples $cN
+Assert-Equal 'noise' $dNoise.Status    'paired jitter CI includes 0 -> noise'
+
+# Higher-is-better regression caught when the CI excludes 0.
+$bRps = @(3.6, 3.58, 3.62, 3.59, 3.61, 3.57, 3.6, 3.63, 3.58, 3.6)
+$cRps = @(3.4, 3.38, 3.42, 3.39, 3.41, 3.37, 3.4, 3.43, 3.38, 3.4)
+$dReg = Get-PerfDelta -Baseline 3.6 -Candidate 3.4 -LowerIsBetter $false -BaselineSamples $bRps -CandidateSamples $cRps
+Assert-Equal 'worse' $dReg.Status      'higher-better paired regression (CI excludes 0)'
+
+# Back-compat: with < 2 usable pairs it falls back to the scalar floor path.
+$dFallback = Get-PerfDelta -Baseline 100 -Candidate 95 -LowerIsBetter $true -BaselineSamples @(100) -CandidateSamples @(95)
+Assert-Equal 'better' $dFallback.Status 'insufficient samples -> floor fallback still flags'
+Assert-Null  $dFallback.CiLowPct        'fallback path has null CI'
+
+# ── Format-PerfDeltaCell with CI ─────────────────────────────────────────────
+$cellCi = Format-PerfDeltaCell ([pscustomobject]@{ DeltaPct = -3.4; CiLowPct = -6.1; CiHighPct = -0.6 })
+Assert-Match $cellCi '-3.4%'            'CI cell shows point delta'
+Assert-Match $cellCi '95% CI'            'CI cell shows the interval label'
+Assert-Match $cellCi '-6.1, -0.6'        'CI cell shows the interval bounds'
+# Legacy callers passing only DeltaPct must still render a bare percentage.
+Assert-Equal '+20.0%' (Format-PerfDeltaCell ([pscustomobject]@{ DeltaPct = 20.0 })) 'no-CI cell stays bare'
+
+# ── Measure-PerfRuns carries ordered per-run samples (incl. alloc keys) ───────
+$runsForSamples = @(
+    [pscustomobject]@{ RendersPerSec = 10; AvgReconcileMs = 5; AvgDiffMs = 2; AvgMemoryMB = 200; AllocBytesPerRender = 52000; Gen0PerKRenders = 4.1; Gen0 = 10; Gen1 = 2; Gen2 = 0; TotalRenders = 100; DurationSeconds = 10 }
+    [pscustomobject]@{ RendersPerSec = 12; AvgReconcileMs = 4; AvgDiffMs = 1.8; AvgMemoryMB = 195; AllocBytesPerRender = 48000; Gen0PerKRenders = 3.8; Gen0 = 9; Gen1 = 2; Gen2 = 0; TotalRenders = 120; DurationSeconds = 10 }
+)
+$aggS = Measure-PerfRuns -Runs $runsForSamples
+Assert-Equal 2 $aggS.RendersPerSecSamples.Count        'samples array preserves per-run order/count'
+Assert-Equal 10 $aggS.RendersPerSecSamples[0]          'samples array keeps first run value'
+Assert-Equal 52000 $aggS.AllocBytesPerRenderSamples[0] 'alloc samples captured'
+Assert-Equal 50000 $aggS.AllocBytesPerRender           'alloc median across runs'
+# A run object lacking the alloc key (legacy harness) -> null placeholder, not a throw.
+$aggMixed = Measure-PerfRuns -Runs @(
+    [pscustomobject]@{ RendersPerSec = 10; AvgReconcileMs = 5; AvgDiffMs = 2; AvgMemoryMB = 200; TotalRenders = 100; DurationSeconds = 10 }
+)
+Assert-Null $aggMixed.AllocBytesPerRender               'absent alloc key -> null median (no throw under StrictMode)'
+Assert-Null $aggMixed.AllocBytesPerRenderSamples[0]     'absent alloc key -> null sample placeholder'
+
+# ── Read-HarnessMetrics parses the new allocation fields ─────────────────────
+$tmp2 = Join-Path ([IO.Path]::GetTempPath()) ("perflib-alloc-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp2 -Force | Out-Null
+try {
+    # report.txt with the alloc lines PerfTracker now emits.
+    $allocReport = @"
+StressPerf.ReactorOptimized report
+Total Renders: 1000
+Duration: 10.0 s
+Avg Reconcile: 5.50 ms
+Avg Diff: 2.20 ms
+Avg Memory: 210.0 MB
+Alloc/render: 51234 bytes
+GC Gen0/1/2: 12 / 3 / 1
+Gen0/Krender: 4.07
+"@
+    Set-Content -LiteralPath (Join-Path $tmp2 'StressPerf.ReactorOptimized.report.txt') -Value $allocReport -Encoding UTF8
+    $am = Read-HarnessMetrics -Directory $tmp2 -AppName 'StressPerf.ReactorOptimized'
+    Assert-Equal 51234 $am.AllocBytesPerRender 'report alloc bytes/render parsed'
+    Assert-Equal 4.07  $am.Gen0PerKRenders     'report Gen0/Krender parsed'
+    Assert-Equal 12    $am.Gen0                'report Gen0 count parsed'
+    Assert-Equal 1     $am.Gen2                'report Gen2 count parsed'
+
+    # metrics.json with the new alloc fields wins and is parsed.
+    $allocJson = '{"app":"StressPerf.ReactorOptimized","percent":50,"durationSeconds":10,"rendersPerSec":99.9,"totalRenders":999,"avgReconcileMs":1.1,"avgDiffMs":2.2,"avgMemoryMB":150.5,"allocBytesPerRender":47777,"gen0":9,"gen1":2,"gen2":0,"gen0PerKRenders":3.55,"avgFps":60,"sampleCount":5}'
+    Set-Content -LiteralPath (Join-Path $tmp2 'StressPerf.ReactorOptimized.metrics.json') -Value $allocJson -Encoding UTF8
+    $aj = Read-HarnessMetrics -Directory $tmp2 -AppName 'StressPerf.ReactorOptimized'
+    Assert-Equal 'json' $aj.Source             'json wins over report'
+    Assert-Equal 47777 $aj.AllocBytesPerRender 'json alloc bytes/render parsed'
+    Assert-Equal 3.55  $aj.Gen0PerKRenders     'json Gen0/Krender parsed'
+
+    # Back-compat: a metrics.json WITHOUT alloc fields still parses, alloc -> null.
+    $oldJson = '{"app":"StressPerf.Old","percent":50,"durationSeconds":10,"rendersPerSec":50,"totalRenders":500,"avgReconcileMs":3,"avgDiffMs":1,"avgMemoryMB":180,"avgFps":60,"sampleCount":5}'
+    Set-Content -LiteralPath (Join-Path $tmp2 'StressPerf.Old.metrics.json') -Value $oldJson -Encoding UTF8
+    $oj = Read-HarnessMetrics -Directory $tmp2 -AppName 'StressPerf.Old'
+    Assert-Equal 'json' $oj.Source             'legacy json (no alloc) still parses'
+    Assert-Null  $oj.AllocBytesPerRender       'legacy json -> alloc n/a (null)'
+}
+finally {
+    Remove-Item -LiteralPath $tmp2 -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ── Format-PerfComment: allocation table + CI header + CI-based footnote ──────
+$allocMain = Measure-PerfRuns -Runs @(
+    [pscustomobject]@{ RendersPerSec = 3.55; AvgReconcileMs = 76; AvgDiffMs = 66; AvgMemoryMB = 303; AllocBytesPerRender = 52000; Gen0PerKRenders = 4.10; Gen0 = 10; Gen1 = 2; Gen2 = 0; TotalRenders = 35; DurationSeconds = 10 }
+    [pscustomobject]@{ RendersPerSec = 3.56; AvgReconcileMs = 76; AvgDiffMs = 66; AvgMemoryMB = 303; AllocBytesPerRender = 52100; Gen0PerKRenders = 4.12; Gen0 = 10; Gen1 = 2; Gen2 = 0; TotalRenders = 35; DurationSeconds = 10 }
+    [pscustomobject]@{ RendersPerSec = 3.54; AvgReconcileMs = 76; AvgDiffMs = 66; AvgMemoryMB = 303; AllocBytesPerRender = 51900; Gen0PerKRenders = 4.08; Gen0 = 10; Gen1 = 2; Gen2 = 0; TotalRenders = 35; DurationSeconds = 10 }
+)
+$allocPr = Measure-PerfRuns -Runs @(
+    [pscustomobject]@{ RendersPerSec = 3.55; AvgReconcileMs = 76; AvgDiffMs = 66; AvgMemoryMB = 303; AllocBytesPerRender = 48000; Gen0PerKRenders = 3.80; Gen0 = 9; Gen1 = 2; Gen2 = 0; TotalRenders = 35; DurationSeconds = 10 }
+    [pscustomobject]@{ RendersPerSec = 3.56; AvgReconcileMs = 76; AvgDiffMs = 66; AvgMemoryMB = 303; AllocBytesPerRender = 48100; Gen0PerKRenders = 3.82; Gen0 = 9; Gen1 = 2; Gen2 = 0; TotalRenders = 35; DurationSeconds = 10 }
+    [pscustomobject]@{ RendersPerSec = 3.54; AvgReconcileMs = 76; AvgDiffMs = 66; AvgMemoryMB = 303; AllocBytesPerRender = 47900; Gen0PerKRenders = 3.78; Gen0 = 9; Gen1 = 2; Gen2 = 0; TotalRenders = 35; DurationSeconds = 10 }
+)
+$allocComment = Format-PerfComment -Main $allocMain -Pr $allocPr -WinUI3 $null -Rust $null -Context $ctx
+Assert-Match $allocComment 'Allocation (Reactor)'  'comment renders the allocation table when alloc present'
+Assert-Match $allocComment 'Alloc bytes/render'    'alloc table has bytes/render row'
+Assert-Match $allocComment 'Gen0 GC / 1k renders'  'alloc table has Gen0 row'
+Assert-Match $allocComment '95% CI'                'delta cells carry a 95% CI'
+Assert-Match $allocComment 'confidence interval of the paired'  'footnote describes the CI-based noise rule'
+
+# Alloc table is omitted when neither side reports allocation metrics (legacy heads).
+$noAllocComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -Context $ctx
+Assert-True (-not ($noAllocComment -like '*Allocation (Reactor)*')) 'alloc table omitted when no alloc metric present'
+
+
 if ($script:Fail -gt 0) {
     Write-Host "FAILED: $($script:Fail) / $($script:Pass + $script:Fail) assertions" -ForegroundColor Red
     foreach ($f in $script:Failures) { Write-Host "  ✗ $f" -ForegroundColor Red }

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -233,10 +233,15 @@ Assert-Match $noRust 'n/a'      'n/a cells rendered when winui3 + rust null'
 Assert-Equal 12.706 (Get-StudentTCritical -Df 1)  't critical df=1'
 Assert-Equal 2.201  (Get-StudentTCritical -Df 11) 't critical df=11'
 Assert-Equal 2.042  (Get-StudentTCritical -Df 30) 't critical df=30 (table edge)'
-Assert-Equal 2.0    (Get-StudentTCritical -Df 45) 't critical df 31..60 -> 2.000'
-Assert-Equal 1.98   (Get-StudentTCritical -Df 90) 't critical df 61..120 -> 1.980'
-Assert-Equal 1.96   (Get-StudentTCritical -Df 500) 't critical df>120 -> 1.960 (z)'
+Assert-Equal 2.021  (Get-StudentTCritical -Df 45) 't critical df 41..45 -> t(40)=2.021 conservative'
+Assert-Equal 1.99   (Get-StudentTCritical -Df 90) 't critical df 81..90 -> t(80)=1.990 conservative'
+Assert-Equal 1.968  (Get-StudentTCritical -Df 500) 't critical df 301..500 -> t(300)=1.968 conservative'
 Assert-True ([double]::IsNaN((Get-StudentTCritical -Df 0))) 't critical df<1 -> NaN'
+# Conservatism property: returned value must be >= the true two-sided 95% t critical.
+Assert-True ((Get-StudentTCritical -Df 45)  -ge 2.0141) 't(45) >= true 2.0141 (never understated)'
+Assert-True ((Get-StudentTCritical -Df 90)  -ge 1.9867) 't(90) >= true 1.9867 (never understated)'
+Assert-True ((Get-StudentTCritical -Df 500) -ge 1.9647) 't(500) >= true 1.9647 (never understated)'
+Assert-True ((Get-StudentTCritical -Df 5000) -ge 1.96)  't(5000) >= z 1.960 (never understated)'
 
 # ── Get-PerfPairedDeltaStats (paired CI over per-iteration deltas) ────────────
 # A clear, low-variance ~5% reduction: the 95% CI must exclude 0.

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -99,6 +99,8 @@ Assert-Equal 'na' $d.Status 'zero baseline -> na'
 # ── Format-PerfNumber / Format-PerfDeltaCell ─────────────────────────────────
 Assert-Equal 'n/a'   (Format-PerfNumber $null 1) 'format null -> n/a'
 Assert-Equal '8.70'  (Format-PerfNumber 8.7 2)   'format 2 digits invariant'
+Assert-Equal '52000' (Format-PerfNumber 52000 0) 'format 0 digits -> clean integer (no trailing dot)'
+Assert-Equal '13'    (Format-PerfNumber 12.6 0)  'format 0 digits rounds to integer'
 Assert-Equal '+20.0%' (Format-PerfDeltaCell ([pscustomobject]@{ DeltaPct = 20.0 })) 'delta cell signs positive'
 Assert-Equal '-5.0%'  (Format-PerfDeltaCell ([pscustomobject]@{ DeltaPct = -5.0 })) 'delta cell signs negative'
 Assert-Equal '—'      (Format-PerfDeltaCell ([pscustomobject]@{ DeltaPct = $null })) 'delta cell na -> dash'

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -269,6 +269,13 @@ Assert-Null (Get-PerfPairedDeltaStats -BaselineSamples @(100) -CandidateSamples 
 Assert-Null (Get-PerfPairedDeltaStats -BaselineSamples $null -CandidateSamples $null)  'null samples -> null'
 Assert-Null (Get-PerfPairedDeltaStats -BaselineSamples @(0, 0) -CandidateSamples @(5, 5)) 'zero baselines skipped -> null'
 
+# Stats are returned at FULL precision (not pre-rounded to 2dp): the per-pair
+# delta here is exactly -0.999%, which 2dp rounding would have collapsed to -1.00.
+$bPrec = @(100, 100, 100, 100)
+$cPrec = @(99.001, 99.001, 99.001, 99.001)
+$sPrec = Get-PerfPairedDeltaStats -BaselineSamples $bPrec -CandidateSamples $cPrec
+Assert-True ([math]::Abs([double]$sPrec.MeanPct - (-0.999)) -lt 1e-9) 'stats keep full precision (mean not rounded to 2dp)'
+
 # ── Get-PerfDelta with samples (CI-excludes-0 replaces the 4% floor) ──────────
 # A ~2% improvement that the OLD 4% floor would have buried as "noise", now
 # resolved as a real improvement because the paired CI excludes 0.
@@ -293,6 +300,14 @@ Assert-Equal 'worse' $dReg.Status      'higher-better paired regression (CI excl
 $dFallback = Get-PerfDelta -Baseline 100 -Candidate 95 -LowerIsBetter $true -BaselineSamples @(100) -CandidateSamples @(95)
 Assert-Equal 'better' $dFallback.Status 'insufficient samples -> floor fallback still flags'
 Assert-Null  $dFallback.CiLowPct        'fallback path has null CI'
+
+# Full-precision gating: a CI strictly just above 0 (here +0.004%) must be flagged,
+# not collapsed to "noise" by 2dp rounding of the bound to 0.00. Under the old
+# pre-rounded stats this returned 'noise'; the full-precision decision returns it.
+$bTiny = @(100, 100, 100, 100)
+$cTiny = @(100.004, 100.004, 100.004, 100.004)
+$dTiny = Get-PerfDelta -Baseline 100 -Candidate 100.004 -LowerIsBetter $false -BaselineSamples $bTiny -CandidateSamples $cTiny
+Assert-Equal 'better' $dTiny.Status 'CI just above 0 (+0.004) flagged, not rounded to noise'
 
 # ── Format-PerfDeltaCell with CI ─────────────────────────────────────────────
 $cellCi = Format-PerfDeltaCell ([pscustomobject]@{ DeltaPct = -3.4; CiLowPct = -6.1; CiHighPct = -0.6 })

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -262,6 +262,8 @@ function Get-PerfPairedDeltaStats {
         standard error, and a two-sided 95% confidence interval for the MEAN
         change (mean +/- t(.975, N-1) * SE). The interval excluding 0 is the
         data-driven "is this a real change?" test that replaces a fixed % floor.
+        All fields are returned at full precision (no rounding) because callers
+        gate significance on them; round only when formatting for display.
     .OUTPUTS
         PSCustomObject { N; MeanPct; MedianPct; SdPct; SePct; CiLowPct; CiHighPct;
         CiHalfWidthPct } or $null.
@@ -290,15 +292,19 @@ function Get-PerfPairedDeltaStats {
     $sd = [math]::Sqrt($ss / ($cnt - 1))
     $se = $sd / [math]::Sqrt($cnt)
     $half = (Get-StudentTCritical -Df ($cnt - 1)) * $se
+    # Full precision on purpose: Get-PerfDelta gates significance/direction on
+    # these values, so rounding here (e.g. a CI bound of 0.004 -> 0.00) could
+    # silently flip a real change to "noise". Rounding is a display concern and
+    # happens at format time (Format-PerfDeltaCell / Get-PerfDelta display fields).
     return [pscustomobject]@{
         N              = $cnt
-        MeanPct        = [math]::Round($mean, 2)
-        MedianPct      = [math]::Round((Get-PerfMedian ([double[]]$deltas.ToArray())), 2)
-        SdPct          = [math]::Round($sd, 2)
-        SePct          = [math]::Round($se, 2)
-        CiLowPct       = [math]::Round($mean - $half, 2)
-        CiHighPct      = [math]::Round($mean + $half, 2)
-        CiHalfWidthPct = [math]::Round($half, 2)
+        MeanPct        = $mean
+        MedianPct      = Get-PerfMedian ([double[]]$deltas.ToArray())
+        SdPct          = $sd
+        SePct          = $se
+        CiLowPct       = $mean - $half
+        CiHighPct      = $mean + $half
+        CiHalfWidthPct = $half
     }
 }
 
@@ -373,16 +379,22 @@ function Get-PerfDelta {
     # 95% CI excludes 0 — the data-driven band that replaces the fixed % floor.
     $stats = Get-PerfPairedDeltaStats -BaselineSamples $BaselineSamples -CandidateSamples $CandidateSamples
     if ($null -ne $stats) {
+        # Decide direction + significance on FULL-PRECISION stats. Rounding is a
+        # display-only concern: a CI bound like 0.004 must not round to 0.00 and
+        # silently flip a genuine change to "noise". The returned CI fields are
+        # rounded to 2dp for presentation; the cell format rounds again to 1dp.
         $meanPct = [double]$stats.MeanPct
+        $ciLow = [double]$stats.CiLowPct
+        $ciHigh = [double]$stats.CiHighPct
         $improved = if ($LowerIsBetter) { $meanPct -lt 0 } else { $meanPct -gt 0 }
-        $ciExcludesZero = ($stats.CiLowPct -gt 0) -or ($stats.CiHighPct -lt 0)
+        $ciExcludesZero = ($ciLow -gt 0) -or ($ciHigh -lt 0)
         $status = if (-not $ciExcludesZero) { 'noise' } elseif ($improved) { 'better' } else { 'worse' }
         return [pscustomobject]@{
             DeltaPct  = [math]::Round($meanPct, 1)
             Status    = $status
             Improved  = $improved
-            CiLowPct  = $stats.CiLowPct
-            CiHighPct = $stats.CiHighPct
+            CiLowPct  = [math]::Round($ciLow, 2)
+            CiHighPct = [math]::Round($ciHigh, 2)
             N         = $stats.N
         }
     }

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -35,6 +35,17 @@ $script:PerfMetricSpec = @(
     [pscustomobject]@{ Key = 'AvgMemoryMB';    Label = 'Avg Memory (MB)';    LowerIsBetter = $true;  Digits = 1; Arrow = [char]0x2193 }
 )
 
+# Allocation metric table spec (Reactor main-vs-PR only — there is no meaningful
+# cross-framework allocation comparison). Lower is better for both. These move
+# directly when an allocation-reduction PR lands, where the mean-ms / working-set
+# headline metrics above are largely insensitive. Emitted by PerfTracker as
+# allocBytesPerRender / gen0PerKRenders; absent (n/a) for harness builds that
+# predate the metric (e.g. a PR head opened before this gate merged).
+$script:PerfAllocMetricSpec = @(
+    [pscustomobject]@{ Key = 'AllocBytesPerRender'; Label = 'Alloc bytes/render';   LowerIsBetter = $true; Digits = 0; Arrow = [char]0x2193 }
+    [pscustomobject]@{ Key = 'Gen0PerKRenders';     Label = 'Gen0 GC / 1k renders'; LowerIsBetter = $true; Digits = 2; Arrow = [char]0x2193 }
+)
+
 function ConvertTo-PerfDouble {
     <#
     .SYNOPSIS Culture-tolerant parse of a captured numeric string, or $null.
@@ -82,14 +93,19 @@ function Read-HarnessMetrics {
     )
 
     $result = [pscustomobject]@{
-        AppName         = $AppName
-        RendersPerSec   = $null
-        AvgReconcileMs  = $null
-        AvgDiffMs       = $null
-        AvgMemoryMB     = $null
-        TotalRenders    = $null
-        DurationSeconds = $null
-        Source          = 'none'
+        AppName             = $AppName
+        RendersPerSec       = $null
+        AvgReconcileMs      = $null
+        AvgDiffMs           = $null
+        AvgMemoryMB         = $null
+        AllocBytesPerRender = $null
+        Gen0PerKRenders     = $null
+        Gen0                = $null
+        Gen1                = $null
+        Gen2                = $null
+        TotalRenders        = $null
+        DurationSeconds     = $null
+        Source              = 'none'
     }
 
     $jsonPath   = Join-Path $Directory ("{0}.metrics.json" -f $AppName)
@@ -117,6 +133,15 @@ function Read-HarnessMetrics {
                 $result.AvgMemoryMB     = [double]$j.avgMemoryMB
                 $result.TotalRenders    = [int]$j.totalRenders
                 $result.DurationSeconds = [double]$j.durationSeconds
+                # Optional allocation fields (added after the headline four). Read
+                # when present so a PR head that predates them still parses via the
+                # required-set above (its alloc cells just read n/a) instead of being
+                # rejected. Guarded with PSObject.Properties for Set-StrictMode.
+                if ($j.PSObject.Properties['allocBytesPerRender'] -and $null -ne $j.allocBytesPerRender) { $result.AllocBytesPerRender = [double]$j.allocBytesPerRender }
+                if ($j.PSObject.Properties['gen0PerKRenders'] -and $null -ne $j.gen0PerKRenders) { $result.Gen0PerKRenders = [double]$j.gen0PerKRenders }
+                if ($j.PSObject.Properties['gen0'] -and $null -ne $j.gen0) { $result.Gen0 = [int]$j.gen0 }
+                if ($j.PSObject.Properties['gen1'] -and $null -ne $j.gen1) { $result.Gen1 = [int]$j.gen1 }
+                if ($j.PSObject.Properties['gen2'] -and $null -ne $j.gen2) { $result.Gen2 = [int]$j.gen2 }
                 $result.Source          = 'json'
                 return $result
             }
@@ -140,6 +165,16 @@ function Read-HarnessMetrics {
     $result.AvgReconcileMs  = Get-PerfReportField $text 'Avg Reconcile:\s*([0-9][0-9.,]*)\s*ms'
     $result.AvgDiffMs       = Get-PerfReportField $text 'Avg Diff:\s*([0-9][0-9.,]*)\s*ms'
     $result.AvgMemoryMB     = Get-PerfReportField $text 'Avg Memory:\s*([0-9][0-9.,]*)\s*MB'
+    # Optional allocation lines: absent in pre-metric harness builds and in the
+    # Rust port's report.txt, so they stay $null (n/a) there.
+    $result.AllocBytesPerRender = Get-PerfReportField $text 'Alloc/render:\s*([0-9][0-9.,]*)\s*bytes'
+    $result.Gen0PerKRenders     = Get-PerfReportField $text 'Gen0/Krender:\s*([0-9][0-9.,]*)'
+    $gcm = [regex]::Match($text, 'GC Gen0/1/2:\s*([0-9]+)\s*/\s*([0-9]+)\s*/\s*([0-9]+)')
+    if ($gcm.Success) {
+        $result.Gen0 = [int]$gcm.Groups[1].Value
+        $result.Gen1 = [int]$gcm.Groups[2].Value
+        $result.Gen2 = [int]$gcm.Groups[3].Value
+    }
 
     if ($null -ne $result.TotalRenders -and $null -ne $result.DurationSeconds -and $result.DurationSeconds -gt 0) {
         $result.RendersPerSec = [math]::Round($result.TotalRenders / $result.DurationSeconds, 4)
@@ -171,6 +206,79 @@ function Get-PerfRelativeSpreadPct {
     return [math]::Round((($max - $min) / [math]::Abs($med)) * 100.0, 1)
 }
 
+function Get-StudentTCritical {
+    <#
+    .SYNOPSIS
+        Two-sided 95% Student-t critical value for the given degrees of freedom.
+        Hard-coded table for df 1..30, then a slightly conservative constant
+        (so the resulting CI is never understated) — keeps PerfLib dependency-free.
+    #>
+    param([int]$Df)
+    if ($Df -lt 1) { return [double]::NaN }
+    $t = @(
+        12.706, 4.303, 3.182, 2.776, 2.571, 2.447, 2.365, 2.306, 2.262, 2.228,
+        2.201, 2.179, 2.160, 2.145, 2.131, 2.120, 2.110, 2.101, 2.093, 2.086,
+        2.080, 2.074, 2.069, 2.064, 2.060, 2.056, 2.052, 2.048, 2.045, 2.042
+    )
+    if ($Df -le 30) { return [double]$t[$Df - 1] }
+    if ($Df -le 60) { return 2.000 }
+    if ($Df -le 120) { return 1.980 }
+    return 1.960
+}
+
+function Get-PerfPairedDeltaStats {
+    <#
+    .SYNOPSIS
+        Paired per-iteration percent-change statistics for two index-aligned
+        samples (Baseline run i vs Candidate run i, as collected interleaved).
+        Returns $null when fewer than 2 valid pairs survive (a CI needs >= 2).
+    .DESCRIPTION
+        For each index i where both samples are non-null and the baseline is
+        non-zero, the per-pair change is ((cand_i - base_i) / |base_i|) * 100.
+        Reports N, the mean / median change, the sample standard deviation, the
+        standard error, and a two-sided 95% confidence interval for the MEAN
+        change (mean +/- t(.975, N-1) * SE). The interval excluding 0 is the
+        data-driven "is this a real change?" test that replaces a fixed % floor.
+    .OUTPUTS
+        PSCustomObject { N; MeanPct; MedianPct; SdPct; SePct; CiLowPct; CiHighPct;
+        CiHalfWidthPct } or $null.
+    #>
+    param(
+        [AllowNull()][object[]]$BaselineSamples,
+        [AllowNull()][object[]]$CandidateSamples
+    )
+    if ($null -eq $BaselineSamples -or $null -eq $CandidateSamples) { return $null }
+    $n = [math]::Min($BaselineSamples.Count, $CandidateSamples.Count)
+    $deltas = [System.Collections.Generic.List[double]]::new()
+    for ($i = 0; $i -lt $n; $i++) {
+        $b = $BaselineSamples[$i]
+        $c = $CandidateSamples[$i]
+        if ($null -eq $b -or $null -eq $c) { continue }
+        $bd = [double]$b
+        $cd = [double]$c
+        if ($bd -eq 0) { continue }
+        $deltas.Add((($cd - $bd) / [math]::Abs($bd)) * 100.0)
+    }
+    if ($deltas.Count -lt 2) { return $null }
+    $cnt = $deltas.Count
+    $mean = ($deltas | Measure-Object -Average).Average
+    $ss = 0.0
+    foreach ($d in $deltas) { $ss += ($d - $mean) * ($d - $mean) }
+    $sd = [math]::Sqrt($ss / ($cnt - 1))
+    $se = $sd / [math]::Sqrt($cnt)
+    $half = (Get-StudentTCritical -Df ($cnt - 1)) * $se
+    return [pscustomobject]@{
+        N              = $cnt
+        MeanPct        = [math]::Round($mean, 2)
+        MedianPct      = [math]::Round((Get-PerfMedian ([double[]]$deltas.ToArray())), 2)
+        SdPct          = [math]::Round($sd, 2)
+        SePct          = [math]::Round($se, 2)
+        CiLowPct       = [math]::Round($mean - $half, 2)
+        CiHighPct      = [math]::Round($mean + $half, 2)
+        CiHalfWidthPct = [math]::Round($half, 2)
+    }
+}
+
 function Measure-PerfRuns {
     <#
     .SYNOPSIS
@@ -180,12 +288,20 @@ function Measure-PerfRuns {
     #>
     param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Runs)
 
-    $keys = 'RendersPerSec', 'AvgReconcileMs', 'AvgDiffMs', 'AvgMemoryMB', 'TotalRenders', 'DurationSeconds'
+    $keys = 'RendersPerSec', 'AvgReconcileMs', 'AvgDiffMs', 'AvgMemoryMB',
+            'AllocBytesPerRender', 'Gen0PerKRenders', 'Gen0', 'Gen1', 'Gen2',
+            'TotalRenders', 'DurationSeconds'
     $agg = [ordered]@{ RunCount = @($Runs).Count }
     foreach ($k in $keys) {
-        $vals = @($Runs | ForEach-Object { $_.$k } | Where-Object { $null -ne $_ } | ForEach-Object { [double]$_ })
+        # Ordered per-run values WITH $null placeholders preserved (and tolerant of
+        # run objects that lack a key, e.g. a variant that predates the metric), so
+        # a paired analysis downstream can zip Baseline run i against Candidate run i
+        # by index. Get-PerfPairedDeltaStats skips any pair with a null/zero side.
+        $ordered = @($Runs | ForEach-Object { if ($_.PSObject.Properties[$k]) { $_.$k } else { $null } })
+        $vals = @($ordered | Where-Object { $null -ne $_ } | ForEach-Object { [double]$_ })
         $agg[$k] = Get-PerfMedian $vals
         $agg["${k}Spread"] = Get-PerfRelativeSpreadPct $vals
+        $agg["${k}Samples"] = $ordered
     }
     return [pscustomobject]$agg
 }
@@ -193,31 +309,66 @@ function Measure-PerfRuns {
 function Get-PerfDelta {
     <#
     .SYNOPSIS
-        Signed percent change of Candidate vs Baseline, direction-aware, with a
-        noise band. Status is one of: better | worse | noise | na.
+        Signed percent change of Candidate vs Baseline, direction-aware. Status is
+        one of: better | worse | noise | na.
+    .DESCRIPTION
+        Preferred path (when per-iteration samples are supplied): a paired 95%
+        confidence interval over the per-pair percent deltas. The change is flagged
+        better/worse ONLY when that CI excludes 0 — the data-driven band that
+        replaces the fixed % floor. DeltaPct is the mean paired change; CiLowPct /
+        CiHighPct / N describe the interval.
+
+        Fallback path (no samples, e.g. legacy callers / unit tests): the point
+        delta of the scalar Baseline/Candidate vs a max(NoiseFloorPct, SpreadPct)
+        noise band.
     .PARAMETER NoiseFloorPct
-        Absolute floor for the "within noise" band (default 4%).
+        Absolute floor for the fallback "within noise" band (default 4%). Unused on
+        the sample/CI path.
     .PARAMETER SpreadPct
-        Run-to-run dispersion for this metric; the effective noise band is
+        Run-to-run dispersion for this metric; the fallback band is
         max(NoiseFloorPct, SpreadPct).
+    .PARAMETER BaselineSamples / CandidateSamples
+        Index-aligned per-run values (with $null placeholders) for the paired CI.
     #>
     param(
         [AllowNull()]$Baseline,
         [AllowNull()]$Candidate,
         [Parameter(Mandatory)][bool]$LowerIsBetter,
         [double]$NoiseFloorPct = 4.0,
-        [double]$SpreadPct = 0.0
+        [double]$SpreadPct = 0.0,
+        [AllowNull()][object[]]$BaselineSamples,
+        [AllowNull()][object[]]$CandidateSamples
     )
     if ($null -eq $Baseline -or $null -eq $Candidate -or [double]$Baseline -eq 0) {
-        return [pscustomobject]@{ DeltaPct = $null; Status = 'na'; Improved = $null }
+        return [pscustomobject]@{ DeltaPct = $null; Status = 'na'; Improved = $null; CiLowPct = $null; CiHighPct = $null; N = $null }
     }
     $b = [double]$Baseline
     $c = [double]$Candidate
     $deltaPct = (($c - $b) / [math]::Abs($b)) * 100.0
+
+    # Preferred: paired CI over the per-iteration deltas. Significant only when the
+    # 95% CI excludes 0 — the data-driven band that replaces the fixed % floor.
+    $stats = Get-PerfPairedDeltaStats -BaselineSamples $BaselineSamples -CandidateSamples $CandidateSamples
+    if ($null -ne $stats) {
+        $meanPct = [double]$stats.MeanPct
+        $improved = if ($LowerIsBetter) { $meanPct -lt 0 } else { $meanPct -gt 0 }
+        $ciExcludesZero = ($stats.CiLowPct -gt 0) -or ($stats.CiHighPct -lt 0)
+        $status = if (-not $ciExcludesZero) { 'noise' } elseif ($improved) { 'better' } else { 'worse' }
+        return [pscustomobject]@{
+            DeltaPct  = [math]::Round($meanPct, 1)
+            Status    = $status
+            Improved  = $improved
+            CiLowPct  = $stats.CiLowPct
+            CiHighPct = $stats.CiHighPct
+            N         = $stats.N
+        }
+    }
+
+    # Fallback: point delta vs a max(floor, spread) noise band.
     $improved = if ($LowerIsBetter) { $deltaPct -lt 0 } else { $deltaPct -gt 0 }
     $band = [math]::Max($NoiseFloorPct, $SpreadPct)
     $status = if ([math]::Abs($deltaPct) -lt $band) { 'noise' } elseif ($improved) { 'better' } else { 'worse' }
-    return [pscustomobject]@{ DeltaPct = [math]::Round($deltaPct, 1); Status = $status; Improved = $improved }
+    return [pscustomobject]@{ DeltaPct = [math]::Round($deltaPct, 1); Status = $status; Improved = $improved; CiLowPct = $null; CiHighPct = $null; N = $null }
 }
 
 function Format-PerfNumber {
@@ -230,7 +381,16 @@ function Format-PerfDeltaCell {
     param([pscustomobject]$Delta)
     if ($null -eq $Delta.DeltaPct) { return '—' }
     $s = ('{0:+0.0;-0.0;0.0}' -f $Delta.DeltaPct)
-    return "$s%"
+    $cell = "$s%"
+    # Append the 95% CI of the paired delta when present. Set-StrictMode-safe
+    # property probe so legacy callers passing only DeltaPct still render a bare %.
+    if (($Delta.PSObject.Properties['CiLowPct']) -and ($null -ne $Delta.CiLowPct) -and
+        ($Delta.PSObject.Properties['CiHighPct']) -and ($null -ne $Delta.CiHighPct)) {
+        $lo = ('{0:+0.0;-0.0;0.0}' -f $Delta.CiLowPct)
+        $hi = ('{0:+0.0;-0.0;0.0}' -f $Delta.CiHighPct)
+        $cell += " <sub>95% CI [$lo, $hi]</sub>"
+    }
+    return $cell
 }
 
 function Get-PerfStatusGlyph {
@@ -274,7 +434,7 @@ function Format-PerfComment {
     $plat = if ($Context.ContainsKey('Platform') -and $Context.Platform) { $Context.Platform } else { 'x64' }
     $methodology = "**Workload:** ``StressPerf.ReactorOptimized`` StocksGrid &middot; " +
         "``--percent $($Context.Percent) --duration $($Context.Duration)`` &middot; $plat Release &middot; " +
-        "median of $($Context.Reps) runs ($($Context.Warmup) warmup dropped) &middot; " +
+        "median of $($Context.Reps) paired runs ($($Context.Warmup) warmup dropped); Δ is the mean change with a 95% CI &middot; " +
         "PR head and ``main`` built and run **interleaved on the same runner**."
     & $add $methodology
     & $add ''
@@ -282,13 +442,14 @@ function Format-PerfComment {
     # ── Table 1: regression vs main ──────────────────────────────────────────
     & $add "### Regression vs ``main`` baseline"
     & $add ''
-    & $add '| Metric | `main` (baseline) | This PR | Δ | Status |'
+    & $add '| Metric | `main` (baseline) | This PR | Δ (95% CI) | Status |'
     & $add '|---|--:|--:|--:|:--|'
     foreach ($m in $script:PerfMetricSpec) {
         $bVal = $Main.($m.Key)
         $pVal = $Pr.($m.Key)
         $spread = [math]::Max([double]$Main."$($m.Key)Spread", [double]$Pr."$($m.Key)Spread")
-        $delta = Get-PerfDelta -Baseline $bVal -Candidate $pVal -LowerIsBetter $m.LowerIsBetter -SpreadPct $spread
+        $delta = Get-PerfDelta -Baseline $bVal -Candidate $pVal -LowerIsBetter $m.LowerIsBetter -SpreadPct $spread `
+            -BaselineSamples $Main."$($m.Key)Samples" -CandidateSamples $Pr."$($m.Key)Samples"
         $row = '| {0} {1} | {2} | {3} | {4} | {5} |' -f `
             $m.Label, $m.Arrow, `
             (Format-PerfNumber $bVal $m.Digits), `
@@ -298,6 +459,33 @@ function Format-PerfComment {
         & $add $row
     }
     & $add ''
+
+    # ── Allocation table (Reactor main vs PR; lower is better) ────────────────
+    # Rendered only when at least one side reports an allocation metric. A PR head
+    # opened before this metric landed reports n/a until rebased onto main.
+    $hasAlloc = ($null -ne $Main.AllocBytesPerRender) -or ($null -ne $Pr.AllocBytesPerRender) -or
+                ($null -ne $Main.Gen0PerKRenders) -or ($null -ne $Pr.Gen0PerKRenders)
+    if ($hasAlloc) {
+        & $add "### Allocation (Reactor) &mdash; lower is better"
+        & $add ''
+        & $add '| Metric | `main` (baseline) | This PR | Δ (95% CI) | Status |'
+        & $add '|---|--:|--:|--:|:--|'
+        foreach ($m in $script:PerfAllocMetricSpec) {
+            $bVal = $Main.($m.Key)
+            $pVal = $Pr.($m.Key)
+            $spread = [math]::Max([double]$Main."$($m.Key)Spread", [double]$Pr."$($m.Key)Spread")
+            $delta = Get-PerfDelta -Baseline $bVal -Candidate $pVal -LowerIsBetter $m.LowerIsBetter -SpreadPct $spread `
+                -BaselineSamples $Main."$($m.Key)Samples" -CandidateSamples $Pr."$($m.Key)Samples"
+            $row = '| {0} {1} | {2} | {3} | {4} | {5} |' -f `
+                $m.Label, $m.Arrow, `
+                (Format-PerfNumber $bVal $m.Digits), `
+                (Format-PerfNumber $pVal $m.Digits), `
+                (Format-PerfDeltaCell $delta), `
+                (Get-PerfStatusGlyph $delta.Status)
+            & $add $row
+        }
+        & $add ''
+    }
 
     # ── Table 2: cross-framework reference ───────────────────────────────────
     & $add "### Cross-framework reference (same StocksGrid workload)"
@@ -323,7 +511,8 @@ function Format-PerfComment {
     } else {
         '*Not run* on this runner (Rust toolchain/checkout unavailable or the Rust leg failed) — its cells read *n/a*.'
     }
-    & $add "<sub>$up higher is better &middot; $down lower is better. **Within noise** = |Δ| below the larger of the run-to-run spread and a 4% floor; treat as no measurable change.</sub>"
+    & $add "<sub>$up higher is better &middot; $down lower is better. **Within noise** = the 95% confidence interval of the paired Δ includes 0 (no change resolvable at this sample size); $([char]0x2705) improvement / $([char]0x26A0)$([char]0xFE0F) regression require the CI to **exclude** 0.</sub>"
+    & $add "<sub>Allocation metrics (alloc bytes/render, Gen0 GC) are the sensitive signal for allocation-reduction work, where the mean-ms / memory figures are largely flat. They read *n/a* for a harness built from a revision that predates them (rebase the PR onto ``main`` to populate them).</sub>"
     & $add "<sub>$([char]0x00B9) vanilla WinUI3 = ``StressPerf.Direct`` (imperative; no virtual-DOM, so it has no reconcile/diff phase — those cells read *n/a*). Measured live on this runner.</sub>"
     & $add "<sub>$([char]0x00B2) Rust = ``test_reactor_perf`` from [microsoft/windows-rs](https://github.com/microsoft/windows-rs/tree/master/crates/tests/libs/reactor_perf) — a port of this harness (same StocksGrid, same ``--percent``/``--duration`` CLI). $rustNote</sub>"
     & $add "<sub>Absolute numbers are runner-dependent — trust the **Δ vs main**, not the absolute values. Memory (working set) is the noisiest metric.</sub>"

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -210,8 +210,17 @@ function Get-StudentTCritical {
     <#
     .SYNOPSIS
         Two-sided 95% Student-t critical value for the given degrees of freedom.
-        Hard-coded table for df 1..30, then a slightly conservative constant
-        (so the resulting CI is never understated) — keeps PerfLib dependency-free.
+        Exact hard-coded table for df 1..30, then a CONSERVATIVE step function
+        for df > 30 — keeps PerfLib dependency-free.
+    .DESCRIPTION
+        t(.975, df) decreases monotonically in df, so for any df in a band
+        (a, b] the largest true value occurs at the small-df edge. Each band
+        therefore returns t(.975, a) (the value at its left edge), which is
+        >= the true critical value for every df it covers. This guarantees the
+        resulting CI half-width is never understated (we never flag a delta as
+        significant on too-narrow an interval); it is mildly conservative within
+        a band. The default reps (12 -> df=11) land in the exact table, so this
+        only matters if someone runs >31 reps.
     #>
     param([int]$Df)
     if ($Df -lt 1) { return [double]::NaN }
@@ -221,9 +230,23 @@ function Get-StudentTCritical {
         2.080, 2.074, 2.069, 2.064, 2.060, 2.056, 2.052, 2.048, 2.045, 2.042
     )
     if ($Df -le 30) { return [double]$t[$Df - 1] }
-    if ($Df -le 60) { return 2.000 }
-    if ($Df -le 120) { return 1.980 }
-    return 1.960
+    # Step down using each band's left-edge t(.975) value (>= true across the band).
+    if ($Df -le 35) { return 2.042 }   # t(30)
+    if ($Df -le 40) { return 2.030 }   # t(35)
+    if ($Df -le 45) { return 2.021 }   # t(40)
+    if ($Df -le 50) { return 2.014 }   # t(45)
+    if ($Df -le 60) { return 2.009 }   # t(50)
+    if ($Df -le 70) { return 2.000 }   # t(60)
+    if ($Df -le 80) { return 1.994 }   # t(70)
+    if ($Df -le 90) { return 1.990 }   # t(80)
+    if ($Df -le 100) { return 1.987 }  # t(90)
+    if ($Df -le 120) { return 1.984 }  # t(100)
+    if ($Df -le 150) { return 1.980 }  # t(120)
+    if ($Df -le 200) { return 1.976 }  # t(150)
+    if ($Df -le 300) { return 1.972 }  # t(200)
+    if ($Df -le 500) { return 1.968 }  # t(300)
+    if ($Df -le 1000) { return 1.965 } # t(500)
+    return 1.962                       # t(1000); asymptote -> 1.960
 }
 
 function Get-PerfPairedDeltaStats {

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -409,7 +409,13 @@ function Get-PerfDelta {
 function Format-PerfNumber {
     param([AllowNull()]$Value, [int]$Digits = 1)
     if ($null -eq $Value) { return 'n/a' }
-    return ([math]::Round([double]$Value, $Digits)).ToString("0.$('0' * $Digits)", [System.Globalization.CultureInfo]::InvariantCulture)
+    # Digits=0 (used by the alloc-bytes metric) must render a clean integer — a
+    # "0.<zeros>" format with zero zeros collapses to "0." and emits a trailing
+    # dot ("52000."), so format integers with a plain "0" pattern instead.
+    $d = [math]::Max(0, $Digits)
+    $rounded = [math]::Round([double]$Value, $d)
+    $fmt = if ($d -le 0) { '0' } else { "0.$('0' * $d)" }
+    return $rounded.ToString($fmt, [System.Globalization.CultureInfo]::InvariantCulture)
 }
 
 function Format-PerfDeltaCell {

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -29,6 +29,23 @@ Measured on the `StressPerf.ReactorOptimized` StocksGrid workload (Release, buil
 Imperative WinUI3 (`StressPerf.Direct`) has no virtual-DOM, so it has **no**
 reconcile/diff phase — those cells read *n/a*.
 
+### Allocation metrics (Reactor, lower is better)
+
+The mean-ms and working-set numbers above are largely **blind to
+allocation-reduction work** — a PR that removes per-render allocations often
+moves them < 1% while cutting allocations by double digits. So the comment also
+reports a Reactor-only allocation table, captured by `PerfTracker` over the
+measured render loop:
+
+| Metric | Meaning | Direction |
+|---|---|:--:|
+| **Alloc bytes/render** | managed bytes allocated per render (`GC.GetTotalAllocatedBytes` Δ ÷ renders) | lower is better ↓ |
+| **Gen0 GC / 1k renders** | Gen0 collections per 1,000 renders (`GC.CollectionCount(0)` Δ) | lower is better ↓ |
+
+These read *n/a* for a PR head whose harness sources predate the metric — rebase
+onto `main` to populate them. They are the **sensitive signal** for the
+allocation-focused PRs in the current fleet.
+
 ## Prerequisites
 
 - **Windows** with a real interactive desktop session (the harness opens a real
@@ -82,8 +99,10 @@ git worktree remove ../main
 | `-BaselineRoot` | _(unset)_ | A second checkout (the **`main`** baseline). Setting it enables **compare mode** and renders `comment.md`. |
 | `-Percent` | `50` | Fraction of grid cells mutated per tick (methodology default). |
 | `-Duration` | `10` | Measured seconds per run (methodology default). |
-| `-Reps` | `2` | Measured runs whose **median** is reported (methodology "median of two"). Bump for tighter numbers. |
-| `-Warmup` | `1` | Leading runs discarded before the measured `Reps`. |
+| `-Reps` | `12` | Measured runs per side whose **median** is reported and whose per-run samples feed the **paired 95% CI**. 12 resolves the ~1–3% deltas these PRs target; a 2-run median cannot. |
+| `-Warmup` | `2` | Leading runs discarded before the measured `Reps` (absorbs JIT / first-window warm-up). |
+| `-RefReps` | `3` | Measured runs for the **reference-only** legs (vanilla WinUI3, Rust) — a single reference absolute, not a paired CI, so it needs far fewer reps. |
+| `-RefWarmup` | `1` | Warm-up runs discarded for the reference-only legs. |
 | `-Apps` | `ReactorOptimized,Direct` | Single-tree mode only: which harnesses to run. |
 | `-Platform` | host arch | Target architecture (`x64` or `ARM64`). Defaults to your machine's native arch so the WinUI harness runs without emulation. |
 | `-SelfContained` | `$true` | Build with the bundled WinApp runtime (no machine-wide install). |
@@ -137,10 +156,19 @@ is the security control, because the job has a write token.
 
 Two tables plus footnotes:
 
-- **Regression vs `main`** — `Metric | main | This PR | Δ% | Status`, where
-  Status is direction-aware (`✅ improvement` / `⚠️ regression` / `≈ within
-  noise`). "Within noise" means `|Δ|` is below the larger of the run-to-run
-  spread and a 4% floor — treat it as no measurable change.
+- **Regression vs `main`** — `Metric | main | This PR | Δ (95% CI) | Status`,
+  where Status is direction-aware (`✅ improvement` / `⚠️ regression` / `≈ within
+  noise`). The Δ is the **mean of the paired per-run deltas** (PR run *i* vs
+  `main` run *i*, collected interleaved) with a two-sided **95% confidence
+  interval**. A change is flagged improvement/regression **only when that CI
+  excludes 0**; if the CI straddles 0 it is *within noise* — no change resolvable
+  at this sample size. This data-driven band replaces the old fixed 4% floor,
+  which both buried real sub-4% wins and rubber-stamped any sub-4% number as
+  "noise" regardless of how tight the runs were.
+- **Allocation (Reactor)** — `Alloc bytes/render` and `Gen0 GC / 1k renders`,
+  `main` vs PR with the same paired-CI band. Rendered only when the harness
+  reports the metric (n/a for pre-metric PR heads). This is the table that moves
+  for allocation-reduction PRs.
 - **Cross-framework reference** — `vanilla WinUI3 | Rust windows-reactor |
   Reactor (this PR)` on the same StocksGrid workload, **all measured live on the
   same runner**. The Rust column builds and runs the
@@ -178,26 +206,31 @@ between runs and machines. We do not own them, so the design leans on
 - **Same-runner A/B** — PR and `main` are built and measured on the *same*
   machine in the *same* job, so machine-class differences cancel.
 - **Interleaving** — runs alternate `main, PR, main, PR, …` so slow time
-  windows hit both sides roughly equally.
-- **Warm-up discard + median of N** — the first run(s) are dropped; the median
-  rejects single-run outliers.
-- **Noise band** — a delta smaller than the larger of the measured run-to-run
-  spread and a 4% floor is reported as *within noise*, not a win/regression.
-- **Process priority + power plan** — runs use High priority and a
-  high-performance power plan (restored afterward), with a best-effort Defender
-  exclusion on the output tree.
+  windows hit both sides roughly equally, and each `main`/PR pair is measured
+  back-to-back so the **paired** delta cancels time-correlated drift.
+- **Warm-up discard + 12 measured reps** — the first runs are dropped; 12 paired
+  reps give the delta's confidence interval enough power to resolve a few-percent
+  change (a 2-run median cannot — its run-to-run swing dwarfs the effect).
+- **Paired 95% CI, not a fixed floor** — a change is called only when the 95% CI
+  of the paired delta excludes 0. This adapts to the actual run-to-run noise
+  instead of a blanket 4% threshold that both hid real sub-4% wins and accepted
+  any sub-4% number as noise.
+- **Pinned runtime** — High process priority, a high-performance power plan, a
+  pinned **workstation / non-concurrent GC** (`DOTNET_gcServer=0`,
+  `DOTNET_gcConcurrent=0`, applied identically to both sides), and `-PinAffinity`
+  in CI, all restored afterward, plus a best-effort Defender exclusion.
 - **Runner identity** — CPU / cores / RAM are recorded in the comment so the
   absolute numbers are read in context.
 
-For the steadiest local numbers: close other apps, stay on AC power, and bump
-`-Reps` (e.g. `-Reps 5`).
+For the steadiest local numbers: close other apps, stay on AC power, and keep the
+default `-Reps 12` (drop to e.g. `-Reps 3` only for a quick smoke run).
 
 ## Files here
 
 | File | Role |
 |---|---|
 | [`Run-PerfBenchmark.ps1`](Run-PerfBenchmark.ps1) | Orchestrator — build, run, interleave, render. Used by both the workflow and humans. |
-| [`PerfLib.ps1`](PerfLib.ps1) | Pure, side-effect-free helpers (parse, median, spread, direction-aware delta, comment renderer) + the sticky-comment marker. |
+| [`PerfLib.ps1`](PerfLib.ps1) | Pure, side-effect-free helpers (parse, median, spread, paired-Δ 95% CI stats, direction-aware delta, comment renderer) + the sticky-comment marker. |
 
 ## Troubleshooting
 

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -19,11 +19,13 @@
         the two-table sticky comment to comment.md for the workflow to post.
 
     Variance mitigations (we don't own CI runners): same-runner A/B, interleaved
-    reps, warm-up discard, median of N, a noise band on the deltas (PerfLib),
-    High process priority, a high-performance power plan for the duration, and an
-    opt-in Defender exclusion (-DefenderExclude). Runner identity (CPU / cores /
-    RAM) is recorded in the comment so absolute numbers are interpreted in
-    context — trust the delta, not the absolutes.
+    reps, warm-up discard, median of N with a paired 95%-confidence-interval band
+    on the deltas (PerfLib flags a change only when its CI excludes 0), High
+    process priority, a pinned workstation/non-concurrent GC, a high-performance
+    power plan for the duration, and an opt-in Defender exclusion
+    (-DefenderExclude). Runner identity (CPU / cores / RAM) is recorded in the
+    comment so absolute numbers are interpreted in context — trust the delta, not
+    the absolutes.
 
     The Rust `windows-reactor` cross-framework column is measured live when
     -RustRepo points at a microsoft/windows-rs checkout (its `test_reactor_perf`
@@ -45,11 +47,22 @@
     Measured seconds per run. Methodology default 10.
 
 .PARAMETER Reps
-    Measured runs whose median is reported (default 2 — methodology "median of
-    two"). Bump locally for tighter numbers.
+    Measured runs per side whose median is reported and whose per-run samples feed
+    the paired 95% CI (default 12 — enough to resolve the ~1-3% deltas these perf
+    PRs target; a 2-run median cannot). Lower it only for a quick local smoke run.
 
 .PARAMETER Warmup
-    Leading runs discarded before the Reps measured runs (default 1).
+    Leading runs discarded before the Reps measured runs (default 2) to absorb
+    JIT/tiered-compilation and first-window warm-up.
+
+.PARAMETER RefReps
+    Measured runs for the reference-only legs — vanilla WinUI3 (StressPerf.Direct)
+    and the Rust column (default 3). These contribute a single reference absolute,
+    not a paired CI, so they don't need the full -Reps budget; keeping them small
+    bounds total runner time.
+
+.PARAMETER RefWarmup
+    Warm-up runs discarded for the reference-only legs (default 1).
 
 .PARAMETER Apps
     Which harnesses to run in single-tree mode: ReactorOptimized, Direct.
@@ -116,8 +129,10 @@ param(
     [string]$BaselineRoot = '',
     [double]$Percent = 50,
     [int]$Duration = 10,
-    [int]$Reps = 2,
-    [int]$Warmup = 1,
+    [int]$Reps = 12,
+    [int]$Warmup = 2,
+    [int]$RefReps = 3,
+    [int]$RefWarmup = 1,
     [ValidateSet('ReactorOptimized', 'Direct')]
     [string[]]$Apps = @('ReactorOptimized', 'Direct'),
     [string]$OutDir,
@@ -513,7 +528,7 @@ function Invoke-RustLeg {
         Write-Log "Rust windows-reactor (test_reactor_perf)" 'Green'
         # The Rust port writes StressPerf.Reactor.report.txt next to its exe and has
         # no --json mode, so run with -NoJson and read the report.
-        $rustRuns = Measure-Sequential -Exe $rustExe -AppMeta @{ AppName = 'StressPerf.Reactor' } -Tag 'rust' -NoJson
+        $rustRuns = Measure-Sequential -Exe $rustExe -AppMeta @{ AppName = 'StressPerf.Reactor' } -Tag 'rust' -NoJson -RepCount $RefReps -WarmupCount $RefWarmup
         if ($rustRuns.Count) { return Measure-PerfRuns -Runs $rustRuns }
         Write-Log "Rust harness produced no metrics — Rust column n/a" 'Yellow'
         return $null
@@ -568,11 +583,18 @@ function Invoke-OneRun {
 }
 
 function Measure-Sequential {
-    param([string]$Exe, [hashtable]$AppMeta, [string]$Tag, [switch]$NoJson)
+    # RepCount/WarmupCount default to the script-level paired-A/B budget but are
+    # overridable so the reference-only legs (vanilla WinUI3, Rust) can run a small
+    # fixed number of reps — they contribute a single reference absolute, not a
+    # paired CI, so spending the full -Reps on them is wasted runner time.
+    param(
+        [string]$Exe, [hashtable]$AppMeta, [string]$Tag, [switch]$NoJson,
+        [int]$RepCount = $Reps, [int]$WarmupCount = $Warmup
+    )
     $runs = @()
-    for ($i = 1; $i -le ($Warmup + $Reps); $i++) {
+    for ($i = 1; $i -le ($WarmupCount + $RepCount); $i++) {
         $m = Invoke-OneRun -Exe $Exe -AppMeta $AppMeta -Index $i -Tag $Tag -NoJson:$NoJson
-        if ($i -le $Warmup) { Write-Log "  (warmup #$i discarded)" 'DarkGray'; continue }
+        if ($i -le $WarmupCount) { Write-Log "  (warmup #$i discarded)" 'DarkGray'; continue }
         if ($m) { $runs += $m }
     }
     return , $runs
@@ -586,6 +608,20 @@ try {
     & powercfg /setactive SCHEME_MIN 2>$null | Out-Null   # High performance
     Write-Log "power plan -> High performance (was $prevScheme)" 'DarkGray'
 } catch { Write-Log "power plan unchanged ($_)" 'DarkGray' }
+
+# ── GC mode pinning (restored on exit) ───────────────────────────────────────
+# Pin a deterministic GC for every harness child process so run-to-run variance
+# is governed by the workload, not by background-GC scheduling, and so main and
+# PR are compared under identical runtime settings. Workstation + non-concurrent
+# is the low-variance choice for this single-window render loop; env vars override
+# each harness' runtimeconfig and are inherited by Start-Process. Captured and
+# restored in the finally below so we never leak runtime state to later steps.
+$prevGcServer     = $env:DOTNET_gcServer
+$prevGcConcurrent = $env:DOTNET_gcConcurrent
+$env:DOTNET_gcServer     = '0'
+$env:DOTNET_gcConcurrent = '0'
+Write-Log "GC pinned -> workstation, non-concurrent (DOTNET_gcServer=0 DOTNET_gcConcurrent=0)" 'DarkGray'
+
 if ($DefenderExclude) {
     try { Add-MpPreference -ExclusionPath $Root -ErrorAction Stop; Write-Log "Defender exclusion added for $Root" 'DarkGray' }
     catch { Write-Log "Defender exclusion skipped ($_)" 'DarkGray' }
@@ -626,7 +662,7 @@ try {
         $winRuns = @()
         if ($directExe) {
             Write-Log "vanilla WinUI3 (StressPerf.Direct)" 'Green'
-            $winRuns = Measure-Sequential -Exe $directExe -AppMeta $direct -Tag 'winui3'
+            $winRuns = Measure-Sequential -Exe $directExe -AppMeta $direct -Tag 'winui3' -RepCount $RefReps -WarmupCount $RefWarmup
         } else {
             Write-Log "StressPerf.Direct exe not found — WinUI3 column will read n/a" 'Yellow'
         }
@@ -705,6 +741,8 @@ try {
 }
 finally {
     if ($prevScheme) { try { & powercfg /setactive $prevScheme 2>$null | Out-Null; Write-Log "power plan restored -> $prevScheme" 'DarkGray' } catch {} }
+    $env:DOTNET_gcServer     = $prevGcServer
+    $env:DOTNET_gcConcurrent = $prevGcConcurrent
     if ($DefenderExclude) { try { Remove-MpPreference -ExclusionPath $Root -ErrorAction SilentlyContinue } catch {} }
 }
 


### PR DESCRIPTION
> **Draft** — methodology change to the `/perf` harness itself. Do **not** merge until the coordinator/user signs off. No `/perf` run is needed on this PR (it changes `/perf`); we re-run `/perf` on the fleet **after** this lands.

## Why

`/perf` ran on PR #656 and returned "within noise" on a **2-run median** with a **4% floor**. I validated that result locally with **n=12 paired runs** (PR head `0df2ced` vs main `1402d1c`, off-OneDrive ARM64, interleaved, identical build). The methodology can't actually resolve the deltas it prints:

**2-run median is a coin flip.** Across all 2v2 subsamples of the n=12 data:

| Metric | Δ range across 2v2 | reproduces GH sign |
|---|--:|--:|
| Renders/sec | [−7.0%, +11.2%] | **23%** |
| Avg Reconcile | [−11.4%, +7.1%] | 85% |
| Avg Diff | [−11.6%, +7.8%] | 81% |

The headline **renders/sec −0.6% reproduces only 23% of the time** (74% of 2-run medians show the PR *faster*).

**The 4% floor preordains every sub-4% verdict** — independent of run count — so it masks a real, directionally-consistent signal. At n=12, paired 95% CIs:

| Metric | local Δ paired (95% CI) | GH Δ |
|---|--:|--:|
| Renders/sec | +2.03% (±2.10, **incl 0**) | −0.6% |
| Avg Reconcile ms | −3.56% (±2.48, **excl 0**) | −1.2% |
| Avg Diff ms | −3.33% (±2.36, **excl 0**) | −1.0% |
| Avg Memory MB | +0.03% (±0.47, incl 0) | +0.1% |

Per-side run-to-run noise is **3.1–4.4% CoV** on the timing metrics — *larger* than the ~1% deltas GH printed.

**renders/sec is ~76% render-bound.** One render cycle is ~269 ms, of which reconcile is only ~24% — the rest is native-grid measure/arrange/render *after* `OnRenderComplete`. A −3.5% reconcile win ⇒ ~+0.8% theoretical rps, **4–5× below the rps noise floor**. rps structurally cannot see reconcile/diff wins.

**The harness was blind to allocations.** It reported only mean-ms + working set — both largely insensitive to allocation churn, which is exactly what several fleet PRs reduce. A real `ReactorOptimized` render allocates **~9 MB/render** (~0.3 Gen0 GC/render); nothing in `/perf` surfaced that.

## What this PR changes

File-disjoint from `src/Reactor` and the in-flight perf PRs — only `tests/stress_perf/**` + the workflow.

- **Allocation metric** (`PerfTracker.cs`): brackets the render loop with `GC.GetTotalAllocatedBytes()` + `GC.CollectionCount(0/1/2)`, baselined lazily on the first render (so app-startup allocations are excluded). Emits `Alloc/render`, `GC Gen0/1/2`, `Gen0/Krender` to `report.txt` + `metrics.json`. AOT/trim-safe; **no change to the Reactor host under measurement**.
- **Paired statistics** (`PerfLib.ps1`): `Get-StudentTCritical` + `Get-PerfPairedDeltaStats` compute the paired per-run %-delta mean and a two-sided **95% CI**. `Get-PerfDelta` now flags improvement/regression **only when the CI excludes 0** — the data-driven band that **replaces the blanket 4% floor** (the scalar floor stays as the `<2-sample` fallback for back-compat). The comment gains a **`Δ (95% CI)`** column and a **Reactor-only Allocation table**.
- **Runner robustness** (`Run-PerfBenchmark.ps1` + workflow): default **`-Reps 2 → 12`**, **`-Warmup 1 → 2`**; pins a deterministic **workstation / non-concurrent GC** (restored on exit, applied equally to both sides); keeps interleaving + `-PinAffinity`. Reference-only legs (vanilla WinUI3, Rust) use a small **`-RefReps`/`-RefWarmup`** so the rep bump stays within the 60-min CI budget.
- **Tests + docs**: +47 `PerfLib.Tests.ps1` assertions (t-table, paired CI, CI-excludes-0 gating, ordered sample plumbing, alloc parse/back-compat, alloc-table render) → **108 green**; `RunPerfBenchmark.Tests.ps1` AST parse-gate green. `ci/README.md` + `METHODOLOGY.md` updated.

Validated end-to-end locally: a real `ReactorOptimized` run now emits the alloc fields through `report.txt` → `metrics.json` → aggregated medians + ordered sample arrays, and the comment renders the CI cells + alloc table (unit-covered).

## Scope / follow-up

This is **PR 1 of 2** (pre-blessed split). **PR 2 (fast-follow)** wires the existing `tests/perf_bench` micro-suite (spec-047 M1–M13: PropertyDiff / Allocation / StructuralSharing / ControlModel — MeanNs + AllocBytes + Gen0/1/2, ns-resolution, no WinUI dilution) into `/perf` — a separate WinUI-app run-model + JSONL orchestration, kept out of this PR to keep it reviewable.

Remaining secondary ideas (not in this PR): demote renders/sec to a labeled macro sanity check; add a naive `StressPerf.Reactor` / keyed `VirtualList` / Flex-Yoga workload for a larger, more representative diff signal.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>