### PR TITLE
test(perf): make StressPerf.DataGrid editable by default to exercise the #671 skip-blocker

### DIFF
--- a/tests/stress_perf/StressPerf.DataGrid/Program.cs
+++ b/tests/stress_perf/StressPerf.DataGrid/Program.cs
@@ -25,6 +25,15 @@
 // .OnTapped/.OnPointerPressed closures inside RenderRow (the #671 churn). A small
 // rowHeight keeps many rows realized so that delegate churn is at measurable scale.
 //
+// EDITABLE BY DEFAULT: the columns are editable, so the control attaches the per-cell click-to-edit
+// .OnTapped to every realized cell — #671's skip-blocker (site 2). Stabilizing those handlers (#671)
+// lets unchanged cells skip Update: a reconcile/diff-time + skip-avoided-alloc win (local A/B:
+// reconcile -17%@50% / -25%@5%, alloc -7%/-10%, rps +10%/+26%). A read-only grid attaches no per-cell
+// handler, so #671's primary path would be unmeasurable — hence editable is the /perf default. A
+// future #663/#669-class array/LINQ PR author can set REACTOR_DATAGRID_EDITABLE=0 to run this leg
+// READ-ONLY locally for the clean low-baseline per-render alloc signal (the editable path adds
+// ~+6.8MB/render of cell-edit machinery), with no harness re-wiring and no recurring dual-run cost.
+//
 // MEASUREMENT CAVEAT (for maintainers + whoever measures #669/#671 against this leg):
 // the DataGrid's re-render is ASYNC/DEBOUNCED — DataChanged → LoadDataAsync →
 // StateChanged → a dispatcher-coalesced forceRender (plus a scroll-settle timer) —
@@ -79,6 +88,24 @@ class DataGridApp : Component
 
     public static CliOptions CliOpts { get; set; } = new();
 
+    // EDITABLE BY DEFAULT. The /perf run measures the DataGrid with editable cells so the per-cell
+    // click-to-edit .OnTapped (#671's skip-blocker, site 2) is attached to every realized cell — the
+    // delegate-stabilization win #671 targets only shows when that handler exists. A future
+    // #663/#669-class array/LINQ PR author can set REACTOR_DATAGRID_EDITABLE=0 (also false/no) to run
+    // this leg READ-ONLY locally, recovering the clean low-baseline per-render alloc signal for their
+    // change — without re-wiring the harness or paying a recurring dual-run on every /perf. Unset or
+    // any other value = editable (the /perf default).
+    private static readonly bool Editable = ResolveEditable();
+
+    private static bool ResolveEditable()
+    {
+        var v = Environment.GetEnvironmentVariable("REACTOR_DATAGRID_EDITABLE");
+        if (v is null) return true; // default: editable
+        return !(v == "0"
+                 || v.Equals("false", StringComparison.OrdinalIgnoreCase)
+                 || v.Equals("no", StringComparison.OrdinalIgnoreCase));
+    }
+
     // Cache brushes — lazy because SolidColorBrush requires the WinUI thread.
     private static SolidColorBrush? _greenBrush;
     private static SolidColorBrush? _redBrush;
@@ -130,8 +157,11 @@ class DataGridApp : Component
             CompositionTarget.Rendering += (_, _) => perf.FrameRendered();
         }
 
-        // Build column descriptors once. 30 sortable columns over StockRow.Cells[col],
-        // so the per-column header/row LINQ lookups (#128) run at full width each render.
+        // Build column descriptors once. 30 sortable columns over StockRow.Cells[col], so the
+        // per-column header/row LINQ lookups (#128) run at full width each render. EDITABLE by
+        // default (see the `Editable` field): editable columns make the control attach the per-cell
+        // click-to-edit .OnTapped to every realized cell — #671's skip-blocker. Set
+        // REACTOR_DATAGRID_EDITABLE=0 to run read-only (clean per-render array/LINQ alloc baseline).
         var columns = UseMemo(() =>
         {
             var cols = new FieldDescriptor[ColumnCount];
@@ -144,7 +174,11 @@ class DataGridApp : Component
                     DisplayName = $"Col {c}",
                     FieldType = typeof(StockItem),
                     GetValue = obj => ((StockRow)obj).Cells[col],
-                    IsReadOnly = true,
+                    // No-op setter: non-null + IsReadOnly:false is all the control needs to attach the
+                    // per-cell .OnTapped (#671 site 2). The benchmark never commits an edit (headless:
+                    // no taps fire), so the body is intentionally inert.
+                    SetValue = Editable ? (obj, val) => obj : null,
+                    IsReadOnly = !Editable,
                     Width = 64,
                     Sortable = true,
                     Filterable = false,
@@ -226,6 +260,7 @@ class DataGridApp : Component
             source: source,
             columns: columns,
             selectionMode: SelectionMode.Multiple,
+            editable: Editable,
             rowHeight: 18,
             showSearch: false,
             cellTemplate: ctx =>


### PR DESCRIPTION
## What

Makes the `StressPerf.DataGrid` `/perf` leg run **editable by default**, so the control attaches the per-cell click-to-edit `.OnTapped` (#671's skip-blocker, site 2) to every realized cell — the prerequisite for measuring #671. Editability is parameterized behind an env var so a read-only run is a **local opt-in**.

**Single file** (`StressPerf.DataGrid/Program.cs`, +38/−3). Test-scaffolding only (no `src/Reactor`) → perf-neutral. Merges **before** the #671 control PR (#759) so `/perf` builds the editable leg from both A/B sides.

## Decision: option (a), single editable leg

This started as a flip-to-editable, briefly became a second "editable dimension" (skip-floor-style), and — per the final review — landed back on **(a)**: a single editable leg. The dimension approach was reverted because running the **slowest, async-debounced** DataGrid leg **twice on every `/perf` forever** is a real recurring tax, and its benefit (preserving the read-only alloc baseline as the default) is modest + speculative (a future multi-MB #669-class win still resolves cleanly at the ~29.5 MB editable baseline; only marginal/below-floor wins are affected).

To keep the read-only baseline's value at **~zero recurring cost**, editability is gated on **`REACTOR_DATAGRID_EDITABLE`**:
- **unset (default) → editable** — the `/perf` run measures #671's per-cell skip path.
- **`=0` / `false` / `no` → read-only** — a future #663/#669-class array/LINQ PR author runs `StressPerf.DataGrid` read-only **locally** to get the clean low-baseline alloc signal for their change, with no harness re-wiring and no recurring dual-run.

Smoke-confirmed: default ~29.5 MB/render (editable), `=0` ~21.6 MB/render (read-only) — both pass the structural self-check.

## Why editable is needed for #671

A read-only grid attaches **no** per-cell `.OnTapped`, so #671's primary skip-blocker doesn't exist and the win is unmeasurable. With editable cells, stabilizing the handler (#671) lets unchanged cells skip `Update`:

| churn | Reconcile/Diff | Alloc/render | Renders/sec |
|---|--:|--:|--:|
| `--percent 50` | −17% | −6.8% | +10% |
| `--percent 5` | **−25%** | **−9.9%** | **+26%** |

(local A/B, #671-cached vs main-fresh; win scales up at low churn as more cells skip.)

## Validation

- `dotnet build StressPerf.DataGrid` (Release x64) — **0/0**
- Both modes (default editable + `REACTOR_DATAGRID_EDITABLE=0`) smoke-pass the structural self-check and emit metrics.
- Perf-neutral to other legs (StocksGrid/KeyedList/Flex untouched) and to `src/Reactor`.

## Sequence

Merge this → I rebase #759 (#671 control change) on the now-editable main → `/perf` → judge #671 on the DataGrid leg's **reconcile/diff** (CI excludes 0) + alloc + rps.

Relates to #671, #663, #669.