### PR TITLE
test(perf): add StressPerf.DataGrid /perf macro leg

### DIFF
--- a/Reactor.slnx
+++ b/Reactor.slnx
@@ -388,6 +388,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="tests/stress_perf/StressPerf.DataGrid/StressPerf.DataGrid.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="tests/stress_perf/StressPerf.Direct/StressPerf.Direct.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/tests/stress_perf/StressPerf.DataGrid/DataGridSceneSource.cs
+++ b/tests/stress_perf/StressPerf.DataGrid/DataGridSceneSource.cs
@@ -1,0 +1,139 @@
+using Microsoft.UI.Reactor.Data;
+
+namespace StressPerf.DataGrid;
+
+/// <summary>
+/// A row of stock data for the DataGrid. Each row holds one cell per column.
+/// Mirrors the row shape used by the legacy <c>StressPerf.ReactorGrid</c> scene,
+/// reused here on the modern compare-mode /perf contract.
+/// </summary>
+public sealed record StockRow(int Id, StressPerf.Shared.StockItem[] Cells);
+
+/// <summary>
+/// Deterministic DataGrid workload data source for the /perf macro benchmark.
+///
+/// Unlike <see cref="StressPerf.Shared.StockDataSource"/> (a flat positional cell
+/// array fed to a native <c>Grid</c> by the StocksGrid leg), this source drives the
+/// REAL <c>DataGrid</c> control (<c>DataGridComponent&lt;StockRow&gt;</c>) through its
+/// <see cref="IDataSource{T}"/> + <see cref="IObservableDataSource{T}"/> paging path —
+/// the path that owns the per-render array/LINQ allocation (#663/#669) and the
+/// per-cell/row modifier-delegate churn (#671) no other wired leg exercises.
+///
+/// Each tick, <see cref="Update"/> mutates a <c>percent</c> fraction of cells and
+/// fires <see cref="DataChanged"/>. The grid's observable subscription reloads the
+/// page, which bumps DataGridState and schedules a full
+/// <c>DataGridComponent.Render()</c> — re-running, EVERY render and regardless of
+/// whether sort/filter changed, the unconditional per-render rebuilds #663/#669
+/// target (the <c>sortKey</c> join, the <c>DataRequest</c> + <c>.ToList()</c>s, the
+/// header+row <c>colWidths</c>/<c>gridColDefs</c> arrays, the <c>Columns</c> getter's
+/// <c>Where+ToList</c>, the per-column <c>GetSortDirection</c>/<c>GetColumnWidth</c>
+/// LINQ, the row-def arrays, the setter spread) and re-allocating the per-realized-
+/// cell/row <c>.OnTapped</c>/<c>.OnPointerPressed</c> closures inside <c>RenderRow</c>.
+///
+/// Deterministic (fixed RNG seed 42, matching <see cref="StressPerf.Shared.StockDataSource"/>)
+/// so main-vs-PR /perf runs compare identical edit sequences; the row SET and count
+/// are held constant (only cell VALUES change) so working-set and render-count stay
+/// stable across the run.
+/// </summary>
+public sealed class DataGridSceneSource : IDataSource<StockRow>, IObservableDataSource<StockRow>
+{
+    /// <summary>Column count — wide so the per-column header/row LINQ (#128) scales.</summary>
+    public const int DefaultColumns = 30;
+
+    /// <summary>Row count — large enough to fully realize a tall viewport's worth of rows.</summary>
+    public const int DefaultRows = 200;
+
+    private readonly int _columnCount;
+    private readonly int _rowCount;
+    private readonly int _totalCells;
+    private readonly StockRow[] _rows;
+    private readonly Random _rng = new(42); // deterministic seed (matches StockDataSource)
+
+    public DataGridSceneSource(int columns = DefaultColumns, int rows = DefaultRows)
+    {
+        if (columns < 1) columns = 1;
+        if (rows < 1) rows = 1;
+        _columnCount = columns;
+        _rowCount = rows;
+        _totalCells = columns * rows;
+        _rows = new StockRow[rows];
+
+        var rng = _rng;
+        for (int r = 0; r < rows; r++)
+        {
+            var cells = new StressPerf.Shared.StockItem[columns];
+            for (int c = 0; c < columns; c++)
+            {
+                char c1 = (char)('A' + (r % 26));
+                char c2 = (char)('A' + (c / 3 % 26));
+                char c3 = (char)('A' + (c % 26));
+                string symbol = string.Create(3, (c1, c2, c3), static (span, s) =>
+                {
+                    span[0] = s.c1;
+                    span[1] = s.c2;
+                    span[2] = s.c3;
+                });
+                double price = Math.Round(10.0 + rng.NextDouble() * 990.0, 2);
+                cells[c] = new StressPerf.Shared.StockItem(symbol, price, price, true);
+            }
+            _rows[r] = new StockRow(r, cells);
+        }
+    }
+
+    public int ColumnCount => _columnCount;
+    public int RowCount => _rowCount;
+
+    public event EventHandler? DataChanged;
+
+    public DataSourceCapabilities Capabilities => DataSourceCapabilities.ServerCount;
+
+    public RowKey GetRowKey(StockRow item) => item.Id;
+
+    public Task<DataPage<StockRow>> GetPageAsync(DataRequest request, CancellationToken cancellationToken = default)
+    {
+        var offset = 0;
+        if (request.ContinuationToken is not null && int.TryParse(request.ContinuationToken, out var parsed))
+            offset = parsed;
+
+        var pageSize = Math.Min(request.PageSize, _rowCount - offset);
+        if (pageSize <= 0)
+            return Task.FromResult(new DataPage<StockRow>(Array.Empty<StockRow>(), null, _rowCount));
+
+        var items = new StockRow[pageSize];
+        Array.Copy(_rows, offset, items, 0, pageSize);
+
+        var nextOffset = offset + pageSize;
+        var continuation = nextOffset < _rowCount ? nextOffset.ToString() : null;
+
+        return Task.FromResult(new DataPage<StockRow>(items, continuation, _rowCount));
+    }
+
+    /// <summary>
+    /// Mutate a <paramref name="percent"/> fraction of cells (same value-churn logic
+    /// as <see cref="StressPerf.Shared.StockDataSource.Update"/>) and fire
+    /// <see cref="DataChanged"/> to drive the DataGrid's reload → re-render.
+    /// The row SET is unchanged (only cell VALUES mutate), so the workload measures
+    /// the per-render reconcile/allocation path, not structural list churn.
+    /// </summary>
+    /// <returns>The number of cells actually mutated (for logging parity).</returns>
+    public int Update(double percent)
+    {
+        int count = Math.Max(1, (int)(_totalCells * percent / 100.0));
+        var rng = _rng;
+
+        for (int i = 0; i < count; i++)
+        {
+            int idx = rng.Next(_totalCells);
+            int row = idx / _columnCount;
+            int col = idx % _columnCount;
+            var cells = _rows[row].Cells;
+            var item = cells[col];
+            double delta = ((rng.NextDouble() - 0.48) * 2.0) * item.CurrentPrice * 0.02;
+            double newPrice = Math.Max(0.01, Math.Round(item.CurrentPrice + delta, 2));
+            cells[col] = new StressPerf.Shared.StockItem(item.Symbol, item.CurrentPrice, newPrice, newPrice >= item.CurrentPrice);
+        }
+
+        DataChanged?.Invoke(this, EventArgs.Empty);
+        return count;
+    }
+}

--- a/tests/stress_perf/StressPerf.DataGrid/Program.cs
+++ b/tests/stress_perf/StressPerf.DataGrid/Program.cs
@@ -1,0 +1,276 @@
+// StressPerf.DataGrid — a /perf macro workload that exercises Reactor's DataGrid
+// control (src/Reactor/Controls/DataGrid/) — the per-render array/LINQ allocation
+// path (#663/#669) and the per-cell/row modifier-delegate churn (#671) — that NO
+// existing WIRED /perf leg reaches.
+//
+// The StocksGrid leg (StressPerf.ReactorOptimized) mutates a fixed positional native
+// Grid in place; the keyed-list leg (StressPerf.KeyedList) reorders keyed rows; the
+// flex leg (StressPerf.Flex) drives the Yoga layout engine. None instantiate the
+// DataGrid control, so #669's per-render rebuilds and #671's per-render delegate
+// closures can't be measured. (A legacy StressPerf.ReactorGrid project DOES stand up
+// a DataGrid, but it predates the compare-mode contract — it emits no metrics.json /
+// REACTOR_PERF_JSON / alloc table and is wired only into the old single-tree
+// full-matrix scripts (run_full_matrix.ps1 / run_sweep_arm64.ps1 / run_benchmark.sh),
+// NOT Run-PerfBenchmark.ps1 compare mode. This leg is the modern equivalent; the two
+// intentionally coexist.)
+//
+// This harness renders the real DataGrid control over a 30-column × 200-row
+// IObservableDataSource and, every tick, mutates a `--percent` fraction of cells
+// (firing DataChanged) AND updates the on-screen FPS/Update/Mem labels. Both force a
+// full DataGridComponent.Render() each frame — which re-runs, UNCONDITIONALLY and
+// regardless of whether sort/filter changed, the per-render rebuilds #663/#669 target
+// (the sortKey join, the DataRequest + .ToList()s, the header+row colWidths/
+// gridColDefs arrays, the Columns getter's Where+ToList, the per-column LINQ lookups,
+// the row-def arrays, the setter spread) and re-allocates the per-realized-cell/row
+// .OnTapped/.OnPointerPressed closures inside RenderRow (the #671 churn). A small
+// rowHeight keeps many rows realized so that delegate churn is at measurable scale.
+//
+// MEASUREMENT CAVEAT (for maintainers + whoever measures #669/#671 against this leg):
+// the DataGrid's re-render is ASYNC/DEBOUNCED — DataChanged → LoadDataAsync →
+// StateChanged → a dispatcher-coalesced forceRender (plus a scroll-settle timer) —
+// unlike the synchronous KeyedList/Flex element trees. So the per-render `avgReconcileMs`
+// / `avgDiffMs` numbers (captured by the OnRenderComplete phase hook) are noisier here
+// and a render may be coalesced. Judge DataGrid allocation/delegate wins primarily on
+// the allocation table (`allocBytesPerRender` / `gen0`, which the shared PerfTracker
+// reads from process-wide GC counters across the whole run) plus `rendersPerSec` — the
+// same guidance the Flex leg documents for its deferred-layout caveat. No post-render
+// timing hook is added here (that would touch the shared PerfTracker used by the other
+// legs); add one only if a /perf run actually needs a finer signal (measure-then-escalate).
+//
+// The harness contract is mirrored byte-for-byte from StressPerf.Flex: the same CLI
+// flags (--headless / --percent / --duration / --json via the shared CliOptions), the
+// same shutdown emission (report.txt + metrics.json + the REACTOR_PERF_JSON stdout
+// line) via the shared PerfTracker, and the same OnRenderComplete phase-capture wiring.
+// Only the SCENE and its per-tick mutation differ, so Run-PerfBenchmark.ps1 /
+// PerfLib.ps1 can drive it identically.
+
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Data;
+using Microsoft.UI.Reactor.Controls;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using StressPerf.DataGrid;
+using StressPerf.Shared;
+using static Microsoft.UI.Reactor.Factories;
+
+// Parse CLI args before WinUI starts
+var cliOptions = CliOptions.Parse(args);
+if (cliOptions.Headless)
+    ConsoleHelper.EnsureConsole();
+
+DataGridApp.CliOpts = cliOptions;
+
+// Opt into the full built-in catalog once at startup so every built-in element record
+// has a registered handler before the first reconcile — the documented one-line
+// prelude for the direct-record idiom (spec-048 §3.4), identical to StressPerf.Flex.
+ReactorApp.RegisterAllBuiltIns();
+
+ReactorApp.Run<DataGridApp>("StressPerf.DataGrid", fullScreen: true);
+
+// ---------------------------------------------------------------------------
+
+class DataGridApp : Component
+{
+    private const string AppName = "StressPerf.DataGrid";
+    private const int ColumnCount = DataGridSceneSource.DefaultColumns;
+    private const int RowCount = DataGridSceneSource.DefaultRows;
+
+    public static CliOptions CliOpts { get; set; } = new();
+
+    // Cache brushes — lazy because SolidColorBrush requires the WinUI thread.
+    private static SolidColorBrush? _greenBrush;
+    private static SolidColorBrush? _redBrush;
+    private static SolidColorBrush GreenBrush => _greenBrush ??= new(global::Windows.UI.Color.FromArgb(255, 0, 128, 0));
+    private static SolidColorBrush RedBrush => _redBrush ??= new(global::Windows.UI.Color.FromArgb(255, 255, 0, 0));
+
+    public override Element Render()
+    {
+        // The data source survives across renders via ref.
+        var sourceRef = UseRef<DataGridSceneSource?>(null);
+        if (sourceRef.Current == null)
+            sourceRef.Current = new DataGridSceneSource(ColumnCount, RowCount);
+        var source = sourceRef.Current;
+
+        var (percent, setPercent) = UseState(CliOpts.Percent);
+        var (running, setRunning) = UseState(false);
+        var (fps, setFps) = UseState("FPS: --");
+        var (updateMs, setUpdateMs) = UseState("Update: -- ms");
+        var (mem, setMem) = UseState("Mem: -- MB");
+
+        var perfRef = UseRef<PerfTracker?>(null);
+        var timerRef = UseRef<DispatcherTimer?>(null);
+        var shutdownRef = UseRef<DispatcherTimer?>(null);
+        var benchmarkUpdatePending = UseRef(false);
+        var shapeVerifiedRef = UseRef(false);
+
+        // Lazily create PerfTracker and wire up render-complete callback
+        if (perfRef.Current == null)
+        {
+            perfRef.Current = new PerfTracker();
+            var perf = perfRef.Current;
+            var pending = benchmarkUpdatePending;
+            ReactorApp.PrimaryWindow!.Host.OnRenderComplete = (treeMs, reconcileMs, effectsMs) =>
+            {
+                if (pending.Current)
+                {
+                    pending.Current = false;
+                    perf.RecordPhases(treeMs, reconcileMs, effectsMs);
+                }
+            };
+        }
+
+        // CompositionTarget.Rendering for FPS counting
+        var renderHooked = UseRef(false);
+        if (!renderHooked.Current)
+        {
+            renderHooked.Current = true;
+            var perf = perfRef.Current;
+            CompositionTarget.Rendering += (_, _) => perf.FrameRendered();
+        }
+
+        // Build column descriptors once. 30 sortable columns over StockRow.Cells[col],
+        // so the per-column header/row LINQ lookups (#128) run at full width each render.
+        var columns = UseMemo(() =>
+        {
+            var cols = new FieldDescriptor[ColumnCount];
+            for (int c = 0; c < ColumnCount; c++)
+            {
+                int col = c;
+                cols[c] = new FieldDescriptor
+                {
+                    Name = $"Col{c}",
+                    DisplayName = $"Col {c}",
+                    FieldType = typeof(StockItem),
+                    GetValue = obj => ((StockRow)obj).Cells[col],
+                    IsReadOnly = true,
+                    Width = 64,
+                    Sortable = true,
+                    Filterable = false,
+                };
+            }
+            return (IReadOnlyList<FieldDescriptor>)cols;
+        });
+
+        // Start/stop the update timer when `running` changes
+        UseEffect(() =>
+        {
+            if (running)
+            {
+                var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(33) };
+                timer.Tick += (_, _) =>
+                {
+                    var perf = perfRef.Current!;
+                    perf.BeginUpdate();
+
+                    source.Update(percent);
+                    benchmarkUpdatePending.Current = true;
+
+                    perf.EndUpdate();
+
+                    setFps($"FPS: {perf.CurrentFps:F0}");
+                    setUpdateMs($"Update: {perf.LastUpdateMs:F1} ms");
+                    setMem($"Mem: {perf.CurrentMemoryMB} MB");
+                };
+                timer.Start();
+                timerRef.Current = timer;
+            }
+            else
+            {
+                timerRef.Current?.Stop();
+                timerRef.Current = null;
+            }
+
+            return () =>
+            {
+                timerRef.Current?.Stop();
+                timerRef.Current = null;
+            };
+        }, running, percent);
+
+        // Headless auto-start
+        UseEffect(() =>
+        {
+            if (!CliOpts.Headless) return;
+            setPercent(CliOpts.Percent);
+            setRunning(true);
+
+            var shutdownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(CliOpts.DurationSeconds) };
+            shutdownTimer.Tick += (_, _) =>
+            {
+                setRunning(false);
+                shutdownTimer.Stop();
+                var perf = perfRef.Current!;
+                perf.WriteReportFile(AppName, CliOpts.Percent);
+                if (CliOpts.Json)
+                {
+                    perf.WriteMetricsJsonFile(AppName, CliOpts.Percent);
+                    // Echo a single marked line so log scrapers have a fallback to the
+                    // {AppName}.metrics.json file written next to the exe.
+                    Console.WriteLine("REACTOR_PERF_JSON " + perf.GetMetricsJson(AppName, CliOpts.Percent));
+                }
+                Application.Current.Exit();
+            };
+            shutdownTimer.Start();
+            shutdownRef.Current = shutdownTimer;
+        }, Array.Empty<object>());
+
+        // ── Build the DataGrid scene ────────────────────────────────────────
+        // The cellTemplate is a fresh closure each render, so the DataGridElement props
+        // differ render-to-render and the DataGridComponent re-renders its subtree every
+        // tick (the per-render allocation path under measurement). Small rowHeight (18)
+        // keeps many rows realized so the per-cell/row .OnTapped/.OnPointerPressed
+        // closures (#671) churn at measurable scale.
+        Element dataGridEl = DataGrid(
+            source: source,
+            columns: columns,
+            selectionMode: SelectionMode.Multiple,
+            rowHeight: 18,
+            showSearch: false,
+            cellTemplate: ctx =>
+            {
+                if (ctx.Value is not StockItem item)
+                    return TextBlock("").FontSize(8);
+                return TextBlock(StockDataSource.FormatCell(in item))
+                    .FontSize(8)
+                    .Foreground(item.IsUp ? GreenBrush : RedBrush)
+                    .Padding(2, 1, 2, 1);
+            }
+        ).Flex(grow: 1);
+
+        // Structural self-check (runs once): the scene root MUST be a DataGrid component
+        // element. This guards against a refactor silently swapping the scene off the
+        // DataGrid control (onto a native Grid / VirtualList), which would never enter the
+        // DataGridComponent render path under measurement — making every mutation a no-op
+        // for #669/#671 and the reported numbers meaningless. Fail loudly (no metrics.json
+        // is written) rather than report misleading DataGrid numbers.
+        if (!shapeVerifiedRef.Current)
+        {
+            shapeVerifiedRef.Current = true;
+            bool isDataGrid = dataGridEl is ComponentElement<DataGridElement<StockRow>>;
+            if (!isDataGrid)
+            {
+                Console.Error.WriteLine(
+                    $"FATAL: {AppName} scene root is not a DataGrid component element " +
+                    $"(got {dataGridEl.GetType().Name}) — the DataGrid control under " +
+                    "measurement would not run (mutations would be no-ops); results are invalid.");
+                Environment.FailFast(
+                    $"{AppName}: DataGrid-control invariant violated (scene root not " +
+                    "ComponentElement<DataGridElement<StockRow>>).");
+            }
+        }
+
+        return VStack(
+            HStack(12,
+                Button(running ? "Stop" : "Start", () => setRunning(!running)),
+                TextBlock("Update %:").VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center),
+                Slider(percent, 0, 100, v => setPercent(v)).Width(200),
+                TextBlock(fps).VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center).Width(100),
+                TextBlock(updateMs).VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center).Width(120),
+                TextBlock(mem).VAlign(Microsoft.UI.Xaml.VerticalAlignment.Center).Width(120)
+            ).Padding(8),
+            dataGridEl
+        );
+    }
+}

--- a/tests/stress_perf/StressPerf.DataGrid/StressPerf.DataGrid.csproj
+++ b/tests/stress_perf/StressPerf.DataGrid/StressPerf.DataGrid.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
+    <Platforms>x64;ARM64</Platforms>
+    <RootNamespace>StressPerf.DataGrid</RootNamespace>
+    <AssemblyName>StressPerf.DataGrid</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseWinUI>true</UseWinUI>
+    <WindowsPackageType>None</WindowsPackageType>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <!--
+    On-demand perf-comparison CI (.github/workflows/perf-compare.yml) builds this
+    harness with -p:PerfCiSelfContained=true so it carries its own Windows App SDK
+    runtime and needs NO machine-wide runtime install on the GitHub-hosted runner —
+    the same hermetic trick the WinUI selftest hosts use to open real windows in CI.
+    Scoped to THIS executable (rather than a global -p:WindowsAppSDKSelfContained)
+    so the flag never flows into the referenced class libraries (Reactor.csproj /
+    StressPerf.Shared), which reject self-contained packaging. Run-PerfBenchmark.ps1
+    passes it by default; pass -SelfContained:$false to build framework-dependent.
+    Mirrors StressPerf.Flex.csproj — the flex-workload build recipe — so the DataGrid
+    workload launches under the identical hermetic /perf conditions.
+  -->
+  <PropertyGroup Condition="'$(PerfCiSelfContained)' == 'true'">
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' != 'ARM64'">win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StressPerf.Shared\StressPerf.Shared.csproj" />
+    <ProjectReference Include="..\..\..\src\Reactor\Reactor.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -631,6 +631,90 @@ Assert-Match $bothFlexAllocComment 'Allocation (Reactor)' 'full comment keeps th
 Assert-Match $bothFlexAllocComment 'Allocation (flex)'    'full comment adds the distinct flex allocation sub-table'
 
 
+# ── Format-PerfDataGridSection + Format-PerfComment: DataGrid control workload ─
+# Same direction-aware, by-significance shape as the keyed/flex blocks above: rps/
+# reconcile/diff move DOWN main->PR while memory carries a small SYMMETRIC per-pair
+# jitter (mean Δ ~0). The verdicts must split exactly as for the flex leg — proving the
+# DataGrid section reuses the shared direction-aware paired-CI machinery.
+$dgMainRuns = @(); $dgPrRuns = @()
+1..12 | ForEach-Object {
+    $j = ($_ % 4) * 0.05
+    $mj = ((($_ % 2) * 2) - 1) * 0.2  # alternating +0.2 / -0.2 so the paired memory Δ straddles 0
+    $dgMainRuns += [pscustomobject]@{ RendersPerSec = 8.0 + $j; AvgReconcileMs = 9.0 + $j; AvgDiffMs = 7.0 + $j; AvgMemoryMB = 250 + $mj; TotalRenders = 80; DurationSeconds = 10 }
+    $dgPrRuns   += [pscustomobject]@{ RendersPerSec = 7.0 + $j; AvgReconcileMs = 7.0 + $j; AvgDiffMs = 5.0 + $j; AvgMemoryMB = 250 - $mj; TotalRenders = 70; DurationSeconds = 10 }
+}
+$dgMain = Measure-PerfRuns -Runs $dgMainRuns
+$dgPr   = Measure-PerfRuns -Runs $dgPrRuns
+
+# Direct section renderer: empty when either side is null, populated when both present.
+Assert-Equal 0 @(Format-PerfDataGridSection -MainDataGrid $null -PrDataGrid $dgPr -Percent 50).Count 'datagrid section empty when main datagrid null'
+Assert-Equal 0 @(Format-PerfDataGridSection -MainDataGrid $dgMain -PrDataGrid $null -Percent 50).Count 'datagrid section empty when pr datagrid null'
+$dgSection = Format-PerfDataGridSection -MainDataGrid $dgMain -PrDataGrid $dgPr -Percent 50
+$dgSectionText = $dgSection -join "`n"
+Assert-Match $dgSectionText 'DataGrid control workload' 'datagrid section has heading'
+Assert-Match $dgSectionText 'StressPerf.DataGrid'       'datagrid heading names the workload'
+Assert-Match $dgSectionText 'Avg Reconcile'             'datagrid section has reconcile row'
+Assert-Match $dgSectionText 'DataGridComponent'         'datagrid preamble names the DataGrid control'
+# Direction-awareness: rps and reconcile both DECREASE main->PR, yet rps (higher-is-
+# better) must read regression while reconcile (lower-is-better) reads improvement.
+$dgRpsRow   = ($dgSection | Where-Object { $_ -match 'Renders/sec' })   -join ' '
+$dgReconRow = ($dgSection | Where-Object { $_ -match 'Avg Reconcile' }) -join ' '
+$dgDiffRow  = ($dgSection | Where-Object { $_ -match 'Avg Diff' })      -join ' '
+$dgMemRow   = ($dgSection | Where-Object { $_ -match 'Avg Memory' })    -join ' '
+Assert-Match $dgRpsRow   'regression'  'datagrid: rps DOWN reads regression (higher-is-better honored)'
+Assert-Match $dgReconRow 'improvement' 'datagrid: reconcile DOWN reads improvement (lower-is-better honored)'
+Assert-Match $dgDiffRow  'improvement' 'datagrid: diff DOWN reads improvement (lower-is-better honored)'
+Assert-Match $dgMemRow   'within noise' 'datagrid: symmetric memory Δ reads within noise (paired CI straddles 0)'
+# -Percent threads into the heading independently of the methodology line.
+$dgSection75 = (Format-PerfDataGridSection -MainDataGrid $dgMain -PrDataGrid $dgPr -Percent 75) -join "`n"
+Assert-Match $dgSection75 'DataGrid control workload*--percent 75' 'datagrid heading reflects the -Percent argument'
+
+# Threaded through Format-PerfComment: present when datagrid aggregates present, sitting
+# after the flex table and before the cross-framework table.
+$dgComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -MainFloor $floorMain -PrFloor $floorPr -MainKeyed $keyedMain -PrKeyed $keyedPr -MainFlex $flexMain -PrFlex $flexPr -MainDataGrid $dgMain -PrDataGrid $dgPr -Context $ctx
+Assert-Match $dgComment 'DataGrid control workload' 'comment renders datagrid table when datagrid aggregates present'
+$idxFlexD = $dgComment.IndexOf('Flex/Yoga layout workload')
+$idxDgD   = $dgComment.IndexOf('DataGrid control workload')
+$idxXfwD  = $dgComment.IndexOf('Cross-framework reference')
+Assert-True (($idxFlexD -lt $idxDgD) -and ($idxDgD -lt $idxXfwD)) 'datagrid table sits after the flex table and before cross-framework'
+
+# Omitted entirely when datagrid aggregates are absent (datagrid leg disabled / build omitted).
+$noDgComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -MainDataGrid $null -PrDataGrid $null -Context $ctx
+Assert-True (-not ($noDgComment -like '*DataGrid control workload*')) 'datagrid table omitted when datagrid aggregates null'
+
+# Allocation sub-table for the datagrid leg: shared PerfAllocMetricSpec over datagrid
+# aggregates. Alloc moves DOWN main->PR (an improvement on a lower-is-better metric);
+# tiny jitter keeps each paired CI off 0.
+$dgAllocMain = Measure-PerfRuns -Runs @(
+    [pscustomobject]@{ RendersPerSec = 18.5; AvgReconcileMs = 6.98; AvgDiffMs = 6.86; AvgMemoryMB = 186; AllocBytesPerRender = 612000; Gen0PerKRenders = 118.2; Gen0 = 11; Gen1 = 3; Gen2 = 1; TotalRenders = 96; DurationSeconds = 5 }
+    [pscustomobject]@{ RendersPerSec = 18.6; AvgReconcileMs = 6.98; AvgDiffMs = 6.86; AvgMemoryMB = 186; AllocBytesPerRender = 612200; Gen0PerKRenders = 118.4; Gen0 = 11; Gen1 = 3; Gen2 = 1; TotalRenders = 96; DurationSeconds = 5 }
+    [pscustomobject]@{ RendersPerSec = 18.4; AvgReconcileMs = 6.98; AvgDiffMs = 6.86; AvgMemoryMB = 186; AllocBytesPerRender = 611800; Gen0PerKRenders = 118.0; Gen0 = 11; Gen1 = 3; Gen2 = 1; TotalRenders = 96; DurationSeconds = 5 }
+)
+$dgAllocPr = Measure-PerfRuns -Runs @(
+    [pscustomobject]@{ RendersPerSec = 18.5; AvgReconcileMs = 6.98; AvgDiffMs = 6.86; AvgMemoryMB = 186; AllocBytesPerRender = 458000; Gen0PerKRenders = 88.2; Gen0 = 8; Gen1 = 3; Gen2 = 1; TotalRenders = 96; DurationSeconds = 5 }
+    [pscustomobject]@{ RendersPerSec = 18.6; AvgReconcileMs = 6.98; AvgDiffMs = 6.86; AvgMemoryMB = 186; AllocBytesPerRender = 458200; Gen0PerKRenders = 88.4; Gen0 = 8; Gen1 = 3; Gen2 = 1; TotalRenders = 96; DurationSeconds = 5 }
+    [pscustomobject]@{ RendersPerSec = 18.4; AvgReconcileMs = 6.98; AvgDiffMs = 6.86; AvgMemoryMB = 186; AllocBytesPerRender = 457800; Gen0PerKRenders = 88.0; Gen0 = 8; Gen1 = 3; Gen2 = 1; TotalRenders = 96; DurationSeconds = 5 }
+)
+$dgAllocSection = Format-PerfDataGridSection -MainDataGrid $dgAllocMain -PrDataGrid $dgAllocPr -Percent 50
+$dgAllocText = $dgAllocSection -join "`n"
+Assert-Match $dgAllocText 'Allocation (datagrid)' 'datagrid section renders the allocation sub-table when alloc present'
+Assert-Match $dgAllocText 'Alloc bytes/render'    'datagrid alloc sub-table has bytes/render row'
+Assert-Match $dgAllocText 'Gen0 GC / 1k renders'  'datagrid alloc sub-table has Gen0 row'
+$dgAllocRow = ($dgAllocSection | Where-Object { $_ -match 'Alloc bytes/render' }) -join ' '
+Assert-Match $dgAllocRow 'improvement' 'datagrid alloc DOWN main->PR reads improvement (lower-is-better honored)'
+$idxDgHead  = $dgAllocText.IndexOf('Avg Reconcile')
+$idxDgAlloc = $dgAllocText.IndexOf('Allocation (datagrid)')
+Assert-True (($idxDgHead -ge 0) -and ($idxDgHead -lt $idxDgAlloc)) 'datagrid alloc sub-table follows the datagrid headline metrics table'
+# Omitted when the datagrid aggregates carry no alloc metrics (legacy datagrid head).
+Assert-True (-not ($dgSectionText -like '*Allocation (datagrid)*')) 'datagrid alloc sub-table omitted when datagrid aggregates lack alloc'
+
+# In a full comment the positional StocksGrid allocation table and the datagrid
+# allocation sub-table are DISTINCT, separately-labelled tables.
+$bothDgAllocComment = Format-PerfComment -Main $allocMain -Pr $allocPr -WinUI3 $null -Rust $null -MainDataGrid $dgAllocMain -PrDataGrid $dgAllocPr -Context $ctx
+Assert-Match $bothDgAllocComment 'Allocation (Reactor)'  'full comment keeps the StocksGrid allocation table'
+Assert-Match $bothDgAllocComment 'Allocation (datagrid)' 'full comment adds the distinct datagrid allocation sub-table'
+
+
 # ── Reconciler micro-suite: Read-MicroBenchResults / comparison / render ──────
 function New-MicroRow {
     param([string]$BenchId, [string]$Name, [string]$Variant, [int]$Rep, [double]$MeanNs, [double]$AllocBytes, [string]$Status = 'ok', [int]$Iterations = 1)

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -1050,6 +1050,102 @@ function Format-PerfFlexSection {
     return $lines.ToArray()
 }
 
+function Format-PerfDataGridSection {
+    <#
+    .SYNOPSIS
+        Render the DataGrid workload section: the four headline metrics plus an
+        allocation sub-table measured on StressPerf.DataGrid — the real DataGrid control
+        (DataGridComponent) over a 30-column × 200-row IObservableDataSource whose cells
+        are mutated on a fraction each tick. Empty array when there is nothing to show.
+    .DESCRIPTION
+        Unlike the positional StocksGrid headline/skip-floor legs (a native Grid mutated
+        in place), the keyed-list leg (reordered keyed rows) and the flex leg (Yoga layout),
+        this is a SEPARATE macro workload that drives the **DataGrid control** itself: each
+        tick mutates a fraction of cells and fires DataChanged, forcing a full
+        DataGridComponent.Render() that unconditionally rebuilds its per-render arrays / LINQ
+        (the sortKey join, the DataRequest + .ToList()s, the header+row colWidths/gridColDefs
+        arrays, the Columns getter Where+ToList, the per-column lookups, the row-def arrays,
+        the setter spread — #663/#669) and re-allocates the per-realized-cell/row
+        .OnTapped/.OnPointerPressed closures (#671). It is the sensitive macro measure for
+        DataGrid per-render allocation + delegate-stability work that the positional
+        StocksGrid, keyed-list and flex legs can never exercise. Reuses the same paired-Δ
+        95% CI machinery (Get-PerfDelta over the index-aligned per-run samples) as the
+        headline table. Also appends an **allocation** sub-table — the shared
+        PerfAllocMetricSpec (alloc bytes/render + Gen0 GC / 1k renders) over the DataGrid
+        aggregates — the sensitive macro signal for DataGrid allocation reductions that the
+        positional StocksGrid allocation table can never isolate; rendered only when the
+        DataGrid leg reported allocation metrics. Returns an empty array when either
+        aggregate is $null (DataGrid leg disabled, build omitted, or one side produced no
+        metrics), so the caller renders nothing.
+    .PARAMETER MainDataGrid  Aggregated baseline DataGrid metrics (Measure-PerfRuns), or $null.
+    .PARAMETER PrDataGrid    Aggregated PR-head DataGrid metrics, or $null.
+    .PARAMETER Percent       The churn percent the DataGrid leg ran at (heading / preamble).
+    #>
+    param(
+        [AllowNull()][pscustomobject]$MainDataGrid,
+        [AllowNull()][pscustomobject]$PrDataGrid,
+        [double]$Percent = 50
+    )
+    if ($null -eq $MainDataGrid -or $null -eq $PrDataGrid) { return @() }
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add("### DataGrid control workload (``StressPerf.DataGrid``, ``--percent $Percent``)")
+    $lines.Add('')
+    $lines.Add("A separate macro workload: the **real DataGrid control** (``DataGridComponent``) over a **30-column × 200-row** ``IObservableDataSource`` whose cells are mutated on a ``--percent`` fraction each tick, forcing a full ``DataGridComponent.Render()`` every frame. This re-runs &mdash; unconditionally, regardless of whether sort/filter changed &mdash; the per-render array/LINQ rebuilds (#663/#669) and re-allocates the per-realized-cell/row ``.OnTapped``/``.OnPointerPressed`` closures (#671) that the StocksGrid, keyed-list and flex legs never reach. Same interleaved paired-Δ 95% CI as the headline table.")
+    $lines.Add('')
+    $lines.Add("> **Reading this table:** the DataGrid's re-render is **async / dispatcher-debounced** (``DataChanged`` &rarr; ``LoadDataAsync`` &rarr; coalesced ``forceRender`` + a scroll-settle timer), so the **reconcile / diff timing** rows are noisier here and a render may be coalesced. Judge DataGrid allocation / delegate wins primarily on the **DataGrid allocation table** below (process-wide GC counters capture the whole run) and the **renders-per-second** figure. The working-set memory figure is informational only.")
+    $lines.Add('')
+    $lines.Add('| Metric | `main` (baseline) | This PR | Δ (95% CI) | Status |')
+    $lines.Add('|---|--:|--:|--:|:--|')
+    foreach ($m in $script:PerfMetricSpec) {
+        $bVal = $MainDataGrid.($m.Key)
+        $pVal = $PrDataGrid.($m.Key)
+        $spread = [math]::Max([double]$MainDataGrid."$($m.Key)Spread", [double]$PrDataGrid."$($m.Key)Spread")
+        $delta = Get-PerfDelta -Baseline $bVal -Candidate $pVal -LowerIsBetter $m.LowerIsBetter -SpreadPct $spread `
+            -BaselineSamples $MainDataGrid."$($m.Key)Samples" -CandidateSamples $PrDataGrid."$($m.Key)Samples"
+        $lines.Add(('| {0} {1} | {2} | {3} | {4} | {5} |' -f `
+                $m.Label, $m.Arrow, `
+            (Format-PerfNumber $bVal $m.Digits), `
+            (Format-PerfNumber $pVal $m.Digits), `
+            (Format-PerfDeltaCell $delta), `
+            (Get-PerfStatusGlyph $delta.Status)))
+    }
+    $lines.Add('')
+
+    # Allocation sub-table for the DataGrid workload: the shared PerfAllocMetricSpec
+    # (Alloc bytes/render, Gen0 GC / 1k renders) rendered over the DataGrid aggregates with
+    # the identical paired-Δ 95% CI machinery used above. This is the sensitive MACRO
+    # signal for DataGrid allocation reductions — allocBytesPerRender tracks the per-render
+    # array/LINQ + delegate-closure alloc volume on the DataGridComponent path, an alloc
+    # signal the positional StocksGrid allocation table can never isolate. Rendered only
+    # when the DataGrid leg reported allocation metrics (every StressPerf.DataGrid build
+    # does; n/a only for a legacy head opened before the metric landed).
+    $hasDgAlloc = ($null -ne $MainDataGrid.AllocBytesPerRender) -or ($null -ne $PrDataGrid.AllocBytesPerRender) -or
+                  ($null -ne $MainDataGrid.Gen0PerKRenders) -or ($null -ne $PrDataGrid.Gen0PerKRenders)
+    if ($hasDgAlloc) {
+        $lines.Add('**Allocation (datagrid)** &mdash; lower is better')
+        $lines.Add('')
+        $lines.Add('| Metric | `main` (baseline) | This PR | Δ (95% CI) | Status |')
+        $lines.Add('|---|--:|--:|--:|:--|')
+        foreach ($m in $script:PerfAllocMetricSpec) {
+            $bVal = $MainDataGrid.($m.Key)
+            $pVal = $PrDataGrid.($m.Key)
+            $spread = [math]::Max([double]$MainDataGrid."$($m.Key)Spread", [double]$PrDataGrid."$($m.Key)Spread")
+            $delta = Get-PerfDelta -Baseline $bVal -Candidate $pVal -LowerIsBetter $m.LowerIsBetter -SpreadPct $spread `
+                -BaselineSamples $MainDataGrid."$($m.Key)Samples" -CandidateSamples $PrDataGrid."$($m.Key)Samples"
+            $lines.Add(('| {0} {1} | {2} | {3} | {4} | {5} |' -f `
+                    $m.Label, $m.Arrow, `
+                (Format-PerfNumber $bVal $m.Digits), `
+                (Format-PerfNumber $pVal $m.Digits), `
+                (Format-PerfDeltaCell $delta), `
+                (Get-PerfStatusGlyph $delta.Status)))
+        }
+        $lines.Add('')
+    }
+
+    return $lines.ToArray()
+}
+
 function Format-PerfComment {
     <#
     .SYNOPSIS
@@ -1072,6 +1168,8 @@ function Format-PerfComment {
     .PARAMETER PrKeyed     Aggregated PR-head keyed-list workload metrics, or $null.
     .PARAMETER MainFlex   Aggregated baseline flex workload metrics, or $null.
     .PARAMETER PrFlex      Aggregated PR-head flex workload metrics, or $null.
+    .PARAMETER MainDataGrid  Aggregated baseline DataGrid workload metrics, or $null.
+    .PARAMETER PrDataGrid    Aggregated PR-head DataGrid workload metrics, or $null.
     .PARAMETER Context    Hashtable: Percent, Duration, Reps, Warmup, SkipFloorPercent,
                           BaseSha, HeadSha, Runner, Cpu, Cores, MemoryGB, RunUrl,
                           Timestamp, Note.
@@ -1089,6 +1187,8 @@ function Format-PerfComment {
         [AllowNull()][pscustomobject]$PrKeyed,
         [AllowNull()][pscustomobject]$MainFlex,
         [AllowNull()][pscustomobject]$PrFlex,
+        [AllowNull()][pscustomobject]$MainDataGrid,
+        [AllowNull()][pscustomobject]$PrDataGrid,
         [Parameter(Mandatory)][hashtable]$Context
     )
 
@@ -1179,6 +1279,15 @@ function Format-PerfComment {
     # Rendered only when both flex aggregates are present.
     $flexPct = if ($Context.ContainsKey('Percent')) { [double]$Context.Percent } else { 50 }
     foreach ($fline in (Format-PerfFlexSection -MainFlex $MainFlex -PrFlex $PrFlex -Percent $flexPct)) { & $add $fline }
+
+    # ── DataGrid control workload table (StressPerf.DataGrid) ────────────────
+    # A separate macro workload driving the real DataGrid control (DataGridComponent) —
+    # its per-render array/LINQ rebuilds (#663/#669) and per-cell/row modifier-delegate
+    # churn (#671) — that neither the positional StocksGrid legs, the keyed-list leg nor
+    # the flex layout leg reach. The sensitive macro signal for DataGrid allocation +
+    # delegate-stability optimizations. Rendered only when both DataGrid aggregates present.
+    $dataGridPct = if ($Context.ContainsKey('Percent')) { [double]$Context.Percent } else { 50 }
+    foreach ($dline in (Format-PerfDataGridSection -MainDataGrid $MainDataGrid -PrDataGrid $PrDataGrid -Percent $dataGridPct)) { & $add $dline }
 
     # ── Reconciler micro-benchmarks (ns-resolution, WinUI-undiluted) ──────────
     # Rendered only when the PerfBench.ControlModel micro leg produced results for

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -132,11 +132,22 @@
     (a Flex build failure just omits the table). Disable with -IncludeFlex:$false to skip
     the extra leg.
 
+.PARAMETER IncludeDataGrid
+    Run a fifth interleaved A/B leg on StressPerf.DataGrid — the real DataGrid control
+    (DataGridComponent) over a 30-column × 200-row IObservableDataSource whose cells are
+    mutated on a `--percent` fraction each tick, forcing a full DataGridComponent.Render()
+    every frame — and append its own PR-vs-main table to the comment (compare mode). This
+    exercises the DataGrid control's per-render array/LINQ allocation path (#663/#669) and
+    its per-cell/row modifier-delegate churn (#671) that the StocksGrid / keyed-list / flex
+    legs never reach, so it is the sensitive macro measure for DataGrid allocation +
+    delegate-stability optimizations. Default $true; build is best-effort (a DataGrid build
+    failure just omits the table). Disable with -IncludeDataGrid:$false to skip the extra leg.
+
 .PARAMETER Apps
     Which harnesses to run in single-tree mode: ReactorOptimized, Direct, KeyedList,
-    Flex. Ignored in compare mode (which always does ReactorOptimized both sides +
+    Flex, DataGrid. Ignored in compare mode (which always does ReactorOptimized both sides +
     Direct once for the WinUI3 column, and — unless -IncludeKeyedList:$false /
-    -IncludeFlex:$false — KeyedList and Flex both sides).
+    -IncludeFlex:$false / -IncludeDataGrid:$false — KeyedList, Flex and DataGrid both sides).
 
 .PARAMETER OutDir
     Where logs, comment.md and result.json land. Defaults to ci\out next to this
@@ -211,7 +222,8 @@ param(
     [bool]$IncludeSkipFloor = $true,
     [bool]$IncludeKeyedList = $true,
     [bool]$IncludeFlex = $true,
-    [ValidateSet('ReactorOptimized', 'Direct', 'KeyedList', 'Flex')]
+    [bool]$IncludeDataGrid = $true,
+    [ValidateSet('ReactorOptimized', 'Direct', 'KeyedList', 'Flex', 'DataGrid')]
     [string[]]$Apps = @('ReactorOptimized', 'Direct'),
     [string]$OutDir,
     [switch]$SkipBuild,
@@ -245,6 +257,7 @@ $AppRegistry = @{
     Direct           = @{ AppName = 'StressPerf.Direct';           ProjectRel = 'tests\stress_perf\StressPerf.Direct\StressPerf.Direct.csproj' }
     KeyedList        = @{ AppName = 'StressPerf.KeyedList';         ProjectRel = 'tests\stress_perf\StressPerf.KeyedList\StressPerf.KeyedList.csproj' }
     Flex             = @{ AppName = 'StressPerf.Flex';              ProjectRel = 'tests\stress_perf\StressPerf.Flex\StressPerf.Flex.csproj' }
+    DataGrid         = @{ AppName = 'StressPerf.DataGrid';          ProjectRel = 'tests\stress_perf\StressPerf.DataGrid\StressPerf.DataGrid.csproj' }
     MicroControlModel = @{ AppName = 'PerfBench.ControlModel';     ProjectRel = 'tests\perf_bench\PerfBench.ControlModel\PerfBench.ControlModel.csproj' }
 }
 
@@ -857,10 +870,11 @@ Write-Log ("runner: {0} | {1} cores | {2} GB | {3}" -f $runner.Cpu, $runner.Core
 $modeSuffix = if ($Compare) {
     # COMPARE mode runs the interleaved A/B legs, so the skip-floor / keyed-list
     # opt-out switches are what actually decide which legs run.
-    "skip-floor={0} | keyed-list={1} | flex={2}" -f `
+    "skip-floor={0} | keyed-list={1} | flex={2} | datagrid={3}" -f `
         $(if ($IncludeSkipFloor) { "on (--percent $SkipFloorPercent)" } else { 'off' }), `
         $(if ($IncludeKeyedList) { 'on' } else { 'off' }), `
-        $(if ($IncludeFlex) { 'on' } else { 'off' })
+        $(if ($IncludeFlex) { 'on' } else { 'off' }), `
+        $(if ($IncludeDataGrid) { 'on' } else { 'off' })
 } else {
     # LOCAL mode ignores the interleaved-leg switches entirely; the workload set is
     # whatever -Apps selects, so report that instead of a misleading on/off.
@@ -876,6 +890,7 @@ try {
         $direct = $AppRegistry.Direct
         $keyed = $AppRegistry.KeyedList
         $flex = $AppRegistry.Flex
+        $datagrid = $AppRegistry.DataGrid
         $microMeta = $AppRegistry.MicroControlModel
 
         if (-not $SkipBuild) {
@@ -908,6 +923,15 @@ try {
             } catch {
                 Write-Log "flex workload build failed ($_) — omitting the flex table" 'Yellow'
                 $IncludeFlex = $false
+            }
+        }
+        if ($IncludeDataGrid -and -not $SkipBuild) {
+            try {
+                Build-Harness -TreeRoot $BaselineRoot -AppMeta $datagrid
+                Build-Harness -TreeRoot $Root -AppMeta $datagrid
+            } catch {
+                Write-Log "datagrid workload build failed ($_) — omitting the datagrid table" 'Yellow'
+                $IncludeDataGrid = $false
             }
         }
         $mainExe = Resolve-HarnessExe -TreeRoot $BaselineRoot -AppMeta $ro
@@ -1007,6 +1031,37 @@ try {
             }
         }
 
+        # Fifth interleaved A/B leg: the DataGrid workload. StressPerf.DataGrid stands up
+        # the real DataGrid control (DataGridComponent) over a 30-column × 200-row
+        # IObservableDataSource and mutates a --percent fraction of cells each tick,
+        # forcing a full DataGridComponent.Render() every frame — the per-render
+        # array/LINQ allocation path (#663/#669) and per-cell/row .OnTapped/.OnPointerPressed
+        # delegate churn (#671) that StocksGrid's native Grid, the keyed-list reorder leg
+        # and the flex layout leg never reach. Same paired interleaving + drop-both
+        # alignment as above. Best-effort: if either exe is missing (build omitted/failed)
+        # the leg is skipped and the datagrid table is omitted — the StocksGrid comparison
+        # is unaffected.
+        $mainDataGridRuns = @(); $prDataGridRuns = @()
+        if ($IncludeDataGrid) {
+            $mainDataGridExe = Resolve-HarnessExe -TreeRoot $BaselineRoot -AppMeta $datagrid
+            $prDataGridExe   = Resolve-HarnessExe -TreeRoot $Root -AppMeta $datagrid
+            if (-not $mainDataGridExe -or -not $prDataGridExe) {
+                Write-Log "datagrid exe not found (main=$([bool]$mainDataGridExe) pr=$([bool]$prDataGridExe)) — omitting the datagrid table" 'Yellow'
+            } else {
+                Write-Log "interleaving main/PR datagrid (--percent $Percent; $($Warmup) warmup + $($Reps) measured each)" 'Green'
+                for ($i = 1; $i -le ($Warmup + $Reps); $i++) {
+                    $mm = Invoke-OneRun -Exe $mainDataGridExe -AppMeta $datagrid -Index $i -Tag 'main-datagrid'
+                    $pm = Invoke-OneRun -Exe $prDataGridExe -AppMeta $datagrid -Index $i -Tag 'pr-datagrid'
+                    if ($i -le $Warmup) { Write-Log "  (datagrid warmup pair #$i discarded)" 'DarkGray'; continue }
+                    if ($mm -and $pm) { $mainDataGridRuns += $mm; $prDataGridRuns += $pm }
+                    elseif ($mm -or $pm) { Write-Log "  datagrid pair #$i incomplete (main=$([bool]$mm) pr=$([bool]$pm)) — dropped to keep the paired CI aligned" 'Yellow' }
+                }
+                if ($mainDataGridRuns.Count -lt $Reps -or $prDataGridRuns.Count -lt $Reps) {
+                    Write-Log "  datagrid leg short (main $($mainDataGridRuns.Count)/$Reps, PR $($prDataGridRuns.Count)/$Reps) — its paired CI uses fewer samples" 'Yellow'
+                }
+            }
+        }
+
         $winRuns = @()
         if ($directExe) {
             Write-Log "vanilla WinUI3 (StressPerf.Direct)" 'Green'
@@ -1081,6 +1136,8 @@ try {
         $prKeyed = if ($prKeyedRuns.Count) { Measure-PerfRuns -Runs $prKeyedRuns } else { $null }
         $mainFlex = if ($mainFlexRuns.Count) { Measure-PerfRuns -Runs $mainFlexRuns } else { $null }
         $prFlex = if ($prFlexRuns.Count) { Measure-PerfRuns -Runs $prFlexRuns } else { $null }
+        $mainDataGrid = if ($mainDataGridRuns.Count) { Measure-PerfRuns -Runs $mainDataGridRuns } else { $null }
+        $prDataGrid = if ($prDataGridRuns.Count) { Measure-PerfRuns -Runs $prDataGridRuns } else { $null }
 
         $note = $null
         if ($prRuns.Count -eq 0 -or $mainRuns.Count -eq 0) {
@@ -1105,17 +1162,18 @@ try {
             MainFloorSamples = $mainFloorRuns.Count; PrFloorSamples = $prFloorRuns.Count
             MainKeyedSamples = $mainKeyedRuns.Count; PrKeyedSamples = $prKeyedRuns.Count
             MainFlexSamples = $mainFlexRuns.Count; PrFlexSamples = $prFlexRuns.Count
+            MainDataGridSamples = $mainDataGridRuns.Count; PrDataGridSamples = $prDataGridRuns.Count
             BaseSha = $(if ($BaseSha) { $BaseSha.Substring(0, [Math]::Min(7, $BaseSha.Length)) } else { '' })
             HeadSha = $(if ($HeadSha) { $HeadSha.Substring(0, [Math]::Min(7, $HeadSha.Length)) } else { '' })
             Runner = $runner.Runner; Cpu = $runner.Cpu; Cores = $runner.Cores; MemoryGB = $runner.MemoryGB
             RunUrl = $RunUrl; Timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'); Note = $note
         }
-        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Rust $rust -Micro $micro -MicroOmitReason $microOmitReason -MainFloor $mainFloor -PrFloor $prFloor -MainKeyed $mainKeyed -PrKeyed $prKeyed -MainFlex $mainFlex -PrFlex $prFlex -Context $ctx
+        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Rust $rust -Micro $micro -MicroOmitReason $microOmitReason -MainFloor $mainFloor -PrFloor $prFloor -MainKeyed $mainKeyed -PrKeyed $prKeyed -MainFlex $mainFlex -PrFlex $prFlex -MainDataGrid $mainDataGrid -PrDataGrid $prDataGrid -Context $ctx
         $commentPath = Join-Path $OutDir 'comment.md'
         Set-Content -LiteralPath $commentPath -Value $comment -Encoding UTF8
         Write-Log "comment.md written -> $commentPath" 'Green'
 
-        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; mainFloor = $mainFloor; prFloor = $prFloor; mainKeyed = $mainKeyed; prKeyed = $prKeyed; mainFlex = $mainFlex; prFlex = $prFlex; rust = $rust; micro = $micro; runner = $runner; context = $ctx }
+        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; mainFloor = $mainFloor; prFloor = $prFloor; mainKeyed = $mainKeyed; prKeyed = $prKeyed; mainFlex = $mainFlex; prFlex = $prFlex; mainDataGrid = $mainDataGrid; prDataGrid = $prDataGrid; rust = $rust; micro = $micro; runner = $runner; context = $ctx }
         $result | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutDir 'result.json') -Encoding UTF8
 
         Write-Host "`n----- comment.md -----" -ForegroundColor DarkGray

--- a/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
+++ b/tests/stress_perf/ci/RunPerfBenchmark.Tests.ps1
@@ -440,6 +440,38 @@ Assert-True ($src -match 'mainFlex = \$mainFlex')   '[flex] result.json object i
 Assert-True ($src -match 'prFlex = \$prFlex')       '[flex] result.json object includes the PR flex aggregate'
 
 # ===========================================================================
+#  DataGrid leg — static wiring contract (param + registry + leg + comment)
+# ===========================================================================
+# Mirrors the flex leg contract above: a fifth interleaved A/B leg
+# (StressPerf.DataGrid) whose opt-out switch defaults on, registry resolves the right
+# exe/csproj, interleave runs both sides with drop-both pairing, and aggregates reach
+# the renderer. Its Invoke-OneRun threading inherits $Percent (no -RunPercent), as the
+# flex leg does.
+$dp = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'IncludeDataGrid' } | Select-Object -First 1
+Assert-True ($null -ne $dp) '[datagrid] -IncludeDataGrid parameter exists'
+Assert-True ($dp -and $dp.DefaultValue -and $dp.DefaultValue.Extent.Text -eq '$true') '[datagrid] -IncludeDataGrid defaults to $true (on unless opted out)'
+Assert-True ($src -match "DataGrid\s*=\s*@\{\s*AppName\s*=\s*'StressPerf\.DataGrid';\s*ProjectRel\s*=\s*'tests\\stress_perf\\StressPerf\.DataGrid") '[datagrid] AppRegistry maps DataGrid -> StressPerf.DataGrid exe + csproj'
+Assert-True ($src -match "-Tag 'main-datagrid'") '[datagrid] leg interleaves the main side (main-datagrid)'
+Assert-True ($src -match "-Tag 'pr-datagrid'")   '[datagrid] leg interleaves the PR side (pr-datagrid)'
+Assert-True ($src -match '-MainDataGrid \$mainDataGrid') '[datagrid] Format-PerfComment receives the main datagrid aggregate'
+Assert-True ($src -match '-PrDataGrid \$prDataGrid')     '[datagrid] Format-PerfComment receives the PR datagrid aggregate'
+
+# Opt-out + best-effort build fallback: the datagrid build is guarded by the switch, and
+# a build failure flips the switch off (omit the table, never throw) so the leg is skipped.
+Assert-True ($src -match 'if \(\$IncludeDataGrid -and -not \$SkipBuild\)') '[datagrid] build is guarded by -IncludeDataGrid (and -SkipBuild)'
+Assert-True ($src -match '(?s)datagrid workload build failed.*?\$IncludeDataGrid = \$false') '[datagrid] a build failure flips -IncludeDataGrid off (best-effort: omit table, never throw)'
+Assert-True ($src -match '\$mainDataGridRuns = @\(\); \$prDataGridRuns = @\(\)\s*\r?\n\s*if \(\$IncludeDataGrid\)') '[datagrid] the run leg is skipped unless -IncludeDataGrid is on'
+
+# Paired drop-both alignment: a complete datagrid pair appends BOTH sides; a one-sided
+# failure drops BOTH halves so the paired CI's main[i]/pr[i] zip stays index-aligned.
+Assert-True ($src -match 'if \(\$mm -and \$pm\) \{ \$mainDataGridRuns \+= \$mm; \$prDataGridRuns \+= \$pm \}') '[datagrid] a complete pair appends both main + pr samples'
+Assert-True ($src -match 'elseif \(\$mm -or \$pm\) \{ Write-Log "  datagrid pair #\$i incomplete') '[datagrid] a one-sided datagrid run drops both halves (paired CI stays aligned)'
+
+# result.json carries the datagrid aggregates so downstream tooling can read the leg.
+Assert-True ($src -match 'mainDataGrid = \$mainDataGrid') '[datagrid] result.json object includes the main datagrid aggregate'
+Assert-True ($src -match 'prDataGrid = \$prDataGrid')     '[datagrid] result.json object includes the PR datagrid aggregate'
+
+# ===========================================================================
 #  Micro rep-interleave — ConvertTo-MicroRepLines + Invoke-MicroInterleaved
 # ===========================================================================
 # Per-rep interleaving runs a FRESH process per round per side (so the


### PR DESCRIPTION
## What

Adds a new compare-mode `/perf` **macro leg** — `StressPerf.DataGrid` — that drives the **real DataGrid control** (`DataGridComponent`) over a 30-column × 200-row `IObservableDataSource`, mutating a `--percent` fraction of cells each tick (firing `DataChanged`) to force a full `DataGridComponent.Render()` every frame.

This closes the instrument gap in **#732**: no *wired* `/perf` leg instantiated a DataGrid, so the DataGrid per-render array/LINQ allocation work (**#663/#669**) and per-cell/row modifier-delegate churn (**#671**) could not be measured. This is the direct analog of how `StressPerf.KeyedList` (#737) and `StressPerf.Flex` unlocked their respective subsystems.

**Test-scaffolding only — no `src/Reactor` changes → perf-neutral.** This must merge first so the `/perf` harness can build the baseline leg from `main` before #669 can be A/B-measured against it.

## Why it works

The #663/#669 per-render costs (the `sortKey` join, the `DataRequest` + `.ToList()`s, the header+row `colWidths`/`gridColDefs` arrays, the `Columns` getter `Where+ToList`, the per-column `GetSortDirection`/`GetColumnWidth` LINQ, the row-def arrays, the setter spread) run on **every** `DataGridComponent.Render()` — unconditionally, regardless of whether sort/filter changed. So forcing frequent full re-renders on a wide grid is the core requirement. A small `rowHeight` (18) keeps many rows realized, so the per-realized-cell/row `.OnTapped`/`.OnPointerPressed` closures (#671) churn at measurable scale.

A `shapeVerifiedRef` structural self-check fails fast if the scene root is ever not a `ComponentElement<DataGridElement<StockRow>>`, so a refactor can't silently swap the scene off the DataGrid control and report misleading numbers (mirrors the Flex/KeyedList self-checks).

## Smoke run (headless, `--percent 50 --duration 8`)

```json
{"app":"StressPerf.DataGrid","percent":50,"rendersPerSec":2.107,"totalRenders":18,
 "avgReconcileMs":187.94,"avgDiffMs":187.63,"avgMemoryMB":433.93,
 "allocBytesPerRender":17824136,"gen0":55,"gen0PerKRenders":3235.29,"avgFps":8.39}
```

**~17.8 MB allocated per render (≈35× the Flex leg's ~512 KB)** — a strong, non-trivial DataGrid allocation signal, exactly the path #669 caches.

> **Measurement caveat:** the DataGrid's re-render is async/dispatcher-debounced, so the reconcile/diff timing rows are noisier and may coalesce. Judge DataGrid wins primarily on the **Allocation (datagrid)** sub-table (process-wide GC counters) + `rendersPerSec` — the same guidance the Flex leg documents for its deferred-layout caveat. The leg emits `allocBytesPerRender` + Gen0 like the other legs.

## Harness wiring (mirrors the Flex leg exactly)

- `Reactor.slnx` — project entry
- `Run-PerfBenchmark.ps1` — `AppRegistry.DataGrid`, `-IncludeDataGrid` switch (default `$true`), guarded best-effort build leg (a build failure flips it off, never throws), interleaved A/B run leg with drop-both pairing, `Format-PerfComment -Main/PrDataGrid`, `result.json` aggregates, `-Apps` ValidateSet
- `PerfLib.ps1` — `Format-PerfDataGridSection` (headline metrics + **Allocation (datagrid)** sub-table), invoked after the Flex table
- `PerfLib.Tests.ps1` + `RunPerfBenchmark.Tests.ps1` — DataGrid Pester cases mirroring the Flex/keyed ones (section heading/naming, direction-aware verdicts, omitted-when-null, alloc sub-table ordering, param/registry/leg/comment static-wiring asserts)

## Coexistence note

A legacy `StressPerf.ReactorGrid` project also stands up a DataGrid, but it predates the compare-mode contract (no `metrics.json` / `REACTOR_PERF_JSON` / alloc table) and is wired only into the old single-tree full-matrix scripts (`run_full_matrix.ps1` / `run_sweep_arm64.ps1` / `run_benchmark.sh`), **not** `Run-PerfBenchmark.ps1` compare mode. It is intentionally left untouched; this new leg is the modern equivalent and the two coexist.

## Validation

- `dotnet build src/Reactor/Reactor.csproj -c Release` — **0 warnings, 0 errors**
- `dotnet build StressPerf.DataGrid` (Release) — **0/0**
- `dotnet test tests/Reactor.Tests` — **9887 passed, 0 failed, 64 skipped**
- `PerfLib.Tests.ps1` — **328 assertions passed**; `RunPerfBenchmark.Tests.ps1` — **104 assertions passed**
- Headless smoke run opens a real window, exercises the DataGrid, passes the structural self-check, and emits `metrics.json` + the `REACTOR_PERF_JSON` line (above)

## Follow-ups (separate PRs, coordinated)

1. Revive **#669** — reopen, update-branch onto main (now carrying this leg), `/perf`, judge alloc/Gen0/rps vs the noise band.
2. **#671** — now LIVE (its gate #665 is merged); measure delegate churn on this leg and fix if it clears the noise band.

Relates to #732, #663, #669, #671.