### PR TITLE
Add StressPerf.KeyedList /perf macro workload (keyed child-diff path)

### DIFF
--- a/Reactor.slnx
+++ b/Reactor.slnx
@@ -396,6 +396,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="tests/stress_perf/StressPerf.KeyedList/StressPerf.KeyedList.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="tests/stress_perf/StressPerf.Reactor/StressPerf.Reactor.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/tests/stress_perf/README.md
+++ b/tests/stress_perf/README.md
@@ -34,6 +34,13 @@ StressPerf.Reactor/                ← Reactor (this repo's framework, naive —
 StressPerf.ReactorOptimized/       ← Reactor with spec-034 perf-tuning idioms
                                      (direct-record-initializer construction +
                                      UseMemoCells; spec 034 reference impl)
+StressPerf.KeyedList/              ← Reactor KEYED child-reconcile scenario: ~500
+                                     stably-keyed children reordered / inserted /
+                                     removed per tick, driving ChildReconciler
+                                     .ReconcileKeyed → ReconcileKeyedMiddle (LIS) —
+                                     the path the positional StocksGrid never hits.
+                                     --percent sets the per-tick reorder budget
+                                     (0 = the keyed all-match floor).
 StressPerf.Shared/                 ← PerfTracker, StockDataSource, ListItemSource
 
 StressPerf.VirtualList.Reactor/    ← virtualizing-list scenario (Reactor LazyVStack)

--- a/tests/stress_perf/StressPerf.KeyedList/KeyedListSource.cs
+++ b/tests/stress_perf/StressPerf.KeyedList/KeyedListSource.cs
@@ -1,0 +1,111 @@
+using System.Globalization;
+
+namespace StressPerf.KeyedList;
+
+/// <summary>
+/// One keyed row. <see cref="Key"/> is the stable reconciler identity
+/// (<c>.WithKey(...)</c>); <see cref="Label"/> is the display text. Both strings
+/// are computed once at construction so the per-render hot path only pays for the
+/// element-record allocation under measurement — never per-render key/label
+/// formatting (mirrors how StockDataSource pre-bakes its cell symbols).
+/// </summary>
+public readonly record struct KeyedRow(int Id, string Key, string Label);
+
+/// <summary>
+/// Deterministic keyed-list workload data source for the /perf macro benchmark.
+///
+/// Unlike <see cref="StressPerf.Shared.StockDataSource"/> — whose cells are
+/// POSITIONAL (mutated in place by index, hitting
+/// <c>ChildReconciler.ReconcilePositional</c>) — this source maintains an ORDERED
+/// list of stably-keyed rows and, each tick, REORDERS / INSERTS / REMOVES them.
+/// When the rendered children carry those keys, the child reconciler takes the
+/// keyed arm (<c>ReconcileKeyed</c> → <c>ReconcileKeyedMiddle</c>, the LIS-based
+/// minimal-move machinery) instead of the positional arm. That is the hot path
+/// the StocksGrid workload can never exercise.
+///
+/// Deterministic (fixed RNG seed) so main-vs-PR /perf runs compare identical
+/// edit sequences; the list size is held constant (insertions paired with
+/// removals) so working-set and render-count stay stable across the run.
+/// </summary>
+public sealed class KeyedListSource
+{
+    /// <summary>Default row count — ~500 to mirror StocksGrid's cell magnitude.</summary>
+    public const int DefaultCount = 500;
+
+    private readonly List<KeyedRow> _items;
+    private readonly Random _rng = new(42); // deterministic seed (matches StockDataSource)
+    private int _nextId;
+
+    public KeyedListSource(int count = DefaultCount)
+    {
+        if (count < 1) count = 1;
+        _items = new List<KeyedRow>(count);
+        for (int i = 0; i < count; i++)
+            _items.Add(MakeRow(i));
+        _nextId = count;
+    }
+
+    /// <summary>Current row count (held constant across ticks).</summary>
+    public int Count => _items.Count;
+
+    /// <summary>
+    /// Reorder / insert / remove a percentage of the keyed rows for one tick.
+    ///
+    /// <paramref name="percent"/> sets the structural-edit budget
+    /// <c>k = round(N * percent / 100)</c> (clamped to <c>[1, N]</c>). Of that
+    /// budget a quarter is spent on insert+remove CHURN — each removal paired with
+    /// a fresh-key insertion so the row SET changes over time (not just a fixed
+    /// permutation) while N stays constant — and the remainder on MOVES (pull a row
+    /// from one position and reinsert it at another, key preserved). Both kinds keep
+    /// matched keys in the post-prefix/suffix "middle", which is what drives
+    /// <c>ReconcileKeyedMiddle</c>'s LIS reorder pass.
+    /// </summary>
+    /// <returns>The structural-edit budget actually applied (for logging parity).</returns>
+    public int Update(double percent)
+    {
+        var rng = _rng;
+        int n = _items.Count;
+        int k = (int)Math.Round(n * percent / 100.0, MidpointRounding.AwayFromZero);
+        if (k < 1) k = 1;
+        if (k > n) k = n;
+
+        // Insert/remove churn — net-zero so the list size is invariant. Removing
+        // before inserting keeps every index access in range.
+        int churn = k / 4;
+        for (int i = 0; i < churn; i++)
+        {
+            _items.RemoveAt(rng.Next(_items.Count));
+            _items.Insert(rng.Next(_items.Count + 1), MakeRow(_nextId++));
+        }
+
+        // Moves — reorder existing rows, preserving their keys, so the keyed diff
+        // sees a permutation in the middle region and computes an LIS.
+        int moves = k - churn;
+        for (int i = 0; i < moves; i++)
+        {
+            int from = rng.Next(_items.Count);
+            var row = _items[from];
+            _items.RemoveAt(from);
+            _items.Insert(rng.Next(_items.Count + 1), row);
+        }
+
+        return k;
+    }
+
+    /// <summary>
+    /// Immutable snapshot of the current row order. The Reactor variant rebuilds its
+    /// full keyed child array from this each render (no positional memo fast-path),
+    /// so the reconciler runs a real keyed diff every tick.
+    /// </summary>
+    public KeyedRow[] Snapshot() => _items.ToArray();
+
+    private static KeyedRow MakeRow(int id)
+    {
+        string key = id.ToString(CultureInfo.InvariantCulture);
+        // Deterministic, content-stable label derived from the row's identity, so a
+        // moved row's text never changes — isolating the STRUCTURAL (keyed-diff)
+        // signal from per-cell property updates.
+        string label = string.Create(CultureInfo.InvariantCulture, $"Row {id} · item-{id % 97:000}");
+        return new KeyedRow(id, key, label);
+    }
+}

--- a/tests/stress_perf/StressPerf.KeyedList/KeyedListSource.cs
+++ b/tests/stress_perf/StressPerf.KeyedList/KeyedListSource.cs
@@ -52,7 +52,8 @@ public sealed class KeyedListSource
     /// Reorder / insert / remove a percentage of the keyed rows for one tick.
     ///
     /// <paramref name="percent"/> sets the structural-edit budget
-    /// <c>k = round(N * percent / 100)</c> (clamped to <c>[1, N]</c>). Of that
+    /// <c>k = round(N * percent / 100)</c> (clamped to <c>[0, N]</c>; <c>percent == 0</c>
+    /// leaves the order untouched — the keyed ALL-MATCH FLOOR). Of that
     /// budget a quarter is spent on insert+remove CHURN — each removal paired with
     /// a fresh-key insertion so the row SET changes over time (not just a fixed
     /// permutation) while N stays constant — and the remainder on MOVES (pull a row
@@ -66,8 +67,15 @@ public sealed class KeyedListSource
         var rng = _rng;
         int n = _items.Count;
         int k = (int)Math.Round(n * percent / 100.0, MidpointRounding.AwayFromZero);
-        if (k < 1) k = 1;
+        if (k < 0) k = 0;
         if (k > n) k = n;
+
+        // percent == 0 → k == 0: leave the order untouched so every key matches in
+        // place. That is the keyed ALL-MATCH FLOOR (LIS == whole list, zero moves) —
+        // the case the keyed structural-skip optimization targets. Snapshot() still
+        // allocates a fresh array each tick, so a render (and a keyed diff) still runs.
+        if (k == 0)
+            return 0;
 
         // Insert/remove churn — net-zero so the list size is invariant. Removing
         // before inserting keeps every index access in range.

--- a/tests/stress_perf/StressPerf.KeyedList/Program.cs
+++ b/tests/stress_perf/StressPerf.KeyedList/Program.cs
@@ -75,6 +75,7 @@ class KeyedListApp : Component
         var timerRef = UseRef<DispatcherTimer?>(null);
         var shutdownRef = UseRef<DispatcherTimer?>(null);
         var benchmarkUpdatePending = UseRef(false);
+        var keysVerifiedRef = UseRef(false);
 
         if (perfRef.Current == null)
         {
@@ -177,6 +178,27 @@ class KeyedListApp : Component
                 Key = row.Key,
                 FontSize = 12,
             };
+        }
+
+        // Structural self-check (runs once): EVERY emitted child must carry a non-null
+        // Key. If any key were missing, ChildReconciler.HasAnyKeys would be false and the
+        // entire scene would silently fall onto ReconcilePositional — measuring the WRONG
+        // reconcile path and invalidating the whole workload. Fail loudly (no metrics.json
+        // is written) rather than report misleading keyed numbers.
+        if (!keysVerifiedRef.Current)
+        {
+            keysVerifiedRef.Current = true;
+            for (int i = 0; i < children.Length; i++)
+            {
+                if (children[i].Key is null)
+                {
+                    Console.Error.WriteLine(
+                        $"FATAL: {AppName} child {i} has no Key — the keyed reconcile path " +
+                        "(ReconcileKeyed/ReconcileKeyedMiddle) would not run; results are invalid.");
+                    Environment.FailFast(
+                        $"{AppName}: keyed-path invariant violated (child {i} missing Key).");
+                }
+            }
         }
 
         return VStack(

--- a/tests/stress_perf/StressPerf.KeyedList/Program.cs
+++ b/tests/stress_perf/StressPerf.KeyedList/Program.cs
@@ -1,0 +1,196 @@
+// StressPerf.KeyedList — a /perf macro workload that exercises Reactor's KEYED
+// child-reconciliation path (ChildReconciler.ReconcileKeyed →
+// ReconcileKeyedMiddle, the LIS-based minimal-move machinery) that the existing
+// StocksGrid workload (StressPerf.ReactorOptimized) can never reach.
+//
+// StocksGrid's cells are POSITIONAL: a fixed Grid of N cells mutated in place by
+// index, so its child diff always takes ChildReconciler.ReconcilePositional. This
+// harness instead renders a list of N stably-KEYED children (each carries a
+// `.WithKey(...)`) and, every tick, REORDERS / INSERTS / REMOVES them — forcing
+// the keyed arm and its LIS reorder pass. Several reconciler optimizations target
+// exactly that path (keyed-list diff, keyed structural-skip); /perf needs this
+// workload to measure them.
+//
+// The harness contract is mirrored byte-for-byte from StressPerf.ReactorOptimized:
+// the same CLI flags (--headless / --percent / --duration / --json via the shared
+// CliOptions), the same shutdown emission (report.txt + metrics.json + the
+// REACTOR_PERF_JSON stdout line) via the shared PerfTracker, and the same
+// OnRenderComplete phase-capture wiring. Only the SCENE and its per-tick mutation
+// differ, so Run-PerfBenchmark.ps1 / PerfLib.ps1 can drive it identically.
+
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Hooks;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using StressPerf.KeyedList;
+using StressPerf.Shared;
+using static Microsoft.UI.Reactor.Factories;
+
+// Parse CLI args before WinUI starts
+var cliOptions = CliOptions.Parse(args);
+if (cliOptions.Headless)
+    ConsoleHelper.EnsureConsole();
+
+KeyedListApp.CliOpts = cliOptions;
+
+// Children are built via the direct record initializer (`new TextBlockElement(...)`)
+// to avoid factory overhead in the hot path, which bypasses the factory's lazy
+// handler registration. Opt into the full built-in catalog once at startup so every
+// built-in element record has a registered handler before the first reconcile —
+// the documented one-line prelude for the direct-record idiom (spec-048 §3.4),
+// identical to StressPerf.ReactorOptimized.
+ReactorApp.RegisterAllBuiltIns();
+
+ReactorApp.Run<KeyedListApp>("StressPerf.KeyedList", fullScreen: true);
+
+// ---------------------------------------------------------------------------
+
+class KeyedListApp : Component
+{
+    private const string AppName = "StressPerf.KeyedList";
+
+    public static CliOptions CliOpts { get; set; } = new();
+
+    public override Element Render()
+    {
+        var sourceRef = UseRef<KeyedListSource?>(null);
+        if (sourceRef.Current == null)
+            sourceRef.Current = new KeyedListSource();
+        var source = sourceRef.Current;
+
+        // The full keyed snapshot drives a complete child-array rebuild every render
+        // (deliberately NO positional memo fast-path), so the child reconciler runs a
+        // real keyed diff each tick.
+        var (data, setData) = UseState(source.Snapshot());
+
+        var (percent, setPercent) = UseState(CliOpts.Percent);
+        var (running, setRunning) = UseState(false);
+        var (fps, setFps) = UseState("FPS: --");
+        var (updateMs, setUpdateMs) = UseState("Update: -- ms");
+        var (mem, setMem) = UseState("Mem: -- MB");
+
+        var perfRef = UseRef<PerfTracker?>(null);
+        var timerRef = UseRef<DispatcherTimer?>(null);
+        var shutdownRef = UseRef<DispatcherTimer?>(null);
+        var benchmarkUpdatePending = UseRef(false);
+
+        if (perfRef.Current == null)
+        {
+            perfRef.Current = new PerfTracker();
+            var perf = perfRef.Current;
+            var pending = benchmarkUpdatePending;
+            ReactorApp.PrimaryWindow!.Host.OnRenderComplete = (treeMs, reconcileMs, effectsMs) =>
+            {
+                if (pending.Current)
+                {
+                    pending.Current = false;
+                    perf.RecordPhases(treeMs, reconcileMs, effectsMs);
+                }
+            };
+        }
+
+        var renderHooked = UseRef(false);
+        if (!renderHooked.Current)
+        {
+            renderHooked.Current = true;
+            var perf = perfRef.Current;
+            CompositionTarget.Rendering += (_, _) => perf.FrameRendered();
+        }
+
+        UseEffect(() =>
+        {
+            if (running)
+            {
+                var src = sourceRef.Current!;
+                var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(33) };
+                timer.Tick += (_, _) =>
+                {
+                    var perf = perfRef.Current!;
+                    perf.BeginUpdate();
+
+                    src.Update(percent);
+                    benchmarkUpdatePending.Current = true;
+                    setData(src.Snapshot());
+
+                    perf.EndUpdate();
+
+                    setFps($"FPS: {perf.CurrentFps:F0}");
+                    setUpdateMs($"Update: {perf.LastUpdateMs:F1} ms");
+                    setMem($"Mem: {perf.CurrentMemoryMB} MB");
+                };
+                timer.Start();
+                timerRef.Current = timer;
+            }
+            else
+            {
+                timerRef.Current?.Stop();
+                timerRef.Current = null;
+            }
+
+            return () =>
+            {
+                timerRef.Current?.Stop();
+                timerRef.Current = null;
+            };
+        }, running, percent);
+
+        UseEffect(() =>
+        {
+            if (!CliOpts.Headless) return;
+            setPercent(CliOpts.Percent);
+            setRunning(true);
+
+            var shutdownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(CliOpts.DurationSeconds) };
+            shutdownTimer.Tick += (_, _) =>
+            {
+                setRunning(false);
+                shutdownTimer.Stop();
+                var perf = perfRef.Current!;
+                perf.WriteReportFile(AppName, CliOpts.Percent);
+                if (CliOpts.Json)
+                {
+                    perf.WriteMetricsJsonFile(AppName, CliOpts.Percent);
+                    // Echo a single marked line so log scrapers have a fallback to the
+                    // {AppName}.metrics.json file written next to the exe.
+                    Console.WriteLine("REACTOR_PERF_JSON " + perf.GetMetricsJson(AppName, CliOpts.Percent));
+                }
+                Application.Current.Exit();
+            };
+            shutdownTimer.Start();
+            shutdownRef.Current = shutdownTimer;
+        }, Array.Empty<object>());
+
+        // ── Build element tree ──────────────────────────────────────────
+        // Each row is a single keyed TextBlockElement. The `.Key` is what flips the
+        // child reconciler onto its keyed arm (ChildReconciler.HasAnyKeys); reordered
+        // keys in the post-prefix/suffix middle drive the LIS minimal-move pass. Built
+        // via the direct record initializer (no fluent clones) to keep the per-render
+        // tree-build cost dominated by the element allocation under measurement.
+        var children = new Element[data.Length];
+        for (int i = 0; i < data.Length; i++)
+        {
+            var row = data[i];
+            children[i] = new TextBlockElement(row.Label)
+            {
+                Key = row.Key,
+                FontSize = 12,
+            };
+        }
+
+        return VStack(
+            HStack(12,
+                Button(running ? "Stop" : "Start", () => setRunning(!running)),
+                TextBlock("Move %:").VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center),
+                Slider(percent, 0, 100, v => setPercent(v)).Width(200),
+                TextBlock(fps).VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center).Width(100),
+                TextBlock(updateMs).VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center).Width(120),
+                TextBlock(mem).VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center).Width(120)
+            ).Padding(8),
+            ScrollView(
+                VStack(children)
+            )
+        );
+    }
+}

--- a/tests/stress_perf/StressPerf.KeyedList/StressPerf.KeyedList.csproj
+++ b/tests/stress_perf/StressPerf.KeyedList/StressPerf.KeyedList.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
+    <Platforms>x64;ARM64</Platforms>
+    <RootNamespace>StressPerf.KeyedList</RootNamespace>
+    <AssemblyName>StressPerf.KeyedList</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseWinUI>true</UseWinUI>
+    <WindowsPackageType>None</WindowsPackageType>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <!--
+    On-demand perf-comparison CI (.github/workflows/perf-compare.yml) builds this
+    harness with -p:PerfCiSelfContained=true so it carries its own Windows App SDK
+    runtime and needs NO machine-wide runtime install on the GitHub-hosted runner —
+    the same hermetic trick the WinUI selftest hosts use to open real windows in CI.
+    Scoped to THIS executable (rather than a global -p:WindowsAppSDKSelfContained)
+    so the flag never flows into the referenced class libraries (Reactor.csproj /
+    StressPerf.Shared), which reject self-contained packaging. Run-PerfBenchmark.ps1
+    passes it by default; pass -SelfContained:$false to build framework-dependent.
+    Mirrors StressPerf.ReactorOptimized.csproj — the StocksGrid build recipe — so
+    the keyed-list workload launches under the identical hermetic /perf conditions.
+  -->
+  <PropertyGroup Condition="'$(PerfCiSelfContained)' == 'true'">
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' != 'ARM64'">win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StressPerf.Shared\StressPerf.Shared.csproj" />
+    <ProjectReference Include="..\..\..\src\Reactor\Reactor.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Why

The `/perf` harness only ships **StressPerf.ReactorOptimized** (StocksGrid), whose cells are **positional** — they always take `ChildReconciler.ReconcilePositional`. That leaves the **keyed** arm (`ReconcileKeyed` → `ReconcileKeyedMiddle`, the LIS-based minimal-move machinery) — the target of the keyed-list-diff and the planned keyed structural-skip optimizations — **unmeasured**. This PR gives `/perf` a workload that exercises exactly that hot path.

## What

A new **`StressPerf.KeyedList`** harness: ~500 stably-**keyed** `TextBlock` children in a `StackPanel` that are **reordered / inserted / removed** every tick (driven by `--percent`), forcing the keyed reconcile arm and its LIS reorder pass.

It **mirrors the StocksGrid harness contract byte-for-byte** so the existing orchestration drives it with no special-casing:

- **CLI**: `--headless --percent <double> --duration <int> --json` (shared `CliOptions.Parse`).
- **Emission** (shared `PerfTracker`, on shutdown): `StressPerf.KeyedList.metrics.json` + `.report.txt` + `.samples.csv`, plus the `REACTOR_PERF_JSON {…}` stdout line.
- **metrics.json schema**: identical (`rendersPerSec`, `avgReconcileMs`, `avgDiffMs`, `avgMemoryMB`, `totalRenders`, `durationSeconds` + `allocBytesPerRender`, `gen0/1/2`, `gen0PerKRenders`, `avgFps`, `sampleCount`).
- **Phase capture**: `Host.OnRenderComplete → PerfTracker.RecordPhases`, gated by a pending flag.

Only the **scene** and its per-tick mutation differ.

### Keyed-path guarantee & all-match floor

- **Verified by construction**: every child carries a stable non-null `Key`, so `ChildReconciler.HasAnyKeys` is definitionally true and the scene always takes `ReconcileKeyed`. A one-time **fail-loud self-check** scans the emitted child array and `Environment.FailFast`s (after a `FATAL` stderr line, before any `metrics.json` is written) if any child lacks a `Key` — so a DSL slip onto `ReconcilePositional` can never silently report bogus "keyed" numbers.
- **Genuine middle reordering**: the per-tick mutation does random *interior* remove+insert across the whole list (not tail-only churn), so head/tail fast-paths don't absorb it and `ReconcileKeyedMiddle`'s LIS does real work.
- **`--percent 0` = the keyed all-match floor**: at 0% no edits are applied, so all keys match in place (LIS == whole list, zero moves) — the floor the keyed structural-skip optimization targets. A fresh snapshot array is still allocated each tick, so a render + keyed diff still runs.

## Footprint — additive & disjoint

- **New project only** + a `Reactor.slnx` registration. The data source (`KeyedListSource`) lives inside the new project.
- **No `src/Reactor` changes** (no runtime changes).
- **No harness-orchestration changes** (`perf-compare.yml` / `Run-PerfBenchmark.ps1` / `PerfLib.ps1` are untouched — owned by the perf-harness wiring PR, which will register this workload separately).
- The existing StocksGrid workload is untouched.

## Validation (headless, ARM64 self-contained — the artifact CI runs)

- `Reactor.csproj` and the new project both build **0 warning / 0 error**.
- `metrics.json` emits **every field**, including the allocation set; the keyed-path self-check passes on every run (exit 0, no `FATAL`).
- **Cost concentrates in the keyed child-diff phase**: avg diff is ~99% of avg reconcile (avg tree ≈ 0.1 ms).
- **Diff scales with reorder volume**: avg diff ms **0.64 @ 0% (all-match floor) → 6.61 @ 50% → ~8 @ 90%** — a ~10× range a *positional* diff cannot produce, confirming the keyed LIS path is exercised.

> Draft until the perf-harness wiring PR registers this workload and confirms it produces sane `/perf` output.