### PR TITLE
perf: remove dead LayoutResults.Reset() (#681, finding #146)

### DIFF
--- a/src/Reactor/Yoga/LayoutResults.cs
+++ b/src/Reactor/Yoga/LayoutResults.cs
@@ -128,40 +128,6 @@ internal sealed class LayoutResults
     public float GetPadding(YogaPhysicalEdge edge) => _padding[(int)edge];
     public void SetPadding(YogaPhysicalEdge edge, float value) => _padding[(int)edge] = value;
 
-    /// <summary>
-    /// Reset all layout results to default values.
-    /// </summary>
-    public void Reset()
-    {
-        ComputedFlexBasisGeneration = 0;
-        ComputedFlexBasis = float.NaN;
-        GenerationCount = 0;
-        ConfigVersion = 0;
-        LastOwnerDirection = FlexLayoutDirection.Inherit;
-        NextCachedMeasurementsIndex = 0;
-        _direction = FlexLayoutDirection.Inherit;
-        _hadOverflow = false;
-
-        _dimensions[0] = float.NaN;
-        _dimensions[1] = float.NaN;
-        _measuredDimensions[0] = float.NaN;
-        _measuredDimensions[1] = float.NaN;
-        _rawDimensions[0] = float.NaN;
-        _rawDimensions[1] = float.NaN;
-
-        for (int i = 0; i < 4; i++)
-        {
-            _position[i] = 0;
-            _margin[i] = 0;
-            _border[i] = 0;
-            _padding[i] = 0;
-        }
-
-        for (int i = 0; i < MaxCachedMeasurements; i++)
-            _cachedMeasurements[i] = new CachedMeasurement();
-        CachedLayout = new CachedMeasurement();
-    }
-
     public bool EqualTo(LayoutResults other)
     {
         if (_direction != other._direction || _hadOverflow != other._hadOverflow)

--- a/tests/Reactor.Tests/YogaLayoutResultsTests.cs
+++ b/tests/Reactor.Tests/YogaLayoutResultsTests.cs
@@ -127,53 +127,6 @@ public class YogaLayoutResultsTests
         Assert.True(r.HadOverflow);
     }
 
-    // ── Reset() ─────────────────────────────────────────────────────
-
-    [Fact]
-    public void Reset_Clears_Every_Field()
-    {
-        var r = new LayoutResults
-        {
-            ComputedFlexBasisGeneration = 7,
-            ComputedFlexBasis = 50f,
-            GenerationCount = 3,
-            ConfigVersion = 4,
-            LastOwnerDirection = FlexLayoutDirection.RTL,
-            NextCachedMeasurementsIndex = 5,
-            Direction = FlexLayoutDirection.LTR,
-            HadOverflow = true,
-        };
-        r.SetDimension(YogaDimension.Width, 100f);
-        r.SetMeasuredDimension(YogaDimension.Height, 80f);
-        r.SetRawDimension(YogaDimension.Width, 120f);
-        r.SetPosition(YogaPhysicalEdge.Left, 5f);
-        r.SetMargin(YogaPhysicalEdge.Top, 6f);
-        r.SetBorder(YogaPhysicalEdge.Right, 7f);
-        r.SetPadding(YogaPhysicalEdge.Bottom, 8f);
-        r.CachedMeasurements[0] = new CachedMeasurement { ComputedWidth = 99 };
-        r.CachedLayout = new CachedMeasurement { ComputedWidth = 33 };
-
-        r.Reset();
-
-        Assert.Equal(0u, r.ComputedFlexBasisGeneration);
-        Assert.True(float.IsNaN(r.ComputedFlexBasis));
-        Assert.Equal(0u, r.GenerationCount);
-        Assert.Equal(0u, r.ConfigVersion);
-        Assert.Equal(FlexLayoutDirection.Inherit, r.LastOwnerDirection);
-        Assert.Equal(0u, r.NextCachedMeasurementsIndex);
-        Assert.Equal(FlexLayoutDirection.Inherit, r.Direction);
-        Assert.False(r.HadOverflow);
-        Assert.True(float.IsNaN(r.GetDimension(YogaDimension.Width)));
-        Assert.True(float.IsNaN(r.GetMeasuredDimension(YogaDimension.Height)));
-        Assert.True(float.IsNaN(r.GetRawDimension(YogaDimension.Width)));
-        Assert.Equal(0f, r.GetPosition(YogaPhysicalEdge.Left));
-        Assert.Equal(0f, r.GetMargin(YogaPhysicalEdge.Top));
-        Assert.Equal(0f, r.GetBorder(YogaPhysicalEdge.Right));
-        Assert.Equal(0f, r.GetPadding(YogaPhysicalEdge.Bottom));
-        Assert.Equal(-1f, r.CachedMeasurements[0].ComputedWidth); // default
-        Assert.Equal(-1f, r.CachedLayout.ComputedWidth);
-    }
-
     // ── EqualTo() ───────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
Follow-up to the Yoga layout-engine work (#681, finding #146). Removes dead code.

`LayoutResults.Reset()` has **no production callers**. The GC concern it once addressed is superseded by `CachedMeasurement` being a struct (#142). The only reference was a unit test that exercised the dead method, which is removed alongside it.

## Scope
`src/Reactor/Yoga/` only. No behavior change.

## Validation
- `dotnet build src/Reactor/Reactor.csproj -c Release` -> 0 warnings / 0 errors.
- Yoga fixtures: 693 passed / 0 failed / 46 skipped.
- Full `dotnet test tests/Reactor.Tests`: 9911 passed / 0 failed.

Part of #681.

---
🤖 Draft for coordinator review (dual-review before merge). No /perf needed — pure dead-code removal, zero behavior change.