### PR TITLE
feat(analyzer): Grid string-track CS0618 code fix (spec 060 §4.5)

### DIFF
--- a/src/Reactor.Analyzers/GridStringTrackCodeFix.cs
+++ b/src/Reactor.Analyzers/GridStringTrackCodeFix.cs
@@ -40,12 +40,14 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// and the <c>CS0618</c> warning is left to stand.
 /// </para>
 /// <para>
-/// The string→<c>GridSize</c> mapping mirrors <c>GridSize.Parse</c> (which agrees
-/// with the runtime layout parse on every valid track): <c>"Auto"</c>
-/// (case-insensitive) → <c>GridSize.Auto</c>; <c>"*"</c> → <c>GridSize.Star()</c>;
-/// <c>"&lt;n&gt;*"</c> → <c>GridSize.Star(n)</c>; <c>"&lt;n&gt;"</c> →
-/// <c>GridSize.Px(n)</c>. Any other literal cannot be mapped safely, so the whole
-/// fix is withheld.
+/// The string→<c>GridSize</c> mapping mirrors the obsolete overload's runtime
+/// parser <c>PanelAttachedHooks.ParseColumnDef</c>/<c>ParseRowDef</c> EXACTLY (raw
+/// string, exact matches): <c>"*"</c> → <c>GridSize.Star()</c>; <c>"Auto"</c>/<c>"auto"</c>
+/// (exact) → <c>GridSize.Auto</c>; a whole-string numeric (incl. surrounding
+/// whitespace, which <c>NumberStyles.Float</c> allows) → <c>GridSize.Px(n)</c>; a raw
+/// <c>*</c>-suffixed numeric → <c>GridSize.Star(n)</c>. The legacy parser's catch-all
+/// is <c>Star(1)</c>; the fix withholds there (and on non-finite/out-of-range) so
+/// those keep the <c>CS0618</c> warning rather than risk a silent layout change.
 /// </para>
 /// </remarks>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(GridStringTrackCodeFix))]
@@ -282,55 +284,63 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
     }
 
     /// <summary>
-    /// Maps a track string to a <c>GridSize</c> factory expression, mirroring
-    /// <c>GridSize.Parse</c>. Returns <see langword="false"/> for any string that
-    /// does not map cleanly (so the whole fix is withheld rather than change
-    /// runtime behaviour). Numeric weights/pixels are re-emitted from the parsed
+    /// Maps a track string to a <c>GridSize</c> factory expression, mirroring the
+    /// obsolete overload's runtime parser <c>ParseColumnDef</c>/<c>ParseRowDef</c>
+    /// exactly (raw string, exact <c>"*"</c>/<c>"Auto"</c>/<c>"auto"</c>). Returns
+    /// <see langword="false"/> for anything that would hit the legacy <c>Star(1)</c>
+    /// catch-all or is non-finite/out-of-range, so the whole fix is withheld rather than
+    /// change runtime behaviour. Numeric weights/pixels are re-emitted from the parsed
     /// value in round-trip invariant form, so lenient-but-not-C#-literal inputs
     /// (e.g. <c>"5."</c>) still yield a compiling literal (<c>5</c>).
     /// </summary>
     private static bool TryConvertTrack(string raw, string gridSizeName, out ExpressionSyntax? gridSize)
     {
         gridSize = null;
-        var trimmed = raw.Trim();
-        if (trimmed.Length == 0) return false;
 
-        // "Auto" / "auto" -> GridSize.Auto  (property — no parens)
-        if (string.Equals(trimmed, "Auto", System.StringComparison.OrdinalIgnoreCase))
-        {
-            gridSize = GridSizeAccess(gridSizeName, "Auto");
-            return true;
-        }
+        // Mirror the obsolete overload's ACTUAL runtime parser
+        // (PanelAttachedHooks.ParseColumnDef/ParseRowDef) EXACTLY, so the rewrite can
+        // never change layout: switch on the RAW string, match "*"/"Auto"/"auto"
+        // exactly (no Trim, no extra casing), then the whole-string numeric parse, then
+        // the raw '*' suffix. The legacy catch-all is Star(1); we WITHHOLD there (and on
+        // non-finite / out-of-range) so those keep the CS0618 warning rather than risk a
+        // silent change. Note NumberStyles.Float already allows surrounding whitespace,
+        // so a faithful " 200 " still converts to Px(200) — matching the legacy parser.
 
         // "*" -> GridSize.Star()
-        if (trimmed == "*")
+        if (raw == "*")
         {
             gridSize = Call(gridSizeName, "Star");
             return true;
         }
 
-        // "<n>*" -> GridSize.Star(n)
-        if (trimmed[trimmed.Length - 1] == '*')
+        // "Auto" / "auto" (exact) -> GridSize.Auto  (property — no parens)
+        if (raw == "Auto" || raw == "auto")
         {
-            var numericText = trimmed.Substring(0, trimmed.Length - 1).Trim();
-            if (numericText.Length == 0) return false;
-            if (double.TryParse(numericText, NumberStyles.Float, CultureInfo.InvariantCulture, out var stars)
-                && stars > 0 && IsFinite(stars))
-            {
-                gridSize = Call(gridSizeName, "Star", FormatNumber(stars));
-                return true;
-            }
-            return false;
+            gridSize = GridSizeAccess(gridSizeName, "Auto");
+            return true;
         }
 
         // "<n>" -> GridSize.Px(n)
-        if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var pixels)
+        if (double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var pixels)
             && pixels >= 0 && IsFinite(pixels))
         {
             gridSize = Call(gridSizeName, "Px", FormatNumber(pixels));
             return true;
         }
 
+        // "<n>*" -> GridSize.Star(n). The legacy parser tests raw.EndsWith('*'), so a
+        // trailing space defeats it (and it falls back to Star(1)); match that exactly by
+        // testing the RAW final char rather than a trimmed string.
+        if (raw.Length > 0 && raw[raw.Length - 1] == '*'
+            && double.TryParse(raw.Substring(0, raw.Length - 1), NumberStyles.Float, CultureInfo.InvariantCulture, out var stars)
+            && stars > 0 && IsFinite(stars))
+        {
+            gridSize = Call(gridSizeName, "Star", FormatNumber(stars));
+            return true;
+        }
+
+        // Legacy fallback is Star(1); withhold so the CS0618 warning stands (safe — no
+        // semantic change, the author converts by hand).
         return false;
     }
 

--- a/src/Reactor.Analyzers/GridStringTrackCodeFix.cs
+++ b/src/Reactor.Analyzers/GridStringTrackCodeFix.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.UI.Reactor.Analyzers;
 
@@ -83,27 +84,35 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
             // overload — CS0618 at this span could be any other obsolete symbol.
             if (!IsObsoleteGridStringOverload(model, invocation, context.CancellationToken)) continue;
 
-            var args = invocation.ArgumentList.Arguments;
-            if (args.Count < 2) continue;
+            // Bind the columns/rows arguments by parameter (robust to named /
+            // reordered args), never by syntactic position — a named call such as
+            // `Grid(children: [], columns: […], rows: […])` would otherwise let a
+            // non-track argument sit in slot 0/1 and get rewritten.
+            if (!TryGetTrackArguments(model, invocation, context.CancellationToken, out var columnsExpr, out var rowsExpr))
+                continue;
 
-            var columnsExpr = args[0].Expression;
-            var rowsExpr = args[1].Expression;
+            // Render `GridSize` with exactly enough qualification to compile at this
+            // call site: bare `GridSize` when the namespace is imported, otherwise a
+            // qualified name. Mirrors CommandDebounceCodeFix's ToMinimalDisplayString use.
+            var gridSizeName = ResolveGridSizeName(model, invocation.SpanStart);
 
             // Both track arrays must be inline literal arrays whose every element
             // parses to a GridSize. If either can't be rewritten mechanically we
             // offer nothing and let the warning stand (spec 060 §4.5).
-            if (!TryRewriteTrackArray(columnsExpr, out var newColumns)) continue;
-            if (!TryRewriteTrackArray(rowsExpr, out var newRows)) continue;
+            if (!TryRewriteTrackArray(columnsExpr!, gridSizeName, out var newColumns)) continue;
+            if (!TryRewriteTrackArray(rowsExpr!, gridSizeName, out var newRows)) continue;
 
+            var capturedColumns = columnsExpr!;
+            var capturedRows = rowsExpr!;
             context.RegisterCodeFix(
                 CodeAction.Create(
                     "Use typed GridSize tracks",
                     ct =>
                     {
                         var newInvocation = invocation.ReplaceNodes(
-                            new SyntaxNode[] { columnsExpr, rowsExpr },
+                            new SyntaxNode[] { capturedColumns, capturedRows },
                             (original, _) =>
-                                ReferenceEquals(original, columnsExpr) ? newColumns! : newRows!);
+                                ReferenceEquals(original, capturedColumns) ? newColumns! : newRows!);
 
                         var newRoot = root.ReplaceNode(invocation, newInvocation);
                         return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
@@ -137,12 +146,52 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
         type is IArrayTypeSymbol { ElementType.SpecialType: SpecialType.System_String };
 
     /// <summary>
+    /// Resolves the syntax of the arguments bound to the <c>columns</c> and
+    /// <c>rows</c> parameters via the invocation operation, so named / reordered
+    /// arguments map correctly (never assume positional slot 0/1).
+    /// </summary>
+    private static bool TryGetTrackArguments(
+        SemanticModel model, InvocationExpressionSyntax invocation, CancellationToken ct,
+        out ExpressionSyntax? columnsExpr, out ExpressionSyntax? rowsExpr)
+    {
+        columnsExpr = null;
+        rowsExpr = null;
+
+        if (model.GetOperation(invocation, ct) is not IInvocationOperation operation) return false;
+
+        foreach (var argument in operation.Arguments)
+        {
+            if (argument.Syntax is not ArgumentSyntax argumentSyntax) continue;
+            switch (argument.Parameter?.Name)
+            {
+                case "columns": columnsExpr = argumentSyntax.Expression; break;
+                case "rows": rowsExpr = argumentSyntax.Expression; break;
+            }
+        }
+
+        return columnsExpr is not null && rowsExpr is not null;
+    }
+
+    /// <summary>
+    /// The shortest name for <c>Microsoft.UI.Reactor.GridSize</c> that is
+    /// unambiguous at <paramref name="position"/> — bare <c>GridSize</c> when the
+    /// namespace is in scope, otherwise a qualified form so the emitted fix always
+    /// compiles (even when the call site imported only
+    /// <c>using static Microsoft.UI.Reactor.Factories;</c>).
+    /// </summary>
+    private static string ResolveGridSizeName(SemanticModel model, int position)
+    {
+        var gridSize = model.Compilation.GetTypeByMetadataName("Microsoft.UI.Reactor.GridSize");
+        return gridSize is null ? "GridSize" : gridSize.ToMinimalDisplayString(model, position);
+    }
+
+    /// <summary>
     /// Rewrites an inline literal track array to the typed <c>GridSize[]</c> form
     /// in place (preserving separators/trivia). Returns <see langword="false"/>
     /// when the argument is not an inline literal array or any element cannot be
     /// mapped to a <c>GridSize</c>.
     /// </summary>
-    private static bool TryRewriteTrackArray(ExpressionSyntax expr, out ExpressionSyntax? rewritten)
+    private static bool TryRewriteTrackArray(ExpressionSyntax expr, string gridSizeName, out ExpressionSyntax? rewritten)
     {
         rewritten = null;
 
@@ -159,26 +208,26 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
                     literals.Add(literal);
                 }
 
-                if (!TryBuildReplacements(literals, out var map)) return false;
+                if (!TryBuildReplacements(literals, gridSizeName, out var map)) return false;
                 rewritten = collection.ReplaceNodes(literals, (original, _) => map[original]);
                 return true;
             }
 
             // Implicitly typed array: new[] { "*", "Auto" }
             case ImplicitArrayCreationExpressionSyntax implicitArray:
-                return TryRewriteInitializer(implicitArray, implicitArray.Initializer, out rewritten);
+                return TryRewriteInitializer(implicitArray, implicitArray.Initializer, gridSizeName, out rewritten);
 
             // Explicitly typed array: new string[] { "*", "Auto" }
             case ArrayCreationExpressionSyntax explicitArray:
             {
                 if (explicitArray.Initializer is null) return false;
                 if (!IsStringElementType(explicitArray.Type)) return false;
-                if (!TryRewriteInitializer(explicitArray, explicitArray.Initializer, out var withElements)) return false;
+                if (!TryRewriteInitializer(explicitArray, explicitArray.Initializer, gridSizeName, out var withElements)) return false;
 
                 // Swap the element type string -> GridSize so overload resolution
                 // picks the typed Grid overload.
                 var rewrittenArray = (ArrayCreationExpressionSyntax)withElements!;
-                var newElementType = SyntaxFactory.IdentifierName("GridSize")
+                var newElementType = SyntaxFactory.ParseTypeName(gridSizeName)
                     .WithTriviaFrom(explicitArray.Type.ElementType);
                 var newArrayType = rewrittenArray.Type.WithElementType(newElementType);
                 rewritten = rewrittenArray.WithType(newArrayType);
@@ -192,7 +241,7 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
     }
 
     private static bool TryRewriteInitializer(
-        ExpressionSyntax container, InitializerExpressionSyntax initializer, out ExpressionSyntax? rewritten)
+        ExpressionSyntax container, InitializerExpressionSyntax initializer, string gridSizeName, out ExpressionSyntax? rewritten)
     {
         rewritten = null;
 
@@ -203,18 +252,18 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
             literals.Add(literal);
         }
 
-        if (!TryBuildReplacements(literals, out var map)) return false;
+        if (!TryBuildReplacements(literals, gridSizeName, out var map)) return false;
         rewritten = container.ReplaceNodes(literals, (original, _) => map[original]);
         return true;
     }
 
     private static bool TryBuildReplacements(
-        List<LiteralExpressionSyntax> literals, out Dictionary<SyntaxNode, SyntaxNode> map)
+        List<LiteralExpressionSyntax> literals, string gridSizeName, out Dictionary<SyntaxNode, SyntaxNode> map)
     {
         map = new Dictionary<SyntaxNode, SyntaxNode>();
         foreach (var literal in literals)
         {
-            if (!TryConvertTrack(literal.Token.ValueText, out var gridSize)) return false;
+            if (!TryConvertTrack(literal.Token.ValueText, gridSizeName, out var gridSize)) return false;
             map[literal] = gridSize!.WithTriviaFrom(literal);
         }
         return true;
@@ -236,9 +285,11 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
     /// Maps a track string to a <c>GridSize</c> factory expression, mirroring
     /// <c>GridSize.Parse</c>. Returns <see langword="false"/> for any string that
     /// does not map cleanly (so the whole fix is withheld rather than change
-    /// runtime behaviour).
+    /// runtime behaviour). Numeric weights/pixels are re-emitted from the parsed
+    /// value in round-trip invariant form, so lenient-but-not-C#-literal inputs
+    /// (e.g. <c>"5."</c>) still yield a compiling literal (<c>5</c>).
     /// </summary>
-    private static bool TryConvertTrack(string raw, out ExpressionSyntax? gridSize)
+    private static bool TryConvertTrack(string raw, string gridSizeName, out ExpressionSyntax? gridSize)
     {
         gridSize = null;
         var trimmed = raw.Trim();
@@ -247,14 +298,14 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
         // "Auto" / "auto" -> GridSize.Auto  (property — no parens)
         if (string.Equals(trimmed, "Auto", System.StringComparison.OrdinalIgnoreCase))
         {
-            gridSize = GridSizeAccess("Auto");
+            gridSize = GridSizeAccess(gridSizeName, "Auto");
             return true;
         }
 
         // "*" -> GridSize.Star()
         if (trimmed == "*")
         {
-            gridSize = Call("Star");
+            gridSize = Call(gridSizeName, "Star");
             return true;
         }
 
@@ -265,7 +316,7 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
             if (numericText.Length == 0) return false;
             if (double.TryParse(numericText, NumberStyles.Float, CultureInfo.InvariantCulture, out var stars) && stars > 0)
             {
-                gridSize = Call("Star", numericText);
+                gridSize = Call(gridSizeName, "Star", FormatNumber(stars));
                 return true;
             }
             return false;
@@ -274,28 +325,30 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
         // "<n>" -> GridSize.Px(n)
         if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var pixels) && pixels >= 0)
         {
-            gridSize = Call("Px", trimmed);
+            gridSize = Call(gridSizeName, "Px", FormatNumber(pixels));
             return true;
         }
 
         return false;
     }
 
-    private static MemberAccessExpressionSyntax GridSizeAccess(string member) =>
+    /// <summary>Round-trip invariant form that is always a valid C# numeric literal.</summary>
+    private static string FormatNumber(double value) => value.ToString("R", CultureInfo.InvariantCulture);
+
+    private static MemberAccessExpressionSyntax GridSizeAccess(string gridSizeName, string member) =>
         SyntaxFactory.MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
-            SyntaxFactory.IdentifierName("GridSize"),
+            SyntaxFactory.ParseExpression(gridSizeName),
             SyntaxFactory.IdentifierName(member));
 
-    private static ExpressionSyntax Call(string member) =>
-        SyntaxFactory.InvocationExpression(GridSizeAccess(member));
+    private static ExpressionSyntax Call(string gridSizeName, string member) =>
+        SyntaxFactory.InvocationExpression(GridSizeAccess(gridSizeName, member));
 
-    private static ExpressionSyntax Call(string member, string numericLiteralText)
+    private static ExpressionSyntax Call(string gridSizeName, string member, string numericLiteralText)
     {
-        var argument = SyntaxFactory.Argument(
-            (ExpressionSyntax)SyntaxFactory.ParseExpression(numericLiteralText));
+        var argument = SyntaxFactory.Argument(SyntaxFactory.ParseExpression(numericLiteralText));
         return SyntaxFactory.InvocationExpression(
-            GridSizeAccess(member),
+            GridSizeAccess(gridSizeName, member),
             SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(argument)));
     }
 

--- a/src/Reactor.Analyzers/GridStringTrackCodeFix.cs
+++ b/src/Reactor.Analyzers/GridStringTrackCodeFix.cs
@@ -314,7 +314,8 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
         {
             var numericText = trimmed.Substring(0, trimmed.Length - 1).Trim();
             if (numericText.Length == 0) return false;
-            if (double.TryParse(numericText, NumberStyles.Float, CultureInfo.InvariantCulture, out var stars) && stars > 0)
+            if (double.TryParse(numericText, NumberStyles.Float, CultureInfo.InvariantCulture, out var stars)
+                && stars > 0 && IsFinite(stars))
             {
                 gridSize = Call(gridSizeName, "Star", FormatNumber(stars));
                 return true;
@@ -323,7 +324,8 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
         }
 
         // "<n>" -> GridSize.Px(n)
-        if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var pixels) && pixels >= 0)
+        if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var pixels)
+            && pixels >= 0 && IsFinite(pixels))
         {
             gridSize = Call(gridSizeName, "Px", FormatNumber(pixels));
             return true;
@@ -331,6 +333,12 @@ public sealed class GridStringTrackCodeFix : CodeFixProvider
 
         return false;
     }
+
+    // NumberStyles.Float accepts "Infinity"/"-Infinity" and overflows (e.g. "1e400")
+    // to ±Infinity; "R" would then emit "Infinity", which is not a valid C# numeric
+    // literal (and GridLength rejects non-finite anyway). Withhold the fix instead.
+    // (netstandard2.0 has no double.IsFinite.)
+    private static bool IsFinite(double value) => !double.IsInfinity(value) && !double.IsNaN(value);
 
     /// <summary>Round-trip invariant form that is always a valid C# numeric literal.</summary>
     private static string FormatNumber(double value) => value.ToString("R", CultureInfo.InvariantCulture);

--- a/src/Reactor.Analyzers/GridStringTrackCodeFix.cs
+++ b/src/Reactor.Analyzers/GridStringTrackCodeFix.cs
@@ -1,0 +1,309 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix registered on the compiler diagnostic <c>CS0618</c> for the obsolete
+/// string-form <c>Grid(string[], string[], …)</c> factory
+/// (<c>Microsoft.UI.Reactor.Factories</c>). Rewrites each inline string-literal
+/// track (<c>"*"</c> / <c>"Auto"</c> / <c>"2*"</c> / <c>"200"</c>) to the typed
+/// <see cref="M:Microsoft.UI.Reactor.GridSize.Star(System.Double)"/> /
+/// <c>GridSize.Auto</c> / <c>GridSize.Px</c> form, which swaps overload resolution
+/// to the typed <c>Grid(GridSize[], GridSize[], …)</c> overload — killing the
+/// obsolete warning. Spec 060 §4.5.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the one documented id-less member of the spec-060 suite: there is no
+/// new diagnostic id, no <see cref="DiagnosticDescriptor"/>, and no
+/// <c>AnalyzerReleases.Unshipped.md</c> row. It keys off the compiler's own
+/// obsolete diagnostic, so the false-positive risk is nil.
+/// </para>
+/// <para>
+/// The rewrite is fully mechanical, but only for <b>inline literal arrays</b>
+/// whose every element is a plain string literal (collection expressions
+/// <c>["*", …]</c>, <c>new[] { … }</c>, or <c>new string[] { … }</c>). When a
+/// track array is a variable, a non-literal expression, an interpolated string,
+/// or a spread — the concrete track values aren't visible, so no fix is offered
+/// and the <c>CS0618</c> warning is left to stand.
+/// </para>
+/// <para>
+/// The string→<c>GridSize</c> mapping mirrors <c>GridSize.Parse</c> (which agrees
+/// with the runtime layout parse on every valid track): <c>"Auto"</c>
+/// (case-insensitive) → <c>GridSize.Auto</c>; <c>"*"</c> → <c>GridSize.Star()</c>;
+/// <c>"&lt;n&gt;*"</c> → <c>GridSize.Star(n)</c>; <c>"&lt;n&gt;"</c> →
+/// <c>GridSize.Px(n)</c>. Any other literal cannot be mapped safely, so the whole
+/// fix is withheld.
+/// </para>
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(GridStringTrackCodeFix))]
+[Shared]
+public sealed class GridStringTrackCodeFix : CodeFixProvider
+{
+    /// <summary>The C# compiler's "member is obsolete (warning)" diagnostic.</summary>
+    private const string ObsoleteWarningId = "CS0618";
+
+    private const string EquivalenceKey = "Reactor_GridStringTrack";
+
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(ObsoleteWarningId);
+
+    // Each fix is local and self-contained (it rewrites one invocation's two
+    // track arrays), and only genuine Grid(string[],string[],…) call sites ever
+    // register an action — unrelated CS0618s simply get no offer. That makes the
+    // batch fixer safe for the common "convert every legacy Grid in the file" case.
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        var model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (model is null) return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocation is null) continue;
+
+            // Confirm the obsolete target is specifically our string-track Grid
+            // overload — CS0618 at this span could be any other obsolete symbol.
+            if (!IsObsoleteGridStringOverload(model, invocation, context.CancellationToken)) continue;
+
+            var args = invocation.ArgumentList.Arguments;
+            if (args.Count < 2) continue;
+
+            var columnsExpr = args[0].Expression;
+            var rowsExpr = args[1].Expression;
+
+            // Both track arrays must be inline literal arrays whose every element
+            // parses to a GridSize. If either can't be rewritten mechanically we
+            // offer nothing and let the warning stand (spec 060 §4.5).
+            if (!TryRewriteTrackArray(columnsExpr, out var newColumns)) continue;
+            if (!TryRewriteTrackArray(rowsExpr, out var newRows)) continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Use typed GridSize tracks",
+                    ct =>
+                    {
+                        var newInvocation = invocation.ReplaceNodes(
+                            new SyntaxNode[] { columnsExpr, rowsExpr },
+                            (original, _) =>
+                                ReferenceEquals(original, columnsExpr) ? newColumns! : newRows!);
+
+                        var newRoot = root.ReplaceNode(invocation, newInvocation);
+                        return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+                    },
+                    equivalenceKey: EquivalenceKey),
+                diagnostic);
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="invocation"/> binds to
+    /// <c>Microsoft.UI.Reactor.Factories.Grid(string[], string[], …)</c> — the
+    /// obsolete string-track overload.
+    /// </summary>
+    private static bool IsObsoleteGridStringOverload(
+        SemanticModel model, InvocationExpressionSyntax invocation, CancellationToken ct)
+    {
+        var symbolInfo = model.GetSymbolInfo(invocation, ct);
+        var method = symbolInfo.Symbol as IMethodSymbol
+                     ?? symbolInfo.CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
+        if (method is null) return false;
+
+        if (method.Name != "Grid") return false;
+        if (method.ContainingType?.ToDisplayString() != "Microsoft.UI.Reactor.Factories") return false;
+        if (method.Parameters.Length < 2) return false;
+
+        return IsStringArray(method.Parameters[0].Type) && IsStringArray(method.Parameters[1].Type);
+    }
+
+    private static bool IsStringArray(ITypeSymbol type) =>
+        type is IArrayTypeSymbol { ElementType.SpecialType: SpecialType.System_String };
+
+    /// <summary>
+    /// Rewrites an inline literal track array to the typed <c>GridSize[]</c> form
+    /// in place (preserving separators/trivia). Returns <see langword="false"/>
+    /// when the argument is not an inline literal array or any element cannot be
+    /// mapped to a <c>GridSize</c>.
+    /// </summary>
+    private static bool TryRewriteTrackArray(ExpressionSyntax expr, out ExpressionSyntax? rewritten)
+    {
+        rewritten = null;
+
+        switch (expr)
+        {
+            // C# 12 collection expression: ["*", "Auto", "200"]
+            case CollectionExpressionSyntax collection:
+            {
+                var literals = new List<LiteralExpressionSyntax>();
+                foreach (var element in collection.Elements)
+                {
+                    if (element is not ExpressionElementSyntax exprElement) return false;
+                    if (!TryGetStringLiteral(exprElement.Expression, out var literal)) return false;
+                    literals.Add(literal);
+                }
+
+                if (!TryBuildReplacements(literals, out var map)) return false;
+                rewritten = collection.ReplaceNodes(literals, (original, _) => map[original]);
+                return true;
+            }
+
+            // Implicitly typed array: new[] { "*", "Auto" }
+            case ImplicitArrayCreationExpressionSyntax implicitArray:
+                return TryRewriteInitializer(implicitArray, implicitArray.Initializer, out rewritten);
+
+            // Explicitly typed array: new string[] { "*", "Auto" }
+            case ArrayCreationExpressionSyntax explicitArray:
+            {
+                if (explicitArray.Initializer is null) return false;
+                if (!IsStringElementType(explicitArray.Type)) return false;
+                if (!TryRewriteInitializer(explicitArray, explicitArray.Initializer, out var withElements)) return false;
+
+                // Swap the element type string -> GridSize so overload resolution
+                // picks the typed Grid overload.
+                var rewrittenArray = (ArrayCreationExpressionSyntax)withElements!;
+                var newElementType = SyntaxFactory.IdentifierName("GridSize")
+                    .WithTriviaFrom(explicitArray.Type.ElementType);
+                var newArrayType = rewrittenArray.Type.WithElementType(newElementType);
+                rewritten = rewrittenArray.WithType(newArrayType);
+                return true;
+            }
+
+            default:
+                // Variable, member access, interpolated string, spread, etc.
+                return false;
+        }
+    }
+
+    private static bool TryRewriteInitializer(
+        ExpressionSyntax container, InitializerExpressionSyntax initializer, out ExpressionSyntax? rewritten)
+    {
+        rewritten = null;
+
+        var literals = new List<LiteralExpressionSyntax>();
+        foreach (var element in initializer.Expressions)
+        {
+            if (!TryGetStringLiteral(element, out var literal)) return false;
+            literals.Add(literal);
+        }
+
+        if (!TryBuildReplacements(literals, out var map)) return false;
+        rewritten = container.ReplaceNodes(literals, (original, _) => map[original]);
+        return true;
+    }
+
+    private static bool TryBuildReplacements(
+        List<LiteralExpressionSyntax> literals, out Dictionary<SyntaxNode, SyntaxNode> map)
+    {
+        map = new Dictionary<SyntaxNode, SyntaxNode>();
+        foreach (var literal in literals)
+        {
+            if (!TryConvertTrack(literal.Token.ValueText, out var gridSize)) return false;
+            map[literal] = gridSize!.WithTriviaFrom(literal);
+        }
+        return true;
+    }
+
+    private static bool TryGetStringLiteral(ExpressionSyntax expression, out LiteralExpressionSyntax literal)
+    {
+        if (expression is LiteralExpressionSyntax { RawKind: (int)SyntaxKind.StringLiteralExpression } stringLiteral)
+        {
+            literal = stringLiteral;
+            return true;
+        }
+
+        literal = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// Maps a track string to a <c>GridSize</c> factory expression, mirroring
+    /// <c>GridSize.Parse</c>. Returns <see langword="false"/> for any string that
+    /// does not map cleanly (so the whole fix is withheld rather than change
+    /// runtime behaviour).
+    /// </summary>
+    private static bool TryConvertTrack(string raw, out ExpressionSyntax? gridSize)
+    {
+        gridSize = null;
+        var trimmed = raw.Trim();
+        if (trimmed.Length == 0) return false;
+
+        // "Auto" / "auto" -> GridSize.Auto  (property — no parens)
+        if (string.Equals(trimmed, "Auto", System.StringComparison.OrdinalIgnoreCase))
+        {
+            gridSize = GridSizeAccess("Auto");
+            return true;
+        }
+
+        // "*" -> GridSize.Star()
+        if (trimmed == "*")
+        {
+            gridSize = Call("Star");
+            return true;
+        }
+
+        // "<n>*" -> GridSize.Star(n)
+        if (trimmed[trimmed.Length - 1] == '*')
+        {
+            var numericText = trimmed.Substring(0, trimmed.Length - 1).Trim();
+            if (numericText.Length == 0) return false;
+            if (double.TryParse(numericText, NumberStyles.Float, CultureInfo.InvariantCulture, out var stars) && stars > 0)
+            {
+                gridSize = Call("Star", numericText);
+                return true;
+            }
+            return false;
+        }
+
+        // "<n>" -> GridSize.Px(n)
+        if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var pixels) && pixels >= 0)
+        {
+            gridSize = Call("Px", trimmed);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static MemberAccessExpressionSyntax GridSizeAccess(string member) =>
+        SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            SyntaxFactory.IdentifierName("GridSize"),
+            SyntaxFactory.IdentifierName(member));
+
+    private static ExpressionSyntax Call(string member) =>
+        SyntaxFactory.InvocationExpression(GridSizeAccess(member));
+
+    private static ExpressionSyntax Call(string member, string numericLiteralText)
+    {
+        var argument = SyntaxFactory.Argument(
+            (ExpressionSyntax)SyntaxFactory.ParseExpression(numericLiteralText));
+        return SyntaxFactory.InvocationExpression(
+            GridSizeAccess(member),
+            SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(argument)));
+    }
+
+    private static bool IsStringElementType(ArrayTypeSyntax arrayType) => arrayType.ElementType switch
+    {
+        PredefinedTypeSyntax predefined => predefined.Keyword.IsKind(SyntaxKind.StringKeyword),
+        IdentifierNameSyntax { Identifier.ValueText: "String" or "string" } => true,
+        QualifiedNameSyntax { Right.Identifier.ValueText: "String" } => true,
+        _ => false,
+    };
+}

--- a/tests/Reactor.Tests/AnalyzerTests/GridStringTrackCodeFixTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/GridStringTrackCodeFixTests.cs
@@ -409,6 +409,30 @@ namespace TestApp
         await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
     }
 
+    // ── No fix: non-finite tracks (parse to Infinity — no valid C# literal) ──
+
+    [Theory]
+    [InlineData(@"""Infinity""")]   // literal +Infinity
+    [InlineData(@"""Infinity*""")]  // +Infinity star weight
+    [InlineData(@"""1e400""")]      // overflows to +Infinity
+    public async Task No_Fix_When_Track_Is_Non_Finite(string track)
+    {
+        var source = Stubs + $@"
+namespace TestApp
+{{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {{
+        public static Element Build() =>
+            {{|CS0618:Grid([{track}], [""*""])|}};
+    }}
+}}";
+
+        await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
     // ── Fix emits compiling GridSize even with only the static factory import ──
 
     [Fact]

--- a/tests/Reactor.Tests/AnalyzerTests/GridStringTrackCodeFixTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/GridStringTrackCodeFixTests.cs
@@ -433,6 +433,93 @@ namespace TestApp
         await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
     }
 
+    // ── No fix: literals that DIVERGE from the legacy parser, or don't map ──
+    // ParseColumnDef/ParseRowDef match "*"/"Auto"/"auto" EXACTLY on the raw string
+    // (no trim, no other casing) and fall back to Star(1) otherwise. Converting any of
+    // these would silently change layout, so the fix must withhold and leave CS0618.
+    [Theory]
+    [InlineData("\"AUTO\"")]       // wrong casing → legacy Star(1), NOT Auto
+    [InlineData("\"aUtO\"")]       // wrong casing
+    [InlineData("\" Auto \"")]     // whitespace around Auto → legacy Star(1)
+    [InlineData("\" 2* \"")]       // trailing space defeats legacy raw EndsWith('*') → Star(1)
+    [InlineData("\"\"")]           // empty
+    [InlineData("\"   \"")]        // whitespace only
+    [InlineData("\"-1*\"")]        // negative star weight
+    public async Task No_Fix_When_Track_Diverges_From_Legacy_Parser(string track)
+    {
+        var source = Stubs + $@"
+namespace TestApp
+{{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {{
+        public static Element Build() =>
+            {{|CS0618:Grid([{track}], [""*""])|}};
+    }}
+}}";
+
+        await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Faithful: whitespace-padded numerics still convert (Float allows the
+    //    surrounding whitespace, matching the legacy parser's double.TryParse) ──
+    [Fact]
+    public async Task Fix_Converts_Whitespace_Padded_Pixels()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid(["" 200 ""], [""*""])|};
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            Grid([GridSize.Px(200)], [GridSize.Star()]);
+    }
+}";
+
+        await MakeTest(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── No fix: interpolated-string and collection-spread elements ──
+    [Fact]
+    public async Task No_Fix_When_Element_Is_Interpolated_Or_Spread()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Interp(int w) =>
+            {|CS0618:Grid([$""{w}""], [""*""])|};
+
+        public static Element Spread(string[] tracks) =>
+            {|CS0618:Grid([""*"", ..tracks], [""*""])|};
+    }
+}";
+
+        await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
     // ── Fix emits compiling GridSize even with only the static factory import ──
 
     [Fact]

--- a/tests/Reactor.Tests/AnalyzerTests/GridStringTrackCodeFixTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/GridStringTrackCodeFixTests.cs
@@ -53,6 +53,14 @@ namespace Microsoft.UI.Reactor
     {
         public static Element Build() { return null; }
     }
+
+    // Same-named obsolete Grid(string[],string[],...) in a DIFFERENT type — the
+    // symbol gate must reject it (ContainingType != Microsoft.UI.Reactor.Factories).
+    public static class OtherFactories
+    {
+        [System.Obsolete(""A different Grid — not the DSL factory."", error: false)]
+        public static Element Grid(string[] columns, string[] rows, params Element[] children) { return null; }
+    }
 }
 ";
 
@@ -337,5 +345,207 @@ namespace TestApp
 }";
 
         await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Near-miss: an obsolete Grid(string[],string[],...) in a DIFFERENT type ──
+
+    [Fact]
+    public async Task No_Fix_For_Same_Shape_Grid_In_Different_Type()
+    {
+        // Guards the ContainingType half of the symbol gate: only
+        // Microsoft.UI.Reactor.Factories.Grid is fixable.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:OtherFactories.Grid([""*""], [""*""])|};
+    }
+}";
+
+        await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── No fix: numeric bounds (weight must be > 0, pixels must be >= 0) ──
+
+    [Fact]
+    public async Task No_Fix_When_Star_Weight_Is_Zero()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid([""0*""], [""*""])|};
+    }
+}";
+
+        await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Fix_When_Pixels_Are_Negative()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid([""-5""], [""*""])|};
+    }
+}";
+
+        await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Fix emits compiling GridSize even with only the static factory import ──
+
+    [Fact]
+    public async Task Fix_Qualifies_GridSize_When_Namespace_Not_Imported()
+    {
+        // The call site imports ONLY `using static ...Factories;`, so a bare
+        // `GridSize` would not resolve. ToMinimalDisplayString qualifies it.
+        var before = Stubs + @"
+namespace TestApp
+{
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static object Build() =>
+            {|CS0618:Grid([""*"", ""Auto""], [""200""])|};
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static object Build() =>
+            Grid([Microsoft.UI.Reactor.GridSize.Star(), Microsoft.UI.Reactor.GridSize.Auto], [Microsoft.UI.Reactor.GridSize.Px(200)]);
+    }
+}";
+
+        await MakeTest(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Lenient-but-not-C#-literal numerics normalize to a compiling literal ──
+
+    [Fact]
+    public async Task Fix_Normalizes_Trailing_Dot_Numeric_Tracks()
+    {
+        // "5.*" / "5." parse as doubles at runtime but "5." is not a valid C#
+        // literal; the fix must emit "5", not "5.".
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid([""5.*""], [""5.""])|};
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            Grid([GridSize.Star(5)], [GridSize.Px(5)]);
+    }
+}";
+
+        await MakeTest(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Named / reordered args: only the columns & rows params are rewritten ──
+
+    [Fact]
+    public async Task Fix_Rewrites_Only_Track_Params_With_Reordered_Named_Args()
+    {
+        // `children` named first must NOT be treated as a track array; the fix
+        // must bind columns/rows by parameter, not by syntactic position.
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid(children: new Element[] { }, columns: [""*""], rows: [""Auto""])|};
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            Grid(children: new Element[] { }, columns: [GridSize.Star()], rows: [GridSize.Auto]);
+    }
+}";
+
+        await MakeTest(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Fix-all: every legacy Grid in the document is converted ──────────
+
+    [Fact]
+    public async Task Fix_Converts_Multiple_Call_Sites()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element A() => {|CS0618:Grid([""*""], [""Auto""])|};
+        public static Element B() => {|CS0618:Grid([""2*""], [""200""])|};
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element A() => Grid([GridSize.Star()], [GridSize.Auto]);
+        public static Element B() => Grid([GridSize.Star(2)], [GridSize.Px(200)]);
+    }
+}";
+
+        await MakeTest(before, after).RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/GridStringTrackCodeFixTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/GridStringTrackCodeFixTests.cs
@@ -1,0 +1,341 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.UI.Reactor.Analyzers;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="GridStringTrackCodeFix"/> — the id-less spec-060 §4.5
+/// code fix registered on the compiler diagnostic <c>CS0618</c> for the obsolete
+/// <c>Grid(string[], string[], …)</c> overload. No analyzer produces the
+/// diagnostic (the compiler does), so the fix test pairs
+/// <see cref="EmptyDiagnosticAnalyzer"/> with the code fix and turns on compiler
+/// <b>warning</b> verification so <c>CS0618</c> is surfaced and fixable.
+/// </summary>
+public class GridStringTrackCodeFixTests
+{
+    // Minimal Reactor-shaped surface: the two overloaded Grid factories (the
+    // string one flagged [Obsolete(error:false)] so CS0618 fires) plus a GridSize
+    // whose shape matches the real type — Auto is a PROPERTY, Star/Px are methods.
+    private const string Stubs = @"
+namespace Microsoft.UI.Reactor
+{
+    public abstract class Element { }
+
+    public sealed class TextBlockElement : Element
+    {
+        public TextBlockElement(string text) { Text = text; }
+        public string Text { get; }
+    }
+
+    public struct GridSize
+    {
+        public static GridSize Auto { get { return default; } }
+        public static GridSize Star(double weight = 1) { return default; }
+        public static GridSize Px(double pixels) { return default; }
+    }
+
+    public static class Factories
+    {
+        public static TextBlockElement TextBlock(string text) { return new TextBlockElement(text); }
+
+        public static Element Grid(GridSize[] columns, GridSize[] rows, params Element[] children) { return null; }
+
+        [System.Obsolete(""Use Grid(GridSize[], GridSize[], ...) — GridSize.Star/.Auto/.Px helpers."", error: false)]
+        public static Element Grid(string[] columns, string[] rows, params Element[] children) { return null; }
+    }
+
+    [System.Obsolete(""Legacy helper."", error: false)]
+    public static class Legacy
+    {
+        public static Element Build() { return null; }
+    }
+}
+";
+
+    private static CSharpCodeFixTest<EmptyDiagnosticAnalyzer, GridStringTrackCodeFix, DefaultVerifier> MakeTest(
+        string testCode, string fixedCode)
+    {
+        var test = new CSharpCodeFixTest<EmptyDiagnosticAnalyzer, GridStringTrackCodeFix, DefaultVerifier>
+        {
+            TestCode = testCode,
+            FixedCode = fixedCode,
+            // The fix keys off the compiler's own obsolete WARNING, so warnings
+            // must be part of the verified diagnostic set.
+            CompilerDiagnostics = CompilerDiagnostics.Warnings,
+        };
+
+        // The stub deliberately omits XML docs on its public shims — ignore the
+        // resulting doc-comment noise so only the CS0618 we care about is asserted.
+        test.DisabledDiagnostics.Add("CS1591");
+        // Collection expressions ("*"-style tracks) need C# 12+.
+        test.SolutionTransforms.Add(LatestLanguageVersion);
+
+        return test;
+    }
+
+    private static Microsoft.CodeAnalysis.Solution LatestLanguageVersion(
+        Microsoft.CodeAnalysis.Solution solution, Microsoft.CodeAnalysis.ProjectId projectId)
+    {
+        var project = solution.GetProject(projectId)!;
+        var options = (CSharpParseOptions)project.ParseOptions!;
+        return solution.WithProjectParseOptions(projectId, options.WithLanguageVersion(LanguageVersion.Latest));
+    }
+
+    // ── The stub actually produces CS0618 (guards the [Obsolete] wiring) ──
+
+    [Fact]
+    public async Task Obsolete_String_Overload_Emits_CS0618()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid(new string[] { ""*"" }, new string[] { ""*"" })|};
+    }
+}";
+
+        var test = new CSharpAnalyzerTest<EmptyDiagnosticAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+            CompilerDiagnostics = CompilerDiagnostics.Warnings,
+        };
+        test.DisabledDiagnostics.Add("CS1591");
+        test.SolutionTransforms.Add(LatestLanguageVersion);
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Fix round-trip: inline collection-expression literal arrays ──────
+
+    [Fact]
+    public async Task Fix_Rewrites_CollectionExpression_Tracks()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid([""*"", ""Auto"", ""200""], [""*""], TextBlock(""x""))|};
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            Grid([GridSize.Star(), GridSize.Auto, GridSize.Px(200)], [GridSize.Star()], TextBlock(""x""));
+    }
+}";
+
+        await MakeTest(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Fix round-trip: star weights + pixels ───────────────────────────
+
+    [Fact]
+    public async Task Fix_Rewrites_Star_Weights_And_Pixels()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid([""2*"", ""1.5*"", ""120""], [""auto""])|};
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            Grid([GridSize.Star(2), GridSize.Star(1.5), GridSize.Px(120)], [GridSize.Auto]);
+    }
+}";
+
+        await MakeTest(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Fix round-trip: new[] { ... } implicit array ────────────────────
+
+    [Fact]
+    public async Task Fix_Rewrites_Implicit_Array_Tracks()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid(new[] { ""*"", ""Auto"" }, new[] { ""*"" })|};
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            Grid(new[] { GridSize.Star(), GridSize.Auto }, new[] { GridSize.Star() });
+    }
+}";
+
+        await MakeTest(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Fix round-trip: new string[] { ... } explicit array ─────────────
+
+    [Fact]
+    public async Task Fix_Rewrites_Explicit_String_Array_Tracks()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid(new string[] { ""*"", ""200"" }, new string[] { ""Auto"" })|};
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            Grid(new GridSize[] { GridSize.Star(), GridSize.Px(200) }, new GridSize[] { GridSize.Auto });
+    }
+}";
+
+        await MakeTest(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── No fix: a variable string[] (track values not visible) ──────────
+
+    [Fact]
+    public async Task No_Fix_When_Tracks_Are_A_Variable()
+    {
+        // CS0618 still fires, but the concrete tracks aren't inline literals, so
+        // the fix declines and the warning is left to stand.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build()
+        {
+            string[] cols = new[] { ""*"", ""Auto"" };
+            string[] rows = new[] { ""*"" };
+            return {|CS0618:Grid(cols, rows)|};
+        }
+    }
+}";
+
+        // FixedCode == TestCode: nothing changes.
+        await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── No fix: an element is a non-literal expression ──────────────────
+
+    [Fact]
+    public async Task No_Fix_When_An_Element_Is_Not_A_Literal()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build(string dynamicTrack) =>
+            {|CS0618:Grid([""*"", dynamicTrack], [""*""])|};
+    }
+}";
+
+        await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── No fix: an unparseable literal track ────────────────────────────
+
+    [Fact]
+    public async Task No_Fix_When_A_Literal_Track_Is_Unparseable()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build() =>
+            {|CS0618:Grid([""*"", ""nonsense""], [""*""])|};
+    }
+}";
+
+        await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Near-miss: a different obsolete member must not be touched ───────
+
+    [Fact]
+    public async Task No_Fix_For_Unrelated_Obsolete_Call()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+
+    public static class C
+    {
+        public static Element Build() => {|CS0618:Legacy|}.Build();
+    }
+}";
+
+        await MakeTest(source, source).RunAsync(TestContext.Current.CancellationToken);
+    }
+}


### PR DESCRIPTION
## What

Adds `GridStringTrackCodeFix` — the id-less **Wave A** packet from spec 060 §4.5 ([`docs/specs/060-analyzer-suite-expansion.md`](../blob/azchohfi-spec-060-analyzer-suite/docs/specs/060-analyzer-suite-expansion.md), "Grid string-track migration").

It is a `CodeFixProvider` registered on the **compiler** diagnostic **`CS0618`** for the obsolete string-form factory `Grid(string[], string[], …)` (`Dsl.cs:746-752`). The fix rewrites each inline string-literal track to the typed `GridSize` form and, because both `Grid` overloads share a name, that swap alone re-binds the call to the typed `Grid(GridSize[], GridSize[], …)` overload (`Dsl.cs:733`) — clearing the obsolete warning.

```csharp
Grid(["*", "Auto", "200"], ["*"], child)
// ↓ Use typed GridSize tracks
Grid([GridSize.Star(), GridSize.Auto, GridSize.Px(200)], [GridSize.Star()], child)
```

## Design notes (per the coordination contract)

- **Id-less by design.** No new diagnostic id, **no** `DiagnosticDescriptor`, **no** `AnalyzerReleases.Unshipped.md` row. This is the one documented exception in `docs/specs/tasks/060-analyzer-suite-expansion-implementation.md` §1/§4 — `REACTOR_GRID_001` is reserved for a different Batch-2 "unused-column" rule. Keying off the compiler's own obsolete diagnostic means **zero** false-positive risk.
- **Inline literal arrays only.** Handles collection expressions `[...]`, `new[] { … }`, and `new string[] { … }` whose every element is a plain string literal. A variable / non-literal / interpolated / spread element, or an unparseable literal, yields **no** fix — the `CS0618` warning is left to stand (values aren't statically visible).
- **String→`GridSize` mapping mirrors `GridSize.Parse`** (which agrees with the runtime layout parse on every valid track):
  - `"Auto"` / `"auto"` → `GridSize.Auto`  *(**property** — no parens)*
  - `"*"` → `GridSize.Star()`
  - `"<n>*"` → `GridSize.Star(n)`  (e.g. `"2*"` → `Star(2)`)
  - `"<n>"` → `GridSize.Px(n)`  (e.g. `"200"` → `Px(200)`)
- **Symbol-gated:** only fires when the `CS0618` target resolves to `Microsoft.UI.Reactor.Factories.Grid` whose first two params are `string[]`, so unrelated obsolete calls are never touched.

## Tests

`tests/Reactor.Tests/AnalyzerTests/GridStringTrackCodeFixTests.cs` (9 tests, all green) using `CSharpCodeFixTest<EmptyDiagnosticAnalyzer, GridStringTrackCodeFix, DefaultVerifier>` with `CompilerDiagnostics.Warnings` so the compiler's `CS0618` is surfaced and fixable. The stub declares an `[Obsolete(error:false)]` string `Grid`, a typed `Grid`, and a `GridSize` with `Auto`/`Star`/`Px`. Coverage: the stub actually emits `CS0618`; fix round-trips for collection-expression, star-weight/pixel, `new[]{…}`, and `new string[]{…}` forms; and no-fix cases for a `string[]` variable, a non-literal element, an unparseable literal, and an unrelated obsolete call.

- `dotnet build src/Reactor.Analyzers/Reactor.Analyzers.csproj` → clean
- `dotnet test tests/Reactor.Tests --filter FullyQualifiedName~GridStringTrack` → 9/9 pass
- Full `AnalyzerTests` namespace → 224/224 pass (no regressions)

## Deviation from the packet brief

The kickoff example wrote `GridSize.Auto()`, but source (`GridSize.cs`) and every sample confirm `Auto` is a **static property**, not a method — so the fix emits `GridSize.Auto` (no parens). Otherwise the mapping matches the packet exactly.

> Stacked on `azchohfi-spec-060-analyzer-suite` (the foundation branch that carries the coordination contract).
