### PR TITLE
Add REACTOR_HOOKS_009 analyzer: Command.DebounceMs requires UseCommand

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -111,6 +111,7 @@ via `.editorconfig`.
 | `REACTOR_HOOKS_006` | Info | Resource fetcher looks non-idempotent | `HookRulesAnalyzer.cs` |
 | `REACTOR_HOOKS_007` | Warning | UseMemoCells builder captures variable not in deps | `UseMemoCellsAnalyzer.cs` |
 | `REACTOR_HOOKS_008` | Info | State variable read after its setter in the same synchronous handler | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_009` | Warning | Command.DebounceMs set on a command bound without UseCommand | `CommandDebounceAnalyzer.cs` |
 | `REACTOR_A11Y_001` | Warning | Icon-only button needs an accessible name | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_002` | Warning | Image needs alt text or AccessibilityHidden | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_003` | Warning | Form field needs a label | `AccessibilityAnalyzers.cs` |
@@ -158,6 +159,31 @@ map it to a suggested theme token. The descriptor message format has a
 `ColorToThemeToken` after the syntactic match. The diagnostic flows
 through to a paired `CodeFixProvider` that rewrites the literal to the
 matching `Theme.Accent` / `Theme.PrimaryText` member.
+
+## Local-dataflow matching — the DebounceMs case
+
+[`REACTOR_HOOKS_009`](rules-of-reactor.md) sits at the other end of the
+spectrum from the substring-only WithKey check: it needs a little local
+data-flow. `Command.DebounceMs` only takes effect when the command is
+routed through `UseCommand` — the leading-edge debounce window lives in
+the hook store, and a plain `Command` record reconstructed every render
+has nowhere to persist it. So `Button(new Command { … DebounceMs =
+1500 })` is silently inert; nothing fails at compile or run time.
+
+`CommandDebounceAnalyzer` anchors on the `new Command { … }` /
+`… with { DebounceMs = … }` expression that sets a non-zero
+`DebounceMs`, confirms via the semantic model that the type is the
+Reactor `Command` / `Command<T>`, then asks one question: does this
+value reach a control binding without passing through `UseCommand`?
+When the command is assigned to a local, the rule walks every in-scope
+reference to that local — if any reference is an argument to
+`UseCommand`, the command is correctly routed and the rule stays
+silent; if instead it flows into a Reactor binding factory (`Button`,
+`MenuItem`, the `.Command(...)` modifier, …) the rule fires. A command
+that is merely returned or stored is left alone, so a factory method
+like `Command MakeSave() => new Command { … DebounceMs = … }` is not a
+false positive. The paired code fix wraps the offending expression in
+`UseCommand(...)`.
 
 ## Property-bag handoff to the code fix
 

--- a/docs/_pipeline/templates/rules-of-reactor.md.dt
+++ b/docs/_pipeline/templates/rules-of-reactor.md.dt
@@ -40,6 +40,7 @@ The five core rules:
 | Hook order is stable | `REACTOR_HOOKS_001` | [Hooks](hooks.md) |
 | Hooks called from Render only | `REACTOR_HOOKS_005` | [Hooks](hooks.md) |
 | Deps are stable | `REACTOR_HOOKS_004` | [Hooks](hooks.md) |
+| Debounced commands need UseCommand | `REACTOR_HOOKS_009` | [Commanding](commanding.md) |
 | Render is pure | *(convention)* | [Components](components.md) |
 | Lists need keys | *(convention)* | [Collections](collections.md) |
 | Theme tokens not literals | `REACTOR_THEME_001` | [Theming Tokens](theming-tokens.md) |
@@ -206,6 +207,7 @@ Full coverage on [Theming Tokens](theming-tokens.md).
 | Deps must be stable | `REACTOR_HOOKS_004` | [Hooks](hooks.md) |
 | UseResource fetcher is idempotent | `REACTOR_HOOKS_006` | [Async Resources](async-resources.md) |
 | UseMemoCells builder must close over deps | `REACTOR_HOOKS_007` | [Hooks](hooks.md) |
+| Debounced commands routed through UseCommand | `REACTOR_HOOKS_009` | [Commanding](commanding.md) |
 | Render must be pure | *(convention — no analyzer)* | [Components](components.md), [Effects](effects.md) |
 | Lists need keys | *(convention — no analyzer)* | [Collections](collections.md), [Reconciliation](reconciliation.md) |
 | Theme-aware modifiers want a token | `REACTOR_THEME_001` | [Theming Tokens](theming-tokens.md) |

--- a/docs/guide/analyzer-architecture.md
+++ b/docs/guide/analyzer-architecture.md
@@ -137,6 +137,7 @@ via `.editorconfig`.
 | `REACTOR_HOOKS_006` | Info | Resource fetcher looks non-idempotent | `HookRulesAnalyzer.cs` |
 | `REACTOR_HOOKS_007` | Warning | UseMemoCells builder captures variable not in deps | `UseMemoCellsAnalyzer.cs` |
 | `REACTOR_HOOKS_008` | Info | State variable read after its setter in the same synchronous handler | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_009` | Warning | Command.DebounceMs set on a command bound without UseCommand | `CommandDebounceAnalyzer.cs` |
 | `REACTOR_A11Y_001` | Warning | Icon-only button needs an accessible name | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_002` | Warning | Image needs alt text or AccessibilityHidden | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_003` | Warning | Form field needs a label | `AccessibilityAnalyzers.cs` |
@@ -226,6 +227,31 @@ map it to a suggested theme token. The descriptor message format has a
 `ColorToThemeToken` after the syntactic match. The diagnostic flows
 through to a paired `CodeFixProvider` that rewrites the literal to the
 matching `Theme.Accent` / `Theme.PrimaryText` member.
+
+## Local-dataflow matching — the DebounceMs case
+
+[`REACTOR_HOOKS_009`](rules-of-reactor.md) sits at the other end of the
+spectrum from the substring-only WithKey check: it needs a little local
+data-flow. `Command.DebounceMs` only takes effect when the command is
+routed through `UseCommand` — the leading-edge debounce window lives in
+the hook store, and a plain `Command` record reconstructed every render
+has nowhere to persist it. So `Button(new Command { … DebounceMs =
+1500 })` is silently inert; nothing fails at compile or run time.
+
+`CommandDebounceAnalyzer` anchors on the `new Command { … }` /
+`… with { DebounceMs = … }` expression that sets a non-zero
+`DebounceMs`, confirms via the semantic model that the type is the
+Reactor `Command` / `Command<T>`, then asks one question: does this
+value reach a control binding without passing through `UseCommand`?
+When the command is assigned to a local, the rule walks every in-scope
+reference to that local — if any reference is an argument to
+`UseCommand`, the command is correctly routed and the rule stays
+silent; if instead it flows into a Reactor binding factory (`Button`,
+`MenuItem`, the `.Command(...)` modifier, …) the rule fires. A command
+that is merely returned or stored is left alone, so a factory method
+like `Command MakeSave() => new Command { … DebounceMs = … }` is not a
+false positive. The paired code fix wraps the offending expression in
+`UseCommand(...)`.
 
 ## Property-bag handoff to the code fix
 

--- a/docs/guide/rules-of-reactor.md
+++ b/docs/guide/rules-of-reactor.md
@@ -46,6 +46,7 @@ class HookOrderBad : Component
 | Hook order is stable | `REACTOR_HOOKS_001` | [Hooks](hooks.md) |
 | Hooks called from Render only | `REACTOR_HOOKS_005` | [Hooks](hooks.md) |
 | Deps are stable | `REACTOR_HOOKS_004` | [Hooks](hooks.md) |
+| Debounced commands need UseCommand | `REACTOR_HOOKS_009` | [Commanding](commanding.md) |
 | Render is pure | *(convention)* | [Components](components.md) |
 | Lists need keys | *(convention)* | [Collections](collections.md) |
 | Theme tokens not literals | `REACTOR_THEME_001` | [Theming Tokens](theming-tokens.md) |
@@ -306,6 +307,7 @@ Full coverage on [Theming Tokens](theming-tokens.md).
 | Deps must be stable | `REACTOR_HOOKS_004` | [Hooks](hooks.md) |
 | UseResource fetcher is idempotent | `REACTOR_HOOKS_006` | [Async Resources](async-resources.md) |
 | UseMemoCells builder must close over deps | `REACTOR_HOOKS_007` | [Hooks](hooks.md) |
+| Debounced commands routed through UseCommand | `REACTOR_HOOKS_009` | [Commanding](commanding.md) |
 | Render must be pure | *(convention — no analyzer)* | [Components](components.md), [Effects](effects.md) |
 | Lists need keys | *(convention — no analyzer)* | [Collections](collections.md), [Reconciliation](reconciliation.md) |
 | Theme-aware modifiers want a token | `REACTOR_THEME_001` | [Theming Tokens](theming-tokens.md) |

--- a/docs/specs/041/under-the-hood-source-map.md
+++ b/docs/specs/041/under-the-hood-source-map.md
@@ -120,6 +120,7 @@ Reactor equivalents.
 - `RequestedThemeSetAnalyzer.cs` — REACTOR_THEME_003
 - `MissingWithKeyAnalyzer.cs` — REACTOR_DSL_001
 - `UseMemoCellsAnalyzer.cs` — REACTOR_HOOKS_007
+- `CommandDebounceAnalyzer.cs` — REACTOR_HOOKS_009
 - (After Phase 1.8: `XmlDocSummaryAnalyzer.cs`, `XmlDocCrefAnalyzer.cs`
   for REACTOR_DOC_001 / 002)
 

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -80,6 +80,7 @@ Additional flags:
 | `REACTOR_HOOKS_005` | warning | Hook called outside `Render()` or a custom-hook method | Move the call into `Render()` or a `Use*` helper. Hooks read slot state that only exists during render. |
 | `REACTOR_HOOKS_006` | info | `UseResource` fetcher looks non-idempotent (`Post*`/`Create*`/`Delete*`/`Save*`) | Use `UseMutation` for writes — `UseResource` re-runs on deps change, retry, focus revalidation. |
 | `REACTOR_HOOKS_007` | warning | `UseMemoCells` builder closure missing dependencies | Add the captured variable to the deps array. |
+| `REACTOR_HOOKS_009` | warning | `Command.DebounceMs` set on a command bound without `UseCommand` | Route it through `UseCommand`: `var cmd = UseCommand(new Command { …, DebounceMs = 1500 });`. The debounce window lives in the hook store, so a raw bound `Command` never debounces. |
 | `REACTOR_DSL_001` | warning | `Select(...)` projecting into a layout container without `.WithKey(...)` | `items.Select(i => Row(i).WithKey(i.Id)).ToArray<Element?>()`. Keys keep focus + animation state across reorders. |
 | `REACTOR_THEME_001` | warning | Hardcoded color on a themed surface | Use `Theme.*` tokens (e.g. `Theme.PrimaryText`, `Theme.CardBackground`). See `reactor-design`. |
 | `REACTOR_THEME_002` | info | Lightweight styling opportunity | Optional. Use `.Resources(r => r.Set("ButtonBackground", …))` for visual-state overrides. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -11,6 +11,7 @@ REACTOR_HOOKS_005 | Reactor.Hooks | Warning | HookRulesAnalyzer - Hook called ou
 REACTOR_HOOKS_006 | Reactor.Hooks | Info | HookRulesAnalyzer - UseResource fetcher looks non-idempotent (use UseMutation for writes)
 REACTOR_HOOKS_007 | Reactor.Hooks | Warning | UseMemoCellsAnalyzer - Builder closure capture missing from dependencies
 REACTOR_HOOKS_008 | Reactor.Hooks | Info | HookRulesAnalyzer - State variable read after its setter was called in the same synchronous handler (stale read)
+REACTOR_HOOKS_009 | Reactor.Hooks | Warning | CommandDebounceAnalyzer - Command.DebounceMs is inert unless the command is routed through UseCommand
 REACTOR_A11Y_001 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Icon-only button needs an accessible name
 REACTOR_A11Y_002 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Image needs alt text or AccessibilityHidden
 REACTOR_A11Y_003 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Form field needs a label

--- a/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
+++ b/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
@@ -1,0 +1,228 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_HOOKS_009</c> — flags a <c>Command</c> / <c>Command&lt;T&gt;</c> that sets a
+/// non-zero <c>DebounceMs</c> and is bound to a control <b>without</b> being routed through
+/// <c>UseCommand(...)</c> first.
+/// </summary>
+/// <remarks>
+/// The leading-edge debounce state (last-accepted-fire timestamp, in-window flag, re-enable
+/// timer) lives in the <c>UseCommand</c> hook store on <c>RenderContext</c> — the only place
+/// that persists across renders. A plain <c>Command</c> record is immutable and reconstructed
+/// every render, so <c>new Command { DebounceMs = … }</c> bound directly to a control has
+/// nowhere to persist that state and is therefore <b>inert: it does not debounce</b> (issue
+/// #136 / #636). The runtime gives no error or warning, so this analyzer makes the footgun
+/// visible and the code fix wraps the command in <c>UseCommand(...)</c>.
+///
+/// Heuristic (conservative, local-dataflow): anchor on a <c>new Command { … DebounceMs =
+/// &lt;non-zero&gt; … }</c> / <c>new() { … }</c> / <c>cmd with { DebounceMs = … }</c> whose
+/// resolved type is the Reactor <c>Command</c>/<c>Command&lt;T&gt;</c>. Report only when the
+/// value (inline, or via the local it initializes) flows into a Reactor binding factory /
+/// <c>.Command(...)</c> modifier and never passes through a <c>UseCommand</c> call. A command
+/// that is returned, stored, or otherwise not obviously bound is left alone.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
+{
+    public const string Id = "REACTOR_HOOKS_009";
+
+    private const string CommandNamespace = "Microsoft.UI.Reactor.Core";
+    private const string ReactorNamespacePrefix = "Microsoft.UI.Reactor";
+    private const string UseCommandName = "UseCommand";
+
+    // Syntactic fallback for the binding sink when full symbol info is unavailable.
+    // Mirrors the Command-accepting factories in src/Reactor/Elements/Dsl.cs; the
+    // `.Command(...)` fluent modifier (ElementExtensions.cs) is matched by name separately.
+    private static readonly HashSet<string> KnownBindingFactories = new(System.StringComparer.Ordinal)
+    {
+        "Button", "HyperlinkButton", "RepeatButton", "ToggleButton",
+        "SplitButton", "ToggleSplitButton", "MenuItem", "AppBarButton",
+    };
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        Id,
+        "Command.DebounceMs is inert unless routed through UseCommand",
+        "This {0} sets a non-zero DebounceMs but is bound without UseCommand; the debounce state lives in the UseCommand hook store, so the command will not debounce. Route it through UseCommand(...).",
+        "Reactor.Hooks",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "DebounceMs only takes effect through RenderContext.UseCommand — the hook store is the only place the debounce window can persist across renders. A raw Command bound directly to a control is reconstructed every render and silently does not debounce. Wrap the command: var cmd = UseCommand(new Command { …, DebounceMs = 1500 }); (issue #136).");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(
+            Analyze,
+            SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.ImplicitObjectCreationExpression,
+            SyntaxKind.WithExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext ctx)
+    {
+        var node = (ExpressionSyntax)ctx.Node;
+
+        // Cheap syntactic gate first — an initializer that assigns a non-zero DebounceMs.
+        var initializer = GetInitializer(node);
+        if (initializer is null) return;
+
+        var debounce = FindDebounceAssignment(initializer);
+        if (debounce is null) return;
+
+        // DebounceMs = 0 (or a constant that folds to 0) is the documented "off" value — never warn.
+        var constant = ctx.SemanticModel.GetConstantValue(debounce.Right, ctx.CancellationToken);
+        if (constant.HasValue && constant.Value is int zero && zero == 0) return;
+
+        // Confirm this is actually the Reactor Command type (avoid matching unrelated `Command`s).
+        var type = ctx.SemanticModel.GetTypeInfo(node, ctx.CancellationToken).Type;
+        if (!IsReactorCommandType(type)) return;
+
+        // Collect the expressions that represent "this command value": the creation expression
+        // itself when used inline, or every reference to the local it initializes.
+        var usages = CollectUsages(node, ctx);
+
+        // Routed through UseCommand anywhere → correct usage, suppress.
+        if (AnyArgumentTo(usages, isUseCommand: true, ctx)) return;
+
+        // Bound to a Reactor control binding without UseCommand → report at the initializer.
+        if (AnyArgumentTo(usages, isUseCommand: false, ctx))
+        {
+            var commandTypeLabel = type is INamedTypeSymbol { IsGenericType: true } ? "Command<T>" : "Command";
+            ctx.ReportDiagnostic(Diagnostic.Create(Rule, node.GetLocation(), commandTypeLabel));
+        }
+    }
+
+    private static InitializerExpressionSyntax? GetInitializer(ExpressionSyntax node) => node switch
+    {
+        ObjectCreationExpressionSyntax oce => oce.Initializer,
+        ImplicitObjectCreationExpressionSyntax ioce => ioce.Initializer,
+        WithExpressionSyntax we => we.Initializer,
+        _ => null,
+    };
+
+    private static AssignmentExpressionSyntax? FindDebounceAssignment(InitializerExpressionSyntax initializer)
+    {
+        foreach (var expr in initializer.Expressions)
+        {
+            if (expr is AssignmentExpressionSyntax a
+                && a.Left is IdentifierNameSyntax { Identifier.ValueText: "DebounceMs" })
+            {
+                return a;
+            }
+        }
+        return null;
+    }
+
+    private static bool IsReactorCommandType(ITypeSymbol? type)
+    {
+        if (type is not INamedTypeSymbol named) return false;
+        // Command or Command<T>, in Microsoft.UI.Reactor.Core.
+        var name = named.Name;
+        if (name != "Command") return false;
+        return named.ContainingNamespace?.ToDisplayString() == CommandNamespace;
+    }
+
+    /// <summary>
+    /// The set of syntax nodes that carry the command value forward: the creation expression
+    /// itself, or — when it is the initializer of <c>var x = …</c> — every in-scope reference
+    /// to <c>x</c>. The local case is what lets the rule distinguish
+    /// <c>var c = new Command{…}; UseCommand(c);</c> (routed, no warning) from
+    /// <c>var c = new Command{…}; Button(c);</c> (bound directly, warning).
+    /// </summary>
+    private static List<ExpressionSyntax> CollectUsages(ExpressionSyntax node, SyntaxNodeAnalysisContext ctx)
+    {
+        // `var x = <node>;` — node.Parent is EqualsValueClause, whose parent is the declarator.
+        if (node.Parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator }
+            && ctx.SemanticModel.GetDeclaredSymbol(declarator, ctx.CancellationToken) is ILocalSymbol local)
+        {
+            var scope = node.FirstAncestorOrSelf<BlockSyntax>();
+            if (scope is not null)
+            {
+                var refs = new List<ExpressionSyntax>();
+                foreach (var id in scope.DescendantNodes().OfType<IdentifierNameSyntax>())
+                {
+                    if (id.Identifier.ValueText != local.Name) continue;
+                    var symbol = ctx.SemanticModel.GetSymbolInfo(id, ctx.CancellationToken).Symbol;
+                    if (SymbolEqualityComparer.Default.Equals(symbol, local))
+                        refs.Add(id);
+                }
+                if (refs.Count > 0) return refs;
+            }
+        }
+
+        return new List<ExpressionSyntax> { node };
+    }
+
+    /// <summary>
+    /// True when any usage is a direct argument to an invocation that is (or is not, per
+    /// <paramref name="isUseCommand"/>) a <c>UseCommand</c> call. For the non-UseCommand arm
+    /// the invocation must additionally look like a Reactor control binding.
+    /// </summary>
+    private static bool AnyArgumentTo(List<ExpressionSyntax> usages, bool isUseCommand, SyntaxNodeAnalysisContext ctx)
+    {
+        foreach (var usage in usages)
+        {
+            // The usage must be passed *directly* as an argument (`f(usage)`), not as part of a
+            // larger expression (`f(usage.Label)` reads a member and is not a command bind).
+            if (usage.Parent is not ArgumentSyntax arg) continue;
+            if (arg.Parent is not ArgumentListSyntax argList) continue;
+            if (argList.Parent is not InvocationExpressionSyntax invocation) continue;
+
+            var calleeName = GetInvokedName(invocation);
+            var calleeIsUseCommand = calleeName == UseCommandName;
+
+            if (isUseCommand)
+            {
+                if (calleeIsUseCommand) return true;
+            }
+            else if (!calleeIsUseCommand && IsReactorBinding(invocation, calleeName, ctx))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool IsReactorBinding(InvocationExpressionSyntax invocation, string? calleeName, SyntaxNodeAnalysisContext ctx)
+    {
+        // Preferred: the resolved callee is a Reactor API (factory or `.Command(...)` modifier).
+        if (ctx.SemanticModel.GetSymbolInfo(invocation, ctx.CancellationToken).Symbol is IMethodSymbol method)
+        {
+            var ns = method.ContainingNamespace?.ToDisplayString();
+            if (ns is not null && (ns == ReactorNamespacePrefix || ns.StartsWith(ReactorNamespacePrefix + ".", System.StringComparison.Ordinal)))
+                return true;
+        }
+
+        // Syntactic fallback when symbol info is unavailable: a known binding factory, or the
+        // `.Command(...)` fluent modifier (member-access invocation named Command).
+        if (calleeName is not null && KnownBindingFactories.Contains(calleeName)) return true;
+        if (invocation.Expression is MemberAccessExpressionSyntax { Name.Identifier.ValueText: "Command" }) return true;
+
+        return false;
+    }
+
+    private static string? GetInvokedName(InvocationExpressionSyntax invocation) => invocation.Expression switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        GenericNameSyntax g => g.Identifier.ValueText,
+        MemberAccessExpressionSyntax m => m.Name switch
+        {
+            GenericNameSyntax gn => gn.Identifier.ValueText,
+            { } simple => simple.Identifier.ValueText,
+        },
+        MemberBindingExpressionSyntax mb => mb.Name.Identifier.ValueText,
+        _ => null,
+    };
+}

--- a/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
+++ b/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
@@ -81,9 +81,12 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
         var debounce = FindDebounceAssignment(initializer);
         if (debounce is null) return;
 
-        // DebounceMs = 0 (or a constant that folds to 0) is the documented "off" value — never warn.
+        // DebounceMs <= 0 is a no-op at runtime (only > 0 debounces — see RenderContext.UseCommand),
+        // so a constant that folds to zero or negative is never a footgun and must never warn. A
+        // non-constant expression falls through and is judged by the binding (conservative: we
+        // can't prove it's <= 0, and under-warning a dynamic value is safer than a false positive).
         var constant = ctx.SemanticModel.GetConstantValue(debounce.Right, ctx.CancellationToken);
-        if (constant.HasValue && constant.Value is int zero && zero == 0) return;
+        if (constant.HasValue && constant.Value is int ms && ms <= 0) return;
 
         // Confirm this is actually the Reactor Command type (avoid matching unrelated `Command`s).
         var type = ctx.SemanticModel.GetTypeInfo(node, ctx.CancellationToken).Type;

--- a/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
+++ b/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
@@ -115,18 +115,10 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
         _ => null,
     };
 
-    private static AssignmentExpressionSyntax? FindDebounceAssignment(InitializerExpressionSyntax initializer)
-    {
-        foreach (var expr in initializer.Expressions)
-        {
-            if (expr is AssignmentExpressionSyntax a
-                && a.Left is IdentifierNameSyntax { Identifier.ValueText: "DebounceMs" })
-            {
-                return a;
-            }
-        }
-        return null;
-    }
+    private static AssignmentExpressionSyntax? FindDebounceAssignment(InitializerExpressionSyntax initializer) =>
+        initializer.Expressions
+            .OfType<AssignmentExpressionSyntax>()
+            .FirstOrDefault(static a => a.Left is IdentifierNameSyntax { Identifier.ValueText: "DebounceMs" });
 
     private static bool IsReactorCommandType(ITypeSymbol? type)
     {
@@ -153,14 +145,15 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
             var scope = node.FirstAncestorOrSelf<BlockSyntax>();
             if (scope is not null)
             {
-                var refs = new List<ExpressionSyntax>();
-                foreach (var id in scope.DescendantNodes().OfType<IdentifierNameSyntax>())
-                {
-                    if (id.Identifier.ValueText != local.Name) continue;
-                    var symbol = ctx.SemanticModel.GetSymbolInfo(id, ctx.CancellationToken).Symbol;
-                    if (SymbolEqualityComparer.Default.Equals(symbol, local))
-                        refs.Add(id);
-                }
+                // Cheap syntactic name match first, then the semantic symbol check — the .Where
+                // order preserves that short-circuit so GetSymbolInfo only runs on name matches.
+                var refs = scope.DescendantNodes()
+                    .OfType<IdentifierNameSyntax>()
+                    .Where(id => id.Identifier.ValueText == local.Name)
+                    .Where(id => SymbolEqualityComparer.Default.Equals(
+                        ctx.SemanticModel.GetSymbolInfo(id, ctx.CancellationToken).Symbol, local))
+                    .Cast<ExpressionSyntax>()
+                    .ToList();
                 if (refs.Count > 0) return refs;
             }
         }
@@ -175,27 +168,23 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
     /// </summary>
     private static bool AnyArgumentTo(List<ExpressionSyntax> usages, bool isUseCommand, SyntaxNodeAnalysisContext ctx)
     {
-        foreach (var usage in usages)
-        {
-            // The usage must be passed *directly* as an argument (`f(usage)`), not as part of a
-            // larger expression (`f(usage.Label)` reads a member and is not a command bind).
-            if (usage.Parent is not ArgumentSyntax arg) continue;
-            if (arg.Parent is not ArgumentListSyntax argList) continue;
-            if (argList.Parent is not InvocationExpressionSyntax invocation) continue;
-
-            var calleeName = GetInvokedName(invocation);
-            var calleeIsUseCommand = calleeName == UseCommandName;
-
-            if (isUseCommand)
+        // The usage must be passed *directly* as an argument (`f(usage)`), not as part of a
+        // larger expression (`f(usage.Label)` reads a member and is not a command bind). Project
+        // each usage to its enclosing invocation and filter out the ones that aren't direct args.
+        return usages
+            .Select(static usage => usage.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax invocation } }
+                ? invocation
+                : null)
+            .Where(static invocation => invocation is not null)
+            .Any(invocation =>
             {
-                if (calleeIsUseCommand) return true;
-            }
-            else if (!calleeIsUseCommand && IsReactorBinding(invocation, calleeName, ctx))
-            {
-                return true;
-            }
-        }
-        return false;
+                var calleeName = GetInvokedName(invocation!);
+                var calleeIsUseCommand = calleeName == UseCommandName;
+
+                return isUseCommand
+                    ? calleeIsUseCommand
+                    : !calleeIsUseCommand && IsReactorBinding(invocation!, calleeName, ctx);
+            });
     }
 
     private static bool IsReactorBinding(InvocationExpressionSyntax invocation, string? calleeName, SyntaxNodeAnalysisContext ctx)

--- a/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
+++ b/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
@@ -185,7 +185,7 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
                 var calleeIsUseCommand = calleeName == UseCommandName;
 
                 return isUseCommand
-                    ? calleeIsUseCommand
+                    ? calleeIsUseCommand && IsReactorUseCommand(invocation!, ctx)
                     : !calleeIsUseCommand && IsReactorBinding(invocation!, calleeName, ctx);
             });
     }
@@ -201,6 +201,21 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
         return expression;
     }
 
+    // Mirror of IsReactorBinding for the suppression arm. A UseCommand call only counts as routing
+    // through the hook when Roslyn resolves the callee to a method under the Microsoft.UI.Reactor
+    // namespace (the Component / RenderContext hook). An unrelated helper or local function that
+    // merely shares the name must NOT suppress the diagnostic — that would be a false negative
+    // (the command is still bound raw and still does not debounce). When symbol resolution fails
+    // (incomplete code mid-edit) we fall back to trusting the name match the caller already made,
+    // so a genuinely-routed command still suppresses.
+    private static bool IsReactorUseCommand(InvocationExpressionSyntax invocation, SyntaxNodeAnalysisContext ctx)
+    {
+        if (ctx.SemanticModel.GetSymbolInfo(invocation, ctx.CancellationToken).Symbol is IMethodSymbol method)
+            return IsReactorNamespace(method.ContainingNamespace?.ToDisplayString());
+
+        return true;
+    }
+
     private static bool IsReactorBinding(InvocationExpressionSyntax invocation, string? calleeName, SyntaxNodeAnalysisContext ctx)
     {
         // When Roslyn can resolve the callee, trust it: a binding only counts if the method lives
@@ -208,11 +223,7 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
         // in any other namespace is an unrelated API that merely shares a name (someone else's
         // `Button`/`MenuItem`/`.Command(...)`) — not a Reactor bind — so we must not warn on it.
         if (ctx.SemanticModel.GetSymbolInfo(invocation, ctx.CancellationToken).Symbol is IMethodSymbol method)
-        {
-            var ns = method.ContainingNamespace?.ToDisplayString();
-            return ns is not null
-                && (ns == ReactorNamespacePrefix || ns.StartsWith(ReactorNamespacePrefix + ".", System.StringComparison.Ordinal));
-        }
+            return IsReactorNamespace(method.ContainingNamespace?.ToDisplayString());
 
         // Symbol info unavailable (unresolved / incomplete code mid-edit) — fall back to a
         // conservative syntactic match so the footgun is still surfaced: a known binding factory,
@@ -222,6 +233,14 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
 
         return false;
     }
+
+    // True when ns is the Reactor root namespace or a descendant of it. Shared by the binding-sink
+    // check, the UseCommand routing check, and the code fix's UseCommand-in-scope gate so all three
+    // judge "is this Reactor's API" identically.
+    internal static bool IsReactorNamespace(string? ns) =>
+        ns is not null
+            && (ns == ReactorNamespacePrefix
+                || ns.StartsWith(ReactorNamespacePrefix + ".", System.StringComparison.Ordinal));
 
     private static string? GetInvokedName(InvocationExpressionSyntax invocation) => invocation.Expression switch
     {

--- a/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
+++ b/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
@@ -98,7 +98,20 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
         // itself when used inline, or every reference to the local it initializes.
         var usages = CollectUsages(node, ctx);
 
-        // Routed through UseCommand anywhere → correct usage, suppress.
+        // Routed through UseCommand anywhere → treat as correct usage and suppress.
+        //
+        // This deliberately suppresses even when the command is ALSO bound raw elsewhere with the
+        // UseCommand return value discarded (e.g. `UseCommand(save); Button(save);`). That is an
+        // accepted, intentional false negative — not an oversight. RenderContext.UseCommand returns
+        // a NEW `command with { …, DebounceHandled = true }` and does not mutate its argument, so the
+        // idiomatic correct usage rebinds the SAME local: `save = UseCommand(save); Button(save);`.
+        // Suppressing on any UseCommand usage is what keeps that reassignment pattern from drawing a
+        // false POSITIVE — and a false positive erodes trust far more than this narrow false negative.
+        // #636 explicitly accepts conservatism, and the real footgun (no UseCommand at all) is caught.
+        //
+        // Future enhancement (intentionally NOT implemented here — scope creep for this rule): a
+        // strictly FP-safe narrowing could warn only when the SOLE UseCommand usage discards its
+        // return value (a bare `UseCommand(x);` expression statement is always a misuse).
         if (AnyArgumentTo(usages, isUseCommand: true, ctx)) return;
 
         // Bound to a Reactor control binding without UseCommand → report at the initializer.
@@ -174,6 +187,12 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
         // larger expression (`f(usage.Label)` reads a member and is not a command bind). Project
         // each usage to its enclosing invocation and filter out the ones that aren't direct args.
         // ClimbParentheses keeps `f((usage))` recognized as a direct bind.
+        //
+        // Known limitation (accepted): a command passed inside a collection/array rather than as a
+        // direct scalar argument — e.g. `CommandHost(new[] { cmd }, child)` (Dsl.cs) — is not
+        // tracked, so a debounced command bound only that way is a false negative. Such commands are
+        // keyboard accelerators and rarely debounced; widening to array elements would enlarge the
+        // heuristic's false-positive surface for little gain, so it is intentionally left out.
         return usages
             .Select(static usage => ClimbParentheses(usage).Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax invocation } }
                 ? invocation
@@ -222,6 +241,13 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
         // in a Reactor namespace (a Dsl factory or the `.Command(...)` modifier). A resolved callee
         // in any other namespace is an unrelated API that merely shares a name (someone else's
         // `Button`/`MenuItem`/`.Command(...)`) — not a Reactor bind — so we must not warn on it.
+        //
+        // Assumption (verified for the current API surface): every public method in the Reactor
+        // namespaces that takes a single Command argument IS a binding sink (the Dsl factories +
+        // the `.Command(...)` modifier); the lone non-bind is `internal CommandBindings.Invoke`,
+        // which is unreachable from user code, and `UseCommand` is excluded by the caller. So a
+        // namespace match here is a safe proxy for "is a bind." Revisit (whitelist actual binding
+        // APIs) if a *public* non-bind Command-taking API is ever added to a Reactor namespace.
         if (ctx.SemanticModel.GetSymbolInfo(invocation, ctx.CancellationToken).Symbol is IMethodSymbol method)
             return IsReactorNamespace(method.ContainingNamespace?.ToDisplayString());
 

--- a/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
+++ b/src/Reactor.Analyzers/CommandDebounceAnalyzer.cs
@@ -83,8 +83,10 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
 
         // DebounceMs <= 0 is a no-op at runtime (only > 0 debounces — see RenderContext.UseCommand),
         // so a constant that folds to zero or negative is never a footgun and must never warn. A
-        // non-constant expression falls through and is judged by the binding (conservative: we
-        // can't prove it's <= 0, and under-warning a dynamic value is safer than a false positive).
+        // non-constant expression can't be proven <= 0 at compile time, so it falls through and is
+        // judged by the binding: a dynamic value bound directly still warns. We favor surfacing the
+        // footgun (a runtime value that turns out > 0 is exactly the inert case this rule targets)
+        // over staying silent on the chance it happens to be 0.
         var constant = ctx.SemanticModel.GetConstantValue(debounce.Right, ctx.CancellationToken);
         if (constant.HasValue && constant.Value is int ms && ms <= 0) return;
 
@@ -171,8 +173,9 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
         // The usage must be passed *directly* as an argument (`f(usage)`), not as part of a
         // larger expression (`f(usage.Label)` reads a member and is not a command bind). Project
         // each usage to its enclosing invocation and filter out the ones that aren't direct args.
+        // ClimbParentheses keeps `f((usage))` recognized as a direct bind.
         return usages
-            .Select(static usage => usage.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax invocation } }
+            .Select(static usage => ClimbParentheses(usage).Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax invocation } }
                 ? invocation
                 : null)
             .Where(static invocation => invocation is not null)
@@ -187,18 +190,33 @@ public sealed class CommandDebounceAnalyzer : DiagnosticAnalyzer
             });
     }
 
+    // Walks up out of any enclosing parentheses so `Button((cmd))` is still seen as a direct
+    // argument bind (the inner expression's immediate parent would otherwise be a
+    // ParenthesizedExpression, not the ArgumentSyntax). Mirrors the repo's StripParentheses
+    // convention (e.g. ReferenceCurrentReadAnalyzer), but climbs upward rather than downward.
+    private static ExpressionSyntax ClimbParentheses(ExpressionSyntax expression)
+    {
+        while (expression.Parent is ParenthesizedExpressionSyntax parens)
+            expression = parens;
+        return expression;
+    }
+
     private static bool IsReactorBinding(InvocationExpressionSyntax invocation, string? calleeName, SyntaxNodeAnalysisContext ctx)
     {
-        // Preferred: the resolved callee is a Reactor API (factory or `.Command(...)` modifier).
+        // When Roslyn can resolve the callee, trust it: a binding only counts if the method lives
+        // in a Reactor namespace (a Dsl factory or the `.Command(...)` modifier). A resolved callee
+        // in any other namespace is an unrelated API that merely shares a name (someone else's
+        // `Button`/`MenuItem`/`.Command(...)`) — not a Reactor bind — so we must not warn on it.
         if (ctx.SemanticModel.GetSymbolInfo(invocation, ctx.CancellationToken).Symbol is IMethodSymbol method)
         {
             var ns = method.ContainingNamespace?.ToDisplayString();
-            if (ns is not null && (ns == ReactorNamespacePrefix || ns.StartsWith(ReactorNamespacePrefix + ".", System.StringComparison.Ordinal)))
-                return true;
+            return ns is not null
+                && (ns == ReactorNamespacePrefix || ns.StartsWith(ReactorNamespacePrefix + ".", System.StringComparison.Ordinal));
         }
 
-        // Syntactic fallback when symbol info is unavailable: a known binding factory, or the
-        // `.Command(...)` fluent modifier (member-access invocation named Command).
+        // Symbol info unavailable (unresolved / incomplete code mid-edit) — fall back to a
+        // conservative syntactic match so the footgun is still surfaced: a known binding factory,
+        // or the `.Command(...)` fluent modifier (member-access invocation named Command).
         if (calleeName is not null && KnownBindingFactories.Contains(calleeName)) return true;
         if (invocation.Expression is MemberAccessExpressionSyntax { Name.Identifier.ValueText: "Command" }) return true;
 

--- a/src/Reactor.Analyzers/CommandDebounceCodeFix.cs
+++ b/src/Reactor.Analyzers/CommandDebounceCodeFix.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for <see cref="CommandDebounceAnalyzer"/> (<c>REACTOR_HOOKS_009</c>) — wraps the
+/// offending <c>new Command { … DebounceMs = … }</c> / <c>… with { DebounceMs = … }</c> in a
+/// <c>UseCommand(...)</c> call so the debounce state has a hook store to persist in.
+/// </summary>
+/// <remarks>
+/// The wrap is applied to the creation expression itself, so it works for both the inline bind
+/// (<c>Button(new Command{…})</c> → <c>Button(UseCommand(new Command{…}))</c>) and the local
+/// case (<c>var c = new Command{…};</c> → <c>var c = UseCommand(new Command{…});</c>), where the
+/// already-correct downstream <c>Button(c)</c> then binds the wrapped, debounced command.
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CommandDebounceCodeFix))]
+[Shared]
+public sealed class CommandDebounceCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(CommandDebounceAnalyzer.Id);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var commandExpr = node.FirstAncestorOrSelf<ExpressionSyntax>(static e =>
+                e is ObjectCreationExpressionSyntax
+                  or ImplicitObjectCreationExpressionSyntax
+                  or WithExpressionSyntax);
+            if (commandExpr is null) continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Wrap command in UseCommand(...)",
+                    ct =>
+                    {
+                        var wrapped = SyntaxFactory.InvocationExpression(
+                            SyntaxFactory.IdentifierName("UseCommand"),
+                            SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
+                                SyntaxFactory.Argument(commandExpr.WithoutTrivia()))))
+                            .WithTriviaFrom(commandExpr);
+
+                        var newRoot = root.ReplaceNode(commandExpr, wrapped);
+                        return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+                    },
+                    equivalenceKey: CommandDebounceAnalyzer.Id),
+                diagnostic);
+        }
+    }
+}

--- a/src/Reactor.Analyzers/CommandDebounceCodeFix.cs
+++ b/src/Reactor.Analyzers/CommandDebounceCodeFix.cs
@@ -77,7 +77,7 @@ public sealed class CommandDebounceCodeFix : CodeFixProvider
                 var type = semanticModel.GetTypeInfo(implicitNew, context.CancellationToken).Type;
                 if (type is null || type.TypeKind == TypeKind.Error) continue;
 
-                var explicitNew = MakeExplicit(implicitNew, type);
+                var explicitNew = MakeExplicit(implicitNew, type, semanticModel);
                 if (explicitNew is null) continue;
                 replacement = explicitNew;
             }
@@ -107,11 +107,21 @@ public sealed class CommandDebounceCodeFix : CodeFixProvider
     /// using the resolved <paramref name="type"/>, preserving the original initializer (and any
     /// constructor arguments) verbatim so the wrapped result still compiles.
     /// </summary>
+    /// <remarks>
+    /// The type name is rendered with <see cref="SymbolDisplayExtensions.ToMinimalDisplayString"/>,
+    /// which asks Roslyn's reducer for the shortest name that is unambiguous <i>at this position</i>.
+    /// In the common case it stays <c>Command&lt;int&gt;</c>; if a second <c>Command</c>/<c>Command&lt;T&gt;</c>
+    /// is imported it adds exactly enough qualification (up to the fully-qualified
+    /// <c>Microsoft.UI.Reactor.Core.Command&lt;int&gt;</c>) to avoid a <c>CS0104</c> ambiguity, so the
+    /// emitted fix always compiles. A purely syntactic <c>MinimallyQualifiedFormat</c> would emit a
+    /// bare <c>Command&lt;int&gt;</c> that could bind the wrong type or be ambiguous — i.e. break code
+    /// that previously compiled.
+    /// </remarks>
     private static ObjectCreationExpressionSyntax MakeExplicit(
-        ImplicitObjectCreationExpressionSyntax implicitNew, ITypeSymbol type)
+        ImplicitObjectCreationExpressionSyntax implicitNew, ITypeSymbol type, SemanticModel semanticModel)
     {
         var typeSyntax = SyntaxFactory.ParseTypeName(
-            type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+            type.ToMinimalDisplayString(semanticModel, implicitNew.SpanStart));
 
         ArgumentListSyntax? argumentList = implicitNew.ArgumentList;
         if (argumentList is null || argumentList.Arguments.Count == 0)

--- a/src/Reactor.Analyzers/CommandDebounceCodeFix.cs
+++ b/src/Reactor.Analyzers/CommandDebounceCodeFix.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -45,6 +46,19 @@ public sealed class CommandDebounceCodeFix : CodeFixProvider
                   or WithExpressionSyntax);
             if (commandExpr is null) continue;
 
+            semanticModel ??= await context.Document
+                .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            if (semanticModel is null) continue;
+
+            // Never offer a fix that wouldn't compile: UseCommand is a Component hook method, so if
+            // it isn't resolvable at this location (e.g. a static helper, or a type that does not
+            // derive from Component — both of which can still trip the diagnostic via a static Dsl
+            // factory bind), wrapping in UseCommand(...) would produce CS0103. In that case we skip
+            // the fix — the warning still fires and the author lifts the command by hand. Mirrors
+            // the implicit-new guard below: never emit broken code.
+            if (!semanticModel.LookupSymbols(commandExpr.SpanStart, name: "UseCommand").Any(static s => s is IMethodSymbol))
+                continue;
+
             // A target-typed `new() { … }` is typed by *its surrounding context*. Wrapping it
             // verbatim in `UseCommand(...)` re-targets it to UseCommand's parameter, which for a
             // generic Command<T> silently binds the non-generic UseCommand(Command) overload and
@@ -57,9 +71,7 @@ public sealed class CommandDebounceCodeFix : CodeFixProvider
             {
                 if (implicitNew.Initializer is null) continue;
 
-                semanticModel ??= await context.Document
-                    .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-                var type = semanticModel?.GetTypeInfo(implicitNew, context.CancellationToken).Type;
+                var type = semanticModel.GetTypeInfo(implicitNew, context.CancellationToken).Type;
                 if (type is null || type.TypeKind == TypeKind.Error) continue;
 
                 var explicitNew = MakeExplicit(implicitNew, type);

--- a/src/Reactor.Analyzers/CommandDebounceCodeFix.cs
+++ b/src/Reactor.Analyzers/CommandDebounceCodeFix.cs
@@ -50,13 +50,16 @@ public sealed class CommandDebounceCodeFix : CodeFixProvider
                 .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
             if (semanticModel is null) continue;
 
-            // Never offer a fix that wouldn't compile: UseCommand is a Component hook method, so if
-            // it isn't resolvable at this location (e.g. a static helper, or a type that does not
-            // derive from Component — both of which can still trip the diagnostic via a static Dsl
-            // factory bind), wrapping in UseCommand(...) would produce CS0103. In that case we skip
-            // the fix — the warning still fires and the author lifts the command by hand. Mirrors
-            // the implicit-new guard below: never emit broken code.
-            if (!semanticModel.LookupSymbols(commandExpr.SpanStart, name: "UseCommand").Any(static s => s is IMethodSymbol))
+            // Never offer a fix that wouldn't compile or wouldn't actually route through the hook:
+            // UseCommand is a Reactor Component hook, so we require a *Reactor* UseCommand to be in
+            // scope here. If none is (e.g. a static helper, or a type that does not derive from
+            // Component — both of which can still trip the diagnostic via a static Dsl factory bind),
+            // wrapping would either not compile (CS0103) or bind to an unrelated same-named helper
+            // that doesn't debounce (and would keep warning). In that case we skip the fix — the
+            // warning still fires and the author lifts the command by hand. Mirrors the implicit-new
+            // guard below: never emit broken or no-op code.
+            if (!semanticModel.LookupSymbols(commandExpr.SpanStart, name: "UseCommand").Any(static s =>
+                    s is IMethodSymbol m && CommandDebounceAnalyzer.IsReactorNamespace(m.ContainingNamespace?.ToDisplayString())))
                 continue;
 
             // A target-typed `new() { … }` is typed by *its surrounding context*. Wrapping it

--- a/src/Reactor.Analyzers/CommandDebounceCodeFix.cs
+++ b/src/Reactor.Analyzers/CommandDebounceCodeFix.cs
@@ -34,6 +34,8 @@ public sealed class CommandDebounceCodeFix : CodeFixProvider
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         if (root is null) return;
 
+        SemanticModel? semanticModel = null;
+
         foreach (var diagnostic in context.Diagnostics)
         {
             var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
@@ -43,6 +45,29 @@ public sealed class CommandDebounceCodeFix : CodeFixProvider
                   or WithExpressionSyntax);
             if (commandExpr is null) continue;
 
+            // A target-typed `new() { … }` is typed by *its surrounding context*. Wrapping it
+            // verbatim in `UseCommand(...)` re-targets it to UseCommand's parameter, which for a
+            // generic Command<T> silently binds the non-generic UseCommand(Command) overload and
+            // produces non-compiling code (CS0123 / a Command where Command<T> is required). So we
+            // first rewrite the implicit creation to an explicit `new Command<T> { … }` using the
+            // type the analyzer already resolved. If the type can't be resolved, we skip offering
+            // the fix entirely rather than emit a broken one — the warning still fires.
+            var replacement = commandExpr;
+            if (commandExpr is ImplicitObjectCreationExpressionSyntax implicitNew)
+            {
+                if (implicitNew.Initializer is null) continue;
+
+                semanticModel ??= await context.Document
+                    .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                var type = semanticModel?.GetTypeInfo(implicitNew, context.CancellationToken).Type;
+                if (type is null || type.TypeKind == TypeKind.Error) continue;
+
+                var explicitNew = MakeExplicit(implicitNew, type);
+                if (explicitNew is null) continue;
+                replacement = explicitNew;
+            }
+
+            var inner = replacement;
             context.RegisterCodeFix(
                 CodeAction.Create(
                     "Wrap command in UseCommand(...)",
@@ -51,7 +76,7 @@ public sealed class CommandDebounceCodeFix : CodeFixProvider
                         var wrapped = SyntaxFactory.InvocationExpression(
                             SyntaxFactory.IdentifierName("UseCommand"),
                             SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
-                                SyntaxFactory.Argument(commandExpr.WithoutTrivia()))))
+                                SyntaxFactory.Argument(inner.WithoutTrivia()))))
                             .WithTriviaFrom(commandExpr);
 
                         var newRoot = root.ReplaceNode(commandExpr, wrapped);
@@ -60,5 +85,32 @@ public sealed class CommandDebounceCodeFix : CodeFixProvider
                     equivalenceKey: CommandDebounceAnalyzer.Id),
                 diagnostic);
         }
+    }
+
+    /// <summary>
+    /// Rebuilds a target-typed <c>new() { … }</c> as an explicit <c>new Command&lt;T&gt; { … }</c>
+    /// using the resolved <paramref name="type"/>, preserving the original initializer (and any
+    /// constructor arguments) verbatim so the wrapped result still compiles.
+    /// </summary>
+    private static ObjectCreationExpressionSyntax MakeExplicit(
+        ImplicitObjectCreationExpressionSyntax implicitNew, ITypeSymbol type)
+    {
+        var typeSyntax = SyntaxFactory.ParseTypeName(
+            type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+
+        ArgumentListSyntax? argumentList = implicitNew.ArgumentList;
+        if (argumentList is null || argumentList.Arguments.Count == 0)
+        {
+            // Drop the empty `()` so the canonical `new Command<T> { … }` shape is produced, and
+            // give the type a trailing space to separate it from the initializer brace.
+            argumentList = null;
+            typeSyntax = typeSyntax.WithTrailingTrivia(SyntaxFactory.Space);
+        }
+
+        return SyntaxFactory.ObjectCreationExpression(
+            SyntaxFactory.Token(SyntaxKind.NewKeyword).WithTrailingTrivia(SyntaxFactory.Space),
+            typeSyntax,
+            argumentList,
+            implicitNew.Initializer);
     }
 }

--- a/src/Reactor.Cli/Check/CheckCommand.cs
+++ b/src/Reactor.Cli/Check/CheckCommand.cs
@@ -406,6 +406,7 @@ public static class CheckCommand
             "REACTOR_HOOKS_004" => "SKILL.md §Hooks (memoize deps; never freshly allocated)",
             "REACTOR_HOOKS_005" => "SKILL.md §Hooks (only from Render or a Use* method)",
             "REACTOR_HOOKS_006" => "skills/async.md §1 (UseResource is reads-only — use UseMutation)",
+            "REACTOR_HOOKS_009" => "docs/guide/commanding.md (route a DebounceMs command through UseCommand)",
             "REACTOR_THEME_001" => "skills/design.md §1 (use Theme tokens, not hex)",
             "REACTOR_THEME_002" => "skills/design.md §1 (use Theme tokens, not hex)",
             "REACTOR_A11Y_001"  => "skills/design.md §a11y (set AutomationName on icon-only controls)",

--- a/tests/Reactor.Tests/AnalyzerTests/CommandDebounceAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/CommandDebounceAnalyzerTests.cs
@@ -60,6 +60,19 @@ namespace Microsoft.UI.Reactor.Core
         public static ButtonElement Command(this ButtonElement element, Command command) => element;
     }
 }
+
+namespace Microsoft.UI.Reactor
+{
+    using Microsoft.UI.Reactor.Core;
+
+    // Mirrors the static Dsl factories (Dsl.cs). Being static, they bind anywhere — including a
+    // helper outside a Component, where the UseCommand hook is NOT in scope. Used to exercise the
+    // code fix's out-of-scope guard.
+    public static class Factories
+    {
+        public static ButtonElement Button(Command command) => new ButtonElement();
+    }
+}
 ";
 
     // ── Positive: bound directly without UseCommand ─────────────────────
@@ -402,10 +415,11 @@ namespace TestApp
     }
 
     [Fact]
-    public async Task Fires_Via_Syntactic_Factory_Fallback()
+    public async Task No_Diagnostic_When_Resolved_NonReactor_Factory()
     {
-        // A non-Reactor factory named ""Button"" (so the semantic Reactor-namespace arm is false)
-        // still trips the conservative syntactic fallback on the known-binding-factory name list.
+        // A method named ""Button"" that Roslyn resolves to a non-Reactor namespace is an unrelated
+        // API, not a Reactor bind — it must NOT warn (the syntactic factory-name list is only a
+        // fallback for when symbol resolution fails, not an override of a successful resolution).
         var source = Stubs + @"
 namespace TestApp
 {
@@ -421,7 +435,59 @@ namespace TestApp
         void Save() { }
 
         public object Render()
-            => CustomUi.Button({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|});
+            => CustomUi.Button(new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 });
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_Via_Syntactic_Fallback_When_Unresolved()
+    {
+        // When the binding callee can't be resolved (incomplete code mid-edit — here `Button` is
+        // undefined), the conservative syntactic fallback on the known-factory name list still
+        // surfaces the footgun. The CS0103 is expected and declared via markup.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp
+    {
+        void Save() { }
+
+        public void Render()
+        {
+            _ = {|CS0103:Button|}({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|});
+        }
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_Parenthesized_Direct_Bind()
+    {
+        // Parentheses around the argument (`Button((cmd))`) must not hide the direct bind.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button(({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|}));
     }
 }";
 
@@ -632,6 +698,35 @@ namespace TestApp
             TestCode = before,
             FixedCode = after,
             CodeActionEquivalenceKey = CommandDebounceAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Not_Offered_When_UseCommand_Out_Of_Scope()
+    {
+        // The bind resolves to the static Dsl factory (Reactor namespace), so the diagnostic fires
+        // — but this is a static helper with no Component instance, so UseCommand is not in scope.
+        // Wrapping in UseCommand(...) would not compile, so the fix must NOT be offered (FixedCode
+        // is identical to the input — the warning stands, the author fixes it by hand).
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class Helpers
+    {
+        static void Save() { }
+
+        public static Element Build()
+            => Button({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|});
+    }
+}";
+
+        await new CSharpCodeFixTest<CommandDebounceAnalyzer, CommandDebounceCodeFix, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/CommandDebounceAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/CommandDebounceAnalyzerTests.cs
@@ -844,4 +844,134 @@ namespace TestApp
             CodeActionEquivalenceKey = CommandDebounceAnalyzer.Id,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    // ── Non-constant DebounceMs: the common runtime-value path must still fire (L3) ──
+
+    [Fact]
+    public async Task Fires_On_NonConstant_DebounceMs()
+    {
+        // The everyday shape: the debounce value comes from a method/field, not a literal, so
+        // GetConstantValue has no value and the `<= 0` guard falls through. A direct bind of such a
+        // command must still warn — a runtime value that turns out > 0 is exactly the inert case.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+        int GetDelay() => 1500;
+
+        public Element Render()
+            => Button({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = GetDelay() }|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Deliberate M1 conservatism: a Reactor UseCommand anywhere suppresses, even if also bound raw (L4) ──
+
+    [Fact]
+    public async Task No_Diagnostic_When_Reactor_UseCommand_Discarded_But_Also_Bound_Raw()
+    {
+        // Locks the documented false negative: the command flows through Reactor's UseCommand (return
+        // discarded) AND is bound raw to Button. Suppressing on any UseCommand usage is what prevents
+        // a false positive on the idiomatic `save = UseCommand(save)` reassignment, so this narrow FN
+        // is accepted by design. A future change must not silently flip it without updating this test.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+        {
+            var save = new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 };
+            UseCommand(save);
+            return Button(save);
+        }
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code fix: implicit generic new with a conflicting Command<T> imported (H1 regression) ──
+
+    [Fact]
+    public async Task CodeFix_Qualifies_Type_When_Conflicting_Command_In_Scope()
+    {
+        // H1 regression: rewriting a target-typed `new()` to an explicit type with a purely syntactic
+        // minimal name would emit a bare `Command<int>` — CS0104-ambiguous when a second `Command<T>`
+        // is imported, breaking code that compiled before the fix. The position-aware
+        // ToMinimalDisplayString qualifies just enough to stay unambiguous. The CodeFixTest harness
+        // compiles FixedCode, so a CS0104 here would fail the test — this locks the fix.
+        var before = Stubs + @"
+namespace Conflict
+{
+    public sealed record Command<T>
+    {
+        public string Label { get; init; }
+        public System.Action<T> Execute { get; init; }
+        public int DebounceMs { get; init; }
+    }
+}
+
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+    using Conflict;
+
+    public sealed class Comp : Component
+    {
+        void Delete(int id) { }
+
+        public Element Render()
+            => MenuItem({|REACTOR_HOOKS_009:new() { Label = ""Delete"", Execute = Delete, DebounceMs = 1 }|}, 5);
+    }
+}";
+
+        var after = Stubs + @"
+namespace Conflict
+{
+    public sealed record Command<T>
+    {
+        public string Label { get; init; }
+        public System.Action<T> Execute { get; init; }
+        public int DebounceMs { get; init; }
+    }
+}
+
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+    using Conflict;
+
+    public sealed class Comp : Component
+    {
+        void Delete(int id) { }
+
+        public Element Render()
+            => MenuItem(UseCommand(new Microsoft.UI.Reactor.Core.Command<int> { Label = ""Delete"", Execute = Delete, DebounceMs = 1 }), 5);
+    }
+}";
+
+        await new CSharpCodeFixTest<CommandDebounceAnalyzer, CommandDebounceCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = CommandDebounceAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/CommandDebounceAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/CommandDebounceAnalyzerTests.cs
@@ -1,0 +1,368 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="CommandDebounceAnalyzer"/> (<c>REACTOR_HOOKS_009</c>) and its
+/// <see cref="CommandDebounceCodeFix"/>. Stubs a minimal Reactor command surface — the
+/// <c>Command</c>/<c>Command&lt;T&gt;</c> records, an <c>Element</c>/<c>ButtonElement</c>, and a
+/// <c>Component</c> base exposing <c>UseCommand</c> + a <c>Button</c> binding factory — so the
+/// analyzer's semantic checks (Reactor command type, UseCommand routing, Reactor binding sink)
+/// resolve without pulling the framework in.
+/// </summary>
+public class CommandDebounceAnalyzerTests
+{
+    private const string Stubs = @"
+namespace System.Runtime.CompilerServices
+{
+    public static class IsExternalInit { }
+}
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public abstract record Element { }
+    public sealed record ButtonElement : Element { }
+
+    public sealed record Command
+    {
+        public string Label { get; init; }
+        public System.Action Execute { get; init; }
+        public int DebounceMs { get; init; }
+    }
+
+    public sealed record Command<T>
+    {
+        public string Label { get; init; }
+        public System.Action<T> Execute { get; init; }
+        public int DebounceMs { get; init; }
+    }
+
+    // Mirrors Component's protected hook + the Command-accepting binding factories. Living in a
+    // Microsoft.UI.Reactor.* namespace is what makes the analyzer treat Button/MenuItem as a
+    // binding sink and UseCommand as the routing call.
+    public abstract class Component
+    {
+        protected Command UseCommand(Command command) => command;
+        protected Command<T> UseCommand<T>(Command<T> command) => command;
+        protected ButtonElement Button(Command command) => new ButtonElement();
+        protected ButtonElement MenuItem<T>(Command<T> command, T parameter) => new ButtonElement();
+    }
+}
+";
+
+    // ── Positive: bound directly without UseCommand ─────────────────────
+
+    [Fact]
+    public async Task Fires_On_Direct_Button_Bind()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_Local_Bound_Directly()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+        {
+            var save = {|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|};
+            return Button(save);
+        }
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_With_Expression()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+        {
+            var baseCmd = new Command { Label = ""Save"", Execute = Save };
+            return Button({|REACTOR_HOOKS_009:baseCmd with { DebounceMs = 1500 }|});
+        }
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_Generic_Command_Bind()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Delete(int id) { }
+
+        public Element Render()
+            => MenuItem({|REACTOR_HOOKS_009:new Command<int> { Label = ""Delete"", Execute = Delete, DebounceMs = 800 }|}, 5);
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative: routed through UseCommand ─────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_When_Routed_Through_UseCommand_Inline()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button(UseCommand(new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }));
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_Routed_Through_UseCommand_Via_Local()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+        {
+            var save = new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 };
+            var wrapped = UseCommand(save);
+            return Button(wrapped);
+        }
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative: DebounceMs is zero / unset ────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_When_DebounceMs_Zero()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button(new Command { Label = ""Save"", Execute = Save, DebounceMs = 0 });
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_DebounceMs_Unset()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button(new Command { Label = ""Save"", Execute = Save });
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative: created but not bound (e.g. factory method) ───────────
+
+    [Fact]
+    public async Task No_Diagnostic_When_Command_Returned_Not_Bound()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        // Returns the raw command; a caller is expected to wrap it in UseCommand.
+        public Command MakeSave()
+            => new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 };
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code fix ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CodeFix_Wraps_Inline_Bind_In_UseCommand()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|});
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button(UseCommand(new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }));
+    }
+}";
+
+        await new CSharpCodeFixTest<CommandDebounceAnalyzer, CommandDebounceCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = CommandDebounceAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Wraps_Local_Initializer_In_UseCommand()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+        {
+            var save = {|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|};
+            return Button(save);
+        }
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+        {
+            var save = UseCommand(new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 });
+            return Button(save);
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<CommandDebounceAnalyzer, CommandDebounceCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = CommandDebounceAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/CommandDebounceAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/CommandDebounceAnalyzerTests.cs
@@ -729,4 +729,119 @@ namespace TestApp
             FixedCode = source,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    // ── UseCommand routing must be Reactor's hook, not just any same-named call ──
+
+    [Fact]
+    public async Task Fires_When_Routed_Through_NonReactor_UseCommand()
+    {
+        // FP/FN guard: a same-named UseCommand from another namespace is not Reactor's hook, so it
+        // must NOT suppress the warning. Here the command is passed to Foreign.Hooks.UseCommand AND
+        // bound raw to Button — the raw bind still doesn't debounce, so the diagnostic must fire.
+        var source = Stubs + @"
+namespace Foreign
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public static class Hooks
+    {
+        public static Command UseCommand(Command command) => command;
+    }
+}
+
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+    using Foreign;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+        {
+            var save = {|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|};
+            Hooks.UseCommand(save);
+            return Button(save);
+        }
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Not_Offered_When_Only_NonReactor_UseCommand_In_Scope()
+    {
+        // The bind resolves to the static Dsl factory (Reactor) so the diagnostic fires, but the
+        // only UseCommand in scope is a same-named non-Reactor helper. Wrapping in it would compile
+        // yet route through a no-op (and keep warning), so the fix must NOT be offered — FixedCode
+        // is identical to the input.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class Helpers
+    {
+        static void Save() { }
+
+        static Command UseCommand(Command command) => command;
+
+        public static Element Build()
+            => Button({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|});
+    }
+}";
+
+        await new CSharpCodeFixTest<CommandDebounceAnalyzer, CommandDebounceCodeFix, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Preserves_Comment_Inside_Initializer()
+    {
+        // The wrap must not drop a comment that lives inside the initializer (interior trivia of the
+        // command expression), only normalize the outer trivia it copies onto the UseCommand call.
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 /* keep me */ }|});
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button(UseCommand(new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 /* keep me */ }));
+    }
+}";
+
+        await new CSharpCodeFixTest<CommandDebounceAnalyzer, CommandDebounceCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = CommandDebounceAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/CommandDebounceAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/CommandDebounceAnalyzerTests.cs
@@ -49,7 +49,15 @@ namespace Microsoft.UI.Reactor.Core
         protected Command UseCommand(Command command) => command;
         protected Command<T> UseCommand<T>(Command<T> command) => command;
         protected ButtonElement Button(Command command) => new ButtonElement();
+        protected ButtonElement Button(string label) => new ButtonElement();
         protected ButtonElement MenuItem<T>(Command<T> command, T parameter) => new ButtonElement();
+    }
+
+    // Mirrors the `.Command(...)` fluent modifier (ElementExtensions.cs). Living in a
+    // Microsoft.UI.Reactor.* namespace is what makes the analyzer treat it as a binding sink.
+    public static class ButtonModifiers
+    {
+        public static ButtonElement Command(this ButtonElement element, Command command) => element;
     }
 }
 ";
@@ -355,6 +363,267 @@ namespace TestApp
             var save = UseCommand(new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 });
             return Button(save);
         }
+    }
+}";
+
+        await new CSharpCodeFixTest<CommandDebounceAnalyzer, CommandDebounceCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = CommandDebounceAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Binding sinks: `.Command(...)` modifier + syntactic factory fallback ──
+
+    [Fact]
+    public async Task Fires_On_Command_Modifier_Bind()
+    {
+        // The `.Command(...)` fluent sink resolves (semantically) to a Reactor-namespace
+        // extension method, so the member-access binding arm should fire.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button(""Save"").Command({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_Via_Syntactic_Factory_Fallback()
+    {
+        // A non-Reactor factory named ""Button"" (so the semantic Reactor-namespace arm is false)
+        // still trips the conservative syntactic fallback on the known-binding-factory name list.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public static class CustomUi
+    {
+        public static object Button(Command command) => command;
+    }
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public object Render()
+            => CustomUi.Button({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 }|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative: a foreign, same-named Command type must never fire (FP guard) ──
+
+    [Fact]
+    public async Task No_Diagnostic_When_Foreign_Command_Type()
+    {
+        // A different library's `Command` (with its own DebounceMs) bound to its own factory must
+        // NOT warn — the type is not Microsoft.UI.Reactor.Core.Command.
+        var source = Stubs + @"
+namespace Other
+{
+    public sealed record Command
+    {
+        public string Label { get; init; }
+        public int DebounceMs { get; init; }
+    }
+
+    public static class Ui
+    {
+        public static object Button(Command command) => command;
+    }
+}
+
+namespace TestApp
+{
+    public sealed class Comp : Microsoft.UI.Reactor.Core.Component
+    {
+        public object Render()
+            => Other.Ui.Button(new Other.Command { Label = ""x"", DebounceMs = 1500 });
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Constant folding: const positive fires; const/literal <= 0 never does ──
+
+    [Fact]
+    public async Task Fires_On_Const_DebounceMs()
+    {
+        // A non-literal constant must still fold through GetConstantValue and fire when > 0.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        const int Delay = 1500;
+
+        public Element Render()
+            => Button({|REACTOR_HOOKS_009:new Command { Label = ""Save"", Execute = Save, DebounceMs = Delay }|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_DebounceMs_Negative()
+    {
+        // Runtime only debounces > 0; a negative literal is a no-op and must never warn.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+            => Button(new Command { Label = ""Save"", Execute = Save, DebounceMs = -5 });
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_Const_DebounceMs_Zero()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        const int Off = 0;
+
+        public Element Render()
+            => Button(new Command { Label = ""Save"", Execute = Save, DebounceMs = Off });
+    }
+}";
+
+        await new CSharpAnalyzerTest<CommandDebounceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code fix: `with` expression + implicit target-typed generic new ──
+
+    [Fact]
+    public async Task CodeFix_Wraps_With_Expression_In_UseCommand()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+        {
+            var baseCmd = new Command { Label = ""Save"", Execute = Save };
+            return Button({|REACTOR_HOOKS_009:baseCmd with { DebounceMs = 1500 }|});
+        }
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public Element Render()
+        {
+            var baseCmd = new Command { Label = ""Save"", Execute = Save };
+            return Button(UseCommand(baseCmd with { DebounceMs = 1500 }));
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<CommandDebounceAnalyzer, CommandDebounceCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = CommandDebounceAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Rewrites_Implicit_Generic_New_To_Explicit()
+    {
+        // Regression guard (H1): wrapping a target-typed `new() { … }` verbatim re-targets it to
+        // UseCommand's parameter and binds the non-generic overload → CS0123. The fix must first
+        // materialize the resolved type as `new Command<int> { … }` so the result compiles. The
+        // CodeFixTest harness compiles FixedCode, so a broken rewrite would fail here.
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Delete(int id) { }
+
+        public Element Render()
+            => MenuItem({|REACTOR_HOOKS_009:new() { Label = ""Delete"", Execute = Delete, DebounceMs = 800 }|}, 5);
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Delete(int id) { }
+
+        public Element Render()
+            => MenuItem(UseCommand(new Command<int> { Label = ""Delete"", Execute = Delete, DebounceMs = 800 }), 5);
     }
 }";
 


### PR DESCRIPTION
## What

Adds a new Roslyn analyzer diagnostic **`REACTOR_HOOKS_009`** (category `Reactor.Hooks`, severity **Warning**) plus a code fix that flags a `Command` / `Command<T>` with a non-zero `DebounceMs` that is bound to a control **without** being routed through `UseCommand(...)`.

Closes #636.

## Why

#136 (PR #632, merged) added declarative leading-edge debounce via `Command.DebounceMs`. The debounce window (last-accepted-fire timestamp, in-window flag, re-enable timer) lives in the **`UseCommand` hook store on `RenderContext`** — the only place that persists across renders. A plain immutable `Command` record is reconstructed every render, so:

```csharp
Button(new Command { Label = "Save", Execute = Save, DebounceMs = 1500 })
```

is **silently inert** — no compile error, no runtime warning, the debounce simply never happens. Only an XML-doc caveat mitigated this. This analyzer makes the footgun visible and offers a one-click fix.

## Heuristic (conservative, local-dataflow)

`CommandDebounceAnalyzer` registers on `ObjectCreation` / `ImplicitObjectCreation` / `With` expressions and:

1. **Syntactic gate** — the initializer assigns `DebounceMs`.
2. **Skips `DebounceMs = 0`** (constant-folded) — the documented "off" value never warns.
3. **Semantic confirm** — the type is the Reactor `Command` / `Command<T>` in `Microsoft.UI.Reactor.Core`.
4. **Usage set** — inline, the creation expression itself; when assigned to `var c = …`, every in-scope reference to `c` (matched by symbol, within the enclosing block).
5. **Suppress** if any usage is a direct argument to a `UseCommand` call (routed correctly).
6. **Warn** if any usage is a direct argument to a Reactor binding (resolved callee namespace under `Microsoft.UI.Reactor`, or syntactic fallback: `Button`/`MenuItem`/`HyperlinkButton`/… factories and the `.Command(...)` modifier) **and** never passes through `UseCommand`.

### False-positive guards
- A command that is **returned or stored** (not passed as a direct argument to a Reactor binding) is left alone — e.g. `Command MakeSave() => new Command { … DebounceMs = … }` does not warn.
- If a local is routed through `UseCommand` **anywhere**, the whole diagnostic is suppressed.
- The value must be a **direct** argument — `f(cmd.Label)` or `list.Add(cmd)` don't trip it.

## Code fix

Wraps the offending expression in `UseCommand(...)`. Works for both inline binds (`Button(new Command{…})` → `Button(UseCommand(new Command{…}))`) and local initializers (`var c = new Command{…};` → `var c = UseCommand(new Command{…});`, with the existing `Button(c)` downstream now binding the wrapped command).

## Acceptance criteria — all verified by unit tests

| Criterion | Test(s) |
|---|---|
| Fires on non-zero `DebounceMs` bound without `UseCommand` | `Fires_On_Direct_Button_Bind`, `Fires_On_Local_Bound_Directly`, `Fires_On_With_Expression`, `Fires_On_Generic_Command_Bind` |
| No false positive through `UseCommand` (inline **and** via local) | `No_Diagnostic_When_Routed_Through_UseCommand_Inline`, `No_Diagnostic_When_Routed_Through_UseCommand_Via_Local` |
| `DebounceMs = 0` / unset never warns | `No_Diagnostic_When_DebounceMs_Zero`, `No_Diagnostic_When_DebounceMs_Unset` |
| Code fix wraps the command in `UseCommand(...)` | `CodeFix_Wraps_Inline_Bind_In_UseCommand`, `CodeFix_Wraps_Local_Initializer_In_UseCommand` |

Plus `No_Diagnostic_When_Command_Returned_Not_Bound` (factory-method guard). **11 new tests; full analyzer suite 191 passing.**

## Integration

- `src/Reactor.Analyzers/CommandDebounceAnalyzer.cs` + `CommandDebounceCodeFix.cs` (new)
- `AnalyzerReleases.Unshipped.md` — new-rules row
- `docs/specs/041/under-the-hood-source-map.md` — source→ID map line
- `src/Reactor.Cli/Check/CheckCommand.cs` — `mur check` hint
- `docs/_pipeline/templates/analyzer-architecture.md.dt` + `rules-of-reactor.md.dt` — edited templates, regenerated `docs/guide/*.md` via `mur docs compile`

### Notes
- The existing `demo-script-tool` sample already routes its three `DebounceMs` commands through `UseCommand` — verified it does **not** newly warn.
- `AnalyzerPackagingTests` only guards `REACTOR_DOC_*` leakage; no per-ID change needed.
- No `.editorconfig` / `NoWarn` change required — this is a consumer-facing warning, not a framework-source rule.

### Diagnostic ID rationale
Chose `REACTOR_HOOKS_009` — the next free number in the `REACTOR_HOOKS_*` series (001, 004–008 used; 002/003 reserved). Debounce state living in the `UseCommand` hook store makes this a hooks-contract rule, consistent with the existing category numbering.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>