### PR TITLE
Add analyzer for event subscriptions inside .Set(...)

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -122,6 +122,7 @@ via `.editorconfig`.
 | `REACTOR_DSL_001` | Warning | Dynamic list item missing .WithKey | `MissingWithKeyAnalyzer.cs` |
 | `REACTOR_DOCK_001` | Warning | OnLiveLayoutChanged feeds the live layout back into state | `OnLiveLayoutRoundTripAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
+| `REACTOR_EVENT_001` | Warning | `.Set(...)` subscribes to an event that already has a declarative `On*` modifier | `SetEventSubscriptionAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
 

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -18,5 +18,6 @@ REACTOR_A11Y_003 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityA
 REACTOR_REF_001 | Reactor.Reference | Warning | ReferenceCurrentReadAnalyzer - Use descriptor.Reference/binding.Reference instead of assigning ElementRef.Current to reference properties
 REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list item missing .WithKey
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
+REACTOR_EVENT_001 | Reactor.Events | Warning | SetEventSubscriptionAnalyzer - .Set subscribes to an event that already has a declarative On* modifier
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback

--- a/src/Reactor.Analyzers/SetEventSubscriptionAnalyzer.cs
+++ b/src/Reactor.Analyzers/SetEventSubscriptionAnalyzer.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// REACTOR_EVENT_001: Detects <c>.Set(fe =&gt; fe.Event += handler)</c> patterns
+/// where Reactor already exposes a declarative <c>.OnEvent(...)</c> modifier.
+/// Imperative subscriptions inside <c>.Set(...)</c> can accumulate duplicate
+/// handlers as the element rerenders.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SetEventSubscriptionAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_EVENT_001";
+
+    public static readonly IReadOnlyDictionary<string, string> EventModifiers =
+        new Dictionary<string, string>(System.StringComparer.Ordinal)
+        {
+            { "SizeChanged", "OnSizeChanged" },
+            { "PointerPressed", "OnPointerPressed" },
+            { "PointerMoved", "OnPointerMoved" },
+            { "PointerReleased", "OnPointerReleased" },
+            { "Tapped", "OnTapped" },
+            { "KeyDown", "OnKeyDown" },
+            { "PointerEntered", "OnPointerEntered" },
+            { "PointerExited", "OnPointerExited" },
+            { "PointerCanceled", "OnPointerCanceled" },
+            { "PointerCaptureLost", "OnPointerCaptureLost" },
+            { "PointerWheelChanged", "OnPointerWheelChanged" },
+            { "DoubleTapped", "OnDoubleTapped" },
+            { "RightTapped", "OnRightTapped" },
+            { "Holding", "OnHolding" },
+            { "KeyUp", "OnKeyUp" },
+            { "PreviewKeyDown", "OnPreviewKeyDown" },
+            { "PreviewKeyUp", "OnPreviewKeyUp" },
+            { "CharacterReceived", "OnCharacterReceived" },
+            { "AccessKeyDisplayRequested", "OnAccessKeyDisplayRequested" },
+            { "GotFocus", "OnGotFocus" },
+            { "LostFocus", "OnLostFocus" },
+            { "DragEnter", "OnDragEnter" },
+            { "DragOver", "OnDragOver" },
+            { "DragLeave", "OnDragLeave" },
+            { "Drop", "OnDrop" },
+        };
+
+    public static readonly IReadOnlyDictionary<string, string> CodeFixableEventModifiers =
+        new Dictionary<string, string>(System.StringComparer.Ordinal)
+        {
+            { "SizeChanged", "OnSizeChanged" },
+            { "PointerPressed", "OnPointerPressed" },
+            { "PointerMoved", "OnPointerMoved" },
+            { "PointerReleased", "OnPointerReleased" },
+            { "Tapped", "OnTapped" },
+            { "KeyDown", "OnKeyDown" },
+            { "PointerEntered", "OnPointerEntered" },
+            { "PointerExited", "OnPointerExited" },
+            { "PointerCanceled", "OnPointerCanceled" },
+            { "PointerCaptureLost", "OnPointerCaptureLost" },
+            { "PointerWheelChanged", "OnPointerWheelChanged" },
+            { "DoubleTapped", "OnDoubleTapped" },
+            { "RightTapped", "OnRightTapped" },
+            { "Holding", "OnHolding" },
+            { "KeyUp", "OnKeyUp" },
+            { "PreviewKeyDown", "OnPreviewKeyDown" },
+            { "PreviewKeyUp", "OnPreviewKeyUp" },
+            { "CharacterReceived", "OnCharacterReceived" },
+            { "AccessKeyDisplayRequested", "OnAccessKeyDisplayRequested" },
+            { "GotFocus", "OnGotFocus" },
+            { "LostFocus", "OnLostFocus" },
+        };
+
+    private static readonly LocalizableString Title =
+        "Use declarative event modifier instead of .Set subscription";
+
+    private static readonly LocalizableString MessageFormat =
+        "'{0}' subscribed inside '.Set(...)' may accumulate across renders. Use '.{1}(...)' modifier instead.";
+
+    private static readonly LocalizableString Description =
+        "Reactor reruns '.Set(...)' during later updates. Direct event subscriptions " +
+        "inside that lambda can accumulate duplicate handlers across renders. When " +
+        "Reactor already exposes a declarative On* modifier for the event, prefer " +
+        "that render-safe modifier instead.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Events",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!TryGetSetInvocationData(invocation, out var setTarget, out var parameterName, out var assignment))
+            return;
+        if (assignment.Kind() != SyntaxKind.AddAssignmentExpression)
+            return;
+        if (assignment.Left is not MemberAccessExpressionSyntax leftAccess)
+            return;
+        if (leftAccess.Expression is not IdentifierNameSyntax leftTarget || leftTarget.Identifier.Text != parameterName)
+            return;
+
+        var eventName = leftAccess.Name.Identifier.Text;
+        if (!EventModifiers.TryGetValue(eventName, out var modifierName))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.GetLocation(),
+            eventName,
+            modifierName));
+    }
+
+    internal static bool TryGetSetInvocationData(
+        InvocationExpressionSyntax invocation,
+        out ExpressionSyntax setTarget,
+        out string parameterName,
+        out AssignmentExpressionSyntax assignment)
+    {
+        setTarget = null!;
+        parameterName = string.Empty;
+        assignment = null!;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return false;
+        if (memberAccess.Name.Identifier.Text != "Set")
+            return false;
+
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count != 1)
+            return false;
+
+        if (!TryGetLambdaParameterAndAssignment(args[0].Expression, out parameterName, out assignment))
+            return false;
+
+        setTarget = memberAccess.Expression;
+        return true;
+    }
+
+    internal static bool TryGetLambdaParameterAndAssignment(
+        ExpressionSyntax lambdaExpr,
+        out string parameterName,
+        out AssignmentExpressionSyntax assignment)
+    {
+        parameterName = string.Empty;
+        assignment = null!;
+
+        switch (lambdaExpr)
+        {
+            case SimpleLambdaExpressionSyntax simple:
+                parameterName = simple.Parameter.Identifier.Text;
+                return TryGetAssignment(simple.ExpressionBody ?? (SyntaxNode?)simple.Block, out assignment);
+            case ParenthesizedLambdaExpressionSyntax paren when paren.ParameterList.Parameters.Count == 1:
+                parameterName = paren.ParameterList.Parameters[0].Identifier.Text;
+                return TryGetAssignment(paren.ExpressionBody ?? (SyntaxNode?)paren.Block, out assignment);
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryGetAssignment(SyntaxNode? exprOrBlock, out AssignmentExpressionSyntax assignment)
+    {
+        assignment = null!;
+
+        switch (exprOrBlock)
+        {
+            case AssignmentExpressionSyntax expr:
+                assignment = expr;
+                return true;
+            case BlockSyntax block when block.Statements.Count == 1
+                && block.Statements[0] is ExpressionStatementSyntax es
+                && es.Expression is AssignmentExpressionSyntax blockAssignment:
+                assignment = blockAssignment;
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/src/Reactor.Analyzers/SetEventSubscriptionAnalyzer.cs
+++ b/src/Reactor.Analyzers/SetEventSubscriptionAnalyzer.cs
@@ -42,36 +42,6 @@ public sealed class SetEventSubscriptionAnalyzer : DiagnosticAnalyzer
             { "AccessKeyDisplayRequested", "OnAccessKeyDisplayRequested" },
             { "GotFocus", "OnGotFocus" },
             { "LostFocus", "OnLostFocus" },
-            { "DragEnter", "OnDragEnter" },
-            { "DragOver", "OnDragOver" },
-            { "DragLeave", "OnDragLeave" },
-            { "Drop", "OnDrop" },
-        };
-
-    public static readonly IReadOnlyDictionary<string, string> CodeFixableEventModifiers =
-        new Dictionary<string, string>(System.StringComparer.Ordinal)
-        {
-            { "SizeChanged", "OnSizeChanged" },
-            { "PointerPressed", "OnPointerPressed" },
-            { "PointerMoved", "OnPointerMoved" },
-            { "PointerReleased", "OnPointerReleased" },
-            { "Tapped", "OnTapped" },
-            { "KeyDown", "OnKeyDown" },
-            { "PointerEntered", "OnPointerEntered" },
-            { "PointerExited", "OnPointerExited" },
-            { "PointerCanceled", "OnPointerCanceled" },
-            { "PointerCaptureLost", "OnPointerCaptureLost" },
-            { "PointerWheelChanged", "OnPointerWheelChanged" },
-            { "DoubleTapped", "OnDoubleTapped" },
-            { "RightTapped", "OnRightTapped" },
-            { "Holding", "OnHolding" },
-            { "KeyUp", "OnKeyUp" },
-            { "PreviewKeyDown", "OnPreviewKeyDown" },
-            { "PreviewKeyUp", "OnPreviewKeyUp" },
-            { "CharacterReceived", "OnCharacterReceived" },
-            { "AccessKeyDisplayRequested", "OnAccessKeyDisplayRequested" },
-            { "GotFocus", "OnGotFocus" },
-            { "LostFocus", "OnLostFocus" },
         };
 
     private static readonly LocalizableString Title =
@@ -109,7 +79,7 @@ public sealed class SetEventSubscriptionAnalyzer : DiagnosticAnalyzer
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
 
-        if (!TryGetSetInvocationData(invocation, out var setTarget, out var parameterName, out var assignment))
+        if (!TryGetSetInvocationData(invocation, out var parameterName, out var assignment))
             return;
         if (assignment.Kind() != SyntaxKind.AddAssignmentExpression)
             return;
@@ -131,11 +101,9 @@ public sealed class SetEventSubscriptionAnalyzer : DiagnosticAnalyzer
 
     internal static bool TryGetSetInvocationData(
         InvocationExpressionSyntax invocation,
-        out ExpressionSyntax setTarget,
         out string parameterName,
         out AssignmentExpressionSyntax assignment)
     {
-        setTarget = null!;
         parameterName = string.Empty;
         assignment = null!;
 
@@ -150,8 +118,6 @@ public sealed class SetEventSubscriptionAnalyzer : DiagnosticAnalyzer
 
         if (!TryGetLambdaParameterAndAssignment(args[0].Expression, out parameterName, out assignment))
             return false;
-
-        setTarget = memberAccess.Expression;
         return true;
     }
 

--- a/src/Reactor.Analyzers/SetEventSubscriptionCodeFix.cs
+++ b/src/Reactor.Analyzers/SetEventSubscriptionCodeFix.cs
@@ -1,0 +1,60 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SetEventSubscriptionCodeFix))]
+[Shared]
+public sealed class SetEventSubscriptionCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(SetEventSubscriptionAnalyzer.DiagnosticId);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan);
+            if (node is not InvocationExpressionSyntax invocation)
+                continue;
+            if (!SetEventSubscriptionAnalyzer.TryGetSetInvocationData(invocation, out var setTarget, out _, out var assignment))
+                continue;
+            if (assignment.Kind() != SyntaxKind.AddAssignmentExpression)
+                continue;
+            if (assignment.Left is not MemberAccessExpressionSyntax leftAccess)
+                continue;
+
+            var eventName = leftAccess.Name.Identifier.Text;
+            if (!SetEventSubscriptionAnalyzer.CodeFixableEventModifiers.TryGetValue(eventName, out var modifierName))
+                continue;
+
+            var newInvocation = SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        setTarget,
+                        SyntaxFactory.IdentifierName(modifierName)),
+                    SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(assignment.Right))))
+                .WithTriviaFrom(invocation);
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    $"Use .{modifierName}() modifier",
+                    ct => Task.FromResult(context.Document.WithSyntaxRoot(root.ReplaceNode(invocation, newInvocation))),
+                    equivalenceKey: SetEventSubscriptionAnalyzer.DiagnosticId + ":" + modifierName),
+                diagnostic);
+        }
+    }
+}

--- a/src/Reactor.Analyzers/SetEventSubscriptionCodeFix.cs
+++ b/src/Reactor.Analyzers/SetEventSubscriptionCodeFix.cs
@@ -29,21 +29,23 @@ public sealed class SetEventSubscriptionCodeFix : CodeFixProvider
             var node = root.FindNode(diagnostic.Location.SourceSpan);
             if (node is not InvocationExpressionSyntax invocation)
                 continue;
-            if (!SetEventSubscriptionAnalyzer.TryGetSetInvocationData(invocation, out var setTarget, out _, out var assignment))
+            if (!SetEventSubscriptionAnalyzer.TryGetSetInvocationData(invocation, out _, out var assignment))
                 continue;
             if (assignment.Kind() != SyntaxKind.AddAssignmentExpression)
                 continue;
             if (assignment.Left is not MemberAccessExpressionSyntax leftAccess)
                 continue;
+            if (invocation.Expression is not MemberAccessExpressionSyntax setMemberAccess)
+                continue;
 
             var eventName = leftAccess.Name.Identifier.Text;
-            if (!SetEventSubscriptionAnalyzer.CodeFixableEventModifiers.TryGetValue(eventName, out var modifierName))
+            if (!SetEventSubscriptionAnalyzer.EventModifiers.TryGetValue(eventName, out var modifierName))
                 continue;
 
             var newInvocation = SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        setTarget,
+                        setMemberAccess.Expression,
                         SyntaxFactory.IdentifierName(modifierName)),
                     SyntaxFactory.ArgumentList(
                         SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(assignment.Right))))
@@ -51,7 +53,7 @@ public sealed class SetEventSubscriptionCodeFix : CodeFixProvider
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    $"Use .{modifierName}() modifier",
+                    $"Use .{modifierName}(...) modifier",
                     ct => Task.FromResult(context.Document.WithSyntaxRoot(root.ReplaceNode(invocation, newInvocation))),
                     equivalenceKey: SetEventSubscriptionAnalyzer.DiagnosticId + ":" + modifierName),
                 diagnostic);

--- a/tests/Reactor.Tests/AnalyzerTests/SetEventSubscriptionAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/SetEventSubscriptionAnalyzerTests.cs
@@ -49,6 +49,21 @@ public sealed class ChildTarget
     public event Action? Tapped { add {} remove {} }
 }
 
+public sealed class PointerRoutedEventArgs {}
+public sealed class TappedRoutedEventArgs {}
+
+public class TypedFakeElement
+{
+    public event Action<object, TappedRoutedEventArgs>? Tapped { add {} remove {} }
+
+    public TypedFakeElement Set(Action<TypedFakeElement> configure) { configure(this); return this; }
+}
+
+public static class TypedFakeElementExtensions
+{
+    public static TypedFakeElement OnTapped(this TypedFakeElement el, Action<object, TappedRoutedEventArgs> handler) => el;
+}
+
 public static class FakeElementExtensions
 {
     public static FakeElement OnPointerPressed(this FakeElement el, Action handler) => el;
@@ -71,10 +86,6 @@ public static class FakeElementExtensions
     public static FakeElement OnAccessKeyDisplayRequested(this FakeElement el, Action handler) => el;
     public static FakeElement OnGotFocus(this FakeElement el, Action handler) => el;
     public static FakeElement OnLostFocus(this FakeElement el, Action handler) => el;
-    public static FakeElement OnDragEnter(this FakeElement el, Action handler) => el;
-    public static FakeElement OnDragOver(this FakeElement el, Action handler) => el;
-    public static FakeElement OnDragLeave(this FakeElement el, Action handler) => el;
-    public static FakeElement OnDrop(this FakeElement el, Action handler) => el;
     public static FakeElement OnSizeChanged(this FakeElement el, Action handler) => el;
 }
 ";
@@ -106,12 +117,12 @@ class C
         var source = Stubs + @"
 class C
 {
-    void OnDrop() {}
+    void OnTapped() {}
 
     void M()
     {
         var el = new FakeElement();
-        {|REACTOR_EVENT_001:el.Set(fe => { fe.Drop += OnDrop; })|};
+        {|REACTOR_EVENT_001:el.Set(fe => { fe.Tapped += OnTapped; })|};
     }
 }";
 
@@ -134,9 +145,8 @@ class C
         var el = new FakeElement();
         {|REACTOR_EVENT_001:el.Set(fe => fe.PointerPressed += OnHandler)|};
         {|REACTOR_EVENT_001:el.Set(fe => fe.RightTapped += OnHandler)|};
-        {|REACTOR_EVENT_001:el.Set(fe => fe.DragEnter += OnHandler)|};
-        {|REACTOR_EVENT_001:el.Set(fe => fe.DragLeave += OnHandler)|};
         {|REACTOR_EVENT_001:el.Set(fe => fe.SizeChanged += OnHandler)|};
+        {|REACTOR_EVENT_001:el.Set(fe => fe.AccessKeyDisplayRequested += OnHandler)|};
     }
 }";
 
@@ -210,6 +220,73 @@ class C
     }
 
     [Fact]
+    public async Task No_Diagnostic_For_Remove_Assignment()
+    {
+        var source = Stubs + @"
+class C
+{
+    void OnTapped() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        el.Set(fe => fe.Tapped -= OnTapped);
+    }
+}";
+
+        await new CSharpAnalyzerTest<SetEventSubscriptionAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Multi_Statement_Block_Lambda()
+    {
+        var source = Stubs + @"
+class C
+{
+    void OnTapped() {}
+    void Log() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        el.Set(fe => { Log(); fe.Tapped += OnTapped; });
+    }
+}";
+
+        await new CSharpAnalyzerTest<SetEventSubscriptionAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Drag_Target_Events()
+    {
+        var source = Stubs + @"
+class C
+{
+    void OnHandler() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        el.Set(fe => fe.DragEnter += OnHandler);
+        el.Set(fe => fe.DragOver += OnHandler);
+        el.Set(fe => fe.DragLeave += OnHandler);
+        el.Set(fe => fe.Drop += OnHandler);
+    }
+}";
+
+        await new CSharpAnalyzerTest<SetEventSubscriptionAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task CodeFix_Rewrites_To_OnTapped()
     {
         var before = Stubs + @"
@@ -244,7 +321,7 @@ class C
     }
 
     [Fact]
-    public async Task CodeFix_Rewrites_Block_Body_To_OnDrop()
+    public async Task CodeFix_Rewrites_Block_Body_To_OnTapped()
     {
         var before = Stubs + @"
 class C
@@ -278,24 +355,36 @@ class C
     }
 
     [Fact]
-    public async Task Analyzer_Fires_But_CodeFix_Suppressed_For_DragOver()
+    public async Task CodeFix_Rewrites_With_Realistic_Typed_Handler_Signature()
     {
-        var code = Stubs + @"
+        var before = Stubs + @"
 class C
 {
-    void OnDragOver() {}
+    void OnTapped(object sender, TappedRoutedEventArgs args) {}
 
     void M()
     {
-        var el = new FakeElement();
-        {|REACTOR_EVENT_001:el.Set(fe => fe.DragOver += OnDragOver)|};
+        var el = new TypedFakeElement();
+        {|REACTOR_EVENT_001:el.Set(fe => fe.Tapped += OnTapped)|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void OnTapped(object sender, TappedRoutedEventArgs args) {}
+
+    void M()
+    {
+        var el = new TypedFakeElement();
+        el.OnTapped(OnTapped);
     }
 }";
 
         await new CSharpCodeFixTest<SetEventSubscriptionAnalyzer, SetEventSubscriptionCodeFix, DefaultVerifier>
         {
-            TestCode = code,
-            FixedCode = code,
+            TestCode = before,
+            FixedCode = after,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/SetEventSubscriptionAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/SetEventSubscriptionAnalyzerTests.cs
@@ -1,0 +1,301 @@
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.UI.Reactor.Analyzers;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+public class SetEventSubscriptionAnalyzerTests
+{
+    private const string Stubs = @"
+using System;
+
+public class FakeElement
+{
+    public event Action? PointerPressed { add {} remove {} }
+    public event Action? PointerMoved { add {} remove {} }
+    public event Action? PointerReleased { add {} remove {} }
+    public event Action? Tapped { add {} remove {} }
+    public event Action? KeyDown { add {} remove {} }
+    public event Action? PointerEntered { add {} remove {} }
+    public event Action? PointerExited { add {} remove {} }
+    public event Action? PointerCanceled { add {} remove {} }
+    public event Action? PointerCaptureLost { add {} remove {} }
+    public event Action? PointerWheelChanged { add {} remove {} }
+    public event Action? DoubleTapped { add {} remove {} }
+    public event Action? RightTapped { add {} remove {} }
+    public event Action? Holding { add {} remove {} }
+    public event Action? KeyUp { add {} remove {} }
+    public event Action? PreviewKeyDown { add {} remove {} }
+    public event Action? PreviewKeyUp { add {} remove {} }
+    public event Action? CharacterReceived { add {} remove {} }
+    public event Action? AccessKeyDisplayRequested { add {} remove {} }
+    public event Action? GotFocus { add {} remove {} }
+    public event Action? LostFocus { add {} remove {} }
+    public event Action? DragEnter { add {} remove {} }
+    public event Action? DragOver { add {} remove {} }
+    public event Action? DragLeave { add {} remove {} }
+    public event Action? Drop { add {} remove {} }
+    public event Action? SizeChanged { add {} remove {} }
+    public event Action? CustomEvent { add {} remove {} }
+
+    public FakeElement Set(Action<FakeElement> configure) { configure(this); return this; }
+    public FakeElement OnMount(Action<FakeElement> configure) { configure(this); return this; }
+}
+
+public sealed class ChildTarget
+{
+    public event Action? Tapped { add {} remove {} }
+}
+
+public static class FakeElementExtensions
+{
+    public static FakeElement OnPointerPressed(this FakeElement el, Action handler) => el;
+    public static FakeElement OnPointerMoved(this FakeElement el, Action handler) => el;
+    public static FakeElement OnPointerReleased(this FakeElement el, Action handler) => el;
+    public static FakeElement OnTapped(this FakeElement el, Action handler) => el;
+    public static FakeElement OnKeyDown(this FakeElement el, Action handler) => el;
+    public static FakeElement OnPointerEntered(this FakeElement el, Action handler) => el;
+    public static FakeElement OnPointerExited(this FakeElement el, Action handler) => el;
+    public static FakeElement OnPointerCanceled(this FakeElement el, Action handler) => el;
+    public static FakeElement OnPointerCaptureLost(this FakeElement el, Action handler) => el;
+    public static FakeElement OnPointerWheelChanged(this FakeElement el, Action handler) => el;
+    public static FakeElement OnDoubleTapped(this FakeElement el, Action handler) => el;
+    public static FakeElement OnRightTapped(this FakeElement el, Action handler) => el;
+    public static FakeElement OnHolding(this FakeElement el, Action handler) => el;
+    public static FakeElement OnKeyUp(this FakeElement el, Action handler) => el;
+    public static FakeElement OnPreviewKeyDown(this FakeElement el, Action handler) => el;
+    public static FakeElement OnPreviewKeyUp(this FakeElement el, Action handler) => el;
+    public static FakeElement OnCharacterReceived(this FakeElement el, Action handler) => el;
+    public static FakeElement OnAccessKeyDisplayRequested(this FakeElement el, Action handler) => el;
+    public static FakeElement OnGotFocus(this FakeElement el, Action handler) => el;
+    public static FakeElement OnLostFocus(this FakeElement el, Action handler) => el;
+    public static FakeElement OnDragEnter(this FakeElement el, Action handler) => el;
+    public static FakeElement OnDragOver(this FakeElement el, Action handler) => el;
+    public static FakeElement OnDragLeave(this FakeElement el, Action handler) => el;
+    public static FakeElement OnDrop(this FakeElement el, Action handler) => el;
+    public static FakeElement OnSizeChanged(this FakeElement el, Action handler) => el;
+}
+";
+
+    [Fact]
+    public async Task Fires_For_Direct_Set_Event_Subscription()
+    {
+        var source = Stubs + @"
+class C
+{
+    void OnTapped() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_EVENT_001:el.Set(fe => fe.Tapped += OnTapped)|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<SetEventSubscriptionAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Block_Bodied_Set_Event_Subscription()
+    {
+        var source = Stubs + @"
+class C
+{
+    void OnDrop() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_EVENT_001:el.Set(fe => { fe.Drop += OnDrop; })|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<SetEventSubscriptionAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Expanded_Event_Surface()
+    {
+        var source = Stubs + @"
+class C
+{
+    void OnHandler() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_EVENT_001:el.Set(fe => fe.PointerPressed += OnHandler)|};
+        {|REACTOR_EVENT_001:el.Set(fe => fe.RightTapped += OnHandler)|};
+        {|REACTOR_EVENT_001:el.Set(fe => fe.DragEnter += OnHandler)|};
+        {|REACTOR_EVENT_001:el.Set(fe => fe.DragLeave += OnHandler)|};
+        {|REACTOR_EVENT_001:el.Set(fe => fe.SizeChanged += OnHandler)|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<SetEventSubscriptionAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Event_Without_Modifier()
+    {
+        var source = Stubs + @"
+class C
+{
+    void OnCustom() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        el.Set(fe => fe.CustomEvent += OnCustom);
+    }
+}";
+
+        await new CSharpAnalyzerTest<SetEventSubscriptionAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_OnMount_Subscription()
+    {
+        var source = Stubs + @"
+class C
+{
+    void OnTapped() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnMount(fe => fe.Tapped += OnTapped);
+    }
+}";
+
+        await new CSharpAnalyzerTest<SetEventSubscriptionAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Member_Chain_Subscription()
+    {
+        var source = Stubs + @"
+class C
+{
+    void OnTapped() {}
+
+    void M(ChildTarget child)
+    {
+        var el = new FakeElement();
+        el.Set(fe => child.Tapped += OnTapped);
+    }
+}";
+
+        await new CSharpAnalyzerTest<SetEventSubscriptionAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Rewrites_To_OnTapped()
+    {
+        var before = Stubs + @"
+class C
+{
+    void OnTapped() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_EVENT_001:el.Set(fe => fe.Tapped += OnTapped)|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void OnTapped() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnTapped(OnTapped);
+    }
+}";
+
+        await new CSharpCodeFixTest<SetEventSubscriptionAnalyzer, SetEventSubscriptionCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Rewrites_Block_Body_To_OnDrop()
+    {
+        var before = Stubs + @"
+class C
+{
+    void OnTapped() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_EVENT_001:el.Set(fe => { fe.Tapped += OnTapped; })|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void OnTapped() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnTapped(OnTapped);
+    }
+}";
+
+        await new CSharpCodeFixTest<SetEventSubscriptionAnalyzer, SetEventSubscriptionCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_Fires_But_CodeFix_Suppressed_For_DragOver()
+    {
+        var code = Stubs + @"
+class C
+{
+    void OnDragOver() {}
+
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_EVENT_001:el.Set(fe => fe.DragOver += OnDragOver)|};
+    }
+}";
+
+        await new CSharpCodeFixTest<SetEventSubscriptionAnalyzer, SetEventSubscriptionCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/SetEventSubscriptionConsistencyTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/SetEventSubscriptionConsistencyTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.UI.Reactor.Cli.Pack;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+public class SetEventSubscriptionConsistencyTests
+{
+    [Fact]
+    public void Every_Tracked_Event_Has_A_Matching_Modifier()
+    {
+        var safeModifiers = ReadSafeEventModifiers();
+
+        foreach (var modifierName in SetEventSubscriptionAnalyzer.EventModifiers.Values)
+        {
+            Assert.Contains(
+                modifierName,
+                safeModifiers);
+        }
+    }
+
+    [Fact]
+    public void Every_Safe_Modifier_Is_Tracked()
+    {
+        var safeModifiers = ReadSafeEventModifiers();
+        var trackedModifiers = SetEventSubscriptionAnalyzer.EventModifiers.Values.ToHashSet(StringComparer.Ordinal);
+
+        var missing = safeModifiers
+            .Where(modifierName => !trackedModifiers.Contains(modifierName))
+            .OrderBy(name => name)
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            "These safe declarative event modifiers exist in ElementExtensions.cs but are not tracked by SetEventSubscriptionAnalyzer.EventModifiers: " +
+            $"[{string.Join(", ", missing)}]. Add them to the analyzer map or document why they are intentionally excluded.");
+    }
+
+    [Fact]
+    public void Every_CodeFixable_Event_Is_A_Tracked_Event()
+    {
+        foreach (var (eventName, modifierName) in SetEventSubscriptionAnalyzer.CodeFixableEventModifiers)
+        {
+            Assert.True(
+                SetEventSubscriptionAnalyzer.EventModifiers.TryGetValue(eventName, out var trackedModifierName) && trackedModifierName == modifierName,
+                $"Code-fixable event '{eventName}' -> '{modifierName}' must also exist in EventModifiers.");
+        }
+    }
+
+    private static HashSet<string> ReadSafeEventModifiers()
+    {
+        var root = RepoRootFinder.FindRepoRoot();
+        Assert.NotNull(root);
+        var path = Path.Join(root!, "src", "Reactor", "Elements", "ElementExtensions.cs");
+        Assert.True(File.Exists(path), $"ElementExtensions.cs not found at {path}");
+        var source = File.ReadAllText(path);
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var compilationUnit = tree.GetCompilationUnitRoot();
+
+        var modifiers = compilationUnit
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(method => method.Identifier.Text.StartsWith("On", StringComparison.Ordinal))
+            .Where(method => method.ReturnType is IdentifierNameSyntax { Identifier.Text: "T" })
+            .Where(method => MethodBodyContainsSameNamedModifierAssignment(method))
+            .Select(method => method.Identifier.Text)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return modifiers;
+    }
+
+    private static bool MethodBodyContainsSameNamedModifierAssignment(MethodDeclarationSyntax method)
+    {
+        var marker = method.Identifier.Text + " =";
+
+        if (method.ExpressionBody is not null)
+            return method.ExpressionBody.Expression.ToString().Contains(marker, StringComparison.Ordinal);
+
+        if (method.Body is not null)
+            return method.Body.ToString().Contains(marker, StringComparison.Ordinal);
+
+        return false;
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/SetEventSubscriptionConsistencyTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/SetEventSubscriptionConsistencyTests.cs
@@ -23,6 +23,9 @@ public class SetEventSubscriptionConsistencyTests
             "OnDrop",
         };
 
+    private static readonly Lazy<HashSet<string>> SafeEventModifiers =
+        new(ReadSafeEventModifiersCore);
+
     [Fact]
     public void Every_Tracked_Event_Has_A_Matching_Modifier()
     {
@@ -67,6 +70,9 @@ public class SetEventSubscriptionConsistencyTests
     }
 
     private static HashSet<string> ReadSafeEventModifiers()
+        => SafeEventModifiers.Value;
+
+    private static HashSet<string> ReadSafeEventModifiersCore()
     {
         var root = RepoRootFinder.FindRepoRoot();
         Assert.NotNull(root);

--- a/tests/Reactor.Tests/AnalyzerTests/SetEventSubscriptionConsistencyTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/SetEventSubscriptionConsistencyTests.cs
@@ -12,6 +12,17 @@ namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
 
 public class SetEventSubscriptionConsistencyTests
 {
+    private static readonly HashSet<string> IntentionallyExcludedModifiers =
+        new(StringComparer.Ordinal)
+        {
+            // These are drop-target abstractions over DragTargetArgs/DropTargetConfig,
+            // not 1:1 replacements for raw WinUI drag event subscriptions.
+            "OnDragEnter",
+            "OnDragOver",
+            "OnDragLeave",
+            "OnDrop",
+        };
+
     [Fact]
     public void Every_Tracked_Event_Has_A_Matching_Modifier()
     {
@@ -32,7 +43,9 @@ public class SetEventSubscriptionConsistencyTests
         var trackedModifiers = SetEventSubscriptionAnalyzer.EventModifiers.Values.ToHashSet(StringComparer.Ordinal);
 
         var missing = safeModifiers
-            .Where(modifierName => !trackedModifiers.Contains(modifierName))
+            .Where(modifierName =>
+                !IntentionallyExcludedModifiers.Contains(modifierName) &&
+                !trackedModifiers.Contains(modifierName))
             .OrderBy(name => name)
             .ToList();
 
@@ -43,13 +56,13 @@ public class SetEventSubscriptionConsistencyTests
     }
 
     [Fact]
-    public void Every_CodeFixable_Event_Is_A_Tracked_Event()
+    public void Intentionally_Excluded_Modifiers_Exist()
     {
-        foreach (var (eventName, modifierName) in SetEventSubscriptionAnalyzer.CodeFixableEventModifiers)
+        var safeModifiers = ReadSafeEventModifiers();
+
+        foreach (var modifierName in IntentionallyExcludedModifiers)
         {
-            Assert.True(
-                SetEventSubscriptionAnalyzer.EventModifiers.TryGetValue(eventName, out var trackedModifierName) && trackedModifierName == modifierName,
-                $"Code-fixable event '{eventName}' -> '{modifierName}' must also exist in EventModifiers.");
+            Assert.Contains(modifierName, safeModifiers);
         }
     }
 
@@ -78,14 +91,11 @@ public class SetEventSubscriptionConsistencyTests
 
     private static bool MethodBodyContainsSameNamedModifierAssignment(MethodDeclarationSyntax method)
     {
-        var marker = method.Identifier.Text + " =";
-
-        if (method.ExpressionBody is not null)
-            return method.ExpressionBody.Expression.ToString().Contains(marker, StringComparison.Ordinal);
-
-        if (method.Body is not null)
-            return method.Body.ToString().Contains(marker, StringComparison.Ordinal);
-
-        return false;
+        return method
+            .DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Any(assignment =>
+                assignment.Left is IdentifierNameSyntax leftIdentifier &&
+                leftIdentifier.Identifier.Text == method.Identifier.Text);
     }
 }


### PR DESCRIPTION
## Summary

Adds `REACTOR_EVENT_001` for a specific Reactor footgun: subscribing to UI events inside `.Set(...)` when Reactor already provides a declarative `On*` modifier for the same event.

The problem is behavioral, not stylistic. `.Set(...)` can run again on later updates, so `param.Event += handler` can accumulate duplicate handlers across rerenders. The declarative modifier path is render-safe because the reconciler owns detach/reattach behavior.

## Scope

This PR intentionally stays narrow:

- warns on direct `.Set(fe => fe.Event += handler)` subscriptions on the `.Set(...)` lambda parameter
- covers the safe declarative event surface already exposed by `ElementExtensions.cs`
- does not flag `.OnMount(...)`
- does not flag unrelated/member-chain subscriptions
- keeps the code fix narrower than the analyzer: simple signature-compatible event cases auto-rewrite, while drag/drop-style abstractions warn but do not auto-rewrite

## Included changes

- add `SetEventSubscriptionAnalyzer` (`REACTOR_EVENT_001`)
- add `SetEventSubscriptionCodeFix` for the safe rewrite subset
- add focused analyzer tests for positive, negative, and code-fix behavior
- add a consistency test so the tracked event map cannot drift from `src/Reactor/Elements/ElementExtensions.cs`
- register the rule in `AnalyzerReleases.Unshipped.md`

## Validation

- `dotnet test tests/Reactor.Tests/Reactor.Tests.csproj -p:Platform=x64 -m:1 --filter "SetEventSubscriptionAnalyzerTests|SetEventSubscriptionConsistencyTests"`

Closes #762.
