### PR TITLE
perf: add opt-in row-memoization leg to /perf (demonstrates #327 win)

### DIFF
--- a/Reactor.slnx
+++ b/Reactor.slnx
@@ -12,6 +12,12 @@
       <Platform Solution="*|x64" Project="x64" />
     </Project>
   </Folder>
+  <Folder Name="/perf_bench/RowMemo/">
+    <Project Path="tests/perf_bench/PerfBench.RowMemo/PerfBench.RowMemo.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
+  </Folder>
   <Folder Name="/perf_bench/Allocation/">
     <Project Path="tests/perf_bench/PerfBench.Allocation/Allocation.Bound/Allocation.Bound.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />

--- a/src/Reactor/Reactor.csproj
+++ b/src/Reactor/Reactor.csproj
@@ -70,6 +70,10 @@
          against the Direct/Bound baselines; it references internal descriptor
          and handler types to construct representative element trees. -->
     <InternalsVisibleTo Include="PerfBench.ControlModel" />
+    <!-- Issue #327 / PR #753 — PerfBench.RowMemo measures the opt-in keyed
+         row-memoization win; it drives the internal ElementFactory{T}.BuildOrCache
+         realize path and Element.CanSkipUpdate skip decision directly. -->
+    <InternalsVisibleTo Include="PerfBench.RowMemo" />
     <!-- Spec 045 §2.19: the Phase-1 WinUI.Dock XAML wrapper
          (src/Reactor.Docking.Xaml/) and its vendored WinUI.Dock
          dependency were removed at the §2.29 review gate. The docking

--- a/tests/perf_bench/PerfBench.RowMemo/PerfBench.RowMemo.csproj
+++ b/tests/perf_bench/PerfBench.RowMemo/PerfBench.RowMemo.csproj
@@ -1,0 +1,71 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Issue #327 / PR #753 — opt-in keyed row-memoization micro-bench.
+
+    A SEPARATE, single-tree perf_bench project that ISOLATES and MEASURES the win
+    of `Memo(key, () => row)` (the cross-container row-memoization API added on PR
+    #753). It deliberately does NOT live in PerfBench.ControlModel: the /perf
+    workflow builds the micro-suite from BOTH the PR-head AND the `main` baseline
+    trees, and `main` lacks the `Memo` API — so a `Memo`-using bench there would
+    break the main-side build. Run-PerfBenchmark.ps1 builds + runs this one from
+    the PR-head tree ONLY, best-effort (a build/run failure just omits the table).
+
+    Shape mirrors PerfBench.ControlModel (UseWinUI=true + WindowsPackageType=None,
+    which is why ControlModel builds cleanly headless), but this bench needs NO
+    WinUI window: it runs the measurement directly in Main (pure managed — Element
+    construction + ElementFactory.BuildOrCache + Element.CanSkipUpdate) and exits,
+    so OutputType is a plain console Exe. No UIElement is ever realized, so the
+    Windows App SDK runtime is never activated.
+
+    Output: human-readable lines to stdout PLUS machine-parseable `key=value`
+    lines (also written to the path passed via the out-path argument), consumed
+    by the Format-PerfRowMemoSection renderer in PerfLib.ps1.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
+    <Platforms>x64;ARM64</Platforms>
+    <RootNamespace>PerfBench.RowMemo</RootNamespace>
+    <AssemblyName>PerfBench.RowMemo</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseWinUI>true</UseWinUI>
+    <WindowsPackageType>None</WindowsPackageType>
+    <!--
+      This bench never realizes a UIElement, so it never activates the Windows App
+      SDK runtime. By default a framework-dependent Exe with WindowsPackageType=None
+      gets an auto-injected bootstrap module-initializer (MddBootstrapAutoInitializer)
+      that calls MddBootstrapInitialize before Main and HARD-FAILS on a machine with
+      no machine-wide WinAppSDK runtime install (DllNotFound). Disable it: we resolve
+      only Element records + BuildOrCache + CanSkipUpdate, all pure managed, so the
+      bootstrapper is dead weight that would otherwise crash the headless launch.
+    -->
+    <WindowsAppSdkBootstrapInitialize>false</WindowsAppSdkBootstrapInitialize>
+  </PropertyGroup>
+
+  <!--
+    Same gated self-contained knob as PerfBench.ControlModel: when
+    Run-PerfBenchmark.ps1 builds with -p:PerfCiSelfContained=true the bench carries
+    its own Windows App SDK runtime next to the exe, so it launches on a CI runner
+    with no machine-wide runtime install. (This bench never activates the runtime,
+    so even a framework-dependent build runs — the knob is kept purely for parity
+    with how the other perf legs are built.) Scoped to THIS executable so the flag
+    never flows into the referenced Reactor.csproj, which rejects self-contained
+    packaging.
+  -->
+  <PropertyGroup Condition="'$(PerfCiSelfContained)' == 'true'">
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' != 'ARM64'">win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Reactor\Reactor.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
+  </ItemGroup>
+</Project>

--- a/tests/perf_bench/PerfBench.RowMemo/Program.cs
+++ b/tests/perf_bench/PerfBench.RowMemo/Program.cs
@@ -1,0 +1,30 @@
+// Issue #327 / PR #753 — opt-in keyed row-memoization micro-bench host.
+//
+// CLI:
+//   PerfBench.RowMemo.exe [--out <path>] [--headless]
+//
+// Runs the measurement directly (no WinUI window) and exits. Prints a
+// human-readable report plus machine-parseable `key=value` lines to stdout, and
+// — when --out is given — writes the same `key=value` lines to that file for the
+// Run-PerfBenchmark.ps1 harness to parse deterministically. Unknown flags (e.g.
+// --headless, passed by the harness for parity with the other legs) are ignored.
+
+using PerfBench.RowMemo;
+
+string? outPath = null;
+for (int i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--out" when i + 1 < args.Length:
+            outPath = args[++i];
+            break;
+        default:
+            // Ignore unrecognized flags (--headless and friends) so the harness can
+            // launch this exe with the same boilerplate it uses for the other legs.
+            break;
+    }
+}
+
+RowMemoBench.Run(outPath);
+return 0;

--- a/tests/perf_bench/PerfBench.RowMemo/RowMemoBench.cs
+++ b/tests/perf_bench/PerfBench.RowMemo/RowMemoBench.cs
@@ -70,16 +70,21 @@ internal static class RowMemoBench
         long baselineRebuilds = 0;
         var fb = Factory(items, (i, _) => { baselineRebuilds++; return DeepRow(i); });
         Warm(fb);
-        var (baseNs, baseBytes) = TimeAndAlloc(fb);
-        long baselineMeasuredRebuilds = (long)Window * MeasureCycles; // baseline rebuilds EVERY realize
+        // Measure the factory rebuilds for the SAME (best) rep whose time/alloc we report, by
+        // reading the live counter across that rep — a genuine measurement, not a hardcoded
+        // constant. For baseline this comes out to Window*MeasureCycles (it rebuilds on every
+        // realize), but reading it back proves that rather than asserting it, so a regression
+        // that unexpectedly let baseline cache would show up as a smaller number.
+        var (baseNs, baseBytes, baselineMeasuredRebuilds) = TimeAndAlloc(fb, () => baselineRebuilds);
 
         // ── Memo: Memo(i, …). A recycle that re-asks a cached key returns the same instance. ──
         long memoRebuilds = 0;
         var fm = Factory(items, (i, _) => Memo(i, () => { memoRebuilds++; return DeepRow(i); }));
         Warm(fm);
-        long warmMemoRebuilds = memoRebuilds; // == Window (one build per distinct key)
-        var (memoNs, memoBytes) = TimeAndAlloc(fm);
-        long memoMeasuredRebuilds = memoRebuilds - warmMemoRebuilds; // expected 0
+        // Same measurement, symmetric with baseline: rebuilds during the reported rep. After the
+        // warm pass populated the cache, a recycle re-asking a cached key never re-invokes the
+        // inner factory, so this is 0.
+        var (memoNs, memoBytes, memoMeasuredRebuilds) = TimeAndAlloc(fm, () => memoRebuilds);
 
         // ── Reconcile-skip precondition: prove what each arm hands the reconciler on re-realize. ──
         var fbb = Factory(items, (i, _) => DeepRow(i));
@@ -175,9 +180,10 @@ internal static class RowMemoBench
                 _ = Realize(f, i);
     }
 
-    private static (double NsPerRecycle, long BytesPerRecycle) TimeAndAlloc(ElementFactory<int> f)
+    private static (double NsPerRecycle, long BytesPerRecycle, long Rebuilds) TimeAndAlloc(
+        ElementFactory<int> f, Func<long> readRebuilds)
     {
-        long bestNs = long.MaxValue, alloc = 0;
+        long bestNs = long.MaxValue, alloc = 0, rebuilds = 0;
         for (int r = 0; r < Reps; r++)
         {
             // Stabilize the measurement window: drain pending finalizers and collect so a GC
@@ -185,6 +191,7 @@ internal static class RowMemoBench
             // the same isolation the repo's PerfBench.Shared BenchRunner does before each rep.
             GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
             long a0 = GC.GetAllocatedBytesForCurrentThread();
+            long rb0 = readRebuilds();
             var sw = Stopwatch.StartNew();
             for (int c = 0; c < MeasureCycles; c++)
                 for (int i = 0; i < Window; i++)
@@ -192,9 +199,11 @@ internal static class RowMemoBench
             sw.Stop();
             long a1 = GC.GetAllocatedBytesForCurrentThread();
             long ns = (long)(sw.Elapsed.TotalMilliseconds * 1_000_000.0);
-            if (ns < bestNs) { bestNs = ns; alloc = a1 - a0; }
+            // Keep the rebuild count from the SAME rep we keep the time/alloc from, so all three
+            // reported numbers describe one representative measured pass.
+            if (ns < bestNs) { bestNs = ns; alloc = a1 - a0; rebuilds = readRebuilds() - rb0; }
         }
         long total = (long)Window * MeasureCycles;
-        return (bestNs / (double)total, alloc / total);
+        return (bestNs / (double)total, alloc / total, rebuilds);
     }
 }

--- a/tests/perf_bench/PerfBench.RowMemo/RowMemoBench.cs
+++ b/tests/perf_bench/PerfBench.RowMemo/RowMemoBench.cs
@@ -1,0 +1,188 @@
+using System.Globalization;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace PerfBench.RowMemo;
+
+/// <summary>
+/// Issue #327 — minimal repro that ISOLATES and MEASURES the perf win of opt-in keyed row
+/// memoization (<c>Memo(key, () =&gt; row)</c>) — the thing the StocksGrid <c>/perf</c> harness
+/// can't show, because that harness never opts into the API (so the optimization is dormant
+/// there and every metric reads "within noise").
+///
+/// <para>The win lives on ONE path: an ItemsRepeater recycling a container during fast scroll
+/// over variable-height rows. Each recycle calls the real realize entry point
+/// <see cref="ElementFactory{T}.BuildOrCache"/>. On the VirtualList int-index path the built-in
+/// <c>_viewBuilderCache</c> guard (<c>ReferenceEquals(item)</c>) never hits — the index is
+/// re-boxed every call — so WITHOUT memo every recycle (1) rebuilds the row's whole Element
+/// subtree and (2) hands the reconciler a fresh-but-equal tree it must walk node-by-node. WITH
+/// <c>Memo(i, …)</c> a recycle that re-asks for a still-cached key returns the SAME instance, so
+/// (1) the factory is never re-invoked and (2) <see cref="Element.CanSkipUpdate"/> short-circuits
+/// on <c>ReferenceEquals</c> at the root → the reconciler returns without descending.</para>
+///
+/// <para>Runs headlessly (no window needed — this touches only Element construction +
+/// BuildOrCache + the skip decision). Reports, per recycle: factory rebuilds, wall-time, bytes
+/// allocated, for Baseline vs Memo. Real WinUI control-patch savings stack on top and aren't
+/// captured here (that was the issue's original ETL signal).</para>
+/// </summary>
+internal static class RowMemoBench
+{
+    // A realistic, non-trivial VARIABLE-HEIGHT row (mirrors the issue's DataSystem demo row):
+    // Border > HStack > [ badge Border > TextBlock ] + [ VStack > title + 3 subtitle lines ].
+    // 9 Element nodes — the per-row subtree the reconciler must otherwise re-walk on every
+    // recycle, and the allocation the rebuild otherwise re-incurs.
+    private const int RowNodeCount = 9;
+
+    private static Element DeepRow(int i) =>
+        Border(
+            HStack(12,
+                Border(TextBlock($"#{i}")).Width(48).Height(32),
+                VStack(4,
+                    TextBlock($"Row {i} title"),
+                    TextBlock($"subtitle line a - row {i}"),
+                    TextBlock($"subtitle line b - row {i}"),
+                    TextBlock($"subtitle line c - row {i}")
+                )
+            )
+        ).Padding(8);
+
+    private static ElementFactory<int> Factory(IReadOnlyList<int> items, Func<int, int, Element> vb)
+        => new(items, vb, new Reconciler(), requestRerender: static () => { }, pool: null);
+
+    // The real realize entry point. keyed:false = the legacy int-index VirtualList path, where
+    // each call re-boxes `i` so the built-in _viewBuilderCache cannot hit.
+    private static Element Realize(ElementFactory<int> f, int i)
+        => f.BuildOrCache(i.ToString(CultureInfo.InvariantCulture), i, i, keyed: false);
+
+    private const int Window = 50;          // realized working set (rows in/near the viewport)
+    private const int WarmCycles = 300;     // populate cache + JIT before timing
+    private const int MeasureCycles = 20_000;
+    private const int Reps = 5;             // report the best (min-time) rep to cut noise
+
+    public static void Run(string? outPath)
+    {
+        var items = Enumerable.Range(0, Window).ToList();
+
+        // ── Baseline: no memo. The viewBuilder rebuilds the row on every realize. ──
+        long baselineRebuilds = 0;
+        var fb = Factory(items, (i, _) => { baselineRebuilds++; return DeepRow(i); });
+        Warm(fb);
+        var (baseNs, baseBytes) = TimeAndAlloc(fb);
+        long baselineMeasuredRebuilds = (long)Window * MeasureCycles; // baseline rebuilds EVERY realize
+
+        // ── Memo: Memo(i, …). A recycle that re-asks a cached key returns the same instance. ──
+        long memoRebuilds = 0;
+        var fm = Factory(items, (i, _) => Memo(i, () => { memoRebuilds++; return DeepRow(i); }));
+        Warm(fm);
+        long warmMemoRebuilds = memoRebuilds; // == Window (one build per distinct key)
+        var (memoNs, memoBytes) = TimeAndAlloc(fm);
+        long memoMeasuredRebuilds = memoRebuilds - warmMemoRebuilds; // expected 0
+
+        // ── Reconcile-skip precondition: prove what each arm hands the reconciler on re-realize. ──
+        var fbb = Factory(items, (i, _) => DeepRow(i));
+        var pB = Realize(fbb, 7); var cB = Realize(fbb, 7);
+        bool baseSameInstance = ReferenceEquals(pB, cB);
+        bool baseSkippable = Element.CanSkipUpdate(pB, cB);
+
+        var fmm = Factory(items, (i, _) => Memo(i, () => DeepRow(i)));
+        var pM = Realize(fmm, 7); var cM = Realize(fmm, 7);
+        bool memoSameInstance = ReferenceEquals(pM, cM);
+        bool memoSkippable = Element.CanSkipUpdate(pM, cM);
+
+        long recyclesPerArm = (long)Window * MeasureCycles;
+        double timeX = memoNs > 0 ? baseNs / memoNs : 0;
+        double allocX = memoBytes > 0 ? baseBytes / (double)memoBytes : double.PositiveInfinity;
+
+        var inv = CultureInfo.InvariantCulture;
+
+        // ── Human-readable report ────────────────────────────────────────────────
+        var sb = new StringBuilder();
+        sb.AppendLine("Issue #327 - opt-in row memoization: same-build Baseline vs Memo");
+        sb.AppendLine($"Workload: a {RowNodeCount}-node variable-height row, recycled through the REAL");
+        sb.AppendLine($"ElementFactory.BuildOrCache path - window={Window} rows - {MeasureCycles:N0} scroll");
+        sb.AppendLine($"passes = {recyclesPerArm:N0} recycles/arm - best of {Reps} - Release.");
+        sb.AppendLine();
+        sb.AppendLine($"{"Arm",-22}{"ns/recycle",13}{"bytes/recycle",15}{"factory rebuilds",18}");
+        sb.AppendLine(new string('-', 68));
+        sb.AppendLine($"{"Baseline (no memo)",-22}{baseNs,13:0.0}{baseBytes,15:N0}{baselineMeasuredRebuilds,18:N0}");
+        sb.AppendLine($"{"Memo(i, ...)",-22}{memoNs,13:0.0}{memoBytes,15:N0}{memoMeasuredRebuilds,18:N0}");
+        sb.AppendLine(new string('-', 68));
+        sb.AppendLine($"WIN: {timeX:0.0}x faster per recycle - {allocX:0.0}x less allocation - rebuilds eliminated after first sighting");
+        sb.AppendLine();
+        sb.AppendLine("Reconcile-skip precondition (what each arm hands the reconciler on re-realize):");
+        sb.AppendLine($"  Baseline: sameInstance={baseSameInstance}  CanSkipUpdate={baseSkippable}  -> reconciler must WALK the {RowNodeCount}-node subtree");
+        sb.AppendLine($"  Memo    : sameInstance={memoSameInstance}  CanSkipUpdate={memoSkippable}  -> reconciler returns at the ROOT (1 node), descent skipped");
+        Console.WriteLine();
+        Console.WriteLine(sb.ToString());
+
+        // ── Machine-parseable key=value lines (stable contract for PerfLib.ps1) ───
+        var kv = new List<string>
+        {
+            $"baseline_ns={baseNs.ToString("0.0##", inv)}",
+            $"baseline_bytes={baseBytes.ToString(inv)}",
+            $"baseline_rebuilds={baselineMeasuredRebuilds.ToString(inv)}",
+            $"baseline_same_instance={(baseSameInstance ? "true" : "false")}",
+            $"baseline_can_skip={(baseSkippable ? "true" : "false")}",
+            $"memo_ns={memoNs.ToString("0.0##", inv)}",
+            $"memo_bytes={memoBytes.ToString(inv)}",
+            $"memo_rebuilds={memoMeasuredRebuilds.ToString(inv)}",
+            $"memo_same_instance={(memoSameInstance ? "true" : "false")}",
+            $"memo_can_skip={(memoSkippable ? "true" : "false")}",
+            $"recycles_per_arm={recyclesPerArm.ToString(inv)}",
+            $"row_nodes={RowNodeCount.ToString(inv)}",
+            $"window={Window.ToString(inv)}",
+            $"reps={Reps.ToString(inv)}",
+            $"measure_cycles={MeasureCycles.ToString(inv)}",
+            $"time_win_x={timeX.ToString("0.0##", inv)}",
+            $"alloc_win_x={(double.IsInfinity(allocX) ? "inf" : allocX.ToString("0.0##", inv))}",
+        };
+
+        Console.WriteLine("---ROWMEMO-KV---");
+        foreach (var line in kv) Console.WriteLine(line);
+
+        if (!string.IsNullOrWhiteSpace(outPath))
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(Path.GetFullPath(outPath));
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+                File.WriteAllLines(outPath, kv);
+                Console.WriteLine($"wrote {kv.Count} key=value lines -> {outPath}");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"failed to write --out '{outPath}': {ex.Message}");
+            }
+        }
+    }
+
+    private static void Warm(ElementFactory<int> f)
+    {
+        for (int c = 0; c < WarmCycles; c++)
+            for (int i = 0; i < Window; i++)
+                _ = Realize(f, i);
+    }
+
+    private static (double NsPerRecycle, long BytesPerRecycle) TimeAndAlloc(ElementFactory<int> f)
+    {
+        long bestNs = long.MaxValue, alloc = 0;
+        for (int r = 0; r < Reps; r++)
+        {
+            GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+            long a0 = GC.GetAllocatedBytesForCurrentThread();
+            var sw = Stopwatch.StartNew();
+            for (int c = 0; c < MeasureCycles; c++)
+                for (int i = 0; i < Window; i++)
+                    _ = Realize(f, i);
+            sw.Stop();
+            long a1 = GC.GetAllocatedBytesForCurrentThread();
+            long ns = (long)(sw.Elapsed.TotalMilliseconds * 1_000_000.0);
+            if (ns < bestNs) { bestNs = ns; alloc = a1 - a0; }
+        }
+        long total = (long)Window * MeasureCycles;
+        return (bestNs / (double)total, alloc / total);
+    }
+}

--- a/tests/perf_bench/PerfBench.RowMemo/RowMemoBench.cs
+++ b/tests/perf_bench/PerfBench.RowMemo/RowMemoBench.cs
@@ -53,14 +53,27 @@ internal static class RowMemoBench
         => new(items, vb, new Reconciler(), requestRerender: static () => { }, pool: null);
 
     // The real realize entry point. keyed:false = the legacy int-index VirtualList path, where
-    // each call re-boxes `i` so the built-in _viewBuilderCache cannot hit.
+    // each call re-boxes `i` (the T=int item) so the built-in _viewBuilderCache cannot hit. The
+    // key string comes from the precomputed KeyCache so no per-recycle string is allocated
+    // outside BuildOrCache (see KeyCache).
     private static Element Realize(ElementFactory<int> f, int i)
-        => f.BuildOrCache(i.ToString(CultureInfo.InvariantCulture), i, i, keyed: false);
+        => f.BuildOrCache(KeyCache[i], i, i, keyed: false);
 
     private const int Window = 50;          // realized working set (rows in/near the viewport)
     private const int WarmCycles = 300;     // populate cache + JIT before timing
     private const int MeasureCycles = 20_000;
     private const int Reps = 5;             // report the best (min-time) rep to cut noise
+
+    // Precomputed per-index key strings. BuildOrCache needs a string key, but calling
+    // i.ToString() on every Realize would allocate a string per recycle OUTSIDE BuildOrCache
+    // and inflate the measured bytes/recycle — most visibly on the Memo arm, where BuildOrCache
+    // itself allocates almost nothing, so that stray string would dominate its byte figure.
+    // Interning the Window keys once keeps the timed loop measuring only BuildOrCache. (The key
+    // is a stable string per index; it does NOT re-box the int item, so the #327 legacy-path
+    // behaviour BuildOrCache exercises — ReferenceEquals(item) missing on the re-boxed int — is
+    // unchanged.)
+    private static readonly string[] KeyCache =
+        Enumerable.Range(0, Window).Select(static i => i.ToString(CultureInfo.InvariantCulture)).ToArray();
 
     public static void Run(string? outPath)
     {
@@ -164,10 +177,12 @@ internal static class RowMemoBench
                 or ArgumentException
                 or NotSupportedException)
             {
-                // Writing the --out file is a best-effort convenience (stdout carries the
-                // authoritative key=value block the harness parses). Swallow only the expected
-                // path/permission/IO failures so a bad --out never fails the bench; anything
-                // unexpected still propagates.
+                // The --out file is what the harness (Run-PerfBenchmark.ps1 / Invoke-RowMemoRun)
+                // actually parses; stdout carries a human-readable copy for the run log. Writing
+                // the file is best-effort: swallow only the expected path/permission/IO failures
+                // so a bad --out path never crashes the bench (anything unexpected still
+                // propagates). If the write fails the harness finds no file and simply omits the
+                // row-memo table — the intended graceful degradation.
                 Console.Error.WriteLine($"failed to write --out '{outPath}': {ex.Message}");
             }
         }

--- a/tests/perf_bench/PerfBench.RowMemo/RowMemoBench.cs
+++ b/tests/perf_bench/PerfBench.RowMemo/RowMemoBench.cs
@@ -116,7 +116,7 @@ internal static class RowMemoBench
         sb.AppendLine($"  Baseline: sameInstance={baseSameInstance}  CanSkipUpdate={baseSkippable}  -> reconciler must WALK the {RowNodeCount}-node subtree");
         sb.AppendLine($"  Memo    : sameInstance={memoSameInstance}  CanSkipUpdate={memoSkippable}  -> reconciler returns at the ROOT (1 node), descent skipped");
         Console.WriteLine();
-        Console.WriteLine(sb.ToString());
+        Console.WriteLine(sb);
 
         // ── Machine-parseable key=value lines (stable contract for PerfLib.ps1) ───
         var kv = new List<string>
@@ -152,8 +152,17 @@ internal static class RowMemoBench
                 File.WriteAllLines(outPath, kv);
                 Console.WriteLine($"wrote {kv.Count} key=value lines -> {outPath}");
             }
-            catch (Exception ex)
+            catch (Exception ex) when (
+                ex is System.IO.IOException
+                or UnauthorizedAccessException
+                or System.Security.SecurityException
+                or ArgumentException
+                or NotSupportedException)
             {
+                // Writing the --out file is a best-effort convenience (stdout carries the
+                // authoritative key=value block the harness parses). Swallow only the expected
+                // path/permission/IO failures so a bad --out never fails the bench; anything
+                // unexpected still propagates.
                 Console.Error.WriteLine($"failed to write --out '{outPath}': {ex.Message}");
             }
         }
@@ -171,6 +180,9 @@ internal static class RowMemoBench
         long bestNs = long.MaxValue, alloc = 0;
         for (int r = 0; r < Reps; r++)
         {
+            // Stabilize the measurement window: drain pending finalizers and collect so a GC
+            // triggered mid-run doesn't pollute the timed loop's ns or the alloc delta. This is
+            // the same isolation the repo's PerfBench.Shared BenchRunner does before each rep.
             GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
             long a0 = GC.GetAllocatedBytesForCurrentThread();
             var sw = Stopwatch.StartNew();

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -1250,6 +1250,21 @@ try {
         @($rmFull | Where-Object { -not $_.StartsWith("$drop=") }) | Set-Content -LiteralPath $rmDropKv -Encoding UTF8
         Assert-Null (Read-RowMemoResults -Path $rmDropKv) "row-memo parser returns null when $drop is missing (now required)"
     }
+    # A boolean flag present but with a token that isn't exactly true/false (case-insensitive)
+    # must fail fast to $null — never silently read as $false — so a malformed/truncated capture
+    # can't render a wrong skip-precondition claim. Cover each flag with a bad token, and confirm
+    # case-insensitive true/false is still accepted.
+    foreach ($bk in 'baseline_same_instance', 'baseline_can_skip', 'memo_same_instance', 'memo_can_skip') {
+        $rmBadBool = Join-Path $rowMemoTmp ("rowmemo-badbool-{0}.kv.txt" -f $bk)
+        @($rmFull | ForEach-Object { if ($_.StartsWith("$bk=")) { "$bk=maybe" } else { $_ } }) | Set-Content -LiteralPath $rmBadBool -Encoding UTF8
+        Assert-Null (Read-RowMemoResults -Path $rmBadBool) "row-memo parser returns null when $bk has a malformed (non true/false) token"
+    }
+    $rmMixedCase = Join-Path $rowMemoTmp 'rowmemo-mixedcase.kv.txt'
+    @($rmFull | ForEach-Object { if ($_.StartsWith('baseline_can_skip=')) { 'baseline_can_skip=FALSE' } elseif ($_.StartsWith('memo_can_skip=')) { 'memo_can_skip=True' } else { $_ } }) | Set-Content -LiteralPath $rmMixedCase -Encoding UTF8
+    $rmMixed = Read-RowMemoResults -Path $rmMixedCase
+    Assert-True ($null -ne $rmMixed)          'row-memo parser accepts case-insensitive true/false tokens'
+    Assert-True (-not $rmMixed.BaselineCanSkip) 'row-memo parser reads FALSE (upper) as $false'
+    Assert-True $rmMixed.MemoCanSkip           'row-memo parser reads True (mixed) as $true'
 
     # Renderer: empty array when null; full table + Win ratios + note when populated.
     $times = [char]0x00D7

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -1236,6 +1236,20 @@ try {
     Assert-Null (Read-RowMemoResults -Path $rmBadKv)                              'row-memo parser returns null when required keys are missing'
     Assert-Null (Read-RowMemoResults -Path (Join-Path $rowMemoTmp 'nope.txt'))    'row-memo parser returns null when the file is missing'
     Assert-Null (Read-RowMemoResults -Path $null)                                'row-memo parser returns null for a null path'
+    # The two Baseline skip-precondition flags are REQUIRED (the narrative asserts them),
+    # so a capture that dropped either one must fail fast to $null rather than silently
+    # defaulting the flag to $false and rendering a story the bench never measured.
+    $rmFull = @(
+        'baseline_ns=379.275', 'baseline_bytes=4616', 'baseline_rebuilds=1000000',
+        'baseline_same_instance=false', 'baseline_can_skip=false',
+        'memo_ns=43.633', 'memo_bytes=224', 'memo_rebuilds=0',
+        'memo_same_instance=true', 'memo_can_skip=true'
+    )
+    foreach ($drop in 'baseline_same_instance', 'baseline_can_skip') {
+        $rmDropKv = Join-Path $rowMemoTmp ("rowmemo-drop-{0}.kv.txt" -f $drop)
+        @($rmFull | Where-Object { -not $_.StartsWith("$drop=") }) | Set-Content -LiteralPath $rmDropKv -Encoding UTF8
+        Assert-Null (Read-RowMemoResults -Path $rmDropKv) "row-memo parser returns null when $drop is missing (now required)"
+    }
 
     # Renderer: empty array when null; full table + Win ratios + note when populated.
     $times = [char]0x00D7
@@ -1252,6 +1266,19 @@ try {
     Assert-Match $rmText '**eliminated**'                     'row-memo Win cell: rebuilds eliminated (baseline>0, memo=0)'
     Assert-Match $rmText '1,000,000'                          'row-memo renders the per-arm recycle count with separators'
     Assert-Match $rmText 'CanSkipUpdate'                      'row-memo note cites the CanSkipUpdate skip precondition'
+    # The note renders the MEASURED Baseline flags, not hard-coded literals. $rm carries
+    # both false, so the note must show sameInstance=false / CanSkipUpdate=false.
+    Assert-Match $rmText 'sameInstance=false'                'row-memo note renders the measured Baseline sameInstance flag'
+    Assert-Match $rmText 'CanSkipUpdate=false'               'row-memo note renders the measured Baseline CanSkipUpdate flag'
+    # Prove it is DATA-DRIVEN, not a constant: a (hypothetical) result whose Baseline flags
+    # read true must surface true in the note — so a bench bug / runtime change can't leave
+    # the comment asserting a stale "false".
+    $rmFlipped = $rm.PSObject.Copy()
+    $rmFlipped.BaselineSameInstance = $true
+    $rmFlipped.BaselineCanSkip = $true
+    $rmFlippedText = (Format-PerfRowMemoSection -RowMemo $rmFlipped) -join "`n"
+    Assert-Match $rmFlippedText 'sameInstance=true'          'row-memo note reflects a measured Baseline sameInstance=true (note is data-driven, not hard-coded)'
+    Assert-Match $rmFlippedText 'CanSkipUpdate=true'         'row-memo note reflects a measured Baseline CanSkipUpdate=true (note is data-driven, not hard-coded)'
     # The headless-only caveat must be present so reviewers know the real win is bigger.
     Assert-Match $rmText 'captured by the headless' 'row-memo note flags that the stacked reconcile/patch saving is not captured headlessly'
 

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -1199,6 +1199,82 @@ finally {
 }
 
 
+# ── Read-RowMemoResults + Format-PerfRowMemoSection: opt-in row-memo leg ───────
+# The row-memo leg is the one SINGLE-TREE leg: a single PR-head build that prints
+# stable key=value lines internally A/Bing Baseline vs Memo(i, () => row) (#327). The
+# parser must read those lines into a typed object (or null on missing/garbage), and the
+# renderer must produce the same-build Baseline|Memo|Win table + the skip-precondition note.
+$rowMemoTmp = Join-Path ([IO.Path]::GetTempPath()) ("perflib-rowmemo-{0}" -f ([guid]::NewGuid().ToString('N')))
+New-Item -ItemType Directory -Path $rowMemoTmp -Force | Out-Null
+try {
+    $rmKv = Join-Path $rowMemoTmp 'rowmemo.kv.txt'
+    @(
+        'baseline_ns=379.275', 'baseline_bytes=4616', 'baseline_rebuilds=1000000',
+        'baseline_same_instance=false', 'baseline_can_skip=false',
+        'memo_ns=43.633', 'memo_bytes=224', 'memo_rebuilds=0',
+        'memo_same_instance=true', 'memo_can_skip=true',
+        'recycles_per_arm=1000000', 'row_nodes=9', 'window=50'
+    ) | Set-Content -LiteralPath $rmKv -Encoding UTF8
+
+    $rm = Read-RowMemoResults -Path $rmKv
+    Assert-True ($null -ne $rm)              'row-memo parser returns an object for valid key=value output'
+    Assert-Equal 379.275 $rm.BaselineNs      'row-memo parser reads baseline_ns'
+    Assert-Equal 4616    $rm.BaselineBytes   'row-memo parser reads baseline_bytes'
+    Assert-Equal 1000000 $rm.BaselineRebuilds 'row-memo parser reads baseline_rebuilds'
+    Assert-Equal 43.633  $rm.MemoNs          'row-memo parser reads memo_ns'
+    Assert-Equal 224     $rm.MemoBytes       'row-memo parser reads memo_bytes'
+    Assert-Equal 0       $rm.MemoRebuilds    'row-memo parser reads memo_rebuilds'
+    Assert-True  $rm.MemoSameInstance        'row-memo parser reads memo_same_instance=true'
+    Assert-True  $rm.MemoCanSkip             'row-memo parser reads memo_can_skip=true'
+    Assert-True (-not $rm.BaselineSameInstance) 'row-memo parser reads baseline_same_instance=false'
+    Assert-Equal 1000000 $rm.RecyclesPerArm  'row-memo parser reads recycles_per_arm'
+    Assert-Equal 9       $rm.RowNodes         'row-memo parser reads row_nodes'
+
+    # Missing-required-key and missing-file both yield $null so the leg omits the table.
+    $rmBadKv = Join-Path $rowMemoTmp 'rowmemo-bad.kv.txt'
+    @('baseline_ns=379.275', 'memo_ns=43.633') | Set-Content -LiteralPath $rmBadKv -Encoding UTF8
+    Assert-Null (Read-RowMemoResults -Path $rmBadKv)                              'row-memo parser returns null when required keys are missing'
+    Assert-Null (Read-RowMemoResults -Path (Join-Path $rowMemoTmp 'nope.txt'))    'row-memo parser returns null when the file is missing'
+    Assert-Null (Read-RowMemoResults -Path $null)                                'row-memo parser returns null for a null path'
+
+    # Renderer: empty array when null; full table + Win ratios + note when populated.
+    $times = [char]0x00D7
+    Assert-Equal 0 @(Format-PerfRowMemoSection -RowMemo $null).Count 'row-memo section empty when result null'
+    $rmSection = Format-PerfRowMemoSection -RowMemo $rm
+    $rmText = $rmSection -join "`n"
+    Assert-Match $rmText 'Row memoization (opt-in)'           'row-memo section has the heading'
+    Assert-Match $rmText '| Metric | Baseline | Memo | Win |' 'row-memo table uses the Baseline|Memo|Win columns'
+    Assert-Match $rmText 'ns/recycle'                         'row-memo table has the ns/recycle row'
+    Assert-Match $rmText 'bytes/recycle'                      'row-memo table has the bytes/recycle row'
+    Assert-Match $rmText 'factory rebuilds'                   'row-memo table has the factory-rebuilds row'
+    Assert-Match $rmText ("8.7$times faster")                'row-memo Win cell: 8.7x faster (379.275/43.633)'
+    Assert-Match $rmText ("20.6$times less")                 'row-memo Win cell: 20.6x less alloc (4616/224)'
+    Assert-Match $rmText '**eliminated**'                     'row-memo Win cell: rebuilds eliminated (baseline>0, memo=0)'
+    Assert-Match $rmText '1,000,000'                          'row-memo renders the per-arm recycle count with separators'
+    Assert-Match $rmText 'CanSkipUpdate'                      'row-memo note cites the CanSkipUpdate skip precondition'
+    # The headless-only caveat must be present so reviewers know the real win is bigger.
+    Assert-Match $rmText 'captured by the headless' 'row-memo note flags that the stacked reconcile/patch saving is not captured headlessly'
+
+    # Threaded through Format-PerfComment: present when set (after the regression table,
+    # before the cross-framework reference), omitted when null (back-compat with callers
+    # that never pass -RowMemo).
+    $rmComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -RowMemo $rm -Context $ctx
+    Assert-Match $rmComment 'Row memoization (opt-in)' 'comment renders the row-memo table when a result is supplied'
+    $idxRegRm = $rmComment.IndexOf('Regression vs')
+    $idxRowMemo = $rmComment.IndexOf('Row memoization (opt-in)')
+    $idxXfwRm = $rmComment.IndexOf('Cross-framework reference')
+    Assert-True (($idxRegRm -lt $idxRowMemo) -and ($idxRowMemo -lt $idxXfwRm)) 'row-memo table sits after the regression table and before cross-framework'
+    $noRmComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -RowMemo $null -Context $ctx
+    Assert-True (-not ($noRmComment -like '*Row memoization (opt-in)*')) 'row-memo table omitted when no result supplied'
+    # Existing callers that never pass -RowMemo at all must still omit the section.
+    $legacyComment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $null -Rust $null -Context $ctx
+    Assert-True (-not ($legacyComment -like '*Row memoization (opt-in)*')) 'row-memo table omitted for callers that do not pass -RowMemo'
+}
+finally {
+    Remove-Item -LiteralPath $rowMemoTmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+
 if ($script:Fail -gt 0) {
     Write-Host "FAILED: $($script:Fail) / $($script:Pass + $script:Fail) assertions" -ForegroundColor Red
     foreach ($f in $script:Failures) { Write-Host "  ✗ $f" -ForegroundColor Red }

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -1279,6 +1279,21 @@ try {
     Assert-Match $rmText ("8.7$times faster")                'row-memo Win cell: 8.7x faster (379.275/43.633)'
     Assert-Match $rmText ("20.6$times less")                 'row-memo Win cell: 20.6x less alloc (4616/224)'
     Assert-Match $rmText '**eliminated**'                     'row-memo Win cell: rebuilds eliminated (baseline>0, memo=0)'
+    # Direction-aware Win cell: if the Memo arm REGRESSES (higher ns / more bytes than
+    # Baseline) the ratio must read "× slower" / "× more", never a misleading "0.8× faster".
+    $rmRegress = $rm.PSObject.Copy()
+    $rmRegress.MemoNs = 758.55      # 2x the baseline 379.275 -> Memo slower
+    $rmRegress.MemoBytes = 9232     # 2x the baseline 4616     -> Memo more
+    $rmRegressText = (Format-PerfRowMemoSection -RowMemo $rmRegress) -join "`n"
+    Assert-Match $rmRegressText ("2.0$times slower")         'row-memo Win cell reads "slower" when Memo ns regresses above Baseline'
+    Assert-Match $rmRegressText ("2.0$times more")           'row-memo Win cell reads "more" when Memo bytes regress above Baseline'
+    Assert-True (-not ($rmRegressText -match "0\.\d$times faster")) 'row-memo Win cell never emits a sub-1x "faster" ratio on a regression'
+    # Tie: equal Baseline/Memo -> "no change" rather than "1.0x faster".
+    $rmTie = $rm.PSObject.Copy()
+    $rmTie.MemoNs = $rm.BaselineNs
+    $rmTie.MemoBytes = $rm.BaselineBytes
+    $rmTieText = (Format-PerfRowMemoSection -RowMemo $rmTie) -join "`n"
+    Assert-Match $rmTieText 'no change'                       'row-memo Win cell reads "no change" when Memo equals Baseline'
     Assert-Match $rmText '1,000,000'                          'row-memo renders the per-arm recycle count with separators'
     Assert-Match $rmText 'CanSkipUpdate'                      'row-memo note cites the CanSkipUpdate skip precondition'
     # The note renders the MEASURED Baseline flags, not hard-coded literals. $rm carries

--- a/tests/stress_perf/ci/PerfLib.Tests.ps1
+++ b/tests/stress_perf/ci/PerfLib.Tests.ps1
@@ -1296,6 +1296,17 @@ try {
     Assert-Match $rmFlippedText 'CanSkipUpdate=true'         'row-memo note reflects a measured Baseline CanSkipUpdate=true (note is data-driven, not hard-coded)'
     # The headless-only caveat must be present so reviewers know the real win is bigger.
     Assert-Match $rmText 'captured by the headless' 'row-memo note flags that the stacked reconcile/patch saving is not captured headlessly'
+    # Fallback note (Memo skip precondition did NOT hold): when MemoSameInstance/MemoCanSkip
+    # come back false (a regression / bench change), the note must NOT restate the "Memo unlocks
+    # reconcile/patch savings" claim — those savings depend on the failed precondition. It must
+    # instead surface the measured flags and flag it as a likely regression.
+    $rmNoSkip = $rm.PSObject.Copy()
+    $rmNoSkip.MemoCanSkip = $false
+    $rmNoSkipText = (Format-PerfRowMemoSection -RowMemo $rmNoSkip) -join "`n"
+    Assert-Match $rmNoSkipText 'did NOT hold'          'row-memo fallback note flags the missing skip precondition'
+    Assert-Match $rmNoSkipText 'CanSkipUpdate=false'   'row-memo fallback note surfaces the measured Memo CanSkipUpdate=false'
+    Assert-Match $rmNoSkipText 'in effect'             'row-memo fallback states the savings are (not) in effect rather than claiming Memo unlocks them'
+    Assert-True (-not ($rmNoSkipText -match 'Why the real win is bigger')) 'row-memo fallback does not render the win narrative when the precondition failed'
 
     # Threaded through Format-PerfComment: present when set (after the regression table,
     # before the cross-framework reference), omitted when null (back-compat with callers

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -1185,6 +1185,15 @@ function Read-RowMemoResults {
         'baseline_same_instance', 'baseline_can_skip',
         'memo_ns', 'memo_bytes', 'memo_rebuilds', 'memo_same_instance', 'memo_can_skip')
     foreach ($k in $required) { if (-not $kv.ContainsKey($k)) { return $null } }
+    # The four skip-precondition flags must be EXACTLY true/false (case-insensitive). A plain
+    # "== 'true'" test would silently read any other token (e.g. "maybe", a truncated "tru", an
+    # empty value) as false and render a wrong skip-precondition claim, so validate the tokens
+    # up front and fail fast to $null (omit the table) on anything unrecognized.
+    $boolKeys = @('baseline_same_instance', 'baseline_can_skip', 'memo_same_instance', 'memo_can_skip')
+    foreach ($bk in $boolKeys) {
+        $tok = ([string]$kv[$bk]).Trim().ToLowerInvariant()
+        if ($tok -ne 'true' -and $tok -ne 'false') { return $null }
+    }
     $toD = { param($s) [double]::Parse([string]$s, [System.Globalization.NumberStyles]::Float, $inv) }
     $toL = { param($s) [long]::Parse([string]$s, [System.Globalization.NumberStyles]::Integer, $inv) }
     $toB = { param($s) (([string]$s).Trim().ToLowerInvariant() -eq 'true') }

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -1240,6 +1240,17 @@ function Format-PerfRowMemoSection {
     $times = [char]0x00D7
     $inv = [System.Globalization.CultureInfo]::InvariantCulture
     $n0 = { param($v) ([long][math]::Round([double]$v)).ToString('N0', $inv) }
+    # Direction-aware Win cell for a lower-is-better metric (ns and bytes are both
+    # lower-is-better, Memo is the candidate). Memo better => "N× {better}", Memo WORSE =>
+    # "N× {worse}" (so a regression reads as a slowdown/increase, not a misleading "0.8×
+    # faster"), tie => "no change". The ratio is always the larger/smaller so it reads >= 1.
+    $winCell = {
+        param([double]$base, [double]$cand, [string]$better, [string]$worse)
+        if ($base -le 0 -or $cand -le 0) { return [char]0x2014 }
+        if ($cand -lt $base) { return ('{0}{1} {2}' -f (Format-PerfNumber ($base / $cand) 1), $times, $better) }
+        elseif ($cand -gt $base) { return ('{0}{1} {2}' -f (Format-PerfNumber ($cand / $base) 1), $times, $worse) }
+        else { return 'no change' }
+    }
 
     $nodes = if ($RowMemo.RowNodes -gt 0) { [string]$RowMemo.RowNodes } else { 'multi' }
     $rec = if ($RowMemo.RecyclesPerArm -gt 0) { & $n0 $RowMemo.RecyclesPerArm } else { 'N' }
@@ -1252,11 +1263,11 @@ function Format-PerfRowMemoSection {
     $lines.Add('| Metric | Baseline | Memo | Win |')
     $lines.Add('|---|--:|--:|:--|')
 
-    $nsWin = if ($RowMemo.MemoNs -gt 0) { '{0}{1} faster' -f (Format-PerfNumber ($RowMemo.BaselineNs / $RowMemo.MemoNs) 1), $times } else { [char]0x2014 }
+    $nsWin = & $winCell $RowMemo.BaselineNs $RowMemo.MemoNs 'faster' 'slower'
     $lines.Add(('| ns/recycle {0} | {1} | {2} | {3} |' -f $down,
         (Format-PerfNumber $RowMemo.BaselineNs 1), (Format-PerfNumber $RowMemo.MemoNs 1), $nsWin))
 
-    $byWin = if ($RowMemo.MemoBytes -gt 0) { '{0}{1} less' -f (Format-PerfNumber ($RowMemo.BaselineBytes / [double]$RowMemo.MemoBytes) 1), $times } else { [char]0x2014 }
+    $byWin = & $winCell $RowMemo.BaselineBytes $RowMemo.MemoBytes 'less' 'more'
     $lines.Add(('| bytes/recycle {0} | {1} | {2} | {3} |' -f $down,
         (& $n0 $RowMemo.BaselineBytes), (& $n0 $RowMemo.MemoBytes), $byWin))
 

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -1176,7 +1176,13 @@ function Read-RowMemoResults {
     $inv = [System.Globalization.CultureInfo]::InvariantCulture
     # The Win column + the skip-precondition note are computed from these; a row missing
     # any of them can't render a trustworthy table, so treat it as "no result" and omit.
+    # PerfBench.RowMemo always emits the four same_instance / can_skip flags, and the
+    # narrative asserts the Baseline pair is false vs the Memo pair true, so ALL of them are
+    # required: a truncated/partial capture that dropped one must fail fast (return $null and
+    # omit the table) rather than silently default a flag to $false and render a story the
+    # bench never actually measured.
     $required = @('baseline_ns', 'baseline_bytes', 'baseline_rebuilds',
+        'baseline_same_instance', 'baseline_can_skip',
         'memo_ns', 'memo_bytes', 'memo_rebuilds', 'memo_same_instance', 'memo_can_skip')
     foreach ($k in $required) { if (-not $kv.ContainsKey($k)) { return $null } }
     $toD = { param($s) [double]::Parse([string]$s, [System.Globalization.NumberStyles]::Float, $inv) }
@@ -1187,8 +1193,8 @@ function Read-RowMemoResults {
             BaselineNs           = & $toD $kv['baseline_ns']
             BaselineBytes        = & $toL $kv['baseline_bytes']
             BaselineRebuilds     = & $toL $kv['baseline_rebuilds']
-            BaselineSameInstance = if ($kv.ContainsKey('baseline_same_instance')) { & $toB $kv['baseline_same_instance'] } else { $false }
-            BaselineCanSkip      = if ($kv.ContainsKey('baseline_can_skip')) { & $toB $kv['baseline_can_skip'] } else { $false }
+            BaselineSameInstance = & $toB $kv['baseline_same_instance']
+            BaselineCanSkip      = & $toB $kv['baseline_can_skip']
             MemoNs               = & $toD $kv['memo_ns']
             MemoBytes            = & $toL $kv['memo_bytes']
             MemoRebuilds         = & $toL $kv['memo_rebuilds']
@@ -1252,7 +1258,13 @@ function Format-PerfRowMemoSection {
     $lines.Add('')
 
     if ($RowMemo.MemoSameInstance -and $RowMemo.MemoCanSkip) {
-        $lines.Add("> **Why the real win is bigger than the table.** On a recycle that re-asks a still-cached key, ``Memo`` returns the **same ``Element`` instance**, so ``ReferenceEquals`` holds and ``Element.CanSkipUpdate`` is **true** &mdash; the reconciler returns at the row **root** and skips the entire $nodes-node per-row descent **and** the downstream WinUI control-patch. That stacked reconcile + control-patch saving is **not** captured by the headless ns/bytes figures above (which time only ``BuildOrCache``). Baseline hands the reconciler a fresh-but-equal tree every recycle (``sameInstance=false``, ``CanSkipUpdate=false``), forcing the full walk.")
+        # Render the Baseline flags from the MEASURED values rather than hard-coding
+        # "false"/"false": the bench asserts them false, but if a bench bug or a future
+        # runtime change ever flipped one, the note must reflect what was actually measured
+        # instead of a stale claim (the data is right here in $RowMemo).
+        $baseSame = ([string]$RowMemo.BaselineSameInstance).ToLowerInvariant()
+        $baseSkip = ([string]$RowMemo.BaselineCanSkip).ToLowerInvariant()
+        $lines.Add("> **Why the real win is bigger than the table.** On a recycle that re-asks a still-cached key, ``Memo`` returns the **same ``Element`` instance**, so ``ReferenceEquals`` holds and ``Element.CanSkipUpdate`` is **true** &mdash; the reconciler returns at the row **root** and skips the entire $nodes-node per-row descent **and** the downstream WinUI control-patch. That stacked reconcile + control-patch saving is **not** captured by the headless ns/bytes figures above (which time only ``BuildOrCache``). Baseline hands the reconciler a fresh-but-equal tree every recycle (``sameInstance=$baseSame``, ``CanSkipUpdate=$baseSkip``), forcing the full walk.")
     } else {
         $lines.Add("> **Note.** These are headless ``BuildOrCache`` timings only; the reconcile-descent + WinUI control-patch savings that ``Memo`` unlocks via ``ReferenceEquals`` + ``Element.CanSkipUpdate`` stack on top and aren't captured here.")
     }

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -1146,6 +1146,121 @@ function Format-PerfDataGridSection {
     return $lines.ToArray()
 }
 
+function Read-RowMemoResults {
+    <#
+    .SYNOPSIS
+        Parse the PerfBench.RowMemo `key=value` output into a typed result object for
+        the Format-PerfRowMemoSection renderer.
+    .DESCRIPTION
+        PerfBench.RowMemo is a SINGLE self-contained PR-head build (no `main` A/B — see
+        the section renderer) that isolates the opt-in keyed-row-memoization win (#327):
+        a realistic 9-node variable-height row recycled ~1,000,000 times through the real
+        ElementFactory.BuildOrCache realize path, once WITHOUT Memo (Baseline) and once
+        WITH Memo(i, () => row). It emits stable `key=value` lines (also written to its
+        --out path); this reads them into a pscustomobject. Returns $null when the file is
+        missing/empty or any required key is absent/unparseable, so the caller omits the
+        table (the leg is best-effort).
+    .OUTPUTS
+        [pscustomobject] with BaselineNs/MemoNs (double), BaselineBytes/MemoBytes and
+        BaselineRebuilds/MemoRebuilds (long), the four bool skip-precondition flags, and
+        RecyclesPerArm (long) / RowNodes / Window (int) — or $null.
+    #>
+    param([AllowNull()][string]$Path)
+    if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return $null }
+    $kv = @{}
+    foreach ($line in [System.IO.File]::ReadLines($Path)) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $m = [regex]::Match($line, '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*$')
+        if ($m.Success) { $kv[$m.Groups[1].Value] = $m.Groups[2].Value }
+    }
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    # The Win column + the skip-precondition note are computed from these; a row missing
+    # any of them can't render a trustworthy table, so treat it as "no result" and omit.
+    $required = @('baseline_ns', 'baseline_bytes', 'baseline_rebuilds',
+        'memo_ns', 'memo_bytes', 'memo_rebuilds', 'memo_same_instance', 'memo_can_skip')
+    foreach ($k in $required) { if (-not $kv.ContainsKey($k)) { return $null } }
+    $toD = { param($s) [double]::Parse([string]$s, [System.Globalization.NumberStyles]::Float, $inv) }
+    $toL = { param($s) [long]::Parse([string]$s, [System.Globalization.NumberStyles]::Integer, $inv) }
+    $toB = { param($s) (([string]$s).Trim().ToLowerInvariant() -eq 'true') }
+    try {
+        return [pscustomobject]@{
+            BaselineNs           = & $toD $kv['baseline_ns']
+            BaselineBytes        = & $toL $kv['baseline_bytes']
+            BaselineRebuilds     = & $toL $kv['baseline_rebuilds']
+            BaselineSameInstance = if ($kv.ContainsKey('baseline_same_instance')) { & $toB $kv['baseline_same_instance'] } else { $false }
+            BaselineCanSkip      = if ($kv.ContainsKey('baseline_can_skip')) { & $toB $kv['baseline_can_skip'] } else { $false }
+            MemoNs               = & $toD $kv['memo_ns']
+            MemoBytes            = & $toL $kv['memo_bytes']
+            MemoRebuilds         = & $toL $kv['memo_rebuilds']
+            MemoSameInstance     = & $toB $kv['memo_same_instance']
+            MemoCanSkip          = & $toB $kv['memo_can_skip']
+            RecyclesPerArm       = if ($kv.ContainsKey('recycles_per_arm')) { & $toL $kv['recycles_per_arm'] } else { [long]0 }
+            RowNodes             = if ($kv.ContainsKey('row_nodes')) { [int](& $toL $kv['row_nodes']) } else { 0 }
+            Window               = if ($kv.ContainsKey('window')) { [int](& $toL $kv['window']) } else { 0 }
+        }
+    } catch { return $null }
+}
+
+function Format-PerfRowMemoSection {
+    <#
+    .SYNOPSIS
+        Render the opt-in row-memoization section: a SAME-BUILD Baseline-vs-Memo table
+        (ns/recycle, bytes/recycle, factory rebuilds) measured by PerfBench.RowMemo.
+    .DESCRIPTION
+        Unlike every other leg (each a PR-head-vs-`main` interleaved A/B), this is a single
+        self-contained PR-head build that internally compares two arms — a realistic
+        variable-height row realized through the real ElementFactory.BuildOrCache path
+        WITHOUT Memo (Baseline) vs WITH Memo(i, () => row) (#327's opt-in keyed row memo).
+        It exists because the StocksGrid /perf legs can't surface this win: StocksGrid never
+        opts into the API, so its metrics read within-noise, and `main` lacks the Memo API
+        entirely (hence single-tree, PR head only, best-effort). Returns an empty array when
+        $RowMemo is $null (leg disabled, or build/run/parse failed), so the caller renders
+        nothing.
+    .PARAMETER RowMemo  Parsed PerfBench.RowMemo result (Read-RowMemoResults), or $null.
+    #>
+    param([AllowNull()][pscustomobject]$RowMemo)
+    if ($null -eq $RowMemo) { return @() }
+
+    $down = [char]0x2193
+    $times = [char]0x00D7
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    $n0 = { param($v) ([long][math]::Round([double]$v)).ToString('N0', $inv) }
+
+    $nodes = if ($RowMemo.RowNodes -gt 0) { [string]$RowMemo.RowNodes } else { 'multi' }
+    $rec = if ($RowMemo.RecyclesPerArm -gt 0) { & $n0 $RowMemo.RecyclesPerArm } else { 'N' }
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add("### Row memoization (opt-in) &mdash; same-build Baseline vs Memo")
+    $lines.Add('')
+    $lines.Add("A separate **single-build** micro-bench (``PerfBench.RowMemo``, **PR head only**) that isolates the opt-in keyed **row-memoization** win from #327: a realistic **$nodes-node variable-height row** recycled **$rec times** through the real ``ElementFactory.BuildOrCache`` realize path &mdash; once **without** ``Memo`` (Baseline) and once **with** ``Memo(i, () => row)`` (Memo). The StocksGrid ``/perf`` legs can't show this (StocksGrid never opts into the API, so they read within-noise) and ``main`` lacks the ``Memo`` API entirely, so this leg is built + run from the **PR head only**, best-effort. Both arms share **one build**, so the two columns are an apples-to-apples A/B with no cross-tree drift; absolute ns is runner-dependent, so trust the **Win** ratios and the rebuilds&rarr;0 / ``CanSkipUpdate`` facts.")
+    $lines.Add('')
+    $lines.Add('| Metric | Baseline | Memo | Win |')
+    $lines.Add('|---|--:|--:|:--|')
+
+    $nsWin = if ($RowMemo.MemoNs -gt 0) { '{0}{1} faster' -f (Format-PerfNumber ($RowMemo.BaselineNs / $RowMemo.MemoNs) 1), $times } else { [char]0x2014 }
+    $lines.Add(('| ns/recycle {0} | {1} | {2} | {3} |' -f $down,
+        (Format-PerfNumber $RowMemo.BaselineNs 1), (Format-PerfNumber $RowMemo.MemoNs 1), $nsWin))
+
+    $byWin = if ($RowMemo.MemoBytes -gt 0) { '{0}{1} less' -f (Format-PerfNumber ($RowMemo.BaselineBytes / [double]$RowMemo.MemoBytes) 1), $times } else { [char]0x2014 }
+    $lines.Add(('| bytes/recycle {0} | {1} | {2} | {3} |' -f $down,
+        (& $n0 $RowMemo.BaselineBytes), (& $n0 $RowMemo.MemoBytes), $byWin))
+
+    $perN = if ($RowMemo.RecyclesPerArm -gt 0) { ' (per {0} recycles)' -f (& $n0 $RowMemo.RecyclesPerArm) } else { '' }
+    $rbWin = if ($RowMemo.BaselineRebuilds -gt 0 -and $RowMemo.MemoRebuilds -eq 0) { '**eliminated**' } elseif ($RowMemo.MemoRebuilds -lt $RowMemo.BaselineRebuilds) { 'reduced' } else { [char]0x2014 }
+    $lines.Add(('| factory rebuilds{0} {1} | {2} | {3} | {4} |' -f $perN, $down,
+        (& $n0 $RowMemo.BaselineRebuilds), (& $n0 $RowMemo.MemoRebuilds), $rbWin))
+    $lines.Add('')
+
+    if ($RowMemo.MemoSameInstance -and $RowMemo.MemoCanSkip) {
+        $lines.Add("> **Why the real win is bigger than the table.** On a recycle that re-asks a still-cached key, ``Memo`` returns the **same ``Element`` instance**, so ``ReferenceEquals`` holds and ``Element.CanSkipUpdate`` is **true** &mdash; the reconciler returns at the row **root** and skips the entire $nodes-node per-row descent **and** the downstream WinUI control-patch. That stacked reconcile + control-patch saving is **not** captured by the headless ns/bytes figures above (which time only ``BuildOrCache``). Baseline hands the reconciler a fresh-but-equal tree every recycle (``sameInstance=false``, ``CanSkipUpdate=false``), forcing the full walk.")
+    } else {
+        $lines.Add("> **Note.** These are headless ``BuildOrCache`` timings only; the reconcile-descent + WinUI control-patch savings that ``Memo`` unlocks via ``ReferenceEquals`` + ``Element.CanSkipUpdate`` stack on top and aren't captured here.")
+    }
+    $lines.Add('')
+
+    return $lines.ToArray()
+}
+
 function Format-PerfComment {
     <#
     .SYNOPSIS
@@ -1170,6 +1285,8 @@ function Format-PerfComment {
     .PARAMETER PrFlex      Aggregated PR-head flex workload metrics, or $null.
     .PARAMETER MainDataGrid  Aggregated baseline DataGrid workload metrics, or $null.
     .PARAMETER PrDataGrid    Aggregated PR-head DataGrid workload metrics, or $null.
+    .PARAMETER RowMemo    Parsed opt-in row-memoization bench result (Read-RowMemoResults),
+                          or $null when the row-memo leg was disabled / its build/run failed.
     .PARAMETER Context    Hashtable: Percent, Duration, Reps, Warmup, SkipFloorPercent,
                           BaseSha, HeadSha, Runner, Cpu, Cores, MemoryGB, RunUrl,
                           Timestamp, Note.
@@ -1189,6 +1306,7 @@ function Format-PerfComment {
         [AllowNull()][pscustomobject]$PrFlex,
         [AllowNull()][pscustomobject]$MainDataGrid,
         [AllowNull()][pscustomobject]$PrDataGrid,
+        [AllowNull()][pscustomobject]$RowMemo,
         [Parameter(Mandatory)][hashtable]$Context
     )
 
@@ -1288,6 +1406,13 @@ function Format-PerfComment {
     # delegate-stability optimizations. Rendered only when both DataGrid aggregates present.
     $dataGridPct = if ($Context.ContainsKey('Percent')) { [double]$Context.Percent } else { 50 }
     foreach ($dline in (Format-PerfDataGridSection -MainDataGrid $MainDataGrid -PrDataGrid $PrDataGrid -Percent $dataGridPct)) { & $add $dline }
+
+    # ── Row memoization (opt-in) — same-build Baseline vs Memo ───────────────
+    # A single PR-head build that internally A/Bs the #327 Memo(key, () => row) opt-in
+    # keyed row memo (Baseline vs Memo) — the win the StocksGrid legs can't show (they
+    # never opt in) and `main` can't even build (it lacks the Memo API), so this leg is
+    # single-tree / best-effort. Rendered only when the bench produced a parseable result.
+    foreach ($rline in (Format-PerfRowMemoSection -RowMemo $RowMemo)) { & $add $rline }
 
     # ── Reconciler micro-benchmarks (ns-resolution, WinUI-undiluted) ──────────
     # Rendered only when the PerfBench.ControlModel micro leg produced results for

--- a/tests/stress_perf/ci/PerfLib.ps1
+++ b/tests/stress_perf/ci/PerfLib.ps1
@@ -1275,7 +1275,14 @@ function Format-PerfRowMemoSection {
         $baseSkip = ([string]$RowMemo.BaselineCanSkip).ToLowerInvariant()
         $lines.Add("> **Why the real win is bigger than the table.** On a recycle that re-asks a still-cached key, ``Memo`` returns the **same ``Element`` instance**, so ``ReferenceEquals`` holds and ``Element.CanSkipUpdate`` is **true** &mdash; the reconciler returns at the row **root** and skips the entire $nodes-node per-row descent **and** the downstream WinUI control-patch. That stacked reconcile + control-patch saving is **not** captured by the headless ns/bytes figures above (which time only ``BuildOrCache``). Baseline hands the reconciler a fresh-but-equal tree every recycle (``sameInstance=$baseSame``, ``CanSkipUpdate=$baseSkip``), forcing the full walk.")
     } else {
-        $lines.Add("> **Note.** These are headless ``BuildOrCache`` timings only; the reconcile-descent + WinUI control-patch savings that ``Memo`` unlocks via ``ReferenceEquals`` + ``Element.CanSkipUpdate`` stack on top and aren't captured here.")
+        # The Memo arm did NOT achieve the skip precondition this run (sameInstance and/or
+        # CanSkipUpdate came back false). Do NOT restate the "Memo unlocks reconcile/patch
+        # savings" claim — those savings depend on exactly the precondition that failed here,
+        # so asserting them would mislead. Surface the MEASURED flags and flag it as a likely
+        # regression instead.
+        $memoSame = ([string]$RowMemo.MemoSameInstance).ToLowerInvariant()
+        $memoSkip = ([string]$RowMemo.MemoCanSkip).ToLowerInvariant()
+        $lines.Add("> **Note &mdash; the expected skip precondition did NOT hold this run.** The Memo arm measured ``sameInstance=$memoSame`` / ``CanSkipUpdate=$memoSkip``, so on this build a recycle did **not** short-circuit at the row root &mdash; the reconcile-descent + WinUI control-patch savings keyed memoization is meant to unlock are **not** in effect here (the ns/bytes above remain headless ``BuildOrCache`` timings only). That usually signals a bench or runtime regression worth investigating.")
     }
     $lines.Add('')
 

--- a/tests/stress_perf/ci/README.md
+++ b/tests/stress_perf/ci/README.md
@@ -158,6 +158,7 @@ git worktree remove ../main
 | `-IncludeSkipFloor` | `$true` | Run a **second interleaved A/B leg** at `-SkipFloorPercent` and append a low-mutation skip-floor table (compare mode). Set `$false` to skip it (halves the macro runtime). |
 | `-SkipFloorPercent` | `0` | Mutation percent for the skip-floor leg. At `0` the workload still mutates one cell/tick (`StockDataSource.Update` clamps the count to `Math.Max(1, …)`), so reconcile/diff isolate the O(n) per-tick child skip-walk floor the 50% leg dilutes. |
 | `-IncludeKeyedList` | `$true` | Run a **third interleaved A/B leg** on `StressPerf.KeyedList` — a ~500-row stably keyed list reordered/inserted/removed each tick — and append its own table (compare mode). Drives the child reconciler's **keyed arm** (`ReconcileKeyed` → `ReconcileKeyedMiddle`, the LIS minimal-move pass) the positional StocksGrid cells never reach. Build is best-effort; set `$false` to skip the leg. |
+| `-IncludeRowMemo` | `$true` | Run a **single-tree, best-effort leg** that builds + runs `PerfBench.RowMemo` from the **PR head only** (never the `main` baseline — `main` lacks the opt-in `Memo(key, () => row)` API this measures, so it couldn't compile there) and appends a **same-build Baseline-vs-Memo** table for the keyed row-memoization win (#327). The StocksGrid legs can't show it — they never opt into the API, so it reads within-noise. Build + run are best-effort; set `$false` to skip. |
 | `-Apps` | `ReactorOptimized,Direct` | Single-tree mode only: which harnesses to run (`ReactorOptimized`, `Direct`, `KeyedList`). |
 | `-Platform` | host arch | Target architecture (`x64` or `ARM64`). Defaults to your machine's native arch so the WinUI harness runs without emulation. |
 | `-SelfContained` | `$true` | Build with the bundled WinApp runtime (no machine-wide install). |
@@ -246,6 +247,18 @@ Several tables plus footnotes:
   only when the keyed leg reports the metric. Same paired-CI gating as Table 1; omitted
   when `-IncludeKeyedList $false`, the workload build fails, or a side produces no
   metrics.
+- **Row memoization (opt-in)** — a **same-build Baseline-vs-Memo** table from
+  `PerfBench.RowMemo`, the one leg that is **single-tree** (PR head only) rather than a
+  `main`-vs-PR A/B. It recycles a realistic 9-node variable-height row ~1,000,000× through
+  the real `ElementFactory.BuildOrCache` realize path with vs without `Memo(i, () => row)`
+  and reports `ns/recycle`, `bytes/recycle` and factory rebuilds for each arm plus a `Win`
+  ratio. It exists because the StocksGrid legs can't surface the #327 win (they never opt
+  into the API, so every metric reads within-noise) and `main` can't even build the `Memo`
+  API — hence PR-head-only and best-effort: a build / run / parse failure simply omits the
+  table, leaving every other table intact. The headless figures time only `BuildOrCache`;
+  the reconcile-descent + WinUI control-patch that `Memo` *also* skips (via `ReferenceEquals`
+  + `Element.CanSkipUpdate`) stack on top and aren't captured in the number. Omitted when
+  `-IncludeRowMemo $false`, the bench build/run fails, or its output won't parse.
 - **Reconciler micro-benchmarks** — per-bench `ns/op` and `B/op` from the
   `PerfBench.ControlModel` micro-suite (M1–M13), `main` vs PR. ns-resolution and
   WinUI-undiluted, so it resolves Core/Reconciler time and allocation deltas the

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -143,6 +143,17 @@
     delegate-stability optimizations. Default $true; build is best-effort (a DataGrid build
     failure just omits the table). Disable with -IncludeDataGrid:$false to skip the extra leg.
 
+.PARAMETER IncludeRowMemo
+    Run a SINGLE-TREE, best-effort leg that builds + runs PerfBench.RowMemo from the PR
+    head ONLY (never the `main` baseline — `main` lacks the opt-in `Memo(key, () => row)`
+    API this measures, so building it there would fail) and appends a same-build
+    Baseline-vs-Memo table demonstrating the keyed row-memoization win (#327): a realistic
+    9-node variable-height row recycled ~1,000,000× through the real ElementFactory.BuildOrCache
+    realize path, with vs without `Memo`. The StocksGrid macro legs can't surface this — they
+    never opt into the API, so the optimization is dormant there and every metric reads
+    within-noise. Default $true; build + run are best-effort (any failure just omits the
+    table, leaving the rest of the comment unaffected). Disable with -IncludeRowMemo:$false.
+
 .PARAMETER Apps
     Which harnesses to run in single-tree mode: ReactorOptimized, Direct, KeyedList,
     Flex, DataGrid. Ignored in compare mode (which always does ReactorOptimized both sides +
@@ -223,6 +234,7 @@ param(
     [bool]$IncludeKeyedList = $true,
     [bool]$IncludeFlex = $true,
     [bool]$IncludeDataGrid = $true,
+    [bool]$IncludeRowMemo = $true,
     [ValidateSet('ReactorOptimized', 'Direct', 'KeyedList', 'Flex', 'DataGrid')]
     [string[]]$Apps = @('ReactorOptimized', 'Direct'),
     [string]$OutDir,
@@ -259,6 +271,7 @@ $AppRegistry = @{
     Flex             = @{ AppName = 'StressPerf.Flex';              ProjectRel = 'tests\stress_perf\StressPerf.Flex\StressPerf.Flex.csproj' }
     DataGrid         = @{ AppName = 'StressPerf.DataGrid';          ProjectRel = 'tests\stress_perf\StressPerf.DataGrid\StressPerf.DataGrid.csproj' }
     MicroControlModel = @{ AppName = 'PerfBench.ControlModel';     ProjectRel = 'tests\perf_bench\PerfBench.ControlModel\PerfBench.ControlModel.csproj' }
+    RowMemo          = @{ AppName = 'PerfBench.RowMemo';            ProjectRel = 'tests\perf_bench\PerfBench.RowMemo\PerfBench.RowMemo.csproj' }
 }
 
 function Write-Log {
@@ -758,6 +771,52 @@ function Invoke-MicroRun {
     return $outJson
 }
 
+function Invoke-RowMemoRun {
+    <# Run PerfBench.RowMemo once (a single self-contained PR-head build) and return the
+       parsed Baseline-vs-Memo result (Read-RowMemoResults) or $null. The bench runs the
+       measurement headlessly IN-PROCESS — no window, no main-vs-PR interleave: it internally
+       A/Bs a 9-node row realized through ElementFactory.BuildOrCache with vs without
+       Memo(i, () => row), then writes stable key=value lines to the --out path, which we
+       parse. Best-effort: a timeout / nonzero exit / missing or unparseable output yields
+       $null so the caller omits the row-memo table. Mirrors Invoke-MicroRun's launch shape
+       (High priority, redirected std streams, bounded wait). #>
+    param([string]$Exe, [int]$TimeoutSec = 180)
+
+    $outKv = Join-Path $OutDir 'rowmemo.kv.txt'
+    if (Test-Path $outKv) { Remove-Item $outKv -Force -ErrorAction SilentlyContinue }
+    $stdout = Join-Path $OutDir 'rowmemo.out.log'
+    $stderr = Join-Path $OutDir 'rowmemo.err.log'
+    $rmArgs = @('--headless', '--out', $outKv)
+
+    Write-Log "  row-memo PerfBench.RowMemo --out rowmemo.kv.txt"
+    $proc = Start-Process -FilePath $Exe -ArgumentList $rmArgs -PassThru `
+        -RedirectStandardOutput $stdout -RedirectStandardError $stderr -WindowStyle Hidden
+    try { $proc.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::High } catch {}
+
+    if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
+        Write-Log "  row-memo TIMEOUT after ${TimeoutSec}s — killing PerfBench.RowMemo" 'Yellow'
+        try { $proc.Kill($true) } catch { try { $proc.Kill() } catch {} }
+        Start-Sleep -Seconds 2
+        return $null
+    }
+    if ($proc.ExitCode -ne 0) {
+        Write-Log "  row-memo exited non-zero ($($proc.ExitCode)). stderr tail:" 'Yellow'
+        if (Test-Path $stderr) { Get-Content $stderr -Tail 8 | ForEach-Object { Write-Host "      $_" -ForegroundColor DarkYellow } }
+        return $null
+    }
+    $parsed = Read-RowMemoResults -Path $outKv
+    if ($null -eq $parsed) {
+        Write-Log "  row-memo produced no parseable key=value output (exit=$($proc.ExitCode))." 'Yellow'
+        if (Test-Path $stderr) { Get-Content $stderr -Tail 8 | ForEach-Object { Write-Host "      $_" -ForegroundColor DarkYellow } }
+        return $null
+    }
+    Write-Log ("  -> baseline {0} ns / {1} B; memo {2} ns / {3} B; memo_rebuilds={4} can_skip={5}" -f `
+        (Format-PerfNumber $parsed.BaselineNs 1), (Format-PerfNumber $parsed.BaselineBytes 0), `
+        (Format-PerfNumber $parsed.MemoNs 1), (Format-PerfNumber $parsed.MemoBytes 0), `
+            $parsed.MemoRebuilds, $parsed.MemoCanSkip) 'DarkGray'
+    return $parsed
+}
+
 function ConvertTo-MicroRepLines {
     <# Read one per-round micro .jsonl (produced by a single --reps 1 launch, so every
        line carries "repetition":0) and renumber its repetition to $RepIndex, returning
@@ -870,11 +929,12 @@ Write-Log ("runner: {0} | {1} cores | {2} GB | {3}" -f $runner.Cpu, $runner.Core
 $modeSuffix = if ($Compare) {
     # COMPARE mode runs the interleaved A/B legs, so the skip-floor / keyed-list
     # opt-out switches are what actually decide which legs run.
-    "skip-floor={0} | keyed-list={1} | flex={2} | datagrid={3}" -f `
+    "skip-floor={0} | keyed-list={1} | flex={2} | datagrid={3} | row-memo={4}" -f `
         $(if ($IncludeSkipFloor) { "on (--percent $SkipFloorPercent)" } else { 'off' }), `
         $(if ($IncludeKeyedList) { 'on' } else { 'off' }), `
         $(if ($IncludeFlex) { 'on' } else { 'off' }), `
-        $(if ($IncludeDataGrid) { 'on' } else { 'off' })
+        $(if ($IncludeDataGrid) { 'on' } else { 'off' }), `
+        $(if ($IncludeRowMemo) { 'on (PR head only)' } else { 'off' })
 } else {
     # LOCAL mode ignores the interleaved-leg switches entirely; the workload set is
     # whatever -Apps selects, so report that instead of a misleading on/off.
@@ -892,6 +952,7 @@ try {
         $flex = $AppRegistry.Flex
         $datagrid = $AppRegistry.DataGrid
         $microMeta = $AppRegistry.MicroControlModel
+        $rowMemoMeta = $AppRegistry.RowMemo
 
         if (-not $SkipBuild) {
             Build-Harness -TreeRoot $BaselineRoot -AppMeta $ro
@@ -932,6 +993,19 @@ try {
             } catch {
                 Write-Log "datagrid workload build failed ($_) — omitting the datagrid table" 'Yellow'
                 $IncludeDataGrid = $false
+            }
+        }
+        if ($IncludeRowMemo -and -not $SkipBuild) {
+            try {
+                # SINGLE-TREE: build the row-memo bench from the PR head ONLY. It calls the
+                # opt-in Memo(key, () => row) API (#327) that exists on the PR but NOT on the
+                # `main` baseline, so building it against $BaselineRoot would fail the compile —
+                # which is exactly why this leg is single-tree. Best-effort: a build failure
+                # just omits the row-memo table and leaves the rest of the comment intact.
+                Build-Harness -TreeRoot $Root -AppMeta $rowMemoMeta
+            } catch {
+                Write-Log "row-memo bench build failed ($_) — omitting the row-memo table" 'Yellow'
+                $IncludeRowMemo = $false
             }
         }
         $mainExe = Resolve-HarnessExe -TreeRoot $BaselineRoot -AppMeta $ro
@@ -1062,6 +1136,29 @@ try {
             }
         }
 
+        # Row-memoization leg (#327 opt-in win). SINGLE-TREE, NOT a main-vs-PR interleave:
+        # one self-contained PR-head build internally A/Bs Baseline vs Memo(i, () => row) and
+        # prints key=value lines, so it needs no `main` side (which couldn't even compile the
+        # Memo API) and doesn't use the paired-CI machinery — the two columns come from the
+        # bench's own two arms. Best-effort: a missing exe / nonzero exit / unparseable output
+        # leaves $rowMemo = $null and the table is omitted; the StocksGrid comparison and every
+        # other leg are unaffected.
+        $rowMemo = $null
+        if ($IncludeRowMemo) {
+            try {
+                $rowMemoExe = Resolve-HarnessExe -TreeRoot $Root -AppMeta $rowMemoMeta
+                if (-not $rowMemoExe) {
+                    Write-Log "row-memo exe not found under the PR head — omitting the row-memo table" 'Yellow'
+                } else {
+                    Write-Log "row-memo bench (PerfBench.RowMemo, PR head only; same-build Baseline vs Memo)" 'Green'
+                    $rowMemo = Invoke-RowMemoRun -Exe $rowMemoExe
+                }
+            } catch {
+                Write-Log "row-memo leg failed ($_) — omitting the row-memo table" 'Yellow'
+                $rowMemo = $null
+            }
+        }
+
         $winRuns = @()
         if ($directExe) {
             Write-Log "vanilla WinUI3 (StressPerf.Direct)" 'Green'
@@ -1168,12 +1265,12 @@ try {
             Runner = $runner.Runner; Cpu = $runner.Cpu; Cores = $runner.Cores; MemoryGB = $runner.MemoryGB
             RunUrl = $RunUrl; Timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'); Note = $note
         }
-        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Rust $rust -Micro $micro -MicroOmitReason $microOmitReason -MainFloor $mainFloor -PrFloor $prFloor -MainKeyed $mainKeyed -PrKeyed $prKeyed -MainFlex $mainFlex -PrFlex $prFlex -MainDataGrid $mainDataGrid -PrDataGrid $prDataGrid -Context $ctx
+        $comment = Format-PerfComment -Main $main -Pr $pr -WinUI3 $winui3 -Rust $rust -Micro $micro -MicroOmitReason $microOmitReason -MainFloor $mainFloor -PrFloor $prFloor -MainKeyed $mainKeyed -PrKeyed $prKeyed -MainFlex $mainFlex -PrFlex $prFlex -MainDataGrid $mainDataGrid -PrDataGrid $prDataGrid -RowMemo $rowMemo -Context $ctx
         $commentPath = Join-Path $OutDir 'comment.md'
         Set-Content -LiteralPath $commentPath -Value $comment -Encoding UTF8
         Write-Log "comment.md written -> $commentPath" 'Green'
 
-        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; mainFloor = $mainFloor; prFloor = $prFloor; mainKeyed = $mainKeyed; prKeyed = $prKeyed; mainFlex = $mainFlex; prFlex = $prFlex; mainDataGrid = $mainDataGrid; prDataGrid = $prDataGrid; rust = $rust; micro = $micro; runner = $runner; context = $ctx }
+        $result = [pscustomobject]@{ main = $main; pr = $pr; winui3 = $winui3; mainFloor = $mainFloor; prFloor = $prFloor; mainKeyed = $mainKeyed; prKeyed = $prKeyed; mainFlex = $mainFlex; prFlex = $prFlex; mainDataGrid = $mainDataGrid; prDataGrid = $prDataGrid; rowMemo = $rowMemo; rust = $rust; micro = $micro; runner = $runner; context = $ctx }
         $result | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutDir 'result.json') -Encoding UTF8
 
         Write-Host "`n----- comment.md -----" -ForegroundColor DarkGray

--- a/tests/stress_perf/ci/Run-PerfBenchmark.ps1
+++ b/tests/stress_perf/ci/Run-PerfBenchmark.ps1
@@ -793,21 +793,38 @@ function Invoke-RowMemoRun {
         -RedirectStandardOutput $stdout -RedirectStandardError $stderr -WindowStyle Hidden
     try { $proc.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::High } catch {}
 
+    # On any failure, dump BOTH the stderr and stdout tails. PerfBench.RowMemo prints the
+    # machine-parseable key=value block to stdout as well as to --out, so when the --out FILE
+    # write is what failed (parse returned $null) the stdout tail still shows the block — that
+    # is the difference between "the bench crashed" and "the bench ran fine but couldn't write
+    # the file", which stderr alone can't distinguish.
+    $dumpTails = {
+        if (Test-Path $stderr) {
+            $et = @(Get-Content $stderr -Tail 8)
+            if ($et.Count) { Write-Host "      stderr tail:" -ForegroundColor DarkYellow; $et | ForEach-Object { Write-Host "        $_" -ForegroundColor DarkYellow } }
+        }
+        if (Test-Path $stdout) {
+            $ot = @(Get-Content $stdout -Tail 12)
+            if ($ot.Count) { Write-Host "      stdout tail (PerfBench.RowMemo echoes the key=value block here):" -ForegroundColor DarkYellow; $ot | ForEach-Object { Write-Host "        $_" -ForegroundColor DarkYellow } }
+        }
+    }
+
     if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
         Write-Log "  row-memo TIMEOUT after ${TimeoutSec}s — killing PerfBench.RowMemo" 'Yellow'
         try { $proc.Kill($true) } catch { try { $proc.Kill() } catch {} }
         Start-Sleep -Seconds 2
+        & $dumpTails
         return $null
     }
     if ($proc.ExitCode -ne 0) {
-        Write-Log "  row-memo exited non-zero ($($proc.ExitCode)). stderr tail:" 'Yellow'
-        if (Test-Path $stderr) { Get-Content $stderr -Tail 8 | ForEach-Object { Write-Host "      $_" -ForegroundColor DarkYellow } }
+        Write-Log "  row-memo exited non-zero ($($proc.ExitCode)). stderr + stdout tails:" 'Yellow'
+        & $dumpTails
         return $null
     }
     $parsed = Read-RowMemoResults -Path $outKv
     if ($null -eq $parsed) {
-        Write-Log "  row-memo produced no parseable key=value output (exit=$($proc.ExitCode))." 'Yellow'
-        if (Test-Path $stderr) { Get-Content $stderr -Tail 8 | ForEach-Object { Write-Host "      $_" -ForegroundColor DarkYellow } }
+        Write-Log "  row-memo produced no parseable key=value output (exit=$($proc.ExitCode)) — the --out file was missing/partial. stderr + stdout tails:" 'Yellow'
+        & $dumpTails
         return $null
     }
     Write-Log ("  -> baseline {0} ns / {1} B; memo {2} ns / {3} B; memo_rebuilds={4} can_skip={5}" -f `


### PR DESCRIPTION
## What

Adds a new **opt-in row-memoization** leg to the on-demand `/perf` system so the sticky `/perf` comment renders a table that **measures the keyed-row-memoization win from #327** — the win the existing StocksGrid `/perf` legs can't show, because StocksGrid never opts into the `Memo(key, () => row)` API (so the optimization is dormant there and every metric reads "within noise").

## ⚠️ Stacked on #753 (do not merge to `main` first)

This PR is **stacked on #753** (`azchohfi-cross-container-row-memoization`) and is **targeted at that branch**, not `main`. It depends on the new `Memo<TKey>(TKey, Func<Element>)` factory / `KeyedMemoElement` / `KeyedMemoCache` realize path that **only exists on #753** — `main` does not have it.

**Sequencing:** merge #753 first (or together). Once #753 is in `main`, commenting `/perf` on any PR renders the new table. **After #753 merges, retarget this PR to `main`.**

## The leg

New console project `tests/perf_bench/PerfBench.RowMemo` runs **headless** (no WinUI window): a realistic **9-node variable-height row** (`Border > HStack > [badge] + [VStack > title + 3 subtitles]`) recycled **1,000,000×** through the **real** `ElementFactory.BuildOrCache` realize path (`keyed:false`, the int-index VirtualList path where the built-in `_viewBuilderCache` `ReferenceEquals(item)` guard never hits — the exact bug #327 fixes), once **without** `Memo` (Baseline) and once **with** `Memo(i, () => row)` (Memo). It emits human-readable **and** machine-parseable `key=value` output.

Local numbers (AMD64): **~9× faster per recycle**, **~20.6× less allocation**, **factory rebuilds → 0**, and the Memo arm proves the reconcile-skip precondition — `ReferenceEquals(prev,cur)` **and** `Element.CanSkipUpdate(prev,cur)` are **true** (so the reconciler returns at the row root and skips the 9-node descent), while Baseline is `false`/`false`. Absolute ns is machine-dependent; the **ratios** and the **rebuilds→0 / CanSkipUpdate=true** facts are the stable signal.

Rendered table (`### Row memoization (opt-in) — same-build Baseline vs Memo`):

| Metric | Baseline | Memo | Win |
|---|--:|--:|:--|
| ns/recycle ↓ | 371.5 | 41.4 | 9.0× faster |
| bytes/recycle ↓ | 4,616 | 224 | 20.6× less |
| factory rebuilds (per 1,000,000 recycles) ↓ | 1,000,000 | 0 | **eliminated** |

…plus a note that the headless number times only `BuildOrCache`; the per-row reconcile descent **and** WinUI control-patch that `Memo` *also* skips stack on top and aren't captured here, so the real win is larger.

## Single-tree, best-effort (never breaks the main-side build)

The `/perf` workflow builds harness apps from **both** the PR-head tree **and** a clean `main` baseline tree. Since `main` lacks the `Memo` API, this bench **must not** be added to a both-trees project (e.g. `PerfBench.ControlModel`) — that would fail the `main`-side compile. So it lives in a **new, separate** project that the harness builds + runs **single-tree (PR head only)**, **best-effort** — mirroring the DataGrid leg's build-best-effort pattern: any build/run/parse failure simply **omits the table**, leaving every other leg's comment intact.

## Changes

- **New project** `tests/perf_bench/PerfBench.RowMemo/` (console, headless; csproj modeled on `PerfBench.ControlModel`).
- `src/Reactor/Reactor.csproj`: `InternalsVisibleTo` for `PerfBench.RowMemo` (internal `ElementFactory<T>.BuildOrCache` + `Element.CanSkipUpdate`); added to `Reactor.slnx`.
- `tests/stress_perf/ci/Run-PerfBenchmark.ps1`: new `-IncludeRowMemo` leg (default `$true`), single-tree PR-head build/run/parse, best-effort.
- `tests/stress_perf/ci/PerfLib.ps1`: `Read-RowMemoResults` parser + `Format-PerfRowMemoSection` renderer, threaded into `Format-PerfComment`.
- `tests/stress_perf/ci/PerfLib.Tests.ps1`: +31 assertions (parser, renderer, comment threading). README leg docs.
- `.github/workflows/perf-compare.yml`: **unchanged** — the leg is on-by-default and the workflow passes no explicit leg flags.

## Verification

- `PerfBench.RowMemo` builds green (0 warnings) and runs headless; output confirms Baseline slower/heavier, `memo_rebuilds=0`, `memo_can_skip=true`.
- `PerfLib.Tests.ps1` (359 assertions) and `RunPerfBenchmark.Tests.ps1` (104 assertions) pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
