### PR TITLE
ci: let the Coverage workflow run against a branch, not just a PR

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,10 +1,12 @@
 name: Coverage
 
-# Maintainer-gated coverage run for any PR (including forks). Trigger it either by
-# commenting `@codecoverage` on a PR, or by running the workflow manually from the
-# Actions tab (or `gh workflow run`) with the target PR number. Either way it runs
-# the merged unit + selftest coverage recipe from TESTING.md and posts the
-# result back to the PR as a comment.
+# Maintainer-gated coverage run, all paths running the merged unit + selftest
+# coverage recipe from TESTING.md. Trigger it three ways:
+#   - comment `@codecoverage` on a PR — posts the result back as a PR comment;
+#   - run it manually (Actions tab / `gh workflow run`) with a PR number — same,
+#     and works for forks via refs/pull/N/head;
+#   - run it manually with the PR number left blank — measures the selected
+#     branch and writes the result to the run's job summary (no PR to comment on).
 #
 # Security: `issue_comment` workflows run in the base repo with full token
 # permissions. Untrusted code from the PR (build scripts, tests) executes here.
@@ -18,8 +20,8 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: PR number to run merged coverage against
-        required: true
+        description: PR to measure. Leave blank to measure the selected branch instead.
+        required: false
         type: string
 
 permissions:
@@ -29,12 +31,12 @@ permissions:
 jobs:
   coverage:
     name: Merged coverage
-    # One in-flight run per PR; a newer trigger (comment or dispatch) supersedes an
-    # older one. Job-level (not workflow-level) concurrency so that unrelated
-    # issue_comment events — which start a workflow run but skip this job — don't
-    # cancel a live coverage run for the same PR.
+    # One in-flight run per target — a PR number, or the branch ref for a
+    # blank-input dispatch. A newer trigger supersedes an older one. Job-level
+    # (not workflow-level) concurrency so unrelated issue_comment events — which
+    # start a workflow run but skip this job — don't cancel a live coverage run.
     concurrency:
-      group: coverage-${{ github.event.issue.number || github.event.inputs.pr_number }}
+      group: coverage-${{ github.event.issue.number || github.event.inputs.pr_number || github.ref }}
       cancel-in-progress: true
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -56,40 +58,47 @@ jobs:
               content: 'eyes',
             });
 
-      - name: Resolve PR head SHA
+      - name: Resolve coverage target
         id: pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           DISPATCH_PR: ${{ github.event.inputs.pr_number }}
         with:
           script: |
-            let prNumber;
+            // Resolve what to measure:
+            //   - issue_comment             -> the PR the comment is on
+            //   - workflow_dispatch + PR#   -> that PR (works for forks)
+            //   - workflow_dispatch, blank  -> the dispatched branch (no PR)
+            let prNumber = '';
             if (context.eventName === 'workflow_dispatch') {
-              // Validate the raw input without trimming: it must be exactly a
-              // positive integer (no leading zeros or surrounding whitespace) so the
-              // resolved PR stays identical to the raw value the job-level
-              // concurrency group keys on (github.event.inputs.pr_number).
               const raw = process.env.DISPATCH_PR || '';
-              if (!/^[1-9][0-9]*$/.test(raw)) {
-                throw new Error(`Invalid pr_number input '${process.env.DISPATCH_PR}' (expected a positive integer with no leading zeros or whitespace)`);
+              if (raw !== '') {
+                // Validate without trimming so the resolved PR stays identical to
+                // the raw value the job-level concurrency group keys on.
+                if (!/^[1-9][0-9]*$/.test(raw)) {
+                  throw new Error(`Invalid pr_number input '${process.env.DISPATCH_PR}' (expected a positive integer, or leave it blank to measure the selected branch)`);
+                }
+                prNumber = raw;
               }
-              prNumber = Number(raw);
             } else {
-              prNumber = context.issue.number;
+              prNumber = String(context.issue.number);
             }
-            if (!Number.isInteger(prNumber) || prNumber <= 0) {
-              throw new Error(`Could not resolve a valid PR number (got '${process.env.DISPATCH_PR ?? context.issue.number}')`);
+            // Emit the number before the API call so the always()-gated report
+            // step can still post back to the PR if pulls.get below fails.
+            core.setOutput('number', prNumber);
+            if (prNumber !== '') {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(prNumber),
+              });
+              core.setOutput('sha', pr.data.head.sha);
+              core.setOutput('ref', `refs/pull/${prNumber}/head`);
+            } else {
+              // No PR: measure the commit the workflow was dispatched on.
+              core.setOutput('sha', context.sha);
+              core.setOutput('ref', context.sha);
             }
-            // Emit the number before the API call so the always()-gated comment
-            // step can still report back to the PR if pulls.get below fails.
-            core.setOutput('number', String(prNumber));
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-            core.setOutput('sha', pr.data.head.sha);
-            core.setOutput('ref', `refs/pull/${prNumber}/head`);
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -175,7 +184,7 @@ jobs:
           "branches-covered=$covered" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "branches-total=$total"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      - name: Comment results
+      - name: Report results
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -206,9 +215,12 @@ jobs:
             } else {
               body = `**Coverage run failed** for \`${shaLabel}\` — see the [workflow run](${runUrl}) for details.`;
             }
+            // Always surface the result in the run summary — this is the only
+            // output for a branch run (blank-input dispatch, no PR to comment on).
+            await core.summary.addRaw(body).write();
             const prNumber = Number(PR_NUMBER);
             if (!Number.isInteger(prNumber) || prNumber <= 0) {
-              core.warning(`No PR number resolved; skipping result comment. Body was:\n${body}`);
+              core.info('No PR resolved (branch run); result written to the job summary only.');
               return;
             }
             await github.rest.issues.createComment({

--- a/TESTING.md
+++ b/TESTING.md
@@ -234,10 +234,14 @@ Replace `$(RuntimeIdentifier)` with `ARM64` or `x64`, or omit the platform segme
 ### Running coverage in CI
 
 You don't have to run the merge locally — the **Coverage** workflow
-(`.github/workflows/coverage.yml`) runs this same unit + selftest recipe against a
-PR and posts the merged line/branch numbers back as a PR comment. Trigger it either
-way:
+(`.github/workflows/coverage.yml`) runs this same unit + selftest recipe and
+reports the merged line/branch numbers. Trigger it any of these ways:
 
-- **Comment trigger:** a maintainer comments `@codecoverage` on the PR.
-- **Manual trigger:** use **Actions → Coverage → Run workflow** and enter the PR
-  number, or from the CLI run `gh workflow run coverage.yml -f pr_number=<PR>`.
+- **Comment trigger:** a maintainer comments `@codecoverage` on a PR. The result
+  is posted back as a PR comment.
+- **Manual trigger (PR):** use **Actions → Coverage → Run workflow** and enter the
+  PR number, or run `gh workflow run coverage.yml -f pr_number=<PR>`. Same PR
+  comment output; works for forks too.
+- **Manual trigger (branch):** run it with the PR number left **blank** to measure
+  the selected branch — e.g. `gh workflow run coverage.yml --ref main`. With no PR
+  to comment on, the numbers are written to the run's **job summary** instead.


### PR DESCRIPTION
Follow-up to #736. Manually dispatching the Coverage workflow on a branch failed because pr_number was **required** — entering a branch name like main errored with `Invalid pr_number input 'main'` ([example run](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/28302767999)).

## Fix

Make pr_number **optional** so the manual trigger can measure a branch:

- **Blank input → branch run.** Resolve the commit from context.sha and check that out, instead of efs/pull/N/head.
- **Always write a job summary.** The merged line/branch table is written to the run's job summary on every run; a PR comment is only posted when a PR was actually resolved (branch runs have none to comment on).
- **Concurrency** falls back to github.ref for branch runs, so two runs on the same branch still supersede one another.
- Document the branch-run option in TESTING.md.

A PR number still behaves exactly as before — the @codecoverage comment trigger and dispatch-with-PR-number paths are unchanged (still validated as a strict positive integer, still comment back on the PR, still work for forks).

## How to run it now

- PR: `gh workflow run coverage.yml -f pr_number=<PR>` (or **Actions → Coverage → Run workflow**).
- Branch: `gh workflow run coverage.yml --ref main` with the PR number left blank → result in the run's job summary.

## Validation

- yaml.safe_load parses; pr_number.required is now false.
- All three embedded github-script blocks pass 
ode --check.