### PR TITLE
perf-harness: add M14 DSL-cascade alloc micro (instrument for #665 diff-skip + DSL allocs)

### DIFF
--- a/tests/perf_bench/PerfBench.ControlModel/Benches/AllBenches.cs
+++ b/tests/perf_bench/PerfBench.ControlModel/Benches/AllBenches.cs
@@ -897,6 +897,212 @@ public sealed class C207_ChangeHandlerDpRead : IBench
     }
 }
 
+/// <summary>
+/// M14 — <c>Dsl_Rebuild_Cascade</c>. Rebuild a moderate leaf tree through a DEEP
+/// fluent-modifier cascade (typed layout + visual modifiers AND a <c>.Set(...)</c>
+/// setter) on EVERY iteration with no memoization, then reconcile it against the
+/// structurally-equal prior tree.
+///
+/// <para>
+/// Instrument for PR #665 ("restore diff skip-path + cut DSL/element per-render
+/// allocations"). The macro (StocksGrid) leg memoizes unchanged cells and writes
+/// <c>new TextBlockElement{…}</c> initializers, BYPASSING the fluent cascade; and
+/// none of the M1–M13 / OAlloc / OUpdate micros rebuild a deep fluent + <c>.Set()</c>
+/// tree and re-diff it against an equal prior tree. So #665's two effects had no
+/// sensitive instrument:
+/// </para>
+/// <list type="number">
+///   <item><b>DSL alloc cut</b> — each chained layout/visual modifier
+///     (<c>.Foreground().Padding().Margin().Width().Height()</c>) merges its delta
+///     into the <c>Layout</c> / <c>Visual</c> bucket instead of allocating a
+///     throwaway parent <see cref="ElementModifiers"/> per step. Rebuilding the whole
+///     tree every op makes that per-step <see cref="ElementModifiers"/> churn the
+///     dominant, robustly-measured allocation, so M14's allocated-bytes/op drops
+///     when #665 is applied.</item>
+///   <item><b>SettersEqual diff-skip</b> — the <c>.Set(…)</c> on each cell drives the
+///     reconciler down the <c>Setters</c>-array comparison arm that #665 reroutes
+///     from a raw <c>ReferenceEquals</c> through <c>SettersEqual</c>, so the skip-path
+///     restore is exercised on every re-diff.</item>
+/// </list>
+///
+/// <para>
+/// Most cells stay structurally unchanged across iterations (a rotating ~1/16 are
+/// mutated) so the equal-tree re-diff is the common case — the same way
+/// <see cref="OptionalReconcilerUpdateBench"/> (OUpdate) isolates a controlled-prop
+/// update the macro buries. This bench changes no framework behavior; it only adds a
+/// measurement surface.
+/// </para>
+/// </summary>
+public sealed class M14_DslRebuildCascade : IBench
+{
+    public string Id => "M14";
+    public string Name => "Dsl_Rebuild_Cascade";
+
+    // Moderate leaf count (spec window 200–500). Big enough that the per-step
+    // ElementModifiers churn dominates the alloc signal, small enough that the
+    // reconcile stays comfortably inside the micro per-round budget.
+    private const int TreeSize = 300;
+
+    // A rotating ~1/16 of cells flip their text each iteration; the rest are
+    // rebuilt structurally identical so SettersEqual / ShallowEquals see an equal
+    // prior tree (the case #665 targets).
+    private const int MutateStride = 16;
+
+    public void RunOne(BenchVariant variant, BenchContext ctx)
+    {
+        var fixture = ctx.Scratch as Fixture;
+        if (fixture is null)
+        {
+            // First iteration of each repetition: build + mount the initial tree.
+            // Negligible (1 of N) against the measured rebuild/reconcile loop.
+            fixture = new Fixture(ctx, variant);
+            ctx.Scratch = fixture;
+            return;
+        }
+
+        if (variant == BenchVariant.Direct)
+            fixture.RebuildDirect(ctx);
+        else
+            fixture.RebuildAndReconcile(ctx);
+    }
+
+    public void DemoMount(BenchVariant variant, BenchContext ctx)
+    {
+        var stack = new StackPanel { Orientation = Orientation.Vertical };
+        stack.Children.Add(new TextBlock
+        {
+            Text = $"M14 {variant}: deep DSL cascade + .Set ×{TreeSize}, rebuilt & reconciled",
+            FontSize = 16,
+        });
+        const int demoCells = 6;
+        for (int i = 0; i < demoCells; i++)
+        {
+            if (variant == BenchVariant.Direct)
+            {
+                var tb = new TextBlock();
+                ApplyDirect(tb, Texts[i]);
+                stack.Children.Add(tb);
+            }
+            else
+            {
+                var ui = ctx.Reconciler.Mount(BuildCell(i, mutated: false), NoOp);
+                if (ui is not null) stack.Children.Add(ui);
+            }
+        }
+        ctx.Parent.Children.Add(stack);
+    }
+
+    // Shared, cached brush so .Foreground(brush) binds the Brush overload (not the
+    // color-string parser) and reuses one instance across cells/iterations — the
+    // cascade's allocation profile stays dominated by the ElementModifiers churn
+    // #665 targets, and ModifiersEqual sees an unchanged Foreground on re-diff.
+    private static readonly Microsoft.UI.Xaml.Media.Brush CellBrush =
+        new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.SteelBlue);
+
+    // Non-capturing setter — the compiler caches it as a static singleton, so .Set
+    // allocates only the fresh Setters array (the path #665's SettersEqual arm
+    // compares), not a per-call delegate.
+    private static readonly Action<TextBlock> WrapSetter =
+        static tb => tb.TextWrapping = TextWrapping.NoWrap;
+
+    private static readonly string[] Texts =
+        Enumerable.Range(0, TreeSize).Select(static i => "row-" + i).ToArray();
+
+    // Build one leaf through the deep fluent cascade. Layout-bucket modifiers
+    // (.Padding/.Margin/.Width/.Height) + a visual-bucket modifier (.Foreground)
+    // are exactly the chained steps #665 reroutes off the throwaway-ElementModifiers
+    // path; FontSize/Bold/Opacity round out the cascade and the .Set hits the
+    // Setters-array arm.
+    private static TextBlockElement BuildCell(int index, bool mutated)
+    {
+        var text = mutated ? "row-*" : Texts[index];
+        return TextBlock(text)
+            .FontSize(14)
+            .Bold()
+            .Foreground(CellBrush)
+            .Padding(4, 2)
+            .Margin(2, 1)
+            .Width(120)
+            .Height(20)
+            .Opacity(0.99)
+            .Set(WrapSetter);
+    }
+
+    private static void ApplyDirect(TextBlock tb, string text)
+    {
+        // Imperative floor: the same property writes a hand-coded (no-Reactor) view
+        // would do, so the Direct variant is a fair lower bound for the cascade.
+        tb.Text = text;
+        tb.FontSize = 14;
+        tb.FontWeight = Microsoft.UI.Text.FontWeights.Bold;
+        tb.Foreground = CellBrush;
+        tb.Padding = new Thickness(4, 2, 4, 2);
+        tb.Margin = new Thickness(2, 1, 2, 1);
+        tb.Width = 120;
+        tb.Height = 20;
+        tb.Opacity = 0.99;
+        tb.TextWrapping = TextWrapping.NoWrap;
+    }
+
+    private sealed class Fixture
+    {
+        // Reactor variants thread the prior element tree so each iteration diffs
+        // fresh-vs-prior; Direct has no element tree (null) and re-applies props.
+        private readonly TextBlockElement[]? _elements;
+        private readonly UIElement[] _controls;
+
+        public Fixture(BenchContext ctx, BenchVariant variant)
+        {
+            _controls = new UIElement[TreeSize];
+            if (variant == BenchVariant.Direct)
+            {
+                for (int i = 0; i < TreeSize; i++)
+                {
+                    var tb = new TextBlock();
+                    ApplyDirect(tb, Texts[i]);
+                    _controls[i] = tb;
+                    ctx.Parent.Children.Add(tb);
+                }
+            }
+            else
+            {
+                _elements = new TextBlockElement[TreeSize];
+                for (int i = 0; i < TreeSize; i++)
+                {
+                    var el = BuildCell(i, mutated: false);
+                    _elements[i] = el;
+                    var ui = ctx.Reconciler.Mount(el, NoOp);
+                    if (ui is not null) { _controls[i] = ui; ctx.Parent.Children.Add(ui); }
+                }
+            }
+        }
+
+        public void RebuildAndReconcile(BenchContext ctx)
+        {
+            var elements = _elements!;
+            for (int i = 0; i < TreeSize; i++)
+            {
+                bool mutated = ((i + ctx.Iteration) % MutateStride) == 0;
+                var fresh = BuildCell(i, mutated);
+                ctx.Reconciler.UpdateChild(elements[i], fresh, _controls[i], NoOp);
+                elements[i] = fresh;
+            }
+        }
+
+        public void RebuildDirect(BenchContext ctx)
+        {
+            for (int i = 0; i < TreeSize; i++)
+            {
+                bool mutated = ((i + ctx.Iteration) % MutateStride) == 0;
+                if (_controls[i] is TextBlock tb)
+                    ApplyDirect(tb, mutated ? "row-*" : Texts[i]);
+            }
+        }
+    }
+
+    private static readonly Action NoOp = static () => { };
+}
+
 public static class BenchCatalog
 {
     public static IReadOnlyList<IBench> All { get; } = new IBench[]
@@ -917,5 +1123,6 @@ public static class BenchCatalog
         new OptionalElementAllocBench(),
         new OptionalReconcilerUpdateBench(),
         new C207_ChangeHandlerDpRead(),
+        new M14_DslRebuildCascade(),
     };
 }

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -952,7 +952,7 @@ try {
     # absent (the #693 regression: a per-round timeout dropped the whole section and it went
     # unnoticed for the PR's entire life). Three render contracts:
     #   (1) rows present & complete (4/4)   -> no note (the happy path above);
-    #   (2) rows present but < canonical 16 -> a "N/16 Incomplete" warning above the table;
+    #   (2) rows present but < the expected count -> a "N/<expected> Incomplete" warning above the table;
     #   (3) null rows + an omit reason      -> a visible "omitted this run -- <reason>" callout;
     #   (4) null rows + no reason           -> still silent (the leg was simply not requested).
     Assert-True (-not $sectionText.Contains('Incomplete'))       'complete render (4/4 benches): no incompleteness note'
@@ -965,7 +965,7 @@ try {
     # Default-count resolution (the production call shape): Format-PerfComment never passes
     # -ExpectedCount, so the default MUST resolve to $script:MicroExpectedBenchCount. A wrong
     # default (the 13 this PR fixed) would silently mis-label a real 13-of-16 run as complete.
-    Assert-Equal 16 $script:MicroExpectedBenchCount             'canonical micro bench count is the full 16-bench emitted set (M1-M13 + 3 supplementary)'
+    Assert-Equal 17 $script:MicroExpectedBenchCount             'canonical micro bench count is the full 17-bench emitted set (M1-M14 + 3 supplementary)'
     $defaultText = (Format-PerfMicroSection -Micro $cmp) -join "`n"
     Assert-Match $defaultText 'Incomplete'                       'default-count render: a 4-row run is incomplete vs the canonical full suite'
     Assert-Match $defaultText "4/$($script:MicroExpectedBenchCount)" 'default-count render: denominator is the script-scoped canonical count, not a literal'
@@ -991,7 +991,7 @@ try {
     $catalogInit = [regex]::Match($catalogSrc, '(?s)All\s*\{\s*get;\s*\}\s*=\s*new\s+IBench\[\]\s*\{(.*?)\};')
     Assert-True $catalogInit.Success 'drift guard: located the BenchCatalog.All initializer block'
     $catalogCount = ([regex]::Matches($catalogInit.Groups[1].Value, 'new\s+\w+\s*\(')).Count
-    Assert-Equal 16 $catalogCount                               'drift guard: BenchCatalog.All declares 16 benches (M1-M13 + OAlloc/OUpdate/C207)'
+    Assert-Equal 17 $catalogCount                               'drift guard: BenchCatalog.All declares 17 benches (M1-M13 + OAlloc/OUpdate/C207 + M14)'
     Assert-Equal $script:MicroExpectedBenchCount $catalogCount  'drift guard: $script:MicroExpectedBenchCount matches the C# catalog count (no silent drift)'
 
     # Format-PerfComment threads -Micro through into the comment.

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -86,7 +86,8 @@ $script:MicroNsMinEffectPct = 3.0
 $script:MicroNsAutoFlag = $false
 
 # Canonical reconciler micro-suite size: the FULL emitted comparison set. That is the
-# spec-047 M1-M13 set PLUS 3 supplementary benches (ids OAlloc / OUpdate / C207) that
+# spec-047 M1-M13 set, the M14 DSL-cascade alloc instrument (PR #665), PLUS 3 supplementary
+# benches (ids OAlloc / OUpdate / C207) that
 # BenchCatalog.All also runs for `--variant Reactor`. The source of truth is
 # tests/perf_bench/PerfBench.ControlModel/Benches/AllBenches.cs (BenchCatalog.All); there is
 # NO bench-id allowlist in Read-MicroBenchResults, so every Reactor 'ok' row is compared and a
@@ -96,7 +97,7 @@ $script:MicroNsAutoFlag = $false
 # is indistinguishable from a clean full run. A drift-guard test (RunPerfBenchmark.Tests)
 # asserts this equals the BenchCatalog.All count so the two can't silently diverge -- keep them
 # in sync when the suite changes.
-$script:MicroExpectedBenchCount = 16
+$script:MicroExpectedBenchCount = 17
 
 function ConvertTo-PerfDouble {
     <#

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -79,8 +79,8 @@
 
 .PARAMETER MicroIterations
     Inner iterations per micro repetition (default 1000) over which each bench's
-    mean ns/op and allocated bytes/op are averaged. The suite runs 16 benches
-    (the spec-047 M1&ndash;M13 set plus 3 supplementary) and the heaviest
+    mean ns/op and allocated bytes/op are averaged. The suite runs 17 benches
+    (the spec-047 M1&ndash;M14 set plus 3 supplementary) and the heaviest
     (M7&ndash;M9 reconcile a 1000-node tree per op) run >=120 us/op,
     so even 1000 iterations keep each per-rep mean >=120 ms &mdash; hundreds of
     thousands of times the Stopwatch floor &mdash; while letting each per-round
@@ -89,7 +89,7 @@
 
 .PARAMETER MicroRepTimeoutSec
     Per-round launch timeout in seconds for one micro side (default 180). Each
-    interleaved round runs the 16-bench suite once (one inner --reps) per side; a
+    interleaved round runs the 17-bench suite once (one inner --reps) per side; a
     round that exceeds this is dropped on BOTH sides to keep the rep indices
     aligned. Replaces the old whole-suite timeout that silently truncated the
     suite to M1&ndash;M4.
@@ -690,7 +690,7 @@ function Invoke-MicroRun {
     $microArgs = @('--variant', 'Reactor', '--reps', $RepCount.ToString($inv),
         '--iterations', $IterCount.ToString($inv), '--out', $outJson, '--headless')
     # Per-launch budget. When the interleaver calls this with -RepCount 1 the launch runs
-    # the 16-bench suite once (each bench still does its own internal warmup + one timed
+    # the 17-bench suite once (each bench still does its own internal warmup + one timed
     # rep), so the default 180s the caller passes is sized with wide headroom over the
     # tens of seconds a single round needs at 2000 iters, while a genuine hang is still
     # bounded. (At 420s with 10000 iterations the whole-suite single launch timed out


### PR DESCRIPTION
## What this is

A new reconciler micro-benchmark — **M14 `Dsl_Rebuild_Cascade`** — added to the `PerfBench.ControlModel` suite. **It is a measurement instrument, not a perf change.** It contains no `src/Reactor` edits; it only adds a bench that can finally *resolve* the allocation/diff-skip effects of **#665** ("perf: restore diff skip-path + cut DSL/element per-render allocations").

This is the **#665 analogue of #694** — the keyed-list workload that converted #657 from "not-exercised" into a clean, measurable alloc win.

## Why #665 needs a new instrument

#665 has two effects, both in the element-construction / diff path:
1. **DSL/element per-render alloc cut** — chained layout/visual modifiers merge their delta into the `Layout`/`Visual` bucket instead of allocating a throwaway parent `ElementModifiers` per step.
2. **SettersEqual diff-skip restore** — routes ~51 `ShallowEquals` arms through `SettersEqual` instead of raw `ReferenceEquals(Setters)`.

Every existing instrument is blind to it:
- The **StocksGrid macro** memoizes unchanged cells (`UseMemoCellsByIndex`) and uses `new TextBlockElement{…}` initializers — it **bypasses the fluent cascade**, pre-empting both effects.
- **No M1–M13 / OAlloc / OUpdate micro** rebuilds a deep fluent + `.Set()` element tree and re-diffs it against a structurally-equal prior tree.

## What M14 does

In the **Reactor** variant it builds a 300-leaf tree where each cell is constructed through a deep fluent cascade — `.FontSize().Bold().Foreground(brush).Padding().Margin().Width().Height().Opacity().Set(...)` — exercising both the layout/visual bucket modifiers (#665 effect 1) and the `Setters`-array arm (#665 effect 2). It mounts once, then on every measured iteration **rebuilds the identical tree (no memo)** and reconciles it against the prior tree, with a rotating ~1/16 of cells mutated. `Direct` (imperative property writes) and `ReactorToday` variants match the sibling benches' shape.

The harness brackets each bench with per-thread alloc + GC counters, so the rebuild churn surfaces as a deterministic **allocated-bytes/op** signal.

## Local sensitivity read — M14 *responds* to #665

Applying only #665's 4 `src/` files on top of this branch, measuring M14, then reverting (Reactor variant, `--iterations 1000`, Release ARM64):

| | alloc B/op (median of 3 reps) | mean ns/op |
|---|---:|---:|
| WITHOUT #665 | 3,500,897 | 1,343,577 |
| WITH #665 | 2,816,897 | 1,061,748 |
| **Δ** | **−684,000 (−19.5%)** | **−21%** |

The delta was **exactly 684,000,000 B over 1000 iters on every repetition** — a clean, deterministic signal that M14 resolves #665's DSL-cascade allocation cut. (#665's source is **not** included in this PR; it was applied only to take this reading, then reverted. src/ is untouched.)

## Scope / guard

- Registers `M14_DslRebuildCascade` in `BenchCatalog.All` (now 17 benches).
- Bumps the loud-incompleteness guard `MicroExpectedBenchCount` 16 → 17 and its drift-guard test, so the new bench doesn't trip a false "N/16 Incomplete" note.
- Purely additive harness/test code under `tests/`; **no `src/Reactor` changes**.

## Validation
- `dotnet build PerfBench.ControlModel` — 0 warnings / 0 errors.
- M14 runs headless, emits alloc-bytes/op for all three variants (Direct / ReactorToday / Reactor).
- `PerfLib.Tests.ps1` (283) + `RunPerfBenchmark.Tests.ps1` (76) green — the 17-count drift guard passes.
- `dotnet test tests/Reactor.Tests` — 9702 passed, 0 failed, 64 skipped.

> **Draft on purpose.** This is the instrument; the rigorous CI measurement of #665 against M14 is routed to a separate session. Do not merge.