### PR TITLE
Issue #701: complete ThemeRef ResourceOverrides skip-arm audit (keyed-middle teeth + docs)

### DIFF
--- a/src/Reactor/Core/ChildReconciler.cs
+++ b/src/Reactor/Core/ChildReconciler.cs
@@ -731,6 +731,15 @@ internal static class ChildReconciler
         public void Patch(int oldRelIdx, int newIdx, int panelIdx)
         {
             if (panelIdx >= _children.Count) return;
+            // Issue #701 (theme-correctness audit) — the keyed-MIDDLE patch intentionally has NO
+            // CanSkipUpdate early-skip arm (unlike the positional / keyed prefix+suffix arms): it
+            // unconditionally routes every reordered survivor through UpdateChild → Update, whose
+            // element-level shallow-skip is the single place that re-resolves ThemeBindings /
+            // ThemeRef ResourceOverrides against the current effective theme. This is what keeps a
+            // themed survivor's fe.Resources[key] fresh across a LIS reorder. A future optimization
+            // that adds a CanSkipUpdate fast-path here MUST mirror Reconciler.Update's skip arm
+            // (ApplyThemeBindings + ApplyResourceOverrides) or it will re-introduce the #701/#675
+            // staleness — see Issue675ResourceOverrideSkipFixtures.KeyedMiddleReorderReResolves.
             var replacement = _reconciler.UpdateChild(
                 _oldChildren[_oldStart + oldRelIdx],
                 _newChildren[_newStart + newIdx],

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue675ResourceOverrideSkipFixtures.cs
@@ -16,8 +16,19 @@ namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
 /// <summary>
 /// Issue #675 — live-FrameworkElement proofs that <c>ResourceOverrides.ThemeRefs</c>
 /// re-resolve across ALL reconciler skip fast-paths (element-level shallow-skip,
-/// positional child-skip, keyed child-skip) plus the <c>ApplyResourceOverrides</c>
-/// stale-key removal gate.
+/// positional child-skip, keyed prefix/suffix child-skip) plus the
+/// <c>ApplyResourceOverrides</c> stale-key removal gate.
+///
+/// <para>Issue #701 audit completion — extends the proofs to the sixth and final reconciler
+/// surface, the keyed-MIDDLE (LIS reorder) patch (<see cref="KeyedMiddleReorderReResolves"/>).
+/// The #701 cross-cutting audit confirmed every reconciler skip/patch surface re-resolves a
+/// ThemeRef <c>ResourceOverrides</c>: surfaces 1-5 (element-level, positional child-skip,
+/// keyed prefix, keyed suffix, bulk array fast-path) decline the skip — via
+/// <c>Element.CanSkipUpdate</c> and <c>ChildDiffHints.IsThemeSensitive</c> — and re-resolve in
+/// <c>Reconciler.Update</c>'s element-level shallow-skip arm; the keyed-middle (#6) has no skip
+/// arm at all and re-resolves by unconditionally routing every survivor through
+/// <c>UpdateChild</c> → <c>Update</c>. <c>Reconciler.Update</c> is the single source of truth
+/// for skip-path theme re-resolution.</para>
 ///
 /// <para>WHY A SOURCE-RESOURCE MUTATION, NOT A RequestedTheme TOGGLE: the existing
 /// <c>StructuralSkipFixtures</c> remarks document that a parent <c>RequestedTheme</c>
@@ -475,5 +486,102 @@ internal static class Issue675ResourceOverrideSkipFixtures
 
             return Task.CompletedTask;
         }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Keyed-MIDDLE (LIS reorder) patch re-resolve — #701 audit completion
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Issue #701 audit completion — the keyed-MIDDLE (LIS reorder) patch surface, the one
+    /// reconciler skip/patch arm the #675 fixtures above did not cover. The keyed prefix/suffix
+    /// arms (<see cref="KeyedChildSkipReResolves"/> / <see cref="KeyedSuffixChildSkipReResolves"/>)
+    /// share <c>Element.CanSkipUpdate</c>, but a REORDERED keyed survivor is patched by
+    /// <c>RealKeyedMiddleSink.Patch</c> instead, which has NO skip arm — it unconditionally routes
+    /// every survivor through <c>UpdateChild</c> → <c>Update</c>, whose element-level shallow-skip
+    /// re-applies <c>ApplyResourceOverrides</c>. So the middle path re-resolves a ThemeRef override
+    /// by construction; this fixture pins that and is the teeth guarding against a future
+    /// middle-path skip optimization that forgets to re-resolve.
+    ///
+    /// <para>Three keyed children <c>[anchor(a), themed(t), other(o)]</c> reorder to
+    /// <c>[anchor(a), other(o), themed(t)]</c>: the keyed prefix consumes <c>a</c>, the suffix is
+    /// empty (tail <c>o</c> vs <c>t</c> mismatch), and the <c>{t,o}</c> middle reorders, so
+    /// <c>ReconcileKeyedMiddle</c>'s LIS pass patches the themed survivor via
+    /// <c>RealKeyedMiddleSink.Patch</c> (<c>RunKeyedMiddleCore</c> calls <c>sink.Patch</c> for
+    /// every survivor, LIS member or mover alike). Uses the file's deterministic source-brush
+    /// mutation rather than a <c>RequestedTheme</c> toggle — an unreliable observable for the
+    /// <c>ThemeRef.Resolve</c> snapshot (see the class remarks).</para>
+    /// </summary>
+    internal sealed class KeyedMiddleReorderReResolves(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var red = MakeBrush(30, 90, 150);
+            var blue = MakeBrush(150, 90, 30);
+            var srcDict = InstallSourceDict(SrcKey, red);
+            try
+            {
+                // #721-style positive guard: the themed cell is structurally shallow-equal across
+                // renders (its Key is matched separately via KeyMatch, not by ShallowEquals), so
+                // its re-resolution hinges only on the middle path routing through Update — not an
+                // incidental modifier diff that would force a full property update and mask a broken
+                // middle-path re-resolve as a false-green.
+                H.Check("Issue701_KeyedMiddle_CellSkipEligible", Element.ShallowEquals(
+                    TextBlock("kmThemed").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))).WithKey("t"),
+                    TextBlock("kmThemed").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))).WithKey("t")));
+
+                Action<int>? bump = null;
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (n, setN) = ctx.UseState(0);
+                    bump = setN;
+                    var anchor = TextBlock("kmAnchor").WithKey("a");
+                    var themed = TextBlock("kmThemed")
+                        .Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey)))
+                        .WithKey("t");
+                    var other = TextBlock("kmOther").WithKey("o");
+                    // n even: [a, t, o]; n odd: [a, o, t]. The {t,o} middle reorders — the keyed
+                    // prefix consumes 'a', the suffix is empty — forcing ReconcileKeyedMiddle.
+                    return (n % 2 == 0)
+                        ? VStack(anchor, themed, other)
+                        : VStack(anchor, other, themed);
+                });
+
+                await Harness.Render();
+                var cell = H.FindControl<TextBlock>(t => t.Text == "kmThemed");
+                var cellBefore = cell;
+                int idxBefore = ChildIndex(cell);
+                H.Check("Issue701_KeyedMiddle_MountResolvedRed",
+                    ReferenceEquals(ResourceBrush(cell, TargetKey), red));
+
+                // Mutate the SOURCE brush, then trigger the reorder render.
+                SetSource(srcDict, SrcKey, blue);
+                bump!(1);
+                await Harness.Render();
+
+                cell = H.FindControl<TextBlock>(t => t.Text == "kmThemed");
+                // Right-reason A: the control is REUSED in place (not remounted) — proves it was
+                // patched by RealKeyedMiddleSink.Patch, not dropped + freshly mounted (a remount
+                // would carry the new brush for the wrong reason).
+                H.Check("Issue701_KeyedMiddle_ControlReusedInPlace",
+                    ReferenceEquals(cellBefore, cell));
+                // Right-reason B: the themed cell actually MOVED within its parent panel — proves
+                // the keyed-MIDDLE reorder engaged, not an incidental prefix/suffix skip.
+                int idxAfter = ChildIndex(cell);
+                H.Check($"Issue701_KeyedMiddle_ReorderEngaged[{idxBefore}->{idxAfter}]",
+                    idxBefore >= 0 && idxAfter >= 0 && idxBefore != idxAfter);
+                // The payload: the themed survivor re-resolved its ThemeRef through the middle patch.
+                H.Check("Issue701_KeyedMiddle_ReResolvedBlueOnMiddlePatch",
+                    ReferenceEquals(ResourceBrush(cell, TargetKey), blue));
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(srcDict);
+            }
+        }
+
+        private static int ChildIndex(TextBlock? cell) =>
+            cell?.Parent is Panel panel ? panel.Children.IndexOf(cell) : -1;
     }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -390,6 +390,7 @@ internal static class SelfTestFixtureRegistry
         "Issue675_TransitionAwayRemovesStaleOverride",
         "Issue675_KeyedSuffixChildSkipReResolves",
         "Issue675_LiteralOverrideNoFalseDecline",
+        "Issue701_KeyedMiddleReorderReResolves",
         "HotReload_ChildHookOrderRecovery",
         "HotReload_ComponentMigratesState",
         // DSL and extension tests
@@ -1854,6 +1855,7 @@ internal static class SelfTestFixtureRegistry
         "Issue675_TransitionAwayRemovesStaleOverride" => new Issue675ResourceOverrideSkipFixtures.TransitionAwayRemovesStaleOverride(harness),
         "Issue675_KeyedSuffixChildSkipReResolves" => new Issue675ResourceOverrideSkipFixtures.KeyedSuffixChildSkipReResolves(harness),
         "Issue675_LiteralOverrideNoFalseDecline" => new Issue675ResourceOverrideSkipFixtures.LiteralOverrideNoFalseDecline(harness),
+        "Issue701_KeyedMiddleReorderReResolves" => new Issue675ResourceOverrideSkipFixtures.KeyedMiddleReorderReResolves(harness),
         "HotReload_ChildHookOrderRecovery" => new HotReloadRecoveryFixtures.ChildRecoversAndSiblingStateSurvives(harness),
         "HotReload_ComponentMigratesState" => new HotReloadComponentMigrationFixtures.MigratesPreservingState(harness),
         // DSL and extension tests


### PR DESCRIPTION
Closes #701.

## Summary

#701 asked for a cross-cutting audit of **every reconciler structural-skip arm** to ensure ThemeRef `ResourceOverrides` re-resolve on theme change, fixed consistently, each with a test that fails when reverted ("teeth").

The audit found the **core asymmetry #701 described was already resolved by #675 (PR #758)**, which landed (2026-06-29) *after* #701 was filed (2026-06-26 against commit `3623025f`). #675 took a *centralized* approach rather than #701's per-arm sketch:

- `Element.CanSkipUpdate` now **declines the skip** for any element with `ThemeBindings` **or** `ResourceOverrides is { ThemeRefs.Count: > 0 }`, routing it through `Update`, whose element-level shallow-skip re-applies `ApplyResourceOverrides`. **`Reconciler.Update` is the single source of truth for skip-path theme re-resolution.**
- `ChildDiffHints.IsThemeSensitive` includes `ResourceOverrides.ThemeRefs`, so the bulk array fast-path (`ReconcilePositional`, gated `!AnyThemeSensitive`) falls back to the full walk for themed cells.
- `Element.ShallowEquals` compares `ResourceOverrides` (transition-away handled).

### Per-surface audit result

| # | Skip / patch surface | Re-resolves? | Mechanism | Teeth test |
|---|---|---|---|---|
| 1 | Element-level shallow-skip (`Reconciler.Update`) | ✅ | re-applies `ApplyResourceOverrides` directly | `Issue675_ElementLevelSkipReResolves` |
| 2 | Positional child-skip (`UpdateCommonChild`) | ✅ | `CanSkipUpdate` declines → `Update` | `Issue675_PositionalChildSkipReResolves` |
| 3 | Keyed **prefix** (`ReconcileKeyed`) | ✅ | `CanSkipUpdate` declines | `Issue675_KeyedChildSkipReResolves` |
| 4 | Keyed **suffix** (`ReconcileKeyed`) | ✅ | `CanSkipUpdate` declines | `Issue675_KeyedSuffixChildSkipReResolves` |
| 5 | Bulk array fast-path (`ReconcilePositional`) | ✅ | `!AnyThemeSensitive` gate | `ThemeSensitive_Hint_Forces_Full_Walk` + `IsThemeSensitive_True_For_ResourceOverrides_ThemeRefs` |
| 6 | Keyed **middle / LIS reorder** (`RealKeyedMiddleSink.Patch`) | ✅ | **no skip arm** — always `UpdateChild` → `Update` | ❌ → ✅ **added here** |

**Conclusion: production is already correct on all six surfaces.** The only audit gap was a missing teeth/defensive test for the keyed-middle (LIS reorder) path — the one surface #701 enumerated with no dedicated re-resolve test.

## Changes (test + docs only — no reconciler behavior change)

- **`Issue675ResourceOverrideSkipFixtures.cs`** — add `KeyedMiddleReorderReResolves` selftest covering surface #6. Three keyed children `[a, t, o]` reorder to `[a, o, t]`: prefix consumes `a`, suffix empty, `{t,o}` middle reorders → `ReconcileKeyedMiddle` LIS pass patches the themed survivor via `RealKeyedMiddleSink.Patch`. It mutates the source brush red→blue and asserts the survivor's `fe.Resources[key]` re-resolves to blue, with **right-reason guards**: shallow-equal skip-eligibility, control reused in place (proves `Patch`, not remount), and parent index actually moved (proves the middle path engaged). Class docstring extended to record the full six-surface audit.
- **`SelfTestFixtureRegistry.cs`** — register the new fixture (name list + factory switch).
- **`ChildReconciler.cs`** — audit comment at `RealKeyedMiddleSink.Patch` (comment only) noting it intentionally has **no** skip arm, so a future skip optimization there must mirror `Reconciler.Update`'s re-resolve arm or it will re-introduce the #701/#675 staleness.

## Validation

- ✅ Full Host build clean
- ✅ `Issue701_KeyedMiddleReorderReResolves` selftest: **5/5 green** (incl. the core re-resolve proof + all right-reason guards)
- ✅ All **7** existing `Issue675_*` selftests green (no regression)
- ✅ **22** `ChildDiffHints` + `ChildReconcilerStructuralSkip` unit tests green

## Notes

- Out of scope: the separate `GetEffectiveThemeName`-during-reconcile limitation (a ThemeRef RO resolves against the app fallback theme at reconcile time, so a `RequestedTheme` toggle may not pick the new theme reliably) — already documented in `UseMemoCellsThemeReResolveFixtures` and unrelated to the skip-arm re-resolution #701 targets. This is why the fixtures use deterministic source-brush mutation + `ThemeRef.InvalidateResolutionCache` instead of a theme toggle.