### PR TITLE
perf(reconciler): structural-skip untouched child ranges (positional, P4)

### DIFF
--- a/docs/guide/reference/hooks/UseMemoCellsByIndex.md
+++ b/docs/guide/reference/hooks/UseMemoCellsByIndex.md
@@ -20,19 +20,40 @@ or [UseMemoCellsByKey](UseMemoCellsByKey.md) ([guide](../../hooks.md)), both of 
 short-circuit per-cell on value or key equality across length
 changes.
 
+On the steady-state path (unchanged count) the returned array reuses
+the previous render's element instance for every index NOT named in
+<paramref name="changedIndices" />, and publishes a positional
+structural-skip hint (Spec 034 §C) keyed by reference on that array so
+the reconciler can update only the changed cells and skip the
+reference-equal remainder. The returned array is therefore the hook's
+retained memoized state AND the key of that hint: treat it as immutable
+and declare every change through a subsequent render's
+<paramref name="changedIndices" /> (React-style immutability — see
+AGENTS.md "Never mutate"). Mutating an unchanged slot in place both
+corrupts the memo's view of the previous render and can cause the
+reconciler to skip the mutated cell.
+
 ## Parameters
 
 - **ctx** — The render context.
 - **items** — Source items.
 - **changedIndices** — Indices whose item differs from the
 previous render. Negative indices and indices >= <c>items.Count</c>
-throw `ArgumentOutOfRangeException`.
+throw `ArgumentOutOfRangeException`. Duplicate indices are a
+caller-contract violation but are tolerated: they are de-duplicated
+before the named cells are rebuilt, so each cell is rebuilt exactly once
+and the structural-skip hint's theme tally stays exact.
 - **builder** — Cell builder; same contract as
 [UseMemoCells](UseMemoCells.md) ([guide](../../hooks.md)).
 - **dependencies** — Trailing-<c>params</c> deps.
 
 ## Discussion
 
-Spec 034 §C.
+Spec 034 §C. A cell is "theme-sensitive" when it carries
+ThemeBindings or a ThemeRef-backed ResourceOverride; the hook tracks how
+many cells are theme-sensitive (carried forward incrementally) so the
+reconciler falls back to the full walk — which re-resolves themed brushes
+against the current effective theme — instead of structurally skipping
+such a range.
 
 

--- a/src/Reactor/Core/ChildDiffHints.cs
+++ b/src/Reactor/Core/ChildDiffHints.cs
@@ -65,7 +65,18 @@ internal sealed class ChildDiffHint
     /// <c>RequestedTheme</c> toggle changes the effective theme WITHOUT touching
     /// the element tree, so a structural skip would otherwise leave brushes stale.
     /// </summary>
-    internal bool AnyThemeSensitive => ThemeSensitiveCount > 0;
+    /// <remarks>
+    /// Tested with <c>!= 0</c> rather than <c>&gt; 0</c> as a fail-safe. The only
+    /// producer (<c>UseMemoCellsByIndex</c>) already clamps its incremental tally
+    /// to a non-negative floor before publishing (see <c>UseMemoCells</c>), so a
+    /// negative count is unreachable — and <c>!= 0</c> is therefore behaviorally
+    /// identical to <c>&gt; 0</c> for every value the producer can actually emit
+    /// (all <c>&gt;= 0</c>). The difference is purely defensive: were an anomalous
+    /// negative ever published, this still reports theme-sensitive and BLOCKS the
+    /// skip, forcing the always-correct full walk. For a correctness gate the safe
+    /// fail direction is to re-resolve (do more), never to silently skip (do less).
+    /// </remarks>
+    internal bool AnyThemeSensitive => ThemeSensitiveCount != 0;
 }
 
 /// <summary>

--- a/src/Reactor/Core/ChildDiffHints.cs
+++ b/src/Reactor/Core/ChildDiffHints.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
@@ -18,10 +19,11 @@ namespace Microsoft.UI.Reactor.Core;
 /// </summary>
 internal sealed class ChildDiffHint
 {
-    internal ChildDiffHint(int[] changedIndices, int themeSensitiveCount)
+    internal ChildDiffHint(int[] changedIndices, int themeSensitiveCount, Element[] previousChildren)
     {
         ChangedIndices = changedIndices;
         ThemeSensitiveCount = themeSensitiveCount;
+        PreviousChildren = new WeakReference<Element[]>(previousChildren);
     }
 
     /// <summary>
@@ -31,6 +33,22 @@ internal sealed class ChildDiffHint
     /// for unchanged indices and only rebuilds these).
     /// </summary>
     internal int[] ChangedIndices { get; }
+
+    /// <summary>
+    /// Weak handle to the EXACT previous-render array the <see cref="ChangedIndices"/>
+    /// were diffed against. The positional fast path engages only when the
+    /// reconciler's old-children array IS this array — a cheap, self-documenting
+    /// sufficient condition for the real invariant (every unchanged index is
+    /// reference-equal between old and new). Holds in steady state by construction
+    /// (the reconciler reconciles consecutive committed trees, and the V1 panel
+    /// descriptor surfaces the producer's <c>Element[]</c> by reference for both
+    /// sides); a mismatch (any defensive copy) safely falls back to the full walk.
+    /// Weak on purpose: a strong reference here would chain
+    /// <c>children_N → hint_N → children_(N-1) → hint_(N-1) → …</c> through the
+    /// reference-keyed <see cref="ChildDiffHints"/> table and pin every past
+    /// render's array for the lifetime of the live one.
+    /// </summary>
+    internal WeakReference<Element[]> PreviousChildren { get; }
 
     /// <summary>
     /// Number of cells carrying <c>ThemeBindings</c> or a ThemeRef-backed

--- a/src/Reactor/Core/ChildDiffHints.cs
+++ b/src/Reactor/Core/ChildDiffHints.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.UI.Reactor.Core;
+
+// AI-HINT: Structural-skip side-channel for positional child reconciliation.
+//   Published per render by UseMemoCellsByIndex; read by ChildReconciler's
+//   positional fast path. Keyed on the hook's fresh-per-render Element[] by
+//   reference identity, mirroring #681's _dirtyAncestorPath bridge: no
+//   Element-record widening, AOT-safe (ConditionalWeakTable, no reflection).
+
+/// <summary>
+/// Spec 034 §C — a hint describing which positional cells changed since the
+/// previous render, plus whether any cell re-resolves a theme-keyed value.
+/// Lets <see cref="ChildReconciler"/> update only the changed indices and skip
+/// the (provably reference-equal) untouched range — turning the positional
+/// skip-walk from O(count) into O(changed).
+/// </summary>
+internal sealed class ChildDiffHint
+{
+    internal ChildDiffHint(int[] changedIndices, int themeSensitiveCount)
+    {
+        ChangedIndices = changedIndices;
+        ThemeSensitiveCount = themeSensitiveCount;
+    }
+
+    /// <summary>
+    /// Indices whose new cell differs (by reference) from the previous render.
+    /// Every OTHER index is guaranteed reference-equal to the prior array by
+    /// <c>UseMemoCellsByIndex</c> construction (it reuses <c>prevChildren[i]</c>
+    /// for unchanged indices and only rebuilds these).
+    /// </summary>
+    internal int[] ChangedIndices { get; }
+
+    /// <summary>
+    /// Number of cells carrying <c>ThemeBindings</c> or a ThemeRef-backed
+    /// <c>ResourceOverrides</c>. Carried forward incrementally across reuse
+    /// renders so the producer stays O(changed) in steady state.
+    /// </summary>
+    internal int ThemeSensitiveCount { get; }
+
+    /// <summary>
+    /// True when ANY cell re-resolves a theme-keyed value. The positional fast
+    /// path must then fall back to the full walk so <c>ApplyThemeBindings</c> /
+    /// <c>ApplyResourceOverrides</c> re-resolve against the (possibly changed)
+    /// effective theme even on untouched, reference-equal cells — a parent
+    /// <c>RequestedTheme</c> toggle changes the effective theme WITHOUT touching
+    /// the element tree, so a structural skip would otherwise leave brushes stale.
+    /// </summary>
+    internal bool AnyThemeSensitive => ThemeSensitiveCount > 0;
+}
+
+/// <summary>
+/// Reference-keyed registry mapping a render's child <see cref="Element"/>[] to
+/// its <see cref="ChildDiffHint"/>. Weak keys: entries evict automatically when
+/// the per-render array is collected, so no explicit cleanup is needed.
+/// </summary>
+internal static class ChildDiffHints
+{
+    private static readonly ConditionalWeakTable<Element[], ChildDiffHint> s_hints = new();
+
+    internal static void Publish(Element[] children, ChildDiffHint hint)
+        => s_hints.AddOrUpdate(children, hint);
+
+    internal static bool TryGet(Element[] children, [NotNullWhen(true)] out ChildDiffHint? hint)
+        => s_hints.TryGetValue(children, out hint);
+
+    /// <summary>
+    /// True when the element re-resolves a theme-keyed value on each update —
+    /// either <c>ThemeBindings</c> brushes or a ThemeRef-backed resource override.
+    /// Mirrors the theme arms in <c>Reconciler.Update</c> (the only work the full
+    /// walk performs for an untouched cell that a structural skip would drop).
+    /// </summary>
+    internal static bool IsThemeSensitive(Element element)
+        => element.ThemeBindings is not null
+           || element.ResourceOverrides is { ThemeRefs.Count: > 0 };
+}

--- a/src/Reactor/Core/ChildDiffHints.cs
+++ b/src/Reactor/Core/ChildDiffHints.cs
@@ -88,8 +88,13 @@ internal static class ChildDiffHints
     /// either <c>ThemeBindings</c> brushes or a ThemeRef-backed resource override.
     /// Mirrors the theme arms in <c>Reconciler.Update</c> (the only work the full
     /// walk performs for an untouched cell that a structural skip would drop).
+    /// A <c>null</c> cell is treated as non-theme-sensitive: child arrays may
+    /// legitimately contain nulls (a builder may return null; <c>ChildReconciler.Filter</c>
+    /// drops them downstream), and a null has no bindings to re-resolve — so the
+    /// theme tally must tolerate it rather than throw.
     /// </summary>
-    internal static bool IsThemeSensitive(Element element)
-        => element.ThemeBindings is not null
-           || element.ResourceOverrides is { ThemeRefs.Count: > 0 };
+    internal static bool IsThemeSensitive(Element? element)
+        => element is not null
+           && (element.ThemeBindings is not null
+               || element.ResourceOverrides is { ThemeRefs.Count: > 0 });
 }

--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -81,18 +81,39 @@ internal static class ChildReconciler
         //   • a hint is present for THIS array — a CWT hit also proves Filter
         //     returned the same reference (no null/EmptyElement shifted the index
         //     space), so the hint's indices line up with both filtered arrays;
+        //   • no hot-reload force pass is active — else an untouched, reference-equal
+        //     WRAPPER cell (Component/Memo/Func) must still re-render through the
+        //     wrapper to pick up an edited method body; a structural skip would
+        //     swallow it (the full walk honours ForceRenderThroughWrapper per cell);
+        //   • the reconciler's OLD array IS the array the hint's indices were diffed
+        //     against — a cheap, self-documenting guard for the real invariant that
+        //     every unchanged index is reference-equal old↔new (holds in steady state
+        //     by construction; any defensive copy safely falls back to the full walk);
         //   • no cell is theme-sensitive — else an untouched, reference-equal cell
         //     could still need ApplyThemeBindings / ApplyResourceOverrides
         //     re-resolved against an effective theme that a parent RequestedTheme
         //     toggle changed without touching the element tree;
-        //   • the container is not on #681's dirty-ancestor path — else a
-        //     self-triggered descendant (e.g. a stateful memoized cell) would be
-        //     unreachable through a structural skip and must take the full walk.
+        //   • the container is not on #681's dirty-ancestor path — conservative
+        //     defense-in-depth for a self-triggered descendant (e.g. a stateful
+        //     memoized cell). NOTE: given the gates above this is behaviorally
+        //     redundant — an untouched index is reference-equal old↔new, and a
+        //     reference-equal cell is skipped IDENTICALLY by the full walk (via
+        //     Element.CanSkipUpdate in UpdateCommonChild) and this fast path, so a
+        //     self-triggered reused cell re-renders (or not) through the SAME
+        //     top-level dirty descent either way. The gate is retained as cheap
+        //     insurance so the fast path's early return can never short-circuit a
+        //     dirty subtree if CanSkipUpdate's contract changes. It costs nothing on
+        //     the target workload: a memoized grid's cell panel is a DESCENDANT of
+        //     the self-triggered grid component, not an ancestor, so it is not on the
+        //     ancestor-only dirty path and the fast path still engages.
         if (ambientKind is null
             && oldChildren.Length == newChildren.Length
             && childCount == newChildren.Length
+            && !reconciler.ForceFullRenderActive
             && ChildDiffHints.TryGet(newChildren, out var hint)
             && !hint.AnyThemeSensitive
+            && hint.PreviousChildren.TryGetTarget(out var hintPrev)
+            && ReferenceEquals(oldChildren, hintPrev)
             && !reconciler.IsOnDirtyAncestorPath(parentControl))
         {
             var changed = hint.ChangedIndices;

--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -30,7 +30,8 @@ internal static class ChildReconciler
         Element[] newChildren,
         IChildCollection children,
         Reconciler reconciler,
-        Action requestRerender)
+        Action requestRerender,
+        UIElement? parentControl = null)
     {
         // Filter out nulls and EmptyElements
         var oldFiltered = Filter(oldChildren);
@@ -48,7 +49,7 @@ internal static class ChildReconciler
         if (hasKeys)
             ReconcileKeyed(oldFiltered, newFiltered, children, reconciler, requestRerender, ambientKind);
         else
-            ReconcilePositional(oldFiltered, newFiltered, children, reconciler, requestRerender, ambientKind);
+            ReconcilePositional(oldFiltered, newFiltered, children, reconciler, requestRerender, ambientKind, parentControl);
     }
     // </snippet:child-diff>
 
@@ -62,59 +63,56 @@ internal static class ChildReconciler
         IChildCollection children,
         Reconciler reconciler,
         Action requestRerender,
-        AnimationKind? ambientKind)
+        AnimationKind? ambientKind,
+        UIElement? parentControl)
     {
         int childCount = children.Count; // cache to avoid repeated COM calls
         int common = Math.Min(oldChildren.Length, newChildren.Length);
+
+        // PR-C (Spec 034 §C) — structural skip of untouched child ranges.
+        // When a memoizing producer (UseMemoCellsByIndex) publishes a hint, only
+        // the named indices differ (by reference) from the previous render; every
+        // other cell is provably reference-equal, so we update just those indices
+        // and skip the O(count) walk. Required gates (each preserves correctness):
+        //   • counts match on both element sides AND the live collection equals
+        //     that count (no in-flight exit/enter animation has inflated it) — so
+        //     every changed index maps 1:1 to an existing control;
+        //   • no animation ambient (insert / move / exit reshape the child list);
+        //   • a hint is present for THIS array — a CWT hit also proves Filter
+        //     returned the same reference (no null/EmptyElement shifted the index
+        //     space), so the hint's indices line up with both filtered arrays;
+        //   • no cell is theme-sensitive — else an untouched, reference-equal cell
+        //     could still need ApplyThemeBindings / ApplyResourceOverrides
+        //     re-resolved against an effective theme that a parent RequestedTheme
+        //     toggle changed without touching the element tree;
+        //   • the container is not on #681's dirty-ancestor path — else a
+        //     self-triggered descendant (e.g. a stateful memoized cell) would be
+        //     unreachable through a structural skip and must take the full walk.
+        if (ambientKind is null
+            && oldChildren.Length == newChildren.Length
+            && childCount == newChildren.Length
+            && ChildDiffHints.TryGet(newChildren, out var hint)
+            && !hint.AnyThemeSensitive
+            && !reconciler.IsOnDirtyAncestorPath(parentControl))
+        {
+            var changed = hint.ChangedIndices;
+            for (int k = 0; k < changed.Length; k++)
+            {
+                int idx = changed[k];
+                if ((uint)idx >= (uint)common) continue; // defensive against a bad hint
+                UpdateCommonChild(idx, oldChildren, newChildren, children, reconciler, requestRerender);
+            }
+            // Untouched indices are reference-equal and skipped wholesale; keep the
+            // skipped-element diagnostic consistent with the full-walk path.
+            reconciler.DebugElementsSkipped += common - changed.Length;
+            return;
+        }
 
         // Update common children in place
         for (int i = 0; i < common; i++)
         {
             if (i >= childCount) break;
-
-            // Early skip: if the element is structurally identical (and has no
-            // theme bindings that need re-evaluation), we can avoid the expensive
-            // children.Get(i) COM call entirely. This saves ~2 COM roundtrips per
-            // unchanged child (IVector.GetAt + all the property diffing inside Update).
-            var oldEl = oldChildren[i];
-            var newEl = newChildren[i];
-            if (Element.CanSkipUpdate(oldEl, newEl)
-                && !reconciler.ForceRenderThroughWrapper(newEl))
-            {
-                reconciler.DebugElementsSkipped++;
-                // Refresh Tag when the element carries callbacks. The skip short-
-                // circuits Update, so without this the event trampoline keeps
-                // dispatching through the previous render's closure — stale state
-                // (e.g., Counter's `() => setCount(count + 1)` would keep capturing
-                // the initial count). For callback-free elements we still avoid
-                // the children.Get COM call.
-                if (newEl.HasCallbacks && children.Get(i) is FrameworkElement fe)
-                    Reconciler.SetElementTag(fe, newEl);
-                continue;
-            }
-
-            if (reconciler.CanUpdate(oldEl, newEl))
-            {
-                var existingControl = children.Get(i);
-                var replacement = reconciler.UpdateChild(oldEl, newEl, existingControl, requestRerender);
-                if (replacement is not null)
-                {
-                    // Child type changed at runtime — replace in place
-                    reconciler.UnmountChild(existingControl);
-                    children.Replace(i, replacement);
-                }
-            }
-            else
-            {
-                // Type mismatch — mount new, replace old with exit transition support
-                var newControl = reconciler.Mount(newEl, requestRerender);
-                if (newControl is not null)
-                    reconciler.ReplaceChildWithExitTransition(children, i, newControl);
-                else
-                {
-                    reconciler.UnmountChild(children.Get(i));
-                }
-            }
+            UpdateCommonChild(i, oldChildren, newChildren, children, reconciler, requestRerender);
         }
 
         // Remove excess old children (from end to start to keep indices stable).
@@ -134,6 +132,64 @@ internal static class ChildReconciler
             {
                 children.Insert(children.Count, ctrl);
                 ApplyAmbientEnterIfActive(ctrl, newChildren[i], ambientKind);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reconciles a single common (overlapping) child position in place. Shared by
+    /// the full positional walk and the PR-C structural-skip fast path so both
+    /// honour identical skip / update / type-mismatch semantics.
+    /// </summary>
+    private static void UpdateCommonChild(
+        int i,
+        Element[] oldChildren,
+        Element[] newChildren,
+        IChildCollection children,
+        Reconciler reconciler,
+        Action requestRerender)
+    {
+        // Early skip: if the element is structurally identical (and has no
+        // theme bindings that need re-evaluation), we can avoid the expensive
+        // children.Get(i) COM call entirely. This saves ~2 COM roundtrips per
+        // unchanged child (IVector.GetAt + all the property diffing inside Update).
+        var oldEl = oldChildren[i];
+        var newEl = newChildren[i];
+        if (Element.CanSkipUpdate(oldEl, newEl)
+            && !reconciler.ForceRenderThroughWrapper(newEl))
+        {
+            reconciler.DebugElementsSkipped++;
+            // Refresh Tag when the element carries callbacks. The skip short-
+            // circuits Update, so without this the event trampoline keeps
+            // dispatching through the previous render's closure — stale state
+            // (e.g., Counter's `() => setCount(count + 1)` would keep capturing
+            // the initial count). For callback-free elements we still avoid
+            // the children.Get COM call.
+            if (newEl.HasCallbacks && children.Get(i) is FrameworkElement fe)
+                Reconciler.SetElementTag(fe, newEl);
+            return;
+        }
+
+        if (reconciler.CanUpdate(oldEl, newEl))
+        {
+            var existingControl = children.Get(i);
+            var replacement = reconciler.UpdateChild(oldEl, newEl, existingControl, requestRerender);
+            if (replacement is not null)
+            {
+                // Child type changed at runtime — replace in place
+                reconciler.UnmountChild(existingControl);
+                children.Replace(i, replacement);
+            }
+        }
+        else
+        {
+            // Type mismatch — mount new, replace old with exit transition support
+            var newControl = reconciler.Mount(newEl, requestRerender);
+            if (newControl is not null)
+                reconciler.ReplaceChildWithExitTransition(children, i, newControl);
+            else
+            {
+                reconciler.UnmountChild(children.Get(i));
             }
         }
     }

--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -117,15 +117,21 @@ internal static class ChildReconciler
             && !reconciler.IsOnDirtyAncestorPath(parentControl))
         {
             var changed = hint.ChangedIndices;
+            int visited = 0;
             for (int k = 0; k < changed.Length; k++)
             {
                 int idx = changed[k];
                 if ((uint)idx >= (uint)common) continue; // defensive against a bad hint
                 UpdateCommonChild(idx, oldChildren, newChildren, children, reconciler, requestRerender);
+                visited++;
             }
-            // Untouched indices are reference-equal and skipped wholesale; keep the
-            // skipped-element diagnostic consistent with the full-walk path.
-            reconciler.DebugElementsSkipped += common - changed.Length;
+            // Untouched indices are reference-equal and skipped wholesale. Base the
+            // skipped-element diagnostic on indices ACTUALLY visited (not the raw
+            // hint length) so a defensively-ignored out-of-range index can't skew it
+            // or drive it negative. The producer publishes deduped, in-range indices,
+            // so visited == the real changed count in steady state; this only hardens
+            // the directly-supplied-hint path.
+            reconciler.DebugElementsSkipped += common - visited;
             return;
         }
 

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -160,6 +160,15 @@ public sealed partial class Reconciler : IDisposable
     internal volatile bool ForceFullRenderPending;
     private bool _forceFullRenderActive;
 
+    // True for the duration of a hot-reload force pass. Read by ChildReconciler's
+    // positional fast path: while a force pass is active, untouched wrapper cells
+    // (Component/Memo/Func) in a memoized range must still re-render through the
+    // wrapper, so the structural skip must defer to the full walk (which honours
+    // ForceRenderThroughWrapper per cell). A pure hot-reload force does NOT mark
+    // any node SelfTriggered before the dirty-ancestor path is built, so the
+    // IsOnDirtyAncestorPath gate alone does not cover this case.
+    internal bool ForceFullRenderActive => _forceFullRenderActive;
+
     // True only during a force pass and only for the wrapper elements whose
     // skip would prevent ReconcileComponent from running. Used by Update()
     // and ChildReconciler to bypass their structural-equality short-circuits.

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -1916,11 +1916,11 @@ public sealed partial class Reconciler : IDisposable
                 global::System.Diagnostics.Tracing.EventLevel.Informational,
                 Diagnostics.ReactorEventSource.Keywords.Reconcile))
         {
-            ChildReconciler.Reconcile(oldChildren, newChildren, childCollection, this, requestRerender);
+            ChildReconciler.Reconcile(oldChildren, newChildren, childCollection, this, requestRerender, panel);
             return;
         }
         Diagnostics.ReactorEventSource.Log.ChildReconcileStart(oldChildren.Length, newChildren.Length);
-        try { ChildReconciler.Reconcile(oldChildren, newChildren, childCollection, this, requestRerender); }
+        try { ChildReconciler.Reconcile(oldChildren, newChildren, childCollection, this, requestRerender, panel); }
         finally { Diagnostics.ReactorEventSource.Log.ChildReconcileStop(); }
     }
 
@@ -1932,18 +1932,19 @@ public sealed partial class Reconciler : IDisposable
     // descriptor panels match the legacy hand-coded Update* methods byte-for-byte.
     internal void ReconcilePanelChildrenInto(
         Element[] oldChildren, Element[] newChildren,
-        UIElementCollection collection, Action requestRerender)
+        UIElementCollection collection, Action requestRerender,
+        UIElement? parentControl = null)
     {
         var childCollection = new PanelChildCollection(collection);
         if (!Diagnostics.ReactorEventSource.Log.IsEnabled(
                 global::System.Diagnostics.Tracing.EventLevel.Informational,
                 Diagnostics.ReactorEventSource.Keywords.Reconcile))
         {
-            ChildReconciler.Reconcile(oldChildren, newChildren, childCollection, this, requestRerender);
+            ChildReconciler.Reconcile(oldChildren, newChildren, childCollection, this, requestRerender, parentControl);
             return;
         }
         Diagnostics.ReactorEventSource.Log.ChildReconcileStart(oldChildren.Length, newChildren.Length);
-        try { ChildReconciler.Reconcile(oldChildren, newChildren, childCollection, this, requestRerender); }
+        try { ChildReconciler.Reconcile(oldChildren, newChildren, childCollection, this, requestRerender, parentControl); }
         finally { Diagnostics.ReactorEventSource.Log.ChildReconcileStop(); }
     }
 

--- a/src/Reactor/Core/V1Protocol/V1HandlerAdapter.cs
+++ b/src/Reactor/Core/V1Protocol/V1HandlerAdapter.cs
@@ -283,7 +283,7 @@ internal sealed class V1HandlerAdapter<TElement, TControl> : IV1HandlerEntry
                 var newChildren = newList as Element[] ?? global::System.Linq.Enumerable.ToArray(newList);
                 var oldChildren = oldList as Element[] ?? global::System.Linq.Enumerable.ToArray(oldList);
 
-                reconciler.ReconcilePanelChildrenInto(oldChildren, newChildren, collection, requestRerender);
+                reconciler.ReconcilePanelChildrenInto(oldChildren, newChildren, collection, requestRerender, control);
 
                 // Re-apply per-child attached props by walking filtered-new
                 // children (null / EmptyElement skipped) in lockstep with the

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -225,15 +225,25 @@ public static class UseMemoCellsExtensions
             // Start with full reuse from prev, then rebuild only the named
             // indices. Validate bounds first so a bad caller can't half-update
             // the array before throwing.
-            for (int k = 0; k < changedIndices.Count; k++)
+            var prevChildren = prev!.Children;
+
+            // Snapshot + dedupe the caller's changed indices up front. Duplicates
+            // are a caller-contract violation; left in place they would (a) double
+            // the incremental theme tally's subtract for a single cell — an
+            // undercount can stay >= 0 and wrongly publish AnyThemeSensitive=false
+            // while a themed cell remains — and (b) make the reconciler update the
+            // same cell twice. Dedupe is order-irrelevant here: each cell is
+            // rebuilt/updated independently of the others.
+            int[] changed = SnapshotChangedIndices(changedIndices);
+            for (int k = 0; k < changed.Length; k++)
             {
-                int idx = changedIndices[k];
+                int idx = changed[k];
                 if ((uint)idx >= (uint)count)
                     throw new ArgumentOutOfRangeException(nameof(changedIndices),
                         $"Index {idx} is out of range for items list of length {count}.");
             }
+            changed = Dedupe(changed);
 
-            var prevChildren = prev!.Children;
             for (int i = 0; i < count; i++)
                 children[i] = prevChildren[i];
 
@@ -241,27 +251,34 @@ public static class UseMemoCellsExtensions
             // the positional reconciler can safely structural-skip the untouched
             // (reference-equal) range. Start from the previous render's hint —
             // O(1); only on the first reuse after a full rebuild do we scan once.
+            // "Theme-sensitive" = ThemeBindings OR a ThemeRef-backed ResourceOverride
+            // (see ChildDiffHints.IsThemeSensitive). The ResourceOverrides arm is
+            // conservative: today the full-walk fallback also skips a reference-equal
+            // ResourceOverrides cell (Element.CanSkipUpdate only un-skips for
+            // ThemeBindings), so gating on it costs a fallback without a re-resolve —
+            // kept deliberately as belt-and-suspenders / future-proofing, and because
+            // making CanSkipUpdate consistent is a framework-wide change out of scope
+            // here.
             int themeSensitiveCount = ChildDiffHints.TryGet(prevChildren, out var prevHint)
                 ? prevHint.ThemeSensitiveCount
                 : CountThemeSensitive(prevChildren);
 
-            for (int k = 0; k < changedIndices.Count; k++)
+            for (int k = 0; k < changed.Length; k++)
             {
-                int idx = changedIndices[k];
+                int idx = changed[k];
                 if (ChildDiffHints.IsThemeSensitive(prevChildren[idx])) themeSensitiveCount--;
                 var built = builder(items[idx], idx);
                 children[idx] = built;
                 if (ChildDiffHints.IsThemeSensitive(built)) themeSensitiveCount++;
             }
 
-            // Defensive: duplicate indices in changedIndices (a caller-contract
-            // violation) could under-count; recompute rather than publish a count
-            // that would let the reconciler unsafely skip a theme-sensitive cell.
+            // With deduped indices the incremental tally is exact; keep a defensive
+            // floor as belt-and-suspenders against any unforeseen drift.
             if (themeSensitiveCount < 0)
                 themeSensitiveCount = CountThemeSensitive(children);
 
             ChildDiffHints.Publish(children, new ChildDiffHint(
-                SnapshotChangedIndices(changedIndices), themeSensitiveCount));
+                changed, themeSensitiveCount, prevChildren));
         }
 
         stateRef.Current = new MemoCellsState<T>(SnapshotItems(items), children, SnapshotDeps(dependencies));
@@ -302,6 +319,30 @@ public static class UseMemoCellsExtensions
         for (int i = 0; i < n; i++)
             arr[i] = changedIndices[i];
         return arr;
+    }
+
+    // PR-C (Spec 034 §C) — remove duplicate indices from the (private, already
+    // snapshotted) changed-index array. Duplicates are a caller-contract violation
+    // that would corrupt the incremental theme tally and double the reconciler's
+    // per-cell work. Sorting in place is acceptable: the array is private to this
+    // call, callers get no ordering guarantee, and each cell reconciles
+    // independently. Returns the same array when already duplicate-free (the
+    // overwhelmingly common case), so steady-state reuse adds only an O(k log k)
+    // sort over the typically-small changed set.
+    private static int[] Dedupe(int[] indices)
+    {
+        if (indices.Length <= 1) return indices;
+        Array.Sort(indices);
+        int w = 1;
+        for (int r = 1; r < indices.Length; r++)
+        {
+            if (indices[r] != indices[w - 1])
+                indices[w++] = indices[r];
+        }
+        if (w == indices.Length) return indices;
+        var trimmed = new int[w];
+        Array.Copy(indices, trimmed, w);
+        return trimmed;
     }
 
     // O(count) theme-sensitivity scan — used only on the first reuse render

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -236,11 +236,32 @@ public static class UseMemoCellsExtensions
             var prevChildren = prev!.Children;
             for (int i = 0; i < count; i++)
                 children[i] = prevChildren[i];
+
+            // PR-C (Spec 034 §C): carry the theme-sensitive cell count forward so
+            // the positional reconciler can safely structural-skip the untouched
+            // (reference-equal) range. Start from the previous render's hint —
+            // O(1); only on the first reuse after a full rebuild do we scan once.
+            int themeSensitiveCount = ChildDiffHints.TryGet(prevChildren, out var prevHint)
+                ? prevHint.ThemeSensitiveCount
+                : CountThemeSensitive(prevChildren);
+
             for (int k = 0; k < changedIndices.Count; k++)
             {
                 int idx = changedIndices[k];
-                children[idx] = builder(items[idx], idx);
+                if (ChildDiffHints.IsThemeSensitive(prevChildren[idx])) themeSensitiveCount--;
+                var built = builder(items[idx], idx);
+                children[idx] = built;
+                if (ChildDiffHints.IsThemeSensitive(built)) themeSensitiveCount++;
             }
+
+            // Defensive: duplicate indices in changedIndices (a caller-contract
+            // violation) could under-count; recompute rather than publish a count
+            // that would let the reconciler unsafely skip a theme-sensitive cell.
+            if (themeSensitiveCount < 0)
+                themeSensitiveCount = CountThemeSensitive(children);
+
+            ChildDiffHints.Publish(children, new ChildDiffHint(
+                SnapshotChangedIndices(changedIndices), themeSensitiveCount));
         }
 
         stateRef.Current = new MemoCellsState<T>(SnapshotItems(items), children, SnapshotDeps(dependencies));
@@ -268,6 +289,30 @@ public static class UseMemoCellsExtensions
         var copy = new object[deps.Length];
         Array.Copy(deps, copy, deps.Length);
         return copy;
+    }
+
+    // PR-C (Spec 034 §C) — snapshot the caller's changed-index list into a
+    // private int[] so the published ChildDiffHint can't be corrupted by a
+    // later caller mutation (the hint outlives the call via the weak-keyed CWT).
+    private static int[] SnapshotChangedIndices(IReadOnlyList<int> changedIndices)
+    {
+        int n = changedIndices.Count;
+        if (n == 0) return Array.Empty<int>();
+        var arr = new int[n];
+        for (int i = 0; i < n; i++)
+            arr[i] = changedIndices[i];
+        return arr;
+    }
+
+    // O(count) theme-sensitivity scan — used only on the first reuse render
+    // after a full rebuild (no prior hint to carry forward) and as the
+    // defensive recompute path; steady-state reuse stays O(changed).
+    private static int CountThemeSensitive(Element[] cells)
+    {
+        int n = 0;
+        for (int i = 0; i < cells.Length; i++)
+            if (ChildDiffHints.IsThemeSensitive(cells[i])) n++;
+        return n;
     }
 
     private static bool DepsEqual(object[] prev, object[] next)

--- a/src/Reactor/Hooks/UseMemoCells.cs
+++ b/src/Reactor/Hooks/UseMemoCells.cs
@@ -184,16 +184,38 @@ public static class UseMemoCellsExtensions
     /// or <see cref="UseMemoCellsByKey{T,TKey}"/>, both of which can
     /// short-circuit per-cell on value or key equality across length
     /// changes.
+    /// <para>
+    /// On the steady-state path (unchanged count) the returned array reuses
+    /// the previous render's element instance for every index NOT named in
+    /// <paramref name="changedIndices"/>, and publishes a positional
+    /// structural-skip hint (Spec 034 §C) keyed by reference on that array so
+    /// the reconciler can update only the changed cells and skip the
+    /// reference-equal remainder. The returned array is therefore the hook's
+    /// retained memoized state AND the key of that hint: treat it as immutable
+    /// and declare every change through a subsequent render's
+    /// <paramref name="changedIndices"/> (React-style immutability — see
+    /// AGENTS.md "Never mutate"). Mutating an unchanged slot in place both
+    /// corrupts the memo's view of the previous render and can cause the
+    /// reconciler to skip the mutated cell.
+    /// </para>
     /// </summary>
     /// <param name="ctx">The render context.</param>
     /// <param name="items">Source items.</param>
     /// <param name="changedIndices">Indices whose item differs from the
     /// previous render. Negative indices and indices >= <c>items.Count</c>
-    /// throw <see cref="ArgumentOutOfRangeException"/>.</param>
+    /// throw <see cref="ArgumentOutOfRangeException"/>. Duplicate indices are a
+    /// caller-contract violation but are tolerated: they are de-duplicated
+    /// before the named cells are rebuilt, so each cell is rebuilt exactly once
+    /// and the structural-skip hint's theme tally stays exact.</param>
     /// <param name="builder">Cell builder; same contract as
     /// <see cref="UseMemoCells{T}"/>.</param>
     /// <param name="dependencies">Trailing-<c>params</c> deps.</param>
-    /// <remarks>Spec 034 §C.</remarks>
+    /// <remarks>Spec 034 §C. A cell is "theme-sensitive" when it carries
+    /// ThemeBindings or a ThemeRef-backed ResourceOverride; the hook tracks how
+    /// many cells are theme-sensitive (carried forward incrementally) so the
+    /// reconciler falls back to the full walk — which re-resolves themed brushes
+    /// against the current effective theme — instead of structurally skipping
+    /// such a range.</remarks>
     public static Element[] UseMemoCellsByIndex<T>(
         this RenderContext ctx,
         IReadOnlyList<T> items,

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/StructuralSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/StructuralSkipFixtures.cs
@@ -1,0 +1,203 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Hooks;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// PR-C (Spec 034 §C) end-to-end proofs through the REAL reconciler for the
+/// positional structural-skip fast path in <c>ChildReconciler.ReconcilePositional</c>.
+///
+/// A memoizing producer (<c>UseMemoCellsByIndex</c>) publishes a
+/// <c>ChildDiffHint</c> keyed on the fresh-per-render <c>Element[]</c>; the
+/// consumer then updates ONLY the changed indices and skips the rest (provably
+/// reference-equal). These fixtures mount a live WinUI tree so the actual hint
+/// production + fast-path consumption are exercised, not just the headless
+/// primitives in <c>ChildReconcilerStructuralSkipTests</c> /
+/// <c>ChildDiffHintsTests</c>.
+///
+/// Two complementary live observables, each matched to what the path actually does:
+///   • <see cref="LifecycleParity"/> uses an <c>OnUpdateAdd</c> tally. A CHANGED
+///     cell (ShallowEquals false) takes the full <c>UpdateChild</c> → <c>ApplyModifiers</c>
+///     path, so <c>OnUpdateAction</c> fires; an untouched reference-equal cell takes
+///     the skip arm and never fires it — identical under the fast path and the full
+///     walk. This pins the changed-index ⇒ fires / untouched ⇒ skipped semantics.
+///   • <see cref="ThemeRangeParity"/> is a live PARITY / SMOKE check over a
+///     theme-sensitive reference-equal range under a parent <c>RequestedTheme</c>
+///     toggle: every themed cell must render and its <c>{ThemeResource}</c> Foreground
+///     must re-resolve Light↔Dark, with no cell dropped by the fast-path-eligible
+///     range. It is deliberately NOT the gate teeth — see its remarks.
+///
+/// <para>WHY THE GATE TEETH IS HEADLESS, NOT HERE: the load-bearing teeth for the
+/// <c>!AnyThemeSensitive</c> gate is the headless
+/// <c>ChildReconcilerStructuralSkipTests.ThemeSensitive_Hint_Forces_Full_Walk</c>
+/// (revert the gate → it FAILS). A live color delta CANNOT witness the gate because
+/// WinUI auto-re-resolves a <c>{ThemeResource}</c> Style setter on any effective-theme
+/// change — empirically, with the gate reverted the themed cells were structurally
+/// skipped (ApplyThemeBindings never re-ran) yet their Foreground brushes STILL went
+/// Light→Dark. The one snapshot a skip truly leaves stale —
+/// <c>ApplyResourceOverrides</c>' concrete <c>ThemeRef.Resolve</c> into
+/// <c>fe.Resources[key]</c> — does not reliably re-resolve in the reconcile harness
+/// (its effective-theme view lags a parent RequestedTheme propagation), so it makes
+/// an unreliable live observable. The headless visited-index assertion is therefore
+/// the authoritative gate teeth; this fixture is the end-to-end parity companion.</para>
+/// </summary>
+internal static class StructuralSkipFixtures
+{
+    /// <summary>
+    /// Lifecycle PARITY: an <c>OnUpdateAction</c>-bearing cell sits at BOTH a
+    /// changed index AND untouched reference-equal indices under the hinted
+    /// (fast-path-eligible) range. The engaged fast path must fire the update
+    /// callback for the changed cell and leave the untouched cells untouched —
+    /// identical to the full O(count) walk (whose ref-equal cells also hit the
+    /// CanSkipUpdate skip arm and never fire OnUpdateAction).
+    /// </summary>
+    internal class LifecycleParity(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            // Reference-stable tally the cells write to (no static mutable state):
+            // index i counts how many times cell i actually went through Update.
+            var counts = new int[5];
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (vals, setVals) = ctx.UseState(new[] { 0, 0, 0, 0, 0 });
+                var (changed, setChanged) = ctx.UseState(new int[0]);
+
+                // Plain (non-theme) cells. For i not in changedIndices the hook
+                // reuses the previous element reference verbatim, so the consumer's
+                // fast path can skip it; only changed indices are rebuilt.
+                var cells = ctx.UseMemoCellsByIndex(
+                    vals,
+                    changed,
+                    (item, i) => TextBlock($"cellL-{i}:{item}").OnUpdateAdd(_ => counts[i]++));
+
+                return VStack(
+                    Button("BumpL2", () =>
+                    {
+                        var next = (int[])vals.Clone();
+                        next[2]++;
+                        setChanged(new[] { 2 });
+                        setVals(next);
+                    }),
+                    VStack(cells));
+            });
+
+            await Harness.Render();
+            // OnUpdateAction is update-only — it must NEVER fire at mount.
+            H.Check("StructuralSkip_NoUpdateAtMount",
+                counts[0] == 0 && counts[2] == 0 && counts[4] == 0);
+            H.Check("StructuralSkip_MountTextPresent", H.FindText("cellL-2:0") is not null);
+
+            // Bump exactly one cell (index 2): changedIndices=[2] → cell 2 is rebuilt
+            // (fresh instance, new text) while cells 0/1/3/4 are reused reference-equal,
+            // so the fast path engages (no theme cells, container not on the dirty path).
+            H.ClickButton("BumpL2");
+            await Harness.Render();
+
+            // The changed index goes through the real Update path → its tally fires.
+            H.Check("StructuralSkip_ChangedCellUpdated", counts[2] >= 1);
+            H.Check("StructuralSkip_ChangedTextUpdated", H.FindText("cellL-2:1") is not null);
+            // Untouched reference-equal indices are skipped wholesale → no tally fires,
+            // exactly as the full walk would (ref-equal cells hit CanSkipUpdate).
+            H.Check("StructuralSkip_UntouchedHeadNotUpdated", counts[0] == 0);
+            H.Check("StructuralSkip_UntouchedTailNotUpdated", counts[4] == 0);
+            H.Check("StructuralSkip_UntouchedTextUnchanged", H.FindText("cellL-0:0") is not null);
+        }
+    }
+
+    /// <summary>
+    /// THEME RANGE PARITY (live smoke): a reference-equal range of theme-sensitive cells
+    /// (each carries a <c>{ThemeResource}</c> Foreground via <c>.Foreground(Theme.PrimaryText)</c>)
+    /// sits under a parent whose <c>RequestedTheme</c> is toggled Light↔Dark. Because the
+    /// producer flags <c>AnyThemeSensitive=true</c>, the structural fast path is gated off
+    /// (gate 5) and the full walk runs; this fixture proves the end-to-end scenario is
+    /// healthy — every themed cell renders, none is dropped across the toggle, and each
+    /// cell's Foreground brush re-resolves to the new effective theme.
+    ///
+    /// <para>NOT THE GATE TEETH (by construction it cannot be): WinUI auto-re-resolves a
+    /// <c>{ThemeResource}</c> Style setter on any effective-theme change, so the Foreground
+    /// brush flips Light↔Dark whether the cell is re-applied OR structurally skipped — this
+    /// check passes under both the correct gate and a reverted one. Its value is catching a
+    /// fast path that DROPS or CORRUPTS themed cells, not detecting an over-eager skip. The
+    /// authoritative teeth for the <c>!AnyThemeSensitive</c> gate is the deterministic
+    /// headless visited-index assertion
+    /// <c>ChildReconcilerStructuralSkipTests.ThemeSensitive_Hint_Forces_Full_Walk</c>
+    /// (revert the gate → that test FAILS). See the class remarks for the empirical basis.</para>
+    /// </summary>
+    internal class ThemeRangeParity(Harness h) : SelfTestFixtureBase(h)
+    {
+        // Reference-stable items: changedIndices is ALWAYS empty, so every cell is reused
+        // reference-equal across the theme toggle (the untouched-range case the fast path
+        // targets — here defeated by AnyThemeSensitive, exercising the gated full walk).
+        private static readonly int[] Items = { 0, 1, 2, 3, 4 };
+
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (theme, setTheme) = ctx.UseState(ElementTheme.Light);
+
+                // Each cell carries a {ThemeResource} Foreground → the range is
+                // theme-sensitive (hint.AnyThemeSensitive = true). The cells take no theme
+                // dependency, so changedIndices stays empty and every cell is reused
+                // reference-equal across the toggle.
+                var cells = ctx.UseMemoCellsByIndex(
+                    Items,
+                    new int[0],
+                    (item, i) => TextBlock($"cellT-{i}").Foreground(Theme.PrimaryText));
+
+                return VStack(
+                    Button("ToggleThemeT", () =>
+                        setTheme(theme == ElementTheme.Light ? ElementTheme.Dark : ElementTheme.Light)),
+                    // The parent RequestedTheme toggle changes the effective theme for the
+                    // subtree WITHOUT touching the (reference-equal) cell elements. The inner
+                    // VStack still updates (fresh children array each render), so child
+                    // reconciliation runs over the theme-sensitive range.
+                    VStack(cells).RequestedTheme(theme));
+            });
+
+            await Harness.Render();
+
+            // All themed cells render and their Foreground resolves at mount (Light theme).
+            H.Check("ThemeRange_AllCellsPresentAtMount", AllCellsPresent());
+            var lightColor = CellForeground("cellT-2")?.Color;
+            H.Check("ThemeRange_MountForegroundThemed", lightColor is not null);
+
+            // Toggle the parent RequestedTheme Light→Dark. WinUI re-resolves the live
+            // {ThemeResource} Foreground for the whole subtree; the cells must survive the
+            // fast-path-eligible range and re-theme.
+            H.ClickButton("ToggleThemeT");
+            var reresolved = await Harness.WaitFor(() =>
+            {
+                var b = CellForeground("cellT-2");
+                return b is not null && b.Color != lightColor;
+            });
+
+            H.Check("ThemeRange_AllCellsSurviveToggle", AllCellsPresent());
+            H.Check("ThemeRange_ForegroundReresolvedOnToggle", reresolved);
+        }
+
+        private bool AllCellsPresent()
+        {
+            for (int i = 0; i < Items.Length; i++)
+                if (H.FindText($"cellT-{i}") is null)
+                    return false;
+            return true;
+        }
+
+        private SolidColorBrush? CellForeground(string text)
+        {
+            var tb = H.FindControl<TextBlock>(t => t.Text == text);
+            return tb?.Foreground as SolidColorBrush;
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/StructuralSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/StructuralSkipFixtures.cs
@@ -1,6 +1,8 @@
+using System.Threading;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Hooks;
+using Microsoft.UI.Reactor.Hosting;
 using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -198,6 +200,85 @@ internal static class StructuralSkipFixtures
         {
             var tb = H.FindControl<TextBlock>(t => t.Text == text);
             return tb?.Foreground as SolidColorBrush;
+        }
+    }
+
+    /// <summary>
+    /// HOT-RELOAD GATE TEETH (C1, Spec 034 §C): a memoized range built by
+    /// <c>UseMemoCellsByIndex</c> contains a WRAPPER cell (a <c>Component</c>) whose
+    /// rendered body is changed by a simulated hot-reload "edit" (a flipped static
+    /// shape flag, exactly as <see cref="HotReloadRecoveryFixtures"/> does). Across a
+    /// normal render the wrapper is reused reference-equal and correctly skipped; but
+    /// during a hot-reload FORCE pass the structural fast path MUST defer to the full
+    /// walk so the wrapper re-renders its edited body (the full walk honours
+    /// <c>ForceRenderThroughWrapper</c> per cell, which a wholesale structural skip
+    /// would bypass).
+    ///
+    /// <para>This is the teeth for the fast path's <c>!reconciler.ForceFullRenderActive</c>
+    /// gate (<c>ChildReconciler.ReconcilePositional</c>): the memoized cells are reused
+    /// reference-equal with EMPTY <c>changedIndices</c>, so every other gate is satisfied
+    /// during the force pass and only this gate keeps the fast path from engaging. Revert
+    /// the gate → the force pass structurally skips the untouched wrapper, the edited body
+    /// is swallowed, and <c>HotReloadStructuralSkip_WrapperReRenders</c> FAILS. A pure
+    /// hot-reload force does not mark any node self-triggered, so the dirty-ancestor-path
+    /// gate alone does NOT cover this case — hence the dedicated gate + this teeth.</para>
+    /// </summary>
+    internal sealed class HotReloadWrapperReRender(Harness h) : SelfTestFixtureBase(h)
+    {
+        // Drives the memoized wrapper cell's body. 0 = pre-edit, 1 = post-edit.
+        private static int _cellShape;
+
+        // A WRAPPER cell (Component) whose body a hot-reload edit changes. Only a
+        // wrapper re-render is at risk from a structural skip during a force pass;
+        // plain elements are safe to skip because their fields are unchanged.
+        private sealed class MemoizedCellComponent : Component
+        {
+            public override Element Render() =>
+                TextBlock(Volatile.Read(ref _cellShape) == 0 ? "wrapCell: v1" : "wrapCell: v2");
+        }
+
+        public override async Task RunAsync()
+        {
+            Volatile.Write(ref _cellShape, 0);
+
+            var items = new[] { 0, 1, 2 };
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                // changedIndices is ALWAYS empty: every cell is reused reference-equal
+                // across renders, so the producer publishes a hint with no changed
+                // indices and the structural fast path is otherwise eligible — it must
+                // be gated off during the hot-reload force pass so the wrapper at index
+                // 1 re-renders its edited body.
+                var cells = ctx.UseMemoCellsByIndex(
+                    items,
+                    new int[0],
+                    (item, i) => i == 1
+                        ? Component<MemoizedCellComponent>()   // wrapper cell
+                        : TextBlock($"plainCell-{i}"));        // plain cells around it
+                return VStack(cells);
+            });
+
+            await Harness.Render();
+            H.Check("HotReloadStructuralSkip_MountV1", H.FindText("wrapCell: v1") is not null);
+
+            // Simulate the developer's edit to the wrapper cell's body.
+            Volatile.Write(ref _cellShape, 1);
+
+            // Drive a real hot-reload force pass. The memoized cells are still reused
+            // reference-equal (changedIndices empty), so WITHOUT the gate the fast path
+            // would skip the untouched wrapper and swallow the edit.
+            HotReloadService.UpdateApplication(null);
+            host.RequestRender(force: true);
+            await Harness.Render();
+
+            // The wrapper re-rendered its edited body. Revert the
+            // !ForceFullRenderActive gate and this stays "wrapCell: v1" (the structural
+            // skip swallowed the edit) → the teeth fails.
+            H.Check("HotReloadStructuralSkip_WrapperReRenders", H.FindText("wrapCell: v2") is not null);
+            H.Check("HotReloadStructuralSkip_OldBodyGone", H.FindText("wrapCell: v1") is null);
+
+            Volatile.Write(ref _cellShape, 0);
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -373,6 +373,8 @@ internal static class SelfTestFixtureRegistry
         "ComponentHook_UseBreakpoint",
         "ComponentHook_MultipleComponents",
         "ComponentMemo_SkipRefreshesLiveDelegate",
+        "StructuralSkip_LifecycleParity",
+        "StructuralSkip_ThemeRangeParity",
         "HotReload_ChildHookOrderRecovery",
         "HotReload_ComponentMigratesState",
         // DSL and extension tests
@@ -1792,6 +1794,8 @@ internal static class SelfTestFixtureRegistry
         "ComponentHook_UseBreakpoint" => new ComponentHookFixtures.UseBreakpointHook(harness),
         "ComponentHook_MultipleComponents" => new ComponentHookFixtures.MultipleComponents(harness),
         "ComponentMemo_SkipRefreshesLiveDelegate" => new CallbacksMemoSkipFixtures.SkipRefreshesLiveDelegate(harness),
+        "StructuralSkip_LifecycleParity" => new StructuralSkipFixtures.LifecycleParity(harness),
+        "StructuralSkip_ThemeRangeParity" => new StructuralSkipFixtures.ThemeRangeParity(harness),
         "HotReload_ChildHookOrderRecovery" => new HotReloadRecoveryFixtures.ChildRecoversAndSiblingStateSurvives(harness),
         "HotReload_ComponentMigratesState" => new HotReloadComponentMigrationFixtures.MigratesPreservingState(harness),
         // DSL and extension tests

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -375,6 +375,7 @@ internal static class SelfTestFixtureRegistry
         "ComponentMemo_SkipRefreshesLiveDelegate",
         "StructuralSkip_LifecycleParity",
         "StructuralSkip_ThemeRangeParity",
+        "StructuralSkip_HotReloadWrapperReRender",
         "HotReload_ChildHookOrderRecovery",
         "HotReload_ComponentMigratesState",
         // DSL and extension tests
@@ -1796,6 +1797,7 @@ internal static class SelfTestFixtureRegistry
         "ComponentMemo_SkipRefreshesLiveDelegate" => new CallbacksMemoSkipFixtures.SkipRefreshesLiveDelegate(harness),
         "StructuralSkip_LifecycleParity" => new StructuralSkipFixtures.LifecycleParity(harness),
         "StructuralSkip_ThemeRangeParity" => new StructuralSkipFixtures.ThemeRangeParity(harness),
+        "StructuralSkip_HotReloadWrapperReRender" => new StructuralSkipFixtures.HotReloadWrapperReRender(harness),
         "HotReload_ChildHookOrderRecovery" => new HotReloadRecoveryFixtures.ChildRecoversAndSiblingStateSurvives(harness),
         "HotReload_ComponentMigratesState" => new HotReloadComponentMigrationFixtures.MigratesPreservingState(harness),
         // DSL and extension tests

--- a/tests/Reactor.Tests/ChildDiffHintsTests.cs
+++ b/tests/Reactor.Tests/ChildDiffHintsTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Elements;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Unit tests for the PR-C structural-skip side-channel (<see cref="ChildDiffHints"/>
+/// + <see cref="ChildDiffHint"/>). Pure: no reconciler, no WinUI controls — exercises
+/// the reference-keyed registry and the theme-sensitivity predicate that gates the
+/// positional fast path.
+/// </summary>
+public class ChildDiffHintsTests
+{
+    private static Element[] Cells(params string[] labels)
+    {
+        var arr = new Element[labels.Length];
+        for (int i = 0; i < labels.Length; i++)
+            arr[i] = new TextBlockElement(labels[i]);
+        return arr;
+    }
+
+    // ── Registry round-trip ──────────────────────────────────────────
+
+    [Fact]
+    public void Publish_Then_TryGet_Returns_Same_Hint()
+    {
+        var children = Cells("a", "b", "c");
+        var hint = new ChildDiffHint(new[] { 1 }, themeSensitiveCount: 0);
+        ChildDiffHints.Publish(children, hint);
+
+        Assert.True(ChildDiffHints.TryGet(children, out var got));
+        Assert.Same(hint, got);
+        Assert.Equal(new[] { 1 }, got!.ChangedIndices);
+    }
+
+    [Fact]
+    public void TryGet_Unpublished_Array_Misses()
+    {
+        var children = Cells("a", "b");
+        Assert.False(ChildDiffHints.TryGet(children, out var got));
+        Assert.Null(got);
+    }
+
+    [Fact]
+    public void Hint_Is_Keyed_By_Reference_Not_Structural_Equality()
+    {
+        // Two distinct arrays with structurally-equal contents must not collide:
+        // the CWT keys on the fresh-per-render array identity.
+        var first = Cells("a", "b");
+        var second = Cells("a", "b");
+        ChildDiffHints.Publish(first, new ChildDiffHint(Array.Empty<int>(), 0));
+
+        Assert.True(ChildDiffHints.TryGet(first, out _));
+        Assert.False(ChildDiffHints.TryGet(second, out _));
+    }
+
+    [Fact]
+    public void Publish_Twice_Overwrites_Prior_Hint()
+    {
+        var children = Cells("a", "b", "c");
+        ChildDiffHints.Publish(children, new ChildDiffHint(new[] { 0 }, 0));
+        var second = new ChildDiffHint(new[] { 2 }, 0);
+        ChildDiffHints.Publish(children, second);
+
+        Assert.True(ChildDiffHints.TryGet(children, out var got));
+        Assert.Same(second, got);
+        Assert.Equal(new[] { 2 }, got!.ChangedIndices);
+    }
+
+    // ── AnyThemeSensitive flag ───────────────────────────────────────
+
+    [Fact]
+    public void AnyThemeSensitive_Tracks_Count()
+    {
+        Assert.False(new ChildDiffHint(Array.Empty<int>(), 0).AnyThemeSensitive);
+        Assert.True(new ChildDiffHint(Array.Empty<int>(), 1).AnyThemeSensitive);
+        Assert.True(new ChildDiffHint(Array.Empty<int>(), 5).AnyThemeSensitive);
+    }
+
+    // ── IsThemeSensitive predicate ───────────────────────────────────
+
+    [Fact]
+    public void IsThemeSensitive_False_For_Plain_Element()
+    {
+        Assert.False(ChildDiffHints.IsThemeSensitive(new TextBlockElement("plain")));
+    }
+
+    [Fact]
+    public void IsThemeSensitive_True_For_ThemeBindings()
+    {
+        var el = new TextBlockElement("themed")
+        {
+            ThemeBindings = new Dictionary<string, ThemeRef> { ["Foreground"] = new ThemeRef("SystemAccentColor") },
+        };
+        Assert.True(ChildDiffHints.IsThemeSensitive(el));
+    }
+
+    [Fact]
+    public void IsThemeSensitive_True_For_ResourceOverrides_ThemeRefs()
+    {
+        var el = new TextBlockElement("themed")
+        {
+            ResourceOverrides = new ResourceOverrides(
+                Literals: new Dictionary<string, object>(),
+                ThemeRefs: new Dictionary<string, ThemeRef> { ["ButtonBackground"] = new ThemeRef("AccentBrush") }),
+        };
+        Assert.True(ChildDiffHints.IsThemeSensitive(el));
+    }
+
+    [Fact]
+    public void IsThemeSensitive_False_For_ResourceOverrides_With_Only_Literals()
+    {
+        // Literal overrides are NOT theme-reactive — only ThemeRefs re-resolve on
+        // a theme flip, so a literal-only override must not block the fast path.
+        var el = new TextBlockElement("literal")
+        {
+            ResourceOverrides = new ResourceOverrides(
+                Literals: new Dictionary<string, object> { ["Pad"] = 4.0 },
+                ThemeRefs: new Dictionary<string, ThemeRef>()),
+        };
+        Assert.False(ChildDiffHints.IsThemeSensitive(el));
+    }
+}

--- a/tests/Reactor.Tests/ChildDiffHintsTests.cs
+++ b/tests/Reactor.Tests/ChildDiffHintsTests.cs
@@ -89,6 +89,20 @@ public class ChildDiffHintsTests
         Assert.True(new ChildDiffHint(Array.Empty<int>(), 5, Array.Empty<Element>()).AnyThemeSensitive);
     }
 
+    [Fact]
+    public void AnyThemeSensitive_Is_FailSafe_For_Anomalous_Negative_Count()
+    {
+        // The producer (UseMemoCellsByIndex) clamps its incremental tally to a
+        // >= 0 floor before publishing, so a negative count is unreachable in
+        // production. This pins the type's FAIL-SAFE posture regardless: were a
+        // negative ever published, AnyThemeSensitive must stay TRUE so the
+        // structural-skip fast path falls back to the (always-correct) full walk
+        // and re-resolves themes — never silently allow a skip that drops a theme
+        // re-resolve. Reverting the guard from `!= 0` to `> 0` makes this go red.
+        Assert.True(new ChildDiffHint(Array.Empty<int>(), -1, Array.Empty<Element>()).AnyThemeSensitive);
+        Assert.True(new ChildDiffHint(Array.Empty<int>(), -5, Array.Empty<Element>()).AnyThemeSensitive);
+    }
+
     // ── IsThemeSensitive predicate ───────────────────────────────────
 
     [Fact]

--- a/tests/Reactor.Tests/ChildDiffHintsTests.cs
+++ b/tests/Reactor.Tests/ChildDiffHintsTests.cs
@@ -28,12 +28,21 @@ public class ChildDiffHintsTests
     public void Publish_Then_TryGet_Returns_Same_Hint()
     {
         var children = Cells("a", "b", "c");
-        var hint = new ChildDiffHint(new[] { 1 }, themeSensitiveCount: 0);
+        var hint = new ChildDiffHint(new[] { 1 }, themeSensitiveCount: 0, previousChildren: Array.Empty<Element>());
         ChildDiffHints.Publish(children, hint);
 
         Assert.True(ChildDiffHints.TryGet(children, out var got));
         Assert.Same(hint, got);
         Assert.Equal(new[] { 1 }, got!.ChangedIndices);
+    }
+
+    [Fact]
+    public void Hint_Exposes_PreviousChildren_Weakly()
+    {
+        var prev = Cells("a", "b");
+        var hint = new ChildDiffHint(new[] { 0 }, themeSensitiveCount: 0, previousChildren: prev);
+        Assert.True(hint.PreviousChildren.TryGetTarget(out var got));
+        Assert.Same(prev, got);
     }
 
     [Fact]
@@ -51,7 +60,7 @@ public class ChildDiffHintsTests
         // the CWT keys on the fresh-per-render array identity.
         var first = Cells("a", "b");
         var second = Cells("a", "b");
-        ChildDiffHints.Publish(first, new ChildDiffHint(Array.Empty<int>(), 0));
+        ChildDiffHints.Publish(first, new ChildDiffHint(Array.Empty<int>(), 0, Array.Empty<Element>()));
 
         Assert.True(ChildDiffHints.TryGet(first, out _));
         Assert.False(ChildDiffHints.TryGet(second, out _));
@@ -61,8 +70,8 @@ public class ChildDiffHintsTests
     public void Publish_Twice_Overwrites_Prior_Hint()
     {
         var children = Cells("a", "b", "c");
-        ChildDiffHints.Publish(children, new ChildDiffHint(new[] { 0 }, 0));
-        var second = new ChildDiffHint(new[] { 2 }, 0);
+        ChildDiffHints.Publish(children, new ChildDiffHint(new[] { 0 }, 0, Array.Empty<Element>()));
+        var second = new ChildDiffHint(new[] { 2 }, 0, Array.Empty<Element>());
         ChildDiffHints.Publish(children, second);
 
         Assert.True(ChildDiffHints.TryGet(children, out var got));
@@ -75,9 +84,9 @@ public class ChildDiffHintsTests
     [Fact]
     public void AnyThemeSensitive_Tracks_Count()
     {
-        Assert.False(new ChildDiffHint(Array.Empty<int>(), 0).AnyThemeSensitive);
-        Assert.True(new ChildDiffHint(Array.Empty<int>(), 1).AnyThemeSensitive);
-        Assert.True(new ChildDiffHint(Array.Empty<int>(), 5).AnyThemeSensitive);
+        Assert.False(new ChildDiffHint(Array.Empty<int>(), 0, Array.Empty<Element>()).AnyThemeSensitive);
+        Assert.True(new ChildDiffHint(Array.Empty<int>(), 1, Array.Empty<Element>()).AnyThemeSensitive);
+        Assert.True(new ChildDiffHint(Array.Empty<int>(), 5, Array.Empty<Element>()).AnyThemeSensitive);
     }
 
     // ── IsThemeSensitive predicate ───────────────────────────────────

--- a/tests/Reactor.Tests/ChildDiffHintsTests.cs
+++ b/tests/Reactor.Tests/ChildDiffHintsTests.cs
@@ -98,6 +98,15 @@ public class ChildDiffHintsTests
     }
 
     [Fact]
+    public void IsThemeSensitive_False_For_Null_Cell()
+    {
+        // Child arrays may legitimately contain nulls (a builder can return null;
+        // ChildReconciler.Filter drops them downstream). The theme tally must treat
+        // a null as non-theme-sensitive rather than NRE on element.ThemeBindings.
+        Assert.False(ChildDiffHints.IsThemeSensitive(null));
+    }
+
+    [Fact]
     public void IsThemeSensitive_True_For_ThemeBindings()
     {
         var el = new TextBlockElement("themed")

--- a/tests/Reactor.Tests/ChildReconcilerStructuralSkipTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerStructuralSkipTests.cs
@@ -1,0 +1,198 @@
+using System.Collections.Generic;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Xunit;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Consumer-side tests for the PR-C positional structural-skip fast path
+/// (<see cref="ChildReconciler"/>, spec 034 §C). These run headless: cells are
+/// callback-bearing <c>Button</c> elements that are <c>CanSkipUpdate</c>-equal
+/// across renders, so reconciliation only ever takes the cheap skip arm — which
+/// calls <c>children.Get(i)</c> to refresh the callback Tag. A tracking child
+/// collection records exactly which indices are visited, making the difference
+/// between the O(count) full walk and the O(changed) fast path directly
+/// observable without a live WinUI control.
+/// </summary>
+public class ChildReconcilerStructuralSkipTests
+{
+    private static readonly global::System.Action NoOp = () => { };
+
+    /// <summary>
+    /// Records the indices passed to <see cref="IChildCollection.Get"/> (the
+    /// per-visit COM read) plus any structural mutation. Returns <c>null</c> from
+    /// Get — the skip arm's <c>is FrameworkElement</c> guard tolerates it, so no
+    /// live control is needed.
+    /// </summary>
+    private sealed class TrackingChildCollection : IChildCollection
+    {
+        private int _count;
+        public List<int> GetCalls { get; } = new();
+        public List<string> Structural { get; } = new();
+
+        public TrackingChildCollection(int count) => _count = count;
+
+        public int Count => _count;
+        public UIElement Get(int index) { GetCalls.Add(index); return null!; }
+        public void Insert(int index, UIElement element) { Structural.Add($"Insert({index})"); _count++; }
+        public void RemoveAt(int index) { Structural.Add($"RemoveAt({index})"); if (_count > 0) _count--; }
+        public void Move(int oldIndex, int newIndex) => Structural.Add($"Move({oldIndex},{newIndex})");
+        public void Replace(int index, UIElement element) => Structural.Add($"Replace({index})");
+    }
+
+    // Callback-bearing button cells are CanSkipUpdate-equal across renders when
+    // their labels match (OnClick identity is intentionally ignored), so the
+    // reconciler always takes the skip arm.
+    private static Element[] ButtonCells(int n)
+    {
+        var arr = new Element[n];
+        for (int i = 0; i < n; i++)
+            arr[i] = Button($"cell-{i}", NoOp);
+        return arr;
+    }
+
+    private static Element[] FreshCopyWithSameLabels(int n)
+    {
+        // New instances, same labels => ShallowEquals true => skip arm.
+        var arr = new Element[n];
+        for (int i = 0; i < n; i++)
+            arr[i] = Button($"cell-{i}", NoOp);
+        return arr;
+    }
+
+    [Fact]
+    public void NoHint_Full_Walk_Visits_Every_Common_Index()
+    {
+        const int n = 5;
+        var oldChildren = ButtonCells(n);
+        var newChildren = FreshCopyWithSameLabels(n);
+        var coll = new TrackingChildCollection(n);
+        var reconciler = new Reconciler();
+
+        ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp);
+
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, coll.GetCalls);
+        Assert.Empty(coll.Structural);
+        Assert.Equal(n, reconciler.DebugElementsSkipped);
+    }
+
+    [Fact]
+    public void Hint_Fast_Path_Visits_Only_Changed_Indices()
+    {
+        const int n = 6;
+        var oldChildren = ButtonCells(n);
+        var newChildren = FreshCopyWithSameLabels(n);
+        var coll = new TrackingChildCollection(n);
+        var reconciler = new Reconciler();
+
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 1, 4 }, themeSensitiveCount: 0));
+        ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp);
+
+        // Only the changed indices are visited; the untouched range is skipped.
+        Assert.Equal(new[] { 1, 4 }, coll.GetCalls);
+        Assert.Empty(coll.Structural);
+        // The skipped-element diagnostic still accounts for every cell.
+        Assert.Equal(n, reconciler.DebugElementsSkipped);
+    }
+
+    [Fact]
+    public void Hint_And_Full_Walk_Produce_Identical_Skip_Accounting()
+    {
+        const int n = 5;
+        // Full walk (no hint).
+        var collFull = new TrackingChildCollection(n);
+        var rFull = new Reconciler();
+        ChildReconciler.Reconcile(ButtonCells(n), FreshCopyWithSameLabels(n), collFull, rFull, NoOp);
+
+        // Fast path (hint present).
+        var newChildren = FreshCopyWithSameLabels(n);
+        var collFast = new TrackingChildCollection(n);
+        var rFast = new Reconciler();
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 2 }, themeSensitiveCount: 0));
+        ChildReconciler.Reconcile(ButtonCells(n), newChildren, collFast, rFast, NoOp);
+
+        // Both paths skip the same number of elements and mutate nothing.
+        Assert.Equal(rFull.DebugElementsSkipped, rFast.DebugElementsSkipped);
+        Assert.Empty(collFull.Structural);
+        Assert.Empty(collFast.Structural);
+        // The fast path is strictly a subset of the full walk's visits.
+        Assert.Equal(new[] { 2 }, collFast.GetCalls);
+    }
+
+    [Fact]
+    public void ThemeSensitive_Hint_Forces_Full_Walk()
+    {
+        // The consumer reads only hint.AnyThemeSensitive; the cells themselves
+        // are plain so the full walk stays on the safe skip arm. A theme-sensitive
+        // hint must defeat the fast path and visit every index.
+        const int n = 5;
+        var oldChildren = ButtonCells(n);
+        var newChildren = FreshCopyWithSameLabels(n);
+        var coll = new TrackingChildCollection(n);
+        var reconciler = new Reconciler();
+
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 1 }, themeSensitiveCount: 1));
+        ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp);
+
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, coll.GetCalls);
+        Assert.Equal(n, reconciler.DebugElementsSkipped);
+    }
+
+    [Fact]
+    public void Count_Mismatch_Defeats_Fast_Path()
+    {
+        // Live collection count != element count (e.g. an in-flight animation
+        // inflated/deflated it) — gate (2) must fall back to the full walk.
+        const int n = 5;
+        var oldChildren = ButtonCells(n);
+        var newChildren = FreshCopyWithSameLabels(n);
+        var coll = new TrackingChildCollection(n - 1); // mismatched
+        var reconciler = new Reconciler();
+
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 1 }, themeSensitiveCount: 0));
+        ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp);
+
+        // Full walk truncated at the live count; NOT the single hinted index.
+        Assert.Equal(new[] { 0, 1, 2, 3 }, coll.GetCalls);
+    }
+
+    [Fact]
+    public void Out_Of_Range_Hint_Index_Is_Skipped_Safely()
+    {
+        // Defense-in-depth: the producer validates indices before publishing, but
+        // a directly-supplied bad hint must not throw — out-of-range indices are
+        // ignored and the in-range ones still update.
+        const int n = 4;
+        var oldChildren = ButtonCells(n);
+        var newChildren = FreshCopyWithSameLabels(n);
+        var coll = new TrackingChildCollection(n);
+        var reconciler = new Reconciler();
+
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 2, 99 }, themeSensitiveCount: 0));
+        var ex = Record.Exception(() =>
+            ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp));
+
+        Assert.Null(ex);
+        Assert.Equal(new[] { 2 }, coll.GetCalls); // 99 ignored, 2 visited
+        Assert.Empty(coll.Structural);
+    }
+
+    [Fact]
+    public void Empty_Changed_Hint_Skips_Entire_Range()
+    {
+        const int n = 5;
+        var oldChildren = ButtonCells(n);
+        var newChildren = FreshCopyWithSameLabels(n);
+        var coll = new TrackingChildCollection(n);
+        var reconciler = new Reconciler();
+
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(global::System.Array.Empty<int>(), themeSensitiveCount: 0));
+        ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp);
+
+        Assert.Empty(coll.GetCalls);       // nothing visited
+        Assert.Empty(coll.Structural);     // nothing mutated
+        Assert.Equal(n, reconciler.DebugElementsSkipped);
+    }
+}

--- a/tests/Reactor.Tests/ChildReconcilerStructuralSkipTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerStructuralSkipTests.cs
@@ -226,4 +226,63 @@ public class ChildReconcilerStructuralSkipTests
         Assert.Equal(new[] { 0, 1, 2, 3, 4 }, coll.GetCalls);
         Assert.Empty(coll.Structural);
     }
+
+    [Fact]
+    public void Fast_Path_Output_Matches_Full_Walk_With_Reference_Equal_Reuse()
+    {
+        // Differential A/B mirroring the REAL producer: untouched indices REUSE the
+        // previous render's element instances (reference-equal, as
+        // UseMemoCellsByIndex does via children[i] = prevChildren[i]); only the
+        // changed index is a fresh instance. The fast path (hint present) and the
+        // full walk (no hint) must produce identical observable output. This is the
+        // invariant the structural skip relies on — that an untouched cell is
+        // reference-equal old<->new, so skipping its update is provably a no-op.
+        const int n = 5;
+        const int changedIdx = 2;
+
+        static Element[] BuildNewReusing(Element[] prev)
+        {
+            // Reuse prev references everywhere except the one changed index, which is
+            // rebuilt as a fresh (value-equal) instance — exactly the producer's shape.
+            var arr = new Element[prev.Length];
+            for (int i = 0; i < prev.Length; i++)
+                arr[i] = i == changedIdx ? Button($"cell-{i}", NoOp) : prev[i];
+            return arr;
+        }
+
+        // Full walk (no hint).
+        var oldFull = ButtonCells(n);
+        var newFull = BuildNewReusing(oldFull);
+        var collFull = new TrackingChildCollection(n);
+        var rFull = new Reconciler();
+        ChildReconciler.Reconcile(oldFull, newFull, collFull, rFull, NoOp);
+
+        // Fast path (hint present), identical inputs.
+        var oldFast = ButtonCells(n);
+        var newFast = BuildNewReusing(oldFast);
+        var collFast = new TrackingChildCollection(n);
+        var rFast = new Reconciler();
+        ChildDiffHints.Publish(newFast,
+            new ChildDiffHint(new[] { changedIdx }, themeSensitiveCount: 0, previousChildren: oldFast));
+        ChildReconciler.Reconcile(oldFast, newFast, collFast, rFast, NoOp);
+
+        // The reference-equality invariant the fast path trusts actually holds here.
+        for (int i = 0; i < n; i++)
+            if (i != changedIdx)
+                Assert.Same(oldFast[i], newFast[i]);
+
+        // Identical observable output: same total skip accounting, no structural
+        // mutation on either path.
+        Assert.Equal(rFull.DebugElementsSkipped, rFast.DebugElementsSkipped);
+        Assert.Equal(n, rFull.DebugElementsSkipped);
+        Assert.Empty(collFull.Structural);
+        Assert.Empty(collFast.Structural);
+
+        // The full walk visits every common index; the fast path visits only the
+        // changed one and skips the reference-equal remainder wholesale. Because the
+        // skipped cells are reference-equal, the full walk's per-cell work on them
+        // (the callback Tag refresh) is a provable no-op, so the two paths converge.
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, collFull.GetCalls);
+        Assert.Equal(new[] { changedIdx }, collFast.GetCalls);
+    }
 }

--- a/tests/Reactor.Tests/ChildReconcilerStructuralSkipTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerStructuralSkipTests.cs
@@ -178,6 +178,13 @@ public class ChildReconcilerStructuralSkipTests
         Assert.Null(ex);
         Assert.Equal(new[] { 2 }, coll.GetCalls); // 99 ignored, 2 visited
         Assert.Empty(coll.Structural);
+        // All 4 in-range elements end up skipped (nothing mutated): indices 0,1,3
+        // via the structural skip + index 2 via CanSkipUpdate (its fresh copy is
+        // value-equal). The fix bases the structural part on indices ACTUALLY
+        // visited — common(4) - visited(1) = 3 — so the total (3 + 1) matches the
+        // full walk. The old `common - changed.Length` = 2 undercounted the
+        // untouched range (and with more out-of-range indices could go negative).
+        Assert.Equal(4, reconciler.DebugElementsSkipped);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/ChildReconcilerStructuralSkipTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerStructuralSkipTests.cs
@@ -285,4 +285,121 @@ public class ChildReconcilerStructuralSkipTests
         Assert.Equal(new[] { 0, 1, 2, 3, 4 }, collFull.GetCalls);
         Assert.Equal(new[] { changedIdx }, collFast.GetCalls);
     }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  Allocation-budget teeth for the structural-skip win (spec 034 §C, #699).
+    //
+    //  The behavioural tests above pin the VISIT COUNT (which indices the fast
+    //  path reads). This pins the SAME elision as a GC-bytes budget — the shape
+    //  the #692 / #665 regression guards use — so the measured StocksGrid
+    //  allocation win cannot be silently reverted with the visit-count tests
+    //  still green.
+    //
+    //  What the win is: for every UNTOUCHED cell the full positional walk issues
+    //  a children.Get(i) read — a COM IVector.GetAt round-trip that marshals /
+    //  projects a wrapper per call on a live control. The structural skip elides
+    //  that read for the reference-equal untouched range. Headless there is no
+    //  XAML core, so the real COM/marshaling cost cannot be incurred (Get returns
+    //  null and allocates nothing). To make the elision measurable as managed
+    //  bytes, the measuring collection below charges a fixed allocation per read,
+    //  modeling the per-cell marshaling the skip avoids. The fast path then
+    //  allocates O(changed); the full walk O(count); a reverted skip makes the
+    //  hinted path walk every cell too, collapsing the two and failing the budget.
+
+    /// <summary>
+    /// An <see cref="IChildCollection"/> that charges a fixed managed allocation
+    /// per <see cref="Get"/>, modeling the per-cell COM read / marshaling the
+    /// structural skip elides for untouched cells (unmeasurable headless, where
+    /// no live control exists). Returns null so no WinUI control is needed — the
+    /// skip arm's <c>is FrameworkElement</c> guard tolerates it.
+    /// </summary>
+    private sealed class MeasuringChildCollection : IChildCollection
+    {
+        private readonly int _count;
+        // Public field so the per-read allocation provably escapes: the JIT may
+        // not elide a heap write to a reachable field, so each read is counted by
+        // GetAllocatedBytesForCurrentThread.
+        public object? LastRead;
+        public int Reads { get; private set; }
+
+        public MeasuringChildCollection(int count) => _count = count;
+
+        public int Count => _count;
+        public UIElement Get(int index)
+        {
+            Reads++;
+            LastRead = new byte[48]; // models the elided per-cell COM read / marshaling
+            return null!;
+        }
+        public void Insert(int index, UIElement element) { }
+        public void RemoveAt(int index) { }
+        public void Move(int oldIndex, int newIndex) { }
+        public void Replace(int index, UIElement element) { }
+    }
+
+    [Fact]
+    public void Structural_Skip_Pins_PerCell_Read_Elision_As_Allocation_Budget()
+    {
+        const int n = 500;            // StocksGrid cell count
+        const int changedCount = 5;   // steady-state moderate churn
+        const int warmup = 200;
+        const int iterations = 1_000;
+
+        // Steady-state producer shape: the new array REUSES the previous render's
+        // element instances at untouched indices (reference-equal) and a fresh
+        // value-equal copy at each changed index — exactly UseMemoCellsByIndex.
+        int[] changedIdx = new int[changedCount];
+        for (int k = 0; k < changedCount; k++)
+            changedIdx[k] = (k + 1) * (n / (changedCount + 1));
+
+        var oldFast = ButtonCells(n);
+        var newFast = (Element[])oldFast.Clone();
+        foreach (int idx in changedIdx)
+            newFast[idx] = Button($"cell-{idx}", NoOp); // fresh, value-equal copy
+        ChildDiffHints.Publish(newFast,
+            new ChildDiffHint(changedIdx, themeSensitiveCount: 0, previousChildren: oldFast));
+
+        // FAST PATH — hint present, so the positional walk visits only changedIdx.
+        var fastColl = new MeasuringChildCollection(n);
+        var rFast = new Reconciler();
+        for (int i = 0; i < warmup; i++)
+            ChildReconciler.Reconcile(oldFast, newFast, fastColl, rFast, NoOp);
+        long fb = global::System.GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iterations; i++)
+            ChildReconciler.Reconcile(oldFast, newFast, fastColl, rFast, NoOp);
+        long fastAlloc = global::System.GC.GetAllocatedBytesForCurrentThread() - fb;
+        int fastReadsPerIter = fastColl.Reads / (warmup + iterations);
+
+        // FULL WALK — identical inputs but NO published hint, so the fast path
+        // cannot engage and every common index is read.
+        var oldFull = ButtonCells(n);
+        var newFull = (Element[])oldFull.Clone();
+        foreach (int idx in changedIdx)
+            newFull[idx] = Button($"cell-{idx}", NoOp);
+        // (deliberately no ChildDiffHints.Publish for newFull — defeats the skip)
+        var fullColl = new MeasuringChildCollection(n);
+        var rFull = new Reconciler();
+        for (int i = 0; i < warmup; i++)
+            ChildReconciler.Reconcile(oldFull, newFull, fullColl, rFull, NoOp);
+        long ub = global::System.GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iterations; i++)
+            ChildReconciler.Reconcile(oldFull, newFull, fullColl, rFull, NoOp);
+        long fullAlloc = global::System.GC.GetAllocatedBytesForCurrentThread() - ub;
+        int fullReadsPerIter = fullColl.Reads / (warmup + iterations);
+
+        // Mechanism: the fast path reads ONLY the changed cells; the full walk
+        // reads EVERY cell. This read-elision is exactly what the budget pins.
+        Assert.Equal(changedCount, fastReadsPerIter);
+        Assert.Equal(n, fullReadsPerIter);
+
+        // Budget: the full walk allocates ~n/changedCount× (≈100×) the fast path.
+        // Require a wide ≥8× margin — robust to measurement noise, yet the test
+        // FAILS if the structural skip is disabled/reverted, because the hinted
+        // path then walks every cell too and fastAlloc collapses onto fullAlloc.
+        Assert.True(fullAlloc > fastAlloc * 8,
+            $"Structural skip no longer cuts the per-cell read allocation: " +
+            $"fast={fastAlloc}B ({fastReadsPerIter} reads/iter), " +
+            $"full={fullAlloc}B ({fullReadsPerIter} reads/iter) over {iterations} iters. " +
+            $"Expected full > 8x fast; a reverted skip makes them equal.");
+    }
 }

--- a/tests/Reactor.Tests/ChildReconcilerStructuralSkipTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerStructuralSkipTests.cs
@@ -87,7 +87,7 @@ public class ChildReconcilerStructuralSkipTests
         var coll = new TrackingChildCollection(n);
         var reconciler = new Reconciler();
 
-        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 1, 4 }, themeSensitiveCount: 0));
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 1, 4 }, themeSensitiveCount: 0, previousChildren: oldChildren));
         ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp);
 
         // Only the changed indices are visited; the untouched range is skipped.
@@ -107,11 +107,12 @@ public class ChildReconcilerStructuralSkipTests
         ChildReconciler.Reconcile(ButtonCells(n), FreshCopyWithSameLabels(n), collFull, rFull, NoOp);
 
         // Fast path (hint present).
+        var oldFast = ButtonCells(n);
         var newChildren = FreshCopyWithSameLabels(n);
         var collFast = new TrackingChildCollection(n);
         var rFast = new Reconciler();
-        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 2 }, themeSensitiveCount: 0));
-        ChildReconciler.Reconcile(ButtonCells(n), newChildren, collFast, rFast, NoOp);
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 2 }, themeSensitiveCount: 0, previousChildren: oldFast));
+        ChildReconciler.Reconcile(oldFast, newChildren, collFast, rFast, NoOp);
 
         // Both paths skip the same number of elements and mutate nothing.
         Assert.Equal(rFull.DebugElementsSkipped, rFast.DebugElementsSkipped);
@@ -133,7 +134,7 @@ public class ChildReconcilerStructuralSkipTests
         var coll = new TrackingChildCollection(n);
         var reconciler = new Reconciler();
 
-        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 1 }, themeSensitiveCount: 1));
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 1 }, themeSensitiveCount: 1, previousChildren: oldChildren));
         ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp);
 
         Assert.Equal(new[] { 0, 1, 2, 3, 4 }, coll.GetCalls);
@@ -151,7 +152,7 @@ public class ChildReconcilerStructuralSkipTests
         var coll = new TrackingChildCollection(n - 1); // mismatched
         var reconciler = new Reconciler();
 
-        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 1 }, themeSensitiveCount: 0));
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 1 }, themeSensitiveCount: 0, previousChildren: oldChildren));
         ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp);
 
         // Full walk truncated at the live count; NOT the single hinted index.
@@ -170,7 +171,7 @@ public class ChildReconcilerStructuralSkipTests
         var coll = new TrackingChildCollection(n);
         var reconciler = new Reconciler();
 
-        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 2, 99 }, themeSensitiveCount: 0));
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(new[] { 2, 99 }, themeSensitiveCount: 0, previousChildren: oldChildren));
         var ex = Record.Exception(() =>
             ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp));
 
@@ -188,11 +189,34 @@ public class ChildReconcilerStructuralSkipTests
         var coll = new TrackingChildCollection(n);
         var reconciler = new Reconciler();
 
-        ChildDiffHints.Publish(newChildren, new ChildDiffHint(global::System.Array.Empty<int>(), themeSensitiveCount: 0));
+        ChildDiffHints.Publish(newChildren, new ChildDiffHint(global::System.Array.Empty<int>(), themeSensitiveCount: 0, previousChildren: oldChildren));
         ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp);
 
         Assert.Empty(coll.GetCalls);       // nothing visited
         Assert.Empty(coll.Structural);     // nothing mutated
         Assert.Equal(n, reconciler.DebugElementsSkipped);
+    }
+
+    [Fact]
+    public void Stale_Old_Array_Defeats_Fast_Path()
+    {
+        // The hint's ChangedIndices were diffed against a SPECIFIC prior array.
+        // If the reconciler's old array is a different instance (e.g. an upstream
+        // defensive copy), the indices can't be trusted, so the fast path must
+        // fall back to the full walk rather than skip a possibly-stale cell.
+        const int n = 5;
+        var oldChildren = ButtonCells(n);
+        var unrelatedPrev = ButtonCells(n); // NOT the array passed to Reconcile
+        var newChildren = FreshCopyWithSameLabels(n);
+        var coll = new TrackingChildCollection(n);
+        var reconciler = new Reconciler();
+
+        ChildDiffHints.Publish(newChildren,
+            new ChildDiffHint(new[] { 1 }, themeSensitiveCount: 0, previousChildren: unrelatedPrev));
+        ChildReconciler.Reconcile(oldChildren, newChildren, coll, reconciler, NoOp);
+
+        // Old-array identity mismatch => full walk visits every common index.
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, coll.GetCalls);
+        Assert.Empty(coll.Structural);
     }
 }

--- a/tests/Reactor.Tests/UseMemoCellsTests.cs
+++ b/tests/Reactor.Tests/UseMemoCellsTests.cs
@@ -460,5 +460,71 @@ public class UseMemoCellsTests
         Assert.Equal(1, h3!.ThemeSensitiveCount);
         Assert.True(h3.AnyThemeSensitive);
     }
+
+    [Fact]
+    public void ByIndex_Incremental_ThemeCount_Carries_Across_Chained_Reuse()
+    {
+        var ctx = NewCtx();
+        Func<int, int, Element> themed = (item, i) => MakeThemedCell(item);
+        // R1/R2: [themed, themed, themed] -> count 3.
+        ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), themed);
+        ctx.BeginRender(() => { });
+        var r2 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), themed);
+        Assert.True(ChildDiffHints.TryGet(r2, out var h2));
+        Assert.Equal(3, h2!.ThemeSensitiveCount);
+        // R3 consumes h2: idx 0 themed -> plain. 3 -> 2.
+        ctx.BeginRender(() => { });
+        var r3 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, new[] { 0 }, (item, i) => MakeCell(item));
+        Assert.True(ChildDiffHints.TryGet(r3, out var h3));
+        Assert.Equal(2, h3!.ThemeSensitiveCount);
+        // R4 consumes h3: idx 1 themed -> plain. 2 -> 1.
+        ctx.BeginRender(() => { });
+        var r4 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, new[] { 1 }, (item, i) => MakeCell(item));
+        Assert.True(ChildDiffHints.TryGet(r4, out var h4));
+        Assert.Equal(1, h4!.ThemeSensitiveCount);
+        // R5 consumes h4: idx 1 plain -> themed again. 1 -> 2.
+        ctx.BeginRender(() => { });
+        var r5 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, new[] { 1 },
+            (item, i) => i == 1 ? MakeThemedCell(item) : MakeCell(item));
+        Assert.True(ChildDiffHints.TryGet(r5, out var h5));
+        Assert.Equal(2, h5!.ThemeSensitiveCount);
+    }
+
+    [Fact]
+    public void ByIndex_Duplicate_Changed_Index_Does_Not_Falsely_Clear_ThemeSensitive()
+    {
+        var ctx = NewCtx();
+        // R1/R2: [themed, themed] -> reused count 2.
+        Func<int, int, Element> themed = (item, i) => MakeThemedCell(item);
+        ctx.UseMemoCellsByIndex<int>(new[] { 1, 2 }, Array.Empty<int>(), themed);
+        ctx.BeginRender(() => { });
+        var r2 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2 }, Array.Empty<int>(), themed);
+        Assert.True(ChildDiffHints.TryGet(r2, out var h2));
+        Assert.Equal(2, h2!.ThemeSensitiveCount);
+
+        // R3: change index 0 themed -> plain, listed TWICE (caller-contract
+        // violation). Without dedup the incremental tally goes 2 -> 1 -> 0 and
+        // publishes AnyThemeSensitive=false while cell 1 is still themed — the
+        // reconciler would then unsafely structural-skip a theme-sensitive cell on
+        // a theme flip. Dedup keeps the count exact and the safety flag honest.
+        ctx.BeginRender(() => { });
+        var r3 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2 }, new[] { 0, 0 }, (item, i) => MakeCell(item));
+        Assert.True(ChildDiffHints.TryGet(r3, out var h3));
+        Assert.Equal(1, h3!.ThemeSensitiveCount);   // cell 1 still themed
+        Assert.True(h3.AnyThemeSensitive);          // MUST stay true — the safety bit
+        Assert.Equal(new[] { 0 }, h3.ChangedIndices); // published indices are deduped
+    }
+
+    [Fact]
+    public void ByIndex_Duplicate_Changed_Index_Builds_Cell_Once()
+    {
+        var ctx = NewCtx();
+        ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), (item, i) => MakeCell(item));
+        ctx.BeginRender(() => { });
+        int builds = 0;
+        ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, new[] { 1, 1, 1 },
+            (item, i) => { builds++; return MakeCell(item); });
+        Assert.Equal(1, builds); // deduped: index 1 rebuilt once, not three times
+    }
 }
 

--- a/tests/Reactor.Tests/UseMemoCellsTests.cs
+++ b/tests/Reactor.Tests/UseMemoCellsTests.cs
@@ -526,5 +526,31 @@ public class UseMemoCellsTests
             (item, i) => { builds++; return MakeCell(item); });
         Assert.Equal(1, builds); // deduped: index 1 rebuilt once, not three times
     }
+
+    [Fact]
+    public void ByIndex_Null_Cell_Does_Not_Throw_Theme_Scan()
+    {
+        var ctx = NewCtx();
+        // A builder may legitimately return null (ChildReconciler.Filter drops nulls
+        // downstream). PR-C's theme tally inspects prev/built cells, so it MUST treat
+        // a null as non-theme-sensitive rather than NRE on element.ThemeBindings.
+        Func<int, int, Element> withNull = (item, i) => i == 1 ? null! : MakeCell(item);
+        ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), withNull);
+
+        // First reuse: TryGet(prev) misses (first render publishes no hint), so the
+        // O(count) CountThemeSensitive scans the prior array — which holds a null.
+        ctx.BeginRender(() => { });
+        var r2 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), withNull);
+        Assert.True(ChildDiffHints.TryGet(r2, out var h2));
+        Assert.Equal(0, h2!.ThemeSensitiveCount);
+        Assert.Null(r2[1]); // null cell preserved through reuse
+
+        // Change the null cell -> themed: the incremental tally reads prev[1] (null,
+        // not sensitive -> no decrement) and built (themed -> increment).
+        ctx.BeginRender(() => { });
+        var r3 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, new[] { 1 }, (item, i) => MakeThemedCell(item));
+        Assert.True(ChildDiffHints.TryGet(r3, out var h3));
+        Assert.Equal(1, h3!.ThemeSensitiveCount);
+    }
 }
 

--- a/tests/Reactor.Tests/UseMemoCellsTests.cs
+++ b/tests/Reactor.Tests/UseMemoCellsTests.cs
@@ -335,4 +335,130 @@ public class UseMemoCellsTests
         Assert.Throws<ArgumentNullException>(() =>
             ctx.UseMemoCellsByIndex<int>(new[] { 1 }, null!, (item, i) => MakeCell(item)));
     }
+
+    // ════════════════════════════════════════════════════════════════
+    //  UseMemoCellsByIndex — PR-C ChildDiffHint publication (spec 034 §C)
+    // ════════════════════════════════════════════════════════════════
+
+    private static Element MakeThemedCell(int v)
+        => new DivElement(Array.Empty<Element>(), $"v={v}")
+        {
+            ThemeBindings = new Dictionary<string, ThemeRef> { ["Foreground"] = new ThemeRef("SystemAccentColor") },
+        };
+
+    [Fact]
+    public void ByIndex_First_Render_Publishes_No_Hint()
+    {
+        // The rebuild-all branch does NOT publish: the fresh array is unrelated by
+        // reference to any prior render, so a structural-skip hint would be unsound.
+        var ctx = NewCtx();
+        var first = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), (item, i) => MakeCell(item));
+        Assert.False(ChildDiffHints.TryGet(first, out _));
+    }
+
+    [Fact]
+    public void ByIndex_Count_Change_Publishes_No_Hint()
+    {
+        var ctx = NewCtx();
+        ctx.UseMemoCellsByIndex<int>(new[] { 1, 2 }, Array.Empty<int>(), (item, i) => MakeCell(item));
+        ctx.BeginRender(() => { });
+        var grown = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), (item, i) => MakeCell(item));
+        Assert.False(ChildDiffHints.TryGet(grown, out _));
+    }
+
+    [Fact]
+    public void ByIndex_Reuse_Publishes_Hint_With_ChangedIndices()
+    {
+        var ctx = NewCtx();
+        ctx.UseMemoCellsByIndex<int>(new[] { 10, 20, 30 }, Array.Empty<int>(), (item, i) => MakeCell(item));
+        ctx.BeginRender(() => { });
+        var second = ctx.UseMemoCellsByIndex<int>(new[] { 10, 99, 30 }, new[] { 1 }, (item, i) => MakeCell(item));
+
+        Assert.True(ChildDiffHints.TryGet(second, out var hint));
+        Assert.Equal(new[] { 1 }, hint!.ChangedIndices);
+        Assert.False(hint.AnyThemeSensitive);
+    }
+
+    [Fact]
+    public void ByIndex_Reuse_Empty_Changes_Publishes_Empty_Hint()
+    {
+        var ctx = NewCtx();
+        var items = new[] { 10, 20, 30 };
+        ctx.UseMemoCellsByIndex<int>(items, Array.Empty<int>(), (item, i) => MakeCell(item));
+        ctx.BeginRender(() => { });
+        var second = ctx.UseMemoCellsByIndex<int>(items, Array.Empty<int>(), (item, i) => MakeCell(item));
+
+        Assert.True(ChildDiffHints.TryGet(second, out var hint));
+        Assert.Empty(hint!.ChangedIndices);
+    }
+
+    [Fact]
+    public void ByIndex_ChangedIndices_Are_Snapshotted_Against_Caller_Mutation()
+    {
+        var ctx = NewCtx();
+        ctx.UseMemoCellsByIndex<int>(new[] { 10, 20, 30 }, Array.Empty<int>(), (item, i) => MakeCell(item));
+        ctx.BeginRender(() => { });
+        var changed = new[] { 1 };
+        var second = ctx.UseMemoCellsByIndex<int>(new[] { 10, 99, 30 }, changed, (item, i) => MakeCell(item));
+
+        changed[0] = 2; // caller mutates after the call — hint must be unaffected
+
+        Assert.True(ChildDiffHints.TryGet(second, out var hint));
+        Assert.Equal(new[] { 1 }, hint!.ChangedIndices);
+    }
+
+    [Fact]
+    public void ByIndex_Reuse_Hint_Counts_ThemeSensitive_Cells()
+    {
+        var ctx = NewCtx();
+        // Cells 0 and 2 themed, cell 1 plain.
+        Func<int, int, Element> build = (item, i) => i == 1 ? MakeCell(item) : MakeThemedCell(item);
+        var items = new[] { 10, 20, 30 };
+        ctx.UseMemoCellsByIndex<int>(items, Array.Empty<int>(), build);
+        ctx.BeginRender(() => { });
+        var second = ctx.UseMemoCellsByIndex<int>(items, Array.Empty<int>(), build);
+
+        Assert.True(ChildDiffHints.TryGet(second, out var hint));
+        Assert.True(hint!.AnyThemeSensitive);
+        Assert.Equal(2, hint.ThemeSensitiveCount);
+    }
+
+    [Fact]
+    public void ByIndex_Incremental_ThemeCount_Decrements_When_Cell_Becomes_Plain()
+    {
+        var ctx = NewCtx();
+        // R1 (rebuild-all): [themed, themed, plain] — no hint yet.
+        Func<int, int, Element> r1 = (item, i) => i == 2 ? MakeCell(item) : MakeThemedCell(item);
+        ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), r1);
+        // R2 (reuse, no change): counts prev = 2, publishes hint count 2.
+        ctx.BeginRender(() => { });
+        var r2 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), r1);
+        Assert.True(ChildDiffHints.TryGet(r2, out var h2));
+        Assert.Equal(2, h2!.ThemeSensitiveCount);
+        // R3 (reuse, change idx 0 -> plain): incremental from prior hint, 2 -> 1.
+        ctx.BeginRender(() => { });
+        var r3 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, new[] { 0 }, (item, i) => MakeCell(item));
+        Assert.True(ChildDiffHints.TryGet(r3, out var h3));
+        Assert.Equal(1, h3!.ThemeSensitiveCount);
+    }
+
+    [Fact]
+    public void ByIndex_Incremental_ThemeCount_Increments_When_Cell_Becomes_Themed()
+    {
+        var ctx = NewCtx();
+        // R1: all plain.
+        ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), (item, i) => MakeCell(item));
+        // R2 (reuse, no change): count 0.
+        ctx.BeginRender(() => { });
+        var r2 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, Array.Empty<int>(), (item, i) => MakeCell(item));
+        Assert.True(ChildDiffHints.TryGet(r2, out var h2));
+        Assert.Equal(0, h2!.ThemeSensitiveCount);
+        // R3 (reuse, change idx 1 -> themed): 0 -> 1.
+        ctx.BeginRender(() => { });
+        var r3 = ctx.UseMemoCellsByIndex<int>(new[] { 1, 2, 3 }, new[] { 1 }, (item, i) => MakeThemedCell(item));
+        Assert.True(ChildDiffHints.TryGet(r3, out var h3));
+        Assert.Equal(1, h3!.ThemeSensitiveCount);
+        Assert.True(h3.AnyThemeSensitive);
+    }
 }
+


### PR DESCRIPTION
## What

Makes `ChildReconciler.ReconcilePositional` **O(changed) instead of O(count)** when a memoizing producer (`UseMemoCellsByIndex`) reuses untouched cells reference-equal. This attacks the positional **skip-walk floor** — the per-render O(count) cost of visiting every cell just to confirm it can be skipped — which dominates **low-mutation** renders of large keyed grids (e.g. StocksGrid).

This is **P4** of the reconciler perf workstream. P1 (#692, self-merge alloc guard) and P3 (#695, automation early-out) are the per-changed-cell levers; **P4 is the different, larger lever for low-mutation renders** (the all-skip floor).

## Mechanism — CWT side-channel hint (mirrors #681's `_dirtyAncestorPath` bridge)

- **Producer** — the `UseMemoCellsByIndex` reuse branch publishes a `ChildDiffHint` (`ChangedIndices` + `ThemeSensitiveCount`) keyed **by reference** on the fresh-per-render `Element[]`. No `Element`-record widening; AOT-safe (`ConditionalWeakTable`, no reflection). The theme count is carried forward **incrementally** so steady-state reuse stays O(changed); a one-time O(count) scan runs only on the first reuse after a full rebuild and as a defensive recompute.
- **Consumer** — `ReconcilePositional` engages a fast path that updates **only** the hinted changed indices and skips the rest, iff **all six gates** hold:
  1. old/new element counts match;
  2. the live child collection equals that count (no in-flight animation inflated it);
  3. no animation ambient (insert/move/exit reshape the child list);
  4. a hint is present for **this** array — a CWT hit also proves `Filter` returned the same reference (no `null`/`EmptyElement` shifted the index space), so the hint's indices line up with both filtered arrays;
  5. **no cell is theme-sensitive** (`!hint.AnyThemeSensitive`) — the load-bearing safety gate;
  6. the container is **not** on #681's dirty-ancestor path — else a self-triggered descendant (e.g. a stateful memoized cell) would be unreachable through a structural skip and must take the full walk.

## Correctness

- Untouched indices are reference-equal **by construction**: the hook reuses `prevChildren[i]` for unchanged `i` and rebuilds only `changedIndices`. The fast path and the full walk share a single **`UpdateCommonChild`** helper, so both honour identical skip / update / type-mismatch semantics — the fast path does not re-implement the per-index body.
- **Theme gate is the load-bearing property.** The *only* work the full walk does for an untouched cell that a structural skip would drop is re-resolving `ApplyThemeBindings` / `ApplyResourceOverrides` ThemeRefs against the effective theme (which a parent `RequestedTheme` toggle can change **without touching the element tree**). Gating on the whole-array `AnyThemeSensitive` flag is provably safe and sidesteps the subtle dirty-path reasoning that bit P2.

## Tests

**Headless (`Reactor.Tests`)**
- `UseMemoCellsTests` (+8) — producer hint correctness incl. first-render-no-hint, count-change-no-hint, empty-changes, **incremental theme-count carry** (decrement/increment), and **caller-mutation snapshot**.
- `ChildDiffHintsTests` (+9) — registry publish/get, reference-keying, overwrite, `AnyThemeSensitive` tracking, `IsThemeSensitive` for plain / `ThemeBindings` / `ResourceOverrides.ThemeRefs` / literals-only.
- `ChildReconcilerStructuralSkipTests` (+7) — consumer differential vs full walk, incl. the **gate teeth** `ThemeSensitive_Hint_Forces_Full_Walk` (revert gate 5 → it fails), count-mismatch defeat, defensive out-of-range index, empty-changed.

**Live selftests (`Reactor.AppTests.Host`)**
- `StructuralSkip_LifecycleParity` — an `OnUpdateAction` cell at a changed index **and** untouched ref-equal indices: fires for the changed cell, never for untouched — identical to the full walk.
- `StructuralSkip_ThemeRangeParity` — a themed ref-equal range under a `RequestedTheme` toggle renders + re-themes, no cell dropped.

### Empirical theme-teeth note (important)
A **live color-delta teeth** for the theme gate is genuinely **impossible**: WinUI auto-re-resolves a `{ThemeResource}` Style setter on any effective-theme change **even when Reactor structurally skips the cell** (verified — gate reverted → cells skipped, `ApplyThemeBindings` not re-run, yet brushes still went Light→Dark). The one snapshot a skip truly leaves stale (`ApplyResourceOverrides`' concrete `ThemeRef.Resolve` into `fe.Resources`) does not reliably re-resolve in the reconcile harness. So the **headless** `ThemeSensitive_Hint_Forces_Full_Walk` is the gate's authoritative teeth; the live fixture is the end-to-end parity companion. This *strengthens* the safety story — a skipped themed cell's brush updates anyway.

## Measurement

The win shows under the **low-mutation skip-floor metric** (`--percent 0`) added to `/perf` by #693/the skip-floor column — which is now on `main`, so this PR is measurable. On the default **50%-mutation** StocksGrid the effect is within noise (most cells change → little to skip), which is expected and fine data.

## File-disjointness

Disjoint from the perf fleet: #692/#695 own `Reconciler.Update.cs`; this PR touches `ChildReconciler.cs` / new `ChildDiffHints.cs` / `UseMemoCells.cs` + a small `parentControl` thread-through in `Reconciler.cs` (lines ~1916–1947) and `V1HandlerAdapter.cs` — both far from the automation region.

## Gate status

DRAFT, **held for merge** (reactor-perf class — reviewed by the user with `/perf` numbers). Full `Reactor.Tests` green (9726), core lib AOT-clean (warnings-as-errors), headless gate teeth verified biting.

🔒 Do not merge until the user GOes with measured deltas.