### PR TITLE
perf(ci): add low-mutation skip-floor column to /perf

### DIFF
--- a/.github/workflows/perf-compare.yml
+++ b/.github/workflows/perf-compare.yml
@@ -14,10 +14,12 @@
 #   Avg Diff ms       lower is better
 #   Avg Memory MB     lower is better
 #
-# Each metric shows main, PR, a signed Δ%, and an improvement/regression/within-
-# noise status. A second table cross-references vanilla WinUI3 (StressPerf.Direct)
-# and the Rust `windows-reactor` port (test_reactor_perf from microsoft/windows-rs)
-# — both built and measured live on the same runner.
+# Each metric shows main, PR, a signed Δ (with a 95% CI), and an improvement/
+# regression/within-noise status. Further tables follow: a low-mutation skip-floor
+# leg, an allocation comparison, the reconciler micro-suite, and a cross-framework
+# reference (vanilla WinUI3 (StressPerf.Direct) + the Rust `windows-reactor` port,
+# test_reactor_perf from microsoft/windows-rs — both measured live on the same
+# runner). See tests/stress_perf/ci/README.md for the authoritative comment layout.
 #
 # ── Why `issue_comment` (not a label) ────────────────────────────────────────
 # `issue_comment` always runs the workflow from the DEFAULT branch, so the perf

--- a/tests/stress_perf/METHODOLOGY.md
+++ b/tests/stress_perf/METHODOLOGY.md
@@ -220,6 +220,26 @@ equivalent is collected) and absent in a harness built before the metric landed.
 > target; its run-to-run swing is larger than the effect. Full rationale in
 > [`ci/README.md`](ci/README.md#variance-trust-the-delta-not-the-absolutes).
 
+## Low-mutation skip-floor: isolating the O(n) child skip-walk
+
+The headline macro leg runs at `--percent 50` (half the cells mutate each tick).
+At that mutation rate the per-tick cost is dominated by the *changed* cells, and a
+large fixed cost is **diluted**: `ChildReconciler` re-walks **all** children every
+tick to find what moved, an O(n) pass that runs whether 1 cell changed or 500 did.
+At 50% that skip-walk is a fraction of the work; a structural-skip optimization
+(skip untouched child ranges) barely moves the headline number.
+
+So `/perf` runs a **second interleaved A/B leg at `--percent 0`** and reports it as
+its own *low-mutation skip-floor* table. At 0% the workload still mutates exactly
+one cell per tick — `StockDataSource.Update` clamps the change count to
+`Math.Max(1, …)` — so virtually every child is unchanged and reconcile/diff time
+*is* the skip-walk floor. That makes the floor the whole signal instead of a diluted
+fraction, which is what lets a structural-skip PR's win clear a paired-Δ CI. It uses
+the same interleaving, reps, warm-up, and 95%-CI gating as the headline table (so
+each leg's delta independently cancels time-correlated drift); it is opt-out via
+`-IncludeSkipFloor $false`. See
+[`ci/README.md`](ci/README.md#the-comment).
+
 ## Reconciler micro-benchmarks: ns-resolution Core path
 
 Every metric above is measured **across a live WinUI render pipeline**, which is

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -402,8 +402,9 @@ Assert-True (-not ($noAllocComment -like '*Allocation (Reactor)*')) 'alloc table
 
 
 # ── Format-PerfSkipFloorSection + Format-PerfComment: low-mutation skip-floor ──
-# 12 paired floor runs. EVERY metric moves DOWN main->PR, but the verdicts must
-# differ BY DIRECTION: rps (higher-better) going down is a regression, while
+# 12 paired floor runs. rps, reconcile, and diff all move DOWN main->PR (memory is
+# held flat as a within-noise control), but the verdicts must differ BY DIRECTION:
+# rps (higher-better) going down is a regression, while
 # reconcile/diff (lower-better) going down are improvements — locking that the
 # section is direction-aware per metric (reusing Table 1's paired-CI machinery),
 # not hard-coded to one direction. Small jitter keeps each paired CI off 0.

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -401,6 +401,47 @@ $noAllocComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $nu
 Assert-True (-not ($noAllocComment -like '*Allocation (Reactor)*')) 'alloc table omitted when no alloc metric present'
 
 
+# ── Format-PerfSkipFloorSection + Format-PerfComment: low-mutation skip-floor ──
+# 12 paired floor runs with a clear, consistent improvement (reconcile 14->11,
+# diff 12->10) and small jitter, so the paired CI excludes 0 and resolves "better"
+# — proving the skip-floor table reuses the same data-driven CI machinery as Table 1.
+$floorMainRuns = @(); $floorPrRuns = @()
+1..12 | ForEach-Object {
+    $j = ($_ % 4) * 0.04
+    $floorMainRuns += [pscustomobject]@{ RendersPerSec = 5.0 + $j; AvgReconcileMs = 14.0 + $j; AvgDiffMs = 12.0 + $j; AvgMemoryMB = 300 + $j; TotalRenders = 50; DurationSeconds = 10 }
+    $floorPrRuns   += [pscustomobject]@{ RendersPerSec = 6.0 + $j; AvgReconcileMs = 11.0 + $j; AvgDiffMs = 10.0 + $j; AvgMemoryMB = 300 + $j; TotalRenders = 60; DurationSeconds = 10 }
+}
+$floorMain = Measure-PerfRuns -Runs $floorMainRuns
+$floorPr   = Measure-PerfRuns -Runs $floorPrRuns
+
+# Direct section renderer: empty when either side is null, populated when both present.
+Assert-Equal 0 @(Format-PerfSkipFloorSection -MainFloor $null -PrFloor $floorPr -Percent 0).Count 'skip-floor section empty when main floor null'
+Assert-Equal 0 @(Format-PerfSkipFloorSection -MainFloor $floorMain -PrFloor $null -Percent 0).Count 'skip-floor section empty when pr floor null'
+$floorSection = Format-PerfSkipFloorSection -MainFloor $floorMain -PrFloor $floorPr -Percent 0
+$floorSectionText = $floorSection -join "`n"
+Assert-Match $floorSectionText 'Low-mutation skip-floor' 'skip-floor section has heading'
+Assert-Match $floorSectionText 'Avg Reconcile'           'skip-floor section has reconcile row'
+Assert-Match $floorSectionText 'skip-walk floor'         'skip-floor preamble explains the O(n) skip-walk floor'
+Assert-Match $floorSectionText 'improvement'             'skip-floor reconcile/diff resolve as improvements (paired CI excludes 0)'
+
+# Threaded through Format-PerfComment, between the regression and cross-framework tables.
+$floorComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -MainFloor $floorMain -PrFloor $floorPr -Context $ctx
+Assert-Match $floorComment 'Low-mutation skip-floor' 'comment renders skip-floor table when floor aggregates present'
+$idxReg = $floorComment.IndexOf('Regression vs')
+$idxFloor = $floorComment.IndexOf('Low-mutation skip-floor')
+$idxXfw = $floorComment.IndexOf('Cross-framework reference')
+Assert-True (($idxReg -lt $idxFloor) -and ($idxFloor -lt $idxXfw)) 'skip-floor table sits between the regression and cross-framework tables'
+
+# Omitted entirely when floor aggregates are absent (skip-floor leg disabled).
+$noFloorComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -MainFloor $null -PrFloor $null -Context $ctx
+Assert-True (-not ($noFloorComment -like '*Low-mutation skip-floor*')) 'skip-floor table omitted when floor aggregates null'
+
+# Context.SkipFloorPercent threads into the heading (default 0 when absent).
+$ctxFloor1 = $ctx.Clone(); $ctxFloor1['SkipFloorPercent'] = 1
+$floorComment1 = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -MainFloor $floorMain -PrFloor $floorPr -Context $ctxFloor1
+Assert-Match $floorComment1 '--percent 1' 'skip-floor heading reflects Context.SkipFloorPercent'
+
+
 # ── Reconciler micro-suite: Read-MicroBenchResults / comparison / render ──────
 function New-MicroRow {
     param([string]$BenchId, [string]$Name, [string]$Variant, [int]$Rep, [double]$MeanNs, [double]$AllocBytes, [string]$Status = 'ok', [int]$Iterations = 1)

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -402,14 +402,16 @@ Assert-True (-not ($noAllocComment -like '*Allocation (Reactor)*')) 'alloc table
 
 
 # ── Format-PerfSkipFloorSection + Format-PerfComment: low-mutation skip-floor ──
-# 12 paired floor runs with a clear, consistent improvement (reconcile 14->11,
-# diff 12->10) and small jitter, so the paired CI excludes 0 and resolves "better"
-# — proving the skip-floor table reuses the same data-driven CI machinery as Table 1.
+# 12 paired floor runs. EVERY metric moves DOWN main->PR, but the verdicts must
+# differ BY DIRECTION: rps (higher-better) going down is a regression, while
+# reconcile/diff (lower-better) going down are improvements — locking that the
+# section is direction-aware per metric (reusing Table 1's paired-CI machinery),
+# not hard-coded to one direction. Small jitter keeps each paired CI off 0.
 $floorMainRuns = @(); $floorPrRuns = @()
 1..12 | ForEach-Object {
     $j = ($_ % 4) * 0.04
-    $floorMainRuns += [pscustomobject]@{ RendersPerSec = 5.0 + $j; AvgReconcileMs = 14.0 + $j; AvgDiffMs = 12.0 + $j; AvgMemoryMB = 300 + $j; TotalRenders = 50; DurationSeconds = 10 }
-    $floorPrRuns   += [pscustomobject]@{ RendersPerSec = 6.0 + $j; AvgReconcileMs = 11.0 + $j; AvgDiffMs = 10.0 + $j; AvgMemoryMB = 300 + $j; TotalRenders = 60; DurationSeconds = 10 }
+    $floorMainRuns += [pscustomobject]@{ RendersPerSec = 6.0 + $j; AvgReconcileMs = 14.0 + $j; AvgDiffMs = 12.0 + $j; AvgMemoryMB = 300 + $j; TotalRenders = 60; DurationSeconds = 10 }
+    $floorPrRuns   += [pscustomobject]@{ RendersPerSec = 5.0 + $j; AvgReconcileMs = 11.0 + $j; AvgDiffMs = 10.0 + $j; AvgMemoryMB = 300 + $j; TotalRenders = 50; DurationSeconds = 10 }
 }
 $floorMain = Measure-PerfRuns -Runs $floorMainRuns
 $floorPr   = Measure-PerfRuns -Runs $floorPrRuns
@@ -422,7 +424,12 @@ $floorSectionText = $floorSection -join "`n"
 Assert-Match $floorSectionText 'Low-mutation skip-floor' 'skip-floor section has heading'
 Assert-Match $floorSectionText 'Avg Reconcile'           'skip-floor section has reconcile row'
 Assert-Match $floorSectionText 'skip-walk floor'         'skip-floor preamble explains the O(n) skip-walk floor'
-Assert-Match $floorSectionText 'improvement'             'skip-floor reconcile/diff resolve as improvements (paired CI excludes 0)'
+# Direction-awareness: rps and reconcile both DECREASE main->PR, yet rps (higher-is-
+# better) must read regression while reconcile (lower-is-better) reads improvement.
+$floorRpsRow   = ($floorSection | Where-Object { $_ -match 'Renders/sec' })   -join ' '
+$floorReconRow = ($floorSection | Where-Object { $_ -match 'Avg Reconcile' }) -join ' '
+Assert-Match $floorRpsRow   'regression'  'skip-floor: rps DOWN reads regression (higher-is-better honored)'
+Assert-Match $floorReconRow 'improvement' 'skip-floor: reconcile DOWN reads improvement (lower-is-better honored)'
 
 # Threaded through Format-PerfComment, between the regression and cross-framework tables.
 $floorComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -MainFloor $floorMain -PrFloor $floorPr -Context $ctx

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -721,7 +721,7 @@ function Format-PerfSkipFloorSection {
     $lines = [System.Collections.Generic.List[string]]::new()
     $lines.Add("### Low-mutation skip-floor (``--percent $Percent``)")
     $lines.Add('')
-    $lines.Add("At ``--percent $Percent`` virtually no cell changes (the workload still mutates one cell/tick), so **reconcile/diff isolate the O(n) per-tick child skip-walk floor** &mdash; ``ChildReconciler`` re-walks every child each tick even when nothing moved. The headline table above dilutes this fixed cost; here it _is_ the signal, so a structural-skip optimization shows up cleanly. Δ is the mean paired change with a 95% CI.")
+    $lines.Add("At ``--percent $Percent`` the workload mutates few cells per tick (always at least one), so **reconcile/diff isolate the O(n) per-tick child skip-walk floor** that higher mutation rates dilute &mdash; ``ChildReconciler`` re-walks every child each tick even when nothing moved. The closer ``--percent`` is to 0, the more this floor _is_ the signal, so a structural-skip optimization shows up cleanly where the headline table above buries it. Δ is the mean paired change with a 95% CI.")
     $lines.Add('')
     $lines.Add('| Metric | `main` (baseline) | This PR | Δ (95% CI) | Status |')
     $lines.Add('|---|--:|--:|--:|:--|')

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -718,11 +718,10 @@ function Format-PerfSkipFloorSection {
     )
     if ($null -eq $MainFloor -or $null -eq $PrFloor) { return @() }
 
-    $down = [char]0x2193
     $lines = [System.Collections.Generic.List[string]]::new()
     $lines.Add("### Low-mutation skip-floor (``--percent $Percent``)")
     $lines.Add('')
-    $lines.Add("At ``--percent $Percent`` virtually no cell changes (the workload still mutates one cell/tick), so **reconcile/diff isolate the O(n) per-tick child skip-walk floor** &mdash; ``ChildReconciler`` re-walks every child each tick even when nothing moved. The headline table above dilutes this fixed cost; here it _is_ the signal, so a structural-skip optimization shows up cleanly. $down lower is better; Δ is the mean paired change with a 95% CI.")
+    $lines.Add("At ``--percent $Percent`` virtually no cell changes (the workload still mutates one cell/tick), so **reconcile/diff isolate the O(n) per-tick child skip-walk floor** &mdash; ``ChildReconciler`` re-walks every child each tick even when nothing moved. The headline table above dilutes this fixed cost; here it _is_ the signal, so a structural-skip optimization shows up cleanly. Δ is the mean paired change with a 95% CI.")
     $lines.Add('')
     $lines.Add('| Metric | `main` (baseline) | This PR | Δ (95% CI) | Status |')
     $lines.Add('|---|--:|--:|--:|:--|')

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -722,7 +722,7 @@ function Format-PerfSkipFloorSection {
     $lines = [System.Collections.Generic.List[string]]::new()
     $lines.Add("### Low-mutation skip-floor (``--percent $Percent``)")
     $lines.Add('')
-    $lines.Add("At ``--percent $Percent`` virtually no cell changes (the workload still mutates one cell/tick), so **reconcile/diff isolate the O(n) per-tick child skip-walk floor** &mdash; ``ChildReconciler`` re-walks every child each tick even when nothing moved. The 50%-mutation table above dilutes this fixed cost; here it _is_ the signal, so a structural-skip optimization shows up cleanly. $down lower is better; Δ is the mean paired change with a 95% CI.")
+    $lines.Add("At ``--percent $Percent`` virtually no cell changes (the workload still mutates one cell/tick), so **reconcile/diff isolate the O(n) per-tick child skip-walk floor** &mdash; ``ChildReconciler`` re-walks every child each tick even when nothing moved. The headline table above dilutes this fixed cost; here it _is_ the signal, so a structural-skip optimization shows up cleanly. $down lower is better; Δ is the mean paired change with a 95% CI.")
     $lines.Add('')
     $lines.Add('| Metric | `main` (baseline) | This PR | Δ (95% CI) | Status |')
     $lines.Add('|---|--:|--:|--:|:--|')

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -689,6 +689,60 @@ function Format-PerfMicroSection {
     return $lines.ToArray()
 }
 
+function Format-PerfSkipFloorSection {
+    <#
+    .SYNOPSIS
+        Render the low-mutation skip-floor table: the four headline metrics measured
+        at a near-zero mutation percent, isolating the per-tick O(n) child skip-walk
+        floor that the 50%-mutation headline workload dilutes. Empty array when there
+        is nothing to show.
+    .DESCRIPTION
+        At ``--percent 0`` the StocksGrid source still mutates exactly one cell per
+        tick (StockDataSource.Update clamps the change count to Math.Max(1, ...)), so
+        virtually every child is unchanged and reconcile/diff time is dominated by
+        ChildReconciler's positional re-walk over all children — the fixed per-tick
+        cost a structural-skip optimization targets. The 50%-mutation headline table
+        dilutes this floor; here it is the whole signal. Reuses the same paired-Δ 95%
+        CI machinery (Get-PerfDelta over the index-aligned per-run samples) as the
+        headline table. Returns an empty array when either floor aggregate is $null
+        (skip-floor leg disabled, or one side produced no metrics), so the caller
+        renders nothing.
+    .PARAMETER MainFloor  Aggregated baseline low-mutation metrics (Measure-PerfRuns), or $null.
+    .PARAMETER PrFloor    Aggregated PR-head low-mutation metrics, or $null.
+    .PARAMETER Percent    The mutation percent the floor leg ran at (heading / preamble).
+    #>
+    param(
+        [AllowNull()][pscustomobject]$MainFloor,
+        [AllowNull()][pscustomobject]$PrFloor,
+        [double]$Percent = 0
+    )
+    if ($null -eq $MainFloor -or $null -eq $PrFloor) { return @() }
+
+    $down = [char]0x2193
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add("### Low-mutation skip-floor (``--percent $Percent``)")
+    $lines.Add('')
+    $lines.Add("At ``--percent $Percent`` virtually no cell changes (the workload still mutates one cell/tick), so **reconcile/diff isolate the O(n) per-tick child skip-walk floor** &mdash; ``ChildReconciler`` re-walks every child each tick even when nothing moved. The 50%-mutation table above dilutes this fixed cost; here it _is_ the signal, so a structural-skip optimization shows up cleanly. $down lower is better; Δ is the mean paired change with a 95% CI.")
+    $lines.Add('')
+    $lines.Add('| Metric | `main` (baseline) | This PR | Δ (95% CI) | Status |')
+    $lines.Add('|---|--:|--:|--:|:--|')
+    foreach ($m in $script:PerfMetricSpec) {
+        $bVal = $MainFloor.($m.Key)
+        $pVal = $PrFloor.($m.Key)
+        $spread = [math]::Max([double]$MainFloor."$($m.Key)Spread", [double]$PrFloor."$($m.Key)Spread")
+        $delta = Get-PerfDelta -Baseline $bVal -Candidate $pVal -LowerIsBetter $m.LowerIsBetter -SpreadPct $spread `
+            -BaselineSamples $MainFloor."$($m.Key)Samples" -CandidateSamples $PrFloor."$($m.Key)Samples"
+        $lines.Add(('| {0} {1} | {2} | {3} | {4} | {5} |' -f `
+                $m.Label, $m.Arrow, `
+            (Format-PerfNumber $bVal $m.Digits), `
+            (Format-PerfNumber $pVal $m.Digits), `
+            (Format-PerfDeltaCell $delta), `
+            (Get-PerfStatusGlyph $delta.Status)))
+    }
+    $lines.Add('')
+    return $lines.ToArray()
+}
+
 function Format-PerfComment {
     <#
     .SYNOPSIS
@@ -701,8 +755,11 @@ function Format-PerfComment {
                           measured live on this runner, or $null when not run.
     .PARAMETER Micro      Per-bench reconciler micro-suite comparison rows
                           (Get-PerfMicroComparison output), or $null when not run.
-    .PARAMETER Context    Hashtable: Percent, Duration, Reps, Warmup, BaseSha, HeadSha,
-                          Runner, Cpu, Cores, MemoryGB, RunUrl, Timestamp, Note.
+    .PARAMETER MainFloor  Aggregated baseline low-mutation skip-floor metrics, or $null.
+    .PARAMETER PrFloor    Aggregated PR-head low-mutation skip-floor metrics, or $null.
+    .PARAMETER Context    Hashtable: Percent, Duration, Reps, Warmup, SkipFloorPercent,
+                          BaseSha, HeadSha, Runner, Cpu, Cores, MemoryGB, RunUrl,
+                          Timestamp, Note.
     #>
     param(
         [Parameter(Mandatory)][pscustomobject]$Main,
@@ -710,6 +767,8 @@ function Format-PerfComment {
         [AllowNull()][pscustomobject]$WinUI3,
         [AllowNull()][pscustomobject]$Rust,
         [AllowNull()][object[]]$Micro,
+        [AllowNull()][pscustomobject]$MainFloor,
+        [AllowNull()][pscustomobject]$PrFloor,
         [Parameter(Mandatory)][hashtable]$Context
     )
 
@@ -748,6 +807,14 @@ function Format-PerfComment {
         & $add $row
     }
     & $add ''
+
+    # ── Low-mutation skip-floor table (--percent ~0) ─────────────────────────
+    # A second interleaved A/B leg at near-zero mutation. With ~1 cell changing per
+    # tick, reconcile/diff isolate the O(n) positional child skip-walk floor that the
+    # 50%-mutation headline table above dilutes — the signal a structural-skip
+    # optimization moves. Rendered only when both floor aggregates are present.
+    $floorPct = if ($Context.ContainsKey('SkipFloorPercent')) { [double]$Context.SkipFloorPercent } else { 0 }
+    foreach ($fline in (Format-PerfSkipFloorSection -MainFloor $MainFloor -PrFloor $PrFloor -Percent $floorPct)) { & $add $fline }
 
     # ── Allocation table (Reactor main vs PR; lower is better) ────────────────
     # Rendered only when at least one side reports an allocation metric. A PR head

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -201,7 +201,7 @@ is the security control, because the job has a write token.
 
 ### The comment
 
-Two tables plus footnotes:
+Several tables plus footnotes:
 
 - **Regression vs `main`** — `Metric | main | This PR | Δ (95% CI) | Status`,
   where Status is direction-aware (`✅ improvement` / `⚠️ regression` / `≈ within

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -148,6 +148,8 @@ git worktree remove ../main
 | `-IncludeMicro` | `$true` | Run the `PerfBench.ControlModel` reconciler micro-suite (compare mode) and append its per-bench ns/op + B/op table. Set `$false` to skip it. |
 | `-MicroReps` | `12` | Repetitions per side for the micro-suite — each feeds the paired 95% CI, mirroring `-Reps`. |
 | `-MicroIterations` | `10000` | Inner iterations per repetition inside each micro-bench (amortises timer resolution). |
+| `-IncludeSkipFloor` | `$true` | Run a **second interleaved A/B leg** at `-SkipFloorPercent` and append a low-mutation skip-floor table (compare mode). Set `$false` to skip it (halves the macro runtime). |
+| `-SkipFloorPercent` | `0` | Mutation percent for the skip-floor leg. At `0` the workload still mutates one cell/tick (`StockDataSource.Update` clamps the count to `Math.Max(1, …)`), so reconcile/diff isolate the O(n) per-tick child skip-walk floor the 50% leg dilutes. |
 | `-Apps` | `ReactorOptimized,Direct` | Single-tree mode only: which harnesses to run. |
 | `-Platform` | host arch | Target architecture (`x64` or `ARM64`). Defaults to your machine's native arch so the WinUI harness runs without emulation. |
 | `-SelfContained` | `$true` | Build with the bundled WinApp runtime (no machine-wide install). |
@@ -210,6 +212,14 @@ Two tables plus footnotes:
   at this sample size. This data-driven band replaces the old fixed 4% floor,
   which both buried real sub-4% wins and rubber-stamped any sub-4% number as
   "noise" regardless of how tight the runs were.
+- **Low-mutation skip-floor (`--percent 0`)** — the same four headline metrics
+  from a **second interleaved A/B leg** at near-zero mutation. With ~1 cell
+  changing per tick, reconcile/diff are dominated by the **O(n) positional child
+  skip-walk** (`ChildReconciler` re-walks every child each tick even when nothing
+  moved) — the fixed per-tick cost the 50%-mutation headline table dilutes. This
+  is the column a structural-skip optimization moves cleanly: at 50% the floor is
+  a fraction of the work, at 0% it *is* the work. Same paired-CI gating as Table 1;
+  omitted when `-IncludeSkipFloor $false` or a side produces no metrics.
 - **Allocation (Reactor)** — `Alloc bytes/render` and `Gen0 GC / 1k renders`,
   `main` vs PR with the same paired-CI band. Rendered only when the harness
   reports the metric (n/a for pre-metric PR heads). This is the table that moves

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -150,6 +150,8 @@ param(
     [int]$MicroReps = 12,
     [int]$MicroIterations = 10000,
     [bool]$IncludeMicro = $true,
+    [double]$SkipFloorPercent = 0,
+    [bool]$IncludeSkipFloor = $true,
     [ValidateSet('ReactorOptimized', 'Direct')]
     [string[]]$Apps = @('ReactorOptimized', 'Direct'),
     [string]$OutDir,
@@ -558,7 +560,7 @@ function Invoke-RustLeg {
 
 function Invoke-OneRun {
     <# Run the harness once; return a metric object (Read-HarnessMetrics) or $null. #>
-    param([string]$Exe, [hashtable]$AppMeta, [int]$Index, [string]$Tag, [switch]$NoJson)
+    param([string]$Exe, [hashtable]$AppMeta, [int]$Index, [string]$Tag, [switch]$NoJson, [double]$RunPercent = $Percent)
 
     $exeDir = Split-Path $Exe
     foreach ($ext in 'metrics.json', 'report.txt', 'samples.csv') {
@@ -570,11 +572,11 @@ function Invoke-OneRun {
     $stderr = Join-Path $OutDir ("run-{0}-{1}-{2}.err.log" -f $AppMeta.AppName, $Tag, $Index)
     $inv = [System.Globalization.CultureInfo]::InvariantCulture
     # The Rust port has no --json mode; it always writes report.txt. C# harnesses get --json.
-    $harnessArgs = @('--headless', '--percent', $Percent.ToString($inv), '--duration', $Duration.ToString($inv))
+    $harnessArgs = @('--headless', '--percent', $RunPercent.ToString($inv), '--duration', $Duration.ToString($inv))
     if (-not $NoJson) { $harnessArgs += '--json' }
     $timeoutSec = $Duration + 90
 
-    Write-Log ("  run [{0} #{1}] {2} --percent {3} --duration {4}" -f $Tag, $Index, $AppMeta.AppName, $Percent, $Duration)
+    Write-Log ("  run [{0} #{1}] {2} --percent {3} --duration {4}" -f $Tag, $Index, $AppMeta.AppName, $RunPercent, $Duration)
     $proc = Start-Process -FilePath $Exe -ArgumentList $harnessArgs -PassThru `
         -RedirectStandardOutput $stdout -RedirectStandardError $stderr -WindowStyle Hidden
     try {
@@ -703,7 +705,7 @@ if ($DefenderExclude) {
 
 $runner = Get-RunnerInfo
 Write-Log ("runner: {0} | {1} cores | {2} GB | {3}" -f $runner.Cpu, $runner.Cores, $runner.MemoryGB, ($runner.Runner ?? 'local')) 'Cyan'
-Write-Log ("mode: {0} | platform={1} | percent={2} duration={3} reps={4} warmup={5}" -f ($(if ($Compare) { 'COMPARE' } else { 'LOCAL' })), $Platform, $Percent, $Duration, $Reps, $Warmup) 'Cyan'
+Write-Log ("mode: {0} | platform={1} | percent={2} duration={3} reps={4} warmup={5} | skip-floor={6}" -f ($(if ($Compare) { 'COMPARE' } else { 'LOCAL' })), $Platform, $Percent, $Duration, $Reps, $Warmup, $(if ($IncludeSkipFloor) { "on (--percent $SkipFloorPercent)" } else { 'off' })) 'Cyan'
 
 $exit = 0
 try {
@@ -741,6 +743,26 @@ try {
             if ($i -le $Warmup) { Write-Log "  (warmup pair #$i discarded)" 'DarkGray'; continue }
             if ($mm) { $mainRuns += $mm }
             if ($pm) { $prRuns += $pm }
+        }
+
+        # Second interleaved A/B leg at near-zero mutation. Same two exes, same paired
+        # interleaving, but at $SkipFloorPercent so reconcile/diff isolate the O(n)
+        # positional child skip-walk floor the 50% leg dilutes. Each side's delta is
+        # internally interleaved (main-floor vs pr-floor pair-by-pair), so it controls
+        # for drift the same way the headline leg does.
+        $mainFloorRuns = @(); $prFloorRuns = @()
+        if ($IncludeSkipFloor) {
+            Write-Log "interleaving main/PR skip-floor (--percent $SkipFloorPercent; $($Warmup) warmup + $($Reps) measured each)" 'Green'
+            for ($i = 1; $i -le ($Warmup + $Reps); $i++) {
+                $mm = Invoke-OneRun -Exe $mainExe -AppMeta $ro -Index $i -Tag 'main-floor' -RunPercent $SkipFloorPercent
+                $pm = Invoke-OneRun -Exe $prExe -AppMeta $ro -Index $i -Tag 'pr-floor' -RunPercent $SkipFloorPercent
+                if ($i -le $Warmup) { Write-Log "  (floor warmup pair #$i discarded)" 'DarkGray'; continue }
+                if ($mm) { $mainFloorRuns += $mm }
+                if ($pm) { $prFloorRuns += $pm }
+            }
+            if ($mainFloorRuns.Count -lt $Reps -or $prFloorRuns.Count -lt $Reps) {
+                Write-Log "  skip-floor leg short (main $($mainFloorRuns.Count)/$Reps, PR $($prFloorRuns.Count)/$Reps) — its paired CI uses fewer samples" 'Yellow'
+            }
         }
 
         $winRuns = @()
@@ -782,6 +804,8 @@ try {
         $main = Measure-PerfRuns -Runs $mainRuns
         $pr = Measure-PerfRuns -Runs $prRuns
         $winui3 = if ($winRuns.Count) { Measure-PerfRuns -Runs $winRuns } else { $null }
+        $mainFloor = if ($mainFloorRuns.Count) { Measure-PerfRuns -Runs $mainFloorRuns } else { $null }
+        $prFloor = if ($prFloorRuns.Count) { Measure-PerfRuns -Runs $prFloorRuns } else { $null }
 
         $note = $null
         if ($prRuns.Count -eq 0 -or $mainRuns.Count -eq 0) {
@@ -800,19 +824,21 @@ try {
 
         $ctx = @{
             Percent = $Percent; Duration = $Duration; Reps = $Reps; Warmup = $Warmup
+            SkipFloorPercent = $SkipFloorPercent
             Platform = $Platform
             MainSamples = $mainRuns.Count; PrSamples = $prRuns.Count
+            MainFloorSamples = $mainFloorRuns.Count; PrFloorSamples = $prFloorRuns.Count
             BaseSha = $(if ($BaseSha) { $BaseSha.Substring(0, [Math]::Min(7, $BaseSha.Length)) } else { '' })
             HeadSha = $(if ($HeadSha) { $HeadSha.Substring(0, [Math]::Min(7, $HeadSha.Length)) } else { '' })
             Runner = $runner.Runner; Cpu = $runner.Cpu; Cores = $runner.Cores; MemoryGB = $runner.MemoryGB
             RunUrl = $RunUrl; Timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'); Note = $note
         }
-        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Rust $rust -Micro $micro -Context $ctx
+        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Rust $rust -Micro $micro -MainFloor $mainFloor -PrFloor $prFloor -Context $ctx
         $commentPath = Join-Path $OutDir 'comment.md'
         Set-Content -LiteralPath $commentPath -Value $comment -Encoding UTF8
         Write-Log "comment.md written -> $commentPath" 'Green'
 
-        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; rust = $rust; micro = $micro; runner = $runner; context = $ctx }
+        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; mainFloor = $mainFloor; prFloor = $prFloor; rust = $rust; micro = $micro; runner = $runner; context = $ctx }
         $result | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutDir 'result.json') -Encoding UTF8
 
         Write-Host "`n----- comment.md -----" -ForegroundColor DarkGray

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -78,6 +78,17 @@
     alloc-bytes/op PR-vs-main table (ns-resolution, WinUI-undiluted) to the
     comment. Default $true; disable with -IncludeMicro:$false.
 
+.PARAMETER IncludeSkipFloor
+    Run a second interleaved A/B leg at -SkipFloorPercent and append a low-mutation
+    skip-floor table to the comment (compare mode). Default $true; disable with
+    -IncludeSkipFloor:$false to halve the macro runtime.
+
+.PARAMETER SkipFloorPercent
+    Mutation percent for the skip-floor leg (default 0). At 0 the workload still
+    mutates one cell/tick (StockDataSource.Update clamps the count to Math.Max(1, ...)),
+    so reconcile/diff isolate the O(n) per-tick child skip-walk floor the 50% leg
+    dilutes — the fixed cost a structural-skip optimization targets.
+
 .PARAMETER Apps
     Which harnesses to run in single-tree mode: ReactorOptimized, Direct.
     Ignored in compare mode (which always does ReactorOptimized both sides +
@@ -741,8 +752,10 @@ try {
             $mm = Invoke-OneRun -Exe $mainExe -AppMeta $ro -Index $i -Tag 'main'
             $pm = Invoke-OneRun -Exe $prExe -AppMeta $ro -Index $i -Tag 'pr'
             if ($i -le $Warmup) { Write-Log "  (warmup pair #$i discarded)" 'DarkGray'; continue }
-            if ($mm) { $mainRuns += $mm }
-            if ($pm) { $prRuns += $pm }
+            # Keep the A/B pair index-aligned: the paired CI zips main[i] vs pr[i], so a
+            # one-sided failure must drop BOTH halves of the pair, not shift later runs.
+            if ($mm -and $pm) { $mainRuns += $mm; $prRuns += $pm }
+            elseif ($mm -or $pm) { Write-Log "  pair #$i incomplete (main=$([bool]$mm) pr=$([bool]$pm)) — dropped to keep the paired CI aligned" 'Yellow' }
         }
 
         # Second interleaved A/B leg at near-zero mutation. Same two exes, same paired
@@ -757,8 +770,8 @@ try {
                 $mm = Invoke-OneRun -Exe $mainExe -AppMeta $ro -Index $i -Tag 'main-floor' -RunPercent $SkipFloorPercent
                 $pm = Invoke-OneRun -Exe $prExe -AppMeta $ro -Index $i -Tag 'pr-floor' -RunPercent $SkipFloorPercent
                 if ($i -le $Warmup) { Write-Log "  (floor warmup pair #$i discarded)" 'DarkGray'; continue }
-                if ($mm) { $mainFloorRuns += $mm }
-                if ($pm) { $prFloorRuns += $pm }
+                if ($mm -and $pm) { $mainFloorRuns += $mm; $prFloorRuns += $pm }
+                elseif ($mm -or $pm) { Write-Log "  floor pair #$i incomplete (main=$([bool]$mm) pr=$([bool]$pm)) — dropped to keep the paired CI aligned" 'Yellow' }
             }
             if ($mainFloorRuns.Count -lt $Reps -or $prFloorRuns.Count -lt $Reps) {
                 Write-Log "  skip-floor leg short (main $($mainFloorRuns.Count)/$Reps, PR $($prFloorRuns.Count)/$Reps) — its paired CI uses fewer samples" 'Yellow'

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -278,6 +278,49 @@ finally {
     Remove-Item function:Start-Sleep -ErrorAction SilentlyContinue
 }
 
+# ===========================================================================
+#  Invoke-OneRun — --percent threading (-RunPercent defaults to $Percent)
+# ===========================================================================
+# The low-mutation skip-floor leg drives the SAME exe at a different mutation
+# percent via -RunPercent. Lock the contract that the harness CLI actually
+# receives that percent (and that omitting -RunPercent falls back to $Percent),
+# so a floor run can't silently re-measure the 50% workload. Stub Start-Process
+# to capture the ArgumentList, plus the two PerfLib helpers Invoke-OneRun calls
+# (Read-HarnessMetrics / Format-PerfNumber) that aren't loaded in this file.
+Invoke-Expression (Get-Func 'Invoke-OneRun')
+$Percent = 50; $Duration = 10; $PinAffinity = $false
+$roMeta = @{ AppName = 'RO' }
+$oneRunExe = Join-Path ([IO.Path]::GetTempPath()) 'RO.exe'
+function Read-HarnessMetrics { param($Directory, $AppName) [pscustomobject]@{ Source = 'json'; RendersPerSec = 1; AvgReconcileMs = 1; AvgDiffMs = 1; AvgMemoryMB = 1 } }
+function Format-PerfNumber { param($Value, $Digits) [string]$Value }
+$global:SAWARGS = $null
+function Start-Process {
+    param([string]$FilePath, [string[]]$ArgumentList, [switch]$PassThru,
+        [string]$RedirectStandardOutput, [string]$RedirectStandardError, $WindowStyle)
+    $global:SAWARGS = $ArgumentList
+    [pscustomobject]@{ PriorityClass = $null; ExitCode = 0 } |
+        Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($ms) $true } -PassThru |
+        Add-Member -MemberType ScriptMethod -Name Kill -Value { param($t) } -PassThru
+}
+function Start-Sleep { param([int]$Seconds, [int]$Milliseconds) }
+try {
+    # default: -RunPercent omitted -> harness gets the script-level $Percent (50).
+    $null = Invoke-OneRun -Exe $oneRunExe -AppMeta $roMeta -Index 1 -Tag 'main'
+    $pIdx = [Array]::IndexOf($global:SAWARGS, '--percent')
+    Assert-True (($pIdx -ge 0) -and ($global:SAWARGS[$pIdx + 1] -eq '50')) '[onerun] -RunPercent omitted -> harness gets --percent 50 ($Percent)'
+
+    # explicit -RunPercent 0 -> the skip-floor leg drives the harness at --percent 0.
+    $null = Invoke-OneRun -Exe $oneRunExe -AppMeta $roMeta -Index 1 -Tag 'main-floor' -RunPercent 0
+    $fIdx = [Array]::IndexOf($global:SAWARGS, '--percent')
+    Assert-True (($fIdx -ge 0) -and ($global:SAWARGS[$fIdx + 1] -eq '0')) '[onerun] -RunPercent 0 -> harness gets --percent 0 (skip-floor leg)'
+}
+finally {
+    Remove-Item function:Start-Process -ErrorAction SilentlyContinue
+    Remove-Item function:Start-Sleep -ErrorAction SilentlyContinue
+    Remove-Item function:Read-HarnessMetrics -ErrorAction SilentlyContinue
+    Remove-Item function:Format-PerfNumber -ErrorAction SilentlyContinue
+}
+
 # cleanup
 foreach ($d in @($baseTree, $prTree, $OutDir, $exeDir)) {
     if (Test-Path $d) { Remove-Item $d -Recurse -Force -ErrorAction SilentlyContinue }


### PR DESCRIPTION
## What

Adds a **low-mutation skip-floor** column to the `/perf` comparison: a second interleaved A/B macro leg run at `--percent 0`, rendered as its own table directly after the 50%-mutation headline regression table.

This is **PR3** of the harness-improvement split (PR1 #691 alloc metric + paired-CI, PR2 #693 micro-suite — both merged). Measurement-tooling only: **7 files, all measurement-tooling (incl. `.github/workflows/perf-compare.yml`), 0 `src/Reactor`.**

## Why

The headline leg runs at `--percent 50` (half the cells mutate per tick). At that rate the per-tick cost is dominated by the *changed* cells, and a large **fixed** cost is diluted: `ChildReconciler` re-walks **all** children every tick to find what moved — an O(n) pass that runs whether 1 cell changed or 500 did. At 50% that skip-walk is a fraction of the work, so a **structural-skip optimization** (skip untouched child ranges) barely moves the headline number.

At `--percent 0` the workload still mutates exactly **one** cell per tick (`StockDataSource.Update` clamps the change count to `Math.Max(1, …)`), so virtually every child is unchanged and reconcile/diff time **is** the skip-walk floor. That makes the floor the whole signal instead of a diluted fraction — which is what lets a structural-skip PR's win clear a paired-Δ 95% CI.

This is the column the in-flight reconciler structural-skip work needs to be measured cleanly: at 50% mutation its win is buried; at 0% it is isolated.

## Methodology rationale (carried from the n=12 validation)

The earlier validation (12 interleaved PR-vs-`main` pairs on this workload) established the band these harness PRs are built on:

- A **2-run median is a coin flip** for ~1–3% deltas — the headline rps reproduced its sign only ~23% of the time, and the run-to-run swing (±7–11%) dwarfs the effect.
- The old blanket **4% floor preordained** every sub-4% verdict as "noise," both burying real wins and rubber-stamping noise.
- Macro **reconcile/diff at 50% mutation is render-/dilution-bound** — the very signal a structural-skip optimization moves is the part the headline workload dilutes.

The skip-floor leg attacks that last point directly: same interleaving, reps (12), warm-up (2), GC/affinity pinning, and **paired-Δ 95%-CI gating** as the headline leg (a change is flagged only when the CI excludes 0), but at a mutation rate where the O(n) floor is the dominant term.

## Changes

- **`Run-PerfBenchmark.ps1`** — `-IncludeSkipFloor` (default `$true`) + `-SkipFloorPercent` (default `0`); `Invoke-OneRun` gains `-RunPercent` (defaults to `$Percent`); a second interleaved A/B loop tagged `main-floor`/`pr-floor`; floor aggregates threaded into `$ctx` + `result.json`.
- **`PerfLib.ps1`** — new `Format-PerfSkipFloorSection` (mirrors Table 1, reuses `$PerfMetricSpec` + the paired-CI `Get-PerfDelta`; empty when either floor aggregate is null); `Format-PerfComment` gains `-MainFloor`/`-PrFloor` and renders the section after the regression table.
- **Tests** — `PerfLib.Tests.ps1` (+11 assertions → **203**): section renders/omits, ordering between the regression and cross-framework tables, and a **mixed-direction fixture** proving per-metric direction-awareness (rps and reconcile both fall, but rps reads *regression* / reconcile reads *improvement*). `RunPerfBenchmark.Tests.ps1` (+2 → **27**): locks that the floor leg actually drives the harness at `--percent 0` (and that omitting `-RunPercent` falls back to `$Percent`).
- **Docs** — `ci/README.md` (params + comment section) and `METHODOLOGY.md` (new skip-floor subsection).

No harness/`src` change — the floor leg just drives the existing exe at a different mutation percent.

## Validation

- `PerfLib.Tests.ps1` **202** green · `RunPerfBenchmark.Tests.ps1` **27** green.
- **End-to-end smoke** with a stub harness (emits a `metrics.json` whose reconcile/diff scale with `--percent`): the real orchestrator ran both interleaved legs and rendered the skip-floor table in the designed position with sane numbers (floor reconcile ~8 ms vs 50% headline ~76 ms). `-IncludeSkipFloor $false` correctly omits the leg and the table.

## Cost

The floor leg roughly **doubles the macro-leg runtime** (a second `Warmup + Reps` interleaved A/B). It is opt-out via `-IncludeSkipFloor $false`. The workflow leaves it on by default so `/perf` on a fleet PR picks it up automatically.

## Review

Ran the internal `pr-review` skill (8 dimensions + a cross-family multi-model check). It surfaced **0 critical / 0 high**; all actionable findings are addressed:
- **Paired-CI alignment (correctness):** a one-sided run failure could misalign the index-paired CI. Both macro legs (headline + skip-floor) now drop **both** halves of a pair on any one-sided failure — a no-op on the happy path, but it keeps `Get-PerfPairedDeltaStats` (which zips `main[i]` vs `pr[i]`) from ever comparing mismatched indices.
- **Direction-awareness test (coverage):** added a mixed-direction fixture so the renderer's per-metric higher/lower-is-better logic is locked, not just "some row says improvement."
- **Docs/help:** added `.PARAMETER` help for the two new params; reworded the floor preamble to "headline table" (accurate for any `-Percent`); refreshed the stale `perf-compare.yml` header + `ci/README` table list.

Declined with rationale: the `Format-PerfComment` optional-before-mandatory param order (consistent with the pre-existing `-WinUI3`/`-Rust`/`-Micro` convention; all callers use named binding) and a full orchestration-flow unit test (the main script body isn't dot-sourceable — same reason the pre-existing headline leg isn't unit-tested at that layer; covered by an end-to-end smoke).

## Discipline

DRAFT until the 5-point harness gate holds (footprint = tooling-only ✓, CI green, Copilot 0-unresolved on final HEAD, `pr-review` skill + findings addressed, PerfLib.Tests green + local smoke ✓). No `/perf` run needed — this changes `/perf` itself.
