### PR TITLE
feat(analyzer): REACTOR_PERSIST_001 — UsePersisted default-scope warning

### DIFF
--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_PERSIST_001` | warning | 2-arg `UsePersisted(key, initial)` defaults to process-wide `PersistedScope.Application` | Pass an explicit scope: `PersistedScope.Window` (host lifetime) or `PersistedScope.Application` (make current behavior explicit). |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_PERSIST_001 | Reactor.Persistence | Warning | UsePersistedScopeAnalyzer - 2-arg UsePersisted defaults to Application scope; specify scope

--- a/src/Reactor.Analyzers/UsePersistedScopeAnalyzer.cs
+++ b/src/Reactor.Analyzers/UsePersistedScopeAnalyzer.cs
@@ -43,7 +43,7 @@ public sealed class UsePersistedScopeAnalyzer : DiagnosticAnalyzer
         "UsePersisted defaults to Application (process-wide) scope";
 
     private static readonly LocalizableString MessageFormat =
-        "UsePersisted({0}, …) uses the two-argument overload, which defaults to PersistedScope.Application (process-wide — state is shared across windows). Specify PersistedScope.Window (host lifetime) or PersistedScope.Application (make the current behavior explicit).";
+        "UsePersisted({0}, …) defaults to PersistedScope.Application (process-wide). Specify PersistedScope.Window or PersistedScope.Application explicitly.";
 
     private static readonly LocalizableString Description =
         "The two-argument RenderContext.UsePersisted<T>(string, T) overload delegates to " +

--- a/src/Reactor.Analyzers/UsePersistedScopeAnalyzer.cs
+++ b/src/Reactor.Analyzers/UsePersistedScopeAnalyzer.cs
@@ -19,11 +19,14 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// <remarks>
 /// Detection is a cheap syntactic gate (name <c>UsePersisted</c>, exactly two
 /// arguments, no explicit <c>scope:</c>) followed by a single semantic check that
-/// the call really binds to <c>RenderContext.UsePersisted&lt;T&gt;(string, T)</c>.
-/// The two-argument overload with an explicit third scope argument, or any call on
-/// a same-named method that is not <c>RenderContext</c>, is left alone (spec 060
-/// §4.8). The paired <see cref="UsePersistedScopeCodeFix"/> offers
-/// <c>PersistedScope.Window</c> (recommended) or <c>PersistedScope.Application</c>.
+/// the call really binds to the default-scope <c>UsePersisted&lt;T&gt;(string, T)</c>
+/// hook — either on <c>RenderContext</c> (where it is declared) or on
+/// <c>Component</c> (whose <c>protected</c> wrapper delegates to it, so an
+/// unqualified <c>UsePersisted(...)</c> inside a component's <c>Render</c> is covered).
+/// The three-argument overload, or any call on a same-named method that is not one
+/// of those hook types, is left alone (spec 060 §4.8). The paired
+/// <see cref="UsePersistedScopeCodeFix"/> offers <c>PersistedScope.Window</c>
+/// (recommended) or <c>PersistedScope.Application</c>.
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class UsePersistedScopeAnalyzer : DiagnosticAnalyzer
@@ -31,10 +34,10 @@ public sealed class UsePersistedScopeAnalyzer : DiagnosticAnalyzer
     public const string DiagnosticId = "REACTOR_PERSIST_001";
 
     private const string MethodName = "UsePersisted";
-    private const string ContainingTypeName = "RenderContext";
+    private const string RenderContextTypeName = "RenderContext";
+    private const string ComponentTypeName = "Component";
     private const string ReactorNamespacePrefix = "Microsoft.UI.Reactor";
     private const string ScopeParameterName = "scope";
-    private const string ScopeTypeName = "PersistedScope";
 
     private static readonly LocalizableString Title =
         "UsePersisted defaults to Application (process-wide) scope";
@@ -90,12 +93,12 @@ public sealed class UsePersistedScopeAnalyzer : DiagnosticAnalyzer
         if (args.Any(static a => a.NameColon?.Name.Identifier.ValueText == ScopeParameterName))
             return;
 
-        // Semantic confirmation — the call actually binds to
-        // RenderContext.UsePersisted<T>(string, T). One GetSymbolInfo, gated behind
-        // the syntactic checks above (spec 060 §3).
+        // Semantic confirmation — the call actually binds to the default-scope
+        // UsePersisted overload on RenderContext (or Component's protected wrapper).
+        // One GetSymbolInfo, gated behind the syntactic checks above (spec 060 §3).
         if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method)
             return;
-        if (!IsRenderContextDefaultScopeOverload(method))
+        if (!IsDefaultScopeUsePersistedOverload(method))
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(
@@ -105,28 +108,40 @@ public sealed class UsePersistedScopeAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// True when <paramref name="method"/> is the two-argument
-    /// <c>RenderContext.UsePersisted&lt;T&gt;(string key, T initialValue)</c> overload
-    /// (the one that silently defaults to <c>PersistedScope.Application</c>).
+    /// True when <paramref name="method"/> is the two-argument default-scope
+    /// <c>UsePersisted&lt;T&gt;(string key, T initialValue)</c> hook — the overload that
+    /// silently resolves to <c>PersistedScope.Application</c>. Recognized both on
+    /// <c>RenderContext</c> (where it is declared) and on <c>Component</c> (whose
+    /// <c>protected</c> wrapper delegates to it, <c>Component.cs:260</c>), because an
+    /// unqualified <c>UsePersisted(...)</c> in a component's <c>Render</c> binds to the
+    /// Component-declared method.
     /// </summary>
-    private static bool IsRenderContextDefaultScopeOverload(IMethodSymbol method)
+    private static bool IsDefaultScopeUsePersistedOverload(IMethodSymbol method)
     {
         if (method.Name != MethodName)
             return false;
 
         var containingType = method.ContainingType;
-        if (containingType?.Name != ContainingTypeName)
+        if (containingType is null)
+            return false;
+        if (containingType.Name != RenderContextTypeName && containingType.Name != ComponentTypeName)
             return false;
 
         if (!IsReactorNamespace(containingType.ContainingNamespace?.ToDisplayString()))
             return false;
 
-        // The target overload is (string key, T initialValue): exactly two
-        // parameters and no PersistedScope among them. This distinguishes it from
-        // the three-argument overload and from any (string, PersistedScope) shape.
+        // Target overload shape: (string key, T initialValue). Inspect the ORIGINAL
+        // definition so a call that infers T = PersistedScope still matches (the
+        // second parameter is the method's own type parameter), while the
+        // three-argument overload (length 3) and any (string, PersistedScope) shape
+        // (second parameter is the enum, not a type parameter) are excluded.
         if (method.Parameters.Length != 2)
             return false;
-        if (method.Parameters.Any(static p => p.Type.Name == ScopeTypeName))
+
+        var original = method.OriginalDefinition;
+        if (original.Parameters[0].Type.SpecialType != SpecialType.System_String)
+            return false;
+        if (original.Parameters[1].Type.TypeKind != TypeKind.TypeParameter)
             return false;
 
         return true;

--- a/src/Reactor.Analyzers/UsePersistedScopeAnalyzer.cs
+++ b/src/Reactor.Analyzers/UsePersistedScopeAnalyzer.cs
@@ -102,9 +102,10 @@ public sealed class UsePersistedScopeAnalyzer : DiagnosticAnalyzer
         if (!IsDefaultScopeUsePersistedOverload(method))
             return;
 
-        // Report against the key argument specifically — it is the first positional
-        // argument, but a caller may reorder named arguments (e.g.
-        // `UsePersisted(initialValue: x, key: k)`), so prefer an explicit `key:` when present.
+        // The diagnostic underlines the whole invocation (see location below); only the
+        // message's {0} placeholder uses the key. A caller may reorder named arguments
+        // (e.g. `UsePersisted(initialValue: x, key: k)`), so resolve an explicit `key:`
+        // argument for the message, falling back to the first positional argument.
         var keyExpression = args.FirstOrDefault(static a => a.NameColon?.Name.Identifier.ValueText == KeyParameterName)?.Expression
             ?? args[0].Expression;
 

--- a/src/Reactor.Analyzers/UsePersistedScopeAnalyzer.cs
+++ b/src/Reactor.Analyzers/UsePersistedScopeAnalyzer.cs
@@ -38,6 +38,7 @@ public sealed class UsePersistedScopeAnalyzer : DiagnosticAnalyzer
     private const string ComponentTypeName = "Component";
     private const string ReactorNamespacePrefix = "Microsoft.UI.Reactor";
     private const string ScopeParameterName = "scope";
+    private const string KeyParameterName = "key";
 
     private static readonly LocalizableString Title =
         "UsePersisted defaults to Application (process-wide) scope";
@@ -101,10 +102,16 @@ public sealed class UsePersistedScopeAnalyzer : DiagnosticAnalyzer
         if (!IsDefaultScopeUsePersistedOverload(method))
             return;
 
+        // Report against the key argument specifically — it is the first positional
+        // argument, but a caller may reorder named arguments (e.g.
+        // `UsePersisted(initialValue: x, key: k)`), so prefer an explicit `key:` when present.
+        var keyExpression = args.FirstOrDefault(static a => a.NameColon?.Name.Identifier.ValueText == KeyParameterName)?.Expression
+            ?? args[0].Expression;
+
         context.ReportDiagnostic(Diagnostic.Create(
             Rule,
             invocation.GetLocation(),
-            args[0].Expression.ToString()));
+            keyExpression.ToString()));
     }
 
     /// <summary>

--- a/src/Reactor.Analyzers/UsePersistedScopeAnalyzer.cs
+++ b/src/Reactor.Analyzers/UsePersistedScopeAnalyzer.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_PERSIST_001</c> — flags a two-argument
+/// <c>UsePersisted(key, initialValue)</c> call. That overload is
+/// <c>=&gt; UsePersisted(key, initialValue, PersistedScope.Application)</c>
+/// (<c>RenderContext.cs:824</c>), so the value is <b>process-wide</b> and bleeds
+/// across windows/tabs that share the key — invisible until two windows are open
+/// at once. The rule asks the author to state the scope explicitly.
+/// </summary>
+/// <remarks>
+/// Detection is a cheap syntactic gate (name <c>UsePersisted</c>, exactly two
+/// arguments, no explicit <c>scope:</c>) followed by a single semantic check that
+/// the call really binds to <c>RenderContext.UsePersisted&lt;T&gt;(string, T)</c>.
+/// The two-argument overload with an explicit third scope argument, or any call on
+/// a same-named method that is not <c>RenderContext</c>, is left alone (spec 060
+/// §4.8). The paired <see cref="UsePersistedScopeCodeFix"/> offers
+/// <c>PersistedScope.Window</c> (recommended) or <c>PersistedScope.Application</c>.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UsePersistedScopeAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_PERSIST_001";
+
+    private const string MethodName = "UsePersisted";
+    private const string ContainingTypeName = "RenderContext";
+    private const string ReactorNamespacePrefix = "Microsoft.UI.Reactor";
+    private const string ScopeParameterName = "scope";
+    private const string ScopeTypeName = "PersistedScope";
+
+    private static readonly LocalizableString Title =
+        "UsePersisted defaults to Application (process-wide) scope";
+
+    private static readonly LocalizableString MessageFormat =
+        "UsePersisted({0}, …) uses the two-argument overload, which defaults to PersistedScope.Application (process-wide — state is shared across windows). Specify PersistedScope.Window (host lifetime) or PersistedScope.Application (make the current behavior explicit).";
+
+    private static readonly LocalizableString Description =
+        "The two-argument RenderContext.UsePersisted<T>(string, T) overload delegates to " +
+        "PersistedScope.Application, so the persisted value lives for the whole process and " +
+        "bleeds across windows or tabs that share the same key. This is invisible until two " +
+        "windows are open at once. Call the three-argument overload and pass " +
+        "PersistedScope.Window for host-scoped state, or PersistedScope.Application to make the " +
+        "process-wide intent explicit (spec 033 §2 / spec 060 §4.8).";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Persistence",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Syntactic gate #1 — the invoked simple name is UsePersisted. Handles
+        // `ctx.UsePersisted(...)`, unqualified `UsePersisted(...)`, and the
+        // explicit type-argument forms `ctx.UsePersisted<T>(...)` / `UsePersisted<T>(...)`.
+        if (GetInvokedName(invocation) != MethodName)
+            return;
+
+        // Syntactic gate #2 — exactly two arguments (the shape of the default-scope overload).
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count != 2)
+            return;
+
+        // Syntactic gate #3 — the author has not already named a `scope:` argument.
+        // (No valid call to the (string, T) overload names `scope`, but a same-named
+        // overload that takes a scope could, and this keeps the fast path honest.)
+        if (args.Any(static a => a.NameColon?.Name.Identifier.ValueText == ScopeParameterName))
+            return;
+
+        // Semantic confirmation — the call actually binds to
+        // RenderContext.UsePersisted<T>(string, T). One GetSymbolInfo, gated behind
+        // the syntactic checks above (spec 060 §3).
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method)
+            return;
+        if (!IsRenderContextDefaultScopeOverload(method))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.GetLocation(),
+            args[0].Expression.ToString()));
+    }
+
+    /// <summary>
+    /// True when <paramref name="method"/> is the two-argument
+    /// <c>RenderContext.UsePersisted&lt;T&gt;(string key, T initialValue)</c> overload
+    /// (the one that silently defaults to <c>PersistedScope.Application</c>).
+    /// </summary>
+    private static bool IsRenderContextDefaultScopeOverload(IMethodSymbol method)
+    {
+        if (method.Name != MethodName)
+            return false;
+
+        var containingType = method.ContainingType;
+        if (containingType?.Name != ContainingTypeName)
+            return false;
+
+        if (!IsReactorNamespace(containingType.ContainingNamespace?.ToDisplayString()))
+            return false;
+
+        // The target overload is (string key, T initialValue): exactly two
+        // parameters and no PersistedScope among them. This distinguishes it from
+        // the three-argument overload and from any (string, PersistedScope) shape.
+        if (method.Parameters.Length != 2)
+            return false;
+        if (method.Parameters.Any(static p => p.Type.Name == ScopeTypeName))
+            return false;
+
+        return true;
+    }
+
+    private static bool IsReactorNamespace(string? ns) =>
+        ns is not null
+            && (ns == ReactorNamespacePrefix
+                || ns.StartsWith(ReactorNamespacePrefix + ".", StringComparison.Ordinal));
+
+    private static string? GetInvokedName(InvocationExpressionSyntax invocation) => invocation.Expression switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        GenericNameSyntax g => g.Identifier.ValueText,
+        MemberAccessExpressionSyntax m => m.Name switch
+        {
+            GenericNameSyntax gn => gn.Identifier.ValueText,
+            { } simple => simple.Identifier.ValueText,
+        },
+        MemberBindingExpressionSyntax mb => mb.Name.Identifier.ValueText,
+        _ => null,
+    };
+}

--- a/src/Reactor.Analyzers/UsePersistedScopeCodeFix.cs
+++ b/src/Reactor.Analyzers/UsePersistedScopeCodeFix.cs
@@ -1,0 +1,91 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for <see cref="UsePersistedScopeAnalyzer"/> (<c>REACTOR_PERSIST_001</c>).
+/// Appends an explicit scope argument to a two-argument <c>UsePersisted(key, initial)</c>
+/// call, offering two actions:
+/// <list type="bullet">
+///   <item><c>, PersistedScope.Window</c> — host-lifetime scope (recommended).</item>
+///   <item><c>, PersistedScope.Application</c> — process-wide, i.e. make the current
+///   implicit behavior explicit.</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// Both actions are always safe (the three-argument overload always exists), so both
+/// are offered unconditionally and the author picks. The rewrite only inserts the
+/// argument; <c>PersistedScope</c> resolves through the same namespace that already
+/// brings <c>RenderContext</c> into scope at the call site.
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UsePersistedScopeCodeFix))]
+[Shared]
+public sealed class UsePersistedScopeCodeFix : CodeFixProvider
+{
+    private const string ScopeTypeName = "PersistedScope";
+    private const string RecommendedScope = "Window";
+    private const string ExplicitScope = "Application";
+
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(UsePersistedScopeAnalyzer.DiagnosticId);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var invocation = node as InvocationExpressionSyntax
+                ?? node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocation is null) continue;
+            if (invocation.ArgumentList.Arguments.Count != 2) continue;
+
+            RegisterScopeFix(context, root, invocation, diagnostic, RecommendedScope,
+                "Scope to the host window (PersistedScope.Window, recommended)");
+            RegisterScopeFix(context, root, invocation, diagnostic, ExplicitScope,
+                "Keep process-wide scope (PersistedScope.Application, explicit)");
+        }
+    }
+
+    private static void RegisterScopeFix(
+        CodeFixContext context,
+        SyntaxNode root,
+        InvocationExpressionSyntax invocation,
+        Diagnostic diagnostic,
+        string scopeMember,
+        string title)
+    {
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title,
+                _ =>
+                {
+                    var scopeArgument = SyntaxFactory.Argument(
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.IdentifierName(ScopeTypeName),
+                            SyntaxFactory.IdentifierName(scopeMember)))
+                        .WithLeadingTrivia(SyntaxFactory.Space);
+
+                    var newArgumentList = invocation.ArgumentList.WithArguments(
+                        invocation.ArgumentList.Arguments.Add(scopeArgument));
+                    var newInvocation = invocation.WithArgumentList(newArgumentList);
+
+                    var newRoot = root.ReplaceNode(invocation, newInvocation);
+                    return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+                },
+                equivalenceKey: UsePersistedScopeAnalyzer.DiagnosticId + ":" + scopeMember),
+            diagnostic);
+    }
+}

--- a/src/Reactor.Analyzers/UsePersistedScopeCodeFix.cs
+++ b/src/Reactor.Analyzers/UsePersistedScopeCodeFix.cs
@@ -97,7 +97,7 @@ public sealed class UsePersistedScopeCodeFix : CodeFixProvider
         context.RegisterCodeFix(
             CodeAction.Create(
                 title,
-                _ =>
+                ct =>
                 {
                     var argument = SyntaxFactory.Argument(
                         SyntaxFactory.ParseExpression($"{scopeTypeName}.{scopeMember}"));

--- a/src/Reactor.Analyzers/UsePersistedScopeCodeFix.cs
+++ b/src/Reactor.Analyzers/UsePersistedScopeCodeFix.cs
@@ -37,6 +37,7 @@ public sealed class UsePersistedScopeCodeFix : CodeFixProvider
 {
     private const string ScopeTypeName = "PersistedScope";
     private const string ScopeTypeMetadataName = "Microsoft.UI.Reactor.Core.PersistedScope";
+    private const string ScopeTypeFullyQualifiedName = "global::Microsoft.UI.Reactor.Core.PersistedScope";
     private const string ScopeParameterName = "scope";
     private const string RecommendedScope = "Window";
     private const string ExplicitScope = "Application";
@@ -66,12 +67,13 @@ public sealed class UsePersistedScopeCodeFix : CodeFixProvider
 
             // Shortest name for PersistedScope that compiles at this call site — bare
             // `PersistedScope` when the namespace is imported (the common case),
-            // otherwise a qualified name. Falls back to the simple name if the symbol
-            // can't be resolved.
+            // otherwise a qualified name. Falls back to the fully-qualified global
+            // name if the symbol can't be resolved (e.g. an ambiguous metadata lookup),
+            // so the emitted fix compiles even without a `using` at the call site.
             var scopeTypeName = semanticModel?.Compilation
                 .GetTypeByMetadataName(ScopeTypeMetadataName)
                 ?.ToMinimalDisplayString(semanticModel, invocation.SpanStart)
-                ?? ScopeTypeName;
+                ?? ScopeTypeFullyQualifiedName;
 
             var useNamedArgument = invocation.ArgumentList.Arguments.Any(static a => a.NameColon is not null);
 

--- a/src/Reactor.Analyzers/UsePersistedScopeCodeFix.cs
+++ b/src/Reactor.Analyzers/UsePersistedScopeCodeFix.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -21,15 +22,22 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// </summary>
 /// <remarks>
 /// Both actions are always safe (the three-argument overload always exists), so both
-/// are offered unconditionally and the author picks. The rewrite only inserts the
-/// argument; <c>PersistedScope</c> resolves through the same namespace that already
-/// brings <c>RenderContext</c> into scope at the call site.
+/// are offered unconditionally. Two robustness details keep the rewrite compiling:
+/// the <c>PersistedScope</c> reference is rendered with
+/// <see cref="SymbolDisplayExtensions.ToMinimalDisplayString"/> so it is qualified
+/// exactly as much as the call site needs (bare <c>PersistedScope</c> when the
+/// namespace is imported, otherwise fully qualified); and the appended argument is
+/// passed by name (<c>scope:</c>) whenever the original call already uses named
+/// arguments, so a call with reordered named arguments does not become an illegal
+/// "positional after named" argument list.
 /// </remarks>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UsePersistedScopeCodeFix))]
 [Shared]
 public sealed class UsePersistedScopeCodeFix : CodeFixProvider
 {
     private const string ScopeTypeName = "PersistedScope";
+    private const string ScopeTypeMetadataName = "Microsoft.UI.Reactor.Core.PersistedScope";
+    private const string ScopeParameterName = "scope";
     private const string RecommendedScope = "Window";
     private const string ExplicitScope = "Application";
 
@@ -43,6 +51,8 @@ public sealed class UsePersistedScopeCodeFix : CodeFixProvider
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         if (root is null) return;
 
+        SemanticModel? semanticModel = null;
+
         foreach (var diagnostic in context.Diagnostics)
         {
             var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
@@ -51,10 +61,24 @@ public sealed class UsePersistedScopeCodeFix : CodeFixProvider
             if (invocation is null) continue;
             if (invocation.ArgumentList.Arguments.Count != 2) continue;
 
-            RegisterScopeFix(context, root, invocation, diagnostic, RecommendedScope,
-                "Scope to the host window (PersistedScope.Window, recommended)");
-            RegisterScopeFix(context, root, invocation, diagnostic, ExplicitScope,
-                "Keep process-wide scope (PersistedScope.Application, explicit)");
+            semanticModel ??= await context.Document
+                .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+            // Shortest name for PersistedScope that compiles at this call site — bare
+            // `PersistedScope` when the namespace is imported (the common case),
+            // otherwise a qualified name. Falls back to the simple name if the symbol
+            // can't be resolved.
+            var scopeTypeName = semanticModel?.Compilation
+                .GetTypeByMetadataName(ScopeTypeMetadataName)
+                ?.ToMinimalDisplayString(semanticModel, invocation.SpanStart)
+                ?? ScopeTypeName;
+
+            var useNamedArgument = invocation.ArgumentList.Arguments.Any(static a => a.NameColon is not null);
+
+            RegisterScopeFix(context, root, invocation, diagnostic, RecommendedScope, scopeTypeName, useNamedArgument,
+                $"Scope to the host window ({ScopeTypeName}.{RecommendedScope}, recommended)");
+            RegisterScopeFix(context, root, invocation, diagnostic, ExplicitScope, scopeTypeName, useNamedArgument,
+                $"Keep process-wide scope ({ScopeTypeName}.{ExplicitScope}, explicit)");
         }
     }
 
@@ -64,6 +88,8 @@ public sealed class UsePersistedScopeCodeFix : CodeFixProvider
         InvocationExpressionSyntax invocation,
         Diagnostic diagnostic,
         string scopeMember,
+        string scopeTypeName,
+        bool useNamedArgument,
         string title)
     {
         context.RegisterCodeFix(
@@ -71,15 +97,21 @@ public sealed class UsePersistedScopeCodeFix : CodeFixProvider
                 title,
                 _ =>
                 {
-                    var scopeArgument = SyntaxFactory.Argument(
-                        SyntaxFactory.MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            SyntaxFactory.IdentifierName(ScopeTypeName),
-                            SyntaxFactory.IdentifierName(scopeMember)))
-                        .WithLeadingTrivia(SyntaxFactory.Space);
+                    var argument = SyntaxFactory.Argument(
+                        SyntaxFactory.ParseExpression($"{scopeTypeName}.{scopeMember}"));
+
+                    if (useNamedArgument)
+                    {
+                        var nameColon = SyntaxFactory.NameColon(SyntaxFactory.IdentifierName(ScopeParameterName))
+                            .WithColonToken(SyntaxFactory.Token(SyntaxKind.ColonToken)
+                                .WithTrailingTrivia(SyntaxFactory.Space));
+                        argument = argument.WithNameColon(nameColon);
+                    }
+
+                    argument = argument.WithLeadingTrivia(SyntaxFactory.Space);
 
                     var newArgumentList = invocation.ArgumentList.WithArguments(
-                        invocation.ArgumentList.Arguments.Add(scopeArgument));
+                        invocation.ArgumentList.Arguments.Add(argument));
                     var newInvocation = invocation.WithArgumentList(newArgumentList);
 
                     var newRoot = root.ReplaceNode(invocation, newInvocation);

--- a/tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs
@@ -349,4 +349,82 @@ class C
             CodeActionEquivalenceKey = UsePersistedScopeAnalyzer.DiagnosticId + ":Window",
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task No_Diagnostic_For_ThreeArg_Component_Call()
+    {
+        // The 3-arg Component wrapper already states the scope — leave it alone.
+        var source = Stubs + @"
+class MyComponent : Component
+{
+    void Build()
+    {
+        UsePersisted(""filter"", """", PersistedScope.Window);
+    }
+}";
+
+        await new CSharpAnalyzerTest<UsePersistedScopeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Qualifies_Scope_When_Namespace_Not_Imported()
+    {
+        // No `using Microsoft.UI.Reactor.Core;` and a fully-qualified receiver: the fix
+        // must still emit a COMPILING PersistedScope reference. Simplifier keeps it
+        // qualified here (a bare `PersistedScope` would not resolve). The harness fails
+        // the test if the fixed code has any compiler error, so this proves robustness.
+        const string before = @"
+using System;
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public enum PersistedScope { Window, Application }
+    public class RenderContext
+    {
+        public void UsePersisted<T>(string key, T initialValue) { }
+        public void UsePersisted<T>(string key, T initialValue, PersistedScope scope) { }
+    }
+}
+
+class C
+{
+    void M()
+    {
+        var ctx = new Microsoft.UI.Reactor.Core.RenderContext();
+        {|REACTOR_PERSIST_001:ctx.UsePersisted(""filter"", """")|};
+    }
+}";
+
+        const string after = @"
+using System;
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public enum PersistedScope { Window, Application }
+    public class RenderContext
+    {
+        public void UsePersisted<T>(string key, T initialValue) { }
+        public void UsePersisted<T>(string key, T initialValue, PersistedScope scope) { }
+    }
+}
+
+class C
+{
+    void M()
+    {
+        var ctx = new Microsoft.UI.Reactor.Core.RenderContext();
+        ctx.UsePersisted(""filter"", """", Microsoft.UI.Reactor.Core.PersistedScope.Window);
+    }
+}";
+
+        await new CSharpCodeFixTest<UsePersistedScopeAnalyzer, UsePersistedScopeCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = UsePersistedScopeAnalyzer.DiagnosticId + ":Window",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs
@@ -394,8 +394,8 @@ class MyComponent : Component
     public async Task CodeFix_Qualifies_Scope_When_Namespace_Not_Imported()
     {
         // No `using Microsoft.UI.Reactor.Core;` and a fully-qualified receiver: the fix
-        // must still emit a COMPILING PersistedScope reference. Simplifier keeps it
-        // qualified here (a bare `PersistedScope` would not resolve). The harness fails
+        // must still emit a COMPILING PersistedScope reference. ToMinimalDisplayString
+        // qualifies it here (a bare `PersistedScope` would not resolve). The harness fails
         // the test if the fixed code has any compiler error, so this proves robustness.
         const string before = @"
 using System;

--- a/tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs
@@ -1,0 +1,238 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="UsePersistedScopeAnalyzer"/> (<c>REACTOR_PERSIST_001</c>) and its
+/// <see cref="UsePersistedScopeCodeFix"/>. Stubs a minimal Reactor-shaped
+/// <c>RenderContext</c> with both <c>UsePersisted</c> overloads plus a
+/// <c>PersistedScope</c> enum, so the arity + symbol gate fires without pulling the
+/// framework in.
+/// </summary>
+public class UsePersistedScopeAnalyzerTests
+{
+    // Mirrors the real shape (RenderContext.cs:824/842): a two-argument overload that
+    // implicitly means Application scope, and a three-argument overload that takes the
+    // scope explicitly. The extra (string, PersistedScope) overload exists ONLY so the
+    // "scope named by hand" near-miss below is a legal call to compile against.
+    // The `using` directives sit at the top of the compilation unit (before the
+    // namespace) so the appended test bodies resolve RenderContext / PersistedScope.
+    private const string Stubs = @"
+using System;
+using Microsoft.UI.Reactor.Core;
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public enum PersistedScope { Window, Application }
+
+    public class RenderContext
+    {
+        // Target overload — silently defaults to Application scope.
+        public void UsePersisted<T>(string key, T initialValue) { }
+
+        // Explicit-scope overload.
+        public void UsePersisted<T>(string key, T initialValue, PersistedScope scope) { }
+
+        // Only here so `UsePersisted(""k"", scope: ...)` is a legal 2-arg near-miss.
+        public void UsePersisted(string key, PersistedScope scope) { }
+    }
+
+    // Same method name + 2-arg shape, but NOT RenderContext — must never fire.
+    public class NotRenderContext
+    {
+        public void UsePersisted<T>(string key, T initialValue) { }
+    }
+}
+";
+
+    // ── Positive ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Fires_For_TwoArg_Call()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        {|REACTOR_PERSIST_001:ctx.UsePersisted(""filter"", """")|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<UsePersistedScopeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_TwoArg_Call_With_Explicit_TypeArgument()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        {|REACTOR_PERSIST_001:ctx.UsePersisted<string>(""filter"", """")|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<UsePersistedScopeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_When_Key_And_InitialValue_Are_Named()
+    {
+        // Named arguments are fine — only an explicit `scope:` suppresses the rule.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        {|REACTOR_PERSIST_001:ctx.UsePersisted(key: ""filter"", initialValue: """")|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<UsePersistedScopeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_ThreeArg_Explicit_Scope()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        ctx.UsePersisted(""filter"", """", PersistedScope.Window);
+    }
+}";
+
+        await new CSharpAnalyzerTest<UsePersistedScopeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Near-miss: syntactic fast path almost trips ─────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_TwoArg_On_NonRenderContext()
+    {
+        // A same-named 2-arg method on a different type — the semantic check rejects it.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var other = new NotRenderContext();
+        other.UsePersisted(""filter"", """");
+    }
+}";
+
+        await new CSharpAnalyzerTest<UsePersistedScopeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_TwoArg_With_Named_Scope()
+    {
+        // Two arguments, but the author already stated the scope by name — leave it alone.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        ctx.UsePersisted(""filter"", scope: PersistedScope.Window);
+    }
+}";
+
+        await new CSharpAnalyzerTest<UsePersistedScopeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code-fix round trips ────────────────────────────────────────────
+
+    [Fact]
+    public async Task CodeFix_Adds_Window_Scope()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        {|REACTOR_PERSIST_001:ctx.UsePersisted(""filter"", """")|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        ctx.UsePersisted(""filter"", """", PersistedScope.Window);
+    }
+}";
+
+        await new CSharpCodeFixTest<UsePersistedScopeAnalyzer, UsePersistedScopeCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = UsePersistedScopeAnalyzer.DiagnosticId + ":Window",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Adds_Application_Scope()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        {|REACTOR_PERSIST_001:ctx.UsePersisted(""filter"", """")|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        ctx.UsePersisted(""filter"", """", PersistedScope.Application);
+    }
+}";
+
+        await new CSharpCodeFixTest<UsePersistedScopeAnalyzer, UsePersistedScopeCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = UsePersistedScopeAnalyzer.DiagnosticId + ":Application",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs
@@ -118,6 +118,27 @@ class C
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Fires_When_Named_Arguments_Are_Reordered()
+    {
+        // Reordered named args are legal; the rule must still fire (and the message
+        // resolves the key: argument rather than blindly using the first argument).
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        {|REACTOR_PERSIST_001:ctx.UsePersisted(initialValue: ""v"", key: ""filter"")|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<UsePersistedScopeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
     // ── Negative ────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs
@@ -41,7 +41,16 @@ namespace Microsoft.UI.Reactor.Core
         public void UsePersisted(string key, PersistedScope scope) { }
     }
 
-    // Same method name + 2-arg shape, but NOT RenderContext — must never fire.
+    // Component re-exposes the hook as a protected wrapper (Component.cs:260) that
+    // also defaults to Application scope; an unqualified `UsePersisted(...)` inside a
+    // component's Render binds here, not to RenderContext.
+    public class Component
+    {
+        protected void UsePersisted<T>(string key, T initialValue) { }
+        protected void UsePersisted<T>(string key, T initialValue, PersistedScope scope) { }
+    }
+
+    // Same method name + 2-arg shape, but neither RenderContext nor Component — must never fire.
     public class NotRenderContext
     {
         public void UsePersisted<T>(string key, T initialValue) { }
@@ -233,6 +242,111 @@ class C
             TestCode = before,
             FixedCode = after,
             CodeActionEquivalenceKey = UsePersistedScopeAnalyzer.DiagnosticId + ":Application",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Component wrapper (the idiomatic unqualified call shape) ─────────
+
+    [Fact]
+    public async Task Fires_For_Unqualified_Component_Call()
+    {
+        // Real components call the protected Component.UsePersisted wrapper
+        // unqualified inside Render (e.g. samples/apps/regedit/App.cs).
+        var source = Stubs + @"
+class MyComponent : Component
+{
+    void Build()
+    {
+        {|REACTOR_PERSIST_001:UsePersisted(""filter"", """")|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<UsePersistedScopeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_When_Value_Type_Is_PersistedScope()
+    {
+        // T inferred as PersistedScope is still the 2-arg default-scope overload —
+        // it must fire (guards the OriginalDefinition type-parameter check).
+        var source = Stubs + @"
+class MyComponent : Component
+{
+    void Build()
+    {
+        {|REACTOR_PERSIST_001:UsePersisted(""preferred-scope"", PersistedScope.Window)|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<UsePersistedScopeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Adds_Scope_For_Unqualified_Component_Call()
+    {
+        var before = Stubs + @"
+class MyComponent : Component
+{
+    void Build()
+    {
+        {|REACTOR_PERSIST_001:UsePersisted(""filter"", """")|};
+    }
+}";
+
+        var after = Stubs + @"
+class MyComponent : Component
+{
+    void Build()
+    {
+        UsePersisted(""filter"", """", PersistedScope.Window);
+    }
+}";
+
+        await new CSharpCodeFixTest<UsePersistedScopeAnalyzer, UsePersistedScopeCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = UsePersistedScopeAnalyzer.DiagnosticId + ":Window",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Passes_Scope_By_Name_When_Arguments_Are_Named()
+    {
+        // Appending a positional argument after named arguments could be illegal
+        // C# (positional-after-named), so the fix names the scope argument when the
+        // call already uses named arguments.
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        {|REACTOR_PERSIST_001:ctx.UsePersisted(key: ""filter"", initialValue: """")|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var ctx = new RenderContext();
+        ctx.UsePersisted(key: ""filter"", initialValue: """", scope: PersistedScope.Window);
+    }
+}";
+
+        await new CSharpCodeFixTest<UsePersistedScopeAnalyzer, UsePersistedScopeCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = UsePersistedScopeAnalyzer.DiagnosticId + ":Window",
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 }


### PR DESCRIPTION
## REACTOR_PERSIST_001 — UsePersisted default-scope warning

Spec 060 (Analyzer Suite Expansion) **Wave A**, packet ⭐ `REACTOR_PERSIST_001`. Stacked on the foundation branch `azchohfi-spec-060-analyzer-suite`.

### What & why
The two-argument `RenderContext.UsePersisted<T>(string, T)` overload is `=> UsePersisted(key, initialValue, PersistedScope.Application)` (`RenderContext.cs:824`). It reads like "just remember this," but `Application` scope is **process-wide**, so persisted state bleeds across windows/tabs that share the key — invisible until two windows are open at once. The rule asks the author to state the scope explicitly.

### Detect
Syntactic gate → single semantic check (per spec §3):
1. Invoked simple name is `UsePersisted` (handles qualified, unqualified, and explicit-type-argument forms).
2. Exactly two arguments.
3. No explicit `scope:` named argument.
4. Symbol binds to `RenderContext.UsePersisted<T>(string, T)` (containing type `RenderContext` in a `Microsoft.UI.Reactor` namespace; two parameters; no `PersistedScope` parameter).

FP risk: none (arity + symbol check).

### Fix
Two code actions append a third argument:
- `, PersistedScope.Window` — host lifetime (recommended)
- `, PersistedScope.Application` — make the current process-wide behavior explicit

### Tests
`tests/Reactor.Tests/AnalyzerTests/UsePersistedScopeAnalyzerTests.cs`, inline stubs (no framework reference). Positive (2-arg, generic type-arg, named key/initialValue), negative (3-arg explicit scope), near-miss (same-named 2-arg method not on `RenderContext`; 2-arg call that already passes `scope:` by name), and fix round-trips for both actions. 8/8 pass; full analyzer suite 223/223.

### Samples sweep
Every `UsePersisted(...)` call site under `samples/` already uses the 3-arg explicit-scope form — the rule correctly stays silent (verified via the negative test covering that exact shape). No 2-arg sites to migrate, as expected for a hygiene rule.

### Release row
Appended to `AnalyzerReleases.Unshipped.md` (descriptor + row land together per RS2000/RS2002):
```
REACTOR_PERSIST_001 | Reactor.Persistence | Warning | UsePersistedScopeAnalyzer - 2-arg UsePersisted defaults to Application scope; specify scope
```

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>