### PR TITLE
Fix #721: refresh gesture/drag dispatch closures on the reconciler skip fast-path

### DIFF
--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -133,6 +133,11 @@ internal static class ChildReconciler
             // or drive it negative. The producer publishes deduped, in-range indices,
             // so visited == the real changed count in steady state; this only hardens
             // the directly-supplied-hint path.
+            // #721 — no gesture/drag dispatch-state refresh is needed for the skipped
+            // (untouched) indices: they are reference-equal old↔new, so their gesture/
+            // drag closures are the SAME instances already cached — there is no stale
+            // capture to refresh. Only the changed indices (handled by UpdateCommonChild
+            // above, which refreshes on its own skip arm) can carry a new closure.
             reconciler.DebugElementsSkipped += common - visited;
             return;
         }
@@ -194,8 +199,18 @@ internal static class ChildReconciler
             // (e.g., Counter's `() => setCount(count + 1)` would keep capturing
             // the initial count). For callback-free elements we still avoid
             // the children.Get COM call.
-            if (newEl.HasCallbacks && children.Get(i) is FrameworkElement fe)
-                Reconciler.SetElementTag(fe, newEl);
+            // #721 — the gesture/drag slots are excluded from the skip predicate,
+            // so refresh their cached dispatch closures here too (same stale-closure
+            // hazard as Tag). Fetch the control once for either need.
+            if ((newEl.HasCallbacks
+                    || Reconciler.HasGestureOrDragSlots(newEl.Modifiers)
+                    || Reconciler.HasGestureOrDragSlots(oldEl.Modifiers))
+                && children.Get(i) is FrameworkElement fe)
+            {
+                if (newEl.HasCallbacks)
+                    Reconciler.SetElementTag(fe, newEl);
+                Reconciler.RefreshGestureDragStateOnSkip(fe, oldEl.Modifiers, newEl.Modifiers);
+            }
             return;
         }
 
@@ -265,8 +280,17 @@ internal static class ChildReconciler
                 reconciler.DebugElementsSkipped++;
                 // Refresh the Tag when the element carries callbacks so the
                 // event trampoline dispatches through the latest closure.
-                if (newEl.HasCallbacks && prefixLen < childCount && children.Get(prefixLen) is FrameworkElement fe)
-                    Reconciler.SetElementTag(fe, newEl);
+                // #721 — likewise refresh the cached gesture/drag dispatch closures
+                // (excluded from the skip predicate). Fetch the control once.
+                if ((newEl.HasCallbacks
+                        || Reconciler.HasGestureOrDragSlots(newEl.Modifiers)
+                        || Reconciler.HasGestureOrDragSlots(oldEl.Modifiers))
+                    && prefixLen < childCount && children.Get(prefixLen) is FrameworkElement fe)
+                {
+                    if (newEl.HasCallbacks)
+                        Reconciler.SetElementTag(fe, newEl);
+                    Reconciler.RefreshGestureDragStateOnSkip(fe, oldEl.Modifiers, newEl.Modifiers);
+                }
                 prefixLen++;
                 continue;
             }
@@ -303,8 +327,16 @@ internal static class ChildReconciler
                 && !reconciler.ForceRenderThroughWrapper(newEl))
             {
                 reconciler.DebugElementsSkipped++;
-                if (newEl.HasCallbacks && panelIdx >= 0 && panelIdx < childCount && children.Get(panelIdx) is FrameworkElement fe)
-                    Reconciler.SetElementTag(fe, newEl);
+                // #721 — refresh Tag + cached gesture/drag dispatch closures on skip.
+                if ((newEl.HasCallbacks
+                        || Reconciler.HasGestureOrDragSlots(newEl.Modifiers)
+                        || Reconciler.HasGestureOrDragSlots(oldEl.Modifiers))
+                    && panelIdx >= 0 && panelIdx < childCount && children.Get(panelIdx) is FrameworkElement fe)
+                {
+                    if (newEl.HasCallbacks)
+                        Reconciler.SetElementTag(fe, newEl);
+                    Reconciler.RefreshGestureDragStateOnSkip(fe, oldEl.Modifiers, newEl.Modifiers);
+                }
                 suffixLen++;
                 continue;
             }

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -1247,8 +1247,12 @@ public abstract record Element
     /// skipped, re-arming an in-flight gesture mid-interaction (e.g. re-registering
     /// a long-press handler between its Began and Ended phases, so the released
     /// callback fires against a refreshed closure and double-dispatches). Excluding
-    /// them preserves observable behavior exactly; grid cells use only routed
-    /// handlers, so the skip-path perf lever is unaffected.
+    /// them keeps the skip-path perf lever intact (grid cells use only routed
+    /// handlers). The latent staleness this creates — a skipped element keeping a
+    /// previous-render gesture/drag closure — is closed on the skip path itself by
+    /// <see cref="Reconciler.RefreshGestureDragStateOnSkip"/> (#721), which refreshes
+    /// the cached dispatch closures WITHOUT re-subscribing the trampolines, so the
+    /// latest closure fires while no in-flight gesture is re-armed.
     /// </summary>
     private static bool ModifierCallbacksEqual(ElementModifiers a, ElementModifiers b)
     {

--- a/src/Reactor/Core/Reconciler.DragDrop.cs
+++ b/src/Reactor/Core/Reconciler.DragDrop.cs
@@ -56,7 +56,18 @@ public sealed partial class Reconciler
             return;
 
         var state = GetOrCreateDndState(fe);
-        state.Source = m.DragSource;
+        // #721 — if the drag SOURCE is being removed while a drag is in flight, keep the
+        // previous Source config alive so the pending DropCompleted can still fire OnEnd
+        // and Unregister the transfer. Nulling it here would make OnDropCompleted
+        // early-return on `state.Source is null`, leaking the DragData registration and
+        // suppressing the completion callback. CanDrag is still cleared below, so no NEW
+        // drag can start. (Reconciler-path-agnostic: also hardens the non-skip Update
+        // path's mid-drag source removal.)
+        bool removingSourceMidDrag = m.DragSource is null
+            && oldM?.DragSource is not null
+            && state.ActiveTransferId != Guid.Empty;
+        if (!removingSourceMidDrag)
+            state.Source = m.DragSource;
         state.Target = m.DropTarget;
 
         // ── Source side ───────────────────────────────────────────────

--- a/src/Reactor/Core/Reconciler.DragDrop.cs
+++ b/src/Reactor/Core/Reconciler.DragDrop.cs
@@ -43,6 +43,12 @@ public sealed partial class Reconciler
         return state;
     }
 
+    // Test-only accessor (InternalsVisibleTo Reactor.Tests / Reactor.AppTests.Host).
+    // Lets the #721 skip-path regression fixture read the cached drag dispatch
+    // closures so it can invoke the latest Source/Target config after a skipped render.
+    internal static DragDropState? DebugTryGetDndState(FrameworkElement fe)
+        => _dndStates.TryGetValue(fe, out var state) ? state : null;
+
     private static void ApplyDragDropHandlers(FrameworkElement fe, ElementModifiers? oldM, ElementModifiers m)
     {
         if (m.DragSource is null && m.DropTarget is null

--- a/src/Reactor/Core/Reconciler.Gestures.cs
+++ b/src/Reactor/Core/Reconciler.Gestures.cs
@@ -68,6 +68,72 @@ public sealed partial class Reconciler
         return state;
     }
 
+    // Test-only accessor (InternalsVisibleTo Reactor.Tests / Reactor.AppTests.Host).
+    // Lets the #721 skip-path regression fixture read the cached gesture dispatch
+    // closures so it can invoke the latest OnChanged after a skipped render.
+    internal static GestureState? DebugTryGetGestureState(FrameworkElement fe)
+        => _gestureStates.TryGetValue(fe, out var state) ? state : null;
+
+    /// <summary>
+    /// #721 — cheap predicate: does this modifier set carry any gesture
+    /// (Pan/Pinch/Rotate/LongPress) or drag-drop (DragSource/DropTarget) slot? Used to
+    /// gate the skip-path dispatch-state refresh so a leaf with no gesture/drag slot
+    /// (every grid cell) never probes the gesture/drag CWTs or fetches its control.
+    /// </summary>
+    internal static bool HasGestureOrDragSlots(ElementModifiers? m)
+        => m is not null
+            && (m.Pan is not null || m.Pinch is not null || m.Rotate is not null
+                || m.LongPress is not null || m.DragSource is not null || m.DropTarget is not null);
+
+    /// <summary>
+    /// #721 — refresh the cached gesture/drag dispatch closures on a skip fast-path
+    /// WITHOUT re-subscribing the manipulation/drag trampolines.
+    ///
+    /// The skip predicate (<c>ModifierCallbacksEqual</c>) deliberately excludes the
+    /// gesture and drag-drop slots, so an element whose only change is a per-render
+    /// gesture/drag closure is skip-eligible — yet those handlers dispatch through the
+    /// mutable <see cref="GestureState"/>/<see cref="DragDropState"/> config fields the
+    /// stable trampolines read at dispatch time, and those fields are otherwise
+    /// refreshed only on the non-skip Update path (<c>ApplyGestureHandlers</c>/
+    /// <c>ApplyDragDropHandlers</c>). Without this, a skipped render strands the
+    /// previous closure and dispatch fires stale captured state.
+    ///
+    /// Overwriting just the config fields swaps the dispatch target to the latest
+    /// closure — mirroring how the Tag / <c>ModifierEventHandlerState</c> refresh keeps
+    /// routed handlers current on skip — while leaving the trampolines and the in-flight
+    /// gesture cursors (<c>PanBeganDispatched</c>, the LongPress timer, …) untouched, so
+    /// an in-flight gesture is never re-armed mid-interaction (no Began/Ended
+    /// double-dispatch). Sourcing the fields from <paramref name="newM"/> also correctly
+    /// clears a slot that was removed across a skipped render (stale removed gesture no
+    /// longer dispatches).
+    ///
+    /// Using <c>ConditionalWeakTable.TryGetValue</c> (not GetOrCreate) avoids
+    /// allocating state for an element that was never wired — a mounted gesture/drag
+    /// element always has its state, and an unwired one has nothing to dispatch.
+    /// </summary>
+    internal static void RefreshGestureDragStateOnSkip(FrameworkElement fe, ElementModifiers? oldM, ElementModifiers? newM)
+    {
+        bool gestureNow = newM is not null
+            && (newM.Pan is not null || newM.Pinch is not null || newM.Rotate is not null || newM.LongPress is not null);
+        bool gestureBefore = oldM is not null
+            && (oldM.Pan is not null || oldM.Pinch is not null || oldM.Rotate is not null || oldM.LongPress is not null);
+        if ((gestureNow || gestureBefore) && _gestureStates.TryGetValue(fe, out var gs))
+        {
+            gs.Pan = newM?.Pan;
+            gs.Pinch = newM?.Pinch;
+            gs.Rotate = newM?.Rotate;
+            gs.LongPress = newM?.LongPress;
+        }
+
+        bool dragNow = newM is not null && (newM.DragSource is not null || newM.DropTarget is not null);
+        bool dragBefore = oldM is not null && (oldM.DragSource is not null || oldM.DropTarget is not null);
+        if ((dragNow || dragBefore) && _dndStates.TryGetValue(fe, out var ds))
+        {
+            ds.Source = newM?.DragSource;
+            ds.Target = newM?.DropTarget;
+        }
+    }
+
     /// <summary>
     /// Computes the union of <see cref="ManipulationModes"/> flags required by the
     /// currently-attached gestures. Returns <see cref="ManipulationModes.None"/> when

--- a/src/Reactor/Core/Reconciler.Gestures.cs
+++ b/src/Reactor/Core/Reconciler.Gestures.cs
@@ -85,52 +85,74 @@ public sealed partial class Reconciler
             && (m.Pan is not null || m.Pinch is not null || m.Rotate is not null
                 || m.LongPress is not null || m.DragSource is not null || m.DropTarget is not null);
 
+    // Shared empty sentinel so a (theoretically) null newM on a remove transition can be
+    // passed to the Apply* handlers (which require a non-null modifier set) without
+    // allocating. On the skip path newM is never null when a transition is detected
+    // (ModifiersEqual requires both sides non-null or both null), so this is defensive.
+    private static readonly ElementModifiers _emptyModifiers = new();
+
     /// <summary>
-    /// #721 — refresh the cached gesture/drag dispatch closures on a skip fast-path
-    /// WITHOUT re-subscribing the manipulation/drag trampolines.
+    /// #721 — keep the cached gesture/drag dispatch state correct when the reconciler
+    /// takes its skip fast-path for an element whose gesture/drag slots changed (those
+    /// slots are excluded from the skip predicate, so such an element is skip-eligible).
+    /// Two distinct cases, handled differently:
     ///
-    /// The skip predicate (<c>ModifierCallbacksEqual</c>) deliberately excludes the
-    /// gesture and drag-drop slots, so an element whose only change is a per-render
-    /// gesture/drag closure is skip-eligible — yet those handlers dispatch through the
-    /// mutable <see cref="GestureState"/>/<see cref="DragDropState"/> config fields the
-    /// stable trampolines read at dispatch time, and those fields are otherwise
-    /// refreshed only on the non-skip Update path (<c>ApplyGestureHandlers</c>/
-    /// <c>ApplyDragDropHandlers</c>). Without this, a skipped render strands the
-    /// previous closure and dispatch fires stale captured state.
+    /// <para><b>Presence transition</b> (a family is present on exactly one side — an
+    /// ADD or a REMOVE-last): route to the full <see cref="ApplyGestureHandlers"/> /
+    /// <see cref="ApplyDragDropHandlers"/>. The config-only refresh below is NOT enough
+    /// here — an ADD has no <see cref="GestureState"/>/<see cref="DragDropState"/> yet
+    /// (so a <c>TryGetValue</c>-only path would no-op and the gesture/drag would never
+    /// wire — silently dead), and a REMOVE must clear the platform flags
+    /// (<c>ManipulationMode</c> / <c>CanDrag</c> / <c>AllowDrop</c>), which only the full
+    /// handler does. A transition means the family was inactive on one side, so the full
+    /// Apply is safe: there is no in-flight gesture of a not-yet/​no-longer-present family
+    /// to re-arm (and a mid-drag source removal is preserved by the in-flight guard in
+    /// <see cref="ApplyDragDropHandlers"/> so its pending DropCompleted still fires).</para>
     ///
-    /// Overwriting just the config fields swaps the dispatch target to the latest
-    /// closure — mirroring how the Tag / <c>ModifierEventHandlerState</c> refresh keeps
-    /// routed handlers current on skip — while leaving the trampolines and the in-flight
-    /// gesture cursors (<c>PanBeganDispatched</c>, the LongPress timer, …) untouched, so
-    /// an in-flight gesture is never re-armed mid-interaction (no Began/Ended
-    /// double-dispatch). Sourcing the fields from <paramref name="newM"/> also correctly
-    /// clears a slot that was removed across a skipped render (stale removed gesture no
-    /// longer dispatches).
-    ///
-    /// Using <c>ConditionalWeakTable.TryGetValue</c> (not GetOrCreate) avoids
-    /// allocating state for an element that was never wired — a mounted gesture/drag
-    /// element always has its state, and an unwired one has nothing to dispatch.
+    /// <para><b>Identity change</b> (a family is present on BOTH sides, only the captured
+    /// closure changed): overwrite just the mutable config fields the stable trampolines
+    /// read at dispatch time. This swaps the dispatch target to the latest closure —
+    /// mirroring how the Tag / <c>ModifierEventHandlerState</c> refresh keeps routed
+    /// handlers current on skip — while leaving the trampolines and the in-flight gesture
+    /// cursors (<c>PanBeganDispatched</c>, the LongPress timer, …) untouched, so an
+    /// in-flight gesture is never re-armed mid-interaction (no Began/Ended
+    /// double-dispatch). <c>TryGetValue</c> (not GetOrCreate) never allocates: an
+    /// already-wired family always has its state.</para>
     /// </summary>
     internal static void RefreshGestureDragStateOnSkip(FrameworkElement fe, ElementModifiers? oldM, ElementModifiers? newM)
     {
+        // ── Gesture family (Pan/Pinch/Rotate/LongPress) ──
         bool gestureNow = newM is not null
             && (newM.Pan is not null || newM.Pinch is not null || newM.Rotate is not null || newM.LongPress is not null);
         bool gestureBefore = oldM is not null
             && (oldM.Pan is not null || oldM.Pinch is not null || oldM.Rotate is not null || oldM.LongPress is not null);
-        if ((gestureNow || gestureBefore) && _gestureStates.TryGetValue(fe, out var gs))
+        if (gestureNow != gestureBefore)
         {
-            gs.Pan = newM?.Pan;
-            gs.Pinch = newM?.Pinch;
-            gs.Rotate = newM?.Rotate;
-            gs.LongPress = newM?.LongPress;
+            // ADD or REMOVE-last — wire / unwire through the full handler.
+            ApplyGestureHandlers(fe, oldM, newM ?? _emptyModifiers);
+        }
+        else if (gestureNow && _gestureStates.TryGetValue(fe, out var gs))
+        {
+            // Already-wired identity change — config-only refresh (mid-gesture-safe).
+            gs.Pan = newM!.Pan;
+            gs.Pinch = newM.Pinch;
+            gs.Rotate = newM.Rotate;
+            gs.LongPress = newM.LongPress;
         }
 
+        // ── Drag-drop family (DragSource/DropTarget) ──
         bool dragNow = newM is not null && (newM.DragSource is not null || newM.DropTarget is not null);
         bool dragBefore = oldM is not null && (oldM.DragSource is not null || oldM.DropTarget is not null);
-        if ((dragNow || dragBefore) && _dndStates.TryGetValue(fe, out var ds))
+        if (dragNow != dragBefore)
         {
-            ds.Source = newM?.DragSource;
-            ds.Target = newM?.DropTarget;
+            // ADD or REMOVE-last — wire / unwire (CanDrag/AllowDrop + trampolines + the
+            // in-flight-drag guard so a mid-drag source removal still completes cleanly).
+            ApplyDragDropHandlers(fe, oldM, newM ?? _emptyModifiers);
+        }
+        else if (dragNow && _dndStates.TryGetValue(fe, out var ds))
+        {
+            ds.Source = newM!.DragSource;
+            ds.Target = newM.DropTarget;
         }
     }
 

--- a/src/Reactor/Core/Reconciler.Gestures.cs
+++ b/src/Reactor/Core/Reconciler.Gestures.cs
@@ -122,18 +122,28 @@ public sealed partial class Reconciler
     internal static void RefreshGestureDragStateOnSkip(FrameworkElement fe, ElementModifiers? oldM, ElementModifiers? newM)
     {
         // ── Gesture family (Pan/Pinch/Rotate/LongPress) ──
-        bool gestureNow = newM is not null
-            && (newM.Pan is not null || newM.Pinch is not null || newM.Rotate is not null || newM.LongPress is not null);
-        bool gestureBefore = oldM is not null
-            && (oldM.Pan is not null || oldM.Pinch is not null || oldM.Rotate is not null || oldM.LongPress is not null);
-        if (gestureNow != gestureBefore)
+        // Route on PER-SLOT presence, not aggregate: if the null/non-null pattern of ANY
+        // of the four gesture slots differs, a slot was added or removed — even alongside
+        // a co-present sibling (e.g. Pinch -> Pinch+Pan, or Pan+Pinch -> Pinch). That needs
+        // the full handler to (re)compute ManipulationMode / IsHoldingEnabled and lazily
+        // wire any new trampoline; the config-only arm would set the field but never widen
+        // the platform mode, leaving the added gesture silently dead. Only when every
+        // slot's presence is identical (a pure per-render closure swap) is config-only both
+        // sufficient AND mid-gesture-safe.
+        bool gesturePresenceChanged =
+            (oldM?.Pan is null) != (newM?.Pan is null)
+            || (oldM?.Pinch is null) != (newM?.Pinch is null)
+            || (oldM?.Rotate is null) != (newM?.Rotate is null)
+            || (oldM?.LongPress is null) != (newM?.LongPress is null);
+        if (gesturePresenceChanged)
         {
-            // ADD or REMOVE-last — wire / unwire through the full handler.
             ApplyGestureHandlers(fe, oldM, newM ?? _emptyModifiers);
         }
-        else if (gestureNow && _gestureStates.TryGetValue(fe, out var gs))
+        else if ((newM?.Pan is not null || newM?.Pinch is not null || newM?.Rotate is not null || newM?.LongPress is not null)
+                 && _gestureStates.TryGetValue(fe, out var gs))
         {
-            // Already-wired identity change — config-only refresh (mid-gesture-safe).
+            // Every slot present-identically, only the closures differ — config-only
+            // refresh (mid-gesture-safe: no trampoline re-subscribe, cursors untouched).
             gs.Pan = newM!.Pan;
             gs.Pinch = newM.Pinch;
             gs.Rotate = newM.Rotate;
@@ -141,15 +151,20 @@ public sealed partial class Reconciler
         }
 
         // ── Drag-drop family (DragSource/DropTarget) ──
-        bool dragNow = newM is not null && (newM.DragSource is not null || newM.DropTarget is not null);
-        bool dragBefore = oldM is not null && (oldM.DragSource is not null || oldM.DropTarget is not null);
-        if (dragNow != dragBefore)
+        // Per-slot presence again: a DragSource removed while a DropTarget stays present
+        // (or vice-versa) is a transition, not an identity change. Routing it to the full
+        // handler is what makes ApplyDragDropHandlers' in-flight-drag guard reachable on a
+        // mid-drag source removal (the config-only arm would null state.Source directly,
+        // stranding the pending DropCompleted -> leak + suppressed OnEnd).
+        bool dragPresenceChanged =
+            (oldM?.DragSource is null) != (newM?.DragSource is null)
+            || (oldM?.DropTarget is null) != (newM?.DropTarget is null);
+        if (dragPresenceChanged)
         {
-            // ADD or REMOVE-last — wire / unwire (CanDrag/AllowDrop + trampolines + the
-            // in-flight-drag guard so a mid-drag source removal still completes cleanly).
             ApplyDragDropHandlers(fe, oldM, newM ?? _emptyModifiers);
         }
-        else if (dragNow && _dndStates.TryGetValue(fe, out var ds))
+        else if ((newM?.DragSource is not null || newM?.DropTarget is not null)
+                 && _dndStates.TryGetValue(fe, out var ds))
         {
             ds.Source = newM!.DragSource;
             ds.Target = newM.DropTarget;
@@ -223,6 +238,13 @@ public sealed partial class Reconciler
         var mode = ComputeManipulationMode(m);
         if (mode != ManipulationModes.None)
             fe.ManipulationMode = mode;
+        else if (oldM?.Pan is not null || oldM?.Pinch is not null || oldM?.Rotate is not null)
+            // #721 — all manipulation gestures (Pan/Pinch/Rotate) were removed. Clear the
+            // mode Reactor previously set so the element stops capturing manipulations
+            // (a leftover TranslateX/Scale would keep eating an ancestor ScrollViewer's
+            // pans). Gated on oldM having had one so we never clobber a user-set mode on
+            // a control that never carried a Reactor gesture.
+            fe.ManipulationMode = ManipulationModes.None;
 
         // Lazy-attach manipulation trampolines (one-time). Skip when only LongPress is wired.
         bool needsManipulation = m.Pan is not null || m.Pinch is not null || m.Rotate is not null
@@ -286,6 +308,14 @@ public sealed partial class Reconciler
                 state.LongPressPointerMovedTrampoline = (s, e) => OnLongPressPointerMoved(fe, state, e);
                 fe.AddHandler(UIElement.PointerMovedEvent, state.LongPressPointerMovedTrampoline, handledEventsToo: true);
             }
+        }
+        else if (oldM?.LongPress is not null)
+        {
+            // #721 — LongPress removed: stop generating Holding events. The trampolines stay
+            // attached (wired-once design) but read state.LongPress == null at dispatch, so
+            // they no-op; clearing IsHoldingEnabled is what actually stops the platform from
+            // raising Holding (and the mouse-emulation arm is already inert via the null cfg).
+            fe.IsHoldingEnabled = false;
         }
     }
 

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -96,6 +96,12 @@ public sealed partial class Reconciler
             // Re-resolve ThemeRef-based resource overrides on theme change
             if (newEl.ResourceOverrides is { ThemeRefs.Count: > 0 } && control is FrameworkElement resFeSE)
                 ApplyResourceOverrides(resFeSE, newEl.ResourceOverrides, newEl.ResourceOverrides);
+            // #721 — refresh the cached gesture/drag dispatch closures so a skipped
+            // element whose only change is a per-render gesture/drag closure dispatches
+            // the latest closure (not a stale capture) without re-arming the trampolines.
+            if ((HasGestureOrDragSlots(modifiers) || HasGestureOrDragSlots(oldModifiers))
+                && control is FrameworkElement gestFeSE)
+                RefreshGestureDragStateOnSkip(gestFeSE, oldModifiers, modifiers);
             return null; // null = keep existing control as-is
         }
 

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -367,14 +367,23 @@ public static partial class ElementExtensions
 
     /// <summary>
     /// Zero-argument convenience overload for long-press. Use when you don't need the
-    /// gesture snapshot (Position, Duration, Phase).
+    /// gesture snapshot (Position, Duration, Phase). Fires exactly ONCE per recognized
+    /// long-press, at the moment it triggers (<see cref="Microsoft.UI.Reactor.Input.GesturePhase.Began"/>) —
+    /// not again on release (<see cref="Microsoft.UI.Reactor.Input.GesturePhase.Ended"/>)
+    /// or cancel. The underlying <c>OnTriggered</c> contract fires Began then Ended/Cancelled;
+    /// a phase-agnostic convenience action must filter to Began or it double-fires. (This
+    /// was previously masked when a per-render capturing action went stale across a skipped
+    /// render — both calls became idempotent; the skip-path closure refresh in #721 exposed
+    /// it, so the filter makes the single-fire contract explicit.)
     /// </summary>
     public static T OnLongPress<T>(this T el,
         Action onTriggered,
         TimeSpan? minimumDuration = null,
         double cancelDistance = 10.0,
         bool enableMouseEmulation = false) where T : Element =>
-        el.OnLongPress(_ => onTriggered(), minimumDuration, cancelDistance, enableMouseEmulation);
+        el.OnLongPress(
+            g => { if (g.Phase == Microsoft.UI.Reactor.Input.GesturePhase.Began) onTriggered(); },
+            minimumDuration, cancelDistance, enableMouseEmulation);
 
     /// <summary>
     /// Zero-argument convenience overload for double-tap. Equivalent to

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SkipPathGestureDragFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SkipPathGestureDragFixtures.cs
@@ -419,4 +419,180 @@ internal static class SkipPathGestureDragFixtures
             H.Check("RemoveDragIdle_CanDragCleared", rect is not null && !rect.CanDrag);
         }
     }
+
+    /// <summary>
+    /// #748 re-review — SUBFAMILY add: a gesture slot added alongside a co-present sibling
+    /// (Pinch -> Pinch+Pan) is skip-eligible and, under AGGREGATE routing, wrongly took the
+    /// config-only arm (gestureNow==gestureBefore==true) — which sets gs.Pan but never
+    /// widens ManipulationMode, so the platform never reports translation and the added Pan
+    /// is silently dead. Per-slot routing sends it to ApplyGestureHandlers, widening the mode.
+    /// </summary>
+    internal class SkipAddPanAlongsidePinchWidensMode(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (hasPan, setHasPan) = ctx.UseState(false);
+                // Pinch is present on every render; Pan is added on the 2nd. The element is
+                // otherwise structurally identical (gesture slots excluded from the diff).
+                var rect = Factories.Rectangle().Size(80, 80).OnPinch(_ => { });
+                if (hasPan)
+                    rect = rect.OnPan(_ => { }, axis: PanAxis.Both);
+                return VStack(
+                    TextBlock("submode"),
+                    Button("AddPanBtn", () => setHasPan(true)),
+                    rect);
+            });
+
+            await Harness.Render();
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("AddPan_PinchModeInitially",
+                rect is not null && rect.ManipulationMode.HasFlag(ManipulationModes.Scale));
+            H.Check("AddPan_NoTranslateInitially",
+                rect is not null && !rect.ManipulationMode.HasFlag(ManipulationModes.TranslateX));
+
+            H.ClickButton("AddPanBtn");
+            await Harness.Render();
+
+            // Post-fix: ManipulationMode widened to include translation; the cached Pan config exists.
+            H.Check("AddPan_ManipulationWidened",
+                rect is not null && rect.ManipulationMode.HasFlag(ManipulationModes.TranslateX));
+            var state = rect is not null ? Reconciler.DebugTryGetGestureState(rect) : null;
+            H.Check("AddPan_PanConfigCached", state?.Pan is not null);
+            H.Check("AddPan_PinchStillCached", state?.Pinch is not null);
+        }
+    }
+
+    /// <summary>
+    /// #748 re-review — SUBFAMILY add (drag): adding a DragSource alongside a co-present
+    /// DropTarget is skip-eligible; aggregate routing took config-only (set ds.Source but
+    /// never CanDrag=true) so the new source couldn't start a drag. Per-slot routing wires it.
+    /// </summary>
+    internal class SkipAddDragSourceAlongsideDropTargetWires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (hasSource, setHasSource) = ctx.UseState(false);
+                var rect = Factories.Rectangle().Size(80, 80).OnDrop(_ => { });
+                if (hasSource)
+                    rect = rect.OnDragStart(() => new DragData());
+                return VStack(
+                    TextBlock("subdrag"),
+                    Button("AddSourceBtn", () => setHasSource(true)),
+                    rect);
+            });
+
+            await Harness.Render();
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("AddSource_AllowDropInitially", rect is not null && rect.AllowDrop);
+            H.Check("AddSource_CanDragFalseInitially", rect is not null && !rect.CanDrag);
+
+            H.ClickButton("AddSourceBtn");
+            await Harness.Render();
+
+            // Post-fix: CanDrag set (source wired) while DropTarget's AllowDrop is preserved.
+            H.Check("AddSource_CanDragSet", rect is not null && rect.CanDrag);
+            H.Check("AddSource_AllowDropPreserved", rect is not null && rect.AllowDrop);
+            var state = rect is not null ? Reconciler.DebugTryGetDndState(rect) : null;
+            H.Check("AddSource_SourceCached", state?.Source is not null);
+            H.Check("AddSource_TargetStillCached", state?.Target is not null);
+        }
+    }
+
+    /// <summary>
+    /// #748 re-review — THE CRITICAL case: a DragSource removed MID-DRAG while a DropTarget
+    /// stays present. Under aggregate routing dragNow==dragBefore==true → the config-only arm
+    /// nulled ds.Source DIRECTLY, bypassing the in-flight guard in ApplyDragDropHandlers →
+    /// OnDropCompleted early-returns → leaks the DragData registration + suppresses OnEnd.
+    /// Per-slot routing detects the DragSource presence change and routes to the full handler
+    /// so the guard is reached and Source is preserved for the pending completion.
+    /// </summary>
+    internal class SkipRemoveDragSourceWithDropTargetMidDragPreservesState(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (hasSource, setHasSource) = ctx.UseState(true);
+                // DropTarget present every render; DragSource removed on the 2nd.
+                var rect = Factories.Rectangle().Size(80, 80).OnDrop(_ => { });
+                if (hasSource)
+                    rect = rect.OnDragStart(() => new DragData());
+                return VStack(
+                    TextBlock("subdrag2"),
+                    Button("RemoveSourceBtn", () => setHasSource(false)),
+                    rect);
+            });
+
+            await Harness.Render();
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            var state = rect is not null ? Reconciler.DebugTryGetDndState(rect) : null;
+            H.Check("MidDragWithTarget_SourceWiredInitially", state?.Source is not null);
+            H.Check("MidDragWithTarget_TargetWiredInitially", state?.Target is not null);
+            H.Check("MidDragWithTarget_CanDragInitially", rect is not null && rect.CanDrag);
+
+            // Simulate a drag in flight, then remove only the source (DropTarget stays).
+            if (state is not null) state.ActiveTransferId = Guid.NewGuid();
+            var inflightSource = state?.Source;
+
+            H.ClickButton("RemoveSourceBtn");
+            await Harness.Render();
+
+            var state2 = rect is not null ? Reconciler.DebugTryGetDndState(rect) : null;
+            // Post-fix: Source preserved (guard reached via per-slot routing) so the pending
+            // DropCompleted still fires OnEnd + Unregister; DropTarget stays live; CanDrag cleared.
+            H.Check("MidDragWithTarget_SourcePreserved", ReferenceEquals(state2?.Source, inflightSource));
+            H.Check("MidDragWithTarget_TransferStillInFlight", state2 is not null && state2.ActiveTransferId != Guid.Empty);
+            H.Check("MidDragWithTarget_TargetStillLive", state2?.Target is not null && rect is not null && rect.AllowDrop);
+            H.Check("MidDragWithTarget_CanDragCleared", rect is not null && !rect.CanDrag);
+        }
+    }
+
+    /// <summary>
+    /// #748 re-review — gesture REMOVE must CLEAR the platform flags ApplyGestureHandlers set:
+    /// ManipulationMode back to None (a leftover TranslateX/Scale keeps eating an ancestor
+    /// ScrollViewer's pans) and IsHoldingEnabled false (stop raising Holding). Since
+    /// ApplyGestureHandlers is shared, this corrects both the skip and non-skip paths.
+    /// </summary>
+    internal class SkipRemoveGestureClearsPlatformFlags(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (hasGesture, setHasGesture) = ctx.UseState(true);
+                var rect = Factories.Rectangle().Size(80, 80);
+                if (hasGesture)
+                    rect = rect.OnPan(_ => { }, axis: PanAxis.Both)
+                               .OnLongPress(() => { }, enableMouseEmulation: true);
+                return VStack(
+                    TextBlock("rmflags"),
+                    Button("RemoveGestureBtn", () => setHasGesture(false)),
+                    rect);
+            });
+
+            await Harness.Render();
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("RemoveFlags_TranslateModeInitially",
+                rect is not null && rect.ManipulationMode.HasFlag(ManipulationModes.TranslateX));
+            H.Check("RemoveFlags_HoldingEnabledInitially", rect is not null && rect.IsHoldingEnabled);
+
+            H.ClickButton("RemoveGestureBtn");
+            await Harness.Render();
+
+            // Post-fix: both platform flags cleared on the skip-path remove.
+            H.Check("RemoveFlags_ManipulationCleared",
+                rect is not null && rect.ManipulationMode == ManipulationModes.None);
+            H.Check("RemoveFlags_HoldingDisabled", rect is not null && !rect.IsHoldingEnabled);
+            var state = rect is not null ? Reconciler.DebugTryGetGestureState(rect) : null;
+            H.Check("RemoveFlags_GestureConfigsNulled", state is null || (state.Pan is null && state.LongPress is null));
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SkipPathGestureDragFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SkipPathGestureDragFixtures.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Input;
 using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
 using static Microsoft.UI.Reactor.Factories;
 
 namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
@@ -272,6 +273,150 @@ internal static class SkipPathGestureDragFixtures
             // re-fire Began; and the refresh itself dispatched no Began (no duplicate).
             H.Check("MidGesture_CursorPreserved", state.PanBeganDispatched);
             H.Check("MidGesture_NoDuplicateBegan", !log.Entries.Exists(e => e.Phase == "Began"));
+        }
+    }
+
+    /// <summary>
+    /// #721 H1 — gesture PRESENCE TRANSITION (add-first) on the skip path. A gesture slot
+    /// is excluded from the skip predicate, so adding <c>.OnPan</c> to an otherwise
+    /// skip-equal element takes the skip arm. The config-only refresh can't wire a brand
+    /// new gesture (no GestureState exists yet), so the skip path must route an
+    /// add-transition to the full ApplyGestureHandlers — otherwise the gesture is silently
+    /// dead. Asserts the gesture actually wires (state + ManipulationMode) and fires.
+    /// </summary>
+    internal class SkipAddFirstGestureWires(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (hasGesture, setHasGesture) = ctx.UseState(false);
+                var (fired, setFired) = ctx.UseState(false);
+
+                var rect = Factories.Rectangle().Size(80, 80);
+                // Gesture appears only on the 2nd render; the element is otherwise
+                // structurally identical, so the reconciler skips it.
+                if (hasGesture)
+                    rect = rect.OnPan(_ => setFired(true), axis: PanAxis.Both);
+
+                return VStack(
+                    TextBlock($"addfired:{fired}"),
+                    Button("AddGestureBtn", () => setHasGesture(true)),
+                    rect);
+            });
+
+            await Harness.Render();
+            var rect0 = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("AddGesture_NoStateInitially",
+                rect0 is null || Reconciler.DebugTryGetGestureState(rect0)?.Pan is null);
+
+            // Add the gesture on a skip-eligible render.
+            H.ClickButton("AddGestureBtn");
+            await Harness.Render();
+
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("AddGesture_TargetMounted", rect is not null);
+            var state = rect is not null ? Reconciler.DebugTryGetGestureState(rect) : null;
+
+            // Post-fix: the add-on-skip routed to the full handler → gesture wired.
+            H.Check("AddGesture_Wired", state?.Pan is not null);
+            H.Check("AddGesture_ManipulationModeSet",
+                rect is not null && rect.ManipulationMode.HasFlag(ManipulationModes.TranslateX));
+
+            state?.Pan?.OnChanged(default);
+            await Harness.Render();
+            H.Check("AddGesture_ClosureFires", H.FindText("addfired:True") is not null);
+        }
+    }
+
+    /// <summary>
+    /// #721 H1 — drag SOURCE removal MID-DRAG on the skip path must not strand the
+    /// in-flight transfer. A naive config-only null of <c>DragDropState.Source</c> would
+    /// make the pending <c>OnDropCompleted</c> early-return (<c>state.Source is null</c>),
+    /// leaking the DragData registration and suppressing <c>OnEnd</c>. The remove is a
+    /// presence transition routed to the full ApplyDragDropHandlers, whose in-flight guard
+    /// preserves Source while a drag is active (ActiveTransferId set) yet still clears
+    /// CanDrag so no NEW drag starts.
+    /// </summary>
+    internal class SkipRemoveDragSourceMidDragPreservesState(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (hasDrag, setHasDrag) = ctx.UseState(true);
+
+                var rect = Factories.Rectangle().Size(80, 80);
+                if (hasDrag)
+                    rect = rect.OnDragStart(() => new DragData());
+
+                return VStack(
+                    TextBlock("dragstate"),
+                    Button("RemoveDragBtn", () => setHasDrag(false)),
+                    rect);
+            });
+
+            await Harness.Render();
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("RemoveDrag_TargetMounted", rect is not null);
+            var state = rect is not null ? Reconciler.DebugTryGetDndState(rect) : null;
+            H.Check("RemoveDrag_SourceWiredInitially", state?.Source is not null);
+            H.Check("RemoveDrag_CanDragInitially", rect is not null && rect.CanDrag);
+
+            // Simulate a drag in flight: DragStarting fired, transfer registered.
+            if (state is not null) state.ActiveTransferId = Guid.NewGuid();
+            var inflightSource = state?.Source;
+
+            // Remove the drag source on a skip-eligible render.
+            H.ClickButton("RemoveDragBtn");
+            await Harness.Render();
+
+            var state2 = rect is not null ? Reconciler.DebugTryGetDndState(rect) : null;
+            // Post-fix: in-flight guard preserves Source so the pending DropCompleted can
+            // still fire OnEnd + Unregister. Pre-fix the config-only null stranded it.
+            H.Check("RemoveDrag_SourcePreservedMidDrag", ReferenceEquals(state2?.Source, inflightSource));
+            H.Check("RemoveDrag_TransferStillInFlight", state2 is not null && state2.ActiveTransferId != Guid.Empty);
+            // But a NEW drag can no longer start.
+            H.Check("RemoveDrag_CanDragClearedAfterRemove", rect is not null && !rect.CanDrag);
+        }
+    }
+
+    /// <summary>
+    /// #721 H1 regression — the in-flight guard is in-flight-SPECIFIC: removing a drag
+    /// source on the skip path while NO drag is active must still null the cached Source
+    /// and clear CanDrag (full unwire), so the guard never over-preserves a stale source.
+    /// </summary>
+    internal class SkipRemoveDragSourceNotInFlightClears(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (hasDrag, setHasDrag) = ctx.UseState(true);
+                var rect = Factories.Rectangle().Size(80, 80);
+                if (hasDrag)
+                    rect = rect.OnDragStart(() => new DragData());
+                return VStack(
+                    TextBlock("dragstate2"),
+                    Button("RemoveDragBtn2", () => setHasDrag(false)),
+                    rect);
+            });
+
+            await Harness.Render();
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("RemoveDragIdle_SourceWiredInitially",
+                rect is not null && Reconciler.DebugTryGetDndState(rect)?.Source is not null);
+
+            // No ActiveTransferId set → not in flight.
+            H.ClickButton("RemoveDragBtn2");
+            await Harness.Render();
+
+            var state2 = rect is not null ? Reconciler.DebugTryGetDndState(rect) : null;
+            H.Check("RemoveDragIdle_SourceCleared", state2?.Source is null);
+            H.Check("RemoveDragIdle_CanDragCleared", rect is not null && !rect.CanDrag);
         }
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SkipPathGestureDragFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SkipPathGestureDragFixtures.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Input;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Issue #721 — the reconciler skip fast-path
+/// (<see cref="Element.ShallowEquals"/> → <see cref="Element.ModifiersEqual"/> →
+/// ModifierCallbacksEqual) deliberately ignores the gesture
+/// (Pan/Pinch/Rotate/LongPress) and drag-drop (DragSource/DropTarget) slots, so a
+/// per-render gesture/drag closure stays skip-eligible. Those handlers dispatch
+/// through cached per-element state (<c>GestureState.Pan</c> / <c>DragDropState.
+/// Source</c>/<c>.Target</c>) that is refreshed on the non-skip Update path only.
+///
+/// Before the fix, a skipped render strands the PREVIOUS render's closure: a gesture
+/// callback fires against stale captured state. These fixtures mount a live element,
+/// change ONLY the gesture/drag closure across a render the reconciler skips, and
+/// assert the LATEST closure is what dispatch sees — proving the skip arms now refresh
+/// the cached dispatch state without re-subscribing the trampolines.
+/// </summary>
+internal static class SkipPathGestureDragFixtures
+{
+    /// <summary>
+    /// A live Rectangle carries a per-render <c>.OnPan</c> closure that captures a
+    /// <c>tick</c> counter and writes it into <c>fired</c>. The Rectangle is otherwise
+    /// structurally constant, so a tick bump is skipped by the child-skip arm (the
+    /// gesture slot is excluded from the diff). Invoking the cached pan closure must
+    /// then fire the CURRENT (tick=1) delegate, not the stale (tick=0) one.
+    /// </summary>
+    internal class SkipRefreshesLivePanClosure(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (tick, setTick) = ctx.UseState(0);
+                var (fired, setFired) = ctx.UseState(-1);
+
+                // Fresh pan closure every render, capturing the CURRENT tick. Everything
+                // else about the Rectangle is constant, so on a tick bump the reconciler
+                // takes the gesture-excluding skip arm — the only thing that changed is
+                // this excluded slot.
+                return VStack(
+                    TextBlock($"panfired:{fired}"),
+                    Button("PanBumpTick", () => setTick(tick + 1)),
+                    Factories.Rectangle()
+                        .Size(80, 80)
+                        .OnPan(_ => setFired(tick), axis: PanAxis.Both));
+            });
+
+            await Harness.Render();
+            H.Check("SkipPan_FiredInitial", H.FindText("panfired:-1") is not null);
+
+            // Re-render with a NEW pan closure (captures tick=1); the Rectangle is
+            // structurally identical so the real reconciler skips it.
+            H.ClickButton("PanBumpTick");
+            await Harness.Render();
+
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("SkipPan_TargetMounted", rect is not null);
+
+            var state = rect is not null ? Reconciler.DebugTryGetGestureState(rect) : null;
+            H.Check("SkipPan_GestureStateCached", state?.Pan is not null);
+
+            // Dispatch through the cached pan config exactly as the manipulation
+            // trampoline would. Post-fix this is the tick=1 closure; pre-fix it is the
+            // stale tick=0 closure.
+            state?.Pan?.OnChanged(default);
+            await Harness.Render();
+
+            H.Check("SkipPan_CurrentClosureInvoked", H.FindText("panfired:1") is not null);
+            H.Check("SkipPan_StaleClosureNotInvoked", H.FindText("panfired:0") is null);
+        }
+    }
+
+    /// <summary>
+    /// Same shape via the keyed prefix skip arm: the Rectangle is given a stable key so
+    /// reconciliation takes the keyed path, whose prefix loop has its own
+    /// CanSkipUpdate short-circuit. Proves the keyed arms refresh too.
+    /// </summary>
+    internal class SkipRefreshesLivePanClosure_Keyed(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (tick, setTick) = ctx.UseState(0);
+                var (fired, setFired) = ctx.UseState(-1);
+
+                return VStack(
+                    TextBlock($"kpanfired:{fired}"),
+                    Button("KPanBumpTick", () => setTick(tick + 1)),
+                    // Keyed children force ReconcileKeyed; the unchanged-but-for-gesture
+                    // Rectangle rides the keyed prefix skip arm.
+                    VStack(
+                        Factories.Rectangle()
+                            .Size(40, 40)
+                            .WithKey("kpan-a")
+                            .OnPan(_ => setFired(tick), axis: PanAxis.Both),
+                        TextBlock("kpan-tail").WithKey("kpan-b")));
+            });
+
+            await Harness.Render();
+            H.Check("SkipKPan_FiredInitial", H.FindText("kpanfired:-1") is not null);
+
+            H.ClickButton("KPanBumpTick");
+            await Harness.Render();
+
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("SkipKPan_TargetMounted", rect is not null);
+
+            var state = rect is not null ? Reconciler.DebugTryGetGestureState(rect) : null;
+            H.Check("SkipKPan_GestureStateCached", state?.Pan is not null);
+
+            state?.Pan?.OnChanged(default);
+            await Harness.Render();
+
+            H.Check("SkipKPan_CurrentClosureInvoked", H.FindText("kpanfired:1") is not null);
+            H.Check("SkipKPan_StaleClosureNotInvoked", H.FindText("kpanfired:0") is null);
+        }
+    }
+
+    /// <summary>
+    /// Drag-drop counterpart. A per-render <c>.OnDrop</c> closure is stashed into a
+    /// reference-stable holder; after a skipped render the cached
+    /// <c>DragDropState.Target.OnDrop</c> must be the LATEST closure instance, not the
+    /// first. (Dispatching a real drag needs sealed DragEventArgs, so we assert on the
+    /// cached config identity that the trampolines read at dispatch time.)
+    /// </summary>
+    internal class SkipRefreshesLiveDropTarget(Harness h) : SelfTestFixtureBase(h)
+    {
+        // Reference-stable holder the render writes the current handler into. Its identity
+        // never changes, so it never drives a re-render — it only lets the test observe
+        // which drop closure the latest render produced.
+        private sealed class HandlerHolder { public Action<DragTargetArgs>? Latest; }
+
+        public override async Task RunAsync()
+        {
+            var holder = new HandlerHolder();
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (tick, setTick) = ctx.UseState(0);
+
+                // Fresh drop closure every render; otherwise the Rectangle is constant.
+                Action<DragTargetArgs> dropHandler = _ => { var _t = tick; };
+                holder.Latest = dropHandler;
+
+                return VStack(
+                    TextBlock($"droptick:{tick}"),
+                    Button("DropBumpTick", () => setTick(tick + 1)),
+                    Factories.Rectangle()
+                        .Size(80, 80)
+                        .OnDrop(dropHandler));
+            });
+
+            await Harness.Render();
+            var firstHandler = holder.Latest;
+            H.Check("SkipDrop_FirstHandlerCaptured", firstHandler is not null);
+
+            // Re-render with a NEW drop closure; the Rectangle is otherwise structurally
+            // identical so the reconciler skips it (drag slots excluded from the diff).
+            H.ClickButton("DropBumpTick");
+            await Harness.Render();
+            var secondHandler = holder.Latest;
+            H.Check("SkipDrop_SecondHandlerDistinct",
+                secondHandler is not null && !ReferenceEquals(firstHandler, secondHandler));
+
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("SkipDrop_TargetMounted", rect is not null);
+
+            var state = rect is not null ? Reconciler.DebugTryGetDndState(rect) : null;
+            H.Check("SkipDrop_DndStateCached", state?.Target is not null);
+
+            // Post-fix the cached target carries the latest closure; pre-fix it is the stale first.
+            H.Check("SkipDrop_CachedTargetIsLatest", ReferenceEquals(state?.Target?.OnDrop, secondHandler));
+            H.Check("SkipDrop_CachedTargetNotStale", !ReferenceEquals(state?.Target?.OnDrop, firstHandler));
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SkipPathGestureDragFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/SkipPathGestureDragFixtures.cs
@@ -186,4 +186,92 @@ internal static class SkipPathGestureDragFixtures
             H.Check("SkipDrop_CachedTargetNotStale", !ReferenceEquals(state?.Target?.OnDrop, firstHandler));
         }
     }
+
+    /// <summary>
+    /// #721 mid-gesture SAFETY proof. The simple stale-closure repros above show the
+    /// refresh swaps the dispatch target; this proves the refresh is non-destructive to
+    /// an IN-FLIGHT gesture: it does NOT re-subscribe the once-per-lifetime trampolines
+    /// and does NOT reset the in-flight cursor — so a mid-interaction skip neither drops
+    /// the gesture nor double-dispatches Began/Ended.
+    ///
+    /// We simulate "Began already fired" by setting the live cursor on the cached state
+    /// (a real ManipulationDelta can't be synthesized — its args are sealed). Then a
+    /// skip-path refresh is driven by bumping unrelated state, and we assert: (a) the
+    /// cached pan config is the LATEST closure (staleness fix), (b) every manipulation
+    /// trampoline delegate is the SAME instance (no re-subscribe → no duplicate event
+    /// delivery), and (c) PanBeganDispatched is still true (cursor preserved → the delta
+    /// path's `if (!PanBeganDispatched)` Began gate stays closed → no second Began).
+    /// Finally we dispatch Changed + Ended through the cached config and confirm the
+    /// LATEST closure receives them.
+    /// </summary>
+    internal class SkipMidGesturePreservesCursorsAndSubscriptions(Harness h) : SelfTestFixtureBase(h)
+    {
+        // Reference-stable event log the per-render closures write into. Identity never
+        // changes, so it never drives a re-render — it just records which closure ran.
+        private sealed class EventLog { public readonly List<(string Phase, int Tick)> Entries = new(); }
+
+        public override async Task RunAsync()
+        {
+            var log = new EventLog();
+
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (tick, setTick) = ctx.UseState(0);
+
+                // Per-render pan config capturing the CURRENT tick into the log. The
+                // Rectangle is otherwise constant, so a tick bump is taken by the skip arm.
+                return VStack(
+                    TextBlock($"mgtick:{tick}"),
+                    Button("MgBumpTick", () => setTick(tick + 1)),
+                    Factories.Rectangle()
+                        .Size(80, 80)
+                        .OnPan(
+                            onChanged: _ => log.Entries.Add(("Changed", tick)),
+                            onEnded: _ => log.Entries.Add(("Ended", tick)),
+                            onBegan: _ => log.Entries.Add(("Began", tick)),
+                            axis: PanAxis.Both));
+            });
+
+            await Harness.Render();
+
+            var rect = H.FindControl<Microsoft.UI.Xaml.Shapes.Rectangle>(_ => true);
+            H.Check("MidGesture_TargetMounted", rect is not null);
+            var state = rect is not null ? Reconciler.DebugTryGetGestureState(rect) : null;
+            H.Check("MidGesture_GestureStateCached", state?.Pan is not null);
+
+            // Capture the once-per-lifetime trampoline delegates + simulate an in-flight
+            // gesture (Began already dispatched, partway through a drag).
+            var started0 = state!.StartedTrampoline;
+            var delta0 = state.DeltaTrampoline;
+            var completed0 = state.CompletedTrampoline;
+            var inertia0 = state.InertiaStartingTrampoline;
+            state.PanBeganDispatched = true;
+            state.PanLastTranslation = new global::Windows.Foundation.Point(12, 0);
+
+            // Drive the skip-path refresh: bump unrelated state so the child-skip arm
+            // engages while the gesture is "in flight".
+            H.ClickButton("MgBumpTick");
+            await Harness.Render();
+
+            // (a) staleness fix — cached config is the latest (tick=1) closure.
+            state.Pan!.OnChanged(default);
+            H.Check("MidGesture_LatestClosureGetsChanged",
+                log.Entries.Count > 0 && log.Entries[^1] == ("Changed", 1));
+            state.Pan!.OnEnded?.Invoke(default);
+            H.Check("MidGesture_LatestClosureGetsEnded",
+                log.Entries.Count > 0 && log.Entries[^1] == ("Ended", 1));
+
+            // (b) safety — no trampoline was re-subscribed (same delegate instances).
+            H.Check("MidGesture_StartedTrampolineUnchanged", ReferenceEquals(state.StartedTrampoline, started0));
+            H.Check("MidGesture_DeltaTrampolineUnchanged", ReferenceEquals(state.DeltaTrampoline, delta0));
+            H.Check("MidGesture_CompletedTrampolineUnchanged", ReferenceEquals(state.CompletedTrampoline, completed0));
+            H.Check("MidGesture_InertiaTrampolineUnchanged", ReferenceEquals(state.InertiaStartingTrampoline, inertia0));
+
+            // (c) safety — the in-flight cursor was NOT reset, so the delta path would not
+            // re-fire Began; and the refresh itself dispatched no Began (no duplicate).
+            H.Check("MidGesture_CursorPreserved", state.PanBeganDispatched);
+            H.Check("MidGesture_NoDuplicateBegan", !log.Entries.Exists(e => e.Phase == "Began"));
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -854,6 +854,11 @@ internal static class SelfTestFixtureRegistry
         "Gesture_OnRotateSetsRotateFlag",
         "Gesture_PanAndPinchCombine",
 
+        // #721 — skip fast-path refreshes cached gesture/drag dispatch closures
+        "SkipPath_RefreshesLivePanClosure",
+        "SkipPath_RefreshesLivePanClosure_Keyed",
+        "SkipPath_RefreshesLiveDropTarget",
+
         // LongPress + focus — spec 027 Tier 3 Part 2 / Tier 5 (Phase 4)
         "Gesture_OnLongPressAutoEnablesHolding",
         "Gesture_OnLongPressMouseEmulationOptIn",
@@ -2299,6 +2304,11 @@ internal static class SelfTestFixtureRegistry
         "Gesture_OnPinchSetsScaleFlag" => new GestureFixtures.OnPinchSetsScaleFlag(harness),
         "Gesture_OnRotateSetsRotateFlag" => new GestureFixtures.OnRotateSetsRotateFlag(harness),
         "Gesture_PanAndPinchCombine" => new GestureFixtures.PanAndPinchCombine(harness),
+
+        // #721 — skip fast-path refreshes cached gesture/drag dispatch closures
+        "SkipPath_RefreshesLivePanClosure" => new SkipPathGestureDragFixtures.SkipRefreshesLivePanClosure(harness),
+        "SkipPath_RefreshesLivePanClosure_Keyed" => new SkipPathGestureDragFixtures.SkipRefreshesLivePanClosure_Keyed(harness),
+        "SkipPath_RefreshesLiveDropTarget" => new SkipPathGestureDragFixtures.SkipRefreshesLiveDropTarget(harness),
 
         // LongPress + focus — spec 027 Tier 3 Part 2 / Tier 5 (Phase 4)
         "Gesture_OnLongPressAutoEnablesHolding" => new GestureFixtures.OnLongPressAutoEnablesHolding(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -862,6 +862,10 @@ internal static class SelfTestFixtureRegistry
         "SkipPath_AddFirstGestureWires",
         "SkipPath_RemoveDragSourceMidDragPreservesState",
         "SkipPath_RemoveDragSourceNotInFlightClears",
+        "SkipPath_AddPanAlongsidePinchWidensMode",
+        "SkipPath_AddDragSourceAlongsideDropTargetWires",
+        "SkipPath_RemoveDragSourceWithDropTargetMidDragPreservesState",
+        "SkipPath_RemoveGestureClearsPlatformFlags",
 
         // LongPress + focus — spec 027 Tier 3 Part 2 / Tier 5 (Phase 4)
         "Gesture_OnLongPressAutoEnablesHolding",
@@ -2317,6 +2321,10 @@ internal static class SelfTestFixtureRegistry
         "SkipPath_AddFirstGestureWires" => new SkipPathGestureDragFixtures.SkipAddFirstGestureWires(harness),
         "SkipPath_RemoveDragSourceMidDragPreservesState" => new SkipPathGestureDragFixtures.SkipRemoveDragSourceMidDragPreservesState(harness),
         "SkipPath_RemoveDragSourceNotInFlightClears" => new SkipPathGestureDragFixtures.SkipRemoveDragSourceNotInFlightClears(harness),
+        "SkipPath_AddPanAlongsidePinchWidensMode" => new SkipPathGestureDragFixtures.SkipAddPanAlongsidePinchWidensMode(harness),
+        "SkipPath_AddDragSourceAlongsideDropTargetWires" => new SkipPathGestureDragFixtures.SkipAddDragSourceAlongsideDropTargetWires(harness),
+        "SkipPath_RemoveDragSourceWithDropTargetMidDragPreservesState" => new SkipPathGestureDragFixtures.SkipRemoveDragSourceWithDropTargetMidDragPreservesState(harness),
+        "SkipPath_RemoveGestureClearsPlatformFlags" => new SkipPathGestureDragFixtures.SkipRemoveGestureClearsPlatformFlags(harness),
 
         // LongPress + focus — spec 027 Tier 3 Part 2 / Tier 5 (Phase 4)
         "Gesture_OnLongPressAutoEnablesHolding" => new GestureFixtures.OnLongPressAutoEnablesHolding(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -859,6 +859,9 @@ internal static class SelfTestFixtureRegistry
         "SkipPath_RefreshesLivePanClosure_Keyed",
         "SkipPath_RefreshesLiveDropTarget",
         "SkipPath_MidGesturePreservesCursorsAndSubscriptions",
+        "SkipPath_AddFirstGestureWires",
+        "SkipPath_RemoveDragSourceMidDragPreservesState",
+        "SkipPath_RemoveDragSourceNotInFlightClears",
 
         // LongPress + focus — spec 027 Tier 3 Part 2 / Tier 5 (Phase 4)
         "Gesture_OnLongPressAutoEnablesHolding",
@@ -2311,6 +2314,9 @@ internal static class SelfTestFixtureRegistry
         "SkipPath_RefreshesLivePanClosure_Keyed" => new SkipPathGestureDragFixtures.SkipRefreshesLivePanClosure_Keyed(harness),
         "SkipPath_RefreshesLiveDropTarget" => new SkipPathGestureDragFixtures.SkipRefreshesLiveDropTarget(harness),
         "SkipPath_MidGesturePreservesCursorsAndSubscriptions" => new SkipPathGestureDragFixtures.SkipMidGesturePreservesCursorsAndSubscriptions(harness),
+        "SkipPath_AddFirstGestureWires" => new SkipPathGestureDragFixtures.SkipAddFirstGestureWires(harness),
+        "SkipPath_RemoveDragSourceMidDragPreservesState" => new SkipPathGestureDragFixtures.SkipRemoveDragSourceMidDragPreservesState(harness),
+        "SkipPath_RemoveDragSourceNotInFlightClears" => new SkipPathGestureDragFixtures.SkipRemoveDragSourceNotInFlightClears(harness),
 
         // LongPress + focus — spec 027 Tier 3 Part 2 / Tier 5 (Phase 4)
         "Gesture_OnLongPressAutoEnablesHolding" => new GestureFixtures.OnLongPressAutoEnablesHolding(harness),

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -858,6 +858,7 @@ internal static class SelfTestFixtureRegistry
         "SkipPath_RefreshesLivePanClosure",
         "SkipPath_RefreshesLivePanClosure_Keyed",
         "SkipPath_RefreshesLiveDropTarget",
+        "SkipPath_MidGesturePreservesCursorsAndSubscriptions",
 
         // LongPress + focus — spec 027 Tier 3 Part 2 / Tier 5 (Phase 4)
         "Gesture_OnLongPressAutoEnablesHolding",
@@ -2309,6 +2310,7 @@ internal static class SelfTestFixtureRegistry
         "SkipPath_RefreshesLivePanClosure" => new SkipPathGestureDragFixtures.SkipRefreshesLivePanClosure(harness),
         "SkipPath_RefreshesLivePanClosure_Keyed" => new SkipPathGestureDragFixtures.SkipRefreshesLivePanClosure_Keyed(harness),
         "SkipPath_RefreshesLiveDropTarget" => new SkipPathGestureDragFixtures.SkipRefreshesLiveDropTarget(harness),
+        "SkipPath_MidGesturePreservesCursorsAndSubscriptions" => new SkipPathGestureDragFixtures.SkipMidGesturePreservesCursorsAndSubscriptions(harness),
 
         // LongPress + focus — spec 027 Tier 3 Part 2 / Tier 5 (Phase 4)
         "Gesture_OnLongPressAutoEnablesHolding" => new GestureFixtures.OnLongPressAutoEnablesHolding(harness),

--- a/tests/Reactor.Tests/GestureTypesTests.cs
+++ b/tests/Reactor.Tests/GestureTypesTests.cs
@@ -203,14 +203,21 @@ public class GestureTypesTests
     }
 
     [Fact]
-    public void OnLongPress_ZeroArgOverload_RoutesToOnTriggered()
+    public void OnLongPress_ZeroArgOverload_FiresOnceAtBegan_NotOnEndedOrCancelled()
     {
         int count = 0;
         var el = TextBlock("x").OnLongPress(() => count++);
 
-        // Invoke the wrapped action directly to verify the adapter closes over the zero-arg.
-        el.Modifiers!.LongPress!.OnTriggered(new LongPressGesture(
-            Position: new Point(0, 0), Duration: TimeSpan.Zero, Phase: GesturePhase.Began));
+        // OnTriggered fires Began then Ended (or Cancelled) per the gesture contract.
+        // The phase-agnostic zero-arg convenience action must filter to Began so a single
+        // recognized long-press increments exactly once — otherwise it double-fires
+        // (the regression #721's skip-path closure refresh unmasked, since a stale
+        // captured closure previously made both calls idempotent). E2E canary:
+        // GestureTests.Interactive_OnLongPress_FiresAfterHold.
+        var cfg = el.Modifiers!.LongPress!;
+        cfg.OnTriggered(new LongPressGesture(new Point(0, 0), TimeSpan.Zero, GesturePhase.Began));
+        cfg.OnTriggered(new LongPressGesture(new Point(0, 0), TimeSpan.Zero, GesturePhase.Ended));
+        cfg.OnTriggered(new LongPressGesture(new Point(0, 0), TimeSpan.Zero, GesturePhase.Cancelled));
         Assert.Equal(1, count);
     }
 

--- a/tests/Reactor.Tests/PerfDiffSkipPathTests.cs
+++ b/tests/Reactor.Tests/PerfDiffSkipPathTests.cs
@@ -206,6 +206,26 @@ public class PerfDiffSkipPathTests
     }
 
     [Fact]
+    public void HasGestureOrDragSlots_True_For_Each_Slot_False_Otherwise()
+    {
+        // #721 — the skip-path gesture/drag dispatch-state refresh is gated on this
+        // cheap predicate so a leaf with no gesture/drag slot (every grid cell) never
+        // probes the gesture/drag CWTs or fetches its control. Lock that it sees every
+        // slot and stays false for the common no-gesture leaf + null modifiers.
+        Assert.False(Reconciler.HasGestureOrDragSlots(null));
+        Assert.False(Reconciler.HasGestureOrDragSlots(new ElementModifiers()));
+        // A modifier set carrying only routed handlers / layout is NOT a gesture/drag carrier.
+        Assert.False(Reconciler.HasGestureOrDragSlots(new ElementModifiers { OnTapped = (_, _) => { } }));
+
+        Assert.True(Reconciler.HasGestureOrDragSlots(new ElementModifiers { Pan = new(_ => { }) }));
+        Assert.True(Reconciler.HasGestureOrDragSlots(new ElementModifiers { Pinch = new(_ => { }) }));
+        Assert.True(Reconciler.HasGestureOrDragSlots(new ElementModifiers { Rotate = new(_ => { }) }));
+        Assert.True(Reconciler.HasGestureOrDragSlots(new ElementModifiers { LongPress = new(_ => { }) }));
+        Assert.True(Reconciler.HasGestureOrDragSlots(new ElementModifiers { DragSource = new(() => default!) }));
+        Assert.True(Reconciler.HasGestureOrDragSlots(new ElementModifiers { DropTarget = new() }));
+    }
+
+    [Fact]
     public void ShallowEquals_GridCell_Stable_Primary_Plus_Changing_Secondary_Declines_Skip()
     {
         // Combined FLAGSHIP-1 regression at the ShallowEquals/element level, mirroring

--- a/tests/Reactor.Tests/PerfDiffSkipPathTests.cs
+++ b/tests/Reactor.Tests/PerfDiffSkipPathTests.cs
@@ -226,6 +226,25 @@ public class PerfDiffSkipPathTests
     }
 
     [Fact]
+    public void CanSkipUpdate_False_For_ModifiedElement_So_Wrapper_Gesture_Cannot_Strand()
+    {
+        // #721 MEDIUM — a gesture/drag carried via a ModifiedElement WRAPPER
+        // (WrappedModifiers) is not seen by the child skip arms' direct
+        // HasGestureOrDragSlots(newEl.Modifiers) probe. That hole is UNREACHABLE: the
+        // main ShallowEquals has no ModifiedElement arm → default false, so CanSkipUpdate
+        // is false for any ModifiedElement pair and such a child never enters a child skip
+        // arm. It goes through the full Update path, which unwraps WrappedModifiers and
+        // applies gesture/drag correctly. (Production never constructs ModifiedElement;
+        // it's a test/legacy-only wrapper.) Lock the invariant so the child-skip probe
+        // staying on newEl.Modifiers can never silently strand a wrapped gesture.
+        var inner = TextBlock("x");
+        var a = new ModifiedElement(inner, new ElementModifiers { Pan = new(_ => { }) });
+        var b = new ModifiedElement(inner, new ElementModifiers { Pan = new(_ => { }) });
+        Assert.False(Element.ShallowEquals(a, b));
+        Assert.False(Element.CanSkipUpdate(a, b));
+    }
+
+    [Fact]
     public void ShallowEquals_GridCell_Stable_Primary_Plus_Changing_Secondary_Declines_Skip()
     {
         // Combined FLAGSHIP-1 regression at the ShallowEquals/element level, mirroring


### PR DESCRIPTION
## Summary

Fixes #721 — a correctness bug found during the #665 review: when the reconciler takes its skip fast-path for an unchanged element, it does **not** refresh the cached gesture/drag dispatch closures, so a gesture/drag handler can fire with a **stale** captured closure after a skipped update.

The skip predicate (`ShallowEquals` → `ModifiersEqual` → `ModifierCallbacksEqual`) deliberately excludes the gesture (`Pan`/`Pinch`/`Rotate`/`LongPress`) and drag-drop (`DragSource`/`DropTarget`) slots, so an element whose gesture/drag slots changed stays skip-eligible — yet those handlers dispatch through cached per-element state (`GestureState`/`DragDropState`) refreshed only on the non-skip Update path.

## Fix

`RefreshGestureDragStateOnSkip`, gated by the cheap `HasGestureOrDragSlots` (zero hot-path cost — short-circuits behind the existing `HasCallbacks` check), wired into all four skip arms (element-level + positional + keyed prefix/suffix). It distinguishes two cases:

- **Identity change** (family present on both sides, only the closure changed): overwrite the mutable config fields the stable trampolines read at dispatch time — **without re-subscribing trampolines** and leaving in-flight cursors untouched (mid-gesture-safe; no Began/Ended double-dispatch).
- **Presence transition** (family present on exactly one side — ADD or REMOVE-last): route to the full `ApplyGestureHandlers`/`ApplyDragDropHandlers` so an ADD actually **wires** (trampolines + `ManipulationMode`/`CanDrag`/`AllowDrop`) and a REMOVE **unwires** the platform flags. Plus an **in-flight-drag guard** in `ApplyDragDropHandlers`: it no longer nulls `state.Source` while a drag is in flight, so the pending `DropCompleted` still fires `OnEnd` + `Unregister` (no transfer-registry leak); `CanDrag` is still cleared so no new drag starts. (This also hardens the non-skip Update path's mid-drag source removal.)

The PR-C structural fast-path (#699) needs no refresh — its skipped indices are reference-equal old↔new. Stays entirely off the keyed LIS move path.

**MEDIUM (ModifiedElement-wrapped gesture on child skip): assessed UNREACHABLE + documented.** The main `ShallowEquals` has no `ModifiedElement` arm → default `false`, so `CanSkipUpdate` is `false` for any `ModifiedElement` pair; such a child never enters a child skip arm and goes through the full `Update` path (which unwraps `WrappedModifiers` and applies gesture/drag correctly). Production never constructs `ModifiedElement`. Locked by a unit test.

## Tests (RED-before-GREEN, all verified)

Live-control selftest fixtures:
- `SkipRefreshesLivePanClosure` (positional), `..._Keyed` (keyed prefix), `SkipRefreshesLiveDropTarget` (drag) — identity-change staleness (6 failures pre-#721 → green).
- `SkipMidGesturePreservesCursorsAndSubscriptions` — mid-gesture safety (trampolines unchanged, cursor preserved, no duplicate Began, latest closure gets Changed/Ended).
- `SkipAddFirstGestureWires`, `SkipRemoveDragSourceMidDragPreservesState`, `SkipRemoveDragSourceNotInFlightClears` — presence transitions (**6 failures pre-fix → 0 after**, verified by reverting the fix: add never wired, mid-drag source stranded, `CanDrag` never cleared).

Headless unit tests: `HasGestureOrDragSlots_*` (gate) + `CanSkipUpdate_False_For_ModifiedElement_*` (wrapper-unreachability invariant).

## Validation

- `dotnet build src/Reactor/Reactor.csproj -c Release` → **0/0** (AOT/trim WaE).
- `dotnet test tests/Reactor.Tests` → **9913 passed, 0 failed**.
- Gesture + DragDrop + SkipPath selftests green (no regression from the in-flight guard).
- Rebased on latest `origin/main`.

Related skip-path-correctness follow-ups #675/#676 are intentionally not bundled here.

🤖 Draft PR — do not merge; coordinator runs dual-review (gesture/drag-safety focus) + `/perf` before merge.