### PR TITLE
test: regression guards for Yoga cross-axis measure-cache staleness (#681)

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CrossAxisMeasureStalenessFixture.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/CrossAxisMeasureStalenessFixture.cs
@@ -1,0 +1,102 @@
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Layout;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Issue #681 (correctness) — cross-axis measure-cache staleness regression guard.
+///
+/// A flex child whose CONTENT changes its cross-axis size (wrapping text whose
+/// line count grows while the longest word — i.e. the main-axis min-content —
+/// is unchanged) must re-flow the panel. Yoga's per-leaf measurement cache is
+/// keyed by the constraint (available size + sizing mode), NOT by content, so
+/// an identical constraint with changed content can serve a STALE cached size
+/// unless the leaf is marked dirty. FlexPanel.SyncYogaTree re-dirties every
+/// child node every MeasureOverride (via the unconditional Display / MinWidth /
+/// Margin setters), which clears that cache — so the new cross-axis size flows
+/// through.
+///
+/// This bug was latent under the former #138 setter equality-guards (which made
+/// those per-pass writes no-ops on unchanged values, leaving the leaf clean →
+/// stale). PR #740 reverted the guards to unconditional dirty, fixing it. This
+/// fixture locks the fixed behavior: if anyone re-introduces a "skip re-dirty on
+/// unchanged value" scheme (the #742 danger zone), the wrapping-text height
+/// below would freeze and this fixture fails.
+/// </summary>
+internal sealed class CrossAxisMeasureStalenessFixture(Harness h) : SelfTestFixtureBase(h)
+{
+    // Same longest word ("ww", length 2) in both strings, so the main-axis
+    // min-content of the child is identical across the two renders; only the
+    // line count — and therefore the cross-axis (height) — changes.
+    private const string ShortText = "ww ww";
+    private const string TallText = "ww ww ww ww ww ww ww ww ww ww ww ww ww ww";
+
+    public override async Task RunAsync()
+    {
+        var host = H.CreateHost();
+
+        // FlexRow → main axis is horizontal, cross axis is vertical (height).
+        // The single child is a wrapping TextBlock with an explicit narrow
+        // width, so its CONSTRAINT is identical across both renders while its
+        // wrapped height grows with content. The row width is fixed; its height
+        // is auto, so it tracks the child's (cross-axis) height.
+        host.Mount(_ => BuildRow(ShortText));
+        await Harness.Render();
+
+        var row = H.FindControl<FlexPanel>(p => p.Direction == FlexDirection.Row);
+        var text = H.FindText(ShortText);
+        H.Check("CrossAxisStaleness_RowMounted", row is not null && text is not null);
+
+        double shortRowHeight = row?.DesiredSize.Height ?? 0;
+        double shortTextHeight = text?.ActualHeight ?? 0;
+
+        // Re-render in place with the taller content. The reconciler reuses the
+        // same TextBlock + FlexPanel controls (and thus the same Yoga node and
+        // its measurement cache), so this exercises the cache-invalidation path
+        // rather than building a fresh tree.
+        host.Mount(_ => BuildRow(TallText));
+        await Harness.Render();
+
+        var rowAfter = H.FindControl<FlexPanel>(p => p.Direction == FlexDirection.Row);
+        var textAfter = H.FindText(TallText);
+        H.Check("CrossAxisStaleness_TallTextMounted", rowAfter is not null && textAfter is not null);
+
+        double tallRowHeight = rowAfter?.DesiredSize.Height ?? 0;
+        double tallTextHeight = textAfter?.ActualHeight ?? 0;
+
+        Console.WriteLine($"# CrossAxisStaleness shortRow={shortRowHeight:F1} tallRow={tallRowHeight:F1} shortText={shortTextHeight:F1} tallText={tallTextHeight:F1}");
+
+        // Sanity: the wrapping TextBlock itself actually grew taller (WinUI
+        // re-measured the child correctly).
+        H.Check(
+            "CrossAxisStaleness_ChildTextGrewTaller",
+            tallTextHeight > shortTextHeight + 1.0);
+
+        // Core assertion: the panel's cross-axis (height) tracked the child's
+        // new content height — no stale cached measurement was served.
+        H.Check(
+            "CrossAxisStaleness_PanelHeightTrackedContent",
+            tallRowHeight > shortRowHeight + 1.0);
+
+        // And the panel is at least as tall as its child (it did not clamp to a
+        // stale, shorter cached height).
+        H.Check(
+            "CrossAxisStaleness_PanelNotStaleVsChild",
+            tallRowHeight >= tallTextHeight - 2.0);
+
+        H.SetContent(null);
+        await Harness.Render();
+    }
+
+    private static Element BuildRow(string text) =>
+        VStack(
+            FlexRow(
+                TextBlock(text)
+                    .Width(60)
+                    .Set(tb => tb.TextWrapping = TextWrapping.Wrap)
+            ).Width(200)
+        );
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1459,6 +1459,7 @@ internal static class SelfTestFixtureRegistry
         "OptionalSetterCollision",
         "InitialOnly",
         "BrushHelperParse",
+        "CrossAxisMeasureStaleness",
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
@@ -2869,6 +2870,7 @@ internal static class SelfTestFixtureRegistry
         "OptionalSetterCollision" => new OptionalSetterCollisionFixture.Execution(harness),
         "InitialOnly" => new InitialOnlyFixture.Execution(harness),
         "BrushHelperParse" => new BrushHelperParseFixture.Execution(harness),
+        "CrossAxisMeasureStaleness" => new CrossAxisMeasureStalenessFixture(harness),
 
         _ => null,
     };

--- a/tests/Reactor.Tests/YogaMeasureCacheStalenessTests.cs
+++ b/tests/Reactor.Tests/YogaMeasureCacheStalenessTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.UI.Reactor.Layout;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Issue #681 (correctness) — Yoga measurement-cache contract underpinning the
+/// FlexPanel cross-axis staleness guard.
+///
+/// Yoga caches per-leaf measure results keyed by the constraint (available size
+/// + sizing mode), NOT by content. So if a measure-backed leaf's content changes
+/// but the constraint passed to it is identical, the cache can serve a stale
+/// size. Marking the leaf dirty is what clears that cache (see the
+/// <c>needToVisitNode</c> reset in <c>YogaAlgorithm</c>). FlexPanel relies on
+/// this by re-dirtying every child node every MeasureOverride.
+///
+/// These tests pin the contract from both sides so that any future
+/// "skip re-dirty on unchanged value" optimization (the #742 danger zone) that
+/// would suppress the dirty is caught here.
+/// </summary>
+public class YogaMeasureCacheStalenessTests
+{
+    private static (YogaNode root, YogaNode leaf, Func<float> getMeasured) BuildRootWithMeasureLeaf(
+        Func<float> contentHeight)
+    {
+        var config = new YogaConfig();
+        var root = new YogaNode(config)
+        {
+            FlexDirection = FlexDirection.Column,
+            Width = YogaValue.Point(100f),
+            // Height is auto so it tracks the leaf's measured (main-axis) size.
+        };
+        var leaf = new YogaNode(config);
+        // Constant cross-axis width, content-driven height. The constraint Yoga
+        // passes is identical across passes; only the returned size changes.
+        leaf.MeasureFunction = (n, w, wm, h, hm) => new YogaSize(50f, contentHeight());
+        root.InsertChild(leaf, 0);
+        return (root, leaf, contentHeight);
+    }
+
+    [Fact]
+    public void MeasureLeaf_DirtyAfterContentChange_RemeasuresForIdenticalConstraint()
+    {
+        float measured = 20f;
+        var (root, leaf, _) = BuildRootWithMeasureLeaf(() => measured);
+
+        root.CalculateLayout(100f, float.NaN, FlexLayoutDirection.LTR);
+        Assert.Equal(20f, leaf.LayoutHeight);
+        Assert.Equal(20f, root.LayoutHeight);
+
+        // Content changes (taller) — same constraint. FlexPanel would mark the
+        // leaf dirty here; do the same. The new size must flow through.
+        measured = 40f;
+        leaf.MarkDirty();
+
+        root.CalculateLayout(100f, float.NaN, FlexLayoutDirection.LTR);
+        Assert.Equal(40f, leaf.LayoutHeight);
+        Assert.Equal(40f, root.LayoutHeight);
+    }
+
+    [Fact]
+    public void MeasureLeaf_NotDirtied_ServesStaleCachedSize_NegativeControl()
+    {
+        // Negative control: this is exactly the staleness the #138 setter guards
+        // could trigger — without dirtying, the constraint-keyed cache serves the
+        // old size even though the measure function would now return a new one.
+        float measured = 20f;
+        var (root, leaf, _) = BuildRootWithMeasureLeaf(() => measured);
+
+        root.CalculateLayout(100f, float.NaN, FlexLayoutDirection.LTR);
+        Assert.Equal(20f, leaf.LayoutHeight);
+
+        // Content changes but the leaf is NOT dirtied and the constraint is
+        // identical → the cache serves the stale 20.
+        measured = 40f;
+        root.CalculateLayout(100f, float.NaN, FlexLayoutDirection.LTR);
+        Assert.Equal(20f, leaf.LayoutHeight);
+    }
+}


### PR DESCRIPTION
## Summary
Triage + regression guards for the **#681 correctness item**: `cross-axis measure-cache staleness`.

## Conclusion: already fixed by #740 — no production change
The staleness was a side-effect of the former **#138 setter equality-guards**. Those made FlexPanel's per-pass node writes no-ops on unchanged values, leaving a measure-backed leaf *clean* so Yoga's constraint-keyed measurement cache served a stale cross-axis size. **PR #740 reverted those guards to unconditional dirty.** `FlexPanel.SyncYogaTree` now re-dirties every child node every `MeasureOverride` (via the `Display` / `MinWidth` / `Margin` setters), and a dirty node clears its measurement cache (the `needToVisitNode` reset in `YogaAlgorithm`). So a content change that grows a flex child's **cross-axis** size re-flows the panel even when the **main-axis** min-content (longest word) is unchanged.

## What this adds (tests only)
Two regression guards so any future re-introduction of a *skip-re-dirty-on-unchanged-value* scheme (the **#742** danger zone) is caught:
- **`YogaMeasureCacheStalenessTests`** (headless) — engine contract: a dirty measure leaf re-measures for an *identical* constraint; a negative control proves the cache would otherwise serve a stale size.
- **`CrossAxisMeasureStalenessFixture`** (selftest) — faithful end-to-end repro: a wrapping `TextBlock` whose line count grows (longest word unchanged) re-flows the panel height (`shortRow=19` -> `tallRow=131` tracking `shortText=18.6` -> `tallText=130.3`).

## Validation
- New Yoga unit tests: 2/2 pass (incl. negative control).
- Selftest `CrossAxisMeasureStaleness`: 5/5 checks pass.
- Yoga fixtures: 696 passed / 0 failed.
- No `src/` change -> Release build + AOT gate unaffected.

Resolves the correctness portion of #681. Recommend the remaining #681 cache-style perf items (skip-clean-children, cached min-content) stay deferred pending Flex-leg measurement.

---
🤖 Draft for coordinator review.