### PR TITLE
perf(reconciler): SIMD-vectorize keyed-middle index shifts — recover #657 keyed-reconcile time, keep −30.9% alloc

### DIFF
--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Numerics;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Reactor.Core.Internal;
 using WinUI = Microsoft.UI.Xaml.Controls;
@@ -569,8 +570,7 @@ internal static class ChildReconciler
                 {
                     // Insertion at `anchor` shifts every tracked survivor at an
                     // index >= anchor one slot to the right.
-                    for (int r = 0; r < oldMidLen; r++)
-                        if (oldRelToPanel[r] >= anchor) oldRelToPanel[r]++;
+                    BumpAtOrAfter(oldRelToPanel, oldMidLen, anchor);
                     // The new control now occupies `anchor` and is the anchor for
                     // the next (left) item, so `anchor` itself is unchanged.
                 }
@@ -594,19 +594,13 @@ internal static class ChildReconciler
                     // between the two endpoints by one slot.
                     if (cur < to)
                     {
-                        for (int r = 0; r < oldMidLen; r++)
-                        {
-                            int p = oldRelToPanel[r];
-                            if (p > cur && p <= to) oldRelToPanel[r] = p - 1;
-                        }
+                        // Survivors in (cur, to] shift one left to close the gap.
+                        DecrementWhereGtLe(oldRelToPanel, oldMidLen, cur, to);
                     }
                     else
                     {
-                        for (int r = 0; r < oldMidLen; r++)
-                        {
-                            int p = oldRelToPanel[r];
-                            if (p >= to && p < cur) oldRelToPanel[r] = p + 1;
-                        }
+                        // Survivors in [to, cur) shift one right to open the gap.
+                        IncrementWhereGeLt(oldRelToPanel, oldMidLen, to, cur);
                     }
                     oldRelToPanel[oldRel] = to;
                     cur = to;
@@ -615,6 +609,101 @@ internal static class ChildReconciler
 
             sink.Patch(oldRel, i, cur);
             anchor = cur;
+        }
+    }
+
+    // ---- Vectorized survivor-position shifts (keyed-middle bookkeeping) -------
+    // RunKeyedMiddleCore keeps `oldRelToPanel` exact by shifting a band of
+    // survivor positions on every Insert/Move. At the keyed-grid scale those
+    // shifts are the per-frame hot loop (one full O(oldMidLen) pass per
+    // structural op); each is a branchless compare-and-conditional-±1 over an
+    // int[], so they vectorize cleanly with System.Numerics.Vector (SSE/AVX on
+    // x64, NEON on ARM64 — fully AOT/trim-safe, no reflection). Each helper is
+    // the EXACT scalar predicate applied Vector<int>.Count lanes at a time with
+    // a scalar remainder; the same scalar loop also runs verbatim when SIMD is
+    // unavailable (Vector.IsHardwareAccelerated == false) or the span is shorter
+    // than one vector — so the result is bit-identical to the original scalar
+    // loops on every platform. The masks exploit that the Vector.* comparisons
+    // return all-ones (-1) in matching lanes, so `v - mask` adds 1 and
+    // `v + mask` subtracts 1 exactly where the predicate holds; negative
+    // sentinels (-1, unrealized survivors) never satisfy any predicate and pass
+    // through untouched, matching the scalar code. ChildReconcilerKeyedMiddle
+    // SimdTests differentially asserts the emitted Move/Insert/Patch sequence
+    // equals a scalar reference over thousands of random + steady-state cases.
+
+    /// <summary>Add 1 to every <c>map[0..len)</c> entry that is
+    /// &gt;= <paramref name="threshold"/> — an insertion at
+    /// <paramref name="threshold"/> pushes survivors at or past it one slot
+    /// right. Vectorization of <c>if (p &gt;= threshold) p++</c>.</summary>
+    private static void BumpAtOrAfter(int[] map, int len, int threshold)
+    {
+        int r = 0;
+        if (Vector.IsHardwareAccelerated && len >= Vector<int>.Count)
+        {
+            int w = Vector<int>.Count;
+            var thr = new Vector<int>(threshold);
+            for (; r <= len - w; r += w)
+            {
+                var v = new Vector<int>(map, r);
+                var mask = Vector.GreaterThanOrEqual(v, thr); // -1 where p >= threshold
+                (v - mask).CopyTo(map, r);                    // subtract -1 == +1
+            }
+        }
+        for (; r < len; r++)
+            if (map[r] >= threshold) map[r]++;
+    }
+
+    /// <summary>Subtract 1 from every <c>map[0..len)</c> entry in the half-open
+    /// band <c>(lo, hi]</c> — the survivors a left-to-right Move steps over,
+    /// closing the vacated gap. Vectorization of
+    /// <c>if (p &gt; lo &amp;&amp; p &lt;= hi) p--</c>.</summary>
+    private static void DecrementWhereGtLe(int[] map, int len, int lo, int hi)
+    {
+        int r = 0;
+        if (Vector.IsHardwareAccelerated && len >= Vector<int>.Count)
+        {
+            int w = Vector<int>.Count;
+            var loV = new Vector<int>(lo);
+            var hiV = new Vector<int>(hi);
+            for (; r <= len - w; r += w)
+            {
+                var v = new Vector<int>(map, r);
+                // -1 where (p > lo) AND (p <= hi); add the mask to subtract 1.
+                var mask = Vector.GreaterThan(v, loV) & Vector.LessThanOrEqual(v, hiV);
+                (v + mask).CopyTo(map, r);
+            }
+        }
+        for (; r < len; r++)
+        {
+            int p = map[r];
+            if (p > lo && p <= hi) map[r] = p - 1;
+        }
+    }
+
+    /// <summary>Add 1 to every <c>map[0..len)</c> entry in the half-open band
+    /// <c>[lo, hi)</c> — the survivors a right-to-left Move steps over, opening
+    /// the gap. Vectorization of
+    /// <c>if (p &gt;= lo &amp;&amp; p &lt; hi) p++</c>.</summary>
+    private static void IncrementWhereGeLt(int[] map, int len, int lo, int hi)
+    {
+        int r = 0;
+        if (Vector.IsHardwareAccelerated && len >= Vector<int>.Count)
+        {
+            int w = Vector<int>.Count;
+            var loV = new Vector<int>(lo);
+            var hiV = new Vector<int>(hi);
+            for (; r <= len - w; r += w)
+            {
+                var v = new Vector<int>(map, r);
+                // -1 where (p >= lo) AND (p < hi); subtract the mask to add 1.
+                var mask = Vector.GreaterThanOrEqual(v, loV) & Vector.LessThan(v, hiV);
+                (v - mask).CopyTo(map, r);
+            }
+        }
+        for (; r < len; r++)
+        {
+            int p = map[r];
+            if (p >= lo && p < hi) map[r] = p + 1;
         }
     }
 

--- a/tests/Reactor.Tests/ChildReconcilerKeyedMiddleSimdTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerKeyedMiddleSimdTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using Microsoft.UI.Reactor.Core;
 using Xunit;
 
@@ -232,6 +233,15 @@ public class ChildReconcilerKeyedMiddleSimdTests
         var refk = new DiffSink { Cells = new List<Cell>(m.CellsBase), Ops = new List<Op>() };
         RunScalarReference(ref refk, m.NewToOld, m.InLis, m.NewMidLen, m.OldMidLen, m.InitialAnchor, refPanel);
 
+        // Tighter, localized guard: the survivor-position model itself must end
+        // identical, not just the ops/cells it drove. This pinpoints a
+        // bookkeeping divergence (e.g. a SIMD remainder-tail bug) even in a case
+        // where it didn't (yet) change an emitted op.
+        Assert.True(prodPanel.Length == refPanel.Length, $"case {caseId}: panel-length mismatch");
+        for (int r = 0; r < prodPanel.Length; r++)
+            Assert.True(prodPanel[r] == refPanel[r],
+                $"case {caseId}: oldRelToPanel[{r}] {prodPanel[r]} (simd) vs {refPanel[r]} (scalar)");
+
         Assert.True(prod.Ops.Count == refk.Ops.Count,
             $"case {caseId}: op-count {prod.Ops.Count} (simd) vs {refk.Ops.Count} (scalar)");
         for (int o = 0; o < prod.Ops.Count; o++)
@@ -379,6 +389,80 @@ public class ChildReconcilerKeyedMiddleSimdTests
         var model = BuildModel(Parse(oldCsv), Parse(newCsv));
         var (cells, _) = RunBothAndCompare(model, 0);
         AssertInvariants(model, cells);
+    }
+
+    /// <summary>
+    /// Pin the SIMD/scalar seam explicitly at every length around the vector
+    /// width — <c>oldMidLen</c> = 0, 1, w−1, w, w+1, 2w, 2w+1 (w =
+    /// <see cref="Vector{T}.Count"/>, computed at runtime so this is correct on
+    /// both the ARM64 dev box (NEON, w=4) and the x64 CI runner (AVX2, w=8)).
+    /// The sub-w lengths take the pure-scalar <c>len &lt; width</c> fallback; the
+    /// w+1 / 2w+1 lengths run one (or two) full SIMD chunk(s) plus a 1-element
+    /// remainder tail — the exact seam where a vectorized remainder bug hides.
+    /// Each constructed pair has no common prefix/suffix, so <c>oldMidLen</c>
+    /// equals the old length (asserted), and each forces real Insert/Move shifts
+    /// so the helpers actually run at that length.
+    /// </summary>
+    [Fact]
+    public void Simd_Matches_Scalar_At_Vector_Width_Boundaries()
+    {
+        int w = Vector<int>.Count;
+        var lengths = new SortedSet<int> { 0, 1, w - 1, w, w + 1, 2 * w, 2 * w + 1 };
+
+        int caseId = 0;
+        foreach (int L in lengths)
+        {
+            foreach (var (oldKeys, newKeys) in BoundaryPairs(L))
+            {
+                var model = BuildModel(oldKeys, newKeys);
+                Assert.True(model.OldMidLen == L, $"L={L}: built oldMidLen={model.OldMidLen}, expected {L}");
+                var (cells, _) = RunBothAndCompare(model, caseId++);
+                AssertInvariants(model, cells);
+            }
+        }
+    }
+
+    // (old, new) key pairs whose stripped middle length is exactly L, each with
+    // real shift activity. No common prefix/suffix: the ends never match, so
+    // BuildModel's oldMidLen == oldKeys.Length == L.
+    private static IEnumerable<(int[] Old, int[] New)> BoundaryPairs(int L)
+    {
+        if (L == 0)
+        {
+            yield return (Array.Empty<int>(), Array.Empty<int>());          // len-0 no-op path
+            yield return (Array.Empty<int>(), new[] { 100, 200 });          // pure inserts, len-0 shifts
+            yield break;
+        }
+        if (L == 1)
+        {
+            // For oldMidLen to be exactly 1, the lone survivor (0) must be
+            // strictly interior in `new` (else it strips as prefix/suffix).
+            // Inserts on both sides → BumpAtOrAfter runs at len=1.
+            yield return (new[] { 0 }, new[] { 100, 0, 200 });
+            yield return (new[] { 0 }, new[] { 300, 0, 400, 500 });
+            yield break;
+        }
+
+        var old = new int[L];
+        for (int i = 0; i < L; i++) old[i] = i;
+
+        // Full reverse: maximal moves over the whole band (many shift calls).
+        var rev = new int[L];
+        for (int i = 0; i < L; i++) rev[i] = L - 1 - i;
+        yield return (old, rev);
+
+        // Rotation [0,1,..]→[1,2,..,0]: single non-LIS mover across the full band.
+        var rot = new int[L];
+        for (int i = 0; i < L - 1; i++) rot[i] = i + 1;
+        rot[L - 1] = 0;
+        yield return (old, rot);
+
+        // Reverse bracketed by inserts on both ends → mixes Insert + Move shifts.
+        var bracket = new int[L + 2];
+        bracket[0] = 500;
+        for (int i = 0; i < L; i++) bracket[1 + i] = L - 1 - i;
+        bracket[L + 1] = 600;
+        yield return (old, bracket);
     }
 
     [Fact]

--- a/tests/Reactor.Tests/ChildReconcilerKeyedMiddleSimdTests.cs
+++ b/tests/Reactor.Tests/ChildReconcilerKeyedMiddleSimdTests.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// SIMD-equivalence + allocation guard for the keyed-middle bookkeeping.
+///
+/// <see cref="ChildReconciler.RunKeyedMiddleCore{TSink}"/> keeps its
+/// <c>oldRelToPanel</c> survivor-position model exact by shifting a band of
+/// entries on every Insert/Move. Those three shift loops were vectorized with
+/// <c>System.Numerics.Vector</c> (recovering the keyed-reconcile time the
+/// correct right-to-left rewrite cost — see #657 follow-up). Vectorized hot
+/// paths are exactly where tail/remainder and overlapping-range bugs hide, so
+/// this test pins the production (now SIMD) core to a hand-rolled SCALAR
+/// REFERENCE core: it runs both over thousands of random + steady-state keyed
+/// edit sequences and asserts the emitted Mount/Move/Patch op stream and the
+/// resulting cell model are BIT-FOR-BIT identical. It also asserts the core
+/// allocates zero bytes per call (the shifts stay on pooled buffers; Vector is
+/// a stack value type).
+/// </summary>
+public class ChildReconcilerKeyedMiddleSimdTests
+{
+    private const int NewBase = 1000;
+    private const int PrefixBase = 2000;
+    private const int SuffixBase = 3000;
+    private const int Unpatched = -1;
+
+    private struct Cell
+    {
+        public int Control;
+        public int Content;
+    }
+
+    // One recorded sink op: Kind 0 = MountInsert, 1 = MoveExisting, 2 = Patch.
+    private readonly record struct Op(int Kind, int A, int B, int C);
+
+    /// <summary>Records the op stream AND maintains the cell model (so both the
+    /// emitted sequence and the final order/identity/content can be compared).
+    /// Mirrors the real sink's structural mutations exactly.</summary>
+    private struct DiffSink : ChildReconciler.IKeyedMiddleSink
+    {
+        public List<Cell> Cells;
+        public List<Op> Ops;
+
+        public bool MountInsert(int newIdx, int panelIdx)
+        {
+            Cells.Insert(panelIdx, new Cell { Control = NewBase + newIdx, Content = newIdx });
+            Ops.Add(new Op(0, newIdx, panelIdx, 0));
+            return true;
+        }
+
+        public void MoveExisting(int fromIdx, int toIdx)
+        {
+            var cell = Cells[fromIdx];
+            Cells.RemoveAt(fromIdx);
+            Cells.Insert(toIdx, cell);
+            Ops.Add(new Op(1, fromIdx, toIdx, 0));
+        }
+
+        public void Patch(int oldRelIdx, int newIdx, int panelIdx)
+        {
+            Ops.Add(new Op(2, oldRelIdx, newIdx, panelIdx));
+            if (panelIdx >= 0 && panelIdx < Cells.Count)
+            {
+                var cell = Cells[panelIdx];
+                cell.Content = newIdx;
+                Cells[panelIdx] = cell;
+            }
+        }
+    }
+
+    /// <summary>Allocation-probe sink: counts only, touches no heap.</summary>
+    private struct NoOpSink : ChildReconciler.IKeyedMiddleSink
+    {
+        public int Mounts;
+        public int Moves;
+        public int Patches;
+        public bool MountInsert(int newIdx, int panelIdx) { Mounts++; return true; }
+        public void MoveExisting(int fromIdx, int toIdx) { Moves++; }
+        public void Patch(int oldRelIdx, int newIdx, int panelIdx) { Patches++; }
+    }
+
+    /// <summary>
+    /// Hand-rolled SCALAR reference — a faithful copy of the pre-SIMD
+    /// <see cref="ChildReconciler.RunKeyedMiddleCore{TSink}"/> shift loops. The
+    /// production core must match this exactly.
+    /// </summary>
+    private static void RunScalarReference<TSink>(
+        ref TSink sink, int[] newToOld, bool[] inLis,
+        int newMidLen, int oldMidLen, int initialAnchor, int[] oldRelToPanel)
+        where TSink : struct, ChildReconciler.IKeyedMiddleSink
+    {
+        int anchor = initialAnchor;
+        for (int i = newMidLen - 1; i >= 0; i--)
+        {
+            int oldRel = newToOld[i];
+            if (oldRel < 0)
+            {
+                if (sink.MountInsert(i, anchor))
+                    for (int r = 0; r < oldMidLen; r++)
+                        if (oldRelToPanel[r] >= anchor) oldRelToPanel[r]++;
+                continue;
+            }
+
+            int cur = oldRelToPanel[oldRel];
+            if (cur < 0) continue;
+
+            if (!inLis[i])
+            {
+                int to = cur < anchor ? anchor - 1 : anchor;
+                if (cur != to)
+                {
+                    sink.MoveExisting(cur, to);
+                    if (cur < to)
+                    {
+                        for (int r = 0; r < oldMidLen; r++)
+                        {
+                            int p = oldRelToPanel[r];
+                            if (p > cur && p <= to) oldRelToPanel[r] = p - 1;
+                        }
+                    }
+                    else
+                    {
+                        for (int r = 0; r < oldMidLen; r++)
+                        {
+                            int p = oldRelToPanel[r];
+                            if (p >= to && p < cur) oldRelToPanel[r] = p + 1;
+                        }
+                    }
+                    oldRelToPanel[oldRel] = to;
+                    cur = to;
+                }
+            }
+
+            sink.Patch(oldRel, i, cur);
+            anchor = cur;
+        }
+    }
+
+    private sealed class Model
+    {
+        public required int[] NewToOld;
+        public required bool[] InLis;
+        public required int NewMidLen;
+        public required int OldMidLen;
+        public required int InitialAnchor;
+        public required int[] OldRelToPanelBase; // immutable; cloned per run
+        public required Cell[] CellsBase;         // immutable; cloned per run
+        public required int PrefixLen;
+        public required int SuffixLen;
+    }
+
+    /// <summary>
+    /// Build the post-Step-1 model exactly as production
+    /// <c>ReconcileKeyedMiddle</c> does: prefix/suffix strip, last-wins key map,
+    /// matched survivors compacted in OLD order to live slots, LIS via the real
+    /// <see cref="ChildReconciler.ComputeLISInto"/>.
+    /// </summary>
+    private static Model BuildModel(int[] oldKeys, int[] newKeys)
+    {
+        int oldLen = oldKeys.Length, newLen = newKeys.Length;
+        int prefix = 0;
+        while (prefix < oldLen && prefix < newLen && oldKeys[prefix] == newKeys[prefix]) prefix++;
+        int suffix = 0;
+        while (suffix < oldLen - prefix && suffix < newLen - prefix &&
+               oldKeys[oldLen - 1 - suffix] == newKeys[newLen - 1 - suffix]) suffix++;
+
+        int oldMidLen = oldLen - prefix - suffix;
+        int newMidLen = newLen - prefix - suffix;
+
+        var oldKeyMap = new Dictionary<int, int>(oldMidLen);
+        for (int r = 0; r < oldMidLen; r++) oldKeyMap[oldKeys[prefix + r]] = r;
+
+        var newToOld = new int[newMidLen];
+        var matched = new bool[oldMidLen];
+        for (int j = 0; j < newMidLen; j++)
+        {
+            if (oldKeyMap.TryGetValue(newKeys[prefix + j], out int r)) { newToOld[j] = r; matched[r] = true; }
+            else newToOld[j] = -1;
+        }
+
+        var inLis = new bool[newMidLen];
+        ChildReconciler.ComputeLISInto(newToOld, newMidLen, inLis);
+
+        var oldRelToPanel = new int[oldMidLen];
+        for (int r = 0; r < oldMidLen; r++) oldRelToPanel[r] = -1;
+
+        var cells = new List<Cell>();
+        for (int k = 0; k < prefix; k++) cells.Add(new Cell { Control = PrefixBase + k, Content = -2 });
+        int compact = 0;
+        for (int r = 0; r < oldMidLen; r++)
+        {
+            if (matched[r])
+            {
+                oldRelToPanel[r] = prefix + compact;
+                cells.Add(new Cell { Control = r, Content = Unpatched });
+                compact++;
+            }
+        }
+        int initialAnchor = prefix + compact;
+        for (int k = 0; k < suffix; k++) cells.Add(new Cell { Control = SuffixBase + k, Content = -2 });
+
+        return new Model
+        {
+            NewToOld = newToOld,
+            InLis = inLis,
+            NewMidLen = newMidLen,
+            OldMidLen = oldMidLen,
+            InitialAnchor = initialAnchor,
+            OldRelToPanelBase = oldRelToPanel,
+            CellsBase = cells.ToArray(),
+            PrefixLen = prefix,
+            SuffixLen = suffix,
+        };
+    }
+
+    /// <summary>Run the production (SIMD) core and the scalar reference over the
+    /// same model and assert the op stream + cell model are identical. Returns
+    /// the production cells/ops for invariant checks.</summary>
+    private static (List<Cell> Cells, List<Op> Ops) RunBothAndCompare(Model m, int caseId)
+    {
+        // Production (SIMD) core.
+        var prodPanel = (int[])m.OldRelToPanelBase.Clone();
+        var prod = new DiffSink { Cells = new List<Cell>(m.CellsBase), Ops = new List<Op>() };
+        ChildReconciler.RunKeyedMiddleCore(ref prod, m.NewToOld, m.InLis, m.NewMidLen, m.OldMidLen, m.InitialAnchor, prodPanel);
+
+        // Scalar reference core.
+        var refPanel = (int[])m.OldRelToPanelBase.Clone();
+        var refk = new DiffSink { Cells = new List<Cell>(m.CellsBase), Ops = new List<Op>() };
+        RunScalarReference(ref refk, m.NewToOld, m.InLis, m.NewMidLen, m.OldMidLen, m.InitialAnchor, refPanel);
+
+        Assert.True(prod.Ops.Count == refk.Ops.Count,
+            $"case {caseId}: op-count {prod.Ops.Count} (simd) vs {refk.Ops.Count} (scalar)");
+        for (int o = 0; o < prod.Ops.Count; o++)
+            Assert.True(prod.Ops[o] == refk.Ops[o],
+                $"case {caseId}: op[{o}] {prod.Ops[o]} (simd) vs {refk.Ops[o]} (scalar)");
+
+        Assert.True(prod.Cells.Count == refk.Cells.Count, $"case {caseId}: cell-count mismatch");
+        for (int c = 0; c < prod.Cells.Count; c++)
+            Assert.True(prod.Cells[c].Control == refk.Cells[c].Control && prod.Cells[c].Content == refk.Cells[c].Content,
+                $"case {caseId}: cell[{c}] mismatch");
+
+        return (prod.Cells, prod.Ops);
+    }
+
+    /// <summary>Assert the four keyed-reorder invariants on the production
+    /// output (independent ground truth, not just SIMD==scalar).</summary>
+    private static void AssertInvariants(Model m, List<Cell> cells)
+    {
+        Assert.Equal(m.PrefixLen + m.NewMidLen + m.SuffixLen, cells.Count);
+        for (int k = 0; k < m.PrefixLen; k++) Assert.Equal(PrefixBase + k, cells[k].Control);
+        for (int k = 0; k < m.SuffixLen; k++) Assert.Equal(SuffixBase + k, cells[m.PrefixLen + m.NewMidLen + k].Control);
+        for (int j = 0; j < m.NewMidLen; j++)
+        {
+            var cell = cells[m.PrefixLen + j];
+            int expected = m.NewToOld[j] >= 0 ? m.NewToOld[j] : NewBase + j;
+            Assert.Equal(expected, cell.Control);
+            Assert.Equal(j, cell.Content);
+        }
+    }
+
+    // Deterministic port of StressPerf.KeyedList.KeyedListSource (the regressing
+    // workload): N stable keys, each tick churns (k/4 insert+remove) + moves.
+    private sealed class KeyedListSim
+    {
+        private readonly List<int> _items = new();
+        private readonly Random _rng;
+        private int _nextId;
+        public KeyedListSim(int count, int seed)
+        {
+            _rng = new Random(seed);
+            for (int i = 0; i < count; i++) _items.Add(i);
+            _nextId = count;
+        }
+        public int[] Snapshot() => _items.ToArray();
+        public void Update(double percent)
+        {
+            int n = _items.Count;
+            int k = (int)Math.Round(n * percent / 100.0, MidpointRounding.AwayFromZero);
+            if (k < 0) k = 0; if (k > n) k = n;
+            if (k == 0) return;
+            int churn = k / 4;
+            for (int i = 0; i < churn; i++)
+            {
+                _items.RemoveAt(_rng.Next(_items.Count));
+                _items.Insert(_rng.Next(_items.Count + 1), _nextId++);
+            }
+            int moves = k - churn;
+            for (int i = 0; i < moves; i++)
+            {
+                int from = _rng.Next(_items.Count);
+                int row = _items[from];
+                _items.RemoveAt(from);
+                _items.Insert(_rng.Next(_items.Count + 1), row);
+            }
+        }
+    }
+
+    [Fact]
+    public void Simd_Matches_Scalar_Over_Random_Workloads()
+    {
+        int cases = 0;
+        for (int seed = 1; seed <= 5000; seed++)
+        {
+            var rng = new Random(seed);
+            int n = 1 + rng.Next(80);
+            double pct = rng.Next(0, 60);
+            var sim = new KeyedListSim(n, seed);
+            int[] oldKeys = sim.Snapshot();
+            sim.Update(pct);
+            int[] newKeys = sim.Snapshot();
+
+            var model = BuildModel(oldKeys, newKeys);
+            var (cells, _) = RunBothAndCompare(model, seed);
+            AssertInvariants(model, cells);
+            cases++;
+        }
+        Assert.Equal(5000, cases);
+    }
+
+    [Theory]
+    [InlineData(500, 10.0, 200)]
+    [InlineData(500, 25.0, 150)]
+    [InlineData(500, 5.0, 200)]
+    [InlineData(2000, 10.0, 60)]
+    public void Simd_Matches_Scalar_Over_SteadyState_Ticks(int n, double pct, int ticks)
+    {
+        var sim = new KeyedListSim(n, 42);
+        int[] prev = sim.Snapshot();
+        for (int t = 0; t < ticks; t++)
+        {
+            sim.Update(pct);
+            int[] cur = sim.Snapshot();
+            var model = BuildModel(prev, cur);
+            var (cells, _) = RunBothAndCompare(model, t);
+            AssertInvariants(model, cells);
+            prev = cur;
+        }
+    }
+
+    [Theory]
+    [InlineData(2000)]
+    [InlineData(4096)]   // exercises wide vector spans + remainder tails
+    [InlineData(4099)]
+    public void LargeN_Churn_Sequence_Stays_Exact(int n)
+    {
+        // A churn sequence at large N — the live-index oracle must stay exact
+        // through many overlapping shifts (the guard the buggy O(1)-update
+        // original, and any SIMD tail/range bug, would fail).
+        var sim = new KeyedListSim(n, 7);
+        int[] prev = sim.Snapshot();
+        for (int t = 0; t < 40; t++)
+        {
+            sim.Update(12.0);
+            int[] cur = sim.Snapshot();
+            var model = BuildModel(prev, cur);
+            var (cells, _) = RunBothAndCompare(model, t);
+            AssertInvariants(model, cells);
+            prev = cur;
+        }
+    }
+
+    [Theory]
+    [InlineData("a,b,c,d", "b,c,d,a")]   // rotation (the C1 repro)
+    [InlineData("a,b,c,d,e", "e,d,c,b,a")] // full reverse
+    [InlineData("a,b,c,d,e,f,g,h,i,j", "j,a,i,b,h,c,g,d,f,e")] // interleave
+    public void Simd_Matches_Scalar_Explicit(string oldCsv, string newCsv)
+    {
+        int[] Parse(string s)
+        {
+            var parts = s.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var r = new int[parts.Length];
+            for (int i = 0; i < parts.Length; i++) r[i] = parts[i][0]; // char code as key
+            return r;
+        }
+        var model = BuildModel(Parse(oldCsv), Parse(newCsv));
+        var (cells, _) = RunBothAndCompare(model, 0);
+        AssertInvariants(model, cells);
+    }
+
+    [Fact]
+    public void KeyedMiddleCore_Is_Allocation_Free()
+    {
+        // A representative N=500/pct=10 steady-state tick.
+        var sim = new KeyedListSim(500, 42);
+        int[] prev = sim.Snapshot();
+        for (int i = 0; i < 6; i++) { sim.Update(10.0); prev = sim.Snapshot(); }
+        sim.Update(10.0);
+        var model = BuildModel(prev, sim.Snapshot());
+
+        var panel = new int[model.OldMidLen];
+        long sink = 0;
+
+        // Warm up JIT/tiering so the measured window is steady-state.
+        for (int i = 0; i < 64; i++)
+        {
+            Array.Copy(model.OldRelToPanelBase, panel, model.OldMidLen);
+            var s = new NoOpSink();
+            ChildReconciler.RunKeyedMiddleCore(ref s, model.NewToOld, model.InLis, model.NewMidLen, model.OldMidLen, model.InitialAnchor, panel);
+            sink += s.Moves + s.Mounts + s.Patches; // long += int: no boxing
+        }
+
+        const int iters = 500;
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iters; i++)
+        {
+            Array.Copy(model.OldRelToPanelBase, panel, model.OldMidLen);
+            var s = new NoOpSink();
+            ChildReconciler.RunKeyedMiddleCore(ref s, model.NewToOld, model.InLis, model.NewMidLen, model.OldMidLen, model.InitialAnchor, panel);
+            sink += s.Moves + s.Mounts + s.Patches;
+        }
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.True(sink >= 0); // observe `sink` so the loop body can't be elided
+        Assert.True(after - before == 0,
+            $"keyed-middle core allocated {after - before} bytes over {iters} iters (expected 0 — Vector<int> is a stack value type, shifts run on the caller's pooled buffer).");
+    }
+}


### PR DESCRIPTION
## What & why

Fix-forward for the keyed-reconcile **time** regression introduced by #657.

#657 shipped a **−30.8% keyed-list allocation** win, but its *correct* right-to-left LIS rewrite (which fixed the C1/H1 keyed-identity corruption) replaced H1's buggy O(1) survivor-index update with an **exact O(oldMidLen) shift-bookkeeping** pass per Insert/Move. Post-merge `/perf` on the keyed-list workload measured **reconcile +20.4%**, **diff +20.5%**, **rps −10.2%** (alloc still −30.9% ✅) — keyed-only (StocksGrid positional + all 17 micros flat). The cost lives entirely in those `oldRelToPanel` shift scans.

This PR **vectorizes those three shift loops** with `System.Numerics.Vector<int>` to recover the time while **keeping the −30.9% alloc win flat** (non-negotiable — main already carries it).

## Mechanism

`RunKeyedMiddleCore` keeps its `oldRelToPanel` survivor-position model exact by shifting a band of entries on every structural op. Each shift is a branchless *compare-and-conditional-±1* over an `int[]` — a textbook SIMD pattern. Three private helpers replace the scalar loops:

| Helper | Predicate (scalar) | Op |
|---|---|---|
| `BumpAtOrAfter(map,len,thr)` | `if (p >= thr) p++` | insertion shifts survivors ≥ anchor right |
| `DecrementWhereGtLe(map,len,lo,hi)` | `if (p > lo && p <= hi) p--` | left-to-right Move closes the gap over `(lo,hi]` |
| `IncrementWhereGeLt(map,len,lo,hi)` | `if (p >= lo && p < hi) p++` | right-to-left Move opens the gap over `[lo,hi)` |

Each applies the **EXACT** scalar predicate `Vector<int>.Count` lanes at a time (SSE/AVX2 on x64, NEON on ARM64) + a scalar remainder, and falls back to the verbatim scalar loop when `!Vector.IsHardwareAccelerated` or `len < width`. The masks exploit that `Vector.GreaterThan` et al. return all-ones (−1) in matching lanes, so `v - mask` adds 1 and `v + mask` subtracts 1 exactly where the predicate holds. Negative sentinels (−1 unrealized survivors) never satisfy any predicate → pass through untouched, matching scalar. Reads are bounded to `[0, len)` (`r ≤ len − width`), so the larger pooled tail is never touched.

## Behavior-preserving (hard requirement)

Only the **index oracle** is vectorized. The LIS computation, the move **set**, the move **order**, and patch-by-live-index are **bit-for-bit unchanged**. The corrected C1/H1 algorithm stays exactly as merged.

## Alloc-neutral (hard requirement)

Reuses the **same pooled `int[]`**; `Vector<int>` is a stack value type — zero new per-frame heap allocs. A new test asserts **0 B/iter** through the core via `GC.GetAllocatedBytesForCurrentThread`.

## Tests — `ChildReconcilerKeyedMiddleSimdTests.cs`

The correctness guard for a vectorized hot path is a **checked-in differential test**: it runs the production (SIMD) core and a hand-rolled **scalar reference** core over the same models and asserts the emitted **Mount/Move/Patch op stream + final cell model are identical**:

- **5000 random** keyed edit workloads (n≤80, churn 0–60%).
- **Steady-state ticks** at N=500 (pct 5/10/25) and N=2000 — the regressing workload, faithfully ported from `KeyedListSource`.
- **Large-N churn** at N=2000/4096/4099 — exercises full vector spans **+ remainder tails**.
- Explicit teeth: rotation `[a,b,c,d]→[b,c,d,a]` (the C1 repro), full reverse, interleave.
- The 4-invariant reorder oracle (length, prefix/suffix untouched, per-slot identity + content) on every case — independent ground truth, not just SIMD==scalar.
- Alloc-free assertion (0 B/iter).

The existing `ChildReconcilerKeyedMiddleCoreTests` (28 cases + rotation + dup teeth) now exercise the SIMD core through production and stay green unchanged.

## Why SIMD (and not Fenwick)

The fix-forward was originally scoped to an O(log N) Fenwick/BIT index oracle. I built a self-contained differential microbench (4 cores: array / Fenwick / SIMD / hybrid — all proven bit-for-bit identical) and **measured** it: the pure Fenwick is **slower at the N=500 target** (the `oldRelToPanel` array is L1-resident and the shift loops are branch-predictable sequential scans; Fenwick's log²N searches don't pay off until N≈2000, beyond Reactor's realistic non-virtualized keyed-list sizes). SIMD is **~65% faster at N=500** and faster at every realistic size, with the lowest correctness risk (a pure micro-opt of the already-proven in-main shift logic).

Bookkeeping-only microbench (µs/tick, ARM64 NEON 4-wide; x64 AVX2 runner is 8-wide → larger margin):

| workload | array | fenwick | **simd** |
|---|---|---|---|
| N=200 pct=10 | 7.7 | 19.7 (+158%) | 7.5 (−2%) |
| **N=500 pct=10** ★ | 16.0 | 21.7 (+35%) | **5.6 (−65%)** |
| N=500 pct=25 | 38.1 | 40.4 (+6%) | 11.2 (−71%) |
| N=1000 pct=10 | 52.3 | 50.5 (−3%) | 19.7 (−62%) |
| N=2000 pct=10 | 197.4 | 110.8 (−44%) | 70.5 (−64%) |

(Bench source archived in the session for traceability.)

## `/perf` success criteria (coordinator measures end-to-end)

Keyed **reconcile/diff substantially recovered** toward flat (a small residual is acceptable — the bench is bookkeeping-only and SIMD recovers ~62–65% of it on NEON, more on the AVX2 runner), **rps substantially recovered**, and keyed **alloc stays ~flat (−30.9% preserved)**. StocksGrid + all 17 micros flat.

## Gates (ARM64 local)

- `dotnet build src/Reactor/Reactor.csproj -c Release` = **0 warnings / 0 errors** (AOT/trim-clean).
- `dotnet test tests/Reactor.Tests` = **9899 passed / 0 failed / 64 skipped** (incl. the new differential suite + existing keyed teeth).

## Scope

`src/Reactor/Core/ChildReconciler.cs` (+101/−12) + the new test file only.

---

**DRAFT** — do not merge. Held for dual review + the `/perf` gate per the fix-forward plan.
