### PR TITLE
Fix #675: unify ApplyResourceOverrides + ThemeRef re-resolution across skip fast-paths

### DIFF
--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -183,10 +183,27 @@ internal static class ChildReconciler
         Reconciler reconciler,
         Action requestRerender)
     {
-        // Early skip: if the element is structurally identical (and has no
-        // theme bindings that need re-evaluation), we can avoid the expensive
-        // children.Get(i) COM call entirely. This saves ~2 COM roundtrips per
-        // unchanged child (IVector.GetAt + all the property diffing inside Update).
+        // Early skip: if the element is structurally identical (and carries no
+        // theme-reactive resources that need re-evaluation), we can avoid the
+        // expensive children.Get(i) COM call entirely. This saves ~2 COM roundtrips
+        // per unchanged child (IVector.GetAt + all the property diffing inside Update).
+        //
+        // Issue #675 — the skip contract lives entirely in Element.CanSkipUpdate
+        // (shared by the positional + keyed prefix/suffix arms): it declines the skip
+        // for any element carrying ThemeBindings OR ResourceOverrides.ThemeRefs, so a
+        // theme-sensitive child falls through to UpdateChild → Update, whose
+        // element-level shallow-skip re-resolves the themed value. Reconciler.Update
+        // is therefore the single place that performs skip-path theme re-resolution.
+        //
+        // We deliberately do NOT also gate this arm on IsOnDirtyAncestorPath (the
+        // element-level skip in Update.cs does). It is provably unnecessary here:
+        // every container arm in Element.ShallowEquals compares its children/child BY
+        // REFERENCE, and Component/Memo/Func wrappers return false — so any element
+        // that is CanSkipUpdate-eligible is either a leaf or a reference-equal-children
+        // container, neither of which can be a STRICT ANCESTOR of a freshly re-rendered
+        // self-triggered descendant (that ancestor would carry a new children reference
+        // and fail ShallowEquals). Adding a dirty-ancestor check would only force a
+        // COM fetch on the hot skip-floor for a path that cannot be reached.
         var oldEl = oldChildren[i];
         var newEl = newChildren[i];
         if (Element.CanSkipUpdate(oldEl, newEl)
@@ -274,6 +291,9 @@ internal static class ChildReconciler
             // keyed prefix is the steady-state path for stable lists (e.g. grid
             // rows whose keys never change), so without this they re-diff every
             // tick.
+            // Issue #675 — shares Element.CanSkipUpdate with the positional arm, so a
+            // ThemeBindings/ResourceOverrides.ThemeRefs child likewise declines the
+            // skip and re-resolves through Update (see UpdateCommonChild's contract note).
             if (Element.CanSkipUpdate(oldEl, newEl)
                 && !reconciler.ForceRenderThroughWrapper(newEl))
             {

--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -196,14 +196,21 @@ internal static class ChildReconciler
         // is therefore the single place that performs skip-path theme re-resolution.
         //
         // We deliberately do NOT also gate this arm on IsOnDirtyAncestorPath (the
-        // element-level skip in Update.cs does). It is provably unnecessary here:
-        // every container arm in Element.ShallowEquals compares its children/child BY
-        // REFERENCE, and Component/Memo/Func wrappers return false — so any element
-        // that is CanSkipUpdate-eligible is either a leaf or a reference-equal-children
-        // container, neither of which can be a STRICT ANCESTOR of a freshly re-rendered
-        // self-triggered descendant (that ancestor would carry a new children reference
-        // and fail ShallowEquals). Adding a dirty-ancestor check would only force a
-        // COM fetch on the hot skip-floor for a path that cannot be reached.
+        // element-level skip in Update.cs does). For non-explicitly-memoized trees this
+        // is unnecessary: every container arm in Element.ShallowEquals compares its
+        // children/child BY REFERENCE, and Component/Memo/Func wrappers return false — so
+        // a CanSkipUpdate-eligible element is a leaf or a reference-equal-children
+        // container, and a parent that re-rendered to reach a self-triggered descendant
+        // would carry a NEW children reference and fail ShallowEquals (so it wouldn't be
+        // skip-eligible here). The one residual (pre-existing, LOW) edge is an EXPLICITLY
+        // memoized wrapper — e.g. UseMemo(() => Border(Counter()), []) yields a
+        // reference-equal Border whose Counter self-triggers; this arm (lacking the
+        // IsOnDirtyAncestorPath check) could in principle swallow that re-render. That is
+        // a pre-existing property of the child-skip path, orthogonal to #675 (a ThemeRef
+        // child inherits the dirty-ancestor check via the Update fall-through), and the
+        // bulk array-fast-path (ReconcilePositional, ~line 119) retains the
+        // IsOnDirtyAncestorPath gate as cheap insurance. We keep this per-child arm free
+        // of the COM fetch a membership check would cost on the hot skip-floor.
         var oldEl = oldChildren[i];
         var newEl = newChildren[i];
         if (Element.CanSkipUpdate(oldEl, newEl)

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -427,6 +427,10 @@ public abstract record Element
         {
             if (!AttachedEqual(a.Attached, b.Attached)) return false;
             if (!ThemeBindingsEqual(a.ThemeBindings, b.ThemeBindings)) return false;
+            // Issue #675 — compare ResourceOverrides for symmetry with ThemeBindings: a
+            // dropped/changed override while otherwise shallow-equal must decline the skip
+            // so ApplyResourceOverrides on the full-Update path strips/re-applies it.
+            if (!ResourceOverridesEqual(a.ResourceOverrides, b.ResourceOverrides)) return false;
             if (!ContextValuesEqual(a.ContextValues, b.ContextValues)) return false;
         }
 
@@ -1357,6 +1361,59 @@ public abstract record Element
             if (!Equals(valA, valB)) return false;
         }
         return true;
+    }
+
+    // Issue #675 — structural equality for per-control ResourceOverrides (lightweight
+    // styling). ShallowEquals must compare these for the SAME reason it compares
+    // ThemeBindings (line ~417): without it, an element that DROPS or CHANGES a
+    // ResourceOverrides entry while otherwise shallow-equal would be skipped and the
+    // stale resolved brush (or stale literal) would survive in fe.Resources[key] — the
+    // remove/change side of the contract. Returning false here routes the element through
+    // full Update, where ApplyResourceOverrides(old, new) strips the dropped managed key
+    // and applies the new value. This is symmetric with the ThemeBindings transition-away
+    // handling (ShallowEquals catches it + ClearThemeBindings on the Update path). Gated
+    // behind the no-extras fast-path in ShallowEquals, so override-free cells pay nothing.
+    // The CanSkipUpdate ThemeRefs gate is still required for the STEADY-STATE case (same
+    // overrides, effective theme changed → ShallowEquals stays true → the gate forces the
+    // re-resolve); the two are complementary.
+    internal static bool ResourceOverridesEqual(
+        Microsoft.UI.Reactor.Elements.ResourceOverrides? a,
+        Microsoft.UI.Reactor.Elements.ResourceOverrides? b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+
+        // Literals: compare by VALUE. Brushes are re-parsed to fresh instances each render
+        // (e.g. .Set("X", "#0078D4")), so reference compare would false-decline the skip for
+        // an UNCHANGED literal-override cell — use BrushesEqual; other literal kinds (double,
+        // CornerRadius) are value types whose Equals is correct.
+        var la = a.Literals;
+        var lb = b.Literals;
+        if (la.Count != lb.Count) return false;
+        foreach (var (key, valA) in la)
+        {
+            if (!lb.TryGetValue(key, out var valB)) return false;
+            if (!ResourceLiteralEqual(valA, valB)) return false;
+        }
+
+        // ThemeRefs: compare by key + ResourceKey (same semantics as ThemeBindingsEqual).
+        var ta = a.ThemeRefs;
+        var tb = b.ThemeRefs;
+        if (ta.Count != tb.Count) return false;
+        foreach (var (key, valA) in ta)
+        {
+            if (!tb.TryGetValue(key, out var valB)) return false;
+            if (valA.ResourceKey != valB.ResourceKey) return false;
+        }
+        return true;
+    }
+
+    private static bool ResourceLiteralEqual(object? a, object? b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+        if (a is Brush ba && b is Brush bb) return BrushesEqual(ba, bb);
+        return a.Equals(b);
     }
 }
 

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -379,19 +379,31 @@ public abstract record Element
     /// <summary>
     /// Returns true if two elements are structurally identical AND the child can be
     /// completely skipped during reconciliation (no need to call Update at all).
-    /// This is stricter than ShallowEquals: elements with ThemeBindings must still
-    /// go through Update so bindings can be re-evaluated against the current theme,
-    /// and a change in callback *presence* must run Update so the lazy-wire path
-    /// can subscribe to the WinRT event on a null→non-null transition.
+    /// This is stricter than ShallowEquals: elements with ThemeBindings or
+    /// theme-reactive <see cref="ResourceOverrides"/> (<c>ThemeRefs</c>) must still
+    /// go through Update so the themed values can be re-resolved against the current
+    /// effective theme, and a change in callback *presence* must run Update so the
+    /// lazy-wire path can subscribe to the WinRT event on a null→non-null transition.
     /// IMPORTANT: keep in sync with the ShallowEquals fast-path in Reconciler.Update().
     /// Note: when both elements have a null <see cref="Extensions"/> bucket (spec 047
     /// §4.4 — the common no-extras leaf), ShallowEquals skips the Attached /
     /// ThemeBindings / ContextValues structural compares entirely, since all 14
     /// bucketed fields are provably null on both sides.
     /// </summary>
+    /// <remarks>
+    /// Issue #675 — the <c>ResourceOverrides.ThemeRefs</c> gate mirrors the
+    /// <c>ThemeBindings</c> gate and <see cref="Core.ChildDiffHints.IsThemeSensitive"/>.
+    /// A child themed only via <c>ResourceOverrides.ThemeRefs</c> (no ThemeBindings)
+    /// must NOT take the cheap child-skip arms in <c>ChildReconciler</c>: declining
+    /// the skip routes it through <c>Update</c>, whose element-level shallow-skip
+    /// re-resolves the ThemeRef into <c>fe.Resources[...]</c> on an effective-theme
+    /// change. This keeps Reconciler.Update the single source of truth for skip
+    /// side-effects rather than duplicating the re-resolve across every child-skip arm.
+    /// </remarks>
     internal static bool CanSkipUpdate(Element oldEl, Element newEl)
         => ShallowEquals(oldEl, newEl)
             && newEl.ThemeBindings is null
+            && newEl.ResourceOverrides is not { ThemeRefs.Count: > 0 }
             && oldEl.HasCallbacks == newEl.HasCallbacks;
 
     /// <summary>

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -4808,15 +4808,23 @@ public sealed partial class Reconciler : IDisposable
         // Track which keys Reactor has set on this element
         var managed = _managedResourceKeys.GetOrCreateValue(fe);
 
-        // Remove old keys that are no longer present in the new overrides
-        if (oldOverrides is not null)
+        // Remove managed keys that are no longer present in the new overrides.
+        // Issue #675 — drive removal off `managed` vs `newOverrides`, independent of
+        // `oldOverrides` nullness. A control can carry Reactor-managed keys that did
+        // NOT arrive via `oldOverrides` (e.g. a pooled/reused control, or the Mount
+        // path which always passes oldOverrides==null): gating removal on
+        // `oldOverrides is not null` would leak those stale keys into fe.Resources.
+        // Removal only strips managed keys absent from newOverrides; the apply loop
+        // below re-adds the current keys, so this never fights the apply path. At a
+        // truly-fresh mount `managed` is empty and this is a no-op.
+        if (managed.Count > 0)
         {
             var newKeys = newOverrides?.AllKeys.ToHashSet() ?? new HashSet<string>();
             foreach (var key in managed.ToArray())
             {
                 if (!newKeys.Contains(key))
                 {
-                    fe.Resources.Remove(key);
+                    fe.Resources?.Remove(key);
                     managed.Remove(key);
                 }
             }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Elements;
+using Microsoft.UI.Reactor.Hooks;
+using Microsoft.UI.Reactor.Hosting;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Issue #675 — live-FrameworkElement proofs that <c>ResourceOverrides.ThemeRefs</c>
+/// re-resolve across ALL reconciler skip fast-paths (element-level shallow-skip,
+/// positional child-skip, keyed child-skip) plus the <c>ApplyResourceOverrides</c>
+/// stale-key removal gate.
+///
+/// <para>WHY A SOURCE-RESOURCE MUTATION, NOT A RequestedTheme TOGGLE: the existing
+/// <c>StructuralSkipFixtures</c> remarks document that a parent <c>RequestedTheme</c>
+/// toggle is an UNRELIABLE observable for the <c>ThemeRef.Resolve</c> →
+/// <c>fe.Resources[key]</c> snapshot — its effective-theme view lags the propagation
+/// within a synchronous reconcile pass. These fixtures sidestep that entirely: they
+/// register a plain (non-themed) brush under a unique key in
+/// <c>Application.Current.Resources</c>, which <c>ThemeRef.Resolve</c> picks up via its
+/// <c>TryResolveNonThemed</c> fallback, then MUTATE that source brush between two
+/// shallow-equal renders. A correctly-behaving skip path re-runs
+/// <c>ApplyResourceOverrides</c> and the control's <c>Resources[targetKey]</c> flips to
+/// the new brush; a skip path that drops the re-resolution leaves the stale brush. This
+/// is deterministic and theme-independent.</para>
+/// </summary>
+internal static class Issue675ResourceOverrideSkipFixtures
+{
+    private const string SrcKey = "Issue675_SourceBrush";
+    private const string TargetKey = "Issue675_TargetBrush";
+
+    private static SolidColorBrush MakeBrush(byte r, byte g, byte b) =>
+        new SolidColorBrush(global::Windows.UI.Color.FromArgb(255, r, g, b));
+
+    private static SolidColorBrush? ResourceBrush(FrameworkElement? fe, string key)
+    {
+        if (fe?.Resources is { } res && res.ContainsKey(key))
+            return res[key] as SolidColorBrush;
+        return null;
+    }
+
+    // The app-level ResourceDictionary has a Source set (XamlControlsResources), so it
+    // rejects direct local values. Register the ThemeRef source brush in our OWN
+    // (Source-less) dictionary merged into Application.Current.Resources, which
+    // ThemeRef.Resolve discovers via its TryResolveNonThemed MergedDictionaries scan.
+    // Mutating the brush is then a write to our dictionary, never the sealed app one.
+    private static ResourceDictionary InstallSourceDict(string key, SolidColorBrush initial)
+    {
+        var dict = new ResourceDictionary { [key] = initial };
+        Application.Current.Resources.MergedDictionaries.Add(dict);
+        return dict;
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Element-level shallow-skip (Reconciler.Update.cs) — GREEN today
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A themed leaf carrying ONLY <c>ResourceOverrides.ThemeRefs</c> is the sole output
+    /// of a function component, so it is reconciled through <c>UpdateChild</c> →
+    /// <c>Update</c> (no child-skip). When it re-renders shallow-equal, Update's
+    /// element-level shallow-skip (Update.cs ~97-98) re-applies the ThemeRef. This is the
+    /// behavior test missing for that branch (issue #675 Finding C / TC-M2) and the
+    /// regression guard that keeps the element-level path re-resolving after the fix.
+    /// </summary>
+    internal sealed class ElementLevelSkipReResolves(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var red = MakeBrush(220, 0, 0);
+            var blue = MakeBrush(0, 0, 220);
+            var srcDict = InstallSourceDict(SrcKey, red);
+            try
+            {
+                Action<int>? bump = null;
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (n, setN) = ctx.UseState(0);
+                    bump = setN;
+                    // Leaf output → reconciled via Update directly. Shallow-equal across the
+                    // state bump (ResourceOverrides is not part of ShallowEquals), so the
+                    // element-level skip arm runs and re-resolves the ThemeRef.
+                    return TextBlock("elemMarker")
+                        .Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey)));
+                });
+
+                await Harness.Render();
+                var tb = H.FindControl<TextBlock>(t => t.Text == "elemMarker");
+                H.Check("Issue675_ElementLevel_MountResolvedRed",
+                    ReferenceEquals(ResourceBrush(tb, TargetKey), red));
+
+                // Mutate the SOURCE brush, then re-render shallow-equal.
+                srcDict[SrcKey] = blue;
+                bump!(1);
+                await Harness.Render();
+
+                tb = H.FindControl<TextBlock>(t => t.Text == "elemMarker");
+                H.Check("Issue675_ElementLevel_ReResolvedBlueOnSkip",
+                    ReferenceEquals(ResourceBrush(tb, TargetKey), blue));
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(srcDict);
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Positional child-skip (ChildReconciler.UpdateCommonChild) — RED pre-fix
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A themed child (ResourceOverrides.ThemeRefs only) sits at a stable index in a
+    /// VStack whose sibling changes every render (so the VStack itself is not
+    /// shallow-equal and its children reconcile positionally). Before the fix the themed
+    /// cell satisfies <c>CanSkipUpdate</c> (it gates only on ThemeBindings), so the
+    /// positional skip arm short-circuits and the ThemeRef is never re-resolved — the
+    /// control's <c>Resources[TargetKey]</c> stays stale. After the fix
+    /// <c>CanSkipUpdate</c> declines the skip, routing the cell through Update where it
+    /// re-resolves. RED pre-fix, GREEN post-fix.
+    /// </summary>
+    internal sealed class PositionalChildSkipReResolves(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var red = MakeBrush(0, 160, 0);
+            var blue = MakeBrush(120, 0, 160);
+            var srcDict = InstallSourceDict(SrcKey, red);
+            try
+            {
+                Action<int>? bump = null;
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (n, setN) = ctx.UseState(0);
+                    bump = setN;
+                    return VStack(
+                        // Changing sibling → fresh VStack children array AND a non-skippable
+                        // index 0, so the positional walk runs over the themed cell at index 1.
+                        TextBlock($"posSibling{n}"),
+                        TextBlock("posCell")
+                            .Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))));
+                });
+
+                await Harness.Render();
+                var cell = H.FindControl<TextBlock>(t => t.Text == "posCell");
+                H.Check("Issue675_Positional_MountResolvedRed",
+                    ReferenceEquals(ResourceBrush(cell, TargetKey), red));
+
+                srcDict[SrcKey] = blue;
+                bump!(1);
+                await Harness.Render();
+
+                cell = H.FindControl<TextBlock>(t => t.Text == "posCell");
+                H.Check("Issue675_Positional_ReResolvedBlueOnChildSkip",
+                    ReferenceEquals(ResourceBrush(cell, TargetKey), blue));
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(srcDict);
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Keyed child-skip (ChildReconciler keyed prefix/suffix) — RED pre-fix
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Same scenario as <see cref="PositionalChildSkipReResolves"/> but the children carry
+    /// keys (<c>.WithKey</c>), so reconciliation takes the keyed path. The themed cell is
+    /// matched in the keyed prefix/suffix scan, which shares <c>CanSkipUpdate</c> with the
+    /// positional arm — proving the fix applies to the keyed skip too. RED pre-fix,
+    /// GREEN post-fix.
+    /// </summary>
+    internal sealed class KeyedChildSkipReResolves(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var red = MakeBrush(200, 120, 0);
+            var blue = MakeBrush(0, 120, 200);
+            var srcDict = InstallSourceDict(SrcKey, red);
+            try
+            {
+                Action<int>? bump = null;
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (n, setN) = ctx.UseState(0);
+                    bump = setN;
+                    return VStack(
+                        TextBlock($"keySibling{n}").WithKey("sibling"),
+                        TextBlock("keyCell")
+                            .Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey)))
+                            .WithKey("cell"));
+                });
+
+                await Harness.Render();
+                var cell = H.FindControl<TextBlock>(t => t.Text == "keyCell");
+                H.Check("Issue675_Keyed_MountResolvedRed",
+                    ReferenceEquals(ResourceBrush(cell, TargetKey), red));
+
+                srcDict[SrcKey] = blue;
+                bump!(1);
+                await Harness.Render();
+
+                cell = H.FindControl<TextBlock>(t => t.Text == "keyCell");
+                H.Check("Issue675_Keyed_ReResolvedBlueOnChildSkip",
+                    ReferenceEquals(ResourceBrush(cell, TargetKey), blue));
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(srcDict);
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  ApplyResourceOverrides removal gate (oldOverrides == null) — RED pre-fix
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Drives <c>Reconciler.ApplyResourceOverrides</c> directly on a live control with
+    /// <c>oldOverrides == null</c> on BOTH calls (the Mount path always passes null). The
+    /// first call seeds two Reactor-managed keys; the second supplies overrides missing
+    /// one of them. Before the fix the removal block was gated on
+    /// <c>oldOverrides is not null</c>, so the dropped key leaked into <c>fe.Resources</c>;
+    /// after the fix removal is driven off the managed-key set vs the new overrides,
+    /// independent of <c>oldOverrides</c> nullness. RED pre-fix, GREEN post-fix.
+    /// </summary>
+    internal sealed class RemovalGateStaleKeyWhenOldOverridesNull(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync()
+        {
+            var fe = new TextBlock();
+            var brushA = MakeBrush(10, 20, 30);
+            var brushB = MakeBrush(40, 50, 60);
+
+            var first = new ResourceOverrides(
+                Literals: new Dictionary<string, object> { ["KeyA"] = brushA, ["KeyB"] = brushB },
+                ThemeRefs: new Dictionary<string, ThemeRef>());
+
+            // Seed managed keys with oldOverrides == null (the Mount-path shape).
+            Reconciler.ApplyResourceOverrides(fe, null, first);
+            H.Check("Issue675_Removal_SeededKeyA", fe.Resources.ContainsKey("KeyA"));
+            H.Check("Issue675_Removal_SeededKeyB", fe.Resources.ContainsKey("KeyB"));
+
+            // New overrides drop KeyB; oldOverrides is STILL null. The stale-key removal
+            // must run regardless and strip KeyB.
+            var second = new ResourceOverrides(
+                Literals: new Dictionary<string, object> { ["KeyA"] = brushA },
+                ThemeRefs: new Dictionary<string, ThemeRef>());
+            Reconciler.ApplyResourceOverrides(fe, null, second);
+
+            H.Check("Issue675_Removal_KeyARemains", fe.Resources.ContainsKey("KeyA"));
+            H.Check("Issue675_Removal_StaleKeyBRemoved", !fe.Resources.ContainsKey("KeyB"));
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
@@ -318,6 +318,13 @@ internal static class Issue675ResourceOverrideSkipFixtures
             var srcDict = InstallSourceDict(SrcKey, red);
             try
             {
+                // #721 positive guard: absent the override the leaf is structurally
+                // shallow-equal, so the transition's skip-decline is driven by the override
+                // DROP (detected by the ShallowEquals ResourceOverrides compare), not an
+                // incidental modifier.
+                H.Check("Issue675_TransitionAway_BaseShapeSkipEligible",
+                    Element.ShallowEquals(TextBlock("transCell"), TextBlock("transCell")));
+
                 Action<int>? bump = null;
                 var host = H.CreateHost();
                 host.Mount(ctx =>
@@ -333,6 +340,7 @@ internal static class Issue675ResourceOverrideSkipFixtures
 
                 await Harness.Render();
                 var cell = H.FindControl<TextBlock>(t => t.Text == "transCell");
+                var cellBefore = cell;
                 H.Check("Issue675_TransitionAway_MountHasOverride",
                     ResourceBrush(cell, TargetKey) is not null);
 
@@ -341,6 +349,11 @@ internal static class Issue675ResourceOverrideSkipFixtures
                 await Harness.Render();
 
                 cell = H.FindControl<TextBlock>(t => t.Text == "transCell");
+                // #721 right-reason: the control is REUSED in place (not remounted), so the
+                // override removal is the removal-gate stripping the managed key on the full
+                // Update path — a remount would trivially drop resources for the wrong reason.
+                H.Check("Issue675_TransitionAway_ControlReusedInPlace",
+                    ReferenceEquals(cellBefore, cell));
                 H.Check("Issue675_TransitionAway_StaleOverrideRemoved",
                     ResourceBrush(cell, TargetKey) is null);
             }
@@ -371,6 +384,12 @@ internal static class Issue675ResourceOverrideSkipFixtures
             var srcDict = InstallSourceDict(SrcKey, red);
             try
             {
+                // #721 positive guard: the themed cell is structurally shallow-equal across
+                // renders, so its keyed-suffix skip eligibility hinges only on the ThemeRefs gate.
+                H.Check("Issue675_KeyedSuffix_CellSkipEligible", Element.ShallowEquals(
+                    TextBlock("keySuffixCell").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))).WithKey("cellSuffix"),
+                    TextBlock("keySuffixCell").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))).WithKey("cellSuffix")));
+
                 Action<int>? bump = null;
                 var host = H.CreateHost();
                 host.Mount(ctx =>
@@ -388,6 +407,7 @@ internal static class Issue675ResourceOverrideSkipFixtures
 
                 await Harness.Render();
                 var cell = H.FindControl<TextBlock>(t => t.Text == "keySuffixCell");
+                var cellBefore = cell;
                 H.Check("Issue675_KeyedSuffix_MountResolvedRed",
                     ReferenceEquals(ResourceBrush(cell, TargetKey), red));
 
@@ -396,6 +416,10 @@ internal static class Issue675ResourceOverrideSkipFixtures
                 await Harness.Render();
 
                 cell = H.FindControl<TextBlock>(t => t.Text == "keySuffixCell");
+                // #721 right-reason: the cell is updated IN PLACE (control reused), confirming
+                // it was matched by the keyed SUFFIX arm, not remounted by the keyed middle.
+                H.Check("Issue675_KeyedSuffix_ControlReusedInPlace",
+                    ReferenceEquals(cellBefore, cell));
                 H.Check("Issue675_KeyedSuffix_ReResolvedBlueOnChildSkip",
                     ReferenceEquals(ResourceBrush(cell, TargetKey), blue));
             }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
@@ -80,6 +80,14 @@ internal static class Issue675ResourceOverrideSkipFixtures
             var srcDict = InstallSourceDict(SrcKey, red);
             try
             {
+                // #721 positive guard: the leaf is structurally shallow-equal across renders, so
+                // Update takes the element-level shallow-skip arm (Update.cs:81 -> 97-98
+                // skip-AND-re-resolve, return null) rather than a full property diff. This pins the
+                // GREEN to the skip-and-re-resolve path, not an incidental full update.
+                H.Check("Issue675_ElementLevel_CellSkipEligible", Element.ShallowEquals(
+                    TextBlock("elemMarker").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))),
+                    TextBlock("elemMarker").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey)))));
+
                 Action<int>? bump = null;
                 var host = H.CreateHost();
                 host.Mount(ctx =>
@@ -137,6 +145,16 @@ internal static class Issue675ResourceOverrideSkipFixtures
             var srcDict = InstallSourceDict(SrcKey, red);
             try
             {
+                // #721 positive skip-eligibility guard: prove the themed cell is structurally
+                // shallow-equal across renders, so its child-skip eligibility hinges ONLY on the
+                // ResourceOverrides.ThemeRefs gate — not an incidental Setters/modifier difference
+                // that would route it through full Update and mask a broken child-skip re-resolve as
+                // a false-green. ShallowEquals ignores ResourceOverrides, so this stays true pre/post
+                // fix; a refactor that makes the cell decline the skip for any OTHER reason flips it.
+                H.Check("Issue675_Positional_CellSkipEligible", Element.ShallowEquals(
+                    TextBlock("posCell").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))),
+                    TextBlock("posCell").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey)))));
+
                 Action<int>? bump = null;
                 var host = H.CreateHost();
                 host.Mount(ctx =>
@@ -191,6 +209,15 @@ internal static class Issue675ResourceOverrideSkipFixtures
             var srcDict = InstallSourceDict(SrcKey, red);
             try
             {
+                // #721 positive skip-eligibility guard (see PositionalChildSkipReResolves): the keyed
+                // cell is structurally shallow-equal across renders (Key is not compared by
+                // ShallowEquals — it is matched separately via KeyMatch), so its keyed child-skip
+                // eligibility hinges only on the ResourceOverrides.ThemeRefs gate. Guards against a
+                // refactor silently turning the RED into a false-green.
+                H.Check("Issue675_Keyed_CellSkipEligible", Element.ShallowEquals(
+                    TextBlock("keyCell").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))).WithKey("cell"),
+                    TextBlock("keyCell").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))).WithKey("cell")));
+
                 Action<int>? bump = null;
                 var host = H.CreateHost();
                 host.Mount(ctx =>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
@@ -52,11 +52,29 @@ internal static class Issue675ResourceOverrideSkipFixtures
     // (Source-less) dictionary merged into Application.Current.Resources, which
     // ThemeRef.Resolve discovers via its TryResolveNonThemed MergedDictionaries scan.
     // Mutating the brush is then a write to our dictionary, never the sealed app one.
+    //
+    // #660 — ThemeRef.Resolve now caches (resourceKey, themeName) -> Brush, cleared only
+    // by InvalidateResolutionCache (wired to the hosts' theme-change handlers). Our test
+    // mutates the source brush WITHOUT a theme change, so we must invalidate the cache
+    // ourselves — faithfully mirroring what the host does on an effective-theme change —
+    // both here (clears any prior fixture's cached entry for the shared key) and after
+    // each mutation. Without it the cache returns the stale resolved brush and a skipped
+    // child's re-resolution can't be observed.
     private static ResourceDictionary InstallSourceDict(string key, SolidColorBrush initial)
     {
         var dict = new ResourceDictionary { [key] = initial };
         Application.Current.Resources.MergedDictionaries.Add(dict);
+        global::Microsoft.UI.Reactor.Core.ThemeRef.InvalidateResolutionCache();
         return dict;
+    }
+
+    // Mutate the source brush AND invalidate the #660 resolution cache, so the next
+    // ThemeRef.Resolve re-reads the merged dictionary (as it would after a real theme
+    // change). A skip path that drops re-resolution still leaves fe.Resources[key] stale.
+    private static void SetSource(ResourceDictionary dict, string key, SolidColorBrush brush)
+    {
+        dict[key] = brush;
+        global::Microsoft.UI.Reactor.Core.ThemeRef.InvalidateResolutionCache();
     }
 
     // ════════════════════════════════════════════════════════════════════
@@ -107,7 +125,7 @@ internal static class Issue675ResourceOverrideSkipFixtures
                     ReferenceEquals(ResourceBrush(tb, TargetKey), red));
 
                 // Mutate the SOURCE brush, then re-render shallow-equal.
-                srcDict[SrcKey] = blue;
+                SetSource(srcDict, SrcKey, blue);
                 bump!(1);
                 await Harness.Render();
 
@@ -174,7 +192,7 @@ internal static class Issue675ResourceOverrideSkipFixtures
                 H.Check("Issue675_Positional_MountResolvedRed",
                     ReferenceEquals(ResourceBrush(cell, TargetKey), red));
 
-                srcDict[SrcKey] = blue;
+                SetSource(srcDict, SrcKey, blue);
                 bump!(1);
                 await Harness.Render();
 
@@ -236,7 +254,7 @@ internal static class Issue675ResourceOverrideSkipFixtures
                 H.Check("Issue675_Keyed_MountResolvedRed",
                     ReferenceEquals(ResourceBrush(cell, TargetKey), red));
 
-                srcDict[SrcKey] = blue;
+                SetSource(srcDict, SrcKey, blue);
                 bump!(1);
                 await Harness.Render();
 
@@ -411,7 +429,7 @@ internal static class Issue675ResourceOverrideSkipFixtures
                 H.Check("Issue675_KeyedSuffix_MountResolvedRed",
                     ReferenceEquals(ResourceBrush(cell, TargetKey), red));
 
-                srcDict[SrcKey] = blue;
+                SetSource(srcDict, SrcKey, blue);
                 bump!(1);
                 await Harness.Render();
 

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
@@ -294,4 +294,144 @@ internal static class Issue675ResourceOverrideSkipFixtures
             return Task.CompletedTask;
         }
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  ResourceOverrides transition-away (remove side of the contract) — RED pre-fix
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A cell carrying a <c>ResourceOverrides.ThemeRefs</c> override DROPS it while
+    /// otherwise shallow-equal (a conditional <c>.Resources(...)</c> whose condition flips).
+    /// <c>ShallowEquals</c> does not compare ResourceOverrides, and the new element has no
+    /// ThemeRefs so the <c>CanSkipUpdate</c> gate doesn't decline either — so before the
+    /// ShallowEquals ResourceOverrides comparison the cell is child-skipped,
+    /// <c>ApplyResourceOverrides</c> never runs, and the resolved brush survives stale in
+    /// <c>fe.Resources[key]</c>. After the fix <c>ShallowEquals</c> declines (overrides
+    /// differ) → full Update → the removal gate strips the dropped managed key. RED pre-fix,
+    /// GREEN post-fix. This closes the remove side, symmetric with ThemeBindings transition-away.
+    /// </summary>
+    internal sealed class TransitionAwayRemovesStaleOverride(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var red = MakeBrush(180, 30, 30);
+            var srcDict = InstallSourceDict(SrcKey, red);
+            try
+            {
+                Action<int>? bump = null;
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (n, setN) = ctx.UseState(0);
+                    bump = setN;
+                    // n==0: carries the ThemeRef override; n>=1: drops it (otherwise identical).
+                    var cell = TextBlock("transCell");
+                    if (n == 0)
+                        cell = cell.Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey)));
+                    return VStack(cell);
+                });
+
+                await Harness.Render();
+                var cell = H.FindControl<TextBlock>(t => t.Text == "transCell");
+                H.Check("Issue675_TransitionAway_MountHasOverride",
+                    ResourceBrush(cell, TargetKey) is not null);
+
+                // Drop the override while the cell is otherwise shallow-equal.
+                bump!(1);
+                await Harness.Render();
+
+                cell = H.FindControl<TextBlock>(t => t.Text == "transCell");
+                H.Check("Issue675_TransitionAway_StaleOverrideRemoved",
+                    ResourceBrush(cell, TargetKey) is null);
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(srcDict);
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Keyed SUFFIX child-skip re-resolve (coverage parity with the keyed prefix)
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Coverage companion to <see cref="KeyedChildSkipReResolves"/> (which exercises the keyed
+    /// PREFIX arm). Here the FIRST child's KEY changes every render, so the keyed prefix scan
+    /// stops at index 0 (KeyMatch fails) and the trailing themed cell (stable key) is matched
+    /// by the keyed SUFFIX scan instead — locking the shared <c>CanSkipUpdate</c> contract on
+    /// the suffix arm too. The themed cell re-resolves its ThemeRef across a source-brush change.
+    /// </summary>
+    internal sealed class KeyedSuffixChildSkipReResolves(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var red = MakeBrush(60, 60, 200);
+            var blue = MakeBrush(200, 60, 60);
+            var srcDict = InstallSourceDict(SrcKey, red);
+            try
+            {
+                Action<int>? bump = null;
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (n, setN) = ctx.UseState(0);
+                    bump = setN;
+                    // First child's KEY changes each render → keyed prefix scan stops at index 0,
+                    // so the trailing themed cell (stable key) is consumed by the SUFFIX scan.
+                    return VStack(
+                        TextBlock("keySuffixSibling").WithKey($"sib{n}"),
+                        TextBlock("keySuffixCell")
+                            .Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey)))
+                            .WithKey("cellSuffix"));
+                });
+
+                await Harness.Render();
+                var cell = H.FindControl<TextBlock>(t => t.Text == "keySuffixCell");
+                H.Check("Issue675_KeyedSuffix_MountResolvedRed",
+                    ReferenceEquals(ResourceBrush(cell, TargetKey), red));
+
+                srcDict[SrcKey] = blue;
+                bump!(1);
+                await Harness.Render();
+
+                cell = H.FindControl<TextBlock>(t => t.Text == "keySuffixCell");
+                H.Check("Issue675_KeyedSuffix_ReResolvedBlueOnChildSkip",
+                    ReferenceEquals(ResourceBrush(cell, TargetKey), blue));
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(srcDict);
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Literal-override no-false-decline (skip-floor guard for the RO compare)
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Live (brush creation needs WinUI activation): proves the new ShallowEquals
+    /// ResourceOverrides comparison does NOT regress the skip-floor for literal-override
+    /// cells. A hex literal is re-parsed to a FRESH brush instance each render, so a
+    /// reference compare would false-decline an UNCHANGED override; ResourceOverridesEqual
+    /// compares brush literals by value (BrushesEqual) → same hex stays shallow-equal, a
+    /// changed hex declines.
+    /// </summary>
+    internal sealed class LiteralOverrideNoFalseDecline(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override Task RunAsync()
+        {
+            var same1 = TextBlock("lit").Resources(r => r.Set("ButtonBackground", "#0078D4"));
+            var same2 = TextBlock("lit").Resources(r => r.Set("ButtonBackground", "#0078D4"));
+            H.Check("Issue675_LiteralBrush_SameHex_ShallowEqual",
+                Element.ShallowEquals(same1, same2));
+
+            var diff = TextBlock("lit").Resources(r => r.Set("ButtonBackground", "#106EBE"));
+            H.Check("Issue675_LiteralBrush_DiffHex_NotShallowEqual",
+                !Element.ShallowEquals(same1, diff));
+
+            return Task.CompletedTask;
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -387,6 +387,9 @@ internal static class SelfTestFixtureRegistry
         "Issue675_PositionalChildSkipReResolves",
         "Issue675_KeyedChildSkipReResolves",
         "Issue675_RemovalGateStaleKeyWhenOldOverridesNull",
+        "Issue675_TransitionAwayRemovesStaleOverride",
+        "Issue675_KeyedSuffixChildSkipReResolves",
+        "Issue675_LiteralOverrideNoFalseDecline",
         "HotReload_ChildHookOrderRecovery",
         "HotReload_ComponentMigratesState",
         // DSL and extension tests
@@ -1848,6 +1851,9 @@ internal static class SelfTestFixtureRegistry
         "Issue675_PositionalChildSkipReResolves" => new Issue675ResourceOverrideSkipFixtures.PositionalChildSkipReResolves(harness),
         "Issue675_KeyedChildSkipReResolves" => new Issue675ResourceOverrideSkipFixtures.KeyedChildSkipReResolves(harness),
         "Issue675_RemovalGateStaleKeyWhenOldOverridesNull" => new Issue675ResourceOverrideSkipFixtures.RemovalGateStaleKeyWhenOldOverridesNull(harness),
+        "Issue675_TransitionAwayRemovesStaleOverride" => new Issue675ResourceOverrideSkipFixtures.TransitionAwayRemovesStaleOverride(harness),
+        "Issue675_KeyedSuffixChildSkipReResolves" => new Issue675ResourceOverrideSkipFixtures.KeyedSuffixChildSkipReResolves(harness),
+        "Issue675_LiteralOverrideNoFalseDecline" => new Issue675ResourceOverrideSkipFixtures.LiteralOverrideNoFalseDecline(harness),
         "HotReload_ChildHookOrderRecovery" => new HotReloadRecoveryFixtures.ChildRecoversAndSiblingStateSurvives(harness),
         "HotReload_ComponentMigratesState" => new HotReloadComponentMigrationFixtures.MigratesPreservingState(harness),
         // DSL and extension tests

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -383,6 +383,10 @@ internal static class SelfTestFixtureRegistry
         "StructuralSkip_ThemeRangeParity",
         "UseMemoCells_BaseReThemeOnAncestorToggle",
         "StructuralSkip_HotReloadWrapperReRender",
+        "Issue675_ElementLevelSkipReResolves",
+        "Issue675_PositionalChildSkipReResolves",
+        "Issue675_KeyedChildSkipReResolves",
+        "Issue675_RemovalGateStaleKeyWhenOldOverridesNull",
         "HotReload_ChildHookOrderRecovery",
         "HotReload_ComponentMigratesState",
         // DSL and extension tests
@@ -1840,6 +1844,10 @@ internal static class SelfTestFixtureRegistry
         "StructuralSkip_ThemeRangeParity" => new StructuralSkipFixtures.ThemeRangeParity(harness),
         "UseMemoCells_BaseReThemeOnAncestorToggle" => new UseMemoCellsThemeReResolveFixtures.BaseMemoCellsReThemeOnAncestorToggle(harness),
         "StructuralSkip_HotReloadWrapperReRender" => new StructuralSkipFixtures.HotReloadWrapperReRender(harness),
+        "Issue675_ElementLevelSkipReResolves" => new Issue675ResourceOverrideSkipFixtures.ElementLevelSkipReResolves(harness),
+        "Issue675_PositionalChildSkipReResolves" => new Issue675ResourceOverrideSkipFixtures.PositionalChildSkipReResolves(harness),
+        "Issue675_KeyedChildSkipReResolves" => new Issue675ResourceOverrideSkipFixtures.KeyedChildSkipReResolves(harness),
+        "Issue675_RemovalGateStaleKeyWhenOldOverridesNull" => new Issue675ResourceOverrideSkipFixtures.RemovalGateStaleKeyWhenOldOverridesNull(harness),
         "HotReload_ChildHookOrderRecovery" => new HotReloadRecoveryFixtures.ChildRecoversAndSiblingStateSurvives(harness),
         "HotReload_ComponentMigratesState" => new HotReloadComponentMigrationFixtures.MigratesPreservingState(harness),
         // DSL and extension tests

--- a/tests/Reactor.Tests/ElementTests.cs
+++ b/tests/Reactor.Tests/ElementTests.cs
@@ -890,6 +890,58 @@ public class ElementTests
         Assert.Equal(new Thickness(10), merged.Margin);
     }
 
+    // ════════════════════════════════════════════════════════════════
+    //  CanSkipUpdate — theme-sensitivity gate (issue #675)
+    // ════════════════════════════════════════════════════════════════
+    //
+    // CanSkipUpdate drives the cheap child-skip arms in ChildReconciler
+    // (positional + keyed prefix/suffix). It must decline the skip for any
+    // element carrying ResourceOverrides.ThemeRefs — exactly as it already
+    // does for ThemeBindings — so such a child falls through to Update, where
+    // the element-level shallow-skip re-resolves the ThemeRef against the
+    // current effective theme. Without the gate the child is skipped wholesale
+    // and its themed fe.Resources[...] entry goes stale on a theme change.
+
+    [Fact]
+    public void CanSkipUpdate_ThemeRefOnly_ForcesUpdate()
+    {
+        // Two shallow-equal TextBlocks; one carries a ThemeRef-only resource
+        // override (no ThemeBindings). CanSkipUpdate must return false so the
+        // child-skip arms route it through Update for re-resolution.
+        var themeRef = global::Microsoft.UI.Reactor.Core.Theme.Ref("Issue675AccentBrush");
+        var a = TextBlock("Hello").Resources(r => r.Set("Foreground", themeRef));
+        var b = TextBlock("Hello").Resources(r => r.Set("Foreground", themeRef));
+
+        // Sanity: they are shallow-equal (ResourceOverrides is not part of the
+        // own-props compare), so only the explicit ThemeRefs gate keeps the
+        // child-skip from engaging.
+        Assert.True(Element.ShallowEquals(a, b));
+        Assert.False(Element.CanSkipUpdate(a, b));
+    }
+
+    [Fact]
+    public void CanSkipUpdate_LiteralOnlyOverrides_StillSkips()
+    {
+        // Literal overrides are NOT theme-reactive (they never re-resolve), so
+        // a literal-only override must NOT block the cheap child-skip.
+        var a = TextBlock("Hello").Resources(r => r.Set("ControlCornerRadius", 8.0));
+        var b = TextBlock("Hello").Resources(r => r.Set("ControlCornerRadius", 8.0));
+
+        Assert.True(Element.ShallowEquals(a, b));
+        Assert.True(Element.CanSkipUpdate(a, b));
+    }
+
+    [Fact]
+    public void CanSkipUpdate_NoOverrides_StillSkips()
+    {
+        // The gesture-free skip-floor: plain shallow-equal leaves with no
+        // theme-sensitive resources must keep skipping (zero added cost).
+        var a = TextBlock("Hello");
+        var b = TextBlock("Hello");
+
+        Assert.True(Element.CanSkipUpdate(a, b));
+    }
+
     // ── Test component stubs ────────────────────────────────────────
 
     private class TestComponent : Component

--- a/tests/Reactor.Tests/ElementTests.cs
+++ b/tests/Reactor.Tests/ElementTests.cs
@@ -942,6 +942,65 @@ public class ElementTests
         Assert.True(Element.CanSkipUpdate(a, b));
     }
 
+    // ════════════════════════════════════════════════════════════════
+    //  ShallowEquals — ResourceOverrides remove/change symmetry (issue #675)
+    // ════════════════════════════════════════════════════════════════
+    //
+    // ShallowEquals must compare ResourceOverrides for the same reason it compares
+    // ThemeBindings: a dropped/changed override on an otherwise shallow-equal element
+    // must decline the skip so the full-Update ApplyResourceOverrides path strips the
+    // stale managed key / applies the new value. Without this, a transition-away leaves
+    // a stale resolved brush in fe.Resources[key].
+
+    [Fact]
+    public void ShallowEquals_ResourceOverrides_TransitionAway_NotEqual()
+    {
+        // old carries a ThemeRef override; new drops it while otherwise identical.
+        var withRef = TextBlock("Hello").Resources(r => r.Set("X", global::Microsoft.UI.Reactor.Core.Theme.Ref("SomeKey")));
+        var without = TextBlock("Hello");
+        Assert.False(Element.ShallowEquals(withRef, without));
+        Assert.False(Element.ShallowEquals(without, withRef));
+    }
+
+    [Fact]
+    public void ShallowEquals_ResourceOverrides_SameThemeRef_Equal()
+    {
+        var a = TextBlock("Hello").Resources(r => r.Set("X", global::Microsoft.UI.Reactor.Core.Theme.Ref("SomeKey")));
+        var b = TextBlock("Hello").Resources(r => r.Set("X", global::Microsoft.UI.Reactor.Core.Theme.Ref("SomeKey")));
+        Assert.True(Element.ShallowEquals(a, b));
+    }
+
+    [Fact]
+    public void ShallowEquals_ResourceOverrides_ChangedThemeRefKey_NotEqual()
+    {
+        var a = TextBlock("Hello").Resources(r => r.Set("X", global::Microsoft.UI.Reactor.Core.Theme.Ref("KeyA")));
+        var b = TextBlock("Hello").Resources(r => r.Set("X", global::Microsoft.UI.Reactor.Core.Theme.Ref("KeyB")));
+        Assert.False(Element.ShallowEquals(a, b));
+    }
+
+    [Fact]
+    public void ShallowEquals_ResourceOverrides_ChangedLiteral_NotEqual()
+    {
+        // A changed literal override value must decline the skip (so the new value applies).
+        // Use a value-type literal (double) — brush literals need WinUI activation and are
+        // covered live in Issue675ResourceOverrideSkipFixtures.
+        var a = TextBlock("Hello").Resources(r => r.Set("ControlCornerRadius", 8.0));
+        var b = TextBlock("Hello").Resources(r => r.Set("ControlCornerRadius", 12.0));
+        Assert.False(Element.ShallowEquals(a, b));
+    }
+
+    [Fact]
+    public void ShallowEquals_ResourceOverrides_SameLiteralValue_Equal_NoFalseDecline()
+    {
+        // An UNCHANGED literal override must stay shallow-equal so the skip-floor isn't
+        // regressed for override-bearing cells (compared by value). Brush-literal value
+        // equality (re-parsed fresh each render → BrushesEqual, not reference) is verified
+        // live in Issue675ResourceOverrideSkipFixtures.
+        var a = TextBlock("Hello").Resources(r => r.Set("ControlCornerRadius", 8.0));
+        var b = TextBlock("Hello").Resources(r => r.Set("ControlCornerRadius", 8.0));
+        Assert.True(Element.ShallowEquals(a, b));
+    }
+
     // ── Test component stubs ────────────────────────────────────────
 
     private class TestComponent : Component


### PR DESCRIPTION
## Issue
Fixes #675 (behavior-changing correctness audit of the reconciler skip fast-path's `ApplyResourceOverrides` + dirty-ancestor side-effects). Off fresh `main` (post-#748).

## Why the gap is real — self-healing vs concrete-resolved
- **`ThemeBindings`** emit WinUI `{ThemeResource}` markup → WinUI re-resolves automatically on theme change (**self-healing**). `CanSkipUpdate` declining to skip ThemeBindings children is belt-and-suspenders.
- **`ResourceOverrides.ThemeRefs`** resolve to a **concrete brush** at reconcile time (`ThemeRef.Resolve` → `fe.Resources[key]`) and do **not** self-heal — they must be re-resolved at reconcile on an effective-theme change, and **removed** when the override is dropped. This is the actual bug surface: the element-level skip re-resolves them, but `CanSkipUpdate` (the child arms) gated only on `ThemeBindings`.

## The contract — three complementary mechanisms
1. **Add / steady-state re-resolve — `CanSkipUpdate` gates on `ResourceOverrides.ThemeRefs`** (shape (i)). A ThemeRefs child declines the cheap child-skip and falls through to `Update`'s element-level skip-and-re-resolve (`Update.cs:81→96-98`) — element-level *parity*, not a full diff. Kept because it's required for the **steady-state** case (same overrides, effective theme changed → `ShallowEquals` stays true → the gate forces the re-resolve).
2. **Remove / change — `ShallowEquals` now compares `ResourceOverrides`** (review Point A). Symmetric with how `ShallowEquals` already compares `ThemeBindings`: a dropped or changed override on an otherwise shallow-equal element declines the skip → full `Update` → `ApplyResourceOverrides(old, new)` strips the stale managed key / applies the new value. Gated inside the no-extras fast-path, so override-free cells (StocksGrid) pay nothing. `ResourceOverridesEqual` compares ThemeRefs by `ResourceKey` and **Literals by value** — brush literals via `BrushesEqual` (Color+Opacity), so a re-parsed-same-hex literal does **not** false-decline the skip (no skip-floor regression for literal-override cells). Bonus: a changed literal override value now applies instead of being silently dropped on skip.
3. **Stale-key removal gate** (Finding A) — `ApplyResourceOverrides` drives removal off `managed` vs `newOverrides`, independent of `oldOverrides` nullness (fixes Mount-path / pooling leaks).

Mechanisms 1 and 2 are complementary: 1 covers identical-override theme changes; 2 covers override add/remove/change.

## Changes
- **`Element.CanSkipUpdate`** declines the skip for `ResourceOverrides is { ThemeRefs.Count: > 0 }`.
- **`Element.ShallowEquals`** + new `ResourceOverridesEqual` — compares ResourceOverrides next to the `ThemeBindings` compare, inside the no-extras-gated block.
- **`Reconciler.ApplyResourceOverrides`** — removal driven off `managed` vs `newOverrides`.
- **`ChildReconciler`** — comment-only; the child arms inherit the `CanSkipUpdate` contract. The dirty-ancestor note is softened (Point B): it holds for non-explicitly-memoized trees; the one residual pre-existing LOW edge (an explicitly-memoized self-triggering wrapper) is flagged, and the bulk array-fast-path retains the `IsOnDirtyAncestorPath` gate as insurance.

### Relies on the existing `AnyThemeSensitive` bulk gate (unchanged, load-bearing)
`ChildReconciler`'s `!hint.AnyThemeSensitive` gate stays so theme-sensitive ranges take the full walk and reach `CanSkipUpdate` → Update → re-resolve.

## Perf
The `CanSkipUpdate` gate and the `ShallowEquals` RO compare are both gated so override-free cells pay nothing (null/`Count` check / no-extras fast-path). StocksGrid stress cells carry no `ResourceOverrides`, so the gesture-free skip-floor is untouched. Harness is the authority for `/perf`.

## Tests (RED-before-GREEN)
- **Headless** (`ElementTests`): `CanSkipUpdate_ThemeRefOnly_ForcesUpdate` (+ literal-only/no-override skip-floor guards); **5 new `ShallowEquals_ResourceOverrides_*`**: transition-away / changed-themeref-key / changed-literal → NOT equal; same-themeref / same-literal-value → equal (no false-decline).
- **Live selftests** (`Issue675ResourceOverrideSkipFixtures`): element-level skip (GREEN pre-fix = Finding C); positional + keyed-prefix child-skip (RED pre-fix); **keyed-SUFFIX child-skip** (Point C — first child's key changes so the suffix scan matches the trailing themed cell); the `oldOverrides == null` removal gate; **`TransitionAwayRemovesStaleOverride`** (Point A, RED→GREEN — verified by reverting the ShallowEquals RO compare: the stale brush survives); **`LiteralOverrideNoFalseDecline`** (brush value-compare, live). Plus the #721 `CellSkipEligible` false-green guards on each re-resolve fixture.

**Test-method note:** the re-resolve fixtures use a deterministic source-brush mutation in a merged dictionary (not a `RequestedTheme` toggle, which is self-defeating on the skip path / documented-unreliable in `StructuralSkipFixtures`).

## Gates
- `dotnet build src/Reactor/Reactor.csproj -c Release` — 0 warning / 0 error (AOT/trim WaE).
- `dotnet test tests/Reactor.Tests` — 9932 passed / 0 failed (no pre-existing test regressed by the ShallowEquals change).
- ARM64 selftests — `Issue675` (all fixtures) + `StructuralSkip` + theme/resource-adjacent fixtures all green.

## Cross-workstream note — #750 is COMPLEMENTARY, not redundant (informational, not coupled)
#750 (Hooks/UseMemoCells) gates its memo early-out on `IsThemeSensitive` (ThemeBindings OR ResourceOverrides.ThemeRefs). The two act at **different skip entry points**: #750 = container recurse-vs-skip (a theme-sensitive memoizing container with reference-equal `Children` otherwise takes the element-level skip and short-circuits the whole subtree, so its children are NEVER visited); #675 = child-arm re-resolve (fires only after recursion reaches the child arm).

> **COMPLEMENTARY, NOT redundant — #675 ACTIVATES #750's ResourceOverrides.ThemeRefs arm (which is inert without #675: today a #750-forced-recurse ResO child still child-arm-skips without re-resolving). The two are at DIFFERENT skip entry points (#750 = container recurse-vs-skip; #675 = child-arm re-resolve), both load-bearing. #750 is NARROWABLE — its self-healing ThemeBindings arm can later be dropped — but its ResourceOverrides arm is NEVER removable; it relies on #675.**

A reviewer must NOT greenlight a future removal of #750's ResourceOverrides arm thinking #675 covers it. Not fixing/coupling to #750 here.

## Out of scope (aware, not fixed)
Phase-2 bug: ResourceOverride ThemeRef→concrete-brush resolution uses the app-fallback theme rather than the ancestor `RequestedTheme` during reconcile (wrong at MOUNT). Distinct from this skip-path re-resolution/removal contract.

## Status
Draft — coordinator owns dual-review + `/perf` + merge. Review findings A (remove/change side via ShallowEquals), B (dirty-ancestor comment soften), C (keyed-suffix coverage) addressed in the latest commit.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>