### PR TITLE
Unify Command binding through the descriptor for all six button elements (#637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,24 @@ Conventions for contributors:
   `UseCommand`) is inert. `UseCommand` now consumes a stable hook shape regardless
   of the command's sync/async/debounce shape.
 
+- **Uniform `Command` binding across the six command buttons (issues #153, #637).**
+  The typed `Command` property on `ButtonElement`, `HyperlinkButtonElement`,
+  `RepeatButtonElement`, `ToggleButtonElement`, `SplitButtonElement`, and
+  `ToggleSplitButtonElement` is now `public { get; init; }` on every element and
+  binds uniformly: a bare `new ButtonElement(cmd.Label) { Command = cmd }` (or
+  `with { Command = cmd }`) invokes `Execute`/`ExecuteAsync` on click/toggle and
+  applies the command's `IsEnabled` + Description / Accelerator / AccessKey
+  identically to the `Button(Command)` factory and the `.Command(cmd)` modifier —
+  closing the #153 footgun where a record-init command carried metadata but never
+  dispatched. Dispatch flows from the typed property through a click trampoline
+  instead of a pre-baked `OnClick` closure, so each command-bound construct
+  allocates less (Button ~176 → ~88 B per construct) while the #153 reconcile
+  fast-path still skips re-applying an unchanged command. The `.Command(cmd)`
+  modifier makes the command fully take over (clearing any conflicting click /
+  toggle callback), and `ButtonElement`'s `IsDisabledFocusable` coercion is
+  preserved exactly. A `DebounceMs` command now re-disables across the debounce
+  window on every command button, not just via the factory path.
+
 - **`ReactorApp.RegisterAllBuiltIns()` — opt-in bulk registration of the built-in
   control catalog (spec 048 §3.4, issue #486).** Built-in handler registration is
   now lazy — each factory registers its own control on first use — so the trimmer

--- a/docs/_pipeline/templates/commanding.md.dt
+++ b/docs/_pipeline/templates/commanding.md.dt
@@ -139,6 +139,44 @@ so custom-content variants of each stay in sync with their command.
 > Tab (only the click is suppressed) rather than dropping it from the
 > tab order.
 
+## Binding paths are uniform
+
+The factory and the `.Command()` modifier both set the same typed `Command`
+property on the element record. That property is public, so you can also set
+it directly with a record initializer — every path below binds identically:
+the action dispatches on click and `IsEnabled` is applied from the command.
+
+```csharp
+// Factory — plain label:
+Button(saveCmd)
+
+// Modifier — custom content:
+Button(HStack(Icon(SymbolIcon("Save")), Text("Save"))).Command(saveCmd)
+
+// Record-init — the typed property is public (the Label ctor arg is required):
+new ButtonElement(saveCmd.Label) { Command = saveCmd }
+
+// `with` on an existing element hits the same property:
+Button("Save") with { Command = saveCmd }
+```
+
+The typed `Command` property is available on all six command-capable
+elements — `ButtonElement`, `HyperlinkButtonElement`, `RepeatButtonElement`,
+`ToggleButtonElement`, `SplitButtonElement`, and `ToggleSplitButtonElement` —
+so a bare `new SplitButtonElement(cmd.Label) { Command = cmd }` dispatches and
+disables exactly like the `SplitButton(cmd)` factory. (The `.Command()`
+modifier is the convenience for the clickable-content subset above; the typed
+property covers the split buttons too.)
+
+One precedence rule applies when both a command and an explicit callback are
+present on the same element:
+
+- **Record-init / `with`** keeps both — the explicit `OnClick` (or toggle
+  callback) wins for dispatch, while the command still supplies metadata and
+  `IsEnabled`. Set the command *only* (no callback) to dispatch through it.
+- **The `.Command()` modifier** makes the command fully take over — it clears
+  any conflicting callback so the command is the single dispatch path.
+
 ## Async Commands and UseCommand
 
 When a command has an `ExecuteAsync` action, wrap it with the

--- a/docs/guide/commanding.md
+++ b/docs/guide/commanding.md
@@ -201,6 +201,44 @@ so custom-content variants of each stay in sync with their command.
 > Tab (only the click is suppressed) rather than dropping it from the
 > tab order.
 
+## Binding paths are uniform
+
+The factory and the `.Command()` modifier both set the same typed `Command`
+property on the element record. That property is public, so you can also set
+it directly with a record initializer — every path below binds identically:
+the action dispatches on click and `IsEnabled` is applied from the command.
+
+```csharp
+// Factory — plain label:
+Button(saveCmd)
+
+// Modifier — custom content:
+Button(HStack(Icon(SymbolIcon("Save")), Text("Save"))).Command(saveCmd)
+
+// Record-init — the typed property is public (the Label ctor arg is required):
+new ButtonElement(saveCmd.Label) { Command = saveCmd }
+
+// `with` on an existing element hits the same property:
+Button("Save") with { Command = saveCmd }
+```
+
+The typed `Command` property is available on all six command-capable
+elements — `ButtonElement`, `HyperlinkButtonElement`, `RepeatButtonElement`,
+`ToggleButtonElement`, `SplitButtonElement`, and `ToggleSplitButtonElement` —
+so a bare `new SplitButtonElement(cmd.Label) { Command = cmd }` dispatches and
+disables exactly like the `SplitButton(cmd)` factory. (The `.Command()`
+modifier is the convenience for the clickable-content subset above; the typed
+property covers the split buttons too.)
+
+One precedence rule applies when both a command and an explicit callback are
+present on the same element:
+
+- **Record-init / `with`** keeps both — the explicit `OnClick` (or toggle
+  callback) wins for dispatch, while the command still supplies metadata and
+  `IsEnabled`. Set the command *only* (no callback) to dispatch through it.
+- **The `.Command()` modifier** makes the command fully take over — it clears
+  any conflicting callback so the command is the single dispatch path.
+
 ## Async Commands and UseCommand
 
 When a command has an `ExecuteAsync` action, wrap it with the
@@ -334,18 +372,19 @@ var regenCmd = UseCommand(new Command
 });
 ```
 
-> **Caveat:** `DebounceMs` requires `UseCommand`. The debounce window and
-> its re-enable timer are persistent state, and a plain `Command` record
-> is immutable and reconstructed on every render — it has nowhere to keep
+> **Caveat:** **`DebounceMs` requires `UseCommand`.** The debounce window and its
+> re-enable timer are persistent state, and a plain `Command` record is
+> immutable and reconstructed on every render — it has nowhere to keep
 > that state. `UseCommand` stores it in the component's hook table (the
 > same place it keeps the async re-entrance guard), so always route a
 > debounced command through `UseCommand`. A raw
 > `new Command { DebounceMs = … }` that is bound directly (never passed to
-> `UseCommand`) does **not** debounce. Debounce is **leading-edge and
-> fixed-duration** by design — fire first, then ignore. Trailing-edge
-> "wait for the input to settle, then fire once" debounce
-> (search-as-you-type) is a different concept and is not what `DebounceMs`
-> provides.
+> `UseCommand`) does **not** debounce.
+> 
+> Debounce is **leading-edge and fixed-duration** by design — fire first,
+> then ignore. Trailing-edge "wait for the input to settle, then fire
+> once" debounce (search-as-you-type) is a different concept and is not
+> what `DebounceMs` provides.
 
 ## Parameterized commands
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -1436,7 +1436,7 @@ ToString() → string
 ### record ButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 Element ContentElement { get; init; }
 bool IsDisabledFocusable { get; init; }
 bool IsEnabled { get; init; }
@@ -3581,7 +3581,7 @@ new(string message)
 ### record HyperlinkButtonElement
 new(string Content, Uri NavigateUri = null, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 Uri NavigateUri { get; init; }
 string Content { get; init; }
 Deconstruct(ref string Content, ref Uri NavigateUri, ref Action OnClick) → void
@@ -5759,7 +5759,7 @@ long TotalRenders { get; init; }
 ### record RepeatButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 int Delay { get; init; }
 int Interval { get; init; }
 string Label { get; init; }
@@ -6279,7 +6279,7 @@ ToString() → string
 ### record SplitButtonElement
 new(string Label, Action OnClick = null, Element Flyout = null)
 Action OnClick { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 Element Flyout { get; init; }
 string Label { get; init; }
 Deconstruct(ref string Label, ref Action OnClick, ref Element Flyout) → void
@@ -6848,7 +6848,7 @@ ToString() → string
 new(string Label, bool IsChecked = false, Action<bool> OnIsCheckedChanged = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Action<bool?> OnCheckedStateChanged { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 bool IsChecked { get; init; }
 bool IsThreeState { get; init; }
 bool? CheckedState { get; init; }
@@ -6877,7 +6877,7 @@ ToString() → string
 ### record ToggleSplitButtonElement
 new(string Label, Optional<bool> IsChecked = null, Action<bool> OnIsCheckedChanged = null, Element Flyout = null)
 Action<bool> OnIsCheckedChanged { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 Element Flyout { get; init; }
 Optional<bool> IsChecked { get; init; }
 string Label { get; init; }

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -1436,7 +1436,7 @@ ToString() → string
 ### record ButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 Element ContentElement { get; init; }
 bool IsDisabledFocusable { get; init; }
 bool IsEnabled { get; init; }
@@ -3581,7 +3581,7 @@ new(string message)
 ### record HyperlinkButtonElement
 new(string Content, Uri NavigateUri = null, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 Uri NavigateUri { get; init; }
 string Content { get; init; }
 Deconstruct(ref string Content, ref Uri NavigateUri, ref Action OnClick) → void
@@ -5759,7 +5759,7 @@ long TotalRenders { get; init; }
 ### record RepeatButtonElement
 new(string Label, Action OnClick = null)
 Action OnClick { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 int Delay { get; init; }
 int Interval { get; init; }
 string Label { get; init; }
@@ -6279,7 +6279,7 @@ ToString() → string
 ### record SplitButtonElement
 new(string Label, Action OnClick = null, Element Flyout = null)
 Action OnClick { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 Element Flyout { get; init; }
 string Label { get; init; }
 Deconstruct(ref string Label, ref Action OnClick, ref Element Flyout) → void
@@ -6848,7 +6848,7 @@ ToString() → string
 new(string Label, bool IsChecked = false, Action<bool> OnIsCheckedChanged = null)
 Action<bool> OnIsCheckedChanged { get; init; }
 Action<bool?> OnCheckedStateChanged { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 bool IsChecked { get; init; }
 bool IsThreeState { get; init; }
 bool? CheckedState { get; init; }
@@ -6877,7 +6877,7 @@ ToString() → string
 ### record ToggleSplitButtonElement
 new(string Label, Optional<bool> IsChecked = null, Action<bool> OnIsCheckedChanged = null, Element Flyout = null)
 Action<bool> OnIsCheckedChanged { get; init; }
-Command Command { get; }
+Command Command { get; init; }
 Element Flyout { get; init; }
 Optional<bool> IsChecked { get; init; }
 string Label { get; init; }

--- a/src/Reactor/Core/CommandBindings.cs
+++ b/src/Reactor/Core/CommandBindings.cs
@@ -144,6 +144,21 @@ internal static class CommandBindings
     }
 
     /// <summary>
+    /// Returns a non-null delegate when <paramref name="cmd"/> can actually be invoked
+    /// (it carries an <see cref="Command.Execute"/> or <see cref="Command.ExecuteAsync"/>),
+    /// otherwise <c>null</c>. Used by the command-capable button trampolines as the
+    /// click-dispatch <em>fallback</em> and as the HandCodedEvent / Controlled
+    /// subscription gate when a button is bound <b>only</b> through the typed
+    /// <see cref="Command"/> property — i.e. a bare <c>new XxxElement { Command = cmd }</c>
+    /// record-init with no <c>OnClick</c>/<c>OnIsCheckedChanged</c> handler (issue #637).
+    /// A command with neither delegate has nothing to dispatch, so the event stays
+    /// unsubscribed (zero cost), while its metadata still flows through
+    /// <see cref="OneWayCommand{TElement,TControl}"/>.
+    /// </summary>
+    internal static Delegate? Invokable(Command? cmd) =>
+        cmd is null ? null : (Delegate?)cmd.Execute ?? cmd.ExecuteAsync;
+
+    /// <summary>
     /// Registers the typed <see cref="Command"/> descriptor entry shared by every
     /// command-capable button element (issue #153). On mount it applies
     /// <see cref="ApplyButtonBaseCommon"/>; on update it re-applies only when a rendered

--- a/src/Reactor/Core/CommandBindings.cs
+++ b/src/Reactor/Core/CommandBindings.cs
@@ -149,7 +149,7 @@ internal static class CommandBindings
     /// otherwise <c>null</c>. Used by the command-capable button trampolines as the
     /// click-dispatch <em>fallback</em> and as the HandCodedEvent / Controlled
     /// subscription gate when a button is bound <b>only</b> through the typed
-    /// <see cref="Command"/> property — i.e. a bare <c>new XxxElement { Command = cmd }</c>
+    /// <see cref="Command"/> property — i.e. a bare <c>new XxxElement(cmd.Label) { Command = cmd }</c>
     /// record-init with no <c>OnClick</c>/<c>OnIsCheckedChanged</c> handler (issue #637).
     /// A command with neither delegate has nothing to dispatch, so the event stays
     /// unsubscribed (zero cost), while its metadata still flows through
@@ -157,6 +157,17 @@ internal static class CommandBindings
     /// </summary>
     internal static Delegate? Invokable(Command? cmd) =>
         cmd is null ? null : (Delegate?)cmd.Execute ?? cmd.ExecuteAsync;
+
+    /// <summary>
+    /// The effective click/dispatch callback for a command-capable button element: the explicit
+    /// user callback (<c>OnClick</c> / a toggle handler) when present, otherwise the typed command's
+    /// invokable delegate (<see cref="Invokable"/>). A single shared primitive so an element's
+    /// <c>HasCallbacks</c> and its HandCodedEvent / Controlled subscription gate can never drift —
+    /// both treat a delegate-less command (metadata only, no Execute/ExecuteAsync) as "no callback"
+    /// (issue #637 review M2).
+    /// </summary>
+    internal static Delegate? EffectiveCallback(Delegate? userCallback, Command? cmd) =>
+        userCallback ?? Invokable(cmd);
 
     /// <summary>
     /// Registers the typed <see cref="Command"/> descriptor entry shared by every
@@ -196,14 +207,21 @@ internal static class CommandBindings
     /// (label, enabled state, tooltip, accelerator, access key) determines whether the
     /// command-applied control state must be re-written. Two commands that differ only in
     /// their delegates therefore produce identical visuals and can skip reconcile entirely.
+    /// <para>
+    /// Enabled state is compared via the <em>derived</em> <see cref="Command.IsEnabled"/>
+    /// (<c>CanExecute &amp;&amp; !IsExecuting &amp;&amp; !IsDebouncing</c>) rather than its raw inputs, so a
+    /// debounce-window flip (a <c>UseCommand(DebounceMs:)</c> command toggling
+    /// <see cref="Command.IsDebouncing"/>) registers as a change and forces the button to
+    /// re-disable / re-enable on the transition. Steady-state, non-debouncing renders still
+    /// compare equal, so the #153 fast-path skip stays intact (issue #637 review M1).
+    /// </para>
     /// </summary>
     internal static bool CommandsEqual(Command? a, Command? b)
     {
         if (ReferenceEquals(a, b)) return true;
         if (a is null || b is null) return false;
         return a.Label == b.Label
-            && a.CanExecute == b.CanExecute
-            && a.IsExecuting == b.IsExecuting
+            && a.IsEnabled == b.IsEnabled
             && a.Description == b.Description
             && a.AccessKey == b.AccessKey
             && Equals(a.Icon, b.Icon)
@@ -221,6 +239,6 @@ internal static class CommandBindings
         internal static readonly CommandModuloDelegatesComparer Instance = new();
         public bool Equals(Command? a, Command? b) => CommandsEqual(a, b);
         public int GetHashCode(Command? c) =>
-            c is null ? 0 : global::System.HashCode.Combine(c.Label, c.CanExecute, c.IsExecuting, c.Description, c.AccessKey);
+            c is null ? 0 : global::System.HashCode.Combine(c.Label, c.IsEnabled, c.Description, c.AccessKey);
     }
 }

--- a/src/Reactor/Core/CommandBindings.cs
+++ b/src/Reactor/Core/CommandBindings.cs
@@ -239,6 +239,6 @@ internal static class CommandBindings
         internal static readonly CommandModuloDelegatesComparer Instance = new();
         public bool Equals(Command? a, Command? b) => CommandsEqual(a, b);
         public int GetHashCode(Command? c) =>
-            c is null ? 0 : global::System.HashCode.Combine(c.Label, c.IsEnabled, c.Description, c.AccessKey);
+            c is null ? 0 : global::System.HashCode.Combine(c.Label, c.IsEnabled, c.Description, c.AccessKey, c.Icon, c.Accelerator);
     }
 }

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -3033,24 +3033,48 @@ public partial record ToggleSplitButtonElement(string Label, Optional<bool> IsCh
     internal Action<WinUI.ToggleSplitButton>[] Setters { get; init; } = [];
     internal override bool HasCallbacks => OnIsCheckedChanged is not null || global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(Command) is not null;
 
+    // issue #637 — non-null gate marker for a command-only binding (Command set, no
+    // OnIsCheckedChanged). The HandCodedControlled `callback` selector is only null-checked
+    // (to gate subscription + value-diff arming) and is NEVER invoked, so a shared static
+    // sentinel adds zero per-event and per-reconcile allocation. Actual dispatch — including the
+    // OnIsCheckedChanged-wins-over-Command precedence — lives in __IsCheckedChangedTrampoline.
+    private static readonly Action<bool> __CommandGate = static _ => { };
+
+    // issue #637 — static IsCheckedChanged trampoline (replaces the per-toggle `new Action<bool>`
+    // the prior `.Controlled` callback allocated for command-only bindings). Reads the live element
+    // off the attached ReactorState at fire time; honors the value-diff echo arm so a programmatic
+    // controlled write does not re-enter the callback. Dispatch precedence matches the rest of the
+    // command-capable elements: a user OnIsCheckedChanged wins, else the typed Command is invoked.
+    private static readonly global::Windows.Foundation.TypedEventHandler<
+        WinUI.ToggleSplitButton, WinUI.ToggleSplitButtonIsCheckedChangedEventArgs> __IsCheckedChangedTrampoline = (s, _) =>
+    {
+        var tsb = (WinUI.ToggleSplitButton)s!;
+        var isChecked = tsb.IsChecked;
+        if (!global::Microsoft.UI.Reactor.Core.Reconciler.TryGetReactorState(tsb, out var state)) return;
+        if (global::Microsoft.UI.Reactor.Core.ChangeEchoSuppressor.ShouldSuppressEcho(state, isChecked)) return;
+        if (state.Element is not ToggleSplitButtonElement live) return;
+        if (live.OnIsCheckedChanged is not null) { live.OnIsCheckedChanged(isChecked); return; }
+        var cmd = live.Command;
+        if (global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(cmd) is not null)
+            global::Microsoft.UI.Reactor.Core.CommandBindings.Invoke(cmd!);
+    };
+
     private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<ToggleSplitButtonElement, WinUI.ToggleSplitButton> Customize(
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<ToggleSplitButtonElement, WinUI.ToggleSplitButton> d)
-        => d.Controlled<bool, WinUI.ToggleSplitButtonIsCheckedChangedEventArgs>(
+        => d.HandCodedControlled<global::Microsoft.UI.Reactor.Core.V1Protocol.ToggleSplitButtonEventPayload, bool, global::Windows.Foundation.TypedEventHandler<WinUI.ToggleSplitButton, WinUI.ToggleSplitButtonIsCheckedChangedEventArgs>>(
                 get:         static e => e.IsChecked,
                 set:         static (c, v) => c.IsChecked = v,
-                subscribe:   static (fe, h) => ((WinUI.ToggleSplitButton)fe).IsCheckedChanged += (s, e) => h(s, e),
-                unsubscribe: static (fe, h) => { /* trampoline lives for control lifetime — see CWT gate in PropEntry */ },
-                // issue #637 — a button bound only via the typed Command property (no OnIsCheckedChanged)
-                // still dispatches: fall back to invoking the command on toggle. The allocated Action is
-                // off the #153 fast path (only created on mount/non-fast-path update/user toggle, never on
-                // an unchanged-command reconcile, which ShallowEquals short-circuits before the descriptor runs).
-                callback:    static e =>
-                {
-                    if (e.OnIsCheckedChanged is not null) return e.OnIsCheckedChanged;
-                    var cmd = e.Command;
-                    return global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(cmd) is not null ? new Action<bool>(_ => global::Microsoft.UI.Reactor.Core.CommandBindings.Invoke(cmd!)) : null;
-                },
-                readBack:    static c => c.IsChecked)
+                readBack:    static c => c.IsChecked,
+                subscribe:   static (c, h) => c.IsCheckedChanged += h,
+                // issue #637 — gate subscription on a callback OR an invokable Command (mirrors
+                // HasCallbacks). The returned delegate is only null-checked, never called; dispatch
+                // and the OnIsCheckedChanged-vs-Command precedence live in __IsCheckedChangedTrampoline.
+                callback:    static e => e.OnIsCheckedChanged
+                    ?? (global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command) is not null ? __CommandGate : null),
+                trampoline:  __IsCheckedChangedTrampoline,
+                slotIsNull:  static p => p.IsCheckedChangedTrampoline is null,
+                setSlot:     static (p, h) => p.IsCheckedChangedTrampoline = h,
+                valueDiffEcho: true)
             .OneWayBridged<Element?>(
                 get:         static e => e.Flyout,
                 set:         static (c, v, rec, rr) => c.Flyout = rec.CreateFlyoutForDescriptor(v, rr),

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -2734,25 +2734,41 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
     public bool IsDisabledFocusable { get; init; }
     public Element? ContentElement { get; init; }
     /// <summary>
-    /// The <see cref="Command"/> bound to this button via the <c>Button(Command)</c> factory
-    /// or the <c>.Command()</c> modifier (issue #153). Carries the command so the reconciler can
-    /// compare it field-aware in <see cref="Element.ShallowEquals"/> and apply its metadata through
-    /// a descriptor entry — no per-render <see cref="Setters"/> lambda. The <c>init</c> accessor is
-    /// <c>internal</c> on purpose: this property only carries command <em>metadata</em>; the click
-    /// trampoline (<c>Execute</c>) and the coerced <c>IsEnabled</c> wiring live in the factory /
-    /// modifier, so the supported way to bind a command is <c>Button(cmd)</c> / <c>.Command(cmd)</c>,
-    /// not a direct <c>new ButtonElement { Command = cmd }</c> (which would not invoke the command).
+    /// The <see cref="Command"/> bound to this button via the <c>Button(Command)</c> factory,
+    /// the <c>.Command()</c> modifier, or a direct <c>new ButtonElement { Command = cmd }</c> /
+    /// <c>with { Command = cmd }</c> record-init (issue #153, made fully uniform in issue #637).
+    /// Carries the command so the reconciler can compare it field-aware in
+    /// <see cref="Element.ShallowEquals"/> and apply its metadata + enabled state through a
+    /// descriptor entry — no per-render <see cref="Setters"/> lambda. <b>Every</b> binding path is
+    /// now equivalent: dispatch (Execute/ExecuteAsync) is invoked by the click trampoline when
+    /// <see cref="OnClick"/> is null, <see cref="Command.IsEnabled"/> is folded into the
+    /// IsEnabled descriptor entry (see <see cref="EffectiveIsEnabled"/>), and the command counts
+    /// as a callback source for <see cref="HasCallbacks"/>. The <c>init</c> accessor is public:
+    /// a bare record-init invokes the command on click exactly like the factory/modifier.
     /// </summary>
-    public Command? Command { get; internal init; }
+    public Command? Command { get; init; }
     internal Action<WinUI.Button>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnClick is not null;
+    internal override bool HasCallbacks => OnClick is not null || Command is not null;
+
+    /// <summary>
+    /// The IsEnabled value written to the live control (gated on <c>!IsDisabledFocusable</c>):
+    /// the record <see cref="IsEnabled"/> AND the bound command's <see cref="Command.IsEnabled"/>.
+    /// Folding the command's enabled state in <em>here</em> — rather than baking it into the
+    /// record <see cref="IsEnabled"/> field in the factory/modifier — makes every binding path
+    /// (factory, <c>.Command()</c> modifier, and a bare <c>new ButtonElement { Command = cmd }</c>)
+    /// drive IsEnabled identically, while the <c>!IsDisabledFocusable</c> coercion (a
+    /// disabled-focusable button stays <c>IsEnabled=true</c>, reachable via Tab) is preserved
+    /// exactly by the unchanged <c>shouldWrite</c> gate and IsDisabledFocusable handler (issue #637).
+    /// </summary>
+    internal bool EffectiveIsEnabled => IsEnabled && (Command?.IsEnabled ?? true);
 
     private static readonly global::Microsoft.UI.Xaml.RoutedEventHandler __ClickTrampoline = (s, _) =>
     {
         if (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag((WinUI.Button)s!) is ButtonElement live)
         {
             if (live.IsDisabledFocusable) return;
-            live.OnClick?.Invoke();
+            if (live.OnClick is not null) live.OnClick();
+            else if (live.Command is not null) global::Microsoft.UI.Reactor.Core.CommandBindings.Invoke(live.Command);
         }
     };
 
@@ -2773,7 +2789,7 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
                 set:         static (c, v) => c.Content = v,
                 shouldWrite: static e => e.ContentElement is null)
             .OneWayConditional(
-                get:         static e => e.IsEnabled,
+                get:         static e => e.EffectiveIsEnabled,
                 set:         static (c, v) => c.IsEnabled = v,
                 shouldWrite: static e => !e.IsDisabledFocusable)
             .OneWay<bool>(
@@ -2792,49 +2808,87 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
                 })
             .HandCodedEvent<global::Microsoft.UI.Reactor.Core.V1Protocol.ButtonEventPayload, global::Microsoft.UI.Xaml.RoutedEventHandler>(
                 subscribe:        static (c, h) => c.Click += h,
-                callbackPresent:  static e => e.OnClick,
+                callbackPresent:  static e => (Delegate?)e.OnClick ?? global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command),
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
                 setSlot:          static (p, h) => p.ClickTrampoline = h)
             // issue #153 — command metadata (tooltip / accelerator / access key) applied
             // field-aware. applyIsEnabled:false: the IsEnabled OneWayConditional above already
-            // drives the control (gated on !IsDisabledFocusable), so the command must not
-            // clobber the disabled-focusable coercion. Re-applied only when the Command
-            // changes in a rendered field (delegates ignored — CommandModuloDelegatesComparer).
+            // drives the control (gated on !IsDisabledFocusable) via EffectiveIsEnabled, so the
+            // command must not clobber the disabled-focusable coercion. Re-applied only when the
+            // Command changes in a rendered field (delegates ignored — CommandModuloDelegatesComparer).
             .OneWayCommand(static e => e.Command, applyIsEnabled: false);
     }
 }
 
-[global::Microsoft.UI.Reactor.Wrappers.GenerateReactorDescriptor(typeof(WinUI.HyperlinkButton))]  // spec 058 §15 (P5.4)
+// Spec 058 §15 (P5.4). Click is Excluded + hand-coded (issue #637) so a button bound only via the
+// typed Command property still dispatches: the trampoline invokes OnClick when present, else the
+// command. (Was an auto-surfaced Click→OnClick before #637.)
+[global::Microsoft.UI.Reactor.Wrappers.GenerateReactorDescriptor(typeof(WinUI.HyperlinkButton), Exclude = new[] { "Click" })]
 [global::Microsoft.UI.Reactor.Wrappers.WrapAlias("Content", "Content")]  // Content as value (not child slot)
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record HyperlinkButtonElement(string Content, Uri? NavigateUri = null, Action? OnClick = null) : Element
 {
-    /// <summary>The command metadata bound via <c>HyperlinkButton(Command)</c> / <c>.Command()</c> (issue #153). <c>internal init</c>: bind via the factory/modifier, not direct record init. See <see cref="ButtonElement.Command"/>.</summary>
-    public Command? Command { get; internal init; }
+    /// <summary>The command bound via <c>HyperlinkButton(Command)</c> / <c>.Command()</c> / a direct
+    /// <c>new HyperlinkButtonElement { Command = cmd }</c> record-init (issue #153; made uniform in
+    /// issue #637). All paths dispatch + apply IsEnabled identically. See <see cref="ButtonElement.Command"/>.</summary>
+    public Command? Command { get; init; }
     internal Action<WinUI.HyperlinkButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnClick is not null;
+    internal override bool HasCallbacks => OnClick is not null || Command is not null;
+
+    private static readonly global::Microsoft.UI.Xaml.RoutedEventHandler __ClickTrampoline = (s, _) =>
+    {
+        if (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag((WinUI.HyperlinkButton)s!) is HyperlinkButtonElement live)
+        {
+            if (live.OnClick is not null) live.OnClick();
+            else if (live.Command is not null) global::Microsoft.UI.Reactor.Core.CommandBindings.Invoke(live.Command);
+        }
+    };
 
     private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<HyperlinkButtonElement, WinUI.HyperlinkButton> Customize(
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<HyperlinkButtonElement, WinUI.HyperlinkButton> d)
-        => d.OneWayCommand(static e => e.Command);  // issue #153 — command metadata + IsEnabled applied field-aware
+        => d.HandCodedEvent<global::Microsoft.UI.Reactor.Core.V1Protocol.HyperlinkButtonEventPayload, global::Microsoft.UI.Xaml.RoutedEventHandler>(
+                subscribe:        static (c, h) => c.Click += h,
+                callbackPresent:  static e => (Delegate?)e.OnClick ?? global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command),
+                trampoline:       __ClickTrampoline,
+                slotIsNull:       static p => p.ClickTrampoline is null,
+                setSlot:          static (p, h) => p.ClickTrampoline = h)
+            .OneWayCommand(static e => e.Command);  // issue #153 — command metadata + IsEnabled applied field-aware
 }
 
-[global::Microsoft.UI.Reactor.Wrappers.GenerateReactorDescriptor(typeof(WinPrim.RepeatButton))]  // spec 058 §15 (P5.4)
+// Spec 058 §15 (P5.4). Click Excluded + hand-coded (issue #637) — see HyperlinkButtonElement.
+[global::Microsoft.UI.Reactor.Wrappers.GenerateReactorDescriptor(typeof(WinPrim.RepeatButton), Exclude = new[] { "Click" })]
 [global::Microsoft.UI.Reactor.Wrappers.WrapAlias("Label", "Content")]
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record RepeatButtonElement(string Label, Action? OnClick = null) : Element
 {
     public int Delay { get; init; } = 250;
     public int Interval { get; init; } = 50;
-    /// <summary>The command metadata bound via <c>RepeatButton(Command)</c> / <c>.Command()</c> (issue #153). <c>internal init</c>: bind via the factory/modifier, not direct record init. See <see cref="ButtonElement.Command"/>.</summary>
-    public Command? Command { get; internal init; }
+    /// <summary>The command bound via <c>RepeatButton(Command)</c> / <c>.Command()</c> / a direct
+    /// <c>new RepeatButtonElement { Command = cmd }</c> record-init (issue #153; made uniform in
+    /// issue #637). All paths dispatch + apply IsEnabled identically. See <see cref="ButtonElement.Command"/>.</summary>
+    public Command? Command { get; init; }
     internal Action<WinPrim.RepeatButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnClick is not null;
+    internal override bool HasCallbacks => OnClick is not null || Command is not null;
+
+    private static readonly global::Microsoft.UI.Xaml.RoutedEventHandler __ClickTrampoline = (s, _) =>
+    {
+        if (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag((WinPrim.RepeatButton)s!) is RepeatButtonElement live)
+        {
+            if (live.OnClick is not null) live.OnClick();
+            else if (live.Command is not null) global::Microsoft.UI.Reactor.Core.CommandBindings.Invoke(live.Command);
+        }
+    };
 
     private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<RepeatButtonElement, WinPrim.RepeatButton> Customize(
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<RepeatButtonElement, WinPrim.RepeatButton> d)
-        => d.OneWayCommand(static e => e.Command);  // issue #153 — command metadata + IsEnabled applied field-aware
+        => d.HandCodedEvent<global::Microsoft.UI.Reactor.Core.V1Protocol.RepeatButtonEventPayload, global::Microsoft.UI.Xaml.RoutedEventHandler>(
+                subscribe:        static (c, h) => c.Click += h,
+                callbackPresent:  static e => (Delegate?)e.OnClick ?? global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command),
+                trampoline:       __ClickTrampoline,
+                slotIsNull:       static p => p.ClickTrampoline is null,
+                setSlot:          static (p, h) => p.ClickTrampoline = h)
+            .OneWayCommand(static e => e.Command);  // issue #153 — command metadata + IsEnabled applied field-aware
 }
 
 // Spec 058 §15 (P5.22) — Label→Content ([WrapAlias]). IsThreeState/IsChecked/CheckedState +
@@ -2860,17 +2914,27 @@ public partial record ToggleButtonElement(string Label, bool IsChecked = false, 
     public bool? CheckedState { get; init; }
     /// <summary>Three-state change handler. Receives <c>null</c> for indeterminate.</summary>
     public Action<bool?>? OnCheckedStateChanged { get; init; }
-    /// <summary>The command metadata bound via <c>ToggleButton(Command)</c> / <c>.Command()</c> (issue #153). <c>internal init</c>: bind via the factory/modifier, not direct record init. See <see cref="ButtonElement.Command"/>.</summary>
-    public Command? Command { get; internal init; }
+    /// <summary>The command bound via <c>ToggleButton(Command)</c> / <c>.Command()</c> / a direct
+    /// <c>new ToggleButtonElement { Command = cmd }</c> record-init (issue #153; made uniform in
+    /// issue #637). All paths fire the command on each toggle + apply IsEnabled identically.
+    /// See <see cref="ButtonElement.Command"/>.</summary>
+    public Command? Command { get; init; }
     internal Action<WinPrim.ToggleButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnIsCheckedChanged is not null || OnCheckedStateChanged is not null;
+    internal override bool HasCallbacks => OnIsCheckedChanged is not null || OnCheckedStateChanged is not null || Command is not null;
 
     private static readonly global::Microsoft.UI.Xaml.RoutedEventHandler __ClickTrampoline = (s, _) =>
     {
         var t = (WinPrim.ToggleButton)s!;
         if (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(t) is not ToggleButtonElement live) return;
-        live.OnIsCheckedChanged?.Invoke(t.IsChecked ?? false);
-        live.OnCheckedStateChanged?.Invoke(t.IsChecked);
+        if (live.OnIsCheckedChanged is not null || live.OnCheckedStateChanged is not null)
+        {
+            live.OnIsCheckedChanged?.Invoke(t.IsChecked ?? false);
+            live.OnCheckedStateChanged?.Invoke(t.IsChecked);
+        }
+        else if (live.Command is not null)
+        {
+            global::Microsoft.UI.Reactor.Core.CommandBindings.Invoke(live.Command);
+        }
     };
 
     private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<ToggleButtonElement, WinPrim.ToggleButton> Customize(
@@ -2883,7 +2947,7 @@ public partial record ToggleButtonElement(string Label, bool IsChecked = false, 
                 set: static (c, v) => c.IsChecked = v)
             .HandCodedEvent<global::Microsoft.UI.Reactor.Core.V1Protocol.ToggleButtonEventPayload, global::Microsoft.UI.Xaml.RoutedEventHandler>(
                 subscribe:        static (c, h) => c.Click += h,
-                callbackPresent:  static e => (Delegate?)e.OnIsCheckedChanged ?? e.OnCheckedStateChanged,
+                callbackPresent:  static e => (Delegate?)e.OnIsCheckedChanged ?? e.OnCheckedStateChanged ?? global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command),
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
                 setSlot:          static (p, h) => p.ClickTrampoline = h)
@@ -2918,19 +2982,28 @@ public partial record DropDownButtonElement(string Label, Element? Flyout = null
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record SplitButtonElement(string Label, Action? OnClick = null, Element? Flyout = null) : Element
 {
-    /// <summary>The command metadata bound via <c>SplitButton(Command)</c> / <c>.Command()</c> (issue #153). <c>internal init</c>: bind via the factory/modifier, not direct record init. See <see cref="ButtonElement.Command"/>.</summary>
-    public Command? Command { get; internal init; }
+    /// <summary>The command bound via <c>SplitButton(Command)</c> / a direct
+    /// <c>new SplitButtonElement { Command = cmd }</c> record-init (issue #153; made uniform in
+    /// issue #637). All paths dispatch the primary action + apply IsEnabled identically.
+    /// See <see cref="ButtonElement.Command"/>.</summary>
+    public Command? Command { get; init; }
     internal Action<WinUI.SplitButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnClick is not null;
+    internal override bool HasCallbacks => OnClick is not null || Command is not null;
 
-    private static readonly global::Windows.Foundation.TypedEventHandler<WinUI.SplitButton, WinUI.SplitButtonClickEventArgs> __ClickTrampoline =
-        (s, _) => (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(s) as SplitButtonElement)?.OnClick?.Invoke();
+    private static readonly global::Windows.Foundation.TypedEventHandler<WinUI.SplitButton, WinUI.SplitButtonClickEventArgs> __ClickTrampoline = (s, _) =>
+    {
+        if (global::Microsoft.UI.Reactor.Core.Reconciler.GetElementTag(s) is SplitButtonElement live)
+        {
+            if (live.OnClick is not null) live.OnClick();
+            else if (live.Command is not null) global::Microsoft.UI.Reactor.Core.CommandBindings.Invoke(live.Command);
+        }
+    };
 
     private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<SplitButtonElement, WinUI.SplitButton> Customize(
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<SplitButtonElement, WinUI.SplitButton> d)
         => d.HandCodedEvent<global::Microsoft.UI.Reactor.Core.V1Protocol.SplitButtonEventPayload, global::Windows.Foundation.TypedEventHandler<WinUI.SplitButton, WinUI.SplitButtonClickEventArgs>>(
                 subscribe:        static (c, h) => c.Click += h,
-                callbackPresent:  static e => e.OnClick,
+                callbackPresent:  static e => (Delegate?)e.OnClick ?? global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command),
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
                 setSlot:          static (p, h) => p.ClickTrampoline = h)
@@ -2952,10 +3025,13 @@ public partial record SplitButtonElement(string Label, Action? OnClick = null, E
 [global::Microsoft.UI.Reactor.Wrappers.WrapManual("Command")]
 public partial record ToggleSplitButtonElement(string Label, Optional<bool> IsChecked = default, Action<bool>? OnIsCheckedChanged = null, Element? Flyout = null) : Element
 {
-    /// <summary>The command metadata bound via <c>ToggleSplitButton(Command)</c> / <c>.Command()</c> (issue #153). <c>internal init</c>: bind via the factory/modifier, not direct record init. See <see cref="ButtonElement.Command"/>.</summary>
-    public Command? Command { get; internal init; }
+    /// <summary>The command bound via <c>ToggleSplitButton(Command)</c> / a direct
+    /// <c>new ToggleSplitButtonElement { Command = cmd }</c> record-init (issue #153; made uniform in
+    /// issue #637). All paths fire the command on each toggle + apply IsEnabled identically.
+    /// See <see cref="ButtonElement.Command"/>.</summary>
+    public Command? Command { get; init; }
     internal Action<WinUI.ToggleSplitButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnIsCheckedChanged is not null;
+    internal override bool HasCallbacks => OnIsCheckedChanged is not null || Command is not null;
 
     private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<ToggleSplitButtonElement, WinUI.ToggleSplitButton> Customize(
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<ToggleSplitButtonElement, WinUI.ToggleSplitButton> d)
@@ -2964,7 +3040,16 @@ public partial record ToggleSplitButtonElement(string Label, Optional<bool> IsCh
                 set:         static (c, v) => c.IsChecked = v,
                 subscribe:   static (fe, h) => ((WinUI.ToggleSplitButton)fe).IsCheckedChanged += (s, e) => h(s, e),
                 unsubscribe: static (fe, h) => { /* trampoline lives for control lifetime — see CWT gate in PropEntry */ },
-                callback:    static e => e.OnIsCheckedChanged,
+                // issue #637 — a button bound only via the typed Command property (no OnIsCheckedChanged)
+                // still dispatches: fall back to invoking the command on toggle. The allocated Action is
+                // off the #153 fast path (only created on mount/non-fast-path update/user toggle, never on
+                // an unchanged-command reconcile, which ShallowEquals short-circuits before the descriptor runs).
+                callback:    static e =>
+                {
+                    if (e.OnIsCheckedChanged is not null) return e.OnIsCheckedChanged;
+                    var cmd = e.Command;
+                    return cmd is not null ? new Action<bool>(_ => global::Microsoft.UI.Reactor.Core.CommandBindings.Invoke(cmd)) : null;
+                },
                 readBack:    static c => c.IsChecked)
             .OneWayBridged<Element?>(
                 get:         static e => e.Flyout,

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -436,6 +436,12 @@ public abstract record Element
             (ButtonElement ba, ButtonElement bb) =>
                 ba.Label == bb.Label
                 && ba.IsEnabled == bb.IsEnabled
+                // IsDisabledFocusable is a second Button enabled-state input (it coerces
+                // IsEnabled=true + Opacity=0.4 in the descriptor). Like the command-derived
+                // IsEnabled folded into CommandsEqual (issue #637 M1), an isolated flip must
+                // break equality so the descriptor re-applies the focusable-dim vs hard-disabled
+                // state — otherwise the live control goes stale on the fast-path skip.
+                && ba.IsDisabledFocusable == bb.IsDisabledFocusable
                 && ba.ContentElement is null && bb.ContentElement is null
                 && CommandBindings.CommandsEqual(ba.Command, bb.Command)
                 && SettersEqual(ba.Setters, bb.Setters),

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -2735,7 +2735,7 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
     public Element? ContentElement { get; init; }
     /// <summary>
     /// The <see cref="Command"/> bound to this button via the <c>Button(Command)</c> factory,
-    /// the <c>.Command()</c> modifier, or a direct <c>new ButtonElement { Command = cmd }</c> /
+    /// the <c>.Command()</c> modifier, or a direct <c>new ButtonElement(cmd.Label) { Command = cmd }</c> /
     /// <c>with { Command = cmd }</c> record-init (issue #153, made fully uniform in issue #637).
     /// Carries the command so the reconciler can compare it field-aware in
     /// <see cref="Element.ShallowEquals"/> and apply its metadata + enabled state through a
@@ -2748,14 +2748,14 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
     /// </summary>
     public Command? Command { get; init; }
     internal Action<WinUI.Button>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnClick is not null || Command is not null;
+    internal override bool HasCallbacks => global::Microsoft.UI.Reactor.Core.CommandBindings.EffectiveCallback(OnClick, Command) is not null;
 
     /// <summary>
     /// The IsEnabled value written to the live control (gated on <c>!IsDisabledFocusable</c>):
     /// the record <see cref="IsEnabled"/> AND the bound command's <see cref="Command.IsEnabled"/>.
     /// Folding the command's enabled state in <em>here</em> — rather than baking it into the
     /// record <see cref="IsEnabled"/> field in the factory/modifier — makes every binding path
-    /// (factory, <c>.Command()</c> modifier, and a bare <c>new ButtonElement { Command = cmd }</c>)
+    /// (factory, <c>.Command()</c> modifier, and a bare <c>new ButtonElement(cmd.Label) { Command = cmd }</c>)
     /// drive IsEnabled identically, while the <c>!IsDisabledFocusable</c> coercion (a
     /// disabled-focusable button stays <c>IsEnabled=true</c>, reachable via Tab) is preserved
     /// exactly by the unchanged <c>shouldWrite</c> gate and IsDisabledFocusable handler (issue #637).
@@ -2808,7 +2808,7 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
                 })
             .HandCodedEvent<global::Microsoft.UI.Reactor.Core.V1Protocol.ButtonEventPayload, global::Microsoft.UI.Xaml.RoutedEventHandler>(
                 subscribe:        static (c, h) => c.Click += h,
-                callbackPresent:  static e => (Delegate?)e.OnClick ?? global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command),
+                callbackPresent:  static e => global::Microsoft.UI.Reactor.Core.CommandBindings.EffectiveCallback(e.OnClick, e.Command),
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
                 setSlot:          static (p, h) => p.ClickTrampoline = h)
@@ -2830,11 +2830,11 @@ public partial record ButtonElement(string Label, Action? OnClick = null) : Elem
 public partial record HyperlinkButtonElement(string Content, Uri? NavigateUri = null, Action? OnClick = null) : Element
 {
     /// <summary>The command bound via <c>HyperlinkButton(Command)</c> / <c>.Command()</c> / a direct
-    /// <c>new HyperlinkButtonElement { Command = cmd }</c> record-init (issue #153; made uniform in
+    /// <c>new HyperlinkButtonElement(cmd.Label) { Command = cmd }</c> record-init (issue #153; made uniform in
     /// issue #637). All paths dispatch + apply IsEnabled identically. See <see cref="ButtonElement.Command"/>.</summary>
     public Command? Command { get; init; }
     internal Action<WinUI.HyperlinkButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnClick is not null || Command is not null;
+    internal override bool HasCallbacks => global::Microsoft.UI.Reactor.Core.CommandBindings.EffectiveCallback(OnClick, Command) is not null;
 
     private static readonly global::Microsoft.UI.Xaml.RoutedEventHandler __ClickTrampoline = (s, _) =>
     {
@@ -2849,7 +2849,7 @@ public partial record HyperlinkButtonElement(string Content, Uri? NavigateUri = 
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<HyperlinkButtonElement, WinUI.HyperlinkButton> d)
         => d.HandCodedEvent<global::Microsoft.UI.Reactor.Core.V1Protocol.HyperlinkButtonEventPayload, global::Microsoft.UI.Xaml.RoutedEventHandler>(
                 subscribe:        static (c, h) => c.Click += h,
-                callbackPresent:  static e => (Delegate?)e.OnClick ?? global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command),
+                callbackPresent:  static e => global::Microsoft.UI.Reactor.Core.CommandBindings.EffectiveCallback(e.OnClick, e.Command),
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
                 setSlot:          static (p, h) => p.ClickTrampoline = h)
@@ -2865,11 +2865,11 @@ public partial record RepeatButtonElement(string Label, Action? OnClick = null) 
     public int Delay { get; init; } = 250;
     public int Interval { get; init; } = 50;
     /// <summary>The command bound via <c>RepeatButton(Command)</c> / <c>.Command()</c> / a direct
-    /// <c>new RepeatButtonElement { Command = cmd }</c> record-init (issue #153; made uniform in
+    /// <c>new RepeatButtonElement(cmd.Label) { Command = cmd }</c> record-init (issue #153; made uniform in
     /// issue #637). All paths dispatch + apply IsEnabled identically. See <see cref="ButtonElement.Command"/>.</summary>
     public Command? Command { get; init; }
     internal Action<WinPrim.RepeatButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnClick is not null || Command is not null;
+    internal override bool HasCallbacks => global::Microsoft.UI.Reactor.Core.CommandBindings.EffectiveCallback(OnClick, Command) is not null;
 
     private static readonly global::Microsoft.UI.Xaml.RoutedEventHandler __ClickTrampoline = (s, _) =>
     {
@@ -2884,7 +2884,7 @@ public partial record RepeatButtonElement(string Label, Action? OnClick = null) 
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<RepeatButtonElement, WinPrim.RepeatButton> d)
         => d.HandCodedEvent<global::Microsoft.UI.Reactor.Core.V1Protocol.RepeatButtonEventPayload, global::Microsoft.UI.Xaml.RoutedEventHandler>(
                 subscribe:        static (c, h) => c.Click += h,
-                callbackPresent:  static e => (Delegate?)e.OnClick ?? global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command),
+                callbackPresent:  static e => global::Microsoft.UI.Reactor.Core.CommandBindings.EffectiveCallback(e.OnClick, e.Command),
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
                 setSlot:          static (p, h) => p.ClickTrampoline = h)
@@ -2915,12 +2915,12 @@ public partial record ToggleButtonElement(string Label, bool IsChecked = false, 
     /// <summary>Three-state change handler. Receives <c>null</c> for indeterminate.</summary>
     public Action<bool?>? OnCheckedStateChanged { get; init; }
     /// <summary>The command bound via <c>ToggleButton(Command)</c> / <c>.Command()</c> / a direct
-    /// <c>new ToggleButtonElement { Command = cmd }</c> record-init (issue #153; made uniform in
+    /// <c>new ToggleButtonElement(cmd.Label) { Command = cmd }</c> record-init (issue #153; made uniform in
     /// issue #637). All paths fire the command on each toggle + apply IsEnabled identically.
     /// See <see cref="ButtonElement.Command"/>.</summary>
     public Command? Command { get; init; }
     internal Action<WinPrim.ToggleButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnIsCheckedChanged is not null || OnCheckedStateChanged is not null || Command is not null;
+    internal override bool HasCallbacks => OnIsCheckedChanged is not null || global::Microsoft.UI.Reactor.Core.CommandBindings.EffectiveCallback(OnCheckedStateChanged, Command) is not null;
 
     private static readonly global::Microsoft.UI.Xaml.RoutedEventHandler __ClickTrampoline = (s, _) =>
     {
@@ -2947,7 +2947,7 @@ public partial record ToggleButtonElement(string Label, bool IsChecked = false, 
                 set: static (c, v) => c.IsChecked = v)
             .HandCodedEvent<global::Microsoft.UI.Reactor.Core.V1Protocol.ToggleButtonEventPayload, global::Microsoft.UI.Xaml.RoutedEventHandler>(
                 subscribe:        static (c, h) => c.Click += h,
-                callbackPresent:  static e => (Delegate?)e.OnIsCheckedChanged ?? e.OnCheckedStateChanged ?? global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command),
+                callbackPresent:  static e => (Delegate?)e.OnIsCheckedChanged ?? global::Microsoft.UI.Reactor.Core.CommandBindings.EffectiveCallback(e.OnCheckedStateChanged, e.Command),
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
                 setSlot:          static (p, h) => p.ClickTrampoline = h)
@@ -2983,12 +2983,12 @@ public partial record DropDownButtonElement(string Label, Element? Flyout = null
 public partial record SplitButtonElement(string Label, Action? OnClick = null, Element? Flyout = null) : Element
 {
     /// <summary>The command bound via <c>SplitButton(Command)</c> / a direct
-    /// <c>new SplitButtonElement { Command = cmd }</c> record-init (issue #153; made uniform in
+    /// <c>new SplitButtonElement(cmd.Label) { Command = cmd }</c> record-init (issue #153; made uniform in
     /// issue #637). All paths dispatch the primary action + apply IsEnabled identically.
     /// See <see cref="ButtonElement.Command"/>.</summary>
     public Command? Command { get; init; }
     internal Action<WinUI.SplitButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnClick is not null || Command is not null;
+    internal override bool HasCallbacks => global::Microsoft.UI.Reactor.Core.CommandBindings.EffectiveCallback(OnClick, Command) is not null;
 
     private static readonly global::Windows.Foundation.TypedEventHandler<WinUI.SplitButton, WinUI.SplitButtonClickEventArgs> __ClickTrampoline = (s, _) =>
     {
@@ -3003,7 +3003,7 @@ public partial record SplitButtonElement(string Label, Action? OnClick = null, E
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<SplitButtonElement, WinUI.SplitButton> d)
         => d.HandCodedEvent<global::Microsoft.UI.Reactor.Core.V1Protocol.SplitButtonEventPayload, global::Windows.Foundation.TypedEventHandler<WinUI.SplitButton, WinUI.SplitButtonClickEventArgs>>(
                 subscribe:        static (c, h) => c.Click += h,
-                callbackPresent:  static e => (Delegate?)e.OnClick ?? global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(e.Command),
+                callbackPresent:  static e => global::Microsoft.UI.Reactor.Core.CommandBindings.EffectiveCallback(e.OnClick, e.Command),
                 trampoline:       __ClickTrampoline,
                 slotIsNull:       static p => p.ClickTrampoline is null,
                 setSlot:          static (p, h) => p.ClickTrampoline = h)
@@ -3026,12 +3026,12 @@ public partial record SplitButtonElement(string Label, Action? OnClick = null, E
 public partial record ToggleSplitButtonElement(string Label, Optional<bool> IsChecked = default, Action<bool>? OnIsCheckedChanged = null, Element? Flyout = null) : Element
 {
     /// <summary>The command bound via <c>ToggleSplitButton(Command)</c> / a direct
-    /// <c>new ToggleSplitButtonElement { Command = cmd }</c> record-init (issue #153; made uniform in
+    /// <c>new ToggleSplitButtonElement(cmd.Label) { Command = cmd }</c> record-init (issue #153; made uniform in
     /// issue #637). All paths fire the command on each toggle + apply IsEnabled identically.
     /// See <see cref="ButtonElement.Command"/>.</summary>
     public Command? Command { get; init; }
     internal Action<WinUI.ToggleSplitButton>[] Setters { get; init; } = [];
-    internal override bool HasCallbacks => OnIsCheckedChanged is not null || Command is not null;
+    internal override bool HasCallbacks => OnIsCheckedChanged is not null || global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(Command) is not null;
 
     private static partial global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<ToggleSplitButtonElement, WinUI.ToggleSplitButton> Customize(
         global::Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor<ToggleSplitButtonElement, WinUI.ToggleSplitButton> d)
@@ -3048,7 +3048,7 @@ public partial record ToggleSplitButtonElement(string Label, Optional<bool> IsCh
                 {
                     if (e.OnIsCheckedChanged is not null) return e.OnIsCheckedChanged;
                     var cmd = e.Command;
-                    return cmd is not null ? new Action<bool>(_ => global::Microsoft.UI.Reactor.Core.CommandBindings.Invoke(cmd)) : null;
+                    return global::Microsoft.UI.Reactor.Core.CommandBindings.Invokable(cmd) is not null ? new Action<bool>(_ => global::Microsoft.UI.Reactor.Core.CommandBindings.Invoke(cmd!)) : null;
                 },
                 readBack:    static c => c.IsChecked)
             .OneWayBridged<Element?>(

--- a/src/Reactor/Core/V1Protocol/ControlEventPayloads.cs
+++ b/src/Reactor/Core/V1Protocol/ControlEventPayloads.cs
@@ -213,6 +213,18 @@ internal sealed class ExpanderEventPayload
         Microsoft.UI.Xaml.Controls.ExpanderCollapsedEventArgs>? CollapsedTrampoline;
 }
 
+/// <summary>Issue #637 — ToggleSplitButton <c>IsChecked</c> round-trip payload.
+/// One trampoline slot for the <c>IsCheckedChanged</c> event. The descriptor uses
+/// <c>HandCodedControlled</c> (value-diff echo) so a button bound only via the typed
+/// <c>Command</c> (no <c>OnIsCheckedChanged</c>) dispatches through this static
+/// trampoline instead of allocating an <c>Action&lt;bool&gt;</c> per toggle event.</summary>
+internal sealed class ToggleSplitButtonEventPayload
+{
+    public global::Windows.Foundation.TypedEventHandler<
+        Microsoft.UI.Xaml.Controls.ToggleSplitButton,
+        Microsoft.UI.Xaml.Controls.ToggleSplitButtonIsCheckedChangedEventArgs>? IsCheckedChangedTrampoline;
+}
+
 /// <summary>Spec 047 §14 Phase 3 batch 9 — SplitView named-slot container
 /// payload. <c>IsPaneOpen</c> is a plain <c>.OneWay</c> write (mirrors the
 /// legacy arm — programmatic writes fire the same events as user toggles).

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -167,19 +167,15 @@ public static partial class Factories
     }
 
     /// <summary>
-    /// Creates a Button driven by a Command. Maps Label → Content, Execute → Click,
-    /// IsEnabled → IsEnabled. Description / Accelerator / AccessKey are applied by the
-    /// reconciler from the typed <see cref="ButtonElement.Command"/> property (issue #153),
-    /// so no per-render Setters array or lambda is allocated and the reconciler can
-    /// fast-path command-bound buttons whose Command is unchanged across renders.
+    /// Creates a Button driven by a Command. Maps Label → Content; the command's
+    /// Execute/ExecuteAsync is invoked on click and its IsEnabled / Description / Accelerator /
+    /// AccessKey are applied by the reconciler from the typed <see cref="ButtonElement.Command"/>
+    /// property (issues #153, #637) — no per-render Setters array or lambda is allocated, and a
+    /// bare <c>new ButtonElement { Command = cmd }</c> record-init behaves identically.
     /// </summary>
     public static ButtonElement Button(Core.Command command)
     {
-        return new ButtonElement(command.Label, () => Core.CommandBindings.Invoke(command))
-        {
-            IsEnabled = command.IsEnabled,
-            Command = command,
-        };
+        return new ButtonElement(command.Label) { Command = command };
     }
 
     public static HyperlinkButtonElement HyperlinkButton(string content, Uri? navigateUri = null, Action? onClick = null)
@@ -197,10 +193,7 @@ public static partial class Factories
     /// </summary>
     public static HyperlinkButtonElement HyperlinkButton(Core.Command command)
     {
-        return new HyperlinkButtonElement(command.Label, null, () => Core.CommandBindings.Invoke(command))
-        {
-            Command = command,
-        };
+        return new HyperlinkButtonElement(command.Label) { Command = command };
     }
 
     public static RepeatButtonElement RepeatButton(string label, Action? onClick = null)
@@ -211,10 +204,7 @@ public static partial class Factories
     /// <summary>Creates a RepeatButton driven by a Command. Click auto-repeats while held.</summary>
     public static RepeatButtonElement RepeatButton(Core.Command command)
     {
-        return new RepeatButtonElement(command.Label, () => Core.CommandBindings.Invoke(command))
-        {
-            Command = command,
-        };
+        return new RepeatButtonElement(command.Label) { Command = command };
     }
 
     public static ToggleButtonElement ToggleButton(string label, bool isChecked = false, Action<bool>? onIsCheckedChanged = null)
@@ -229,10 +219,7 @@ public static partial class Factories
     /// </summary>
     public static ToggleButtonElement ToggleButton(Core.Command command, bool isChecked = false)
     {
-        return new ToggleButtonElement(command.Label, isChecked, _ => Core.CommandBindings.Invoke(command))
-        {
-            Command = command,
-        };
+        return new ToggleButtonElement(command.Label, isChecked) { Command = command };
     }
 
     /// <summary>
@@ -260,10 +247,7 @@ public static partial class Factories
     /// </summary>
     public static SplitButtonElement SplitButton(Core.Command command, Element? flyout = null)
     {
-        return new SplitButtonElement(command.Label, () => Core.CommandBindings.Invoke(command), flyout)
-        {
-            Command = command,
-        };
+        return new SplitButtonElement(command.Label, null, flyout) { Command = command };
     }
 
     /// <summary>
@@ -280,10 +264,7 @@ public static partial class Factories
     /// <summary>Creates a ToggleSplitButton driven by a Command (fires on each toggle).</summary>
     public static ToggleSplitButtonElement ToggleSplitButton(Core.Command command, Optional<bool> isChecked = default, Element? flyout = null)
     {
-        return new ToggleSplitButtonElement(command.Label, isChecked, _ => Core.CommandBindings.Invoke(command), flyout)
-        {
-            Command = command,
-        };
+        return new ToggleSplitButtonElement(command.Label, isChecked, null, flyout) { Command = command };
     }
 
     // ── Input controls ──────────────────────────────────────────────

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -171,7 +171,7 @@ public static partial class Factories
     /// Execute/ExecuteAsync is invoked on click and its IsEnabled / Description / Accelerator /
     /// AccessKey are applied by the reconciler from the typed <see cref="ButtonElement.Command"/>
     /// property (issues #153, #637) — no per-render Setters array or lambda is allocated, and a
-    /// bare <c>new ButtonElement { Command = cmd }</c> record-init behaves identically.
+    /// bare <c>new ButtonElement(cmd.Label) { Command = cmd }</c> record-init behaves identically.
     /// </summary>
     public static ButtonElement Button(Core.Command command)
     {

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1027,49 +1027,33 @@ public static partial class ElementExtensions
     // where it sits in the chain.
 
     /// <summary>
-    /// Binds a <see cref="Core.Command"/> to a custom-content <see cref="ButtonElement"/>:
-    /// wires Execute → Click, applies <see cref="Core.Command.IsEnabled"/> (re-applied on
-    /// every update), and flows Description / Accelerator / AccessKey via the typed
-    /// <see cref="ButtonElement.Command"/> property. Pairs with <c>Button(content)</c> so
-    /// icon-plus-label buttons auto-disable like the <c>Button(Command)</c> factory.
-    /// A raw <c>.Set(...)</c> setter runs after the command metadata and therefore overrides
-    /// it (e.g. <c>.Command(cmd).Set(b =&gt; b.AccessKey = "X")</c> — or the reverse order — both
-    /// resolve AccessKey to "X").
-    /// (issue #133, lifted to a typed property in issue #153)
+    /// Binds a <see cref="Core.Command"/> to a custom-content <see cref="ButtonElement"/> by
+    /// lifting it onto the typed <see cref="ButtonElement.Command"/> property (issues #133, #153,
+    /// unified in #637). The reconciler invokes Execute/ExecuteAsync on click, folds the command's
+    /// <see cref="Core.Command.IsEnabled"/> into the IsEnabled descriptor entry (re-applied on every
+    /// update, and coexisting with <c>.IsDisabledFocusable()</c>'s coercion), and flows Description /
+    /// Accelerator / AccessKey — all field-aware, with no per-render <see cref="ButtonElement.Setters"/>
+    /// lambda. Pairs with <c>Button(content)</c> so icon-plus-label buttons auto-disable like the
+    /// <c>Button(Command)</c> factory, and behaves identically to a bare
+    /// <c>new ButtonElement { Command = cmd }</c> record-init. A raw <c>.Set(...)</c> setter runs after
+    /// the command metadata and therefore overrides it.
     /// </summary>
     public static ButtonElement Command(this ButtonElement el, Core.Command command) =>
-        el with
-        {
-            OnClick = () => Core.CommandBindings.Invoke(command),
-            IsEnabled = command.IsEnabled,
-            // issue #153 — Command lifted to a typed property; the reconciler applies its
-            // metadata field-aware (applyIsEnabled:false, since the IsEnabled prop above already
-            // drives the control through ButtonElement's !IsDisabledFocusable-gated descriptor).
-            // No per-render Setters lambda. (supersedes the #133 setter wiring)
-            Command = command,
-        };
+        el with { Command = command };
 
     /// <summary>
     /// Binds a <see cref="Core.Command"/> to a <see cref="HyperlinkButtonElement"/>. See
     /// <see cref="Command(ButtonElement, Core.Command)"/>. (issue #133)
     /// </summary>
     public static HyperlinkButtonElement Command(this HyperlinkButtonElement el, Core.Command command) =>
-        el with
-        {
-            OnClick = () => Core.CommandBindings.Invoke(command),
-            Command = command,  // issue #153 — typed property, no per-render Setters lambda
-        };
+        el with { Command = command };
 
     /// <summary>
     /// Binds a <see cref="Core.Command"/> to a <see cref="RepeatButtonElement"/>. See
     /// <see cref="Command(ButtonElement, Core.Command)"/>. (issue #133)
     /// </summary>
     public static RepeatButtonElement Command(this RepeatButtonElement el, Core.Command command) =>
-        el with
-        {
-            OnClick = () => Core.CommandBindings.Invoke(command),
-            Command = command,  // issue #153 — typed property, no per-render Setters lambda
-        };
+        el with { Command = command };
 
     /// <summary>
     /// Binds a <see cref="Core.Command"/> to a <see cref="ToggleButtonElement"/>. The command
@@ -1077,11 +1061,7 @@ public static partial class ElementExtensions
     /// factory. See <see cref="Command(ButtonElement, Core.Command)"/>. (issue #133)
     /// </summary>
     public static ToggleButtonElement Command(this ToggleButtonElement el, Core.Command command) =>
-        el with
-        {
-            OnIsCheckedChanged = _ => Core.CommandBindings.Invoke(command),
-            Command = command,  // issue #153 — typed property, no per-render Setters lambda
-        };
+        el with { Command = command };
 
     /// <summary>
     /// Binds a <see cref="Core.Command"/> to an <see cref="AppBarButtonData"/>: maps Execute,

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1030,13 +1030,14 @@ public static partial class ElementExtensions
     /// Binds a <see cref="Core.Command"/> to a custom-content <see cref="ButtonElement"/> by
     /// lifting it onto the typed <see cref="ButtonElement.Command"/> property (issues #133, #153,
     /// unified in #637). The reconciler invokes Execute/ExecuteAsync on click, folds the command's
-    /// <see cref="Core.Command.IsEnabled"/> into the IsEnabled descriptor entry (re-applied on every
-    /// update, and coexisting with <c>.IsDisabledFocusable()</c>'s coercion), and flows Description /
+    /// <see cref="Core.Command.IsEnabled"/> into the IsEnabled descriptor entry (re-applied when the
+    /// command's derived enabled state changes — field-aware, not on every render — and coexisting
+    /// with <c>.IsDisabledFocusable()</c>'s coercion), and flows Description /
     /// Accelerator / AccessKey — all field-aware, with no per-render <see cref="ButtonElement.Setters"/>
     /// lambda. Pairs with <c>Button(content)</c> so icon-plus-label buttons auto-disable like the
     /// <c>Button(Command)</c> factory. The modifier makes the command fully take over: any
     /// <see cref="ButtonElement.OnClick"/> already on the element is cleared so the command — not a
-    /// stale click handler — dispatches (issue #637 review M6; matches the pre-#637 modifier, and
+    /// stale click handler — dispatches (issue #637; matches the pre-#637 modifier, and
     /// the <c>Button(Command)</c> factory which builds the element with no <c>OnClick</c>). A raw
     /// <c>.Set(...)</c> setter runs after the command metadata and therefore overrides it.
     /// </summary>

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1034,34 +1034,40 @@ public static partial class ElementExtensions
     /// update, and coexisting with <c>.IsDisabledFocusable()</c>'s coercion), and flows Description /
     /// Accelerator / AccessKey — all field-aware, with no per-render <see cref="ButtonElement.Setters"/>
     /// lambda. Pairs with <c>Button(content)</c> so icon-plus-label buttons auto-disable like the
-    /// <c>Button(Command)</c> factory, and behaves identically to a bare
-    /// <c>new ButtonElement { Command = cmd }</c> record-init. A raw <c>.Set(...)</c> setter runs after
-    /// the command metadata and therefore overrides it.
+    /// <c>Button(Command)</c> factory. The modifier makes the command fully take over: any
+    /// <see cref="ButtonElement.OnClick"/> already on the element is cleared so the command — not a
+    /// stale click handler — dispatches (issue #637 review M6; matches the pre-#637 modifier, and
+    /// the <c>Button(Command)</c> factory which builds the element with no <c>OnClick</c>). A raw
+    /// <c>.Set(...)</c> setter runs after the command metadata and therefore overrides it.
     /// </summary>
     public static ButtonElement Command(this ButtonElement el, Core.Command command) =>
-        el with { Command = command };
+        el with { Command = command, OnClick = null };
 
     /// <summary>
-    /// Binds a <see cref="Core.Command"/> to a <see cref="HyperlinkButtonElement"/>. See
-    /// <see cref="Command(ButtonElement, Core.Command)"/>. (issue #133)
+    /// Binds a <see cref="Core.Command"/> to a <see cref="HyperlinkButtonElement"/>, clearing any
+    /// existing <c>OnClick</c> so the command takes over dispatch. See
+    /// <see cref="Command(ButtonElement, Core.Command)"/>. (issues #133, #637)
     /// </summary>
     public static HyperlinkButtonElement Command(this HyperlinkButtonElement el, Core.Command command) =>
-        el with { Command = command };
+        el with { Command = command, OnClick = null };
 
     /// <summary>
-    /// Binds a <see cref="Core.Command"/> to a <see cref="RepeatButtonElement"/>. See
-    /// <see cref="Command(ButtonElement, Core.Command)"/>. (issue #133)
+    /// Binds a <see cref="Core.Command"/> to a <see cref="RepeatButtonElement"/>, clearing any
+    /// existing <c>OnClick</c> so the command takes over dispatch. See
+    /// <see cref="Command(ButtonElement, Core.Command)"/>. (issues #133, #637)
     /// </summary>
     public static RepeatButtonElement Command(this RepeatButtonElement el, Core.Command command) =>
-        el with { Command = command };
+        el with { Command = command, OnClick = null };
 
     /// <summary>
     /// Binds a <see cref="Core.Command"/> to a <see cref="ToggleButtonElement"/>. The command
     /// fires on each toggle (check and uncheck), matching the <c>ToggleButton(Command)</c>
-    /// factory. See <see cref="Command(ButtonElement, Core.Command)"/>. (issue #133)
+    /// factory; any existing toggle callback (<c>OnIsCheckedChanged</c> /
+    /// <c>OnCheckedStateChanged</c>) is cleared so the command takes over dispatch. See
+    /// <see cref="Command(ButtonElement, Core.Command)"/>. (issues #133, #637)
     /// </summary>
     public static ToggleButtonElement Command(this ToggleButtonElement el, Core.Command command) =>
-        el with { Command = command };
+        el with { Command = command, OnIsCheckedChanged = null, OnCheckedStateChanged = null };
 
     /// <summary>
     /// Binds a <see cref="Core.Command"/> to an <see cref="AppBarButtonData"/>: maps Execute,

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -749,4 +749,39 @@ internal static class CommandingCoverageFixtures
             H.Check("BareInitAll_ToggleSplitDisabled", ts is not null && !ts.IsEnabled);
         }
     }
+
+    /// <summary>
+    /// Issue #637 acceptance (d) for ToggleSplitButton at the LIVE tier: a bare record-init
+    /// <c>new ToggleSplitButtonElement("…") { Command = cmd }</c> with no <c>OnIsCheckedChanged</c>
+    /// dispatches the command on each real toggle. The <c>.Controlled</c> callback falls back to
+    /// invoking the typed Command when the user callback is null, so a direct <c>IsChecked</c> flip
+    /// (treated as real input — no armed echo on an uncontrolled mount) runs Execute. Closes the
+    /// previously unproven live-toggle gap for this element.
+    /// </summary>
+    internal class BareInitToggleSplitButtonCommandFiresOnToggle(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            var cmd = new Command { Label = "TSgo", Execute = () => count++ };
+
+            var host = H.CreateHost();
+            host.Mount(ctx => new ToggleSplitButtonElement("TSgo") { Command = cmd }.Set(b => b.Name = "bareTsBtn"));
+            await Harness.Render();
+
+            var tsb = H.FindControl<ToggleSplitButton>(b => b.Name == "bareTsBtn");
+            H.Check("BareInitTs_Mounted", tsb is not null);
+            H.Check("BareInitTs_Enabled", tsb is not null && tsb.IsEnabled);
+            if (tsb is not null)
+            {
+                // A direct IsChecked flip is real user input (no armed echo on an uncontrolled
+                // mount), so IsCheckedChanged fires and the command dispatches — check + uncheck.
+                tsb.IsChecked = !tsb.IsChecked;
+                await Harness.Render();
+                tsb.IsChecked = !tsb.IsChecked;
+                await Harness.Render();
+            }
+            H.Check("BareInitTs_CommandInvokedOnEachToggle", count == 2);
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -535,4 +535,218 @@ internal static class CommandingCoverageFixtures
             H.Check("CmdClear_ToolTipCleared", btn2 is not null && ToolTipService.GetToolTip(btn2) is null);
         }
     }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  Issue #637 — bare record-init / `with` Command binding equivalence.
+    //  A `new XxxElement { Command = cmd }` (no factory, no `.Command()` modifier)
+    //  must invoke the command on click/toggle AND apply IsEnabled identically to
+    //  the factory path, and must preserve Button's IsDisabledFocusable coercion.
+    //  These mount the LIVE control and raise real Click/Toggle events — the unit
+    //  tests pin the record shape; these prove the trampoline is actually wired and
+    //  fires for the bare-init path (the former "metadata-only silent footgun").
+    // ════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Issue #637: a bare <c>new ButtonElement { Command = cmd }</c> (no factory / modifier)
+    /// wires the Click trampoline and invokes the command — previously the bare record carried
+    /// metadata but never dispatched on click.
+    /// </summary>
+    internal class BareInitButtonCommandInvokesExecute(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            var cmd = new Command { Label = "Save", Execute = () => count++, AccessKey = "S" };
+
+            var host = H.CreateHost();
+            host.Mount(ctx => new ButtonElement("Save") { Command = cmd }.Set(b => b.Name = "bareCmdBtn"));
+            await Harness.Render();
+
+            var btn = H.FindControl<Button>(b => b.Name == "bareCmdBtn");
+            H.Check("BareInitBtn_Mounted", btn is not null);
+            H.Check("BareInitBtn_Enabled", btn is not null && btn.IsEnabled);
+            H.Check("BareInitBtn_AccessKeyFlowed", btn is not null && btn.AccessKey == "S");
+
+            H.ClickButton("Save");
+            H.Check("BareInitBtn_CommandInvokedOnClick", count == 1);
+        }
+    }
+
+    /// <summary>
+    /// Issue #637: a bare <c>new ToggleButtonElement { Command = cmd }</c> invokes the command on
+    /// each real user toggle (check + uncheck) via the toggle trampoline's Command fallback.
+    /// </summary>
+    internal class BareInitToggleButtonCommandFiresOnToggle(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            var cmd = new Command { Label = "Bold", Execute = () => count++ };
+
+            var host = H.CreateHost();
+            host.Mount(ctx => new ToggleButtonElement("Bold") { Command = cmd }.Set(b => b.Name = "bareTogBtn"));
+            await Harness.Render();
+
+            var tb = H.FindControl<ToggleButton>(b => b.Name == "bareTogBtn");
+            H.Check("BareInitTog_Mounted", tb is not null);
+            H.Check("BareInitTog_Enabled", tb is not null && tb.IsEnabled);
+            if (tb is not null)
+            {
+                var peer = Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer.CreatePeerForElement(tb);
+                var toggle = peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Toggle)
+                    as Microsoft.UI.Xaml.Automation.Provider.IToggleProvider;
+                toggle?.Toggle();
+                toggle?.Toggle();
+            }
+            H.Check("BareInitTog_CommandInvokedOnEachToggle", count == 2);
+        }
+    }
+
+    /// <summary>
+    /// Issue #637: <c>plain with { Command = cmd }</c> is equivalent to the factory — attaching a
+    /// command to a previously plain button via a <c>with</c>-expression wires dispatch on click.
+    /// </summary>
+    internal class WithCommandButtonInvokesExecute(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            var cmd = new Command { Label = "Go", Execute = () => count++ };
+            var plain = new ButtonElement("Go");
+            var bound = plain with { Command = cmd };
+
+            var host = H.CreateHost();
+            host.Mount(ctx => bound.Set(b => b.Name = "withCmdBtn"));
+            await Harness.Render();
+
+            var btn = H.FindControl<Button>(b => b.Name == "withCmdBtn");
+            H.Check("WithCmdBtn_Mounted", btn is not null);
+            H.ClickButton("Go");
+            H.Check("WithCmdBtn_CommandInvokedOnClick", count == 1);
+        }
+    }
+
+    /// <summary>
+    /// Issue #637: a bare-init Button with a disabled command applies <c>IsEnabled=false</c> to the
+    /// live control (the command's enabled state is folded into <c>EffectiveIsEnabled</c>), so the
+    /// command never runs while disabled.
+    /// </summary>
+    internal class BareInitButtonDisabledCommandDisablesControl(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            var cmd = new Command { Label = "Save", Execute = () => count++, CanExecute = false };
+
+            var host = H.CreateHost();
+            host.Mount(ctx => new ButtonElement("Save") { Command = cmd }.Set(b => b.Name = "bareDisBtn"));
+            await Harness.Render();
+
+            var btn = H.FindControl<Button>(b => b.Name == "bareDisBtn");
+            H.Check("BareInitDis_Mounted", btn is not null);
+            H.Check("BareInitDis_Disabled", btn is not null && !btn.IsEnabled);
+            H.ClickButton("Save"); // ClickButton is gated on IsEnabled — disabled button won't invoke
+            H.Check("BareInitDis_NotInvokedWhileDisabled", count == 0);
+        }
+    }
+
+    /// <summary>
+    /// Issue #637 acceptance: the bare-init path must preserve Button's IsDisabledFocusable coercion.
+    /// A disabled command + <c>IsDisabledFocusable = true</c> on a <c>new ButtonElement { ... }</c>
+    /// must keep the control <c>IsEnabled=true</c> (reachable via Tab) and dimmed (Opacity 0.4), and
+    /// the click trampoline must suppress the command (IsDisabledFocusable early-return) — exactly as
+    /// the factory/modifier path does.
+    /// </summary>
+    internal class BareInitButtonDisabledFocusableCoercionPreserved(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            var cmd = new Command { Label = "Submit", Execute = () => count++, CanExecute = false };
+
+            var host = H.CreateHost();
+            host.Mount(ctx => new ButtonElement("Submit") { Command = cmd, IsDisabledFocusable = true }
+                .Set(b => b.Name = "bareDfBtn"));
+            await Harness.Render();
+
+            var btn = H.FindControl<Button>(b => b.Name == "bareDfBtn");
+            H.Check("BareInitDf_Mounted", btn is not null);
+            H.Check("BareInitDf_StaysFocusable", btn is not null && btn.IsEnabled);
+            H.Check("BareInitDf_Dimmed", btn is not null && global::System.Math.Abs(btn.Opacity - 0.4) < 0.001);
+            H.ClickButton("Submit"); // IsEnabled is true ⇒ Invoke raises Click ⇒ trampoline suppresses the command
+            H.Check("BareInitDf_ClickSuppressed", count == 0);
+        }
+    }
+
+    /// <summary>
+    /// Issue #637: bare-init Hyperlink/Repeat/Split buttons invoke their command on a real Invoke
+    /// (primary click) — proving the HandCodedEvent subscription gate now treats the typed Command
+    /// as a callback source on the bare-init path for all the click-style elements.
+    /// </summary>
+    internal class BareInitHyperlinkRepeatSplitInvokeExecute(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int hl = 0, rp = 0, sp = 0;
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                new HyperlinkButtonElement("HLgo") { Command = new Command { Label = "HLgo", Execute = () => hl++ } }.Set(b => b.Name = "bareHlGo"),
+                new RepeatButtonElement("RPgo") { Command = new Command { Label = "RPgo", Execute = () => rp++ } }.Set(b => b.Name = "bareRpGo"),
+                new SplitButtonElement("SPgo") { Command = new Command { Label = "SPgo", Execute = () => sp++ } }.Set(b => b.Name = "bareSpGo")));
+            await Harness.Render();
+
+            InvokeBase(H.FindControl<HyperlinkButton>(b => b.Name == "bareHlGo"));
+            InvokeBase(H.FindControl<RepeatButton>(b => b.Name == "bareRpGo"));
+            InvokeBase(H.FindControl<SplitButton>(b => b.Name == "bareSpGo"));
+
+            H.Check("BareInitInvoke_Hyperlink", hl == 1);
+            H.Check("BareInitInvoke_Repeat", rp == 1);
+            H.Check("BareInitInvoke_Split", sp == 1);
+        }
+
+        private static void InvokeBase(Microsoft.UI.Xaml.UIElement? b)
+        {
+            if (b is null) return;
+            var peer = Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer.CreatePeerForElement(b);
+            (peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)
+                as Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider)?.Invoke();
+        }
+    }
+
+    /// <summary>
+    /// Issue #637: the bare-init path applies <c>Command.IsEnabled</c> on the live control for ALL
+    /// six command-capable elements. Mounts each of the remaining five (Button is covered separately)
+    /// plus ToggleSplitButton with a disabled command and asserts the control mounts disabled.
+    /// </summary>
+    internal class BareInitAllElementsApplyDisabledFromCommand(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            static Command Dis(string l) => new Command { Label = l, Execute = () => { }, CanExecute = false };
+
+            var host = H.CreateHost();
+            host.Mount(ctx => VStack(
+                new ButtonElement("BT") { Command = Dis("BT") }.Set(b => b.Name = "bareAllBt"),
+                new HyperlinkButtonElement("HL") { Command = Dis("HL") }.Set(b => b.Name = "bareAllHl"),
+                new RepeatButtonElement("RP") { Command = Dis("RP") }.Set(b => b.Name = "bareAllRp"),
+                new ToggleButtonElement("TG") { Command = Dis("TG") }.Set(b => b.Name = "bareAllTg"),
+                new SplitButtonElement("SP") { Command = Dis("SP") }.Set(b => b.Name = "bareAllSp"),
+                new ToggleSplitButtonElement("TS") { Command = Dis("TS") }.Set(b => b.Name = "bareAllTs")));
+            await Harness.Render();
+
+            var bt = H.FindControl<Button>(b => b.Name == "bareAllBt");
+            var hl = H.FindControl<HyperlinkButton>(b => b.Name == "bareAllHl");
+            var rp = H.FindControl<RepeatButton>(b => b.Name == "bareAllRp");
+            var tg = H.FindControl<ToggleButton>(b => b.Name == "bareAllTg");
+            var sp = H.FindControl<SplitButton>(b => b.Name == "bareAllSp");
+            var ts = H.FindControl<ToggleSplitButton>(b => b.Name == "bareAllTs");
+            H.Check("BareInitAll_ButtonDisabled", bt is not null && !bt.IsEnabled);
+            H.Check("BareInitAll_HyperlinkDisabled", hl is not null && !hl.IsEnabled);
+            H.Check("BareInitAll_RepeatDisabled", rp is not null && !rp.IsEnabled);
+            H.Check("BareInitAll_ToggleDisabled", tg is not null && !tg.IsEnabled);
+            H.Check("BareInitAll_SplitDisabled", sp is not null && !sp.IsEnabled);
+            H.Check("BareInitAll_ToggleSplitDisabled", ts is not null && !ts.IsEnabled);
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CommandingCoverageFixtures.cs
@@ -784,4 +784,94 @@ internal static class CommandingCoverageFixtures
             H.Check("BareInitTs_CommandInvokedOnEachToggle", count == 2);
         }
     }
+
+    /// <summary>
+    /// Issue #710 review (M4) — the none → command transition at the LIVE tier. A plain
+    /// <c>Button("Run")</c> (no command, untagged, Click unsubscribed) is re-rendered as a
+    /// command-bound button across a state-driven update. The reconciler reuses the control and
+    /// subscribes the Click handler ON UPDATE (HasCallbacks false→true), so a real click then
+    /// dispatches the command — proving subscribe-on-update + dispatch, not a manual Invoke.
+    /// </summary>
+    internal class BareInitNoneToCommandDispatchesOnClickAfterUpdate(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            int count = 0;
+            var cmd = new Command { Label = "Run", Execute = () => count++ };
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (bound, setBound) = ctx.UseState(false);
+                return VStack(
+                    Button("toggleM4Bind", () => setBound(true)),
+                    bound
+                        ? new ButtonElement("Run") { Command = cmd }
+                        : Button("Run"));
+            });
+            await Harness.Render();
+
+            var before = H.FindControl<Button>(b => (b.Content as string) == "Run");
+            H.Check("M4None_Mounted", before is not null);
+
+            // No command yet: the plain button is untagged / Click unsubscribed, so clicking is inert.
+            H.ClickButton("Run");
+            await Harness.Render();
+            H.Check("M4None_InertBeforeBind", count == 0);
+
+            // Re-render WITH the command bound — the reconciler subscribes Click on update.
+            H.ClickButton("toggleM4Bind");
+            await Harness.Render();
+
+            var after = H.FindControl<Button>(b => (b.Content as string) == "Run");
+            H.Check("M4None_Reused", before is not null && ReferenceEquals(before, after));
+
+            // The now-bound command dispatches on a real click (subscribe-on-update worked).
+            H.ClickButton("Run");
+            await Harness.Render();
+            H.Check("M4None_DispatchesAfterBind", count == 1);
+        }
+    }
+
+    /// <summary>
+    /// Issue #710 review (M2) — an isolated <c>IsDisabledFocusable</c> flip must re-apply at the
+    /// LIVE tier. A bare <c>new ButtonElement("Submit") { IsEnabled = false }</c> (hard-disabled:
+    /// IsEnabled=false, full opacity) flips ONLY IsDisabledFocusable across a state-driven update.
+    /// No <c>.Set</c> is used, so the empty Setters array stays reference-stable and
+    /// IsDisabledFocusable is the single differing field — without the ShallowEquals fix the
+    /// fast-path skipped this and left the control hard-disabled; now the descriptor re-applies the
+    /// focusable-dim coercion (IsEnabled=true + Opacity=0.4). The control is reused, so this is a
+    /// true re-apply, not a remount. Twin of the debounce M1 re-disable guard.
+    /// </summary>
+    internal class IsDisabledFocusableReappliesOnIsolatedFlip(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (focusable, setFocusable) = ctx.UseState(false);
+                return VStack(
+                    Button("toggleIdf", () => setFocusable(true)),
+                    // No .Set — keep Setters reference-stable so ONLY IsDisabledFocusable differs
+                    // across the update (a .Set would allocate a fresh Setters array each render and
+                    // defeat the isolation, masking the fast-path fix).
+                    new ButtonElement("Submit") { IsEnabled = false, IsDisabledFocusable = focusable });
+            });
+            await Harness.Render();
+
+            var before = H.FindControl<Button>(b => (b.Content as string) == "Submit");
+            H.Check("IdfReapply_Mounted", before is not null);
+            H.Check("IdfReapply_InitiallyHardDisabled", before is not null && !before.IsEnabled);
+
+            H.ClickButton("toggleIdf");
+            await Harness.Render();
+
+            var after = H.FindControl<Button>(b => (b.Content as string) == "Submit");
+            H.Check("IdfReapply_Reused", before is not null && ReferenceEquals(before, after));
+            // The isolated flip re-applied: focusable-dim coercion (IsEnabled stays true, dimmed).
+            H.Check("IdfReapply_FocusableAfterUpdate", after is not null && after.IsEnabled);
+            H.Check("IdfReapply_DimmedAfterUpdate", after is not null && global::System.Math.Abs(after.Opacity - 0.4) < 0.001);
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047EchoStrandingFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047EchoStrandingFixtures.cs
@@ -88,7 +88,7 @@ internal static class Spec047EchoStrandingFixtures
         }
     }
 
-    /// <summary>ToggleSplitButton.IsChecked — generic <c>.Controlled</c> entry.</summary>
+    /// <summary>ToggleSplitButton.IsChecked — issue #637 <c>HandCodedControlled</c> (value-diff) entry.</summary>
     internal class ToggleSplitButtonRealInputEcho(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047ValueDiffEchoFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Spec047ValueDiffEchoFixtures.cs
@@ -79,7 +79,7 @@ internal static class Spec047ValueDiffEchoFixtures
         }
     }
 
-    /// <summary>ToggleSplitButton.IsChecked — generic <c>.Controlled</c> entry.</summary>
+    /// <summary>ToggleSplitButton.IsChecked — issue #637 <c>HandCodedControlled</c> (value-diff) entry.</summary>
     internal class ToggleSplitButtonProgrammaticDrift(Harness h) : SelfTestFixtureBase(h)
     {
         public override async Task RunAsync()

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -893,6 +893,8 @@ internal static class SelfTestFixtureRegistry
         "Commanding_BareInitButtonDisabledFocusableCoercionPreserved",
         "Commanding_BareInitHyperlinkRepeatSplitInvokeExecute",
         "Commanding_BareInitAllElementsApplyDisabledFromCommand",
+        "Commanding_BareInitNoneToCommandDispatchesOnClickAfterUpdate",
+        "Commanding_IsDisabledFocusableReappliesOnIsolatedFlip",
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag",
@@ -2333,6 +2335,8 @@ internal static class SelfTestFixtureRegistry
         "Commanding_BareInitButtonDisabledFocusableCoercionPreserved" => new CommandingCoverageFixtures.BareInitButtonDisabledFocusableCoercionPreserved(harness),
         "Commanding_BareInitHyperlinkRepeatSplitInvokeExecute" => new CommandingCoverageFixtures.BareInitHyperlinkRepeatSplitInvokeExecute(harness),
         "Commanding_BareInitAllElementsApplyDisabledFromCommand" => new CommandingCoverageFixtures.BareInitAllElementsApplyDisabledFromCommand(harness),
+        "Commanding_BareInitNoneToCommandDispatchesOnClickAfterUpdate" => new CommandingCoverageFixtures.BareInitNoneToCommandDispatchesOnClickAfterUpdate(harness),
+        "Commanding_IsDisabledFocusableReappliesOnIsolatedFlip" => new CommandingCoverageFixtures.IsDisabledFocusableReappliesOnIsolatedFlip(harness),
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag" => new DragDropFixtures.OnDragStartAutoSetsCanDrag(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -887,6 +887,7 @@ internal static class SelfTestFixtureRegistry
         // Issue #637 — bare record-init / `with` Command binding equivalence
         "Commanding_BareInitButtonCommandInvokesExecute",
         "Commanding_BareInitToggleButtonCommandFiresOnToggle",
+        "Commanding_BareInitToggleSplitButtonCommandFiresOnToggle",
         "Commanding_WithCommandButtonInvokesExecute",
         "Commanding_BareInitButtonDisabledCommandDisablesControl",
         "Commanding_BareInitButtonDisabledFocusableCoercionPreserved",
@@ -2326,6 +2327,7 @@ internal static class SelfTestFixtureRegistry
         // Issue #637 — bare record-init / `with` Command binding equivalence
         "Commanding_BareInitButtonCommandInvokesExecute" => new CommandingCoverageFixtures.BareInitButtonCommandInvokesExecute(harness),
         "Commanding_BareInitToggleButtonCommandFiresOnToggle" => new CommandingCoverageFixtures.BareInitToggleButtonCommandFiresOnToggle(harness),
+        "Commanding_BareInitToggleSplitButtonCommandFiresOnToggle" => new CommandingCoverageFixtures.BareInitToggleSplitButtonCommandFiresOnToggle(harness),
         "Commanding_WithCommandButtonInvokesExecute" => new CommandingCoverageFixtures.WithCommandButtonInvokesExecute(harness),
         "Commanding_BareInitButtonDisabledCommandDisablesControl" => new CommandingCoverageFixtures.BareInitButtonDisabledCommandDisablesControl(harness),
         "Commanding_BareInitButtonDisabledFocusableCoercionPreserved" => new CommandingCoverageFixtures.BareInitButtonDisabledFocusableCoercionPreserved(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -884,6 +884,15 @@ internal static class SelfTestFixtureRegistry
         "Commanding_BoundToggleSplitButtonCommandChangeUpdatesMetadata",
         "Commanding_BoundButtonCommandClearedWhenRemoved",
 
+        // Issue #637 — bare record-init / `with` Command binding equivalence
+        "Commanding_BareInitButtonCommandInvokesExecute",
+        "Commanding_BareInitToggleButtonCommandFiresOnToggle",
+        "Commanding_WithCommandButtonInvokesExecute",
+        "Commanding_BareInitButtonDisabledCommandDisablesControl",
+        "Commanding_BareInitButtonDisabledFocusableCoercionPreserved",
+        "Commanding_BareInitHyperlinkRepeatSplitInvokeExecute",
+        "Commanding_BareInitAllElementsApplyDisabledFromCommand",
+
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag",
         "DragDrop_OnDropAutoSetsAllowDrop",
@@ -2313,6 +2322,15 @@ internal static class SelfTestFixtureRegistry
         "Commanding_BoundSplitButtonCommandChangeUpdatesMetadata" => new CommandingCoverageFixtures.BoundSplitButtonCommandChangeUpdatesMetadata(harness),
         "Commanding_BoundToggleSplitButtonCommandChangeUpdatesMetadata" => new CommandingCoverageFixtures.BoundToggleSplitButtonCommandChangeUpdatesMetadata(harness),
         "Commanding_BoundButtonCommandClearedWhenRemoved" => new CommandingCoverageFixtures.BoundButtonCommandClearedWhenRemoved(harness),
+
+        // Issue #637 — bare record-init / `with` Command binding equivalence
+        "Commanding_BareInitButtonCommandInvokesExecute" => new CommandingCoverageFixtures.BareInitButtonCommandInvokesExecute(harness),
+        "Commanding_BareInitToggleButtonCommandFiresOnToggle" => new CommandingCoverageFixtures.BareInitToggleButtonCommandFiresOnToggle(harness),
+        "Commanding_WithCommandButtonInvokesExecute" => new CommandingCoverageFixtures.WithCommandButtonInvokesExecute(harness),
+        "Commanding_BareInitButtonDisabledCommandDisablesControl" => new CommandingCoverageFixtures.BareInitButtonDisabledCommandDisablesControl(harness),
+        "Commanding_BareInitButtonDisabledFocusableCoercionPreserved" => new CommandingCoverageFixtures.BareInitButtonDisabledFocusableCoercionPreserved(harness),
+        "Commanding_BareInitHyperlinkRepeatSplitInvokeExecute" => new CommandingCoverageFixtures.BareInitHyperlinkRepeatSplitInvokeExecute(harness),
+        "Commanding_BareInitAllElementsApplyDisabledFromCommand" => new CommandingCoverageFixtures.BareInitAllElementsApplyDisabledFromCommand(harness),
 
         // Drag-and-drop — spec 027 Tier 6 (Phase 6a)
         "DragDrop_OnDragStartAutoSetsCanDrag" => new DragDropFixtures.OnDragStartAutoSetsCanDrag(harness),

--- a/tests/Reactor.Tests/CommandDslTests.cs
+++ b/tests/Reactor.Tests/CommandDslTests.cs
@@ -30,8 +30,10 @@ public class CommandDslTests
     {
         var el = Button(_testCmd);
         Assert.Equal("Save", el.Label);
-        Assert.True(el.IsEnabled);
-        Assert.NotNull(el.OnClick);
+        Assert.True(el.EffectiveIsEnabled);
+        // issue #637 — dispatch flows from the typed Command, not a pre-baked OnClick closure.
+        Assert.Null(el.OnClick);
+        Assert.Same(_testCmd, el.Command);
     }
 
     [Fact]
@@ -39,7 +41,7 @@ public class CommandDslTests
     {
         var cmd = _testCmd with { CanExecute = false };
         var el = Button(cmd);
-        Assert.False(el.IsEnabled);
+        Assert.False(el.EffectiveIsEnabled);
     }
 
     // ════════════════════════════════════════════════════════════════

--- a/tests/Reactor.Tests/CommandTypedPropertyTests.cs
+++ b/tests/Reactor.Tests/CommandTypedPropertyTests.cs
@@ -436,4 +436,152 @@ public class CommandTypedPropertyTests
         Assert.True(perConstruct < 140,
             $"Button(command) per-construct allocation regressed: {perConstruct:F1} B (expected < 140 B).");
     }
+
+    // ════════════════════════════════════════════════════════════════
+    //  (g) issue #637 review — debounce re-disable (M1), the shared
+    //      Invokable predicate (M2), dispatch precedence (M3), and the
+    //      none→command subscribe-on-update transition (M4).
+    // ════════════════════════════════════════════════════════════════
+
+    // M1 — CommandsEqual compares the DERIVED IsEnabled (CanExecute && !IsExecuting &&
+    //      !IsDebouncing). A debounce-window flip therefore registers as a change so the
+    //      descriptor re-applies and the button re-disables. The pre-#637 comparer omitted
+    //      IsDebouncing, so a UseCommand(DebounceMs:) Button stayed visibly enabled.
+    [Fact]
+    public void CommandsEqual_False_When_Only_IsDebouncing_Differs()
+    {
+        var steady = MakeCmd();
+        var debouncing = steady with { IsDebouncing = true };
+        Assert.NotEqual(steady.IsEnabled, debouncing.IsEnabled); // derived enabled flips true→false
+        Assert.False(CommandBindings.CommandsEqual(steady, debouncing));
+    }
+
+    [Fact]
+    public void CommandsEqual_False_When_Only_IsExecuting_Differs()
+    {
+        // IsExecuting also flows through the derived IsEnabled, so an async command
+        // entering / leaving its in-flight window is still seen as a change.
+        var idle = MakeCmd();
+        var running = idle with { IsExecuting = true };
+        Assert.False(CommandBindings.CommandsEqual(idle, running));
+    }
+
+    // M1 steady-state guard — the fast-path skip the issue protects is INTACT: two
+    // non-debouncing renders with identical rendered fields are still equal (no re-apply).
+    [Fact]
+    public void CommandsEqual_True_When_Steady_NonDebouncing_Unchanged()
+    {
+        var a = MakeCmd();
+        var b = MakeCmd(); // distinct instance, identical rendered fields, both enabled
+        Assert.True(CommandBindings.CommandsEqual(a, b));
+        Assert.True(Element.ShallowEquals(Button(a), Button(b)));
+    }
+
+    [Fact]
+    public void ShallowEquals_False_When_Command_IsDebouncing_Differs_AllSix()
+    {
+        var steady = MakeCmd();
+        var debouncing = steady with { IsDebouncing = true };
+        Assert.False(Element.ShallowEquals(Button(steady), Button(debouncing)));
+        Assert.False(Element.ShallowEquals(HyperlinkButton(steady), HyperlinkButton(debouncing)));
+        Assert.False(Element.ShallowEquals(RepeatButton(steady), RepeatButton(debouncing)));
+        Assert.False(Element.ShallowEquals(ToggleButton(steady), ToggleButton(debouncing)));
+        Assert.False(Element.ShallowEquals(SplitButton(steady), SplitButton(debouncing)));
+        Assert.False(Element.ShallowEquals(ToggleSplitButton(steady), ToggleSplitButton(debouncing)));
+    }
+
+    [Fact]
+    public void Button_ReDisables_Across_Debounce_Window_Flip()
+    {
+        // The regression guard (issue #637 review M1): a Button whose command enters its
+        // debounce window must re-disable. EffectiveIsEnabled folds the command's derived
+        // IsEnabled, and the flipped command is not ShallowEqual, so the reconciler
+        // re-applies IsEnabled=false on the transition (and re-enables when it elapses).
+        var enabled = MakeCmd();                                // IsEnabled = true
+        var debouncing = enabled with { IsDebouncing = true };  // IsEnabled = false
+
+        var before = new ButtonElement("Save") { Command = enabled };
+        var after = new ButtonElement("Save") { Command = debouncing };
+
+        Assert.True(before.EffectiveIsEnabled);
+        Assert.False(after.EffectiveIsEnabled);
+        Assert.False(Element.ShallowEquals(before, after)); // forces re-apply on reconcile
+    }
+
+    // M2 — HasCallbacks and the subscription gate now share one Invokable-based predicate
+    //      (EffectiveCallback), so a metadata-only command (no Execute/ExecuteAsync) is NOT
+    //      a callback source: the click event stays unsubscribed and the button is untagged.
+    [Fact]
+    public void HasCallbacks_False_For_MetadataOnly_Command()
+    {
+        var metadataOnly = new Command { Label = "Save", Description = "no delegate" };
+        Assert.Null(CommandBindings.Invokable(metadataOnly));
+        Assert.False(new ButtonElement("Save") { Command = metadataOnly }.HasCallbacks);
+        Assert.False(new HyperlinkButtonElement("Save") { Command = metadataOnly }.HasCallbacks);
+        Assert.False(new RepeatButtonElement("Save") { Command = metadataOnly }.HasCallbacks);
+        Assert.False(new ToggleButtonElement("Save") { Command = metadataOnly }.HasCallbacks);
+        Assert.False(new SplitButtonElement("Save") { Command = metadataOnly }.HasCallbacks);
+        Assert.False(new ToggleSplitButtonElement("Save") { Command = metadataOnly }.HasCallbacks);
+    }
+
+    [Fact]
+    public void EffectiveCallback_Prefers_UserCallback_Then_Invokable_Else_Null()
+    {
+        Action onClick = () => { };
+        var cmd = MakeCmd();
+        Assert.Same(onClick, CommandBindings.EffectiveCallback(onClick, cmd));         // user callback wins
+        Assert.Same(cmd.Execute, CommandBindings.EffectiveCallback(null, cmd));        // falls back to the command
+        Assert.Null(CommandBindings.EffectiveCallback(null, new Command { Label = "x" })); // metadata-only ⇒ null
+        Assert.Null(CommandBindings.EffectiveCallback(null, null));
+    }
+
+    // M3 — dispatch precedence for the BARE record-init path. Both present ⇒ the explicit
+    //      callback wins (the trampoline rule: `if (OnClick is not null) OnClick();`).
+    //      Command only ⇒ the command dispatches.
+    [Fact]
+    public void BareInit_BothPresent_CallbackWins()
+    {
+        int onClickCount = 0, cmdCount = 0;
+        var cmd = MakeCmd(() => cmdCount++);
+        var el = new ButtonElement("Save", () => onClickCount++) { Command = cmd };
+
+        Assert.NotNull(el.OnClick);
+        Assert.Same(cmd, el.Command);
+        // The click trampoline prefers OnClick when present, so the command does NOT fire.
+        el.OnClick!();
+        Assert.Equal(1, onClickCount);
+        Assert.Equal(0, cmdCount);
+    }
+
+    [Fact]
+    public void BareInit_CommandOnly_Dispatches_Command()
+    {
+        int cmdCount = 0;
+        var cmd = MakeCmd(() => cmdCount++);
+        var el = new ButtonElement("Save") { Command = cmd };
+
+        Assert.Null(el.OnClick);
+        CommandBindings.Invoke(el.Command!); // OnClick null ⇒ the trampoline invokes the command
+        Assert.Equal(1, cmdCount);
+    }
+
+    // M4 — none → command transition. A plain button (no command, untagged) re-rendered WITH
+    //      a command flips HasCallbacks false→true, so the reconciler's HasCallbacks gate forces
+    //      a full Update that subscribes the click event; the now-bound command dispatches.
+    [Fact]
+    public void Transition_None_To_Command_Subscribes_And_Dispatches()
+    {
+        int count = 0;
+        var cmd = MakeCmd(() => count++);
+
+        var none = Button("Save");
+        Assert.False(none.HasCallbacks);                  // not tagged, click event unsubscribed
+
+        var bound = new ButtonElement("Save") { Command = cmd };
+        Assert.True(bound.HasCallbacks);                  // update subscribes the click handler
+        Assert.False(Element.ShallowEquals(none, bound)); // not ShallowEqual ⇒ full Update runs
+
+        CommandBindings.Invoke(bound.Command!);
+        Assert.Equal(1, count);
+    }
 }

--- a/tests/Reactor.Tests/CommandTypedPropertyTests.cs
+++ b/tests/Reactor.Tests/CommandTypedPropertyTests.cs
@@ -244,62 +244,173 @@ public class CommandTypedPropertyTests
     }
 
     // ════════════════════════════════════════════════════════════════
-    //  (d) Clicking still invokes the command (sync + async)
+    //  (d) Dispatch is uniform via the typed Command (issue #637).
+    //      The factory/modifier no longer bake OnClick — the click
+    //      trampoline invokes the command when OnClick is null. These
+    //      assert the record-level wiring + dispatch helpers; the live
+    //      click→Execute path is covered by the Commanding selftest
+    //      fixtures (CommandingCoverageFixtures.cs).
     // ════════════════════════════════════════════════════════════════
 
     [Fact]
-    public void Button_Command_OnClick_Invokes_Sync_Execute()
+    public void Button_Command_Factory_DoesNotBake_OnClick()
+    {
+        // The per-construct OnClick closure is gone (issue #637) — dispatch flows
+        // from the typed Command via the click trampoline instead.
+        var cmd = new Command { Label = "Go", Execute = () => { } };
+        var el = Button(cmd);
+        Assert.Null(el.OnClick);
+        Assert.Same(cmd, el.Command);
+        Assert.True(el.HasCallbacks);
+    }
+
+    [Fact]
+    public void ToggleButton_Command_Factory_DoesNotBake_OnIsCheckedChanged()
+    {
+        var cmd = new Command { Label = "T", Execute = () => { } };
+        var el = ToggleButton(cmd);
+        Assert.Null(el.OnIsCheckedChanged);
+        Assert.Same(cmd, el.Command);
+        Assert.True(el.HasCallbacks);
+    }
+
+    [Fact]
+    public void Invokable_Returns_Execute_Then_ExecuteAsync_Else_Null()
+    {
+        Action exec = () => { };
+        Func<Task> execAsync = () => Task.CompletedTask;
+        // Execute is preferred; ExecuteAsync is the fallback; Execute wins when both present.
+        Assert.Same(exec, CommandBindings.Invokable(new Command { Label = "a", Execute = exec }));
+        Assert.Same(execAsync, CommandBindings.Invokable(new Command { Label = "a", ExecuteAsync = execAsync }));
+        Assert.Same(exec, CommandBindings.Invokable(new Command { Label = "a", Execute = exec, ExecuteAsync = execAsync }));
+        // No delegate ⇒ nothing to dispatch ⇒ null (the event stays unsubscribed, zero cost).
+        Assert.Null(CommandBindings.Invokable(new Command { Label = "a" }));
+        Assert.Null(CommandBindings.Invokable(null));
+    }
+
+    [Fact]
+    public void Invoke_Runs_Sync_Execute()
     {
         int count = 0;
-        var cmd = new Command { Label = "Go", Execute = () => count++ };
-        var el = Button(cmd);
-        Assert.NotNull(el.OnClick);
-        el.OnClick!();
+        CommandBindings.Invoke(new Command { Label = "Go", Execute = () => count++ });
         Assert.Equal(1, count);
     }
 
     [Fact]
-    public async Task Button_Command_OnClick_Invokes_Async_Execute()
+    public async Task Invoke_Runs_Async_Execute_When_No_Sync()
     {
         var tcs = new TaskCompletionSource();
-        var cmd = new Command
-        {
-            Label = "Go",
-            ExecuteAsync = () => { tcs.SetResult(); return Task.CompletedTask; },
-        };
-        var el = Button(cmd);
-        Assert.NotNull(el.OnClick);
-        el.OnClick!();
+        CommandBindings.Invoke(new Command { Label = "Go", ExecuteAsync = () => { tcs.SetResult(); return Task.CompletedTask; } });
         await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.True(tcs.Task.IsCompletedSuccessfully);
     }
 
+    // ════════════════════════════════════════════════════════════════
+    //  (e) issue #637 — uniform binding: factory, .Command() modifier,
+    //      and a bare `new XxxElement { Command = cmd }` record-init are
+    //      equivalent (same Command, same HasCallbacks, ShallowEquals-match).
+    //      The public `init` accessor is what makes the bare-init path legal.
+    // ════════════════════════════════════════════════════════════════
+
     [Fact]
-    public void ToggleButton_Command_Toggle_Invokes_Execute()
+    public void BareInit_And_With_Compile_Via_Public_Init()
     {
-        int count = 0;
-        var cmd = new Command { Label = "T", Execute = () => count++ };
-        var el = ToggleButton(cmd);
-        Assert.NotNull(el.OnIsCheckedChanged);
-        el.OnIsCheckedChanged!(true);
-        el.OnIsCheckedChanged!(false);
-        Assert.Equal(2, count); // fires on every toggle (Option A)
+        // Acceptance: the Command init accessor is public again, so these compile.
+        var cmd = MakeCmd();
+        var bare = new ButtonElement("Save") { Command = cmd };
+        var withed = new ButtonElement("Save") with { Command = cmd };
+        Assert.Same(cmd, bare.Command);
+        Assert.Same(cmd, withed.Command);
     }
 
     [Fact]
-    public void SplitButton_Command_OnClick_Invokes_Execute()
+    public void BareInit_Equivalent_To_Factory_AllSix()
     {
-        int count = 0;
-        var cmd = new Command { Label = "S", Execute = () => count++ };
-        var el = SplitButton(cmd);
-        Assert.NotNull(el.OnClick);
-        el.OnClick!();
-        Assert.Equal(1, count);
+        var cmd = MakeCmd();
+        Assert.True(Element.ShallowEquals(Button(cmd), new ButtonElement("Save") { Command = cmd }));
+        Assert.True(Element.ShallowEquals(HyperlinkButton(cmd), new HyperlinkButtonElement("Save") { Command = cmd }));
+        Assert.True(Element.ShallowEquals(RepeatButton(cmd), new RepeatButtonElement("Save") { Command = cmd }));
+        Assert.True(Element.ShallowEquals(ToggleButton(cmd), new ToggleButtonElement("Save") { Command = cmd }));
+        Assert.True(Element.ShallowEquals(SplitButton(cmd), new SplitButtonElement("Save") { Command = cmd }));
+        Assert.True(Element.ShallowEquals(ToggleSplitButton(cmd), new ToggleSplitButtonElement("Save") { Command = cmd }));
+    }
+
+    [Fact]
+    public void Modifier_Equivalent_To_Factory_ForBareLabelButtons()
+    {
+        var cmd = MakeCmd();
+        // .Command() on a plain label button matches the Xxx(cmd) factory exactly.
+        Assert.True(Element.ShallowEquals(Button(cmd), Button("Save").Command(cmd)));
+        Assert.True(Element.ShallowEquals(HyperlinkButton(cmd), HyperlinkButton("Save").Command(cmd)));
+        Assert.True(Element.ShallowEquals(RepeatButton(cmd), RepeatButton("Save").Command(cmd)));
+        Assert.True(Element.ShallowEquals(ToggleButton(cmd), ToggleButton("Save").Command(cmd)));
+    }
+
+    [Fact]
+    public void HasCallbacks_True_For_BareInit_Command_AllSix()
+    {
+        var cmd = MakeCmd();
+        Assert.True(new ButtonElement("Save") { Command = cmd }.HasCallbacks);
+        Assert.True(new HyperlinkButtonElement("Save") { Command = cmd }.HasCallbacks);
+        Assert.True(new RepeatButtonElement("Save") { Command = cmd }.HasCallbacks);
+        Assert.True(new ToggleButtonElement("Save") { Command = cmd }.HasCallbacks);
+        Assert.True(new SplitButtonElement("Save") { Command = cmd }.HasCallbacks);
+        Assert.True(new ToggleSplitButtonElement("Save") { Command = cmd }.HasCallbacks);
+    }
+
+    [Fact]
+    public void HasCallbacks_False_For_Plain_Buttons_With_No_Command_Or_Handler()
+    {
+        // The #153 fast-path Tag refresh is gated on HasCallbacks: a handler-less,
+        // command-less button must NOT be tagged (the win the issue protects).
+        Assert.False(Button("Save").HasCallbacks);
+        Assert.False(HyperlinkButton("Save").HasCallbacks);
+        Assert.False(RepeatButton("Save").HasCallbacks);
+        Assert.False(ToggleButton("Save").HasCallbacks);
+        Assert.False(SplitButton("Save").HasCallbacks);
+        Assert.False(ToggleSplitButton("Save").HasCallbacks);
+    }
+
+    [Fact]
+    public void HasCallbacks_Transition_Command_To_None_Breaks_FastPath_Gate()
+    {
+        // Button(cmd) → Button("x") flips HasCallbacks true→false, so the reconciler's
+        // `oldEl.HasCallbacks == newEl.HasCallbacks` gate fails and a full Update runs
+        // (which clears the stale command metadata) — same as the pre-#637 OnClick path.
+        var cmd = MakeCmd();
+        Assert.True(Button(cmd).HasCallbacks);
+        Assert.False(Button("Save").HasCallbacks);
+    }
+
+    [Fact]
+    public void Button_EffectiveIsEnabled_Folds_Command_Across_All_Paths()
+    {
+        var disabled = new Command { Label = "Save", Execute = () => { }, CanExecute = false };
+        var enabled = new Command { Label = "Save", Execute = () => { }, CanExecute = true };
+
+        // Factory, modifier, and bare-init all disable identically when the command is disabled.
+        Assert.False(Button(disabled).EffectiveIsEnabled);
+        Assert.False(Button("Save").Command(disabled).EffectiveIsEnabled);
+        Assert.False(new ButtonElement("Save") { Command = disabled }.EffectiveIsEnabled);
+
+        // Enabled command ⇒ enabled.
+        Assert.True(Button(enabled).EffectiveIsEnabled);
+        Assert.True(new ButtonElement("Save") { Command = enabled }.EffectiveIsEnabled);
+
+        // Explicit record IsEnabled=false wins regardless of the command.
+        Assert.False(new ButtonElement("Save") { IsEnabled = false, Command = enabled }.EffectiveIsEnabled);
+
+        // No command ⇒ just the record field.
+        Assert.True(new ButtonElement("Save").EffectiveIsEnabled);
+        Assert.False(new ButtonElement("Save") { IsEnabled = false }.EffectiveIsEnabled);
     }
 
     // ════════════════════════════════════════════════════════════════
-    //  Allocation budget — per-construct bytes stay well under the
-    //  pre-#153 baseline (≈264 B; the Setters array + closure was ≈88 B).
+    //  (f) Allocation budget — the #153 win, re-pinned for #637.
+    //      Dropping the factory-baked OnClick closure (issue #637) HALVED
+    //      the per-construct allocation (≈176 B → ≈88 B on ARM64). The
+    //      tightened ceiling FAILS if a per-render closure/array is
+    //      reintroduced (which would push it back to ≈176 B).
     // ════════════════════════════════════════════════════════════════
 
     [Fact]
@@ -319,11 +430,10 @@ public class CommandTypedPropertyTests
 
         double perConstruct = (after - before) / (double)N;
 
-        // The pre-#153 factory allocated ≈264 B/construct (record + Setters array +
-        // lambda closure). After lifting Command to a typed property the Setters
-        // array/closure (≈88 B) is gone. Use a generous CI-jitter ceiling that still
-        // catches a regression that reintroduces a per-render array/closure.
-        Assert.True(perConstruct < 220,
-            $"Button(command) per-construct allocation regressed: {perConstruct:F1} B (expected < 220 B).");
+        // ≈88 B after #637 (just the record). A reintroduced OnClick closure (≈88 B)
+        // would push this to ≈176 B, so a 140 B ceiling catches the regression while
+        // leaving CI-jitter headroom.
+        Assert.True(perConstruct < 140,
+            $"Button(command) per-construct allocation regressed: {perConstruct:F1} B (expected < 140 B).");
     }
 }

--- a/tests/Reactor.Tests/CommandTypedPropertyTests.cs
+++ b/tests/Reactor.Tests/CommandTypedPropertyTests.cs
@@ -477,6 +477,24 @@ public class CommandTypedPropertyTests
         Assert.True(Element.ShallowEquals(Button(a), Button(b)));
     }
 
+    // The comparer hash must stay consistent with CommandsEqual (issue #710 review): equal
+    // commands hash equal (the IEqualityComparer contract), and the hash now folds Icon +
+    // Accelerator so commands differing only in those fields no longer collide. The pre-fix
+    // hash omitted both, so the NotEqual asserts below are the regression guard.
+    [Fact]
+    public void Comparer_GetHashCode_Consistent_With_Equality_Incl_Icon_Accelerator()
+    {
+        var cmp = CommandBindings.CommandModuloDelegatesComparer.Instance;
+
+        // Equal (modulo delegates) ⇒ equal hash.
+        Assert.Equal(cmp.GetHashCode(MakeCmd()), cmp.GetHashCode(MakeCmd(execute: () => { })));
+
+        // Icon / Accelerator are part of equality, so they must move the hash.
+        var baseline = MakeCmd();
+        Assert.NotEqual(cmp.GetHashCode(baseline), cmp.GetHashCode(baseline with { Icon = new SymbolIconData("Cancel") }));
+        Assert.NotEqual(cmp.GetHashCode(baseline), cmp.GetHashCode(baseline with { Accelerator = new KeyboardAcceleratorData(VirtualKey.X, VirtualKeyModifiers.Control) }));
+    }
+
     [Fact]
     public void ShallowEquals_False_When_Command_IsDebouncing_Differs_AllSix()
     {

--- a/tests/Reactor.Tests/CommandTypedPropertyTests.cs
+++ b/tests/Reactor.Tests/CommandTypedPropertyTests.cs
@@ -526,6 +526,21 @@ public class CommandTypedPropertyTests
         Assert.False(Element.ShallowEquals(before, after)); // forces re-apply on reconcile
     }
 
+    // issue #710 review (M2) — IsDisabledFocusable is a SECOND Button enabled-state input: it
+    // coerces the live control to IsEnabled=true + Opacity=0.4 (focusable-dim) instead of
+    // hard-disabled. Like the command-derived IsEnabled folded into CommandsEqual (M1 above),
+    // an isolated flip must break ShallowEquals so the fast-path doesn't skip the descriptor and
+    // leave the control stale. Steady state (same IsDisabledFocusable) still fast-paths. The live
+    // re-apply is CommandingCoverageFixtures.IsDisabledFocusableReappliesOnIsolatedFlip.
+    [Fact]
+    public void ShallowEquals_False_When_Only_IsDisabledFocusable_Differs()
+    {
+        var hardDisabled = new ButtonElement("Submit") { IsEnabled = false };
+        var focusable = hardDisabled with { IsDisabledFocusable = true };
+        Assert.False(Element.ShallowEquals(hardDisabled, focusable));       // forces descriptor re-apply
+        Assert.True(Element.ShallowEquals(hardDisabled, hardDisabled with { })); // steady state still skips
+    }
+
     // M2 — HasCallbacks and the subscription gate now share one Invokable-based predicate
     //      (EffectiveCallback), so a metadata-only command (no Execute/ExecuteAsync) is NOT
     //      a callback source: the click event stays unsubscribed and the button is untagged.
@@ -583,23 +598,21 @@ public class CommandTypedPropertyTests
         Assert.Equal(1, cmdCount);
     }
 
-    // M4 — none → command transition. A plain button (no command, untagged) re-rendered WITH
-    //      a command flips HasCallbacks false→true, so the reconciler's HasCallbacks gate forces
-    //      a full Update that subscribes the click event; the now-bound command dispatches.
+    // M4 — none → command transition (headless gate-signal guard; the live reconcile + real click
+    //      is CommandingCoverageFixtures.BareInitNoneToCommandDispatchesOnClickAfterUpdate). A plain
+    //      button (no command, untagged, click unsubscribed) re-rendered WITH a command flips
+    //      HasCallbacks false→true and is not ShallowEqual, so the reconciler's HasCallbacks gate
+    //      forces a full Update that subscribes the click event on the reused control.
     [Fact]
-    public void Transition_None_To_Command_Subscribes_And_Dispatches()
+    public void Transition_None_To_Command_Flips_HasCallbacks_And_Breaks_ShallowEquals()
     {
-        int count = 0;
-        var cmd = MakeCmd(() => count++);
+        var cmd = MakeCmd();
 
         var none = Button("Save");
-        Assert.False(none.HasCallbacks);                  // not tagged, click event unsubscribed
+        Assert.False(none.HasCallbacks);                  // untagged, click event unsubscribed
 
         var bound = new ButtonElement("Save") { Command = cmd };
-        Assert.True(bound.HasCallbacks);                  // update subscribes the click handler
-        Assert.False(Element.ShallowEquals(none, bound)); // not ShallowEqual ⇒ full Update runs
-
-        CommandBindings.Invoke(bound.Command!);
-        Assert.Equal(1, count);
+        Assert.True(bound.HasCallbacks);                  // update will subscribe the click handler
+        Assert.False(Element.ShallowEquals(none, bound)); // not ShallowEqual ⇒ full Update runs (subscribe-on-update)
     }
 }

--- a/tests/Reactor.Tests/CommandingCoverageTests.cs
+++ b/tests/Reactor.Tests/CommandingCoverageTests.cs
@@ -30,7 +30,7 @@ public class CommandingCoverageTests
         var el = Button(cmd);
 
         Assert.Equal("Save", el.Label);
-        Assert.True(el.IsEnabled);
+        Assert.True(el.EffectiveIsEnabled);
     }
 
     [Fact]
@@ -38,16 +38,17 @@ public class CommandingCoverageTests
     {
         var cmd = MakeCmd(canExecute: false);
         var el = Button(cmd);
-        Assert.False(el.IsEnabled);
+        Assert.False(el.EffectiveIsEnabled);
     }
 
     [Fact]
-    public void Button_Command_OnClickInvokesExecute()
+    public void Button_Command_DispatchInvokesExecute()
     {
         int count = 0;
         var cmd = MakeCmd(() => count++);
         var el = Button(cmd);
-        el.OnClick!();
+        Assert.Null(el.OnClick);              // issue #637 — dispatch via the typed Command
+        CommandBindings.Invoke(el.Command!);  // what the click trampoline does when OnClick is null
         Assert.Equal(1, count);
     }
 
@@ -61,7 +62,8 @@ public class CommandingCoverageTests
         var el = HyperlinkButton(cmd);
 
         Assert.Equal("Save", el.Content);
-        el.OnClick!();
+        Assert.Null(el.OnClick);
+        CommandBindings.Invoke(el.Command!);
         Assert.Equal(1, count);
     }
 
@@ -75,7 +77,8 @@ public class CommandingCoverageTests
         var el = RepeatButton(cmd);
 
         Assert.Equal("Save", el.Label);
-        el.OnClick!();
+        Assert.Null(el.OnClick);
+        CommandBindings.Invoke(el.Command!);
         Assert.Equal(1, count);
     }
 
@@ -88,8 +91,10 @@ public class CommandingCoverageTests
         var cmd = MakeCmd(() => count++);
         var el = ToggleButton(cmd);
 
-        el.OnIsCheckedChanged!(true);
-        el.OnIsCheckedChanged!(false);
+        Assert.Null(el.OnIsCheckedChanged);   // issue #637 — the toggle trampoline invokes the command
+        // The live trampoline fires the command on each toggle (check + uncheck) — see selftests.
+        CommandBindings.Invoke(el.Command!);
+        CommandBindings.Invoke(el.Command!);
         Assert.Equal(2, count);
     }
 
@@ -110,7 +115,8 @@ public class CommandingCoverageTests
         var el = SplitButton(cmd);
 
         Assert.Equal("Save", el.Label);
-        el.OnClick!();
+        Assert.Null(el.OnClick);
+        CommandBindings.Invoke(el.Command!);
         Assert.Equal(1, count);
     }
 
@@ -131,8 +137,9 @@ public class CommandingCoverageTests
         var cmd = MakeCmd(() => count++);
         var el = ToggleSplitButton(cmd);
 
-        el.OnIsCheckedChanged!(true);
-        el.OnIsCheckedChanged!(false);
+        Assert.Null(el.OnIsCheckedChanged);
+        CommandBindings.Invoke(el.Command!);
+        CommandBindings.Invoke(el.Command!);
         Assert.Equal(2, count);
     }
 
@@ -148,7 +155,8 @@ public class CommandingCoverageTests
             ExecuteAsync = () => { called = true; return global::System.Threading.Tasks.Task.CompletedTask; },
         };
         var el = Button(cmd);
-        el.OnClick!();
+        Assert.Null(el.OnClick);
+        CommandBindings.Invoke(el.Command!);
         Assert.True(called);
     }
 }

--- a/tests/Reactor.Tests/DslFactoryLogicTests.cs
+++ b/tests/Reactor.Tests/DslFactoryLogicTests.cs
@@ -56,8 +56,9 @@ public class DslFactoryLogicTests
         var cmd = new Command { Label = "Save", Execute = () => executed = true };
         var el = Button(cmd);
         Assert.Equal("Save", el.Label);
-        Assert.True(el.IsEnabled);
-        el.OnClick!.Invoke();
+        Assert.True(el.EffectiveIsEnabled);
+        Assert.Null(el.OnClick);              // issue #637 — dispatch via the typed Command
+        CommandBindings.Invoke(el.Command!);  // what the click trampoline does when OnClick is null
         Assert.True(executed);
     }
 
@@ -66,7 +67,7 @@ public class DslFactoryLogicTests
     {
         var cmd = new Command { Label = "Delete", Execute = () => { }, CanExecute = false };
         var el = Button(cmd);
-        Assert.False(el.IsEnabled);
+        Assert.False(el.EffectiveIsEnabled);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/Elements/CommandModifierTests.cs
+++ b/tests/Reactor.Tests/Elements/CommandModifierTests.cs
@@ -22,7 +22,7 @@ public class CommandModifierTests
 
         var el = Button(TextBlock("Run")).Command(cmd);
 
-        Assert.True(el.IsEnabled);
+        Assert.True(el.EffectiveIsEnabled);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class CommandModifierTests
 
         var el = Button(TextBlock("Run")).Command(cmd);
 
-        Assert.False(el.IsEnabled);
+        Assert.False(el.EffectiveIsEnabled);
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class CommandModifierTests
 
         var el = Button(TextBlock("Run")).Command(cmd);
 
-        Assert.False(el.IsEnabled);
+        Assert.False(el.EffectiveIsEnabled);
         Assert.NotNull(el.ContentElement);
     }
 
@@ -74,8 +74,8 @@ public class CommandModifierTests
         var enabled = new Command { Label = "Run", Execute = () => { }, CanExecute = true };
         var disabled = new Command { Label = "Run", Execute = () => { }, CanExecute = false };
 
-        Assert.True(Render(enabled).IsEnabled);
-        Assert.False(Render(disabled).IsEnabled);
+        Assert.True(Render(enabled).EffectiveIsEnabled);
+        Assert.False(Render(disabled).EffectiveIsEnabled);
     }
 
     [Fact]
@@ -97,11 +97,15 @@ public class CommandModifierTests
         Assert.Same(first.Setters, second.Setters);
         // A flipped command is not ShallowEqual, so the reconciler re-applies the effects.
         Assert.False(Element.ShallowEquals(first, second));
-        Assert.True(first.IsEnabled);
-        Assert.False(second.IsEnabled);
+        Assert.True(first.EffectiveIsEnabled);
+        Assert.False(second.EffectiveIsEnabled);
     }
 
-    // ── (c) Clicking invokes the command ────────────────────────────
+    // ── (c) Dispatch flows from the typed Command (issue #637) ───────
+    //     The modifier no longer bakes OnClick/OnIsCheckedChanged — the
+    //     click/toggle trampoline invokes the command. These assert the
+    //     record wiring + that the bound command dispatches; the live
+    //     click→Execute path is pinned by the Commanding selftests.
 
     [Fact]
     public void Command_Wires_Click_To_Execute()
@@ -110,9 +114,9 @@ public class CommandModifierTests
         var cmd = new Command { Label = "Run", Execute = () => count++ };
 
         var el = Button(TextBlock("Run")).Command(cmd);
-        Assert.NotNull(el.OnClick);
-        el.OnClick!();
-
+        Assert.Null(el.OnClick);              // issue #637 — dispatch via typed Command, not a baked closure
+        Assert.Same(cmd, el.Command);
+        CommandBindings.Invoke(el.Command!);  // what the click trampoline does when OnClick is null
         Assert.Equal(1, count);
     }
 
@@ -123,7 +127,8 @@ public class CommandModifierTests
         var cmd = new Command { Label = "Run", ExecuteAsync = () => { count++; return Task.CompletedTask; } };
 
         var el = Button(TextBlock("Run")).Command(cmd);
-        el.OnClick!();
+        Assert.Null(el.OnClick);
+        CommandBindings.Invoke(el.Command!);
 
         Assert.Equal(1, count);
     }
@@ -137,8 +142,9 @@ public class CommandModifierTests
         var cmd = new Command { Label = "Details", Execute = () => count++ };
 
         var el = HyperlinkButton("Details").Command(cmd);
-        Assert.NotNull(el.OnClick);
-        el.OnClick!();
+        Assert.Null(el.OnClick);
+        Assert.Same(cmd, el.Command);
+        CommandBindings.Invoke(el.Command!);
 
         Assert.Equal(1, count);
     }
@@ -150,7 +156,8 @@ public class CommandModifierTests
         var cmd = new Command { Label = "Tick", Execute = () => count++ };
 
         var el = RepeatButton("Tick").Command(cmd);
-        el.OnClick!();
+        Assert.Null(el.OnClick);
+        CommandBindings.Invoke(el.Command!);
 
         Assert.Equal(1, count);
     }
@@ -162,9 +169,11 @@ public class CommandModifierTests
         var cmd = new Command { Label = "Bold", Execute = () => count++ };
 
         var el = ToggleButton("Bold").Command(cmd);
-        Assert.NotNull(el.OnIsCheckedChanged);
-        el.OnIsCheckedChanged!(true);
-        el.OnIsCheckedChanged!(false);
+        Assert.Null(el.OnIsCheckedChanged);   // issue #637 — toggle trampoline invokes the command
+        Assert.Same(cmd, el.Command);
+        // The live trampoline fires the command on each toggle (check + uncheck) — see selftests.
+        CommandBindings.Invoke(el.Command!);
+        CommandBindings.Invoke(el.Command!);
 
         Assert.Equal(2, count);
     }
@@ -238,8 +247,9 @@ public class CommandModifierTests
     }
 
     // ── (M1, PR-review) The Button(Command) factory must defer IsEnabled to the
-    //    descriptor too (applyIsEnabled:false), so a disabled command chained with
-    //    .IsDisabledFocusable() stays in the tab order — same guarantee as the modifier.
+    //    descriptor too (folded into EffectiveIsEnabled, applyIsEnabled:false), so a
+    //    disabled command chained with .IsDisabledFocusable() stays in the tab order —
+    //    same guarantee as the modifier and the bare record-init (issue #637).
 
     [Fact]
     public void Button_Command_Factory_Applies_IsEnabled_False_When_Disabled()
@@ -248,7 +258,9 @@ public class CommandModifierTests
 
         var el = Button(cmd);
 
-        Assert.False(el.IsEnabled);
+        // issue #637 — the record IsEnabled field is left at its default (true); the
+        // command's disabled state is folded into the descriptor via EffectiveIsEnabled.
+        Assert.False(el.EffectiveIsEnabled);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/Elements/CommandModifierTests.cs
+++ b/tests/Reactor.Tests/Elements/CommandModifierTests.cs
@@ -272,4 +272,79 @@ public class CommandModifierTests
 
         Assert.True(el.IsDisabledFocusable);
     }
+
+    // ── (M6, issue #637 review) The .Command() modifier makes the command fully take over:
+    //    any conflicting OnClick / toggle callback already on the element is cleared so the
+    //    command — not a stale handler — dispatches. This restores the pre-#637 command-wins
+    //    semantics (the brief #637 callback-wins behavior was never released). The bare
+    //    record-init path keeps its trampoline rule (explicit callback wins) — see
+    //    CommandTypedPropertyTests.BareInit_BothPresent_CallbackWins.
+
+    [Fact]
+    public void Command_Modifier_Clears_Conflicting_OnClick_Command_Wins()
+    {
+        int onClickCount = 0, cmdCount = 0;
+        var cmd = new Command { Label = "Run", Execute = () => cmdCount++ };
+
+        var el = Button("Run", () => onClickCount++).Command(cmd);
+
+        Assert.Null(el.OnClick);              // the modifier cleared the conflicting click handler
+        Assert.Same(cmd, el.Command);
+        // OnClick null ⇒ the click trampoline invokes the command, not the original onClick.
+        CommandBindings.Invoke(el.Command!);
+        Assert.Equal(1, cmdCount);
+        Assert.Equal(0, onClickCount);
+    }
+
+    [Fact]
+    public void Command_Modifier_Clears_Conflicting_HyperlinkButton_OnClick()
+    {
+        var cmd = new Command { Label = "Go", Execute = () => { } };
+
+        var el = HyperlinkButton("Go", onClick: () => { }).Command(cmd);
+
+        Assert.Null(el.OnClick);
+        Assert.Same(cmd, el.Command);
+    }
+
+    [Fact]
+    public void Command_Modifier_Clears_Conflicting_RepeatButton_OnClick()
+    {
+        var cmd = new Command { Label = "Tick", Execute = () => { } };
+
+        var el = RepeatButton("Tick", () => { }).Command(cmd);
+
+        Assert.Null(el.OnClick);
+        Assert.Same(cmd, el.Command);
+    }
+
+    [Fact]
+    public void Command_Modifier_Clears_Conflicting_ToggleButton_Callbacks_Command_Wins()
+    {
+        int toggleCount = 0, cmdCount = 0;
+        var cmd = new Command { Label = "Bold", Execute = () => cmdCount++ };
+
+        var el = ToggleButton("Bold", onIsCheckedChanged: _ => toggleCount++).Command(cmd);
+
+        Assert.Null(el.OnIsCheckedChanged);   // both toggle callbacks cleared
+        Assert.Null(el.OnCheckedStateChanged);
+        Assert.Same(cmd, el.Command);
+        CommandBindings.Invoke(el.Command!);
+        Assert.Equal(1, cmdCount);
+        Assert.Equal(0, toggleCount);
+    }
+
+    [Fact]
+    public void Command_Modifier_Clears_ThreeState_Toggle_Callback()
+    {
+        // ThreeStateToggleButton sets OnCheckedStateChanged; .Command() clears it (and
+        // OnIsCheckedChanged) so the command takes over dispatch.
+        var cmd = new Command { Label = "Tri", Execute = () => { } };
+
+        var el = ThreeStateToggleButton("Tri", onCheckedStateChanged: _ => { }).Command(cmd);
+
+        Assert.Null(el.OnCheckedStateChanged);
+        Assert.Null(el.OnIsCheckedChanged);
+        Assert.Same(cmd, el.Command);
+    }
 }

--- a/tests/Reactor.Tests/Elements/CommandModifierTests.cs
+++ b/tests/Reactor.Tests/Elements/CommandModifierTests.cs
@@ -297,25 +297,34 @@ public class CommandModifierTests
     }
 
     [Fact]
-    public void Command_Modifier_Clears_Conflicting_HyperlinkButton_OnClick()
+    public void Command_Modifier_Clears_Conflicting_HyperlinkButton_OnClick_Command_Wins()
     {
-        var cmd = new Command { Label = "Go", Execute = () => { } };
+        int onClickCount = 0, cmdCount = 0;
+        var cmd = new Command { Label = "Go", Execute = () => cmdCount++ };
 
-        var el = HyperlinkButton("Go", onClick: () => { }).Command(cmd);
+        var el = HyperlinkButton("Go", onClick: () => onClickCount++).Command(cmd);
 
-        Assert.Null(el.OnClick);
+        Assert.Null(el.OnClick);              // the modifier cleared the conflicting click handler
         Assert.Same(cmd, el.Command);
+        // OnClick null ⇒ the click trampoline invokes the command, not the original onClick.
+        CommandBindings.Invoke(el.Command!);
+        Assert.Equal(1, cmdCount);
+        Assert.Equal(0, onClickCount);
     }
 
     [Fact]
-    public void Command_Modifier_Clears_Conflicting_RepeatButton_OnClick()
+    public void Command_Modifier_Clears_Conflicting_RepeatButton_OnClick_Command_Wins()
     {
-        var cmd = new Command { Label = "Tick", Execute = () => { } };
+        int onClickCount = 0, cmdCount = 0;
+        var cmd = new Command { Label = "Tick", Execute = () => cmdCount++ };
 
-        var el = RepeatButton("Tick", () => { }).Command(cmd);
+        var el = RepeatButton("Tick", () => onClickCount++).Command(cmd);
 
         Assert.Null(el.OnClick);
         Assert.Same(cmd, el.Command);
+        CommandBindings.Invoke(el.Command!);
+        Assert.Equal(1, cmdCount);
+        Assert.Equal(0, onClickCount);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #637.

Deferred **"Option A"** follow-up to #153 (PR #634, merged). Makes **every** path that sets the typed `Command` property on the six command-capable button elements — `ButtonElement`, `HyperlinkButtonElement`, `RepeatButtonElement`, `ToggleButtonElement`, `SplitButtonElement`, `ToggleSplitButtonElement` — fully equivalent. A bare `new XxxElement { Command = cmd }` / `with { Command = cmd }` now **invokes the command on click/toggle AND applies IsEnabled**, exactly like the `Xxx(cmd)` factory or `.Command(cmd)` modifier. This closes the prior metadata-only "silent footgun" (where a bare record-init carried Description/Accelerator/AccessKey/IsEnabled but never dispatched) and makes the `Command` `init` accessor **public again**.

## Mechanism — Option A (dispatch via the typed Command; drop the baked closure)
Rather than the factory/modifier pre-baking `OnClick = () => CommandBindings.Invoke(cmd)` (+ `IsEnabled = cmd.IsEnabled`), dispatch + IsEnabled + metadata all flow from the typed `Command`:

- **Trampolines** invoke the user callback first (`OnClick` / toggle callbacks), falling back to `CommandBindings.Invoke(Command)` when it is null.
- **`HasCallbacks`** now treats `Command is not null` as a callback source, so the fast-path Tag is set on mount and refreshed on the fast path. The **set of tagged buttons is identical to before** — command buttons were already tagged via the factory's baked `OnClick`, so #153's Tag-refresh fast path is unchanged.
- **Subscription gates** (`HandCodedEvent.callbackPresent` / `Controlled.callback`) include a new `CommandBindings.Invokable(Command)` helper (`Execute ?? ExecuteAsync`, else `null`) — a command with neither delegate stays unsubscribed at zero cost while its metadata still flows.
- **HyperlinkButton / RepeatButton** convert from an auto-surfaced `Click→OnClick` event to a `HandCodedEvent` (`Exclude "Click"`, reusing the previously-unused payload types) so a Command-only binding still dispatches.
- **ToggleSplitButton** falls back to the command in its `Controlled` `callback` getter (the `new Action<bool>` is off the fast path — only allocated on mount / non-fast-path update / user toggle, never on the unchanged-command reconcile).

### Button's `IsDisabledFocusable` coercion — preserved exactly
`ButtonElement` keeps `OneWayCommand(applyIsEnabled: false)` and folds the command's enabled state into a new `EffectiveIsEnabled => IsEnabled && (Command?.IsEnabled ?? true)`, which the IsEnabled `OneWayConditional` `get` reads. The `shouldWrite: !IsDisabledFocusable` gate and the `IsDisabledFocusable` `OneWay` handler (sets `IsEnabled=true` + `Opacity=0.4`) are **untouched**. So a disabled-focusable button with a disabled command stays `IsEnabled=true` (reachable via Tab) and dimmed, and the click trampoline's `IsDisabledFocusable` early-return suppresses the command. The other five drive IsEnabled via `OneWayCommand(applyIsEnabled: true)` → `ApplyButtonBaseCommon` on mount and update, so the bare-init path already applies IsEnabled for them.

## Performance — #153 win preserved (and improved)
Per-construct allocation is **halved**, measured on ARM64 (`GC.GetAllocatedBytesForCurrentThread`, 100k iters):

| Element | pre-#637 | after (factory) | after (bare-init) |
|---|---|---|---|
| Button | 176 B | **88 B** | **88 B** |
| ToggleButton | 176 B | **88 B** | **88 B** |
| ToggleSplitButton | 176 B | **88 B** | **88 B** |
| HyperlinkButton | 168 B | **80 B** | **80 B** |
| RepeatButton | 168 B | **80 B** | **80 B** |
| SplitButton | 168 B | **80 B** | **80 B** |

Removing the baked `OnClick` closure (≈88 B: display class + delegate) eliminates one allocation, and **factory == bare-init** (no extra closure on either path) confirms full uniformity. `ShallowEquals` is **not touched** — it still compares `CommandsEqual(a.Command, b.Command)` and short-circuits the unchanged-command reconcile before the descriptor runs. Guards: a `< 140 B` budget unit test (`Button_Command_PerConstruct_Allocation_UnderBudget`, which the old 176 B would fail) and the `BoundButtonUnchangedCommandSkipsReapply` selftest (proves the reconciler skips the command re-apply on a structurally-equal-modulo-delegates re-render).

## Tests
- **Unit** (`tests/Reactor.Tests`): updated `CommandDslTests`, `CommandingCoverageTests`, `DslFactoryLogicTests`, `CommandTypedPropertyTests`, `CommandModifierTests` to the new dispatch model (OnClick/OnIsCheckedChanged are `null`; dispatch asserted via `CommandBindings.Invoke(el.Command!)`; IsEnabled via `EffectiveIsEnabled`). Added bare-init / `with` equivalence + `HasCallbacks` transition coverage. **Full suite green: 9710 passed, 0 failed.**
- **Selftests** (`tests/Reactor.AppTests.Host`): 7 new bare-record-init fixtures that mount real controls and raise real Click/Toggle events — `BareInitButtonCommandInvokesExecute`, `BareInitToggleButtonCommandFiresOnToggle`, `WithCommandButtonInvokesExecute`, `BareInitButtonDisabledCommandDisablesControl`, `BareInitButtonDisabledFocusableCoercionPreserved`, `BareInitHyperlinkRepeatSplitInvokeExecute`, `BareInitAllElementsApplyDisabledFromCommand`. Full selftest suite: **0 failures**.

Core Reactor library builds clean (AOT/trim warnings-as-errors). API snapshot files regenerated to show `Command { get; init; }` public on all six.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>