### PR TITLE
test: UI-thread selftest for BrushHelper.Parse correctness + non-aliasing (#682)

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/BrushHelperParseFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/BrushHelperParseFixture.cs
@@ -1,0 +1,70 @@
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Issue #682 — UI-thread coverage for <see cref="BrushHelper.Parse"/>. The
+/// headless unit tests (<c>PerfDiffSkipPathTests.ParseColor_*</c>) can only
+/// assert the cached <see cref="Color"/>; constructing/inspecting a
+/// <see cref="SolidColorBrush"/> needs a UI thread. This fixture verifies that
+/// <see cref="BrushHelper.Parse"/> yields a correct brush AND locks the
+/// non-aliasing invariant: two parses of the same input must return DISTINCT
+/// instances. That guard exists so any future reintroduction of brush-instance
+/// caching (#168, reverted) must first prove it is safe under a <c>.Set</c>
+/// mutation shared across elements — a <see cref="SolidColorBrush"/> is a
+/// thread-affine, mutable <c>DependencyObject</c> and cannot be safely shared.
+/// </summary>
+internal static class BrushHelperParseFixture
+{
+    internal sealed class Execution(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync()
+        {
+            // ── 1. Hex #RRGGBB → correct fully-opaque Color + default Opacity ──
+            var hex = BrushHelper.Parse("#3366CC");
+            H.Check(
+                "BrushHelperParse_Hex_Color",
+                hex.Color == Color.FromArgb(255, 0x33, 0x66, 0xCC));
+            H.Check(
+                "BrushHelperParse_Hex_DefaultOpacity",
+                hex.Opacity == 1.0);
+
+            // ── 2. Hex #AARRGGBB → alpha is honored ──
+            var hexAlpha = BrushHelper.Parse("#80112233");
+            H.Check(
+                "BrushHelperParse_HexAlpha_Color",
+                hexAlpha.Color == Color.FromArgb(0x80, 0x11, 0x22, 0x33));
+
+            // ── 3. Named color (case-insensitive) → correct Color ──
+            var red = BrushHelper.Parse("red");
+            H.Check(
+                "BrushHelperParse_Named_Color",
+                red.Color == Color.FromArgb(255, 255, 0, 0));
+            var redMixedCase = BrushHelper.Parse("ReD");
+            H.Check(
+                "BrushHelperParse_Named_CaseInsensitive",
+                redMixedCase.Color == red.Color);
+
+            // ── 4. Non-aliasing: two parses of the SAME input → DISTINCT brushes ──
+            // Locks the invariant behind the reverted #168 shared-brush cache.
+            var a = BrushHelper.Parse("#3366CC");
+            var b = BrushHelper.Parse("#3366CC");
+            H.Check(
+                "BrushHelperParse_NonAliasing_DistinctInstances",
+                !ReferenceEquals(a, b));
+            H.Check(
+                "BrushHelperParse_NonAliasing_SameColorValue",
+                a.Color == b.Color);
+
+            // Mutating one brush must not leak into the other (the reason a
+            // SolidColorBrush cannot be shared across controls).
+            a.Color = Color.FromArgb(255, 0, 0, 0);
+            H.Check(
+                "BrushHelperParse_NonAliasing_MutationIsolated",
+                b.Color == Color.FromArgb(255, 0x33, 0x66, 0xCC));
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1458,6 +1458,7 @@ internal static class SelfTestFixtureRegistry
         "OptionalTriStateCheckBox",
         "OptionalSetterCollision",
         "InitialOnly",
+        "BrushHelperParse",
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
@@ -2867,6 +2868,7 @@ internal static class SelfTestFixtureRegistry
         "OptionalTriStateCheckBox" => new OptionalTriStateCheckBoxFixture.Execution(harness),
         "OptionalSetterCollision" => new OptionalSetterCollisionFixture.Execution(harness),
         "InitialOnly" => new InitialOnlyFixture.Execution(harness),
+        "BrushHelperParse" => new BrushHelperParseFixture.Execution(harness),
 
         _ => null,
     };


### PR DESCRIPTION
## Summary
Follow-up to #665 (part of the #664 perf effort). Adds a UI-thread selftest fixture for `BrushHelper.Parse`.

The headless unit tests (`PerfDiffSkipPathTests.ParseColor_*`) can only assert the cached `Color` value — constructing/inspecting a `SolidColorBrush` requires a UI thread, so there was no test that `Parse` actually yields a correct brush, nor a guard locking the non-aliasing invariant.

## What this adds
A selftest fixture (`BrushHelperParseFixture`) that, on the UI thread, asserts:
1. `Parse("#RRGGBB")` and a named color produce a `SolidColorBrush` whose `Color` and default `Opacity` (1.0) match expectations; `#AARRGGBB` honors alpha; named-color parsing is case-insensitive.
2. Two `Parse(...)` calls for the same input return **distinct** instances (non-aliasing), and mutating one does not leak into the other — so any future reintroduction of brush-instance caching (the reverted #168 shared-brush cache) must first prove it is safe under `.Set` mutation across elements.

## Scope
Small, additive, test-only — no production change. Registered in `SelfTestFixtureRegistry`.

## Validation
- `dotnet build src/Reactor/Reactor.csproj -c Release` → 0 warnings / 0 errors.
- Selftest `BrushHelperParse` → 8/8 checks pass.

Closes #682.

---
🤖 Draft for coordinator review (dual-review + /perf before merge).