### PR TITLE
Cross-container row memoization for VirtualList — opt-in keyed Memo (#327)

### DIFF
--- a/docs/_pipeline/templates/advanced.md.dt
+++ b/docs/_pipeline/templates/advanced.md.dt
@@ -410,6 +410,14 @@ blind spot — the analyzer can't see through a method call without
 whole-program analysis (same blind spot as React's
 `react-hooks/exhaustive-deps`).
 
+**Recycle-boundary sibling.** `UseMemoCells` runs at the parent's **render**
+boundary — it skips cell-builds when the list component re-renders. It does
+*not* help during pure fast-scroll, where a virtualized list recycles
+containers without re-rendering the parent. For that, wrap the row in
+[`Memo(key, factory)`](collections.md#memoizing-rows-across-recycles) — the
+opt-in cross-recycle row cache. The two compose: `UseMemoCells` covers
+re-renders, `Memo(key, …)` covers scroll recycles.
+
 ## Patterns
 
 ### Custom hook authoring

--- a/docs/_pipeline/templates/collections.md.dt
+++ b/docs/_pipeline/templates/collections.md.dt
@@ -259,6 +259,12 @@ wrap behave exactly as before — and works on every `ElementFactory`-backed
 collection: `VirtualList`, `LazyVStack<T>`, `LazyHStack<T>`, `ItemsView<T>`,
 `ItemsRepeater<T>`, and `DataGrid` rows.
 
+**Keep the modifier *inside* the factory.** The cache only kicks in for a *bare*
+`Memo(key, …)` returned by the row builder. Writing `Memo(id, () => …).Padding(8)`
+— a modifier on the *wrapper* — opts that row out of the cache and silently loses
+the perf benefit. Put modifiers on the element the factory returns instead:
+`Memo(id, () => Border(…).Padding(8))` (as above).
+
 **Purity contract — the key must capture every input the factory reads.**
 The cache cannot see through your closure. If the factory reads anything not
 folded into the key — a selection flag, the current theme, an expand toggle —

--- a/docs/_pipeline/templates/collections.md.dt
+++ b/docs/_pipeline/templates/collections.md.dt
@@ -259,11 +259,12 @@ wrap behave exactly as before — and works on every `ElementFactory`-backed
 collection: `VirtualList`, `LazyVStack<T>`, `LazyHStack<T>`, `ItemsView<T>`,
 `ItemsRepeater<T>`, and `DataGrid` rows.
 
-**Keep the modifier *inside* the factory.** The cache only kicks in for a *bare*
-`Memo(key, …)` returned by the row builder. Writing `Memo(id, () => …).Padding(8)`
-— a modifier on the *wrapper* — opts that row out of the cache and silently loses
-the perf benefit. Put modifiers on the element the factory returns instead:
-`Memo(id, () => Border(…).Padding(8))` (as above).
+**Keep modifiers (and attached state) *inside* the factory.** The cache only kicks
+in for a *bare* `Memo(key, …)` returned by the row builder — no fluent modifiers,
+no `.WithKey(…)`, and no attached props / `.Provide(…)` / theme bindings on the
+wrapper. Decorating the wrapper (`Memo(id, () => …).Padding(8)`) opts that row out
+of the cache and silently loses the perf benefit. Put them on the element the
+factory returns instead: `Memo(id, () => Border(…).Padding(8))` (as above).
 
 **Purity contract — the key must capture every input the factory reads.**
 The cache cannot see through your closure. If the factory reads anything not

--- a/docs/_pipeline/templates/collections.md.dt
+++ b/docs/_pipeline/templates/collections.md.dt
@@ -231,6 +231,97 @@ Set `itemHeight` for a fixed-height fast path (O(1) offset calculation) or
 `estimatedItemHeight` for variable-height rows with automatic measurement.
 Use `onVisibleRangeChanged` to load data blocks as the user scrolls.
 
+## Memoizing rows across recycles
+
+Virtualized lists recycle containers as you scroll. On a **variable-height**
+list the `ItemsRepeater` recycles aggressively, and by default each recycle
+rebuilds that row's element tree and diffs it — even when the row's data
+didn't change. When a row is a pure function of a stable key, `Memo<TKey>`
+removes that rebuild:
+
+```csharp
+LazyVStack<Note>(notes, n => n.Id, (note, i) =>
+    Memo(note.Id, () =>                 // ← key, then the row factory
+        Border(
+            VStack(4,
+                TextBlock(note.Title).SemiBold(),
+                Caption(note.Body).Foreground(SecondaryText)
+            )
+        ).Padding(12)));
+```
+
+`Memo(key, factory)` caches the element `factory` returns in a bounded,
+per-list cache keyed by `key`. When a recycle re-asks for a key still in the
+cache it returns the **same element instance**, so the reconciler's
+`ReferenceEquals` shortcut fires and the row's diff is skipped entirely
+(sub-µs) instead of walking the subtree. It is **opt-in** — lists you don't
+wrap behave exactly as before — and works on every `ElementFactory`-backed
+collection: `VirtualList`, `LazyVStack<T>`, `LazyHStack<T>`, `ItemsView<T>`,
+`ItemsRepeater<T>`, and `DataGrid` rows.
+
+**Purity contract — the key must capture every input the factory reads.**
+The cache cannot see through your closure. If the factory reads anything not
+folded into the key — a selection flag, the current theme, an expand toggle —
+a cached instance is served and the change is **silently lost**. That is the
+author's responsibility, not the framework's. Widen the key to a tuple so it
+changes whenever any input does:
+
+```csharp
+// Row chrome depends on selection AND theme, so both belong in the key.
+Memo((note.Id, isSelected, theme.IsDark), () => RowBody(note, isSelected));
+```
+
+Keying on the whole item record (`Memo(note, …)`) is the simplest safe choice
+when the row is a pure function of the item — records compare by value, so any
+field change is a new key.
+
+**`Memo(key, …)` is not `Memo(ctx => …)`.** They share a name but the compiler
+picks by argument shape. `Memo(key, factory)` is the cross-recycle row cache
+here. [`Memo(ctx => …, deps)`](advanced.md#memo) is the render-time subtree
+skip — it freezes a subtree across a parent **re-render**. They also compose
+with [`UseMemoCells`](advanced.md#memoizing-list-cells): `UseMemoCells` skips
+cell-builds when the parent re-renders, while `Memo(key, …)` additionally
+skips them on pure scroll recycles, where no re-render runs at all.
+
+**Cache policy.** A bounded LRU, default capacity 128 (a few× a typical
+realized window), so it never grows with list length — scrolling a
+million-row list keeps at most 128 entries warm and evicts the
+least-recently-used beyond that. It is cleared automatically whenever the
+list's items or row builder is replaced (the same boundary that invalidates
+Reactor's internal view cache), so a new builder closure can never serve an
+instance the old one built.
+
+**Outside a virtualized list,** `Memo(key, factory)` is a transparent wrapper:
+it renders `factory()` on every reconcile with no caching. Caching only
+happens when a virtualized list's factory owns the cache; as a plain child
+(say, a `VStack` child) it is a safe no-op.
+
+### Escape hatch without the API
+
+`Memo<TKey>` is the supported path, but the same idea works today with a plain
+dictionary you own — handy on a Reactor build without the API, or when you
+want full control over the cache's lifetime. Cache the **element instance** by
+key yourself and return the cached one on a hit, so the reconciler's
+`ReferenceEquals` skip still fires:
+
+```csharp
+// Held in the parent component via UseRef so it survives re-renders.
+var cache = UseRef(new Dictionary<int, Element>()).Current;
+
+Element Row(Note note)
+{
+    if (!cache.TryGetValue(note.Id, out var el))
+        cache[note.Id] = el = Border(/* … */);   // build once per id
+    return el;                                    // same instance on reuse
+}
+
+return LazyVStack<Note>(notes, n => n.Id, (note, i) => Row(note));
+```
+
+You then own the parts `Memo` handles for you: bound the dictionary (evict so
+it can't grow without limit) and drop or rebuild an entry when the data behind
+its key changes — the purity contract above, enforced by hand.
+
 ## ForEach
 
 For small, non-virtualized inline lists, use `ForEach`. It maps a collection

--- a/docs/_pipeline/templates/collections.md.dt
+++ b/docs/_pipeline/templates/collections.md.dt
@@ -291,10 +291,12 @@ list's items or row builder is replaced (the same boundary that invalidates
 Reactor's internal view cache), so a new builder closure can never serve an
 instance the old one built.
 
-**Outside a virtualized list,** `Memo(key, factory)` is a transparent wrapper:
-it renders `factory()` on every reconcile with no caching. Caching only
-happens when a virtualized list's factory owns the cache; as a plain child
-(say, a `VStack` child) it is a safe no-op.
+**Outside a virtualized list,** `Memo(key, factory)` is a transparent but *keyed*
+wrapper: a re-render with the same key is a no-op (the factory is not re-invoked
+and the subtree is not diffed), and a changed key replaces the inner (unmount +
+fresh mount of a new `factory()` result). The cross-recycle cache only happens
+when a virtualized list's factory owns the cache; as a plain child (say, a
+`VStack` child) it is a safe, keyed no-op.
 
 ### Escape hatch without the API
 

--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -618,6 +618,14 @@ blind spot — the analyzer can't see through a method call without
 whole-program analysis (same blind spot as React's
 `react-hooks/exhaustive-deps`).
 
+**Recycle-boundary sibling.** `UseMemoCells` runs at the parent's **render**
+boundary — it skips cell-builds when the list component re-renders. It does
+*not* help during pure fast-scroll, where a virtualized list recycles
+containers without re-rendering the parent. For that, wrap the row in
+[`Memo(key, factory)`](collections.md#memoizing-rows-across-recycles) — the
+opt-in cross-recycle row cache. The two compose: `UseMemoCells` covers
+re-renders, `Memo(key, …)` covers scroll recycles.
+
 ## Patterns
 
 ### Custom hook authoring

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -340,6 +340,97 @@ Set `itemHeight` for a fixed-height fast path (O(1) offset calculation) or
 `estimatedItemHeight` for variable-height rows with automatic measurement.
 Use `onVisibleRangeChanged` to load data blocks as the user scrolls.
 
+## Memoizing rows across recycles
+
+Virtualized lists recycle containers as you scroll. On a **variable-height**
+list the `ItemsRepeater` recycles aggressively, and by default each recycle
+rebuilds that row's element tree and diffs it — even when the row's data
+didn't change. When a row is a pure function of a stable key, `Memo<TKey>`
+removes that rebuild:
+
+```csharp
+LazyVStack<Note>(notes, n => n.Id, (note, i) =>
+    Memo(note.Id, () =>                 // ← key, then the row factory
+        Border(
+            VStack(4,
+                TextBlock(note.Title).SemiBold(),
+                Caption(note.Body).Foreground(SecondaryText)
+            )
+        ).Padding(12)));
+```
+
+`Memo(key, factory)` caches the element `factory` returns in a bounded,
+per-list cache keyed by `key`. When a recycle re-asks for a key still in the
+cache it returns the **same element instance**, so the reconciler's
+`ReferenceEquals` shortcut fires and the row's diff is skipped entirely
+(sub-µs) instead of walking the subtree. It is **opt-in** — lists you don't
+wrap behave exactly as before — and works on every `ElementFactory`-backed
+collection: `VirtualList`, `LazyVStack<T>`, `LazyHStack<T>`, `ItemsView<T>`,
+`ItemsRepeater<T>`, and `DataGrid` rows.
+
+**Purity contract — the key must capture every input the factory reads.**
+The cache cannot see through your closure. If the factory reads anything not
+folded into the key — a selection flag, the current theme, an expand toggle —
+a cached instance is served and the change is **silently lost**. That is the
+author's responsibility, not the framework's. Widen the key to a tuple so it
+changes whenever any input does:
+
+```csharp
+// Row chrome depends on selection AND theme, so both belong in the key.
+Memo((note.Id, isSelected, theme.IsDark), () => RowBody(note, isSelected));
+```
+
+Keying on the whole item record (`Memo(note, …)`) is the simplest safe choice
+when the row is a pure function of the item — records compare by value, so any
+field change is a new key.
+
+**`Memo(key, …)` is not `Memo(ctx => …)`.** They share a name but the compiler
+picks by argument shape. `Memo(key, factory)` is the cross-recycle row cache
+here. [`Memo(ctx => …, deps)`](advanced.md#memo) is the render-time subtree
+skip — it freezes a subtree across a parent **re-render**. They also compose
+with [`UseMemoCells`](advanced.md#memoizing-list-cells): `UseMemoCells` skips
+cell-builds when the parent re-renders, while `Memo(key, …)` additionally
+skips them on pure scroll recycles, where no re-render runs at all.
+
+**Cache policy.** A bounded LRU, default capacity 128 (a few× a typical
+realized window), so it never grows with list length — scrolling a
+million-row list keeps at most 128 entries warm and evicts the
+least-recently-used beyond that. It is cleared automatically whenever the
+list's items or row builder is replaced (the same boundary that invalidates
+Reactor's internal view cache), so a new builder closure can never serve an
+instance the old one built.
+
+**Outside a virtualized list,** `Memo(key, factory)` is a transparent wrapper:
+it renders `factory()` on every reconcile with no caching. Caching only
+happens when a virtualized list's factory owns the cache; as a plain child
+(say, a `VStack` child) it is a safe no-op.
+
+### Escape hatch without the API
+
+`Memo<TKey>` is the supported path, but the same idea works today with a plain
+dictionary you own — handy on a Reactor build without the API, or when you
+want full control over the cache's lifetime. Cache the **element instance** by
+key yourself and return the cached one on a hit, so the reconciler's
+`ReferenceEquals` skip still fires:
+
+```csharp
+// Held in the parent component via UseRef so it survives re-renders.
+var cache = UseRef(new Dictionary<int, Element>()).Current;
+
+Element Row(Note note)
+{
+    if (!cache.TryGetValue(note.Id, out var el))
+        cache[note.Id] = el = Border(/* … */);   // build once per id
+    return el;                                    // same instance on reuse
+}
+
+return LazyVStack<Note>(notes, n => n.Id, (note, i) => Row(note));
+```
+
+You then own the parts `Memo` handles for you: bound the dictionary (evict so
+it can't grow without limit) and drop or rebuild an entry when the data behind
+its key changes — the purity contract above, enforced by hand.
+
 ## ForEach
 
 For small, non-virtualized inline lists, use `ForEach`. It maps a collection

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -368,11 +368,12 @@ wrap behave exactly as before — and works on every `ElementFactory`-backed
 collection: `VirtualList`, `LazyVStack<T>`, `LazyHStack<T>`, `ItemsView<T>`,
 `ItemsRepeater<T>`, and `DataGrid` rows.
 
-**Keep the modifier *inside* the factory.** The cache only kicks in for a *bare*
-`Memo(key, …)` returned by the row builder. Writing `Memo(id, () => …).Padding(8)`
-— a modifier on the *wrapper* — opts that row out of the cache and silently loses
-the perf benefit. Put modifiers on the element the factory returns instead:
-`Memo(id, () => Border(…).Padding(8))` (as above).
+**Keep modifiers (and attached state) *inside* the factory.** The cache only kicks
+in for a *bare* `Memo(key, …)` returned by the row builder — no fluent modifiers,
+no `.WithKey(…)`, and no attached props / `.Provide(…)` / theme bindings on the
+wrapper. Decorating the wrapper (`Memo(id, () => …).Padding(8)`) opts that row out
+of the cache and silently loses the perf benefit. Put them on the element the
+factory returns instead: `Memo(id, () => Border(…).Padding(8))` (as above).
 
 **Purity contract — the key must capture every input the factory reads.**
 The cache cannot see through your closure. If the factory reads anything not

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -400,10 +400,12 @@ list's items or row builder is replaced (the same boundary that invalidates
 Reactor's internal view cache), so a new builder closure can never serve an
 instance the old one built.
 
-**Outside a virtualized list,** `Memo(key, factory)` is a transparent wrapper:
-it renders `factory()` on every reconcile with no caching. Caching only
-happens when a virtualized list's factory owns the cache; as a plain child
-(say, a `VStack` child) it is a safe no-op.
+**Outside a virtualized list,** `Memo(key, factory)` is a transparent but *keyed*
+wrapper: a re-render with the same key is a no-op (the factory is not re-invoked
+and the subtree is not diffed), and a changed key replaces the inner (unmount +
+fresh mount of a new `factory()` result). The cross-recycle cache only happens
+when a virtualized list's factory owns the cache; as a plain child (say, a
+`VStack` child) it is a safe, keyed no-op.
 
 ### Escape hatch without the API
 

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -368,6 +368,12 @@ wrap behave exactly as before — and works on every `ElementFactory`-backed
 collection: `VirtualList`, `LazyVStack<T>`, `LazyHStack<T>`, `ItemsView<T>`,
 `ItemsRepeater<T>`, and `DataGrid` rows.
 
+**Keep the modifier *inside* the factory.** The cache only kicks in for a *bare*
+`Memo(key, …)` returned by the row builder. Writing `Memo(id, () => …).Padding(8)`
+— a modifier on the *wrapper* — opts that row out of the cache and silently loses
+the perf benefit. Put modifiers on the element the factory returns instead:
+`Memo(id, () => Border(…).Padding(8))` (as above).
+
 **Purity contract — the key must capture every input the factory reads.**
 The cache cannot see through your closure. If the factory reads anything not
 folded into the key — a selection flag, the current theme, an expand toggle —

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -120,6 +120,7 @@ Markdown(string markdown) → Element
 Markdown(string markdown, MarkdownOptions options) → Element
 MediaPlayerElement(string source = null) → MediaPlayerElementElement
 Memo(Func<RenderContext, Element> render, object[] dependencies) → MemoElement
+Memo<TKey>(TKey key, Func<Element> factory) → KeyedMemoElement
 Menu(string title, MenuFlyoutItemBase[] items) → MenuBarItemData
 MenuBar(MenuBarItemData[] items) → MenuBarElement
 MenuFlyout(Element target, MenuFlyoutItemBase[] items) → MenuFlyoutElement
@@ -4004,6 +4005,17 @@ int Count { get; init; }
 string ControlContext { get; init; }
 Deconstruct(ref DateTime TimestampUtc, ref string ControlContext, ref KeyedListDiagnosticKind Kind, ref IReadOnlyList<string> SampleKeys, ref int Count) → void
 Equals(KeyedListDiagnostic other) → bool
+Equals(object obj) → bool
+GetHashCode() → int
+ToString() → string
+
+### record KeyedMemoElement
+new(object MemoKey, Func<Element> Factory)
+Func<Element> Factory { get; init; }
+object MemoKey { get; init; }
+Deconstruct(ref object MemoKey, ref Func<Element> Factory) → void
+Equals(Element other) → bool
+Equals(KeyedMemoElement other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string

--- a/samples/Reactor.TestApp/Demos/VirtualizationDemo.cs
+++ b/samples/Reactor.TestApp/Demos/VirtualizationDemo.cs
@@ -30,7 +30,20 @@ class VirtualizationDemo : Component
             "LazyVStack" => LazyVStack<ItemData>(
                 items,
                 item => item.Id.ToString(),
-                (item, index) => Border(
+                // Issue #327 (Option A): opt into cross-container row memoization. On a fast
+                // scroll over these variable-height rows the ItemsRepeater recycles containers
+                // constantly; without the memo every recycle rebuilds this whole Border/HStack
+                // tree and the reconciler diffs it. Memo(key, factory) caches the inner element
+                // per key in the ElementFactory's bounded LRU, so a recycle that re-asks for a
+                // key still in the window returns the SAME instance → Element.ShallowEquals'
+                // ReferenceEquals fast-path fires and the per-row reconcile is skipped.
+                //
+                // Purity contract: the key MUST capture every input the factory reads. Here the
+                // row is a pure function of `item`, and `item` is fully determined by `item.Id`
+                // (Title/Subtitle are derived from it), so the int Id is a complete key. If this
+                // row closed over state NOT derived from the key (e.g. a selection flag or theme),
+                // fold it into the key to avoid staleness, e.g. Memo((item.Id, isSelected), …).
+                (item, index) => Memo(item.Id, () => Border(
                     HStack(12,
                         Border(
                             Caption($"{item.Id}")
@@ -40,7 +53,7 @@ class VirtualizationDemo : Component
                             Caption(item.Subtitle).Foreground(SecondaryText)
                         )
                     )
-                ).Padding(horizontal: 12, vertical: 8).Margin(0, 0, 0, 1)
+                ).Padding(horizontal: 12, vertical: 8).Margin(0, 0, 0, 1))
             ),
 
             "ListView" => ListView(

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -120,6 +120,7 @@ Markdown(string markdown) → Element
 Markdown(string markdown, MarkdownOptions options) → Element
 MediaPlayerElement(string source = null) → MediaPlayerElementElement
 Memo(Func<RenderContext, Element> render, object[] dependencies) → MemoElement
+Memo<TKey>(TKey key, Func<Element> factory) → KeyedMemoElement
 Menu(string title, MenuFlyoutItemBase[] items) → MenuBarItemData
 MenuBar(MenuBarItemData[] items) → MenuBarElement
 MenuFlyout(Element target, MenuFlyoutItemBase[] items) → MenuFlyoutElement
@@ -4004,6 +4005,17 @@ int Count { get; init; }
 string ControlContext { get; init; }
 Deconstruct(ref DateTime TimestampUtc, ref string ControlContext, ref KeyedListDiagnosticKind Kind, ref IReadOnlyList<string> SampleKeys, ref int Count) → void
 Equals(KeyedListDiagnostic other) → bool
+Equals(object obj) → bool
+GetHashCode() → int
+ToString() → string
+
+### record KeyedMemoElement
+new(object MemoKey, Func<Element> Factory)
+Func<Element> Factory { get; init; }
+object MemoKey { get; init; }
+Deconstruct(ref object MemoKey, ref Func<Element> Factory) → void
+Equals(Element other) → bool
+Equals(KeyedMemoElement other) → bool
 Equals(object obj) → bool
 GetHashCode() → int
 ToString() → string

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -1433,6 +1433,36 @@ public record FuncElement(Func<RenderContext, Element> RenderFunc) : Element;
 /// </summary>
 public record MemoElement(Func<RenderContext, Element> RenderFunc, object?[]? Dependencies = null) : Element;
 
+/// <summary>
+/// Issue #327 — an opt-in, typed keyed memo wrapper produced by the
+/// <c>Memo(key, factory)</c> factory (see <see cref="Microsoft.UI.Reactor.Factories"/>).
+/// The author asserts <see cref="Factory"/> is a <b>pure function of <see cref="MemoKey"/></b>:
+/// when a virtualized <see cref="ElementFactory{T}"/> recycles a container and asks for the
+/// same key again, the factory-scoped LRU returns the previously-built inner
+/// <see cref="Element"/> instance unchanged instead of rebuilding+diffing the subtree.
+/// Returning the <em>same</em> instance lets <c>Element.ShallowEquals</c> hit its
+/// <c>ReferenceEquals</c> fast-path so the per-row reconcile descent is skipped entirely.
+///
+/// <para><b>Purity contract.</b> The key must capture <em>every</em> input the factory reads.
+/// Closing over unkeyed mutable state (a <c>UseState</c> cell, an external counter, the theme)
+/// without folding it into the key will serve stale content — that is the author's
+/// responsibility. Widen the key to a tuple (e.g. <c>Memo((item.Id, isSelected), …)</c>) to
+/// capture extra inputs. <see cref="MemoKey"/> is compared with
+/// <see cref="object.Equals(object)"/> / <see cref="object.GetHashCode"/>, so value keys
+/// (ints, strings, records, value tuples) dedupe by value — this is what makes the int-index
+/// VirtualList path hit the cache where the reference-identity <c>_viewBuilderCache</c> cannot.</para>
+///
+/// <para><b>Used outside a virtualized factory</b> (e.g. a plain <c>VStack</c> child), the
+/// reconciler treats it as a <em>transparent</em> wrapper: it renders <see cref="Factory"/> on
+/// every pass with no caching, so it is always safe to drop a <c>Memo(key, …)</c> anywhere a
+/// normal element is expected. The cache benefit only applies on the
+/// <see cref="ElementFactory{T}"/> recycle path.</para>
+///
+/// <para>The positional parameter is named <c>MemoKey</c> (not <c>Key</c>) so it does not clash
+/// with the inherited <see cref="Element.Key"/> string used for keyed reconciliation.</para>
+/// </summary>
+public sealed record KeyedMemoElement(object MemoKey, Func<Element> Factory) : Element;
+
 // ════════════════════════════════════════════════════════════════════════
 //  Semantic wrapper for composite accessibility
 // ════════════════════════════════════════════════════════════════════════

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -1453,9 +1453,12 @@ public record MemoElement(Func<RenderContext, Element> RenderFunc, object?[]? De
 /// VirtualList path hit the cache where the reference-identity <c>_viewBuilderCache</c> cannot.</para>
 ///
 /// <para><b>Used outside a virtualized factory</b> (e.g. a plain <c>VStack</c> child), the
-/// reconciler treats it as a <em>transparent</em> wrapper: it renders <see cref="Factory"/> on
-/// every pass with no caching, so it is always safe to drop a <c>Memo(key, …)</c> anywhere a
-/// normal element is expected. The cache benefit only applies on the
+/// reconciler treats it as a <em>transparent, keyed</em> wrapper: a re-render with the same
+/// <see cref="MemoKey"/> is a no-op (by the purity contract the factory output is identical to
+/// the mounted inner, so there is nothing to diff), and a CHANGED key replaces the inner
+/// (unmount + fresh mount of the new <see cref="Factory"/> output). The old factory is never
+/// re-invoked at update time, so it is always safe to drop a <c>Memo(key, …)</c> anywhere a
+/// normal element is expected. The cross-recycle cache benefit only applies on the
 /// <see cref="ElementFactory{T}"/> recycle path.</para>
 ///
 /// <para>The positional parameter is named <c>MemoKey</c> (not <c>Key</c>) so it does not clash

--- a/src/Reactor/Core/ElementFactory.cs
+++ b/src/Reactor/Core/ElementFactory.cs
@@ -67,6 +67,7 @@ public sealed partial class ElementFactory<T> : IElementFactory
     internal int DebugLastElementByControlCount => _lastElementByControl.Count;
     internal int DebugMountedElementsCount => _mountedElements.Count;
     internal int DebugKeyByControlCount => _keyByControl.Count;
+    internal int DebugViewBuilderCacheCount => _viewBuilderCache.Count;
     internal bool DebugTryGetLastElementByControl(UIElement control, out Element? element)
         => _lastElementByControl.TryGetValue(control, out element!);
 
@@ -111,6 +112,13 @@ public sealed partial class ElementFactory<T> : IElementFactory
     // KeyedMemoCache for bound/eviction/invalidation.
     private readonly KeyedMemoCache _keyedMemoCache = new();
 
+    // Issue #327 review — for a value-type T (the int-index VirtualList path) the
+    // _viewBuilderCache lookup can never hit (its ReferenceEquals(item) guard re-boxes both
+    // operands), so populating it is dead weight that also grows UNBOUNDED — one retained entry
+    // per distinct key (index) as the user scrolls. JIT-folded per instantiation, so the guard is
+    // free. The cross-recycle cache for value-type T is the bounded KeyedMemoCache (opt-in Memo).
+    private static readonly bool s_valueTypeItem = typeof(T).IsValueType;
+
     /// <summary>
     /// Resolve the viewBuilder output for a (key, item, index) tuple,
     /// memoized by reference identity of <paramref name="item"/>. See
@@ -150,7 +158,12 @@ public sealed partial class ElementFactory<T> : IElementFactory
             built = _keyedMemoCache.Resolve(km, keyed ? key : null);
         else if (keyed)
             built = ApplyItemIdentityKey(built, key);
-        _viewBuilderCache[key] = new ViewBuilderCacheEntry(item, index, built);
+        // Skip the never-hitting _viewBuilderCache for value-type T (see s_valueTypeItem): on the
+        // int-index path it can only grow unbounded (one pinned row Element per scrolled index)
+        // without ever serving a hit. Reference-type T (LazyVStack<record>, ItemsView resize, …)
+        // still uses the ReferenceEquals fast-path, so keep populating there. (issue #327 review)
+        if (!s_valueTypeItem)
+            _viewBuilderCache[key] = new ViewBuilderCacheEntry(item, index, built);
         return built;
     }
 

--- a/src/Reactor/Core/ElementFactory.cs
+++ b/src/Reactor/Core/ElementFactory.cs
@@ -70,6 +70,13 @@ public sealed partial class ElementFactory<T> : IElementFactory
     internal bool DebugTryGetLastElementByControl(UIElement control, out Element? element)
         => _lastElementByControl.TryGetValue(control, out element!);
 
+    // Issue #327 (Option A) test seam: the keyed-memo LRU's rebuild (Factory invocation)
+    // counter and live entry count. The headless effectiveness fixture drives BuildOrCache
+    // through N recycle cycles and asserts FactoryInvocations stops climbing once keys are
+    // cached. Gated by InternalsVisibleTo on Reactor.Tests / Reactor.AppTests.Host.
+    internal long DebugKeyedMemoFactoryInvocations => _keyedMemoCache.FactoryInvocations;
+    internal int DebugKeyedMemoCacheCount => _keyedMemoCache.Count;
+
     // Per-key memoization of the last viewBuilder result. Critical for
     // WinUI ItemsView under <see cref="WinUI.UniformGridLayout"/>: window
     // resize causes the framework to recycle most realized containers
@@ -96,6 +103,14 @@ public sealed partial class ElementFactory<T> : IElementFactory
         { Item = item; Index = index; Built = built; }
     }
 
+    // Issue #327 (Option A) — opt-in keyed memo LRU. When the viewBuilder returns a
+    // KeyedMemoElement (author wrote `Memo(key, () => …)`), BuildOrCache resolves it here.
+    // Keyed by the author's MemoKey with value equality, so the int-index VirtualList path
+    // (where _viewBuilderCache's ReferenceEquals(item) guard never hits because each access
+    // re-boxes the index) still serves the SAME inner Element instance across recycles. See
+    // KeyedMemoCache for bound/eviction/invalidation.
+    private readonly KeyedMemoCache _keyedMemoCache = new();
+
     /// <summary>
     /// Resolve the viewBuilder output for a (key, item, index) tuple,
     /// memoized by reference identity of <paramref name="item"/>. See
@@ -108,7 +123,7 @@ public sealed partial class ElementFactory<T> : IElementFactory
     /// legacy int-index path, where the "key" is just the realized index and
     /// propagating it would force a control swap on every scroll.</para>
     /// </summary>
-    private Element BuildOrCache(string key, T item, int index, bool keyed)
+    internal Element BuildOrCache(string key, T item, int index, bool keyed)
     {
         if (_viewBuilderCache.TryGetValue(key, out var cached)
             && ReferenceEquals(cached.Item, item)
@@ -117,7 +132,23 @@ public sealed partial class ElementFactory<T> : IElementFactory
             return cached.Built;
         }
         var built = _viewBuilder(item, index);
-        if (keyed)
+        // Issue #327 (Option A): a KeyedMemoElement asserts its inner Factory is a pure
+        // function of MemoKey. Resolve it through the factory-owned bounded LRU so a cache
+        // HIT returns the SAME inner Element instance across container recycles → the next
+        // Reconcile observes ReferenceEquals via Element.ShallowEquals and skips the per-row
+        // reconcile descent; a MISS invokes Factory() exactly once. The identity-key stamp is
+        // folded into the resolve (keyed path only) so the cached instance is the final one
+        // returned on every subsequent hit (preserving ReferenceEquals).
+        //
+        // Only a "bare" wrapper is memoized: resolution returns the inner element, so any
+        // modifiers / Key / Extensions applied ON the wrapper itself (the non-idiomatic
+        // `Memo(k, …).Margin(8)` shape — modifiers belong inside the factory lambda) would be
+        // dropped. A decorated wrapper instead falls through unchanged and is rendered by the
+        // reconciler's transparent unwrap path (Mount/Update), which preserves those modifiers.
+        if (built is KeyedMemoElement km
+            && km.Modifiers is null && km.Key is null && km.Extensions is null)
+            built = _keyedMemoCache.Resolve(km, keyed ? key : null);
+        else if (keyed)
             built = ApplyItemIdentityKey(built, key);
         _viewBuilderCache[key] = new ViewBuilderCacheEntry(item, index, built);
         return built;
@@ -171,14 +202,17 @@ public sealed partial class ElementFactory<T> : IElementFactory
     {
         _items = items;
         _viewBuilder = viewBuilder;
-        // A new viewBuilder closure may capture different external state
-        // (UseState cells, Observable subscriptions, theme, etc.) than
-        // the one that produced the cached <see cref="ViewBuilderCacheEntry.Built"/>
-        // entries. We can't see through delegate captures cheaply, so
-        // invalidate conservatively here. Resize-driven recycle/realize
-        // cycles still hit the cache because window resize doesn't run
+        // A new viewBuilder closure may capture different external state (UseState
+        // cells, Observable subscriptions, theme, etc.) than the one that produced the
+        // cached <see cref="ViewBuilderCacheEntry.Built"/> entries. We can't see through
+        // delegate captures cheaply, so invalidate conservatively here. Resize-driven
+        // recycle/realize cycles still hit the cache because window resize doesn't run
         // the component render path → UpdateInPlace doesn't fire.
         _viewBuilderCache.Clear();
+        // Issue #327 (Option A): same invalidation boundary for the keyed memo LRU — a new
+        // viewBuilder closure may produce different inner content for the same MemoKey, so a
+        // previously-cached inner instance must not be served (mirrors the clear above).
+        _keyedMemoCache.Clear();
     }
 
     /// <summary>

--- a/src/Reactor/Core/KeyedMemoCache.cs
+++ b/src/Reactor/Core/KeyedMemoCache.cs
@@ -86,6 +86,12 @@ internal sealed class KeyedMemoCache
     /// </param>
     internal Element Resolve(KeyedMemoElement memo, string? identityKey)
     {
+        // KeyedMemoElement is a public record, so a caller can construct it directly (or via a
+        // `with` expression) bypassing the Memo<TKey> factory's validation. Guard here so a null
+        // key/factory fails deterministically at the contract violation instead of later as an
+        // opaque Dictionary ArgumentNullException or a null-delegate NullReferenceException.
+        global::System.ArgumentNullException.ThrowIfNull(memo.MemoKey, "memo.MemoKey");
+        global::System.ArgumentNullException.ThrowIfNull(memo.Factory, "memo.Factory");
         var key = memo.MemoKey;
         if (_map.TryGetValue(key, out var existing))
         {

--- a/src/Reactor/Core/KeyedMemoCache.cs
+++ b/src/Reactor/Core/KeyedMemoCache.cs
@@ -90,8 +90,8 @@ internal sealed class KeyedMemoCache
         // `with` expression) bypassing the Memo<TKey> factory's validation. Guard here so a null
         // key/factory fails deterministically at the contract violation instead of later as an
         // opaque Dictionary ArgumentNullException or a null-delegate NullReferenceException.
-        global::System.ArgumentNullException.ThrowIfNull(memo.MemoKey, "memo.MemoKey");
-        global::System.ArgumentNullException.ThrowIfNull(memo.Factory, "memo.Factory");
+        global::System.ArgumentNullException.ThrowIfNull(memo.MemoKey);
+        global::System.ArgumentNullException.ThrowIfNull(memo.Factory);
         var key = memo.MemoKey;
         if (_map.TryGetValue(key, out var existing))
         {

--- a/src/Reactor/Core/KeyedMemoCache.cs
+++ b/src/Reactor/Core/KeyedMemoCache.cs
@@ -1,0 +1,136 @@
+namespace Microsoft.UI.Reactor.Core;
+
+/// <summary>
+/// Issue #327 (Option A) — a bounded, factory-scoped LRU that memoizes the inner
+/// <see cref="Element"/> produced by a <see cref="KeyedMemoElement.Factory"/>, keyed by the
+/// author-supplied <see cref="KeyedMemoElement.MemoKey"/>.
+///
+/// <para>Owned by <see cref="ElementFactory{T}"/>. On the variable-height VirtualList recycle
+/// path the framework rebuilds each row's element tree on every container recycle
+/// (<see cref="ElementFactory{T}.GetElement"/>) — the existing <c>_viewBuilderCache</c> guards on
+/// <c>ReferenceEquals(item)</c> and never hits on the int-index path because each access re-boxes
+/// the index. This cache keys on the author's <see cref="KeyedMemoElement.MemoKey"/> with value
+/// equality instead, so a recycle that re-asks for a key still inside the LRU window returns the
+/// <em>same</em> inner instance — letting <see cref="Element.ShallowEquals"/> short-circuit on
+/// <c>ReferenceEquals</c> and collapsing the per-row reconcile to a single sub-µs skip.</para>
+///
+/// <para><b>Bound.</b> Capacity defaults to <see cref="DefaultCapacity"/> (a few× a typical
+/// realized window). Inserting past capacity evicts the least-recently-resolved entry. The cache
+/// is therefore never unbounded regardless of list length.</para>
+///
+/// <para><b>Invalidation.</b> <see cref="Clear"/> is called from
+/// <see cref="ElementFactory{T}.UpdateInPlace"/> alongside the existing
+/// <c>_viewBuilderCache.Clear()</c>: a new <c>viewBuilder</c> closure may capture different
+/// external state, so any inner instance built by the previous closure must not be served.</para>
+///
+/// <para>Keys are compared with the default <c>EqualityComparer&lt;object&gt;</c>
+/// (i.e. <see cref="object.Equals(object)"/> / <see cref="object.GetHashCode"/>),
+/// so boxed value-type keys (ints, value tuples, records) dedupe by value.</para>
+/// </summary>
+internal sealed class KeyedMemoCache
+{
+    /// <summary>
+    /// Default LRU capacity. Sized to comfortably exceed a realized window (typically a few
+    /// dozen rows) plus the off-screen buffer the ItemsRepeater keeps warm, so steady-state
+    /// scrolling stays in-cache while the working set stays bounded.
+    /// </summary>
+    internal const int DefaultCapacity = 128;
+
+    private sealed class Entry
+    {
+        public readonly object Key;
+        public Element Value;
+        public Entry(object key, Element value) { Key = key; Value = value; }
+    }
+
+    private readonly int _capacity;
+    private readonly Dictionary<object, LinkedListNode<Entry>> _map;
+    // First node = most-recently-used, Last node = least-recently-used (eviction target).
+    private readonly LinkedList<Entry> _lru = new();
+
+    /// <summary>
+    /// Number of times a <see cref="KeyedMemoElement.Factory"/> was actually invoked (cache
+    /// MISS / rebuild count). The effectiveness metric: with the cache working, this rises only
+    /// while keys are first seen (or after eviction/invalidation) and stays flat across recycles
+    /// of already-cached keys. Exposed for the headless effectiveness fixture.
+    /// </summary>
+    internal long FactoryInvocations { get; private set; }
+
+    internal KeyedMemoCache(int capacity = DefaultCapacity)
+    {
+        _capacity = capacity < 1 ? 1 : capacity;
+        _map = new Dictionary<object, LinkedListNode<Entry>>(_capacity);
+    }
+
+    /// <summary>Current number of cached entries (≤ capacity). Test/diagnostic accessor.</summary>
+    internal int Count => _map.Count;
+
+    /// <summary>Configured LRU capacity. Test/diagnostic accessor.</summary>
+    internal int Capacity => _capacity;
+
+    /// <summary>
+    /// Resolve <paramref name="memo"/> to a stable inner <see cref="Element"/> instance.
+    /// HIT: promote the key to most-recently-used and return the cached instance unchanged
+    /// (so the caller observes <c>ReferenceEquals</c> across recycles). MISS: invoke
+    /// <see cref="KeyedMemoElement.Factory"/> exactly once, optionally stamp the per-item
+    /// identity <paramref name="identityKey"/> onto it (mirrors
+    /// <see cref="ElementFactory{T}.ApplyItemIdentityKey"/>), cache and return it, evicting the
+    /// least-recently-used entry if at capacity.
+    /// </summary>
+    /// <param name="memo">The opt-in keyed memo wrapper to resolve.</param>
+    /// <param name="identityKey">
+    /// When non-null, the stable per-item key to stamp onto a freshly-built inner element whose
+    /// own <see cref="Element.Key"/> is still null — preserves the issue #326 recycle-on-reuse
+    /// remount semantics on the keyed <c>ReactorRow</c> path. Pass null on the legacy int-index
+    /// path where stamping a key would force a control swap on every scroll.
+    /// </param>
+    internal Element Resolve(KeyedMemoElement memo, string? identityKey)
+    {
+        var key = memo.MemoKey;
+        if (_map.TryGetValue(key, out var existing))
+        {
+            // HIT — move to MRU front, return the previously-built instance unchanged.
+            _lru.Remove(existing);
+            _lru.AddFirst(existing);
+            return existing.Value.Value;
+        }
+
+        // MISS — invoke the (author-asserted-pure) factory exactly once.
+        FactoryInvocations++;
+        var inner = memo.Factory() ?? EmptyElement.Instance;
+
+        // Mirror ElementFactory<T>.ApplyItemIdentityKey on the inner: an explicit author key
+        // inside the factory always wins; otherwise stamp the per-item identity so recycle-reuse
+        // for a different logical item flips Reconciler.CanUpdate → fresh mount (issue #326).
+        if (identityKey is not null && inner.Key is null)
+            inner = inner with { Key = identityKey };
+
+        var node = new LinkedListNode<Entry>(new Entry(key, inner));
+        _lru.AddFirst(node);
+        _map[key] = node;
+
+        if (_map.Count > _capacity)
+        {
+            var evict = _lru.Last;
+            if (evict is not null)
+            {
+                _lru.RemoveLast();
+                _map.Remove(evict.Value.Key);
+            }
+        }
+
+        return inner;
+    }
+
+    /// <summary>
+    /// Drop all cached entries. Called on the items-reference / <c>UpdateInPlace</c> boundary so a
+    /// new <c>viewBuilder</c> closure can never serve an instance built by the previous one.
+    /// Resets neither <see cref="FactoryInvocations"/> (a monotonic lifetime counter) — clearing
+    /// only the entries forces the next resolve of each key to rebuild.
+    /// </summary>
+    internal void Clear()
+    {
+        _map.Clear();
+        _lru.Clear();
+    }
+}

--- a/src/Reactor/Core/KeyedMemoCache.cs
+++ b/src/Reactor/Core/KeyedMemoCache.cs
@@ -39,7 +39,7 @@ internal sealed class KeyedMemoCache
     private sealed class Entry
     {
         public readonly object Key;
-        public Element Value;
+        public readonly Element Value;
         public Entry(object key, Element value) { Key = key; Value = value; }
     }
 

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -86,6 +86,12 @@ public sealed partial class Reconciler
             ComponentElement comp => MountComponent(comp, requestRerender),
             FuncElement func => MountFuncComponent(func, requestRerender),
             MemoElement memo => MountMemoComponent(memo, requestRerender),
+            // Issue #327 (Option A): a KeyedMemoElement that reaches Mount directly was used
+            // OUTSIDE a virtualized ElementFactory (which resolves it to its inner element in
+            // BuildOrCache before mounting). Treat it as a TRANSPARENT wrapper — mount its
+            // factory output with no caching. Any modifiers on the wrapper itself are applied
+            // by the post-dispatch ApplyModifiers below, exactly like any other element.
+            KeyedMemoElement km => Mount(km.Factory() ?? EmptyElement.Instance, requestRerender),
             // EmptyElement is a no-op sentinel — callers (Reconcile, panel
             // children loops, ChildReconciler) already filter it before
             // reaching Mount, but MountContext.MountChild does not, so a V1

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -89,8 +89,11 @@ public sealed partial class Reconciler
             // Issue #327 (Option A): a KeyedMemoElement that reaches Mount directly was used
             // OUTSIDE a virtualized ElementFactory (which resolves it to its inner element in
             // BuildOrCache before mounting). Treat it as a TRANSPARENT wrapper — mount its
-            // factory output with no caching. Any modifiers on the wrapper itself are applied
-            // by the post-dispatch ApplyModifiers below, exactly like any other element.
+            // factory output directly (no extra control, no cache). A later update is keyed:
+            // CanUpdate skips when the MemoKey is unchanged and replaces (remounts the new
+            // factory output) when it changes, so the mounted inner is never re-derived from
+            // the old factory. Any modifiers on the wrapper itself are applied by the
+            // post-dispatch ApplyModifiers below, exactly like any other element.
             KeyedMemoElement km => Mount(km.Factory() ?? EmptyElement.Instance, requestRerender),
             // EmptyElement is a no-op sentinel — callers (Reconcile, panel
             // children loops, ChildReconciler) already filter it before

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -183,6 +183,18 @@ public sealed partial class Reconciler
                 => UpdateComponent(oldEl, newEl, control, requestRerender),
             (MemoElement, MemoElement, _)
                 => UpdateComponent(oldEl, newEl, control, requestRerender),
+            // Issue #327 (Option A): transparent unwrap for a KeyedMemoElement reaching the
+            // reconciler directly (used outside a virtualized factory). Re-render BOTH sides'
+            // factories and diff the rebuilt inner trees in place against the existing control.
+            // No per-node reconciler state; child state inside the inner subtree is preserved
+            // because Update patches in place (and only remounts on an inner type change, which
+            // the recursive Update handles identically to any sibling). Modifiers on the wrapper
+            // are applied by the post-dispatch ApplyModifiers below.
+            (KeyedMemoElement oldKm, KeyedMemoElement newKm, _)
+                => Update(
+                    oldKm.Factory() ?? EmptyElement.Instance,
+                    newKm.Factory() ?? EmptyElement.Instance,
+                    control, requestRerender),
             _ => Mount(newEl, requestRerender),
         };
         }

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -183,18 +183,17 @@ public sealed partial class Reconciler
                 => UpdateComponent(oldEl, newEl, control, requestRerender),
             (MemoElement, MemoElement, _)
                 => UpdateComponent(oldEl, newEl, control, requestRerender),
-            // Issue #327 (Option A): transparent unwrap for a KeyedMemoElement reaching the
-            // reconciler directly (used outside a virtualized factory). Re-render BOTH sides'
-            // factories and diff the rebuilt inner trees in place against the existing control.
-            // No per-node reconciler state; child state inside the inner subtree is preserved
-            // because Update patches in place (and only remounts on an inner type change, which
-            // the recursive Update handles identically to any sibling). Modifiers on the wrapper
-            // are applied by the post-dispatch ApplyModifiers below.
-            (KeyedMemoElement oldKm, KeyedMemoElement newKm, _)
-                => Update(
-                    oldKm.Factory() ?? EmptyElement.Instance,
-                    newKm.Factory() ?? EmptyElement.Instance,
-                    control, requestRerender),
+            // Issue #327 (Option A) — a KeyedMemoElement reconciled directly (used OUTSIDE a
+            // virtualized ElementFactory, which resolves it to its inner element in BuildOrCache
+            // before mounting). CanUpdate only routes here when the MemoKey is UNCHANGED, so by
+            // the purity contract the factory output is identical to what is already mounted —
+            // skip the inner diff entirely (return null = keep the existing control). A CHANGED
+            // key returns false from CanUpdate and takes the standard replace path (unmount old +
+            // mount the new factory output), so the OLD factory is never re-invoked at update
+            // time to reconstruct the old tree (which would diff against the wrong "old" if the
+            // factory reads mutable state by reference). Wrapper modifiers are still applied by
+            // the post-dispatch ApplyModifiers below.
+            (KeyedMemoElement, KeyedMemoElement, _) => null,
             _ => Mount(newEl, requestRerender),
         };
         }

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -2455,6 +2455,15 @@ public sealed partial class Reconciler : IDisposable
             return oldComp.ComponentType == newComp.ComponentType;
         if (oldEl is XamlHostElement oldHost && newEl is XamlHostElement newHost)
             return oldHost.TypeKey == newHost.TypeKey;
+        // Issue #327 — a directly-reconciled KeyedMemoElement (used outside a virtualized
+        // ElementFactory, which resolves it to its inner before reconcile) can update in place
+        // only when its MemoKey is unchanged: same key ⇒ identical factory output by contract ⇒
+        // the existing inner control is already correct (the KeyedMemoElement arm in
+        // Reconciler.Update then skips). A changed key means different content, so return false to
+        // take the standard replace path (unmount + fresh mount of the new factory output) rather
+        // than re-invoking the OLD factory at update time to reconstruct the old tree.
+        if (oldEl is KeyedMemoElement oldKm && newEl is KeyedMemoElement newKm)
+            return Equals(oldKm.MemoKey, newKm.MemoKey);
         // MemoElement can always update to MemoElement (same type check above handles it)
         return true;
     }

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -1264,7 +1264,17 @@ public static partial class Factories
     /// <param name="key">Stable identity that fully determines <paramref name="factory"/>'s output.</param>
     /// <param name="factory">Builds the row element. Invoked once per key on a cache miss.</param>
     public static Core.KeyedMemoElement Memo<TKey>(TKey key, Func<Element> factory)
-        => new(key!, factory);
+    {
+        // Validate up front so a null reference key fails HERE (with the argument name) instead
+        // of later as an opaque throw from the KeyedMemoCache dictionary lookup at realize time.
+        // Boxing a value-type key yields a non-null object, so int / value-tuple / record keys
+        // always pass; the boxed instance is reused for the element, so there is no double-box on
+        // the per-row virtualized path.
+        object? boxedKey = key;
+        global::System.ArgumentNullException.ThrowIfNull(boxedKey, nameof(key));
+        global::System.ArgumentNullException.ThrowIfNull(factory);
+        return new(boxedKey, factory);
+    }
 
     /// <summary>
     /// Define an inline function component that re-renders on every parent render

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -1253,8 +1253,11 @@ public static partial class Factories
     /// If the body also depends on, say, a selection flag, fold it into the key:
     /// <c>Memo((items[i].Id, isSelected), () =&gt; …)</c>. Closing over unkeyed mutable state will serve
     /// stale content. The cache is cleared automatically when the list's items/renderItem change.</para>
-    /// <para>Outside a virtualized factory the wrapper is transparent — it simply renders the factory
-    /// each pass with no caching — so it is always safe to use anywhere an element is expected.</para>
+    /// <para>Outside a virtualized factory the wrapper is transparent but <em>keyed</em>: a re-render
+    /// with the same key is a no-op (the factory is not re-invoked and the inner subtree is not
+    /// diffed), while a changed key replaces the inner (unmount + fresh mount of the new factory
+    /// output). The cross-recycle cache only applies on the virtualized-list path. It is always safe
+    /// to use anywhere an element is expected.</para>
     /// </summary>
     /// <typeparam name="TKey">
     /// Key type. Boxed to <see cref="object"/> and compared with <see cref="object.Equals(object)"/> /

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -1254,8 +1254,10 @@ public static partial class Factories
     /// <c>Memo((items[i].Id, isSelected), () =&gt; …)</c>. Closing over unkeyed mutable state will serve
     /// stale content. The cache is cleared automatically when the list's items/renderItem change.</para>
     /// <para><b>Apply modifiers inside the factory, not on the wrapper.</b> The cross-recycle cache
-    /// only unwraps a <em>bare</em> <c>Memo(key, …)</c>. Writing <c>Memo(id, () =&gt; …).Padding(8)</c>
-    /// — a modifier on the wrapper itself — opts the row out of caching and silently loses the perf
+    /// only unwraps a <em>bare</em> <c>Memo(key, …)</c> — one with no fluent modifiers, no
+    /// <c>.WithKey(…)</c>, and no attached state (Grid/Canvas attached properties, <c>.Provide(…)</c>
+    /// context, or theme bindings) on the wrapper itself. Decorating the wrapper
+    /// (<c>Memo(id, () =&gt; …).Padding(8)</c>) opts the row out of caching and silently loses the perf
     /// benefit; put modifiers on the element the factory returns instead:
     /// <c>Memo(id, () =&gt; Border(…).Padding(8))</c>.</para>
     /// <para>Outside a virtualized factory the wrapper is transparent but <em>keyed</em>: a re-render

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -1253,6 +1253,11 @@ public static partial class Factories
     /// If the body also depends on, say, a selection flag, fold it into the key:
     /// <c>Memo((items[i].Id, isSelected), () =&gt; …)</c>. Closing over unkeyed mutable state will serve
     /// stale content. The cache is cleared automatically when the list's items/renderItem change.</para>
+    /// <para><b>Apply modifiers inside the factory, not on the wrapper.</b> The cross-recycle cache
+    /// only unwraps a <em>bare</em> <c>Memo(key, …)</c>. Writing <c>Memo(id, () =&gt; …).Padding(8)</c>
+    /// — a modifier on the wrapper itself — opts the row out of caching and silently loses the perf
+    /// benefit; put modifiers on the element the factory returns instead:
+    /// <c>Memo(id, () =&gt; Border(…).Padding(8))</c>.</para>
     /// <para>Outside a virtualized factory the wrapper is transparent but <em>keyed</em>: a re-render
     /// with the same key is a no-op (the factory is not re-invoked and the inner subtree is not
     /// diffed), while a changed key replaces the inner (unmount + fresh mount of the new factory

--- a/src/Reactor/Elements/Dsl.cs
+++ b/src/Reactor/Elements/Dsl.cs
@@ -1240,6 +1240,33 @@ public static partial class Factories
         => new(render, dependencies.Length == 0 ? null : dependencies);
 
     /// <summary>
+    /// Opt-in typed keyed memo for virtualized rows (issue #327). Wrap a row body in
+    /// <c>Memo(key, () =&gt; …)</c> to assert the body is a <b>pure function of <paramref name="key"/></b>.
+    /// Inside a virtualized list (<c>VirtualList</c>, <c>LazyVStack&lt;T&gt;</c>, …) the owning
+    /// <see cref="Core.ElementFactory{T}"/> caches the built element per key in a bounded LRU, so a
+    /// container recycle that re-asks for the same key returns the <em>same</em> element instance —
+    /// the reconciler then skips the row's rebuild + per-row diff entirely (sub-µs). This targets the
+    /// fast-scroll cost of variable-height rows, where every recycle otherwise rebuilds and diffs the
+    /// row from scratch.
+    /// <para>Usage: <c>renderItem: i =&gt; Memo(items[i].Id, () =&gt; Border(BigVariableHeightRow(items[i])))</c></para>
+    /// <para><b>Purity is your responsibility.</b> The key must capture every input the factory reads.
+    /// If the body also depends on, say, a selection flag, fold it into the key:
+    /// <c>Memo((items[i].Id, isSelected), () =&gt; …)</c>. Closing over unkeyed mutable state will serve
+    /// stale content. The cache is cleared automatically when the list's items/renderItem change.</para>
+    /// <para>Outside a virtualized factory the wrapper is transparent — it simply renders the factory
+    /// each pass with no caching — so it is always safe to use anywhere an element is expected.</para>
+    /// </summary>
+    /// <typeparam name="TKey">
+    /// Key type. Boxed to <see cref="object"/> and compared with <see cref="object.Equals(object)"/> /
+    /// <see cref="object.GetHashCode"/>, so value keys (ints, strings, records, value tuples) dedupe by
+    /// value. This is what lets the int-index <c>VirtualList</c> path hit the cache.
+    /// </typeparam>
+    /// <param name="key">Stable identity that fully determines <paramref name="factory"/>'s output.</param>
+    /// <param name="factory">Builds the row element. Invoked once per key on a cache miss.</param>
+    public static Core.KeyedMemoElement Memo<TKey>(TKey key, Func<Element> factory)
+        => new(key!, factory);
+
+    /// <summary>
     /// Define an inline function component that re-renders on every parent render
     /// (no memoization), keeping its own hook scope. Equivalent to the legacy
     /// <see cref="Func"/> behavior, made explicit so the reader can tell the

--- a/tests/Reactor.Tests/KeyedMemoTests.cs
+++ b/tests/Reactor.Tests/KeyedMemoTests.cs
@@ -1,0 +1,274 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Issue #327 (Option A) — typed keyed memo, ElementFactory-scoped.
+///
+/// <para>These are HEADLESS tests: they drive <see cref="ElementFactory{T}.BuildOrCache"/> and the
+/// underlying <see cref="KeyedMemoCache"/> directly — no WinUI controls are mounted — so they run in
+/// the fast xUnit tier. <see cref="ElementFactory{T}.BuildOrCache"/> is the exact per-recycle
+/// resolution step that both <see cref="ElementFactory{T}.GetElement"/> (realize) and
+/// <see cref="ElementFactory{T}.RefreshRealizedItems"/> (in-place refresh) funnel through, so calling
+/// it in a loop faithfully simulates fast-scroll recycle/realize cycles.</para>
+///
+/// <para>The effectiveness metric is the <b>rebuild count</b> — the number of times the row's inner
+/// <c>Factory</c> delegate actually runs. Without the memo, the int-index VirtualList path rebuilds
+/// every row on every recycle (the <c>_viewBuilderCache</c> guard never hits because each int access
+/// re-boxes). With the memo, a rebuild happens only on a genuine cache miss (first sight / after
+/// eviction / after invalidation). Returning the SAME inner instance on a hit is what lets
+/// <see cref="Element.ShallowEquals"/> short-circuit on <c>ReferenceEquals</c> and collapse the
+/// per-row reconcile descent to a sub-µs skip — asserted here via <see cref="Element.CanSkipUpdate"/>.</para>
+/// </summary>
+public class KeyedMemoTests
+{
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private static ElementFactory<int> MakeIntFactory(
+        IReadOnlyList<int> items, global::System.Func<int, int, Element> viewBuilder)
+        => new(items, viewBuilder, new Reconciler(), requestRerender: static () => { }, pool: null);
+
+    // A deliberately non-trivial row body so the "same instance → skip descent" win is meaningful:
+    // ShallowEquals short-circuits at the root on ReferenceEquals and never walks these children.
+    private static Element Row(int i, string suffix = "")
+        => new BorderElement(new TextBlockElement($"row {i}{suffix}"));
+
+    // Legacy int-index path: key is the index string, item is the boxed index, keyed=false.
+    private static Element Realize(ElementFactory<int> factory, int index)
+        => factory.BuildOrCache(index.ToString(), index, index, keyed: false);
+
+    // ── Overload resolution (required) ──────────────────────────────
+
+    [Fact]
+    public void Memo_KeyedOverload_BindsForValueKey()
+    {
+        // Memo(key, () => …) must bind to the NEW typed keyed overload.
+        var el = Memo(5, () => new TextBlockElement("x"));
+        var keyed = Assert.IsType<KeyedMemoElement>(el);
+        Assert.Equal(5, keyed.MemoKey);
+    }
+
+    [Fact]
+    public void Memo_ClassicOverload_BindsForRenderContextLambda()
+    {
+        // Memo(ctx => …) and Memo(ctx => …, deps) must still bind to the EXISTING overload.
+        var noDeps = Memo(ctx => new TextBlockElement("y"));
+        Assert.IsType<MemoElement>(noDeps);
+
+        var withDeps = Memo(ctx => new TextBlockElement("z"), 1, "a");
+        var memo = Assert.IsType<MemoElement>(withDeps);
+        Assert.NotNull(memo.Dependencies);
+        Assert.Equal(2, memo.Dependencies!.Length);
+    }
+
+    [Fact]
+    public void Memo_KeyedOverload_AcceptsTupleKeyForWidenedInputs()
+    {
+        // The documented escape from staleness: fold extra inputs into the key.
+        var el = Memo((id: 7, selected: true), () => new TextBlockElement("t"));
+        var keyed = Assert.IsType<KeyedMemoElement>(el);
+        Assert.Equal((7, true), keyed.MemoKey);
+    }
+
+    // ── Effectiveness: rebuilds collapse across recycle cycles ───────
+
+    [Fact]
+    public void KeyedMemo_CollapsesRebuilds_AcrossRecycleCycles()
+    {
+        const int Window = 20;   // realized window of rows
+        const int Cycles = 50;   // scroll passes that recycle/realize the whole window
+        var items = Enumerable.Range(0, Window).ToList();
+
+        // BEFORE — plain viewBuilder, no memo. Every recycle rebuilds the row and yields a
+        // fresh instance, so the reconciler would descend the whole subtree every time.
+        int beforeBuilds = 0;
+        var before = MakeIntFactory(items, (i, _) => { beforeBuilds++; return Row(i); });
+        var beforeLast = new Element[Window];
+        int beforeSameInstanceHits = 0;
+        for (int c = 0; c < Cycles; c++)
+            for (int i = 0; i < Window; i++)
+            {
+                var el = Realize(before, i);
+                if (c > 0 && ReferenceEquals(beforeLast[i], el)) beforeSameInstanceHits++;
+                beforeLast[i] = el;
+            }
+
+        // AFTER — same rows wrapped in Memo(i, …). Rebuild only on the first miss per key.
+        int afterBuilds = 0;
+        var after = MakeIntFactory(items, (i, _) => Memo(i, () => { afterBuilds++; return Row(i); }));
+        var afterLast = new Element[Window];
+        int afterSameInstanceHits = 0;
+        int afterSkippableHits = 0;
+        for (int c = 0; c < Cycles; c++)
+            for (int i = 0; i < Window; i++)
+            {
+                var el = Realize(after, i);
+                if (c > 0)
+                {
+                    if (ReferenceEquals(afterLast[i], el)) afterSameInstanceHits++;
+                    // The reconcile-descent skip precondition: identical instance ⇒ CanSkipUpdate.
+                    if (Element.CanSkipUpdate(afterLast[i], el)) afterSkippableHits++;
+                }
+                afterLast[i] = el;
+            }
+
+        int recycleHits = (Cycles - 1) * Window; // realizations after the first cycle
+
+        // Rebuild counts: BEFORE rebuilds every realization; AFTER rebuilds once per distinct key.
+        Assert.Equal(Window * Cycles, beforeBuilds);            // 1000
+        Assert.Equal(Window, afterBuilds);                     // 20
+        Assert.Equal(Window, (int)after.DebugKeyedMemoFactoryInvocations);
+
+        // BEFORE never returns the same instance across recycles (→ full reconcile descent).
+        Assert.Equal(0, beforeSameInstanceHits);
+        // AFTER returns the SAME instance on every recycle hit (→ ShallowEquals ReferenceEquals
+        // short-circuit → reconcile descent skipped). All hits are skippable.
+        Assert.Equal(recycleHits, afterSameInstanceHits);
+        Assert.Equal(recycleHits, afterSkippableHits);
+
+        // The headline win: rebuilds-per-recycle drop from 100% to ~0% on the cache-hit cycles.
+        Assert.True(afterBuilds < beforeBuilds / 10,
+            $"expected ≥10× fewer rebuilds; before={beforeBuilds} after={afterBuilds}");
+    }
+
+    // ── Correctness guard: a changed keyed input is never served stale ──
+
+    [Fact]
+    public void KeyedMemo_KeyChange_DoesNotServeStaleContent()
+    {
+        // Author widens the key to a tuple (id, value). When `value` changes the KEY changes,
+        // so the cache must build fresh content — never return the previous value's element.
+        var items = Enumerable.Range(0, 1).ToList();
+        string version = "a";
+        var factory = MakeIntFactory(items,
+            (i, _) => Memo((id: i, v: version), () => new TextBlockElement($"item {i} = {version}")));
+
+        var first = Assert.IsType<TextBlockElement>(Realize(factory, 0));
+        Assert.Equal("item 0 = a", first.Content);
+
+        // Same realization while the keyed input is unchanged → cached SAME instance (no rebuild).
+        var firstAgain = Realize(factory, 0);
+        Assert.Same(first, firstAgain);
+
+        // Keyed input changes → new key → fresh content (NOT the stale "= a").
+        version = "b";
+        var second = Assert.IsType<TextBlockElement>(Realize(factory, 0));
+        Assert.Equal("item 0 = b", second.Content);
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void KeyedMemo_UnkeyedExternalState_IsAuthorsResponsibility()
+    {
+        // Documents the purity contract: closing over state NOT folded into the key returns the
+        // memoized instance (stale) — by design. This is the behavior the XML doc/guide warn about.
+        var items = Enumerable.Range(0, 1).ToList();
+        string external = "a";
+        var factory = MakeIntFactory(items,
+            // BUG-on-purpose: `external` is read but not in the key.
+            (i, _) => Memo(i, () => new TextBlockElement($"v={external}")));
+
+        var first = Assert.IsType<TextBlockElement>(Realize(factory, 0));
+        Assert.Equal("v=a", first.Content);
+
+        external = "b";
+        var second = Assert.IsType<TextBlockElement>(Realize(factory, 0));
+        // Stale by design — key didn't change, so the cached instance is reused.
+        Assert.Same(first, second);
+        Assert.Equal("v=a", ((TextBlockElement)second).Content);
+    }
+
+    // ── Invalidation: UpdateInPlace clears the cache (new closure boundary) ──
+
+    [Fact]
+    public void KeyedMemo_UpdateInPlace_InvalidatesCache()
+    {
+        var items = Enumerable.Range(0, 3).ToList();
+        int buildsV1 = 0;
+        var factory = MakeIntFactory(items,
+            (i, _) => Memo(i, () => { buildsV1++; return Row(i, ":v1"); }));
+
+        for (int c = 0; c < 5; c++)
+            for (int i = 0; i < 3; i++)
+                Realize(factory, i);
+
+        Assert.Equal(3, buildsV1);                       // one build per key despite 15 realizations
+        Assert.Equal(3, factory.DebugKeyedMemoCacheCount);
+
+        // New items/viewBuilder closure (e.g. a component re-render). The cache must drop every
+        // entry so the new closure's content is never shadowed by a stale instance.
+        int buildsV2 = 0;
+        factory.UpdateInPlace(items, (i, _) => Memo(i, () => { buildsV2++; return Row(i, ":v2"); }));
+        Assert.Equal(0, factory.DebugKeyedMemoCacheCount);
+
+        var rebuilt = Realize(factory, 0);
+        var inner = Assert.IsType<TextBlockElement>(((BorderElement)rebuilt).Child);
+        Assert.Equal("row 0:v2", inner.Content);
+        Assert.Equal(1, buildsV2);
+    }
+
+    // ── Bound: LRU never grows past capacity; eviction forces a rebuild ──
+
+    [Fact]
+    public void KeyedMemoCache_IsBounded_AndEvictsLeastRecentlyUsed()
+    {
+        var cache = new KeyedMemoCache(capacity: 3);
+
+        int Build(int k, global::System.Func<Element> body)
+        {
+            int before = (int)cache.FactoryInvocations;
+            cache.Resolve(new KeyedMemoElement(k, body), identityKey: null);
+            return (int)cache.FactoryInvocations - before; // 1 = rebuilt (miss), 0 = cache hit
+        }
+
+        Assert.Equal(1, Build(0, () => Row(0))); // miss
+        Assert.Equal(1, Build(1, () => Row(1))); // miss
+        Assert.Equal(1, Build(2, () => Row(2))); // miss   → LRU = [2,1,0]
+        Assert.Equal(0, Build(0, () => Row(0))); // hit, promotes 0 → LRU = [0,2,1]
+        Assert.Equal(3, cache.Count);            // never exceeds capacity
+
+        // Insert a 4th distinct key → evicts the LRU tail (key 1, the least-recently-used).
+        Assert.Equal(1, Build(3, () => Row(3))); // miss   → evicts 1 → LRU = [3,0,2]
+        Assert.Equal(3, cache.Count);
+
+        Assert.Equal(1, Build(1, () => Row(1))); // 1 was evicted → rebuild
+        Assert.Equal(0, Build(0, () => Row(0))); // 0 still cached → hit
+    }
+
+    [Fact]
+    public void KeyedMemoCache_Hit_ReturnsReferenceEqualInstance()
+    {
+        var cache = new KeyedMemoCache();
+        var memo = new KeyedMemoElement(42, () => Row(42));
+
+        var a = cache.Resolve(memo, identityKey: null);
+        var b = cache.Resolve(memo, identityKey: null);
+
+        Assert.Same(a, b);                       // identical instance across resolves
+        Assert.True(Element.CanSkipUpdate(a, b)); // ⇒ reconcile descent is skipped
+        Assert.Equal(1, (int)cache.FactoryInvocations);
+    }
+
+    [Fact]
+    public void KeyedMemoCache_StampsIdentityKey_OnlyWhenInnerKeyIsNull()
+    {
+        var cache = new KeyedMemoCache();
+
+        // keyed path (ReactorRow): inner has no Key → stamp the per-item identity key.
+        var stamped = cache.Resolve(new KeyedMemoElement("k1", () => Row(1)), identityKey: "row-1");
+        Assert.Equal("row-1", stamped.Key);
+
+        // explicit author key inside the factory always wins.
+        var explicitKey = cache.Resolve(
+            new KeyedMemoElement("k2", () => Row(2) with { Key = "author" }), identityKey: "row-2");
+        Assert.Equal("author", explicitKey.Key);
+
+        // int-index path passes identityKey=null → never stamps.
+        var unstamped = cache.Resolve(new KeyedMemoElement("k3", () => Row(3)), identityKey: null);
+        Assert.Null(unstamped.Key);
+    }
+}

--- a/tests/Reactor.Tests/KeyedMemoTests.cs
+++ b/tests/Reactor.Tests/KeyedMemoTests.cs
@@ -120,6 +120,40 @@ public class KeyedMemoTests
         Assert.False(rec.CanUpdate(sameKeyA, otherKey));
     }
 
+    // ── Value-type T: the never-hitting _viewBuilderCache is skipped (no unbounded growth) ──
+
+    [Fact]
+    public void BuildOrCache_ValueTypeKey_DoesNotPopulateViewBuilderCache()
+    {
+        // On the int-index (value-type T) path the _viewBuilderCache ReferenceEquals(item) guard
+        // can never hit, so populating it would only grow unbounded — one pinned row Element per
+        // scrolled index. It must stay empty no matter how many distinct keys scroll past; the
+        // bounded KeyedMemoCache is the real cache here.
+        var items = Enumerable.Range(0, 200).ToList();
+        var memoFactory = MakeIntFactory(items, (i, _) => Memo(i, () => Row(i)));
+        for (int i = 0; i < 200; i++) _ = Realize(memoFactory, i);
+        Assert.Equal(0, memoFactory.DebugViewBuilderCacheCount);
+
+        // The skip is unconditional for value-type T — a plain (non-Memo) row also never populates
+        // it, and behavior is unchanged because the cache never hit on this path to begin with.
+        var plainFactory = MakeIntFactory(items, (i, _) => Row(i));
+        for (int i = 0; i < 50; i++) _ = Realize(plainFactory, i);
+        Assert.Equal(0, plainFactory.DebugViewBuilderCacheCount);
+    }
+
+    [Fact]
+    public void KeyedMemoCache_Resolve_NullMemoKeyOrFactory_ThrowsArgumentNullException()
+    {
+        // KeyedMemoElement is a public record, so direct construction (or a `with`) can bypass the
+        // Memo<TKey> factory's validation. Resolve must still fail deterministically rather than
+        // throwing opaquely from the dictionary lookup or a null-delegate invocation.
+        var cache = new KeyedMemoCache();
+        Assert.Throws<global::System.ArgumentNullException>(
+            () => { cache.Resolve(new KeyedMemoElement(null!, () => new TextBlockElement("x")), null); });
+        Assert.Throws<global::System.ArgumentNullException>(
+            () => { cache.Resolve(new KeyedMemoElement("k", null!), null); });
+    }
+
     // ── Effectiveness: rebuilds collapse across recycle cycles ───────
 
     [Fact]

--- a/tests/Reactor.Tests/KeyedMemoTests.cs
+++ b/tests/Reactor.Tests/KeyedMemoTests.cs
@@ -39,7 +39,9 @@ public class KeyedMemoTests
 
     // Legacy int-index path: key is the index string, item is the boxed index, keyed=false.
     private static Element Realize(ElementFactory<int> factory, int index)
-        => factory.BuildOrCache(index.ToString(), index, index, keyed: false);
+        => factory.BuildOrCache(
+            index.ToString(global::System.Globalization.CultureInfo.InvariantCulture),
+            index, index, keyed: false);
 
     // ── Overload resolution (required) ──────────────────────────────
 

--- a/tests/Reactor.Tests/KeyedMemoTests.cs
+++ b/tests/Reactor.Tests/KeyedMemoTests.cs
@@ -74,6 +74,50 @@ public class KeyedMemoTests
         Assert.Equal((7, true), keyed.MemoKey);
     }
 
+    // ── Argument validation (issue #327 review) ─────────────────────
+
+    [Fact]
+    public void Memo_KeyedOverload_NullKey_ThrowsArgumentNullException()
+    {
+        // A null reference key is rejected up front with the argument name, instead of being
+        // deferred to an opaque throw from the KeyedMemoCache dictionary lookup at realize time.
+        var ex = Assert.Throws<global::System.ArgumentNullException>(
+            () => { Memo((string)null!, () => new TextBlockElement("x")); });
+        Assert.Equal("key", ex.ParamName);
+    }
+
+    [Fact]
+    public void Memo_KeyedOverload_NullFactory_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<global::System.ArgumentNullException>(
+            () => { Memo(1, (global::System.Func<Element>)null!); });
+        Assert.Equal("factory", ex.ParamName);
+    }
+
+    // ── Direct (non-virtualized) reconcile: keyed update-vs-replace ──
+
+    [Fact]
+    public void KeyedMemo_DirectReconcile_IsKeyed_SameKeyUpdates_DifferentKeyReplaces()
+    {
+        // When a KeyedMemoElement is reconciled directly (outside a virtualized ElementFactory),
+        // the reconciler must NOT reconstruct the "old" inner tree by re-invoking the old factory
+        // (which would diff against the wrong "old" if the factory reads mutable state by ref).
+        // Instead CanUpdate is key-driven: SAME key ⇒ update in place (the Update arm then skips,
+        // since the factory output is identical by contract — regardless of factory identity);
+        // DIFFERENT key ⇒ replace (unmount + fresh mount of the new factory output). This proves
+        // the old factory is never re-run at update time.
+        var rec = new Reconciler();
+
+        // Different factory closures, SAME key → update in place (key, not closure, decides).
+        var sameKeyA = Memo(1, () => new TextBlockElement("a"));
+        var sameKeyB = Memo(1, () => new TextBlockElement("b"));
+        Assert.True(rec.CanUpdate(sameKeyA, sameKeyB));
+
+        // Changed key → replace path (no old-factory re-invocation).
+        var otherKey = Memo(2, () => new TextBlockElement("a"));
+        Assert.False(rec.CanUpdate(sameKeyA, otherKey));
+    }
+
     // ── Effectiveness: rebuilds collapse across recycle cycles ───────
 
     [Fact]


### PR DESCRIPTION
Closes #327.

## What

Adds an **opt-in**, cross-container row memoization API for virtualized lists:

```csharp
public static KeyedMemoElement Memo<TKey>(TKey key, Func<Element> factory)
```

```csharp
// variable-height row that no longer rebuilds + re-diffs on every recycle
renderItem: i => Memo(item.Id, () => Border(
    HStack(12, /* … */ )
).Padding(12, 8))
```

## Why

During fast scroll over variable-height rows, every `ItemsRepeater` container recycle made `ElementFactory<T>.GetElement` rebuild the row's `Element` tree from scratch and diff it — ~36% of scroll wall-clock in the profiled trace. Root cause: `ElementFactory<T>.BuildOrCache` guards its existing memo on `ReferenceEquals(cached.Item, item)`, and on the VirtualList `int`-index path every access **re-boxes** the index, so the guard never hits. Handing the reconciler the **same `Element` instance** per key makes `Element.ShallowEquals`' `ReferenceEquals` short-circuit collapse the whole per-row reconcile to a `CanSkipUpdate → null` skip (sub-µs).

Auto/transparent caching was explicitly rejected in the issue (a `renderItem` can close over external state the framework can't see → silent staleness), so this is opt-in: the author asserts the row is pure for `key`.

## How

- New `KeyedMemoElement(object MemoKey, Func<Element> Factory)` record + the `Memo<TKey>` factory (overload-disjoint from the existing `Memo(ctx => …, deps)` — proven by tests).
- `ElementFactory<T>.BuildOrCache` resolves a bare `KeyedMemoElement` through a factory-owned **bounded LRU** (`KeyedMemoCache`, default cap 128) keyed by `TKey` **value equality** (boxed `int`/tuple/record dedupe — this is the re-boxing fix). A hit returns the same inner instance → reconcile skip; a miss invokes the factory once. The existing #326 per-item identity-key stamp is preserved.
- Cache is cleared in `UpdateInPlace` alongside the existing `_viewBuilderCache.Clear()` (the items-reference / new-closure boundary), so a fresh `renderItem` closure can never serve stale instances.
- If a `KeyedMemoElement` ever reaches the reconciler directly (used outside a virtualized factory), two transparent unwrap arms in `Mount`/`Update` render `Factory()` each time — no caching, no new per-node reconciler state, the central skip path (`ShallowEquals`/`CanSkipUpdate`) is untouched.

## Generality

Works for **every `ElementFactory<T>`-backed surface** — VirtualList, LazyVStack/HStack, ItemsView, ItemsRepeater, and DataGrid rows — and is a transparent no-op anywhere else.

## Tests & docs

- 10 new headless `KeyedMemoTests` (overload resolution, cross-recycle effectiveness 1000→20 rebuilds, key-change-not-stale correctness guard, `UpdateInPlace` invalidation, bounded LRU eviction, identity-key preservation). `dotnet test tests/Reactor.Tests` green; core builds 0 warnings/0 errors (AOT/trim-clean — no reflection).
- Guide updated (`docs/_pipeline/templates/collections.md.dt` → regenerated `collections.md`), documenting the API **and** the user-land `Dictionary` cache as the today-available escape hatch.

## Notes

Two sibling designs (a VirtualList-only `cacheRowsBy` list flag, and a free-floating reconciler-level `Memoize(deps, …)`) were prototyped and benchmarked; A was chosen for the best reach-vs-invasiveness (covers DataGrid/LazyVStack without touching the central reconcile skip path). A headless microbenchmark put A within noise of the list-flag on CPU per realize and ~2.5× faster than no caching.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>