### PR TITLE
perf(ci): startup / first-frame metric for /perf (PR6)

### DIFF
--- a/tests/stress_perf/METHODOLOGY.md
+++ b/tests/stress_perf/METHODOLOGY.md
@@ -311,6 +311,50 @@ It is the **authoritative instrument** for per-reconcile allocation deltas (and,
 once the ns flag is armed, reconcile-time deltas); the macro tables remain the
 user-facing throughput sanity check.
 
+## Startup / first frame: the from-scratch mount the steady-state windows exclude
+
+Every table above measures the **steady state** — its alloc/timing windows baseline
+on the *first* benchmark tick, so the cost of building the whole element tree, creating
+every WinUI control, and the first layout (the from-scratch **mount**) is excluded by
+construction. That mount is exactly where a `#696`-class regression lives, and nothing
+else in the harness sees it. `StressPerf.ReactorOptimized` therefore captures four
+**startup** anchors once per process (`StressPerf.Shared/StartupTiming.cs` marks managed
+entry at the top of `Main`; `PerfTracker.RecordFirstRenderIfUnset` records the first
+`OnRenderComplete`; `FrameRendered` records the first composed frame after it):
+
+```
+firstReconcileDurationMs       <- first OnRenderComplete's reconcile/diff-patch arg
+entryToFirstReconcileMs        <- managed entry -> first reconcile complete
+windowOpenToFirstReconcileMs   <- window Activated -> first reconcile (n/a-guarded)
+entryToFirstFrameMs            <- managed entry -> first composed frame ("first frame rendered")
+```
+
+`firstReconcileDurationMs` is the **Reactor-isolated** signal: it is the first render's
+reconcile-phase *duration* (the same phase the steady-state **Avg Diff** column averages),
+undiluted by AOT runtime init, window creation, or XAML resource load — so a 2× mount
+regression shows up as a 2× number here, where it would be a single-digit-% blip diluted
+into the bootstrap-dominated `entryToFirstFrameMs`. The mount value is much larger than
+steady-state Avg Diff because it creates every control rather than patching a few.
+`entryToFirstFrameMs` is the human-recognisable "first frame rendered" number.
+`windowOpenToFirstReconcileMs` is **n/a-guarded**: the window's `Activated` event and the
+first mount race across launches, so it is emitted only when `Activated` demonstrably
+preceded the mount (else JSON `null` -> n/a, never a negative number that would poison a
+paired CI).
+
+These piggyback the headline per-rep ReactorOptimized launches — **one sample per process,
+so the cold first launch is dropped with the warmup rep** (startup rides the same per-rep
+metrics object the interleave loop already warmup-drops) — and reuse the same paired 95% CI
+machinery with **zero extra CI time**. The `/perf` comment renders a *Startup / first frame*
+table directly under the regression table. Like the micro ns flag the startup flag
+(`$StartupAutoFlag`) ships **dormant** / informational-only: one sample per launch plus
+bootstrap process-to-process variance (AOT init, OS file cache, thermal) make this the
+noisiest axis, so the Δ + CI are reported but no row is auto-flagged better-or-worse until
+the band is calibrated from a real-CI identical-binary A/B (the same discipline as the ns
+flip; measurement-only, never changes what merges). Lineage matches the alloc fields: a
+harness built from a revision that predates the metric reads *n/a* (so on the metric's own
+introducing run the `main` baseline shows n/a and the paired Δ populates on the next run),
+surfaced with a visible note rather than a silent gap.
+
 ## Don'ts (so we don't redo this analysis)
 
 1. **Don't trust `CompositionTarget.Rendering` for "FPS."** It's UI-thread-

--- a/tests/stress_perf/StressPerf.ReactorOptimized/Program.cs
+++ b/tests/stress_perf/StressPerf.ReactorOptimized/Program.cs
@@ -19,6 +19,11 @@ using Microsoft.UI.Xaml.Media;
 using StressPerf.Shared;
 using static Microsoft.UI.Reactor.Factories;
 
+// Mark managed entry FIRST so the startup / first-frame metric measures the whole
+// managed-startup cost (entry → first reconcile / first frame). Must precede any
+// WinUI bootstrap. See StartupTiming + PerfTracker.RecordFirstRenderIfUnset.
+StartupTiming.MarkEntry();
+
 // Parse CLI args before WinUI starts
 var cliOptions = CliOptions.Parse(args);
 if (cliOptions.Headless)
@@ -88,8 +93,14 @@ class StockGridApp : Component
             perfRef.Current = new PerfTracker();
             var perf = perfRef.Current;
             var pending = benchmarkUpdatePending;
+            // Startup / first-frame metric: record the window-open anchor and the
+            // from-scratch mount cost the steady-state windows exclude (#696). The
+            // first OnRenderComplete carries the full mount; RecordFirstRenderIfUnset
+            // is one-shot and runs BEFORE the benchmark gate so it sees that mount.
+            ReactorApp.PrimaryWindow!.Activated += (_, _) => StartupTiming.MarkWindowOpen();
             ReactorApp.PrimaryWindow!.Host.OnRenderComplete = (treeMs, reconcileMs, effectsMs) =>
             {
+                perf.RecordFirstRenderIfUnset(treeMs, reconcileMs, effectsMs);
                 if (pending.Current)
                 {
                     pending.Current = false;

--- a/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
+++ b/tests/stress_perf/StressPerf.Shared/PerfTracker.cs
@@ -53,6 +53,20 @@ public sealed class PerfTracker
     private int _endGen2;
     private int _endRenderCount;
 
+    // ── Startup / first-frame anchors (one-shot per process) ─────────────────
+    // The from-scratch mount (build the whole element tree + create every WinUI
+    // control + first layout) is EXCLUDED from the steady-state alloc/timing windows
+    // by construction (RecordRender baselines on the first benchmark tick), so these
+    // fields are the only place the #696-class first-render cost is captured. All ms
+    // are measured from managed entry (StartupTiming.MarkEntry, called at the top of
+    // Main); see StartupTiming + RecordFirstRenderIfUnset.
+    private bool _firstRenderCaptured;
+    private double _firstReconcileDurationMs;
+    private double _entryToFirstReconcileMs;
+    private double? _windowOpenToFirstReconcileMs;
+    private bool _firstFrameCaptured;
+    private double _entryToFirstFrameMs;
+
     public double CurrentFps => _currentFps;
     public double LastUpdateMs => _lastUpdateMs;
     public long CurrentMemoryMB => Process.GetCurrentProcess().WorkingSet64 / (1024 * 1024);
@@ -62,6 +76,15 @@ public sealed class PerfTracker
     /// </summary>
     public void FrameRendered()
     {
+        // First composed frame AFTER the from-scratch mount = the user-facing "first
+        // frame rendered". Gated on the first render being captured so an empty
+        // pre-content composition tick can't claim it; this guarantees
+        // T_firstFrame >= T_firstReconcile (monotonic) for the paired CI.
+        if (_firstRenderCaptured && !_firstFrameCaptured)
+        {
+            _firstFrameCaptured = true;
+            _entryToFirstFrameMs = StartupTiming.MsSinceEntry();
+        }
         _frameCount++;
         double now = _wallClock.Elapsed.TotalSeconds;
         double elapsed = now - _lastSampleTime;
@@ -153,6 +176,53 @@ public sealed class PerfTracker
         _reconcileTimeSamples.Add(treeBuildMs + diffPatchMs + effectsMs);
         RecordRender();
     }
+
+    // ── Startup / first-frame metric ─────────────────────────────────────────
+    // Captured once per process on the first from-scratch mount + first composed
+    // frame, piggybacking the existing per-rep process launches. Tier 1: always-on,
+    // zero extra CI. See the first-frame design note + StartupTiming.
+
+    /// <summary>
+    /// One-shot capture of the from-scratch mount on the FIRST OnRenderComplete. Call
+    /// from the host's OnRenderComplete callback BEFORE any benchmark gate so the very
+    /// first render — the full mount the steady-state windows exclude — is recorded.
+    /// <paramref name="reconcileMs"/> is the host's reconcile/diff-patch phase
+    /// duration (the 2nd OnRenderComplete arg): the Reactor-isolated first-render
+    /// signal, undiluted by bootstrap (entry→first-frame is bootstrap-dominated).
+    /// Idempotent — only the first call records.
+    /// </summary>
+    public void RecordFirstRenderIfUnset(double treeBuildMs, double reconcileMs, double effectsMs)
+    {
+        if (_firstRenderCaptured) return;
+        _firstRenderCaptured = true;
+        _firstReconcileDurationMs = reconcileMs;
+        _entryToFirstReconcileMs = StartupTiming.MsSinceEntry();
+        // Window-open → first reconcile only when Activated demonstrably preceded the
+        // mount (monotonic). Activated-vs-mount ordering is non-deterministic across
+        // launches; emit n/a (null) rather than a negative number that would poison a
+        // paired CI on the consuming side.
+        double? winOpen = StartupTiming.WindowOpenMsSinceEntry();
+        _windowOpenToFirstReconcileMs = (winOpen.HasValue && winOpen.Value <= _entryToFirstReconcileMs)
+            ? _entryToFirstReconcileMs - winOpen.Value
+            : null;
+    }
+
+    /// <summary>
+    /// First-render reconcile/diff-patch duration (ms) — the 2nd OnRenderComplete arg
+    /// of the from-scratch mount — or null when no render has completed. Directly
+    /// comparable to the steady-state <see cref="AvgDiffMs"/> (same phase); the mount
+    /// value is much larger because it creates every control rather than patching a few.
+    /// </summary>
+    public double? FirstReconcileDurationMs => _firstRenderCaptured ? _firstReconcileDurationMs : null;
+
+    /// <summary>Managed entry → first reconcile complete (ms), or null. Always defined once a render completes (entry precedes mount).</summary>
+    public double? EntryToFirstReconcileMs => _firstRenderCaptured ? _entryToFirstReconcileMs : null;
+
+    /// <summary>Window Activated → first reconcile (ms), or null (n/a) when the ordering was non-monotonic or the window never reported Activated.</summary>
+    public double? WindowOpenToFirstReconcileMs => _firstRenderCaptured ? _windowOpenToFirstReconcileMs : null;
+
+    /// <summary>Managed entry → first composed frame after mount (ms) — the user-facing "first frame rendered" — or null when no frame composed after the mount.</summary>
+    public double? EntryToFirstFrameMs => _firstFrameCaptured ? _entryToFirstFrameMs : null;
 
     public double ElapsedSeconds => _wallClock.Elapsed.TotalSeconds;
 
@@ -303,6 +373,11 @@ public sealed class PerfTracker
     public string GetMetricsJson(string appName, double percent)
     {
         static string F(double v) => v.ToString("0.####", CultureInfo.InvariantCulture);
+        // Nullable variant for the optional startup fields: emit JSON null for an
+        // un-captured anchor (e.g. window-open when Activated trailed the mount) so a
+        // within-run n/a is distinguishable from a hard 0 and the PS parser reads it
+        // as n/a via its existing null guard.
+        static string FN(double? v) => v.HasValue ? v.Value.ToString("0.####", CultureInfo.InvariantCulture) : "null";
         // Minimal JSON string escaping for the one string field (appName) so the
         // hand-built JSON stays valid even if a name ever carries a quote /
         // backslash / control char. The numbers are culture-invariant already.
@@ -345,6 +420,13 @@ public sealed class PerfTracker
         sb.Append("\"gen1\":").Append(Gen1Collections.ToString(CultureInfo.InvariantCulture)).Append(',');
         sb.Append("\"gen2\":").Append(Gen2Collections.ToString(CultureInfo.InvariantCulture)).Append(',');
         sb.Append("\"gen0PerKRenders\":").Append(F(Gen0PerKRenders)).Append(',');
+        // Startup / first-frame metric (optional fields; a PR head built before this
+        // metric landed simply omits them and the PS side reads n/a, exactly like the
+        // alloc fields above). firstReconcileDurationMs is the Reactor-isolated #696 signal.
+        sb.Append("\"firstReconcileDurationMs\":").Append(FN(FirstReconcileDurationMs)).Append(',');
+        sb.Append("\"entryToFirstReconcileMs\":").Append(FN(EntryToFirstReconcileMs)).Append(',');
+        sb.Append("\"windowOpenToFirstReconcileMs\":").Append(FN(WindowOpenToFirstReconcileMs)).Append(',');
+        sb.Append("\"entryToFirstFrameMs\":").Append(FN(EntryToFirstFrameMs)).Append(',');
         sb.Append("\"avgFps\":").Append(F(_fpsSamples.Count > 0 ? _fpsSamples.Average() : 0.0)).Append(',');
         sb.Append("\"sampleCount\":").Append(_fpsSamples.Count.ToString(CultureInfo.InvariantCulture));
         sb.Append('}');

--- a/tests/stress_perf/StressPerf.Shared/StartupTiming.cs
+++ b/tests/stress_perf/StressPerf.Shared/StartupTiming.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics;
+
+namespace StressPerf.Shared;
+
+/// <summary>
+/// Process-wide startup anchors for the first-frame / startup metric. The managed
+/// entry timestamp must be captured at the very top of <c>Main</c> — BEFORE the
+/// WinUI app is built and well before the per-render <see cref="PerfTracker"/>
+/// instance exists — so it lives here as a process static rather than on the
+/// tracker. Times are monotonic <see cref="Stopwatch"/> ticks; cost is a couple of
+/// timestamp reads that all happen once at startup, so the steady-state render loop
+/// is never perturbed. AOT/trim-safe (no reflection, no allocation).
+/// </summary>
+public static class StartupTiming
+{
+    private static long _entryTimestamp;
+    private static bool _entryMarked;
+    private static long _windowOpenTimestamp;
+    private static bool _windowOpenMarked;
+
+    /// <summary>
+    /// Record managed entry. Call as the FIRST statement of <c>Main</c> (before any
+    /// WinUI bootstrap) so the entry→first-reconcile / entry→first-frame segments
+    /// measure the whole managed-startup cost. Idempotent — the first call wins, so a
+    /// stray repeat (or a workload that calls it twice) cannot move the anchor.
+    /// </summary>
+    public static void MarkEntry()
+    {
+        if (_entryMarked) return;
+        _entryTimestamp = Stopwatch.GetTimestamp();
+        _entryMarked = true;
+    }
+
+    /// <summary>
+    /// Record the first window <c>Activated</c>. Call from
+    /// <c>ReactorApp.PrimaryWindow.Activated</c>. Idempotent (first wins). May never
+    /// fire before the first reconcile — Activated-vs-mount ordering is
+    /// non-deterministic across launches — which is why the window-open segment is
+    /// n/a-guarded by the consumer rather than assumed monotonic.
+    /// </summary>
+    public static void MarkWindowOpen()
+    {
+        if (_windowOpenMarked) return;
+        _windowOpenTimestamp = Stopwatch.GetTimestamp();
+        _windowOpenMarked = true;
+    }
+
+    /// <summary>True once <see cref="MarkEntry"/> has run.</summary>
+    public static bool EntryMarked => _entryMarked;
+
+    /// <summary>True once <see cref="MarkWindowOpen"/> has run.</summary>
+    public static bool WindowOpenMarked => _windowOpenMarked;
+
+    /// <summary>
+    /// Milliseconds from managed entry to now, or 0 when entry was never marked.
+    /// </summary>
+    public static double MsSinceEntry()
+    {
+        if (!_entryMarked) return 0.0;
+        return (Stopwatch.GetTimestamp() - _entryTimestamp) * 1000.0 / Stopwatch.Frequency;
+    }
+
+    /// <summary>
+    /// Milliseconds from managed entry to the window-open mark, or null when either
+    /// anchor is unset (entry not marked, or the window never reported Activated).
+    /// </summary>
+    public static double? WindowOpenMsSinceEntry()
+    {
+        if (!_entryMarked || !_windowOpenMarked) return null;
+        return (_windowOpenTimestamp - _entryTimestamp) * 1000.0 / Stopwatch.Frequency;
+    }
+}

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -1030,6 +1030,144 @@ finally {
 }
 
 
+# ── Startup / first-frame metric (PR6): parse + aggregate + render ────────────
+# The 4 startup fields piggyback the headline ReactorOptimized metrics.json (one sample
+# per process). They are optional (a head built before the metric omits them -> n/a),
+# windowOpen may be JSON null within an otherwise-present run (Activated trailed the
+# mount), and the section is informational-first (the $StartupAutoFlag dormant flag)
+# until a real-CI identical-binary band calibration — exactly like the micro ns flag.
+
+# (1) Read-HarnessMetrics parses the 4 startup fields; a JSON-null windowOpen -> n/a, and
+#     a head that predates them parses fine with all 4 -> null (not rejected).
+$tmpSU = Join-Path ([IO.Path]::GetTempPath()) ("perflib-startup-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmpSU -Force | Out-Null
+try {
+    $suJson = '{"app":"StressPerf.ReactorOptimized","percent":50,"durationSeconds":10,"rendersPerSec":3.5,"totalRenders":35,"avgReconcileMs":76,"avgDiffMs":66,"avgMemoryMB":303,"allocBytesPerRender":52000,"gen0":10,"gen1":2,"gen2":0,"gen0PerKRenders":4.1,"firstReconcileDurationMs":420.5,"entryToFirstReconcileMs":830.2,"windowOpenToFirstReconcileMs":120.7,"entryToFirstFrameMs":910.4,"avgFps":60,"sampleCount":5}'
+    Set-Content -LiteralPath (Join-Path $tmpSU 'StressPerf.ReactorOptimized.metrics.json') -Value $suJson -Encoding UTF8
+    $suM = Read-HarnessMetrics -Directory $tmpSU -AppName 'StressPerf.ReactorOptimized'
+    Assert-Equal 420.5 $suM.FirstReconcileDurationMs      'json firstReconcileDurationMs parsed'
+    Assert-Equal 830.2 $suM.EntryToFirstReconcileMs       'json entryToFirstReconcileMs parsed'
+    Assert-Equal 120.7 $suM.WindowOpenToFirstReconcileMs  'json windowOpenToFirstReconcileMs parsed'
+    Assert-Equal 910.4 $suM.EntryToFirstFrameMs           'json entryToFirstFrameMs parsed'
+
+    # windowOpen as JSON null within an otherwise-present run -> n/a (Activated-vs-mount
+    # ordering was non-monotonic on this launch); the other three still parse.
+    $suNullWin = '{"app":"StressPerf.ReactorOptimized","percent":50,"durationSeconds":10,"rendersPerSec":3.5,"totalRenders":35,"avgReconcileMs":76,"avgDiffMs":66,"avgMemoryMB":303,"firstReconcileDurationMs":400,"entryToFirstReconcileMs":800,"windowOpenToFirstReconcileMs":null,"entryToFirstFrameMs":900,"avgFps":60,"sampleCount":5}'
+    Set-Content -LiteralPath (Join-Path $tmpSU 'StressPerf.NullWin.metrics.json') -Value $suNullWin -Encoding UTF8
+    $suNW = Read-HarnessMetrics -Directory $tmpSU -AppName 'StressPerf.NullWin'
+    Assert-Equal 400 $suNW.FirstReconcileDurationMs       'null-window json: firstReconcile still parsed'
+    Assert-Null      $suNW.WindowOpenToFirstReconcileMs   'null-window json: windowOpen -> n/a (null)'
+    Assert-Equal 900 $suNW.EntryToFirstFrameMs            'null-window json: entryToFirstFrame still parsed'
+
+    # A head that predates the metric (no startup fields) parses fine, all 4 -> null.
+    $suOld = '{"app":"StressPerf.Pre","percent":50,"durationSeconds":10,"rendersPerSec":3.5,"totalRenders":35,"avgReconcileMs":76,"avgDiffMs":66,"avgMemoryMB":303,"avgFps":60,"sampleCount":5}'
+    Set-Content -LiteralPath (Join-Path $tmpSU 'StressPerf.Pre.metrics.json') -Value $suOld -Encoding UTF8
+    $suP = Read-HarnessMetrics -Directory $tmpSU -AppName 'StressPerf.Pre'
+    Assert-Equal 'json' $suP.Source                  'pre-metric json still parses'
+    Assert-Null  $suP.FirstReconcileDurationMs       'pre-metric json: firstReconcile -> n/a'
+    Assert-Null  $suP.EntryToFirstFrameMs            'pre-metric json: entryToFirstFrame -> n/a'
+}
+finally {
+    Remove-Item -LiteralPath $tmpSU -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# (2) Measure-PerfRuns aggregates the startup keys, and the cold FIRST launch (an outlier
+#     warmup rep) is dropped by the CALLER (the interleave loop accumulates only kept rep
+#     files) BEFORE aggregation -- so the median over the kept reps must exclude rep-0's
+#     cold-start outlier. This is the startup-specific warmup-drop assertion: startup
+#     piggybacks the rep launches, so dropping a warmup rep drops its startup sample too.
+$suWarmRep = [pscustomobject]@{ RendersPerSec=3.5; AvgReconcileMs=76; AvgDiffMs=66; AvgMemoryMB=303; TotalRenders=35; DurationSeconds=10; FirstReconcileDurationMs=9000; EntryToFirstReconcileMs=9000; WindowOpenToFirstReconcileMs=$null; EntryToFirstFrameMs=9000 }
+$suKept = @(1..4 | ForEach-Object {
+    [pscustomobject]@{ RendersPerSec=3.5; AvgReconcileMs=76; AvgDiffMs=66; AvgMemoryMB=303; TotalRenders=35; DurationSeconds=10; FirstReconcileDurationMs=(400 + $_); EntryToFirstReconcileMs=(800 + $_); WindowOpenToFirstReconcileMs=(120 + $_); EntryToFirstFrameMs=(900 + $_) }
+})
+$suAggKept = Measure-PerfRuns -Runs $suKept
+Assert-Equal 402.5 $suAggKept.FirstReconcileDurationMs           'startup median over kept reps (401..404 -> 402.5)'
+Assert-True  ($suAggKept.FirstReconcileDurationMs -lt 9000)      'cold first-launch outlier excluded from the startup median'
+Assert-Equal 4 @($suAggKept.FirstReconcileDurationMsSamples).Count 'startup samples carry one entry per kept rep'
+# Contrast: keeping the cold rep-0 skews the median upward -> why warmup-drop matters here.
+$suAggWithCold = Measure-PerfRuns -Runs (@($suWarmRep) + $suKept)
+Assert-True ($suAggWithCold.FirstReconcileDurationMs -gt $suAggKept.FirstReconcileDurationMs) 'including the cold rep-0 skews the startup median upward (warmup-drop is load-bearing)'
+
+# (3) Format-PerfStartupSection: both sides present -> 4-row table, informational status
+#     (flag dormant), Δ + 95% CI cells. Empty only when a side aggregate is null or
+#     NEITHER side reported startup fields.
+$suMainRuns = @(); $suPrRuns = @()
+1..6 | ForEach-Object {
+    $j = ($_ % 3) * 0.5
+    $suMainRuns += [pscustomobject]@{ RendersPerSec=3.5; AvgReconcileMs=76; AvgDiffMs=66; AvgMemoryMB=303; TotalRenders=35; DurationSeconds=10; FirstReconcileDurationMs=(420 + $j); EntryToFirstReconcileMs=(830 + $j); WindowOpenToFirstReconcileMs=(120 + $j); EntryToFirstFrameMs=(910 + $j) }
+    $suPrRuns   += [pscustomobject]@{ RendersPerSec=3.5; AvgReconcileMs=76; AvgDiffMs=66; AvgMemoryMB=303; TotalRenders=35; DurationSeconds=10; FirstReconcileDurationMs=(410 + $j); EntryToFirstReconcileMs=(820 + $j); WindowOpenToFirstReconcileMs=(118 + $j); EntryToFirstFrameMs=(905 + $j) }
+}
+$suMain = Measure-PerfRuns -Runs $suMainRuns
+$suPr   = Measure-PerfRuns -Runs $suPrRuns
+$suNoData = Measure-PerfRuns -Runs @([pscustomobject]@{ RendersPerSec=3.5; AvgReconcileMs=76; AvgDiffMs=66; AvgMemoryMB=303; TotalRenders=35; DurationSeconds=10 })
+
+Assert-Equal 0 @(Format-PerfStartupSection -Main $null -Pr $suPr).Count   'startup section empty when Main aggregate null'
+Assert-Equal 0 @(Format-PerfStartupSection -Main $suMain -Pr $null).Count 'startup section empty when Pr aggregate null'
+Assert-Equal 0 @(Format-PerfStartupSection -Main $suNoData -Pr $suNoData).Count 'startup section empty when neither side reports startup fields'
+
+$suSection = Format-PerfStartupSection -Main $suMain -Pr $suPr
+$suText = $suSection -join "`n"
+Assert-Match $suText 'Startup / first frame'              'startup section has heading'
+Assert-Match $suText 'First reconcile (ms)'               'startup section has the Reactor-isolated first-reconcile row'
+Assert-Match $suText 'Entry &rarr; first frame'           'startup section has the human first-frame row'
+Assert-Match $suText 'Window open &rarr; first reconcile' 'startup section has the n/a-guarded window-open row'
+Assert-Match $suText 'Reactor-isolated'                   'startup preamble flags the Reactor-isolated first-reconcile signal'
+Assert-Match $suText 'Informational only'                 'startup section is informational-first while the flag is dormant'
+Assert-Match $suText 'informational'                      'dormant rows show the informational status glyph'
+Assert-Match $suText '95% CI'                             'startup Δ cells carry a 95% CI'
+# Dormant: no better/worse verdict leaks into the status column.
+Assert-True (-not ($suText -like '*improvement*')) 'dormant startup: no improvement verdict'
+Assert-True (-not ($suText -like '*regression*'))  'dormant startup: no regression verdict'
+# Monotonic shape: the human entry->first-frame value is >= the entry->first-reconcile
+# value (first frame composes after the mount completes) in the rendered medians.
+Assert-True ($suMain.EntryToFirstFrameMs -ge $suMain.EntryToFirstReconcileMs) 'startup shape: entry->first-frame >= entry->first-reconcile (monotonic)'
+
+# (4) Armed: flipping $script:StartupAutoFlag promotes the rows from informational to the
+#     band-gated verdict (the one-line flip reserved for after a real-CI calibration). Reset
+#     to dormant afterwards so later assertions (none below, but for safety) see the default.
+$prevStartupFlag = $script:StartupAutoFlag
+$script:StartupAutoFlag = $true
+try {
+    $suFastMainRuns = @(); $suFastPrRuns = @()
+    1..6 | ForEach-Object {
+        $j = ($_ % 3) * 0.5
+        $suFastMainRuns += [pscustomobject]@{ RendersPerSec=3.5; AvgReconcileMs=76; AvgDiffMs=66; AvgMemoryMB=303; TotalRenders=35; DurationSeconds=10; FirstReconcileDurationMs=(800 + $j); EntryToFirstReconcileMs=(1600 + $j); WindowOpenToFirstReconcileMs=(120 + $j); EntryToFirstFrameMs=(1700 + $j) }
+        $suFastPrRuns   += [pscustomobject]@{ RendersPerSec=3.5; AvgReconcileMs=76; AvgDiffMs=66; AvgMemoryMB=303; TotalRenders=35; DurationSeconds=10; FirstReconcileDurationMs=(400 + $j); EntryToFirstReconcileMs=(800 + $j); WindowOpenToFirstReconcileMs=(118 + $j); EntryToFirstFrameMs=(850 + $j) }
+    }
+    $suFastText = (Format-PerfStartupSection -Main (Measure-PerfRuns -Runs $suFastMainRuns) -Pr (Measure-PerfRuns -Runs $suFastPrRuns)) -join "`n"
+    Assert-Match $suFastText 'improvement' 'armed startup: a large faster delta reads improvement (CI excludes 0, clears the band)'
+    Assert-True (-not ($suFastText -like '*informational*'))   'armed startup: rows drop the informational status'
+    Assert-True (-not ($suFastText -like '*Informational only*')) 'armed startup: preamble drops the informational-only note'
+}
+finally {
+    $script:StartupAutoFlag = $prevStartupFlag
+}
+
+# (5) Lineage (the per-tree build mechanic): on THIS metric's introducing run the main
+#     baseline predates the fields -> n/a cells, no paired Δ, and a visible NOTE saying
+#     the Δ populates on the next run. The reverse (PR predates) prints a rebase note.
+$suIntroText = (Format-PerfStartupSection -Main $suNoData -Pr $suMain) -join "`n"  # main predates, PR has data
+Assert-Match $suIntroText 'populates on the next' 'introducing run: note says Δ populates on the next /perf after merge'
+Assert-Match $suIntroText 'n/a'                   'introducing run: main baseline cells read n/a'
+$suRebaseText = (Format-PerfStartupSection -Main $suMain -Pr $suNoData) -join "`n"  # pr predates, main has data
+Assert-Match $suRebaseText 'Rebase onto' 'pr-predates run: note says rebase to populate'
+
+# (6) Threaded through Format-PerfComment, between the regression and cross-framework tables.
+$suComment = Format-PerfComment -Main $suMain -Pr $suPr -WinUI3 $null -Rust $null -Context $ctx
+Assert-Match $suComment 'Startup / first frame' 'comment renders the startup section when startup data present'
+Assert-Match $suComment 'Reactor-isolated'      'comment carries the startup footnote'
+$idxRegSU   = $suComment.IndexOf('Regression vs')
+$idxStartup = $suComment.IndexOf('Startup / first frame')
+$idxXfwSU   = $suComment.IndexOf('Cross-framework reference')
+Assert-True (($idxRegSU -lt $idxStartup) -and ($idxStartup -lt $idxXfwSU)) 'startup section sits between the regression and cross-framework tables'
+# Omitted entirely when neither side reports startup fields (back-compat with existing callers).
+$suNoStartupComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -Context $ctx
+Assert-True (-not ($suNoStartupComment -like '*Startup / first frame*')) 'startup section omitted when neither side reports startup fields'
+
+# Get-PerfStatusGlyph: the informational glyph the dormant rows use.
+Assert-Equal "$([char]0x2139)$([char]0xFE0F) informational" (Get-PerfStatusGlyph 'info') 'info -> information-source glyph'
+
+
 if ($script:Fail -gt 0) {
     Write-Host "FAILED: $($script:Fail) / $($script:Pass + $script:Fail) assertions" -ForegroundColor Red
     foreach ($f in $script:Failures) { Write-Host "  ✗ $f" -ForegroundColor Red }

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -46,6 +46,25 @@ $script:PerfAllocMetricSpec = @(
     [pscustomobject]@{ Key = 'Gen0PerKRenders';     Label = 'Gen0 GC / 1k renders'; LowerIsBetter = $true; Digits = 2; Arrow = [char]0x2193 }
 )
 
+# Startup / first-frame metric table spec (Reactor main-vs-PR). All lower-is-better
+# (faster startup). Piggybacks the headline ReactorOptimized per-rep launches — one
+# sample per process, Reps samples per side — so it reuses the same paired-Δ 95% CI
+# machinery with no extra CI time. The from-scratch mount cost is excluded from the
+# steady-state alloc/timing windows by construction, so this is the only place the
+# #696-class first-render cost surfaces. firstReconcileDurationMs is the Reactor-ISOLATED
+# signal (the first OnRenderComplete reconcile-phase arg, undiluted by AOT/bootstrap);
+# entryToFirstFrameMs is the human-recognisable "first frame rendered" number;
+# windowOpenToFirstReconcileMs is n/a-guarded (Activated-vs-mount ordering is
+# non-deterministic across launches). Emitted by PerfTracker as the matching camelCase
+# fields; absent (n/a) for a harness built from a revision that predates the metric (e.g.
+# the main baseline on this metric's INTRODUCING run — see Format-PerfStartupSection).
+$script:PerfStartupMetricSpec = @(
+    [pscustomobject]@{ Key = 'EntryToFirstFrameMs';          Label = 'Entry &rarr; first frame (ms)';           LowerIsBetter = $true; Digits = 1; Arrow = [char]0x2193 }
+    [pscustomobject]@{ Key = 'FirstReconcileDurationMs';     Label = 'First reconcile (ms)';                    LowerIsBetter = $true; Digits = 1; Arrow = [char]0x2193 }
+    [pscustomobject]@{ Key = 'EntryToFirstReconcileMs';      Label = 'Entry &rarr; first reconcile (ms)';       LowerIsBetter = $true; Digits = 1; Arrow = [char]0x2193 }
+    [pscustomobject]@{ Key = 'WindowOpenToFirstReconcileMs'; Label = 'Window open &rarr; first reconcile (ms)'; LowerIsBetter = $true; Digits = 1; Arrow = [char]0x2193 }
+)
+
 # Minimum-effect band (percent) for the micro-suite ALLOC flag. Even though the micro
 # runs are now rep-interleaved (PR5b: a fresh process per rep randomizes the
 # process-to-process alloc offset on non-deterministic benches -- dispatcher /
@@ -84,6 +103,24 @@ $script:MicroNsMinEffectPct = 3.0
 # real-CI identical-binary band calibration above. Arming is MEASUREMENT-ONLY — it
 # changes /perf verdict labels, never what merges.
 $script:MicroNsAutoFlag = $false
+
+# Startup / first-frame flagging. DORMANT ($false) for release 1 (informational-only),
+# exactly like the micro ns flag above: the Δ + 95% CI are shown for every startup row
+# but the Status reads "informational" and never drives a verdict. ONE sample per launch
+# (vs a 300-tick steady-state average) plus bootstrap process-to-process variance (AOT
+# init, OS file cache, thermal) make this plausibly the noisiest axis, so arming it
+# ($true) is a deliberate, separately-ratified one-line follow-up gated on the SAME
+# real-CI identical-binary ~0-false-flag band calibration required for the ns flip.
+# Arming is MEASUREMENT-ONLY — it changes /perf verdict labels, never what merges.
+$script:StartupAutoFlag = $false
+
+# Minimum-effect band (percent) for the startup flag, applied ONLY once armed. PROVISIONAL:
+# startup is single-sample-per-launch and bootstrap-variance-dominated, so this is a
+# conservative interim hedge (>= the micro bands) and MUST be reset from a real-CI
+# identical-binary interleaved A/B at the live launch count before the flag goes live
+# (same calibration discipline as the micro ns/alloc bands; /perf builds the harness from
+# the default branch, so it can only run post-merge). Inert while the flag is dormant.
+$script:StartupMinEffectPct = 5.0
 
 # Canonical reconciler micro-suite size: the FULL emitted comparison set. That is the
 # spec-047 M1-M13 set PLUS 3 supplementary benches (ids OAlloc / OUpdate / C207) that
@@ -155,6 +192,10 @@ function Read-HarnessMetrics {
         Gen0                = $null
         Gen1                = $null
         Gen2                = $null
+        FirstReconcileDurationMs     = $null
+        EntryToFirstReconcileMs      = $null
+        WindowOpenToFirstReconcileMs = $null
+        EntryToFirstFrameMs          = $null
         TotalRenders        = $null
         DurationSeconds     = $null
         Source              = 'none'
@@ -194,6 +235,15 @@ function Read-HarnessMetrics {
                 if ($j.PSObject.Properties['gen0'] -and $null -ne $j.gen0) { $result.Gen0 = [int]$j.gen0 }
                 if ($j.PSObject.Properties['gen1'] -and $null -ne $j.gen1) { $result.Gen1 = [int]$j.gen1 }
                 if ($j.PSObject.Properties['gen2'] -and $null -ne $j.gen2) { $result.Gen2 = [int]$j.gen2 }
+                # Optional startup / first-frame fields (added after the alloc set). Same
+                # predates-them-reads-n/a contract: a harness built before this metric omits
+                # them entirely (-> $null), and windowOpenToFirstReconcileMs is emitted as
+                # JSON null when the Activated-vs-mount ordering made it unmeasurable on a
+                # given launch — both land as $null here, which Get-PerfDelta renders as n/a.
+                if ($j.PSObject.Properties['firstReconcileDurationMs'] -and $null -ne $j.firstReconcileDurationMs) { $result.FirstReconcileDurationMs = [double]$j.firstReconcileDurationMs }
+                if ($j.PSObject.Properties['entryToFirstReconcileMs'] -and $null -ne $j.entryToFirstReconcileMs) { $result.EntryToFirstReconcileMs = [double]$j.entryToFirstReconcileMs }
+                if ($j.PSObject.Properties['windowOpenToFirstReconcileMs'] -and $null -ne $j.windowOpenToFirstReconcileMs) { $result.WindowOpenToFirstReconcileMs = [double]$j.windowOpenToFirstReconcileMs }
+                if ($j.PSObject.Properties['entryToFirstFrameMs'] -and $null -ne $j.entryToFirstFrameMs) { $result.EntryToFirstFrameMs = [double]$j.entryToFirstFrameMs }
                 $result.Source          = 'json'
                 return $result
             }
@@ -371,6 +421,8 @@ function Measure-PerfRuns {
 
     $keys = 'RendersPerSec', 'AvgReconcileMs', 'AvgDiffMs', 'AvgMemoryMB',
             'AllocBytesPerRender', 'Gen0PerKRenders', 'Gen0', 'Gen1', 'Gen2',
+            'FirstReconcileDurationMs', 'EntryToFirstReconcileMs',
+            'WindowOpenToFirstReconcileMs', 'EntryToFirstFrameMs',
             'TotalRenders', 'DurationSeconds'
     $agg = [ordered]@{ RunCount = @($Runs).Count }
     foreach ($k in $keys) {
@@ -525,6 +577,7 @@ function Get-PerfStatusGlyph {
         'worse'  { return [char]0x26A0 + [char]0xFE0F + ' regression' }          # warning
         'noise'  { return [char]0x2248 + ' within noise' }                       # almost-equal
         'mixed'  { return [char]0x2195 + [char]0xFE0F + ' mixed' }               # up-down arrow
+        'info'   { return [char]0x2139 + [char]0xFE0F + ' informational' }       # information source
         default  { return '—' }
     }
 }
@@ -952,6 +1005,93 @@ function Format-PerfKeyedListSection {
     return $lines.ToArray()
 }
 
+function Format-PerfStartupSection {
+    <#
+    .SYNOPSIS
+        Render the startup / first-frame table: entry&rarr;first-frame, the Reactor-isolated
+        first-reconcile duration, entry&rarr;first-reconcile, and the n/a-guarded window-open&rarr;
+        first-reconcile, PR vs main with the paired 95% CI. Returns an empty array when
+        neither side reported any startup field (the leg was not requested -> stay silent).
+    .DESCRIPTION
+        These piggyback the headline ReactorOptimized per-rep launches (one sample per
+        process, Reps samples per side), so they reuse the same paired-Δ 95% CI machinery
+        ($Main/$Pr aggregates) with zero extra CI time. The from-scratch mount cost is
+        excluded from the steady-state alloc/timing windows by construction, so this section
+        is the only place the #696-class first-render cost surfaces.
+
+        INFORMATIONAL-FIRST: while $script:StartupAutoFlag is dormant ($false, the default)
+        every row's Status reads "informational" — the Δ + 95% CI are shown but never drive a
+        verdict — pending a real-CI identical-binary band calibration, exactly like the micro
+        ns flag. Arming flips the Status to the band-gated better/worse/noise verdict.
+
+        LINEAGE (mirrors the alloc-fields n/a contract): /perf builds the baseline exe from a
+        separate main worktree and overlays only the PR's project references, so on THIS
+        metric's introducing run the main baseline predates the fields -> its cells read n/a
+        and no paired Δ resolves; a visible note says the Δ populates on the next run once the
+        metric is on main. The reverse (PR head predates the metric) prints a rebase note.
+    .PARAMETER Main  Aggregated baseline metrics (Measure-PerfRuns), carrying the startup keys, or $null.
+    .PARAMETER Pr    Aggregated PR-head metrics, or $null.
+    #>
+    param(
+        [AllowNull()][pscustomobject]$Main,
+        [AllowNull()][pscustomobject]$Pr
+    )
+    if ($null -eq $Main -or $null -eq $Pr) { return @() }
+
+    $spec = $script:PerfStartupMetricSpec
+    $mainHasData = @($spec | Where-Object { $null -ne $Main.($_.Key) }).Count -gt 0
+    $prHasData = @($spec | Where-Object { $null -ne $Pr.($_.Key) }).Count -gt 0
+    if (-not $mainHasData -and -not $prHasData) { return @() }
+
+    $down = [char]0x2193
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add('### Startup / first frame')
+    $lines.Add('')
+    $preamble = "Per-launch **first-frame / first-reconcile** cost the steady-state tables above exclude by construction (their windows baseline on the first benchmark tick, after the mount). Captured once per process and aggregated over the same interleaved per-rep launches &mdash; $down lower is better. ``First reconcile (ms)`` is the **Reactor-isolated** first-render reconcile-phase duration (the #696 signal, undiluted by AOT / window / XAML bootstrap and directly comparable to the steady-state Diff column); ``Entry &rarr; first frame`` is the human-facing first-composed-frame number. Δ is the mean paired change with a 95% CI."
+    if (-not $script:StartupAutoFlag) {
+        $preamble += " **Informational only** &mdash; the Δ / CI are reported but no row is auto-flagged better-or-worse yet (one sample per launch + bootstrap process-to-process variance is the noisiest axis; the flag stays dormant pending a real-CI identical-binary band calibration, like the micro ns metric)."
+    }
+    $lines.Add($preamble)
+    $lines.Add('')
+    $lines.Add('| Metric | `main` (baseline) | This PR | Δ (95% CI) | Status |')
+    $lines.Add('|---|--:|--:|--:|:--|')
+    foreach ($m in $spec) {
+        $bVal = $Main.($m.Key)
+        $pVal = $Pr.($m.Key)
+        $spread = [math]::Max([double]$Main."$($m.Key)Spread", [double]$Pr."$($m.Key)Spread")
+        # Paired CI is the ONLY admissible flag (RequirePairedCI): the single-sample point
+        # delta vs a spread band is exactly the thin "2-run median" signal this whole effort
+        # is removing. With <2 aligned pairs (e.g. the lineage one-sided run) the Status is
+        # 'na' and the Δ cell renders '—'.
+        $delta = Get-PerfDelta -Baseline $bVal -Candidate $pVal -LowerIsBetter $m.LowerIsBetter -SpreadPct $spread `
+            -BaselineSamples $Main."$($m.Key)Samples" -CandidateSamples $Pr."$($m.Key)Samples" `
+            -MinEffectPct $script:StartupMinEffectPct -RequirePairedCI
+        # Informational-first: a missing-side delta stays 'na' (—); otherwise the row reads
+        # 'informational' until the flag is armed, then it shows the band-gated verdict.
+        $statusKey = if ($delta.Status -eq 'na') { 'na' } elseif ($script:StartupAutoFlag) { $delta.Status } else { 'info' }
+        $lines.Add(('| {0} {1} | {2} | {3} | {4} | {5} |' -f `
+                $m.Label, $m.Arrow, `
+            (Format-PerfNumber $bVal $m.Digits), `
+            (Format-PerfNumber $pVal $m.Digits), `
+            (Format-PerfDeltaCell $delta), `
+            (Get-PerfStatusGlyph $statusKey)))
+    }
+    $lines.Add('')
+    # Lineage note: a side built before the metric landed reads n/a; surface it loudly
+    # (a visible note, never a silent gap) per the per-tree build mechanic.
+    if ($prHasData -and -not $mainHasData) {
+        $lines.Add('> [!NOTE]')
+        $lines.Add('> The `main` baseline was built from a revision that predates this metric, so its cells read *n/a* and no paired Δ is resolvable on this run. The Δ vs `main` populates on the next `/perf` after this lands (the baseline exe then emits the fields too).')
+        $lines.Add('')
+    }
+    elseif ($mainHasData -and -not $prHasData) {
+        $lines.Add('> [!NOTE]')
+        $lines.Add('> This PR head was built from a revision that predates the startup metric, so its cells read *n/a*. Rebase onto `main` to populate them.')
+        $lines.Add('')
+    }
+    return $lines.ToArray()
+}
+
 function Format-PerfComment {
     <#
     .SYNOPSIS
@@ -1025,6 +1165,13 @@ function Format-PerfComment {
         & $add $row
     }
     & $add ''
+
+    # ── Startup / first-frame table ──────────────────────────────────────────
+    # Per-launch first-frame / first-reconcile cost (the #696 signal) the steady-state
+    # tables exclude by construction. Piggybacks the headline per-rep launches (one
+    # sample per process), so it reuses $Main/$Pr with zero extra CI. Informational-
+    # first while $StartupAutoFlag is dormant. Rendered only when a side reported it.
+    foreach ($sline in (Format-PerfStartupSection -Main $Main -Pr $Pr)) { & $add $sline }
 
     # ── Low-mutation skip-floor table (--percent ~0) ─────────────────────────
     # A second interleaved A/B leg at near-zero mutation. With ~1 cell changing per
@@ -1101,6 +1248,10 @@ function Format-PerfComment {
     }
     & $add "<sub>$up higher is better &middot; $down lower is better. **Within noise** = the 95% confidence interval of the paired Δ includes 0 (no change resolvable at this sample size); $([char]0x2705) improvement / $([char]0x26A0)$([char]0xFE0F) regression require the CI to **exclude** 0.</sub>"
     & $add "<sub>Allocation metrics (alloc bytes/render, Gen0 GC) are the sensitive signal for allocation-reduction work, where the mean-ms / memory figures are largely flat. They read *n/a* for a harness built from a revision that predates them (rebase the PR onto ``main`` to populate them).</sub>"
+    $hasStartup = (@($script:PerfStartupMetricSpec | Where-Object { ($null -ne $Main.($_.Key)) -or ($null -ne $Pr.($_.Key)) }).Count -gt 0)
+    if ($hasStartup) {
+        & $add "<sub>Startup / first-frame metrics piggyback the same interleaved per-rep launches (one sample per process). ``First reconcile (ms)`` is the **Reactor-isolated** first-render reconcile-phase duration (the #696 mount-cost signal, undiluted by AOT / window / XAML bootstrap and directly comparable to the steady-state Diff column); ``Entry &rarr; first frame`` is the human-facing first composed frame. They read *n/a* for a harness built from a revision that predates them &mdash; the paired Δ populates on the next run once the metric is on ``main``. **Informational only** until the band is calibrated: the Δ / CI are shown but no startup row is auto-flagged yet (single-sample-per-launch + bootstrap variance, the noisiest axis).</sub>"
+    }
     if ($null -ne $Micro -and @($Micro).Count -gt 0) {
         if ($script:MicroNsAutoFlag) {
             & $add "<sub>Reconciler micro-benchmarks run ``PerfBench.ControlModel --variant Reactor`` (M1&ndash;M13) as a headless loop bracketed by per-thread alloc + GC counters &mdash; ns-resolution and free of WinUI render / working-set dilution, so they resolve Core/Reconciler time and allocation deltas the macro StocksGrid workload cannot. ``main`` and PR each link their own ``src/Reactor`` build and are **rep-interleaved** (a fresh alternated process per rep), so the paired ns CI is unbiased. The **Status** column combines ns/op and allocated bytes/op &mdash; a bench flags when either axis' 95% CI clears its minimum-effect band, and $([char]0x2195)$([char]0xFE0F) mixed when the axes disagree.</sub>"

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -220,6 +220,19 @@ Several tables plus footnotes:
   at this sample size. This data-driven band replaces the old fixed 4% floor,
   which both buried real sub-4% wins and rubber-stamped any sub-4% number as
   "noise" regardless of how tight the runs were.
+- **Startup / first frame** — the from-scratch **mount** the steady-state tables
+  exclude by construction, captured once per process: `First reconcile (ms)` (the
+  **Reactor-isolated** first-render reconcile-phase duration — the same phase the
+  steady-state Avg Diff column averages — undiluted by AOT / window / XAML bootstrap,
+  so a mount regression shows here at full size), `Entry → first frame (ms)` (the
+  human-facing "first frame rendered"), `Entry → first reconcile (ms)`, and the
+  n/a-guarded `Window open → first reconcile (ms)`. Piggybacks the headline per-rep
+  launches (one sample/process, so the cold first launch is warmup-dropped) for a
+  paired 95% CI at zero extra CI time. **Informational-first**: the flag
+  (`$StartupAutoFlag`) ships dormant — Δ + CI are shown but no row is auto-flagged
+  better-or-worse until a real-CI identical-binary band calibration (same discipline
+  as the micro ns flag; measurement-only). Reads n/a for a pre-metric head, so on the
+  introducing run the `main` baseline shows n/a and the Δ populates on the next run.
 - **Low-mutation skip-floor (`--percent 0`)** — the same four headline metrics
   from a **second interleaved A/B leg** at near-zero mutation. With ~1 cell
   changing per tick, reconcile/diff are dominated by the **O(n) positional child


### PR DESCRIPTION
## What

Adds a **startup / first-frame** section to the `/perf` comment — the from-scratch **mount** cost that every steady-state table excludes by construction (they window-average over benchmark ticks, *after* the mount). This is exactly where a #696-class mount/reconcile regression lives, and nothing in the harness measured it. Closes the user's originating *"first frame rendered"* question.

**Class-B harness PR — 0 `src/Reactor` changes** (everything under `tests/stress_perf/**`).

## The four anchors (captured once per process, all "lower is better", ms from managed entry)

| Field | What it is | Why |
|---|---|---|
| `firstReconcileDurationMs` | **Reactor-isolated** first-render reconcile-phase duration (the first `OnRenderComplete`'s `reconcile` arg) | The diagnostic. Same phase steady-state **Avg Diff** averages, so it's directly comparable — but **undiluted** by AOT/window/XAML bootstrap, so a 2× mount regression shows at full size instead of as a single-digit-% bootstrap blip. This is the field that makes the metric catch the user's class of bug. |
| `entryToFirstFrameMs` | managed entry → first composed frame | The human-facing *"first frame rendered"* headline. |
| `entryToFirstReconcileMs` | managed entry → first reconcile | Guaranteed-monotonic companion. |
| `windowOpenToFirstReconcileMs` | window `Activated` → first reconcile | **n/a-guarded** secondary — `Activated`-vs-mount ordering is non-deterministic across launches, so it emits JSON `null` → renders `n/a` rather than a garbage negative that would poison the paired CI. |

## How it's wired (0 src/Reactor)

- **`StressPerf.Shared/StartupTiming.cs`** (new) — process-static monotonic entry/window-open anchors (`Stopwatch.GetTimestamp()`), idempotent first-wins, AOT/trim-safe.
- **`StressPerf.Shared/PerfTracker.cs`** — `RecordFirstRenderIfUnset` (one-shot, called *before* the benchmark gate so it sees the full mount); first-frame capture gated so `T_firstFrame ≥ T_firstReconcile`; 4 nullable accessors; JSON emission (`null` for an un-captured anchor).
- **`StressPerf.ReactorOptimized/Program.cs`** — `MarkEntry()` as the first statement of `Main`; subscribe `PrimaryWindow.Activated` → `MarkWindowOpen()`; `RecordFirstRenderIfUnset(...)` as the first line of `OnRenderComplete`.
- **`ci/PerfLib.ps1`** — parse the 4 optional fields (a head that predates them → `n/a`, exactly like the alloc fields), aggregate them as headline keys (reuses the paired-95%-CI machinery), `Format-PerfStartupSection`, a dormant flag + provisional band, and an `info` glyph.

The section **piggybacks the existing headline per-rep launches** (one sample/process) — so it costs **zero extra CI time**, and the cold first launch is **warmup-dropped automatically** because it rides the same per-rep metrics object that `Run-PerfBenchmark.ps1`'s interleave loop already discards. **`Run-PerfBenchmark.ps1` needs no change.**

## ⚠️ Flags for the reviewer / coordinator

1. **This introducing run renders PR-side shape only — by design.** `perf-compare.yml` builds the baseline exe from a separate `main` worktree and overlays the PR via ProjectReference (not `Program.cs`/`PerfTracker.cs`). So on *this* PR's `/perf` run the **`main` side predates the startup fields → emits `null` → no paired Δ** (the section renders a visible n/a note: "populates on the next `/perf` after this lands"). The paired Δ + the identical-binary band calibration only populate on the **first run after merge**. The gate-clean run here can prove **PR-side shape** (fields present, monotonic, `firstReconcile >> AvgDiff`), not the paired delta.
2. **`firstReconcileDurationMs` is directly comparable to steady-state Avg Diff** (same reconcile/diff-patch phase). Expected shape: `firstReconcileDurationMs >> AvgDiffMs` (mount creates every control; steady ticks patch a few).
3. **Informational-first (dormant flag).** `$StartupAutoFlag` ships `$false` — Δ + CI are shown but no row auto-flags better-or-worse until a real-CI identical-binary ~0-false-flag band calibration (same discipline as the micro ns flag; measurement-only, never changes what merges). Startup is the noisiest axis (one sample/launch + bootstrap process-to-process variance), so provisional band ≥ the micro band.
4. **Carry-for-user (please confirm):** the headline `entryToFirstFrameMs` (managed entry → first composed frame) should match whatever the user's dashboard labels *"first frame rendered"*. Flagging so the harness number is directly comparable to what they originally raised.

## Tests

+39 `PerfLib.Tests` assertions: parse (incl. JSON-`null` window-open + pre-metric head), aggregate, render (informational/dormant + armed verdict), §11 lineage both directions, monotonic shape, **cold-first-launch warmup-drop**, comment ordering/footnote, info glyph. **PerfLib.Tests 322 + RunPerfBenchmark.Tests 76 green.**

Docs: `METHODOLOGY.md` + `ci/README.md` startup sections.

---
🤖 Draft — held for coordinator independent-verify + merge (Class-B coordinator-merge discipline).
