### PR TITLE
fix(reconciler): resolve ThemeRef ResourceOverrides against ancestor theme at mount

### DIFF
--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -5607,7 +5607,8 @@ IReadOnlyList<UIElement> LastModifiedElements { get; }
 IReadOnlyList<UIElement> LastMountedElements { get; }
 bool EnableBitmaskDiff { get; set; }
 ApplyDefaultAutomationName(FrameworkElement fe, string caption) → void
-ApplyResourceOverrides(FrameworkElement fe, ResourceOverrides oldOverrides, ResourceOverrides newOverrides, ElementTheme effectiveTheme = ElementTheme.Default) → void
+ApplyResourceOverrides(FrameworkElement fe, ResourceOverrides oldOverrides, ResourceOverrides newOverrides) → void
+ApplyResourceOverrides(FrameworkElement fe, ResourceOverrides oldOverrides, ResourceOverrides newOverrides, ElementTheme effectiveTheme) → void
 ApplySetters<T>(Action<T>[] setters, T control) → void
 ApplyThemeBindings(FrameworkElement fe, IReadOnlyDictionary<string, ThemeRef> bindings) → void
 DetachReactorState(FrameworkElement fe) → void

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -5607,7 +5607,7 @@ IReadOnlyList<UIElement> LastModifiedElements { get; }
 IReadOnlyList<UIElement> LastMountedElements { get; }
 bool EnableBitmaskDiff { get; set; }
 ApplyDefaultAutomationName(FrameworkElement fe, string caption) → void
-ApplyResourceOverrides(FrameworkElement fe, ResourceOverrides oldOverrides, ResourceOverrides newOverrides) → void
+ApplyResourceOverrides(FrameworkElement fe, ResourceOverrides oldOverrides, ResourceOverrides newOverrides, ElementTheme effectiveTheme = ElementTheme.Default) → void
 ApplySetters<T>(Action<T>[] setters, T control) → void
 ApplyThemeBindings(FrameworkElement fe, IReadOnlyDictionary<string, ThemeRef> bindings) → void
 DetachReactorState(FrameworkElement fe) → void

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -5607,7 +5607,8 @@ IReadOnlyList<UIElement> LastModifiedElements { get; }
 IReadOnlyList<UIElement> LastMountedElements { get; }
 bool EnableBitmaskDiff { get; set; }
 ApplyDefaultAutomationName(FrameworkElement fe, string caption) → void
-ApplyResourceOverrides(FrameworkElement fe, ResourceOverrides oldOverrides, ResourceOverrides newOverrides, ElementTheme effectiveTheme = ElementTheme.Default) → void
+ApplyResourceOverrides(FrameworkElement fe, ResourceOverrides oldOverrides, ResourceOverrides newOverrides) → void
+ApplyResourceOverrides(FrameworkElement fe, ResourceOverrides oldOverrides, ResourceOverrides newOverrides, ElementTheme effectiveTheme) → void
 ApplySetters<T>(Action<T>[] setters, T control) → void
 ApplyThemeBindings(FrameworkElement fe, IReadOnlyDictionary<string, ThemeRef> bindings) → void
 DetachReactorState(FrameworkElement fe) → void

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -5607,7 +5607,7 @@ IReadOnlyList<UIElement> LastModifiedElements { get; }
 IReadOnlyList<UIElement> LastMountedElements { get; }
 bool EnableBitmaskDiff { get; set; }
 ApplyDefaultAutomationName(FrameworkElement fe, string caption) → void
-ApplyResourceOverrides(FrameworkElement fe, ResourceOverrides oldOverrides, ResourceOverrides newOverrides) → void
+ApplyResourceOverrides(FrameworkElement fe, ResourceOverrides oldOverrides, ResourceOverrides newOverrides, ElementTheme effectiveTheme = ElementTheme.Default) → void
 ApplySetters<T>(Action<T>[] setters, T control) → void
 ApplyThemeBindings(FrameworkElement fe, IReadOnlyDictionary<string, ThemeRef> bindings) → void
 DetachReactorState(FrameworkElement fe) → void

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -48,6 +48,15 @@ public sealed partial class Reconciler
             ctxCount = ctxValues.Count;
         }
 
+        // Thread the ancestor-aware effective theme for ThemeRef-backed ResourceOverrides
+        // resolution (mount-theme bug). The element's own RequestedTheme wins; otherwise
+        // the subtree inherits the ambient threaded from its ancestors. Children mounted
+        // inside MountXxx (and this element's own ApplyResourceOverrides below) see it;
+        // restored in the finally so siblings are unaffected.
+        var prevAmbientTheme = _ambientRequestedTheme;
+        if (modifiers?.RequestedTheme is { } ownTheme && ownTheme != ElementTheme.Default)
+            _ambientRequestedTheme = ownTheme;
+
         UIElement? control;
         // Push stagger scope if this element has StaggerConfig — children mounted
         // inside MountXxx will consume stagger indices for their enter transitions.
@@ -132,7 +141,7 @@ public sealed partial class Reconciler
 
         // Apply per-control resource overrides (lightweight styling)
         if (element.ResourceOverrides is not null && control is FrameworkElement resFe)
-            ApplyResourceOverrides(resFe, null, element.ResourceOverrides);
+            ApplyResourceOverrides(resFe, null, element.ResourceOverrides, _ambientRequestedTheme);
 
         // Apply transitions after mounting (runs after .Set() callbacks)
         if (control is not null && (element.ImplicitTransitions is not null || element.ThemeTransitions is not null))
@@ -180,6 +189,7 @@ public sealed partial class Reconciler
                 PopStaggerScope();
             if (ctxCount > 0)
                 _contextScope.Pop(ctxCount);
+            _ambientRequestedTheme = prevAmbientTheme;
         }
 
         return control;

--- a/src/Reactor/Core/Reconciler.Mount.cs
+++ b/src/Reactor/Core/Reconciler.Mount.cs
@@ -48,14 +48,14 @@ public sealed partial class Reconciler
             ctxCount = ctxValues.Count;
         }
 
-        // Thread the ancestor-aware effective theme for ThemeRef-backed ResourceOverrides
+        // Compute the ancestor-aware effective theme for ThemeRef-backed ResourceOverrides
         // resolution (mount-theme bug). The element's own RequestedTheme wins; otherwise
-        // the subtree inherits the ambient threaded from its ancestors. Children mounted
-        // inside MountXxx (and this element's own ApplyResourceOverrides below) see it;
-        // restored in the finally so siblings are unaffected.
+        // the subtree inherits the ambient threaded from its ancestors. Saved here so the
+        // finally can restore the parent's value; the field itself is written INSIDE the
+        // try below so an exception during child mount can't leak it to siblings.
         var prevAmbientTheme = _ambientRequestedTheme;
-        if (modifiers?.RequestedTheme is { } ownTheme && ownTheme != ElementTheme.Default)
-            _ambientRequestedTheme = ownTheme;
+        var effectiveTheme = (modifiers?.RequestedTheme is { } ownTheme && ownTheme != ElementTheme.Default)
+            ? ownTheme : prevAmbientTheme;
 
         UIElement? control;
         // Push stagger scope if this element has StaggerConfig — children mounted
@@ -65,6 +65,11 @@ public sealed partial class Reconciler
             PushStaggerScope(element.StaggerConfig!.Delay);
         try
         {
+        // Publish the effective theme for the subtree — INSIDE the try so the finally
+        // restores it on every exit (including an exception during child mount below).
+        // Children mounted inside MountXxx and this element's own ApplyResourceOverrides
+        // resolve ThemeRef ResourceOverrides against it.
+        _ambientRequestedTheme = effectiveTheme;
 
         // Spec 048 §8 — four-arm dispatch precedence:
         //   (1) per-host `_v1Handlers` (explicit RegisterHandler + cached

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -60,15 +60,16 @@ public sealed partial class Reconciler
         if (newEl.Modifiers is not null && !ReferenceEquals(modifiers, newEl.Modifiers))
             modifiers = modifiers is not null ? modifiers.Merge(newEl.Modifiers) : newEl.Modifiers;
 
-        // Thread the ancestor-aware effective theme for ThemeRef-backed ResourceOverrides
+        // Compute the ancestor-aware effective theme for ThemeRef-backed ResourceOverrides
         // resolution (mount-theme bug): the element's own RequestedTheme wins, else the
-        // subtree inherits the ambient threaded from its ancestors. Set the field BEFORE
-        // the shallow-skip check so children recursed inside UpdateXxx — and any fresh
-        // subtree this Update mounts — resolve against it; restored on every exit.
+        // subtree inherits the ambient threaded from its ancestors. Kept as a LOCAL here;
+        // the shallow-skip arm below passes it directly. The _ambientRequestedTheme FIELD
+        // (read by children recursed inside UpdateXxx / fresh subtrees this Update mounts)
+        // is written ONLY on the non-skip path inside the try/finally below, so the
+        // early-returning skip arm can never leak it to callers/siblings on an exception.
         var prevAmbientTheme = _ambientRequestedTheme;
         var effectiveTheme = (modifiers?.RequestedTheme is { } ownTheme && ownTheme != ElementTheme.Default)
             ? ownTheme : prevAmbientTheme;
-        _ambientRequestedTheme = effectiveTheme;
 
         // Short-circuit: if old and new elements are structurally identical,
         // skip all WinUI property access. This is the critical optimization for
@@ -113,7 +114,9 @@ public sealed partial class Reconciler
             if ((HasGestureOrDragSlots(modifiers) || HasGestureOrDragSlots(oldModifiers))
                 && control is FrameworkElement gestFeSE)
                 RefreshGestureDragStateOnSkip(gestFeSE, oldModifiers, modifiers);
-            _ambientRequestedTheme = prevAmbientTheme;
+            // No _ambientRequestedTheme restore here: the field is written only on the
+            // non-skip path inside the try below, never on this early-return arm (which
+            // reads the LOCAL effectiveTheme at line ~109), so it cannot leak.
             return null; // null = keep existing control as-is
         }
 
@@ -157,6 +160,12 @@ public sealed partial class Reconciler
         UIElement? result;
         try
         {
+        // Publish the effective theme for the subtree now that we're committed to the
+        // non-skip path — INSIDE the try so the finally restores it on every exit
+        // (including an exception in the recursion below). Children recursed inside
+        // UpdateXxx (and any fresh subtree this Update mounts) resolve ThemeRef
+        // ResourceOverrides against it.
+        _ambientRequestedTheme = effectiveTheme;
 
         // Spec 048 §8 — four-arm dispatch precedence (matches Mount):
         //   (1) per-host `_v1Handlers`, (2) per-host `_typeRegistry`,

--- a/src/Reactor/Core/Reconciler.Update.cs
+++ b/src/Reactor/Core/Reconciler.Update.cs
@@ -60,6 +60,16 @@ public sealed partial class Reconciler
         if (newEl.Modifiers is not null && !ReferenceEquals(modifiers, newEl.Modifiers))
             modifiers = modifiers is not null ? modifiers.Merge(newEl.Modifiers) : newEl.Modifiers;
 
+        // Thread the ancestor-aware effective theme for ThemeRef-backed ResourceOverrides
+        // resolution (mount-theme bug): the element's own RequestedTheme wins, else the
+        // subtree inherits the ambient threaded from its ancestors. Set the field BEFORE
+        // the shallow-skip check so children recursed inside UpdateXxx — and any fresh
+        // subtree this Update mounts — resolve against it; restored on every exit.
+        var prevAmbientTheme = _ambientRequestedTheme;
+        var effectiveTheme = (modifiers?.RequestedTheme is { } ownTheme && ownTheme != ElementTheme.Default)
+            ? ownTheme : prevAmbientTheme;
+        _ambientRequestedTheme = effectiveTheme;
+
         // Short-circuit: if old and new elements are structurally identical,
         // skip all WinUI property access. This is the critical optimization for
         // large grids where only a fraction of elements change each frame.
@@ -93,15 +103,17 @@ public sealed partial class Reconciler
                 SetElementTag(tagFeSE, newEl);
             if (newEl.ThemeBindings is not null && control is FrameworkElement thFeSE)
                 ApplyThemeBindings(thFeSE, newEl.ThemeBindings);
-            // Re-resolve ThemeRef-based resource overrides on theme change
+            // Re-resolve ThemeRef-based resource overrides on theme change, against the
+            // ancestor-aware effective theme (lag-free vs. fe's own ActualTheme view).
             if (newEl.ResourceOverrides is { ThemeRefs.Count: > 0 } && control is FrameworkElement resFeSE)
-                ApplyResourceOverrides(resFeSE, newEl.ResourceOverrides, newEl.ResourceOverrides);
+                ApplyResourceOverrides(resFeSE, newEl.ResourceOverrides, newEl.ResourceOverrides, effectiveTheme);
             // #721 — refresh the cached gesture/drag dispatch closures so a skipped
             // element whose only change is a per-render gesture/drag closure dispatches
             // the latest closure (not a stale capture) without re-arming the trampolines.
             if ((HasGestureOrDragSlots(modifiers) || HasGestureOrDragSlots(oldModifiers))
                 && control is FrameworkElement gestFeSE)
                 RefreshGestureDragStateOnSkip(gestFeSE, oldModifiers, modifiers);
+            _ambientRequestedTheme = prevAmbientTheme;
             return null; // null = keep existing control as-is
         }
 
@@ -220,7 +232,7 @@ public sealed partial class Reconciler
 
         // Apply per-control resource overrides (lightweight styling)
         if ((newEl.ResourceOverrides is not null || oldEl.ResourceOverrides is not null) && target is FrameworkElement resFe)
-            ApplyResourceOverrides(resFe, oldEl.ResourceOverrides, newEl.ResourceOverrides);
+            ApplyResourceOverrides(resFe, oldEl.ResourceOverrides, newEl.ResourceOverrides, effectiveTheme);
 
         // Apply transitions after update (re-applies when transition config changes)
         if (newEl.ImplicitTransitions is not null || newEl.ThemeTransitions is not null)
@@ -265,6 +277,7 @@ public sealed partial class Reconciler
         {
             if (ctxCount > 0)
                 _contextScope.Pop(ctxCount);
+            _ambientRequestedTheme = prevAmbientTheme;
         }
 
         return result;

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -50,6 +50,15 @@ public sealed partial class Reconciler : IDisposable
     internal readonly ILogger? _logger;
     private readonly List<(ConnectedAnimation Animation, UIElement Target)> _pendingConnectedAnimationStarts = new();
     private readonly ContextScope _contextScope = new();
+    // Ancestor-aware effective theme for the subtree currently being mounted/updated,
+    // threaded top-down through Mount/Update (an element's own RequestedTheme wins,
+    // otherwise the subtree inherits its ancestor's). ElementTheme.Default means "no
+    // Reactor-tree ancestor override" — resolution then falls back to the element's own
+    // fe-based walk / app theme. At mount the element is not yet parented, so an
+    // ancestor RequestedTheme is unreachable via fe's visual-tree walk; this field
+    // carries the reconciler's top-down knowledge so ThemeRef-backed ResourceOverrides
+    // resolve their concrete brush against the correct effective theme at mount.
+    private ElementTheme _ambientRequestedTheme = ElementTheme.Default;
     private int _errorBoundaryDepth;
     /// <summary>
     /// Active rerender-callback depth. Throws past
@@ -4800,10 +4809,23 @@ public sealed partial class Reconciler : IDisposable
     /// existing-api-surface.md). Applies per-control resource overrides
     /// (lightweight styling). Provisional API; see <c>REACTOR_V1_PREVIEW</c>.
     /// </summary>
+    /// <param name="fe">The control whose <c>Resources</c> receive the overrides.</param>
+    /// <param name="oldOverrides">The previously-applied overrides, or null at mount.</param>
+    /// <param name="newOverrides">The overrides to apply, or null to clear managed keys.</param>
+    /// <param name="effectiveTheme">
+    /// The ancestor-aware effective theme threaded by the reconciler. When non-Default,
+    /// ThemeRef-backed overrides resolve their concrete brush against it via
+    /// <see cref="ThemeRef.Resolve(string, bool)"/> — necessary at mount, where the
+    /// element is not yet parented and so an ancestor <c>RequestedTheme</c> is
+    /// unreachable through <paramref name="fe"/>'s own visual-tree walk. Defaults to
+    /// <see cref="ElementTheme.Default"/>, which falls back to fe-based resolution for
+    /// direct callers / host-window themes set outside the Reactor element tree.
+    /// </param>
     public static void ApplyResourceOverrides(
         FrameworkElement fe,
         Microsoft.UI.Reactor.Elements.ResourceOverrides? oldOverrides,
-        Microsoft.UI.Reactor.Elements.ResourceOverrides? newOverrides)
+        Microsoft.UI.Reactor.Elements.ResourceOverrides? newOverrides,
+        ElementTheme effectiveTheme = ElementTheme.Default)
     {
         // Track which keys Reactor has set on this element
         var managed = _managedResourceKeys.GetOrCreateValue(fe);
@@ -4841,10 +4863,18 @@ public sealed partial class Reconciler : IDisposable
             managed.Add(key);
         }
 
-        // Apply ThemeRef resources (resolved from Application.Current.Resources)
+        // Apply ThemeRef resources (resolved from Application.Current.Resources).
+        // When the reconciler threaded an explicit ancestor-aware effective theme,
+        // resolve against it: at mount fe is not yet parented, so its own visual-tree
+        // walk cannot see an ancestor RequestedTheme and would otherwise fall back to
+        // the app theme (the mount-theme bug). When no ambient theme is supplied
+        // (Default — direct public-API callers, or a host/window theme set outside the
+        // Reactor tree), keep the fe-based resolution.
         foreach (var (key, themeRef) in newOverrides.ThemeRefs)
         {
-            var resolved = ThemeRef.Resolve(themeRef.ResourceKey, fe);
+            var resolved = effectiveTheme != ElementTheme.Default
+                ? ThemeRef.Resolve(themeRef.ResourceKey, effectiveTheme == ElementTheme.Dark)
+                : ThemeRef.Resolve(themeRef.ResourceKey, fe);
             if (resolved is not null)
             {
                 fe.Resources[key] = resolved;

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -4802,12 +4802,26 @@ public sealed partial class Reconciler : IDisposable
     /// Applies per-control resource overrides (lightweight styling) to a
     /// <see cref="FrameworkElement"/>. Literal values are set directly;
     /// <see cref="ThemeRef"/>-based values are resolved from
-    /// <c>Application.Current.Resources</c>.
+    /// <c>Application.Current.Resources</c> using the element's own effective theme.
     /// </summary>
+    /// <remarks>
+    /// Binary-compatible original 3-arg surface (Spec 047 §14 Phase 1 (1.3), promoted
+    /// from private per audit existing-api-surface.md). Delegates to the 4-arg overload
+    /// with <see cref="ElementTheme.Default"/>; the reconciler uses the 4-arg form to
+    /// pass an explicit ancestor-aware theme (needed at mount, before the control is
+    /// parented). Provisional API; see <c>REACTOR_V1_PREVIEW</c>.
+    /// </remarks>
+    public static void ApplyResourceOverrides(
+        FrameworkElement fe,
+        Microsoft.UI.Reactor.Elements.ResourceOverrides? oldOverrides,
+        Microsoft.UI.Reactor.Elements.ResourceOverrides? newOverrides)
+        => ApplyResourceOverrides(fe, oldOverrides, newOverrides, ElementTheme.Default);
+
     /// <summary>
-    /// Spec 047 §14 Phase 1 (1.3) — promoted from private (per audit
-    /// existing-api-surface.md). Applies per-control resource overrides
-    /// (lightweight styling). Provisional API; see <c>REACTOR_V1_PREVIEW</c>.
+    /// Applies per-control resource overrides (lightweight styling), resolving
+    /// <see cref="ThemeRef"/>-backed values against an explicit
+    /// <paramref name="effectiveTheme"/>. Provisional API (Spec 047 §14 Phase 1);
+    /// see <c>REACTOR_V1_PREVIEW</c>.
     /// </summary>
     /// <param name="fe">The control whose <c>Resources</c> receive the overrides.</param>
     /// <param name="oldOverrides">The previously-applied overrides, or null at mount.</param>
@@ -4817,15 +4831,15 @@ public sealed partial class Reconciler : IDisposable
     /// ThemeRef-backed overrides resolve their concrete brush against it via
     /// <see cref="ThemeRef.Resolve(string, bool)"/> — necessary at mount, where the
     /// element is not yet parented and so an ancestor <c>RequestedTheme</c> is
-    /// unreachable through <paramref name="fe"/>'s own visual-tree walk. Defaults to
-    /// <see cref="ElementTheme.Default"/>, which falls back to fe-based resolution for
-    /// direct callers / host-window themes set outside the Reactor element tree.
+    /// unreachable through <paramref name="fe"/>'s own visual-tree walk. Pass
+    /// <see cref="ElementTheme.Default"/> to fall back to fe-based resolution
+    /// (host-window themes set outside the Reactor tree; the 3-arg overload).
     /// </param>
     public static void ApplyResourceOverrides(
         FrameworkElement fe,
         Microsoft.UI.Reactor.Elements.ResourceOverrides? oldOverrides,
         Microsoft.UI.Reactor.Elements.ResourceOverrides? newOverrides,
-        ElementTheme effectiveTheme = ElementTheme.Default)
+        ElementTheme effectiveTheme)
     {
         // Track which keys Reactor has set on this element
         var managed = _managedResourceKeys.GetOrCreateValue(fe);

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ResourceOverrideMountThemeFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ResourceOverrideMountThemeFixtures.cs
@@ -220,4 +220,139 @@ internal static class ResourceOverrideMountThemeFixtures
             }
         }
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Post-mount ancestor theme toggle re-resolves through BOTH Update paths
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The mount fix also threads the effective theme through the UPDATE path. Toggling an
+    /// ancestor's <c>RequestedTheme</c> on a later render must re-resolve the descendants'
+    /// ThemeRef ResourceOverrides — through BOTH arms of <c>Reconciler.Update</c>:
+    /// <list type="bullet">
+    /// <item>a child that stays shallow-equal (constant text) is declined by
+    /// <c>CanSkipUpdate</c> (it carries ThemeRefs) and routed to Update's element-level
+    /// shallow-skip arm, which re-applies against the ancestor-aware effective theme;</item>
+    /// <item>a child that also changes a prop (text carries a counter) takes the full-update
+    /// branch, which re-applies the same way.</item>
+    /// </list>
+    /// Uses concrete ThemeRef overrides (NOT self-healing {ThemeResource}), so the brush
+    /// only flips if Reactor actually re-resolves — and does so lag-free via the threaded
+    /// ambient rather than fe's ActualTheme view. Also guards the MUST-FIX exception-safety
+    /// refactor of the ambient save/restore in Update.
+    /// </summary>
+    internal sealed class PostMountAncestorToggleReResolves(Harness h) : SelfTestFixtureBase(h)
+    {
+        private const string SrcKey = "Item1ThemedBrush_Toggle";
+        private const string TargetKey = "Item1Target_Toggle";
+
+        public override async Task RunAsync()
+        {
+            var light = MakeBrush(0, 0, 160);
+            var dark = MakeBrush(160, 0, 0);
+            var dict = InstallThemedDict(SrcKey, light, dark);
+            try
+            {
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                {
+                    var (theme, setTheme) = ctx.UseState(ElementTheme.Dark);
+                    var (counter, setCounter) = ctx.UseState(0);
+                    return VStack(
+                        Button("ToggleAncestorTheme", () =>
+                        {
+                            setTheme(theme == ElementTheme.Dark ? ElementTheme.Light : ElementTheme.Dark);
+                            setCounter(counter + 1);
+                        }),
+                        VStack(
+                            // Constant text → shallow-equal across renders → Update's
+                            // element-level shallow-skip arm re-resolves via the ambient.
+                            TextBlock("toggleSkipChild").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))),
+                            // Text carries the counter → NOT shallow-equal → Update's
+                            // full-update branch re-resolves via the ambient.
+                            TextBlock($"toggleFullChild-{counter}").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))))
+                        .RequestedTheme(theme));
+                });
+
+                await Harness.Render();
+
+                // Ancestor Dark at mount → both children resolve the Dark brush.
+                var skipTb = H.FindControl<TextBlock>(t => t.Text == "toggleSkipChild");
+                var fullTb = H.FindControl<TextBlock>(t => t.Text == "toggleFullChild-0");
+                H.Check("Item1Toggle_MountChildrenPresent", skipTb is not null && fullTb is not null);
+                H.Check("Item1Toggle_SkipChildMountDark", ReferenceEquals(ResourceBrush(skipTb, TargetKey), dark));
+                H.Check("Item1Toggle_FullChildMountDark", ReferenceEquals(ResourceBrush(fullTb, TargetKey), dark));
+
+                // Toggle ancestor Dark→Light (and bump the counter so fullChild changes a prop).
+                H.ClickButton("ToggleAncestorTheme");
+
+                // Shallow-equal child re-resolves to Light via Update's shallow-skip arm.
+                var skipReResolved = await Harness.WaitFor(() =>
+                {
+                    var tb = H.FindControl<TextBlock>(t => t.Text == "toggleSkipChild");
+                    return ReferenceEquals(ResourceBrush(tb, TargetKey), light);
+                });
+                H.Check("Item1Toggle_SkipChildReResolvedLight", skipReResolved);
+
+                // Prop-changed child re-resolves to Light via Update's full-update branch.
+                var fullReResolved = await Harness.WaitFor(() =>
+                {
+                    var tb = H.FindControl<TextBlock>(t => t.Text == "toggleFullChild-1");
+                    return ReferenceEquals(ResourceBrush(tb, TargetKey), light);
+                });
+                H.Check("Item1Toggle_FullChildReResolvedLight", fullReResolved);
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(dict);
+                global::Microsoft.UI.Reactor.Core.ThemeRef.InvalidateResolutionCache();
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Sibling isolation — the ambient save/restore must not leak across peers
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Two sibling subtrees under different <c>RequestedTheme</c>s, each with a ThemeRef
+    /// override, in a single render. Each must resolve its OWN ancestor brush — proving the
+    /// per-frame ambient save/restore (and the exception-safe field placement) never leaks
+    /// the first sibling's theme into the second's subtree.
+    /// </summary>
+    internal sealed class SiblingSubtreesResolveIndependently(Harness h) : SelfTestFixtureBase(h)
+    {
+        private const string SrcKey = "Item1ThemedBrush_Sibling";
+        private const string TargetKey = "Item1Target_Sibling";
+
+        public override async Task RunAsync()
+        {
+            var light = MakeBrush(0, 0, 140);
+            var dark = MakeBrush(140, 0, 0);
+            var dict = InstallThemedDict(SrcKey, light, dark);
+            try
+            {
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                    VStack(
+                        VStack(TextBlock("siblingDark").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))))
+                            .RequestedTheme(ElementTheme.Dark),
+                        VStack(TextBlock("siblingLight").Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))))
+                            .RequestedTheme(ElementTheme.Light)));
+
+                await Harness.Render();
+
+                var darkTb = H.FindControl<TextBlock>(t => t.Text == "siblingDark");
+                var lightTb = H.FindControl<TextBlock>(t => t.Text == "siblingLight");
+                H.Check("Item1Sibling_ChildrenPresent", darkTb is not null && lightTb is not null);
+                H.Check("Item1Sibling_DarkSubtreeResolvedDark", ReferenceEquals(ResourceBrush(darkTb, TargetKey), dark));
+                H.Check("Item1Sibling_LightSubtreeResolvedLight", ReferenceEquals(ResourceBrush(lightTb, TargetKey), light));
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(dict);
+                global::Microsoft.UI.Reactor.Core.ThemeRef.InvalidateResolutionCache();
+            }
+        }
+    }
 }

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ResourceOverrideMountThemeFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ResourceOverrideMountThemeFixtures.cs
@@ -1,0 +1,223 @@
+using System;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Elements;
+using Microsoft.UI.Reactor.Hooks;
+using Microsoft.UI.Reactor.Hosting;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Mount-theme bug — a ThemeRef-backed <c>ResourceOverrides</c>
+/// (<c>.Resources(r =&gt; r.Set(key, Theme.Ref(srcKey)))</c>) on a subtree whose
+/// effective theme comes from an <b>ancestor's</b> <c>RequestedTheme</c> (not the
+/// element's own) must resolve its concrete brush against that ancestor theme at
+/// mount — NOT the app fallback.
+///
+/// <para>ROOT CAUSE: <c>ApplyResourceOverrides</c> resolved via
+/// <c>ThemeRef.Resolve(key, fe)</c>, whose effective-theme walk needs the element to
+/// be parented. At mount the control is not yet in the visual tree, so an ancestor
+/// <c>RequestedTheme</c> is unreachable and resolution falls back to
+/// <c>Application.Current.RequestedTheme</c>. A subtree with ancestor
+/// <c>RequestedTheme=Dark</c> under a Light app got the LIGHT brush. FIX: the
+/// reconciler threads the ancestor-aware effective theme top-down
+/// (<c>_ambientRequestedTheme</c>) and passes it to <c>ApplyResourceOverrides</c>,
+/// which resolves via <c>ThemeRef.Resolve(key, isDark)</c>.</para>
+///
+/// <para>DETERMINISM: the ancestor theme is always set to the OPPOSITE of the live
+/// app theme, so "resolve against ancestor" and "resolve against app" produce
+/// different brushes regardless of whether the host app runs Light or Dark. A unique
+/// themed <c>ResourceDictionary</c> (explicit Light + Dark <c>ThemeDictionaries</c>)
+/// is merged into <c>Application.Current.Resources</c> so <c>ThemeRef.Resolve</c>
+/// returns the exact shared brush instance per theme — asserted by reference.
+/// RED before the fix (resolves the app variant), GREEN after (the ancestor variant).</para>
+/// </summary>
+internal static class ResourceOverrideMountThemeFixtures
+{
+    private static SolidColorBrush MakeBrush(byte r, byte g, byte b) =>
+        new SolidColorBrush(global::Windows.UI.Color.FromArgb(255, r, g, b));
+
+    private static SolidColorBrush? ResourceBrush(FrameworkElement? fe, string key)
+    {
+        if (fe?.Resources is { } res && res.TryGetValue(key, out var v))
+            return v as SolidColorBrush;
+        return null;
+    }
+
+    // The app-level ResourceDictionary has a Source (XamlControlsResources) and rejects
+    // direct local values, but a merged Source-less dictionary is fine. Install one whose
+    // ThemeDictionaries carry a different brush per theme under a unique key; ThemeRef.Resolve
+    // discovers it via its ThemeDictionaries scan over MergedDictionaries. #660 — the
+    // (key,theme)->Brush cache is invalidated on install so a prior run's entry can't leak.
+    private static ResourceDictionary InstallThemedDict(string key, SolidColorBrush light, SolidColorBrush dark)
+    {
+        var dict = new ResourceDictionary();
+        dict.ThemeDictionaries["Light"] = new ResourceDictionary { [key] = light };
+        dict.ThemeDictionaries["Dark"] = new ResourceDictionary { [key] = dark };
+        Application.Current.Resources.MergedDictionaries.Add(dict);
+        global::Microsoft.UI.Reactor.Core.ThemeRef.InvalidateResolutionCache();
+        return dict;
+    }
+
+    // ancestorTheme is the OPPOSITE of the live app theme; the matching ancestor brush is the
+    // value the fix must resolve, and the app-theme brush is the (wrong) pre-fix value.
+    private static (ElementTheme ancestorTheme, SolidColorBrush ancestorBrush, SolidColorBrush appBrush)
+        AncestorAgainstApp(SolidColorBrush light, SolidColorBrush dark)
+    {
+        var appIsDark = Application.Current.RequestedTheme == ApplicationTheme.Dark;
+        return appIsDark
+            ? (ElementTheme.Light, light, dark)
+            : (ElementTheme.Dark, dark, light);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Single-level inheritance — RED pre-fix, GREEN post-fix
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// A child carrying ONLY a ThemeRef-backed ResourceOverride (no own RequestedTheme)
+    /// sits directly under an ancestor whose RequestedTheme is the opposite of the app
+    /// theme. At mount the child must resolve the ancestor brush. RED pre-fix (resolved
+    /// the app brush via the unparented fe walk falling back to app theme), GREEN after.
+    /// </summary>
+    internal sealed class AncestorThemeResolvesAtMount(Harness h) : SelfTestFixtureBase(h)
+    {
+        private const string SrcKey = "Item1ThemedBrush_Single";
+        private const string TargetKey = "Item1Target_Single";
+
+        public override async Task RunAsync()
+        {
+            var light = MakeBrush(0, 0, 220);
+            var dark = MakeBrush(220, 0, 0);
+            var (ancestorTheme, ancestorBrush, appBrush) = AncestorAgainstApp(light, dark);
+            var dict = InstallThemedDict(SrcKey, light, dark);
+            try
+            {
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                    VStack(
+                        TextBlock("singleChild")
+                            .Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey))))
+                    .RequestedTheme(ancestorTheme));
+
+                await Harness.Render();
+
+                var tb = H.FindControl<TextBlock>(t => t.Text == "singleChild");
+                H.Check("Item1Single_ChildPresent", tb is not null);
+                var resolved = ResourceBrush(tb, TargetKey);
+                // The crux: ancestor brush (opposite of app), not the app fallback.
+                H.Check("Item1Single_ResolvedAncestorBrush", ReferenceEquals(resolved, ancestorBrush));
+                H.Check("Item1Single_NotAppBrush", !ReferenceEquals(resolved, appBrush));
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(dict);
+                global::Microsoft.UI.Reactor.Core.ThemeRef.InvalidateResolutionCache();
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Multi-level inheritance through a themeless intermediate — RED pre-fix
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The ancestor RequestedTheme is inherited across an intermediate container that
+    /// declares no theme of its own. The deeply-nested child's override must still
+    /// resolve the ancestor brush at mount — proving the ambient threads through the
+    /// whole subtree, not just one level.
+    /// </summary>
+    internal sealed class NestedAncestorThemeResolvesAtMount(Harness h) : SelfTestFixtureBase(h)
+    {
+        private const string SrcKey = "Item1ThemedBrush_Nested";
+        private const string TargetKey = "Item1Target_Nested";
+
+        public override async Task RunAsync()
+        {
+            var light = MakeBrush(0, 0, 200);
+            var dark = MakeBrush(200, 0, 0);
+            var (ancestorTheme, ancestorBrush, appBrush) = AncestorAgainstApp(light, dark);
+            var dict = InstallThemedDict(SrcKey, light, dark);
+            try
+            {
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                    VStack(
+                        VStack( // intermediate: no RequestedTheme of its own
+                            TextBlock("nestedChild")
+                                .Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey)))))
+                    .RequestedTheme(ancestorTheme));
+
+                await Harness.Render();
+
+                var tb = H.FindControl<TextBlock>(t => t.Text == "nestedChild");
+                H.Check("Item1Nested_ChildPresent", tb is not null);
+                var resolved = ResourceBrush(tb, TargetKey);
+                H.Check("Item1Nested_ResolvedAncestorBrush", ReferenceEquals(resolved, ancestorBrush));
+                H.Check("Item1Nested_NotAppBrush", !ReferenceEquals(resolved, appBrush));
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(dict);
+                global::Microsoft.UI.Reactor.Core.ThemeRef.InvalidateResolutionCache();
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Element's OWN RequestedTheme still wins — regression guard (GREEN both)
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// When the override-bearing element declares its OWN RequestedTheme (differing from
+    /// the ancestor), its own theme must win — the ambient only supplies the inherited
+    /// fallback. This stayed correct pre-fix (fe.RequestedTheme is set before
+    /// ApplyResourceOverrides) and must remain correct after; a guard that the fix never
+    /// lets an inherited ancestor theme override an explicit own theme.
+    /// </summary>
+    internal sealed class OwnThemeWinsAtMount(Harness h) : SelfTestFixtureBase(h)
+    {
+        private const string SrcKey = "Item1ThemedBrush_OwnWins";
+        private const string TargetKey = "Item1Target_OwnWins";
+
+        public override async Task RunAsync()
+        {
+            var light = MakeBrush(0, 0, 180);
+            var dark = MakeBrush(180, 0, 0);
+            // Ancestor = opposite of app; the child's OWN theme = the app theme (so it
+            // differs from the ancestor). The child must resolve its OWN-theme brush.
+            var (ancestorTheme, _, ownBrush) = AncestorAgainstApp(light, dark);
+            var ownTheme = ancestorTheme == ElementTheme.Dark ? ElementTheme.Light : ElementTheme.Dark;
+            var ancestorBrush = ownTheme == ElementTheme.Dark ? light : dark; // the brush the child must NOT pick
+            var dict = InstallThemedDict(SrcKey, light, dark);
+            try
+            {
+                var host = H.CreateHost();
+                host.Mount(ctx =>
+                    VStack(
+                        TextBlock("ownChild")
+                            .Resources(r => r.Set(TargetKey, Theme.Ref(SrcKey)))
+                            .RequestedTheme(ownTheme))
+                    .RequestedTheme(ancestorTheme));
+
+                await Harness.Render();
+
+                var tb = H.FindControl<TextBlock>(t => t.Text == "ownChild");
+                H.Check("Item1OwnWins_ChildPresent", tb is not null);
+                var resolved = ResourceBrush(tb, TargetKey);
+                H.Check("Item1OwnWins_ResolvedOwnBrush", ReferenceEquals(resolved, ownBrush));
+                H.Check("Item1OwnWins_NotAncestorBrush", !ReferenceEquals(resolved, ancestorBrush));
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(dict);
+                global::Microsoft.UI.Reactor.Core.ThemeRef.InvalidateResolutionCache();
+            }
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -391,6 +391,9 @@ internal static class SelfTestFixtureRegistry
         "Issue675_KeyedSuffixChildSkipReResolves",
         "Issue675_LiteralOverrideNoFalseDecline",
         "Issue701_KeyedMiddleReorderReResolves",
+        "Item1Mount_AncestorThemeResolvesAtMount",
+        "Item1Mount_NestedAncestorThemeResolvesAtMount",
+        "Item1Mount_OwnThemeWinsAtMount",
         "HotReload_ChildHookOrderRecovery",
         "HotReload_ComponentMigratesState",
         // DSL and extension tests
@@ -1856,6 +1859,9 @@ internal static class SelfTestFixtureRegistry
         "Issue675_KeyedSuffixChildSkipReResolves" => new Issue675ResourceOverrideSkipFixtures.KeyedSuffixChildSkipReResolves(harness),
         "Issue675_LiteralOverrideNoFalseDecline" => new Issue675ResourceOverrideSkipFixtures.LiteralOverrideNoFalseDecline(harness),
         "Issue701_KeyedMiddleReorderReResolves" => new Issue675ResourceOverrideSkipFixtures.KeyedMiddleReorderReResolves(harness),
+        "Item1Mount_AncestorThemeResolvesAtMount" => new ResourceOverrideMountThemeFixtures.AncestorThemeResolvesAtMount(harness),
+        "Item1Mount_NestedAncestorThemeResolvesAtMount" => new ResourceOverrideMountThemeFixtures.NestedAncestorThemeResolvesAtMount(harness),
+        "Item1Mount_OwnThemeWinsAtMount" => new ResourceOverrideMountThemeFixtures.OwnThemeWinsAtMount(harness),
         "HotReload_ChildHookOrderRecovery" => new HotReloadRecoveryFixtures.ChildRecoversAndSiblingStateSurvives(harness),
         "HotReload_ComponentMigratesState" => new HotReloadComponentMigrationFixtures.MigratesPreservingState(harness),
         // DSL and extension tests

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -394,6 +394,8 @@ internal static class SelfTestFixtureRegistry
         "Item1Mount_AncestorThemeResolvesAtMount",
         "Item1Mount_NestedAncestorThemeResolvesAtMount",
         "Item1Mount_OwnThemeWinsAtMount",
+        "Item1Mount_PostMountAncestorToggleReResolves",
+        "Item1Mount_SiblingSubtreesResolveIndependently",
         "HotReload_ChildHookOrderRecovery",
         "HotReload_ComponentMigratesState",
         // DSL and extension tests
@@ -1862,6 +1864,8 @@ internal static class SelfTestFixtureRegistry
         "Item1Mount_AncestorThemeResolvesAtMount" => new ResourceOverrideMountThemeFixtures.AncestorThemeResolvesAtMount(harness),
         "Item1Mount_NestedAncestorThemeResolvesAtMount" => new ResourceOverrideMountThemeFixtures.NestedAncestorThemeResolvesAtMount(harness),
         "Item1Mount_OwnThemeWinsAtMount" => new ResourceOverrideMountThemeFixtures.OwnThemeWinsAtMount(harness),
+        "Item1Mount_PostMountAncestorToggleReResolves" => new ResourceOverrideMountThemeFixtures.PostMountAncestorToggleReResolves(harness),
+        "Item1Mount_SiblingSubtreesResolveIndependently" => new ResourceOverrideMountThemeFixtures.SiblingSubtreesResolveIndependently(harness),
         "HotReload_ChildHookOrderRecovery" => new HotReloadRecoveryFixtures.ChildRecoversAndSiblingStateSurvives(harness),
         "HotReload_ComponentMigratesState" => new HotReloadComponentMigrationFixtures.MigratesPreservingState(harness),
         // DSL and extension tests


### PR DESCRIPTION
## Item 1 of 2 — deferred Tier-1 reconciler theme-resolution follow-ups

**Draft** — do not merge without explicit GO from the coordinating session. This is reconciler-core; please dual-review + `/perf`.

### The bug (real correctness defect)
A ThemeRef-backed `ResourceOverride` — `.Resources(r => r.Set("Foo", Theme.Ref(key)))` — resolved its **concrete brush** at mount via `ThemeRef.Resolve(key, fe)`. That helper's effective-theme walk (`Theme.GetEffectiveThemeName`) needs the element to be **parented**: it checks `fe.RequestedTheme`, then walks visual parents, then `ActualTheme`, then the app theme.

At mount the control is **not yet in the visual tree**, so when the effective theme comes from an **ancestor's** `RequestedTheme` (not the element's own), the walk-up finds nothing and falls back to `Application.Current.RequestedTheme`. A subtree with ancestor `RequestedTheme=Dark` under a Light app got the **Light** brush — wrong at mount. Pre-existing; surfaced during #750/#751.

### The fix — thread the ancestor effective theme top-down
The reconciler descends the element tree and *knows* each ancestor's `RequestedTheme`; use that instead of `fe`'s (disconnected) walk.

- New `Reconciler._ambientRequestedTheme`, set at `Mount`/`Update` entry (own `RequestedTheme` wins, else inherited), mirroring the existing context-scope push/pop and restored in `finally` (and before the shallow-skip early return).
- `ApplyResourceOverrides` gains an optional `ElementTheme effectiveTheme = ElementTheme.Default`. When non-Default it resolves ThemeRefs via the **existing** `ThemeRef.Resolve(key, isDark)` (already built for "resolve before the control is in the tree"); otherwise it keeps the prior `fe`-based resolution for direct callers / host-window themes set outside the Reactor tree.
- Scope: only the **concrete-brush** `ResourceOverrides` path changes. `ApplyThemeBindings` (`{ThemeResource}`) is untouched.

The public-API change is additive/back-compatible (optional parameter); the `reactor.api.txt` surface files are regenerated accordingly.

### Tests (RED→GREEN, verified)
New live selftests in `ResourceOverrideMountThemeFixtures` (ancestor theme always set to the *opposite* of the live app theme, so the assertion is deterministic on Light or Dark hosts):
- `Item1Mount_AncestorThemeResolvesAtMount` — single-level inheritance resolves the ancestor brush. **RED** without the fix.
- `Item1Mount_NestedAncestorThemeResolvesAtMount` — inheritance through a themeless intermediate. **RED** without the fix.
- `Item1Mount_OwnThemeWinsAtMount` — an element's own `RequestedTheme` still wins (regression guard; green both).

Verified by stashing only the 3 source files: the 4 inheritance assertions fail pre-fix, the own-theme guard passes both.

### Validation
- `dotnet test tests/Reactor.Tests` — **9978 passed, 0 failed**, 64 skipped.
- Full selftest suite (x64) — **0 failures**.
- ARM64 (native) — new `Item1Mount` fixtures + existing `Issue675` / `StructuralSkip` / `UseMemoCells` / `ThemeBrush` / `Issue701` — **0 failures**.
- Core library builds clean (0 warnings, 0 errors).

`/perf` expected neutral (correctness change: one field read + a couple comparisons per Mount/Update).