### PR TITLE
hooks: typed-arity UseEffect/UseMemo/UseCallback overloads + #688 api/docs follow-ups

### DIFF
--- a/docs/_pipeline/templates/effects.md.dt
+++ b/docs/_pipeline/templates/effects.md.dt
@@ -37,6 +37,7 @@ subscriptions, and DOM manipulation all belong in effects, not in `Render()`.
 |---|---|---|
 | `UseEffect(Action body, params object[] deps)` | After every commit where any entry in `deps` compares unequal (`Array.Empty<object>()` → mount only). | Never — no cleanup function. |
 | `UseEffect(Func<Action> bodyWithCleanup, params object[] deps)` | Same as above. | Before the next body run, and on unmount. |
+| `UseEffect<T1>(Action body, T1 d1)` (also `<T1,T2>`, `<T1,T2,T3>`, and `Func<Action>` flavors) | Same as the `params` overload — typed-arity sugar for 1–3 deps. | As above. |
 
 Both overloads accept a `params` deps argument; pass no values for "run every
 commit" (rarely correct), `Array.Empty<object>()` for "run once on mount",
@@ -44,6 +45,16 @@ or one-or-more reactive values for "re-run when any of these change". Compare
 with <!-- ref:UseResource --> when the side effect is a cached async read —
 see [Async Resources](async-resources.md) for the cached-fetch shape, which
 handles cancellation, retry, and revalidation for you.
+
+When you have one, two, or three dependencies, the **typed-arity overloads**
+(`UseEffect(body, a, b)`) are a drop-in alternative to the `params` form. They
+pass the deps positionally instead of through a `params object[]`, so the
+unchanged-deps path allocates no array and never boxes value-type deps (`int`,
+`bool`, enums, structs). Behaviour is otherwise identical — the same per-element
+equality comparison decides whether the body re-runs — so prefer them on hot
+render paths. A single dependency whose compile-time type is an array (for
+example `string[]`) is still compared element-by-element, matching the `params`
+form.
 
 ## Running Once on Mount
 

--- a/docs/_pipeline/templates/effects.md.dt
+++ b/docs/_pipeline/templates/effects.md.dt
@@ -52,9 +52,11 @@ pass the deps positionally instead of through a `params object[]`, so the
 unchanged-deps path allocates no array and never boxes value-type deps (`int`,
 `bool`, enums, structs). Behaviour is otherwise identical — the same per-element
 equality comparison decides whether the body re-runs — so prefer them on hot
-render paths. A single dependency whose compile-time type is an array (for
-example `string[]`) is still compared element-by-element, matching the `params`
-form.
+render paths. A single dependency whose compile-time type is an array **of
+reference types** (for example `string[]`) is still compared element-by-element,
+matching the `params` form; a value-type array such as `int[]` is treated as one
+reference-compared dependency, so pass its elements as separate deps if you want
+element-wise comparison.
 
 ## Running Once on Mount
 

--- a/docs/_pipeline/templates/hooks.md.dt
+++ b/docs/_pipeline/templates/hooks.md.dt
@@ -114,6 +114,11 @@ Key details:
 - **Empty dependencies** `UseEffect(() => { ... })` — runs once on mount.
 - **With dependencies** `UseEffect(() => { ... }, running)` — runs when
   `running` changes.
+- **Typed-arity overloads** — for one, two, or three dependencies,
+  `UseEffect(body, a, b)` passes the deps positionally instead of through a
+  `params object[]`. The unchanged-deps path allocates no array and avoids
+  boxing value-type deps; behaviour is otherwise identical. The same overloads
+  exist for `UseMemo` and `UseCallback`.
 
 ## UseMemo
 
@@ -127,6 +132,10 @@ Cache an expensive computation so it only recalculates when its inputs change:
 `UseMemo` compares the dependency values between renders. If they haven't
 changed, it returns the cached result. Use it for string processing, filtering
 large lists, or any computation you don't want to repeat every render.
+
+For one to three dependencies, the typed-arity overloads
+`UseMemo(factory, a, b)` avoid the `params object[]` allocation and value-type
+boxing on the unchanged path — handy when a memo sits on a hot render path.
 
 ## UseRef
 
@@ -159,6 +168,10 @@ Without `UseCallback`, the lambda `() => updateCount(c => c + 1)` would be a new
 object every render. `UseCallback` returns the same delegate instance as long
 as the dependencies haven't changed. This matters when passing callbacks to
 memoized [child components](components.md).
+
+As with `UseEffect` and `UseMemo`, the typed-arity overloads
+`UseCallback(callback, a, b)` (1–3 deps) skip the `params object[]` allocation
+and value-type boxing on the unchanged path.
 
 ## Updating State From Background Work
 

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -26,6 +26,7 @@ subscriptions, and DOM manipulation all belong in effects, not in `Render()`.
 |---|---|---|
 | `UseEffect(Action body, params object[] deps)` | After every commit where any entry in `deps` compares unequal (`Array.Empty<object>()` → mount only). | Never — no cleanup function. |
 | `UseEffect(Func<Action> bodyWithCleanup, params object[] deps)` | Same as above. | Before the next body run, and on unmount. |
+| `UseEffect<T1>(Action body, T1 d1)` (also `<T1,T2>`, `<T1,T2,T3>`, and `Func<Action>` flavors) | Same as the `params` overload — typed-arity sugar for 1–3 deps. | As above. |
 
 Both overloads accept a `params` deps argument; pass no values for "run every
 commit" (rarely correct), `Array.Empty<object>()` for "run once on mount",
@@ -33,6 +34,16 @@ or one-or-more reactive values for "re-run when any of these change". Compare
 with [UseResource](reference/hooks/UseResource.md) when the side effect is a cached async read —
 see [Async Resources](async-resources.md) for the cached-fetch shape, which
 handles cancellation, retry, and revalidation for you.
+
+When you have one, two, or three dependencies, the **typed-arity overloads**
+(`UseEffect(body, a, b)`) are a drop-in alternative to the `params` form. They
+pass the deps positionally instead of through a `params object[]`, so the
+unchanged-deps path allocates no array and never boxes value-type deps (`int`,
+`bool`, enums, structs). Behaviour is otherwise identical — the same per-element
+equality comparison decides whether the body re-runs — so prefer them on hot
+render paths. A single dependency whose compile-time type is an array (for
+example `string[]`) is still compared element-by-element, matching the `params`
+form.
 
 ## Running Once on Mount
 

--- a/docs/guide/effects.md
+++ b/docs/guide/effects.md
@@ -41,9 +41,11 @@ pass the deps positionally instead of through a `params object[]`, so the
 unchanged-deps path allocates no array and never boxes value-type deps (`int`,
 `bool`, enums, structs). Behaviour is otherwise identical — the same per-element
 equality comparison decides whether the body re-runs — so prefer them on hot
-render paths. A single dependency whose compile-time type is an array (for
-example `string[]`) is still compared element-by-element, matching the `params`
-form.
+render paths. A single dependency whose compile-time type is an array **of
+reference types** (for example `string[]`) is still compared element-by-element,
+matching the `params` form; a value-type array such as `int[]` is treated as one
+reference-compared dependency, so pass its elements as separate deps if you want
+element-wise comparison.
 
 ## Running Once on Mount
 

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -206,6 +206,11 @@ Key details:
 - **Empty dependencies** `UseEffect(() => { ... })` — runs once on mount.
 - **With dependencies** `UseEffect(() => { ... }, running)` — runs when
   `running` changes.
+- **Typed-arity overloads** — for one, two, or three dependencies,
+  `UseEffect(body, a, b)` passes the deps positionally instead of through a
+  `params object[]`. The unchanged-deps path allocates no array and avoids
+  boxing value-type deps; behaviour is otherwise identical. The same overloads
+  exist for `UseMemo` and `UseCallback`.
 
 ## UseMemo
 
@@ -241,6 +246,10 @@ class MemoDemo : Component
 `UseMemo` compares the dependency values between renders. If they haven't
 changed, it returns the cached result. Use it for string processing, filtering
 large lists, or any computation you don't want to repeat every render.
+
+For one to three dependencies, the typed-arity overloads
+`UseMemo(factory, a, b)` avoid the `params object[]` allocation and value-type
+boxing on the unchanged path — handy when a memo sits on a hot render path.
 
 ## UseRef
 
@@ -310,6 +319,10 @@ Without `UseCallback`, the lambda `() => updateCount(c => c + 1)` would be a new
 object every render. `UseCallback` returns the same delegate instance as long
 as the dependencies haven't changed. This matters when passing callbacks to
 memoized [child components](components.md).
+
+As with `UseEffect` and `UseMemo`, the typed-arity overloads
+`UseCallback(callback, a, b)` (1–3 deps) skip the `params object[]` allocation
+and value-type boxing on the unchanged path.
 
 ## Updating State From Background Work
 

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -857,6 +857,9 @@ RenderContext.UseAnnounce() → AnnounceHandle
 RenderContext.UseBreakpoint(Window window, double minWidth) → bool
 RenderContext.UseBreakpoint(double minWidth) → bool
 RenderContext.UseCallback(Action callback, object[] dependencies) → Action
+RenderContext.UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3) → Action
+RenderContext.UseCallback<T1, T2>(Action callback, T1 d1, T2 d2) → Action
+RenderContext.UseCallback<T1>(Action callback, T1 d1) → Action
 RenderContext.UseChildValidationContext() → ValueTuple<ValidationContext, ValidationContext>
 RenderContext.UseClosingGuard(Func<bool> canClose) → void
 RenderContext.UseCollection<T>(ObservableCollection<T> collection) → IReadOnlyList<T>
@@ -875,6 +878,12 @@ RenderContext.UseDockState() → DockPaneState
 RenderContext.UseDpi() → UInt32
 RenderContext.UseEffect(Action effect, object[] dependencies) → void
 RenderContext.UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
+RenderContext.UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void
+RenderContext.UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3) → void
+RenderContext.UseEffect<T1, T2>(Action effect, T1 d1, T2 d2) → void
+RenderContext.UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2) → void
+RenderContext.UseEffect<T1>(Action effect, T1 d1) → void
+RenderContext.UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1) → void
 RenderContext.UseElementFocus(FocusState state = FocusState.Programmatic) → ValueTuple<ElementRef, Action>
 RenderContext.UseElementRef<T>() → ElementRef<T>
 RenderContext.UseFilePickerAsync(FilePickerOptions options) → Task<StorageFile>
@@ -890,6 +899,9 @@ RenderContext.UseIsActive() → bool
 RenderContext.UseIsActivePane() → bool
 RenderContext.UseIsCovered() → bool
 RenderContext.UseIsDarkTheme() → bool
+RenderContext.UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3) → T
+RenderContext.UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2) → T
+RenderContext.UseMemo<T, T1>(Func<T> factory, T1 d1) → T
 RenderContext.UseMemo<T>(Func<T> factory, object[] dependencies) → T
 RenderContext.UseMemoCells<T>(IReadOnlyList<T> items, Func<T, int, Element> builder, object[] dependencies) → Element[]
 RenderContext.UseMemoCellsByIndex<T>(IReadOnlyList<T> items, IReadOnlyList<int> changedIndices, Func<T, int, Element> builder, object[] dependencies) → Element[]
@@ -5699,6 +5711,9 @@ new()
 UseBreakpoint(Window window, double minWidth) → bool
 UseBreakpoint(double minWidth) → bool
 UseCallback(Action callback, object[] dependencies) → Action
+UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3) → Action
+UseCallback<T1, T2>(Action callback, T1 d1, T2 d2) → Action
+UseCallback<T1>(Action callback, T1 d1) → Action
 UseClosingGuard(Func<bool> canClose) → void
 UseCollection<T>(ObservableCollection<T> collection) → IReadOnlyList<T>
 UseColorScheme() → ColorScheme
@@ -5709,6 +5724,12 @@ UseDisplays() → IReadOnlyList<DisplayInfo>
 UseDpi() → UInt32
 UseEffect(Action effect, object[] dependencies) → void
 UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
+UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void
+UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3) → void
+UseEffect<T1, T2>(Action effect, T1 d1, T2 d2) → void
+UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2) → void
+UseEffect<T1>(Action effect, T1 d1) → void
+UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1) → void
 UseFilePickerAsync(FilePickerOptions options) → Task<StorageFile>
 UseFolderPickerAsync(FolderPickerOptions options) → Task<StorageFolder>
 UseHighContrast() → bool
@@ -5717,6 +5738,9 @@ UseIntl() → IntlAccessor
 UseIsActive() → bool
 UseIsCovered() → bool
 UseIsDarkTheme() → bool
+UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3) → T
+UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2) → T
+UseMemo<T, T1>(Func<T> factory, T1 d1) → T
 UseMemo<T>(Func<T> factory, object[] dependencies) → T
 UseNavigation<TRoute>() → NavigationHandle<TRoute>
 UseNavigation<TRoute>(TRoute initial) → NavigationHandle<TRoute>

--- a/skills/perf-tips.md
+++ b/skills/perf-tips.md
@@ -29,7 +29,10 @@ If none of those apply, close this file and write the obvious thing.
 
 The everyday wrappers. `UseMemo` caches the result of an expensive
 computation; `UseCallback` returns a stable callback identity across renders.
-Both take trailing `params object[] deps`.
+Both take trailing `params object[] deps`; for one to three deps the typed-arity
+overloads (`UseMemo(() => Sort(items), items)`, `UseCallback(cb, a, b)`) skip the
+`params object[]` allocation and value-type boxing on the unchanged-deps path —
+prefer them on the hot paths this file is about.
 
 ```csharp
 var sortedItems = ctx.UseMemo(() => Sort(items), items);

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -857,6 +857,9 @@ RenderContext.UseAnnounce() → AnnounceHandle
 RenderContext.UseBreakpoint(Window window, double minWidth) → bool
 RenderContext.UseBreakpoint(double minWidth) → bool
 RenderContext.UseCallback(Action callback, object[] dependencies) → Action
+RenderContext.UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3) → Action
+RenderContext.UseCallback<T1, T2>(Action callback, T1 d1, T2 d2) → Action
+RenderContext.UseCallback<T1>(Action callback, T1 d1) → Action
 RenderContext.UseChildValidationContext() → ValueTuple<ValidationContext, ValidationContext>
 RenderContext.UseClosingGuard(Func<bool> canClose) → void
 RenderContext.UseCollection<T>(ObservableCollection<T> collection) → IReadOnlyList<T>
@@ -875,6 +878,12 @@ RenderContext.UseDockState() → DockPaneState
 RenderContext.UseDpi() → UInt32
 RenderContext.UseEffect(Action effect, object[] dependencies) → void
 RenderContext.UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
+RenderContext.UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void
+RenderContext.UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3) → void
+RenderContext.UseEffect<T1, T2>(Action effect, T1 d1, T2 d2) → void
+RenderContext.UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2) → void
+RenderContext.UseEffect<T1>(Action effect, T1 d1) → void
+RenderContext.UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1) → void
 RenderContext.UseElementFocus(FocusState state = FocusState.Programmatic) → ValueTuple<ElementRef, Action>
 RenderContext.UseElementRef<T>() → ElementRef<T>
 RenderContext.UseFilePickerAsync(FilePickerOptions options) → Task<StorageFile>
@@ -890,6 +899,9 @@ RenderContext.UseIsActive() → bool
 RenderContext.UseIsActivePane() → bool
 RenderContext.UseIsCovered() → bool
 RenderContext.UseIsDarkTheme() → bool
+RenderContext.UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3) → T
+RenderContext.UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2) → T
+RenderContext.UseMemo<T, T1>(Func<T> factory, T1 d1) → T
 RenderContext.UseMemo<T>(Func<T> factory, object[] dependencies) → T
 RenderContext.UseMemoCells<T>(IReadOnlyList<T> items, Func<T, int, Element> builder, object[] dependencies) → Element[]
 RenderContext.UseMemoCellsByIndex<T>(IReadOnlyList<T> items, IReadOnlyList<int> changedIndices, Func<T, int, Element> builder, object[] dependencies) → Element[]
@@ -5699,6 +5711,9 @@ new()
 UseBreakpoint(Window window, double minWidth) → bool
 UseBreakpoint(double minWidth) → bool
 UseCallback(Action callback, object[] dependencies) → Action
+UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3) → Action
+UseCallback<T1, T2>(Action callback, T1 d1, T2 d2) → Action
+UseCallback<T1>(Action callback, T1 d1) → Action
 UseClosingGuard(Func<bool> canClose) → void
 UseCollection<T>(ObservableCollection<T> collection) → IReadOnlyList<T>
 UseColorScheme() → ColorScheme
@@ -5709,6 +5724,12 @@ UseDisplays() → IReadOnlyList<DisplayInfo>
 UseDpi() → UInt32
 UseEffect(Action effect, object[] dependencies) → void
 UseEffect(Func<Action> effectWithCleanup, object[] dependencies) → void
+UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3) → void
+UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3) → void
+UseEffect<T1, T2>(Action effect, T1 d1, T2 d2) → void
+UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2) → void
+UseEffect<T1>(Action effect, T1 d1) → void
+UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1) → void
 UseFilePickerAsync(FilePickerOptions options) → Task<StorageFile>
 UseFolderPickerAsync(FolderPickerOptions options) → Task<StorageFolder>
 UseHighContrast() → bool
@@ -5717,6 +5738,9 @@ UseIntl() → IntlAccessor
 UseIsActive() → bool
 UseIsCovered() → bool
 UseIsDarkTheme() → bool
+UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3) → T
+UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2) → T
+UseMemo<T, T1>(Func<T> factory, T1 d1) → T
 UseMemo<T>(Func<T> factory, object[] dependencies) → T
 UseNavigation<TRoute>() → NavigationHandle<TRoute>
 UseNavigation<TRoute>(TRoute initial) → NavigationHandle<TRoute>

--- a/src/Reactor.Analyzers/HookRulesAnalyzer.cs
+++ b/src/Reactor.Analyzers/HookRulesAnalyzer.cs
@@ -355,9 +355,10 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
             }
 
             if (param is null) continue;
-            // Skip unless this is the "deps" parameter (conventionally named). Several
-            // overloads exist — names include "deps", "dependencies".
-            if (param.Name is not ("deps" or "dependencies")) continue;
+            // Skip unless this is a "deps" parameter. Several overloads exist: the
+            // `params object[]` flavor names it "deps"/"dependencies", while the typed-arity
+            // overloads (UseEffect&lt;T1&gt;, UseMemo&lt;T,T1&gt;, ...) name them "d1"/"d2"/"d3".
+            if (param.Name is not ("deps" or "dependencies" or "d1" or "d2" or "d3")) continue;
             // Params arrays are handled by the tail-pass below; skip here to avoid
             // double-reporting when the user passes a scalar to a `params object[] deps`
             // parameter.

--- a/src/Reactor.Analyzers/HookRulesAnalyzer.cs
+++ b/src/Reactor.Analyzers/HookRulesAnalyzer.cs
@@ -364,30 +364,22 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
             // parameter.
             if (param.IsParams) continue;
 
-            // If the deps parameter is an explicit `object[]`, the argument will be a
-            // single array-creation expression (explicit or implicit). Flag the array
-            // elements individually.
-            if (arg.Expression is ArrayCreationExpressionSyntax arrCreation
-                && arrCreation.Initializer is { } init)
+            // An array-literal argument bound to a deps parameter is treated as a
+            // dependency LIST (flagged element-by-element) only when its element type is
+            // a REFERENCE type — mirroring the runtime AsParamsArrayDep gate, which
+            // unwraps a covariant object[]/string[] but compares a value-type array
+            // (e.g. int[]) as ONE reference dep. For a value-type array we fall through
+            // and flag the freshly-allocated array itself, matching the per-render
+            // re-run the hook actually performs at runtime.
+            var depListElements = ReferenceArrayDepElements(model, arg.Expression);
+            if (depListElements is not null)
             {
-                foreach (var el in init.Expressions) CheckSingleDepExpression(context, el, methodName);
-            }
-            else if (arg.Expression is ImplicitArrayCreationExpressionSyntax implArr)
-            {
-                foreach (var el in implArr.Initializer.Expressions) CheckSingleDepExpression(context, el, methodName);
-            }
-            else if (arg.Expression is CollectionExpressionSyntax collExpr)
-            {
-                foreach (var el in collExpr.Elements)
-                {
-                    if (el is ExpressionElementSyntax exprEl)
-                        CheckSingleDepExpression(context, exprEl.Expression, methodName);
-                }
+                foreach (var el in depListElements) CheckSingleDepExpression(context, el, methodName);
             }
             else
             {
-                // Single scalar / reference passed. For params-arrays this is the happy
-                // path; check the one expression.
+                // A single scalar / reference / value-type-array dep — check the one
+                // expression (a fresh allocation here is the REACTOR_HOOKS_004 case).
                 CheckSingleDepExpression(context, arg.Expression, methodName);
             }
         }
@@ -408,6 +400,29 @@ public sealed class HookRulesAnalyzer : DiagnosticAnalyzer
                 CheckSingleDepExpression(context, args[i].Expression, methodName);
             }
         }
+    }
+
+    // Returns the per-element dependency expressions when <paramref name="expr"/> is an
+    // array-literal deps argument whose ELEMENT type is a reference type (object[],
+    // string[], …) — the only arrays the runtime unwraps and compares element-wise
+    // (AsParamsArrayDep). Returns null for non-array deps and for value-type arrays such
+    // as int[], which the runtime compares as a single reference dependency (so a fresh
+    // one each render is the freshly-allocated-deps case the caller then flags).
+    private static IEnumerable<ExpressionSyntax>? ReferenceArrayDepElements(SemanticModel model, ExpressionSyntax expr)
+    {
+        var type = model.GetTypeInfo(expr).Type ?? model.GetTypeInfo(expr).ConvertedType;
+        if (type is not IArrayTypeSymbol { ElementType.IsReferenceType: true })
+            return null;
+
+        return expr switch
+        {
+            ArrayCreationExpressionSyntax { Initializer: { } init } => init.Expressions,
+            ImplicitArrayCreationExpressionSyntax impl => impl.Initializer.Expressions,
+            CollectionExpressionSyntax coll => coll.Elements
+                .OfType<ExpressionElementSyntax>()
+                .Select(static e => e.Expression),
+            _ => null,
+        };
     }
 
     private static void CheckSingleDepExpression(SyntaxNodeAnalysisContext context, ExpressionSyntax expr, string methodName)

--- a/src/Reactor/Core/Component.cs
+++ b/src/Reactor/Core/Component.cs
@@ -48,14 +48,65 @@ public abstract class Component
     protected void UseEffect(Action effect, params object[] dependencies)
         => Context.UseEffect(effect, dependencies);
 
+    /// <summary>Typed-arity <see cref="UseEffect(Action, object[])"/> — passes one dependency
+    /// positionally, avoiding the <c>params object[]</c> allocation and value-type boxing.</summary>
+    protected void UseEffect<T1>(Action effect, T1 d1)
+        => Context.UseEffect(effect, d1);
+
+    /// <inheritdoc cref="UseEffect{T1}(Action, T1)"/>
+    protected void UseEffect<T1, T2>(Action effect, T1 d1, T2 d2)
+        => Context.UseEffect(effect, d1, d2);
+
+    /// <inheritdoc cref="UseEffect{T1}(Action, T1)"/>
+    protected void UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3)
+        => Context.UseEffect(effect, d1, d2, d3);
+
     protected void UseEffect(Func<Action> effectWithCleanup, params object[] dependencies)
         => Context.UseEffect(effectWithCleanup, dependencies);
+
+    /// <inheritdoc cref="UseEffect{T1}(Action, T1)"/>
+    protected void UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1)
+        => Context.UseEffect(effectWithCleanup, d1);
+
+    /// <inheritdoc cref="UseEffect{T1}(Action, T1)"/>
+    protected void UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2)
+        => Context.UseEffect(effectWithCleanup, d1, d2);
+
+    /// <inheritdoc cref="UseEffect{T1}(Action, T1)"/>
+    protected void UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3)
+        => Context.UseEffect(effectWithCleanup, d1, d2, d3);
 
     protected T UseMemo<T>(Func<T> factory, params object[] dependencies)
         => Context.UseMemo(factory, dependencies);
 
+    /// <summary>Typed-arity <see cref="UseMemo{T}(Func{T}, object[])"/> — passes one dependency
+    /// positionally, avoiding the <c>params object[]</c> allocation and value-type boxing.</summary>
+    protected T UseMemo<T, T1>(Func<T> factory, T1 d1)
+        => Context.UseMemo(factory, d1);
+
+    /// <inheritdoc cref="UseMemo{T, T1}(Func{T}, T1)"/>
+    protected T UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2)
+        => Context.UseMemo(factory, d1, d2);
+
+    /// <inheritdoc cref="UseMemo{T, T1}(Func{T}, T1)"/>
+    protected T UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3)
+        => Context.UseMemo(factory, d1, d2, d3);
+
     protected Action UseCallback(Action callback, params object[] dependencies)
         => Context.UseCallback(callback, dependencies);
+
+    /// <summary>Typed-arity <see cref="UseCallback(Action, object[])"/> — passes one dependency
+    /// positionally, avoiding the <c>params object[]</c> allocation and value-type boxing.</summary>
+    protected Action UseCallback<T1>(Action callback, T1 d1)
+        => Context.UseCallback(callback, d1);
+
+    /// <inheritdoc cref="UseCallback{T1}(Action, T1)"/>
+    protected Action UseCallback<T1, T2>(Action callback, T1 d1, T2 d2)
+        => Context.UseCallback(callback, d1, d2);
+
+    /// <inheritdoc cref="UseCallback{T1}(Action, T1)"/>
+    protected Action UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3)
+        => Context.UseCallback(callback, d1, d2, d3);
 
     protected Ref<T> UseRef<T>(T initialValue = default!)
         => Context.UseRef(initialValue);

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -752,8 +752,14 @@ public sealed class RenderContext
     // unconditional (T)stored cast. A hot-reload edit or a dynamic call site can change
     // a dependency's runtime type at the same hook slot across renders; an
     // InvalidCastException while COMPARING deps is worse than simply treating the slot
-    // as changed, so a type mismatch returns false ("changed"). This mirrors the
-    // non-generic params DepsEqual, which compares via object.Equals and never throws.
+    // as changed, so a type mismatch returns false ("changed"). Like the non-generic
+    // params DepsEqual, this never throws on a type change. Equality itself goes through
+    // EqualityComparer<T>.Default — the same comparer UseState/UseReducer use — rather than
+    // the params path's boxed object.Equals. The two agree for every well-behaved type and
+    // this keeps the value-type fast path allocation-free; the only observable difference
+    // is a (pathological) value type whose IEquatable<T>.Equals disagrees with its
+    // object.Equals override, which compares by the former here. That is an intentional,
+    // boxing-free choice consistent with the rest of the hooks runtime.
     // Value-type T unboxes through the `is T` pattern with no extra allocation, and the
     // current dep is still passed through EqualityComparer<T> unboxed.
     //

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -753,15 +753,19 @@ public sealed class RenderContext
     // a dependency's runtime type at the same hook slot across renders; an
     // InvalidCastException while COMPARING deps is worse than simply treating the slot
     // as changed, so a type mismatch returns false ("changed"). Like the non-generic
-    // params DepsEqual, this never throws on a type change. Equality itself goes through
-    // EqualityComparer<T>.Default — the same comparer UseState/UseReducer use — rather than
-    // the params path's boxed object.Equals. The two agree for every well-behaved type and
-    // this keeps the value-type fast path allocation-free; the only observable difference
-    // is a (pathological) value type whose IEquatable<T>.Equals disagrees with its
-    // object.Equals override, which compares by the former here. That is an intentional,
-    // boxing-free choice consistent with the rest of the hooks runtime.
-    // Value-type T unboxes through the `is T` pattern with no extra allocation, and the
-    // current dep is still passed through EqualityComparer<T> unboxed.
+    // params DepsEqual, this never throws on a type change.
+    //
+    // Equality is split by kind so typed-arity stays behaviorally identical to params:
+    //   • Reference-type T compares via object.Equals (stored.Equals(current)), EXACTLY
+    //     like the params path's Equals(prev[i], next[i]). References don't box, so this
+    //     costs nothing, and it avoids a divergence for a reference type that implements
+    //     IEquatable<T> but does not override Equals(object) — EqualityComparer<T>.Default
+    //     would compare such a type by value, while params compares it by reference.
+    //   • Value-type T uses EqualityComparer<T>.Default — the allocation-free, no-boxing
+    //     fast path this overload exists for, and the same comparer UseState/UseReducer use.
+    //     It unboxes the stored value through the `is T` pattern with no extra allocation.
+    // typeof(T).IsValueType is a JIT-time constant, so each instantiation keeps only its
+    // branch with no runtime type check.
     //
     // Nullable value-type deps (T = U?) are handled correctly. Boxing a non-null
     // Nullable<U> stores a boxed U, but the GENERIC `stored is T` test still succeeds for
@@ -774,6 +778,10 @@ public sealed class RenderContext
     private static bool DepEquals<T>(object? stored, T current)
     {
         if (stored is null) return current is null;
+        // Reference-type deps: object.Equals, matching the params path exactly (no boxing).
+        if (!typeof(T).IsValueType)
+            return stored.Equals(current);
+        // Value-type deps: typed comparer, allocation-free and boxing-free.
         return stored is T t && EqualityComparer<T>.Default.Equals(t, current);
     }
 

--- a/src/Reactor/Core/RenderContext.cs
+++ b/src/Reactor/Core/RenderContext.cs
@@ -362,31 +362,14 @@ public sealed class RenderContext
     // <snippet:effect-schedule>
     public void UseEffect(Action effect, params object[] dependencies)
     {
-        if (_hookIndex >= _hooks.Count)
-        {
-            _hooks.Add(new EffectHookState { Dependencies = null, Effect = effect });
-        }
-
-        if (_hooks[_hookIndex] is not EffectHookState hook)
-            throw new HookOrderException(
-                $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected EffectHookState. " +
-                "Hooks must be called in the same order every render.");
-        _hookIndex++;
-
+        var hook = AcquireEffectSlot();
+        // Snapshot the deps on store (SnapshotDeps): a caller can pass — and then
+        // reuse and mutate in place — the same array instance across renders, so the
+        // stored copy must be isolated or DepsEqual would alias prev/next and skip a
+        // real change (Issue #659 review #3). Only the deps-CHANGED path stores, so
+        // this adds no steady-state allocation.
         if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
-        {
-            hook.PendingCleanup = hook.Cleanup;
-            hook.Cleanup = null;
-            // Issue #659 review (#3): snapshot the deps. A params-array LITERAL is a
-            // fresh compiler temporary, but a caller passing an explicit mutable
-            // object[] could mutate it afterward and corrupt this stored "previous
-            // deps", breaking the next render's change detection. ToArray runs only
-            // on the deps-CHANGED path (never the steady-state hot path), so the copy
-            // is ~free; the per-render win is the call-site array, not this.
-            hook.Dependencies = dependencies.ToArray();
-            hook.Effect = effect;
-            hook.Pending = true;
-        }
+            ScheduleEffect(hook, effect, null, SnapshotDeps(dependencies));
     }
     // </snippet:effect-schedule>
 
@@ -395,26 +378,111 @@ public sealed class RenderContext
     /// </summary>
     public void UseEffect(Func<Action> effectWithCleanup, params object[] dependencies)
     {
-        if (_hookIndex >= _hooks.Count)
-        {
-            _hooks.Add(new EffectHookState { Dependencies = null });
-        }
-
-        if (_hooks[_hookIndex] is not EffectHookState hook)
-            throw new HookOrderException(
-                $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected EffectHookState. " +
-                "Hooks must be called in the same order every render.");
-        _hookIndex++;
-
+        var hook = AcquireEffectSlot();
         if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
+            ScheduleEffect(hook, null, effectWithCleanup, SnapshotDeps(dependencies));
+    }
+
+    // #688: arity 1-3 overloads so the common "a couple of deps" call avoids the
+    // params-array allocation AND the value-type boxing on the steady-state
+    // (deps-unchanged) path. Storage stays object[] for hot-reload / snapshot /
+    // DepsEqual compatibility; the array is only allocated when deps actually
+    // change. Comparison unboxes the stored value (no new allocation) and uses
+    // the typed EqualityComparer so the incoming dep is never boxed.
+    /// <summary>
+    /// Single-dependency <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation (and value-type boxing) on the
+    /// deps-unchanged path. Semantically identical to the params overload called
+    /// with one dependency: the effect re-runs only when <paramref name="d1"/>
+    /// changes.
+    /// </summary>
+    /// <remarks>
+    /// If <paramref name="d1"/>'s compile-time type is an array of reference types
+    /// (e.g. <c>string[]</c>), it is treated as a dependency <em>list</em> and compared
+    /// element-wise — matching the <c>params object[]</c> overload — not as a single
+    /// reference-compared value. A dependency whose static type is not an array is
+    /// always compared as one value, even if its runtime value happens to be an array.
+    /// </remarks>
+    public void UseEffect<T1>(Action effect, T1 d1)
+    {
+        var hook = AcquireEffectSlot();
+        // A lone dependency whose compile-time type is a reference-type array (e.g. a
+        // covariant string[]) binds this generic but historically went through the
+        // params overload and was compared element-wise — preserve that so an array
+        // re-allocated each render with equal contents does not spuriously re-run.
+        if (AsParamsArrayDep(d1) is { } arr)
         {
-            hook.PendingCleanup = hook.Cleanup;
-            hook.Cleanup = null;
-            // Issue #659 review (#3): snapshot deps (see UseEffect above).
-            hook.Dependencies = dependencies.ToArray();
-            hook.EffectWithCleanup = effectWithCleanup;
-            hook.Pending = true;
+            if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
+                ScheduleEffect(hook, effect, null, SnapshotDeps(arr));
+            return;
         }
+        if (!DepsEqual1(hook.Dependencies, d1)) ScheduleEffect(hook, effect, null, PackDeps(d1));
+    }
+
+    /// <summary>
+    /// Two-dependency <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path. Re-runs when
+    /// either dependency changes.
+    /// </summary>
+    public void UseEffect<T1, T2>(Action effect, T1 d1, T2 d2)
+    {
+        var hook = AcquireEffectSlot();
+        if (!DepsEqual2(hook.Dependencies, d1, d2)) ScheduleEffect(hook, effect, null, PackDeps(d1, d2));
+    }
+
+    /// <summary>
+    /// Three-dependency <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path. Re-runs when
+    /// any dependency changes.
+    /// </summary>
+    public void UseEffect<T1, T2, T3>(Action effect, T1 d1, T2 d2, T3 d3)
+    {
+        var hook = AcquireEffectSlot();
+        if (!DepsEqual3(hook.Dependencies, d1, d2, d3)) ScheduleEffect(hook, effect, null, PackDeps(d1, d2, d3));
+    }
+
+    /// <summary>
+    /// Single-dependency cleanup-flavor <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path. Semantically
+    /// identical to the params overload called with one dependency.
+    /// </summary>
+    /// <remarks>
+    /// If <paramref name="d1"/>'s compile-time type is an array of reference types
+    /// (e.g. <c>string[]</c>), it is treated as a dependency <em>list</em> and compared
+    /// element-wise — matching the <c>params object[]</c> overload — not as a single
+    /// reference-compared value. A dependency whose static type is not an array is
+    /// always compared as one value, even if its runtime value happens to be an array.
+    /// </remarks>
+    public void UseEffect<T1>(Func<Action> effectWithCleanup, T1 d1)
+    {
+        var hook = AcquireEffectSlot();
+        if (AsParamsArrayDep(d1) is { } arr)
+        {
+            if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
+                ScheduleEffect(hook, null, effectWithCleanup, SnapshotDeps(arr));
+            return;
+        }
+        if (!DepsEqual1(hook.Dependencies, d1)) ScheduleEffect(hook, null, effectWithCleanup, PackDeps(d1));
+    }
+
+    /// <summary>
+    /// Two-dependency cleanup-flavor <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
+    public void UseEffect<T1, T2>(Func<Action> effectWithCleanup, T1 d1, T2 d2)
+    {
+        var hook = AcquireEffectSlot();
+        if (!DepsEqual2(hook.Dependencies, d1, d2)) ScheduleEffect(hook, null, effectWithCleanup, PackDeps(d1, d2));
+    }
+
+    /// <summary>
+    /// Three-dependency cleanup-flavor <c>UseEffect</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
+    public void UseEffect<T1, T2, T3>(Func<Action> effectWithCleanup, T1 d1, T2 d2, T3 d3)
+    {
+        var hook = AcquireEffectSlot();
+        if (!DepsEqual3(hook.Dependencies, d1, d2, d3)) ScheduleEffect(hook, null, effectWithCleanup, PackDeps(d1, d2, d3));
     }
 
     /// <summary>
@@ -422,24 +490,79 @@ public sealed class RenderContext
     /// </summary>
     public T UseMemo<T>(Func<T> factory, params object[] dependencies)
     {
-        if (_hookIndex >= _hooks.Count)
-        {
-            _hooks.Add(new MemoHookState<T> { Dependencies = null });
-        }
-
-        if (_hooks[_hookIndex] is not MemoHookState<T> hook)
-            throw new HookOrderException(
-                $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected MemoHookState<{typeof(T).Name}>. " +
-                "Hooks must be called in the same order every render.");
-        _hookIndex++;
-
+        var hook = AcquireMemoSlot<T>();
         if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
         {
             hook.Value = factory();
             // Issue #659 review (#3): snapshot deps (see UseEffect).
-            hook.Dependencies = dependencies.ToArray();
+            hook.Dependencies = SnapshotDeps(dependencies);
         }
+        return hook.Value;
+    }
 
+    // #688: arity overloads mirror UseEffect — no params array / boxing on the
+    // deps-unchanged path; factory only runs (and array only allocates) on change.
+
+    /// <summary>
+    /// Single-dependency <c>UseMemo</c> overload that avoids the
+    /// <c>params object[]</c> allocation (and value-type boxing) on the
+    /// deps-unchanged path. Recomputes only when <paramref name="d1"/> changes.
+    /// </summary>
+    /// <remarks>
+    /// If <paramref name="d1"/>'s compile-time type is an array of reference types
+    /// (e.g. <c>string[]</c>), it is treated as a dependency <em>list</em> and compared
+    /// element-wise — matching the <c>params object[]</c> overload — not as a single
+    /// reference-compared value. A dependency whose static type is not an array is
+    /// always compared as one value, even if its runtime value happens to be an array.
+    /// </remarks>
+    public T UseMemo<T, T1>(Func<T> factory, T1 d1)
+    {
+        var hook = AcquireMemoSlot<T>();
+        // See UseEffect<T1>: a compile-time array dep keeps element-wise semantics.
+        if (AsParamsArrayDep(d1) is { } arr)
+        {
+            if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
+            {
+                hook.Value = factory();
+                hook.Dependencies = SnapshotDeps(arr);
+            }
+            return hook.Value;
+        }
+        if (!DepsEqual1(hook.Dependencies, d1))
+        {
+            hook.Value = factory();
+            hook.Dependencies = PackDeps(d1);
+        }
+        return hook.Value;
+    }
+
+    /// <summary>
+    /// Two-dependency <c>UseMemo</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
+    public T UseMemo<T, T1, T2>(Func<T> factory, T1 d1, T2 d2)
+    {
+        var hook = AcquireMemoSlot<T>();
+        if (!DepsEqual2(hook.Dependencies, d1, d2))
+        {
+            hook.Value = factory();
+            hook.Dependencies = PackDeps(d1, d2);
+        }
+        return hook.Value;
+    }
+
+    /// <summary>
+    /// Three-dependency <c>UseMemo</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
+    public T UseMemo<T, T1, T2, T3>(Func<T> factory, T1 d1, T2 d2, T3 d3)
+    {
+        var hook = AcquireMemoSlot<T>();
+        if (!DepsEqual3(hook.Dependencies, d1, d2, d3))
+        {
+            hook.Value = factory();
+            hook.Dependencies = PackDeps(d1, d2, d3);
+        }
         return hook.Value;
     }
 
@@ -451,27 +574,201 @@ public sealed class RenderContext
         // Issue #659 (#46): store the callback directly in a memo slot instead of
         // UseMemo(() => callback, deps). The old form allocated a `() => callback`
         // wrapper closure every render (even when deps were unchanged, because the
-        // factory is materialized before the deps short-circuit). Inlining the slot
-        // logic removes that wrapper entirely.
-        if (_hookIndex >= _hooks.Count)
-        {
-            _hooks.Add(new MemoHookState<Action> { Dependencies = null });
-        }
-
-        if (_hooks[_hookIndex] is not MemoHookState<Action> hook)
-            throw new HookOrderException(
-                $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected MemoHookState<Action> (UseCallback). " +
-                "Hooks must be called in the same order every render.");
-        _hookIndex++;
-
+        // factory is materialized before the deps short-circuit). The slot is still
+        // MemoHookState<Action> so hook-order checks / devtools labels are unchanged.
+        var hook = AcquireMemoSlot<Action>();
         if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
         {
             hook.Value = callback;
-            // Issue #659 review (#3): snapshot deps (see UseEffect).
-            hook.Dependencies = dependencies.ToArray();
+            hook.Dependencies = SnapshotDeps(dependencies);
         }
-
         return hook.Value;
+    }
+
+    /// <summary>
+    /// Single-dependency <c>UseCallback</c> overload that avoids the
+    /// <c>params object[]</c> allocation (and value-type boxing) on the
+    /// deps-unchanged path. Returns a stable reference until <paramref name="d1"/>
+    /// changes.
+    /// </summary>
+    /// <remarks>
+    /// If <paramref name="d1"/>'s compile-time type is an array of reference types
+    /// (e.g. <c>string[]</c>), it is treated as a dependency <em>list</em> and compared
+    /// element-wise — matching the <c>params object[]</c> overload — not as a single
+    /// reference-compared value. A dependency whose static type is not an array is
+    /// always compared as one value, even if its runtime value happens to be an array.
+    /// </remarks>
+    public Action UseCallback<T1>(Action callback, T1 d1)
+    {
+        var hook = AcquireMemoSlot<Action>();
+        // See UseEffect<T1>: a compile-time array dep keeps element-wise semantics.
+        if (AsParamsArrayDep(d1) is { } arr)
+        {
+            if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, arr))
+            {
+                hook.Value = callback;
+                hook.Dependencies = SnapshotDeps(arr);
+            }
+            return hook.Value;
+        }
+        if (!DepsEqual1(hook.Dependencies, d1))
+        {
+            hook.Value = callback;
+            hook.Dependencies = PackDeps(d1);
+        }
+        return hook.Value;
+    }
+
+    /// <summary>
+    /// Two-dependency <c>UseCallback</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
+    public Action UseCallback<T1, T2>(Action callback, T1 d1, T2 d2)
+    {
+        var hook = AcquireMemoSlot<Action>();
+        if (!DepsEqual2(hook.Dependencies, d1, d2))
+        {
+            hook.Value = callback;
+            hook.Dependencies = PackDeps(d1, d2);
+        }
+        return hook.Value;
+    }
+
+    /// <summary>
+    /// Three-dependency <c>UseCallback</c> overload that avoids the
+    /// <c>params object[]</c> allocation on the deps-unchanged path.
+    /// </summary>
+    public Action UseCallback<T1, T2, T3>(Action callback, T1 d1, T2 d2, T3 d3)
+    {
+        var hook = AcquireMemoSlot<Action>();
+        if (!DepsEqual3(hook.Dependencies, d1, d2, d3))
+        {
+            hook.Value = callback;
+            hook.Dependencies = PackDeps(d1, d2, d3);
+        }
+        return hook.Value;
+    }
+
+    // ── Hook-slot + deps helpers (shared by the effect / memo / callback hooks) ──
+
+    private EffectHookState AcquireEffectSlot()
+    {
+        if (_hookIndex >= _hooks.Count)
+            _hooks.Add(new EffectHookState { Dependencies = null });
+
+        if (_hooks[_hookIndex] is not EffectHookState hook)
+            throw new HookOrderException(
+                $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected EffectHookState. " +
+                "Hooks must be called in the same order every render.");
+        _hookIndex++;
+        return hook;
+    }
+
+    private MemoHookState<T> AcquireMemoSlot<T>()
+    {
+        if (_hookIndex >= _hooks.Count)
+            _hooks.Add(new MemoHookState<T> { Dependencies = null });
+
+        if (_hooks[_hookIndex] is not MemoHookState<T> hook)
+            throw new HookOrderException(
+                $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected MemoHookState<{typeof(T).Name}>. " +
+                "Hooks must be called in the same order every render.");
+        _hookIndex++;
+        return hook;
+    }
+
+    // The caller is responsible for passing an isolated deps array — either a
+    // freshly packed array (PackDeps, arity overloads) or a defensive clone
+    // (SnapshotDeps, params/AsParamsArrayDep paths). Storing it by reference here
+    // is therefore safe: no caller-owned array is ever aliased onto the hook slot,
+    // so an in-place mutation of a reused caller array cannot make prev/next deps
+    // alias and wrongly short-circuit DepsEqual.
+    private static void ScheduleEffect(EffectHookState hook, Action? effect, Func<Action>? withCleanup, object[] dependencies)
+    {
+        hook.PendingCleanup = hook.Cleanup;
+        hook.Cleanup = null;
+        hook.Dependencies = dependencies;
+        hook.Effect = effect;
+        hook.EffectWithCleanup = withCleanup;
+        hook.Pending = true;
+    }
+
+    private static object[] PackDeps<T1>(T1 d1) => new object[] { d1! };
+    private static object[] PackDeps<T1, T2>(T1 d1, T2 d2) => new object[] { d1!, d2! };
+    private static object[] PackDeps<T1, T2, T3>(T1 d1, T2 d2, T3 d3) => new object[] { d1!, d2!, d3! };
+
+    // Snapshot a caller-supplied deps array before persisting it on a hook slot.
+    // Callers can pass — and then reuse and mutate in place — the same array
+    // instance across renders (a params target, or a covariant array routed through
+    // AsParamsArrayDep). Storing it by reference would alias prev/next so an in-place
+    // mutation is invisible to DepsEqual and would wrongly skip the effect or memo
+    // recompute. Cloning isolates the stored copy. This runs only on the
+    // deps-CHANGED store path (the deps-equal path short-circuits before storing), so
+    // it adds no steady-state allocation; the empty "run once" case reuses the shared
+    // empty array. Always returns a genuine object[] even when the source is a
+    // covariant array (e.g. string[]).
+    private static object[] SnapshotDeps(object[] dependencies)
+    {
+        if (dependencies.Length == 0) return Array.Empty<object>();
+        var copy = new object[dependencies.Length];
+        Array.Copy(dependencies, copy, dependencies.Length);
+        return copy;
+    }
+
+    // A lone arity-1 dependency whose COMPILE-TIME type is an array of reference types
+    // — e.g. a covariant string[]/Element[] — is treated as a dependency LIST and
+    // compared element-wise, matching how the params overload behaved before these
+    // generics existed. The gate is on the *static* type (typeof(T1)) on purpose: a
+    // value whose static type is object/Array/an interface but whose runtime value
+    // happens to be an object[] historically bound the params overload in EXPANDED
+    // form (wrapped as new object[]{ dep }) and was compared as ONE reference dep, so
+    // it must stay a single dep here too — unwrapping it would be a silent semantic
+    // change (observable for UseMemo, whose two overloads are both generic so the
+    // arity-1 wins overload resolution). typeof(T1).IsArray is a JIT-time constant per
+    // instantiation, so value-type and non-array deps fold this to null and never
+    // reach the IsAssignableFrom check or box.
+    private static object[]? AsParamsArrayDep<T1>(T1 d1)
+        => typeof(T1).IsArray && typeof(object[]).IsAssignableFrom(typeof(T1)) && d1 is object[] arr ? arr : null;
+
+    // Returns true when the stored deps already match. Each element is compared via
+    // DepEquals, which unboxes the stored value (no allocation) and compares through
+    // the typed comparer so the incoming dep is never boxed. A null/wrong-arity stored
+    // array counts as "changed".
+    private static bool DepsEqual1<T1>(object[]? prev, T1 d1)
+        => prev is { Length: 1 } && DepEquals(prev[0], d1);
+
+    private static bool DepsEqual2<T1, T2>(object[]? prev, T1 d1, T2 d2)
+        => prev is { Length: 2 }
+           && DepEquals(prev[0], d1)
+           && DepEquals(prev[1], d2);
+
+    private static bool DepsEqual3<T1, T2, T3>(object[]? prev, T1 d1, T2 d2, T3 d3)
+        => prev is { Length: 3 }
+           && DepEquals(prev[0], d1)
+           && DepEquals(prev[1], d2)
+           && DepEquals(prev[2], d3);
+
+    // Compare a stored (boxed) dependency against the current typed value without an
+    // unconditional (T)stored cast. A hot-reload edit or a dynamic call site can change
+    // a dependency's runtime type at the same hook slot across renders; an
+    // InvalidCastException while COMPARING deps is worse than simply treating the slot
+    // as changed, so a type mismatch returns false ("changed"). This mirrors the
+    // non-generic params DepsEqual, which compares via object.Equals and never throws.
+    // Value-type T unboxes through the `is T` pattern with no extra allocation, and the
+    // current dep is still passed through EqualityComparer<T> unboxed.
+    //
+    // Nullable value-type deps (T = U?) are handled correctly. Boxing a non-null
+    // Nullable<U> stores a boxed U, but the GENERIC `stored is T` test still succeeds for
+    // that boxed U and binds the nullable-wrapped value — the CLR special-cases nullable
+    // type-tests (the symmetric counterpart of `(U?)(object)u` unboxing). So an unchanged
+    // nullable dep compares equal, a null nullable boxes to a null reference handled by
+    // the `stored is null` guard above, and value<->null transitions are detected. This
+    // matches the pre-existing `(T)prev[i]` behavior exactly (verified across
+    // int?/long?/double?/enum? incl. null transitions) — it is NOT a per-render re-run.
+    private static bool DepEquals<T>(object? stored, T current)
+    {
+        if (stored is null) return current is null;
+        return stored is T t && EqualityComparer<T>.Default.Equals(t, current);
     }
 
     /// <summary>

--- a/tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs
@@ -263,6 +263,7 @@ namespace Microsoft.UI.Reactor.Core
         protected void UseEffect(System.Action effect, params object[] deps) { }
         protected void UseEffect<T1>(System.Action effect, T1 d1) { }
         protected void UseEffect<T1, T2>(System.Action effect, T1 d1, T2 d2) { }
+        protected void UseEffect<T1, T2, T3>(System.Action effect, T1 d1, T2 d2, T3 d3) { }
         protected T UseMemo<T>(System.Func<T> factory, params object[] deps) => factory();
         protected T UseMemo<T, T1>(System.Func<T> factory, T1 d1) => factory();
     }
@@ -342,6 +343,73 @@ class C : Microsoft.UI.Reactor.Core.Component
     {
         int userId = 42;
         UseEffect(() => { }, userId);
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task UseEffect_Arity3_With_New_Object_In_Third_Dep_Flags()
+    {
+        // Two stable scalars bind T1/T2; the fresh allocation in the THIRD positional
+        // dep maps to parameter "d3", which the gate now inspects.
+        var test = ArityStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        int a = 1, b = 2;
+        UseEffect(() => { }, a, b, {|REACTOR_HOOKS_004:new object()|});
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task UseEffect_Arity1_ValueType_Array_Dep_Flags_Whole_Array()
+    {
+        // A value-type array (int[]) binds UseEffect<T1> with T1 = int[]. The runtime
+        // compares it as ONE reference dep (AsParamsArrayDep only unwraps reference-type
+        // arrays), so a fresh int[] each render re-runs the effect — the analyzer must
+        // flag the whole freshly-allocated array, NOT iterate its (stable) elements.
+        var test = ArityStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        UseEffect(() => { }, {|REACTOR_HOOKS_004:new int[] { 1, 2 }|});
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task UseEffect_Arity1_ReferenceType_Array_Dep_Compared_ElementWise_No_Diagnostic()
+    {
+        // A reference-type array (string[]) is the covariant case the runtime unwraps and
+        // compares element-wise, so the analyzer inspects elements individually. Stable
+        // string elements are not flagged, and the array itself must NOT be reported.
+        var test = ArityStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        UseEffect(() => { }, new[] { ""a"", ""b"" });
         return """";
     }
 }";

--- a/tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs
@@ -243,6 +243,115 @@ class C : Microsoft.UI.Reactor.Core.Component
         await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
     }
 
+    // ── REACTOR_HOOKS_004 — freshly-allocated deps via typed-arity overloads ──
+    //
+    // Issue #688: the typed-arity overloads name their deps "d1"/"d2"/"d3" (not
+    // "deps"). A non-object fresh allocation binds the arity overload (identity
+    // conversion beats boxing-to-object), so REACTOR_HOOKS_004 must fire through
+    // the d1/d2/d3 parameters too. These stubs expose both the params and arity
+    // overloads so overload resolution mirrors the real framework.
+
+    private const string ArityStubs = @"
+namespace Microsoft.UI.Reactor.Core
+{
+    public class RenderContext { }
+
+    public abstract class Component
+    {
+        protected internal RenderContext Context { get; } = new RenderContext();
+        public abstract string Render();
+        protected void UseEffect(System.Action effect, params object[] deps) { }
+        protected void UseEffect<T1>(System.Action effect, T1 d1) { }
+        protected void UseEffect<T1, T2>(System.Action effect, T1 d1, T2 d2) { }
+        protected T UseMemo<T>(System.Func<T> factory, params object[] deps) => factory();
+        protected T UseMemo<T, T1>(System.Func<T> factory, T1 d1) => factory();
+    }
+}
+";
+
+    [Fact]
+    public async Task UseEffect_Arity1_With_New_List_Dep_Flags()
+    {
+        // new List<int>() has static type List<int> (not object) → binds UseEffect<T1>
+        // with the dep at parameter "d1", which the gate now inspects.
+        var test = ArityStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        UseEffect(() => { }, {|REACTOR_HOOKS_004:new System.Collections.Generic.List<int>()|});
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task UseMemo_Arity1_With_New_List_Dep_Flags()
+    {
+        var test = ArityStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        UseMemo(() => 1, {|REACTOR_HOOKS_004:new System.Collections.Generic.List<int>()|});
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task UseEffect_Arity2_With_New_Object_In_Second_Dep_Flags()
+    {
+        // userId (int) binds T1; the fresh allocation in the SECOND positional dep
+        // maps to parameter "d2".
+        var test = ArityStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        int userId = 42;
+        UseEffect(() => { }, userId, {|REACTOR_HOOKS_004:new object()|});
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task UseEffect_Arity1_With_Stable_Scalar_Dep_No_Diagnostic()
+    {
+        // A stable local read passed as d1 must NOT be flagged.
+        var test = ArityStubs + @"
+class C : Microsoft.UI.Reactor.Core.Component
+{
+    public override string Render()
+    {
+        int userId = 42;
+        UseEffect(() => { }, userId);
+        return """";
+    }
+}";
+        var analyzerTest = new CSharpAnalyzerTest<HookRulesAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        };
+        await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
     // ── REACTOR_HOOKS_005 — hook outside Render/custom hook ────────────
 
     [Fact]

--- a/tests/Reactor.Tests/HookArityOverloadTests.cs
+++ b/tests/Reactor.Tests/HookArityOverloadTests.cs
@@ -1,0 +1,461 @@
+using System;
+using Microsoft.UI.Reactor.Core;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Issue #688: behavioral guards for the typed-arity <c>UseEffect</c>/<c>UseMemo</c>/
+/// <c>UseCallback</c> overloads (1–3 positional deps). These are the ergonomic,
+/// allocation-free counterparts to the <c>params object[]</c> overloads — they must
+/// be observationally identical to <c>params</c> on the deps short-circuit:
+///  - factory/effect/callback is skipped while every dep compares equal,
+///  - it re-runs (and the prior effect cleanup fires exactly once) on any change,
+///  - a lone arity-1 dep whose <em>compile-time</em> type is an array stays
+///    element-wise compared (matching the old <c>params</c> path), while an
+///    <c>object</c>-typed array value is reference-compared,
+///  - the comparer never throws when a dep's runtime type changes at a slot,
+///  - nullable value-type deps skip/re-run correctly (incl. null transitions),
+///  - stored deps are snapshotted, so a caller that reuses+mutates one array still
+///    observes the change.
+/// Ported from the (closed) PR #668 allocation suite, scoped to the arity overloads.
+/// </summary>
+public class HookArityOverloadTests
+{
+    private static RenderContext NewCtx()
+    {
+        var ctx = new RenderContext();
+        ctx.BeginRender(() => { });
+        return ctx;
+    }
+
+    private static void Rerender(RenderContext ctx) => ctx.BeginRender(() => { });
+
+    // ── UseMemo: deps short-circuit (params baseline + arity 1/2/3) ──────────
+
+    [Fact]
+    public void UseMemo_Params_Skips_Factory_When_Deps_Unchanged()
+    {
+        // Four deps → the params overload (arity overloads cover 1-3).
+        var ctx = NewCtx();
+        int calls = 0;
+        var v1 = ctx.UseMemo(() => { calls++; return 7; }, "a", 1, "b", 2);
+        Rerender(ctx);
+        var v2 = ctx.UseMemo(() => { calls++; return 7; }, "a", 1, "b", 2);
+        Rerender(ctx);
+        var v3 = ctx.UseMemo(() => { calls++; return 99; }, "a", 1, "b", 3); // changed
+
+        Assert.Equal(7, v1);
+        Assert.Equal(7, v2);
+        Assert.Equal(99, v3);
+        Assert.Equal(2, calls); // first render + the changed render
+    }
+
+    [Fact]
+    public void UseMemo_Arity1_Skips_Factory_When_Dep_Unchanged()
+    {
+        var ctx = NewCtx();
+        int calls = 0;
+        var v1 = ctx.UseMemo(() => { calls++; return calls; }, 5);
+        Rerender(ctx);
+        var v2 = ctx.UseMemo(() => { calls++; return calls; }, 5);
+        Rerender(ctx);
+        var v3 = ctx.UseMemo(() => { calls++; return calls; }, 6); // changed
+
+        Assert.Equal(1, v1);
+        Assert.Equal(1, v2); // reused
+        Assert.Equal(2, v3); // recomputed
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void UseMemo_Arity2_And_Arity3_Skip_Factory_When_Deps_Unchanged()
+    {
+        var ctx = NewCtx();
+        int calls2 = 0, calls3 = 0;
+
+        for (int r = 0; r < 3; r++)
+        {
+            ctx.BeginRender(() => { });
+            ctx.UseMemo(() => { calls2++; return 0; }, 1, "x");
+            ctx.UseMemo(() => { calls3++; return 0; }, 1, "x", 2.5);
+        }
+
+        Assert.Equal(1, calls2);
+        Assert.Equal(1, calls3);
+    }
+
+    // ── UseEffect: deps short-circuit (params baseline + arity 1/2/3) ────────
+
+    [Fact]
+    public void UseEffect_Params_Fires_Once_While_Deps_Unchanged()
+    {
+        var ctx = NewCtx();
+        int runs = 0;
+        ctx.UseEffect(() => { runs++; }, "a", 1);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, "a", 1);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs); // skipped
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, "a", 2); // changed
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+    }
+
+    [Fact]
+    public void UseEffect_Arity1_Fires_Once_While_Dep_Unchanged()
+    {
+        var ctx = NewCtx();
+        int runs = 0;
+        ctx.UseEffect(() => { runs++; }, 10);
+        ctx.FlushEffects();
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, 10);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, 11);
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+    }
+
+    [Fact]
+    public void UseEffect_Arity2_And_Arity3_Fire_Once_While_Deps_Unchanged()
+    {
+        var ctx = NewCtx();
+        int runs2 = 0, runs3 = 0;
+        for (int r = 0; r < 3; r++)
+        {
+            ctx.BeginRender(() => { });
+            ctx.UseEffect(() => { runs2++; }, 1, "x");
+            ctx.UseEffect(() => { runs3++; }, 1, "x", 2.5);
+            ctx.FlushEffects();
+        }
+
+        Assert.Equal(1, runs2);
+        Assert.Equal(1, runs3);
+    }
+
+    [Fact]
+    public void UseEffect_Arity_Empty_Deps_Runs_Once_On_Mount()
+    {
+        var ctx = NewCtx();
+        int runs = 0, cleanups = 0;
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, Array.Empty<object>());
+        ctx.FlushEffects();
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, Array.Empty<object>());
+        ctx.FlushEffects();
+
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+    }
+
+    // ── UseEffect cleanup flavor: prior cleanup fires exactly once on change ──
+
+    [Fact]
+    public void UseEffect_Cleanup_Arity1_Reruns_And_Cleans_Up_On_Dep_Change()
+    {
+        var ctx = NewCtx();
+        int runs = 0, cleanups = 0;
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, 1);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, 1); // unchanged
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, 2); // changed → cleanup + rerun
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+        Assert.Equal(1, cleanups);
+    }
+
+    [Fact]
+    public void UseEffect_Arity2_Cleanup_Skips_While_Unchanged_And_Cleans_Up_Once_On_Change()
+    {
+        var ctx = NewCtx();
+        int runs = 0, cleanups = 0;
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 1);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 1); // unchanged
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);     // skipped
+        Assert.Equal(0, cleanups); // no cleanup while skipped
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 2); // d2 changed
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+        Assert.Equal(1, cleanups); // prior cleanup ran exactly once
+    }
+
+    [Fact]
+    public void UseEffect_Arity3_Cleanup_Skips_While_Unchanged_And_Cleans_Up_Once_On_Change()
+    {
+        var ctx = NewCtx();
+        int runs = 0, cleanups = 0;
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 1, true);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 1, true); // unchanged
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, "a", 1, false); // d3 changed
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+        Assert.Equal(1, cleanups);
+    }
+
+    // ── UseCallback: deps short-circuit (arity 2/3) ──────────────────────────
+
+    [Fact]
+    public void UseCallback_Arity2_And_Arity3_Recompute_On_Change()
+    {
+        var ctx = NewCtx();
+        Action a1 = () => { };
+        Action a2 = () => { };
+        ctx.UseCallback(a1, 1, "x");
+        ctx.UseCallback(a1, 1, "x", 2.5);
+        Rerender(ctx);
+        var c2 = ctx.UseCallback(a2, 1, "x");      // unchanged deps → keep a1
+        var c3 = ctx.UseCallback(a2, 1, "x", 9.9); // changed dep → adopt a2
+
+        Assert.Same(a1, c2);
+        Assert.Same(a2, c3);
+    }
+
+    // ── Arity-1 array-dep semantics (AsParamsArrayDep) ───────────────────────
+
+    [Fact]
+    public void UseEffect_Arity1_ObjectArray_Dep_Uses_ElementWise_Comparison()
+    {
+        // A fresh string[] of equal contents each render must NOT re-run the effect.
+        // (If the array were wrapped as one reference-compared dep it would re-run.)
+        var ctx = NewCtx();
+        int runs = 0;
+        ctx.UseEffect(() => { runs++; }, new[] { "a", "b" });
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, new[] { "a", "b" }); // new array, equal contents
+        ctx.FlushEffects();
+        Assert.Equal(1, runs); // element-wise equal → skipped
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, new[] { "a", "c" }); // contents changed
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+    }
+
+    [Fact]
+    public void UseMemo_Arity1_ObjectArray_Dep_Uses_ElementWise_Comparison()
+    {
+        var ctx = NewCtx();
+        int calls = 0;
+        var v1 = ctx.UseMemo(() => { calls++; return calls; }, new[] { "a", "b" });
+        Rerender(ctx);
+        var v2 = ctx.UseMemo(() => { calls++; return calls; }, new[] { "a", "b" }); // equal contents
+        Rerender(ctx);
+        var v3 = ctx.UseMemo(() => { calls++; return calls; }, new[] { "a", "c" }); // changed
+
+        Assert.Equal(1, v1);
+        Assert.Equal(1, v2); // reused
+        Assert.Equal(2, v3); // recomputed
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void UseCallback_Arity1_ObjectArray_Dep_Uses_ElementWise_Comparison()
+    {
+        var ctx = NewCtx();
+        Action cb1 = () => { };
+        Action cb2 = () => { };
+        Action cb3 = () => { };
+        var r1 = ctx.UseCallback(cb1, new[] { "a", "b" });
+        Rerender(ctx);
+        var r2 = ctx.UseCallback(cb2, new[] { "a", "b" }); // equal contents → retain cb1
+        Rerender(ctx);
+        var r3 = ctx.UseCallback(cb3, new[] { "a", "c" }); // changed → adopt cb3
+
+        Assert.Same(cb1, r1);
+        Assert.Same(cb1, r2); // deps equal element-wise → cached callback retained
+        Assert.Same(cb3, r3); // deps changed → new callback
+    }
+
+    [Fact]
+    public void UseMemo_Arity1_ObjectTyped_ArrayValue_Is_Compared_By_Reference_Like_Params()
+    {
+        // An arity-1 dep whose STATIC type is object (not an array) but whose RUNTIME
+        // value is object[] must be compared as ONE value, exactly as the legacy params
+        // overload did (reference comparison). Only UseMemo binds the arity-1 generic
+        // here — both its overloads are generic, so the normal-form arity-1 wins over
+        // the expanded-form params overload (UseEffect/UseCallback bind their
+        // non-generic params overload for an object-typed single dep).
+        var ctx = NewCtx();
+        int factoryRuns = 0;
+        object dep = new object[] { "a" };          // static type object, runtime object[]
+        ctx.UseMemo(() => { factoryRuns++; return factoryRuns; }, dep);
+        Assert.Equal(1, factoryRuns);
+
+        Rerender(ctx);
+        ctx.UseMemo(() => { factoryRuns++; return factoryRuns; }, dep); // same ref → cached
+        Assert.Equal(1, factoryRuns);
+
+        Rerender(ctx);
+        object depNewEqual = new object[] { "a" };  // NEW reference, equal contents
+        ctx.UseMemo(() => { factoryRuns++; return factoryRuns; }, depNewEqual);
+        Assert.Equal(2, factoryRuns); // reference changed → recompute (NOT element-wise)
+    }
+
+    // ── Comparer robustness: runtime type change must not throw ───────────────
+
+    [Fact]
+    public void Arity1_Deps_Comparer_Treats_Runtime_Type_Change_As_Changed_Without_Throwing()
+    {
+        var ctx = NewCtx();
+        int runs = 0;
+        ctx.UseEffect(() => { runs++; }, 42);    // T1=int → stores boxed int at slot 0
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        // Same slot, but the dep is now a string. Comparing (string)prev[0] over a
+        // boxed int must NOT throw; the mismatch is treated as "changed".
+        Exception? ex = Record.Exception(() =>
+        {
+            ctx.UseEffect(() => { runs++; }, "now-a-string"); // T1=string at the same slot
+            ctx.FlushEffects();
+        });
+        Assert.Null(ex);
+        Assert.Equal(2, runs); // type changed → effect re-ran (no crash)
+    }
+
+    // ── Nullable value-type dep semantics ────────────────────────────────────
+
+    [Fact]
+    public void UseEffect_Arity1_Nullable_ValueType_Dep_Skips_While_Unchanged_And_Reruns_On_Change()
+    {
+        var ctx = NewCtx();
+        int runs = 0;
+
+        ctx.UseEffect(() => { runs++; }, (int?)5);    // T1=int? → boxed int stored at slot 0
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, (int?)5);    // unchanged → skipped
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, (int?)6);    // value changed → re-run
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, (int?)null); // value → null → re-run
+        ctx.FlushEffects();
+        Assert.Equal(3, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, (int?)null); // null unchanged → skipped
+        ctx.FlushEffects();
+        Assert.Equal(3, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, (int?)7);    // null → value → re-run
+        ctx.FlushEffects();
+        Assert.Equal(4, runs);
+    }
+
+    // ── Aliasing guard: stored deps are snapshotted (SnapshotDeps) ───────────
+
+    [Fact]
+    public void UseEffect_Reused_Mutated_Deps_Array_Still_Detects_Change()
+    {
+        var ctx = NewCtx();
+        var deps = new object[] { "a" };
+        int runs = 0;
+
+        ctx.UseEffect(() => { runs++; }, deps);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        deps[0] = "b"; // mutate in place, reuse the SAME instance
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, deps);
+        ctx.FlushEffects();
+        Assert.Equal(2, runs); // change detected despite array aliasing
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, deps); // same instance, same contents
+        ctx.FlushEffects();
+        Assert.Equal(2, runs); // unchanged → skipped
+    }
+
+    [Fact]
+    public void UseMemo_Reused_Mutated_Deps_Array_Still_Recomputes()
+    {
+        var ctx = NewCtx();
+        var deps = new object[] { 1 };
+        int factoryCalls = 0;
+
+        int Render() => ctx.UseMemo(() => { factoryCalls++; return (int)deps[0]; }, deps);
+
+        Assert.Equal(1, Render());
+        Assert.Equal(1, factoryCalls);
+
+        deps[0] = 2; // mutate in place
+        Rerender(ctx);
+        Assert.Equal(2, Render());
+        Assert.Equal(2, factoryCalls); // recomputed despite aliasing
+
+        Rerender(ctx);
+        Assert.Equal(2, Render()); // unchanged contents
+        Assert.Equal(2, factoryCalls); // cached, not recomputed
+    }
+
+    [Fact]
+    public void UseCallback_Reused_Mutated_Deps_Array_Returns_Updated_Callback()
+    {
+        var ctx = NewCtx();
+        var deps = new object[] { 1 };
+        // Capture a distinct value so each callback is a unique delegate instance
+        // (a non-capturing lambda would be compiler-cached and defeat NotSame).
+        static Action Cb(int tag) => () => { _ = tag; };
+
+        Action cb1 = ctx.UseCallback(Cb(1), deps);
+
+        deps[0] = 2; // mutate the same instance in place
+        Rerender(ctx);
+        Action cb2 = ctx.UseCallback(Cb(2), deps);
+        Assert.NotSame(cb1, cb2); // deps change detected despite aliasing → new callback
+
+        Rerender(ctx);
+        Action cb3 = ctx.UseCallback(Cb(3), deps); // unchanged contents
+        Assert.Same(cb2, cb3); // cached
+    }
+}

--- a/tests/Reactor.Tests/HookArityOverloadTests.cs
+++ b/tests/Reactor.Tests/HookArityOverloadTests.cs
@@ -458,4 +458,163 @@ public class HookArityOverloadTests
         Action cb3 = ctx.UseCallback(Cb(3), deps); // unchanged contents
         Assert.Same(cb2, cb3); // cached
     }
+
+    // ── UseCallback arity-1 scalar (issue #688 follow-up coverage) ───────────
+
+    [Fact]
+    public void UseCallback_Arity1_Scalar_Dep_Keeps_Identity_While_Unchanged_And_Adopts_On_Change()
+    {
+        var ctx = NewCtx();
+        Action a1 = () => { };
+        Action a2 = () => { };
+        Action a3 = () => { };
+        var r1 = ctx.UseCallback(a1, 5);
+        Rerender(ctx);
+        var r2 = ctx.UseCallback(a2, 5); // dep unchanged → keep a1
+        Rerender(ctx);
+        var r3 = ctx.UseCallback(a3, 6); // dep changed → adopt a3
+
+        Assert.Same(a1, r1);
+        Assert.Same(a1, r2);
+        Assert.Same(a3, r3);
+    }
+
+    // ── Arity-2/3 reruns on change (not just the unchanged/skip path) ────────
+
+    [Fact]
+    public void UseEffect_Arity2_And_Arity3_Rerun_When_A_Dep_Changes()
+    {
+        var ctx = NewCtx();
+        int runs2 = 0, runs3 = 0;
+
+        ctx.UseEffect(() => { runs2++; }, 1, "x");
+        ctx.UseEffect(() => { runs3++; }, 1, "x", 2.5);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs2);
+        Assert.Equal(1, runs3);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs2++; }, 2, "x");      // d1 changed
+        ctx.UseEffect(() => { runs3++; }, 1, "x", 9.9); // d3 changed
+        ctx.FlushEffects();
+        Assert.Equal(2, runs2);
+        Assert.Equal(2, runs3);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs2++; }, 2, "x");      // unchanged → skip
+        ctx.UseEffect(() => { runs3++; }, 1, "x", 9.9); // unchanged → skip
+        ctx.FlushEffects();
+        Assert.Equal(2, runs2);
+        Assert.Equal(2, runs3);
+    }
+
+    [Fact]
+    public void UseMemo_Arity2_And_Arity3_Recompute_When_A_Dep_Changes()
+    {
+        var ctx = NewCtx();
+        int calls2 = 0, calls3 = 0;
+
+        ctx.UseMemo(() => { calls2++; return calls2; }, 1, "x");
+        ctx.UseMemo(() => { calls3++; return calls3; }, 1, "x", true);
+        Assert.Equal(1, calls2);
+        Assert.Equal(1, calls3);
+
+        Rerender(ctx);
+        ctx.UseMemo(() => { calls2++; return calls2; }, 1, "x");       // unchanged → cached
+        ctx.UseMemo(() => { calls3++; return calls3; }, 1, "x", true); // unchanged → cached
+        Assert.Equal(1, calls2);
+        Assert.Equal(1, calls3);
+
+        Rerender(ctx);
+        ctx.UseMemo(() => { calls2++; return calls2; }, 9, "x");        // d1 changed
+        ctx.UseMemo(() => { calls3++; return calls3; }, 1, "x", false); // d3 changed
+        Assert.Equal(2, calls2);
+        Assert.Equal(2, calls3);
+    }
+
+    // ── Cleanup runs on unmount (RunCleanups), not just on dep change ────────
+
+    [Fact]
+    public void UseEffect_Cleanup_Arity_Runs_Cleanup_Once_On_Unmount()
+    {
+        var ctx = NewCtx();
+        int runs = 0, cleanups = 0;
+        ctx.UseEffect(() => { runs++; return () => cleanups++; }, 1, "x", 2.5);
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+        Assert.Equal(0, cleanups);
+
+        ctx.RunCleanups(); // unmount → live cleanup fires exactly once
+        Assert.Equal(1, cleanups);
+    }
+
+    // ── Reference-type / struct value equality (DepEquals) ───────────────────
+
+    [Fact]
+    public void UseEffect_Arity1_ReferenceType_Dep_Uses_Value_Equality()
+    {
+        // A reference type with value equality (record) skips while equal-by-value across
+        // distinct instances and re-runs when the value differs — matching the params
+        // path's object.Equals.
+        var ctx = NewCtx();
+        int runs = 0;
+        ctx.UseEffect(() => { runs++; }, new Point(1, 2));
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, new Point(1, 2)); // distinct instance, equal value → skip
+        ctx.FlushEffects();
+        Assert.Equal(1, runs);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { runs++; }, new Point(1, 3)); // different value → re-run
+        ctx.FlushEffects();
+        Assert.Equal(2, runs);
+    }
+
+    [Fact]
+    public void UseMemo_Arity1_Struct_Dep_Skips_While_Equal_And_Recomputes_On_Change()
+    {
+        // A struct dep compares by value through EqualityComparer<T>.Default with no
+        // params object[] allocation and no boxing on the unchanged path.
+        var ctx = NewCtx();
+        int calls = 0;
+        var v1 = ctx.UseMemo(() => { calls++; return calls; }, new PointStruct(1, 2));
+        Rerender(ctx);
+        var v2 = ctx.UseMemo(() => { calls++; return calls; }, new PointStruct(1, 2)); // equal → cached
+        Rerender(ctx);
+        var v3 = ctx.UseMemo(() => { calls++; return calls; }, new PointStruct(1, 9)); // changed → recompute
+
+        Assert.Equal(1, v1);
+        Assert.Equal(1, v2);
+        Assert.Equal(2, v3);
+        Assert.Equal(2, calls);
+    }
+
+    // ── Params-vs-arity equivalence (same skip/re-run decision) ──────────────
+
+    [Fact]
+    public void Arity_And_Params_Make_The_Same_Skip_Or_Rerun_Decision()
+    {
+        var ctx = NewCtx();
+        int arityRuns = 0, paramsRuns = 0;
+        var seq = new (int a, string b)[] { (1, "x"), (1, "x"), (2, "x"), (2, "y"), (2, "y") };
+        int[] expected = { 1, 1, 2, 3, 3 }; // cumulative run count after each render
+
+        for (int i = 0; i < seq.Length; i++)
+        {
+            if (i > 0) Rerender(ctx);
+            var (a, b) = seq[i];
+            ctx.UseEffect(() => { arityRuns++; }, a, b);                   // arity-2
+            ctx.UseEffect(() => { paramsRuns++; }, new object[] { a, b }); // params
+            ctx.FlushEffects();
+            Assert.Equal(expected[i], arityRuns);
+            Assert.Equal(expected[i], paramsRuns);
+            Assert.Equal(arityRuns, paramsRuns); // never diverge
+        }
+    }
+
+    private sealed record Point(int X, int Y);
+    private readonly record struct PointStruct(int X, int Y);
 }

--- a/tests/Reactor.Tests/HookArityOverloadTests.cs
+++ b/tests/Reactor.Tests/HookArityOverloadTests.cs
@@ -592,6 +592,32 @@ public class HookArityOverloadTests
         Assert.Equal(2, calls);
     }
 
+    [Fact]
+    public void UseEffect_Arity1_ReferenceType_IEquatable_Without_ObjectEquals_Matches_Params_Identity()
+    {
+        // The case from PR review (Copilot): a reference type implementing IEquatable<T>
+        // but NOT overriding Equals(object). The params path compares it by reference
+        // (identity); typed-arity must agree — NOT compare by the IEquatable value
+        // semantics that EqualityComparer<T>.Default would use. Two equal-X but distinct
+        // instances each render must re-run on BOTH paths in lockstep.
+        var ctx = NewCtx();
+        int arityRuns = 0, paramsRuns = 0;
+
+        ctx.UseEffect(() => { arityRuns++; }, new RefEquatableNoObjectOverride(1));
+        ctx.UseEffect(() => { paramsRuns++; }, new object[] { new RefEquatableNoObjectOverride(1) });
+        ctx.FlushEffects();
+        Assert.Equal(1, arityRuns);
+        Assert.Equal(1, paramsRuns);
+
+        Rerender(ctx);
+        ctx.UseEffect(() => { arityRuns++; }, new RefEquatableNoObjectOverride(1)); // new instance, equal X
+        ctx.UseEffect(() => { paramsRuns++; }, new object[] { new RefEquatableNoObjectOverride(1) });
+        ctx.FlushEffects();
+        Assert.Equal(2, paramsRuns); // reference identity differs → params re-runs
+        Assert.Equal(2, arityRuns);  // typed-arity matches params (would be 1 if it used IEquatable)
+        Assert.Equal(paramsRuns, arityRuns);
+    }
+
     // ── Params-vs-arity equivalence (same skip/re-run decision) ──────────────
 
     [Fact]
@@ -617,4 +643,16 @@ public class HookArityOverloadTests
 
     private sealed record Point(int X, int Y);
     private readonly record struct PointStruct(int X, int Y);
+
+    // A reference type with by-value IEquatable<T> but no Equals(object) override:
+    // EqualityComparer<T>.Default compares it by value, while object.Equals (the params
+    // path) compares it by reference. Locks the reference-type branch of DepEquals.
+#pragma warning disable CA1067 // intentional: exercises the reference-identity params path
+    private sealed class RefEquatableNoObjectOverride : IEquatable<RefEquatableNoObjectOverride>
+    {
+        private readonly int _x;
+        public RefEquatableNoObjectOverride(int x) => _x = x;
+        public bool Equals(RefEquatableNoObjectOverride? other) => other is not null && other._x == _x;
+    }
+#pragma warning restore CA1067
 }


### PR DESCRIPTION
## Summary

Re-introduces the typed-arity (`d1`/`d2`/`d3`) overloads for `UseEffect`, `UseMemo` and `UseCallback` and completes the three **api + docs** follow-ups tracked by #688. The overloads let 1–3 value-typed deps avoid the `params object[]` allocation and per-dep boxing on the unchanged-deps render path, while staying behaviorally equivalent to the existing `params` form.

> **Note on scoping:** #688 suggested a separate PR per item. The three follow-ups all depend on the typed-arity overloads themselves — and because the original perf PR (#668) was closed and re-landed as #750 *without* those overloads, they had to be re-introduced here first. The follow-ups are meaningless without them, so they're delivered together as one cohesive ergonomic feature.

## What's included

- **`RenderContext`** — 12 typed-arity overloads (1–3 deps, both `UseEffect` flavors: `Action` and `Func<Action>`) plus shared helpers (`AcquireEffectSlot`, `AcquireMemoSlot<T>`, `ScheduleEffect`, `PackDeps`, `DepsEqual1/2/3`, `AsParamsArrayDep`, `SnapshotDeps`). The existing `params object[]` methods were refactored to share the same slot/schedule plumbing. Each overload consumes exactly one hook slot, preserving the call-order invariant. The `#750` snapshot-on-store fix is preserved.
- **`Component`** (#688 item 1) — `protected` arity wrappers (1–3 deps) delegating to `Context`, so component-style code reaches the allocation-free path instead of falling back to `params`.
- **`HookRulesAnalyzer`** (#688 item 2) — `REACTOR_HOOKS_004` now inspects the `d1`/`d2`/`d3` typed-dep parameters, so calls through the arity overloads are linted like the `params` path.
- **Docs** (#688 item 3) — typed-arity notes added to the hooks/effects guide (templates `docs/_pipeline/templates/{hooks,effects}.md.dt` + mirrored compiled output).
- **Tests** — 20 arity unit tests (`HookArityOverloadTests.cs`) + 4 analyzer tests.
- **API index** — regenerated `reactor.api.txt` (both committed copies).

## Linked issue / spec

Fixes #688
Refs #659 (tracking), #668 / #750 (perf work)

## Test plan

- [x] Added unit tests in `tests/Reactor.Tests/HookArityOverloadTests.cs` (20) + `tests/Reactor.Tests/AnalyzerTests/HookRulesAnalyzerTests.cs` (4)
- [x] Ran `dotnet test tests/Reactor.Tests` → **10002 passed, 0 failed, 64 skipped**
- [x] Ran hooks/effects/memo/callback selftest buckets → **48 fixtures, 0 failures**
- [x] `dotnet build src/Reactor/Reactor.csproj` → 0 warnings / 0 errors (AOT/trim-clean)

## Risk / breaking changes

Public-API **additive** only — 12 new overloads alongside the existing `params object[]` methods; no signatures removed or changed. Overload resolution: a non-`object` scalar/array dep binds the new arity generic (the allocation-avoiding path); an `object`-typed single dep continues to bind `params` (`UseEffect`/`UseCallback`) or arity-1 (`UseMemo`), matching prior behavior. Deps comparison stays `object.Equals`-equivalent for the common cases; see the discussion of value-type/array edge cases in review.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>