### PR TITLE
perf: salvage #670 Yoga inline-arrays/pooling minus the #138 layout-cache guards (supersedes #670)

### DIFF
--- a/src/Reactor/Yoga/AlgorithmUtils.cs
+++ b/src/Reactor/Yoga/AlgorithmUtils.cs
@@ -283,9 +283,13 @@ internal static class PixelGridHelper
                 - RoundValueToPixelGrid(absoluteNodeTop, pointScaleFactor, false, textRounding));
         }
 
-        foreach (var child in node.Children)
+        // #145: iterate by index via ChildCount/GetChild instead of foreach over
+        // the IReadOnlyList Children (which boxes List<T>.Enumerator per node).
+        // Note: this rounds ALL children (no Display.Contents flattening), matching
+        // the original traversal.
+        for (int i = 0; i < node.ChildCount; i++)
         {
-            RoundLayoutResultsToPixelGrid(child, absoluteNodeLeft, absoluteNodeTop);
+            RoundLayoutResultsToPixelGrid(node.GetChild(i), absoluteNodeLeft, absoluteNodeTop);
         }
     }
 
@@ -394,6 +398,37 @@ internal static class FlexLineHelper
         s_listPool.Push(list);
     }
 
+    // AI-HINT (perf #144): FlexLine is allocated once per flex line per frame.
+    // Pool the object together with its ItemsInFlow list (the list travels with
+    // the FlexLine across rent/return cycles, so it is NOT drawn from s_listPool).
+    // A FlexLine is used entirely within one per-line loop iteration in
+    // CalculateLayoutImpl and is never stored beyond it, so returning it at the
+    // loop tail is safe. Recursive layout of children rents distinct FlexLines
+    // (LIFO stack), so no aliasing.
+    // The line is reset on RETURN (not on rent), matching ReturnList's
+    // clear-before-pool contract: ItemsInFlow holds YogaNode references that
+    // reach whole UI subtrees, so clearing on return keeps the thread-static
+    // pool from pinning that memory between layout passes. The only way into the
+    // pool is ReturnFlexLine, so a popped line is always clean at rent time.
+    [ThreadStatic]
+    private static Stack<FlexLine>? s_flexLinePool;
+
+    internal static FlexLine RentFlexLine()
+    {
+        var pool = s_flexLinePool ??= new Stack<FlexLine>();
+        return pool.Count > 0 ? pool.Pop() : new FlexLine();
+    }
+
+    internal static void ReturnFlexLine(FlexLine line)
+    {
+        line.ItemsInFlow.Clear();
+        line.SizeConsumed = 0;
+        line.NumberOfAutoMargins = 0;
+        line.Layout = default;
+        var pool = s_flexLinePool ??= new Stack<FlexLine>();
+        pool.Push(line);
+    }
+
     /// <summary>
     /// Calculates where a line starting at a given child index should break.
     /// Assumes all children have their computedFlexBasis computed.
@@ -404,7 +439,8 @@ internal static class FlexLineHelper
         ref int childIndex, int lineCount,
         List<YogaNode> layoutChildren)
     {
-        var itemsInFlow = RentList();
+        var line = RentFlexLine();
+        var itemsInFlow = line.ItemsInFlow;
         float sizeConsumed = 0;
         float totalFlexGrowFactors = 0;
         float totalFlexShrinkScaledFactors = 0;
@@ -468,16 +504,13 @@ internal static class FlexLineHelper
         if (totalFlexShrinkScaledFactors > 0 && totalFlexShrinkScaledFactors < 1)
             totalFlexShrinkScaledFactors = 1;
 
-        return new FlexLine
+        line.SizeConsumed = sizeConsumed;
+        line.NumberOfAutoMargins = numberOfAutoMargins;
+        line.Layout = new FlexLineRunningLayout
         {
-            ItemsInFlow = itemsInFlow,
-            SizeConsumed = sizeConsumed,
-            NumberOfAutoMargins = numberOfAutoMargins,
-            Layout = new FlexLineRunningLayout
-            {
-                TotalFlexGrowFactors = totalFlexGrowFactors,
-                TotalFlexShrinkScaledFactors = totalFlexShrinkScaledFactors,
-            }
+            TotalFlexGrowFactors = totalFlexGrowFactors,
+            TotalFlexShrinkScaledFactors = totalFlexShrinkScaledFactors,
         };
+        return line;
     }
 }

--- a/src/Reactor/Yoga/FlexPanel.cs
+++ b/src/Reactor/Yoga/FlexPanel.cs
@@ -8,6 +8,7 @@
 // are synced to Yoga nodes in SyncYogaTree(). MeasureFunc bridge lets Yoga call
 // back into WinUI Measure for leaf children that need intrinsic sizing.
 
+using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Reactor.Layout;
@@ -31,6 +32,33 @@ public partial class FlexPanel : Panel
     private readonly YogaNode _rootNode;
     private readonly HashSet<UIElement> _syncCurrentChildren = new();
     private readonly List<UIElement> _syncToRemove = new();
+
+    // AI-HINT (perf #147): per-child cache of the last-read attached-property
+    // values (Grow/Shrink/Basis/AlignSelf/Position/FlexMin*/insets). Reading
+    // an attached DP via GetValue boxes the double/enum; for a large grid that
+    // is ~11 boxed allocations per child per MeasureOverride. Attached DPs can
+    // only change through the property system, which raises
+    // OnChildPropertyChanged — which drops the child's entry while it is parented
+    // to this panel; the SyncYogaTree sweep drops entries for removed children.
+    // FrameworkElement Width/Height/Margin/Visibility are NOT cached: they change
+    // without our callback, so they are re-read each pass.
+    private readonly Dictionary<UIElement, AttachedProps> _attachedCache = new();
+
+    // AI-HINT (perf #147 correctness): an attached DP can change while a child is
+    // detached from its panel (e.g. removed, re-styled, then re-added before the
+    // next measure). OnChildPropertyChanged then cannot reach the owning panel to
+    // drop its cache entry, so the child is flagged here instead; the next
+    // ApplyAttachedProperties re-reads it rather than trusting a stale snapshot.
+    // Static + weak-keyed: shared across panels, no per-panel state, no leak.
+    private static readonly ConditionalWeakTable<UIElement, object> s_detachedAttachedDirty = new();
+    private static readonly object s_detachedDirtyMarker = new();
+
+    private struct AttachedProps
+    {
+        public double Grow, Shrink, Basis, MinWidth, MinHeight, Left, Top, Right, Bottom;
+        public FlexAlign AlignSelf;
+        public FlexPositionType Position;
+    }
 
     public FlexPanel()
     {
@@ -62,6 +90,7 @@ public partial class FlexPanel : Panel
         foreach (var node in _nodeCache.Values)
             _rootNode.RemoveChild(node);
         _nodeCache.Clear();
+        _attachedCache.Clear();
     }
 
     // ── Container dependency properties ──
@@ -257,8 +286,23 @@ public partial class FlexPanel : Panel
 
     private static void OnChildPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is UIElement el && Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(el) is FlexPanel panel)
+        if (d is not UIElement el)
+            return;
+
+        if (Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(el) is FlexPanel panel)
+        {
+            // Invalidate the cached attached-property snapshot for this child so
+            // the next sync re-reads the changed value (#147).
+            panel._attachedCache.Remove(el);
             panel.InvalidateMeasure();
+        }
+        else
+        {
+            // Detached (or not yet parented): we cannot reach the owning panel's
+            // cache, so flag the element. The next ApplyAttachedProperties (after
+            // it is (re-)added) re-reads it instead of using a stale entry (#147).
+            s_detachedAttachedDirty.AddOrUpdate(el, s_detachedDirtyMarker);
+        }
     }
 
     // ── Layout ──
@@ -619,6 +663,7 @@ public partial class FlexPanel : Panel
             if (_nodeCache.TryGetValue(el, out var node))
                 _rootNode.RemoveChild(node);
             _nodeCache.Remove(el);
+            _attachedCache.Remove(el);
         }
 
         // Ensure each child has a YogaNode at the correct index
@@ -754,14 +799,49 @@ public partial class FlexPanel : Panel
 
     private void ApplyAttachedProperties(UIElement el, YogaNode node)
     {
-        var grow = GetGrow(el);
-        var shrink = GetShrink(el);
-        var basis = GetBasis(el);
-        var alignSelf = GetAlignSelf(el);
-        var position = GetPosition(el);
-        var minWidthExplicit = GetMinWidth(el);
-        var minHeightExplicit = GetMinHeight(el);
+        // Read attached properties from the per-child cache (#147); only the
+        // first sync after a change boxes the GetValue results. The cache is
+        // invalidated in OnChildPropertyChanged (while the child is parented) and
+        // by the SyncYogaTree removal sweep; a change made while the child was
+        // detached is flagged in s_detachedAttachedDirty and honored here. A
+        // missing or invalidated entry means the values must be re-read.
+        bool hit = _attachedCache.TryGetValue(el, out var ap);
+        if (hit && s_detachedAttachedDirty.TryGetValue(el, out _))
+        {
+            // Snapshot was invalidated while the child was detached from a panel.
+            hit = false;
+        }
+        if (!hit)
+        {
+            s_detachedAttachedDirty.Remove(el);
+            ap = new AttachedProps
+            {
+                Grow = GetGrow(el),
+                Shrink = GetShrink(el),
+                Basis = GetBasis(el),
+                AlignSelf = GetAlignSelf(el),
+                Position = GetPosition(el),
+                MinWidth = GetMinWidth(el),
+                MinHeight = GetMinHeight(el),
+                Left = GetLeft(el),
+                Top = GetTop(el),
+                Right = GetRight(el),
+                Bottom = GetBottom(el),
+            };
+            _attachedCache[el] = ap;
+        }
 
+        var grow = ap.Grow;
+        var shrink = ap.Shrink;
+        var basis = ap.Basis;
+        var alignSelf = ap.AlignSelf;
+        var position = ap.Position;
+        var minWidthExplicit = ap.MinWidth;
+        var minHeightExplicit = ap.MinHeight;
+
+        // Attached-property style values are written directly to the node's
+        // style (matching the Width/Height path); the unconditional dirty from
+        // those drives relayout.
         node.Style.FlexGrow = (float)grow;
         node.Style.FlexShrink = (float)shrink;
         node.Style.FlexBasis = double.IsNaN(basis) ? YogaValue.Auto : YogaValue.Point((float)basis);
@@ -788,10 +868,10 @@ public partial class FlexPanel : Panel
             explicitMin: minHeightExplicit, basis: basis, isWidth: false);
 
         // Position insets
-        var left = GetLeft(el);
-        var top = GetTop(el);
-        var right = GetRight(el);
-        var bottom = GetBottom(el);
+        var left = ap.Left;
+        var top = ap.Top;
+        var right = ap.Right;
+        var bottom = ap.Bottom;
 
         node.Style.Position[(int)YogaEdge.Left] = double.IsNaN(left) ? YogaValue.Undefined : YogaValue.Point((float)left);
         node.Style.Position[(int)YogaEdge.Top] = double.IsNaN(top) ? YogaValue.Undefined : YogaValue.Point((float)top);

--- a/src/Reactor/Yoga/LayoutResults.cs
+++ b/src/Reactor/Yoga/LayoutResults.cs
@@ -53,29 +53,46 @@ internal sealed class LayoutResults
     public FlexLayoutDirection LastOwnerDirection = FlexLayoutDirection.Inherit;
 
     public uint NextCachedMeasurementsIndex;
-    public readonly CachedMeasurement[] CachedMeasurements = new CachedMeasurement[MaxCachedMeasurements];
+
+    // Inline fixed-size buffer (#142): replaces a CachedMeasurement[8] heap
+    // array. Exposed as a ref-returning property so existing in-place element
+    // mutation (CachedMeasurements[idx].AvailableWidth = ...) is unchanged.
+    private CachedMeasurementArray _cachedMeasurements;
+    public ref CachedMeasurementArray CachedMeasurements => ref _cachedMeasurements;
     public CachedMeasurement CachedLayout;
 
     // Direction and overflow
     private FlexLayoutDirection _direction = FlexLayoutDirection.Inherit;
     private bool _hadOverflow;
 
-    // Dimensions
-    private readonly float[] _dimensions = { float.NaN, float.NaN };
-    private readonly float[] _measuredDimensions = { float.NaN, float.NaN };
-    private readonly float[] _rawDimensions = { float.NaN, float.NaN };
+    // Dimensions / edges stored inline (#142) instead of 7 separate float[]
+    // arrays. For a ~200-node tree this removes ~1400 GC objects (7 arrays/node)
+    // — a major part of the Yoga memory gap vs the C++ original's inline members.
+    private Float2 _dimensions;
+    private Float2 _measuredDimensions;
+    private Float2 _rawDimensions;
 
     // Position, margin, border, padding (indexed by PhysicalEdge: Left=0, Top=1, Right=2, Bottom=3)
-    private readonly float[] _position = new float[4];
-    private readonly float[] _margin = new float[4];
-    private readonly float[] _border = new float[4];
-    private readonly float[] _padding = new float[4];
+    private Float4 _position;
+    private Float4 _margin;
+    private Float4 _border;
+    private Float4 _padding;
 
     public LayoutResults()
     {
+        // CachedMeasurement's field initializers (the -1 sentinels) only run via
+        // its constructor, NOT for default-initialized inline-array elements, so
+        // seed each slot explicitly to preserve the previous array behavior.
         for (int i = 0; i < MaxCachedMeasurements; i++)
-            CachedMeasurements[i] = new CachedMeasurement();
+            _cachedMeasurements[i] = new CachedMeasurement();
         CachedLayout = new CachedMeasurement();
+
+        // The _dimensions family historically defaulted to NaN (the float[]
+        // initializers); _position/_margin/_border/_padding defaulted to 0,
+        // which matches a zero-initialized inline buffer (no seeding needed).
+        _dimensions[0] = float.NaN; _dimensions[1] = float.NaN;
+        _measuredDimensions[0] = float.NaN; _measuredDimensions[1] = float.NaN;
+        _rawDimensions[0] = float.NaN; _rawDimensions[1] = float.NaN;
     }
 
     public FlexLayoutDirection Direction
@@ -132,13 +149,16 @@ internal sealed class LayoutResults
         _rawDimensions[0] = float.NaN;
         _rawDimensions[1] = float.NaN;
 
-        Array.Clear(_position);
-        Array.Clear(_margin);
-        Array.Clear(_border);
-        Array.Clear(_padding);
+        for (int i = 0; i < 4; i++)
+        {
+            _position[i] = 0;
+            _margin[i] = 0;
+            _border[i] = 0;
+            _padding[i] = 0;
+        }
 
         for (int i = 0; i < MaxCachedMeasurements; i++)
-            CachedMeasurements[i] = new CachedMeasurement();
+            _cachedMeasurements[i] = new CachedMeasurement();
         CachedLayout = new CachedMeasurement();
     }
 
@@ -170,4 +190,33 @@ internal sealed class LayoutResults
 
         return true;
     }
+}
+
+// AI-HINT (perf #142): fixed-size inline buffers embedded directly in the
+// LayoutResults heap object, replacing 7 float[] arrays + a CachedMeasurement[8]
+// per node. For a ~200-node tree that removes ~1600 GC objects — a dominant
+// part of the Yoga memory gap vs the C++ original (which uses inline members).
+// InlineArray is a C# 12 feature: element access is compiler-generated and
+// fully AOT/trim safe (no reflection, no Unsafe). Each struct has exactly one
+// instance field, as InlineArray requires.
+
+/// <summary>Inline buffer of 2 floats (YogaDimension: Width=0, Height=1).</summary>
+[global::System.Runtime.CompilerServices.InlineArray(2)]
+internal struct Float2
+{
+    private float _element0;
+}
+
+/// <summary>Inline buffer of 4 floats (YogaPhysicalEdge: Left=0..Bottom=3).</summary>
+[global::System.Runtime.CompilerServices.InlineArray(4)]
+internal struct Float4
+{
+    private float _element0;
+}
+
+/// <summary>Inline buffer of <see cref="LayoutResults.MaxCachedMeasurements"/> (8) cached measurements.</summary>
+[global::System.Runtime.CompilerServices.InlineArray(8)]
+internal struct CachedMeasurementArray
+{
+    private CachedMeasurement _element0;
 }

--- a/src/Reactor/Yoga/YogaAlgorithm.cs
+++ b/src/Reactor/Yoga/YogaAlgorithm.cs
@@ -428,9 +428,18 @@ internal static class YogaAlgorithm
         float crossAxisGap = node.Style.ComputeGapForAxis(crossAxis, availableInnerCrossDim);
         float maxLineMainDim = 0;
 
-        // Build the list of layout children once for iteration
-        var layoutChildren = new List<YogaNode>();
+        // Build the list of layout children once for iteration.
+        // Rented from the per-thread pool (#141) to avoid a per-container List
+        // allocation each frame; returned at the single method exit below.
+        var layoutChildren = FlexLineHelper.RentList();
         node.CollectLayoutChildren(layoutChildren);
+
+        // #148: baseline-ness depends only on this node's FlexDirection /
+        // AlignItems and its children's AlignSelf / PositionType — all invariant
+        // within a single layout pass. Compute it ONCE here instead of per flex
+        // line inside JustifyMainAxis (and again at STEP 8). No cross-frame cache,
+        // so no invalidation hazard.
+        bool isNodeBaselineLayout = BaselineHelper.IsBaselineLayout(node);
 
         while (startOfLineIndex < layoutChildren.Count)
         {
@@ -508,7 +517,7 @@ internal static class YogaAlgorithm
                 sizingModeMainDim, sizingModeCrossDim,
                 mainAxisOwnerSize, ownerWidth,
                 availableInnerMainDim, availableInnerCrossDim, availableInnerWidth,
-                performLayout);
+                performLayout, isNodeBaselineLayout);
 
             float containerCrossAxis = availableInnerCrossDim;
             if (sizingModeCrossDim == SizingMode.MaxContent || sizingModeCrossDim == SizingMode.FitContent)
@@ -629,12 +638,12 @@ internal static class YogaAlgorithm
             float appliedCrossGap = lineCount != 0 ? crossAxisGap : 0.0f;
             totalLineCrossDim += flexLine.Layout.CrossDim + appliedCrossGap;
             maxLineMainDim = YogaFloat.MaxOrDefined(maxLineMainDim, flexLine.Layout.MainDim);
-            FlexLineHelper.ReturnList(flexLine.ItemsInFlow);
+            FlexLineHelper.ReturnFlexLine(flexLine);
             lineCount++;
         }
 
         // STEP 8: MULTI-LINE CONTENT ALIGNMENT
-        if (performLayout && (isNodeFlexWrap || BaselineHelper.IsBaselineLayout(node)))
+        if (performLayout && (isNodeFlexWrap || isNodeBaselineLayout))
         {
             float leadPerLine = 0;
             float currentLead = leadingPaddingAndBorderCross;
@@ -898,6 +907,8 @@ internal static class YogaAlgorithm
                     0.0f, 0.0f, availableInnerWidth, availableInnerHeight);
             }
         }
+
+        FlexLineHelper.ReturnList(layoutChildren);
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -1332,7 +1343,8 @@ internal static class YogaAlgorithm
     {
         float totalOuterFlexBasis = 0.0f;
         YogaNode? singleFlexChild = null;
-        var children = new List<YogaNode>();
+        // Rented from the per-thread pool (#141); returned at the single exit.
+        var children = FlexLineHelper.RentList();
         node.CollectLayoutChildren(children);
         var sizingModeMainDim = FlexDirectionHelper.IsRow(mainAxis) ? widthSizingMode : heightSizingMode;
 
@@ -1394,6 +1406,7 @@ internal static class YogaAlgorithm
                 child.Style.ComputeMarginForAxis(mainAxis, availableInnerWidth);
         }
 
+        FlexLineHelper.ReturnList(children);
         return totalOuterFlexBasis;
     }
 
@@ -1672,7 +1685,7 @@ internal static class YogaAlgorithm
         SizingMode sizingModeMainDim, SizingMode sizingModeCrossDim,
         float mainAxisOwnerSize, float ownerWidth,
         float availableInnerMainDim, float availableInnerCrossDim,
-        float availableInnerWidth, bool performLayout)
+        float availableInnerWidth, bool performLayout, bool isNodeBaselineLayout)
     {
         var style = node.Style;
 
@@ -1739,7 +1752,6 @@ internal static class YogaAlgorithm
 
         float maxAscentForCurrentLine = 0;
         float maxDescentForCurrentLine = 0;
-        bool isNodeBaselineLayout = BaselineHelper.IsBaselineLayout(node);
         bool isMainAxisRow = FlexDirectionHelper.IsRow(mainAxis);
 
         for (int ci = 0; ci < flexLine.ItemsInFlow.Count; ci++)

--- a/src/Reactor/Yoga/YogaNode.cs
+++ b/src/Reactor/Yoga/YogaNode.cs
@@ -157,18 +157,107 @@ internal sealed class YogaNode
     /// Display.None children are NOT skipped here; the algorithm handles them explicitly.
     /// Ported from yoga/node/LayoutableChildren.h
     /// </summary>
-    internal IEnumerable<YogaNode> GetLayoutChildren()
+    /// <remarks>
+    /// AI-HINT (perf #145): returns a value-type <see cref="LayoutChildren"/> so
+    /// the common (no Display.Contents) case iterates <c>_children</c> by index
+    /// with ZERO heap allocations — a <c>yield</c> iterator allocates a
+    /// state-machine enumerator on every call, and these are hot per-frame paths
+    /// (baseline, trailing positions, wrap-reverse, pixel rounding). The rare
+    /// Display.Contents subtree still falls back to the allocating iterator.
+    /// </remarks>
+    internal LayoutChildren GetLayoutChildren() => new LayoutChildren(this);
+
+    // Allocating fallback used only to flatten a Display.Contents subtree.
+    private IEnumerable<YogaNode> EnumerateLayoutChildrenContents()
     {
         foreach (var child in _children)
         {
             if (child._style.Display == YogaDisplay.Contents)
             {
-                foreach (var grandchild in child.GetLayoutChildren())
+                foreach (var grandchild in child.EnumerateLayoutChildrenContents())
                     yield return grandchild;
             }
             else
             {
                 yield return child;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Allocation-free enumerable over a node's layoutable children (see
+    /// <see cref="GetLayoutChildren"/>). Nested in <see cref="YogaNode"/> so the
+    /// struct enumerator can read the private <c>_children</c> / <c>_style</c>.
+    /// </summary>
+    internal readonly struct LayoutChildren
+    {
+        private readonly YogaNode _node;
+        internal LayoutChildren(YogaNode node) => _node = node;
+
+        public Enumerator GetEnumerator() => new Enumerator(_node);
+
+        // AI-HINT (perf #145): implements IDisposable so a foreach that breaks
+        // out early (e.g. baseline detection in AlgorithmUtils) while a
+        // Display.Contents subtree is mid-drain still releases the fallback
+        // iterator's captured references. foreach emits a finally-Dispose for a
+        // struct enumerator that implements IDisposable as a non-boxing
+        // constrained call, so the common (no-inner) path stays allocation-free.
+        public struct Enumerator : IDisposable
+        {
+            private readonly List<YogaNode> _children;
+            private int _index;
+            private IEnumerator<YogaNode>? _inner;
+            private YogaNode _current;
+
+            internal Enumerator(YogaNode node)
+            {
+                _children = node._children;
+                _index = 0;
+                _inner = null;
+                _current = null!;
+            }
+
+            public readonly YogaNode Current => _current;
+
+            public bool MoveNext()
+            {
+                // Drain an in-progress Display.Contents subtree first.
+                if (_inner != null)
+                {
+                    if (_inner.MoveNext())
+                    {
+                        _current = _inner.Current;
+                        return true;
+                    }
+                    _inner.Dispose();
+                    _inner = null;
+                }
+
+                while (_index < _children.Count)
+                {
+                    var child = _children[_index++];
+                    if (child._style.Display == YogaDisplay.Contents)
+                    {
+                        _inner = child.EnumerateLayoutChildrenContents().GetEnumerator();
+                        if (_inner.MoveNext())
+                        {
+                            _current = _inner.Current;
+                            return true;
+                        }
+                        _inner.Dispose();
+                        _inner = null;
+                        continue;
+                    }
+                    _current = child;
+                    return true;
+                }
+                return false;
+            }
+
+            public void Dispose()
+            {
+                _inner?.Dispose();
+                _inner = null;
             }
         }
     }
@@ -212,6 +301,13 @@ internal sealed class YogaNode
 
     // ── Public style property accessors ──
 
+    // AI-HINT (perf #138): every setter guards with an equality check before
+    // dirtying. FlexPanel re-applies the same container/child style every
+    // MeasureOverride; without these guards the root + every cell are
+    // re-dirtied each frame and the Yoga layout cache NEVER hits. The guards
+    // mirror upstream Yoga's updateStyle, which only dirties on a real change.
+    // YogaValue is a record struct whose == treats two Undefined (NaN) values
+    // as equal; raw floats use float.Equals so NaN==NaN is also a no-op.
     public FlexDirection FlexDirection { get => _style.FlexDirection; set { _style.FlexDirection = value; MarkDirtyAndPropagate(); } }
     public FlexJustify JustifyContent { get => _style.JustifyContent; set { _style.JustifyContent = value; MarkDirtyAndPropagate(); } }
     public FlexAlign AlignItems { get => _style.AlignItems; set { _style.AlignItems = value; MarkDirtyAndPropagate(); } }
@@ -249,16 +345,17 @@ internal sealed class YogaNode
         set
         {
             // Degenerate aspect ratios act as auto
-            _style.AspectRatio = (value == 0 || float.IsInfinity(value)) ? float.NaN : value;
+            float normalized = (value == 0 || float.IsInfinity(value)) ? float.NaN : value;
+            _style.AspectRatio = normalized;
             MarkDirtyAndPropagate();
         }
     }
 
     public void SetMargin(YogaEdge edge, YogaValue value) { _style.Margin[(int)edge] = value; MarkDirtyAndPropagate(); }
     public void SetPadding(YogaEdge edge, YogaValue value) { _style.Padding[(int)edge] = value; MarkDirtyAndPropagate(); }
-    public void SetBorder(YogaEdge edge, float value) { _style.Border[(int)edge] = YogaValue.Point(value); MarkDirtyAndPropagate(); }
+    public void SetBorder(YogaEdge edge, float value) { var v = YogaValue.Point(value); _style.Border[(int)edge] = v; MarkDirtyAndPropagate(); }
     public void SetPosition(YogaEdge edge, YogaValue value) { _style.Position[(int)edge] = value; MarkDirtyAndPropagate(); }
-    public void SetGap(YogaGutter gutter, float value) { _style.Gap[(int)gutter] = YogaValue.Point(value); MarkDirtyAndPropagate(); }
+    public void SetGap(YogaGutter gutter, float value) { var v = YogaValue.Point(value); _style.Gap[(int)gutter] = v; MarkDirtyAndPropagate(); }
     public void SetGap(YogaGutter gutter, YogaValue value) { _style.Gap[(int)gutter] = value; MarkDirtyAndPropagate(); }
 
     // ── Measure/baseline callbacks ──

--- a/src/Reactor/Yoga/YogaNode.cs
+++ b/src/Reactor/Yoga/YogaNode.cs
@@ -301,13 +301,6 @@ internal sealed class YogaNode
 
     // ── Public style property accessors ──
 
-    // AI-HINT (perf #138): every setter guards with an equality check before
-    // dirtying. FlexPanel re-applies the same container/child style every
-    // MeasureOverride; without these guards the root + every cell are
-    // re-dirtied each frame and the Yoga layout cache NEVER hits. The guards
-    // mirror upstream Yoga's updateStyle, which only dirties on a real change.
-    // YogaValue is a record struct whose == treats two Undefined (NaN) values
-    // as equal; raw floats use float.Equals so NaN==NaN is also a no-op.
     public FlexDirection FlexDirection { get => _style.FlexDirection; set { _style.FlexDirection = value; MarkDirtyAndPropagate(); } }
     public FlexJustify JustifyContent { get => _style.JustifyContent; set { _style.JustifyContent = value; MarkDirtyAndPropagate(); } }
     public FlexAlign AlignItems { get => _style.AlignItems; set { _style.AlignItems = value; MarkDirtyAndPropagate(); } }

--- a/src/Reactor/Yoga/YogaNode.cs
+++ b/src/Reactor/Yoga/YogaNode.cs
@@ -301,6 +301,16 @@ internal sealed class YogaNode
 
     // ── Public style property accessors ──
 
+    // AI-HINT (perf): these setters dirty the node UNCONDITIONALLY — do NOT add
+    // equality-guards (`if (_style.X == value) return;`) here. An earlier
+    // optimization (former #138) guarded each setter to skip re-dirtying
+    // unchanged values, intending to let the Yoga layout cache hit across
+    // frames. But /perf on the Flex/Yoga macro workload (PR #740) proved that on
+    // DYNAMIC flex trees those guards thrash Yoga's CanUseCachedMeasurement path
+    // every frame and ~2x the layout pass (−39.6% Flex renders/sec) — the cached
+    // measurements miss as available sizes shift each frame instead of main's
+    // dirty-clear-then-measure-once. The guards only help fully STATIC trees.
+    // Reverted to unconditional dirty = main behavior. See PR #740.
     public FlexDirection FlexDirection { get => _style.FlexDirection; set { _style.FlexDirection = value; MarkDirtyAndPropagate(); } }
     public FlexJustify JustifyContent { get => _style.JustifyContent; set { _style.JustifyContent = value; MarkDirtyAndPropagate(); } }
     public FlexAlign AlignItems { get => _style.AlignItems; set { _style.AlignItems = value; MarkDirtyAndPropagate(); } }

--- a/src/Reactor/Yoga/YogaStyle.cs
+++ b/src/Reactor/Yoga/YogaStyle.cs
@@ -43,31 +43,56 @@ internal sealed class YogaStyle
     public float FlexShrink = float.NaN;
     public YogaValue FlexBasis = YogaValue.Auto;
 
-    // Edge-indexed arrays (indexed by YogaEdge: Left=0..All=8)
-    public readonly YogaValue[] Margin = CreateUndefinedEdges();
-    public readonly YogaValue[] Position = CreateUndefinedEdges();
-    public readonly YogaValue[] Padding = CreateUndefinedEdges();
-    public readonly YogaValue[] Border = CreateUndefinedEdges();
+    // Edge / gutter / dimension values are stored inline (see #143 InlineArray
+    // structs at the bottom of this file) instead of 8 separate YogaValue[]
+    // arrays. Exposed as ref-returning properties so existing indexer reads and
+    // writes (style.Margin[i], style.Position[i] = v) keep working unchanged.
+    private EdgeValues _margin;
+    private EdgeValues _position;
+    private EdgeValues _padding;
+    private EdgeValues _border;
+    private GutterValues _gap;            // Column=0, Row=1, All=2
+    private DimensionValues _dimensions;  // Width=0, Height=1
+    private DimensionValues _minDimensions;
+    private DimensionValues _maxDimensions;
 
-    // Gutter-indexed array (Column=0, Row=1, All=2)
-    public readonly YogaValue[] Gap = new YogaValue[3]
-    {
-        YogaValue.Undefined, YogaValue.Undefined, YogaValue.Undefined
-    };
+    // Edge-indexed values (indexed by YogaEdge: Left=0..All=8)
+    public ref EdgeValues Margin => ref _margin;
+    public ref EdgeValues Position => ref _position;
+    public ref EdgeValues Padding => ref _padding;
+    public ref EdgeValues Border => ref _border;
 
-    // Dimension-indexed arrays (Width=0, Height=1)
-    public readonly YogaValue[] Dimensions = new YogaValue[2]
+    // Gutter-indexed values (Column=0, Row=1, All=2)
+    public ref GutterValues Gap => ref _gap;
+
+    // Dimension-indexed values (Width=0, Height=1)
+    public ref DimensionValues Dimensions => ref _dimensions;
+    public ref DimensionValues MinDimensions => ref _minDimensions;
+    public ref DimensionValues MaxDimensions => ref _maxDimensions;
+
+    public YogaStyle()
     {
-        YogaValue.Auto, YogaValue.Auto
-    };
-    public readonly YogaValue[] MinDimensions = new YogaValue[2]
-    {
-        YogaValue.Undefined, YogaValue.Undefined
-    };
-    public readonly YogaValue[] MaxDimensions = new YogaValue[2]
-    {
-        YogaValue.Undefined, YogaValue.Undefined
-    };
+        // Explicitly seed the inline buffers to match the historic array
+        // initializers. default(YogaValue) is (0, Undefined) — NOT the
+        // (NaN, Undefined) sentinel — so leaving them zero-initialized would
+        // subtly change == and Resolve() behavior. Dimensions default to Auto.
+        for (int i = 0; i < 9; i++)
+        {
+            _margin[i] = YogaValue.Undefined;
+            _position[i] = YogaValue.Undefined;
+            _padding[i] = YogaValue.Undefined;
+            _border[i] = YogaValue.Undefined;
+        }
+        _gap[0] = YogaValue.Undefined;
+        _gap[1] = YogaValue.Undefined;
+        _gap[2] = YogaValue.Undefined;
+        _dimensions[0] = YogaValue.Auto;
+        _dimensions[1] = YogaValue.Auto;
+        _minDimensions[0] = YogaValue.Undefined;
+        _minDimensions[1] = YogaValue.Undefined;
+        _maxDimensions[0] = YogaValue.Undefined;
+        _maxDimensions[1] = YogaValue.Undefined;
+    }
 
     // Aspect ratio (NaN = undefined)
     private float _aspectRatio = float.NaN;
@@ -90,30 +115,22 @@ internal sealed class YogaStyle
         }
     }
 
-    private static YogaValue[] CreateUndefinedEdges()
-    {
-        var arr = new YogaValue[9];
-        for (int i = 0; i < 9; i++)
-            arr[i] = YogaValue.Undefined;
-        return arr;
-    }
-
     // ── Edge computation (resolves Start/End/Horizontal/Vertical/All fallbacks) ──
 
     public YogaValue ComputeColumnGap()
     {
-        var col = Gap[(int)YogaGutter.Column];
-        return col.IsDefined ? col : Gap[(int)YogaGutter.All];
+        var col = _gap[(int)YogaGutter.Column];
+        return col.IsDefined ? col : _gap[(int)YogaGutter.All];
     }
 
     public YogaValue ComputeRowGap()
     {
-        var row = Gap[(int)YogaGutter.Row];
-        return row.IsDefined ? row : Gap[(int)YogaGutter.All];
+        var row = _gap[(int)YogaGutter.Row];
+        return row.IsDefined ? row : _gap[(int)YogaGutter.All];
     }
 
     /// <summary>Resolve the left edge value considering Start/End/Left/Horizontal/All fallbacks.</summary>
-    private YogaValue ComputeLeftEdge(YogaValue[] edges, FlexLayoutDirection layoutDirection)
+    private static YogaValue ComputeLeftEdge(ReadOnlySpan<YogaValue> edges, FlexLayoutDirection layoutDirection)
     {
         if (layoutDirection == FlexLayoutDirection.LTR && edges[(int)YogaEdge.Start].IsDefined)
             return edges[(int)YogaEdge.Start];
@@ -126,14 +143,14 @@ internal sealed class YogaStyle
         return edges[(int)YogaEdge.All];
     }
 
-    private YogaValue ComputeTopEdge(YogaValue[] edges)
+    private static YogaValue ComputeTopEdge(ReadOnlySpan<YogaValue> edges)
     {
         if (edges[(int)YogaEdge.Top].IsDefined) return edges[(int)YogaEdge.Top];
         if (edges[(int)YogaEdge.Vertical].IsDefined) return edges[(int)YogaEdge.Vertical];
         return edges[(int)YogaEdge.All];
     }
 
-    private YogaValue ComputeRightEdge(YogaValue[] edges, FlexLayoutDirection layoutDirection)
+    private static YogaValue ComputeRightEdge(ReadOnlySpan<YogaValue> edges, FlexLayoutDirection layoutDirection)
     {
         if (layoutDirection == FlexLayoutDirection.LTR && edges[(int)YogaEdge.End].IsDefined)
             return edges[(int)YogaEdge.End];
@@ -146,14 +163,14 @@ internal sealed class YogaStyle
         return edges[(int)YogaEdge.All];
     }
 
-    private YogaValue ComputeBottomEdge(YogaValue[] edges)
+    private static YogaValue ComputeBottomEdge(ReadOnlySpan<YogaValue> edges)
     {
         if (edges[(int)YogaEdge.Bottom].IsDefined) return edges[(int)YogaEdge.Bottom];
         if (edges[(int)YogaEdge.Vertical].IsDefined) return edges[(int)YogaEdge.Vertical];
         return edges[(int)YogaEdge.All];
     }
 
-    private YogaValue ComputeEdge(YogaValue[] edges, YogaPhysicalEdge edge, FlexLayoutDirection direction)
+    private static YogaValue ComputeEdge(ReadOnlySpan<YogaValue> edges, YogaPhysicalEdge edge, FlexLayoutDirection direction)
     {
         return edge switch
         {
@@ -168,32 +185,32 @@ internal sealed class YogaStyle
     // ── Position queries ──
 
     public YogaValue ComputePosition(YogaPhysicalEdge edge, FlexLayoutDirection direction)
-        => ComputeEdge(Position, edge, direction);
+        => ComputeEdge(_position, edge, direction);
 
     public YogaValue ComputeMargin(YogaPhysicalEdge edge, FlexLayoutDirection direction)
-        => ComputeEdge(Margin, edge, direction);
+        => ComputeEdge(_margin, edge, direction);
 
     public YogaValue ComputePadding(YogaPhysicalEdge edge, FlexLayoutDirection direction)
-        => ComputeEdge(Padding, edge, direction);
+        => ComputeEdge(_padding, edge, direction);
 
     public YogaValue ComputeBorder(YogaPhysicalEdge edge, FlexLayoutDirection direction)
-        => ComputeEdge(Border, edge, direction);
+        => ComputeEdge(_border, edge, direction);
 
     // ── Inset queries ──
 
     public bool HorizontalInsetsDefined =>
-        Position[(int)YogaEdge.Left].IsDefined ||
-        Position[(int)YogaEdge.Right].IsDefined ||
-        Position[(int)YogaEdge.All].IsDefined ||
-        Position[(int)YogaEdge.Horizontal].IsDefined ||
-        Position[(int)YogaEdge.Start].IsDefined ||
-        Position[(int)YogaEdge.End].IsDefined;
+        _position[(int)YogaEdge.Left].IsDefined ||
+        _position[(int)YogaEdge.Right].IsDefined ||
+        _position[(int)YogaEdge.All].IsDefined ||
+        _position[(int)YogaEdge.Horizontal].IsDefined ||
+        _position[(int)YogaEdge.Start].IsDefined ||
+        _position[(int)YogaEdge.End].IsDefined;
 
     public bool VerticalInsetsDefined =>
-        Position[(int)YogaEdge.Top].IsDefined ||
-        Position[(int)YogaEdge.Bottom].IsDefined ||
-        Position[(int)YogaEdge.All].IsDefined ||
-        Position[(int)YogaEdge.Vertical].IsDefined;
+        _position[(int)YogaEdge.Top].IsDefined ||
+        _position[(int)YogaEdge.Bottom].IsDefined ||
+        _position[(int)YogaEdge.All].IsDefined ||
+        _position[(int)YogaEdge.Vertical].IsDefined;
 
     // ── Flex-direction-aware computed values ──
 
@@ -328,7 +345,7 @@ internal sealed class YogaStyle
 
     public float ResolvedMinDimension(FlexLayoutDirection direction, YogaDimension axis, float referenceLength, float ownerWidth)
     {
-        float value = MinDimensions[(int)axis].Resolve(referenceLength);
+        float value = _minDimensions[(int)axis].Resolve(referenceLength);
         if (BoxSizing == YogaBoxSizing.BorderBox)
             return value;
 
@@ -341,7 +358,7 @@ internal sealed class YogaStyle
 
     public float ResolvedMaxDimension(FlexLayoutDirection direction, YogaDimension axis, float referenceLength, float ownerWidth)
     {
-        float value = MaxDimensions[(int)axis].Resolve(referenceLength);
+        float value = _maxDimensions[(int)axis].Resolve(referenceLength);
         if (BoxSizing == YogaBoxSizing.BorderBox)
             return value;
 
@@ -350,4 +367,36 @@ internal sealed class YogaStyle
         float pb = YogaFloat.IsDefined(paddingAndBorder) ? paddingAndBorder : 0;
         return value + pb;
     }
+}
+
+// AI-HINT (perf #143): fixed-size inline value buffers embedded directly in the
+// YogaStyle heap object. These replace 8 separate YogaValue[] arrays per node —
+// for a ~200-node tree that removes ~1600 GC objects (a dominant Yoga memory
+// regression vs the C++ original, which uses inline members). InlineArray is a
+// first-class C# 12 feature: indexing is compiler-generated and fully AOT/trim
+// safe (no reflection, no Unsafe). Each struct has exactly one instance field,
+// as InlineArray requires. They are explicitly initialized in the YogaStyle
+// constructor (default(YogaValue) is (0, Undefined), not the (NaN, Undefined)
+// sentinel — and dimensions default to Auto), so == and Resolve() semantics
+// stay byte-identical to the previous arrays.
+
+/// <summary>Edge-indexed inline buffer (YogaEdge: Left=0 .. All=8).</summary>
+[global::System.Runtime.CompilerServices.InlineArray(9)]
+internal struct EdgeValues
+{
+    private YogaValue _element0;
+}
+
+/// <summary>Gutter-indexed inline buffer (Column=0, Row=1, All=2).</summary>
+[global::System.Runtime.CompilerServices.InlineArray(3)]
+internal struct GutterValues
+{
+    private YogaValue _element0;
+}
+
+/// <summary>Dimension-indexed inline buffer (Width=0, Height=1).</summary>
+[global::System.Runtime.CompilerServices.InlineArray(2)]
+internal struct DimensionValues
+{
+    private YogaValue _element0;
 }


### PR DESCRIPTION
## Summary

Salvages the genuine allocation/memory wins from #670 while dropping the **one** piece that caused a severe layout-throughput regression: the **#138 YogaNode setter equality-guards**.

#670 was never `/perf`-measurable until the Flex/Yoga macro workload (`StressPerf.Flex`, #737) landed. Measured against it, full #670 is a **Renders/sec −33% to −40%** regression vs `main` (the deferred Yoga Measure/Arrange pass roughly doubled) — for only a ~2% memory/Gen0 sliver. This PR keeps the sliver-and-more and removes the regression.

## Bisection — #138 is the sole regressor

Local interleaved A/B against the Flex `/perf` workload (ARM64, self-contained, headless, 4–5 reps). Each row = full #670 with one piece reverted to `main`:

| variant | Renders/sec | verdict |
|---|---|---|
| `main` | ~2.5 | baseline |
| full #670 | ~1.7 (−33%) | regressed |
| revert #142/#143 inline arrays | ~1.75 | **not** the regressor (and these give the memory win) |
| restore `WebFlexBasis` flex-basis gate | ~1.75 | not the regressor |
| revert #147 FlexPanel DP cache | ~1.68 | not the regressor |
| **strip ONLY the #138 setter guards** (keep everything else) | **~2.5 = main, alloc −6%** | **full recovery** |

### Mechanism
The equality-guards (`if (_style.X == value) return;`) suppress the per-frame re-dirty that `FlexPanel` relies on. On a **churning** layout the now-undirtied nodes fall into Yoga's `CanUseCachedMeasurement` validation path, whose cached entries miss every frame as available sizes shift — thrashing the measurement cache instead of `main`'s dirty-clear-then-measure-once. #138 only helps **static** trees; on dynamic flex it ~2×'s layout time.

## What this PR does

Reverts the **entire #138 unit** to `main`:
- YogaNode setter equality-guards
- the YogaAlgorithm per-generation flex-basis recompute (restores the `WebFlexBasis` gate)
- FlexPanel route-through-guarded-setters (writes `node.Style.X` directly again)

…and **keeps** every clean win from #670:
- **#142/#143** inline per-node arrays (`LayoutResults` / `YogaStyle` `[InlineArray]`) — the memory win
- **#141** layout-children list pool
- **#144** `FlexLine` pool
- **#145** allocation-free layout-children iteration
- **#147** attached-DP push caching
- **#148** `IsBaselineLayout` computed once per pass

## Correctness & build gates

- ✅ **Yoga fixtures: 694 passed / 0 failed / 46 pre-existing skips** (`dotnet test tests/Reactor.Tests --filter ~Yoga`). Reverting #138 as a unit restores `main`'s exact algorithm, so **no numeric layout result changes**.
- ✅ `dotnet build src/Reactor/Reactor.csproj -c Release` — **0 warnings / 0 errors** (AOT/trim-clean; the kept `[InlineArray]` pieces still build clean).

## Follow-up
Investigate whether #138 can be re-introduced **gated to static (non-churning) subtrees**, where its cache-hit premise actually holds.

Supersedes #670 (regression, superseded).

🤖 Diagnosis + bisection by the perf-investigation agent. Do not merge until dual-review + official `/perf` confirm.