### PR TITLE
feat(analyzer): REACTOR_STATE_001 — INPC on a Component

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -123,6 +123,7 @@ via `.editorconfig`.
 | `REACTOR_DOCK_001` | Warning | OnLiveLayoutChanged feeds the live layout back into state | `OnLiveLayoutRoundTripAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
+| `REACTOR_STATE_001` | Warning | INotifyPropertyChanged on a Component is invisible to the render loop | `ComponentInpcAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -81,6 +81,7 @@ Additional flags:
 | `REACTOR_HOOKS_006` | info | `UseResource` fetcher looks non-idempotent (`Post*`/`Create*`/`Delete*`/`Save*`) | Use `UseMutation` for writes — `UseResource` re-runs on deps change, retry, focus revalidation. |
 | `REACTOR_HOOKS_007` | warning | `UseMemoCells` builder closure missing dependencies | Add the captured variable to the deps array. |
 | `REACTOR_HOOKS_009` | warning | `Command.DebounceMs` set on a command bound without `UseCommand` | Route it through `UseCommand`: `var cmd = UseCommand(new Command { …, DebounceMs = 1500 });`. The debounce window lives in the hook store, so a raw bound `Command` never debounces. |
+| `REACTOR_STATE_001` | warning | A `Component` subclass implements `INotifyPropertyChanged` (MVVM habit) | The render loop never subscribes to a component's INPC, so `PropertyChanged` is invisible and does nothing. Hold reactive state with `UseState`, or wrap an external observable source with `UseObservable`. |
 | `REACTOR_DSL_001` | warning | `Select(...)` projecting into a layout container without `.WithKey(...)` | `items.Select(i => Row(i).WithKey(i.Id)).ToArray<Element?>()`. Keys keep focus + animation state across reorders. |
 | `REACTOR_THEME_001` | warning | Hardcoded color on a themed surface | Use `Theme.*` tokens (e.g. `Theme.PrimaryText`, `Theme.CardBackground`). See `reactor-design`. |
 | `REACTOR_THEME_002` | info | Lightweight styling opportunity | Optional. Use `.Resources(r => r.Set("ButtonBackground", …))` for visual-state overrides. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_STATE_001 | Reactor.State | Warning | ComponentInpcAnalyzer - INotifyPropertyChanged on a Component is invisible to the render loop

--- a/src/Reactor.Analyzers/ComponentInpcAnalyzer.cs
+++ b/src/Reactor.Analyzers/ComponentInpcAnalyzer.cs
@@ -95,11 +95,17 @@ public sealed class ComponentInpcAnalyzer : DiagnosticAnalyzer
         if (!ImplementsInterface(type, inpcType))
             return;
 
-        // Report only where INPC is introduced. If a base type already implements it, that
-        // base is the mistake site (and is flagged itself when it is a source Component), so
-        // skipping the derived type avoids a cascade of duplicate diagnostics down the chain.
-        if (type.BaseType is INamedTypeSymbol baseType && ImplementsInterface(baseType, inpcType))
+        // Report only where INPC is introduced. If the immediate base type is declared in
+        // source and also implements INPC, that base is the mistake site and is flagged on
+        // its own, so we skip this derived type to avoid a duplicate cascade. When the base
+        // comes from metadata (a referenced assembly) it is not analyzed here — so we still
+        // flag the derived source type, otherwise the anti-pattern would produce no warning.
+        if (type.BaseType is INamedTypeSymbol baseType
+            && baseType.Locations.Any(loc => loc.IsInSource)
+            && ImplementsInterface(baseType, inpcType))
+        {
             return;
+        }
 
         context.ReportDiagnostic(Diagnostic.Create(
             Rule,

--- a/src/Reactor.Analyzers/ComponentInpcAnalyzer.cs
+++ b/src/Reactor.Analyzers/ComponentInpcAnalyzer.cs
@@ -1,0 +1,129 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// REACTOR_STATE_001: Detects a <c>Component</c> subclass that also implements
+/// <see cref="System.ComponentModel.INotifyPropertyChanged"/>.
+/// </summary>
+/// <remarks>
+/// A common MVVM habit is to implement <c>INotifyPropertyChanged</c> on a view type
+/// and raise <c>PropertyChanged</c> for local state. Reactor's render loop never
+/// subscribes to a component's INPC, so that state is invisible to the reconciler and
+/// the raised change does nothing — no re-render is scheduled. Reactive local state
+/// belongs in <c>UseState</c> (or, for an external observable source, <c>UseObservable</c>),
+/// not on the component itself. This is a symbol-level, two-condition match (derives
+/// from <c>Component</c> <em>and</em> implements INPC), so the false-positive surface is
+/// near zero. There is no auto-fix — removing INPC is a structural change the author must
+/// make; the message points them at the hook APIs.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ComponentInpcAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_STATE_001";
+
+    private const string ComponentMetadataName = "Microsoft.UI.Reactor.Core.Component";
+    private const string InpcMetadataName = "System.ComponentModel.INotifyPropertyChanged";
+
+    private static readonly LocalizableString Title =
+        "INotifyPropertyChanged on a Component is invisible to the render loop";
+
+    private static readonly LocalizableString MessageFormat =
+        "'{0}' is a Component that implements INotifyPropertyChanged; the render loop never " +
+        "subscribes to a component's INPC, so PropertyChanged updates do nothing. Hold reactive " +
+        "state with UseState (or wrap an external observable with UseObservable) instead.";
+
+    private static readonly LocalizableString Description =
+        "A Component subclass that implements INotifyPropertyChanged out of MVVM habit raises " +
+        "PropertyChanged for local state, exactly as a view-model would. The framework never " +
+        "subscribes to a component's INPC, so the value is invisible to the render loop and the " +
+        "update never re-renders. Use UseState for reactive local state, or UseObservable to " +
+        "subscribe an external INotifyPropertyChanged source, rather than implementing INPC on " +
+        "the component.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.State",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        // Resolve the anchor symbols once. If Reactor (or INPC) isn't referenced there is
+        // nothing this rule can match, so we register no per-symbol callback at all.
+        var componentType = context.Compilation.GetTypeByMetadataName(ComponentMetadataName);
+        var inpcType = context.Compilation.GetTypeByMetadataName(InpcMetadataName);
+        if (componentType is null || inpcType is null)
+            return;
+
+        context.RegisterSymbolAction(
+            symbolContext => AnalyzeNamedType(symbolContext, componentType, inpcType),
+            SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeNamedType(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol componentType,
+        INamedTypeSymbol inpcType)
+    {
+        var type = (INamedTypeSymbol)context.Symbol;
+
+        // Condition 1: a class that derives from Reactor's Component base
+        // (covers both Component and the generic Component<TProps>).
+        if (type.TypeKind != TypeKind.Class)
+            return;
+        if (!DerivesFrom(type, componentType))
+            return;
+
+        // Condition 2: the type implements System.ComponentModel.INotifyPropertyChanged.
+        if (!ImplementsInterface(type, inpcType))
+            return;
+
+        // Report only where INPC is introduced. If a base type already implements it, that
+        // base is the mistake site (and is flagged itself when it is a source Component), so
+        // skipping the derived type avoids a cascade of duplicate diagnostics down the chain.
+        if (type.BaseType is INamedTypeSymbol baseType && ImplementsInterface(baseType, inpcType))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            type.Locations.FirstOrDefault() ?? Location.None,
+            type.Name));
+    }
+
+    private static bool DerivesFrom(INamedTypeSymbol type, INamedTypeSymbol baseCandidate)
+    {
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, baseCandidate))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool ImplementsInterface(INamedTypeSymbol type, INamedTypeSymbol interfaceType)
+    {
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, interfaceType))
+                return true;
+        }
+        return false;
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/ComponentInpcAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ComponentInpcAnalyzerTests.cs
@@ -1,6 +1,9 @@
 using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
+using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -117,8 +120,9 @@ class MyThing : System.ComponentModel.Component, System.ComponentModel.INotifyPr
     [Fact]
     public async Task Reports_Once_On_Base_Not_Cascaded_To_Derived()
     {
-        // When a base Component introduces INPC, only the base (the mistake site) is flagged;
-        // a derived type that merely inherits INPC must not produce a duplicate diagnostic.
+        // When a base Component declared IN SOURCE introduces INPC, only the base (the mistake
+        // site, flagged on its own) is reported; a derived type that merely inherits INPC in the
+        // same compilation must not produce a duplicate diagnostic.
         var source = Stubs + @"
 class {|REACTOR_STATE_001:MyBase|} : Component, System.ComponentModel.INotifyPropertyChanged
 {
@@ -170,5 +174,57 @@ class MyViewModel : System.ComponentModel.INotifyPropertyChanged
         {
             TestCode = source,
         }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_Derived_When_Inpc_Component_Base_Is_From_Metadata()
+    {
+        // The cascade suppression must only fire for a base declared IN SOURCE. Here the
+        // Component + INPC base is compiled into a real referenced ASSEMBLY (PE metadata), so
+        // its symbol's locations are not in source and it is not analyzed in this compilation.
+        // The derived source type must therefore still warn — otherwise the anti-pattern would
+        // produce no diagnostic at all (the false-negative this guard is designed to avoid).
+        const string baseLib = @"
+using System.ComponentModel;
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public abstract class Component { }
+}
+
+namespace Lib
+{
+    public abstract class ObservableComponentBase : Microsoft.UI.Reactor.Core.Component, INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+    }
+}";
+
+        var references = await ReferenceAssemblies.Default.ResolveAsync(
+            LanguageNames.CSharp, TestContext.Current.CancellationToken);
+        var baseCompilation = CSharpCompilation.Create(
+            "ReactorMetadataBaseLib",
+            new[] { CSharpSyntaxTree.ParseText(baseLib, cancellationToken: TestContext.Current.CancellationToken) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var peStream = new MemoryStream();
+        var emitResult = baseCompilation.Emit(peStream, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(emitResult.Success, string.Join("\n", emitResult.Diagnostics));
+        peStream.Position = 0;
+        var baseReference = MetadataReference.CreateFromStream(peStream);
+
+        const string appCode = @"
+class {|REACTOR_STATE_001:MyScreen|} : Lib.ObservableComponentBase
+{
+}";
+
+        var test = new CSharpAnalyzerTest<ComponentInpcAnalyzer, DefaultVerifier>
+        {
+            TestCode = appCode,
+        };
+        test.TestState.AdditionalReferences.Add(baseReference);
+
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/ComponentInpcAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ComponentInpcAnalyzerTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="ComponentInpcAnalyzer"/> (<c>REACTOR_STATE_001</c>). Stubs a
+/// minimal <c>Microsoft.UI.Reactor.Core.Component</c> shape so the analyzer's two-condition
+/// symbol match (derives from <c>Component</c> and implements <c>INotifyPropertyChanged</c>)
+/// resolves without pulling the framework in. <c>INotifyPropertyChanged</c> and the near-miss
+/// <c>System.ComponentModel.Component</c> come from the default reference assemblies and are
+/// fully qualified so they never collide with the stubbed Reactor <c>Component</c>.
+/// </summary>
+public class ComponentInpcAnalyzerTests
+{
+    // Mirrors the real base shape: an abstract Component plus the generic Component<TProps>
+    // (which derives from the non-generic Component, exactly as in src/Reactor/Core/Component.cs).
+    // The `using` sits at the top of the compilation unit so the global-namespace test types
+    // below can name `Component` while the namespace block declares it.
+    private const string Stubs = @"
+using Microsoft.UI.Reactor.Core;
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public abstract class Component { }
+    public abstract class Component<TProps> : Component { }
+}
+";
+
+    [Fact]
+    public async Task Fires_For_Component_Implementing_Inpc()
+    {
+        // The XAML habit: a Component subclass raising PropertyChanged for local state.
+        var source = Stubs + @"
+class {|REACTOR_STATE_001:MyComponent|} : Component, System.ComponentModel.INotifyPropertyChanged
+{
+    public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+}";
+
+        await new CSharpAnalyzerTest<ComponentInpcAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Generic_Component_Subclass()
+    {
+        // Component<TProps> derives from Component, so the generic base must also trip the rule.
+        var source = Stubs + @"
+class MyProps { }
+
+class {|REACTOR_STATE_001:MyComponent|} : Component<MyProps>, System.ComponentModel.INotifyPropertyChanged
+{
+    public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+}";
+
+        await new CSharpAnalyzerTest<ComponentInpcAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Component_Without_Inpc()
+    {
+        // Negative: a plain Component with no INotifyPropertyChanged is the idiomatic shape.
+        var source = Stubs + @"
+class MyComponent : Component
+{
+}";
+
+        await new CSharpAnalyzerTest<ComponentInpcAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Plain_Inpc_ViewModel()
+    {
+        // Negative: a real MVVM view-model implementing INPC but not deriving Component
+        // is exactly what UseObservable is meant to consume — never flag it.
+        var source = Stubs + @"
+class MyViewModel : System.ComponentModel.INotifyPropertyChanged
+{
+    public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+}";
+
+        await new CSharpAnalyzerTest<ComponentInpcAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_NonReactor_Component_Lookalike()
+    {
+        // Near-miss: derives from a class literally named 'Component' AND implements INPC,
+        // but it is System.ComponentModel.Component — not Reactor's. The namespace-qualified
+        // symbol match (not a name match) must keep this quiet.
+        var source = Stubs + @"
+class MyThing : System.ComponentModel.Component, System.ComponentModel.INotifyPropertyChanged
+{
+    public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+}";
+
+        await new CSharpAnalyzerTest<ComponentInpcAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Reports_Once_On_Base_Not_Cascaded_To_Derived()
+    {
+        // When a base Component introduces INPC, only the base (the mistake site) is flagged;
+        // a derived type that merely inherits INPC must not produce a duplicate diagnostic.
+        var source = Stubs + @"
+class {|REACTOR_STATE_001:MyBase|} : Component, System.ComponentModel.INotifyPropertyChanged
+{
+    public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+}
+
+class MyDerived : MyBase
+{
+}";
+
+        await new CSharpAnalyzerTest<ComponentInpcAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/ComponentInpcAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ComponentInpcAnalyzerTests.cs
@@ -134,4 +134,41 @@ class MyDerived : MyBase
             TestCode = source,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task Fires_When_Inpc_Comes_Via_A_Derived_Interface()
+    {
+        // The 'implements INPC' check walks AllInterfaces, so an interface that
+        // itself extends INotifyPropertyChanged must still trip the rule.
+        var source = Stubs + @"
+interface IObservableComponent : System.ComponentModel.INotifyPropertyChanged { }
+
+class {|REACTOR_STATE_001:MyComponent|} : Component, IObservableComponent
+{
+    public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+}";
+
+        await new CSharpAnalyzerTest<ComponentInpcAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_Reactor_Component_Not_Referenced()
+    {
+        // The compilation-start early-out registers no symbol callback when
+        // Microsoft.UI.Reactor.Core.Component cannot be resolved. Without the stubs
+        // the Reactor base is absent, so even a plain INPC class must stay quiet.
+        var source = @"
+class MyViewModel : System.ComponentModel.INotifyPropertyChanged
+{
+    public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+}";
+
+        await new CSharpAnalyzerTest<ComponentInpcAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }


### PR DESCRIPTION
Implements **REACTOR_STATE_001** (spec 060, Wave A — `ComponentInpcAnalyzer`).

## What
A `SymbolAction` on named types that flags a class deriving from Reactor's `Component` base that **also** implements `System.ComponentModel.INotifyPropertyChanged`. Reactor's render loop never subscribes to a component's INPC, so `PropertyChanged` for local state is invisible to the reconciler and the update does nothing (the XAML/MVVM habit → silent no-op).

- **Rule:** `REACTOR_STATE_001` · `Reactor.State` · **Warning** · no auto-fix (structural). Message points authors to `UseState` / `UseObservable`.
- **Detect:** two-condition symbol match — derives from `Microsoft.UI.Reactor.Core.Component` (covers `Component<TProps>`) **and** implements INPC. Near-zero FP.
- Reports only where INPC is **introduced** (a derived type that merely inherits it is not re-flagged), avoiding duplicate cascading diagnostics.

## Tests (`tests/Reactor.Tests/AnalyzerTests/ComponentInpcAnalyzerTests.cs`)
Positive (Component + INPC), generic-base (`Component<TProps>` + INPC), negative (Component without INPC), negative (plain INPC view-model), near-miss (`System.ComponentModel.Component` look-alike + INPC → quiet), and no-cascade. `dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~ComponentInpc` → 6/6 green; full `AnalyzerTests` suite 221/221.

## Also
- Appends the canonical row to `AnalyzerReleases.Unshipped.md`.
- Adds the app-author cheat-table row to `reactor-build-and-check/SKILL.md` (§2.6).

Grounding: `docs/specs/060-analyzer-suite-expansion.md` §4.1; `reactor-vs-xaml.md` (Common Mistakes — implementing INPC on local state).