### PR TITLE
feat(analyzer): REACTOR_THREAD_002 — blocking a Task in Render/effect

### DIFF
--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_THREAD_002` | warning | Blocking a `Task` (`.Result` / `.Wait()` / `.GetAwaiter().GetResult()`) inside `Render()` or a `UseEffect` effect | Never block on the UI thread. Fetch with `UseResource(async () => await FetchAsync())`, or `await` inside an async effect and set state. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,7 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
-| `REACTOR_THREAD_002` | warning | Blocking a `Task` (`.Result` / `.Wait()` / `.GetAwaiter().GetResult()`) inside `Render()` or a `UseEffect` effect | Never block on the UI thread. Fetch with `UseResource(async () => await FetchAsync())`, or `await` inside an async effect and set state. |
+| `REACTOR_THREAD_002` | warning | Blocking a `Task` (`.Result` / `.Wait()` / `.GetAwaiter().GetResult()`) inside `Render()` or a `UseEffect` effect | Never block on the UI thread. Fetch with `UseResource(ct => FetchAsync(ct), deps: [])`, or `await` inside an async effect and set state. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,7 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
-| `REACTOR_THREAD_002` | warning | Blocking a `Task` (`.Result` / `.Wait()` / `.GetAwaiter().GetResult()`) inside `Render()` or a `UseEffect` effect | Never block on the UI thread. Fetch with `UseResource(ct => FetchAsync(ct), deps: [])`, or `await` inside an async effect and set state. |
+| `REACTOR_THREAD_002` | warning | Blocking a `Task` (`.Result` / `.Wait()` / `.GetAwaiter().GetResult()`) inside `Render()` or a `UseEffect` effect | Never block on the UI thread. Fetch with `UseResource(ct => FetchAsync(ct), System.Array.Empty<object>())`, or `await` inside an async effect and set state. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_THREAD_002 | Reactor.Threading | Warning | BlockingTaskAnalyzer - Blocking a Task (.Result/.Wait) in Render/effect

--- a/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
+++ b/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
@@ -84,6 +84,8 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
                 ctx => AnalyzeMemberAccess(ctx, known), SyntaxKind.SimpleMemberAccessExpression);
             start.RegisterSyntaxNodeAction(
                 ctx => AnalyzeInvocation(ctx, known), SyntaxKind.InvocationExpression);
+            start.RegisterSyntaxNodeAction(
+                ctx => AnalyzeConditionalAccess(ctx, known), SyntaxKind.ConditionalAccessExpression);
         });
     }
 
@@ -165,6 +167,69 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
         Report(context, invocation, blockingForm, flag);
     }
 
+    /// <summary>
+    /// Handles the null-conditional forms — <c>task?.Result</c>, <c>task?.Wait()</c>,
+    /// and <c>task?.GetAwaiter().GetResult()</c> — where the blocking member binds
+    /// directly to the null-conditioned receiver. These are <c>ConditionalAccessExpression</c>
+    /// nodes (the member is a <c>MemberBindingExpression</c>, not a <c>MemberAccessExpression</c>),
+    /// so the two handlers above never see them.
+    /// </summary>
+    private static void AnalyzeConditionalAccess(SyntaxNodeAnalysisContext context, TaskTypes known)
+    {
+        var conditional = (ConditionalAccessExpressionSyntax)context.Node;
+
+        var blockingForm = ClassifyConditionalWhenNotNull(conditional.WhenNotNull);
+        if (blockingForm is null)
+            return;
+
+        // The receiver whose type must be Task-like is the null-conditioned expression.
+        if (!known.IsTaskLike(context.SemanticModel.GetTypeInfo(conditional.Expression).Type))
+            return;
+
+        var flag = ClassifyContext(context.SemanticModel, conditional);
+        if (flag == FlagContext.None)
+            return;
+
+        Report(context, conditional, blockingForm, flag);
+    }
+
+    /// <summary>
+    /// Returns the blocking-form label when a conditional-access continuation is a
+    /// blocking member bound directly to the receiver, else <c>null</c>. Only the direct
+    /// binding is matched — a longer chain like <c>x?.Foo.Result</c> is left to the
+    /// non-conditional handlers on its inner nodes.
+    /// </summary>
+    private static string? ClassifyConditionalWhenNotNull(ExpressionSyntax whenNotNull) =>
+        whenNotNull switch
+        {
+            // x?.Result
+            MemberBindingExpressionSyntax { Name.Identifier.Text: "Result" } => ".Result",
+
+            // x?.Wait()  (zero-arg only — timeout overloads are out of scope)
+            InvocationExpressionSyntax
+            {
+                Expression: MemberBindingExpressionSyntax { Name.Identifier.Text: "Wait" },
+                ArgumentList.Arguments.Count: 0,
+            } => ".Wait()",
+
+            // x?.GetAwaiter().GetResult()
+            InvocationExpressionSyntax
+            {
+                Expression: MemberAccessExpressionSyntax
+                {
+                    Name.Identifier.Text: "GetResult",
+                    Expression: InvocationExpressionSyntax
+                    {
+                        Expression: MemberBindingExpressionSyntax { Name.Identifier.Text: "GetAwaiter" },
+                        ArgumentList.Arguments.Count: 0,
+                    },
+                },
+                ArgumentList.Arguments.Count: 0,
+            } => ".GetAwaiter().GetResult()",
+
+            _ => null,
+        };
+
     private static void Report(SyntaxNodeAnalysisContext context, SyntaxNode location, string blockingForm, FlagContext flag)
     {
         var contextLabel = flag == FlagContext.Effect ? "a UseEffect effect" : "Render()";
@@ -181,12 +246,22 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
     /// boundary (lambda, local function, or method declaration) is decisive:
     /// <list type="bullet">
     /// <item>a <c>UseEffect</c> effect lambda → <see cref="FlagContext.Effect"/>;</item>
-    /// <item>any other lambda or local function → <see cref="FlagContext.None"/> (the call
-    /// is deferred — a nested <c>Task.Run</c>, an event handler, a LINQ projection — and no
-    /// longer runs on the render/effect thread);</item>
+    /// <item>any other lambda or local function → <see cref="FlagContext.None"/>;</item>
     /// <item>a <c>Render()</c> override reached with no intervening lambda →
     /// <see cref="FlagContext.Render"/>.</item>
     /// </list>
+    /// <para>
+    /// Treating <b>every</b> non-effect nested function as a boundary (rather than only
+    /// <c>Task.Run</c>) is deliberate. It is what excludes the spec's named case —
+    /// <c>Task.Run(() =&gt; t.Result)</c> — but it also covers the other background-dispatch
+    /// forms (<c>Task.Factory.StartNew</c>, <c>ThreadPool.QueueUserWorkItem</c>) and every
+    /// deferred callback whose execution timing is decoupled from render (event handlers,
+    /// LINQ projections, stored delegates). A syntactic analyzer cannot prove whether such a
+    /// lambda runs synchronously during render or later on another thread, so blocking inside
+    /// one is left unflagged to keep false positives near zero — the accepted cost is a false
+    /// negative on a helper that <i>is</i> invoked synchronously in the render path. This
+    /// mirrors the deferred-execution-boundary convention in <c>HookRulesAnalyzer</c>.
+    /// </para>
     /// </summary>
     private static FlagContext ClassifyContext(SemanticModel model, SyntaxNode node)
     {

--- a/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
+++ b/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
@@ -351,14 +351,27 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // Fallback for an unresolved/overload-ambiguous call: the effect is the first
-        // positional argument, and we check the receiver's declared type.
+        // Fallback for an unresolved/overload-ambiguous call (incremental/errored compile):
+        // the effect is the first positional argument, and the call is either a
+        // `receiver.UseEffect(...)` whose receiver derives from RenderContext/Component, or a
+        // bare implicit-receiver `UseEffect(...)` inside a Component-derived class. Mirrors
+        // HookRulesAnalyzer.IsLikelyReactorHook so the rule stays useful mid-edit.
         if (argumentList.Arguments.IndexOf(argument) != 0)
             return false;
 
         if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
             model.GetTypeInfo(memberAccess.Expression).Type is INamedTypeSymbol receiverType &&
             (IsOrDerivesFrom(receiverType, RenderContextType) || IsOrDerivesFrom(receiverType, ComponentType)))
+        {
+            return true;
+        }
+
+        // Implicit receiver (`UseEffect(...)` inside a Component) — the symbol may be null
+        // while the build is mid-type-binding; anchor on the enclosing class instead.
+        if (invocation.Expression is IdentifierNameSyntax &&
+            invocation.FirstAncestorOrSelf<ClassDeclarationSyntax>() is { } enclosingClass &&
+            model.GetDeclaredSymbol(enclosingClass) is INamedTypeSymbol classSymbol &&
+            IsOrDerivesFrom(classSymbol, ComponentType))
         {
             return true;
         }

--- a/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
+++ b/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
@@ -306,9 +306,11 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// True when <paramref name="lambda"/> is the effect argument (index 0) of a
-    /// <c>UseEffect</c> call bound to <c>RenderContext.UseEffect</c> or a
-    /// <c>Component</c> wrapper. Mirrors the Component-or-RenderContext anchoring the
+    /// True when <paramref name="lambda"/> is the effect argument of a <c>UseEffect</c>
+    /// call bound to <c>RenderContext.UseEffect</c> or a <c>Component</c> wrapper. The
+    /// effect is parameter 0 of every overload, but named-argument reordering
+    /// (<c>UseEffect(dependencies: d, effect: () =&gt; ...)</c>) means it is not always the
+    /// first syntactic argument. Mirrors the Component-or-RenderContext anchoring the
     /// shipped hook analyzer uses.
     /// </summary>
     private static bool IsUseEffectEffectLambda(SemanticModel model, SyntaxNode lambda)
@@ -320,10 +322,6 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // The effect is always the first argument of every UseEffect overload.
-        if (argumentList.Arguments.IndexOf(argument) != 0)
-            return false;
-
         // Cheap name gate before touching the semantic model.
         if (GetInvokedSimpleName(invocation) != "UseEffect")
             return false;
@@ -331,6 +329,11 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
         if (model.GetSymbolInfo(invocation).Symbol is IMethodSymbol symbol)
         {
             if (symbol.Name != "UseEffect")
+                return false;
+
+            // Confirm the lambda binds to the effect parameter (index 0), honoring
+            // named-argument reordering.
+            if (!TargetsFirstParameter(argument, argumentList, symbol))
                 return false;
 
             if (symbol.ContainingType is INamedTypeSymbol containing &&
@@ -348,7 +351,11 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // Fallback for an unresolved/overload-ambiguous call: check the receiver's type.
+        // Fallback for an unresolved/overload-ambiguous call: the effect is the first
+        // positional argument, and we check the receiver's declared type.
+        if (argumentList.Arguments.IndexOf(argument) != 0)
+            return false;
+
         if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
             model.GetTypeInfo(memberAccess.Expression).Type is INamedTypeSymbol receiverType &&
             (IsOrDerivesFrom(receiverType, RenderContextType) || IsOrDerivesFrom(receiverType, ComponentType)))
@@ -357,6 +364,23 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// True when <paramref name="argument"/> binds to parameter index 0 of
+    /// <paramref name="symbol"/> — the first positional argument, or a named argument
+    /// whose name matches parameter 0. Handles named-argument reordering.
+    /// </summary>
+    private static bool TargetsFirstParameter(
+        ArgumentSyntax argument, ArgumentListSyntax argumentList, IMethodSymbol symbol)
+    {
+        if (argument.NameColon is { Name.Identifier.Text: var argName })
+        {
+            return symbol.Parameters.Length > 0
+                && string.Equals(argName, symbol.Parameters[0].Name, System.StringComparison.Ordinal);
+        }
+
+        return argumentList.Arguments.IndexOf(argument) == 0;
     }
 
     /// <summary>

--- a/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
+++ b/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
@@ -140,9 +140,11 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
         }
         else if (name == "GetResult")
         {
-            // Require the exact `<task>.GetAwaiter().GetResult()` idiom so we never fire on
-            // an unrelated `GetResult()`. The task receiver is what `.GetAwaiter()` is called on.
-            if (memberAccess.Expression is not InvocationExpressionSyntax getAwaiterInvocation ||
+            // Require the exact zero-arg `<task>.GetAwaiter().GetResult()` idiom (both calls
+            // parameterless) so we never fire on an unrelated `GetResult(x)`. The task
+            // receiver is what `.GetAwaiter()` is called on.
+            if (invocation.ArgumentList.Arguments.Count != 0 ||
+                memberAccess.Expression is not InvocationExpressionSyntax getAwaiterInvocation ||
                 getAwaiterInvocation.Expression is not MemberAccessExpressionSyntax getAwaiterAccess ||
                 getAwaiterAccess.Name.Identifier.Text != "GetAwaiter" ||
                 getAwaiterInvocation.ArgumentList.Arguments.Count != 0)
@@ -411,7 +413,20 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
             return symbol.IsOverride && IsOrDerivesFrom(symbol.ContainingType, ComponentType);
         }
 
-        return method.Modifiers.Any(SyntaxKind.OverrideKeyword);
+        // Fallback: the method symbol is unresolved (mid-edit). Require the `override`
+        // modifier, and still anchor on the enclosing class — a Component is a class, so a
+        // non-class parent or a resolvable non-Component class rules the override out. Only
+        // when even the class symbol is unavailable do we keep the loose name heuristic.
+        if (!method.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            return false;
+
+        if (method.Parent is not ClassDeclarationSyntax enclosingClass)
+            return false;
+
+        if (model.GetDeclaredSymbol(enclosingClass) is INamedTypeSymbol classSymbol)
+            return IsOrDerivesFrom(classSymbol, ComponentType);
+
+        return true;
     }
 
     private static string? GetInvokedSimpleName(InvocationExpressionSyntax invocation) =>

--- a/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
+++ b/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
@@ -126,6 +126,7 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
 
         ExpressionSyntax? taskReceiver;
         string blockingForm;
+        var allowConfiguredAwaitable = false;
 
         if (name == "Wait")
         {
@@ -151,13 +152,20 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
 
             taskReceiver = getAwaiterAccess.Expression;
             blockingForm = ".GetAwaiter().GetResult()";
+            // The GetAwaiter receiver may be a `ConfigureAwait(...)` wrapper over a Task/
+            // ValueTask; GetResult() still blocks, so accept that wrapper here too.
+            allowConfiguredAwaitable = true;
         }
         else
         {
             return;
         }
 
-        if (!known.IsTaskLike(context.SemanticModel.GetTypeInfo(taskReceiver).Type))
+        var receiverType = context.SemanticModel.GetTypeInfo(taskReceiver).Type;
+        var isBlockingReceiver = allowConfiguredAwaitable
+            ? known.IsBlockingAwaiterReceiver(receiverType)
+            : known.IsTaskLike(receiverType);
+        if (!isBlockingReceiver)
             return;
 
         var flag = ClassifyContext(context.SemanticModel, invocation);
@@ -401,17 +409,29 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
         private readonly INamedTypeSymbol? _taskOfT;
         private readonly INamedTypeSymbol? _valueTask;
         private readonly INamedTypeSymbol? _valueTaskOfT;
+        private readonly INamedTypeSymbol? _configuredTaskAwaitable;
+        private readonly INamedTypeSymbol? _configuredTaskAwaitableOfT;
+        private readonly INamedTypeSymbol? _configuredValueTaskAwaitable;
+        private readonly INamedTypeSymbol? _configuredValueTaskAwaitableOfT;
 
         private TaskTypes(
             INamedTypeSymbol? task,
             INamedTypeSymbol? taskOfT,
             INamedTypeSymbol? valueTask,
-            INamedTypeSymbol? valueTaskOfT)
+            INamedTypeSymbol? valueTaskOfT,
+            INamedTypeSymbol? configuredTaskAwaitable,
+            INamedTypeSymbol? configuredTaskAwaitableOfT,
+            INamedTypeSymbol? configuredValueTaskAwaitable,
+            INamedTypeSymbol? configuredValueTaskAwaitableOfT)
         {
             _task = task;
             _taskOfT = taskOfT;
             _valueTask = valueTask;
             _valueTaskOfT = valueTaskOfT;
+            _configuredTaskAwaitable = configuredTaskAwaitable;
+            _configuredTaskAwaitableOfT = configuredTaskAwaitableOfT;
+            _configuredValueTaskAwaitable = configuredValueTaskAwaitable;
+            _configuredValueTaskAwaitableOfT = configuredValueTaskAwaitableOfT;
         }
 
         public bool Any => _task is not null || _taskOfT is not null
@@ -421,7 +441,11 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
             compilation.GetTypeByMetadataName("System.Threading.Tasks.Task"),
             compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1"),
             compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask"),
-            compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1"));
+            compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1"),
+            compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredTaskAwaitable"),
+            compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1"),
+            compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"),
+            compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"));
 
         /// <summary>
         /// True when <paramref name="type"/> is (or, for <c>Task</c>, derives from)
@@ -448,6 +472,30 @@ public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// True when <paramref name="type"/> is a valid receiver for the blocking
+        /// <c>.GetAwaiter().GetResult()</c> form: a <c>Task</c>/<c>ValueTask</c>, OR a
+        /// <c>ConfigureAwait(...)</c> wrapper over one
+        /// (<c>ConfiguredTaskAwaitable[&lt;T&gt;]</c> / <c>ConfiguredValueTaskAwaitable[&lt;T&gt;]</c>).
+        /// <c>ConfigureAwait</c> only affects continuation scheduling — <c>GetResult()</c>
+        /// still blocks the calling thread — and these awaitable types are produced solely by
+        /// <c>Task</c>/<c>ValueTask.ConfigureAwait</c>, so treating them as blocking is FP-free.
+        /// </summary>
+        public bool IsBlockingAwaiterReceiver(ITypeSymbol? type)
+        {
+            if (IsTaskLike(type))
+                return true;
+
+            if (type is null)
+                return false;
+
+            var definition = type.OriginalDefinition;
+            return Matches(definition, _configuredTaskAwaitable)
+                || Matches(definition, _configuredTaskAwaitableOfT)
+                || Matches(definition, _configuredValueTaskAwaitable)
+                || Matches(definition, _configuredValueTaskAwaitableOfT);
         }
 
         private static bool Matches(ITypeSymbol candidate, INamedTypeSymbol? wellKnown) =>

--- a/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
+++ b/src/Reactor.Analyzers/BlockingTaskAnalyzer.cs
@@ -1,0 +1,381 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// REACTOR_THREAD_002: Detects blocking on a <c>Task</c>/<c>ValueTask</c> — a
+/// <c>.Result</c> read, a <c>.Wait()</c> call, or a <c>.GetAwaiter().GetResult()</c>
+/// call — lexically inside a component <c>Render()</c> override or a <c>UseEffect</c>
+/// effect lambda. Both run on the UI thread, so blocking there deadlocks or freezes
+/// the reconciler and the dispatcher together.
+/// </summary>
+/// <remarks>
+/// This is the WinForms/WPF "just block for the result" reflex. There is no mechanical
+/// fix (the correct rewrite is <c>UseResource</c> / an async effect, which restructures
+/// the method) so the diagnostic only points at the async-data recipe.
+///
+/// Detection is a cheap syntactic gate (member name <c>Result</c>/<c>Wait</c>/
+/// <c>GetResult</c>) followed by a semantic receiver-type confirmation, so false
+/// positives are near zero: the receiver must resolve to <c>Task</c>/<c>Task&lt;T&gt;</c>
+/// or <c>ValueTask</c>/<c>ValueTask&lt;T&gt;</c>. A block reached only through a nested
+/// lambda (e.g. <c>Task.Run(() =&gt; t.Result)</c>) is intentionally ignored — it no
+/// longer runs on the render/effect thread — which also covers every other deferred
+/// callback (event handlers, LINQ projections, continuations).
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class BlockingTaskAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_THREAD_002";
+
+    private const string ComponentType = "Microsoft.UI.Reactor.Core.Component";
+    private const string RenderContextType = "Microsoft.UI.Reactor.Core.RenderContext";
+
+    private static readonly LocalizableString Title =
+        "Blocking a Task on the UI thread in Render or an effect";
+
+    private static readonly LocalizableString MessageFormat =
+        "Blocking a Task with '{0}' in {1} freezes the UI thread. Use UseResource or an async effect ('await') instead of blocking.";
+
+    private static readonly LocalizableString Description =
+        "Render() and UseEffect effects run on the UI thread. Reading Task.Result or calling " +
+        ".Wait()/.GetAwaiter().GetResult() there blocks the dispatcher and the reconciler, " +
+        "deadlocking or freezing the app. Fetch async data with UseResource, or do the work in " +
+        "an async effect that awaits and then sets state.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Threading",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    /// <summary>Whether — and how — a blocking expression is inside a flagged context.</summary>
+    private enum FlagContext
+    {
+        None,
+        Render,
+        Effect,
+    }
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(start =>
+        {
+            var known = TaskTypes.Resolve(start.Compilation);
+            if (!known.Any)
+            {
+                // No Task/ValueTask in this compilation — nothing this rule can flag.
+                return;
+            }
+
+            start.RegisterSyntaxNodeAction(
+                ctx => AnalyzeMemberAccess(ctx, known), SyntaxKind.SimpleMemberAccessExpression);
+            start.RegisterSyntaxNodeAction(
+                ctx => AnalyzeInvocation(ctx, known), SyntaxKind.InvocationExpression);
+        });
+    }
+
+    /// <summary>Handles the <c>task.Result</c> property-read form.</summary>
+    private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context, TaskTypes known)
+    {
+        var memberAccess = (MemberAccessExpressionSyntax)context.Node;
+
+        // Syntactic gate first (cheap): only `.Result`.
+        if (memberAccess.Name.Identifier.Text != "Result")
+            return;
+
+        // `Task<T>.Result` is a property, never invoked. If this member access is the
+        // callee of an invocation it is a method named `Result`, not the task property.
+        if (memberAccess.Parent is InvocationExpressionSyntax invParent && invParent.Expression == memberAccess)
+            return;
+
+        // Semantic receiver-type confirmation.
+        if (!known.IsTaskLike(context.SemanticModel.GetTypeInfo(memberAccess.Expression).Type))
+            return;
+
+        var flag = ClassifyContext(context.SemanticModel, memberAccess);
+        if (flag == FlagContext.None)
+            return;
+
+        Report(context, memberAccess, ".Result", flag);
+    }
+
+    /// <summary>Handles the <c>task.Wait()</c> and <c>task.GetAwaiter().GetResult()</c> forms.</summary>
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context, TaskTypes known)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        var name = memberAccess.Name.Identifier.Text;
+
+        ExpressionSyntax? taskReceiver;
+        string blockingForm;
+
+        if (name == "Wait")
+        {
+            // Match `.Wait()` exactly. Timeout overloads (`Wait(int)`/`Wait(TimeSpan)`)
+            // return a bool and include non-blocking poll shapes (`Wait(0)`), so they
+            // are intentionally out of scope.
+            if (invocation.ArgumentList.Arguments.Count != 0)
+                return;
+            taskReceiver = memberAccess.Expression;
+            blockingForm = ".Wait()";
+        }
+        else if (name == "GetResult")
+        {
+            // Require the exact `<task>.GetAwaiter().GetResult()` idiom so we never fire on
+            // an unrelated `GetResult()`. The task receiver is what `.GetAwaiter()` is called on.
+            if (memberAccess.Expression is not InvocationExpressionSyntax getAwaiterInvocation ||
+                getAwaiterInvocation.Expression is not MemberAccessExpressionSyntax getAwaiterAccess ||
+                getAwaiterAccess.Name.Identifier.Text != "GetAwaiter" ||
+                getAwaiterInvocation.ArgumentList.Arguments.Count != 0)
+            {
+                return;
+            }
+
+            taskReceiver = getAwaiterAccess.Expression;
+            blockingForm = ".GetAwaiter().GetResult()";
+        }
+        else
+        {
+            return;
+        }
+
+        if (!known.IsTaskLike(context.SemanticModel.GetTypeInfo(taskReceiver).Type))
+            return;
+
+        var flag = ClassifyContext(context.SemanticModel, invocation);
+        if (flag == FlagContext.None)
+            return;
+
+        Report(context, invocation, blockingForm, flag);
+    }
+
+    private static void Report(SyntaxNodeAnalysisContext context, SyntaxNode location, string blockingForm, FlagContext flag)
+    {
+        var contextLabel = flag == FlagContext.Effect ? "a UseEffect effect" : "Render()";
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            location.GetLocation(),
+            blockingForm,
+            contextLabel));
+    }
+
+    /// <summary>
+    /// Walks up from a blocking expression to decide whether it runs inside a component
+    /// <c>Render()</c> override or a <c>UseEffect</c> effect lambda. The first execution
+    /// boundary (lambda, local function, or method declaration) is decisive:
+    /// <list type="bullet">
+    /// <item>a <c>UseEffect</c> effect lambda → <see cref="FlagContext.Effect"/>;</item>
+    /// <item>any other lambda or local function → <see cref="FlagContext.None"/> (the call
+    /// is deferred — a nested <c>Task.Run</c>, an event handler, a LINQ projection — and no
+    /// longer runs on the render/effect thread);</item>
+    /// <item>a <c>Render()</c> override reached with no intervening lambda →
+    /// <see cref="FlagContext.Render"/>.</item>
+    /// </list>
+    /// </summary>
+    private static FlagContext ClassifyContext(SemanticModel model, SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            switch (current)
+            {
+                case SimpleLambdaExpressionSyntax:
+                case ParenthesizedLambdaExpressionSyntax:
+                case AnonymousMethodExpressionSyntax:
+                    return IsUseEffectEffectLambda(model, current) ? FlagContext.Effect : FlagContext.None;
+
+                case LocalFunctionStatementSyntax:
+                    return FlagContext.None;
+
+                case MethodDeclarationSyntax method:
+                    return IsRenderOverride(model, method) ? FlagContext.Render : FlagContext.None;
+
+                // Any other member body (property/indexer/accessor/ctor/operator/field
+                // initializer) is not a render/effect context.
+                case AccessorDeclarationSyntax:
+                case PropertyDeclarationSyntax:
+                case IndexerDeclarationSyntax:
+                case ConstructorDeclarationSyntax:
+                case DestructorDeclarationSyntax:
+                case OperatorDeclarationSyntax:
+                case ConversionOperatorDeclarationSyntax:
+                case BaseTypeDeclarationSyntax:
+                    return FlagContext.None;
+            }
+        }
+
+        return FlagContext.None;
+    }
+
+    /// <summary>
+    /// True when <paramref name="lambda"/> is the effect argument (index 0) of a
+    /// <c>UseEffect</c> call bound to <c>RenderContext.UseEffect</c> or a
+    /// <c>Component</c> wrapper. Mirrors the Component-or-RenderContext anchoring the
+    /// shipped hook analyzer uses.
+    /// </summary>
+    private static bool IsUseEffectEffectLambda(SemanticModel model, SyntaxNode lambda)
+    {
+        if (lambda.Parent is not ArgumentSyntax argument ||
+            argument.Parent is not ArgumentListSyntax argumentList ||
+            argumentList.Parent is not InvocationExpressionSyntax invocation)
+        {
+            return false;
+        }
+
+        // The effect is always the first argument of every UseEffect overload.
+        if (argumentList.Arguments.IndexOf(argument) != 0)
+            return false;
+
+        // Cheap name gate before touching the semantic model.
+        if (GetInvokedSimpleName(invocation) != "UseEffect")
+            return false;
+
+        if (model.GetSymbolInfo(invocation).Symbol is IMethodSymbol symbol)
+        {
+            if (symbol.Name != "UseEffect")
+                return false;
+
+            if (symbol.ContainingType is INamedTypeSymbol containing &&
+                (IsOrDerivesFrom(containing, ComponentType) || IsOrDerivesFrom(containing, RenderContextType)))
+            {
+                return true;
+            }
+
+            if (symbol.IsExtensionMethod && symbol.ReceiverType is INamedTypeSymbol receiver &&
+                (IsOrDerivesFrom(receiver, RenderContextType) || IsOrDerivesFrom(receiver, ComponentType)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        // Fallback for an unresolved/overload-ambiguous call: check the receiver's type.
+        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+            model.GetTypeInfo(memberAccess.Expression).Type is INamedTypeSymbol receiverType &&
+            (IsOrDerivesFrom(receiverType, RenderContextType) || IsOrDerivesFrom(receiverType, ComponentType)))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when <paramref name="method"/> is a <c>Render()</c> override on a
+    /// <c>Component</c>-derived type. Falls back to the syntactic <c>override</c> modifier
+    /// when the symbol cannot be resolved (incremental compile).
+    /// </summary>
+    private static bool IsRenderOverride(SemanticModel model, MethodDeclarationSyntax method)
+    {
+        if (method.Identifier.Text != "Render")
+            return false;
+
+        if (model.GetDeclaredSymbol(method) is IMethodSymbol symbol)
+        {
+            return symbol.IsOverride && IsOrDerivesFrom(symbol.ContainingType, ComponentType);
+        }
+
+        return method.Modifiers.Any(SyntaxKind.OverrideKeyword);
+    }
+
+    private static string? GetInvokedSimpleName(InvocationExpressionSyntax invocation) =>
+        invocation.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.Text,
+            MemberBindingExpressionSyntax memberBinding => memberBinding.Name.Identifier.Text,
+            _ => null,
+        };
+
+    private static bool IsOrDerivesFrom(INamedTypeSymbol? type, string fullyQualifiedName)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            var name = current.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                .Replace("global::", "");
+            if (name == fullyQualifiedName)
+                return true;
+            // Accept generic forms: Component<T> derives from Component.
+            if (name.StartsWith(fullyQualifiedName + "<", System.StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Well-known blocking receiver types, resolved once per compilation.</summary>
+    private readonly struct TaskTypes
+    {
+        private readonly INamedTypeSymbol? _task;
+        private readonly INamedTypeSymbol? _taskOfT;
+        private readonly INamedTypeSymbol? _valueTask;
+        private readonly INamedTypeSymbol? _valueTaskOfT;
+
+        private TaskTypes(
+            INamedTypeSymbol? task,
+            INamedTypeSymbol? taskOfT,
+            INamedTypeSymbol? valueTask,
+            INamedTypeSymbol? valueTaskOfT)
+        {
+            _task = task;
+            _taskOfT = taskOfT;
+            _valueTask = valueTask;
+            _valueTaskOfT = valueTaskOfT;
+        }
+
+        public bool Any => _task is not null || _taskOfT is not null
+            || _valueTask is not null || _valueTaskOfT is not null;
+
+        public static TaskTypes Resolve(Compilation compilation) => new(
+            compilation.GetTypeByMetadataName("System.Threading.Tasks.Task"),
+            compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1"),
+            compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask"),
+            compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1"));
+
+        /// <summary>
+        /// True when <paramref name="type"/> is (or, for <c>Task</c>, derives from)
+        /// one of the four awaitable task types.
+        /// </summary>
+        public bool IsTaskLike(ITypeSymbol? type)
+        {
+            if (type is null)
+                return false;
+
+            var definition = type.OriginalDefinition;
+            if (Matches(definition, _task) || Matches(definition, _taskOfT)
+                || Matches(definition, _valueTask) || Matches(definition, _valueTaskOfT))
+            {
+                return true;
+            }
+
+            // Custom Task subclasses (rare). ValueTask is a sealed struct — no subclassing.
+            for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+            {
+                var baseDefinition = baseType.OriginalDefinition;
+                if (Matches(baseDefinition, _task) || Matches(baseDefinition, _taskOfT))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool Matches(ITypeSymbol candidate, INamedTypeSymbol? wellKnown) =>
+            wellKnown is not null && SymbolEqualityComparer.Default.Equals(candidate, wellKnown);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs
@@ -61,6 +61,21 @@ namespace App
     {
         public int Result => 42;
     }
+
+    // A non-Task type exposing Wait()/Result()/GetAwaiter().GetResult() members whose
+    // names match the syntactic fast path but whose receiver is not Task-like — the
+    // semantic receiver-type check must reject all of these.
+    public sealed class NotATask
+    {
+        public void Wait() { }
+        public int Result() => 0;              // a method named Result, not the Task property
+        public CustomAwaiter GetAwaiter() => new CustomAwaiter();
+    }
+
+    public sealed class CustomAwaiter
+    {
+        public int GetResult() => 0;
+    }
 }
 ";
 
@@ -322,6 +337,233 @@ namespace App
         private static async void Load()
         {
             var data = await Data.FetchAsync();
+        }
+    }
+}");
+    }
+
+    // ── Positive: null-conditional blocking forms ──────────────────────
+
+    [Fact]
+    public async Task Fires_For_Conditional_Result_In_Render()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var data = {|REACTOR_THREAD_002:Data.FetchAsync()?.Result|};
+            return new TextElement(data.ToString());
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task Fires_For_Conditional_Wait_In_Render()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            {|REACTOR_THREAD_002:Data.RunAsync()?.Wait()|};
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task Fires_For_Conditional_GetAwaiter_GetResult_In_Render()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var data = {|REACTOR_THREAD_002:Data.FetchAsync()?.GetAwaiter().GetResult()|};
+            return new TextElement(data.ToString());
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task Fires_For_Conditional_Result_In_UseEffect_Lambda()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            UseEffect(() =>
+            {
+                var data = {|REACTOR_THREAD_002:Data.FetchAsync()?.Result|};
+            }, System.Array.Empty<object>());
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
+    // ── Negative: .Result inside nested Task.Run within an effect ───────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Result_Inside_Nested_TaskRun_In_Effect()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    using System.Threading.Tasks;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            UseEffect(() =>
+            {
+                _ = Task.Run(() =>
+                {
+                    var data = Data.FetchAsync().Result;
+                    return data;
+                });
+            }, System.Array.Empty<object>());
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
+    // ── Near-miss: invocation fast-path shapes on non-Task receivers ────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Wait_On_Non_Task()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            new NotATask().Wait();
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Result_Method_On_Non_Task()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var value = new NotATask().Result();
+            return new TextElement(value.ToString());
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_GetAwaiter_GetResult_On_Non_Task()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var value = new NotATask().GetAwaiter().GetResult();
+            return new TextElement(value.ToString());
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Wait_With_Timeout_Argument()
+    {
+        // Only zero-arg .Wait() is in scope; the timeout overload (returns bool and
+        // includes the non-blocking Wait(0) poll) is intentionally excluded.
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            _ = Data.RunAsync().Wait(0);
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
+    // ── Accepted false negative: blocking inside a non-effect nested function ──
+
+    [Fact]
+    public async Task No_Diagnostic_For_Result_In_NonEffect_Nested_Lambda_In_Render()
+    {
+        // Blocking inside a nested lambda that is not the UseEffect effect (here a LINQ
+        // projection) is intentionally NOT flagged: a syntactic analyzer cannot prove the
+        // lambda runs synchronously on the render thread, so it is treated as a deferred
+        // boundary to keep false positives near zero (see ClassifyContext).
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    using System.Linq;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var ids = new[] { 1, 2 };
+            var first = ids.Select(i => Data.FetchAsync().Result).First();
+            return new TextElement(first.ToString());
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Result_In_Local_Function_In_Render()
+    {
+        // A local function is a deferred boundary — blocking inside one is not flagged
+        // even though it is declared in Render.
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            int Load() => Data.FetchAsync().Result;
+            return new TextElement(Load().ToString());
         }
     }
 }");

--- a/tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs
@@ -330,11 +330,11 @@ namespace App
     {
         public override Element Render()
         {
-            UseEffect(() => Load(), System.Array.Empty<object>());
+            UseEffect(() => { _ = Load(); }, System.Array.Empty<object>());
             return new TextElement(""hi"");
         }
 
-        private static async void Load()
+        private static async System.Threading.Tasks.Task Load()
         {
             var data = await Data.FetchAsync();
         }

--- a/tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs
@@ -419,6 +419,44 @@ namespace App
 }");
     }
 
+    // ── Positive: ConfigureAwait(false).GetAwaiter().GetResult() ────────
+
+    [Fact]
+    public async Task Fires_For_ConfigureAwait_GetResult_In_Render()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var data = {|REACTOR_THREAD_002:Data.FetchAsync().ConfigureAwait(false).GetAwaiter().GetResult()|};
+            return new TextElement(data.ToString());
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task Fires_For_ValueTask_ConfigureAwait_GetResult_In_Render()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var data = {|REACTOR_THREAD_002:Data.FetchValueAsync().ConfigureAwait(false).GetAwaiter().GetResult()|};
+            return new TextElement(data.ToString());
+        }
+    }
+}");
+    }
+
     // ── Negative: .Result inside nested Task.Run within an effect ───────
 
     [Fact]

--- a/tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs
@@ -419,6 +419,30 @@ namespace App
 }");
     }
 
+    // ── Positive: named-argument UseEffect ─────────────────────────────
+
+    [Fact]
+    public async Task Fires_For_Result_In_UseEffect_With_Named_Arguments()
+    {
+        // Named-argument reordering must still be recognized as the effect lambda.
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            UseEffect(dependencies: System.Array.Empty<object>(), effect: () =>
+            {
+                var data = {|REACTOR_THREAD_002:Data.FetchAsync().Result|};
+            });
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
     // ── Positive: ConfigureAwait(false).GetAwaiter().GetResult() ────────
 
     [Fact]

--- a/tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs
@@ -1,0 +1,329 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="BlockingTaskAnalyzer"/> (<c>REACTOR_THREAD_002</c>). Stubs a
+/// minimal Reactor-shaped <c>Component</c> / <c>RenderContext</c> (with a real
+/// <c>UseEffect</c> overload set) so the analyzer's Render/effect context walk and its
+/// semantic <c>Task</c>-receiver confirmation both fire without pulling the framework in.
+/// </summary>
+public class BlockingTaskAnalyzerTests
+{
+    // Shapes the two anchoring types the analyzer keys off — Component (with a Render()
+    // override target + protected UseEffect wrappers) and RenderContext (public UseEffect)
+    // — under the real Microsoft.UI.Reactor.Core namespace, plus a couple of async helpers.
+    private const string Stubs = @"
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public abstract class Element { }
+
+    public sealed class RenderContext
+    {
+        public void UseEffect(Action effect, params object[] dependencies) { }
+        public void UseEffect(Func<Action> effectWithCleanup, params object[] dependencies) { }
+    }
+
+    public abstract class Component
+    {
+        protected RenderContext Context = new RenderContext();
+        public abstract Element Render();
+        protected void UseEffect(Action effect, params object[] dependencies) { }
+        protected void UseEffect(Func<Action> effectWithCleanup, params object[] dependencies) { }
+    }
+}
+
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class TextElement : Element
+    {
+        public TextElement(string s) { }
+    }
+
+    public static class Data
+    {
+        public static Task<int> FetchAsync() => Task.FromResult(1);
+        public static ValueTask<int> FetchValueAsync() => new ValueTask<int>(1);
+        public static Task RunAsync() => Task.CompletedTask;
+    }
+
+    // A non-Task type that also exposes a .Result member — must never trip the rule.
+    public sealed class Poll
+    {
+        public int Result => 42;
+    }
+}
+";
+
+    private static Task VerifyAsync(string body) =>
+        new CSharpAnalyzerTest<BlockingTaskAnalyzer, DefaultVerifier>
+        {
+            TestCode = Stubs + body,
+        }.RunAsync(TestContext.Current.CancellationToken);
+
+    // ── Positive: blocking inside Render() ──────────────────────────────
+
+    [Fact]
+    public async Task Fires_For_Result_In_Render()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var data = {|REACTOR_THREAD_002:Data.FetchAsync().Result|};
+            return new TextElement(data.ToString());
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task Fires_For_Wait_In_Render()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            {|REACTOR_THREAD_002:Data.RunAsync().Wait()|};
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task Fires_For_GetAwaiter_GetResult_In_Render()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var data = {|REACTOR_THREAD_002:Data.FetchAsync().GetAwaiter().GetResult()|};
+            return new TextElement(data.ToString());
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task Fires_For_ValueTask_Result_In_Render()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var data = {|REACTOR_THREAD_002:Data.FetchValueAsync().Result|};
+            return new TextElement(data.ToString());
+        }
+    }
+}");
+    }
+
+    // ── Positive: blocking inside a UseEffect lambda ────────────────────
+
+    [Fact]
+    public async Task Fires_For_Result_In_UseEffect_Lambda()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            UseEffect(() =>
+            {
+                var data = {|REACTOR_THREAD_002:Data.FetchAsync().Result|};
+            }, System.Array.Empty<object>());
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task Fires_For_Result_In_RenderContext_UseEffect_Lambda()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            Context.UseEffect(() =>
+            {
+                {|REACTOR_THREAD_002:Data.RunAsync().Wait()|};
+            }, System.Array.Empty<object>());
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
+    // ── Negative: nested Task.Run inside Render (background thread) ──────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Result_Inside_Nested_TaskRun()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    using System.Threading.Tasks;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            _ = Task.Run(() =>
+            {
+                var data = Data.FetchAsync().Result;
+                return data;
+            });
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_GetResult_Inside_Nested_TaskRun_In_Effect()
+    {
+        // Task.Run inside a UseEffect body still moves the block off the UI thread.
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    using System.Threading.Tasks;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            UseEffect(() =>
+            {
+                _ = Task.Run(() => Data.FetchAsync().GetAwaiter().GetResult());
+            }, System.Array.Empty<object>());
+            return new TextElement(""hi"");
+        }
+    }
+}");
+    }
+
+    // ── Negative: .Result on a non-Task property ───────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Result_On_Non_Task()
+    {
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            var poll = new Poll();
+            var value = poll.Result;
+            return new TextElement(value.ToString());
+        }
+    }
+}");
+    }
+
+    // ── Near-miss: blocking OUTSIDE any render/effect context ──────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Result_Outside_Render_Or_Effect()
+    {
+        // Same Data.FetchAsync().Result shape, but in a plain method on a Component —
+        // not Render(), not a UseEffect lambda. This is the syntactic near-miss that the
+        // context walk must reject.
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render() => new TextElement(""hi"");
+
+        public int LoadSync()
+        {
+            return Data.FetchAsync().Result;
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Result_In_NonComponent_Render()
+    {
+        // A Render() override that is NOT on a Reactor Component must not fire.
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public abstract class Drawable
+    {
+        public abstract void Render();
+    }
+    public sealed class C : Drawable
+    {
+        public override void Render()
+        {
+            var data = Data.FetchAsync().Result;
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Awaited_Task_In_Render()
+    {
+        // The correct async form: an async effect that awaits. No blocking member.
+        await VerifyAsync(@"
+namespace App
+{
+    using Microsoft.UI.Reactor.Core;
+    public sealed class C : Component
+    {
+        public override Element Render()
+        {
+            UseEffect(() => Load(), System.Array.Empty<object>());
+            return new TextElement(""hi"");
+        }
+
+        private static async void Load()
+        {
+            var data = await Data.FetchAsync();
+        }
+    }
+}");
+    }
+}


### PR DESCRIPTION
## Summary

Implements **REACTOR_THREAD_002** (spec 060, Analyzer Suite Expansion — Wave A packet for `REACTOR_THREAD_002`).

`BlockingTaskAnalyzer` (`Reactor.Threading`, **Warning**, **no fix**) flags the WinForms/WPF "just block for the result" reflex on the UI thread:

- a `.Result` read,
- a `.Wait()` call, or
- a `.GetAwaiter().GetResult()` call

whose receiver is **`Task`/`Task<T>`/`ValueTask`/`ValueTask<T>`** (semantically confirmed), sitting directly in a component **`Render()`** override or a **`UseEffect`** effect lambda. On the UI thread this deadlocks or freezes the reconciler and the dispatcher together.

There is no mechanical fix (the correct rewrite is `UseResource` / an async effect, which restructures the method); the message points at that recipe.

## Detection design

- **Syntactic gate first** (member name `Result`/`Wait`/`GetResult`), then a **semantic receiver-type** check — so FP is near zero.
- **Context walk**: the first execution boundary decides.
  - `UseEffect` effect lambda (arg 0, bound to `Component` or `RenderContext`) → flag.
  - any other lambda / local function → **not** flagged (covers nested `Task.Run` and every other deferred callback — it no longer runs on the render/effect thread).
  - a `Render()` override on a `Component`-derived type, reached with no intervening lambda → flag.
- Render/`UseEffect` anchoring mirrors the shipped `HookRulesAnalyzer` (Component **or** RenderContext), per the contract's battle-tested rule.
- `.Wait()` is matched zero-arg only (timeout overloads return `bool` / include non-blocking `Wait(0)` polls).

## Changes

- `src/Reactor.Analyzers/BlockingTaskAnalyzer.cs` — new analyzer.
- `src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md` — canonical release row.
- `plugins/reactor/skills/reactor-build-and-check/SKILL.md` — app-author cheat-table row.
- `tests/Reactor.Tests/AnalyzerTests/BlockingTaskAnalyzerTests.cs` — 12 tests (inline stubs).

## Tests

`dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~BlockingTask` → **12/12 pass**. Full `AnalyzerTests` namespace → **227/227 pass** (packaging + consistency guards included). Analyzer DLL builds clean under `EnforceExtendedAnalyzerRules`.

Coverage: positive (`.Result`/`.Wait()`/`.GetAwaiter().GetResult()` in `Render()`, `ValueTask.Result`, `.Result` in a `Component`/`RenderContext` `UseEffect` lambda); negative (nested `Task.Run`, `.Result` on a non-Task property); near-miss (`.Result` outside any render/effect method, a non-Component `Render()` override, an awaited task).

Stacked on `azchohfi-spec-060-analyzer-suite` (the spec-060 foundation contract).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>