### PR TITLE
perf(ci): rep-level micro interleaving + dormant ns flag mechanism

### DIFF
--- a/tests/stress_perf/METHODOLOGY.md
+++ b/tests/stress_perf/METHODOLOGY.md
@@ -289,19 +289,27 @@ their own `src/Reactor` — and reports a per-bench `main`-vs-PR table; see
 [`ci/README.md`](ci/README.md#reconciler-micro-benchmarks-ns-resolution-winui-undiluted).
 The two metrics are read differently. **Allocated bytes/op is deterministic** for
 identical code — an unchanged diff reproduces the byte count exactly — so its paired
-95% CI is trustworthy and **drives each row's flag**. **ns/op is informational only**
-in v1: the two per-side runs are not yet rep-interleaved, so a systematic
-process-to-process timing offset (thermal/scheduling drift between the back-to-back
-invocations) shifts every paired ns difference the same way and makes the paired CI
-exclude 0 even for an identical binary. Local validation confirmed it — running the
-**same** ControlModel binary as both sides, alloc was deterministic (14/16 benches
-exactly 0.0% Δ) while ns spuriously flagged up to −14.8% on a no-op. So ns is shown
-for context but excluded from the flag, and **rep-level interleaving of the two sides
-is the documented fast-follow** that would promote ns to a flagged signal.
+95% CI is trustworthy and **drives each row's flag**. **ns/op is rep-interleaved but
+not auto-flagged by default.** The two per-side runs are interleaved at the **rep
+level** — each rep alternates a fresh `main` then PR process — so the
+process-to-process timing offset (thermal/scheduling drift) that a single back-to-back
+pair of invocations leaves as a *constant* bias is instead randomized round-to-round
+into the paired variance, making the ns paired CI unbiased. This matters because
+before interleaving that offset shifted every paired ns difference the same way and
+made the paired CI exclude 0 even for an identical binary: running the **same**
+ControlModel binary as both sides, alloc was deterministic (14/16 benches exactly
+0.0% Δ) while ns spuriously flagged up to −14.8% on a no-op. Even interleaved, ns
+carries residual cold-JIT / scheduling jitter, so promoting it to a flag is gated
+behind a minimum-effect band **and** a master switch (`$MicroNsAutoFlag`) that stays
+**dormant** pending a real-CI identical-binary calibration of that band — which can
+only run once the interleave is on `main`, since `/perf` builds the harness from the
+default branch. Arming the switch is a measurement-only follow-up — it changes verdict
+labels, never what merges. While dormant the row flag tracks allocated bytes/op (v1
+behaviour).
 
 It is the **authoritative instrument** for per-reconcile allocation deltas (and,
-once interleaved, reconcile-time deltas); the macro tables remain the user-facing
-throughput sanity check.
+once the ns flag is armed, reconcile-time deltas); the macro tables remain the
+user-facing throughput sanity check.
 
 ## Don'ts (so we don't redo this analysis)
 

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -712,6 +712,11 @@ try {
         Assert-Equal 'better' (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'na')     'armed: alloc na -> ns drives (differs from dormant na)'
         Assert-Equal 'na'     (Get-PerfMicroRowStatus -NsStatus 'na'     -AllocStatus 'na')     'armed: both na -> na'
         Assert-Equal 'noise'  (Get-PerfMicroRowStatus -NsStatus 'noise'  -AllocStatus 'na')     'armed: ns noise + alloc na -> noise'
+        Assert-Equal 'worse'  (Get-PerfMicroRowStatus -NsStatus 'worse'  -AllocStatus 'na')     'armed: ns worse + alloc na -> worse (ns drives)'
+        Assert-Equal 'better' (Get-PerfMicroRowStatus -NsStatus 'noise'  -AllocStatus 'better') 'armed: ns noise + alloc better -> better'
+        Assert-Equal 'worse'  (Get-PerfMicroRowStatus -NsStatus 'noise'  -AllocStatus 'worse')  'armed: ns noise + alloc worse -> worse'
+        Assert-Equal 'noise'  (Get-PerfMicroRowStatus -NsStatus 'na'     -AllocStatus 'noise')  'armed: ns na + alloc noise -> noise'
+        Assert-Equal 'worse'  (Get-PerfMicroRowStatus -NsStatus 'na'     -AllocStatus 'worse')  'armed: ns na + alloc worse -> worse'
 
         # 'mixed' glyph renders.
         Assert-Equal "$([char]0x2195)$([char]0xFE0F) mixed" (Get-PerfStatusGlyph 'mixed') 'mixed -> up-down arrow glyph'
@@ -773,6 +778,9 @@ try {
     } finally {
         $script:MicroNsAutoFlag = $prevNsFlag
     }
+    # The armed block restored the flag to its dormant default, so the remaining tests
+    # (and production) see v1 alloc-only behaviour — no flag leak across tests.
+    Assert-True (-not $script:MicroNsAutoFlag) 'armed block reset MicroNsAutoFlag to dormant (no leak into later tests)'
 
     # Rep-aligned pairing + consistent medians. Two benches, each with rep1 dropped
     # on the PR side:
@@ -914,11 +922,32 @@ try {
     Assert-Match $sectionText '95% CI'                           'section delta cells carry a CI'
     # numeric sort survives into the rendered table (M2 row appears before M10 row).
     Assert-True (($sectionText.IndexOf('`M2`')) -lt ($sectionText.IndexOf('`M10`'))) 'rendered rows keep numeric order'
+    # Dormant (default) section prose: alloc drives the verdict, ns is context-only.
+    Assert-Match $sectionText 'Status tracks allocated bytes/op' 'dormant section: status tracks alloc bytes/op'
+    Assert-Match $sectionText 'not auto-flagged'                 'dormant section: ns is shown for context, not flagged'
+    Assert-True (-not $sectionText.Contains('Status combines ns/op')) 'dormant section: does NOT claim ns is combined'
 
     # Format-PerfComment threads -Micro through into the comment.
     $microComment = Format-PerfComment -Main $allocMain -Pr $allocPr -WinUI3 $null -Rust $null -Micro $cmp -Context $ctx
     Assert-Match $microComment 'Reconciler micro-benchmarks'     'comment includes micro section when -Micro supplied'
     Assert-Match $microComment 'WinUI-undiluted'                 'comment carries the micro footnote'
+    Assert-Match $microComment 'flag stays dormant pending a real-CI identical-binary band calibration' 'dormant footnote: ns flag dormant pending calibration'
+
+    # Armed render: flip the master switch and confirm the section prose + footnote switch
+    # to the combined-axis wording (and back). Arming is measurement-only, so this just
+    # proves the render contract for when the flag is eventually armed post-calibration.
+    $prevFlagRender = $script:MicroNsAutoFlag
+    $script:MicroNsAutoFlag = $true
+    try {
+        $armedSection = (Format-PerfMicroSection -Micro $cmp) -join "`n"
+        Assert-Match $armedSection 'Status combines ns/op and allocated bytes/op' 'armed section: status combines ns + alloc'
+        Assert-Match $armedSection 'mixed'                                         'armed section: documents the mixed verdict'
+        Assert-True (-not $armedSection.Contains('Status tracks allocated bytes/op')) 'armed section: drops the alloc-only wording'
+        $armedMicroComment = Format-PerfComment -Main $allocMain -Pr $allocPr -WinUI3 $null -Rust $null -Micro $cmp -Context $ctx
+        Assert-Match $armedMicroComment 'combines ns/op and allocated bytes/op'    'armed footnote: combined-axis wording'
+    } finally {
+        $script:MicroNsAutoFlag = $prevFlagRender
+    }
     # Omitted / null -Micro -> no micro section (back-compat with existing callers).
     Assert-True (-not ($allocComment -like '*Reconciler micro-benchmarks*')) 'micro section omitted when -Micro not supplied'
 }

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -692,6 +692,88 @@ try {
     Assert-Equal 'na'     (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'na')     'alloc na -> row na (ns does not rescue)'
     Assert-Equal 'na'     (Get-PerfMicroRowStatus -NsStatus 'na'     -AllocStatus 'na')     'na when alloc na'
 
+    # ── ARMED ns-flag mechanism (dormant by default; exercised here with the flag on) ──
+    # Promoting ns informational -> flagged is gated on $script:MicroNsAutoFlag. When
+    # armed, the row COMBINES the (rep-interleaved, band-gated) ns delta with the alloc
+    # delta: either axis can flag, and a disagreement reads 'mixed'. The flag is reset to
+    # dormant after this block so the remaining tests see v1 behaviour.
+    $prevNsFlag = $script:MicroNsAutoFlag
+    $script:MicroNsAutoFlag = $true
+    try {
+        # Combination matrix: ns now participates.
+        Assert-Equal 'better' (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'noise')  'armed: ns better + alloc noise -> better (ns now drives)'
+        Assert-Equal 'worse'  (Get-PerfMicroRowStatus -NsStatus 'worse'  -AllocStatus 'noise')  'armed: ns worse + alloc noise -> worse'
+        Assert-Equal 'better' (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'better') 'armed: both better -> better'
+        Assert-Equal 'worse'  (Get-PerfMicroRowStatus -NsStatus 'worse'  -AllocStatus 'worse')  'armed: both worse -> worse'
+        Assert-Equal 'mixed'  (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'worse')  'armed: ns better + alloc worse -> mixed'
+        Assert-Equal 'mixed'  (Get-PerfMicroRowStatus -NsStatus 'worse'  -AllocStatus 'better') 'armed: ns worse + alloc better -> mixed'
+        Assert-Equal 'noise'  (Get-PerfMicroRowStatus -NsStatus 'noise'  -AllocStatus 'noise')  'armed: both noise -> noise'
+        Assert-Equal 'better' (Get-PerfMicroRowStatus -NsStatus 'na'     -AllocStatus 'better') 'armed: ns na -> alloc drives'
+        Assert-Equal 'better' (Get-PerfMicroRowStatus -NsStatus 'better' -AllocStatus 'na')     'armed: alloc na -> ns drives (differs from dormant na)'
+        Assert-Equal 'na'     (Get-PerfMicroRowStatus -NsStatus 'na'     -AllocStatus 'na')     'armed: both na -> na'
+        Assert-Equal 'noise'  (Get-PerfMicroRowStatus -NsStatus 'noise'  -AllocStatus 'na')     'armed: ns noise + alloc na -> noise'
+
+        # 'mixed' glyph renders.
+        Assert-Equal "$([char]0x2195)$([char]0xFE0F) mixed" (Get-PerfStatusGlyph 'mixed') 'mixed -> up-down arrow glyph'
+
+        # SYNTHETIC IDENTICAL-BINARY CALIBRATION (the no-false-flag proof, armed):
+        # an unchanged binary produces ns samples drawn from the SAME distribution on both
+        # sides — once rep-interleaved the paired ns differences center on 0 with only
+        # sub-band jitter, so the ns CI must clear neither +band nor -band => 'noise'.
+        # Here main = pr distribution with +-~1% per-rep jitter (well inside the 3% band).
+        $idMain = @(
+            (New-MicroRow 'NS1' 'IdenticalBin' 'Reactor' 0 1000 800)
+            (New-MicroRow 'NS1' 'IdenticalBin' 'Reactor' 1 1000 800)
+            (New-MicroRow 'NS1' 'IdenticalBin' 'Reactor' 2 1000 800)
+            (New-MicroRow 'NS1' 'IdenticalBin' 'Reactor' 3 1000 800)
+            (New-MicroRow 'NS1' 'IdenticalBin' 'Reactor' 4 1000 800)
+        )
+        $idPr = @(
+            (New-MicroRow 'NS1' 'IdenticalBin' 'Reactor' 0 1010 800)
+            (New-MicroRow 'NS1' 'IdenticalBin' 'Reactor' 1  990 800)
+            (New-MicroRow 'NS1' 'IdenticalBin' 'Reactor' 2 1005 800)
+            (New-MicroRow 'NS1' 'IdenticalBin' 'Reactor' 3  995 800)
+            (New-MicroRow 'NS1' 'IdenticalBin' 'Reactor' 4 1002 800)
+        )
+        $idMainJsonl = Join-Path $microTmp 'nsband-id-main.jsonl'
+        $idPrJsonl   = Join-Path $microTmp 'nsband-id-pr.jsonl'
+        Set-Content -LiteralPath $idMainJsonl -Value $idMain -Encoding UTF8
+        Set-Content -LiteralPath $idPrJsonl   -Value $idPr   -Encoding UTF8
+        $idCmp = @(Get-PerfMicroComparison -Main (Read-MicroBenchResults $idMainJsonl) -Pr (Read-MicroBenchResults $idPrJsonl))[0]
+        Assert-Equal 'noise' $idCmp.NsDelta.Status 'armed ns calibration: identical-binary sub-band ns jitter reads noise (no false flag)'
+        Assert-Equal 'noise' (Get-PerfMicroRowStatus -NsStatus $idCmp.NsDelta.Status -AllocStatus $idCmp.AllocDelta.Status) 'armed ns calibration: identical-binary row = noise'
+
+        # SYNTHETIC REAL-EFFECT: a consistent ns improvement well beyond the band must
+        # flag 'better' once armed (the capability the flag delivers).
+        $effMain = @(
+            (New-MicroRow 'NS2' 'RealWin' 'Reactor' 0 1000 800)
+            (New-MicroRow 'NS2' 'RealWin' 'Reactor' 1 1000 800)
+            (New-MicroRow 'NS2' 'RealWin' 'Reactor' 2 1000 800)
+            (New-MicroRow 'NS2' 'RealWin' 'Reactor' 3 1000 800)
+        )
+        $effPr = @(
+            (New-MicroRow 'NS2' 'RealWin' 'Reactor' 0 900 800)
+            (New-MicroRow 'NS2' 'RealWin' 'Reactor' 1 905 800)
+            (New-MicroRow 'NS2' 'RealWin' 'Reactor' 2 898 800)
+            (New-MicroRow 'NS2' 'RealWin' 'Reactor' 3 902 800)
+        )
+        $effMainJsonl = Join-Path $microTmp 'nsband-eff-main.jsonl'
+        $effPrJsonl   = Join-Path $microTmp 'nsband-eff-pr.jsonl'
+        Set-Content -LiteralPath $effMainJsonl -Value $effMain -Encoding UTF8
+        Set-Content -LiteralPath $effPrJsonl   -Value $effPr   -Encoding UTF8
+        $effCmp = @(Get-PerfMicroComparison -Main (Read-MicroBenchResults $effMainJsonl) -Pr (Read-MicroBenchResults $effPrJsonl))[0]
+        Assert-Equal 'better' $effCmp.NsDelta.Status 'armed ns calibration: consistent -10% ns (beyond 3% band) flags better'
+        Assert-Equal 'better' (Get-PerfMicroRowStatus -NsStatus $effCmp.NsDelta.Status -AllocStatus $effCmp.AllocDelta.Status) 'armed ns calibration: real ns win drives row better'
+
+        # The SAME real-effect data must read 'noise' when DORMANT (alloc unchanged), proving
+        # the flag is the only thing that changes the verdict — arming is measurement-only.
+        $script:MicroNsAutoFlag = $false
+        Assert-Equal 'noise' (Get-PerfMicroRowStatus -NsStatus $effCmp.NsDelta.Status -AllocStatus $effCmp.AllocDelta.Status) 'dormant: same real ns win reads noise (alloc-only), so arming only relabels'
+        $script:MicroNsAutoFlag = $true
+    } finally {
+        $script:MicroNsAutoFlag = $prevNsFlag
+    }
+
     # Rep-aligned pairing + consistent medians. Two benches, each with rep1 dropped
     # on the PR side:
     #   A1 — main rep1 is an alloc outlier (2000). Correct rep-keyed alignment pairs

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -56,6 +56,26 @@ $script:PerfAllocMetricSpec = @(
 # "CI excludes 0" rule.
 $script:MicroAllocMinEffectPct = 1.0
 
+# Minimum-effect band (percent) for the micro-suite ns/op flag, applied ONLY when the
+# ns flag is armed (see $MicroNsAutoFlag). ns is noisier than the deterministic alloc
+# metric even once rep-interleaved — a fresh process per rep randomizes the
+# process-to-process timing offset into the paired variance rather than leaving it a
+# constant bias, but residual cold-JIT / scheduling jitter remains — so the ns band is
+# wider than alloc's. This value is PROVISIONAL: per the arming gate it must be
+# recalibrated from a real-CI identical-binary interleaved A/B (which can only run after
+# the interleave is on main, since /perf builds the harness from the default branch)
+# so the ns CI stays within +-band for an unchanged diff before the flag goes live.
+$script:MicroNsMinEffectPct = 3.0
+
+# Master switch promoting the micro ns/op delta from informational to a flagged signal.
+# DORMANT ($false) by default: the row Status tracks allocated bytes/op only (v1
+# behaviour), and the ns column is shown for context but never drives a verdict. The
+# rep-level interleave that makes the ns paired CI unbiased ships with this OFF; arming
+# it ($true) is a deliberate, separately-ratified one-line follow-up gated on the
+# real-CI identical-binary band calibration above. Arming is MEASUREMENT-ONLY — it
+# changes /perf verdict labels, never what merges.
+$script:MicroNsAutoFlag = $false
+
 function ConvertTo-PerfDouble {
     <#
     .SYNOPSIS Culture-tolerant parse of a captured numeric string, or $null.
@@ -482,6 +502,7 @@ function Get-PerfStatusGlyph {
         'better' { return [char]0x2705 + ' improvement' }                       # checkmark
         'worse'  { return [char]0x26A0 + [char]0xFE0F + ' regression' }          # warning
         'noise'  { return [char]0x2248 + ' within noise' }                       # almost-equal
+        'mixed'  { return [char]0x2195 + [char]0xFE0F + ' mixed' }               # up-down arrow
         default  { return '—' }
     }
 }
@@ -611,12 +632,14 @@ function Get-PerfMicroComparison {
         $mainMeanNs = Get-PerfMedian $mNsArr; $prMeanNs = Get-PerfMedian $pNsArr
         $mainAlloc = Get-PerfMedian $mAllocArr; $prAlloc = Get-PerfMedian $pAllocArr
         $nsDelta = Get-PerfDelta -Baseline $mainMeanNs -Candidate $prMeanNs `
-            -LowerIsBetter $true -BaselineSamples $mNsArr -CandidateSamples $pNsArr -RequirePairedCI
-        # Alloc DRIVES the row flag, and not every bench is alloc-deterministic:
-        # dispatcher / background-thread benches (e.g. M5) carry a sub-1% systematic
-        # process-to-process offset that the within-process CI can't cancel, so flag
-        # only when the CI clears the +-MinEffectPct band. ns is informational-only
-        # (never drives the flag) so it keeps the pure CI-excludes-0 rule.
+            -LowerIsBetter $true -BaselineSamples $mNsArr -CandidateSamples $pNsArr `
+            -RequirePairedCI -MinEffectPct $script:MicroNsMinEffectPct
+        # Both deltas clear a +-MinEffectPct band before flagging. Alloc's band is tight
+        # (~1%) because alloc bytes/op are deterministic for identical code; ns's is
+        # wider because even rep-interleaved timing carries residual cold-JIT / scheduling
+        # jitter. Whether ns actually DRIVES the row flag is gated separately on
+        # $MicroNsAutoFlag (see Get-PerfMicroRowStatus): dormant => alloc-only (v1), so a
+        # bench's ns band only matters once the flag is armed.
         $allocDelta = Get-PerfDelta -Baseline $mainAlloc -Candidate $prAlloc `
             -LowerIsBetter $true -BaselineSamples $mAllocArr -CandidateSamples $pAllocArr `
             -RequirePairedCI -MinEffectPct $script:MicroAllocMinEffectPct
@@ -639,23 +662,47 @@ function Get-PerfMicroComparison {
 function Get-PerfMicroRowStatus {
     <#
     .SYNOPSIS
-        Row flag for a micro-bench. v1 tracks the DETERMINISTIC allocation signal
-        only; the ns/op delta is informational and does NOT drive the flag.
+        Row flag for a micro-bench, combining the ns/op and allocated-bytes/op paired
+        deltas. Whether ns participates is gated on $script:MicroNsAutoFlag.
     .DESCRIPTION
         Allocated bytes/op is deterministic for identical code (an unchanged diff
-        reproduces the same byte count exactly), so its paired CI is a trustworthy
-        flag. ns/op is NOT: the per-side micro runs are not yet rep-interleaved, so a
-        systematic process-to-process timing offset (thermal / scheduling drift
-        between the two back-to-back invocations) shifts every paired ns difference
-        the same way and makes the paired CI exclude 0 even for an identical binary
-        — empirically a no-op diff flagged -14.8% ns on one bench. Flagging ns would
-        therefore emit false improvements/regressions. So the row tracks alloc; ns is
-        shown for context. (Rep-level interleaving is the documented fast-follow that
-        would let ns be promoted to a flagged signal.)
+        reproduces the same byte count exactly), so its paired CI is always a trustworthy
+        flag. ns/op is trustworthy only once the per-side runs are rep-interleaved: a
+        fresh alternated process per rep randomizes the process-to-process timing offset
+        into the paired variance instead of leaving it a constant bias between one
+        all-main and one all-pr process (which empirically flagged a no-op diff -14.8% ns
+        on one bench, and on a near-neutral PR pushed ~9/16 benches' ns CI to exclude 0
+        with a uniform negative sign — the offset signature).
+
+        DORMANT ($MicroNsAutoFlag = $false, the default): the row tracks ALLOC ONLY (v1
+        behaviour); ns is shown for context but never drives the verdict.
+
+        ARMED ($MicroNsAutoFlag = $true): ns and alloc are combined. Each is one of
+        better | worse | noise | na (already band-gated by Get-PerfDelta -MinEffectPct).
+        They measure different axes (time vs bytes), so a bench can move on one and not
+        the other; the row summarises both:
+          - any 'worse' and any 'better'  -> 'mixed'   (axes disagree; see the cells)
+          - any 'worse'  (none better)    -> 'worse'
+          - any 'better' (none worse)     -> 'better'
+          - else any 'noise'              -> 'noise'
+          - else (both na/empty)          -> 'na'
     #>
     param([AllowNull()][string]$NsStatus, [AllowNull()][string]$AllocStatus)
-    if ([string]::IsNullOrEmpty($AllocStatus)) { return 'na' }
-    return $AllocStatus
+    if (-not $script:MicroNsAutoFlag) {
+        # Dormant: alloc-only v1 behaviour. ns is ignored (shown for context only).
+        if ([string]::IsNullOrEmpty($AllocStatus)) { return 'na' }
+        return $AllocStatus
+    }
+    # Armed: combine the two axes. Treat empty as 'na'.
+    $ns = if ([string]::IsNullOrEmpty($NsStatus)) { 'na' } else { $NsStatus }
+    $al = if ([string]::IsNullOrEmpty($AllocStatus)) { 'na' } else { $AllocStatus }
+    $hasBetter = ($ns -eq 'better') -or ($al -eq 'better')
+    $hasWorse = ($ns -eq 'worse') -or ($al -eq 'worse')
+    if ($hasBetter -and $hasWorse) { return 'mixed' }
+    if ($hasWorse) { return 'worse' }
+    if ($hasBetter) { return 'better' }
+    if (($ns -eq 'noise') -or ($al -eq 'noise')) { return 'noise' }
+    return 'na'
 }
 
 function Format-PerfMicroSection {
@@ -670,7 +717,11 @@ function Format-PerfMicroSection {
     $lines = [System.Collections.Generic.List[string]]::new()
     $lines.Add("### Reconciler micro-benchmarks (``PerfBench.ControlModel``)")
     $lines.Add('')
-    $lines.Add("Production ``--variant Reactor`` control-model path, ns-resolution and WinUI-undiluted (spec-047 M1&ndash;M13) &mdash; $down lower is better. **Status tracks allocated bytes/op**, the authoritative signal here; it is deterministic for structurally-fixed benches, while dispatcher / background-thread benches carry a small process-to-process offset, so a bench is flagged only when its 95% CI clears a &plusmn;$($script:MicroAllocMinEffectPct)% minimum-effect band (real structural alloc changes are several percent to many-x). **ns/op is shown for context** but is not auto-flagged in v1 (the per-side runs are not yet rep-interleaved, so a process-to-process timing offset can otherwise read as significant). Δ is the mean paired change with a 95% CI.")
+    if ($script:MicroNsAutoFlag) {
+        $lines.Add("Production ``--variant Reactor`` control-model path, ns-resolution and WinUI-undiluted (spec-047 M1&ndash;M13) &mdash; $down lower is better. **Status combines ns/op and allocated bytes/op**: the per-side runs are rep-interleaved (a fresh alternated process per rep), so the ns paired CI is unbiased and a bench is flagged when EITHER axis' 95% CI clears its minimum-effect band &mdash; &plusmn;$($script:MicroNsMinEffectPct)% for ns (residual cold-JIT / scheduling jitter), &plusmn;$($script:MicroAllocMinEffectPct)% for the deterministic alloc metric. When the two axes disagree the row reads $([char]0x2195)$([char]0xFE0F) mixed &mdash; consult the individual Δ cells. Δ is the mean paired change with a 95% CI.")
+    } else {
+        $lines.Add("Production ``--variant Reactor`` control-model path, ns-resolution and WinUI-undiluted (spec-047 M1&ndash;M13) &mdash; $down lower is better. **Status tracks allocated bytes/op**, the authoritative signal here; it is deterministic for structurally-fixed benches, while dispatcher / background-thread benches carry a small process-to-process offset, so a bench is flagged only when its 95% CI clears a &plusmn;$($script:MicroAllocMinEffectPct)% minimum-effect band (real structural alloc changes are several percent to many-x). **ns/op is shown for context** but is not auto-flagged (its paired CI is rep-interleaved but the flag remains dormant pending a real-CI identical-binary band calibration). Δ is the mean paired change with a 95% CI.")
+    }
     $lines.Add('')
     $lines.Add('| Bench | `main` ns/op | Δ ns (95% CI) | `main` B/op | Δ alloc (95% CI) | Status |')
     $lines.Add('|---|--:|--:|--:|--:|:--|')
@@ -976,7 +1027,11 @@ function Format-PerfComment {
     & $add "<sub>$up higher is better &middot; $down lower is better. **Within noise** = the 95% confidence interval of the paired Δ includes 0 (no change resolvable at this sample size); $([char]0x2705) improvement / $([char]0x26A0)$([char]0xFE0F) regression require the CI to **exclude** 0.</sub>"
     & $add "<sub>Allocation metrics (alloc bytes/render, Gen0 GC) are the sensitive signal for allocation-reduction work, where the mean-ms / memory figures are largely flat. They read *n/a* for a harness built from a revision that predates them (rebase the PR onto ``main`` to populate them).</sub>"
     if ($null -ne $Micro -and @($Micro).Count -gt 0) {
-        & $add "<sub>Reconciler micro-benchmarks run ``PerfBench.ControlModel --variant Reactor`` (M1&ndash;M13) as a headless loop bracketed by per-thread alloc + GC counters &mdash; ns-resolution and free of WinUI render / working-set dilution, so they resolve Core/Reconciler allocation deltas the macro StocksGrid workload cannot. ``main`` and PR each link their own ``src/Reactor`` build; Δ is the paired 95% CI over per-rep means. The **Status** column tracks allocated bytes/op (deterministic for identical code); ns/op is informational &mdash; it is not auto-flagged until the per-side runs are rep-interleaved (a documented fast-follow), because a process-to-process timing offset can otherwise make the paired ns CI exclude 0 for an unchanged diff.</sub>"
+        if ($script:MicroNsAutoFlag) {
+            & $add "<sub>Reconciler micro-benchmarks run ``PerfBench.ControlModel --variant Reactor`` (M1&ndash;M13) as a headless loop bracketed by per-thread alloc + GC counters &mdash; ns-resolution and free of WinUI render / working-set dilution, so they resolve Core/Reconciler time and allocation deltas the macro StocksGrid workload cannot. ``main`` and PR each link their own ``src/Reactor`` build and are **rep-interleaved** (a fresh alternated process per rep), so the paired ns CI is unbiased. The **Status** column combines ns/op and allocated bytes/op &mdash; a bench flags when either axis' 95% CI clears its minimum-effect band, and $([char]0x2195)$([char]0xFE0F) mixed when the axes disagree.</sub>"
+        } else {
+            & $add "<sub>Reconciler micro-benchmarks run ``PerfBench.ControlModel --variant Reactor`` (M1&ndash;M13) as a headless loop bracketed by per-thread alloc + GC counters &mdash; ns-resolution and free of WinUI render / working-set dilution, so they resolve Core/Reconciler allocation deltas the macro StocksGrid workload cannot. ``main`` and PR each link their own ``src/Reactor`` build and are rep-interleaved (a fresh alternated process per rep); Δ is the paired 95% CI over per-rep means. The **Status** column tracks allocated bytes/op (deterministic for identical code); ns/op is informational &mdash; its paired CI is now unbiased but the flag stays dormant pending a real-CI identical-binary band calibration.</sub>"
+        }
     }
     & $add "<sub>$([char]0x00B9) vanilla WinUI3 = ``StressPerf.Direct`` (imperative; no virtual-DOM, so it has no reconcile/diff phase — those cells read *n/a*). Measured live on this runner.</sub>"
     & $add "<sub>$([char]0x00B2) Rust = ``test_reactor_perf`` from [microsoft/windows-rs](https://github.com/microsoft/windows-rs/tree/master/crates/tests/libs/reactor_perf) — a port of this harness (same StocksGrid, same ``--percent``/``--duration`` CLI). $rustNote</sub>"

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -56,8 +56,9 @@ operates on — small reconcile-time and per-reconcile allocation deltas are bur
 under render + GC noise.
 
 So `/perf` also runs the **`PerfBench.ControlModel` micro-suite** (spec-047
-M1–M13: `PropertyDiff` / `Allocation` / `StructuralSharing` / `ControlModel`) once
-per side and reports a per-bench PR-vs-`main` table:
+M1–M13: `PropertyDiff` / `Allocation` / `StructuralSharing` / `ControlModel`),
+interleaved at the **rep level** (a fresh alternated `main`/PR process per rep), and
+reports a per-bench PR-vs-`main` table:
 
 | Metric | Meaning | Direction |
 |---|---|:--:|
@@ -74,16 +75,20 @@ machinery as the macro tables, but they are **read differently**:
 - **B/op drives the row flag.** Allocated bytes/op is *deterministic* for identical
   code — an unchanged diff reproduces the same byte count exactly — so its paired CI
   is trustworthy. The ✅/⚠️/≈ status of each row tracks the alloc delta.
-- **ns/op is informational only** (shown, never auto-flagged in v1). The two per-side
-  runs are not yet rep-interleaved, so a systematic process-to-process timing offset
-  (thermal/scheduling drift between the back-to-back invocations) shifts every paired
-  ns difference the same way and makes the paired CI exclude 0 even for an identical
-  binary. Local validation confirmed this: running the **same** ControlModel binary
-  as both "main" and "PR", alloc was deterministic (14/16 benches exactly 0.0% Δ) but
-  ns spuriously flagged up to −14.8% on a no-op. Flagging ns would emit false
-  improvements/regressions, so the column is reported for context and excluded from
-  the flag. **Rep-level interleaving of the two sides is the documented fast-follow**
-  that would let ns be promoted to a flagged signal.
+- **ns/op is rep-interleaved but not auto-flagged by default.** The two per-side runs
+  are interleaved at the **rep level** (each rep alternates a fresh `main` then PR
+  process), so the systematic process-to-process timing offset (thermal/scheduling
+  drift) that a single back-to-back pair leaves as a *constant* bias is randomized
+  round-to-round into the paired variance, making the ns CI unbiased. Before
+  interleaving that offset made the paired CI exclude 0 even for an identical binary —
+  running the **same** ControlModel binary as both "main" and "PR", alloc was
+  deterministic (14/16 benches exactly 0.0% Δ) but ns spuriously flagged up to −14.8%
+  on a no-op. Even interleaved, ns keeps residual cold-JIT / scheduling jitter, so it
+  is promoted to a flag only behind a minimum-effect band **and** a master switch
+  (`$MicroNsAutoFlag`) that stays **dormant** pending a real-CI identical-binary
+  calibration of that band. While dormant the row status tracks the alloc delta;
+  arming the switch — a measurement-only follow-up that never changes what merges —
+  makes the row combine ns and alloc, reading ↕️ mixed when the two axes disagree.
 
 The whole leg is best-effort: if the micro build or run fails, the macro comment is
 unaffected and the section is simply omitted.
@@ -146,8 +151,10 @@ git worktree remove ../main
 | `-RefReps` | `3` | Measured runs for the **reference-only** legs (vanilla WinUI3, Rust) — a single reference absolute, not a paired CI, so it needs far fewer reps. |
 | `-RefWarmup` | `1` | Warm-up runs discarded for the reference-only legs. |
 | `-IncludeMicro` | `$true` | Run the `PerfBench.ControlModel` reconciler micro-suite (compare mode) and append its per-bench ns/op + B/op table. Set `$false` to skip it. |
-| `-MicroReps` | `12` | Repetitions per side for the micro-suite — each feeds the paired 95% CI, mirroring `-Reps`. |
-| `-MicroIterations` | `1000` | Inner iterations per repetition inside each micro-bench (amortises timer resolution; sized so the 16-bench suite finishes inside its per-side timeout). |
+| `-MicroReps` | `12` | Measured **rep rounds** per side for the micro-suite; each round alternates a fresh `main` then PR `--reps 1` process (rep-level interleaving) and feeds the paired 95% CI, mirroring `-Reps`. |
+| `-MicroWarmup` | `1` | Leading interleaved rep rounds discarded before the measured `-MicroReps` (absorbs per-process cold-JIT before the timed rounds are paired). |
+| `-MicroIterations` | `1000` | Inner iterations per repetition inside each micro-bench (amortises timer resolution; sized so each `--reps 1` round finishes well inside its per-round timeout). |
+| `-MicroRepTimeoutSec` | `180` | Per-round launch budget (one `--reps 1` run of the 16-bench suite). A round that overruns is killed and dropped; the previous whole-suite single launch used a 600 s cap. |
 | `-IncludeSkipFloor` | `$true` | Run a **second interleaved A/B leg** at `-SkipFloorPercent` and append a low-mutation skip-floor table (compare mode). Set `$false` to skip it (halves the macro runtime). |
 | `-SkipFloorPercent` | `0` | Mutation percent for the skip-floor leg. At `0` the workload still mutates one cell/tick (`StockDataSource.Update` clamps the count to `Math.Max(1, …)`), so reconcile/diff isolate the O(n) per-tick child skip-walk floor the 50% leg dilutes. |
 | `-IncludeKeyedList` | `$true` | Run a **third interleaved A/B leg** on `StressPerf.KeyedList` — a ~500-row stably keyed list reordered/inserted/removed each tick — and append its own table (compare mode). Drives the child reconciler's **keyed arm** (`ReconcileKeyed` → `ReconcileKeyedMiddle`, the LIS minimal-move pass) the positional StocksGrid cells never reach. Build is best-effort; set `$false` to skip the leg. |
@@ -243,8 +250,10 @@ Several tables plus footnotes:
   `PerfBench.ControlModel` micro-suite (M1–M13), `main` vs PR. ns-resolution and
   WinUI-undiluted, so it resolves Core/Reconciler time and allocation deltas the
   render-bound macro table cannot. The row flag tracks the **deterministic B/op**
-  delta; `ns/op` is shown for context but not auto-flagged in v1 (pending rep-level
-  interleaving — see the section above). Omitted when the micro leg is disabled or
+  delta; the two sides are now rep-interleaved (a fresh alternated process per rep) so
+  the `ns/op` paired CI is unbiased, but ns stays shown-for-context — not auto-flagged
+  by default — pending the band calibration that arms it (see the section above).
+  Omitted when the micro leg is disabled or
   fails to produce results for both sides.
 - **Cross-framework reference** — `vanilla WinUI3 | Rust windows-reactor |
   Reactor (this PR)` on the same StocksGrid workload, **all measured live on the

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -65,9 +65,17 @@
     Warm-up runs discarded for the reference-only legs (default 1).
 
 .PARAMETER MicroReps
-    Measured repetitions per side for the reconciler micro-suite
-    (PerfBench.ControlModel, spec-047 M1&ndash;M13). Default 12; the per-rep
-    samples feed the paired 95% CI on allocated bytes/op.
+    Measured interleaved rep rounds for the reconciler micro-suite
+    (PerfBench.ControlModel, spec-047 M1&ndash;M13). Default 12. Each round runs a
+    FRESH main process then a fresh PR process (one inner --reps each), alternating
+    per round so the process-to-process timing offset randomizes into the paired
+    variance rather than biasing every rep one way; the per-round samples feed the
+    paired 95% CI on ns/op and allocated bytes/op.
+
+.PARAMETER MicroWarmup
+    Interleaved warm-up rounds discarded before the measured MicroReps rounds
+    (default 1). Like the macro -Warmup, the first round per side pays cold-start /
+    JIT costs, so it is dropped from the accumulator on both sides.
 
 .PARAMETER MicroIterations
     Inner iterations per micro repetition (default 1000) over which each bench's
@@ -75,9 +83,16 @@
     (the spec-047 M1&ndash;M13 set plus 3 supplementary) and the heaviest
     (M7&ndash;M9 reconcile a 1000-node tree per op) run >=120 us/op,
     so even 1000 iterations keep each per-rep mean >=120 ms &mdash; hundreds of
-    thousands of times the Stopwatch floor &mdash; while letting the whole suite
-    finish inside its per-side timeout. (At 10000 the suite ran ~3x over budget,
-    completed only M1&ndash;M4, and was silently dropped from every comment.)
+    thousands of times the Stopwatch floor &mdash; while letting each per-round
+    launch finish inside -MicroRepTimeoutSec. (At 10000 the suite ran ~3x over its
+    budget, completed only M1&ndash;M4, and was silently dropped from every comment.)
+
+.PARAMETER MicroRepTimeoutSec
+    Per-round launch timeout in seconds for one micro side (default 180). Each
+    interleaved round runs the 16-bench suite once (one inner --reps) per side; a
+    round that exceeds this is dropped on BOTH sides to keep the rep indices
+    aligned. Replaces the old whole-suite timeout that silently truncated the
+    suite to M1&ndash;M4.
 
 .PARAMETER IncludeMicro
     Run the reconciler micro-suite on each side and append its per-bench ns/op +

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -760,7 +760,10 @@ function Invoke-MicroInterleaved {
        same direction. Mirrors the macro legs' warmup-drop + drop-both alignment: warmup
        rounds are discarded, and a round is kept only if BOTH sides produced output — the
        surviving rounds are appended to the per-side accumulators with contiguous dense
-       repetition indices (0,1,2,...) on both sides. Returns @{ MainJson; PrJson; Reps } or
+       repetition indices (0,1,2,...) on both sides. Best-effort per side: a launcher that
+       THROWS (a transient Start-Process / runner hiccup) is caught and treated like a
+       $null return, so only that round is dropped and the surviving reps still produce a
+       micro section instead of the exception aborting the whole leg. Returns @{ MainJson; PrJson; Reps } or
        $null if fewer than 2 paired rounds survive (too few for a paired CI). #>
     param(
         [scriptblock]$LaunchRep,
@@ -774,8 +777,13 @@ function Invoke-MicroInterleaved {
     }
     $kept = 0
     for ($round = 1; $round -le ($WarmupCount + $RepCount); $round++) {
-        $mainRound = & $LaunchRep 'main' $round
-        $prRound = & $LaunchRep 'pr' $round
+        # Best-effort per side: a launcher that THROWS (e.g. a transient Start-Process
+        # failure) is treated like a $null return — only this round is dropped (drop-both
+        # keeps the paired indices aligned) instead of the exception aborting the whole
+        # micro leg and discarding every surviving rep.
+        $mainRound = $null; $prRound = $null
+        try { $mainRound = & $LaunchRep 'main' $round } catch { Write-Log ("  micro round #{0} main launch threw ({1}) — dropping the round" -f $round, $_) 'Yellow' }
+        try { $prRound = & $LaunchRep 'pr' $round } catch { Write-Log ("  micro round #{0} pr launch threw ({1}) — dropping the round" -f $round, $_) 'Yellow' }
         if ($round -le $WarmupCount) {
             Write-Log ("  (micro warmup round #{0} discarded)" -f $round) 'DarkGray'
             continue

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -176,7 +176,9 @@ param(
     [int]$RefReps = 3,
     [int]$RefWarmup = 1,
     [int]$MicroReps = 12,
+    [int]$MicroWarmup = 1,
     [int]$MicroIterations = 1000,
+    [int]$MicroRepTimeoutSec = 180,
     [bool]$IncludeMicro = $true,
     [double]$SkipFloorPercent = 0,
     [bool]$IncludeSkipFloor = $true,
@@ -655,14 +657,15 @@ function Invoke-MicroRun {
        results .jsonl path (or $null if it produced nothing). The measured region inside
        BenchRunner is bracketed by per-thread alloc + GC counters, so unlike the macro
        StressPerf legs this is ns-resolution and free of WinUI render / working-set
-       dilution. We run it once per side (each tree links its own src/Reactor) with no
-       rep-level interleave and no single-core pin — the within-process reps are already
-       GC-bracketed + warmed, and pinning would only contend the app's dispatcher/render
-       threads. Consequence of NOT interleaving: allocated bytes/op is deterministic and
-       flagged, but ns/op is reported informational-only (a process-to-process timing
-       offset can otherwise make its paired CI exclude 0 for identical code). Rep-level
-       interleaving is the documented fast-follow that would promote ns to a flag. #>
-    param([string]$Exe, [string]$Tag, [int]$RepCount, [int]$IterCount)
+       dilution. This is the single-launch primitive: Invoke-MicroInterleaved drives it
+       once per round per side with -RepCount 1 so each round is a FRESH process, which
+       randomizes the process-to-process timing offset (ASLR/layout/scheduling) into the
+       paired variance instead of biasing every rep one direction. That per-rep interleave
+       is what lets the ns/op paired CI be trusted (see PerfLib Get-PerfMicroRowStatus);
+       allocated bytes/op was already deterministic and flagged. No single-core pin: the
+       within-process reps are GC-bracketed + warmed, and pinning would only contend the
+       app's dispatcher/render threads. #>
+    param([string]$Exe, [string]$Tag, [int]$RepCount, [int]$IterCount, [int]$TimeoutSec = 600)
 
     $outJson = Join-Path $OutDir ("micro-{0}.jsonl" -f $Tag)
     if (Test-Path $outJson) { Remove-Item $outJson -Force -ErrorAction SilentlyContinue }
@@ -671,12 +674,14 @@ function Invoke-MicroRun {
     $inv = [System.Globalization.CultureInfo]::InvariantCulture
     $microArgs = @('--variant', 'Reactor', '--reps', $RepCount.ToString($inv),
         '--iterations', $IterCount.ToString($inv), '--out', $outJson, '--headless')
-    # Per-side budget for the whole 16-bench suite. Sized with headroom over the
-    # ~4-7 min the suite needs at -MicroIterations 1000, so thermal drift on a busy
-    # shared runner can't truncate it, while a genuine hang is still bounded. (At
-    # 420s with 10000 iterations the suite timed out after only M1-M4, so the micro
-    # section was silently absent from every comment.)
-    $timeoutSec = 600
+    # Per-launch budget. When the interleaver calls this with -RepCount 1 the launch runs
+    # the 16-bench suite once (each bench still does its own internal warmup + one timed
+    # rep), so the default 180s the caller passes is sized with wide headroom over the
+    # ~12-15s a single round needs, while a genuine hang is still bounded. (At 420s with
+    # 10000 iterations the whole-suite single launch timed out after only M1-M4, so the
+    # micro section was silently absent from every comment — hence the iter cut + the
+    # per-rep launches.)
+    $timeoutSec = $TimeoutSec
 
     Write-Log ("  micro [{0}] PerfBench.ControlModel --variant Reactor --reps {1} --iterations {2}" -f $Tag, $RepCount, $IterCount)
     $proc = Start-Process -FilePath $Exe -ArgumentList $microArgs -PassThru `
@@ -709,6 +714,78 @@ function Invoke-MicroRun {
         return $null
     }
     return $outJson
+}
+
+function ConvertTo-MicroRepLines {
+    <# Read one per-round micro .jsonl (produced by a single --reps 1 launch, so every
+       line carries "repetition":0) and renumber its repetition to $RepIndex, returning
+       the rewritten line array — or $null if the file is missing/empty so the caller can
+       drop BOTH sides of the round and keep the paired indices aligned. The accumulated
+       per-side file must look byte-compatible with a single multi-rep launch because
+       Get-PerfMicroComparison pairs main<->pr BY repetition value (not file position), so
+       both sides have to carry the SAME dense indices 0,1,2,... The serializer writes the
+       repetition field compact + camelCase ("repetition":0, no space — MeasurementResult
+       uses WriteIndented=false), and -RepCount 1 means the value is always the literal 0,
+       so the surgical literal replace can never collide with another numeric field. #>
+    param([string]$RoundFile, [int]$RepIndex)
+    if (-not $RoundFile -or -not (Test-Path $RoundFile)) { return $null }
+    $lines = @(Get-Content -LiteralPath $RoundFile | Where-Object { $_.Trim() })
+    if ($lines.Count -eq 0) { return $null }
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    $repl = '"repetition":' + $RepIndex.ToString($inv)
+    return @($lines | ForEach-Object { $_ -replace '"repetition":0', $repl })
+}
+
+function Invoke-MicroInterleaved {
+    <# Per-rep interleave of the reconciler micro-suite. Each round launches a FRESH
+       main-side then pr-side process (via $LaunchRep, a (Side,Round)->jsonl-path-or-$null
+       scriptblock so the loop is unit-testable without the exe) so the process-to-process
+       timing offset that otherwise makes the ns paired CI exclude 0 for identical code is
+       randomized round-to-round into the paired variance instead of biasing every rep the
+       same direction. Mirrors the macro legs' warmup-drop + drop-both alignment: warmup
+       rounds are discarded, and a round is kept only if BOTH sides produced output — the
+       surviving rounds are appended to the per-side accumulators with contiguous dense
+       repetition indices (0,1,2,...) on both sides. Returns @{ MainJson; PrJson; Reps } or
+       $null if fewer than 2 paired rounds survive (too few for a paired CI). #>
+    param(
+        [scriptblock]$LaunchRep,
+        [int]$RepCount,
+        [int]$WarmupCount,
+        [string]$MainOut,
+        [string]$PrOut
+    )
+    foreach ($f in @($MainOut, $PrOut)) {
+        if (Test-Path $f) { Remove-Item $f -Force -ErrorAction SilentlyContinue }
+    }
+    $kept = 0
+    for ($round = 1; $round -le ($WarmupCount + $RepCount); $round++) {
+        $mainRound = & $LaunchRep 'main' $round
+        $prRound = & $LaunchRep 'pr' $round
+        if ($round -le $WarmupCount) {
+            Write-Log ("  (micro warmup round #{0} discarded)" -f $round) 'DarkGray'
+            continue
+        }
+        if ($mainRound -and $prRound) {
+            # Validate BOTH sides BEFORE appending either, so a one-sided empty file drops
+            # the whole round and never leaves the accumulators at mismatched rep counts.
+            $mLines = ConvertTo-MicroRepLines -RoundFile $mainRound -RepIndex $kept
+            $pLines = ConvertTo-MicroRepLines -RoundFile $prRound -RepIndex $kept
+            if ($mLines -and $pLines) {
+                Add-Content -LiteralPath $MainOut -Value $mLines -Encoding UTF8
+                Add-Content -LiteralPath $PrOut -Value $pLines -Encoding UTF8
+                $kept++
+            } else {
+                Write-Log ("  micro round #{0} produced empty output (main={1} pr={2}) — dropped" -f $round, [bool]$mLines, [bool]$pLines) 'Yellow'
+            }
+        } elseif ($mainRound -or $prRound) {
+            Write-Log ("  micro round #{0} incomplete (main={1} pr={2}) — dropped to keep the paired CI aligned" -f $round, [bool]$mainRound, [bool]$prRound) 'Yellow'
+        }
+    }
+    if ($kept -lt 2) {
+        Write-Log ("  micro interleave kept only {0} paired round(s) — too few for a paired CI; omitting micro section" -f $kept) 'Yellow'
+        return $null
+    }
+    return @{ MainJson = $MainOut; PrJson = $PrOut; Reps = $kept }
 }
 
 # ── Power plan + Defender (best-effort, restored on exit) ────────────────────
@@ -870,14 +947,25 @@ try {
                 $microMainExe = Resolve-HarnessExe -TreeRoot $BaselineRoot -AppMeta $microMeta
                 $microPrExe   = Resolve-HarnessExe -TreeRoot $Root -AppMeta $microMeta
                 if ($microMainExe -and $microPrExe) {
-                    Write-Log "reconciler micro-suite (PerfBench.ControlModel --variant Reactor, $MicroReps reps each)" 'Green'
-                    $microMainJson = Invoke-MicroRun -Exe $microMainExe -Tag 'main' -RepCount $MicroReps -IterCount $MicroIterations
-                    $microPrJson   = Invoke-MicroRun -Exe $microPrExe   -Tag 'pr'   -RepCount $MicroReps -IterCount $MicroIterations
-                    if ($microMainJson -and $microPrJson) {
+                    Write-Log "reconciler micro-suite (PerfBench.ControlModel --variant Reactor; per-rep interleaved, $MicroWarmup warmup + $MicroReps measured each side)" 'Green'
+                    $microMainJson = Join-Path $OutDir 'micro-main.jsonl'
+                    $microPrJson   = Join-Path $OutDir 'micro-pr.jsonl'
+                    # Fresh process per round per side. A plain scriptblock (NOT a
+                    # GetNewClosure) so it stays bound to THIS script scope: it reads the
+                    # exes/iter/timeout here and calls Invoke-MicroRun, which itself reads
+                    # the script-param $OutDir — a module-bound closure would sever that.
+                    # The captured vars are not reassigned before the loop runs them.
+                    $launchRep = {
+                        param($side, $round)
+                        $exe = if ($side -eq 'main') { $microMainExe } else { $microPrExe }
+                        Invoke-MicroRun -Exe $exe -Tag ("{0}-r{1}" -f $side, $round) -RepCount 1 -IterCount $MicroIterations -TimeoutSec $MicroRepTimeoutSec
+                    }
+                    $microInter = Invoke-MicroInterleaved -LaunchRep $launchRep -RepCount $MicroReps -WarmupCount $MicroWarmup -MainOut $microMainJson -PrOut $microPrJson
+                    if ($microInter) {
                         $micro = Get-PerfMicroComparison `
-                            -Main (Read-MicroBenchResults $microMainJson) `
-                            -Pr (Read-MicroBenchResults $microPrJson)
-                        Write-Log ("  micro: {0} bench(es) compared" -f @($micro).Count) 'DarkGray'
+                            -Main (Read-MicroBenchResults $microInter.MainJson) `
+                            -Pr (Read-MicroBenchResults $microInter.PrJson)
+                        Write-Log ("  micro: {0} bench(es) compared across {1} interleaved rep(s)" -f @($micro).Count, $microInter.Reps) 'DarkGray'
                     }
                 } else {
                     Write-Log "micro-suite exe not found (main=$([bool]$microMainExe) pr=$([bool]$microPrExe)) — omitting micro-benchmarks" 'Yellow'

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -292,8 +292,16 @@ Assert-True ($null -ne $mip) '[micro] -MicroIterations parameter exists'
 Assert-True ($mip -and $mip.DefaultValue -and $mip.DefaultValue.Extent.Text -eq '1000') '[micro] -MicroIterations defaults to 1000 (suite fits its per-side budget)'
 $mrp = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'MicroReps' } | Select-Object -First 1
 Assert-True ($mrp -and $mrp.DefaultValue -and $mrp.DefaultValue.Extent.Text -eq '12') '[micro] -MicroReps defaults to 12 (paired-CI sample count unchanged)'
+$mwp = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'MicroWarmup' } | Select-Object -First 1
+Assert-True ($mwp -and $mwp.DefaultValue -and $mwp.DefaultValue.Extent.Text -eq '1') '[micro] -MicroWarmup defaults to 1 (one interleaved warmup round dropped per side)'
+$mtp = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'MicroRepTimeoutSec' } | Select-Object -First 1
+Assert-True ($mtp -and $mtp.DefaultValue -and $mtp.DefaultValue.Extent.Text -eq '180') '[micro] -MicroRepTimeoutSec defaults to 180 (per-round launch budget, not the whole suite)'
 $microFn = Get-Func 'Invoke-MicroRun'
-Assert-True ($microFn -match '\$timeoutSec\s*=\s*600') '[micro] Invoke-MicroRun per-side timeout is 600s (headroom over the suite cost at 1000 iterations)'
+# Invoke-MicroRun is now the single-launch primitive; its timeout is a param (default
+# 600) that the interleaver overrides per round via -MicroRepTimeoutSec, rather than a
+# hardcoded whole-suite constant.
+Assert-True ($microFn -match '\[int\]\$TimeoutSec\s*=\s*600') '[micro] Invoke-MicroRun -TimeoutSec defaults to 600s'
+Assert-True ($microFn -match '\$timeoutSec\s*=\s*\$TimeoutSec') '[micro] Invoke-MicroRun honors the -TimeoutSec param (no hardcoded constant)'
 
 # ===========================================================================
 #  Invoke-OneRun — --percent threading (-RunPercent defaults to $Percent)
@@ -366,6 +374,98 @@ Assert-True ($src -match '\$mainKeyedRuns = @\(\); \$prKeyedRuns = @\(\)\s*\r?\n
 # failure drops BOTH halves so the paired CI's main[i]/pr[i] zip stays index-aligned.
 Assert-True ($src -match 'if \(\$mm -and \$pm\) \{ \$mainKeyedRuns \+= \$mm; \$prKeyedRuns \+= \$pm \}') '[keyed] a complete pair appends both main + pr samples'
 Assert-True ($src -match 'elseif \(\$mm -or \$pm\) \{ Write-Log "  keyed pair #\$i incomplete') '[keyed] a one-sided keyed run drops both halves (paired CI stays aligned)'
+
+# ===========================================================================
+#  Micro rep-interleave — ConvertTo-MicroRepLines + Invoke-MicroInterleaved
+# ===========================================================================
+# Per-rep interleaving runs a FRESH process per round per side (so the
+# process-to-process timing offset is randomized into the paired variance rather
+# than biasing every rep one way). Each --reps 1 launch emits "repetition":0 on
+# every bench line; the accumulator must look byte-compatible with a single
+# multi-rep launch (Get-PerfMicroComparison pairs main<->pr BY repetition value),
+# so surviving rounds are renumbered to dense indices 0,1,2,... on BOTH sides, and
+# a one-sided failure drops the whole round to keep the indices aligned. Stub the
+# launch with a scriptblock so the loop is exercised without the exe.
+Invoke-Expression (Get-Func 'ConvertTo-MicroRepLines')
+Invoke-Expression (Get-Func 'Invoke-MicroInterleaved')
+
+$microIntTmp = Join-Path ([IO.Path]::GetTempPath()) ("perfci-microint-" + [guid]::NewGuid().ToString('N'))
+$null = New-Item -ItemType Directory -Force $microIntTmp | Out-Null
+
+# A per-round launch writes one line per bench, every line carrying "repetition":0
+# (exactly what a single --reps 1 PerfBench.ControlModel launch produces).
+function New-RoundFile([string]$side, [int]$round, [string[]]$benchIds) {
+    $p = Join-Path $microIntTmp ("round-{0}-{1}.jsonl" -f $side, $round)
+    $lines = $benchIds | ForEach-Object { '{"benchId":"' + $_ + '","variant":"Reactor","repetition":0,"meanNs":100,"allocBytes":200}' }
+    Set-Content -LiteralPath $p -Value $lines -Encoding UTF8
+    $p
+}
+function Get-RepSeq([string[]]$lines, [string]$benchId) {
+    # The repetition indices (in file order) for one bench across the accumulator.
+    ($lines | Where-Object { $_ -match ('"benchId":"' + $benchId + '"') } |
+        ForEach-Object { ([regex]'"repetition":(\d+)').Match($_).Groups[1].Value }) -join ','
+}
+
+try {
+    # --- ConvertTo-MicroRepLines: surgical repetition renumber. ---
+    $roundD = New-RoundFile 'main' 9 @('M1', 'M2', 'M3')
+    $rw = ConvertTo-MicroRepLines -RoundFile $roundD -RepIndex 7
+    Assert-True (@($rw).Count -eq 3) '[rewrite] returns one line per bench'
+    Assert-True (@($rw | Where-Object { $_ -match '"repetition":7' }).Count -eq 3) '[rewrite] every line renumbered to the target rep index'
+    Assert-True (@($rw | Where-Object { $_ -match '"repetition":0' }).Count -eq 0) '[rewrite] no line keeps the original repetition:0'
+    Assert-True (@($rw | Where-Object { $_ -match '"benchId":"M2"' -and $_ -match '"meanNs":100' -and $_ -match '"allocBytes":200' }).Count -eq 1) '[rewrite] payload (benchId/meanNs/allocBytes) preserved — only repetition changes'
+    Assert-True ($null -eq (ConvertTo-MicroRepLines -RoundFile (Join-Path $microIntTmp 'nope.jsonl') -RepIndex 0)) '[rewrite] missing file -> $null (drop the round)'
+    $emptyF = Join-Path $microIntTmp 'empty.jsonl'; Set-Content -LiteralPath $emptyF -Value '' -NoNewline
+    Assert-True ($null -eq (ConvertTo-MicroRepLines -RoundFile $emptyF -RepIndex 0)) '[rewrite] empty file -> $null (drop the round)'
+
+    # --- Invoke-MicroInterleaved: the launch stub (FailRounds drives one-sided failures). ---
+    $global:FailRounds = @{}
+    $launch = {
+        param($side, $round)
+        if ($global:FailRounds.ContainsKey("${side}:${round}")) { return $null }
+        New-RoundFile $side $round @('M1', 'M2')
+    }.GetNewClosure()
+
+    # A. happy path: 1 warmup + 3 measured rounds -> 3 dense reps on both sides.
+    $global:FailRounds = @{}
+    $accMain = Join-Path $microIntTmp 'acc-main.jsonl'; $accPr = Join-Path $microIntTmp 'acc-pr.jsonl'
+    $res = Invoke-MicroInterleaved -LaunchRep $launch -RepCount 3 -WarmupCount 1 -MainOut $accMain -PrOut $accPr
+    Assert-True ($null -ne $res -and $res.Reps -eq 3) '[interleave] 1 warmup + 3 measured rounds -> 3 kept reps'
+    $mL = @(Get-Content $accMain); $pL = @(Get-Content $accPr)
+    Assert-True ($mL.Count -eq 6 -and $pL.Count -eq 6) '[interleave] each accumulator has 3 reps x 2 benches = 6 lines'
+    Assert-True ((Get-RepSeq $mL 'M1') -eq '0,1,2') '[interleave] M1 renumbered to dense 0,1,2 (warmup round not numbered)'
+    Assert-True ((Get-RepSeq $pL 'M2') -eq '0,1,2') '[interleave] pr side carries the SAME dense indices (paired by repetition value)'
+
+    # B. one-sided failure drops the WHOLE round; surviving reps stay dense (no gap).
+    $global:FailRounds = @{ 'pr:3' = $true }   # round 3: pr launch fails
+    $accMain2 = Join-Path $microIntTmp 'acc2-main.jsonl'; $accPr2 = Join-Path $microIntTmp 'acc2-pr.jsonl'
+    $res2 = Invoke-MicroInterleaved -LaunchRep $launch -RepCount 3 -WarmupCount 1 -MainOut $accMain2 -PrOut $accPr2
+    Assert-True ($null -ne $res2 -and $res2.Reps -eq 2) '[interleave] one-sided round failure drops both -> 2 kept (not 3)'
+    $mL2 = @(Get-Content $accMain2); $pL2 = @(Get-Content $accPr2)
+    Assert-True ($mL2.Count -eq 4 -and $pL2.Count -eq 4) '[interleave] drop-both keeps main/pr line counts equal'
+    Assert-True ((Get-RepSeq $mL2 'M1') -eq '0,1') '[interleave] after a dropped round, surviving reps stay dense 0,1 (no gap)'
+    Assert-True (@($mL2 | Where-Object { $_ -match '"benchId":"M1"' }).Count -eq 2) '[interleave] the failed round''s main file was NOT appended (no orphan rep)'
+
+    # C. fewer than 2 paired rounds survive -> $null (too few for a paired CI).
+    $global:FailRounds = @{ 'pr:3' = $true; 'pr:4' = $true }   # only round 2 survives
+    $accMain3 = Join-Path $microIntTmp 'acc3-main.jsonl'; $accPr3 = Join-Path $microIntTmp 'acc3-pr.jsonl'
+    $res3 = Invoke-MicroInterleaved -LaunchRep $launch -RepCount 3 -WarmupCount 1 -MainOut $accMain3 -PrOut $accPr3
+    Assert-True ($null -eq $res3) '[interleave] <2 paired rounds survive -> $null (omit micro section)'
+
+    # D. stale accumulators are cleared before the run (no cross-run bleed).
+    $accMain4 = Join-Path $microIntTmp 'acc4-main.jsonl'; $accPr4 = Join-Path $microIntTmp 'acc4-pr.jsonl'
+    Set-Content -LiteralPath $accMain4 -Value 'STALE' -Encoding UTF8
+    Set-Content -LiteralPath $accPr4 -Value 'STALE' -Encoding UTF8
+    $global:FailRounds = @{}
+    $res4 = Invoke-MicroInterleaved -LaunchRep $launch -RepCount 2 -WarmupCount 0 -MainOut $accMain4 -PrOut $accPr4
+    Assert-True ($null -ne $res4 -and @(Get-Content $accMain4 | Where-Object { $_ -match 'STALE' }).Count -eq 0) '[interleave] pre-existing accumulator content is cleared before appending'
+}
+finally {
+    Remove-Item function:New-RoundFile -ErrorAction SilentlyContinue
+    Remove-Item function:Get-RepSeq -ErrorAction SilentlyContinue
+    Remove-Variable -Name FailRounds -Scope Global -ErrorAction SilentlyContinue
+    if (Test-Path $microIntTmp) { Remove-Item $microIntTmp -Recurse -Force -ErrorAction SilentlyContinue }
+}
 
 # cleanup
 foreach ($d in @($baseTree, $prTree, $OutDir, $exeDir)) {

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -304,6 +304,24 @@ Assert-True ($microFn -match '\[int\]\$TimeoutSec\s*=\s*600') '[micro] Invoke-Mi
 Assert-True ($microFn -match '\$timeoutSec\s*=\s*\$TimeoutSec') '[micro] Invoke-MicroRun honors the -TimeoutSec param (no hardcoded constant)'
 
 # ===========================================================================
+#  Compare-mode micro call-site wiring — the glue that feeds the helpers
+# ===========================================================================
+# ConvertTo-MicroRepLines / Invoke-MicroInterleaved are unit-tested in isolation
+# below with a synthetic launch stub, but the MAIN-FLOW wiring that drives them in a
+# real /perf compare run is only as good as the call site. Lock it so a refactor
+# can't silently break rep interleaving (drop -TimeoutSec, mis-pass the rep/warmup
+# counts, pick the wrong side exe, or read the wrong accumulator). The call site
+# lives in the script body (after the last function), so assert against the raw
+# source scoped to the $IncludeMicro block.
+$microWire = [regex]::Match($src, '(?s)if \(\$IncludeMicro\).*?\$main = Measure-PerfRuns').Value
+Assert-True ($microWire.Length -gt 0) '[micro-wiring] $IncludeMicro call-site block located in the orchestrator body'
+Assert-True ($microWire -match '\$exe\s*=\s*if.*\$microMainExe.*\$microPrExe') '[micro-wiring] launchRep selects the side exe (main vs pr)'
+Assert-True ($microWire -match 'Invoke-MicroRun\s+-Exe\s+\$exe\s+-Tag\s+.+-RepCount\s+1\s+-IterCount\s+\$MicroIterations\s+-TimeoutSec\s+\$MicroRepTimeoutSec') '[micro-wiring] launchRep runs ONE rep/round at the micro iter + per-round timeout budget'
+Assert-True ($microWire -match 'Invoke-MicroInterleaved\s+-LaunchRep\s+\$launchRep\s+-RepCount\s+\$MicroReps\s+-WarmupCount\s+\$MicroWarmup') '[micro-wiring] interleaver gets MicroReps measured + MicroWarmup warmup rounds'
+Assert-True (($microWire -match '\$microInter\.MainJson') -and ($microWire -match '\$microInter\.PrJson')) '[micro-wiring] comparison reads the interleaved accumulators (.MainJson/.PrJson)'
+Assert-True ($microWire -match 'Get-PerfMicroComparison') '[micro-wiring] interleaved accumulators feed Get-PerfMicroComparison'
+
+# ===========================================================================
 #  Invoke-OneRun — --percent threading (-RunPercent defaults to $Percent)
 # ===========================================================================
 # The low-mutation skip-floor leg drives the SAME exe at a different mutation
@@ -420,11 +438,16 @@ try {
 
     # --- Invoke-MicroInterleaved: the launch stub (FailRounds drives one-sided failures). ---
     $global:FailRounds = @{}
+    # Plain scriptblock (NOT .GetNewClosure()): a closure rebinds to a module whose
+    # scope-parent is GLOBAL, which can't see the script-scoped New-RoundFile when the
+    # test runs in its own script scope (CI invokes the file via the call operator, not
+    # dot-source). A plain scriptblock stays bound to THIS session state where both
+    # New-RoundFile and the explicit $global:FailRounds resolve.
     $launch = {
         param($side, $round)
         if ($global:FailRounds.ContainsKey("${side}:${round}")) { return $null }
         New-RoundFile $side $round @('M1', 'M2')
-    }.GetNewClosure()
+    }
 
     # A. happy path: 1 warmup + 3 measured rounds -> 3 dense reps on both sides.
     $global:FailRounds = @{}

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -436,8 +436,10 @@ try {
     $emptyF = Join-Path $microIntTmp 'empty.jsonl'; Set-Content -LiteralPath $emptyF -Value '' -NoNewline
     Assert-True ($null -eq (ConvertTo-MicroRepLines -RoundFile $emptyF -RepIndex 0)) '[rewrite] empty file -> $null (drop the round)'
 
-    # --- Invoke-MicroInterleaved: the launch stub (FailRounds drives one-sided failures). ---
+    # --- Invoke-MicroInterleaved: the launch stub. FailRounds drives one-sided $null
+    #     failures; ThrowRounds drives one-sided EXCEPTIONS (a transient runner hiccup). ---
     $global:FailRounds = @{}
+    $global:ThrowRounds = @{}
     # Plain scriptblock (NOT .GetNewClosure()): a closure rebinds to a module whose
     # scope-parent is GLOBAL, which can't see the script-scoped New-RoundFile when the
     # test runs in its own script scope (CI invokes the file via the call operator, not
@@ -445,6 +447,7 @@ try {
     # New-RoundFile and the explicit $global:FailRounds resolve.
     $launch = {
         param($side, $round)
+        if ($global:ThrowRounds.ContainsKey("${side}:${round}")) { throw "synthetic transient launch failure ${side}:${round}" }
         if ($global:FailRounds.ContainsKey("${side}:${round}")) { return $null }
         New-RoundFile $side $round @('M1', 'M2')
     }
@@ -482,11 +485,23 @@ try {
     $global:FailRounds = @{}
     $res4 = Invoke-MicroInterleaved -LaunchRep $launch -RepCount 2 -WarmupCount 0 -MainOut $accMain4 -PrOut $accPr4
     Assert-True ($null -ne $res4 -and @(Get-Content $accMain4 | Where-Object { $_ -match 'STALE' }).Count -eq 0) '[interleave] pre-existing accumulator content is cleared before appending'
+
+    # E. a launcher that THROWS (transient runner hiccup) is caught and drops only that
+    #    round like a $null return — surviving reps are kept and the leg still produces a
+    #    result, rather than the exception aborting the whole micro leg.
+    $global:FailRounds = @{}
+    $global:ThrowRounds = @{ 'pr:3' = $true }   # round 3: pr launch throws
+    $accMain5 = Join-Path $microIntTmp 'acc5-main.jsonl'; $accPr5 = Join-Path $microIntTmp 'acc5-pr.jsonl'
+    $res5 = Invoke-MicroInterleaved -LaunchRep $launch -RepCount 3 -WarmupCount 1 -MainOut $accMain5 -PrOut $accPr5
+    Assert-True ($null -ne $res5 -and $res5.Reps -eq 2) '[interleave] a throwing launch drops only that round (not the whole leg) -> 2 kept'
+    Assert-True ((Get-RepSeq @(Get-Content $accMain5) 'M1') -eq '0,1') '[interleave] reps surviving a thrown round stay dense 0,1'
+    $global:ThrowRounds = @{}
 }
 finally {
     Remove-Item function:New-RoundFile -ErrorAction SilentlyContinue
     Remove-Item function:Get-RepSeq -ErrorAction SilentlyContinue
     Remove-Variable -Name FailRounds -Scope Global -ErrorAction SilentlyContinue
+    Remove-Variable -Name ThrowRounds -Scope Global -ErrorAction SilentlyContinue
     if (Test-Path $microIntTmp) { Remove-Item $microIntTmp -Recurse -Force -ErrorAction SilentlyContinue }
 }
 


### PR DESCRIPTION
## What

Makes the reconciler micro-suite's **ns/op** paired CI statistically trustworthy by interleaving the two sides at the **rep level**, and ships the ns-flag promotion mechanism **dormant** (capability only — no change to what `/perf` flags yet).

Class-B harness PR: **0 `src/Reactor`**, all changes under `tests/stress_perf/**`.

## Why

The micro-suite ran both sides as *one all-`main`* then *one all-PR* process. A systematic process-to-process timing offset (thermal/scheduling drift) biased every paired ns difference the same way:

- On #692 (a near-neutral PR) it pushed **~9/16 structurally-unrelated benches' ns CI to exclude 0**, nearly all with a *uniform negative sign*, while deterministic alloc was flat 0.0% — the textbook offset signature.
- An **identical binary** as both sides spuriously flagged up to **−14.8% ns** on a no-op.

That's why ns was informational-only.

## How

**Rep-level interleave** (`Invoke-MicroInterleaved`): each round alternates a fresh `main` then PR `--reps 1` launch, so the offset is randomized round-to-round *into the paired variance* instead of a constant bias → the ns paired CI becomes unbiased. Surviving rounds are renumbered to **dense repetition indices** on both sides (drop-both on a one-sided failure), so the accumulator is byte-compatible with a single multi-rep launch and `Get-PerfMicroComparison` is **unchanged**.

**Dormant ns flag** (`$MicroNsAutoFlag = $false`): row status still tracks deterministic **alloc bytes/op** (v1 behaviour). When armed it combines ns + alloc behind a provisional **±3% min-effect band**, reading **↕️ mixed** when the axes disagree. Arming is a measurement-only follow-up (it relabels verdicts, never blocks a merge), gated on a **real-CI identical-binary band calibration** — which can only run *after* this merges, since `/perf` builds the harness from the default branch.

## Changes

- `Run-PerfBenchmark.ps1`: `ConvertTo-MicroRepLines` + `Invoke-MicroInterleaved`; new `-MicroWarmup` (1) + `-MicroRepTimeoutSec` (180); `Invoke-MicroRun` gains `-TimeoutSec`.
- `PerfLib.ps1`: `$MicroNsMinEffectPct` (3.0) + `$MicroNsAutoFlag` gate; combined `Get-PerfMicroRowStatus`; `mixed` glyph; section/footnote prose conditional on the flag.
- Docs: `METHODOLOGY.md` + `ci/README.md` — ns is now rep-interleaved (CI unbiased), flag dormant pending the band calibration; new params documented.
- Tests: `PerfLib.Tests` 226→**243** (armed combination matrix + synthetic identical-binary no-false-flag calibration + clear-effect flag + `mixed` glyph); `RunPerfBenchmark.Tests` 39→**62** (interleave drop-both alignment, dense rep indexing across a dropped round, rewrite correctness, `<2`→`$null`, stale-clear, new param defaults).

## Budget

Per #692 the micro phase had ~10× headroom (55 s/side at `--reps 12` vs the 600 s timeout). Per-rep interleave (~13 rounds/side, each a `--reps 1` launch ≈ 13 s) ≈ **~170 s/side**, comfortably within budget.

## Note on rollout

This PR is **dormant by design** — ns verdicts are unchanged until the flag is separately armed after the post-merge band calibration. The `±3%` band is a documented placeholder to be recalibrated from real interleaved identical-binary data.

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)