### PR TITLE
ci: allow Coverage workflow to be triggered manually

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: Coverage
 # Maintainer-gated coverage run for any PR (including forks). Trigger it either by
 # commenting `@codecoverage` on a PR, or by running the workflow manually from the
 # Actions tab (or `gh workflow run`) with the target PR number. Either way it runs
-# the merged unit + selftest coverage recipe from CONTRIBUTING.md and posts the
+# the merged unit + selftest coverage recipe from TESTING.md and posts the
 # result back to the PR as a comment.
 #
 # Security: `issue_comment` workflows run in the base repo with full token
@@ -22,12 +22,6 @@ on:
         required: true
         type: string
 
-# One in-flight run per PR; a newer trigger (comment or dispatch) supersedes an
-# older one for the same PR.
-concurrency:
-  group: coverage-${{ github.event.issue.number || github.event.inputs.pr_number }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write
@@ -35,9 +29,17 @@ permissions:
 jobs:
   coverage:
     name: Merged coverage
+    # One in-flight run per PR; a newer trigger (comment or dispatch) supersedes an
+    # older one. Job-level (not workflow-level) concurrency so that unrelated
+    # issue_comment events — which start a workflow run but skip this job — don't
+    # cancel a live coverage run for the same PR.
+    concurrency:
+      group: coverage-${{ github.event.issue.number || github.event.inputs.pr_number }}
+      cancel-in-progress: true
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event.issue.pull_request &&
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
        contains(github.event.comment.body, '@codecoverage') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: windows-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -65,10 +65,13 @@ jobs:
           script: |
             let prNumber;
             if (context.eventName === 'workflow_dispatch') {
-              const raw = (process.env.DISPATCH_PR || '').trim();
-              // Digits-only, no leading zero — reject '12abc', '0012', '12.9', ''.
+              // Validate the raw input without trimming: it must be exactly a
+              // positive integer (no leading zeros or surrounding whitespace) so the
+              // resolved PR stays identical to the raw value the job-level
+              // concurrency group keys on (github.event.inputs.pr_number).
+              const raw = process.env.DISPATCH_PR || '';
               if (!/^[1-9][0-9]*$/.test(raw)) {
-                throw new Error(`Invalid PR number input (expected digits, got '${process.env.DISPATCH_PR}')`);
+                throw new Error(`Invalid pr_number input '${process.env.DISPATCH_PR}' (expected a positive integer with no leading zeros or whitespace)`);
               }
               prNumber = Number(raw);
             } else {

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ on:
     types: [created]
   workflow_dispatch:
     inputs:
-      pr:
+      pr_number:
         description: PR number to run merged coverage against
         required: true
         type: string
@@ -25,7 +25,7 @@ on:
 # One in-flight run per PR; a newer trigger (comment or dispatch) supersedes an
 # older one for the same PR.
 concurrency:
-  group: coverage-${{ github.event.issue.number || github.event.inputs.pr }}
+  group: coverage-${{ github.event.issue.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 permissions:
@@ -58,12 +58,20 @@ jobs:
         id: pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          DISPATCH_PR: ${{ github.event.inputs.pr }}
+          DISPATCH_PR: ${{ github.event.inputs.pr_number }}
         with:
           script: |
-            const prNumber = context.eventName === 'workflow_dispatch'
-              ? parseInt(process.env.DISPATCH_PR, 10)
-              : context.issue.number;
+            let prNumber;
+            if (context.eventName === 'workflow_dispatch') {
+              const raw = (process.env.DISPATCH_PR || '').trim();
+              // Digits-only, no leading zero — reject '12abc', '0012', '12.9', ''.
+              if (!/^[1-9][0-9]*$/.test(raw)) {
+                throw new Error(`Invalid PR number input (expected digits, got '${process.env.DISPATCH_PR}')`);
+              }
+              prNumber = Number(raw);
+            } else {
+              prNumber = context.issue.number;
+            }
             if (!Number.isInteger(prNumber) || prNumber <= 0) {
               throw new Error(`Could not resolve a valid PR number (got '${process.env.DISPATCH_PR ?? context.issue.number}')`);
             }

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,18 +1,32 @@
 name: Coverage
 
-# Maintainer-gated, comment-triggered coverage run for any PR (including forks).
-# A maintainer comments `@codecoverage` on a PR; this workflow runs the merged
-# unit + selftest coverage recipe from CONTRIBUTING.md and posts the result back
-# as a comment.
+# Maintainer-gated coverage run for any PR (including forks). Trigger it either by
+# commenting `@codecoverage` on a PR, or by running the workflow manually from the
+# Actions tab (or `gh workflow run`) with the target PR number. Either way it runs
+# the merged unit + selftest coverage recipe from CONTRIBUTING.md and posts the
+# result back to the PR as a comment.
 #
 # Security: `issue_comment` workflows run in the base repo with full token
 # permissions. Untrusted code from the PR (build scripts, tests) executes here.
-# The `author_association` check below limits the trigger to maintainers, who
-# are expected to review the diff before commenting.
+# The `author_association` check below limits the comment trigger to maintainers;
+# `workflow_dispatch` is inherently restricted to users with write access. Either
+# way, the triggerer is expected to review the PR diff before starting a run.
 
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to run merged coverage against
+        required: true
+        type: string
+
+# One in-flight run per PR; a newer trigger (comment or dispatch) supersedes an
+# older one for the same PR.
+concurrency:
+  group: coverage-${{ github.event.issue.number || github.event.inputs.pr }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -22,12 +36,14 @@ jobs:
   coverage:
     name: Merged coverage
     if: |
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '@codecoverage') &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@codecoverage') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: windows-latest
     steps:
       - name: Acknowledge with reaction
+        if: github.event_name == 'issue_comment'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -41,15 +57,26 @@ jobs:
       - name: Resolve PR head SHA
         id: pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DISPATCH_PR: ${{ github.event.inputs.pr }}
         with:
           script: |
+            const prNumber = context.eventName === 'workflow_dispatch'
+              ? parseInt(process.env.DISPATCH_PR, 10)
+              : context.issue.number;
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              throw new Error(`Could not resolve a valid PR number (got '${process.env.DISPATCH_PR ?? context.issue.number}')`);
+            }
+            // Emit the number before the API call so the always()-gated comment
+            // step can still report back to the PR if pulls.get below fails.
+            core.setOutput('number', String(prNumber));
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number,
+              pull_number: prNumber,
             });
             core.setOutput('sha', pr.data.head.sha);
-            core.setOutput('ref', `refs/pull/${context.issue.number}/head`);
+            core.setOutput('ref', `refs/pull/${prNumber}/head`);
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -145,14 +172,16 @@ jobs:
           BRANCHES_TOTAL: ${{ steps.rates.outputs.branches-total }}
           SHA: ${{ steps.pr.outputs.sha }}
           OUTCOME: ${{ job.status }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
-            const { LINE, BRANCH, BRANCHES_COVERED, BRANCHES_TOTAL, SHA, OUTCOME } = process.env;
+            const { LINE, BRANCH, BRANCHES_COVERED, BRANCHES_TOTAL, SHA, OUTCOME, PR_NUMBER } = process.env;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const shaLabel = SHA ? SHA.slice(0, 7) : 'unknown';
             let body;
             if (OUTCOME === 'success') {
               body = [
-                `**Merged coverage** for \`${SHA.slice(0, 7)}\` (unit + selftest)`,
+                `**Merged coverage** for \`${shaLabel}\` (unit + selftest)`,
                 ``,
                 `| Metric | Coverage |`,
                 `|---|---|`,
@@ -162,11 +191,16 @@ jobs:
                 `Cobertura reports attached to the [workflow run](${runUrl}) as artifacts.`,
               ].join('\n');
             } else {
-              body = `**Coverage run failed** for \`${SHA.slice(0, 7)}\` — see the [workflow run](${runUrl}) for details.`;
+              body = `**Coverage run failed** for \`${shaLabel}\` — see the [workflow run](${runUrl}) for details.`;
+            }
+            const prNumber = Number(PR_NUMBER);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.warning(`No PR number resolved; skipping result comment. Body was:\n${body}`);
+              return;
             }
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: prNumber,
               body,
             });

--- a/TESTING.md
+++ b/TESTING.md
@@ -230,3 +230,14 @@ dotnet-coverage merge unit.cobertura.xml selftest.cobertura.xml \
 ```
 
 Replace `$(RuntimeIdentifier)` with `ARM64` or `x64`, or omit the platform segment if you used the default platform from `Directory.Build.props`. The `coverage.settings.xml` file in the repo root controls which modules are included and excludes generated code (`obj/`, `*.g.cs`) and test-host scaffolding exercised only by the winapp/E2E runner.
+
+### Running coverage in CI
+
+You don't have to run the merge locally — the **Coverage** workflow
+(`.github/workflows/coverage.yml`) runs this same unit + selftest recipe against a
+PR and posts the merged line/branch numbers back as a PR comment. Trigger it either
+way:
+
+- **Comment trigger:** a maintainer comments `@codecoverage` on the PR.
+- **Manual trigger:** use **Actions → Coverage → Run workflow** and enter the PR
+  number, or from the CLI run `gh workflow run coverage.yml -f pr_number=<PR>`.


### PR DESCRIPTION
Fixes #735.

## Problem

The Coverage workflow (`.github/workflows/coverage.yml`) could only be started by a maintainer commenting `@codecoverage` on a PR (`issue_comment` trigger). There was no way to run it manually from the **Actions** tab or via `gh workflow run`.

## Fix

Mirror the dual-trigger pattern already used by the sibling `perf-compare.yml`:

- **Add a `workflow_dispatch` trigger** with a required `pr_number` input (the PR number to run merged coverage against).
- **Update the job gate** to allow `workflow_dispatch` in addition to the existing maintainer comment gate.
- **Resolve the PR number** from either the comment context or the dispatch input when looking up the head SHA and posting the result comment. The dispatch input is validated as digits-only before use, and the number is emitted before the `pulls.get` call so the `always()`-gated comment step can still report back if the lookup fails.
- **Guard the "acknowledge with reaction" step** so it only runs for `issue_comment`.
- **Add a per-PR concurrency group** so a manual run and a comment run for the same PR don't race.
- **Harden the result-comment step** against a missing SHA / PR number (e.g. a bad manual PR input).
- **Document both triggers** (comment + manual dispatch) in `TESTING.md`.

`workflow_dispatch` is inherently restricted to users with write access, so this doesn't weaken the existing maintainer gating.

## Validation

- `yaml.safe_load` parses the workflow; triggers are `issue_comment` + `workflow_dispatch`, input `pr_number` present.
- All three embedded `github-script` blocks pass `node --check`.

To run manually after merge: **Actions → Coverage → Run workflow**, enter the PR number; or `gh workflow run coverage.yml -f pr_number=<number>`.