### PR TITLE
[perf-measure only · DO NOT MERGE] #657 rebased past #694 — keyed-leg /perf

### DIFF
--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+using System.Collections.Concurrent;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Reactor.Core.Internal;
 using WinUI = Microsoft.UI.Xaml.Controls;
@@ -153,16 +155,43 @@ internal static class ChildReconciler
         int oldLen = oldChildren.Length;
         int newLen = newChildren.Length;
 
+        // Cache the child count once (#37). Both the prefix and suffix loops
+        // only ever Replace (RemoveAt+Insert — count-neutral) or skip, so the
+        // panel count is stable across them. This avoids re-reading the COM
+        // IVector.get_Size on every iteration of the suffix loop.
+        int childCount = children.Count;
+
         // Phase 1: Common prefix
         int prefixLen = 0;
         while (prefixLen < oldLen && prefixLen < newLen &&
                KeyMatch(oldChildren[prefixLen], newChildren[prefixLen]) &&
                reconciler.CanUpdate(oldChildren[prefixLen], newChildren[prefixLen]))
         {
-            // Update in place
-            if (prefixLen < children.Count)
+            var oldEl = oldChildren[prefixLen];
+            var newEl = newChildren[prefixLen];
+
+            // Early skip (#30): when the element is structurally identical we
+            // can avoid the children.Get COM call and the full property diff
+            // inside UpdateChild — exactly mirroring the positional path. The
+            // keyed prefix is the steady-state path for stable lists (e.g. grid
+            // rows whose keys never change), so without this they re-diff every
+            // tick.
+            if (Element.CanSkipUpdate(oldEl, newEl)
+                && !reconciler.ForceRenderThroughWrapper(newEl))
             {
-                var replacement = reconciler.UpdateChild(oldChildren[prefixLen], newChildren[prefixLen], children.Get(prefixLen), requestRerender);
+                reconciler.DebugElementsSkipped++;
+                // Refresh the Tag when the element carries callbacks so the
+                // event trampoline dispatches through the latest closure.
+                if (newEl.HasCallbacks && prefixLen < childCount && children.Get(prefixLen) is FrameworkElement fe)
+                    Reconciler.SetElementTag(fe, newEl);
+                prefixLen++;
+                continue;
+            }
+
+            // Update in place
+            if (prefixLen < childCount)
+            {
+                var replacement = reconciler.UpdateChild(oldEl, newEl, children.Get(prefixLen), requestRerender);
                 if (replacement is not null)
                 {
                     reconciler.UnmountChild(children.Get(prefixLen));
@@ -180,10 +209,26 @@ internal static class ChildReconciler
         {
             // Update in place (from end)
             int oldIdx = oldLen - 1 - suffixLen;
-            int panelIdx = children.Count - 1 - suffixLen;
-            if (panelIdx >= 0 && panelIdx < children.Count)
+            int newIdx = newLen - 1 - suffixLen;
+            var oldEl = oldChildren[oldIdx];
+            var newEl = newChildren[newIdx];
+            int panelIdx = childCount - 1 - suffixLen;
+
+            // Early skip (#30): same fast-path as the prefix loop, applied from
+            // the end of the list.
+            if (Element.CanSkipUpdate(oldEl, newEl)
+                && !reconciler.ForceRenderThroughWrapper(newEl))
             {
-                var replacement = reconciler.UpdateChild(oldChildren[oldIdx], newChildren[newLen - 1 - suffixLen], children.Get(panelIdx), requestRerender);
+                reconciler.DebugElementsSkipped++;
+                if (newEl.HasCallbacks && panelIdx >= 0 && panelIdx < childCount && children.Get(panelIdx) is FrameworkElement fe)
+                    Reconciler.SetElementTag(fe, newEl);
+                suffixLen++;
+                continue;
+            }
+
+            if (panelIdx >= 0 && panelIdx < childCount)
+            {
+                var replacement = reconciler.UpdateChild(oldEl, newEl, children.Get(panelIdx), requestRerender);
                 if (replacement is not null)
                 {
                     reconciler.UnmountChild(children.Get(panelIdx));
@@ -251,126 +296,151 @@ internal static class ChildReconciler
         Action requestRerender,
         AnimationKind? ambientKind)
     {
-        // Build old key → index map
-        var oldKeyMap = new Dictionary<string, int>(oldMidLen);
-        for (int i = 0; i < oldMidLen; i++)
+        // Pool the per-call working buffers (#33). ChildReconciler recurses
+        // via UpdateChild below, so each (re-entrant) call must own distinct
+        // buffers — ArrayPool and the dict pool guarantee that, whereas a
+        // single ThreadStatic scratch would corrupt the outer diff.
+        var intPool = ArrayPool<int>.Shared;
+        var boolPool = ArrayPool<bool>.Shared;
+        var oldKeyMap = RentKeyIndexDict(oldMidLen);
+        var keyToIndex = RentKeyIndexDict(newMidLen);
+        int[] newToOld = intPool.Rent(newMidLen);
+        bool[] matched = boolPool.Rent(oldMidLen);
+        bool[] inLis = boolPool.Rent(newMidLen);
+        try
         {
-            var key = GetKey(oldChildren[oldStart + i], oldStart + i);
-            oldKeyMap[key] = i;
-        }
+            // A rented bool array can carry stale `true` markers; `matched`
+            // must default to false for the unmatched-removal pass below.
+            global::System.Array.Clear(matched, 0, oldMidLen);
 
-        // Map new keys to old indices
-        var newToOld = new int[newMidLen];
-        var matched = new bool[oldMidLen];
-        for (int i = 0; i < newMidLen; i++)
-        {
-            var key = GetKey(newChildren[newStart + i], newStart + i);
-            if (oldKeyMap.TryGetValue(key, out int oldIdx) &&
-                reconciler.CanUpdate(oldChildren[oldStart + oldIdx], newChildren[newStart + i]))
+            // Build old key → index map
+            for (int i = 0; i < oldMidLen; i++)
             {
-                newToOld[i] = oldIdx;
-                matched[oldIdx] = true;
+                var key = GetKey(oldChildren[oldStart + i], oldStart + i);
+                oldKeyMap[key] = i;
             }
-            else
-            {
-                newToOld[i] = -1;
-            }
-        }
 
-        // Compute LIS on newToOld
-        var lisIndices = ComputeLIS(newToOld);
-        var inLIS = new HashSet<int>(lisIndices);
-
-        // Step 1: Remove unmatched old items (reverse order for stable indices)
-        for (int i = oldMidLen - 1; i >= 0; i--)
-        {
-            if (!matched[i])
+            // Map new keys to old indices
+            for (int i = 0; i < newMidLen; i++)
             {
-                int panelIdx = prefixLen + i;
-                if (panelIdx < children.Count)
+                var key = GetKey(newChildren[newStart + i], newStart + i);
+                if (oldKeyMap.TryGetValue(key, out int oldIdx) &&
+                    reconciler.CanUpdate(oldChildren[oldStart + oldIdx], newChildren[newStart + i]))
                 {
-                    reconciler.RemoveChildWithExitTransition(children, panelIdx);
+                    newToOld[i] = oldIdx;
+                    matched[oldIdx] = true;
+                }
+                else
+                {
+                    newToOld[i] = -1;
                 }
             }
-        }
 
-        // Build key→panel-index lookup for O(1) FindItemByOldIndex (CR-011).
-        var keyToIndex = new Dictionary<string, int>();
-        int searchEnd = children.Count - suffixLen;
-        for (int i = prefixLen; i < searchEnd && i < children.Count; i++)
-        {
-            var child = children.Get(i);
-            if (child is FrameworkElement fe && Reconciler.GetElementTag(fe) is Element tagElement)
+            // Compute LIS on newToOld into a pooled membership mask — avoids
+            // the HashSet allocation and the redundant identical-set copy that
+            // the old `new HashSet<int>(ComputeLIS(...))` pair did (#31/#32).
+            ComputeLISInto(newToOld, newMidLen, inLis);
+
+            // Step 1: Remove unmatched old items (reverse order for stable indices)
+            for (int i = oldMidLen - 1; i >= 0; i--)
             {
-                var key = GetKey(tagElement, i);
-                keyToIndex.TryAdd(key, i);
-            }
-        }
-
-        // Step 2: Process new items - insert new, move existing not in LIS
-        for (int i = 0; i < newMidLen; i++)
-        {
-            int targetPanelIdx = prefixLen + i;
-
-            if (newToOld[i] == -1)
-            {
-                var ctrl = reconciler.Mount(newChildren[newStart + i], requestRerender);
-                if (ctrl is not null)
+                if (!matched[i])
                 {
-                    children.Insert(targetPanelIdx, ctrl);
-                    ApplyAmbientEnterIfActive(ctrl, newChildren[newStart + i], ambientKind);
-                }
-            }
-            else if (inLIS.Contains(i))
-            {
-                if (targetPanelIdx < children.Count)
-                {
-                    var replacement = reconciler.UpdateChild(
-                        oldChildren[oldStart + newToOld[i]],
-                        newChildren[newStart + i],
-                        children.Get(targetPanelIdx),
-                        requestRerender);
-                    if (replacement is not null)
+                    int panelIdx = prefixLen + i;
+                    if (panelIdx < children.Count)
                     {
-                        reconciler.UnmountChild(children.Get(targetPanelIdx));
-                        children.Replace(targetPanelIdx, replacement);
+                        reconciler.RemoveChildWithExitTransition(children, panelIdx);
                     }
                 }
             }
-            else
+
+            // Build key→panel-index lookup for O(1) FindItemByOldIndex (CR-011).
+            int searchEnd = children.Count - suffixLen;
+            for (int i = prefixLen; i < searchEnd && i < children.Count; i++)
             {
-                int oldRelIdx = newToOld[i];
-                int oldAbsIdx = oldStart + oldRelIdx;
-                var lookupKey = oldAbsIdx < oldChildren.Length ? GetKey(oldChildren[oldAbsIdx], oldAbsIdx) : null;
-                int currentPos = lookupKey != null && keyToIndex.TryGetValue(lookupKey, out var pos) ? pos : -1;
-                if (currentPos >= 0 && currentPos != targetPanelIdx)
+                var child = children.Get(i);
+                if (child is FrameworkElement fe && Reconciler.GetElementTag(fe) is Element tagElement)
                 {
-                    var movedChild = children.Get(currentPos);
-                    children.Move(currentPos, targetPanelIdx);
-                    // Update lookup: moved element is now at targetPanelIdx.
-                    if (lookupKey != null) keyToIndex[lookupKey] = targetPanelIdx;
-                    // Spec 042 §6 — implicit Offset animation on the moved
-                    // child so the reorder reads visually under an ambient.
-                    // Attach via the existing Composition helper rather
-                    // than the per-element LayoutAnimation modifier (which
-                    // remains the user's per-element opt-in).
-                    if (ambientKind is { } k && movedChild is UIElement movedUi)
-                        ApplyAmbientMove(movedUi, k);
+                    var key = GetKey(tagElement, i);
+                    keyToIndex.TryAdd(key, i);
                 }
-                if (targetPanelIdx < children.Count)
+            }
+
+            // Step 2: Process new items - insert new, move existing not in LIS
+            for (int i = 0; i < newMidLen; i++)
+            {
+                int targetPanelIdx = prefixLen + i;
+
+                if (newToOld[i] == -1)
                 {
-                    var replacement = reconciler.UpdateChild(
-                        oldChildren[oldStart + oldRelIdx],
-                        newChildren[newStart + i],
-                        children.Get(targetPanelIdx),
-                        requestRerender);
-                    if (replacement is not null)
+                    var ctrl = reconciler.Mount(newChildren[newStart + i], requestRerender);
+                    if (ctrl is not null)
                     {
-                        reconciler.UnmountChild(children.Get(targetPanelIdx));
-                        children.Replace(targetPanelIdx, replacement);
+                        children.Insert(targetPanelIdx, ctrl);
+                        ApplyAmbientEnterIfActive(ctrl, newChildren[newStart + i], ambientKind);
+                    }
+                }
+                else if (inLis[i])
+                {
+                    if (targetPanelIdx < children.Count)
+                    {
+                        var replacement = reconciler.UpdateChild(
+                            oldChildren[oldStart + newToOld[i]],
+                            newChildren[newStart + i],
+                            children.Get(targetPanelIdx),
+                            requestRerender);
+                        if (replacement is not null)
+                        {
+                            reconciler.UnmountChild(children.Get(targetPanelIdx));
+                            children.Replace(targetPanelIdx, replacement);
+                        }
+                    }
+                }
+                else
+                {
+                    int oldRelIdx = newToOld[i];
+                    int oldAbsIdx = oldStart + oldRelIdx;
+                    var lookupKey = oldAbsIdx < oldChildren.Length ? GetKey(oldChildren[oldAbsIdx], oldAbsIdx) : null;
+                    int currentPos = lookupKey != null && keyToIndex.TryGetValue(lookupKey, out var pos) ? pos : -1;
+                    if (currentPos >= 0 && currentPos != targetPanelIdx)
+                    {
+                        var movedChild = children.Get(currentPos);
+                        children.Move(currentPos, targetPanelIdx);
+                        // Update lookup: moved element is now at targetPanelIdx.
+                        if (lookupKey != null) keyToIndex[lookupKey] = targetPanelIdx;
+                        // Spec 042 §6 — implicit Offset animation on the moved
+                        // child so the reorder reads visually under an ambient.
+                        // Attach via the existing Composition helper rather
+                        // than the per-element LayoutAnimation modifier (which
+                        // remains the user's per-element opt-in).
+                        if (ambientKind is { } k && movedChild is UIElement movedUi)
+                            ApplyAmbientMove(movedUi, k);
+                    }
+                    if (targetPanelIdx < children.Count)
+                    {
+                        var replacement = reconciler.UpdateChild(
+                            oldChildren[oldStart + oldRelIdx],
+                            newChildren[newStart + i],
+                            children.Get(targetPanelIdx),
+                            requestRerender);
+                        if (replacement is not null)
+                        {
+                            reconciler.UnmountChild(children.Get(targetPanelIdx));
+                            children.Replace(targetPanelIdx, replacement);
+                        }
                     }
                 }
             }
+        }
+        finally
+        {
+            // Clear + return on every exit (including exceptions) so pooled
+            // buffers never leak references or stale markers across frames.
+            ReturnKeyIndexDict(oldKeyMap);
+            ReturnKeyIndexDict(keyToIndex);
+            intPool.Return(newToOld);
+            boolPool.Return(matched, clearArray: true);
+            boolPool.Return(inLis, clearArray: true);
         }
     }
 
@@ -400,81 +470,123 @@ internal static class ChildReconciler
     }
 
     /// <summary>
-    /// Compute Longest Increasing Subsequence.
-    /// Returns indices into the input array that form the LIS.
-    /// Skips entries with value -1 (unmapped items).
-    /// O(n log n) using patience sorting.
+    /// Compute the Longest Increasing Subsequence over the first
+    /// <paramref name="length"/> entries of <paramref name="arr"/>, writing the
+    /// membership mask into <paramref name="inLis"/> (<c>inLis[i] == true</c> iff
+    /// index <c>i</c> participates in the LIS). Entries with value -1 are skipped
+    /// (unmapped items). O(n log n) patience sorting. All working buffers are
+    /// rented from <see cref="ArrayPool{T}"/>, so the hot reconcile path pays no
+    /// per-call heap allocation (#32).
+    /// </summary>
+    internal static void ComputeLISInto(int[] arr, int length, bool[] inLis)
+    {
+        if (length > 0) Array.Clear(inLis, 0, length);
+        if (length == 0) return;
+
+        var pool = ArrayPool<int>.Shared;
+        int[] tails = pool.Rent(length);        // Smallest tail values
+        int[] tailIndices = pool.Rent(length);  // arr indices matching tails
+        int[] predecessors = pool.Rent(length); // back-pointers for reconstruction
+        try
+        {
+            int tailsCount = 0;
+            for (int i = 0; i < length; i++)
+            {
+                if (arr[i] == -1) continue; // Skip unmapped
+
+                int val = arr[i];
+
+                // Binary search for insertion position in tails[0..tailsCount).
+                int lo = 0, hi = tailsCount;
+                while (lo < hi)
+                {
+                    int mid = (lo + hi) / 2;
+                    if (tails[mid] < val) lo = mid + 1;
+                    else hi = mid;
+                }
+
+                // Predecessor is the previous tail's arr-index (read before the
+                // tails[lo] write — index lo-1 is unaffected by it).
+                predecessors[i] = lo > 0 ? tailIndices[lo - 1] : -1;
+
+                if (lo == tailsCount)
+                {
+                    tails[tailsCount] = val;
+                    tailIndices[tailsCount] = i;
+                    tailsCount++;
+                }
+                else
+                {
+                    tails[lo] = val;
+                    tailIndices[lo] = i;
+                }
+            }
+
+            // Backtrack from the last tail to mark LIS membership. Only
+            // non-skipped indices ever enter the chain, so unwritten
+            // predecessor slots for skipped entries are never read.
+            if (tailsCount == 0) return;
+            int idx = tailIndices[tailsCount - 1];
+            while (idx != -1)
+            {
+                inLis[idx] = true;
+                idx = predecessors[idx];
+            }
+        }
+        finally
+        {
+            pool.Return(tails);
+            pool.Return(tailIndices);
+            pool.Return(predecessors);
+        }
+    }
+
+    /// <summary>
+    /// Compute Longest Increasing Subsequence, returning the set of
+    /// participating indices. Convenience wrapper over
+    /// <see cref="ComputeLISInto"/> for tests and set-shaped callers; the hot
+    /// reconcile path uses the allocation-free <see cref="ComputeLISInto"/>.
     /// </summary>
     internal static HashSet<int> ComputeLIS(int[] arr)
     {
-        if (arr.Length == 0) return new HashSet<int>();
-
-        var tails = new List<int>();     // Smallest tail values
-        var tailIndices = new List<int>(); // Indices in arr corresponding to tails
-        var predecessors = new int[arr.Length];
-        Array.Fill(predecessors, -1);
-
-        for (int i = 0; i < arr.Length; i++)
-        {
-            if (arr[i] == -1) continue; // Skip unmapped
-
-            int val = arr[i];
-
-            // Binary search for insertion position
-            int lo = 0, hi = tails.Count;
-            while (lo < hi)
-            {
-                int mid = (lo + hi) / 2;
-                if (tails[mid] < val) lo = mid + 1;
-                else hi = mid;
-            }
-
-            if (lo == tails.Count)
-            {
-                tails.Add(val);
-                tailIndices.Add(i);
-            }
-            else
-            {
-                tails[lo] = val;
-                tailIndices[lo] = i;
-            }
-
-            if (lo > 0)
-                predecessors[i] = tailIndices[lo - 1];
-        }
-
-        // Backtrack to find actual LIS indices
         var result = new HashSet<int>();
-        if (tailIndices.Count == 0) return result;
+        if (arr.Length == 0) return result;
 
-        int idx = tailIndices[^1];
-        while (idx != -1)
+        var pool = ArrayPool<bool>.Shared;
+        bool[] mask = pool.Rent(arr.Length);
+        try
         {
-            result.Add(idx);
-            idx = predecessors[idx];
+            ComputeLISInto(arr, arr.Length, mask);
+            for (int i = 0; i < arr.Length; i++)
+                if (mask[i]) result.Add(i);
         }
-
+        finally
+        {
+            pool.Return(mask, clearArray: true);
+        }
         return result;
     }
 
     private static Element[] Filter(Element[] elements)
     {
-        // Fast path: if no filtering needed, return as-is
-        bool needsFilter = false;
+        // Single count pass; the result array is then sized exactly and filled
+        // in one more pass — no intermediate List + ToArray double-allocation
+        // (#36). The common no-null case still returns the input untouched.
+        int keep = 0;
         for (int i = 0; i < elements.Length; i++)
         {
-            if (elements[i] is null or EmptyElement) { needsFilter = true; break; }
+            if (elements[i] is not null and not EmptyElement) keep++;
         }
-        if (!needsFilter) return elements;
+        if (keep == elements.Length) return elements;
 
-        var result = new List<Element>(elements.Length);
+        var result = new Element[keep];
+        int j = 0;
         for (int i = 0; i < elements.Length; i++)
         {
             if (elements[i] is not null and not EmptyElement)
-                result.Add(elements[i]);
+                result[j++] = elements[i];
         }
-        return result.ToArray();
+        return result;
     }
 
     private static bool HasAnyKeys(Element[] elements)
@@ -493,11 +605,45 @@ internal static class ChildReconciler
         return a.Key == b.Key;
     }
 
+    // Cache the per-Type display name used by the unkeyed GetKey fallback so we
+    // don't reflect over the runtime type on every diff (#38). Explicit keys
+    // are strongly preferred and bypass this path entirely.
+    private static readonly ConcurrentDictionary<Type, string> _typeNameCache = new();
+
     private static string GetKey(Element element, int positionalIndex)
     {
         // Use explicit key if available, otherwise fall back to type+position
         if (element.Key is not null) return element.Key;
-        return $"__pos_{positionalIndex}_{element.GetType().Name}";
+        var typeName = _typeNameCache.GetOrAdd(element.GetType(), static t => t.Name);
+        return $"__pos_{positionalIndex}_{typeName}";
+    }
+
+    // ── Re-entrancy-safe Dictionary&lt;string,int&gt; pool ────────────────────
+    // ReconcileKeyedMiddle needs two transient key→index maps per call, and it
+    // recurses through UpdateChild. A per-thread stack hands each (nested) call
+    // its own instances: rented dicts are not in the pool, so an inner call can
+    // never grab a buffer the outer call is still using. Pool size is capped so
+    // deep trees don't retain an unbounded number of dictionaries.
+    [ThreadStatic] private static Stack<Dictionary<string, int>>? _keyIndexDictPool;
+    private const int KeyIndexDictPoolCap = 16;
+
+    private static Dictionary<string, int> RentKeyIndexDict(int capacity)
+    {
+        var pool = _keyIndexDictPool;
+        if (pool is { Count: > 0 })
+        {
+            var d = pool.Pop();
+            if (capacity > 0) d.EnsureCapacity(capacity);
+            return d;
+        }
+        return new Dictionary<string, int>(capacity > 0 ? capacity : 0, StringComparer.Ordinal);
+    }
+
+    private static void ReturnKeyIndexDict(Dictionary<string, int> dict)
+    {
+        dict.Clear();
+        var pool = _keyIndexDictPool ??= new Stack<Dictionary<string, int>>();
+        if (pool.Count < KeyIndexDictPoolCap) pool.Push(dict);
     }
 
     /// <summary>

--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -434,13 +434,23 @@ internal static class ChildReconciler
         }
         finally
         {
-            // Clear + return on every exit (including exceptions) so pooled
-            // buffers never leak references or stale markers across frames.
+            // Return every pooled buffer on all exits (including exceptions).
+            // The dict pool clears entries on return (ReturnKeyIndexDict), so
+            // element-key references never leak across frames. The bool buffers
+            // hold no references and have their used range fully (re)initialized
+            // before any read — `matched` via the Array.Clear-on-rent above and
+            // `inLis` via ComputeLISInto's own leading clear — so they return
+            // dirty (clearArray:false) and skip an avoidable O(rented-capacity)
+            // wipe on this hot path. `newToOld` (int) is likewise overwritten in
+            // full for [0,newMidLen) before each read, so it too returns without
+            // clearing. (Reference-typed pooled buffers elsewhere — e.g. the
+            // string[]/ReactorRow[] in KeyedListDiff — DO clear, to avoid pinning
+            // objects across frames.)
             ReturnKeyIndexDict(oldKeyMap);
             ReturnKeyIndexDict(keyToIndex);
             intPool.Return(newToOld);
-            boolPool.Return(matched, clearArray: true);
-            boolPool.Return(inLis, clearArray: true);
+            boolPool.Return(matched);
+            boolPool.Return(inLis);
         }
     }
 

--- a/src/Reactor/Core/Internal/KeyedListDiff.cs
+++ b/src/Reactor/Core/Internal/KeyedListDiff.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.UI.Reactor.Core.Internal;
@@ -42,6 +43,19 @@ namespace Microsoft.UI.Reactor.Core.Internal;
 /// </remarks>
 internal static class KeyedListDiff
 {
+    // Cached sample for the null-key bailout diagnostic so the slow path
+    // doesn't allocate a fresh single-element array every time (#41).
+    private static readonly string[] NullKeySample = { "<null>" };
+
+    // Descending-by-index comparer used to remove doomed rows from the tail
+    // first so earlier OC indices stay stable. Singleton — avoids capturing a
+    // fresh comparison delegate on every diff that has deletions.
+    private sealed class RowIndexDescendingComparer : IComparer<ReactorRow>
+    {
+        public static readonly RowIndexDescendingComparer Instance = new();
+        public int Compare(ReactorRow? a, ReactorRow? b) => b!.Index.CompareTo(a!.Index);
+    }
+
     /// <summary>
     /// Per-diff bookkeeping returned to callers (tests, telemetry, the
     /// Phase 3 animation pipeline) so they can observe the op shape
@@ -118,21 +132,55 @@ internal static class KeyedListDiff
         ArgumentNullException.ThrowIfNull(newItems);
         ArgumentNullException.ThrowIfNull(keySelector);
 
+        int newCount = newItems.Count;
+
+        // Rent the new-keys buffer (#2) rather than allocating a fresh array
+        // every diff. The rented array may be larger than newCount, so the
+        // explicit length is threaded to every consumer below — never
+        // newKeys.Length. The buffer is cleared + returned on every exit
+        // (including exceptions and the early bailouts) via the finally.
+        string[] newKeys = newCount == 0
+            ? global::System.Array.Empty<string>()
+            : ArrayPool<string>.Shared.Rent(newCount);
+        bool rentedKeys = newCount != 0;
+        try
+        {
+            return ApplyCore(state, newItems, keySelector, logger, diagnosticContext, ambient, controlInstance, newKeys, newCount);
+        }
+        finally
+        {
+            if (rentedKeys)
+                ArrayPool<string>.Shared.Return(newKeys, clearArray: true);
+        }
+    }
+
+    /// <summary>
+    /// Core keyed diff over a pre-materialized <paramref name="newKeys"/> buffer
+    /// (valid length <paramref name="newCount"/>; the array may be larger). Split
+    /// out from <see cref="Apply{T}"/> so the rented key buffer is released on
+    /// every exit path via a single try/finally in the caller.
+    /// </summary>
+    private static DiffStats ApplyCore<T>(
+        ReactorListState state,
+        IReadOnlyList<T> newItems,
+        Func<T, int, string> keySelector,
+        ILogger? logger,
+        string? diagnosticContext,
+        AmbientAnimation? ambient,
+        object? controlInstance,
+        string[] newKeys,
+        int newCount)
+    {
         // Resolve the animation intent for this diff once up front. A null
         // result means "no per-container animation work this diff" — every
         // op path below shortcuts on this rather than re-checking the kind.
-        // The contract is symmetric across Insert / Move / Remove so the
-        // user can predict the visual effect from the ambient alone.
         AnimationKind? enterKind = (ambient is { HasEffect: true }) ? ambient.Kind : null;
 
-        int newCount = newItems.Count;
         int oldCount = state.LastKeys.Count;
 
-        // Materialize new keys once. We need this list twice (lockstep walk
-        // and the survivor pass), so paying for one allocation up front is
-        // cheaper than calling keySelector twice and avoids the user-callback
-        // observing each item more than once per diff.
-        string[] newKeys = newCount == 0 ? global::System.Array.Empty<string>() : new string[newCount];
+        // Materialize new keys into the rented buffer. We read them twice
+        // (lockstep walk + survivor pass), so projecting once up front avoids
+        // the user callback observing each item more than once per diff.
         for (int i = 0; i < newCount; i++)
         {
             var k = keySelector(newItems[i], i);
@@ -146,41 +194,44 @@ internal static class KeyedListDiff
                 ReportBailout(
                     controlInstance, diagnosticContext, logger,
                     Microsoft.UI.Reactor.Core.Diagnostics.KeyedListDiagnosticKind.NullKey,
-                    new[] { "<null>" },
+                    NullKeySample,
                     indexHint: i);
                 return Bailout(state, newItems, keySelector);
             }
             newKeys[i] = k;
         }
 
-        // Detect duplicate keys via the same hash set used by the survivor
-        // map below. This costs O(n) on top of the diff but is the only way
-        // to give a useful diagnostic; duplicates inside newKeys would
-        // otherwise silently corrupt the diff (the second occurrence would
-        // never find a survivor because the first one consumed the map entry,
-        // so it would emit an Insert with a duplicate key — and then a later
-        // diff would have two rows with the same key in ByKey).
-        if (HasDuplicates(newKeys))
-        {
-            ReportBailout(
-                controlInstance, diagnosticContext, logger,
-                Microsoft.UI.Reactor.Core.Diagnostics.KeyedListDiagnosticKind.DuplicateKey,
-                CollectDuplicates(newKeys),
-                indexHint: null);
-            return Bailout(state, newItems, keySelector);
-        }
-
-        // ── Fast path 1: no change ─────────────────────────────────────
+        // ── Fast path 1: no change (FLAGSHIP #1) ───────────────────────
         // Most renders don't touch the list shape — Reactor's reducer model
         // means immutable list replacement, but the *contents* (and thus the
-        // keys) usually match. Skip the diff entirely and let the caller's
+        // keys) usually match. This now runs ABOVE the duplicate scan so the
+        // steady-state grid case (keys never change) never allocates or scans
+        // a dup set. Skip the diff entirely and let the caller's
         // RefreshRealizedContainers handle per-row content reconciliation.
-        if (oldCount == newCount && SequenceEqualOrdinal(state.LastKeys, newKeys))
+        if (oldCount == newCount && SequenceEqualOrdinal(state.LastKeys, newKeys, newCount))
             return DiffStats.Empty;
 
         // ── Fast path 2: empty ↔ empty ─────────────────────────────────
         if (oldCount == 0 && newCount == 0)
             return DiffStats.Empty;
+
+        // Detect duplicate keys. Runs after the no-op fast path (#1) so an
+        // unchanged list never pays for it, and reuses the pooled Scratch dict
+        // instead of allocating a HashSet (#11). Duplicates inside newKeys
+        // would otherwise silently corrupt the diff (the second occurrence
+        // would never find a survivor because the first one consumed the map
+        // entry, so it would emit an Insert with a duplicate key — and then a
+        // later diff would have two rows with the same key in ByKey), so they
+        // force a correctness-preserving bailout.
+        if (HasDuplicates(newKeys, newCount, state))
+        {
+            ReportBailout(
+                controlInstance, diagnosticContext, logger,
+                Microsoft.UI.Reactor.Core.Diagnostics.KeyedListDiagnosticKind.DuplicateKey,
+                CollectDuplicates(newKeys, newCount),
+                indexHint: null);
+            return Bailout(state, newItems, keySelector);
+        }
 
         // ── Fast path 3: empty → non-empty (mount-shaped diff) ─────────
         if (oldCount == 0)
@@ -261,52 +312,33 @@ internal static class KeyedListDiff
             return new DiffStats(Inserts: 0, Removes: 1, Moves: 0, Survivors: newCount, Bailout: false);
         }
 
-        // ── Bulk-replace bailout ───────────────────────────────────────
-        // If churn (removed + inserted) exceeds 25% AND the absolute number
-        // of churned ops is large enough that the diff genuinely won't help
-        // animation, fall back to the legacy ItemsSource swap.
-        //
-        // The absolute floor (8 ops) is what keeps small lists from
-        // ever bailing — a 4-item list with Insert+Remove (churn=2) is just
-        // a normal small-list edit; the WinUI delta path animates it
-        // beautifully and we lose nothing by running the general algorithm.
-        //
-        // We approximate churn by counting how many new keys are NOT present
-        // in the old key set. That overcounts "different position same key"
-        // as zero churn (correct), but undercounts deletes — we add the
-        // length delta for that side.
-        state.Scratch.Clear();
-        for (int i = 0; i < oldCount; i++)
-            state.Scratch[state.LastKeys[i]] = null!; // null marker; replaced below
-
-        int additions = 0;
-        int retained = 0;
-        for (int i = 0; i < newCount; i++)
-        {
-            if (state.Scratch.ContainsKey(newKeys[i])) retained++;
-            else additions++;
-        }
-
-        int removals = oldCount - retained;
-        int churn = additions + removals;
-        const int BailoutFloor = 8;
-        // Bailout if (churn / max(oldCount, 1)) > 0.25 AND churn >= floor.
-        // Compute the ratio without floats: churn * 4 > oldCount.
-        if (churn >= BailoutFloor && churn * 4 > global::System.Math.Max(oldCount, 1))
-        {
-            state.Scratch.Clear();
-            return Bailout(state, newItems, keySelector);
-        }
-
         // ── General case: React-style keyed diff ───────────────────────
-        return ApplyGeneral(state, newKeys, enterKind);
+        // The bulk-replace (churn) bailout decision now lives INSIDE
+        // ApplyGeneral (#34): it is computed from the same scratch map the
+        // general walk builds over the post-prefix/suffix diff range, so we
+        // no longer pay a separate O(oldCount) null-marker pre-pass + a second
+        // Scratch.Clear/repopulate. Churn over the diff range is provably
+        // equal to full-range churn because the shared prefix/suffix keys
+        // cancel on both sides (duplicates are already ruled out above).
+        return ApplyGeneral(state, newItems, keySelector, newKeys, newCount, oldCount, enterKind);
     }
 
-    private static DiffStats ApplyGeneral(ReactorListState state, string[] newKeys, AnimationKind? enterKind)
+    /// <summary>
+    /// General keyed diff over the post-prefix/suffix range. Builds the
+    /// survivor map on <see cref="ReactorListState.Scratch"/> once, folds the
+    /// churn-bailout decision into that same map, then emits the minimal
+    /// Insert/Move/Remove op sequence. <paramref name="newKeys"/> is valid for
+    /// <paramref name="newCount"/> entries (the buffer may be larger).
+    /// </summary>
+    private static DiffStats ApplyGeneral<T>(
+        ReactorListState state,
+        IReadOnlyList<T> newItems,
+        Func<T, int, string> keySelector,
+        string[] newKeys,
+        int newCount,
+        int oldCount,
+        AnimationKind? enterKind)
     {
-        int oldCount = state.LastKeys.Count;
-        int newCount = newKeys.Length;
-
         // 1) Lockstep prefix walk — find where the lists first diverge.
         int prefix = 0;
         int sharedFromStart = global::System.Math.Min(oldCount, newCount);
@@ -334,12 +366,32 @@ internal static class KeyedListDiff
         for (int i = prefix; i < oldDiffEnd; i++)
             state.Scratch[state.LastKeys[i]] = state.Source[i];
 
+        // 3a) Bulk-replace bailout (#34, folded in). Count how many new
+        // diff-range keys survive (are present in the old diff-range map);
+        // additions/removals follow without a second populate pass.
+        int retained = 0;
+        for (int i = prefix; i < newDiffEnd; i++)
+            if (state.Scratch.ContainsKey(newKeys[i])) retained++;
+
+        int additions = (newDiffEnd - prefix) - retained;
+        int removals = (oldDiffEnd - prefix) - retained;
+        int churn = additions + removals;
+        const int BailoutFloor = 8;
+        // Bailout if (churn / max(oldCount, 1)) > 0.25 AND churn >= floor.
+        // Compute the ratio without floats: churn * 4 > oldCount.
+        if (churn >= BailoutFloor && churn * 4 > global::System.Math.Max(oldCount, 1))
+        {
+            state.Scratch.Clear();
+            return Bailout(state, newItems, keySelector);
+        }
+
         int inserts = 0;
         int moves = 0;
         int survivors = prefix + suffix;
-        // Collected only when an ambient is active. Null avoids the
-        // allocation in the non-animated (overwhelmingly common) case.
-        List<ReactorRow>? movedRows = enterKind is not null ? new List<ReactorRow>() : null;
+        // Collected lazily — only allocated when an ambient animation is
+        // active AND at least one survivor actually moves (#35). Consumers
+        // treat null as "no moved rows" (they gate on `is { Count: > 0 }`).
+        List<ReactorRow>? movedRows = null;
 
         // 4) Walk new keys in the diff range.
         for (int desired = prefix; desired < newDiffEnd; desired++)
@@ -354,7 +406,8 @@ internal static class KeyedListDiff
                     state.Source.Move(currentIndex, desired);
                     RefreshIndices(state, global::System.Math.Min(desired, currentIndex), global::System.Math.Max(desired, currentIndex));
                     moves++;
-                    movedRows?.Add(survivor);
+                    if (enterKind is not null)
+                        (movedRows ??= new List<ReactorRow>()).Add(survivor);
                 }
                 survivors++;
             }
@@ -370,26 +423,37 @@ internal static class KeyedListDiff
 
         // 5) Whatever remains in the scratch map are removed rows. Remove
         // them in descending OC-index order so earlier indices stay stable.
+        // The doomed buffer is rented from the pool and cleared+returned on
+        // every exit (#3) so it never pins removed rows across frames.
         int removes = state.Scratch.Count;
         if (removes > 0)
         {
-            var doomed = new ReactorRow[removes];
-            int j = 0;
-            foreach (var row in state.Scratch.Values) doomed[j++] = row;
-            global::System.Array.Sort(doomed, static (a, b) => b.Index.CompareTo(a.Index));
-            for (int i = 0; i < removes; i++)
+            ReactorRow[] doomed = ArrayPool<ReactorRow>.Shared.Rent(removes);
+            try
             {
-                state.Source.RemoveAt(doomed[i].Index);
-                state.ByKey.Remove(doomed[i].Key);
+                int j = 0;
+                foreach (var row in state.Scratch.Values) doomed[j++] = row;
+                global::System.Array.Sort(doomed, 0, removes, RowIndexDescendingComparer.Instance);
+                for (int i = 0; i < removes; i++)
+                {
+                    state.Source.RemoveAt(doomed[i].Index);
+                    state.ByKey.Remove(doomed[i].Key);
+                }
+            }
+            finally
+            {
+                ArrayPool<ReactorRow>.Shared.Return(doomed, clearArray: true);
             }
             RefreshIndices(state, 0, state.Source.Count - 1);
         }
 
         state.Scratch.Clear();
 
-        // 6) Sync LastKeys to match the final Source order.
-        state.LastKeys.Clear();
-        for (int i = 0; i < state.Source.Count; i++) state.LastKeys.Add(state.Source[i].Key);
+        // 6) Sync LastKeys to match the final Source order in place (#10),
+        // overwriting shared slots and trimming/extending the tail rather
+        // than Clear()+Add — which would null the whole backing array and
+        // regrow it every diff.
+        SyncLastKeysToSource(state);
 
         return new DiffStats(
             Inserts: inserts,
@@ -398,6 +462,28 @@ internal static class KeyedListDiff
             Survivors: survivors,
             Bailout: false,
             MovedRows: movedRows);
+    }
+
+    /// <summary>
+    /// Overwrites <see cref="ReactorListState.LastKeys"/> to match the current
+    /// <see cref="ReactorListState.Source"/> key order without the full
+    /// Clear()+Add churn. Shared leading slots are overwritten; the tail is
+    /// trimmed or extended as needed. Always leaves LastKeys exactly equal to
+    /// the Source key sequence, so it cannot desync.
+    /// </summary>
+    private static void SyncLastKeysToSource(ReactorListState state)
+    {
+        var lastKeys = state.LastKeys;
+        var source = state.Source;
+        int srcCount = source.Count;
+        int common = global::System.Math.Min(lastKeys.Count, srcCount);
+        for (int i = 0; i < common; i++)
+            lastKeys[i] = source[i].Key;
+        if (lastKeys.Count > srcCount)
+            lastKeys.RemoveRange(srcCount, lastKeys.Count - srcCount);
+        else
+            for (int i = lastKeys.Count; i < srcCount; i++)
+                lastKeys.Add(source[i].Key);
     }
 
     private static void RefreshIndices(ReactorListState state, int fromInclusive, int toInclusive)
@@ -436,28 +522,40 @@ internal static class KeyedListDiff
             Bailout: true);
     }
 
-    private static bool HasDuplicates(string[] keys)
+    private static bool HasDuplicates(string[] keys, int count, ReactorListState state)
     {
-        if (keys.Length < 2) return false;
-        // Small-N optimization: 0/1 already handled, 2..3 is a quick scan.
-        if (keys.Length <= 3)
+        if (count < 2) return false;
+        // Small-N optimization: 0/1 already handled, 2..3 is a quick scan
+        // that never touches the shared scratch dict.
+        if (count <= 3)
         {
-            if (keys.Length == 2) return string.Equals(keys[0], keys[1], global::System.StringComparison.Ordinal);
-            // length == 3
+            if (count == 2) return string.Equals(keys[0], keys[1], global::System.StringComparison.Ordinal);
+            // count == 3
             return string.Equals(keys[0], keys[1], global::System.StringComparison.Ordinal)
                 || string.Equals(keys[0], keys[2], global::System.StringComparison.Ordinal)
                 || string.Equals(keys[1], keys[2], global::System.StringComparison.Ordinal);
         }
-        var seen = new HashSet<string>(keys.Length, global::System.StringComparer.Ordinal);
-        for (int i = 0; i < keys.Length; i++)
-            if (!seen.Add(keys[i])) return true;
+        // Reuse the pooled scratch dict (#11) instead of allocating a fresh
+        // HashSet every diff with 4+ keys. Cleared on entry and on every exit
+        // so it never leaks into the survivor-map build that follows.
+        var scratch = state.Scratch;
+        scratch.Clear();
+        for (int i = 0; i < count; i++)
+        {
+            if (!scratch.TryAdd(keys[i], null!))
+            {
+                scratch.Clear();
+                return true;
+            }
+        }
+        scratch.Clear();
         return false;
     }
 
-    private static bool SequenceEqualOrdinal(List<string> a, string[] b)
+    private static bool SequenceEqualOrdinal(List<string> a, string[] b, int count)
     {
-        if (a.Count != b.Length) return false;
-        for (int i = 0; i < b.Length; i++)
+        if (a.Count != count) return false;
+        for (int i = 0; i < count; i++)
             if (!string.Equals(a[i], b[i], global::System.StringComparison.Ordinal)) return false;
         return true;
     }
@@ -527,15 +625,16 @@ internal static class KeyedListDiff
     // (not every occurrence). For a list with [a, b, a, c, b] returns
     // [a, b] — the dev overlay reader cares about which keys collided,
     // not the per-occurrence count.
-    private static IReadOnlyList<string> CollectDuplicates(string[] keys)
+    private static IReadOnlyList<string> CollectDuplicates(string[] keys, int count)
     {
         // Small set — duplicates in production are rare and the dev surface
-        // caps the displayed list anyway.
+        // caps the displayed list anyway. This is a slow (bailout) path so
+        // the throwaway HashSets are acceptable.
         var seen = new HashSet<string>(global::System.StringComparer.Ordinal);
         var dupes = new HashSet<string>(global::System.StringComparer.Ordinal);
-        foreach (var k in keys)
+        for (int i = 0; i < count; i++)
         {
-            if (!seen.Add(k)) dupes.Add(k);
+            if (!seen.Add(keys[i])) dupes.Add(keys[i]);
         }
         if (dupes.Count == 0) return global::System.Array.Empty<string>();
         var arr = new string[dupes.Count];

--- a/tests/Reactor.Tests/ChildReconcilerKeyedSkipTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerKeyedSkipTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Coverage for the keyed prefix/suffix <c>CanSkipUpdate</c> fast-path added by
+/// issue #653 (fix #30). A stable keyed list — e.g. grid rows whose keys never
+/// change between renders — must short-circuit the per-row <c>UpdateChild</c>
+/// COM round-trip exactly like the positional path already does, instead of
+/// re-diffing every row on every tick. Before #30 the keyed prefix/suffix loops
+/// always called <c>UpdateChild</c>; these tests pin the new skip behavior so a
+/// regression that re-introduces the per-row work (or, conversely, wrongly skips
+/// a row that needed updating) is caught.
+///
+/// These exercise the callback-free path, where the skip must avoid touching the
+/// realized control collection entirely — the mock's <c>Get</c> throws, so a
+/// passing test proves no <c>children.Get</c> COM call happened.
+/// </summary>
+public class ChildReconcilerKeyedSkipTests
+{
+    private static readonly Action NoOp = () => { };
+
+    /// <summary>
+    /// Records structural ops and counts <see cref="Get"/> calls; <see cref="Get"/>
+    /// throws because the #30 skip for callback-free rows must never reach a
+    /// realized control (creating one would also throw COMException headless).
+    /// </summary>
+    private sealed class ThrowingGetChildCollection : IChildCollection
+    {
+        private int _count;
+        public List<string> Operations { get; } = new();
+        public int GetCalls { get; private set; }
+
+        public ThrowingGetChildCollection(int count) => _count = count;
+
+        public int Count => _count;
+
+        public UIElement Get(int index)
+        {
+            GetCalls++;
+            throw new InvalidOperationException(
+                $"Get({index}) must not be called when a keyed row is skipped via CanSkipUpdate.");
+        }
+
+        public void Insert(int index, UIElement element) { Operations.Add($"Insert({index})"); _count++; }
+        public void RemoveAt(int index) { Operations.Add($"RemoveAt({index})"); _count--; }
+        public void Move(int oldIndex, int newIndex) => Operations.Add($"Move({oldIndex},{newIndex})");
+        public void Replace(int index, UIElement element) => Operations.Add($"Replace({index})");
+    }
+
+    // Distinct element instances each call (not reference-equal) with identical
+    // key + content, so the skip is driven by structural CanSkipUpdate — the
+    // realistic re-render shape, where every render allocates fresh records.
+    private static Element[] KeyedRows(int count)
+    {
+        var rows = new Element[count];
+        for (int i = 0; i < count; i++)
+            rows[i] = new TextBlockElement($"row-{i}") { Key = $"k{i}" };
+        return rows;
+    }
+
+    [Theory]
+    [InlineData(1)]   // single-row boundary (prefixLen < childCount guard)
+    [InlineData(2)]
+    [InlineData(5)]
+    [InlineData(32)]  // steady-state grid: many stable rows
+    public void Identical_Keyed_List_Skips_Every_Row_With_No_Ops_And_No_ControlAccess(int count)
+    {
+        var oldRows = KeyedRows(count);
+        var newRows = KeyedRows(count);
+        var mock = new ThrowingGetChildCollection(count);
+        var reconciler = new Reconciler();
+
+        ChildReconciler.Reconcile(oldRows, newRows, mock, reconciler, NoOp);
+
+        Assert.Empty(mock.Operations);                    // no insert/move/remove/replace
+        Assert.Equal(0, mock.GetCalls);                   // callback-free rows never touch controls
+        Assert.Equal(count, reconciler.DebugElementsSkipped); // every row hit the #30 fast-path
+    }
+
+    [Fact]
+    public void Repeated_Reconcile_Of_Stable_Keyed_List_Keeps_Skipping()
+    {
+        // Simulates several frames of a grid whose keys/content are unchanged:
+        // each pass must skip all rows and never fall back to UpdateChild.
+        var mock = new ThrowingGetChildCollection(8);
+        var reconciler = new Reconciler();
+        var previous = KeyedRows(8);
+
+        for (int frame = 0; frame < 4; frame++)
+        {
+            var next = KeyedRows(8);
+            ChildReconciler.Reconcile(previous, next, mock, reconciler, NoOp);
+            previous = next;
+        }
+
+        Assert.Empty(mock.Operations);
+        Assert.Equal(0, mock.GetCalls);
+        Assert.Equal(8 * 4, reconciler.DebugElementsSkipped);
+    }
+}

--- a/tests/Reactor.Tests/ChildReconcilerLisIntoTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerLisIntoTests.cs
@@ -30,6 +30,33 @@ public class ChildReconcilerLisIntoTests
         return set;
     }
 
+    // Independent O(n^2) DP reference for the length of the longest STRICTLY
+    // increasing subsequence. Deliberately NOT routed through ComputeLIS /
+    // ComputeLISInto: issue #653 made ComputeLIS a thin wrapper over
+    // ComputeLISInto, so comparing the two against each other is circular and
+    // would mask a bug shared by both. This DP is the non-circular oracle.
+    //
+    // Mirrors ComputeLISInto's contract: entries equal to -1 are "unmapped"
+    // sentinels (a new child with no surviving old match) and are excluded
+    // from the subsequence entirely — see ChildReconciler.ComputeLISInto's
+    // `if (arr[i] == -1) continue;`.
+    private static int BruteForceLisLength(int[] arr)
+    {
+        int n = arr.Length;
+        var dp = new int[n];
+        int best = 0;
+        for (int i = 0; i < n; i++)
+        {
+            if (arr[i] == -1) continue; // unmapped sentinel, never participates
+            dp[i] = 1;
+            for (int j = 0; j < i; j++)
+                if (arr[j] != -1 && arr[j] < arr[i] && dp[j] + 1 > dp[i])
+                    dp[i] = dp[j] + 1;
+            if (dp[i] > best) best = dp[i];
+        }
+        return best;
+    }
+
     [Theory]
     [InlineData(new int[0])]
     [InlineData(new[] { 5 })]
@@ -41,13 +68,28 @@ public class ChildReconcilerLisIntoTests
     [InlineData(new[] { 2, 0, 1, 3 })]
     [InlineData(new[] { 1, 3, 2, 3 })]
     [InlineData(new[] { 5, 1, 4, 2, 3 })]
-    public void ComputeLISInto_Matches_HashSet_Wrapper(int[] arr)
+    public void ComputeLISInto_Selects_Valid_Maximum_Increasing_Subsequence(int[] arr)
     {
-        var expected = ChildReconciler.ComputeLIS(arr);
+        // Non-circular oracle: the returned mask must mark a strictly increasing
+        // subsequence (in index order) whose length equals the true LIS length.
+        // This validates correctness independently of the ComputeLIS wrapper,
+        // and is robust to LIS tie-breaking (any valid maximum-length strictly
+        // increasing subsequence satisfies both properties).
         var mask = MaskFor(arr);
-        var actual = SetFromMask(mask, arr.Length);
 
-        Assert.Equal(expected, actual);
+        int prev = int.MinValue;
+        int count = 0;
+        for (int i = 0; i < arr.Length; i++)
+        {
+            if (!mask[i]) continue;
+            Assert.True(arr[i] > prev,
+                $"selected LIS values must be strictly increasing in index order; " +
+                $"index {i} (value {arr[i]}) breaks it");
+            prev = arr[i];
+            count++;
+        }
+
+        Assert.Equal(BruteForceLisLength(arr), count);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/ChildReconcilerLisIntoTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerLisIntoTests.cs
@@ -1,0 +1,115 @@
+using System.Buffers;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Tests for <see cref="ChildReconciler.ComputeLISInto"/> — the
+/// allocation-free LIS variant introduced by issue #653 that writes a
+/// membership mask into a caller-supplied (pooled) <c>bool[]</c> instead of
+/// allocating a <see cref="HashSet{T}"/>. These assert it produces exactly the
+/// same membership as the legacy <see cref="ChildReconciler.ComputeLIS"/>
+/// wrapper, clears any stale markers in the supplied mask, and never reads
+/// past <c>length</c> when the mask buffer is larger (the pooled case).
+/// </summary>
+public class ChildReconcilerLisIntoTests
+{
+    private static bool[] MaskFor(int[] arr)
+    {
+        var mask = new bool[arr.Length];
+        ChildReconciler.ComputeLISInto(arr, arr.Length, mask);
+        return mask;
+    }
+
+    private static HashSet<int> SetFromMask(bool[] mask, int length)
+    {
+        var set = new HashSet<int>();
+        for (int i = 0; i < length; i++)
+            if (mask[i]) set.Add(i);
+        return set;
+    }
+
+    [Theory]
+    [InlineData(new int[0])]
+    [InlineData(new[] { 5 })]
+    [InlineData(new[] { 1, 2, 3, 4, 5 })]
+    [InlineData(new[] { 5, 4, 3, 2, 1 })]
+    [InlineData(new[] { -1, 2, -1, 4, -1 })]
+    [InlineData(new[] { -1, -1, -1 })]
+    [InlineData(new[] { 3, 1, 2, 4 })]
+    [InlineData(new[] { 2, 0, 1, 3 })]
+    [InlineData(new[] { 1, 3, 2, 3 })]
+    [InlineData(new[] { 5, 1, 4, 2, 3 })]
+    public void ComputeLISInto_Matches_HashSet_Wrapper(int[] arr)
+    {
+        var expected = ChildReconciler.ComputeLIS(arr);
+        var mask = MaskFor(arr);
+        var actual = SetFromMask(mask, arr.Length);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ComputeLISInto_Clears_Stale_Markers_In_Supplied_Mask()
+    {
+        // A pooled mask can arrive with stale `true` entries. ComputeLISInto
+        // must clear [0,length) so only genuine LIS members remain true.
+        var arr = new[] { 5, 4, 3, 2, 1 }; // LIS is a single element
+        var mask = new bool[arr.Length];
+        for (int i = 0; i < mask.Length; i++) mask[i] = true; // pre-dirty
+
+        ChildReconciler.ComputeLISInto(arr, arr.Length, mask);
+
+        int trues = 0;
+        for (int i = 0; i < arr.Length; i++) if (mask[i]) trues++;
+        Assert.Equal(1, trues); // reverse-sorted ⇒ LIS length 1
+    }
+
+    [Fact]
+    public void ComputeLISInto_Honors_Length_When_Mask_Is_Larger()
+    {
+        // Simulate the hot-path contract: the bool[] comes from ArrayPool and
+        // is larger than `length`. Only [0,length) may be touched/read.
+        int[] arr = { 2, 0, 1, 3 }; // LIS = indices {1,2,3}
+        int length = arr.Length;
+
+        var pool = ArrayPool<bool>.Shared;
+        bool[] mask = pool.Rent(length);
+        try
+        {
+            // Dirty the whole rented buffer including the tail beyond length.
+            for (int i = 0; i < mask.Length; i++) mask[i] = true;
+
+            ChildReconciler.ComputeLISInto(arr, length, mask);
+
+            var actual = SetFromMask(mask, length);
+            Assert.Equal(new HashSet<int> { 1, 2, 3 }, actual);
+        }
+        finally
+        {
+            pool.Return(mask, clearArray: true);
+        }
+    }
+
+    [Fact]
+    public void ComputeLISInto_LargeSequence_With_One_Swap()
+    {
+        var arr = Enumerable.Range(0, 100).ToArray();
+        (arr[50], arr[51]) = (arr[51], arr[50]);
+
+        var mask = MaskFor(arr);
+        int trues = 0;
+        for (int i = 0; i < arr.Length; i++) if (mask[i]) trues++;
+
+        Assert.True(trues >= 99);
+        // Values at LIS positions must be strictly increasing.
+        int prev = int.MinValue;
+        for (int i = 0; i < arr.Length; i++)
+        {
+            if (!mask[i]) continue;
+            Assert.True(arr[i] > prev);
+            prev = arr[i];
+        }
+    }
+}

--- a/tests/Reactor.Tests/Internal/KeyedListDiffPoolingTests.cs
+++ b/tests/Reactor.Tests/Internal/KeyedListDiffPoolingTests.cs
@@ -1,0 +1,307 @@
+using System.Buffers;
+using System.Collections.Specialized;
+using Microsoft.UI.Reactor.Core.Internal;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.Internal;
+
+/// <summary>
+/// Regression coverage for the per-diff allocation-elimination work
+/// (issue #653): the keyed list diff now rents its working buffers from
+/// <see cref="ArrayPool{T}"/> and reuses <see cref="ReactorListState.Scratch"/>
+/// for the duplicate scan, and the no-op / empty fast paths now run ABOVE the
+/// duplicate check. These tests assert that pooling never corrupts results —
+/// across sequential diffs that share the pool, across interleaved diffs on
+/// independent states, and in the rented-buffer-larger-than-count case — and
+/// that correctness (which row moves/inserts/removes) is preserved exactly.
+/// </summary>
+public class KeyedListDiffPoolingTests
+{
+    private sealed record Item(string Id);
+
+    private static string Key(Item i, int _) => i.Id;
+
+    private static ReactorListState Seed(params string[] keys)
+    {
+        var s = new ReactorListState();
+        var seed = new (int Index, string Key)[keys.Length];
+        for (int i = 0; i < keys.Length; i++) seed[i] = (i, keys[i]);
+        s.Reset(seed);
+        return s;
+    }
+
+    private static Item[] Items(params string[] keys)
+    {
+        var arr = new Item[keys.Length];
+        for (int i = 0; i < keys.Length; i++) arr[i] = new Item(keys[i]);
+        return arr;
+    }
+
+    private static void AssertKeysMatch(ReactorListState s, params string[] expected)
+    {
+        Assert.Equal(expected.Length, s.Source.Count);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.Equal(expected[i], s.Source[i].Key);
+            Assert.Equal(i, s.Source[i].Index);
+        }
+        Assert.Equal(expected, s.LastKeys);
+        Assert.Equal(expected.Length, s.ByKey.Count);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  No-op fast path now runs above the duplicate scan (#1)
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NoOp_FastPath_With_Many_Unique_Keys_Emits_Nothing()
+    {
+        // 8 unique keys: previously this allocated/scanned a duplicate HashSet
+        // BEFORE the no-op check. The reorder (#1) must keep it a pure no-op.
+        var keys = new[] { "a", "b", "c", "d", "e", "f", "g", "h" };
+        var s = Seed(keys);
+        var events = new List<NotifyCollectionChangedEventArgs>();
+        s.Source.CollectionChanged += (_, e) => events.Add(e);
+
+        var stats = KeyedListDiff.Apply(s, Items(keys), Key);
+
+        Assert.False(stats.AnyOps);
+        Assert.False(stats.Bailout);
+        Assert.Empty(events);
+        AssertKeysMatch(s, keys);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Rented newKeys buffer may be larger than newCount (#2)
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Large_Then_Small_Diff_Preserves_Correctness_Across_Buffer_Sizes()
+    {
+        // Run diffs whose newCount swings widely so the rented newKeys buffer
+        // is reused at very different sizes. If any code path read
+        // newKeys.Length instead of the threaded newCount, the stale/cleared
+        // tail of a reused (larger) buffer would corrupt the result. The
+        // 64→3 collapse legitimately trips the churn bailout; correctness
+        // (final key order) must hold either way, which is what we assert.
+        var s = Seed();
+
+        var big = new string[64];
+        for (int i = 0; i < big.Length; i++) big[i] = $"k{i}";
+        KeyedListDiff.Apply(s, Items(big), Key);
+        AssertKeysMatch(s, big);
+
+        // Collapse to 3 items — small newCount, large previously-rented buffer.
+        KeyedListDiff.Apply(s, Items("k0", "k1", "k2"), Key);
+        AssertKeysMatch(s, "k0", "k1", "k2");
+
+        // Grow again (general path) to confirm LastKeys sync stayed correct.
+        var stats = KeyedListDiff.Apply(s, Items("k0", "z", "k1", "k2", "w"), Key);
+        Assert.False(stats.Bailout);
+        AssertKeysMatch(s, "k0", "z", "k1", "k2", "w");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Pooled `doomed` buffer for removals (#3) — non-contiguous removes
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Multiple_NonContiguous_Removes_From_Middle_Are_Correct()
+    {
+        // [a,b,c,d,e] → [a,c,e]: prefix 'a', suffix 'e', remove b and d (non
+        // contiguous indices 1 and 3). Exercises the rented doomed[] sorted
+        // descending so RemoveAt keeps earlier indices stable.
+        var s = Seed("a", "b", "c", "d", "e");
+        var rowA = s.ByKey["a"];
+        var rowC = s.ByKey["c"];
+        var rowE = s.ByKey["e"];
+
+        var stats = KeyedListDiff.Apply(s, Items("a", "c", "e"), Key);
+
+        Assert.False(stats.Bailout);
+        Assert.Equal(0, stats.Inserts);
+        Assert.Equal(2, stats.Removes);
+        AssertKeysMatch(s, "a", "c", "e");
+        // Survivors keep identity (proves we removed the right rows).
+        Assert.Same(rowA, s.Source[0]);
+        Assert.Same(rowC, s.Source[1]);
+        Assert.Same(rowE, s.Source[2]);
+        Assert.False(s.ByKey.ContainsKey("b"));
+        Assert.False(s.ByKey.ContainsKey("d"));
+    }
+
+    [Fact]
+    public void Many_Removes_Below_Floor_Use_Pooled_Doomed_Buffer()
+    {
+        // [a,b,c,d,e,f,g] → [a,g]: prefix 'a', suffix 'g', 5 middle removes.
+        // churn = 5 < floor(8) so the general path runs (no bailout), driving
+        // the rented doomed buffer with 5 entries.
+        var s = Seed("a", "b", "c", "d", "e", "f", "g");
+        var stats = KeyedListDiff.Apply(s, Items("a", "g"), Key);
+
+        Assert.False(stats.Bailout);
+        Assert.Equal(5, stats.Removes);
+        AssertKeysMatch(s, "a", "g");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Churn bailout (#34) still correct with a non-empty prefix AND suffix
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Churn_Bailout_Counts_FullRange_Even_With_Shared_Prefix_And_Suffix()
+    {
+        // Stable 5-key prefix + stable 5-key suffix, middle 10 fully replaced.
+        // Diff-range churn (10 add + 10 remove = 20) must equal full-range
+        // churn so the >25% + floor(8) bailout still triggers.
+        var old = new List<string>();
+        var @new = new List<string>();
+        for (int i = 0; i < 5; i++) { old.Add($"p{i}"); @new.Add($"p{i}"); }      // prefix
+        for (int i = 0; i < 10; i++) { old.Add($"m{i}"); @new.Add($"n{i}"); }     // churned middle
+        for (int i = 0; i < 5; i++) { old.Add($"s{i}"); @new.Add($"s{i}"); }      // suffix
+
+        var s = Seed(old.ToArray());
+        var stats = KeyedListDiff.Apply(s, Items(@new.ToArray()), Key);
+
+        Assert.True(stats.Bailout);
+        // Reset still produced a coherent collection in the new order.
+        AssertKeysMatch(s, @new.ToArray());
+    }
+
+    [Fact]
+    public void Stable_Prefix_Suffix_With_Small_Middle_Churn_Does_Not_Bail()
+    {
+        // Same shape but only a 1-key middle change — well under the floor, so
+        // the general diff runs and the merged churn calc must NOT over-count.
+        var old = new List<string>();
+        var @new = new List<string>();
+        for (int i = 0; i < 5; i++) { old.Add($"p{i}"); @new.Add($"p{i}"); }
+        old.Add("mid"); @new.Add("MID");
+        for (int i = 0; i < 5; i++) { old.Add($"s{i}"); @new.Add($"s{i}"); }
+
+        var s = Seed(old.ToArray());
+        var stats = KeyedListDiff.Apply(s, Items(@new.ToArray()), Key);
+
+        Assert.False(stats.Bailout);
+        AssertKeysMatch(s, @new.ToArray());
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Scratch reuse for the duplicate scan (#11) must not leak (clean diff
+    //  after a duplicate bailout on the SAME state)
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Duplicate_Bailout_Then_Reset_Through_Empty_Recovers_Cleanly()
+    {
+        // A duplicate-key diff bails out via Reset, which (by design — see
+        // ReactorListState.Reset) tolerates the duplicate and leaves LastKeys
+        // holding it. The supported recovery is a structural reset; here we go
+        // through the empty list (Fast path 4) and then re-mount a clean unique
+        // list. This proves the duplicate scan's reuse of state.Scratch (#11)
+        // left no residue that survives a bailout + rebuild.
+        var s = Seed("a", "b", "c");
+        var dup = KeyedListDiff.Apply(s, Items("a", "b", "c", "d", "a"), Key);
+        Assert.True(dup.Bailout);
+
+        KeyedListDiff.Apply(s, Items(), Key); // clear to empty (Fast path 4)
+
+        var clean = KeyedListDiff.Apply(s, Items("a", "b", "c", "d", "e"), Key);
+        Assert.False(clean.Bailout);
+        AssertKeysMatch(s, "a", "b", "c", "d", "e");
+    }
+
+    [Fact]
+    public void Duplicate_In_FourPlus_Keys_Still_Detected_Via_Scratch()
+    {
+        // 4+ keys takes the Scratch-backed dup path (not the <=3 inline scan).
+        var s = Seed("a", "b", "c", "d");
+        var stats = KeyedListDiff.Apply(s, Items("a", "b", "c", "d", "b"), Key);
+        Assert.True(stats.Bailout);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Pool sharing: interleaved diffs on independent states
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Interleaved_Diffs_On_Independent_States_Do_Not_Cross_Contaminate()
+    {
+        var s1 = Seed("a", "b", "c", "d", "e");
+        var s2 = Seed("v", "w", "x", "y", "z");
+
+        for (int round = 0; round < 25; round++)
+        {
+            // s1: rotate left by one each round.
+            var k1 = new[] { "b", "c", "d", "e", "a" };
+            KeyedListDiff.Apply(s1, Items(k1), Key);
+            AssertKeysMatch(s1, k1);
+
+            // s2: reverse each round (toggles back and forth).
+            var k2 = new[] { "z", "y", "x", "w", "v" };
+            KeyedListDiff.Apply(s2, Items(k2), Key);
+            AssertKeysMatch(s2, k2);
+
+            // restore both so the next round starts from the seed order.
+            KeyedListDiff.Apply(s1, Items("a", "b", "c", "d", "e"), Key);
+            KeyedListDiff.Apply(s2, Items("v", "w", "x", "y", "z"), Key);
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Randomized stress — the pooled diff must equal a trivial oracle
+    //  (Source order == applied key list) on every step, with survivor
+    //  identity preserved for keys that persist across a step.
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Randomized_Sequence_Of_Diffs_Always_Matches_Oracle()
+    {
+        var rng = new Random(20240613);
+        var universe = new string[40];
+        for (int i = 0; i < universe.Length; i++) universe[i] = $"u{i}";
+
+        var s = Seed();
+        var current = new List<string>();
+
+        for (int step = 0; step < 400; step++)
+        {
+            // Build a random subset of the universe in a random order. Always
+            // unique keys (no dup/null) so we stay on the structural path.
+            int take = rng.Next(0, universe.Length + 1);
+            var pool = new List<string>(universe);
+            var next = new List<string>(take);
+            for (int i = 0; i < take; i++)
+            {
+                int idx = rng.Next(pool.Count);
+                next.Add(pool[idx]);
+                pool.RemoveAt(idx);
+            }
+
+            // Capture survivor rows (keys present before AND after) to assert
+            // identity stability through the diff.
+            var survivorsBefore = new Dictionary<string, ReactorRow>();
+            foreach (var k in next)
+                if (s.ByKey.TryGetValue(k, out var row)) survivorsBefore[k] = row;
+
+            var stats = KeyedListDiff.Apply(s, Items(next.ToArray()), Key);
+
+            // Oracle: the Source must always equal exactly the applied list.
+            AssertKeysMatch(s, next.ToArray());
+
+            // When the diff did NOT bail, survivor ReactorRow identity must be
+            // preserved (WinUI relies on this). A bailout (Reset) legitimately
+            // rebuilds rows, so only check identity on the non-bailout path.
+            if (!stats.Bailout)
+            {
+                foreach (var (k, beforeRow) in survivorsBefore)
+                    Assert.Same(beforeRow, s.ByKey[k]);
+            }
+
+            current = next;
+        }
+
+        // Final state is internally consistent.
+        AssertKeysMatch(s, current.ToArray());
+    }
+}


### PR DESCRIPTION
**MEASUREMENT-ONLY · DO NOT MERGE · throwaway.**

This is #657 (`azchohfi-perf-keyed-list-diff-allocations` @ 13679c98) **rebased onto main 52baebb7** to pull in the #694 `StressPerf.KeyedList` workload so the keyed-LIS leg actually renders under `/perf` (the original branch predates #694, so its whole instrument was dark on positional StocksGrid).

Verified on the rebased head: `Reactor.csproj` Release **0/0**; `Reactor.Tests` **9730 passed / 0 failed / 64 skipped** (--arch arm64).

Original #657 left pristine (gate-clean-HELD). This PR will be **closed and its branch deleted** once the perf comparison lands. Tracks #657.