### PR TITLE
Fix #680: hard-exit the self-test harness to avoid framework teardown access violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,6 +410,33 @@ Conventions for contributors:
   them; and `ReactorWindow.Close()` is now idempotent — a redundant or
   owner-cascade close performs the native close exactly once instead of
   re-entering native teardown.
+- **The full self-test suite no longer faults with an `ACCESS_VIOLATION` at
+  final process exit (issue #680; test infrastructure only).** Distinct from
+  the mid-run multi-window fault fixed in #647/#673, the *entire* self-test
+  suite (~600 fixtures in one process) crashed with `0xC0000005` during final
+  process teardown — green TAP output, then a non-zero process exit. It
+  reproduced only for the whole suite, never for any subset. Root cause is a
+  **Microsoft.UI.Xaml / Microsoft.UI.Windowing framework use-after-free** walked
+  over state the harness deliberately accumulates and never disposes: one shared
+  `Window` carrying hundreds of `Closed` handlers (one per never-disposed
+  `ReactorHost`) plus the windowing fixtures' real `ReactorWindow`s with custom
+  title bars. Every orderly process-exit path trips it — `Environment.Exit`
+  runs the loader's TLS destructors into the XAML core's already-freed tear-off
+  map (`TearoffMemoryInfoPrivate::Discard` → `0xC0000005`), and
+  `Application.Exit` double-releases the caption-buttons UI Automation provider
+  inside `CTitleBar::Uninitialize` (`0xC0000005` → fast-fail `0xC0000409`). Both
+  faults live *inside* framework teardown, so the issue's suspected
+  fix — making Reactor's own `SetTitleBar`/`WindowMessageMonitor`/backdrop
+  unregister idempotent — cannot stop them. Because no real Reactor app
+  accumulates this state (apps dispose hosts and exit via the orderly
+  `ReactorApp.SafeExit` / `Application.Exit` path, already hardened by #647), the
+  fix is scoped to the harness: after flushing the TAP stream, the self-test
+  runner ends via `TerminateProcess(GetCurrentProcess(), exitCode)`, an
+  immediate teardown-free kill that runs neither the loader's TLS destructors nor
+  WinUI's window-close cascade, preserving the exact `0`/`1` exit code. A new CI
+  regression guard (`SelfTestBatch.HostProcessExitsCleanly_NoTeardownCrash`)
+  fails if the Host ever again exits with anything other than `0` or `1`. **No
+  product code changed.**
 - **TitleBar in a non-content-extended window no longer corrupts the heap on
   close (issue #537).** A window whose `WindowSpec` set
   `ExtendsContentIntoTitleBar = false` while its content still rendered a

--- a/tests/Reactor.AppTests.Host/Program.cs
+++ b/tests/Reactor.AppTests.Host/Program.cs
@@ -25,6 +25,11 @@ if (args.Contains("--self-test"))
     if (args.Contains("--no-aot-skip"))
         SelfTestRunner.SkipAotPatterns = false;
     SelfTestRunner.RunAll();
+    // Unreachable in practice: RunAll terminates the process from inside the
+    // dispatcher via SelfTestRunner.EndProcessImmediately (a teardown-free
+    // TerminateProcess — issue #680). This Environment.Exit is only a last-resort
+    // fallback if the message loop ever unwinds without that hard exit firing.
+    Environment.Exit(SelfTestRunner.ExitCode);
 }
 else if (args.Contains("--devtools-stress"))
 {

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -424,9 +424,13 @@ internal static class SelfTestRunner
         // discards anything still sitting in the managed stream buffers. Flushing a
         // closed/redirected stdio pipe throws IOException, and a stream already torn
         // down by an in-flight exit throws ObjectDisposedException; both are expected
-        // on this emergency path and ignored (a typed catch, not a blanket one).
-        try { Console.Out.Flush(); } catch (IOException) { } catch (ObjectDisposedException) { }
-        try { Console.Error.Flush(); } catch (IOException) { } catch (ObjectDisposedException) { }
+        // on this emergency path, so we trace and continue rather than rethrow.
+        try { Console.Out.Flush(); }
+        catch (IOException ex) { Debug.WriteLine($"stdout flush failed during exit, ignored: {ex.Message}"); }
+        catch (ObjectDisposedException ex) { Debug.WriteLine($"stdout flush failed during exit, ignored: {ex.Message}"); }
+        try { Console.Error.Flush(); }
+        catch (IOException ex) { Debug.WriteLine($"stderr flush failed during exit, ignored: {ex.Message}"); }
+        catch (ObjectDisposedException ex) { Debug.WriteLine($"stderr flush failed during exit, ignored: {ex.Message}"); }
 
         // Immediate, teardown-free termination (see the remarks above). -1 is the
         // Win32 current-process pseudo-handle, so no separate GetCurrentProcess

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.UI.Reactor;
@@ -24,8 +25,15 @@ internal static class SelfTestRunner
     /// <c>CTitleBar::Uninitialize</c> double-releases a caption-buttons UI
     /// Automation provider, 0xC0000409) survives the harness's accumulated live
     /// XAML graph. We capture the code here and hard-terminate instead (issue #680).
+    /// <para>
+    /// Defaults to <c>1</c> (failure), not <c>0</c>: the only reader of this
+    /// property is the last-resort <c>Environment.Exit(ExitCode)</c> fallback in
+    /// <c>Program.cs</c>, reached only if the dispatcher loop ever unwinds without
+    /// <see cref="EndProcessImmediately"/> running. Defaulting to failure means
+    /// such an abnormal exit can never masquerade as a clean pass.
+    /// </para>
     /// </summary>
-    internal static int ExitCode { get; private set; }
+    internal static int ExitCode { get; private set; } = 1;
 
     // Guards the one-shot final exit so a per-fixture timeout racing the normal
     // completion path can't terminate the process twice.
@@ -403,32 +411,53 @@ internal static class SelfTestRunner
     /// </summary>
     private static void EndProcessImmediately(int exitCode)
     {
-        ExitCode = exitCode;
         // One-shot: a per-fixture timeout that raced the normal completion path
         // (both funnel here through the run's finally) must not terminate twice.
         if (Interlocked.Exchange(ref _shutdownStarted, 1) != 0)
             return;
+        // Set only after winning the one-shot guard, so a racing second caller
+        // (e.g. the off-dispatcher watchdog) can't overwrite the exit code the
+        // first caller is already terminating with.
+        ExitCode = exitCode;
 
         // Flush TAP/stderr to the OS pipe before the hard kill — TerminateProcess
-        // discards anything still sitting in the managed stream buffers.
-        try { Console.Out.Flush(); } catch { /* mid-exit: nothing we can do */ }
-        try { Console.Error.Flush(); } catch { /* mid-exit: nothing we can do */ }
+        // discards anything still sitting in the managed stream buffers. Flushing a
+        // closed/redirected stdio pipe throws IOException, and a stream already torn
+        // down by an in-flight exit throws ObjectDisposedException; both are expected
+        // on this emergency path and ignored (a typed catch, not a blanket one).
+        try { Console.Out.Flush(); } catch (IOException) { } catch (ObjectDisposedException) { }
+        try { Console.Error.Flush(); } catch (IOException) { } catch (ObjectDisposedException) { }
 
-        // Immediate, teardown-free termination (see the remarks above). Does not
-        // return on success.
-        TerminateProcess(GetCurrentProcess(), unchecked((uint)exitCode));
+        // Immediate, teardown-free termination (see the remarks above). -1 is the
+        // Win32 current-process pseudo-handle, so no separate GetCurrentProcess
+        // interop is needed. On success this never returns — the OS tears the
+        // process down abruptly, running no TLS destructors or window-close cascade
+        // (the whole point). Reaching the lines below therefore means the syscall
+        // itself failed (e.g. blocked by policy); record why before falling back.
+        if (!TerminateProcess(CurrentProcessPseudoHandle, unchecked((uint)exitCode)))
+            Debug.WriteLine($"TerminateProcess failed: 0x{Marshal.GetLastWin32Error():X8}");
 
-        // Unreachable unless TerminateProcess itself failed; fall back to the
-        // managed exit so the process still leaves with the captured code.
+        // Last resort: force a managed exit so a Host that somehow survived the
+        // kill still leaves with the captured code rather than running on. This
+        // path may itself trip the #680 teardown fault, but an abrupt exit beats a
+        // hung Host.
         Environment.Exit(exitCode);
     }
 
-    [DllImport("kernel32.dll")]
-    private static extern IntPtr GetCurrentProcess();
+    // The Win32 current-process pseudo-handle, (HANDLE)-1. Passing it directly
+    // avoids a second P/Invoke just to fetch the current process handle.
+    private static readonly nint CurrentProcessPseudoHandle = -1;
 
+    // The single retained Win32 import. No managed API gives a teardown-free exit
+    // that ALSO carries a specific 0/1 exit code: Environment.Exit runs the loader's
+    // TLS destructors (the issue #680 fault we are dodging), Environment.FailFast
+    // leaves a fail-fast exit code (0xC0000409) plus a WER dump on every run, and
+    // Process.Kill forces exit code -1 — each would defeat the fix or trip the
+    // HostProcessExitsCleanly_NoTeardownCrash regression guard. TerminateProcess is
+    // the only mechanism that terminates immediately with the exact captured code.
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);
+    private static extern bool TerminateProcess(nint hProcess, uint uExitCode);
 
     private static void StartHangWatchdog()
     {

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -35,8 +35,11 @@ internal static class SelfTestRunner
     /// </summary>
     internal static int ExitCode { get; private set; } = 1;
 
-    // Guards the one-shot final exit so a per-fixture timeout racing the normal
-    // completion path can't terminate the process twice.
+    // Defensive idempotency latch for the final exit. EndProcessImmediately has a
+    // single caller today — the run's finally — so this normally just passes
+    // through; it ensures the process still terminates exactly once should a future
+    // change ever add a second exit path. (The off-dispatcher hang watchdog is a
+    // separate, independent FailFast path and never calls EndProcessImmediately.)
     private static int _shutdownStarted;
 
     /// <summary>
@@ -411,13 +414,14 @@ internal static class SelfTestRunner
     /// </summary>
     private static void EndProcessImmediately(int exitCode)
     {
-        // One-shot: a per-fixture timeout that raced the normal completion path
-        // (both funnel here through the run's finally) must not terminate twice.
+        // Idempotency latch. EndProcessImmediately is invoked once, from the run's
+        // finally; the per-fixture timeout path doesn't call it directly — it marks
+        // the fixture failed and breaks into that same finally. The latch is
+        // defensive so any future second exit path still terminates exactly once.
         if (Interlocked.Exchange(ref _shutdownStarted, 1) != 0)
             return;
-        // Set only after winning the one-shot guard, so a racing second caller
-        // (e.g. the off-dispatcher watchdog) can't overwrite the exit code the
-        // first caller is already terminating with.
+        // Set after the latch so that if a second exit path is ever added, the
+        // first caller's code is the one the process terminates with.
         ExitCode = exitCode;
 
         // Flush TAP/stderr to the OS pipe before the hard kill — TerminateProcess

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestRunner.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -13,6 +14,22 @@ namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest;
 internal static class SelfTestRunner
 {
     public static string? Filter { get; set; }
+
+    /// <summary>
+    /// Process exit code captured by the final-exit path (<see
+    /// cref="EndProcessImmediately"/>). The full suite must never run any orderly
+    /// process-exit teardown — neither <see cref="Environment.Exit(int)"/> (whose
+    /// <c>ExitProcess</c> TLS destructors fault in Microsoft.UI.Xaml's tear-off
+    /// teardown, 0xC0000005) nor <see cref="Application.Exit"/> (whose
+    /// <c>CTitleBar::Uninitialize</c> double-releases a caption-buttons UI
+    /// Automation provider, 0xC0000409) survives the harness's accumulated live
+    /// XAML graph. We capture the code here and hard-terminate instead (issue #680).
+    /// </summary>
+    internal static int ExitCode { get; private set; }
+
+    // Guards the one-shot final exit so a per-fixture timeout racing the normal
+    // completion path can't terminate the process twice.
+    private static int _shutdownStarted;
 
     /// <summary>
     /// When true (the default), <see cref="DefaultAotSkipPatterns"/> is honoured
@@ -304,7 +321,15 @@ internal static class SelfTestRunner
                                     Console.WriteLine($"not ok {testIndex} {fixtureName}_TIMEOUT - exceeded {timeout.TotalSeconds:0}s");
                                     Console.Out.Flush();
                                     harness.RecordFailure();
-                                    Environment.Exit(1);
+                                    // Issue #680: do NOT Environment.Exit(1) here. Mark this
+                                    // fixture failed and break so the shared finally drives the
+                                    // single teardown-free EndProcessImmediately() exit (ExitCode
+                                    // = 1 via Failures > 0). Any orderly process-exit from inside
+                                    // the live dispatcher loop, with the suite's accumulated XAML
+                                    // graph still mounted, faults in framework teardown.
+                                    Volatile.Write(ref _currentFixture, null);
+                                    harness.MarkFixtureResult(testIndex - 1, false);
+                                    break;
                                 }
                                 else
                                 {
@@ -338,12 +363,72 @@ internal static class SelfTestRunner
                 }
                 finally
                 {
-                    Console.Out.Flush();
-                    Environment.Exit(harness.Failures > 0 ? 1 : 0);
+                    EndProcessImmediately(harness.Failures > 0 ? 1 : 0);
                 }
             });
         });
     }
+
+    /// <summary>
+    /// Ends the self-test process **without running any WinUI or CLR teardown**.
+    /// <para>
+    /// The harness reuses a single <see cref="Window"/> across ~600 fixtures and
+    /// never disposes the <c>ReactorHost</c>s it creates, and the windowing
+    /// fixtures open real <c>ReactorWindow</c>s with custom title bars. Every
+    /// orderly process-exit path walks that accumulated, still-live XAML object
+    /// graph and trips a Microsoft.UI.Xaml / Microsoft.UI.Windowing framework
+    /// use-after-free during teardown (issue #680):
+    /// </para>
+    /// <list type="bullet">
+    /// <item><see cref="Environment.Exit(int)"/> → <c>ExitProcess</c> runs the
+    /// loader's TLS destructors, which destroy live <c>DependencyObject</c>s and
+    /// dereference the XAML core's already-freed tear-off map
+    /// (<c>TearoffMemoryInfoPrivate::Discard</c>) → 0xC0000005.</item>
+    /// <item><see cref="Application.Exit"/> tears the windows down in order, but
+    /// <c>CTitleBar::Uninitialize</c> double-releases the caption-buttons UI
+    /// Automation provider (<c>CTitleBarCaptionButtonsFragmentProvider</c>),
+    /// which the suite's windowing fixtures created via
+    /// <c>OverlappedPresenter.SetBorderAndTitleBar</c> → 0xC0000005 escalated to
+    /// STATUS_FATAL_USER_CALLBACK_EXCEPTION → fast-fail 0xC0000409.</item>
+    /// </list>
+    /// <para>
+    /// Both faults live in framework teardown the harness cannot make safe from
+    /// managed code, so — once the TAP stream is flushed — we
+    /// <c>TerminateProcess</c> ourselves with the captured exit code. That kills
+    /// every thread immediately, running neither the loader's TLS destructors nor
+    /// WinUI's window-close cascade, so neither teardown bug can fire. A real
+    /// Reactor app never accumulates this state and keeps exiting via the orderly
+    /// <c>ReactorApp.SafeExit</c> / <see cref="Application.Exit"/> path.
+    /// </para>
+    /// </summary>
+    private static void EndProcessImmediately(int exitCode)
+    {
+        ExitCode = exitCode;
+        // One-shot: a per-fixture timeout that raced the normal completion path
+        // (both funnel here through the run's finally) must not terminate twice.
+        if (Interlocked.Exchange(ref _shutdownStarted, 1) != 0)
+            return;
+
+        // Flush TAP/stderr to the OS pipe before the hard kill — TerminateProcess
+        // discards anything still sitting in the managed stream buffers.
+        try { Console.Out.Flush(); } catch { /* mid-exit: nothing we can do */ }
+        try { Console.Error.Flush(); } catch { /* mid-exit: nothing we can do */ }
+
+        // Immediate, teardown-free termination (see the remarks above). Does not
+        // return on success.
+        TerminateProcess(GetCurrentProcess(), unchecked((uint)exitCode));
+
+        // Unreachable unless TerminateProcess itself failed; fall back to the
+        // managed exit so the process still leaves with the captured code.
+        Environment.Exit(exitCode);
+    }
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr GetCurrentProcess();
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);
 
     private static void StartHangWatchdog()
     {

--- a/tests/Reactor.SelfTests/SelfTestBatch.cs
+++ b/tests/Reactor.SelfTests/SelfTestBatch.cs
@@ -26,6 +26,9 @@ public class SelfTestBatch
     private static string _fullOutput = "";
     private static bool _initialized;
     private static string? _initError;
+    // Captured process outcome for the teardown-exit-code guard (issue #680).
+    private static int _exitCode;
+    private static bool _timedOut;
     // When the Host run aborts (hang/timeout) we attribute the failure to a
     // single fixture, but every later fixture still has no entry in
     // _byFixture. _abortedReason marks the run as not-fully-executed so the
@@ -39,6 +42,8 @@ public class SelfTestBatch
     {
         var exe = FindHostExe();
         var (stdout, stderr, exitCode, timedOut) = RunProcess(exe, "--self-test", SelfTestTimeoutMs);
+        _exitCode = exitCode;
+        _timedOut = timedOut;
 
         _fullOutput = stdout;
         if (!string.IsNullOrEmpty(stderr))
@@ -313,6 +318,44 @@ public class SelfTestBatch
 
         if (!result.Passed)
             Assert.Fail(result.Detail);
+    }
+
+    /// <summary>
+    /// Regression guard for issue #680. The full self-test suite used to fault
+    /// with 0xC0000005 at *final process teardown*: <c>SelfTestRunner</c> called
+    /// <see cref="System.Environment.Exit(int)"/> from inside the live WinUI
+    /// desktop message loop, which jumps straight to <c>ExitProcess</c> and lets
+    /// the Windows loader run Microsoft.UI.Xaml's TLS destructors while the
+    /// suite's accumulated XAML object graph is still mounted — a
+    /// <c>DependencyObject</c> destructor then dereferences the XAML core's
+    /// already-freed tear-off bookkeeping map and access-violates.
+    /// <para>
+    /// The per-fixture <see cref="Fixture"/> tests can't catch this: every
+    /// fixture has already emitted its TAP result before the teardown crash, so
+    /// the run looks green even though the process exited with a crash code.
+    /// This guard asserts the Host exited with one of the only two codes the
+    /// runner legitimately produces — 0 (all passed) or 1 (fixture failures) —
+    /// so a teardown access violation (a large negative exit code) fails CI.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public void HostProcessExitsCleanly_NoTeardownCrash()
+    {
+        Assert.IsTrue(_initialized, "Self-test batch did not run.");
+        if (_initError is not null)
+            Assert.Fail(_initError);
+
+        // Hang/timeout is surfaced per-fixture by the watchdog path and the
+        // process is killed (exit code is not meaningful), so this teardown
+        // guard only applies to a run that completed on its own.
+        if (_timedOut || _abortedReason is not null)
+            Assert.Inconclusive(_abortedReason ?? "Self-test process timed out; teardown exit code is not meaningful.");
+
+        Assert.IsTrue(_exitCode is 0 or 1,
+            $"Self-test Host exited with code {_exitCode} (0x{_exitCode & 0xFFFFFFFFL:X8}) — the runner only " +
+            $"ever returns 0 (all passed) or 1 (fixture failures), so any other code means the process faulted " +
+            $"at teardown (e.g. 0xC0000005). This is the issue #680 final-exit access violation.\n" +
+            $"--- tail of full output ---\n{Tail(_fullOutput, 4000)}");
     }
 
     // -- Discovery: one-shot Host launch to list fixture names -----------------


### PR DESCRIPTION
Closes #680.

## Problem

After #647 / #673 fixed the *mid-run* multi-window teardown poisoning, a **distinct, residual** access violation remained: the **full** self-test suite (~600 fixtures in one process) faulted with `0xC0000005` during **final process teardown**. The TAP stream finished green, then the process exited non-zero. It reproduced **only for the whole suite**, never for any subset (Window / AspectRatio / NativeDockingTearOff all exit 0 individually), and was independent of the #647 docking change.

## Root cause (confirmed via PageHeap + cdb)

A **Microsoft.UI.Xaml / Microsoft.UI.Windowing framework use-after-free**, walked over state the harness *deliberately* accumulates and never disposes: one shared `Window` carrying hundreds of `Closed` handlers (one per never-disposed `ReactorHost`), plus the windowing fixtures' real `ReactorWindow`s with custom title bars. **Every** orderly process-exit path trips it:

1. **`Environment.Exit`** (the original exit) → `ExitProcess` runs the loader's TLS destructors, which destroy still-live `DependencyObject`s and dereference the XAML core's already-freed tear-off map (`TearoffMemoryInfoPrivate::Discard`) → **`0xC0000005`**.
2. **`Application.Exit`** (an interim fix attempt) tears the windows down in order, but `CTitleBar::Uninitialize` **double-releases the caption-buttons UI Automation provider** (`CTitleBarCaptionButtonsFragmentProvider`) — created for the windowing fixtures via `OverlappedPresenter.SetBorderAndTitleBar` → `0xC0000005` escalated to `STATUS_FATAL_USER_CALLBACK_EXCEPTION` → fast-fail **`0xC0000409`**.

Both faults live **inside framework teardown**. `ReactorWindow.ApplyWindowStyle` issues a *single*, legitimate `SetBorderAndTitleBar` call — the double-*release* is WinUI-internal, **not** a Reactor double-call. (The existing #537 `PrepareTitleBarForClose` mitigation targets the *XAML `TitleBar` control*, a different mechanism, and does not cover this native-presenter path.)

### Why the issue's suspected direction is insufficient

#680 hypothesized an **idempotent Reactor-side interop unregister** (`SetTitleBar` / `WindowMessageMonitor` / backdrop) during the mass-`Closed` cascade. But the double-release is *inside* WinUI's `CTitleBar::Uninitialize`, not in Reactor's interop — so making Reactor's own teardown idempotent cannot stop it. The harness has to avoid running framework teardown **at all**.

## Fix (test infrastructure only)

Because no real Reactor app accumulates this state — apps dispose hosts and exit via the orderly `ReactorApp.SafeExit` / `Application.Exit` path, already hardened by #647 — the fix is scoped to the **self-test harness**. After flushing the TAP/stderr streams, `SelfTestRunner` ends via:

```
TerminateProcess(GetCurrentProcess(), exitCode)
```

an immediate, teardown-free kill that runs **neither** the loader's TLS destructors **nor** WinUI's window-close cascade, so neither bug can fire — while preserving the exact `0` (all passed) / `1` (failures) exit code. The previous `ShutdownCleanly`/`Environment.Exit` path is replaced by `EndProcessImmediately(int)`; the per-fixture-timeout and `finally` paths both funnel through it (one-shot guarded).

**No product code changed.**

## Regression guard

`SelfTestBatch.HostProcessExitsCleanly_NoTeardownCrash` asserts the Host process exits with only `0` or `1`; any other code (e.g. a `0xC0000005` teardown AV, which surfaces as a large negative exit code) fails CI. It is `Inconclusive` on a watchdog timeout/abort (where the exit code isn't meaningful).

## Verification

- ✅ `Reactor` core, `Reactor.AppTests.Host`, and `Reactor.SelfTests` all build clean x64 (0 warnings / 0 errors) — the whole change compiles.
- ✅ `dotnet test tests/Reactor.Tests` (x64): **9978 passed, 0 failed, 64 skipped**. (Core is untouched.)
- ⚠️ **Full-suite empirical run is deferred to CI.** Locally the suite was diagnosed under full **PageHeap**, where the borderless windowing fixture's first-chance AV becomes a synchronous dispatcher *deadlock* before the exit path is ever reached. CI runs without PageHeap, so the **full self-test suite + the new regression guard** are the empirical confirmation here.

## Notes for reviewers

- The borderless `SetBorderAndTitleBar` UIA double-release is a latent **WinUI framework** bug surfaced by the harness's accumulated state; the API call itself is correct for borderless windows. It is out of scope for this harness-exit fix and is a candidate follow-up (e.g. a WinUI-side report).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>