### PR TITLE
Add E2E coverage for ItemClick once-fire and host theme-change re-resolution (#679)

### DIFF
--- a/tests/Reactor.AppTests.Host/FixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/FixtureRegistry.cs
@@ -61,6 +61,15 @@ internal static class FixtureRegistry
         // Collections
         "ListView_TypedRendering",
 
+        // ItemClick once-fire guard (issue #679 (a) — E2E real-pointer-click coverage of
+        // the ListViewHandler once-subscribe contract across re-renders + items change)
+        "ItemClick_OnceFire",
+
+        // Host theme-change re-resolution (issue #679 (b) — E2E proof that the host
+        // ActualThemeChanged → RequestRender wiring re-resolves a concrete ResourceOverride
+        // ThemeRef brush on a real root-theme change)
+        "ThemeChange_ResourceOverrideReResolve",
+
         // TreeView expand/collapse (mirrors ReactorGallery Basic TreeView —
         // E2E repro/guard for the item-body-collapse bug)
         "TreeView_BasicTextTree",
@@ -215,6 +224,12 @@ internal static class FixtureRegistry
 
         // Collections
         "ListView_TypedRendering" => CollectionFixtures.ListViewTyped(ctx),
+
+        // ItemClick once-fire guard (issue #679 (a))
+        "ItemClick_OnceFire" => ItemClickE2EFixtures.OnceFire(ctx),
+
+        // Host theme-change re-resolution (issue #679 (b))
+        "ThemeChange_ResourceOverrideReResolve" => ThemeChangeE2EFixtures.ThemeReResolve(ctx),
 
         // TreeView expand/collapse
         "TreeView_BasicTextTree" => TreeViewE2EFixtures.BasicTextTree(ctx),

--- a/tests/Reactor.AppTests.Host/Fixtures/ItemClickE2EFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/ItemClickE2EFixtures.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.Fixtures;
+
+/// <summary>
+/// E2E fixture for issue #679 (a) — the ListView <c>OnItemClick</c> "once-fire" guard.
+///
+/// <para>The production <c>ListViewHandler</c> subscribes the native
+/// <c>ListView.ItemClick</c> event exactly once (Mount when <c>OnItemClick</c> is present,
+/// or the Update transition <c>null → non-null</c>) and dispatches through the current
+/// element via <c>GetElementTag</c>. A handler that stays present but changes identity every
+/// render (the idiomatic <c>idx =&gt; setState(...)</c> lambda) must therefore NOT cause a
+/// re-subscribe. If the reconciler regressed to <c>ItemClick +=</c> on every render, a single
+/// real pointer click would invoke the callback N+1 times.</para>
+///
+/// <para>This scene exposes that as UIA-readable state: an authoritative <see cref="Ref{T}"/>
+/// counter (incremented on every dispatch, so a double-fire can't be masked by state
+/// batching) mirrored into <c>Fires</c>, plus the clicked <c>LastIndex</c>. "Rerender" forces
+/// re-renders with the handler continuously present (memoized items → no ItemsSource rebuild);
+/// "ShuffleItems" changes the items array (the #495 rebuild path). The E2E test drives real
+/// pointer input and asserts the callback fires EXACTLY once with the correct index.</para>
+/// </summary>
+internal static class ItemClickE2EFixtures
+{
+    private static readonly string[] LabelsA = ["Alpha", "Bravo", "Charlie", "Delta"];
+    private static readonly string[] LabelsB = ["Delta", "Charlie", "Bravo", "Alpha"];
+
+    internal class OnceFireComponent : Component
+    {
+        public override Element Render()
+        {
+            var (rev, setRev) = UseState(0);
+            var (shuffleGen, setShuffleGen) = UseState(0);
+            var (firesDisplay, setFiresDisplay) = UseState(0);
+            var (lastIndex, setLastIndex) = UseState(-1);
+
+            // Authoritative fire count. A native double-subscription fires both handlers
+            // synchronously for one click, so counting on a Ref (not just state) guarantees
+            // the second dispatch is observed even if the two setState calls collapse.
+            var fires = UseRef(0);
+
+            // Memoize the item elements so a plain "Rerender" keeps the SAME Items array
+            // reference (ListViewHandler.Update sees ReferenceEquals → no ItemsSource
+            // rebuild), isolating the "handler present across re-render" path. "ShuffleItems"
+            // bumps shuffleGen → a new array → the items-change rebuild path.
+            var rows = UseMemo(() =>
+            {
+                var labels = shuffleGen % 2 == 0 ? LabelsA : LabelsB;
+                return labels
+                    .Select((label, i) => (Element)TextBlock($"{i}: {label}").AutomationId($"LvItem_{i}"))
+                    .ToArray();
+            }, shuffleGen);
+
+            return VStack(8,
+                TextBlock($"rev: {rev} shuffle: {shuffleGen}").AutomationId("LvRev"),
+                HStack(8,
+                    Button("Rerender", () => setRev(rev + 1)).AutomationId("LvRerenderBtn"),
+                    Button("ShuffleItems", () => setShuffleGen(shuffleGen + 1)).AutomationId("LvShuffleBtn")
+                ),
+
+                // NEW lambda every render (identity changes) while OnItemClick stays non-null.
+                ListView(rows)
+                    .ItemClick(idx =>
+                    {
+                        fires.Current += 1;
+                        setFiresDisplay(fires.Current);
+                        setLastIndex(idx);
+                    })
+                    .Height(220),
+
+                TextBlock($"Fires: {firesDisplay}").AutomationId("LvFires"),
+                TextBlock($"LastIndex: {lastIndex}").AutomationId("LvLastIndex")
+            );
+        }
+    }
+
+    internal static Element OnceFire(RenderContext ctx) => Component<OnceFireComponent>();
+}

--- a/tests/Reactor.AppTests.Host/Fixtures/ThemeChangeE2EFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/ThemeChangeE2EFixtures.cs
@@ -1,0 +1,158 @@
+using System;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.Fixtures;
+
+/// <summary>
+/// E2E fixture for issue #679 (b) — host theme-change re-resolution of a ThemeRef brush,
+/// proving the shipped #86/#751 wiring (the host's <c>ActualThemeChanged</c> handler →
+/// <c>ThemeRef.InvalidateResolutionCache()</c> + <c>RequestRender()</c>) end-to-end.
+///
+/// <para><b>Why a CONCRETE ResourceOverride ThemeRef, not <c>.Foreground(Theme.X)</c>:</b>
+/// a <c>.Foreground(Theme.X)</c> binding compiles to a <c>{ThemeResource}</c> style setter that
+/// WinUI re-resolves NATIVELY on an effective-theme change — it would flip even if the Reactor
+/// wiring were broken (vacuous). A <c>.Resources(r =&gt; r.Set(key, Theme.Ref(key)))</c> override
+/// instead stores a CONCRETE <see cref="SolidColorBrush"/> in <c>fe.Resources[key]</c> that does
+/// NOT self-heal; it only updates when Reactor re-runs <c>ApplyResourceOverrides</c> on a
+/// re-render, which re-resolves the ThemeRef against the probe's live <c>ActualTheme</c>.</para>
+///
+/// <para><b>Why the toggle does NOT call setState:</b> the button changes only the window-root
+/// <c>RequestedTheme</c> (the canonical app theme switch) and forces no fixture re-render. So the
+/// ONLY thing that can re-render Reactor — and therefore re-resolve the concrete brush — is the
+/// host's <c>ActualThemeChanged → RequestRender</c> wiring. Break that wiring and the surfaced
+/// color never changes. (Selftests drive the re-render via fixture setState, so they never
+/// exercise this host wiring; that is the unique E2E value.) A <c>renders:</c> readout makes the
+/// host-driven re-render observable.</para>
+///
+/// <para>A distinct Light/Dark brush pair is installed under a unique key so the concrete override
+/// resolves (system brushes like <c>TextFillColorPrimaryBrush</c> live in nested
+/// XamlControlsResources theme dictionaries that <c>ThemeRef.Resolve</c> does not reach — mirrors
+/// <c>ResourceOverrideMountThemeFixtures</c>). The dict, cache and root theme are torn down on
+/// unmount so the shared Host session is never left mutated.</para>
+/// </summary>
+internal static class ThemeChangeE2EFixtures
+{
+    private const string ProbeKey = "ReactorE2E_ThemeProbeBrush";
+
+    internal class ThemeReResolveComponent : Component
+    {
+        private FrameworkElement? _probe;   // carries the concrete ResourceOverride
+        private FrameworkElement? _anchor;  // reaches XamlRoot.Content (the window root)
+        private ElementTheme? _originalRootTheme;
+
+        // Participate in parent/host re-renders. A propless Component defaults ShouldUpdate() to
+        // false, so the host's theme-change RequestRender (a NON-self-triggered parent re-render)
+        // would otherwise skip this component entirely — its ThemeRef overrides never re-resolve
+        // and the reader effect never re-runs. Returning true is exactly how any component with
+        // host-reactive content behaves; it is what lets the shipped ActualThemeChanged →
+        // RequestRender wiring reach this subtree end-to-end.
+        protected internal override bool ShouldUpdate() => true;
+
+        public override Element Render()
+        {
+            // Install the themed dictionary BEFORE the probe mounts (guarded to run once) so the
+            // probe's ThemeRef override resolves to a concrete brush at first mount.
+            var dictRef = UseRef<ResourceDictionary?>(null);
+            if (dictRef.Current is null)
+                dictRef.Current = InstallThemedDict();
+
+            var (colorText, setColorText) = UseState("Probe: (pending)");
+            var (settle, setSettle) = UseState(0);
+
+            // Per-render counter (Ref, so bumping it doesn't itself request a render). Used both as
+            // an observable "the host re-rendered" signal AND (with the settle state) as the reader
+            // effect's dependency so the reader re-runs after every render — including the host-
+            // driven one that has no changed state/props of its own.
+            var rc = UseRef(0);
+            rc.Current++;
+            var renderNo = rc.Current;
+
+            // Reader runs AFTER reconciliation, when the probe's ActualTheme has settled to the
+            // host theme. It resolves the SAME ThemeRef the .Resources() override below uses, via
+            // the public ThemeRef.Resolve(key, fe) — the exact resolution the shipped host wiring
+            // makes re-run. Reading it here (rather than the reconciler-applied fe.Resources[key],
+            // which lags one layout pass during the theme-change reconcile) gives a stable, timely
+            // observation. Keyed on renderNo so it re-runs each render; on the host-driven
+            // re-render it re-resolves against the now-current theme. Break the host RequestRender
+            // wiring → the component never re-renders → this never re-runs → the color stays stale.
+            UseEffect(() =>
+            {
+                var brush = _probe is not null ? ThemeRef.Resolve(ProbeKey, _probe) : null;
+                if (brush is SolidColorBrush b)
+                {
+                    var c = b.Color;
+                    var text = $"Probe: #{c.A:X2}{c.R:X2}{c.G:X2}{c.B:X2}";
+                    if (text != colorText) setColorText(text);
+                }
+                else if (settle < 12)
+                {
+                    setSettle(settle + 1);
+                }
+            }, renderNo, settle);
+
+            // Run-once: tear down on unmount (navigate away / Reset) — remove the installed dict,
+            // drop the resolution cache, and restore the original root theme.
+            UseEffect(() => (Action)(() =>
+            {
+                if (dictRef.Current is { } d)
+                    Application.Current.Resources.MergedDictionaries.Remove(d);
+                ThemeRef.InvalidateResolutionCache();
+                if (_anchor?.XamlRoot?.Content is FrameworkElement root && _originalRootTheme is { } t)
+                    root.RequestedTheme = t;
+            }));
+
+            return VStack(8,
+                TextBlock("Host theme-change probe (concrete ResourceOverride ThemeRef)"),
+
+                // The realistic user path — a concrete ThemeRef ResourceOverride. NO .RequestedTheme
+                // so the probe's ActualTheme tracks the host theme; the host theme change flips it.
+                Border(TextBlock("theme probe"))
+                    .Resources(r => r.Set(ProbeKey, Theme.Ref(ProbeKey)))
+                    .Set(fe => _probe = fe)
+                    .Padding(12)
+                    .AutomationId("ThemeProbe"),
+
+                TextBlock(colorText).AutomationId("ThemeProbeColor"),
+                TextBlock($"renders: {renderNo}").AutomationId("RenderCount"),
+
+                Button("Toggle Root Theme", () =>
+                {
+                    if (_anchor?.XamlRoot?.Content is FrameworkElement root)
+                    {
+                        _originalRootTheme ??= root.RequestedTheme;
+                        // Flip off the EFFECTIVE (Actual) theme; the root starts at
+                        // RequestedTheme=Default (effective Dark via the app theme), so keying off
+                        // RequestedTheme would set Dark→Dark (a no-op first click).
+                        root.RequestedTheme = root.ActualTheme == ElementTheme.Dark
+                            ? ElementTheme.Light
+                            : ElementTheme.Dark;
+                        // No setState — rely on host ActualThemeChanged → RequestRender.
+                    }
+                })
+                .Set(fe => _anchor = fe)
+                .AutomationId("ThemeToggleBtn")
+            );
+        }
+
+        // A Source-less merged dictionary whose ThemeDictionaries carry a different concrete brush
+        // per theme under a unique key; ThemeRef.Resolve discovers it via its ThemeDictionaries
+        // scan over MergedDictionaries. Cache invalidated on install so a prior run can't leak.
+        private static ResourceDictionary InstallThemedDict()
+        {
+            var light = new SolidColorBrush(global::Windows.UI.Color.FromArgb(255, 0, 0, 140));   // #FF00008C
+            var dark = new SolidColorBrush(global::Windows.UI.Color.FromArgb(255, 200, 40, 0));   // #FFC82800
+            var dict = new ResourceDictionary();
+            dict.ThemeDictionaries["Light"] = new ResourceDictionary { [ProbeKey] = light };
+            dict.ThemeDictionaries["Dark"] = new ResourceDictionary { [ProbeKey] = dark };
+            Application.Current.Resources.MergedDictionaries.Add(dict);
+            ThemeRef.InvalidateResolutionCache();
+            return dict;
+        }
+    }
+
+    internal static Element ThemeReResolve(RenderContext ctx) => Component<ThemeReResolveComponent>();
+}

--- a/tests/Reactor.AppTests/Infrastructure/WinAppUi.cs
+++ b/tests/Reactor.AppTests/Infrastructure/WinAppUi.cs
@@ -59,6 +59,16 @@ public sealed class WinAppUi
 
     private static string ResolveWinAppExe()
     {
+        // Explicit override — an absolute path to a winapp.exe, honored first.
+        // Needed when the machine's `winapp.exe` app-execution-alias resolves to an
+        // older build that lacks the `ui` UIA verb (alias drift from a sideloaded
+        // winapp-dev package), while a newer ui-capable winapp is installed elsewhere
+        // (e.g. %LOCALAPPDATA%\Microsoft\WindowsApps\winapp_8wekyb3d8bbwe\winapp.exe).
+        // Also lets CI pin an exact winapp build. No effect unless the var is set.
+        var overridePath = Environment.GetEnvironmentVariable("REACTOR_WINAPP_EXE");
+        if (!string.IsNullOrEmpty(overridePath) && File.Exists(overridePath))
+            return Path.GetFullPath(overridePath);
+
         var local = Environment.GetEnvironmentVariable("LOCALAPPDATA");
         if (!string.IsNullOrEmpty(local))
         {
@@ -80,7 +90,8 @@ public sealed class WinAppUi
 
         throw new WinAppException(
             "Could not find winapp.exe. Install the winapp CLI (winget install Microsoft.WinAppCli) " +
-            "or ensure an absolute PATH entry contains winapp.exe.");
+            "or ensure an absolute PATH entry contains winapp.exe, or set REACTOR_WINAPP_EXE to an " +
+            "absolute path to a ui-capable winapp.exe.");
     }
 
     /// <summary>

--- a/tests/Reactor.AppTests/Tests/HostThemeChangeTests.cs
+++ b/tests/Reactor.AppTests/Tests/HostThemeChangeTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Reactor.AppTests.Infrastructure;
+
+namespace Microsoft.UI.Reactor.AppTests.Tests;
+
+/// <summary>
+/// E2E coverage for issue #679 (b) — the host theme-change → ThemeRef re-resolution wiring
+/// (#86 / #751). The <c>ThemeChange_ResourceOverrideReResolve</c> host fixture binds a CONCRETE
+/// <c>ResourceOverride</c> ThemeRef brush (which, unlike a <c>{ThemeResource}</c>
+/// <c>.Foreground(Theme.X)</c> setter, does NOT self-heal natively) and toggles the window-root
+/// <c>RequestedTheme</c> without any fixture <c>setState</c>. So the surfaced brush color can
+/// only change if the host's <c>ActualThemeChanged → RequestRender</c> wiring re-renders Reactor
+/// and re-runs <c>ApplyResourceOverrides</c> — no manual <c>InvalidateCache()</c> anywhere.
+///
+/// Non-vacuous: break the host <c>RequestRender</c> and the color stays stale → this fails.
+///
+/// Residual gap (named): the strict same-theme-<i>name</i> invalidation path (system
+/// <c>ColorValuesChanged</c> / accent / high-contrast, where <c>themeName</c> is unchanged) is not
+/// deterministically reproducible in the winapp ui tier; it remains covered in-process by the
+/// selftest <c>ThemeBrushCacheFixtures.InvalidationReResolves</c>.
+/// </summary>
+[TestClass]
+public class HostThemeChangeTests : AppTestBase
+{
+    private const string Fixture = "ThemeChange_ResourceOverrideReResolve";
+
+    [ClassInitialize]
+    public static void StartAppSession(TestContext context) => TestSession.AssemblyInit(context);
+
+    [ClassCleanup]
+    public static void StopAppSession() => TestSession.AssemblyCleanup();
+
+    /// <summary>
+    /// Toggling the real host theme must re-resolve the concrete ThemeRef override brush
+    /// (color flips), and toggling back must return it to the original theme's brush.
+    /// </summary>
+    // [Retry] mops up rare unattended-desktop UIA read flakes; a real regression fails every attempt.
+    [Retry(3)]
+    [TestMethod]
+    public void HostThemeChange_ReResolvesConcreteResourceOverride()
+    {
+        NavigateToFixtureFresh(Fixture);
+
+        var initial = WaitForConcreteProbeColor();
+
+        // Real host theme change (window-root RequestedTheme); the fixture forces no re-render,
+        // so only the host ActualThemeChanged → RequestRender wiring can update the brush.
+        ClickButton("ThemeToggleBtn");
+        var toggled = WaitUntilProbeColorChanges(initial);
+        Assert.AreNotEqual(initial, toggled,
+            "Concrete ResourceOverride ThemeRef brush should re-resolve after a real host theme change " +
+            "driven solely by the host RequestRender wiring.");
+
+        // Toggle back — re-resolves to the original theme's brush and restores the session theme.
+        ClickButton("ThemeToggleBtn");
+        var restored = WaitUntilProbeColorChanges(toggled);
+        Assert.AreEqual(initial, restored,
+            "Toggling the host theme back should re-resolve the override to the original theme's brush.");
+    }
+
+    private string ReadProbeColor() => App.GetValue("ThemeProbeColor") ?? "";
+
+    private string WaitForConcreteProbeColor(int timeoutMs = 8000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            var cur = ReadProbeColor();
+            if (cur.StartsWith("Probe: #", StringComparison.Ordinal)) return cur;
+            Thread.Sleep(150);
+        }
+        Assert.Fail($"ThemeProbeColor never resolved to a concrete '#' value within {timeoutMs}ms " +
+                    $"(last: '{ReadProbeColor()}').");
+        return ""; // unreachable
+    }
+
+    private string WaitUntilProbeColorChanges(string from, int timeoutMs = 8000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            var cur = ReadProbeColor();
+            if (cur.StartsWith("Probe: #", StringComparison.Ordinal) && cur != from) return cur;
+            Thread.Sleep(150);
+        }
+        Assert.Fail($"ThemeProbeColor did not change from '{from}' within {timeoutMs}ms " +
+                    $"(last: '{ReadProbeColor()}').");
+        return ""; // unreachable
+    }
+}

--- a/tests/Reactor.AppTests/Tests/ItemClickInteractionTests.cs
+++ b/tests/Reactor.AppTests/Tests/ItemClickInteractionTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Reactor.AppTests.Infrastructure;
+
+namespace Microsoft.UI.Reactor.AppTests.Tests;
+
+/// <summary>
+/// E2E coverage for issue #679 (a) — the ListView <c>OnItemClick</c> "once-fire" guarantee.
+///
+/// The <c>ItemClick_OnceFire</c> host fixture renders a <c>ListView</c> whose
+/// <c>OnItemClick</c> is a fresh lambda every render. These tests force the component to
+/// re-render (handler continuously present) and to rebuild its items, then deliver a REAL
+/// pointer click to a specific row and assert the callback fired EXACTLY once with the
+/// correct index. This guards the <c>ListViewHandler</c> once-subscribe contract against
+/// double-fire / double-subscription / stale-handler regressions — a naive
+/// <c>ItemClick +=</c>-every-render regression would make one click report <c>Fires &gt; 1</c>.
+///
+/// Why E2E and not a selftest: WinUI raises <c>ItemClick</c> from real pointer input, not from
+/// a UIA Invoke, so only cross-process real-input delivery exercises the full path.
+/// </summary>
+[TestClass]
+public class ItemClickInteractionTests : AppTestBase
+{
+    private const string Fixture = "ItemClick_OnceFire";
+
+    [ClassInitialize]
+    public static void StartAppSession(TestContext context) => TestSession.AssemblyInit(context);
+
+    [ClassCleanup]
+    public static void StopAppSession() => TestSession.AssemblyCleanup();
+
+    /// <summary>
+    /// Handler stays present across several re-renders (memoized items → no ItemsSource
+    /// rebuild). A single real click on row 2 must fire the callback exactly once.
+    /// </summary>
+    // [Retry] mops up the rare unattended-desktop input-injection flake (SendInput dropped
+    // before the Host foregrounds). A real regression still fails every attempt.
+    [Retry(3)]
+    [TestMethod]
+    public void ItemClick_FiresExactlyOnce_AfterReRenders()
+    {
+        NavigateToFixtureFresh(Fixture);
+        WaitForText("LvFires", "Fires: 0");
+
+        // Force re-renders with OnItemClick continuously present. A re-subscribe-per-render
+        // regression would stack native ItemClick handlers here.
+        ClickButton("LvRerenderBtn");
+        ClickButton("LvRerenderBtn");
+        ClickButton("LvRerenderBtn");
+        WaitForTextContaining("LvRev", "rev: 3");
+
+        RealClick("LvItem_2");
+
+        WaitForText("LvLastIndex", "LastIndex: 2");
+        WaitForText("LvFires", "Fires: 1");
+    }
+
+    /// <summary>
+    /// After the items array is rebuilt (the #495 ItemsSource-rebuild path), a single real
+    /// click still fires the callback exactly once with the correct index.
+    /// </summary>
+    [Retry(3)]
+    [TestMethod]
+    public void ItemClick_FiresExactlyOnce_AfterItemsChange()
+    {
+        NavigateToFixtureFresh(Fixture);
+        WaitForText("LvFires", "Fires: 0");
+
+        ClickButton("LvShuffleBtn");
+        WaitForTextContaining("LvRev", "shuffle: 1");
+
+        RealClick("LvItem_1");
+
+        WaitForText("LvLastIndex", "LastIndex: 1");
+        WaitForText("LvFires", "Fires: 1");
+    }
+
+    /// <summary>
+    /// Deliver a real Win32 pointer click to the center of the element's bounding rectangle.
+    /// A real click (not a UIA Invoke) is required: WinUI raises <c>ListView.ItemClick</c>
+    /// from pointer input.
+    /// </summary>
+    private void RealClick(string automationId)
+    {
+        var r = FindById(automationId).Rect;
+        InputInjector.Foreground(HostHwnd);
+        InputInjector.Click(r.X + r.Width / 2, r.Y + r.Height / 2);
+    }
+}


### PR DESCRIPTION
## What & why

Closes #679 (E2E tier). Adds the missing **winapp-ui E2E guards** for two behaviors that shipped via #751 but had **no end-to-end tests**. Test-only — no production Reactor code changed.

### (a) ListView `OnItemClick` once-fire
- **Fixture** `ItemClick_OnceFire` (`ItemClickE2EFixtures.cs`): a `ListView` whose `OnItemClick` is a fresh lambda every render, an authoritative `UseRef` fire counter mirrored to UIA text, plus `Rerender` and `ShuffleItems` buttons.
- **Tests** `ItemClickInteractionTests`: force re-renders (handler stays present) and an items-array change, then deliver a **real pointer click** (`InputInjector`) and assert the callback fires **exactly once** with the correct index.
- Guards the `ListViewHandler` once-subscribe contract against double-fire / double-subscription / stale-handler regressions (a re-subscribe-per-render regression would report `Fires > 1`).

### (b) Host theme-change re-resolution (#86)
- **Fixture** `ThemeChange_ResourceOverrideReResolve` (`ThemeChangeE2EFixtures.cs`): a **concrete `ResourceOverride` ThemeRef** brush (installed Light/Dark pair), toggled via the **real window-root `RequestedTheme`** with **no fixture `setState`** — so only the host `ActualThemeChanged → RequestRender` wiring can re-resolve it.
- **Test** `HostThemeChangeTests`: capture the resolved color, toggle the host theme, assert it re-resolves to the new theme, toggle back, assert it restores.
- **Why not `.Foreground(Theme.X)`:** that compiles to a `{ThemeResource}` setter WinUI re-resolves *natively*, so it would flip even if the Reactor wiring were broken (vacuous). A concrete `ResourceOverride` does **not** self-heal — it only updates on a Reactor re-render.
- `ThemeReResolveComponent` overrides `ShouldUpdate() => true` so the host's non-self-triggered theme re-render actually reaches the subtree (a propless component defaults `ShouldUpdate()` to `false` and would be skipped).

### Test infra
- `WinAppUi.ResolveWinAppExe` now honors an optional **`REACTOR_WINAPP_EXE`** override (absolute path to a `ui`-capable winapp). No effect unless set; lets a box whose `winapp.exe` app-execution-alias points at an older build (no `ui` verb) pin a working one. Needed to run the tier on this machine; harmless on CI.

## Evidence (captured while the desktop session was interactive)
- **Harness gate:** existing `EventHandlerTests` **5/5 passed** before writing new tests.
- **(a) ItemClick:** `ItemClickInteractionTests` **2/2 passed** (real clicks, exact `Fires: 1` + correct index).
- **(b) Theme:** `HostThemeChangeTests` **1/1 passed**.
- **(b) non-vacuity — PROVEN:** temporarily disabling `RequestRender()` in `ReactorHost.OnActualThemeChanged` made the theme test **fail** (color never changes); reverted.
- **Full `dotnet build Reactor.slnx`:** succeeded, 0 errors.

## Residual gaps / notes for review
- **ItemClick empirical non-vacuity (break-the-guard → `Fires > 1`) is pending a healthy input environment.** Midway through, this unattended desktop **locked** (and a `GameInputSvc` window began aggressively grabbing foreground), which blocks *all* input-injection E2E tests — the existing `EventHandlerTests` input cases fail identically. ItemClick is non-vacuous by construction (asserts an exact count) and passed 2/2 when interactive; please re-run on CI to capture the break-the-guard failure.
- **Same-theme-name cache invalidation** (system `ColorValuesChanged` / accent / high-contrast, where the theme *name* is unchanged) is not deterministically reproducible in winapp-ui; it stays covered by the in-process selftest `ThemeBrushCacheFixtures.InvalidationReResolves`. The Light↔Dark E2E here exercises the host-driven re-render + re-resolution.
- **Follow-up candidates:** symmetric `GridView` / `TemplatedListView` ItemClick E2E; observing the reconciler-applied `fe.Resources[key]` directly (the theme test reads via `ThemeRef.Resolve(key, fe)` in a post-render effect to avoid a one-layout-pass apply lag).

Draft until the coordinator's explicit GO — do not self-merge.