### PR TITLE
perf(ci): wire reconciler micro-suite into /perf (ns + alloc, Core layer)

### DIFF
--- a/tests/perf_bench/PerfBench.ControlModel/PerfBench.ControlModel.csproj
+++ b/tests/perf_bench/PerfBench.ControlModel/PerfBench.ControlModel.csproj
@@ -29,6 +29,25 @@
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
+
+  <!--
+    On-demand perf-comparison CI (.github/workflows/perf-compare.yml) builds this
+    micro-suite with -p:PerfCiSelfContained=true so it carries its own Windows App
+    SDK runtime and launches with NO machine-wide runtime install on the
+    GitHub-hosted runner — the same hermetic trick StressPerf.ReactorOptimized and
+    the WinUI selftest hosts use to open real windows in CI. Scoped to THIS
+    executable (rather than a global -p:WindowsAppSDKSelfContained) so the flag
+    never flows into the referenced class libraries (Reactor.csproj /
+    PerfBench.Shared), which reject self-contained packaging. Run-PerfBenchmark.ps1
+    passes it by default for the reconcile micro-suite leg; pass -SelfContained:$false
+    to build framework-dependent.
+  -->
+  <PropertyGroup Condition="'$(PerfCiSelfContained)' == 'true'">
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' != 'ARM64'">win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>

--- a/tests/stress_perf/METHODOLOGY.md
+++ b/tests/stress_perf/METHODOLOGY.md
@@ -220,6 +220,44 @@ equivalent is collected) and absent in a harness built before the metric landed.
 > target; its run-to-run swing is larger than the effect. Full rationale in
 > [`ci/README.md`](ci/README.md#variance-trust-the-delta-not-the-absolutes).
 
+## Reconciler micro-benchmarks: ns-resolution Core path
+
+Every metric above is measured **across a live WinUI render pipeline**, which is
+the right scope for "what does the app feel like" but the wrong scope for the
+**Core/Reconciler** layer most perf work targets. The StocksGrid macro workload is
+render-bound (renders/sec is ~76% gated by the render thread) and its reconcile/ms
+and alloc figures are diluted by render + working-set noise — small per-reconcile
+deltas are unresolvable there. (The StocksGrid cells also render through a native
+`Grid` with fixed tracks, structurally separate from FlexPanel/Yoga, so layout-engine
+optimizations don't surface in this workload at all.)
+
+For that layer the repo ships a dedicated micro-suite,
+[`tests/perf_bench/PerfBench.ControlModel`](../perf_bench/PerfBench.ControlModel)
+(spec-047 M1–M13). It runs the production reconciler as a **headless loop whose
+measured region brackets only the reconcile body** — no render pipeline — with
+`Stopwatch` for **ns/op** and the **per-thread** `GC.GetAllocatedBytesForCurrentThread()`
+for **bytes/op** (per-thread, so WinUI and background-thread allocations are
+excluded). That makes it ns-resolution and free of the dilution above.
+
+`/perf` builds and runs this suite once per side — `main` and the PR each link
+their own `src/Reactor` — and reports a per-bench `main`-vs-PR table; see
+[`ci/README.md`](ci/README.md#reconciler-micro-benchmarks-ns-resolution-winui-undiluted).
+The two metrics are read differently. **Allocated bytes/op is deterministic** for
+identical code — an unchanged diff reproduces the byte count exactly — so its paired
+95% CI is trustworthy and **drives each row's flag**. **ns/op is informational only**
+in v1: the two per-side runs are not yet rep-interleaved, so a systematic
+process-to-process timing offset (thermal/scheduling drift between the back-to-back
+invocations) shifts every paired ns difference the same way and makes the paired CI
+exclude 0 even for an identical binary. Local validation confirmed it — running the
+**same** ControlModel binary as both sides, alloc was deterministic (14/16 benches
+exactly 0.0% Δ) while ns spuriously flagged up to −14.8% on a no-op. So ns is shown
+for context but excluded from the flag, and **rep-level interleaving of the two sides
+is the documented fast-follow** that would promote ns to a flagged signal.
+
+It is the **authoritative instrument** for per-reconcile allocation deltas (and,
+once interleaved, reconcile-time deltas); the macro tables remain the user-facing
+throughput sanity check.
+
 ## Don'ts (so we don't redo this analysis)
 
 1. **Don't trust `CompositionTarget.Rendering` for "FPS."** It's UI-thread-

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -403,10 +403,10 @@ Assert-True (-not ($noAllocComment -like '*Allocation (Reactor)*')) 'alloc table
 
 # ── Reconciler micro-suite: Read-MicroBenchResults / comparison / render ──────
 function New-MicroRow {
-    param([string]$BenchId, [string]$Name, [string]$Variant, [int]$Rep, [double]$MeanNs, [double]$AllocBytes, [string]$Status = 'ok')
+    param([string]$BenchId, [string]$Name, [string]$Variant, [int]$Rep, [double]$MeanNs, [double]$AllocBytes, [string]$Status = 'ok', [int]$Iterations = 1)
     [pscustomobject]@{
-        benchId = $BenchId; benchName = $Name; variant = $Variant; iterations = 10000
-        repetition = $Rep; totalMs = ($MeanNs * 10000 / 1e6); meanNs = $MeanNs; allocBytes = $AllocBytes
+        benchId = $BenchId; benchName = $Name; variant = $Variant; iterations = $Iterations
+        repetition = $Rep; totalMs = ($MeanNs * $Iterations / 1e6); meanNs = $MeanNs; allocBytes = $AllocBytes
         gen0 = 0; gen1 = 0; gen2 = 0; heapDeltaBytes = 0; counter = 0; counterLabel = $null
         status = $Status; machineSku = 'x'; architecture = 'X64'; configuration = 'Release'
     } | ConvertTo-Json -Compress
@@ -474,6 +474,18 @@ try {
     $emptyJsonl = Join-Path $microTmp 'empty.jsonl'; Set-Content -LiteralPath $emptyJsonl -Value '' -Encoding UTF8
     Assert-Equal 0 (Read-MicroBenchResults $emptyJsonl).Count 'empty file -> empty map'
     Assert-Equal 0 (Read-MicroBenchResults $null).Count       'null path -> empty map'
+
+    # AllocBytesSamples are PER-OP: allocBytes (the whole-loop total) is divided by the
+    # row's iterations so the "B/op" column and the per-op meanNs share one basis. A row
+    # with iterations=10000 and a 1,400,000-byte loop total must parse to 140 B/op.
+    $perOpJsonl = Join-Path $microTmp 'perop.jsonl'
+    Set-Content -LiteralPath $perOpJsonl -Encoding UTF8 -Value @(
+        (New-MicroRow 'M1' 'PropertyDiff' 'Reactor' 0 100 1400000 'ok' 10000)
+        (New-MicroRow 'M1' 'PropertyDiff' 'Reactor' 1 100 1400000 'ok' 10000)
+    )
+    $perOpMap = Read-MicroBenchResults $perOpJsonl
+    Assert-Equal 140 $perOpMap['M1'].AllocBytesSamples[0] 'alloc parsed per-op (allocBytes / iterations)'
+    Assert-Equal 100 $perOpMap['M1'].MeanNsSamples[0]     'ns already per-op, carried unchanged'
 
     $cmp = @(Get-PerfMicroComparison -Main $mainMap -Pr $prMap)
     Assert-Equal 4 $cmp.Count                              'comparison = overlapping benches only (M99 excluded)'
@@ -562,6 +574,87 @@ try {
     Assert-Equal 20 $a2.MainMeanNs                         'consistent medians: main ns median over aligned reps (20), not all-sample (25)'
     Assert-Equal 20 $a2.PrMeanNs                           'consistent medians: pr ns median over aligned reps'
     Assert-Equal 3  $a2.NsDelta.N                          'consistent medians: ns paired over the 3 common reps'
+
+    # Micro paired-CI contract: a bench whose rep-aligned overlap is < 2 pairs has NO
+    # admissible CI (Get-PerfPairedDeltaStats needs >= 2 deltas), so the row must read
+    # 'na' — never be flagged off the point-delta fallback. Get-PerfMicroComparison
+    # passes -RequirePairedCI so Get-PerfDelta returns 'na' instead of the % -floor band.
+    #   Z1 — exactly ONE common rep (rep 0); the lone pair is a huge alloc drop the old
+    #        point-delta path would have flagged 'better' with N=$null.
+    #   Z0 — ZERO common reps (disjoint repetition indices) -> 'na', N stays $null.
+    $naMain = @(
+        (New-MicroRow 'Z1' 'OneCommonRep' 'Reactor' 0 100 1000)
+        (New-MicroRow 'Z1' 'OneCommonRep' 'Reactor' 1 100 1000)
+        (New-MicroRow 'Z0' 'NoCommonRep'  'Reactor' 0 100 1000)
+        (New-MicroRow 'Z0' 'NoCommonRep'  'Reactor' 1 100 1000)
+    )
+    $naPr = @(
+        (New-MicroRow 'Z1' 'OneCommonRep' 'Reactor' 0 50 100)   # only rep 0 overlaps {0,1}
+        (New-MicroRow 'Z1' 'OneCommonRep' 'Reactor' 7 50 100)
+        (New-MicroRow 'Z0' 'NoCommonRep'  'Reactor' 8 50 100)   # no overlap with {0,1}
+        (New-MicroRow 'Z0' 'NoCommonRep'  'Reactor' 9 50 100)
+    )
+    $naMainJsonl = Join-Path $microTmp 'na-main.jsonl'
+    $naPrJsonl   = Join-Path $microTmp 'na-pr.jsonl'
+    Set-Content -LiteralPath $naMainJsonl -Value $naMain -Encoding UTF8
+    Set-Content -LiteralPath $naPrJsonl   -Value $naPr   -Encoding UTF8
+    $naCmp = @(Get-PerfMicroComparison -Main (Read-MicroBenchResults $naMainJsonl) -Pr (Read-MicroBenchResults $naPrJsonl))
+    $naById = @{}; foreach ($r in $naCmp) { $naById[$r.BenchId] = $r }
+    $z1 = $naById['Z1']; $z0 = $naById['Z0']
+    Assert-Equal 'na' $z1.AllocDelta.Status                'Z1 (1 common rep): alloc na — no point-delta flag off one pair'
+    Assert-True ($null -eq $z1.AllocDelta.N)               'Z1 (1 common rep): alloc N stays $null'
+    Assert-Equal 'na' $z1.NsDelta.Status                   'Z1 (1 common rep): ns na'
+    Assert-Equal 'na' (Get-PerfMicroRowStatus -NsStatus $z1.NsDelta.Status -AllocStatus $z1.AllocDelta.Status) 'Z1 (1 common rep): row na'
+    Assert-Equal 'na' $z0.AllocDelta.Status                'Z0 (0 common reps): alloc na'
+    Assert-True ($null -eq $z0.AllocDelta.N)               'Z0 (0 common reps): alloc N stays $null'
+    Assert-Equal 'na' (Get-PerfMicroRowStatus -NsStatus $z0.NsDelta.Status -AllocStatus $z0.AllocDelta.Status) 'Z0 (0 common reps): row na'
+
+    # Minimum-effect band: not every micro bench is alloc-deterministic. A dispatcher /
+    # background-thread bench can carry a sub-1% systematic process-to-process alloc
+    # offset whose within-process CI is tight enough to EXCLUDE 0 on identical code (the
+    # M5 "Dispatch_Switch_Warm" smoke case). -MinEffectPct keeps such a sub-band delta
+    # 'noise' while a real structural delta (>= the band) still flags.
+    #   Direct Get-PerfDelta: same tight +0.3% delta is 'worse' at the default band (0)
+    #   but 'noise' once a 1% band is required; a large +20% delta flags through both.
+    $bandB = @(1000, 1000, 1000, 1000)
+    $bandC = @(1003, 1004, 1002, 1003)            # per-pair Δ ≈ +0.2..+0.4%, tight CI excludes 0
+    $bandNoFloor = Get-PerfDelta -Baseline 1000 -Candidate 1003 -LowerIsBetter $true `
+        -BaselineSamples $bandB -CandidateSamples $bandC -RequirePairedCI
+    Assert-Equal 'worse' $bandNoFloor.Status               'band: sub-1% tight delta flags worse at MinEffectPct=0 (CI excludes 0)'
+    $bandFloor = Get-PerfDelta -Baseline 1000 -Candidate 1003 -LowerIsBetter $true `
+        -BaselineSamples $bandB -CandidateSamples $bandC -RequirePairedCI -MinEffectPct 1.0
+    Assert-Equal 'noise' $bandFloor.Status                 'band: same sub-1% delta reads noise once the 1% band is required'
+    Assert-True (($bandFloor.DeltaPct -gt 0) -and ($bandFloor.DeltaPct -lt 1)) 'band: DeltaPct still reported (sub-band), only the flag is suppressed'
+    $bigB = @(1000, 1000, 1000, 1000)
+    $bigC = @(1200, 1201, 1199, 1200)             # +20% — well past any 1% band
+    $bandBig = Get-PerfDelta -Baseline 1000 -Candidate 1200 -LowerIsBetter $true `
+        -BaselineSamples $bigB -CandidateSamples $bigC -RequirePairedCI -MinEffectPct 1.0
+    Assert-Equal 'worse' $bandBig.Status                   'band: a real >1% delta still flags through the band'
+
+    # Integration: the micro comparison passes the alloc band, so a bench with a tight
+    # sub-1% alloc rise reads 'noise' at the row level (no false regression), while its
+    # ns context is unaffected.
+    $bandMain = @(
+        (New-MicroRow 'B1' 'BandFloor' 'Reactor' 0 500 1000)
+        (New-MicroRow 'B1' 'BandFloor' 'Reactor' 1 500 1000)
+        (New-MicroRow 'B1' 'BandFloor' 'Reactor' 2 500 1000)
+        (New-MicroRow 'B1' 'BandFloor' 'Reactor' 3 500 1000)
+    )
+    $bandPr = @(
+        (New-MicroRow 'B1' 'BandFloor' 'Reactor' 0 500 1003)
+        (New-MicroRow 'B1' 'BandFloor' 'Reactor' 1 500 1004)
+        (New-MicroRow 'B1' 'BandFloor' 'Reactor' 2 500 1002)
+        (New-MicroRow 'B1' 'BandFloor' 'Reactor' 3 500 1003)
+    )
+    $bandMainJsonl = Join-Path $microTmp 'band-main.jsonl'
+    $bandPrJsonl   = Join-Path $microTmp 'band-pr.jsonl'
+    Set-Content -LiteralPath $bandMainJsonl -Value $bandMain -Encoding UTF8
+    Set-Content -LiteralPath $bandPrJsonl   -Value $bandPr   -Encoding UTF8
+    $bandCmp = @(Get-PerfMicroComparison -Main (Read-MicroBenchResults $bandMainJsonl) -Pr (Read-MicroBenchResults $bandPrJsonl))
+    $b1 = $bandCmp[0]
+    Assert-Equal 'noise' $b1.AllocDelta.Status             'band integration: sub-1% alloc rise reads noise (not worse) through the micro path'
+    Assert-Equal 'noise' (Get-PerfMicroRowStatus -NsStatus $b1.NsDelta.Status -AllocStatus $b1.AllocDelta.Status) 'band integration: row = noise'
+    Assert-Equal 4 $b1.AllocDelta.N                        'band integration: all 4 reps paired (band suppresses the flag, not the pairing)'
 
     # Section rendering.
     Assert-Equal 0 @(Format-PerfMicroSection -Micro $null).Count  'micro section empty when null'

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -516,6 +516,36 @@ try {
     Assert-Equal 'na'     (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'na')     'alloc na -> row na (ns does not rescue)'
     Assert-Equal 'na'     (Get-PerfMicroRowStatus -NsStatus 'na'     -AllocStatus 'na')     'na when alloc na'
 
+    # Rep-aligned pairing: a dropped/errored repetition on one side must not
+    # position-shift later samples and mis-pair the paired CI. main A1 has reps
+    # 0..3 (rep1 an outlier=2000); pr A1 is MISSING rep1. Correct rep-keyed alignment
+    # pairs only the common reps {0,2,3} -> a clean -10% alloc delta. The old
+    # position-zip would pair main rep1's 2000 against pr rep2 and smear the mean.
+    $alignMain = @(
+        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 0 500 1000)
+        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 1 500 2000)
+        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 2 500 1000)
+        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 3 500 1000)
+    )
+    $alignPr = @(
+        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 0 500 900)
+        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 2 500 900)
+        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 3 500 900)
+    )
+    $alignMainJsonl = Join-Path $microTmp 'align-main.jsonl'
+    $alignPrJsonl = Join-Path $microTmp 'align-pr.jsonl'
+    Set-Content -LiteralPath $alignMainJsonl -Value $alignMain -Encoding UTF8
+    Set-Content -LiteralPath $alignPrJsonl -Value $alignPr -Encoding UTF8
+    $alignMainMap = Read-MicroBenchResults $alignMainJsonl
+    Assert-Equal 4 $alignMainMap['A1'].Repetitions.Count   'parser captures the repetition index per sample'
+    Assert-Equal 1 $alignMainMap['A1'].Repetitions[1]      'repetitions carried in sorted order'
+    $alignCmp = @(Get-PerfMicroComparison -Main $alignMainMap -Pr (Read-MicroBenchResults $alignPrJsonl))
+    Assert-Equal 1 $alignCmp.Count                         'rep-align: one overlapping bench'
+    $a1 = $alignCmp[0]
+    Assert-Equal 3 $a1.AllocDelta.N                        'rep-align: only the 3 common reps paired (not min-count position zip)'
+    Assert-True (($a1.AllocDelta.DeltaPct -gt -10.5) -and ($a1.AllocDelta.DeltaPct -lt -9.5)) 'rep-align: paired alloc Δ ≈ -10% (rep-keyed), not smeared by the missing rep'
+    Assert-Equal 'better' $a1.AllocDelta.Status            'rep-align: clean -10% alloc flagged better'
+
     # Section rendering.
     Assert-Equal 0 @(Format-PerfMicroSection -Micro $null).Count  'micro section empty when null'
     Assert-Equal 0 @(Format-PerfMicroSection -Micro @()).Count    'micro section empty when no rows'

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -487,6 +487,25 @@ try {
     Assert-Equal 140 $perOpMap['M1'].AllocBytesSamples[0] 'alloc parsed per-op (allocBytes / iterations)'
     Assert-Equal 100 $perOpMap['M1'].MeanNsSamples[0]     'ns already per-op, carried unchanged'
 
+    # Malformed-line resilience: repetition drives the rep-keyed pairing and is cast to
+    # [int], so a row missing repetition (schema drift / truncation) or carrying a
+    # non-numeric value must be SKIPPED at ingestion, not throw past the guard. Two valid
+    # reps (0, 2) bracket a missing-repetition row and a non-numeric-repetition row.
+    $repJsonl = Join-Path $microTmp 'badrep.jsonl'
+    Set-Content -LiteralPath $repJsonl -Encoding UTF8 -Value @(
+        '{"benchId":"M1","benchName":"PropertyDiff","variant":"Reactor","iterations":1,"repetition":0,"meanNs":100,"allocBytes":500,"status":"ok"}'
+        '{"benchId":"M1","benchName":"PropertyDiff","variant":"Reactor","iterations":1,"meanNs":102,"allocBytes":505,"status":"ok"}'           # missing repetition -> skip
+        '{"benchId":"M1","benchName":"PropertyDiff","variant":"Reactor","iterations":1,"repetition":"x","meanNs":103,"allocBytes":507,"status":"ok"}' # non-numeric -> skip
+        '{"benchId":"M1","benchName":"PropertyDiff","variant":"Reactor","iterations":1,"repetition":2,"meanNs":98,"allocBytes":495,"status":"ok"}'
+    )
+    $repMap = $null
+    $repThrew = $false
+    try { $repMap = Read-MicroBenchResults $repJsonl } catch { $repThrew = $true }
+    Assert-True (-not $repThrew)                            'malformed repetition: parser does not throw'
+    Assert-Equal 2 $repMap['M1'].MeanNsSamples.Count       'malformed repetition: only the 2 numeric-repetition rows kept'
+    Assert-Equal 0 $repMap['M1'].Repetitions[0]            'malformed repetition: surviving reps are the valid ones (0, 2)'
+    Assert-Equal 2 $repMap['M1'].Repetitions[1]            'malformed repetition: non-numeric/missing rows dropped, not mis-cast'
+
     $cmp = @(Get-PerfMicroComparison -Main $mainMap -Pr $prMap)
     Assert-Equal 4 $cmp.Count                              'comparison = overlapping benches only (M99 excluded)'
     # numeric (not lexical) sort: M1, M2, M3, M10 — lexical would put M10 before M2/M3.

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -401,6 +401,146 @@ $noAllocComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $nu
 Assert-True (-not ($noAllocComment -like '*Allocation (Reactor)*')) 'alloc table omitted when no alloc metric present'
 
 
+# ── Reconciler micro-suite: Read-MicroBenchResults / comparison / render ──────
+function New-MicroRow {
+    param([string]$BenchId, [string]$Name, [string]$Variant, [int]$Rep, [double]$MeanNs, [double]$AllocBytes, [string]$Status = 'ok')
+    [pscustomobject]@{
+        benchId = $BenchId; benchName = $Name; variant = $Variant; iterations = 10000
+        repetition = $Rep; totalMs = ($MeanNs * 10000 / 1e6); meanNs = $MeanNs; allocBytes = $AllocBytes
+        gen0 = 0; gen1 = 0; gen2 = 0; heapDeltaBytes = 0; counter = 0; counterLabel = $null
+        status = $Status; machineSku = 'x'; architecture = 'X64'; configuration = 'Release'
+    } | ConvertTo-Json -Compress
+}
+
+$microTmp = Join-Path ([System.IO.Path]::GetTempPath()) ("perflib-micro-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $microTmp | Out-Null
+try {
+    $mainJsonl = Join-Path $microTmp 'main.jsonl'
+    $prJsonl = Join-Path $microTmp 'pr.jsonl'
+
+    # main side: M1 (fast/cheap), M2 (mid), M10 (cheap), M99 (main-only). Plus a Direct
+    # variant row and a status=error row that MUST be filtered out by the parser.
+    $mainLines = @(
+        (New-MicroRow 'M1'  'PropertyDiff'      'Reactor' 0 100 520)
+        (New-MicroRow 'M1'  'PropertyDiff'      'Reactor' 1 102 525)
+        (New-MicroRow 'M1'  'PropertyDiff'      'Reactor' 2 98  515)
+        (New-MicroRow 'M1'  'PropertyDiff'      'Direct'  0 999 9999)        # filtered: not Reactor
+        (New-MicroRow 'M2'  'StructuralSharing' 'Reactor' 0 200 1000)
+        (New-MicroRow 'M2'  'StructuralSharing' 'Reactor' 1 203 1005)
+        (New-MicroRow 'M2'  'StructuralSharing' 'Reactor' 2 197 995)
+        (New-MicroRow 'M2'  'StructuralSharing' 'Reactor' 9 0   0    'error') # filtered: status error
+        (New-MicroRow 'M3'  'TimeOnly'          'Reactor' 0 300 5000)
+        (New-MicroRow 'M3'  'TimeOnly'          'Reactor' 1 303 5005)
+        (New-MicroRow 'M3'  'TimeOnly'          'Reactor' 2 297 4995)
+        (New-MicroRow 'M10' 'Allocation'        'Reactor' 0 50  300)
+        (New-MicroRow 'M10' 'Allocation'        'Reactor' 1 51  303)
+        (New-MicroRow 'M10' 'Allocation'        'Reactor' 2 49  297)
+        (New-MicroRow 'M99' 'MainOnly'          'Reactor' 0 10  100)         # no PR counterpart
+    )
+    # pr side: M1 faster + fewer allocs; M2 ~unchanged; M3 much faster but SAME allocs
+    # (the no-false-flag case); M10 slower + more allocs.
+    $prLines = @(
+        (New-MicroRow 'M1'  'PropertyDiff'      'Reactor' 0 80  400)
+        (New-MicroRow 'M1'  'PropertyDiff'      'Reactor' 1 79  398)
+        (New-MicroRow 'M1'  'PropertyDiff'      'Reactor' 2 82  403)
+        (New-MicroRow 'M2'  'StructuralSharing' 'Reactor' 0 199 1001)
+        (New-MicroRow 'M2'  'StructuralSharing' 'Reactor' 1 204 1003)
+        (New-MicroRow 'M2'  'StructuralSharing' 'Reactor' 2 198 998)
+        (New-MicroRow 'M3'  'TimeOnly'          'Reactor' 0 200 5004)
+        (New-MicroRow 'M3'  'TimeOnly'          'Reactor' 1 201 4998)
+        (New-MicroRow 'M3'  'TimeOnly'          'Reactor' 2 199 5002)
+        (New-MicroRow 'M10' 'Allocation'        'Reactor' 0 60  360)
+        (New-MicroRow 'M10' 'Allocation'        'Reactor' 1 61  363)
+        (New-MicroRow 'M10' 'Allocation'        'Reactor' 2 59  357)
+    )
+    Set-Content -LiteralPath $mainJsonl -Value $mainLines -Encoding UTF8
+    Set-Content -LiteralPath $prJsonl -Value $prLines -Encoding UTF8
+
+    $mainMap = Read-MicroBenchResults $mainJsonl
+    $prMap = Read-MicroBenchResults $prJsonl
+
+    Assert-Equal 5 $mainMap.Count                          'parser keeps 5 main benches (M1,M2,M3,M10,M99)'
+    Assert-Equal 4 $prMap.Count                            'parser keeps 4 pr benches (M1,M2,M3,M10)'
+    Assert-Equal 3 $mainMap['M1'].MeanNsSamples.Count      'M1 keeps 3 Reactor reps (Direct row dropped)'
+    Assert-Equal 3 $mainMap['M2'].MeanNsSamples.Count      'M2 keeps 3 ok reps (error row dropped)'
+    Assert-True  (-not $mainMap.Contains('XX'))            'no phantom benches from filtered rows'
+    Assert-Equal 'PropertyDiff' $mainMap['M1'].Name        'bench name carried through'
+    # rows ordered by repetition: first sample is rep 0 (=100 / =520).
+    Assert-Equal 100 $mainMap['M1'].MeanNsSamples[0]       'samples ordered by repetition (ns)'
+    Assert-Equal 520 $mainMap['M1'].AllocBytesSamples[0]   'samples ordered by repetition (alloc)'
+
+    # Missing / empty inputs -> empty map (no throw under StrictMode).
+    Assert-Equal 0 (Read-MicroBenchResults (Join-Path $microTmp 'nope.jsonl')).Count 'missing file -> empty map'
+    $emptyJsonl = Join-Path $microTmp 'empty.jsonl'; Set-Content -LiteralPath $emptyJsonl -Value '' -Encoding UTF8
+    Assert-Equal 0 (Read-MicroBenchResults $emptyJsonl).Count 'empty file -> empty map'
+    Assert-Equal 0 (Read-MicroBenchResults $null).Count       'null path -> empty map'
+
+    $cmp = @(Get-PerfMicroComparison -Main $mainMap -Pr $prMap)
+    Assert-Equal 4 $cmp.Count                              'comparison = overlapping benches only (M99 excluded)'
+    # numeric (not lexical) sort: M1, M2, M3, M10 — lexical would put M10 before M2/M3.
+    Assert-Equal 'M1'  $cmp[0].BenchId                     'sorted: M1 first'
+    Assert-Equal 'M2'  $cmp[1].BenchId                     'sorted: M2 second'
+    Assert-Equal 'M3'  $cmp[2].BenchId                     'sorted: M3 third'
+    Assert-Equal 'M10' $cmp[3].BenchId                     'sorted: M10 last (numeric, not lexical)'
+
+    $byId = @{}; foreach ($r in $cmp) { $byId[$r.BenchId] = $r }
+    $m1 = $byId['M1']; $m2 = $byId['M2']; $m3 = $byId['M3']; $m10 = $byId['M10']
+
+    # The row flag tracks the DETERMINISTIC alloc signal; ns is informational.
+    Assert-Equal 'better' $m1.AllocDelta.Status            'M1 alloc improvement flagged'
+    Assert-Equal 'better' (Get-PerfMicroRowStatus -NsStatus $m1.NsDelta.Status -AllocStatus $m1.AllocDelta.Status) 'M1 row = better (alloc down)'
+    Assert-Equal 'noise'  $m2.AllocDelta.Status            'M2 alloc within noise'
+    Assert-Equal 'noise'  (Get-PerfMicroRowStatus -NsStatus $m2.NsDelta.Status -AllocStatus $m2.AllocDelta.Status) 'M2 row = noise'
+    Assert-Equal 'worse'  $m10.AllocDelta.Status           'M10 alloc regression flagged'
+    Assert-Equal 'worse'  (Get-PerfMicroRowStatus -NsStatus $m10.NsDelta.Status -AllocStatus $m10.AllocDelta.Status) 'M10 row = worse (alloc up)'
+
+    # KEY v1 property: M3 has a clear ns improvement but UNCHANGED alloc — the ns delta
+    # must NOT flag the row (ns is informational until per-side runs are rep-interleaved).
+    Assert-Equal 'better' $m3.NsDelta.Status               'M3 ns delta itself reads better (big ns drop)'
+    Assert-Equal 'noise'  $m3.AllocDelta.Status            'M3 alloc unchanged -> noise'
+    Assert-Equal 'noise'  (Get-PerfMicroRowStatus -NsStatus $m3.NsDelta.Status -AllocStatus $m3.AllocDelta.Status) 'M3 row = noise despite ns better (no ns false-flag)'
+
+    Assert-Equal 100 $m1.MainMeanNs                        'M1 main median ns'
+    Assert-Equal 80  $m1.PrMeanNs                          'M1 pr median ns'
+
+    # Empty / null inputs to the comparison.
+    Assert-Equal 0 (@(Get-PerfMicroComparison -Main ([ordered]@{}) -Pr $prMap)).Count 'empty main -> no rows'
+    Assert-Equal 0 (@(Get-PerfMicroComparison -Main $null -Pr $null)).Count           'null maps -> no rows'
+
+    # Row status tracks the deterministic ALLOC signal only; ns is informational and
+    # never drives the flag in v1 (the per-side runs are not yet rep-interleaved).
+    Assert-Equal 'worse'  (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'worse')  'alloc worse -> row worse (ns ignored)'
+    Assert-Equal 'better' (Get-PerfMicroRowStatus -NsStatus 'worse'  -AllocStatus 'better') 'alloc better -> row better (ns ignored)'
+    Assert-Equal 'noise'  (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'noise')  'alloc noise -> row noise even when ns better (no ns false-flag)'
+    Assert-Equal 'noise'  (Get-PerfMicroRowStatus -NsStatus 'worse'  -AllocStatus 'noise')  'alloc noise -> row noise even when ns worse'
+    Assert-Equal 'na'     (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'na')     'alloc na -> row na (ns does not rescue)'
+    Assert-Equal 'na'     (Get-PerfMicroRowStatus -NsStatus 'na'     -AllocStatus 'na')     'na when alloc na'
+
+    # Section rendering.
+    Assert-Equal 0 @(Format-PerfMicroSection -Micro $null).Count  'micro section empty when null'
+    Assert-Equal 0 @(Format-PerfMicroSection -Micro @()).Count    'micro section empty when no rows'
+    $section = Format-PerfMicroSection -Micro $cmp
+    $sectionText = $section -join "`n"
+    Assert-Match $sectionText 'Reconciler micro-benchmarks'      'section has heading'
+    Assert-Match $sectionText 'ns/op'                            'section header names ns/op'
+    Assert-Match $sectionText 'B/op'                             'section header names B/op'
+    Assert-True ($sectionText.Contains('`M1` PropertyDiff'))     'section row labels bench + name'
+    Assert-Match $sectionText '95% CI'                           'section delta cells carry a CI'
+    # numeric sort survives into the rendered table (M2 row appears before M10 row).
+    Assert-True (($sectionText.IndexOf('`M2`')) -lt ($sectionText.IndexOf('`M10`'))) 'rendered rows keep numeric order'
+
+    # Format-PerfComment threads -Micro through into the comment.
+    $microComment = Format-PerfComment -Main $allocMain -Pr $allocPr -WinUI3 $null -Rust $null -Micro $cmp -Context $ctx
+    Assert-Match $microComment 'Reconciler micro-benchmarks'     'comment includes micro section when -Micro supplied'
+    Assert-Match $microComment 'WinUI-undiluted'                 'comment carries the micro footnote'
+    # Omitted / null -Micro -> no micro section (back-compat with existing callers).
+    Assert-True (-not ($allocComment -like '*Reconciler micro-benchmarks*')) 'micro section omitted when -Micro not supplied'
+}
+finally {
+    Remove-Item -LiteralPath $microTmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+
 if ($script:Fail -gt 0) {
     Write-Host "FAILED: $($script:Fail) / $($script:Pass + $script:Fail) assertions" -ForegroundColor Red
     foreach ($f in $script:Failures) { Write-Host "  ✗ $f" -ForegroundColor Red }

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -516,21 +516,32 @@ try {
     Assert-Equal 'na'     (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'na')     'alloc na -> row na (ns does not rescue)'
     Assert-Equal 'na'     (Get-PerfMicroRowStatus -NsStatus 'na'     -AllocStatus 'na')     'na when alloc na'
 
-    # Rep-aligned pairing: a dropped/errored repetition on one side must not
-    # position-shift later samples and mis-pair the paired CI. main A1 has reps
-    # 0..3 (rep1 an outlier=2000); pr A1 is MISSING rep1. Correct rep-keyed alignment
-    # pairs only the common reps {0,2,3} -> a clean -10% alloc delta. The old
-    # position-zip would pair main rep1's 2000 against pr rep2 and smear the mean.
+    # Rep-aligned pairing + consistent medians. Two benches, each with rep1 dropped
+    # on the PR side:
+    #   A1 — main rep1 is an alloc outlier (2000). Correct rep-keyed alignment pairs
+    #        only the common reps {0,2,3} -> a clean -10% alloc Δ; the old position-zip
+    #        would pair main rep1's 2000 against pr rep2 and smear the mean.
+    #   A2 — main rep1 (unpaired) sits at the ns median position, so the DISPLAYED
+    #        median must be taken over the aligned set ({0,2,3} -> 20), not all four
+    #        samples ({10,20,30,999} -> 25). Proves the table column and the Δ are
+    #        drawn from the same samples.
     $alignMain = @(
-        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 0 500 1000)
-        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 1 500 2000)
-        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 2 500 1000)
-        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 3 500 1000)
+        (New-MicroRow 'A1' 'RepAlignDelta'  'Reactor' 0 500 1000)
+        (New-MicroRow 'A1' 'RepAlignDelta'  'Reactor' 1 500 2000)
+        (New-MicroRow 'A1' 'RepAlignDelta'  'Reactor' 2 500 1000)
+        (New-MicroRow 'A1' 'RepAlignDelta'  'Reactor' 3 500 1000)
+        (New-MicroRow 'A2' 'RepAlignMedian' 'Reactor' 0 10  500)
+        (New-MicroRow 'A2' 'RepAlignMedian' 'Reactor' 1 999 500)
+        (New-MicroRow 'A2' 'RepAlignMedian' 'Reactor' 2 20  500)
+        (New-MicroRow 'A2' 'RepAlignMedian' 'Reactor' 3 30  500)
     )
     $alignPr = @(
-        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 0 500 900)
-        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 2 500 900)
-        (New-MicroRow 'A1' 'RepAlign' 'Reactor' 3 500 900)
+        (New-MicroRow 'A1' 'RepAlignDelta'  'Reactor' 0 500 900)
+        (New-MicroRow 'A1' 'RepAlignDelta'  'Reactor' 2 500 900)
+        (New-MicroRow 'A1' 'RepAlignDelta'  'Reactor' 3 500 900)
+        (New-MicroRow 'A2' 'RepAlignMedian' 'Reactor' 0 10  500)
+        (New-MicroRow 'A2' 'RepAlignMedian' 'Reactor' 2 20  500)
+        (New-MicroRow 'A2' 'RepAlignMedian' 'Reactor' 3 30  500)
     )
     $alignMainJsonl = Join-Path $microTmp 'align-main.jsonl'
     $alignPrJsonl = Join-Path $microTmp 'align-pr.jsonl'
@@ -540,11 +551,17 @@ try {
     Assert-Equal 4 $alignMainMap['A1'].Repetitions.Count   'parser captures the repetition index per sample'
     Assert-Equal 1 $alignMainMap['A1'].Repetitions[1]      'repetitions carried in sorted order'
     $alignCmp = @(Get-PerfMicroComparison -Main $alignMainMap -Pr (Read-MicroBenchResults $alignPrJsonl))
-    Assert-Equal 1 $alignCmp.Count                         'rep-align: one overlapping bench'
-    $a1 = $alignCmp[0]
+    $alignById = @{}; foreach ($r in $alignCmp) { $alignById[$r.BenchId] = $r }
+    $a1 = $alignById['A1']; $a2 = $alignById['A2']
     Assert-Equal 3 $a1.AllocDelta.N                        'rep-align: only the 3 common reps paired (not min-count position zip)'
     Assert-True (($a1.AllocDelta.DeltaPct -gt -10.5) -and ($a1.AllocDelta.DeltaPct -lt -9.5)) 'rep-align: paired alloc Δ ≈ -10% (rep-keyed), not smeared by the missing rep'
     Assert-Equal 'better' $a1.AllocDelta.Status            'rep-align: clean -10% alloc flagged better'
+    Assert-Equal 1000 $a1.MainAllocBytes                   'rep-align: displayed main alloc median over the aligned set'
+    Assert-Equal 900  $a1.PrAllocBytes                     'rep-align: displayed pr alloc median over the aligned set'
+    # The unpaired main rep (999) must NOT enter the displayed median.
+    Assert-Equal 20 $a2.MainMeanNs                         'consistent medians: main ns median over aligned reps (20), not all-sample (25)'
+    Assert-Equal 20 $a2.PrMeanNs                           'consistent medians: pr ns median over aligned reps'
+    Assert-Equal 3  $a2.NsDelta.N                          'consistent medians: ns paired over the 3 common reps'
 
     # Section rendering.
     Assert-Equal 0 @(Format-PerfMicroSection -Micro $null).Count  'micro section empty when null'

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -463,11 +463,14 @@ function Read-MicroBenchResults {
         Each line is one MeasurementResult (camelCase JSON). Only variant == 'Reactor'
         rows with status 'ok' are kept — the legacy Direct / ReactorToday variants are
         an intra-build A/B (Reactor-vs-today / Reactor-vs-raw-WinUI), NOT the PR-vs-main
-        delta /perf reports. Rows are ordered by repetition so a paired analysis can zip
-        baseline rep i against candidate rep i. Malformed lines are skipped.
+        delta /perf reports. Rows are ordered by repetition and tagged with their
+        repetition index so the paired analysis can align baseline rep i against
+        candidate rep i BY REPETITION (not array position) — a dropped/errored rep on
+        one side must not shift every later sample. Malformed lines are skipped.
     .OUTPUTS
         OrderedDictionary benchId -> [pscustomobject]@{ BenchId; Name;
-        MeanNsSamples [double[]]; AllocBytesSamples [double[]] }. Empty when the file is
+        Repetitions [int[]]; MeanNsSamples [double[]]; AllocBytesSamples [double[]] }
+        (the three arrays are parallel / index-aligned). Empty when the file is
         missing / empty / has no usable Reactor rows.
     #>
     param([AllowNull()][string]$Path)
@@ -496,6 +499,7 @@ function Read-MicroBenchResults {
         $map[[string]$g.Name] = [pscustomobject]@{
             BenchId           = [string]$g.Name
             Name              = $name
+            Repetitions       = [int[]]@($ordered | ForEach-Object { [int]$_.repetition })
             MeanNsSamples     = [double[]]@($ordered | ForEach-Object { [double]$_.meanNs })
             AllocBytesSamples = [double[]]@($ordered | ForEach-Object { [double]$_.allocBytes })
         }
@@ -521,10 +525,27 @@ function Get-PerfMicroComparison {
         if (-not $Pr.Contains($benchId)) { continue }
         $m = $Main[$benchId]
         $p = $Pr[$benchId]
+        # Align samples BY REPETITION, not by array position: if a repetition was
+        # dropped/errored (and filtered) on one side, position-zipping would compare
+        # main rep i against pr rep i+1 for every later sample and silently mis-pair
+        # the paired CI. Pair only repetitions present on BOTH sides.
+        $prIdxByRep = @{}
+        for ($j = 0; $j -lt $p.Repetitions.Count; $j++) { $prIdxByRep[[int]$p.Repetitions[$j]] = $j }
+        $mNs = [System.Collections.Generic.List[object]]::new()
+        $pNs = [System.Collections.Generic.List[object]]::new()
+        $mAlloc = [System.Collections.Generic.List[object]]::new()
+        $pAlloc = [System.Collections.Generic.List[object]]::new()
+        for ($i = 0; $i -lt $m.Repetitions.Count; $i++) {
+            $rep = [int]$m.Repetitions[$i]
+            if (-not $prIdxByRep.ContainsKey($rep)) { continue }
+            $j = $prIdxByRep[$rep]
+            $mNs.Add($m.MeanNsSamples[$i]);       $pNs.Add($p.MeanNsSamples[$j])
+            $mAlloc.Add($m.AllocBytesSamples[$i]); $pAlloc.Add($p.AllocBytesSamples[$j])
+        }
         $nsDelta = Get-PerfDelta -Baseline (Get-PerfMedian $m.MeanNsSamples) -Candidate (Get-PerfMedian $p.MeanNsSamples) `
-            -LowerIsBetter $true -BaselineSamples ([object[]]$m.MeanNsSamples) -CandidateSamples ([object[]]$p.MeanNsSamples)
+            -LowerIsBetter $true -BaselineSamples ([object[]]$mNs.ToArray()) -CandidateSamples ([object[]]$pNs.ToArray())
         $allocDelta = Get-PerfDelta -Baseline (Get-PerfMedian $m.AllocBytesSamples) -Candidate (Get-PerfMedian $p.AllocBytesSamples) `
-            -LowerIsBetter $true -BaselineSamples ([object[]]$m.AllocBytesSamples) -CandidateSamples ([object[]]$p.AllocBytesSamples)
+            -LowerIsBetter $true -BaselineSamples ([object[]]$mAlloc.ToArray()) -CandidateSamples ([object[]]$pAlloc.ToArray())
         $rows.Add([pscustomobject]@{
             BenchId        = $benchId
             Name           = $m.Name

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -444,6 +444,156 @@ function Get-PerfStatusGlyph {
     }
 }
 
+# ── Reconciler micro-suite (PerfBench.ControlModel) ──────────────────────────
+# /perf's macro StocksGrid workload is render-bound and WinUI-diluted, so it can
+# neither resolve small Core/Reconciler time deltas nor see allocation changes.
+# The PerfBench.ControlModel micro-suite (spec-047 M1-M13) runs the production
+# `--variant Reactor` control-model path as a headless loop bracketed by
+# per-thread alloc + GC counters at ns-resolution, with no render pipeline in the
+# measured region. These helpers parse its JSON-Lines output and compute the
+# PR-vs-main paired delta per bench, reusing the same CI machinery as the macro
+# table (Get-PerfDelta / Get-PerfPairedDeltaStats).
+
+function Read-MicroBenchResults {
+    <#
+    .SYNOPSIS
+        Parse a PerfBench.ControlModel results.jsonl (JSON-Lines) into a per-bench
+        sample map for the production `Reactor` variant.
+    .DESCRIPTION
+        Each line is one MeasurementResult (camelCase JSON). Only variant == 'Reactor'
+        rows with status 'ok' are kept — the legacy Direct / ReactorToday variants are
+        an intra-build A/B (Reactor-vs-today / Reactor-vs-raw-WinUI), NOT the PR-vs-main
+        delta /perf reports. Rows are ordered by repetition so a paired analysis can zip
+        baseline rep i against candidate rep i. Malformed lines are skipped.
+    .OUTPUTS
+        OrderedDictionary benchId -> [pscustomobject]@{ BenchId; Name;
+        MeanNsSamples [double[]]; AllocBytesSamples [double[]] }. Empty when the file is
+        missing / empty / has no usable Reactor rows.
+    #>
+    param([AllowNull()][string]$Path)
+    $map = [ordered]@{}
+    if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return $map }
+    $rows = [System.Collections.Generic.List[object]]::new()
+    foreach ($line in [System.IO.File]::ReadLines($Path)) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $obj = $null
+        try { $obj = $line | ConvertFrom-Json } catch { continue }
+        if ($null -eq $obj) { continue }
+        $variant = if ($obj.PSObject.Properties['variant']) { [string]$obj.variant } else { '' }
+        if ($variant -ne 'Reactor') { continue }
+        $status = if ($obj.PSObject.Properties['status']) { [string]$obj.status } else { 'ok' }
+        if ($status -and $status -ne 'ok') { continue }
+        if (-not $obj.PSObject.Properties['benchId'] -or
+            -not $obj.PSObject.Properties['meanNs'] -or
+            -not $obj.PSObject.Properties['allocBytes']) { continue }
+        $rows.Add($obj)
+    }
+    if ($rows.Count -eq 0) { return $map }
+    foreach ($g in ($rows | Group-Object -Property benchId)) {
+        $ordered = @($g.Group | Sort-Object { [int]$_.repetition })
+        $name = ''
+        if ($ordered.Count -gt 0 -and $ordered[0].PSObject.Properties['benchName']) { $name = [string]$ordered[0].benchName }
+        $map[[string]$g.Name] = [pscustomobject]@{
+            BenchId           = [string]$g.Name
+            Name              = $name
+            MeanNsSamples     = [double[]]@($ordered | ForEach-Object { [double]$_.meanNs })
+            AllocBytesSamples = [double[]]@($ordered | ForEach-Object { [double]$_.allocBytes })
+        }
+    }
+    return $map
+}
+
+function Get-PerfMicroComparison {
+    <#
+    .SYNOPSIS
+        Per-bench PR-vs-main paired comparison for the micro-suite. For each bench
+        present in BOTH maps, computes the paired 95%-CI delta of mean ns/op and
+        alloc bytes/op (lower is better), reusing Get-PerfDelta. Returns rows sorted
+        by the numeric bench-id suffix (M1, M2, ... M13).
+    .OUTPUTS
+        Array of [pscustomobject]@{ BenchId; Name; MainMeanNs; PrMeanNs; NsDelta;
+        MainAllocBytes; PrAllocBytes; AllocDelta }. Empty when no bench overlaps.
+    #>
+    param([AllowNull()]$Main, [AllowNull()]$Pr)
+    if ($null -eq $Main -or $null -eq $Pr) { return @() }
+    $rows = [System.Collections.Generic.List[object]]::new()
+    foreach ($benchId in @($Main.Keys)) {
+        if (-not $Pr.Contains($benchId)) { continue }
+        $m = $Main[$benchId]
+        $p = $Pr[$benchId]
+        $nsDelta = Get-PerfDelta -Baseline (Get-PerfMedian $m.MeanNsSamples) -Candidate (Get-PerfMedian $p.MeanNsSamples) `
+            -LowerIsBetter $true -BaselineSamples ([object[]]$m.MeanNsSamples) -CandidateSamples ([object[]]$p.MeanNsSamples)
+        $allocDelta = Get-PerfDelta -Baseline (Get-PerfMedian $m.AllocBytesSamples) -Candidate (Get-PerfMedian $p.AllocBytesSamples) `
+            -LowerIsBetter $true -BaselineSamples ([object[]]$m.AllocBytesSamples) -CandidateSamples ([object[]]$p.AllocBytesSamples)
+        $rows.Add([pscustomobject]@{
+            BenchId        = $benchId
+            Name           = $m.Name
+            MainMeanNs     = Get-PerfMedian $m.MeanNsSamples
+            PrMeanNs       = Get-PerfMedian $p.MeanNsSamples
+            NsDelta        = $nsDelta
+            MainAllocBytes = Get-PerfMedian $m.AllocBytesSamples
+            PrAllocBytes   = Get-PerfMedian $p.AllocBytesSamples
+            AllocDelta     = $allocDelta
+        })
+    }
+    return @($rows | Sort-Object `
+        @{ Expression = { $n = 0; if ([int]::TryParse(($_.BenchId -replace '\D', ''), [ref]$n)) { $n } else { [int]::MaxValue } } }, `
+        @{ Expression = { $_.BenchId } })
+}
+
+function Get-PerfMicroRowStatus {
+    <#
+    .SYNOPSIS
+        Row flag for a micro-bench. v1 tracks the DETERMINISTIC allocation signal
+        only; the ns/op delta is informational and does NOT drive the flag.
+    .DESCRIPTION
+        Allocated bytes/op is deterministic for identical code (an unchanged diff
+        reproduces the same byte count exactly), so its paired CI is a trustworthy
+        flag. ns/op is NOT: the per-side micro runs are not yet rep-interleaved, so a
+        systematic process-to-process timing offset (thermal / scheduling drift
+        between the two back-to-back invocations) shifts every paired ns difference
+        the same way and makes the paired CI exclude 0 even for an identical binary
+        — empirically a no-op diff flagged -14.8% ns on one bench. Flagging ns would
+        therefore emit false improvements/regressions. So the row tracks alloc; ns is
+        shown for context. (Rep-level interleaving is the documented fast-follow that
+        would let ns be promoted to a flagged signal.)
+    #>
+    param([AllowNull()][string]$NsStatus, [AllowNull()][string]$AllocStatus)
+    if ([string]::IsNullOrEmpty($AllocStatus)) { return 'na' }
+    return $AllocStatus
+}
+
+function Format-PerfMicroSection {
+    <#
+    .SYNOPSIS
+        Render the reconciler micro-benchmark table (mean ns/op + alloc bytes/op,
+        PR vs main) as markdown lines. Empty array when there is nothing to show.
+    #>
+    param([AllowNull()][object[]]$Micro)
+    if ($null -eq $Micro -or @($Micro).Count -eq 0) { return @() }
+    $down = [char]0x2193
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add("### Reconciler micro-benchmarks (``PerfBench.ControlModel``)")
+    $lines.Add('')
+    $lines.Add("Production ``--variant Reactor`` control-model path, ns-resolution and WinUI-undiluted (spec-047 M1&ndash;M13) &mdash; $down lower is better. **Status tracks allocated bytes/op**, which is deterministic for identical code and the authoritative signal here; **ns/op is shown for context** but is not auto-flagged in v1 (the per-side runs are not yet rep-interleaved, so a process-to-process timing offset can otherwise read as significant). Δ is the mean paired change with a 95% CI.")
+    $lines.Add('')
+    $lines.Add('| Bench | `main` ns/op | Δ ns (95% CI) | `main` B/op | Δ alloc (95% CI) | Status |')
+    $lines.Add('|---|--:|--:|--:|--:|:--|')
+    foreach ($r in $Micro) {
+        $label = if ($r.Name) { ('`{0}` {1}' -f $r.BenchId, $r.Name) } else { ('`{0}`' -f $r.BenchId) }
+        $status = Get-PerfMicroRowStatus -NsStatus $r.NsDelta.Status -AllocStatus $r.AllocDelta.Status
+        $lines.Add(('| {0} | {1} | {2} | {3} | {4} | {5} |' -f `
+                $label, `
+            (Format-PerfNumber $r.MainMeanNs 1), `
+            (Format-PerfDeltaCell $r.NsDelta), `
+            (Format-PerfNumber $r.MainAllocBytes 0), `
+            (Format-PerfDeltaCell $r.AllocDelta), `
+            (Get-PerfStatusGlyph $status)))
+    }
+    $lines.Add('')
+    return $lines.ToArray()
+}
+
 function Format-PerfComment {
     <#
     .SYNOPSIS
@@ -454,6 +604,8 @@ function Format-PerfComment {
     .PARAMETER WinUI3     Aggregated vanilla-WinUI3 (StressPerf.Direct) metrics, or $null.
     .PARAMETER Rust       Aggregated Rust windows-reactor (test_reactor_perf) metrics
                           measured live on this runner, or $null when not run.
+    .PARAMETER Micro      Per-bench reconciler micro-suite comparison rows
+                          (Get-PerfMicroComparison output), or $null when not run.
     .PARAMETER Context    Hashtable: Percent, Duration, Reps, Warmup, BaseSha, HeadSha,
                           Runner, Cpu, Cores, MemoryGB, RunUrl, Timestamp, Note.
     #>
@@ -462,6 +614,7 @@ function Format-PerfComment {
         [Parameter(Mandatory)][pscustomobject]$Pr,
         [AllowNull()][pscustomobject]$WinUI3,
         [AllowNull()][pscustomobject]$Rust,
+        [AllowNull()][object[]]$Micro,
         [Parameter(Mandatory)][hashtable]$Context
     )
 
@@ -528,6 +681,12 @@ function Format-PerfComment {
         & $add ''
     }
 
+    # ── Reconciler micro-benchmarks (ns-resolution, WinUI-undiluted) ──────────
+    # Rendered only when the PerfBench.ControlModel micro leg produced results for
+    # both sides. Resolves Core/Reconciler time + allocation deltas the macro
+    # StocksGrid workload above cannot (it is render-bound and working-set diluted).
+    foreach ($mline in (Format-PerfMicroSection -Micro $Micro)) { & $add $mline }
+
     # ── Table 2: cross-framework reference ───────────────────────────────────
     & $add "### Cross-framework reference (same StocksGrid workload)"
     & $add ''
@@ -554,6 +713,9 @@ function Format-PerfComment {
     }
     & $add "<sub>$up higher is better &middot; $down lower is better. **Within noise** = the 95% confidence interval of the paired Δ includes 0 (no change resolvable at this sample size); $([char]0x2705) improvement / $([char]0x26A0)$([char]0xFE0F) regression require the CI to **exclude** 0.</sub>"
     & $add "<sub>Allocation metrics (alloc bytes/render, Gen0 GC) are the sensitive signal for allocation-reduction work, where the mean-ms / memory figures are largely flat. They read *n/a* for a harness built from a revision that predates them (rebase the PR onto ``main`` to populate them).</sub>"
+    if ($null -ne $Micro -and @($Micro).Count -gt 0) {
+        & $add "<sub>Reconciler micro-benchmarks run ``PerfBench.ControlModel --variant Reactor`` (M1&ndash;M13) as a headless loop bracketed by per-thread alloc + GC counters &mdash; ns-resolution and free of WinUI render / working-set dilution, so they resolve Core/Reconciler allocation deltas the macro StocksGrid workload cannot. ``main`` and PR each link their own ``src/Reactor`` build; Δ is the paired 95% CI over per-rep means. The **Status** column tracks allocated bytes/op (deterministic for identical code); ns/op is informational &mdash; it is not auto-flagged until the per-side runs are rep-interleaved (a documented fast-follow), because a process-to-process timing offset can otherwise make the paired ns CI exclude 0 for an unchanged diff.</sub>"
+    }
     & $add "<sub>$([char]0x00B9) vanilla WinUI3 = ``StressPerf.Direct`` (imperative; no virtual-DOM, so it has no reconcile/diff phase — those cells read *n/a*). Measured live on this runner.</sub>"
     & $add "<sub>$([char]0x00B2) Rust = ``test_reactor_perf`` from [microsoft/windows-rs](https://github.com/microsoft/windows-rs/tree/master/crates/tests/libs/reactor_perf) — a port of this harness (same StocksGrid, same ``--percent``/``--duration`` CLI). $rustNote</sub>"
     & $add "<sub>Absolute numbers are runner-dependent — trust the **Δ vs main**, not the absolute values. Memory (working set) is the noisiest metric.</sub>"

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -46,6 +46,16 @@ $script:PerfAllocMetricSpec = @(
     [pscustomobject]@{ Key = 'Gen0PerKRenders';     Label = 'Gen0 GC / 1k renders'; LowerIsBetter = $true; Digits = 2; Arrow = [char]0x2193 }
 )
 
+# Minimum-effect band (percent) for the micro-suite ALLOC flag. The per-side micro
+# runs are not rep-interleaved, so a sub-1% systematic process-to-process alloc
+# offset on non-deterministic benches (dispatcher / background-thread allocations,
+# e.g. M5 "Dispatch_Switch_Warm" measured 6/6 distinct alloc values per rep) can
+# make the tight within-process 95% CI exclude 0 on identical code. Requiring the CI
+# to clear +-this band absorbs that offset while still catching real structural
+# alloc changes, which are several percent to many-x. Set to 0 to restore the pure
+# "CI excludes 0" rule.
+$script:MicroAllocMinEffectPct = 1.0
+
 function ConvertTo-PerfDouble {
     <#
     .SYNOPSIS Culture-tolerant parse of a captured numeric string, or $null.
@@ -358,6 +368,27 @@ function Get-PerfDelta {
         max(NoiseFloorPct, SpreadPct).
     .PARAMETER BaselineSamples / CandidateSamples
         Index-aligned per-run values (with $null placeholders) for the paired CI.
+    .PARAMETER RequirePairedCI
+        When set, the paired 95% CI is the ONLY admissible flag: if fewer than 2
+        aligned pairs survive (so Get-PerfPairedDeltaStats returns $null) the result
+        is 'na' rather than the point-delta vs % -floor fallback. Used by the
+        micro-suite, whose contract is "flag only when the paired CI excludes 0" —
+        without it a single surviving pair (e.g. after later reps error out and are
+        filtered) would be flagged better/worse off one sample with N=$null. The
+        macro path leaves it off and keeps the legacy point-delta fallback.
+    .PARAMETER MinEffectPct
+        Minimum effect size (percent) for a paired-CI flag. The change is flagged
+        better/worse only when the 95% CI lies ENTIRELY beyond +-MinEffectPct, not
+        merely beyond 0. Default 0 keeps the pure "CI excludes 0" rule (macro path).
+        The micro-suite passes a small band (~1%) on the ALLOC delta because the
+        per-side micro runs are not rep-interleaved: a sub-1% systematic
+        process-to-process alloc offset (dispatcher / background-thread allocations
+        on benches like M5 are not bit-deterministic) can make the tight
+        within-process CI exclude 0 on identical code. Requiring >= MinEffectPct
+        absorbs that offset while still catching real structural alloc changes,
+        which are multiple percent to many-x. This is NOT the blanket point-delta
+        floor PR1 removed: it is a CI-vs-band test, applied only to the
+        non-interleaved micro alloc metric.
     #>
     param(
         [AllowNull()]$Baseline,
@@ -366,7 +397,9 @@ function Get-PerfDelta {
         [double]$NoiseFloorPct = 4.0,
         [double]$SpreadPct = 0.0,
         [AllowNull()][object[]]$BaselineSamples,
-        [AllowNull()][object[]]$CandidateSamples
+        [AllowNull()][object[]]$CandidateSamples,
+        [switch]$RequirePairedCI,
+        [double]$MinEffectPct = 0.0
     )
     if ($null -eq $Baseline -or $null -eq $Candidate -or [double]$Baseline -eq 0) {
         return [pscustomobject]@{ DeltaPct = $null; Status = 'na'; Improved = $null; CiLowPct = $null; CiHighPct = $null; N = $null }
@@ -387,8 +420,11 @@ function Get-PerfDelta {
         $ciLow = [double]$stats.CiLowPct
         $ciHigh = [double]$stats.CiHighPct
         $improved = if ($LowerIsBetter) { $meanPct -lt 0 } else { $meanPct -gt 0 }
-        $ciExcludesZero = ($ciLow -gt 0) -or ($ciHigh -lt 0)
-        $status = if (-not $ciExcludesZero) { 'noise' } elseif ($improved) { 'better' } else { 'worse' }
+        # Flag only when the CI lies entirely beyond +-MinEffectPct (default 0 => the
+        # pure "excludes 0" rule). The micro alloc path passes a small band so a
+        # sub-band process-to-process offset on non-deterministic benches reads noise.
+        $ciExcludesBand = ($ciLow -gt $MinEffectPct) -or ($ciHigh -lt -$MinEffectPct)
+        $status = if (-not $ciExcludesBand) { 'noise' } elseif ($improved) { 'better' } else { 'worse' }
         return [pscustomobject]@{
             DeltaPct  = [math]::Round($meanPct, 1)
             Status    = $status
@@ -397,6 +433,12 @@ function Get-PerfDelta {
             CiHighPct = [math]::Round($ciHigh, 2)
             N         = $stats.N
         }
+    }
+
+    # Micro-suite contract: with < 2 rep-aligned pairs there is no admissible CI, so
+    # report 'na' rather than flag a lone surviving pair off the point-delta fallback.
+    if ($RequirePairedCI) {
+        return [pscustomobject]@{ DeltaPct = $null; Status = 'na'; Improved = $null; CiLowPct = $null; CiHighPct = $null; N = $null }
     }
 
     # Fallback: point delta vs a max(floor, spread) noise band.
@@ -470,8 +512,12 @@ function Read-MicroBenchResults {
     .OUTPUTS
         OrderedDictionary benchId -> [pscustomobject]@{ BenchId; Name;
         Repetitions [int[]]; MeanNsSamples [double[]]; AllocBytesSamples [double[]] }
-        (the three arrays are parallel / index-aligned). Empty when the file is
-        missing / empty / has no usable Reactor rows.
+        (the three arrays are parallel / index-aligned). MeanNsSamples and
+        AllocBytesSamples are both PER-OP: BenchRunner already divides meanNs by the
+        iteration count, and allocBytes (reported as the whole-loop total) is divided
+        by the row's iterations here so both sit on the same per-op basis as the
+        "B/op" column. Empty when the file is missing / empty / has no usable
+        Reactor rows.
     #>
     param([AllowNull()][string]$Path)
     $map = [ordered]@{}
@@ -501,7 +547,14 @@ function Read-MicroBenchResults {
             Name              = $name
             Repetitions       = [int[]]@($ordered | ForEach-Object { [int]$_.repetition })
             MeanNsSamples     = [double[]]@($ordered | ForEach-Object { [double]$_.meanNs })
-            AllocBytesSamples = [double[]]@($ordered | ForEach-Object { [double]$_.allocBytes })
+            AllocBytesSamples = [double[]]@($ordered | ForEach-Object {
+                    # Per-OP allocation: meanNs is already per-op but BenchRunner reports
+                    # allocBytes as the whole-loop total, so normalize by the row's
+                    # iterations to match the "B/op" column. Constant divisor keeps it
+                    # deterministic for identical code.
+                    $iter = if ($_.PSObject.Properties['iterations']) { [double]$_.iterations } else { 0 }
+                    if ($iter -gt 0) { [double]$_.allocBytes / $iter } else { [double]$_.allocBytes }
+                })
         }
     }
     return $map
@@ -550,9 +603,15 @@ function Get-PerfMicroComparison {
         $mainMeanNs = Get-PerfMedian $mNsArr; $prMeanNs = Get-PerfMedian $pNsArr
         $mainAlloc = Get-PerfMedian $mAllocArr; $prAlloc = Get-PerfMedian $pAllocArr
         $nsDelta = Get-PerfDelta -Baseline $mainMeanNs -Candidate $prMeanNs `
-            -LowerIsBetter $true -BaselineSamples $mNsArr -CandidateSamples $pNsArr
+            -LowerIsBetter $true -BaselineSamples $mNsArr -CandidateSamples $pNsArr -RequirePairedCI
+        # Alloc DRIVES the row flag, and not every bench is alloc-deterministic:
+        # dispatcher / background-thread benches (e.g. M5) carry a sub-1% systematic
+        # process-to-process offset that the within-process CI can't cancel, so flag
+        # only when the CI clears the +-MinEffectPct band. ns is informational-only
+        # (never drives the flag) so it keeps the pure CI-excludes-0 rule.
         $allocDelta = Get-PerfDelta -Baseline $mainAlloc -Candidate $prAlloc `
-            -LowerIsBetter $true -BaselineSamples $mAllocArr -CandidateSamples $pAllocArr
+            -LowerIsBetter $true -BaselineSamples $mAllocArr -CandidateSamples $pAllocArr `
+            -RequirePairedCI -MinEffectPct $script:MicroAllocMinEffectPct
         $rows.Add([pscustomobject]@{
             BenchId        = $benchId
             Name           = $m.Name
@@ -603,7 +662,7 @@ function Format-PerfMicroSection {
     $lines = [System.Collections.Generic.List[string]]::new()
     $lines.Add("### Reconciler micro-benchmarks (``PerfBench.ControlModel``)")
     $lines.Add('')
-    $lines.Add("Production ``--variant Reactor`` control-model path, ns-resolution and WinUI-undiluted (spec-047 M1&ndash;M13) &mdash; $down lower is better. **Status tracks allocated bytes/op**, which is deterministic for identical code and the authoritative signal here; **ns/op is shown for context** but is not auto-flagged in v1 (the per-side runs are not yet rep-interleaved, so a process-to-process timing offset can otherwise read as significant). Δ is the mean paired change with a 95% CI.")
+    $lines.Add("Production ``--variant Reactor`` control-model path, ns-resolution and WinUI-undiluted (spec-047 M1&ndash;M13) &mdash; $down lower is better. **Status tracks allocated bytes/op**, the authoritative signal here; it is deterministic for structurally-fixed benches, while dispatcher / background-thread benches carry a small process-to-process offset, so a bench is flagged only when its 95% CI clears a &plusmn;$($script:MicroAllocMinEffectPct)% minimum-effect band (real structural alloc changes are several percent to many-x). **ns/op is shown for context** but is not auto-flagged in v1 (the per-side runs are not yet rep-interleaved, so a process-to-process timing offset can otherwise read as significant). Δ is the mean paired change with a 95% CI.")
     $lines.Add('')
     $lines.Add('| Bench | `main` ns/op | Δ ns (95% CI) | `main` B/op | Δ alloc (95% CI) | Status |')
     $lines.Add('|---|--:|--:|--:|--:|:--|')
@@ -614,7 +673,7 @@ function Format-PerfMicroSection {
                 $label, `
             (Format-PerfNumber $r.MainMeanNs 1), `
             (Format-PerfDeltaCell $r.NsDelta), `
-            (Format-PerfNumber $r.MainAllocBytes 0), `
+            (Format-PerfNumber $r.MainAllocBytes 1), `
             (Format-PerfDeltaCell $r.AllocDelta), `
             (Get-PerfStatusGlyph $status)))
     }

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -542,18 +542,25 @@ function Get-PerfMicroComparison {
             $mNs.Add($m.MeanNsSamples[$i]);       $pNs.Add($p.MeanNsSamples[$j])
             $mAlloc.Add($m.AllocBytesSamples[$i]); $pAlloc.Add($p.AllocBytesSamples[$j])
         }
-        $nsDelta = Get-PerfDelta -Baseline (Get-PerfMedian $m.MeanNsSamples) -Candidate (Get-PerfMedian $p.MeanNsSamples) `
-            -LowerIsBetter $true -BaselineSamples ([object[]]$mNs.ToArray()) -CandidateSamples ([object[]]$pNs.ToArray())
-        $allocDelta = Get-PerfDelta -Baseline (Get-PerfMedian $m.AllocBytesSamples) -Candidate (Get-PerfMedian $p.AllocBytesSamples) `
-            -LowerIsBetter $true -BaselineSamples ([object[]]$mAlloc.ToArray()) -CandidateSamples ([object[]]$pAlloc.ToArray())
+        # Displayed medians AND the paired CI are both computed over the SAME
+        # rep-aligned sample set, so the table's main/PR columns can't be drawn from
+        # a different set of reps than the Δ when a repetition is missing on one side.
+        $mNsArr = [object[]]$mNs.ToArray();    $pNsArr = [object[]]$pNs.ToArray()
+        $mAllocArr = [object[]]$mAlloc.ToArray(); $pAllocArr = [object[]]$pAlloc.ToArray()
+        $mainMeanNs = Get-PerfMedian $mNsArr; $prMeanNs = Get-PerfMedian $pNsArr
+        $mainAlloc = Get-PerfMedian $mAllocArr; $prAlloc = Get-PerfMedian $pAllocArr
+        $nsDelta = Get-PerfDelta -Baseline $mainMeanNs -Candidate $prMeanNs `
+            -LowerIsBetter $true -BaselineSamples $mNsArr -CandidateSamples $pNsArr
+        $allocDelta = Get-PerfDelta -Baseline $mainAlloc -Candidate $prAlloc `
+            -LowerIsBetter $true -BaselineSamples $mAllocArr -CandidateSamples $pAllocArr
         $rows.Add([pscustomobject]@{
             BenchId        = $benchId
             Name           = $m.Name
-            MainMeanNs     = Get-PerfMedian $m.MeanNsSamples
-            PrMeanNs       = Get-PerfMedian $p.MeanNsSamples
+            MainMeanNs     = $mainMeanNs
+            PrMeanNs       = $prMeanNs
             NsDelta        = $nsDelta
-            MainAllocBytes = Get-PerfMedian $m.AllocBytesSamples
-            PrAllocBytes   = Get-PerfMedian $p.AllocBytesSamples
+            MainAllocBytes = $mainAlloc
+            PrAllocBytes   = $prAlloc
             AllocDelta     = $allocDelta
         })
     }

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -508,7 +508,9 @@ function Read-MicroBenchResults {
         delta /perf reports. Rows are ordered by repetition and tagged with their
         repetition index so the paired analysis can align baseline rep i against
         candidate rep i BY REPETITION (not array position) — a dropped/errored rep on
-        one side must not shift every later sample. Malformed lines are skipped.
+        one side must not shift every later sample. Malformed lines are skipped,
+        including any row missing benchId / meanNs / allocBytes or whose repetition
+        is absent or non-numeric (it would otherwise throw on the [int] cast below).
     .OUTPUTS
         OrderedDictionary benchId -> [pscustomobject]@{ BenchId; Name;
         Repetitions [int[]]; MeanNsSamples [double[]]; AllocBytesSamples [double[]] }
@@ -534,7 +536,13 @@ function Read-MicroBenchResults {
         if ($status -and $status -ne 'ok') { continue }
         if (-not $obj.PSObject.Properties['benchId'] -or
             -not $obj.PSObject.Properties['meanNs'] -or
-            -not $obj.PSObject.Properties['allocBytes']) { continue }
+            -not $obj.PSObject.Properties['allocBytes'] -or
+            -not $obj.PSObject.Properties['repetition']) { continue }
+        # repetition drives the rep-keyed pairing and is cast to [int] when ordering /
+        # tagging samples below; a present-but-non-numeric value would throw PAST the
+        # malformed-line guard and break /perf comment generation, so validate the cast
+        # here and skip the row if it won't parse (honors "malformed lines are skipped").
+        try { $null = [int]$obj.repetition } catch { continue }
         $rows.Add($obj)
     }
     if ($rows.Count -eq 0) { return $map }

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -46,6 +46,48 @@ These read *n/a* for a PR head whose harness sources predate the metric — reba
 onto `main` to populate them. They are the **sensitive signal** for the
 allocation-focused PRs in the current fleet.
 
+### Reconciler micro-benchmarks (ns-resolution, WinUI-undiluted)
+
+The StocksGrid macro workload above is **render-bound and working-set diluted**:
+renders/sec is ~76% gated by the WinUI render thread, and the reconcile/diff ms
+and alloc figures are measured across a live render pipeline. That makes it a poor
+instrument for the **Core/Reconciler** layer most of the perf fleet actually
+operates on — small reconcile-time and per-reconcile allocation deltas are buried
+under render + GC noise.
+
+So `/perf` also runs the **`PerfBench.ControlModel` micro-suite** (spec-047
+M1–M13: `PropertyDiff` / `Allocation` / `StructuralSharing` / `ControlModel`) once
+per side and reports a per-bench PR-vs-`main` table:
+
+| Metric | Meaning | Direction |
+|---|---|:--:|
+| **ns/op** | mean reconcile time per operation, `Stopwatch` over the loop body only | lower is better ↓ |
+| **B/op** | managed bytes allocated per operation (`GC.GetAllocatedBytesForCurrentThread` Δ, **per-thread** so it excludes WinUI/background allocs) | lower is better ↓ |
+
+It runs the production **`--variant Reactor`** path as a headless loop whose
+measured region brackets only the reconciler — no render pipeline, ns-resolution,
+free of working-set dilution. `main` and the PR each link their **own
+`src/Reactor` build** (via the project's relative `ProjectReference`), so the
+delta is a clean read on the code change. Both deltas use the **same paired 95% CI**
+machinery as the macro tables, but they are **read differently**:
+
+- **B/op drives the row flag.** Allocated bytes/op is *deterministic* for identical
+  code — an unchanged diff reproduces the same byte count exactly — so its paired CI
+  is trustworthy. The ✅/⚠️/≈ status of each row tracks the alloc delta.
+- **ns/op is informational only** (shown, never auto-flagged in v1). The two per-side
+  runs are not yet rep-interleaved, so a systematic process-to-process timing offset
+  (thermal/scheduling drift between the back-to-back invocations) shifts every paired
+  ns difference the same way and makes the paired CI exclude 0 even for an identical
+  binary. Local validation confirmed this: running the **same** ControlModel binary
+  as both "main" and "PR", alloc was deterministic (14/16 benches exactly 0.0% Δ) but
+  ns spuriously flagged up to −14.8% on a no-op. Flagging ns would emit false
+  improvements/regressions, so the column is reported for context and excluded from
+  the flag. **Rep-level interleaving of the two sides is the documented fast-follow**
+  that would let ns be promoted to a flagged signal.
+
+The whole leg is best-effort: if the micro build or run fails, the macro comment is
+unaffected and the section is simply omitted.
+
 ## Prerequisites
 
 - **Windows** with a real interactive desktop session (the harness opens a real
@@ -103,6 +145,9 @@ git worktree remove ../main
 | `-Warmup` | `2` | Leading runs discarded before the measured `Reps` (absorbs JIT / first-window warm-up). |
 | `-RefReps` | `3` | Measured runs for the **reference-only** legs (vanilla WinUI3, Rust) — a single reference absolute, not a paired CI, so it needs far fewer reps. |
 | `-RefWarmup` | `1` | Warm-up runs discarded for the reference-only legs. |
+| `-IncludeMicro` | `$true` | Run the `PerfBench.ControlModel` reconciler micro-suite (compare mode) and append its per-bench ns/op + B/op table. Set `$false` to skip it. |
+| `-MicroReps` | `12` | Repetitions per side for the micro-suite — each feeds the paired 95% CI, mirroring `-Reps`. |
+| `-MicroIterations` | `10000` | Inner iterations per repetition inside each micro-bench (amortises timer resolution). |
 | `-Apps` | `ReactorOptimized,Direct` | Single-tree mode only: which harnesses to run. |
 | `-Platform` | host arch | Target architecture (`x64` or `ARM64`). Defaults to your machine's native arch so the WinUI harness runs without emulation. |
 | `-SelfContained` | `$true` | Build with the bundled WinApp runtime (no machine-wide install). |
@@ -169,6 +214,13 @@ Two tables plus footnotes:
   `main` vs PR with the same paired-CI band. Rendered only when the harness
   reports the metric (n/a for pre-metric PR heads). This is the table that moves
   for allocation-reduction PRs.
+- **Reconciler micro-benchmarks** — per-bench `ns/op` and `B/op` from the
+  `PerfBench.ControlModel` micro-suite (M1–M13), `main` vs PR. ns-resolution and
+  WinUI-undiluted, so it resolves Core/Reconciler time and allocation deltas the
+  render-bound macro table cannot. The row flag tracks the **deterministic B/op**
+  delta; `ns/op` is shown for context but not auto-flagged in v1 (pending rep-level
+  interleaving — see the section above). Omitted when the micro leg is disabled or
+  fails to produce results for both sides.
 - **Cross-framework reference** — `vanilla WinUI3 | Rust windows-reactor |
   Reactor (this PR)` on the same StocksGrid workload, **all measured live on the
   same runner**. The Rust column builds and runs the
@@ -230,7 +282,9 @@ default `-Reps 12` (drop to e.g. `-Reps 3` only for a quick smoke run).
 | File | Role |
 |---|---|
 | [`Run-PerfBenchmark.ps1`](Run-PerfBenchmark.ps1) | Orchestrator — build, run, interleave, render. Used by both the workflow and humans. |
-| [`PerfLib.ps1`](PerfLib.ps1) | Pure, side-effect-free helpers (parse, median, spread, paired-Δ 95% CI stats, direction-aware delta, comment renderer) + the sticky-comment marker. |
+| [`PerfLib.ps1`](PerfLib.ps1) | Pure, side-effect-free helpers (parse, median, spread, paired-Δ 95% CI stats, direction-aware delta, micro-suite parse/compare, comment renderer) + the sticky-comment marker. |
+| `PerfLib.Tests.ps1` / `RunPerfBenchmark.Tests.ps1` | Dependency-free unit tests for the helpers + orchestrator branching (run on a Linux runner via `perf-lib-tests.yml`). |
+| [`PerfBench.ControlModel`](../../perf_bench/PerfBench.ControlModel) | The reconciler micro-suite (spec-047 M1–M13) the micro leg builds + runs per side. Lives under `tests/perf_bench/`; `/perf` consumes its JSON-Lines output. |
 
 ## Troubleshooting
 

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -648,6 +648,15 @@ function Invoke-MicroRun {
         if (Test-Path $stderr) { Get-Content $stderr -Tail 8 | ForEach-Object { Write-Host "      $_" -ForegroundColor DarkYellow } }
         return $null
     }
+    # A clean run exits 0 (per-bench exceptions are caught and written as a filtered
+    # status:"error" row, so they don't fail the process). A non-zero exit means the
+    # harness crashed — and because the file is written incrementally, whatever is on
+    # disk is a truncated prefix. Discard it rather than compare a silent subset.
+    if ($proc.ExitCode -ne 0) {
+        Write-Log "  micro exited non-zero ($($proc.ExitCode)) for '$Tag' — discarding possibly-truncated output" 'Yellow'
+        if (Test-Path $stderr) { Get-Content $stderr -Tail 8 | ForEach-Object { Write-Host "      $_" -ForegroundColor DarkYellow } }
+        return $null
+    }
     return $outJson
 }
 

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -64,6 +64,20 @@
 .PARAMETER RefWarmup
     Warm-up runs discarded for the reference-only legs (default 1).
 
+.PARAMETER MicroReps
+    Measured repetitions per side for the reconciler micro-suite
+    (PerfBench.ControlModel, spec-047 M1&ndash;M13). Default 12; the per-rep
+    samples feed the paired 95% CI on allocated bytes/op.
+
+.PARAMETER MicroIterations
+    Inner iterations per micro repetition (default 10000) over which each bench's
+    mean ns/op and allocated bytes/op are averaged.
+
+.PARAMETER IncludeMicro
+    Run the reconciler micro-suite on each side and append its per-bench ns/op +
+    alloc-bytes/op PR-vs-main table (ns-resolution, WinUI-undiluted) to the
+    comment. Default $true; disable with -IncludeMicro:$false.
+
 .PARAMETER Apps
     Which harnesses to run in single-tree mode: ReactorOptimized, Direct.
     Ignored in compare mode (which always does ReactorOptimized both sides +

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -633,9 +633,14 @@ function Invoke-MicroRun {
     try { $proc.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::High } catch {}
 
     if (-not $proc.WaitForExit($timeoutSec * 1000)) {
-        Write-Log "  micro TIMEOUT after ${timeoutSec}s — killing PerfBench.ControlModel ($Tag)" 'Yellow'
+        # The bench writes results.jsonl incrementally (one line per rep, flushed
+        # between benches), so a killed run leaves a TRUNCATED file — a prefix subset
+        # of benches/reps. Treat a timeout as "no results" rather than comparing a
+        # silent subset: omit the micro section instead of reporting misleading data.
+        Write-Log "  micro TIMEOUT after ${timeoutSec}s — killing PerfBench.ControlModel ($Tag); discarding any partial output" 'Yellow'
         try { $proc.Kill($true) } catch { try { $proc.Kill() } catch {} }
         Start-Sleep -Seconds 2
+        return $null
     }
 
     if (-not (Test-Path $outJson) -or (Get-Item $outJson).Length -eq 0) {

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -133,6 +133,9 @@ param(
     [int]$Warmup = 2,
     [int]$RefReps = 3,
     [int]$RefWarmup = 1,
+    [int]$MicroReps = 12,
+    [int]$MicroIterations = 10000,
+    [bool]$IncludeMicro = $true,
     [ValidateSet('ReactorOptimized', 'Direct')]
     [string[]]$Apps = @('ReactorOptimized', 'Direct'),
     [string]$OutDir,
@@ -165,6 +168,7 @@ $tfmGuess = 'net10.0-windows10.0.22621.0'
 $AppRegistry = @{
     ReactorOptimized = @{ AppName = 'StressPerf.ReactorOptimized'; ProjectRel = 'tests\stress_perf\StressPerf.ReactorOptimized\StressPerf.ReactorOptimized.csproj' }
     Direct           = @{ AppName = 'StressPerf.Direct';           ProjectRel = 'tests\stress_perf\StressPerf.Direct\StressPerf.Direct.csproj' }
+    MicroControlModel = @{ AppName = 'PerfBench.ControlModel';     ProjectRel = 'tests\perf_bench\PerfBench.ControlModel\PerfBench.ControlModel.csproj' }
 }
 
 function Write-Log {
@@ -600,6 +604,48 @@ function Measure-Sequential {
     return , $runs
 }
 
+function Invoke-MicroRun {
+    <# Run PerfBench.ControlModel once for the production Reactor variant and return the
+       results .jsonl path (or $null if it produced nothing). The measured region inside
+       BenchRunner is bracketed by per-thread alloc + GC counters, so unlike the macro
+       StressPerf legs this is ns-resolution and free of WinUI render / working-set
+       dilution. We run it once per side (each tree links its own src/Reactor) with no
+       rep-level interleave and no single-core pin — the within-process reps are already
+       GC-bracketed + warmed, and pinning would only contend the app's dispatcher/render
+       threads. Consequence of NOT interleaving: allocated bytes/op is deterministic and
+       flagged, but ns/op is reported informational-only (a process-to-process timing
+       offset can otherwise make its paired CI exclude 0 for identical code). Rep-level
+       interleaving is the documented fast-follow that would promote ns to a flag. #>
+    param([string]$Exe, [string]$Tag, [int]$RepCount, [int]$IterCount)
+
+    $outJson = Join-Path $OutDir ("micro-{0}.jsonl" -f $Tag)
+    if (Test-Path $outJson) { Remove-Item $outJson -Force -ErrorAction SilentlyContinue }
+    $stdout = Join-Path $OutDir ("micro-{0}.out.log" -f $Tag)
+    $stderr = Join-Path $OutDir ("micro-{0}.err.log" -f $Tag)
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    $microArgs = @('--variant', 'Reactor', '--reps', $RepCount.ToString($inv),
+        '--iterations', $IterCount.ToString($inv), '--out', $outJson, '--headless')
+    $timeoutSec = 420
+
+    Write-Log ("  micro [{0}] PerfBench.ControlModel --variant Reactor --reps {1} --iterations {2}" -f $Tag, $RepCount, $IterCount)
+    $proc = Start-Process -FilePath $Exe -ArgumentList $microArgs -PassThru `
+        -RedirectStandardOutput $stdout -RedirectStandardError $stderr -WindowStyle Hidden
+    try { $proc.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::High } catch {}
+
+    if (-not $proc.WaitForExit($timeoutSec * 1000)) {
+        Write-Log "  micro TIMEOUT after ${timeoutSec}s — killing PerfBench.ControlModel ($Tag)" 'Yellow'
+        try { $proc.Kill($true) } catch { try { $proc.Kill() } catch {} }
+        Start-Sleep -Seconds 2
+    }
+
+    if (-not (Test-Path $outJson) -or (Get-Item $outJson).Length -eq 0) {
+        Write-Log "  micro produced no results for '$Tag' (exit=$($proc.ExitCode)). stderr tail:" 'Yellow'
+        if (Test-Path $stderr) { Get-Content $stderr -Tail 8 | ForEach-Object { Write-Host "      $_" -ForegroundColor DarkYellow } }
+        return $null
+    }
+    return $outJson
+}
+
 # ── Power plan + Defender (best-effort, restored on exit) ────────────────────
 $prevScheme = $null
 try {
@@ -637,11 +683,21 @@ try {
         # ---- Compare mode: interleaved ReactorOptimized A/B + WinUI3 once -----
         $ro = $AppRegistry.ReactorOptimized
         $direct = $AppRegistry.Direct
+        $microMeta = $AppRegistry.MicroControlModel
 
         if (-not $SkipBuild) {
             Build-Harness -TreeRoot $BaselineRoot -AppMeta $ro
             Build-Harness -TreeRoot $Root -AppMeta $ro
             Build-Harness -TreeRoot $Root -AppMeta $direct
+        }
+        if ($IncludeMicro -and -not $SkipBuild) {
+            try {
+                Build-Harness -TreeRoot $BaselineRoot -AppMeta $microMeta
+                Build-Harness -TreeRoot $Root -AppMeta $microMeta
+            } catch {
+                Write-Log "reconciler micro-suite build failed ($_) — omitting micro-benchmarks" 'Yellow'
+                $IncludeMicro = $false
+            }
         }
         $mainExe = Resolve-HarnessExe -TreeRoot $BaselineRoot -AppMeta $ro
         $prExe = Resolve-HarnessExe -TreeRoot $Root -AppMeta $ro
@@ -668,6 +724,32 @@ try {
         }
 
         $rust = Invoke-RustLeg
+
+        # Reconciler micro-suite (ns-resolution, WinUI-undiluted). Best-effort: any
+        # failure here leaves $micro = $null and the macro comment is unaffected.
+        $micro = $null
+        if ($IncludeMicro) {
+            try {
+                $microMainExe = Resolve-HarnessExe -TreeRoot $BaselineRoot -AppMeta $microMeta
+                $microPrExe   = Resolve-HarnessExe -TreeRoot $Root -AppMeta $microMeta
+                if ($microMainExe -and $microPrExe) {
+                    Write-Log "reconciler micro-suite (PerfBench.ControlModel --variant Reactor, $MicroReps reps each)" 'Green'
+                    $microMainJson = Invoke-MicroRun -Exe $microMainExe -Tag 'main' -RepCount $MicroReps -IterCount $MicroIterations
+                    $microPrJson   = Invoke-MicroRun -Exe $microPrExe   -Tag 'pr'   -RepCount $MicroReps -IterCount $MicroIterations
+                    if ($microMainJson -and $microPrJson) {
+                        $micro = Get-PerfMicroComparison `
+                            -Main (Read-MicroBenchResults $microMainJson) `
+                            -Pr (Read-MicroBenchResults $microPrJson)
+                        Write-Log ("  micro: {0} bench(es) compared" -f @($micro).Count) 'DarkGray'
+                    }
+                } else {
+                    Write-Log "micro-suite exe not found (main=$([bool]$microMainExe) pr=$([bool]$microPrExe)) — omitting micro-benchmarks" 'Yellow'
+                }
+            } catch {
+                Write-Log "reconciler micro-suite leg failed ($_) — omitting micro-benchmarks" 'Yellow'
+                $micro = $null
+            }
+        }
 
         $main = Measure-PerfRuns -Runs $mainRuns
         $pr = Measure-PerfRuns -Runs $prRuns
@@ -697,12 +779,12 @@ try {
             Runner = $runner.Runner; Cpu = $runner.Cpu; Cores = $runner.Cores; MemoryGB = $runner.MemoryGB
             RunUrl = $RunUrl; Timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'); Note = $note
         }
-        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Rust $rust -Context $ctx
+        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Rust $rust -Micro $micro -Context $ctx
         $commentPath = Join-Path $OutDir 'comment.md'
         Set-Content -LiteralPath $commentPath -Value $comment -Encoding UTF8
         Write-Log "comment.md written -> $commentPath" 'Green'
 
-        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; rust = $rust; runner = $runner; context = $ctx }
+        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; rust = $rust; micro = $micro; runner = $runner; context = $ctx }
         $result | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutDir 'result.json') -Encoding UTF8
 
         Write-Host "`n----- comment.md -----" -ForegroundColor DarkGray

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -249,28 +249,34 @@ function Start-Process {
 }
 function Start-Sleep { param([int]$Seconds, [int]$Milliseconds) }   # no-op: skip the post-kill settle wait
 
-# A. clean exit 0 + non-empty output -> returns the jsonl path.
-$global:MicroWaitResult = $true; $global:MicroExit = 0; $global:MicroWriteContent = '{"benchId":"M1"}'
-$resA = Invoke-MicroRun -Exe 'x.exe' -Tag 'okrun' -RepCount 2 -IterCount 10
-Assert-True ($resA -eq (Join-Path $OutDir 'micro-okrun.jsonl')) '[micro] clean exit 0 + output -> returns jsonl path'
+# Wrap the scenarios in try/finally so the stub functions are removed deterministically:
+# if any assertion throws, an un-finally'd Remove-Item would be skipped and the
+# Start-Process / Start-Sleep stubs would leak into the rest of the script.
+try {
+    # A. clean exit 0 + non-empty output -> returns the jsonl path.
+    $global:MicroWaitResult = $true; $global:MicroExit = 0; $global:MicroWriteContent = '{"benchId":"M1"}'
+    $resA = Invoke-MicroRun -Exe 'x.exe' -Tag 'okrun' -RepCount 2 -IterCount 10
+    Assert-True ($resA -eq (Join-Path $OutDir 'micro-okrun.jsonl')) '[micro] clean exit 0 + output -> returns jsonl path'
 
-# B. timeout (WaitForExit=$false) + partial output present -> $null (truncated prefix discarded).
-$global:MicroWaitResult = $false; $global:MicroExit = 0; $global:MicroWriteContent = '{"benchId":"M1"}'
-$resB = Invoke-MicroRun -Exe 'x.exe' -Tag 'timeoutrun' -RepCount 2 -IterCount 10
-Assert-True ($null -eq $resB) '[micro] timeout + partial output -> $null (truncated prefix discarded)'
+    # B. timeout (WaitForExit=$false) + partial output present -> $null (truncated prefix discarded).
+    $global:MicroWaitResult = $false; $global:MicroExit = 0; $global:MicroWriteContent = '{"benchId":"M1"}'
+    $resB = Invoke-MicroRun -Exe 'x.exe' -Tag 'timeoutrun' -RepCount 2 -IterCount 10
+    Assert-True ($null -eq $resB) '[micro] timeout + partial output -> $null (truncated prefix discarded)'
 
-# C. non-zero exit + non-empty output -> $null (a crash leaves a silent subset).
-$global:MicroWaitResult = $true; $global:MicroExit = 3; $global:MicroWriteContent = '{"benchId":"M1"}'
-$resC = Invoke-MicroRun -Exe 'x.exe' -Tag 'crashrun' -RepCount 2 -IterCount 10
-Assert-True ($null -eq $resC) '[micro] non-zero exit + output -> $null (truncated prefix discarded)'
+    # C. non-zero exit + non-empty output -> $null (a crash leaves a silent subset).
+    $global:MicroWaitResult = $true; $global:MicroExit = 3; $global:MicroWriteContent = '{"benchId":"M1"}'
+    $resC = Invoke-MicroRun -Exe 'x.exe' -Tag 'crashrun' -RepCount 2 -IterCount 10
+    Assert-True ($null -eq $resC) '[micro] non-zero exit + output -> $null (truncated prefix discarded)'
 
-# D. clean exit 0 but NO output file written -> $null (nothing produced).
-$global:MicroWaitResult = $true; $global:MicroExit = 0; $global:MicroWriteContent = $null
-$resD = Invoke-MicroRun -Exe 'x.exe' -Tag 'emptyrun' -RepCount 2 -IterCount 10
-Assert-True ($null -eq $resD) '[micro] clean exit but empty/no output -> $null'
-
-Remove-Item function:Start-Process -ErrorAction SilentlyContinue
-Remove-Item function:Start-Sleep -ErrorAction SilentlyContinue
+    # D. clean exit 0 but NO output file written -> $null (nothing produced).
+    $global:MicroWaitResult = $true; $global:MicroExit = 0; $global:MicroWriteContent = $null
+    $resD = Invoke-MicroRun -Exe 'x.exe' -Tag 'emptyrun' -RepCount 2 -IterCount 10
+    Assert-True ($null -eq $resD) '[micro] clean exit but empty/no output -> $null'
+}
+finally {
+    Remove-Item function:Start-Process -ErrorAction SilentlyContinue
+    Remove-Item function:Start-Sleep -ErrorAction SilentlyContinue
+}
 
 # cleanup
 foreach ($d in @($baseTree, $prTree, $OutDir, $exeDir)) {

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -219,6 +219,59 @@ Assert-True (-not (Test-Path $marker4)) `
     '[stage] WebView2 Core DLL missing -> stale marker dropped before restage'
 Remove-Item $exeDir4 -Recurse -Force -ErrorAction SilentlyContinue
 
+# ===========================================================================
+#  Invoke-MicroRun — output-integrity discard paths (timeout / non-zero exit)
+# ===========================================================================
+# PerfBench.ControlModel writes results.jsonl incrementally (one line per rep), so a
+# killed or crashed run leaves a TRUNCATED prefix. Invoke-MicroRun must return $null
+# (omit the micro section) rather than hand back a silent subset. Stub Start-Process so
+# each scenario drives WaitForExit / ExitCode without launching a real child; the stub
+# simulates the child writing output by honoring an --out path it finds in ArgumentList.
+Invoke-Expression (Get-Func 'Invoke-MicroRun')
+
+$global:MicroWaitResult = $true     # $false => WaitForExit timed out
+$global:MicroExit = 0               # process exit code
+$global:MicroWriteContent = $null   # non-null => stub writes it to the --out file
+function Start-Process {
+    param(
+        [string]$FilePath, [string[]]$ArgumentList, [switch]$PassThru,
+        [string]$RedirectStandardOutput, [string]$RedirectStandardError, $WindowStyle
+    )
+    $outIdx = [Array]::IndexOf($ArgumentList, '--out')
+    if ($outIdx -ge 0 -and $global:MicroWriteContent) {
+        Set-Content -LiteralPath $ArgumentList[$outIdx + 1] -Value $global:MicroWriteContent -NoNewline
+    }
+    $exit = $global:MicroExit; $wait = $global:MicroWaitResult
+    [pscustomobject]@{ PriorityClass = $null } |
+        Add-Member -MemberType NoteProperty -Name ExitCode -Value $exit -PassThru |
+        Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($ms) $wait }.GetNewClosure() -PassThru |
+        Add-Member -MemberType ScriptMethod -Name Kill -Value { param($entireTree) } -PassThru
+}
+function Start-Sleep { param([int]$Seconds, [int]$Milliseconds) }   # no-op: skip the post-kill settle wait
+
+# A. clean exit 0 + non-empty output -> returns the jsonl path.
+$global:MicroWaitResult = $true; $global:MicroExit = 0; $global:MicroWriteContent = '{"benchId":"M1"}'
+$resA = Invoke-MicroRun -Exe 'x.exe' -Tag 'okrun' -RepCount 2 -IterCount 10
+Assert-True ($resA -eq (Join-Path $OutDir 'micro-okrun.jsonl')) '[micro] clean exit 0 + output -> returns jsonl path'
+
+# B. timeout (WaitForExit=$false) + partial output present -> $null (truncated prefix discarded).
+$global:MicroWaitResult = $false; $global:MicroExit = 0; $global:MicroWriteContent = '{"benchId":"M1"}'
+$resB = Invoke-MicroRun -Exe 'x.exe' -Tag 'timeoutrun' -RepCount 2 -IterCount 10
+Assert-True ($null -eq $resB) '[micro] timeout + partial output -> $null (truncated prefix discarded)'
+
+# C. non-zero exit + non-empty output -> $null (a crash leaves a silent subset).
+$global:MicroWaitResult = $true; $global:MicroExit = 3; $global:MicroWriteContent = '{"benchId":"M1"}'
+$resC = Invoke-MicroRun -Exe 'x.exe' -Tag 'crashrun' -RepCount 2 -IterCount 10
+Assert-True ($null -eq $resC) '[micro] non-zero exit + output -> $null (truncated prefix discarded)'
+
+# D. clean exit 0 but NO output file written -> $null (nothing produced).
+$global:MicroWaitResult = $true; $global:MicroExit = 0; $global:MicroWriteContent = $null
+$resD = Invoke-MicroRun -Exe 'x.exe' -Tag 'emptyrun' -RepCount 2 -IterCount 10
+Assert-True ($null -eq $resD) '[micro] clean exit but empty/no output -> $null'
+
+Remove-Item function:Start-Process -ErrorAction SilentlyContinue
+Remove-Item function:Start-Sleep -ErrorAction SilentlyContinue
+
 # cleanup
 foreach ($d in @($baseTree, $prTree, $OutDir, $exeDir)) {
     if (Test-Path $d) { Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue }


### PR DESCRIPTION
## What & why

`/perf` measures **only** the StocksGrid macro workload, which is the wrong instrument for the **Core/Reconciler** layer most of the perf fleet optimizes. This PR (PR2 of the harness-improvement split; PR1 #691 added reps + paired-CI + a coarse process-wide alloc metric) wires in the existing **`PerfBench.ControlModel` micro-suite** (spec-047 M1–M13) so `/perf` also reports per-bench, ns-resolution, **WinUI-undiluted** `main`-vs-PR `ns/op` + `B/op` — the layer the fleet actually operates on, which `/perf` previously ignored.

### Methodology rationale (local n=12 analysis)

The macro path could not resolve the deltas the fleet produces:

| Problem (measured on 12 paired local reps) | Evidence |
|---|---|
| **2-run median is a coin flip** | A fresh 2-run median swings **±7–11%** on timing; GH's headline `renders/sec −0.6%` reproduces its sign only **23%** of the time (74% of 2v2 medians show PR *faster*). |
| **The 4% floor preordains every sub-4% verdict** | The old blanket floor marks any \|Δ\|<4% "within noise" *by construction*, independent of run count — it both buries real sub-4% wins and rubber-stamps any sub-4% number. |
| **renders/sec is reconcile-blind** | Reconcile is only **~24%** of the StocksGrid frame cycle; **~76%** is the WinUI measure/arrange/render thread. rps is a render-throughput metric, not a reconcile metric. |
| **No allocation instrument** | Several fleet PRs reduce allocations; the macro path had no per-reconcile alloc signal (PR1's process-wide number is a coarse macro trend, diluted by WinUI/background allocs). |
| **A real ~2–3.5% reconcile/diff signal was masked** | Local reconcile Δ is −3.56% (95% CI excludes 0); GH printed −1.2% but the floor hid it. The harness was hiding wins, not just failing to confirm them. |

The micro-suite brackets **only the reconcile body** with per-thread alloc + GC counters (no render pipeline), so it resolves exactly what the macro path cannot.

## What this adds

- **`PerfBench.ControlModel` builds self-contained per side** — a scoped, opt-in `PerfCiSelfContained` MSBuild knob (unpackaged `WindowsPackageType=None`, so it builds on the runner without the packaged-app MakePri path). `main` and the PR each link their **own `src/Reactor`**, so the per-bench delta is a clean read on the code change.
- **A new micro section** in the sticky comment: per-bench `main` vs PR `ns/op` + `B/op` with the same paired 95% CI machinery as the macro tables.
- **`Run-PerfBenchmark.ps1` orchestration**: `-IncludeMicro` (default on) / `-MicroReps 12` / `-MicroIterations 10000`; best-effort build + run + compare after the Rust leg; threaded into the comment and `result.json`. **Any micro failure leaves the macro comment untouched.**

## v1 flagging — alloc-driven, ns informational

I validated the leg end-to-end on this ARM64 box by running the **same** ControlModel binary as both "main" and "PR" (a true no-op diff). Result:

- **Allocated bytes/op is deterministic** — 14/16 benches read **exactly 0.0%** Δ. Its paired CI is trustworthy, so **the row Status tracks alloc.**
- **ns/op is NOT deterministic across the two processes** — with the per-side runs not yet rep-interleaved, a systematic process-to-process timing offset shifts every paired ns difference the same way and makes the paired CI exclude 0 even for an identical binary (one bench spuriously read **−14.8% ns**). So **ns/op is shown for context but not auto-flagged in v1.**

Sample comment section (rendered from the identical-binary validation run — note `M3` reads −14.8% ns yet the row correctly stays "within noise" because alloc is unchanged):

> | Bench | `main` ns/op | Δ ns (95% CI) | `main` B/op | Δ alloc (95% CI) | Status |
> |---|--:|--:|--:|--:|:--|
> | `M3` Mount_Leaf_ThreeCallbacks | 142593.7 | -14.8% <sub>95% CI [-26.7, -2.9]</sub> | 18066408 | -2.1% <sub>95% CI [-7.5, +3.4]</sub> | ≈ within noise |
> | `M9` Update_AllChanged | 1995411.0 | -0.1% <sub>95% CI [-1.2, +1.0]</sub> | 368556160 | 0.0% <sub>95% CI [0.0, 0.0]</sub> | ≈ within noise |

**Rep-level interleaving of the two sides is the documented fast-follow** that would promote ns to a flagged signal. (Per the coordinator's calibration: PR1's process-wide alloc = coarse macro trend; this micro-suite = the authoritative, WinUI-undiluted per-reconcile alloc instrument.)

## Tests & docs

- `PerfLib.Tests.ps1`: **+46 micro assertions (162 total)**, including a **no-false-flag property** bench (clear ns improvement + unchanged alloc ⇒ row reads `noise`) and alloc-only row-status precedence.
- `RunPerfBenchmark.Tests.ps1`: unchanged-green (21).
- `ci/README.md` + `METHODOLOGY.md`: document the micro leg and the alloc-flagged / ns-informational v1 (with the empirical no-op finding and the interleaving fast-follow).

File-disjoint from `src/Reactor` and the perf fleet — touches only `tests/perf_bench/PerfBench.ControlModel/*` and `tests/stress_perf/**`. No `/perf` run is needed on this PR (it changes `/perf` itself); the fleet gets re-run after this lands.

Draft until reviewed.