### PR TITLE
Add common content-alignment and border fluents

### DIFF
--- a/docs/_pipeline/templates/cheat-sheet.md.dt
+++ b/docs/_pipeline/templates/cheat-sheet.md.dt
@@ -89,9 +89,9 @@ Full coverage on [Controls](controls.md).
 | Group | Methods |
 |---|---|
 | Size | `.Width(n)` `.Height(n)` `.Size(w,h)` |
-| Spacing | `.Margin(n)` `.Padding(n)` `.HAlign(...)` `.VAlign(...)` |
+| Spacing | `.Margin(n)` `.Padding(n)` `.HAlign(...)` `.VAlign(...)` `.HorizontalContentAlignment(...)` `.VerticalContentAlignment(...)` |
 | Text | `.FontSize(n)` `.Bold()` `.SemiBold()` `.Opacity(n)` |
-| Color | `.Background(token)` `.Foreground(token)` `.WithBorder(token, thickness?)` |
+| Color | `.Background(token)` `.Foreground(token)` `.BorderBrush(token)` `.BorderThickness(...)` `.WithBorder(token, thickness?)` |
 | Shape | `.CornerRadius(n)` |
 | Behavior | `.IsEnabled(bool)` `.IsVisible(bool)` `.ToolTip(s)` |
 | Keying | `.WithKey(s)` |

--- a/docs/_pipeline/templates/layout.md.dt
+++ b/docs/_pipeline/templates/layout.md.dt
@@ -217,6 +217,20 @@ VStack(8, items).Margin(24).Padding(16)
 | `.Padding(n)` | Inner spacing (all sides) |
 | `.HAlign(alignment)` | Horizontal alignment (Left, Center, Right, Stretch) |
 | `.VAlign(alignment)` | Vertical alignment (Top, Center, Bottom, Stretch) |
+| `.HorizontalContentAlignment(alignment)` | Horizontal child/content alignment inside a Control |
+| `.VerticalContentAlignment(alignment)` | Vertical child/content alignment inside a Control |
+
+Use the content-alignment fluents when the control itself should stretch,
+but its child content also needs an explicit placement contract. A common
+case is a full-width button whose inner row should also stretch:
+
+<!-- ai:lock -->
+```csharp
+Button(Text("Open"), onClick)
+  .HAlign(HorizontalAlignment.Stretch)
+  .HorizontalContentAlignment(HorizontalAlignment.Stretch)
+```
+<!-- /ai:lock -->
 
 See [modifier-system](modifier-system.md) for how these chain
 internally.

--- a/docs/guide/cheat-sheet.md
+++ b/docs/guide/cheat-sheet.md
@@ -108,9 +108,9 @@ Full coverage on [Controls](controls.md).
 | Group | Methods |
 |---|---|
 | Size | `.Width(n)` `.Height(n)` `.Size(w,h)` |
-| Spacing | `.Margin(n)` `.Padding(n)` `.HAlign(...)` `.VAlign(...)` |
+| Spacing | `.Margin(n)` `.Padding(n)` `.HAlign(...)` `.VAlign(...)` `.HorizontalContentAlignment(...)` `.VerticalContentAlignment(...)` |
 | Text | `.FontSize(n)` `.Bold()` `.SemiBold()` `.Opacity(n)` |
-| Color | `.Background(token)` `.Foreground(token)` `.WithBorder(token, thickness?)` |
+| Color | `.Background(token)` `.Foreground(token)` `.BorderBrush(token)` `.BorderThickness(...)` `.WithBorder(token, thickness?)` |
 | Shape | `.CornerRadius(n)` |
 | Behavior | `.IsEnabled(bool)` `.IsVisible(bool)` `.ToolTip(s)` |
 | Keying | `.WithKey(s)` |

--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -341,6 +341,16 @@ VStack(8, items).Margin(24).Padding(16)
 | `.HAlign(alignment)` | Horizontal alignment (Left, Center, Right, Stretch) |
 | `.VAlign(alignment)` | Vertical alignment (Top, Center, Bottom, Stretch) |
 
+Use the content-alignment fluents when the control itself should stretch,
+but its child content also needs an explicit placement contract. A common
+case is a full-width button whose inner row should also stretch:
+
+```csharp
+Button(Text("Open"), onClick)
+    .HAlign(HorizontalAlignment.Stretch)
+    .HorizontalContentAlignment(HorizontalAlignment.Stretch)
+```
+
 See [modifier-system](modifier-system.md) for how these chain
 internally.
 

--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -340,6 +340,8 @@ VStack(8, items).Margin(24).Padding(16)
 | `.Padding(n)` | Inner spacing (all sides) |
 | `.HAlign(alignment)` | Horizontal alignment (Left, Center, Right, Stretch) |
 | `.VAlign(alignment)` | Vertical alignment (Top, Center, Bottom, Stretch) |
+| `.HorizontalContentAlignment(alignment)` | Horizontal child/content alignment inside a Control |
+| `.VerticalContentAlignment(alignment)` | Vertical child/content alignment inside a Control |
 
 Use the content-alignment fluents when the control itself should stretch,
 but its child content also needs an explicit placement contract. A common

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -569,7 +569,14 @@ T.Backdrop<T>(Func<SystemBackdrop> factory) → T
 T.Background<T>(Brush brush) → T
 T.Background<T>(ThemeRef theme) → T
 T.Background<T>(string color) → T
+T.BorderBrush<T>(Brush brush) → T
+T.BorderBrush<T>(ThemeRef theme) → T
+T.BorderBrush<T>(string color) → T
 T.BorderInlineStart<T>(Thickness thickness) → T
+T.BorderThickness<T>(Thickness thickness) → T
+T.BorderThickness<T>(double horizontal, double vertical) → T
+T.BorderThickness<T>(double left, double top, double right, double bottom) → T
+T.BorderThickness<T>(double thickness) → T
 T.Canvas<T>(double left = 0, double top = 0) → T
 T.Canvas<T>(double left, double top, double anchorX, double anchorY) → T
 T.Center<T>() → T
@@ -603,6 +610,7 @@ T.Height<T>(double height) → T
 T.HelpText<T>(string text) → T
 T.HierarchyLevel<T>(int level) → T
 T.HorizontalAlignment<T>(HorizontalAlignment alignment) → T
+T.HorizontalContentAlignment<T>(HorizontalAlignment alignment) → T
 T.Immediate<T>() → T
 T.InteractionStates<T>(Func<InteractionStatesBuilder, InteractionStatesBuilder> configure, Curve curve = null) → T
 T.IsEnabled<T>(bool enabled = true) → T
@@ -708,6 +716,7 @@ T.Validate<T>(string fieldName, object value, IValidator[] validators) → T
 T.ValidateAsync<T>(string fieldName, IAsyncValidator[] asyncValidators) → T
 T.ValidateAsync<T>(string fieldName, object value, IAsyncValidator[] asyncValidators) → T
 T.VerticalAlignment<T>(VerticalAlignment alignment) → T
+T.VerticalContentAlignment<T>(VerticalAlignment alignment) → T
 T.Width<T>(double width) → T
 T.WithBorder<T>(Brush brush, double thickness = 1) → T
 T.WithBorder<T>(ThemeRef theme, double thickness = 1) → T
@@ -2947,6 +2956,7 @@ ElementTheme? RequestedTheme { get; init; }
 FontFamily FontFamily { get; init; }
 FontWeight? FontWeight { get; init; }
 HorizontalAlignment? HorizontalAlignment { get; init; }
+HorizontalAlignment? HorizontalContentAlignment { get; init; }
 LayoutModifiers Layout { get; init; }
 LongPressGestureConfig LongPress { get; init; }
 PanGestureConfig Pan { get; init; }
@@ -2960,6 +2970,7 @@ Vector3? CenterPoint { get; init; }
 Vector3? Scale { get; init; }
 Vector3? Translation { get; init; }
 VerticalAlignment? VerticalAlignment { get; init; }
+VerticalAlignment? VerticalContentAlignment { get; init; }
 VisualModifiers Visual { get; init; }
 XYFocusKeyboardNavigationMode? XYFocusKeyboardNavigation { get; init; }
 bool? IsEnabled { get; init; }
@@ -4080,10 +4091,12 @@ ToString() → string
 new()
 ElementTheme? RequestedTheme { get; init; }
 HorizontalAlignment? HorizontalAlignment { get; init; }
+HorizontalAlignment? HorizontalContentAlignment { get; init; }
 Thickness? BorderInlineStart { get; init; }
 Thickness? Margin { get; init; }
 Thickness? Padding { get; init; }
 VerticalAlignment? VerticalAlignment { get; init; }
+VerticalAlignment? VerticalContentAlignment { get; init; }
 bool? IsVisible { get; init; }
 double? Height { get; init; }
 double? MarginInlineEnd { get; init; }

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -569,7 +569,14 @@ T.Backdrop<T>(Func<SystemBackdrop> factory) → T
 T.Background<T>(Brush brush) → T
 T.Background<T>(ThemeRef theme) → T
 T.Background<T>(string color) → T
+T.BorderBrush<T>(Brush brush) → T
+T.BorderBrush<T>(ThemeRef theme) → T
+T.BorderBrush<T>(string color) → T
 T.BorderInlineStart<T>(Thickness thickness) → T
+T.BorderThickness<T>(Thickness thickness) → T
+T.BorderThickness<T>(double horizontal, double vertical) → T
+T.BorderThickness<T>(double left, double top, double right, double bottom) → T
+T.BorderThickness<T>(double thickness) → T
 T.Canvas<T>(double left = 0, double top = 0) → T
 T.Canvas<T>(double left, double top, double anchorX, double anchorY) → T
 T.Center<T>() → T
@@ -603,6 +610,7 @@ T.Height<T>(double height) → T
 T.HelpText<T>(string text) → T
 T.HierarchyLevel<T>(int level) → T
 T.HorizontalAlignment<T>(HorizontalAlignment alignment) → T
+T.HorizontalContentAlignment<T>(HorizontalAlignment alignment) → T
 T.Immediate<T>() → T
 T.InteractionStates<T>(Func<InteractionStatesBuilder, InteractionStatesBuilder> configure, Curve curve = null) → T
 T.IsEnabled<T>(bool enabled = true) → T
@@ -708,6 +716,7 @@ T.Validate<T>(string fieldName, object value, IValidator[] validators) → T
 T.ValidateAsync<T>(string fieldName, IAsyncValidator[] asyncValidators) → T
 T.ValidateAsync<T>(string fieldName, object value, IAsyncValidator[] asyncValidators) → T
 T.VerticalAlignment<T>(VerticalAlignment alignment) → T
+T.VerticalContentAlignment<T>(VerticalAlignment alignment) → T
 T.Width<T>(double width) → T
 T.WithBorder<T>(Brush brush, double thickness = 1) → T
 T.WithBorder<T>(ThemeRef theme, double thickness = 1) → T
@@ -2947,6 +2956,7 @@ ElementTheme? RequestedTheme { get; init; }
 FontFamily FontFamily { get; init; }
 FontWeight? FontWeight { get; init; }
 HorizontalAlignment? HorizontalAlignment { get; init; }
+HorizontalAlignment? HorizontalContentAlignment { get; init; }
 LayoutModifiers Layout { get; init; }
 LongPressGestureConfig LongPress { get; init; }
 PanGestureConfig Pan { get; init; }
@@ -2960,6 +2970,7 @@ Vector3? CenterPoint { get; init; }
 Vector3? Scale { get; init; }
 Vector3? Translation { get; init; }
 VerticalAlignment? VerticalAlignment { get; init; }
+VerticalAlignment? VerticalContentAlignment { get; init; }
 VisualModifiers Visual { get; init; }
 XYFocusKeyboardNavigationMode? XYFocusKeyboardNavigation { get; init; }
 bool? IsEnabled { get; init; }
@@ -4080,10 +4091,12 @@ ToString() → string
 new()
 ElementTheme? RequestedTheme { get; init; }
 HorizontalAlignment? HorizontalAlignment { get; init; }
+HorizontalAlignment? HorizontalContentAlignment { get; init; }
 Thickness? BorderInlineStart { get; init; }
 Thickness? Margin { get; init; }
 Thickness? Padding { get; init; }
 VerticalAlignment? VerticalAlignment { get; init; }
+VerticalAlignment? VerticalContentAlignment { get; init; }
 bool? IsVisible { get; init; }
 double? Height { get; init; }
 double? MarginInlineEnd { get; init; }

--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -1199,15 +1199,10 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                     filterIcon
                 ) with { AlignItems = FlexAlign.Center },
                 toggleSort)
-                .Set(b =>
-                {
-                    b.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                        Microsoft.UI.Colors.Transparent);
-                    b.BorderThickness = new Thickness(0);
-                    b.Padding = new Thickness(8, 6, 8, 6);
-                    b.HorizontalAlignment = HorizontalAlignment.Stretch;
-                    b.HorizontalContentAlignment = HorizontalAlignment.Stretch;
-                })
+                .Background("#00000000")
+                .BorderThickness(0)
+                .Padding(8, 6, 8, 6)
+                .HorizontalContentAlignment(HorizontalAlignment.Stretch)
                 .HAlign(HorizontalAlignment.Stretch);
         }
 

--- a/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
+++ b/src/Reactor/Controls/PropertyGrid/PropertyGridComponent.cs
@@ -19,14 +19,12 @@ namespace Microsoft.UI.Reactor.Controls;
 public class PropertyGridComponent : Component<PropertyGridElement>
 {
     static ButtonElement BlankButton(Element content, Action onClick)
-        => Button(content, onClick).Set(b =>
-        {
-            b.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                Microsoft.UI.Colors.Transparent);
-            b.BorderThickness = new Thickness(0);
-            b.Padding = new Thickness(0);
-            b.HorizontalContentAlignment = HorizontalAlignment.Stretch;
-        }).HAlign(HorizontalAlignment.Stretch);
+        => Button(content, onClick)
+            .Background("#00000000")
+            .BorderThickness(0)
+            .Padding(0)
+            .HorizontalContentAlignment(HorizontalAlignment.Stretch)
+            .HAlign(HorizontalAlignment.Stretch);
 
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Object.GetType() does not carry DynamicallyAccessedMembers; PropertyGrid resolves types at runtime.")]
     public override Element Render()

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -1794,6 +1794,16 @@ public record ElementModifiers
         get => Layout?.VerticalAlignment;
         init => Layout = Layout is null ? new LayoutModifiers { VerticalAlignment = value } : Layout with { VerticalAlignment = value };
     }
+    public HorizontalAlignment? HorizontalContentAlignment
+    {
+        get => Layout?.HorizontalContentAlignment;
+        init => Layout = Layout is null ? new LayoutModifiers { HorizontalContentAlignment = value } : Layout with { HorizontalContentAlignment = value };
+    }
+    public VerticalAlignment? VerticalContentAlignment
+    {
+        get => Layout?.VerticalContentAlignment;
+        init => Layout = Layout is null ? new LayoutModifiers { VerticalContentAlignment = value } : Layout with { VerticalContentAlignment = value };
+    }
     public double? Opacity
     {
         get => Visual?.Opacity;
@@ -2076,6 +2086,8 @@ public record LayoutModifiers
     public double? MaxHeight { get; init; }
     public HorizontalAlignment? HorizontalAlignment { get; init; }
     public VerticalAlignment? VerticalAlignment { get; init; }
+    public HorizontalAlignment? HorizontalContentAlignment { get; init; }
+    public VerticalAlignment? VerticalContentAlignment { get; init; }
     public bool? IsVisible { get; init; }
     public double? MarginInlineStart { get; init; }
     public double? MarginInlineEnd { get; init; }
@@ -2102,6 +2114,8 @@ public record LayoutModifiers
         MaxHeight = other.MaxHeight ?? MaxHeight,
         HorizontalAlignment = other.HorizontalAlignment ?? HorizontalAlignment,
         VerticalAlignment = other.VerticalAlignment ?? VerticalAlignment,
+        HorizontalContentAlignment = other.HorizontalContentAlignment ?? HorizontalContentAlignment,
+        VerticalContentAlignment = other.VerticalContentAlignment ?? VerticalContentAlignment,
         IsVisible = other.IsVisible ?? IsVisible,
         MarginInlineStart = other.MarginInlineStart ?? MarginInlineStart,
         MarginInlineEnd = other.MarginInlineEnd ?? MarginInlineEnd,

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -3662,12 +3662,12 @@ public sealed partial class Reconciler : IDisposable
             if (m.HorizontalContentAlignment.HasValue && m.HorizontalContentAlignment != oldM?.HorizontalContentAlignment)
                 contentAlignmentControl.HorizontalContentAlignment = m.HorizontalContentAlignment.Value;
             else if (!m.HorizontalContentAlignment.HasValue && oldM?.HorizontalContentAlignment.HasValue == true)
-                contentAlignmentControl.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+                contentAlignmentControl.ClearValue(WinUI.Control.HorizontalContentAlignmentProperty);
 
             if (m.VerticalContentAlignment.HasValue && m.VerticalContentAlignment != oldM?.VerticalContentAlignment)
                 contentAlignmentControl.VerticalContentAlignment = m.VerticalContentAlignment.Value;
             else if (!m.VerticalContentAlignment.HasValue && oldM?.VerticalContentAlignment.HasValue == true)
-                contentAlignmentControl.VerticalContentAlignment = VerticalAlignment.Stretch;
+                contentAlignmentControl.ClearValue(WinUI.Control.VerticalContentAlignmentProperty);
         }
         if (m.Opacity.HasValue && m.Opacity != oldM?.Opacity)
             AnimationHelper.SetOrAnimate(fe, "Opacity", (float)m.Opacity.Value);
@@ -3767,8 +3767,8 @@ public sealed partial class Reconciler : IDisposable
         }
         else if (!resolvedBorder.HasValue && oldM?.BorderThickness.HasValue == true)
         {
-            if (fe is WinUI.Control btCtrl) btCtrl.BorderThickness = new Thickness(0);
-            else if (fe is WinUI.Border btBdr) btBdr.BorderThickness = new Thickness(0);
+            if (fe is WinUI.Control btCtrl) btCtrl.ClearValue(WinUI.Control.BorderThicknessProperty);
+            else if (fe is WinUI.Border btBdr) btBdr.ClearValue(WinUI.Border.BorderThicknessProperty);
         }
 
         // Background (Panel, Control, or Border)

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -3767,8 +3767,8 @@ public sealed partial class Reconciler : IDisposable
         }
         else if (!resolvedBorder.HasValue && oldM?.BorderThickness.HasValue == true)
         {
-            if (fe is WinUI.Control btCtrl) btCtrl.ClearValue(WinUI.Control.BorderThicknessProperty);
-            else if (fe is WinUI.Border btBdr) btBdr.ClearValue(WinUI.Border.BorderThicknessProperty);
+            if (fe is WinUI.Control btCtrl) btCtrl.BorderThickness = new Thickness(0);
+            else if (fe is WinUI.Border btBdr) btBdr.BorderThickness = new Thickness(0);
         }
 
         // Background (Panel, Control, or Border)

--- a/src/Reactor/Core/Reconciler.cs
+++ b/src/Reactor/Core/Reconciler.cs
@@ -3657,6 +3657,18 @@ public sealed partial class Reconciler : IDisposable
         else if (!m.HorizontalAlignment.HasValue && oldM?.HorizontalAlignment.HasValue == true) fe.HorizontalAlignment = HorizontalAlignment.Stretch;
         if (m.VerticalAlignment.HasValue && m.VerticalAlignment != oldM?.VerticalAlignment) fe.VerticalAlignment = m.VerticalAlignment.Value;
         else if (!m.VerticalAlignment.HasValue && oldM?.VerticalAlignment.HasValue == true) fe.VerticalAlignment = VerticalAlignment.Stretch;
+        if (fe is WinUI.Control contentAlignmentControl)
+        {
+            if (m.HorizontalContentAlignment.HasValue && m.HorizontalContentAlignment != oldM?.HorizontalContentAlignment)
+                contentAlignmentControl.HorizontalContentAlignment = m.HorizontalContentAlignment.Value;
+            else if (!m.HorizontalContentAlignment.HasValue && oldM?.HorizontalContentAlignment.HasValue == true)
+                contentAlignmentControl.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+
+            if (m.VerticalContentAlignment.HasValue && m.VerticalContentAlignment != oldM?.VerticalContentAlignment)
+                contentAlignmentControl.VerticalContentAlignment = m.VerticalContentAlignment.Value;
+            else if (!m.VerticalContentAlignment.HasValue && oldM?.VerticalContentAlignment.HasValue == true)
+                contentAlignmentControl.VerticalContentAlignment = VerticalAlignment.Stretch;
+        }
         if (m.Opacity.HasValue && m.Opacity != oldM?.Opacity)
             AnimationHelper.SetOrAnimate(fe, "Opacity", (float)m.Opacity.Value);
         else if (!m.Opacity.HasValue && oldM?.Opacity.HasValue == true)

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -131,6 +131,12 @@ public static partial class ElementExtensions
     public static T VerticalAlignment<T>(this T el, Microsoft.UI.Xaml.VerticalAlignment alignment) where T : Element =>
         ModifyLayout(el, new LayoutModifiers { VerticalAlignment = alignment });
 
+    public static T HorizontalContentAlignment<T>(this T el, Microsoft.UI.Xaml.HorizontalAlignment alignment) where T : Element =>
+        ModifyLayout(el, new LayoutModifiers { HorizontalContentAlignment = alignment });
+
+    public static T VerticalContentAlignment<T>(this T el, Microsoft.UI.Xaml.VerticalAlignment alignment) where T : Element =>
+        ModifyLayout(el, new LayoutModifiers { VerticalContentAlignment = alignment });
+
     public static T Center<T>(this T el) where T : Element =>
         ModifyLayout(el, new LayoutModifiers
         {
@@ -1151,6 +1157,27 @@ public static partial class ElementExtensions
         ModifyVisual(el, new VisualModifiers { CornerRadius = new Microsoft.UI.Xaml.CornerRadius(topLeft, topRight, bottomRight, bottomLeft) });
 
     // ── Border brush/thickness (on Control and Border) ─────────────
+
+    public static T BorderBrush<T>(this T el, string color) where T : Element =>
+        ModifyVisual(el, new VisualModifiers { BorderBrush = BrushHelper.Parse(color) });
+
+    public static T BorderBrush<T>(this T el, Brush brush) where T : Element =>
+        ModifyVisual(el, new VisualModifiers { BorderBrush = brush });
+
+    public static T BorderBrush<T>(this T el, ThemeRef theme) where T : Element =>
+        ModifyTheme(el, "BorderBrush", theme);
+
+    public static T BorderThickness<T>(this T el, double thickness) where T : Element =>
+        ModifyVisual(el, new VisualModifiers { BorderThickness = new Thickness(thickness) });
+
+    public static T BorderThickness<T>(this T el, double horizontal, double vertical) where T : Element =>
+        ModifyVisual(el, new VisualModifiers { BorderThickness = new Thickness(horizontal, vertical, horizontal, vertical) });
+
+    public static T BorderThickness<T>(this T el, double left, double top, double right, double bottom) where T : Element =>
+        ModifyVisual(el, new VisualModifiers { BorderThickness = new Thickness(left, top, right, bottom) });
+
+    public static T BorderThickness<T>(this T el, Thickness thickness) where T : Element =>
+        ModifyVisual(el, new VisualModifiers { BorderThickness = thickness });
 
     /// <summary>
     /// Sets the border from a color string (named color or #RRGGBB / #AARRGGBB).

--- a/src/Reactor/Elements/ElementExtensions.cs
+++ b/src/Reactor/Elements/ElementExtensions.cs
@@ -1173,7 +1173,7 @@ public static partial class ElementExtensions
     public static T BorderThickness<T>(this T el, double horizontal, double vertical) where T : Element =>
         ModifyVisual(el, new VisualModifiers { BorderThickness = new Thickness(horizontal, vertical, horizontal, vertical) });
 
-    public static T BorderThickness<T>(this T el, double left, double top, double right, double bottom) where T : Element =>
+    public static T BorderThickness<T>(this T el, double left = 0.0, double top = 0.0, double right = 0.0, double bottom = 0.0) where T : Element =>
         ModifyVisual(el, new VisualModifiers { BorderThickness = new Thickness(left, top, right, bottom) });
 
     public static T BorderThickness<T>(this T el, Thickness thickness) where T : Element =>

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ModifierEventFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ModifierEventFixtures.cs
@@ -334,8 +334,9 @@ internal static class ModifierEventFixtures
                 var (phase, setPhase) = ctx.UseState(0);
                 var brush = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Red);
 
-                var controlMods = phase == 0
-                    ? new ElementModifiers
+                var controlMods = phase switch
+                {
+                    0 => new ElementModifiers
                     {
                         RequestedTheme = ElementTheme.Dark,
                         Margin = new Thickness(3, 4, 5, 6),
@@ -348,6 +349,8 @@ internal static class ModifierEventFixtures
                         MaxHeight = 90,
                         HorizontalAlignment = HorizontalAlignment.Right,
                         VerticalAlignment = VerticalAlignment.Bottom,
+                        HorizontalContentAlignment = HorizontalAlignment.Right,
+                        VerticalContentAlignment = VerticalAlignment.Bottom,
                         Opacity = 0.5,
                         IsVisible = false,
                         ToolTip = "clear-me",
@@ -368,8 +371,14 @@ internal static class ModifierEventFixtures
                         FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas"),
                         FontSize = 22,
                         FontWeight = new global::Windows.UI.Text.FontWeight(700),
-                    }
-                    : new ElementModifiers();
+                    },
+                    1 => new ElementModifiers
+                    {
+                        HorizontalContentAlignment = HorizontalAlignment.Left,
+                        VerticalContentAlignment = VerticalAlignment.Top,
+                    },
+                    _ => new ElementModifiers(),
+                };
 
                 var borderMods = phase == 0
                     ? new ElementModifiers
@@ -385,7 +394,7 @@ internal static class ModifierEventFixtures
                     : new ElementModifiers();
 
                 return VStack(
-                    Button("ClearModifierPhase", () => setPhase(1)),
+                    Button("ClearModifierPhase", () => setPhase(phase + 1)),
                     Button("ClearTarget") with { Modifiers = controlMods },
                     Border(TextBlock("ClearBorderChild")) with { Modifiers = borderMods });
             });
@@ -394,6 +403,24 @@ internal static class ModifierEventFixtures
             var initial = H.FindButton("ClearTarget");
             H.Check("ModifierClear_InitialCollapsed",
                 initial is not null && initial.Visibility == Visibility.Collapsed);
+            if (initial is not null)
+            {
+                H.Check("ModifierClear_ContentAlignmentInitial",
+                    initial.HorizontalContentAlignment == HorizontalAlignment.Right
+                    && initial.VerticalContentAlignment == VerticalAlignment.Bottom);
+            }
+
+            H.ClickButton("ClearModifierPhase");
+            await Harness.Render();
+
+            var updated = H.FindButton("ClearTarget");
+            H.Check("ModifierClear_ContentAlignmentUpdated", updated is not null);
+            if (updated is not null)
+            {
+                H.Check("ModifierClear_ContentAlignmentUpdatedValues",
+                    updated.HorizontalContentAlignment == HorizontalAlignment.Left
+                    && updated.VerticalContentAlignment == VerticalAlignment.Top);
+            }
 
             H.ClickButton("ClearModifierPhase");
             await Harness.Render();
@@ -411,6 +438,11 @@ internal static class ModifierEventFixtures
                 H.Check("ModifierClear_AlignmentCleared",
                     button.HorizontalAlignment == HorizontalAlignment.Stretch
                     && button.VerticalAlignment == VerticalAlignment.Stretch);
+                H.Check("ModifierClear_ContentAlignmentCleared",
+                    button.ReadLocalValue(Control.HorizontalContentAlignmentProperty) == DependencyProperty.UnsetValue
+                    && button.ReadLocalValue(Control.VerticalContentAlignmentProperty) == DependencyProperty.UnsetValue
+                    && button.HorizontalContentAlignment == HorizontalAlignment.Center
+                    && button.VerticalContentAlignment == VerticalAlignment.Center);
                 H.Check("ModifierClear_VisibleEnabled",
                     button.Visibility == Visibility.Visible && button.IsEnabled);
                 H.Check("ModifierClear_TooltipCleared",

--- a/tests/Reactor.Tests/DeclarativeModifierTests.cs
+++ b/tests/Reactor.Tests/DeclarativeModifierTests.cs
@@ -71,6 +71,43 @@ public class DeclarativeModifierTests
         Assert.Equal(16.0, el.Modifiers!.FontSize);
     }
 
+    [Fact]
+    public void ContentAlignment_Modifiers_Store_In_Layout_Bucket()
+    {
+        var el = Button("Go")
+            .HorizontalContentAlignment(HorizontalAlignment.Right)
+            .VerticalContentAlignment(VerticalAlignment.Bottom);
+
+        Assert.NotNull(el.Modifiers);
+        Assert.NotNull(el.Modifiers!.Layout);
+        Assert.Equal(HorizontalAlignment.Right, el.Modifiers.HorizontalContentAlignment);
+        Assert.Equal(VerticalAlignment.Bottom, el.Modifiers.VerticalContentAlignment);
+    }
+
+    [Fact]
+    public void BorderBrush_And_BorderThickness_Modifiers_Store_Independent_Surface()
+    {
+        var el = Button("Go")
+            .BorderBrush(Theme.CardStroke)
+            .BorderThickness(1, 2, 3, 4);
+
+        Assert.NotNull(el.Modifiers);
+        Assert.NotNull(el.Modifiers!.Visual);
+        Assert.True(el.ThemeBindings!.ContainsKey("BorderBrush"));
+        Assert.Equal(new Thickness(1, 2, 3, 4), el.Modifiers.BorderThickness);
+    }
+
+    [Fact]
+    public void ContentAlignment_ModifiersEqual_Tracks_Field_Changes()
+    {
+        var a = new ElementModifiers { HorizontalContentAlignment = HorizontalAlignment.Stretch };
+        var b = new ElementModifiers { HorizontalContentAlignment = HorizontalAlignment.Stretch };
+        var c = new ElementModifiers { HorizontalContentAlignment = HorizontalAlignment.Left };
+
+        Assert.True(Element.ModifiersEqual(a, b));
+        Assert.False(Element.ModifiersEqual(a, c));
+    }
+
     // FontFamily_Merge_Overwrites moved to selfhost fixtures (WinUIActivationFixtures).
 
     // ════════════════════════════════════════════════════════════════

--- a/tests/Reactor.Tests/DeclarativeModifierTests.cs
+++ b/tests/Reactor.Tests/DeclarativeModifierTests.cs
@@ -100,12 +100,30 @@ public class DeclarativeModifierTests
     [Fact]
     public void ContentAlignment_ModifiersEqual_Tracks_Field_Changes()
     {
-        var a = new ElementModifiers { HorizontalContentAlignment = HorizontalAlignment.Stretch };
-        var b = new ElementModifiers { HorizontalContentAlignment = HorizontalAlignment.Stretch };
-        var c = new ElementModifiers { HorizontalContentAlignment = HorizontalAlignment.Left };
+        var a = new ElementModifiers
+        {
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Center,
+        };
+        var b = new ElementModifiers
+        {
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Center,
+        };
+        var c = new ElementModifiers
+        {
+            HorizontalContentAlignment = HorizontalAlignment.Left,
+            VerticalContentAlignment = VerticalAlignment.Center,
+        };
+        var d = new ElementModifiers
+        {
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Bottom,
+        };
 
         Assert.True(Element.ModifiersEqual(a, b));
         Assert.False(Element.ModifiersEqual(a, c));
+        Assert.False(Element.ModifiersEqual(a, d));
     }
 
     // FontFamily_Merge_Overwrites moved to selfhost fixtures (WinUIActivationFixtures).

--- a/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
@@ -196,6 +196,7 @@ public class ElementExtensionsCoverageTests
 
         Assert.Equal(new Thickness(6), Button("x").BorderThickness(6).Modifiers!.BorderThickness);
         Assert.Equal(new Thickness(8, 4, 8, 4), Button("x").BorderThickness(8, 4).Modifiers!.BorderThickness);
+        Assert.Equal(new Thickness(0, 0, 0, 1), Button("x").BorderThickness(bottom: 1).Modifiers!.BorderThickness);
         Assert.Equal(new Thickness(7), Button("x").BorderThickness(new Thickness(7)).Modifiers!.BorderThickness);
     }
 

--- a/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementExtensionsCoverageTests.cs
@@ -180,6 +180,25 @@ public class ElementExtensionsCoverageTests
         Assert.Equal(new Thickness(4.0), bd.Modifiers!.BorderThickness);
     }
 
+    [Fact]
+    public void ContentAlignment_And_Independent_Border_Modifiers()
+    {
+        var aligned = Button("x")
+            .HorizontalContentAlignment(HorizontalAlignment.Right)
+            .VerticalContentAlignment(VerticalAlignment.Bottom)
+            .BorderBrush(Theme.CardStroke)
+            .BorderThickness(1, 2, 3, 4);
+
+        Assert.Equal(HorizontalAlignment.Right, aligned.Modifiers!.HorizontalContentAlignment);
+        Assert.Equal(VerticalAlignment.Bottom, aligned.Modifiers.VerticalContentAlignment);
+        Assert.True(aligned.ThemeBindings!.ContainsKey("BorderBrush"));
+        Assert.Equal(new Thickness(1, 2, 3, 4), aligned.Modifiers.BorderThickness);
+
+        Assert.Equal(new Thickness(6), Button("x").BorderThickness(6).Modifiers!.BorderThickness);
+        Assert.Equal(new Thickness(8, 4, 8, 4), Button("x").BorderThickness(8, 4).Modifiers!.BorderThickness);
+        Assert.Equal(new Thickness(7), Button("x").BorderThickness(new Thickness(7)).Modifiers!.BorderThickness);
+    }
+
     // ────────────────────────────────────────────────────────────────
     //  CornerRadius / IsEnabled
     // ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #774.

## Summary

This adds a small common-modifier surface that Reactor already mostly supports underneath but does not yet expose fluently:

- `HorizontalContentAlignment(...)`
- `VerticalContentAlignment(...)`
- `BorderBrush(...)`
- `BorderThickness(...)` with `Thickness`-aware overloads

The goal is to remove a narrow class of `.Set(...)` fallbacks for ordinary control layout/styling without adding control-specific wrapper APIs.

## What changed

- added content-alignment modifier storage to the element modifier model
- wired content-alignment application through the reconciler for `Control`
- added public `BorderBrush(...)` overloads for `string`, `Brush`, and `ThemeRef`
- added public `BorderThickness(...)` overloads for uniform, symmetric, four-side, and raw `Thickness` input
- converted `PropertyGridComponent.BlankButton(...)` from `.Set(...)` to fluent modifiers as a concrete internal proof point
- updated the cheat sheet and layout docs to describe the new surface
- refreshed the generated API index

## Validation

- `dotnet test tests/Reactor.Tests/Reactor.Tests.csproj -p:Platform=x64 -m:1 --filter ElementExtensionsCoverageTests`
- `dotnet run --project src/Reactor.Cli/Reactor.Cli.csproj -- docs compile`

The docs compile completed successfully for this branch. I restored generated screenshot churn before pushing, so the diff stays limited to the intended source/docs changes.

## Why this shape

This keeps the change at the common modifier layer instead of growing Button-specific or TextBox-specific wrappers. It also preserves `WithBorder(...)` as the convenient bundled helper while adding the independent brush/thickness control needed for cases like bottom-only borders and explicit content stretching inside controls.
