### PR TITLE
test: fix flaky LT_OnMountUnmountBalanced selftest (#685)

### DIFF
--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/LifecycleTortureFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/LifecycleTortureFixtures.cs
@@ -59,6 +59,16 @@ internal sealed class LT_OnMountUnmountBalanced(Harness h) : SelfTestFixtureBase
             await Harness.WaitFor(() => H.FindTextContaining("item0") is null);
         }
 
+        // Quiesce before asserting the conserved counts. The per-cycle wait above
+        // keys off a VISUAL-tree predicate (item0 removed), but .OnUnmount callbacks
+        // increment their counter during reconcile, which can lag the visual removal
+        // by a dispatcher tick — so the final clear batch's last few unmounts may not
+        // have flushed yet. Drain render passes until the counts settle (mirrors
+        // LT_EffectCleanupBalanced / LT_NavSwapNoLeak). The asserts stay exact, so a
+        // genuine missed-unmount regression still fails: WaitFor just exhausts its
+        // passes and the Check below reports the real number.
+        await Harness.WaitFor(() => mounts == 30 && unmounts == 30);
+
         H.Check("LT_Mounts_Exactly_30", mounts == 30);
         H.Check("LT_Unmounts_Exactly_30", unmounts == 30);
         H.Check("LT_OnMount_Received_Control", gotControl == mounts);


### PR DESCRIPTION
## Summary
Fixes the intermittent Selftests failure `LT_OnMountUnmountBalanced` (`LT_Unmounts_Exactly_30` / `LT_NoLeak_MountsEqualUnmounts`, `unmounts < 30`) reported in #685. This is a test-side flush race — no product-code change.

## Root cause
The fixture runs 3 grow→clear cycles, then asserts `unmounts == 30` immediately after a **visual-tree** predicate:

```csharp
drive!(0);
await Harness.WaitFor(() => H.FindTextContaining("item0") is null); // visual removal
...
H.Check("LT_Unmounts_Exactly_30", unmounts == 30);                  // counter snapshot
```

`.OnUnmount` callbacks increment their counter during reconcile, but the harness drains renders via dispatcher yields + a fixed delay (the idle-gate in `Harness.Render` runs against the primary host, not the fixture host). So the visual predicate (`item0` removed) can be satisfied a dispatcher tick **before** the final clear batch's last `OnUnmount` callbacks finish — yielding `unmounts < 30`. `mounts == 30` always passed because the grow predicate keys off `item9` (the last-created child), which only appears once all 10 mounts have run.

This was the only one of the three fixtures in the file asserting its counters against a one-shot snapshot. The two siblings already gate on their counters first:
- `LT_EffectCleanupBalanced`: `await Harness.WaitFor(() => _effects == 20 && _cleanups == 20);`
- `LT_NavSwapNoLeak`: `await Harness.WaitFor(() => _mounts >= 200 && _unmounts >= 190);`

…and `TESTING.md` ("Selftest waiting patterns") documents the rule: wait on a concrete predicate via `WaitFor`, never assert a snapshot taken right after a render. (Same remedy as the recently-merged #766.)

## Fix
Add one deterministic quiesce between the loop and the asserts, mirroring the siblings:

```csharp
await Harness.WaitFor(() => mounts == 30 && unmounts == 30);
```

The asserts stay exact (`== 30`), so this does **not** mask a real leak: if the counts never converge, `WaitFor` exhausts its passes and the existing `H.Check` lines fail and report the real number — a genuine missed-unmount / double-mount regression still fails. No new `drive` calls, so the extra render passes are idempotent and the counts cannot overshoot.

## Validation
- Built `Reactor.AppTests.Host` (x64) and ran `--self-test --filter "LT_"`: all 3 lifecycle fixtures green, including the 4 previously-flaky checks.
- Looped `LT_OnMountUnmountBalanced` **25×**: 0 failing runs, 0 `not ok` lines.

Fixes #685