### PR TITLE
Fix stale MountAndActivate landmark in perf docs

### DIFF
--- a/.github/skills/perf-compare/SKILL.md
+++ b/.github/skills/perf-compare/SKILL.md
@@ -58,8 +58,8 @@ reconcile/diff phase — those read *n/a*.
    (committed) and `git status --porcelain` (uncommitted). If both are empty,
    tell the user there is nothing to compare and stop.
 3. **Capability check.** The harness opens a real WinUI window. If you are
-   running on a headless box, runs will crash with `0xC000027B` right after
-   `MountAndActivate ok`. If a first run fails that way, do **not** keep
+   running on a headless box, runs will crash with `0xC000027B` during
+   first-frame window activation. If a first run fails that way, do **not** keep
    retrying — report it (see [Failure handling](#failure-handling)).
 
 ### 2. Set up the `main` baseline worktree

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -322,7 +322,7 @@ default `-Reps 12` (drop to e.g. `-Reps 3` only for a quick smoke run).
 
 ## Troubleshooting
 
-- **Run crashes with `0xC000027B` right after "MountAndActivate ok".** That is a
+- **Run crashes with `0xC000027B` during first-frame window activation.** That is a
   stowed XAML/compositor exception. Most often the box cannot composite a real
   WinUI window (headless server, no GPU/desktop session, or an RDP session
   without composition) — run from an interactive desktop session. **On an ARM64


### PR DESCRIPTION
Updates two perf-tooling docs whose `0xC000027B` troubleshooting landmark still referenced the `[embed:trace] … MountAndActivate ok` log line that has since been removed from the window-open/first-frame path.

- `.github/skills/perf-compare/SKILL.md`
- `tests/stress_perf/ci/README.md`

Both now describe the crash as happening **"during first-frame window activation"** instead of **"right after MountAndActivate ok"**, so the guidance no longer points at a log line that no longer exists.

> **Note:** This PR originally also removed the `[embed:trace]` logging itself from `ReactorApp.cs` / `ReactorWindow.cs`, but that identical cleanup landed independently on `main`. After rebasing, only the documentation landmark fixes remain.