### PR TITLE
Fix flaky AOT selftest RBC_ExitTransitionOnRemove via WaitFor polling

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -817,13 +817,18 @@ internal static class ReconcilerBigCoverageFixtures
             H.Check("ExitTr_Initial3", H.FindText("ex-item-2") is not null);
 
             H.ClickButton("ExitRemove");
-            // Wait long enough for the exit animation (default ~300ms) to complete.
-            await Harness.Render(450);
-            H.Check("ExitTr_Removed", H.FindText("ex-item-2") is null);
+            // The child plays a Fade exit transition (~300ms) before it leaves
+            // the tree; poll with per-pass wall-clock time so we converge as soon
+            // as the transition completes rather than betting on one fixed wait
+            // (which flakes under NativeAOT cold-start jitter — see issue #715).
+            H.Check("ExitTr_Removed",
+                await Harness.WaitFor(() => H.FindText("ex-item-2") is null,
+                    maxPasses: 12, perPassMs: 100));
 
             H.ClickButton("ExitRemove");
-            await Harness.Render(450);
-            H.Check("ExitTr_RemovedAgain", H.FindText("ex-item-1") is null);
+            H.Check("ExitTr_RemovedAgain",
+                await Harness.WaitFor(() => H.FindText("ex-item-1") is null,
+                    maxPasses: 12, perPassMs: 100));
         }
     }
 


### PR DESCRIPTION
## Problem

The selftest fixture `ExitTransitionOnRemove` (`RBC_ExitTransitionOnRemove`) intermittently fails its `ExitTr_Removed` / `ExitTr_RemovedAgain` assertions on the **AOT Selftests** job. It removes a child carrying `.Transition(Transition.Fade)` then waits a **fixed** `await Harness.Render(450)` for the ~300 ms fade to tear down before asserting the element is gone — only ~150 ms of slack. Under NativeAOT cold-start jitter / GC pauses the teardown occasionally slips past the fixed wait, so `FindText` still sees the item and the assertion fails. Timing flake, not a correctness bug.

## Fix

Replace both fixed waits with the existing contention-proof `Harness.WaitFor` poll (`maxPasses: 12, perPassMs: 100`), mirroring the **`CondExit_Removed`** idiom already used a few hundred lines down in the same file for an identical Fade-exit scenario. The poll converges as soon as the transition completes — no fixed margin to outrun.

```csharp
H.ClickButton("ExitRemove");
H.Check("ExitTr_Removed",
    await Harness.WaitFor(() => H.FindText("ex-item-2") is null, maxPasses: 12, perPassMs: 100));
```

Surgical: only the two `ExitTransitionOnRemove` assertions change. The sibling `ExitTransitionOnReplace` (a positive "appears" check, not flaky) is untouched.

## Why poll over widening the wait (data-driven)

I built a deterministic **margin sweep** — driving the fade duration directly (`Curve.Ease(fadeMs)`) in a throwaway instrumented AOT build — to measure each candidate's robustness frontier (max teardown delay tolerated before failure), rather than chasing the rare natural flake. Results (5 fresh-process AOT runs per cell):

| Strategy | Passes up to | First failure | Margin over 300 ms default |
|---|---|---|---|
| baseline `Render(450)` | 400 ms | **≥460 ms** | ~150 ms (razor-thin → flakes) |
| widen `Render(750)` | 700 ms | ≥800 ms (**coin-flip 2✓/3✗ at 760 ms**) | ~450 ms |
| **poll `WaitFor(12×100)`** | **≥1300 ms** | none in range | **≥1000 ms** |

Happy-path wall-clock @ default 300 ms fade (full process incl. AOT cold-start): **poll 1583 ms < baseline 1916 ms < widen 2482 ms**.

Poll is the only strategy with no failure cliff in the realistic range, and it's also the **fastest** (it stops waiting when the fade actually ends instead of always paying a fixed wait). Widening merely moves the cliff from 450 ms to ~760 ms — the 760 ms coin-flip is the same flake mechanism, just relocated.

## Verification

- **40/40** fresh-process AOT runs of `--filter ExitTransitionOnRemove` green, 0 failures.
- JIT selftest (`--self-test --filter ExitTransition`) green, including the untouched `ExitRpl_*` and reference `CondExit_*` checks.

Fixes #715