### PR TITLE
docs: warn against re-adding the #138 Yoga setter equality-guards (see #742)

### DIFF
--- a/src/Reactor/Yoga/YogaNode.cs
+++ b/src/Reactor/Yoga/YogaNode.cs
@@ -310,7 +310,9 @@ internal sealed class YogaNode
     // every frame and ~2x the layout pass (−39.6% Flex renders/sec) — the cached
     // measurements miss as available sizes shift each frame instead of main's
     // dirty-clear-then-measure-once. The guards only help fully STATIC trees.
-    // Reverted to unconditional dirty = main behavior. See PR #740.
+    // Reverted to unconditional dirty = main behavior. See PR #740; the full
+    // #138-harmful-on-dynamic-trees finding (and the static-tree-gating idea) is
+    // tracked in issue #742.
     public FlexDirection FlexDirection { get => _style.FlexDirection; set { _style.FlexDirection = value; MarkDirtyAndPropagate(); } }
     public FlexJustify JustifyContent { get => _style.JustifyContent; set { _style.JustifyContent = value; MarkDirtyAndPropagate(); } }
     public FlexAlign AlignItems { get => _style.AlignItems; set { _style.AlignItems = value; MarkDirtyAndPropagate(); } }


### PR DESCRIPTION
Comment-only follow-up.

**Context:** The squash-merge of #740 already landed the protective warning above the `YogaNode` style setters (it captured my branch HEAD, which included the warning). So main already tells future readers: *these setters dirty UNCONDITIONALLY on purpose — do NOT add equality-guards; the former #138 guards thrash Yoga's `CanUseCachedMeasurement` path and ~2x the layout pass on dynamic flex trees (−39.6% Flex renders/sec), and only help static trees.*

**This PR** adds the one thing that was missing: a reference to issue **#742** (the full #138-harmful-on-dynamic-trees finding + the static-tree-gating idea), so a reader who hits the warning lands on the complete analysis, not just PR #740.

Why it matters: `/perf` is opt-in (someone must comment `/perf`), not an automatic CI gate — so a future dev re-adding the guards could merge without the regression being caught. This in-code, point-of-edit warning is the only always-visible safeguard.

**Gates (comment-only → production IL byte-unchanged):**
- ✅ `dotnet build src/Reactor/Reactor.csproj -c Release` → 0/0
- ✅ Yoga fixtures → 694 passed / 0 failed / 46 skipped