### PR TITLE
test(#675): address CodeQL nits in Issue675 skip fixtures

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
@@ -42,8 +42,8 @@ internal static class Issue675ResourceOverrideSkipFixtures
 
     private static SolidColorBrush? ResourceBrush(FrameworkElement? fe, string key)
     {
-        if (fe?.Resources is { } res && res.ContainsKey(key))
-            return res[key] as SolidColorBrush;
+        if (fe?.Resources is { } res && res.TryGetValue(key, out var v))
+            return v as SolidColorBrush;
         return null;
     }
 
@@ -110,7 +110,7 @@ internal static class Issue675ResourceOverrideSkipFixtures
                 var host = H.CreateHost();
                 host.Mount(ctx =>
                 {
-                    var (n, setN) = ctx.UseState(0);
+                    var (_, setN) = ctx.UseState(0);
                     bump = setN;
                     // Leaf output → reconciled via Update directly. Shallow-equal across the
                     // state bump (ResourceOverrides is not part of ShallowEquals), so the


### PR DESCRIPTION
Trivial, behavior-preserving **test-only** follow-up to #758 (merged as `c0ea1d85`). Addresses the two `github-code-quality[bot]` nits on `Issue675ResourceOverrideSkipFixtures.cs` that landed on main because #758 merged before they were resolved.

1. `ResourceBrush` helper: replace `ContainsKey(key)` + `[key]` double-lookup with a single `TryGetValue(key, out var v)`.
2. `ElementLevelSkipReResolves`: the `UseState` value is unused (only the setter is captured via `bump`), so discard it — `var (_, setN)`. Scoped to that one site only; the other four `var (n, setN)` sites use `n` in rendered text and are deliberately untouched.

No production change. Host builds 0 warn / 0 err; the full `Issue675` selftest suite passes (all assertions green).

Opened as **draft** — @azchohfi / coordinator, mark ready + squash-merge (or close) at your discretion; resolve the two bot threads on #758 against this.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>