### PR TITLE
fix(charting): make PieChart `.SetColors()` colors scanner-visible (#645)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,18 @@ Conventions for contributors:
 
 ### Fixed
 
+- **The accessibility scanner now sees a pie chart's `.SetColors(...)` palette
+  (issue #645, spec 026).** `PieChartElement<T>.SetColors(...)` sets the colors a
+  pie actually renders, but the scanner previously only saw the separate
+  `.Palette(...)` palette — so a `.SetColors(<low-contrast>).ChartBackground(...)`
+  pie looked contrast-checked yet A11Y_CHART_011 never ran on its rendered colors.
+  The rendered `.SetColors` palette is now the single source of truth the scanner
+  validates (`.Palette(...)` is consulted only as a fallback when `.SetColors` is
+  unset), so A11Y_CHART_009/010/011 run on it exactly as they do for `.Palette(...)`.
+  **Behavior change:** existing `.SetColors(...)` users with low-contrast or
+  colorblind-unsafe palettes may now start seeing A11Y_CHART_009/010/011 findings
+  they did not before. Pie palette-fix suggestions also now name `.SetColors(...)`
+  (the modifier a pie exposes) instead of `.SeriesColors(...)`.
 - **Multi-window teardown no longer faults with an `ACCESS_VIOLATION`
   (issue #647).** Closing a docking tear-off floating preview window could
   terminate the process with `0xC0000005` deep in the WinUI backdrop interop —

--- a/docs/_pipeline/templates/charting.md.dt
+++ b/docs/_pipeline/templates/charting.md.dt
@@ -236,6 +236,7 @@ annotations, and `.Interactive()` for keyboard navigation:
 | `.AlternateView(element)` | Toggle between chart and data table (T key) |
 | `.Palette(palette)` | Curated colorblind-safe palette |
 | `.SeriesColors(colors)` | Custom series colors (scanner-validated) |
+| `.SetColors(colors)` | Custom pie-slice colors (scanner-validated; pie counterpart to `.SeriesColors`) |
 | `.RawColors(colors)` | Raw series colors — escape hatch, no validation (Tier 4) |
 | `.ChartBackground(color)` | Declare the rendered background so palette-contrast (A11Y_CHART_011) is checked against that single active background (warning) instead of either fixed light/dark background (info) |
 | `.SeriesShapes(shapes)` | Marker shapes for double-encoding |

--- a/docs/guide/charting.md
+++ b/docs/guide/charting.md
@@ -446,6 +446,7 @@ class AccessibleChartDemo : Component
 | `.AlternateView(element)` | Toggle between chart and data table (T key) |
 | `.Palette(palette)` | Curated colorblind-safe palette |
 | `.SeriesColors(colors)` | Custom series colors (scanner-validated) |
+| `.SetColors(colors)` | Custom pie-slice colors (scanner-validated; pie counterpart to `.SeriesColors`) |
 | `.RawColors(colors)` | Raw series colors — escape hatch, no validation (Tier 4) |
 | `.ChartBackground(color)` | Declare the rendered background so palette-contrast (A11Y_CHART_011) is checked against that single active background (warning) instead of either fixed light/dark background (info) |
 | `.SeriesShapes(shapes)` | Marker shapes for double-encoding |

--- a/docs/specs/026-charting-accessibility-design.md
+++ b/docs/specs/026-charting-accessibility-design.md
@@ -568,6 +568,9 @@ in. Example diagnostic:
 > — indistinguishable to ~5% of male users. Nearest safe alternative for Series 2: #2E5F8F
 > (ΔE 18.7). Apply via `.SeriesColors(...)` or call `ChartPalette.Harden(...)`.
 
+Pie charts expose the same Tier-3 scanner-validated custom colors via `.SetColors(...)`; the checks
+above run on the rendered slice palette identically (issue #645).
+
 #### 7.6.3 Tier 4 — `.RawColors()` escape hatch
 
 For prototypes, designer-review builds, and cases where the developer has out-of-band assurance

--- a/plugins/reactor/skills/reactor-charts/SKILL.md
+++ b/plugins/reactor/skills/reactor-charts/SKILL.md
@@ -217,9 +217,11 @@ Beyond that, your responsibilities:
   `.Palette(ChartPalette.Categorical)` (Tier 1, curated) and `.SeriesColors(…)`
   (Tier 3, your own colors) are both contrast-checked by the a11y scanner
   (`A11Y_CHART_011`). `.RawColors(…)` (Tier 4) is an escape hatch that bypasses
-  the check and itself trips the `A11Y_CHART_012` info. Colors set via the
-  low-level `.SetColors(…)` are **not** seen by the scanner — use
-  `.Palette` / `.SeriesColors` for scanner-visible palettes.
+  the check and itself trips the `A11Y_CHART_012` info. A pie chart's low-level
+  `.SetColors(…)` colors are the slices it actually draws, so they are
+  scanner-visible too — validated as a Tier-3 custom palette. When a pie sets
+  both `.SetColors(…)` and `.Palette(…)`, the rendered `.SetColors(…)` colors are
+  the ones scanned.
 - **Declare the background you render on.** `A11Y_CHART_011` is theme-agnostic
   by default, so it can only flag a custom color against *either* fixed
   light/dark background as an `info`. Call `.ChartBackground("#1E1E1E")` (also

--- a/skills/charts.md
+++ b/skills/charts.md
@@ -226,9 +226,11 @@ Beyond that, your responsibilities:
   `.Palette(ChartPalette.Categorical)` (Tier 1, curated) and `.SeriesColors(…)`
   (Tier 3, your own colors) are both contrast-checked by the a11y scanner
   (`A11Y_CHART_011`). `.RawColors(…)` (Tier 4) is an escape hatch that bypasses
-  the check and itself trips the `A11Y_CHART_012` info. Colors set via the
-  low-level `.SetColors(…)` are **not** seen by the scanner — use
-  `.Palette` / `.SeriesColors` for scanner-visible palettes.
+  the check and itself trips the `A11Y_CHART_012` info. A pie chart's low-level
+  `.SetColors(…)` colors are the slices it actually draws, so they are
+  scanner-visible too — validated as a Tier-3 custom palette. When a pie sets
+  both `.SetColors(…)` and `.Palette(…)`, the rendered `.SetColors(…)` colors are
+  the ones scanned.
 - **Declare the background you render on.** `A11Y_CHART_011` is theme-agnostic
   by default, so it can only flag a custom color against *either* fixed
   light/dark background as an `info`. Call `.ChartBackground("#1E1E1E")` (also

--- a/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
@@ -178,7 +178,7 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                         {
                             Modifier = cd.CustomPaletteModifier,
                             SuggestedValue = string.Join(", ", hardenResult.Palette.Colors.Select(c => c.ToHex())),
-                            CodeSnippet = $".Palette(ChartPalette.OkabeIto) or use .{cd.CustomPaletteModifier}() with the suggested values",
+                            CodeSnippet = $".Palette(ChartPalette.OkabeIto) or use .{cd.CustomPaletteModifier}(...) with the suggested values",
                         },
                         Context = ctx.BuildContext(canvas),
                     });

--- a/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
@@ -178,7 +178,9 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                         {
                             Modifier = cd.CustomPaletteModifier,
                             SuggestedValue = string.Join(", ", hardenResult.Palette.Colors.Select(c => c.ToHex())),
-                            CodeSnippet = $".Palette(ChartPalette.OkabeIto) or use .{cd.CustomPaletteModifier}(...) with the suggested values",
+                            CodeSnippet = cd.IsPaletteAdvisoryOnly
+                                ? $"use .{cd.CustomPaletteModifier}(...) with the suggested values, or remove the .{cd.CustomPaletteModifier}(...) call to fall back to the default palette"
+                                : $".Palette(ChartPalette.OkabeIto) or use .{cd.CustomPaletteModifier}(...) with the suggested values",
                         },
                         Context = ctx.BuildContext(canvas),
                     });
@@ -217,7 +219,9 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                         {
                             Modifier = cd.CustomPaletteModifier,
                             SuggestedValue = string.Join(", ", hardenResult.Palette.Colors.Select(c => c.ToHex())),
-                            CodeSnippet = ".Palette(ChartPalette.OkabeIto) or use hardened alternative",
+                            CodeSnippet = cd.IsPaletteAdvisoryOnly
+                                ? $"use .{cd.CustomPaletteModifier}(...) with the hardened alternative, or remove the .{cd.CustomPaletteModifier}(...) call to fall back to the default palette"
+                                : ".Palette(ChartPalette.OkabeIto) or use hardened alternative",
                         },
                         Context = ctx.BuildContext(canvas),
                     });

--- a/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
@@ -176,9 +176,9 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                         ComponentType = ctx.CurrentComponent,
                         Fix = new A11yFixSuggestion
                         {
-                            Modifier = "SeriesColors",
+                            Modifier = cd.CustomPaletteModifier,
                             SuggestedValue = string.Join(", ", hardenResult.Palette.Colors.Select(c => c.ToHex())),
-                            CodeSnippet = ".Palette(ChartPalette.OkabeIto) or use .SeriesColors() with the suggested values",
+                            CodeSnippet = $".Palette(ChartPalette.OkabeIto) or use .{cd.CustomPaletteModifier}() with the suggested values",
                         },
                         Context = ctx.BuildContext(canvas),
                     });
@@ -215,7 +215,7 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                         ComponentType = ctx.CurrentComponent,
                         Fix = new A11yFixSuggestion
                         {
-                            Modifier = "SeriesColors",
+                            Modifier = cd.CustomPaletteModifier,
                             SuggestedValue = string.Join(", ", hardenResult.Palette.Colors.Select(c => c.ToHex())),
                             CodeSnippet = ".Palette(ChartPalette.OkabeIto) or use hardened alternative",
                         },
@@ -292,7 +292,7 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                     ComponentType = ctx.CurrentComponent,
                     Fix = new A11yFixSuggestion
                     {
-                        Modifier = "SeriesColors",
+                        Modifier = cd.CustomPaletteModifier,
                         SuggestedValue = string.Join(", ", hardenResult.Palette.Colors.Select(c => c.ToHex())),
                         CodeSnippet = "Adjust color lightness to ensure ≥3:1 contrast against chart backgrounds",
                     },
@@ -346,7 +346,7 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                 ComponentType = ctx.CurrentComponent,
                 Fix = new A11yFixSuggestion
                 {
-                    Modifier = "SeriesColors",
+                    Modifier = cd.CustomPaletteModifier,
                     SuggestedValue = suggestedValue,
                     CodeSnippet = "Adjust color lightness to ensure ≥3:1 contrast against the chart background",
                 },

--- a/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
+++ b/src/Reactor/Charting/Accessibility/ChartAccessibilityChecker.cs
@@ -165,6 +165,14 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                     var hardenResult = ChartPalette.Harden(
                         Enumerable.Range(0, palette.Count).Select(k => palette[k]).ToArray());
 
+                    // .Palette(...) takes a ChartPalette, not raw colors, so the palette-only pie
+                    // fallback wraps the suggested colors in ChartPalette.FromColors(...) to keep the
+                    // remediation snippet compilable; .SetColors(...)/.SeriesColors(...) take colors
+                    // directly (issue #645).
+                    string applyFix = cd.CustomPaletteModifier == "Palette"
+                        ? ".Palette(ChartPalette.FromColors(...))"
+                        : $".{cd.CustomPaletteModifier}(...)";
+
                     findings.Add(new A11yDiagnostic
                     {
                         Id = "A11Y_CHART_009",
@@ -179,7 +187,7 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                             Modifier = cd.CustomPaletteModifier,
                             SuggestedValue = string.Join(", ", hardenResult.Palette.Colors.Select(c => c.ToHex())),
                             CodeSnippet = cd.IsPaletteAdvisoryOnly
-                                ? $"use .{cd.CustomPaletteModifier}(...) with the suggested values, or remove the .{cd.CustomPaletteModifier}(...) call to fall back to the default palette"
+                                ? $"use {applyFix} with the suggested values, or remove the .{cd.CustomPaletteModifier}(...) call to fall back to the default palette"
                                 : $".Palette(ChartPalette.OkabeIto) or use .{cd.CustomPaletteModifier}(...) with the suggested values",
                         },
                         Context = ctx.BuildContext(canvas),
@@ -206,6 +214,14 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                     var hardenResult = ChartPalette.Harden(
                         Enumerable.Range(0, palette.Count).Select(k => palette[k]).ToArray());
 
+                    // .Palette(...) takes a ChartPalette, not raw colors, so the palette-only pie
+                    // fallback wraps the suggested colors in ChartPalette.FromColors(...) to keep the
+                    // remediation snippet compilable; .SetColors(...)/.SeriesColors(...) take colors
+                    // directly (issue #645).
+                    string applyFix = cd.CustomPaletteModifier == "Palette"
+                        ? ".Palette(ChartPalette.FromColors(...))"
+                        : $".{cd.CustomPaletteModifier}(...)";
+
                     findings.Add(new A11yDiagnostic
                     {
                         Id = "A11Y_CHART_010",
@@ -220,7 +236,7 @@ internal sealed class ChartAccessibilityChecker : IScanExtension
                             Modifier = cd.CustomPaletteModifier,
                             SuggestedValue = string.Join(", ", hardenResult.Palette.Colors.Select(c => c.ToHex())),
                             CodeSnippet = cd.IsPaletteAdvisoryOnly
-                                ? $"use .{cd.CustomPaletteModifier}(...) with the hardened alternative, or remove the .{cd.CustomPaletteModifier}(...) call to fall back to the default palette"
+                                ? $"use {applyFix} with the hardened alternative, or remove the .{cd.CustomPaletteModifier}(...) call to fall back to the default palette"
                                 : ".Palette(ChartPalette.OkabeIto) or use hardened alternative",
                         },
                         Context = ctx.BuildContext(canvas),

--- a/src/Reactor/Charting/Accessibility/ChartPalette.cs
+++ b/src/Reactor/Charting/Accessibility/ChartPalette.cs
@@ -233,6 +233,19 @@ public sealed class ChartPalette
     }
 
     /// <summary>
+    /// Single-copy overload of <see cref="FromColors(D3.D3Color[])"/> for internal callers that
+    /// already hold the colors in an <see cref="IReadOnlyList{T}"/> (e.g. the pie
+    /// <c>.SetColors(...)</c> scanner palette, issue #645). Produces an identical Tier-3 palette
+    /// but avoids the extra array allocation the <c>params</c> overload incurs when the source is
+    /// not already a <c>D3Color[]</c> — the list is materialized exactly once.
+    /// </summary>
+    internal static ChartPalette FromColors(IReadOnlyList<D3.D3Color> colors)
+    {
+        if (colors.Count == 0) throw new ArgumentException("At least one color is required.", nameof(colors));
+        return new([.. colors]);
+    }
+
+    /// <summary>
     /// Creates a palette from raw colors — escape hatch with no validation (Tier 4).
     /// Triggers scanner warning A11Y_CHART_012.
     /// </summary>

--- a/src/Reactor/Charting/Accessibility/IChartAccessibilityData.cs
+++ b/src/Reactor/Charting/Accessibility/IChartAccessibilityData.cs
@@ -123,10 +123,13 @@ internal sealed record ChartA11yData(IChartAccessibilityData Data)
 
     /// <summary>
     /// DSL modifier the scanner names in its palette-fix suggestions (A11Y_CHART_009/010/011) for
-    /// this chart — e.g. <c>"SeriesColors"</c> for series charts, <c>"SetColors"</c> for pie charts
+    /// this chart — <c>"SeriesColors"</c> for series charts; for pie charts it tracks which field
+    /// fed the scanned palette: <c>"SetColors"</c> when <c>.SetColors(...)</c> is the rendered
+    /// source, or <c>"Palette"</c> when only the advisory <c>.Palette(...)</c> fallback is set
     /// (issue #645). The fix-suggestion modifier is machine-consumable (an agent applies the named
-    /// method), so it must name a modifier the chart actually exposes: a pie has <c>.SetColors(...)</c>,
-    /// not <c>.SeriesColors(...)</c>. Defaults to <c>"SeriesColors"</c>; pie charts override it.
+    /// method), so it must name a modifier the chart actually exposes <b>and the author actually
+    /// used</b>: a pie has <c>.SetColors(...)</c> and <c>.Palette(...)</c>, not
+    /// <c>.SeriesColors(...)</c>. Defaults to <c>"SeriesColors"</c>; pie charts override it.
     /// </summary>
     public string CustomPaletteModifier { get; init; } = "SeriesColors";
 

--- a/src/Reactor/Charting/Accessibility/IChartAccessibilityData.cs
+++ b/src/Reactor/Charting/Accessibility/IChartAccessibilityData.cs
@@ -121,6 +121,15 @@ internal sealed record ChartA11yData(IChartAccessibilityData Data)
     /// <summary>Custom palette set on the chart, if any — scanner validates for contrast.</summary>
     public ChartPalette? CustomPalette { get; init; }
 
+    /// <summary>
+    /// DSL modifier the scanner names in its palette-fix suggestions (A11Y_CHART_009/010/011) for
+    /// this chart — e.g. <c>"SeriesColors"</c> for series charts, <c>"SetColors"</c> for pie charts
+    /// (issue #645). The fix-suggestion modifier is machine-consumable (an agent applies the named
+    /// method), so it must name a modifier the chart actually exposes: a pie has <c>.SetColors(...)</c>,
+    /// not <c>.SeriesColors(...)</c>. Defaults to <c>"SeriesColors"</c>; pie charts override it.
+    /// </summary>
+    public string CustomPaletteModifier { get; init; } = "SeriesColors";
+
     /// <summary>Custom focus indicator color, if any — scanner validates 3:1 contrast (A11Y_CHART_006).</summary>
     public global::Windows.UI.Color? CustomFocusColor { get; init; }
 

--- a/src/Reactor/Charting/Accessibility/IChartAccessibilityData.cs
+++ b/src/Reactor/Charting/Accessibility/IChartAccessibilityData.cs
@@ -130,6 +130,18 @@ internal sealed record ChartA11yData(IChartAccessibilityData Data)
     /// </summary>
     public string CustomPaletteModifier { get; init; } = "SeriesColors";
 
+    /// <summary>
+    /// Whether this chart's <c>.Palette(...)</c> is advisory-only and does NOT drive the rendered
+    /// colors — <c>true</c> for pie charts, where <c>.SetColors(...)</c> (or the Category10 default)
+    /// is what renders and <c>.Palette(...)</c> is merely a scanner fallback (issue #645). When
+    /// <c>true</c>, the palette-contrast fix suggestions (A11Y_CHART_009/010) must NOT offer
+    /// <c>.Palette(ChartPalette.OkabeIto)</c> as a remediation — applying it would not change what
+    /// the chart actually draws — and instead point only at <see cref="CustomPaletteModifier"/>
+    /// (or removing it to fall back to the vetted default palette). Defaults to <c>false</c> (series
+    /// charts, whose <c>.Palette(...)</c> drives rendering); pie charts override it.
+    /// </summary>
+    public bool IsPaletteAdvisoryOnly { get; init; }
+
     /// <summary>Custom focus indicator color, if any — scanner validates 3:1 contrast (A11Y_CHART_006).</summary>
     public global::Windows.UI.Color? CustomFocusColor { get; init; }
 

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -563,9 +563,13 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     /// the override and restores the default palette — we deliberately don't store an
     /// empty palette because every downstream consumer would have to mod-by-zero
     /// guard, and "no colors" isn't a meaningful render state.
-    /// <para><b>Accessibility note:</b> colors set via <c>.SetColors(...)</c> are NOT seen by
-    /// the a11y scanner, so A11Y_CHART_011 contrast checks do not run on them. Use
-    /// <see cref="Palette(Accessibility.ChartPalette)"/> for a scanner-visible palette.</para>
+    /// <para><b>Accessibility:</b> these are the colors the slices are actually drawn with, so the
+    /// a11y scanner validates them as a Tier-3 custom palette (A11Y_CHART_009/010/011) — exactly
+    /// like <see cref="Palette(Accessibility.ChartPalette)"/> colors (issue #645). They are the
+    /// single source of truth for both rendering and the scanner: when both <c>.SetColors(...)</c>
+    /// and <c>.Palette(...)</c> are set, the rendered <c>.SetColors(...)</c> colors are the ones
+    /// scanned. Declare <see cref="ChartBackground(D3Color)"/> to scope the contrast check to the
+    /// background the chart renders on.</para>
     /// </summary>
     public PieChartElement<T> SetColors(params D3Color[] colors)
     {
@@ -629,9 +633,9 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     /// contrast check to this single active background (a <c>warning</c>) instead of flagging
     /// failure against either fixed light/dark background (an <c>info</c>). Omit for charts
     /// that may render on any background.
-    /// <para><b>Note:</b> only a scanner-visible palette (set via <see cref="Palette(Accessibility.ChartPalette)"/>)
-    /// is contrast-checked against this background. Colors set via <c>.SetColors(...)</c> are
-    /// not seen by the scanner.</para>
+    /// <para><b>Note:</b> the custom palette contrast-checked against this background is the one
+    /// the chart actually renders — the <c>.SetColors(...)</c> colors when set, otherwise a
+    /// <see cref="Palette(Accessibility.ChartPalette)"/> palette (issue #645).</para>
     /// <para>The stored value is normalized to opaque RGB: contrast math
     /// (<see cref="Accessibility.ChartPalette.ContrastRatio"/>) cannot evaluate a semi-transparent
     /// background without knowing what is behind it, so any alpha is dropped.</para>
@@ -662,7 +666,23 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
 
     // Internal accessors for scanner
     internal bool IsColorOnly => _colorOnly;
-    internal Accessibility.ChartPalette? CustomPalette => _palette;
+    internal Accessibility.ChartPalette? CustomPalette => ScannerPalette;
+
+    /// <summary>
+    /// The single custom palette the accessibility scanner validates, kept in lockstep with what
+    /// the pie actually renders (issue #645). The pie draws <c>_colorPalette</c>
+    /// (<see cref="SetColors"/>) when set, otherwise the default Category10; <see cref="Palette"/>
+    /// is advisory-only and never changes pie rendering. So that the scanner sees exactly the
+    /// rendered slices, the rendered <c>.SetColors(...)</c> palette wins as a Tier-3
+    /// (<see cref="Accessibility.ChartPalette.FromColors"/>) scanner-validated palette; the
+    /// <see cref="Palette"/> palette is the fallback only when <c>.SetColors(...)</c> is unset,
+    /// preserving the prior scanner-visible behavior. Null — neither set — means the pre-vetted
+    /// Category10 default, which stays unscanned as before.
+    /// </summary>
+    private Accessibility.ChartPalette? ScannerPalette =>
+        _colorPalette is { Count: > 0 } colors
+            ? Accessibility.ChartPalette.FromColors([.. colors])
+            : _palette;
 
     public Element ToElement()
     {
@@ -735,7 +755,7 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
         (Core.CanvasElement)canvas.SetAttached(new Accessibility.ChartA11yData(this)
         {
             IsColorOnly = _colorOnly,
-            CustomPalette = _palette,
+            CustomPalette = ScannerPalette,
             ChartBackground = _chartBackground,
         });
 

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -677,14 +677,14 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     /// (<see cref="SetColors"/>) when set, otherwise the default Category10; <see cref="Palette"/>
     /// is advisory-only and never changes pie rendering. So that the scanner sees exactly the
     /// rendered slices, the rendered <c>.SetColors(...)</c> palette wins as a Tier-3
-    /// (<see cref="Accessibility.ChartPalette.FromColors"/>) scanner-validated palette; the
+    /// (<see cref="Accessibility.ChartPalette.FromColors(D3Color[])"/>) scanner-validated palette; the
     /// <see cref="Palette"/> palette is the fallback only when <c>.SetColors(...)</c> is unset,
     /// preserving the prior scanner-visible behavior. Null — neither set — means the pre-vetted
     /// Category10 default, which stays unscanned as before.
     /// </summary>
     private Accessibility.ChartPalette? ScannerPalette =>
         _colorPalette is { Count: > 0 } colors
-            ? Accessibility.ChartPalette.FromColors([.. colors])
+            ? Accessibility.ChartPalette.FromColors(colors)
             : _palette;
 
     public Element ToElement()

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -760,6 +760,7 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
             IsColorOnly = _colorOnly,
             CustomPalette = ScannerPalette,
             CustomPaletteModifier = "SetColors",
+            IsPaletteAdvisoryOnly = true,
             ChartBackground = _chartBackground,
         });
 

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -624,7 +624,14 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
         return this;
     }
 
-    /// <summary>Sets a curated accessible palette (Tier 1).</summary>
+    /// <summary>
+    /// Declares a scanner-visible accessible palette for the pie (Tier 1). For a pie this is
+    /// <b>advisory-only</b>: it does <b>not</b> change the rendered slice colors (a pie renders the
+    /// <c>.SetColors(...)</c> colors when set, otherwise the built-in Category10 default) and is
+    /// consulted by the accessibility scanner only as a contrast-check fallback when
+    /// <c>.SetColors(...)</c> is unset (issue #645). Use <see cref="SetColors"/> to control the
+    /// colors a pie actually draws.
+    /// </summary>
     public PieChartElement<T> Palette(Accessibility.ChartPalette palette) { _palette = palette; return this; }
 
     /// <summary>
@@ -686,6 +693,17 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
         _colorPalette is { Count: > 0 } colors
             ? Accessibility.ChartPalette.FromColors(colors)
             : _palette;
+
+    /// <summary>
+    /// The DSL modifier the scanner names in its palette-fix suggestions (A11Y_CHART_009/010/011),
+    /// tracking <b>which field actually fed</b> <see cref="ScannerPalette"/>: <c>"SetColors"</c> when
+    /// the rendered <c>_colorPalette</c> (<see cref="SetColors"/>) is the source, otherwise
+    /// <c>"Palette"</c> for the advisory <c>_palette</c> (<see cref="Palette"/>) fallback. Naming a
+    /// call the author never made — e.g. telling a pie that only set <c>.Palette(...)</c> to fix or
+    /// remove a non-existent <c>.SetColors(...)</c> call — is the wrong-guidance footgun issue #645
+    /// exists to kill, so the remediation must reference the call that produced the scanned palette.
+    /// </summary>
+    private string ScannerPaletteModifier => _colorPalette is { Count: > 0 } ? "SetColors" : "Palette";
 
     public Element ToElement()
     {
@@ -759,7 +777,7 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
         {
             IsColorOnly = _colorOnly,
             CustomPalette = ScannerPalette,
-            CustomPaletteModifier = "SetColors",
+            CustomPaletteModifier = ScannerPaletteModifier,
             IsPaletteAdvisoryOnly = true,
             ChartBackground = _chartBackground,
         });

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -625,12 +625,14 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     }
 
     /// <summary>
-    /// Declares a scanner-visible accessible palette for the pie (Tier 1). For a pie this is
+    /// Declares a scanner-visible accessible palette for the pie. For a pie this is
     /// <b>advisory-only</b>: it does <b>not</b> change the rendered slice colors (a pie renders the
     /// <c>.SetColors(...)</c> colors when set, otherwise the built-in Category10 default) and is
     /// consulted by the accessibility scanner only as a contrast-check fallback when
-    /// <c>.SetColors(...)</c> is unset (issue #645). Use <see cref="SetColors"/> to control the
-    /// colors a pie actually draws.
+    /// <c>.SetColors(...)</c> is unset (issue #645). Accepts any <see cref="Accessibility.ChartPalette"/>:
+    /// a curated palette such as <c>ChartPalette.OkabeIto</c> (Tier 1) is recommended for guaranteed
+    /// contrast, but <c>ChartPalette.FromColors(...)</c> (Tier 3) and <c>ChartPalette.FromRaw(...)</c>
+    /// (Tier 4) are accepted too. Use <see cref="SetColors"/> to control the colors a pie actually draws.
     /// </summary>
     public PieChartElement<T> Palette(Accessibility.ChartPalette palette) { _palette = palette; return this; }
 

--- a/src/Reactor/Charting/Charts.cs
+++ b/src/Reactor/Charting/Charts.cs
@@ -633,9 +633,12 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
     /// contrast check to this single active background (a <c>warning</c>) instead of flagging
     /// failure against either fixed light/dark background (an <c>info</c>). Omit for charts
     /// that may render on any background.
-    /// <para><b>Note:</b> the custom palette contrast-checked against this background is the one
-    /// the chart actually renders — the <c>.SetColors(...)</c> colors when set, otherwise a
-    /// <see cref="Palette(Accessibility.ChartPalette)"/> palette (issue #645).</para>
+    /// <para><b>Note:</b> the palette contrast-checked against this background is the one the pie
+    /// actually renders — the <c>.SetColors(...)</c> colors — when set. A
+    /// <see cref="Palette(Accessibility.ChartPalette)"/> palette does <b>not</b> change what a pie
+    /// draws (a pie renders the built-in Category10 default unless <c>.SetColors(...)</c> overrides
+    /// it); it is consulted by the scanner only as an advisory fallback when <c>.SetColors(...)</c>
+    /// is unset (issue #645).</para>
     /// <para>The stored value is normalized to opaque RGB: contrast math
     /// (<see cref="Accessibility.ChartPalette.ContrastRatio"/>) cannot evaluate a semi-transparent
     /// background without knowing what is behind it, so any alpha is dropped.</para>
@@ -756,6 +759,7 @@ public sealed class PieChartElement<T> : IChartAccessibilityData
         {
             IsColorOnly = _colorOnly,
             CustomPalette = ScannerPalette,
+            CustomPaletteModifier = "SetColors",
             ChartBackground = _chartBackground,
         });
 

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -432,6 +432,106 @@ public class ChartScannerRuleTests
         Assert.Equal("warning", finding.Severity);
     }
 
+    // ── A11Y_CHART_011: PieChart .SetColors() is scanner-visible (issue #645) ───────
+
+    [Fact]
+    public void A11Y_CHART_011_PieChart_SetColors_DeclaredBackground_FiresWarning()
+    {
+        // Issue #645 (red→green): PieChartElement<T>.SetColors(...) feeds _colorPalette, the
+        // colors the slices are ACTUALLY drawn with. Before the fix those colors never reached
+        // ChartA11yData.CustomPalette, so A11Y_CHART_011 silently never ran on them — a
+        // .SetColors(low).ChartBackground(low) chart looked contrast-checked but wasn't. Now the
+        // rendered .SetColors palette is the scanner's source of truth, so a near-white slice
+        // color that fails the declared light background fires the same WARNING that the
+        // .Palette(...) path does. This assertion FAILS against the pre-#645 code (zero findings),
+        // so it is the load-bearing guard for the fix.
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .SetColors(new D3Color(255, 255, 200)) // near-white: fails the light background
+            .ChartBackground("#FFFFFF");
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+        Assert.Equal("warning", finding.Severity);
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_PieChart_SetColors_NoBackground_FiresInfo()
+    {
+        // .SetColors colors also flow through the theme-agnostic (no declared background) path
+        // exactly like a .Palette(...) palette: the same near-white color fails against EITHER
+        // fixed light/dark background and is reported as INFO. Pins that the unification covers
+        // the unknown-background arm too, not just the scoped-background warning (issue #645).
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .SetColors(new D3Color(255, 255, 200));
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+        Assert.Equal("info", finding.Severity);
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_PieChart_SetColors_PassesDeclaredBackground_DoesNotFire()
+    {
+        // The same near-white .SetColors color PASSES 3:1 against the declared dark (#202020)
+        // background it actually renders on, so the rule must NOT fire — a palette is only
+        // penalized for the background it renders on. Mirrors the .Palette(...) dark-background
+        // no-fire case, proving .SetColors gets identical treatment (issue #645).
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .SetColors(new D3Color(255, 255, 200))
+            .ChartBackground("#202020");
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        Assert.DoesNotContain(findings, f => f.Id == "A11Y_CHART_011");
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_PieChart_BothSet_RenderedSetColorsWins_FiresOnSetColors()
+    {
+        // Both-set semantics (issue #645): when .SetColors(...) AND .Palette(...) are both set, the
+        // pie still RENDERS the .SetColors colors (_colorPalette), so the scanner validates THOSE —
+        // keeping the scanner and the rendered output in lockstep. Here the rendered .SetColors
+        // color is near-white (fails the declared white background) while the .Palette() color is a
+        // mid-tone gray that PASSES white. The rule fires on the rendered near-white color. If
+        // _palette wrongly won, the scanner would see the passing gray and emit nothing — so this
+        // single-finding assertion pins that the rendered .SetColors palette is the source of truth.
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .SetColors(new D3Color(255, 255, 200))                 // rendered: fails white
+            .Palette(ChartPalette.FromColors(new D3Color(128, 128, 128))) // advisory: passes white
+            .ChartBackground("#FFFFFF");
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+        Assert.Equal("warning", finding.Severity);
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_PieChart_BothSet_PaletteIgnoredWhenSetColorsPasses_DoesNotFire()
+    {
+        // Inverse of the both-set test: the rendered .SetColors color is a mid-tone gray that
+        // PASSES the declared white background, while the advisory .Palette() color is near-white
+        // and would FAIL white. Because only the rendered .SetColors palette is scanned, the rule
+        // must NOT fire. If _palette wrongly won, the near-white .Palette color would trip a
+        // warning — so this no-finding assertion pins that .Palette() is ignored for the scanner
+        // whenever .SetColors() is set (issue #645).
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .SetColors(new D3Color(128, 128, 128))                 // rendered: passes white
+            .Palette(ChartPalette.FromColors(new D3Color(255, 255, 200))) // advisory: fails white
+            .ChartBackground("#FFFFFF");
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        Assert.DoesNotContain(findings, f => f.Id == "A11Y_CHART_011");
+    }
+
     [Fact]
     public void A11Y_CHART_011_KnownBackground_PairwiseGuardBlocksFix_FallsBackToTextualHint()
     {

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -618,7 +618,30 @@ public class ChartScannerRuleTests
         // Source-tracked modifier: .Palette() fed the scanned palette here, so the fix names .Palette(),
         // not .SetColors() — and the advisory pie path still never offers .Palette(ChartPalette.OkabeIto).
         Assert.Equal("Palette", finding.Fix.Modifier);
+        // .Palette(...) takes a ChartPalette, not raw colors, so the apply guidance must wrap the
+        // suggested colors in ChartPalette.FromColors(...); a bare ".Palette(<hex>)" would not compile —
+        // the same wrong-guidance footgun on the advisory path, caught by the PR #708 re-review.
+        Assert.Contains(".Palette(ChartPalette.FromColors(...))", finding.Fix.CodeSnippet);
         Assert.Contains(".Palette(...)", finding.Fix.CodeSnippet);
+        Assert.DoesNotContain(".SetColors(", finding.Fix.CodeSnippet);
+    }
+
+    [Fact]
+    public void A11Y_CHART_010_PieChart_PaletteOnly_FixNamesCompilablePalette()
+    {
+        // Companion to the 009 PaletteOnly test for the colorblind rule (PR #708 re-review). A pie that
+        // set ONLY .Palette(...) trips A11Y_CHART_010; the advisory remediation must name .Palette() —
+        // the call the author made — AND keep it compilable: .Palette() takes a ChartPalette, so the
+        // apply guidance wraps the colors in ChartPalette.FromColors(...), never a bare .Palette(<hex>).
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .Palette(ChartPalette.FromColors(new D3Color(100, 100, 100), new D3Color(101, 100, 100))); // ΔE < 10 under CVD sim
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_010");
+        Assert.Equal("Palette", finding.Fix.Modifier);
+        Assert.Contains(".Palette(ChartPalette.FromColors(...))", finding.Fix.CodeSnippet);
         Assert.DoesNotContain(".SetColors(", finding.Fix.CodeSnippet);
     }
 

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -553,6 +553,10 @@ public class ChartScannerRuleTests
         var findings = AccessibilityScanner.Scan(tree);
         var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_009");
         Assert.Equal("SetColors", finding.Fix.Modifier);
+        // The remediation snippet must imply the modifier takes color args — `.SetColors(...)`,
+        // not an empty-args `.SetColors()` that would read as a non-compiling zero-arg call (PR #708 review).
+        Assert.Contains(".SetColors(...)", finding.Fix.CodeSnippet);
+        Assert.DoesNotContain(".SetColors()", finding.Fix.CodeSnippet);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -203,6 +203,9 @@ public class ChartScannerRuleTests
         // Series charts render their .Palette(...), so the OkabeIto shortcut stays a valid fix here —
         // the chart-type-aware snippet only drops it on the advisory pie path (issue #645).
         Assert.Contains(".Palette(ChartPalette.OkabeIto)", finding.Fix.CodeSnippet);
+        // L2 (PR #708 review): series charts must keep naming the SERIES modifier after the pie
+        // chart-type-aware change — explicit guard for the "series guidance unaffected" invariant.
+        Assert.Equal("SeriesColors", finding.Fix.Modifier);
     }
 
     [Fact]
@@ -234,6 +237,13 @@ public class ChartScannerRuleTests
 
         var findings = AccessibilityScanner.Scan(tree);
         Assert.Contains(findings, f => f.Id == "A11Y_CHART_010");
+
+        // L2 (PR #708 review): pin the series modifier + snippet so a future DTO-default change can't
+        // silently flip series remediation. Series charts render their .Palette(...), so the OkabeIto
+        // shortcut stays a valid fix on the series path.
+        var finding = findings.First(f => f.Id == "A11Y_CHART_010");
+        Assert.Equal("SeriesColors", finding.Fix.Modifier);
+        Assert.Contains(".Palette(ChartPalette.OkabeIto)", finding.Fix.CodeSnippet);
     }
 
     // ── A11Y_CHART_011: Background contrast ─────────────────────────
@@ -254,6 +264,9 @@ public class ChartScannerRuleTests
         var findings = AccessibilityScanner.Scan(tree);
         var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
         Assert.Equal("info", finding.Severity);
+        // L2 (PR #708 review): series 011 also carries the series modifier (the 011 snippet text
+        // itself is the textual lightness hint, so only the modifier needs pinning here).
+        Assert.Equal("SeriesColors", finding.Fix.Modifier);
     }
 
     [Fact]
@@ -584,6 +597,29 @@ public class ChartScannerRuleTests
         // .Palette(...) which wouldn't change a pie's rendered slices (issue #645 / PR #708 review).
         Assert.Contains(".SetColors(...)", finding.Fix.CodeSnippet);
         Assert.DoesNotContain(".Palette(", finding.Fix.CodeSnippet);
+    }
+
+    [Fact]
+    public void A11Y_CHART_009_PieChart_PaletteOnly_FixNamesPaletteNotSetColors()
+    {
+        // M1 (PR #708 review): a pie that set ONLY .Palette(...) (no .SetColors()) makes ScannerPalette
+        // fall back to that advisory palette — the scanner correctly validates it — but the remediation
+        // must name the call the author ACTUALLY made: .Palette(...), never a .SetColors(...) call they
+        // never wrote. Telling an author to fix/remove a non-existent call is the wrong-guidance footgun
+        // #645 exists to kill (the mirror of the chart-type-aware fix that stopped pies emitting the
+        // non-existent .SeriesColors()). The modifier tracks which field fed ScannerPalette.
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .Palette(ChartPalette.FromColors(new D3Color(128, 128, 128), new D3Color(135, 135, 135))); // similar grays: <3:1 pairwise
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_009");
+        // Source-tracked modifier: .Palette() fed the scanned palette here, so the fix names .Palette(),
+        // not .SetColors() — and the advisory pie path still never offers .Palette(ChartPalette.OkabeIto).
+        Assert.Equal("Palette", finding.Fix.Modifier);
+        Assert.Contains(".Palette(...)", finding.Fix.CodeSnippet);
+        Assert.DoesNotContain(".SetColors(", finding.Fix.CodeSnippet);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -454,6 +454,9 @@ public class ChartScannerRuleTests
         var findings = AccessibilityScanner.Scan(tree);
         var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
         Assert.Equal("warning", finding.Severity);
+        // H1 (issue #645): the machine-consumable fix names the modifier a PIE exposes — .SetColors(),
+        // not .SeriesColors() — via ChartA11yData.CustomPaletteModifier (the checker is chart-type-aware).
+        Assert.Equal("SetColors", finding.Fix.Modifier);
     }
 
     [Fact]
@@ -530,6 +533,63 @@ public class ChartScannerRuleTests
 
         var findings = AccessibilityScanner.Scan(tree);
         Assert.DoesNotContain(findings, f => f.Id == "A11Y_CHART_011");
+    }
+
+    // ── .SetColors() is checked across A11Y_CHART_009/010/011 like .Palette() (issue #645) ──
+
+    [Fact]
+    public void A11Y_CHART_009_PieChart_SetColors_MultiColor_FiresPairwise_WithSetColorsFix()
+    {
+        // Issue #645 acceptance: .SetColors() is contrast-checked across 009/010/011 "exactly like"
+        // .Palette() — not just the 011 background rule. Two near-identical grays fail the pairwise
+        // ≥3:1 rule (A11Y_CHART_009). Pins that a MULTI-color .SetColors palette (Count≥2) reaches the
+        // pairwise rule via the pie path, and that the machine-consumable fix names the modifier a PIE
+        // exposes — .SetColors(), not .SeriesColors() (the checker is now chart-type-aware).
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .SetColors(new D3Color(128, 128, 128), new D3Color(135, 135, 135)); // similar grays: <3:1 pairwise
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_009");
+        Assert.Equal("SetColors", finding.Fix.Modifier);
+    }
+
+    [Fact]
+    public void A11Y_CHART_010_PieChart_SetColors_MultiColor_FiresColorblind_WithSetColorsFix()
+    {
+        // Companion to the 009 test: two colors whose colorblind ΔE is under the 10.0 minimum trip
+        // A11Y_CHART_010 via the pie .SetColors() path. Reuses the proven colorblind-unsafe pair from
+        // the series-chart 010 test. Again the fix names .SetColors() — the pie's real modifier —
+        // confirming chart-type-aware remediation across the colorblind rule too (issue #645).
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .SetColors(new D3Color(100, 100, 100), new D3Color(101, 100, 100)); // ΔE < 10 under CVD sim
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_010");
+        Assert.Equal("SetColors", finding.Fix.Modifier);
+    }
+
+    [Fact]
+    public void A11Y_CHART_011_PieChart_EmptySetColors_FallsBackToPaletteForScanner()
+    {
+        // M4: ScannerPalette's `{ Count: > 0 }` guard. Calling .SetColors() with NO args clears
+        // _colorPalette (the pie reverts to its default render palette), so the scanner falls back to
+        // the .Palette() palette — preserving the pre-#645 scanner-visible behavior. Pins that an empty
+        // .SetColors() does NOT suppress the .Palette() contrast finding: the near-white .Palette color
+        // still fails the declared white background and fires the warning (issue #645).
+        var chart = Charts.PieChart(Array.Empty<DataPoint>(), d => d.Y)
+            .Palette(ChartPalette.FromColors(new D3Color(255, 255, 200))) // near-white: fails white
+            .SetColors()                                                  // cleared → ScannerPalette falls back to _palette
+            .ChartBackground("#FFFFFF");
+        var canvas = chart.AttachChartDataForTest(new CanvasElement([]) { Width = 400, Height = 300 });
+        var tree = VStack(canvas);
+
+        var findings = AccessibilityScanner.Scan(tree);
+        var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_011");
+        Assert.Equal("warning", finding.Severity);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
+++ b/tests/Reactor.Tests/D3/ChartScannerRuleTests.cs
@@ -200,6 +200,9 @@ public class ChartScannerRuleTests
 
         var finding = findings.First(f => f.Id == "A11Y_CHART_009");
         Assert.NotNull(finding.Fix.SuggestedValue);
+        // Series charts render their .Palette(...), so the OkabeIto shortcut stays a valid fix here —
+        // the chart-type-aware snippet only drops it on the advisory pie path (issue #645).
+        Assert.Contains(".Palette(ChartPalette.OkabeIto)", finding.Fix.CodeSnippet);
     }
 
     [Fact]
@@ -557,6 +560,9 @@ public class ChartScannerRuleTests
         // not an empty-args `.SetColors()` that would read as a non-compiling zero-arg call (PR #708 review).
         Assert.Contains(".SetColors(...)", finding.Fix.CodeSnippet);
         Assert.DoesNotContain(".SetColors()", finding.Fix.CodeSnippet);
+        // A pie's .Palette(...) is advisory-only and does NOT change rendered slices, so the snippet
+        // must NOT offer .Palette(ChartPalette.OkabeIto) as a fix on the pie path (PR #708 review).
+        Assert.DoesNotContain(".Palette(", finding.Fix.CodeSnippet);
     }
 
     [Fact]
@@ -574,6 +580,10 @@ public class ChartScannerRuleTests
         var findings = AccessibilityScanner.Scan(tree);
         var finding = Assert.Single(findings, f => f.Id == "A11Y_CHART_010");
         Assert.Equal("SetColors", finding.Fix.Modifier);
+        // Same chart-type-aware remediation as 009: name .SetColors(...), and never the advisory-only
+        // .Palette(...) which wouldn't change a pie's rendered slices (issue #645 / PR #708 review).
+        Assert.Contains(".SetColors(...)", finding.Fix.CodeSnippet);
+        Assert.DoesNotContain(".Palette(", finding.Fix.CodeSnippet);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #645.

## Problem

`PieChartElement<T>` stored custom colors in **two divergent fields** with split accessibility visibility:

- `.SetColors(params D3Color[])` → `_colorPalette` — **drives rendering** (`_colorPalette ?? Category10`), but was **never** surfaced to the a11y scanner.
- `.Palette(ChartPalette)` → `_palette` — surfaced to the scanner via `AttachChartData` → `ChartA11yData.CustomPalette`, but **does not** drive pie rendering.

Footgun (pr-review **M3** from #633/#638): a `.SetColors(low).ChartBackground(bg)` pie *looks* contrast-checked, but `A11Y_CHART_011` silently never ran on the slices it actually draws.

## Fix — single source of truth = the rendered palette

`AttachChartData` now derives `CustomPalette` from a new `ScannerPalette`:

```csharp
private Accessibility.ChartPalette? ScannerPalette =>
    _colorPalette is { Count: > 0 } colors
        ? Accessibility.ChartPalette.FromColors([.. colors])   // rendered .SetColors() colors
        : _palette;                                            // fallback: .Palette()
```

The scanner now validates exactly the colors the pie renders. **Rendering is unchanged** — only what the scanner *sees* changed. `.SetColors()` colors flow as a Tier‑3 (`FromColors`) palette, so they get `A11Y_CHART_009/010/011` — exactly like `.Palette()` colors.

### Option chosen & why

The issue offered two mechanisms. I used **the `AttachChartData` fallback** (most surgical; no change to rendering or to what `.SetColors`/`.Palette` store; routes through the existing `ChartA11yData.CustomPalette` seam, so no core→scanner coupling is reintroduced — #498 stays intact).

### Both-set semantics: **rendered `.SetColors()` wins** (decided + documented + tested)

When both `.SetColors()` and `.Palette()` are set, the pie still *draws* `_colorPalette`, so the scanner validates **those**. Rationale: the issue's goal is "a single source of truth drives both rendering **and** the scanner." Letting `_palette` win would re-create a rendered≠scanned divergence (the scanner would validate colors that aren't drawn) — i.e. the exact footgun, narrowed. `.Palette()` is consulted only when `.SetColors()` is absent, preserving prior behavior. Neither set → `null` (pre-vetted Category10), unscanned as before.

## Proof — red → green (`A11Y_CHART_011`)

Same new tests, run against `main`'s `Charts.cs` (fix stashed) then with the fix:

| Test | Before (no fix) | After (fix) |
|---|---|---|
| `..._SetColors_DeclaredBackground_FiresWarning` | ❌ **no finding** (footgun) | ✅ warning |
| `..._SetColors_NoBackground_FiresInfo` | ❌ no finding | ✅ info |
| `..._BothSet_RenderedSetColorsWins_FiresOnSetColors` | ❌ no finding | ✅ warning on rendered color |
| `..._BothSet_PaletteIgnoredWhenSetColorsPasses_DoesNotFire` | ❌ **fired on the non-rendered `.Palette()` color** (old divergence) | ✅ silent |
| `..._SetColors_PassesDeclaredBackground_DoesNotFire` | ✅ (vacuous) | ✅ |

The 4th row is the clearest evidence of the old bug: pre-fix, the scanner warned about the `.Palette()` near-white that *wasn't rendered* while ignoring the rendered `.SetColors()` mid-gray.

## Tests (all green; 431 `~Chart` unit tests pass)

5 new cases in `tests/Reactor.Tests/D3/ChartScannerRuleTests.cs`:
`A11Y_CHART_011_PieChart_SetColors_DeclaredBackground_FiresWarning`, `..._SetColors_NoBackground_FiresInfo`, `..._SetColors_PassesDeclaredBackground_DoesNotFire`, `..._BothSet_RenderedSetColorsWins_FiresOnSetColors`, `..._BothSet_PaletteIgnoredWhenSetColorsPasses_DoesNotFire`.

## Docs

- Removed the interim "`.SetColors()` not seen by the scanner" caveats from `.SetColors()` and `PieChartElement.ChartBackground()` XML docs (added in #638).
- Updated the "Custom colors & the scanner" bullet in both charts skill copies (`skills/charts.md`, `plugins/reactor/skills/reactor-charts/SKILL.md`).
- `charting.md.dt` only references `.SetColors()` neutrally and asserts no asymmetry, so no template recompile was needed.
- `reactor.api.txt` (both copies) confirmed **unchanged** via `mur --regen-api` — no public surface change.

## Build

ARM64, `-p:Platform=ARM64 -m:1`, **0 warnings / 0 errors** (core Reactor AOT/trim-clean).

## Merge-ordering note

Direct follow-on to #638 (merged). Touches the same pie a11y seam (`AttachChartData`/`ChartA11yData`) that #162 / PR #644 lightly touches for the `ChartPointDescriptor._labelName` fallback. **No functional overlap** — this PR only changes how `CustomPalette` is derived; it does not touch label/descriptor logic. A trivial textual conflict in `AttachChartData` is possible if #644 lands first.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>