### PR TITLE
feat(analyzer): REACTOR_DESC_001 — static ControlRegistry.Register lambda

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,6 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_DESC_001` | Warning | Non-static `ControlRegistry.Register*` handler-factory lambda (trim/AOT hygiene) | `StaticRegisterLambdaAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/docs/_pipeline/templates/extending-reactor-controls.md.dt
+++ b/docs/_pipeline/templates/extending-reactor-controls.md.dt
@@ -478,8 +478,8 @@ Writing
 without the `static` modifier compiles, but allocates a closure object
 per `Register` call *and* defeats the trimmer's ability to drop the
 handler/control chain when the factory holder is unreachable. The
-compiler will accept either shape; reviewers and analyzers are your
-only guard. (Issue #486 tracks adding the analyzer.) Always write
+compiler will accept either shape; the `REACTOR_DESC_001` analyzer
+(`StaticRegisterLambdaAnalyzer`) is your guard. Always write
 `static () => new MyHandler()`.
 
 **Bypassing the factory with `new MyElement(...)`.** The whole reason

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_DESC_001 | Reactor.Descriptor | Warning | StaticRegisterLambdaAnalyzer - ControlRegistry.Register* lambda should be static (trim hygiene)

--- a/src/Reactor.Analyzers/StaticRegisterLambdaAnalyzer.cs
+++ b/src/Reactor.Analyzers/StaticRegisterLambdaAnalyzer.cs
@@ -51,7 +51,7 @@ public sealed class StaticRegisterLambdaAnalyzer : DiagnosticAnalyzer
         "ControlRegistry registration lambda should be static";
 
     private static readonly LocalizableString MessageFormat =
-        "The handler factory passed to 'ControlRegistry.{0}' should be a 'static' lambda for trim/AOT hygiene";
+        "The handler factory passed to 'ControlRegistry.{0}' should be a 'static' lambda for trim/AOT hygiene (refactor out any captured state so it can be marked static)";
 
     private static readonly LocalizableString Description =
         "ControlRegistry registration factories should be static lambdas. A non-capturing " +

--- a/src/Reactor.Analyzers/StaticRegisterLambdaAnalyzer.cs
+++ b/src/Reactor.Analyzers/StaticRegisterLambdaAnalyzer.cs
@@ -1,0 +1,134 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_DESC_001</c> — flags a handler-factory lambda passed to one of the four
+/// <c>ControlRegistry</c> registration entry points
+/// (<c>Register</c>, <c>RegisterForDerivedTypes</c>, <c>RegisterDecorator</c>,
+/// <c>RegisterDecoratorForDerivedTypes</c>) that is <b>not</b> declared <c>static</c>.
+/// </summary>
+/// <remarks>
+/// This is a <b>perf / trim-hygiene rule for control authors</b>, not a correctness bug.
+/// A non-capturing <c>() =&gt; new MyHandler()</c> is already interned into a static
+/// field by Roslyn, so the primary cost is trimmer hygiene: a <c>static</c> factory keeps
+/// the trimmer able to drop the holder→handler→control chain from a NativeAOT publish.
+/// A capturing lambda additionally allocates a closure on every registration run — but such
+/// a lambda cannot be marked <c>static</c>, so for those the analyzer only nudges (the code
+/// fix declines to auto-insert <c>static</c>). The authoring guide marks the keyword
+/// mandatory and names this analyzer as the sole guard (issue #486).
+///
+/// Detection is a cheap syntactic gate on the invoked member name, then a single semantic
+/// check that the call resolves to <see cref="ControlRegistryTypeName"/> so an unrelated
+/// method that merely shares one of the four names never trips the rule.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class StaticRegisterLambdaAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_DESC_001";
+
+    private const string ControlRegistryTypeName = "ControlRegistry";
+    private const string ControlRegistryNamespace = "Microsoft.UI.Reactor.Core.V1Protocol";
+
+    /// <summary>
+    /// The four <c>ControlRegistry</c> registration entry points, each taking a single
+    /// <c>Func&lt;…handler…&gt;</c> factory argument
+    /// (<c>ControlRegistry.cs:99,180,214,237</c>).
+    /// </summary>
+    private static readonly ImmutableHashSet<string> RegisterMethodNames =
+        ImmutableHashSet.Create(
+            System.StringComparer.Ordinal,
+            "Register",
+            "RegisterForDerivedTypes",
+            "RegisterDecorator",
+            "RegisterDecoratorForDerivedTypes");
+
+    private static readonly LocalizableString Title =
+        "ControlRegistry registration lambda should be static";
+
+    private static readonly LocalizableString MessageFormat =
+        "The handler factory passed to 'ControlRegistry.{0}' should be a 'static' lambda for trim/AOT hygiene";
+
+    private static readonly LocalizableString Description =
+        "ControlRegistry registration factories should be static lambdas. A non-capturing " +
+        "'() => new MyHandler()' is already cached in a static field by Roslyn, so marking it " +
+        "'static' costs nothing at runtime — its value is trim hygiene: the static form keeps the " +
+        "trimmer able to drop the holder→handler→control chain from a NativeAOT publish. A capturing " +
+        "lambda additionally allocates a closure per registration and cannot be made static; refactor " +
+        "the capture out. This is a performance/trimming recommendation for control authors, not a " +
+        "correctness bug.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Descriptor",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Cheap syntactic gate 1: the invoked simple name is one of the four entry points.
+        var invokedName = GetInvokedName(invocation);
+        if (invokedName is null || !RegisterMethodNames.Contains(invokedName))
+            return;
+
+        // Cheap syntactic gate 2: a single lambda argument that lacks the 'static' modifier.
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count != 1)
+            return;
+        if (args[0].Expression is not AnonymousFunctionExpressionSyntax lambda)
+            return;
+        if (lambda.Modifiers.Any(SyntaxKind.StaticKeyword))
+            return;
+
+        // Semantic confirmation: the call really binds to ControlRegistry (not an unrelated
+        // method that merely shares one of the four names). Purely-syntactic detection would
+        // false-positive here, so this one symbol lookup is the FP guard.
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol
+                is not IMethodSymbol method)
+            return;
+        if (!IsControlRegistryMethod(method))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, lambda.GetLocation(), invokedName));
+    }
+
+    private static bool IsControlRegistryMethod(IMethodSymbol method)
+    {
+        var containingType = method.ContainingType;
+        return containingType is not null
+            && containingType.Name == ControlRegistryTypeName
+            && containingType.ContainingNamespace?.ToDisplayString() == ControlRegistryNamespace;
+    }
+
+    /// <summary>
+    /// The simple (unqualified) name of the invoked method — handles both the qualified
+    /// <c>ControlRegistry.Register&lt;E,C&gt;(…)</c> member-access form (where the name is a
+    /// <see cref="GenericNameSyntax"/>) and an unqualified static-imported call.
+    /// </summary>
+    private static string? GetInvokedName(InvocationExpressionSyntax invocation) => invocation.Expression switch
+    {
+        MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+        MemberBindingExpressionSyntax mb => mb.Name.Identifier.ValueText,
+        SimpleNameSyntax s => s.Identifier.ValueText,
+        _ => null,
+    };
+}

--- a/src/Reactor.Analyzers/StaticRegisterLambdaCodeFix.cs
+++ b/src/Reactor.Analyzers/StaticRegisterLambdaCodeFix.cs
@@ -1,0 +1,92 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for <c>REACTOR_DESC_001</c>: inserts the <c>static</c> modifier on a
+/// <c>ControlRegistry</c> registration lambda — but <b>only</b> when the lambda captures
+/// nothing. A capturing lambda cannot compile with <c>static</c> (CS8820/CS8821), so for
+/// those the analyzer's diagnostic stands as a nudge with no auto-fix, leaving the author to
+/// refactor the capture out by hand.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(StaticRegisterLambdaCodeFix))]
+[Shared]
+public sealed class StaticRegisterLambdaCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(StaticRegisterLambdaAnalyzer.DiagnosticId);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        SemanticModel? semanticModel = null;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            // The diagnostic is reported at the lambda's span, but the enclosing ArgumentSyntax
+            // shares that exact span, so FindNode returns the argument, not the lambda. Match the
+            // lambda by span among the descendants to land on the right node reliably.
+            var span = diagnostic.Location.SourceSpan;
+            var node = root.FindNode(span);
+            var lambda = node.DescendantNodesAndSelf()
+                .OfType<AnonymousFunctionExpressionSyntax>()
+                .FirstOrDefault(l => l.Span == span);
+            if (lambda is null) continue;
+            if (lambda.Modifiers.Any(SyntaxKind.StaticKeyword)) continue;
+
+            semanticModel ??= await context.Document
+                .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            if (semanticModel is null) return;
+
+            // A static lambda may not capture any enclosing local, parameter, or `this`.
+            // If it does, offer no fix — the diagnostic remains as an author nudge.
+            if (!CapturesNothing(semanticModel, lambda))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Make lambda static",
+                    ct => Task.FromResult(
+                        context.Document.WithSyntaxRoot(
+                            root.ReplaceNode(lambda, WithStaticModifier(lambda)))),
+                    equivalenceKey: StaticRegisterLambdaAnalyzer.DiagnosticId),
+                diagnostic);
+        }
+    }
+
+    private static bool CapturesNothing(
+        SemanticModel semanticModel, AnonymousFunctionExpressionSyntax lambda)
+    {
+        var dataFlow = semanticModel.AnalyzeDataFlow(lambda);
+        // Be conservative: only claim "no captures" when the analysis succeeded and the lambda
+        // captured no variables (CapturedInside reports what lambdas within the region — i.e.
+        // this lambda — close over, including the implicit `this` parameter).
+        return dataFlow is { Succeeded: true } && dataFlow.CapturedInside.IsEmpty;
+    }
+
+    private static AnonymousFunctionExpressionSyntax WithStaticModifier(AnonymousFunctionExpressionSyntax lambda)
+    {
+        var staticKeyword = SyntaxFactory.Token(SyntaxKind.StaticKeyword)
+            .WithTrailingTrivia(SyntaxFactory.Space);
+
+        // Move the lambda's leading trivia onto the new `static` keyword so indentation and
+        // preceding newlines are preserved (e.g. a factory on its own line after the call's
+        // open paren stays put).
+        return lambda
+            .WithoutLeadingTrivia()
+            .WithModifiers(lambda.Modifiers.Insert(0, staticKeyword))
+            .WithLeadingTrivia(lambda.GetLeadingTrivia());
+    }
+}

--- a/src/Reactor.Analyzers/StaticRegisterLambdaCodeFix.cs
+++ b/src/Reactor.Analyzers/StaticRegisterLambdaCodeFix.cs
@@ -70,10 +70,38 @@ public sealed class StaticRegisterLambdaCodeFix : CodeFixProvider
         SemanticModel semanticModel, AnonymousFunctionExpressionSyntax lambda)
     {
         var dataFlow = semanticModel.AnalyzeDataFlow(lambda);
-        // Be conservative: only claim "no captures" when the analysis succeeded and the lambda
-        // captured no variables (CapturedInside reports what lambdas within the region — i.e.
-        // this lambda — close over, including the implicit `this` parameter).
-        return dataFlow is { Succeeded: true } && dataFlow.CapturedInside.IsEmpty;
+        if (dataFlow is not { Succeeded: true })
+            return false;
+
+        // CapturedInside reports every variable closed over anywhere inside the region — which
+        // includes locals declared *inside* this factory that its own nested lambdas capture.
+        // Those don't stop THIS lambda from being static; only captures of enclosing state
+        // (the implicit `this`, or a local/parameter declared in an outer scope) do.
+        foreach (var captured in dataFlow.CapturedInside)
+        {
+            if (IsEnclosingCapture(captured, lambda))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsEnclosingCapture(ISymbol symbol, AnonymousFunctionExpressionSyntax lambda)
+    {
+        // The implicit `this` parameter is always an enclosing capture — a static lambda may not
+        // reference `this`/`base`.
+        if (symbol is IParameterSymbol { IsThis: true })
+            return true;
+
+        // A symbol declared inside the lambda (its own parameter/local, or a local of a nested
+        // lambda) is not an enclosing capture. Anything declared in an outer scope is.
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            if (lambda.Span.Contains(reference.Span))
+                return false;
+        }
+
+        return true;
     }
 
     private static AnonymousFunctionExpressionSyntax WithStaticModifier(AnonymousFunctionExpressionSyntax lambda)

--- a/tests/Reactor.Tests/AnalyzerTests/StaticRegisterLambdaAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/StaticRegisterLambdaAnalyzerTests.cs
@@ -1,0 +1,240 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="StaticRegisterLambdaAnalyzer"/> (<c>REACTOR_DESC_001</c>) and its
+/// <see cref="StaticRegisterLambdaCodeFix"/>. Stubs a minimal <c>ControlRegistry</c> in the
+/// real namespace so the analyzer's semantic confirmation fires without pulling the framework
+/// in; a same-named <c>Register</c> on an unrelated type proves the near-miss guard.
+/// </summary>
+public class StaticRegisterLambdaAnalyzerTests
+{
+    // Minimal shape: ControlRegistry lives in Microsoft.UI.Reactor.Core.V1Protocol (the
+    // semantic gate keys off type name + namespace), each entry point takes a single
+    // Func<object> factory. NotTheRegistry mirrors the 'Register' name on a different type so
+    // the near-miss (name matches, symbol does not) can be exercised. The `using` for the
+    // registry namespace sits at the top so appended user code can name ControlRegistry
+    // unqualified (a using must precede all type declarations).
+    private const string Stubs = @"
+using System;
+using Microsoft.UI.Reactor.Core.V1Protocol;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol
+{
+    public static class ControlRegistry
+    {
+        public static void Register<TElement, TControl>(Func<object> handlerFactory) {}
+        public static void RegisterForDerivedTypes<TBase, TControl>(Func<object> handlerFactory) {}
+        public static void RegisterDecorator<TElement>(Func<object> handlerFactory) {}
+        public static void RegisterDecoratorForDerivedTypes<TBase>(Func<object> handlerFactory) {}
+    }
+}
+
+public class MyElement {}
+public class MyControl {}
+public class MyHandler
+{
+    public MyHandler() {}
+    public MyHandler(int captured) {}
+}
+
+public static class NotTheRegistry
+{
+    public static void Register<TElement, TControl>(Func<object> handlerFactory) {}
+}
+";
+
+    // ── Positive ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Fires_For_NonStatic_Register_Lambda()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>({|REACTOR_DESC_001:() => new MyHandler()|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticRegisterLambdaAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_RegisterForDerivedTypes()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.RegisterForDerivedTypes<MyElement, MyControl>({|REACTOR_DESC_001:() => new MyHandler()|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticRegisterLambdaAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_RegisterDecorator()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.RegisterDecorator<MyElement>({|REACTOR_DESC_001:() => new MyHandler()|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticRegisterLambdaAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_RegisterDecoratorForDerivedTypes()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.RegisterDecoratorForDerivedTypes<MyElement>({|REACTOR_DESC_001:() => new MyHandler()|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticRegisterLambdaAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_When_Already_Static()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>(static () => new MyHandler());
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticRegisterLambdaAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Method_Group_Argument()
+    {
+        // A method group has no lambda modifiers to make static — nothing to flag.
+        var source = Stubs + @"
+class C
+{
+    static object CreateHandler() => new MyHandler();
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>(CreateHandler);
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticRegisterLambdaAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Near-miss (syntactic name match, different symbol) ───────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Unrelated_Register_Method()
+    {
+        // Same member name ('Register') and shape, but the symbol is NOT ControlRegistry —
+        // the semantic gate must keep this quiet.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        NotTheRegistry.Register<MyElement, MyControl>(() => new MyHandler());
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticRegisterLambdaAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code fix ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CodeFix_Inserts_Static()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>({|REACTOR_DESC_001:() => new MyHandler()|});
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>(static () => new MyHandler());
+    }
+}";
+
+        await new CSharpCodeFixTest<StaticRegisterLambdaAnalyzer, StaticRegisterLambdaCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Not_Offered_For_Capturing_Lambda()
+    {
+        // A capturing lambda cannot compile with 'static', so the analyzer still reports the
+        // nudge but no code fix is offered: TestCode == FixedCode (diagnostic persists, no
+        // rewrite). This is the "emit the diagnostic but NO auto-fix" contract.
+        var code = Stubs + @"
+class C
+{
+    void M()
+    {
+        int captured = 5;
+        ControlRegistry.Register<MyElement, MyControl>({|REACTOR_DESC_001:() => new MyHandler(captured)|});
+    }
+}";
+
+        await new CSharpCodeFixTest<StaticRegisterLambdaAnalyzer, StaticRegisterLambdaCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/StaticRegisterLambdaAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/StaticRegisterLambdaAnalyzerTests.cs
@@ -41,6 +41,8 @@ public class MyHandler
 {
     public MyHandler() {}
     public MyHandler(int captured) {}
+    public Action? OnReady;
+    public void Ping() {}
 }
 
 public static class NotTheRegistry
@@ -235,6 +237,152 @@ class C
         {
             TestCode = code,
             FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Not_Offered_For_This_Capturing_Lambda()
+    {
+        // Capturing the implicit `this` (via an instance field) also blocks `static`. The
+        // analyzer nudges but the fix is withheld — this exercises the `this`-capture arm of
+        // the code fix's data-flow gate, distinct from the enclosing-local case above.
+        var code = Stubs + @"
+class C
+{
+    int _seed = 7;
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>({|REACTOR_DESC_001:() => new MyHandler(_seed)|});
+    }
+}";
+
+        await new CSharpCodeFixTest<StaticRegisterLambdaAnalyzer, StaticRegisterLambdaCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Offered_When_Only_A_Nested_Lambda_Captures_An_Own_Local()
+    {
+        // The outer factory declares its own local `h` and a nested lambda closes over it. The
+        // OUTER lambda still captures nothing from an enclosing scope, so it can be `static` —
+        // the fix must be offered even though data-flow's CapturedInside lists `h`.
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>({|REACTOR_DESC_001:() => { var h = new MyHandler(); h.OnReady = () => h.Ping(); return h; }|});
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>(static () => { var h = new MyHandler(); h.OnReady = () => h.Ping(); return h; });
+    }
+}";
+
+        await new CSharpCodeFixTest<StaticRegisterLambdaAnalyzer, StaticRegisterLambdaCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Rewrites_Block_Bodied_Lambda()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>({|REACTOR_DESC_001:() => { return new MyHandler(); }|});
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>(static () => { return new MyHandler(); });
+    }
+}";
+
+        await new CSharpCodeFixTest<StaticRegisterLambdaAnalyzer, StaticRegisterLambdaCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Rewrites_Anonymous_Method()
+    {
+        // `delegate { ... }` is also an AnonymousFunctionExpressionSyntax and can be `static`.
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>({|REACTOR_DESC_001:delegate { return new MyHandler(); }|});
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        ControlRegistry.Register<MyElement, MyControl>(static delegate { return new MyHandler(); });
+    }
+}";
+
+        await new CSharpCodeFixTest<StaticRegisterLambdaAnalyzer, StaticRegisterLambdaCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Unqualified_Static_Imported_Call()
+    {
+        // `using static ...ControlRegistry;` makes the call an unqualified GenericNameSyntax;
+        // GetInvokedName's SimpleNameSyntax arm must still resolve it.
+        var source = @"
+using System;
+using static Microsoft.UI.Reactor.Core.V1Protocol.ControlRegistry;
+
+namespace Microsoft.UI.Reactor.Core.V1Protocol
+{
+    public static class ControlRegistry
+    {
+        public static void Register<TElement, TControl>(Func<object> handlerFactory) {}
+    }
+}
+
+public class MyElement {}
+public class MyControl {}
+public class MyHandler { public MyHandler() {} }
+
+class C
+{
+    void M()
+    {
+        Register<MyElement, MyControl>({|REACTOR_DESC_001:() => new MyHandler()|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticRegisterLambdaAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 }


### PR DESCRIPTION
Wave A packet of spec 060 (Analyzer Suite Expansion): **REACTOR_DESC_001**.

## What
Adds StaticRegisterLambdaAnalyzer + StaticRegisterLambdaCodeFix (category `Reactor.Descriptor`, severity **Warning**, ships a code fix).

It flags a handler-factory lambda passed to any of the four `ControlRegistry` registration entry points that lacks the `static` modifier:
- `Register` (`ControlRegistry.cs:99`)
- `RegisterForDerivedTypes` (`:214`)
- `RegisterDecorator` (`:180`)
- `RegisterDecoratorForDerivedTypes` (`:237`)

Framed as a **perf / trim-hygiene** recommendation for control authors, **not** a correctness bug: a non-capturing `() => new MyHandler()` is already interned in a static field by Roslyn, so the real value is keeping the trimmer able to drop the holder->handler->control chain from a NativeAOT publish. (Issue #486.)

## How
- **Detect** (fast syntactic gate on the invoked member name, then one semantic check that the call binds to `ControlRegistry` in `Microsoft.UI.Reactor.Core.V1Protocol` -- so an unrelated same-named `Register` never trips the rule).
- **Fix** inserts `static` **only when the lambda captures nothing** (`AnalyzeDataFlow.CapturedInside` empty, which includes the implicit `this`). A capturing lambda can't compile with `static`, so it keeps the diagnostic as a nudge with no auto-fix.
- Ships the canonical `REACTOR_DESC_001` row in `AnalyzerReleases.Unshipped.md` (RS2000/RS2002 require descriptor + row together).

## Tests
9 cases in `tests/Reactor.Tests/AnalyzerTests/StaticRegisterLambdaAnalyzerTests.cs` with inline stubs (no framework reference): positive (all four entry points), negative (already `static`, method group), near-miss (unrelated `Register` symbol; capturing lambda where the fix is **not** offered), and the fix round-trip.

## Verification
- `dotnet build src/Reactor.Analyzers` -> green, 0 warnings (RS2000/RS2002 satisfied).
- `dotnet test tests/Reactor.Tests --filter StaticRegisterLambda` -> 9/9; full `AnalyzerTests` -> 224/224.
- Samples/src sweep: every `ControlRegistry.Register*` call site in `src/` and `samples/` already uses `static` (zero false positives). The only non-static lambdas live in intentional registry-behavior test probes, and `Reactor.Analyzers` is deliberately **not** wired as an active analyzer on repo projects, so no build noise is introduced.

Stacked on `azchohfi-spec-060-analyzer-suite` (foundation).