### PR TITLE
Cross-container row memoization for VirtualList — opt-in cacheRowsBy flag (Option B, #327)

### DIFF
--- a/docs/_pipeline/templates/collections.md.dt
+++ b/docs/_pipeline/templates/collections.md.dt
@@ -330,6 +330,86 @@ return LazyVStack<Note>(notes, n => n.Id, (note, i) => Row(note));
 You then own the parts `Memo` handles for you: bound the dictionary (evict so
 it can't grow without limit) and drop or rebuild an entry when the data behind
 its key changes — the purity contract above, enforced by hand.
+### Cross-recycle row memoization (`cacheRowsBy`)
+
+Variable-height rows have a hidden scroll cost. With no `itemHeight`, every
+time `ItemsRepeater` recycles a container and re-realizes a row, the list
+rebuilds that row's element tree from `renderItem` and the reconciler diffs
+it against the previous tree. During a fast flick over tall rows that
+rebuild-and-diff can dominate scroll wall-clock. `cacheRowsBy` is an opt-in
+that collapses it:
+
+```csharp
+VirtualList(
+    itemCount: rows.Count,
+    renderItem: i => RenderRow(rows[i]),      // builds a multi-node subtree
+    getItemKey: i => rows[i].Id,
+    estimatedItemHeight: 64,
+    cacheRowsBy: i => rows[i].Id)             // ← opt in
+```
+
+When set, the list keeps a bounded **LRU cache of already-built row
+`Element` instances**, keyed by `cacheRowsBy(index)`. On a recycle for a key
+still in the cache it returns the *same* `Element` instance instead of calling
+`renderItem` again — the reconciler then short-circuits on `ReferenceEquals`
+and skips the entire per-row diff. The rebuild *and* the reconcile descent
+both go to ~zero on a cache hit.
+
+<!-- ai:caveat -->
+`cacheRowsBy` is a **purity assertion you are making**, not a transparent
+optimization. By opting in you promise that `renderItem` is a pure function of
+the inputs your key captures: for a given key, the element it produces must
+not depend on anything the key leaves out. If `renderItem` closes over mutable
+state the key omits — the current selection, a row-revision counter, a theme
+flag it reads ad hoc — cached rows can render **stale** content, and that is
+your bug to fix. Fold every such input into the key:
+
+```csharp
+// Row appearance depends on the item AND whether it's selected — so both
+// must be in the key, or selecting a row won't repaint a cached instance.
+cacheRowsBy: i => $"{rows[i].Id}:{rows[i].Rev}:{(i == selected ? 1 : 0)}"
+```
+
+The framework still resets the whole cache automatically whenever `itemCount`
+or the `renderItem` delegate identity changes (a fresh closure may capture new
+state it can't see through), so a re-render with new data can never be served
+from a stale instance. The cache is **bounded** — it defaults to
+`rowCacheCapacity: 128` (a few× a typical realized window) and evicts
+least-recently-used rows, so it never grows with scroll distance. Reuse the
+key projection only for rows that are genuinely pure; identity (`getItemKey`)
+and purity (`cacheRowsBy`) are deliberately separate opt-ins.
+<!-- /ai:caveat -->
+
+#### Doing it by hand (no `cacheRowsBy`)
+
+The same idea works today without the flag, as a user-land memo: hold a
+`Dictionary` keyed by your row identity in a `UseRef`, return the cached
+`Element` on a hit, and invalidate when your data changes. This is the escape
+hatch if you need custom eviction or are pinned to an older build:
+
+```csharp
+var rowMemo = UseRef(new Dictionary<string, Element>());
+
+// Reset when the data set changes — same role as cacheRowsBy's auto-reset.
+UseEffect(() => { rowMemo.Current.Clear(); return () => { }; }, rows);
+
+Element RenderRowMemoized(int i)
+{
+    // Key must capture everything RenderRow reads — exactly the purity
+    // contract cacheRowsBy formalizes.
+    var key = $"{rows[i].Id}:{rows[i].Rev}";
+    if (!rowMemo.Current.TryGetValue(key, out var cached))
+        rowMemo.Current[key] = cached = RenderRow(rows[i]);
+    return cached;
+}
+
+return VirtualList(rows.Count, RenderRowMemoized, getItemKey: i => rows[i].Id);
+```
+
+`cacheRowsBy` is just this pattern moved into the list, with a bounded LRU and
+automatic invalidation wired in. Prefer the flag; reach for the hand-rolled
+dictionary only when you need behavior it doesn't offer (e.g. a custom
+eviction policy).
 
 ## ForEach
 

--- a/docs/guide/collections.md
+++ b/docs/guide/collections.md
@@ -439,6 +439,84 @@ return LazyVStack<Note>(notes, n => n.Id, (note, i) => Row(note));
 You then own the parts `Memo` handles for you: bound the dictionary (evict so
 it can't grow without limit) and drop or rebuild an entry when the data behind
 its key changes — the purity contract above, enforced by hand.
+### Cross-recycle row memoization (`cacheRowsBy`)
+
+Variable-height rows have a hidden scroll cost. With no `itemHeight`, every
+time `ItemsRepeater` recycles a container and re-realizes a row, the list
+rebuilds that row's element tree from `renderItem` and the reconciler diffs
+it against the previous tree. During a fast flick over tall rows that
+rebuild-and-diff can dominate scroll wall-clock. `cacheRowsBy` is an opt-in
+that collapses it:
+
+```csharp
+VirtualList(
+    itemCount: rows.Count,
+    renderItem: i => RenderRow(rows[i]),      // builds a multi-node subtree
+    getItemKey: i => rows[i].Id,
+    estimatedItemHeight: 64,
+    cacheRowsBy: i => rows[i].Id)             // ← opt in
+```
+
+When set, the list keeps a bounded **LRU cache of already-built row
+`Element` instances**, keyed by `cacheRowsBy(index)`. On a recycle for a key
+still in the cache it returns the *same* `Element` instance instead of calling
+`renderItem` again — the reconciler then short-circuits on `ReferenceEquals`
+and skips the entire per-row diff. The rebuild *and* the reconcile descent
+both go to ~zero on a cache hit.
+
+> **Caveat:** `cacheRowsBy` is a **purity assertion you are making**, not a transparent
+> optimization. By opting in you promise that `renderItem` is a pure function of
+> the inputs your key captures: for a given key, the element it produces must
+> not depend on anything the key leaves out. If `renderItem` closes over mutable
+> state the key omits — the current selection, a row-revision counter, a theme
+> flag it reads ad hoc — cached rows can render **stale** content, and that is
+> your bug to fix. Fold every such input into the key:
+> 
+> ```csharp
+> // Row appearance depends on the item AND whether it's selected — so both
+> // must be in the key, or selecting a row won't repaint a cached instance.
+> cacheRowsBy: i => $"{rows[i].Id}:{rows[i].Rev}:{(i == selected ? 1 : 0)}"
+> ```
+> 
+> The framework still resets the whole cache automatically whenever `itemCount`
+> or the `renderItem` delegate identity changes (a fresh closure may capture new
+> state it can't see through), so a re-render with new data can never be served
+> from a stale instance. The cache is **bounded** — it defaults to
+> `rowCacheCapacity: 128` (a few× a typical realized window) and evicts
+> least-recently-used rows, so it never grows with scroll distance. Reuse the
+> key projection only for rows that are genuinely pure; identity (`getItemKey`)
+> and purity (`cacheRowsBy`) are deliberately separate opt-ins.
+
+#### Doing it by hand (no `cacheRowsBy`)
+
+The same idea works today without the flag, as a user-land memo: hold a
+`Dictionary` keyed by your row identity in a `UseRef`, return the cached
+`Element` on a hit, and invalidate when your data changes. This is the escape
+hatch if you need custom eviction or are pinned to an older build:
+
+```csharp
+var rowMemo = UseRef(new Dictionary<string, Element>());
+
+// Reset when the data set changes — same role as cacheRowsBy's auto-reset.
+UseEffect(() => { rowMemo.Current.Clear(); return () => { }; }, rows);
+
+Element RenderRowMemoized(int i)
+{
+    // Key must capture everything RenderRow reads — exactly the purity
+    // contract cacheRowsBy formalizes.
+    var key = $"{rows[i].Id}:{rows[i].Rev}";
+    if (!rowMemo.Current.TryGetValue(key, out var cached))
+        rowMemo.Current[key] = cached = RenderRow(rows[i]);
+    return cached;
+}
+
+return VirtualList(rows.Count, RenderRowMemoized, getItemKey: i => rows[i].Id);
+```
+
+`cacheRowsBy` is just this pattern moved into the list, with a bounded LRU and
+automatic invalidation wired in. Prefer the flag; reach for the hand-rolled
+dictionary only when you need behavior it doesn't offer (e.g. a custom
+eviction policy).
 
 ## ForEach
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -209,7 +209,7 @@ UniformGrid(Orientation orientation, Element[] items) → GridElement
 VStack(Element[] children) → StackElement
 VStack(double spacing, Element[] children) → StackElement
 Viewbox(Element child) → ViewboxElement
-VirtualList(int itemCount, Func<int, Element> renderItem, Func<int, string> getItemKey = null, double? itemHeight = null, double estimatedItemHeight = 40, double spacing = 0, Action<VirtualListRef> ref = null, Action<int, int> onVisibleRangeChanged = null) → ComponentElement<VirtualListElement>
+VirtualList(int itemCount, Func<int, Element> renderItem, Func<int, string> getItemKey = null, double? itemHeight = null, double estimatedItemHeight = 40, double spacing = 0, Action<VirtualListRef> ref = null, Action<int, int> onVisibleRangeChanged = null, Func<int, string> cacheRowsBy = null, int rowCacheCapacity = 128) → ComponentElement<VirtualListElement>
 WebView2(Uri source = null) → WebView2Element
 When(bool condition, Func<Element> then) → Element
 WrapGrid(Element[] children) → WrapGridElement
@@ -7175,11 +7175,13 @@ Render() → Element
 Action<VirtualListRef> Ref { get; init; }
 Action<int, int> OnVisibleRangeChanged { get; init; }
 Func<int, Element> RenderItem { get; init; }
+Func<int, string> CacheRowsBy { get; init; }
 Func<int, string> GetItemKey { get; init; }
 double EstimatedItemHeight { get; init; }
 double Spacing { get; init; }
 double? ItemHeight { get; init; }
 int ItemCount { get; init; }
+int RowCacheCapacity { get; init; }
 Equals(Element other) → bool
 Equals(VirtualListElement other) → bool
 Equals(object obj) → bool

--- a/samples/Reactor.TestApp/Demos/VirtualizationDemo.cs
+++ b/samples/Reactor.TestApp/Demos/VirtualizationDemo.cs
@@ -19,6 +19,7 @@ class VirtualizationDemo : Component
         var (mode, setMode) = UseState("LazyVStack");
         var (itemCount, setItemCount) = UseState(1000);
         var (selectedIndex, setSelectedIndex) = UseState(-1);
+        var (cacheRows, setCacheRows) = UseState(true);
 
         // Generate item data
         var items = Enumerable.Range(0, itemCount)
@@ -71,6 +72,38 @@ class VirtualizationDemo : Component
             )
             .Set(lv => { lv.Height = 500; lv.SelectionMode = Microsoft.UI.Xaml.Controls.ListViewSelectionMode.Single; }),
 
+            // Count-based VirtualList over genuinely variable-height rows (the
+            // description wraps to 1–4 lines), so there is no fixed itemHeight and
+            // every container recycle would otherwise rebuild + re-diff the whole
+            // row subtree. Issue #327: `cacheRowsBy` opts the row into a bounded LRU
+            // keyed by the item Id — on a recycle for a row still in the cache the
+            // list hands back the *same* Element instance and the reconciler skips
+            // the per-row diff. The row is a pure function of the item here, so the
+            // Id is a complete key; toggle "Cache rows" to A/B it.
+            "VirtualList" => VirtualList(
+                itemCount: items.Count,
+                renderItem: index =>
+                {
+                    var item = items[index];
+                    var lines = 1 + (item.Id % 4);
+                    var blurb = string.Join("  •  ", Enumerable.Repeat(item.Subtitle, lines));
+                    return Border(
+                        HStack(12,
+                            Border(
+                                Caption($"{item.Id}")
+                            ).Background(SubtleFill).CornerRadius(4).Width(48).MinHeight(32).HAlign(HorizontalAlignment.Center),
+                            VStack(4,
+                                TextBlock(item.Title).SemiBold(),
+                                Caption(blurb).Foreground(SecondaryText)
+                            )
+                        )
+                    ).Padding(horizontal: 12, vertical: 8).Margin(0, 0, 0, 1);
+                },
+                getItemKey: index => items[index].Id.ToString(),
+                estimatedItemHeight: 64,
+                cacheRowsBy: cacheRows ? index => items[index].Id.ToString() : null
+            ),
+
             _ => Empty()
         };
 
@@ -85,6 +118,8 @@ class VirtualizationDemo : Component
                     HStack(8,
                         Button("LazyVStack", () => setMode("LazyVStack"))
                             .IsEnabled(!(mode == "LazyVStack")),
+                        Button("VirtualList", () => setMode("VirtualList"))
+                            .IsEnabled(!(mode == "VirtualList")),
                         Button("ListView", () => setMode("ListView"))
                             .IsEnabled(!(mode == "ListView"))
                     )
@@ -97,7 +132,14 @@ class VirtualizationDemo : Component
                         Button("5000", () => setItemCount(5000)).IsEnabled(!(itemCount == 5000)),
                         Button("10000", () => setItemCount(10000)).IsEnabled(!(itemCount == 10000))
                     )
-                )
+                ),
+                mode == "VirtualList"
+                    ? VStack(4,
+                        TextBlock("Row memoization (#327):"),
+                        Button(cacheRows ? "Cache rows: ON" : "Cache rows: OFF",
+                            () => setCacheRows(!cacheRows))
+                      )
+                    : Empty()
             ),
 
             TextBlock($"Mode: {mode} | Items: {itemCount}").Foreground(SecondaryText),

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -209,7 +209,7 @@ UniformGrid(Orientation orientation, Element[] items) → GridElement
 VStack(Element[] children) → StackElement
 VStack(double spacing, Element[] children) → StackElement
 Viewbox(Element child) → ViewboxElement
-VirtualList(int itemCount, Func<int, Element> renderItem, Func<int, string> getItemKey = null, double? itemHeight = null, double estimatedItemHeight = 40, double spacing = 0, Action<VirtualListRef> ref = null, Action<int, int> onVisibleRangeChanged = null) → ComponentElement<VirtualListElement>
+VirtualList(int itemCount, Func<int, Element> renderItem, Func<int, string> getItemKey = null, double? itemHeight = null, double estimatedItemHeight = 40, double spacing = 0, Action<VirtualListRef> ref = null, Action<int, int> onVisibleRangeChanged = null, Func<int, string> cacheRowsBy = null, int rowCacheCapacity = 128) → ComponentElement<VirtualListElement>
 WebView2(Uri source = null) → WebView2Element
 When(bool condition, Func<Element> then) → Element
 WrapGrid(Element[] children) → WrapGridElement
@@ -7175,11 +7175,13 @@ Render() → Element
 Action<VirtualListRef> Ref { get; init; }
 Action<int, int> OnVisibleRangeChanged { get; init; }
 Func<int, Element> RenderItem { get; init; }
+Func<int, string> CacheRowsBy { get; init; }
 Func<int, string> GetItemKey { get; init; }
 double EstimatedItemHeight { get; init; }
 double Spacing { get; init; }
 double? ItemHeight { get; init; }
 int ItemCount { get; init; }
+int RowCacheCapacity { get; init; }
 Equals(Element other) → bool
 Equals(VirtualListElement other) → bool
 Equals(object obj) → bool

--- a/src/Reactor/Controls/Virtualization/RowMemoCache.cs
+++ b/src/Reactor/Controls/Virtualization/RowMemoCache.cs
@@ -1,0 +1,106 @@
+using Microsoft.UI.Reactor.Core;
+
+namespace Microsoft.UI.Reactor.Controls;
+
+/// <summary>
+/// Bounded least-recently-used cache of already-built row <see cref="Element"/>
+/// instances, keyed by the author's <c>CacheRowsBy(index)</c> projection. Backs the
+/// opt-in cross-recycle row memoization on <see cref="VirtualListElement.CacheRowsBy"/>
+/// (issue #327).
+/// </summary>
+/// <remarks>
+/// <para>Why this exists: on the VirtualList <c>int</c>-index realization path the
+/// framework re-boxes the index on every container recycle, so
+/// <c>ElementFactory.BuildOrCache</c>'s <c>ReferenceEquals(item, cached.Item)</c> guard
+/// never hits — the row's Element tree is rebuilt and re-diffed on every recycle.
+/// Holding the previously-built Element here and returning the <em>same reference</em>
+/// on a hit lets the reconciler short-circuit on <see cref="Element.CanSkipUpdate"/>
+/// (its <c>ReferenceEquals</c> fast path), collapsing both the rebuild and the per-row
+/// reconcile descent to ~0.</para>
+///
+/// <para>The cache is intentionally simple and allocation-light: a
+/// <see cref="Dictionary{TKey,TValue}"/> for O(1) lookup plus an intrusive
+/// <see cref="LinkedList{T}"/> for O(1) LRU bookkeeping. No reflection — safe under the
+/// core library's trim/AOT-warnings-as-errors policy. Not thread-safe: it is owned by a
+/// single <see cref="VirtualListComponent"/> instance and only touched from the UI
+/// thread during realization.</para>
+/// </remarks>
+internal sealed class RowMemoCache
+{
+    private readonly int _capacity;
+    private readonly Dictionary<string, LinkedListNode<Entry>> _map;
+    // Most-recently-used at the head, least-recently-used at the tail.
+    private readonly LinkedList<Entry> _lru = new();
+
+    private readonly struct Entry
+    {
+        public readonly string Key;
+        public readonly Element Element;
+        public Entry(string key, Element element) { Key = key; Element = element; }
+    }
+
+    public RowMemoCache(int capacity)
+    {
+        // A non-positive cap would make the cache useless (and break the eviction
+        // math). Clamp to at least 1 so an honest mistake degrades to "cache the
+        // single most-recent row" rather than throwing.
+        _capacity = capacity < 1 ? 1 : capacity;
+        _map = new Dictionary<string, LinkedListNode<Entry>>(global::System.StringComparer.Ordinal);
+    }
+
+    /// <summary>Configured upper bound on retained rows.</summary>
+    public int Capacity => _capacity;
+
+    /// <summary>Number of rows currently retained. Never exceeds <see cref="Capacity"/>.</summary>
+    public int Count => _map.Count;
+
+    /// <summary>
+    /// Returns the cached Element for <paramref name="key"/> and promotes it to
+    /// most-recently-used. <paramref name="element"/> is the exact instance previously
+    /// passed to <see cref="Set"/> — reference-stable, which is the whole point.
+    /// </summary>
+    public bool TryGet(string key, out Element element)
+    {
+        if (_map.TryGetValue(key, out var node))
+        {
+            if (!ReferenceEquals(node, _lru.First))
+            {
+                _lru.Remove(node);
+                _lru.AddFirst(node);
+            }
+            element = node.ValueRef.Element;
+            return true;
+        }
+        element = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// Stores <paramref name="element"/> under <paramref name="key"/> as
+    /// most-recently-used, evicting the least-recently-used entry if the cache is over
+    /// capacity. Re-storing an existing key replaces its value and promotes it.
+    /// </summary>
+    public void Set(string key, Element element)
+    {
+        if (_map.TryGetValue(key, out var existing))
+        {
+            existing.ValueRef = new Entry(key, element);
+            if (!ReferenceEquals(existing, _lru.First))
+            {
+                _lru.Remove(existing);
+                _lru.AddFirst(existing);
+            }
+            return;
+        }
+
+        var node = _lru.AddFirst(new Entry(key, element));
+        _map[key] = node;
+
+        if (_map.Count > _capacity)
+        {
+            var lru = _lru.Last!;
+            _lru.RemoveLast();
+            _map.Remove(lru.ValueRef.Key);
+        }
+    }
+}

--- a/src/Reactor/Controls/Virtualization/VirtualListComponent.cs
+++ b/src/Reactor/Controls/Virtualization/VirtualListComponent.cs
@@ -26,19 +26,48 @@ public class VirtualListComponent : Component<VirtualListElement>
 
         // View builder: wrap the RenderItem callback, applying fixed height when set
         var fixedHeight = el.ItemHeight;
+
+        // Issue #327 — opt-in cross-recycle row memoization. The cache lives in a
+        // UseMemo cell so its lifetime is pinned to (ItemCount, RenderItem identity,
+        // CacheRowsBy identity, fixedHeight, capacity): any change there could alter
+        // what a row renders to, and a fresh RenderItem closure may close over new
+        // state we can't see through, so we conservatively drop the whole cache. The
+        // hook is called unconditionally (null cache when not opted in) to keep hook
+        // order stable across renders. Scroll-driven realize/recycle does NOT re-run
+        // this Render, so the cache persists across every ItemsRepeater container
+        // cycle between component renders — exactly the hot path #327 targets.
+        var cacheRowsBy = el.CacheRowsBy;
+        var rowCache = UseMemo<RowMemoCache?>(
+            () => cacheRowsBy is null ? null : new RowMemoCache(el.RowCacheCapacity),
+            el.ItemCount, el.RenderItem, (object)cacheRowsBy!, fixedHeight ?? double.NaN, el.RowCacheCapacity);
+
         Func<int, int, Element> viewBuilder = (index, _) =>
         {
             if (index < 0 || index >= el.ItemCount)
                 return Empty();
 
-            var item = el.RenderItem(index);
+            // Default path (no opt-in): byte-for-byte the original behavior.
+            if (rowCache is null || cacheRowsBy is null)
+            {
+                var plain = el.RenderItem(index);
+                if (fixedHeight.HasValue)
+                    plain = plain.Height(fixedHeight.Value);
+                return plain;
+            }
 
-            // Fixed-height fast path: force each item to the exact height
-            // so ItemsRepeater skips per-item measurement (O(1) offset)
+            var rowKey = cacheRowsBy(index);
+            if (rowCache.TryGet(rowKey, out var cached))
+                return cached; // hit → same instance → reconciler ReferenceEquals-skips
+
+            var built = el.RenderItem(index);
+            // Apply fixedHeight BEFORE caching. `.Height(...)` returns a NEW element
+            // (modifiers are immutable), so the post-Height instance is the one the
+            // reconciler later compares by reference — caching it (not the pre-Height
+            // element) is what keeps cache hits reference-stable.
             if (fixedHeight.HasValue)
-                item = item.Height(fixedHeight.Value);
-
-            return item;
+                built = built.Height(fixedHeight.Value);
+            rowCache.Set(rowKey, built);
+            return built;
         };
 
         // Configure the LazyVStack with appropriate settings

--- a/src/Reactor/Controls/Virtualization/VirtualListElement.cs
+++ b/src/Reactor/Controls/Virtualization/VirtualListElement.cs
@@ -11,6 +11,15 @@ namespace Microsoft.UI.Reactor.Controls;
 /// </summary>
 public record VirtualListElement : Element
 {
+    /// <summary>
+    /// Default upper bound for <see cref="CacheRowsBy"/>'s LRU cache (issue #327).
+    /// 128 rows ≈ a few× a typical realized window (a 500px viewport over ~40px rows
+    /// realizes on the order of a couple dozen containers), enough to absorb
+    /// scroll-back and brief over-scroll without the cache ever growing unboundedly.
+    /// Override per-list via <see cref="RowCacheCapacity"/>.
+    /// </summary>
+    public const int DefaultRowCacheCapacity = 128;
+
     /// <summary>Total number of items (drives the virtualizer's extent).</summary>
     public required int ItemCount { get; init; }
 
@@ -42,6 +51,47 @@ public record VirtualListElement : Element
 
     /// <summary>Spacing between items in pixels (default 0).</summary>
     public double Spacing { get; init; }
+
+    /// <summary>
+    /// Opt-in cross-recycle row memoization (issue #327). When set, the list keeps a
+    /// bounded LRU cache (see <see cref="RowCacheCapacity"/>) of already-built row
+    /// Elements keyed by <c>CacheRowsBy(index)</c>. On an ItemsRepeater container
+    /// recycle/realize for a key still in the cache, the list returns the <em>same</em>
+    /// Element instance it built before instead of invoking <see cref="RenderItem"/>
+    /// again; the reconciler then short-circuits on <c>ReferenceEquals</c>
+    /// (<see cref="Core.Element.CanSkipUpdate"/>) and skips the entire per-row diff.
+    /// During fast scroll over variable-height rows this is where ~a third of the
+    /// scroll wall-clock goes, so collapsing it to ~0 is the win. Leaving this
+    /// <see langword="null"/> (the default) preserves today's behavior byte-for-byte.
+    ///
+    /// <para><b>Purity contract — you are asserting this.</b> By opting in you promise
+    /// that <see cref="RenderItem"/> is a pure function of the inputs folded into the
+    /// key: for a given key the Element it produces must not depend on anything the key
+    /// does not capture. If <see cref="RenderItem"/> closes over mutable state that the
+    /// key omits — the current selection, a row-revision counter, an ambient theme it
+    /// reads ad-hoc — cached rows can serve <em>stale</em> content, and that is the
+    /// author's bug, not the framework's. Fold every such input into the key, e.g.
+    /// <c>cacheRowsBy: i =&gt; $"{items[i].Id}:{items[i].Rev}:{(i == selected ? 1 : 0)}"</c>.
+    /// The framework still resets the cache automatically whenever <see cref="ItemCount"/>
+    /// or the <see cref="RenderItem"/> delegate identity changes (a new closure may
+    /// capture new state we cannot see through), so a re-render with fresh data cannot
+    /// be served from a stale instance — but <em>within</em> a stable render the key is
+    /// the only staleness barrier.</para>
+    ///
+    /// <para>Keep this a <em>separate, explicit</em> opt-in from <see cref="GetItemKey"/>:
+    /// supplying <see cref="GetItemKey"/> for reconciliation identity does not enable
+    /// caching, because identity and purity are different promises. It is fine to reuse
+    /// the same projection for both when your rows are genuinely pure.</para>
+    /// </summary>
+    public Func<int, string>? CacheRowsBy { get; init; }
+
+    /// <summary>
+    /// Upper bound on the number of row Elements retained by the
+    /// <see cref="CacheRowsBy"/> LRU cache. Defaults to
+    /// <see cref="DefaultRowCacheCapacity"/> (128). Values below 1 are clamped to 1.
+    /// Ignored when <see cref="CacheRowsBy"/> is <see langword="null"/>.
+    /// </summary>
+    public int RowCacheCapacity { get; init; } = DefaultRowCacheCapacity;
 
     /// <summary>
     /// Callback ref for scroll operations. When set, receives a VirtualListRef

--- a/src/Reactor/Controls/Virtualization/VirtualListFactories.cs
+++ b/src/Reactor/Controls/Virtualization/VirtualListFactories.cs
@@ -17,7 +17,9 @@ public static partial class Factories
         double estimatedItemHeight = 40,
         double spacing = 0,
         Action<VirtualListRef>? @ref = null,
-        Action<int, int>? onVisibleRangeChanged = null)
+        Action<int, int>? onVisibleRangeChanged = null,
+        Func<int, string>? cacheRowsBy = null,
+        int rowCacheCapacity = VirtualListElement.DefaultRowCacheCapacity)
     {
         var props = new VirtualListElement
         {
@@ -29,6 +31,8 @@ public static partial class Factories
             Spacing = spacing,
             Ref = @ref,
             OnVisibleRangeChanged = onVisibleRangeChanged,
+            CacheRowsBy = cacheRowsBy,
+            RowCacheCapacity = rowCacheCapacity,
         };
 
         return Component<VirtualListComponent, VirtualListElement>(props)

--- a/tests/Reactor.Tests/VirtualListRowCacheTests.cs
+++ b/tests/Reactor.Tests/VirtualListRowCacheTests.cs
@@ -1,0 +1,347 @@
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Controls;
+using Xunit;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Issue #327 — opt-in cross-container row memoization on <see cref="VirtualListElement.CacheRowsBy"/>.
+///
+/// <para>These are deterministic, headless fixtures: they drive the real
+/// <see cref="VirtualListComponent.Render"/> to obtain the wrapped view builder
+/// (<see cref="LazyVStackElement{T}.ViewBuilder"/>) and then replay
+/// realize/recycle cycles against it, counting how many times the author's
+/// <c>RenderItem</c> is actually invoked (the "rebuild" cost the issue measures at
+/// ~a third of scroll wall-clock) and asserting reference stability (which is what
+/// lets the reconciler short-circuit on <see cref="Element.CanSkipUpdate"/> and skip
+/// the per-row diff descent).</para>
+/// </summary>
+public class VirtualListRowCacheTests
+{
+    // ── Harness ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Mount a VirtualListComponent with <paramref name="props"/> and return the
+    /// wrapped view builder the reconciler would call on every container realize.
+    /// Mirrors the reconciler's component flow: SetProps → BeginRender → Render →
+    /// FlushEffects (same pattern as MemoizationSelfHostTests).
+    /// </summary>
+    private static Func<int, int, Element> RenderViewBuilder(
+        VirtualListComponent comp, VirtualListElement props)
+    {
+        ((IPropsReceiver)comp).SetProps(props);
+        var scope = new ContextScope();
+        comp.Context.BeginRender(() => { }, scope);
+        var element = comp.Render();
+        comp.Context.FlushEffects();
+        return ((LazyVStackElement<int>)element).ViewBuilder;
+    }
+
+    /// <summary>Replay <paramref name="passes"/> sweeps over a rolling window of
+    /// <paramref name="window"/> rows — the same index is realized once per pass,
+    /// modelling the framework recycling and re-realizing a container repeatedly
+    /// during a fast scroll.</summary>
+    private static void DriveRecycleCycles(Func<int, int, Element> vb, int window, int passes)
+    {
+        for (int p = 0; p < passes; p++)
+            for (int i = 0; i < window; i++)
+                _ = vb(i, i); // for LazyVStack<int>, item == index
+    }
+
+    // A small multi-node row, so a real reconcile would have to descend.
+    private static Element Row(int i) =>
+        Border(VStack(4, TextBlock($"Item {i}"), TextBlock($"Description {i}")));
+
+    private static string TextOf(Element e) => ((TextBlockElement)e).Content;
+
+    // ── Effectiveness: rebuild count before vs. after ───────────────
+
+    [Fact]
+    public void CacheRowsBy_CollapsesRowRebuilds_AcrossRecycleCycles()
+    {
+        const int window = 24;
+        const int passes = 20; // 24 * 20 = 480 realize events
+
+        // BEFORE — default behavior (no opt-in): every realize rebuilds the row.
+        int baselineBuilds = 0;
+        var baselineVb = RenderViewBuilder(new VirtualListComponent(), new VirtualListElement
+        {
+            ItemCount = 1000,
+            RenderItem = i => { baselineBuilds++; return Row(i); },
+        });
+        DriveRecycleCycles(baselineVb, window, passes);
+
+        // AFTER — opt-in: each row is built once per unique key, the rest are hits.
+        int cachedBuilds = 0;
+        var cachedVb = RenderViewBuilder(new VirtualListComponent(), new VirtualListElement
+        {
+            ItemCount = 1000,
+            RenderItem = i => { cachedBuilds++; return Row(i); },
+            CacheRowsBy = i => i.ToString(),
+        });
+        DriveRecycleCycles(cachedVb, window, passes);
+
+        Assert.Equal(window * passes, baselineBuilds); // 480 — rebuilt on every realize
+        Assert.Equal(window, cachedBuilds);            // 24  — one rebuild per unique key
+        Assert.True(cachedBuilds * 10 < baselineBuilds,
+            $"expected >10x rebuild reduction; before={baselineBuilds} after={cachedBuilds}");
+    }
+
+    [Fact]
+    public void CacheRowsBy_ReturnsSameInstance_SoReconcilerCanSkip()
+    {
+        var vb = RenderViewBuilder(new VirtualListComponent(), new VirtualListElement
+        {
+            ItemCount = 100,
+            RenderItem = Row,
+            CacheRowsBy = i => i.ToString(),
+        });
+
+        var first = vb(7, 7);
+        var second = vb(7, 7);
+
+        Assert.Same(first, second); // reference-stable across recycles
+        // ReferenceEquals(a, b) is exactly the fast path the reconciler short-circuits
+        // on — zero per-row reconcile descent on a cache hit.
+        Assert.True(Element.CanSkipUpdate(first, second));
+    }
+
+    // ── Correctness guard: no stale content when the keyed input changes ─
+
+    [Fact]
+    public void CacheRowsBy_DoesNotServeStale_WhenKeyedInputChanges()
+    {
+        // Author folds the value RenderItem reads into the key — the documented
+        // purity contract. Mutating it must invalidate that row.
+        var data = new[] { "alpha", "beta", "gamma" };
+        var vb = RenderViewBuilder(new VirtualListComponent(), new VirtualListElement
+        {
+            ItemCount = 3,
+            RenderItem = i => TextBlock(data[i]),
+            CacheRowsBy = i => $"{i}:{data[i]}",
+        });
+
+        var before = vb(1, 1);
+        Assert.Equal("beta", TextOf(before));
+
+        data[1] = "beta-v2";    // the keyed input changed
+        var after = vb(1, 1);   // key changed → miss → fresh render
+
+        Assert.NotSame(before, after);
+        Assert.Equal("beta-v2", TextOf(after)); // never serves the stale instance
+    }
+
+    // ── Bounded LRU: never grows past capacity; evicts least-recently-used ─
+
+    [Fact]
+    public void CacheRowsBy_IsBounded_EvictsLeastRecentlyUsed()
+    {
+        int builds = 0;
+        var vb = RenderViewBuilder(new VirtualListComponent(), new VirtualListElement
+        {
+            ItemCount = 1000,
+            RenderItem = i => { builds++; return Row(i); },
+            CacheRowsBy = i => i.ToString(),
+            RowCacheCapacity = 8,
+        });
+
+        // Fill the cache with keys 0..7 (LRU order: 0 oldest … 7 newest).
+        for (int i = 0; i < 8; i++) _ = vb(i, i);
+        Assert.Equal(8, builds);
+
+        // Re-touch 0..7 — all hits, no rebuilds, but order becomes 0 oldest … 7 newest.
+        for (int i = 0; i < 8; i++) _ = vb(i, i);
+        Assert.Equal(8, builds);
+
+        // A 9th key evicts the LRU entry (key 0).
+        _ = vb(8, 8);
+        Assert.Equal(9, builds);
+
+        // Key 0 was evicted → rebuilds; key 8 is still hot → hit, no rebuild.
+        _ = vb(0, 0);
+        Assert.Equal(10, builds);
+        var hot1 = vb(8, 8);
+        var hot2 = vb(8, 8);
+        Assert.Same(hot1, hot2);
+        Assert.Equal(10, builds);
+    }
+
+    // ── Invalidation: a re-render with new count/closure drops the cache ─
+
+    [Fact]
+    public void CacheRowsBy_Cache_ResetsWhenItemCountOrRenderItemChanges()
+    {
+        var comp = new VirtualListComponent();
+
+        int builds1 = 0;
+        var vb1 = RenderViewBuilder(comp, new VirtualListElement
+        {
+            ItemCount = 100,
+            RenderItem = i => { builds1++; return Row(i); },
+            CacheRowsBy = i => i.ToString(),
+        });
+        _ = vb1(3, 3);
+        _ = vb1(3, 3);
+        Assert.Equal(1, builds1); // cached within this render
+
+        // Re-render the SAME component instance with a different count + closure.
+        // UseMemo's deps changed → a brand new cache, so the new builder cannot
+        // serve the previous (possibly stale) instance.
+        int builds2 = 0;
+        var vb2 = RenderViewBuilder(comp, new VirtualListElement
+        {
+            ItemCount = 200,
+            RenderItem = i => { builds2++; return Row(i); },
+            CacheRowsBy = i => i.ToString(),
+        });
+        _ = vb2(3, 3);
+        Assert.Equal(1, builds2); // freshly rebuilt against the new closure, not reused
+    }
+
+    // ── Default path is untouched when the flag is not used ─────────
+
+    [Fact]
+    public void CacheRowsBy_Null_RebuildsEveryAccess_DefaultBehavior()
+    {
+        int builds = 0;
+        var vb = RenderViewBuilder(new VirtualListComponent(), new VirtualListElement
+        {
+            ItemCount = 100,
+            RenderItem = i => { builds++; return Row(i); },
+        });
+
+        var a = vb(2, 2);
+        var b = vb(2, 2);
+
+        Assert.Equal(2, builds);  // no cache → rebuilt on each realize (today's behavior)
+        Assert.NotSame(a, b);     // a fresh tree every time
+    }
+
+    [Fact]
+    public void CacheRowsBy_WithFixedHeight_CachesPostHeightInstance()
+    {
+        // Wrapping-order correctness: .Height(...) returns a NEW element, so the
+        // cached instance must be the post-Height one for hits to stay reference-stable.
+        int builds = 0;
+        var vb = RenderViewBuilder(new VirtualListComponent(), new VirtualListElement
+        {
+            ItemCount = 100,
+            RenderItem = i => { builds++; return Row(i); },
+            ItemHeight = 48,
+            CacheRowsBy = i => i.ToString(),
+        });
+
+        var a = vb(5, 5);
+        var b = vb(5, 5);
+
+        Assert.Same(a, b);
+        Assert.Equal(1, builds);
+        Assert.True(Element.CanSkipUpdate(a, b));
+    }
+
+    // ── RowMemoCache unit semantics ─────────────────────────────────
+
+    [Fact]
+    public void RowMemoCache_Get_Miss_Then_Hit()
+    {
+        var cache = new RowMemoCache(4);
+        Assert.False(cache.TryGet("a", out _));
+
+        var e = TextBlock("a");
+        cache.Set("a", e);
+
+        Assert.True(cache.TryGet("a", out var got));
+        Assert.Same(e, got);
+        Assert.Equal(1, cache.Count);
+    }
+
+    [Fact]
+    public void RowMemoCache_Evicts_LeastRecentlyUsed_At_Capacity()
+    {
+        var cache = new RowMemoCache(2);
+        var a = TextBlock("a");
+        var b = TextBlock("b");
+        var c = TextBlock("c");
+
+        cache.Set("a", a);
+        cache.Set("b", b);   // {a,b}, a is LRU
+        cache.Set("c", c);   // exceeds cap → evict a → {b,c}
+
+        Assert.Equal(2, cache.Count);
+        Assert.False(cache.TryGet("a", out _)); // evicted
+        Assert.True(cache.TryGet("b", out _));
+        Assert.True(cache.TryGet("c", out _));
+    }
+
+    [Fact]
+    public void RowMemoCache_Get_Promotes_To_MostRecentlyUsed()
+    {
+        var cache = new RowMemoCache(2);
+        cache.Set("a", TextBlock("a"));
+        cache.Set("b", TextBlock("b")); // {a(LRU), b}
+
+        Assert.True(cache.TryGet("a", out _)); // promote a → b is now LRU
+        cache.Set("c", TextBlock("c"));        // evict b (now LRU), keep a
+
+        Assert.True(cache.TryGet("a", out _));
+        Assert.False(cache.TryGet("b", out _));
+        Assert.True(cache.TryGet("c", out _));
+    }
+
+    [Fact]
+    public void RowMemoCache_ReSet_Existing_Key_Updates_Value_And_Promotes()
+    {
+        var cache = new RowMemoCache(2);
+        var a1 = TextBlock("a1");
+        var a2 = TextBlock("a2");
+        cache.Set("a", a1);
+        cache.Set("b", TextBlock("b"));
+        cache.Set("a", a2);             // update a's value + promote → b is LRU
+        cache.Set("c", TextBlock("c")); // evict b
+
+        Assert.Equal(2, cache.Count);
+        Assert.True(cache.TryGet("a", out var got));
+        Assert.Same(a2, got);          // latest value retained
+        Assert.False(cache.TryGet("b", out _));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void RowMemoCache_Capacity_Is_Clamped_To_At_Least_One(int requested)
+    {
+        var cache = new RowMemoCache(requested);
+        Assert.Equal(1, cache.Capacity);
+
+        cache.Set("a", TextBlock("a"));
+        cache.Set("b", TextBlock("b")); // evicts a
+        Assert.Equal(1, cache.Count);
+        Assert.False(cache.TryGet("a", out _));
+        Assert.True(cache.TryGet("b", out _));
+    }
+
+    [Fact]
+    public void VirtualList_Factory_Threads_CacheRowsBy_Onto_Props()
+    {
+        Func<int, string> key = i => $"k{i}";
+        var element = VirtualList(
+            itemCount: 10,
+            renderItem: i => TextBlock($"{i}"),
+            cacheRowsBy: key,
+            rowCacheCapacity: 32);
+
+        var props = ((ComponentElement<VirtualListElement>)element).Props;
+        Assert.Same(key, props.CacheRowsBy);
+        Assert.Equal(32, props.RowCacheCapacity);
+    }
+
+    [Fact]
+    public void VirtualListElement_CacheRowsBy_Defaults_Null_And_Capacity_128()
+    {
+        var el = new VirtualListElement { ItemCount = 1, RenderItem = i => TextBlock($"{i}") };
+        Assert.Null(el.CacheRowsBy);
+        Assert.Equal(128, el.RowCacheCapacity);
+        Assert.Equal(128, VirtualListElement.DefaultRowCacheCapacity);
+    }
+}


### PR DESCRIPTION
Alternative to #753 — same goal (issue #327), different shape. Opened as a **draft for perf/design comparison**; only one of the two should merge.

## What

A list-level, **opt-in** row-memoization flag on `VirtualList` — no new element type, no reconciler/factory changes:

```csharp
VirtualList(
    itemCount: count,
    renderItem: i => Border( /* … */ ),
    cacheRowsBy: i => items[i].Id.ToString(),   // null = current behavior (opt-in)
    estimatedItemHeight: 64)
```

New surface on `VirtualListElement`: `Func<int,string>? CacheRowsBy`, `int RowCacheCapacity = 128`; matching optional params on the `VirtualList(...)` factory.

## Why

Same root cause as #327/#753: on the VirtualList `int`-index path, `ElementFactory.BuildOrCache`'s `ReferenceEquals(item)` guard always misses (the index is re-boxed each recycle), so every container recycle rebuilds + re-diffs the row tree (~36% of scroll wall-clock). Returning the **same `Element` instance** per key makes `Element.ShallowEquals` short-circuit the per-row reconcile to a `CanSkipUpdate → null` skip.

## How

When `CacheRowsBy` is set, `VirtualListComponent` wraps its view builder with a per-instance **bounded LRU** (`RowMemoCache`, default cap 128) keyed by the selector. A hit returns the cached instance (reconciler skips); a miss builds once and stores. The cache lives in a `UseMemo` cell keyed on `(ItemCount, RenderItem identity, CacheRowsBy identity, fixedHeight, capacity)`, so any change — including a fresh `renderItem` closure — drops the whole cache and can't serve stale instances. Scroll-driven realize/recycle does not re-run `Render`, so the cache persists across container cycles (the hot path). `.Height(...)` is applied **before** caching so the cached instance stays reference-stable.

## Trade-offs vs #753 (Option A)

- **Pro:** zero core changes (no `Element.cs`/`Reconciler.cs` edits); declarative one-line call-site; lowest blast radius.
- **Con:** VirtualList-only (A also covers LazyVStack/HStack, ItemsView, DataGrid); whole-row only (A can memoize a sub-tree).

## Tests & docs

- 15 new headless cases in `VirtualListRowCacheTests` (cross-recycle effectiveness 480→24 rebuilds, same-instance/`CanSkipUpdate` proof, key-change-not-stale guard, LRU eviction, cache reset on count/closure change, default-path-unchanged, fixed-height wrapping order). `dotnet test tests/Reactor.Tests` green; core builds 0 warnings/0 errors (AOT/trim-clean).
- Guide updated (`collections.md.dt` → regenerated `collections.md`), documenting the flag **and** the user-land `Dictionary` escape hatch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
