### PR TITLE
perf(reconciler): skip redundant automation-name write when value already matches (P3)

### DIFF
--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -2683,10 +2683,14 @@ public sealed partial class Reconciler : IDisposable
     public static void UpdateDefaultAutomationName(FrameworkElement fe, string? oldCaption, string? newCaption)
     {
         if (fe is null) return;
-        // A whitespace new caption has nothing to write — skip the GetName read too
-        // (main's first line returns on whitespace newCaption, so this is behavior-
-        // identical, it just avoids the interop read). Otherwise read the live Name
-        // and let the pure helper decide; we only touch the DP when it returns a value.
+        // Two arms: a whitespace new caption has nothing to write, so we return before
+        // even reading the Name (main also returns first on whitespace newCaption, so
+        // this is behavior-identical — it just avoids that one interop read). For any
+        // NON-whitespace caption we still read the live Name and let the pure helper
+        // decide. The actual P3 saving lives inside that helper: it skips the SetName
+        // write when the live Name already equals the caption-derived default (the
+        // redundant same-value write). GetName is NOT skipped for unchanged captions —
+        // only the redundant SetName is. We touch the DP only when the helper returns a value.
         if (string.IsNullOrWhiteSpace(newCaption)) return;
         var current = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(fe);
         var resolved = ResolveDefaultAutomationNameUpdate(current, oldCaption, newCaption);

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -2690,7 +2690,8 @@ public sealed partial class Reconciler : IDisposable
         // decide. The actual P3 saving lives inside that helper: it skips the SetName
         // write when the live Name already equals the caption-derived default (the
         // redundant same-value write). GetName is NOT skipped for unchanged captions —
-        // only the redundant SetName is. We touch the DP only when the helper returns a value.
+        // only the redundant SetName is. We perform the SetName write only when the helper
+        // returns a value (the GetName read above always runs for a non-whitespace caption).
         if (string.IsNullOrWhiteSpace(newCaption)) return;
         var current = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(fe);
         var resolved = ResolveDefaultAutomationNameUpdate(current, oldCaption, newCaption);

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -2683,14 +2683,37 @@ public sealed partial class Reconciler : IDisposable
     public static void UpdateDefaultAutomationName(FrameworkElement fe, string? oldCaption, string? newCaption)
     {
         if (fe is null) return;
+        // P3 fast-path — skip the UIA GetName read + SetName write whenever the
+        // outcome is independent of the live Name: an empty/whitespace new caption
+        // (nothing to write), or an unchanged caption (the Name already reflects it
+        // from mount or a prior update, or the author overrode it — either way
+        // nothing to do). These two arms mirror the caption-only arms of
+        // ResolveDefaultAutomationNameUpdate, so the live path and the pure
+        // decision helper stay in lockstep. On a changed caption we fall through to
+        // the original GetName + author-override + SetName behavior, unchanged.
         if (string.IsNullOrWhiteSpace(newCaption)) return;
+        if (string.Equals(oldCaption, newCaption, StringComparison.Ordinal)) return;
         var current = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(fe);
+        var resolved = ResolveDefaultAutomationNameUpdate(current, oldCaption, newCaption);
+        if (resolved is not null)
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(fe, resolved);
+    }
+
+    // Pure decision for UpdateDefaultAutomationName — no DP/UIA interop, so the
+    // caption/override policy is unit-testable headlessly (Reactor.Tests). Returns
+    // the Name to write, or null to leave the live automation Name untouched. Kept
+    // in sync with the UpdateDefaultAutomationName fast-path above: the whitespace-
+    // new-caption and unchanged-caption arms here are the same skips the live path
+    // takes before it ever reads the current Name.
+    internal static string? ResolveDefaultAutomationNameUpdate(string? current, string? oldCaption, string? newCaption)
+    {
+        if (string.IsNullOrWhiteSpace(newCaption)) return null;
+        if (string.Equals(oldCaption, newCaption, StringComparison.Ordinal)) return null;
         bool authorOverride =
             !string.IsNullOrEmpty(current) &&
             (oldCaption is null || !string.Equals(current, oldCaption, StringComparison.Ordinal));
-        if (authorOverride) return;
-        var trimmed = newCaption.Length > 100 ? newCaption.Substring(0, 100) : newCaption;
-        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(fe, trimmed);
+        if (authorOverride) return null;
+        return newCaption.Length > 100 ? newCaption.Substring(0, 100) : newCaption;
     }
 
     internal static string? ExtractElementCaption(Element? element) => element switch

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -2683,16 +2683,11 @@ public sealed partial class Reconciler : IDisposable
     public static void UpdateDefaultAutomationName(FrameworkElement fe, string? oldCaption, string? newCaption)
     {
         if (fe is null) return;
-        // P3 fast-path — skip the UIA GetName read + SetName write whenever the
-        // outcome is independent of the live Name: an empty/whitespace new caption
-        // (nothing to write), or an unchanged caption (the Name already reflects it
-        // from mount or a prior update, or the author overrode it — either way
-        // nothing to do). These two arms mirror the caption-only arms of
-        // ResolveDefaultAutomationNameUpdate, so the live path and the pure
-        // decision helper stay in lockstep. On a changed caption we fall through to
-        // the original GetName + author-override + SetName behavior, unchanged.
+        // A whitespace new caption has nothing to write — skip the GetName read too
+        // (main's first line returns on whitespace newCaption, so this is behavior-
+        // identical, it just avoids the interop read). Otherwise read the live Name
+        // and let the pure helper decide; we only touch the DP when it returns a value.
         if (string.IsNullOrWhiteSpace(newCaption)) return;
-        if (string.Equals(oldCaption, newCaption, StringComparison.Ordinal)) return;
         var current = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(fe);
         var resolved = ResolveDefaultAutomationNameUpdate(current, oldCaption, newCaption);
         if (resolved is not null)
@@ -2701,19 +2696,27 @@ public sealed partial class Reconciler : IDisposable
 
     // Pure decision for UpdateDefaultAutomationName — no DP/UIA interop, so the
     // caption/override policy is unit-testable headlessly (Reactor.Tests). Returns
-    // the Name to write, or null to leave the live automation Name untouched. Kept
-    // in sync with the UpdateDefaultAutomationName fast-path above: the whitespace-
-    // new-caption and unchanged-caption arms here are the same skips the live path
-    // takes before it ever reads the current Name.
+    // the Name to write, or null to leave the live automation Name untouched. Models
+    // main's GetName + author-override + SetName logic exactly, plus one safe saving:
+    // the idempotent-write guard below.
     internal static string? ResolveDefaultAutomationNameUpdate(string? current, string? oldCaption, string? newCaption)
     {
         if (string.IsNullOrWhiteSpace(newCaption)) return null;
-        if (string.Equals(oldCaption, newCaption, StringComparison.Ordinal)) return null;
         bool authorOverride =
             !string.IsNullOrEmpty(current) &&
             (oldCaption is null || !string.Equals(current, oldCaption, StringComparison.Ordinal));
         if (authorOverride) return null;
-        return newCaption.Length > 100 ? newCaption.Substring(0, 100) : newCaption;
+        var trimmed = newCaption.Length > 100 ? newCaption.Substring(0, 100) : newCaption;
+        // Idempotent-write guard — the P3 saving. When the live Name already equals the
+        // caption-derived default, the SetName main would issue is a value no-op, so skip
+        // it (this is the steady-state hot path: an unchanged caption means current ==
+        // trimmed). Crucially we still WRITE when the default must be (re)applied — e.g.
+        // a modifier removal this render cleared the Name (current empty) even though the
+        // caption itself is unchanged — so a removed .AutomationName() override correctly
+        // falls back to the caption default, matching main. Behaviorally identical to main
+        // minus the redundant same-value write.
+        if (string.Equals(current, trimmed, StringComparison.Ordinal)) return null;
+        return trimmed;
     }
 
     internal static string? ExtractElementCaption(Element? element) => element switch

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoreCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CoreCoverageFixtures.cs
@@ -751,7 +751,7 @@ internal static class CoreCoverageFixtures
                             .Landmark(Microsoft.UI.Xaml.Automation.Peers.AutomationLandmarkType.Main)
                     );
                 }
-                else
+                else if (phase == 1)
                 {
                     return VStack(
                         Button("UpdateA11y", () => set(2)),
@@ -768,6 +768,19 @@ internal static class CoreCoverageFixtures
                             .TabNavigation(Microsoft.UI.Xaml.Input.KeyboardNavigationMode.Cycle)
                     );
                 }
+                else
+                {
+                    // phase 2: the .AutomationName() override is removed while the caption
+                    // ("Accessible") is unchanged. ApplyModifiers clears the live UIA Name;
+                    // the P3 idempotent-write guard must still restore the caption-derived
+                    // default (current "" != caption => a real write) rather than leave the
+                    // Name empty. Exercises the live seam's restore-default branch end-to-end.
+                    return VStack(
+                        Button("UpdateA11y", () => set(3)),
+                        TextBlock("Accessible")
+                            .HelpText("Updated help text")
+                    );
+                }
             });
 
             await Harness.Render();
@@ -776,6 +789,9 @@ internal static class CoreCoverageFixtures
             H.Check("A11y_Mounted", tb is not null);
             H.Check("A11y_HelpText",
                 Microsoft.UI.Xaml.Automation.AutomationProperties.GetHelpText(tb!) == "This is help text");
+            // The author-set .AutomationName() override wins over the caption default at mount.
+            H.Check("A11y_Name_Override",
+                Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(tb!) == "test-text");
 
             // Update accessibility modifiers
             H.ClickButton("UpdateA11y");
@@ -786,6 +802,19 @@ internal static class CoreCoverageFixtures
             H.Check("A11y_LiveSetting",
                 Microsoft.UI.Xaml.Automation.AutomationProperties.GetLiveSetting(tb!) ==
                 Microsoft.UI.Xaml.Automation.Peers.AutomationLiveSetting.Polite);
+            // A changed override still flows through (the author name updates, not the caption).
+            H.Check("A11y_Name_OverrideUpdated",
+                Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(tb!) == "test-text-updated");
+
+            // Remove the .AutomationName() override with the caption unchanged. ApplyModifiers
+            // clears the Name; the P3 guard (live seam) must restore the caption-derived default
+            // "Accessible" rather than leave it empty. TEETH: a blanket unchanged-caption skip
+            // (or dropping the live SetName) leaves the Name cleared here and this flips.
+            H.ClickButton("UpdateA11y");
+            await Harness.Render();
+            tb = H.FindText("Accessible");
+            H.Check("A11y_Name_RestoredToCaptionDefault",
+                Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(tb!) == "Accessible");
         }
     }
 

--- a/tests/Reactor.Tests/ReconcilerAutomationNameTests.cs
+++ b/tests/Reactor.Tests/ReconcilerAutomationNameTests.cs
@@ -7,34 +7,40 @@ namespace Microsoft.UI.Reactor.Tests;
 /// <summary>
 /// Pins the decision policy of <see cref="Reconciler.UpdateDefaultAutomationName"/> via its
 /// pure, DP-free helper <see cref="Reconciler.ResolveDefaultAutomationNameUpdate"/> (P3 — trim
-/// the per-cell automation round-trip).
+/// the redundant per-cell automation write).
 ///
-/// The optimization: when the caption is unchanged (or empty/whitespace) the live method skips
-/// the UIA <c>GetName</c> read + <c>SetName</c> write entirely. These tests assert that policy
-/// AND that the two correctness-critical guarantees survive: an author-set automation Name is
-/// never clobbered, and a genuine caption change still flows through to the Name.
+/// The optimization is an idempotent-write guard: the live method still reads the UIA Name, but
+/// skips the <c>SetName</c> write when the Name already equals the caption-derived default (the
+/// steady-state hot path). These tests pin that saving AND the three correctness guarantees that
+/// must survive it: an author-set Name is never clobbered, a genuine caption change still flows
+/// through, and a Name cleared this render (e.g. a removed <c>.AutomationName()</c> override) is
+/// restored to the caption default even when the caption itself is unchanged.
 /// </summary>
 public class ReconcilerAutomationNameTests
 {
     // ────────────────────────────────────────────────────────────────
-    //  The P3 skip (teeth: revert the unchanged-caption fast-path → these flip)
+    //  The P3 idempotent-write guard (teeth: revert it → these flip)
     // ────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Unchanged_Caption_Returns_Null_When_Name_Already_Matches()
+    public void Unchanged_Caption_Skips_Write_When_Name_Already_Matches()
     {
-        // Name already reflects the caption → nothing to write.
+        // Steady-state hot path: the live Name already equals the caption-derived default, so the
+        // SetName main would issue is a value no-op → return null (skip).
+        // TEETH: remove the `current == trimmed` guard and the helper falls through to
+        // `return trimmed` ("X", a redundant write) → this assertion fails.
         Assert.Null(Reconciler.ResolveDefaultAutomationNameUpdate(current: "X", oldCaption: "X", newCaption: "X"));
     }
 
     [Fact]
-    public void Unchanged_Caption_Returns_Null_Even_When_Live_Name_Is_Empty()
+    public void Cleared_Name_Restores_Caption_Default_When_Caption_Unchanged()
     {
-        // TEETH for P3: with the `oldCaption == newCaption` fast-path the unchanged caption is a
-        // skip regardless of the live Name. Remove that line and the helper falls through to the
-        // author-override logic: current "" is not an override, so it returns "X" (a write) and
-        // this assertion fails — i.e. reverting the optimization breaks this test.
-        Assert.Null(Reconciler.ResolveDefaultAutomationNameUpdate(current: "", oldCaption: "X", newCaption: "X"));
+        // Regression guard (the bug a blanket unchanged-caption skip would introduce): a removed
+        // `.AutomationName()` override makes ApplyModifiers clear the live Name to empty *before*
+        // this runs, even though the caption is unchanged. The default must be re-applied — so an
+        // empty current with an unchanged caption "X" resolves to a WRITE of "X", matching main.
+        // TEETH the other way: re-add `if (oldCaption == newCaption) return null;` → this fails.
+        Assert.Equal("X", Reconciler.ResolveDefaultAutomationNameUpdate(current: "", oldCaption: "X", newCaption: "X"));
     }
 
     [Theory]
@@ -64,6 +70,14 @@ public class ReconcilerAutomationNameTests
     {
         // oldCaption null but a non-empty live Name is present → treat as author-owned, leave it.
         Assert.Null(Reconciler.ResolveDefaultAutomationNameUpdate(current: "custom", oldCaption: null, newCaption: "B"));
+    }
+
+    [Fact]
+    public void Author_Override_Survives_Unchanged_Caption()
+    {
+        // Unchanged caption "X" but the live Name is an author override ("custom" ≠ oldCaption) →
+        // the idempotent guard must NOT fire (custom ≠ trimmed "X"); author-override wins → null.
+        Assert.Null(Reconciler.ResolveDefaultAutomationNameUpdate(current: "custom", oldCaption: "X", newCaption: "X"));
     }
 
     // ────────────────────────────────────────────────────────────────

--- a/tests/Reactor.Tests/ReconcilerAutomationNameTests.cs
+++ b/tests/Reactor.Tests/ReconcilerAutomationNameTests.cs
@@ -1,0 +1,98 @@
+using System;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Pins the decision policy of <see cref="Reconciler.UpdateDefaultAutomationName"/> via its
+/// pure, DP-free helper <see cref="Reconciler.ResolveDefaultAutomationNameUpdate"/> (P3 — trim
+/// the per-cell automation round-trip).
+///
+/// The optimization: when the caption is unchanged (or empty/whitespace) the live method skips
+/// the UIA <c>GetName</c> read + <c>SetName</c> write entirely. These tests assert that policy
+/// AND that the two correctness-critical guarantees survive: an author-set automation Name is
+/// never clobbered, and a genuine caption change still flows through to the Name.
+/// </summary>
+public class ReconcilerAutomationNameTests
+{
+    // ────────────────────────────────────────────────────────────────
+    //  The P3 skip (teeth: revert the unchanged-caption fast-path → these flip)
+    // ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Unchanged_Caption_Returns_Null_When_Name_Already_Matches()
+    {
+        // Name already reflects the caption → nothing to write.
+        Assert.Null(Reconciler.ResolveDefaultAutomationNameUpdate(current: "X", oldCaption: "X", newCaption: "X"));
+    }
+
+    [Fact]
+    public void Unchanged_Caption_Returns_Null_Even_When_Live_Name_Is_Empty()
+    {
+        // TEETH for P3: with the `oldCaption == newCaption` fast-path the unchanged caption is a
+        // skip regardless of the live Name. Remove that line and the helper falls through to the
+        // author-override logic: current "" is not an override, so it returns "X" (a write) and
+        // this assertion fails — i.e. reverting the optimization breaks this test.
+        Assert.Null(Reconciler.ResolveDefaultAutomationNameUpdate(current: "", oldCaption: "X", newCaption: "X"));
+    }
+
+    [Theory]
+    [InlineData("X", null)]
+    [InlineData("X", "")]
+    [InlineData("X", "   ")]
+    public void Empty_Or_Whitespace_New_Caption_Returns_Null(string? current, string? newCaption)
+    {
+        // No caption to project onto the Name → never touch it (matches the original guard).
+        Assert.Null(Reconciler.ResolveDefaultAutomationNameUpdate(current, oldCaption: "anything", newCaption));
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    //  Author-override preservation (MED-risk invariant — must not regress)
+    // ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Author_Override_Survives_Caption_Change()
+    {
+        // The live Name ("custom") differs from the previous caption ("A") → the author set it.
+        // A caption change A→B must NOT clobber the author's value.
+        Assert.Null(Reconciler.ResolveDefaultAutomationNameUpdate(current: "custom", oldCaption: "A", newCaption: "B"));
+    }
+
+    [Fact]
+    public void Author_Override_Survives_When_Old_Caption_Unknown()
+    {
+        // oldCaption null but a non-empty live Name is present → treat as author-owned, leave it.
+        Assert.Null(Reconciler.ResolveDefaultAutomationNameUpdate(current: "custom", oldCaption: null, newCaption: "B"));
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    //  The default still follows a genuine caption change
+    // ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Default_Follows_Caption_Change()
+    {
+        // Live Name equals the previous caption ("A") → our default owns it → update to "B".
+        Assert.Equal("B", Reconciler.ResolveDefaultAutomationNameUpdate(current: "A", oldCaption: "A", newCaption: "B"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void FirstTime_Set_When_Live_Name_Empty_And_Caption_Changed(string? current)
+    {
+        // No author Name yet + a real (changed) caption → set it.
+        Assert.Equal("B", Reconciler.ResolveDefaultAutomationNameUpdate(current, oldCaption: "A", newCaption: "B"));
+    }
+
+    [Fact]
+    public void Long_Changed_Caption_Is_Trimmed_To_100_Chars()
+    {
+        var longCaption = new string('a', 250);
+        var resolved = Reconciler.ResolveDefaultAutomationNameUpdate(current: "old", oldCaption: "old", newCaption: longCaption);
+        Assert.NotNull(resolved);
+        Assert.Equal(100, resolved!.Length);
+        Assert.Equal(new string('a', 100), resolved);
+    }
+}


### PR DESCRIPTION
## P3 — skip the redundant per-cell automation-name write

**Phase-1 finding.** `Reconciler.UpdateDefaultAutomationName` runs on every changed cell that goes through `Update`. In the steady state the caption-derived default it computes already equals the live UIA Name, so the `SetName` it issues is a value no-op — pure per-cell overhead.

### Change
- Extract the decision into a **pure, DP-free** `ResolveDefaultAutomationNameUpdate(current, oldCaption, newCaption)` helper (headless-testable in `Reactor.Tests`).
- Add an **idempotent-write guard**: after computing the trimmed caption-derived default, skip the `SetName` when the live Name already equals it. `GetName` still runs for non-whitespace captions — **only the redundant same-value write is skipped**.
- (Behavior-identical micro-skip: a whitespace new caption returns before the `GetName` read, exactly as main's first line does.)

### Correctness (MED-risk area — automation names)
The helper models main's `GetName` + author-override + `SetName` logic **exactly**, plus the idempotent guard:
- Author override (live Name ≠ old caption) → left untouched. ✅
- Genuine caption change A→B → writes B. ✅
- **Restore default**: a removed `.AutomationName()` override makes `ApplyModifiers` clear the Name *before* this runs; with an unchanged caption the default is still re-applied (empty `current` ≠ trimmed → write). ✅ *(This is the regression a naïve "skip when caption unchanged" cut would have introduced — caught in review, now pinned by a teeth test.)*
- Steady state (live Name already == default) → skip the redundant write. ✅ *(the saving)*
- `>100`-char trim preserved. ✅

### Tests
`ReconcilerAutomationNameTests` (12 cases) pin the decision with **teeth both ways**:
- Revert the idempotent guard → the skip test sees a redundant `"X"` write → fails.
- Re-add a blanket unchanged-caption skip → the restore-default test returns `null` → fails.

### Scope / gate
- **`src/Reactor/Core/Reconciler.cs` only** — file-disjoint from #692 (P1) and the rest of the perf fleet.
- AOT core-lib build **0W/0E**; full `Reactor.Tests` **9714 passed / 0 failed / 64 skipped**.
- **Honest framing:** #692 already removed the big alloc chunk. On StocksGrid specifically the guard rarely fires (changed cells have *changed* captions), so the win is a modest base-cost shave and may read within-noise under `/perf` — that's fine *data* (the automation write isn't a StocksGrid bottleneck). The guard still removes provably-redundant writes for any control whose non-caption props change under an unchanged caption.

🔒 **DRAFT + merge-gated:** does not merge until the improved `/perf` can resolve its diff **and** the user gives explicit GO (same rule as #692).