### PR TITLE
feat(analyzer): REACTOR_THEME_004 — hard-coded Brush/Color

### DIFF
--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -85,6 +85,7 @@ Additional flags:
 | `REACTOR_THEME_001` | warning | Hardcoded color on a themed surface | Use `Theme.*` tokens (e.g. `Theme.PrimaryText`, `Theme.CardBackground`). See `reactor-design`. |
 | `REACTOR_THEME_002` | info | Lightweight styling opportunity | Optional. Use `.Resources(r => r.Set("ButtonBackground", …))` for visual-state overrides. |
 | `REACTOR_THEME_003` | info | `RequestedTheme` modifier available | Use `.RequestedTheme(ElementTheme.Dark)` for subtree theme overrides. |
+| `REACTOR_THEME_004` | warning | Inline `new SolidColorBrush(...)` passed to `.Background`/`.Foreground`/`.WithBorder` | Use a `Theme.*` token (e.g. `Theme.SolidBackground`, `Theme.PrimaryText`) — a raw brush is a fixed color that ignores Light/Dark. |
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,6 +5,7 @@ Rule ID | Category | Severity | Notes
 REACTOR_THEME_001 | Reactor.Style | Warning | UseThemeRefAnalyzer - Use ThemeRef instead of hard-coded color
 REACTOR_THEME_002 | Reactor.Style | Info | UseLightweightStylingAnalyzer - Consider lightweight styling for visual-state overrides
 REACTOR_THEME_003 | Reactor.Style | Info | RequestedThemeSetAnalyzer - RequestedTheme modifier available
+REACTOR_THEME_004 | Reactor.Style | Warning | UseThemeRefAnalyzer - Hard-coded Brush/Color object bypasses theme tokens
 REACTOR_HOOKS_001 | Reactor.Hooks | Warning | HookRulesAnalyzer - Hook called conditionally
 REACTOR_HOOKS_004 | Reactor.Hooks | Warning | HookRulesAnalyzer - Hook deps contains freshly allocated value
 REACTOR_HOOKS_005 | Reactor.Hooks | Warning | HookRulesAnalyzer - Hook called outside Render or custom-hook method

--- a/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
+++ b/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
@@ -192,22 +192,28 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
     }
 
     // Accept only the WinUI static Colors class: bare `Colors` (with `using Microsoft.UI;`), or the
-    // qualified `Microsoft.UI.Colors` / `Windows.UI.Colors`. A look-alike such as
-    // `MyCompany.UI.Colors` or an unrelated `Foo.White` is intentionally rejected so the code fix
-    // never maps a non-WinUI palette. (The code fix additionally confirms the SolidColorBrush type
-    // semantically before rewriting.)
+    // qualified `Microsoft.UI.Colors` / `Windows.UI.Colors` (optionally `global::`-qualified). A
+    // look-alike such as `MyCompany.UI.Colors` or an unrelated `Foo.White` is intentionally rejected
+    // so the code fix never maps a non-WinUI palette. (The code fix additionally confirms the
+    // SolidColorBrush type semantically before rewriting.)
     private static bool IsColorsReceiver(ExpressionSyntax receiver) => receiver switch
     {
         IdentifierNameSyntax { Identifier.Text: "Colors" } => true,
         MemberAccessExpressionSyntax
         {
             Name.Identifier.Text: "Colors",
-            Expression: MemberAccessExpressionSyntax
-            {
-                Name.Identifier.Text: "UI",
-                Expression: IdentifierNameSyntax { Identifier.Text: "Microsoft" or "Windows" }
-            }
-        } => true,
+            Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: "UI", Expression: var root }
+        } => IsMicrosoftOrWindowsRoot(root),
+        _ => false,
+    };
+
+    // The `Microsoft` / `Windows` root of `Microsoft.UI.Colors` / `Windows.UI.Colors`, allowing a
+    // `global::` alias qualifier (e.g. `global::Microsoft.UI.Colors`, common in generated/qualified
+    // code — the framework itself uses it).
+    private static bool IsMicrosoftOrWindowsRoot(ExpressionSyntax root) => root switch
+    {
+        IdentifierNameSyntax { Identifier.Text: "Microsoft" or "Windows" } => true,
+        AliasQualifiedNameSyntax { Name.Identifier.Text: "Microsoft" or "Windows" } => true,
         _ => false,
     };
 

--- a/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
+++ b/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
@@ -62,7 +62,7 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
         ImmutableArray.Create(Rule, BrushRule);
 
     /// <summary>Generic suggestion emitted when a hard-coded color has no known token mapping.</summary>
-    internal const string GenericTokenSuggestion = "Accent or another semantic token";
+    internal const string GenericTokenSuggestion = "Accent";
 
     /// <summary>Known color-to-theme-token mappings for code fix suggestions.</summary>
     internal static readonly ImmutableDictionary<string, string> ColorToThemeToken =
@@ -112,8 +112,9 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
         var colorValue = literal.Token.ValueText;
         // </snippet:theme-ref-rule>
 
-        // Suggest a specific theme token if we have a mapping, otherwise generic
-        var suggestion = ColorToThemeToken.TryGetValue(colorValue, out var token)
+        // Suggest a specific theme token when the mapping also fits the target modifier — a surface
+        // token is a poor foreground suggestion (and vice versa) — otherwise stay generic.
+        var suggestion = ColorToThemeToken.TryGetValue(colorValue, out var token) && TokenFitsModifier(token, methodName)
             ? token
             : GenericTokenSuggestion;
 
@@ -147,8 +148,11 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
         if (!IsSolidColorBrushType(creation.Type))
             return;
 
+        var modifier = memberAccess.Name.Identifier.Text;
         var colorName = TryGetColorName(creation);
-        var suggestion = colorName is not null && ColorToThemeToken.TryGetValue(colorName, out var token)
+        var suggestion = colorName is not null
+            && ColorToThemeToken.TryGetValue(colorName, out var token)
+            && TokenFitsModifier(token, modifier)
             ? token
             : GenericTokenSuggestion;
 
@@ -189,8 +193,31 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
 
     private static bool IsColorsReceiver(ExpressionSyntax receiver) => receiver switch
     {
-        IdentifierNameSyntax id => id.Identifier.Text == "Colors",
-        MemberAccessExpressionSyntax member => member.Name.Identifier.Text == "Colors",
+        // Bare `Colors` (with `using Microsoft.UI;`).
+        IdentifierNameSyntax { Identifier.Text: "Colors" } => true,
+        // A qualified `...UI.Colors` (Microsoft.UI.Colors / global::Microsoft.UI.Colors /
+        // Windows.UI.Colors). A nested `MyPalette.Colors.White` or an unrelated `Foo.White` is
+        // intentionally rejected so the code fix never maps a non-WinUI color.
+        MemberAccessExpressionSyntax
+        {
+            Name.Identifier.Text: "Colors",
+            Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: "UI" }
+        } => true,
         _ => false,
+    };
+
+    /// <summary>
+    /// Whether a mapped theme <paramref name="token"/> is a sensible suggestion/auto-fix for the
+    /// target <paramref name="modifier"/>. The color→token map is keyed by color only, so a surface
+    /// token (e.g. <c>SolidBackground</c>) could otherwise be suggested for <c>.Foreground</c> —
+    /// which flips colors the wrong way across themes (white foreground text rewritten to a
+    /// background brush is invisible in Light). Keep in sync with the values in
+    /// <see cref="ColorToThemeToken"/>.
+    /// </summary>
+    internal static bool TokenFitsModifier(string token, string modifier) => token switch
+    {
+        "PrimaryText" => modifier == "Foreground",
+        "SolidBackground" => modifier is "Background" or "WithBorder",
+        _ => true, // Accent / neutral tokens fit any target modifier.
     };
 }

--- a/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
+++ b/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
@@ -191,17 +191,22 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
+    // Accept only the WinUI static Colors class: bare `Colors` (with `using Microsoft.UI;`), or the
+    // qualified `Microsoft.UI.Colors` / `Windows.UI.Colors`. A look-alike such as
+    // `MyCompany.UI.Colors` or an unrelated `Foo.White` is intentionally rejected so the code fix
+    // never maps a non-WinUI palette. (The code fix additionally confirms the SolidColorBrush type
+    // semantically before rewriting.)
     private static bool IsColorsReceiver(ExpressionSyntax receiver) => receiver switch
     {
-        // Bare `Colors` (with `using Microsoft.UI;`).
         IdentifierNameSyntax { Identifier.Text: "Colors" } => true,
-        // A qualified `...UI.Colors` (Microsoft.UI.Colors / global::Microsoft.UI.Colors /
-        // Windows.UI.Colors). A nested `MyPalette.Colors.White` or an unrelated `Foo.White` is
-        // intentionally rejected so the code fix never maps a non-WinUI color.
         MemberAccessExpressionSyntax
         {
             Name.Identifier.Text: "Colors",
-            Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: "UI" }
+            Expression: MemberAccessExpressionSyntax
+            {
+                Name.Identifier.Text: "UI",
+                Expression: IdentifierNameSyntax { Identifier.Text: "Microsoft" or "Windows" }
+            }
         } => true,
         _ => false,
     };

--- a/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
+++ b/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
@@ -34,15 +34,42 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: Description);
 
+    /// <summary>
+    /// REACTOR_THEME_004: the theme-token-bypassing sibling of THEME_001. THEME_001 only
+    /// inspects <em>string</em> literals, so an inline <c>new SolidColorBrush(...)</c> passed to the
+    /// same <c>.Background</c>/<c>.Foreground</c>/<c>.WithBorder</c> modifiers sails past it — the
+    /// same silent dark-mode regression, just expressed as a <c>Brush</c> object.
+    /// </summary>
+    public const string BrushDiagnosticId = "REACTOR_THEME_004";
+
+    private static readonly LocalizableString BrushTitle =
+        "Use ThemeRef instead of a hard-coded brush";
+    private static readonly LocalizableString BrushMessageFormat =
+        "Use a ThemeRef token (e.g., Theme.{0}) instead of an inline SolidColorBrush for theme-reactive styling";
+    private static readonly LocalizableString BrushDescription =
+        "An inline SolidColorBrush is a fixed color that doesn't adapt when the user switches between Light and Dark themes. Use Theme tokens for theme-reactive styling.";
+
+    private static readonly DiagnosticDescriptor BrushRule = new(
+        BrushDiagnosticId,
+        BrushTitle,
+        BrushMessageFormat,
+        "Reactor.Style",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: BrushDescription);
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(Rule);
+        ImmutableArray.Create(Rule, BrushRule);
+
+    /// <summary>Generic suggestion emitted when a hard-coded color has no known token mapping.</summary>
+    internal const string GenericTokenSuggestion = "Accent or another semantic token";
 
     /// <summary>Known color-to-theme-token mappings for code fix suggestions.</summary>
     internal static readonly ImmutableDictionary<string, string> ColorToThemeToken =
         ImmutableDictionary.CreateRange(StringComparer.OrdinalIgnoreCase, new[]
         {
-            new KeyValuePair<string, string>("#FFFFFF", "PrimaryBackground"),
-            new KeyValuePair<string, string>("white", "PrimaryBackground"),
+            new KeyValuePair<string, string>("#FFFFFF", "SolidBackground"),
+            new KeyValuePair<string, string>("white", "SolidBackground"),
             new KeyValuePair<string, string>("#000000", "PrimaryText"),
             new KeyValuePair<string, string>("black", "PrimaryText"),
             new KeyValuePair<string, string>("#0078D4", "Accent"),
@@ -56,6 +83,7 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeBrushArgument, SyntaxKind.InvocationExpression);
     }
 
     // <snippet:theme-ref-rule>
@@ -87,7 +115,7 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
         // Suggest a specific theme token if we have a mapping, otherwise generic
         var suggestion = ColorToThemeToken.TryGetValue(colorValue, out var token)
             ? token
-            : "Accent or another semantic token";
+            : GenericTokenSuggestion;
 
         context.ReportDiagnostic(Diagnostic.Create(
             Rule,
@@ -95,4 +123,74 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
             suggestion,
             colorValue));
     }
+
+    // REACTOR_THEME_004 — the Brush-typed escape hatch THEME_001's string-literal gate misses.
+    private static void AnalyzeBrushArgument(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Reuse THEME_001's target-modifier gate.
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+        if (!TargetMethods.Contains(memberAccess.Name.Identifier.Text))
+            return;
+
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count == 0)
+            return;
+
+        // Only the *inline* `new SolidColorBrush(...)` creation bypasses theming. A brush read from a
+        // field/local (identifier or member access) is deliberately left alone — it may legitimately
+        // hold an already-resolved token brush, and rewriting it would be unsound.
+        if (args[0].Expression is not ObjectCreationExpressionSyntax creation)
+            return;
+        if (!IsSolidColorBrushType(creation.Type))
+            return;
+
+        var colorName = TryGetColorName(creation);
+        var suggestion = colorName is not null && ColorToThemeToken.TryGetValue(colorName, out var token)
+            ? token
+            : GenericTokenSuggestion;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            BrushRule,
+            creation.GetLocation(),
+            suggestion));
+    }
+
+    private static bool IsSolidColorBrushType(TypeSyntax type) => type switch
+    {
+        IdentifierNameSyntax id => id.Identifier.Text == "SolidColorBrush",
+        QualifiedNameSyntax qualified => qualified.Right.Identifier.Text == "SolidColorBrush",
+        _ => false,
+    };
+
+    /// <summary>
+    /// Extracts the WinUI named color from an inline <c>new SolidColorBrush(Colors.X)</c> so the
+    /// diagnostic can suggest — and the code fix can resolve — the matching theme token. Returns
+    /// null for any other constructor shape (empty, a variable, or <c>Color.FromArgb(...)</c>),
+    /// which keeps the diagnostic as a nudge but withholds the auto-fix (there is no key to invent).
+    /// </summary>
+    internal static string? TryGetColorName(ObjectCreationExpressionSyntax creation)
+    {
+        var ctorArgs = creation.ArgumentList?.Arguments;
+        if (ctorArgs is not { Count: >= 1 })
+            return null;
+
+        // Restrict to `Colors.X` / `Microsoft.UI.Colors.X` so we never map an unrelated `Foo.White`.
+        if (ctorArgs.Value[0].Expression is MemberAccessExpressionSyntax colorAccess &&
+            IsColorsReceiver(colorAccess.Expression))
+        {
+            return colorAccess.Name.Identifier.Text;
+        }
+
+        return null;
+    }
+
+    private static bool IsColorsReceiver(ExpressionSyntax receiver) => receiver switch
+    {
+        IdentifierNameSyntax id => id.Identifier.Text == "Colors",
+        MemberAccessExpressionSyntax member => member.Name.Identifier.Text == "Colors",
+        _ => false,
+    };
 }

--- a/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
+++ b/src/Reactor.Analyzers/UseThemeRefAnalyzer.cs
@@ -165,7 +165,11 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
     private static bool IsSolidColorBrushType(TypeSyntax type) => type switch
     {
         IdentifierNameSyntax id => id.Identifier.Text == "SolidColorBrush",
+        // `Microsoft.UI.Xaml.Media.SolidColorBrush` (and its `global::`-qualified form, whose top
+        // node is still a QualifiedName with `global::…` buried in the left).
         QualifiedNameSyntax qualified => qualified.Right.Identifier.Text == "SolidColorBrush",
+        // Degenerate `global::SolidColorBrush` (alias-qualified at the top).
+        AliasQualifiedNameSyntax alias => alias.Name.Identifier.Text == "SolidColorBrush",
         _ => false,
     };
 
@@ -227,8 +231,12 @@ public sealed class UseThemeRefAnalyzer : DiagnosticAnalyzer
     /// </summary>
     internal static bool TokenFitsModifier(string token, string modifier) => token switch
     {
+        // Text token → foreground only.
         "PrimaryText" => modifier == "Foreground",
-        "SolidBackground" => modifier is "Background" or "WithBorder",
+        // Surface/fill token → background only. `.WithBorder` wants a *stroke* token (e.g.
+        // Theme.CardStroke), which this color→token map doesn't carry, so a border falls back to the
+        // generic suggestion rather than a misleading fill-as-border auto-fix.
+        "SolidBackground" => modifier == "Background",
         _ => true, // Accent / neutral tokens fit any target modifier.
     };
 }

--- a/src/Reactor.Analyzers/UseThemeRefCodeFix.cs
+++ b/src/Reactor.Analyzers/UseThemeRefCodeFix.cs
@@ -126,26 +126,25 @@ public sealed class UseThemeRefCodeFix : CodeFixProvider
     /// Builds a <c>Theme.&lt;token&gt;</c> expression guaranteed to compile at
     /// <paramref name="position"/>: it confirms the member exists on the real
     /// <c>Microsoft.UI.Reactor.Core.Theme</c> and renders the shortest unambiguous type name via
-    /// <see cref="SymbolDisplayExtensions.ToMinimalDisplayString"/> (falling back to a fully
-    /// <c>global::</c>-qualified name when no semantic model is available). Returns null when the
-    /// token can't be resolved, so the caller withholds the fix rather than emit broken code.
+    /// <see cref="SymbolDisplayExtensions.ToMinimalDisplayString"/>. Returns null when the token
+    /// can't be resolved — including when no semantic model is available — so the caller withholds
+    /// the fix rather than emit a reference that might not compile.
     /// </summary>
     private static ExpressionSyntax? TryBuildThemeReference(
         SemanticModel? semanticModel, int position, string token, SyntaxNode triviaSource)
     {
-        if (semanticModel is not null)
-        {
-            var themeType = semanticModel.Compilation.GetTypeByMetadataName("Microsoft.UI.Reactor.Core.Theme");
-            if (themeType is null)
-                return null;
-            if (!themeType.GetMembers(token).Any(static m => m is IPropertySymbol or IFieldSymbol))
-                return null;
+        // Without a semantic model we can't confirm Theme.<token> resolves, so withhold rather than
+        // emit an unvalidated reference (the diagnostic still stands with no auto-fix).
+        if (semanticModel is null)
+            return null;
 
-            var themeName = themeType.ToMinimalDisplayString(semanticModel, position);
-            return SyntaxFactory.ParseExpression($"{themeName}.{token}").WithTriviaFrom(triviaSource);
-        }
+        var themeType = semanticModel.Compilation.GetTypeByMetadataName("Microsoft.UI.Reactor.Core.Theme");
+        if (themeType is null)
+            return null;
+        if (!themeType.GetMembers(token).Any(static m => m is IPropertySymbol or IFieldSymbol))
+            return null;
 
-        return SyntaxFactory.ParseExpression($"global::Microsoft.UI.Reactor.Core.Theme.{token}")
-            .WithTriviaFrom(triviaSource);
+        var themeName = themeType.ToMinimalDisplayString(semanticModel, position);
+        return SyntaxFactory.ParseExpression($"{themeName}.{token}").WithTriviaFrom(triviaSource);
     }
 }

--- a/src/Reactor.Analyzers/UseThemeRefCodeFix.cs
+++ b/src/Reactor.Analyzers/UseThemeRefCodeFix.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -10,15 +11,17 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace Microsoft.UI.Reactor.Analyzers;
 
 /// <summary>
-/// Code fix for REACTOR_THEME_001: replaces hard-coded color strings with <c>Theme.X</c>
-/// tokens where a known mapping exists.
+/// Code fix for REACTOR_THEME_001 / REACTOR_THEME_004: replaces a hard-coded color string or an
+/// inline <c>new SolidColorBrush(Colors.X)</c> with the matching <c>Theme.X</c> token, but only
+/// when the color has a known mapping <em>and</em> the token actually resolves on the real
+/// <c>Theme</c> — otherwise the diagnostic stands with no auto-fix.
 /// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseThemeRefCodeFix))]
 [Shared]
 public sealed class UseThemeRefCodeFix : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds =>
-        ImmutableArray.Create(UseThemeRefAnalyzer.DiagnosticId);
+        ImmutableArray.Create(UseThemeRefAnalyzer.DiagnosticId, UseThemeRefAnalyzer.BrushDiagnosticId);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -27,37 +30,85 @@ public sealed class UseThemeRefCodeFix : CodeFixProvider
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         if (root is null) return;
 
+        SemanticModel? semanticModel = null;
+
         foreach (var diagnostic in context.Diagnostics)
         {
-            var span = diagnostic.Location.SourceSpan;
-            var node = root.FindNode(span);
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
 
-            if (node is not LiteralExpressionSyntax literal)
-                continue;
-            if (!literal.IsKind(SyntaxKind.StringLiteralExpression))
-                continue;
+            // Resolve which node to replace and which token to replace it with, depending on the rule.
+            string? token = null;
+            SyntaxNode? target = null;
 
-            var colorValue = literal.Token.ValueText;
-            if (!UseThemeRefAnalyzer.ColorToThemeToken.TryGetValue(colorValue, out var token))
-                continue;
+            if (node.FirstAncestorOrSelf<LiteralExpressionSyntax>() is { } literal &&
+                literal.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                // REACTOR_THEME_001 — hard-coded color string.
+                if (UseThemeRefAnalyzer.ColorToThemeToken.TryGetValue(literal.Token.ValueText, out var t))
+                {
+                    token = t;
+                    target = literal;
+                }
+            }
+            else if (node.FirstAncestorOrSelf<ObjectCreationExpressionSyntax>() is { } creation)
+            {
+                // REACTOR_THEME_004 — inline new SolidColorBrush(Colors.X).
+                var colorName = UseThemeRefAnalyzer.TryGetColorName(creation);
+                if (colorName is not null &&
+                    UseThemeRefAnalyzer.ColorToThemeToken.TryGetValue(colorName, out var t))
+                {
+                    token = t;
+                    target = creation;
+                }
+            }
+
+            if (token is null || target is null)
+                continue; // Unmapped color — no key to invent, so the diagnostic stands without a fix.
+
+            semanticModel ??= await context.Document
+                .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+            var themeAccess = TryBuildThemeReference(semanticModel, target.SpanStart, token, target);
+            if (themeAccess is null)
+                continue; // Theme.<token> can't be resolved here — never emit non-compiling code.
+
+            var nodeToReplace = target;
+            var replacement = themeAccess;
 
             context.RegisterCodeFix(
                 CodeAction.Create(
                     $"Replace with Theme.{token}",
-                    ct =>
-                    {
-                        // Build: Theme.Token
-                        var themeAccess = SyntaxFactory.MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            SyntaxFactory.IdentifierName("Theme"),
-                            SyntaxFactory.IdentifierName(token))
-                            .WithTriviaFrom(literal);
-
-                        var newRoot = root.ReplaceNode(literal, themeAccess);
-                        return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
-                    },
-                    equivalenceKey: $"{UseThemeRefAnalyzer.DiagnosticId}_{token}"),
+                    _ => Task.FromResult(context.Document.WithSyntaxRoot(
+                        root.ReplaceNode(nodeToReplace, replacement))),
+                    equivalenceKey: $"{diagnostic.Id}_{token}"),
                 diagnostic);
         }
+    }
+
+    /// <summary>
+    /// Builds a <c>Theme.&lt;token&gt;</c> expression guaranteed to compile at
+    /// <paramref name="position"/>: it confirms the member exists on the real
+    /// <c>Microsoft.UI.Reactor.Core.Theme</c> and renders the shortest unambiguous type name via
+    /// <see cref="SymbolDisplayExtensions.ToMinimalDisplayString"/> (falling back to a fully
+    /// <c>global::</c>-qualified name when no semantic model is available). Returns null when the
+    /// token can't be resolved, so the caller withholds the fix rather than emit broken code.
+    /// </summary>
+    private static ExpressionSyntax? TryBuildThemeReference(
+        SemanticModel? semanticModel, int position, string token, SyntaxNode triviaSource)
+    {
+        if (semanticModel is not null)
+        {
+            var themeType = semanticModel.Compilation.GetTypeByMetadataName("Microsoft.UI.Reactor.Core.Theme");
+            if (themeType is null)
+                return null;
+            if (!themeType.GetMembers(token).Any(static m => m is IPropertySymbol or IFieldSymbol))
+                return null;
+
+            var themeName = themeType.ToMinimalDisplayString(semanticModel, position);
+            return SyntaxFactory.ParseExpression($"{themeName}.{token}").WithTriviaFrom(triviaSource);
+        }
+
+        return SyntaxFactory.ParseExpression($"global::Microsoft.UI.Reactor.Core.Theme.{token}")
+            .WithTriviaFrom(triviaSource);
     }
 }

--- a/src/Reactor.Analyzers/UseThemeRefCodeFix.cs
+++ b/src/Reactor.Analyzers/UseThemeRefCodeFix.cs
@@ -79,10 +79,12 @@ public sealed class UseThemeRefCodeFix : CodeFixProvider
             semanticModel ??= await context.Document
                 .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
 
-            // The analyzer's brush match is syntactic; before rewriting, confirm the creation is
-            // really WinUI's SolidColorBrush so we never touch an unrelated same-named type.
+            // The analyzer's brush match is syntactic; before rewriting, semantically confirm both the
+            // brush type (WinUI's SolidColorBrush) and the color source (Microsoft.UI/Windows.UI
+            // Colors) so we never rewrite an unrelated same-named type or a non-WinUI palette color.
             if (brushCreation is not null &&
-                !IsWinUiSolidColorBrush(semanticModel, brushCreation, context.CancellationToken))
+                (!IsWinUiSolidColorBrush(semanticModel, brushCreation, context.CancellationToken)
+                 || !IsWinUiColorsArgument(semanticModel, brushCreation, context.CancellationToken)))
                 continue;
 
             var themeAccess = TryBuildThemeReference(semanticModel, target.SpanStart, token, target);
@@ -120,6 +122,32 @@ public sealed class UseThemeRefCodeFix : CodeFixProvider
 
         var actual = semanticModel.GetTypeInfo(creation, cancellationToken).Type;
         return SymbolEqualityComparer.Default.Equals(actual, solidColorBrush);
+    }
+
+    /// <summary>
+    /// Confirms the brush's constructor argument reads from WinUI's <c>Microsoft.UI.Colors</c> (or
+    /// <c>Windows.UI.Colors</c>). <c>TryGetColorName</c> accepts a bare <c>Colors.X</c> syntactically,
+    /// so a look-alike <c>Colors</c> type in scope (e.g. via <c>using MyCompany.UI;</c>) could
+    /// otherwise be rewritten to a theme token even though the color came from a non-WinUI palette.
+    /// </summary>
+    private static bool IsWinUiColorsArgument(
+        SemanticModel? semanticModel, ObjectCreationExpressionSyntax creation, CancellationToken cancellationToken)
+    {
+        if (semanticModel is null)
+            return false;
+
+        var args = creation.ArgumentList?.Arguments;
+        if (args is not { Count: >= 1 } || args.Value[0].Expression is not MemberAccessExpressionSyntax colorAccess)
+            return false;
+
+        var colorsType = semanticModel.GetSymbolInfo(colorAccess.Expression, cancellationToken).Symbol as INamedTypeSymbol;
+        if (colorsType is null)
+            return false;
+
+        var microsoftColors = semanticModel.Compilation.GetTypeByMetadataName("Microsoft.UI.Colors");
+        var windowsColors = semanticModel.Compilation.GetTypeByMetadataName("Windows.UI.Colors");
+        return SymbolEqualityComparer.Default.Equals(colorsType, microsoftColors)
+            || SymbolEqualityComparer.Default.Equals(colorsType, windowsColors);
     }
 
     /// <summary>

--- a/src/Reactor.Analyzers/UseThemeRefCodeFix.cs
+++ b/src/Reactor.Analyzers/UseThemeRefCodeFix.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -39,6 +40,7 @@ public sealed class UseThemeRefCodeFix : CodeFixProvider
             // Resolve which node to replace and which token to replace it with, depending on the rule.
             string? token = null;
             SyntaxNode? target = null;
+            ObjectCreationExpressionSyntax? brushCreation = null;
 
             if (node.FirstAncestorOrSelf<LiteralExpressionSyntax>() is { } literal &&
                 literal.IsKind(SyntaxKind.StringLiteralExpression))
@@ -59,14 +61,29 @@ public sealed class UseThemeRefCodeFix : CodeFixProvider
                 {
                     token = t;
                     target = creation;
+                    brushCreation = creation;
                 }
             }
 
             if (token is null || target is null)
                 continue; // Unmapped color — no key to invent, so the diagnostic stands without a fix.
 
+            // Only offer the fix when the mapped token is sensible for the target modifier: a surface
+            // token as a .Foreground (or a text token as a .Background) would flip colors the wrong
+            // way across themes, so we withhold rather than auto-apply a misleading rewrite.
+            var modifier = (target.FirstAncestorOrSelf<InvocationExpressionSyntax>()?.Expression
+                as MemberAccessExpressionSyntax)?.Name.Identifier.Text;
+            if (modifier is null || !UseThemeRefAnalyzer.TokenFitsModifier(token, modifier))
+                continue;
+
             semanticModel ??= await context.Document
                 .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+            // The analyzer's brush match is syntactic; before rewriting, confirm the creation is
+            // really WinUI's SolidColorBrush so we never touch an unrelated same-named type.
+            if (brushCreation is not null &&
+                !IsWinUiSolidColorBrush(semanticModel, brushCreation, context.CancellationToken))
+                continue;
 
             var themeAccess = TryBuildThemeReference(semanticModel, target.SpanStart, token, target);
             if (themeAccess is null)
@@ -83,6 +100,26 @@ public sealed class UseThemeRefCodeFix : CodeFixProvider
                     equivalenceKey: $"{diagnostic.Id}_{token}"),
                 diagnostic);
         }
+    }
+
+    /// <summary>
+    /// Confirms an inline <c>new SolidColorBrush(...)</c> resolves to WinUI's
+    /// <c>Microsoft.UI.Xaml.Media.SolidColorBrush</c> (not an unrelated same-named type), so the
+    /// syntactic REACTOR_THEME_004 match is semantically sound before we rewrite it.
+    /// </summary>
+    private static bool IsWinUiSolidColorBrush(
+        SemanticModel? semanticModel, ObjectCreationExpressionSyntax creation, CancellationToken cancellationToken)
+    {
+        if (semanticModel is null)
+            return false;
+
+        var solidColorBrush = semanticModel.Compilation
+            .GetTypeByMetadataName("Microsoft.UI.Xaml.Media.SolidColorBrush");
+        if (solidColorBrush is null)
+            return false;
+
+        var actual = semanticModel.GetTypeInfo(creation, cancellationToken).Type;
+        return SymbolEqualityComparer.Default.Equals(actual, solidColorBrush);
     }
 
     /// <summary>

--- a/src/Reactor.Analyzers/UseThemeRefCodeFix.cs
+++ b/src/Reactor.Analyzers/UseThemeRefCodeFix.cs
@@ -141,7 +141,9 @@ public sealed class UseThemeRefCodeFix : CodeFixProvider
         var themeType = semanticModel.Compilation.GetTypeByMetadataName("Microsoft.UI.Reactor.Core.Theme");
         if (themeType is null)
             return null;
-        if (!themeType.GetMembers(token).Any(static m => m is IPropertySymbol or IFieldSymbol))
+        // The fix emits a static `Theme.<token>` access, so require a matching *static* field/property
+        // — an instance member of the same name wouldn't compile through the type name.
+        if (!themeType.GetMembers(token).Any(static m => m.IsStatic && m is IPropertySymbol or IFieldSymbol))
             return null;
 
         var themeName = themeType.ToMinimalDisplayString(semanticModel, position);

--- a/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
@@ -94,7 +94,7 @@ class C
 }";
         var expected = AnalyzerVerifier.Diagnostic(UseThemeRefAnalyzer.DiagnosticId)
             .WithSpan(6, 23, 6, 32)
-            .WithArguments("Accent or another semantic token", "#AABBCC");
+            .WithArguments("Accent", "#AABBCC");
 
         var analyzerTest = new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
         {
@@ -404,6 +404,104 @@ namespace TestApp
         void M(dynamic el)
         {
             el.Background({|REACTOR_THEME_004:new SolidColorBrush(Colors.Red)|});
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Fix_When_Token_Family_Mismatches_Modifier()
+    {
+        // white maps to SolidBackground (a surface token); auto-fixing that onto .Foreground would
+        // invert text/background across themes, so the diagnostic fires but no fix is offered.
+        var code = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Foreground({|REACTOR_THEME_004:new SolidColorBrush(Colors.White)|});
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Fix_When_Theme_Token_Unresolved()
+    {
+        // The mapped token (SolidBackground) is not defined on this Theme, so the fix is withheld to
+        // avoid emitting a reference that wouldn't compile; the diagnostic still fires.
+        var stubs = @"
+namespace Windows.UI { public struct Color { } }
+namespace Microsoft.UI
+{
+    public static class Colors { public static Windows.UI.Color White => default; }
+}
+namespace Microsoft.UI.Xaml.Media
+{
+    public class Brush { }
+    public class SolidColorBrush : Brush { public SolidColorBrush(Windows.UI.Color color) { } }
+}
+namespace Microsoft.UI.Reactor.Core
+{
+    public readonly struct ThemeRef { }
+    public static class Theme { public static ThemeRef PrimaryText => default; }
+}
+";
+        var code = stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background({|REACTOR_THEME_004:new SolidColorBrush(Colors.White)|});
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Fix_For_Non_WinUi_SolidColorBrush()
+    {
+        // A same-named brush type from another namespace fires the syntactic diagnostic, but the fix
+        // confirms WinUI's SolidColorBrush semantically and withholds the rewrite.
+        var code = Stubs + @"
+namespace Custom
+{
+    public class SolidColorBrush { public SolidColorBrush(Windows.UI.Color c) { } }
+}
+namespace TestApp
+{
+    using Microsoft.UI;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background({|REACTOR_THEME_004:new Custom.SolidColorBrush(Colors.White)|});
         }
     }
 }";

--- a/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
@@ -511,4 +511,33 @@ namespace TestApp
             FixedCode = code,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task No_Fix_For_Look_Alike_Colors_Class()
+    {
+        // A non-WinUI `MyCompany.UI.Colors.White` must not be mapped to a theme token: the diagnostic
+        // still fires (inline brush) but with a generic suggestion and no auto-fix.
+        var code = Stubs + @"
+namespace MyCompany.UI
+{
+    public static class Colors { public static Windows.UI.Color White => default; }
+}
+namespace TestApp
+{
+    using Microsoft.UI.Xaml.Media;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background({|REACTOR_THEME_004:new SolidColorBrush(MyCompany.UI.Colors.White)|});
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
@@ -647,4 +647,35 @@ namespace TestApp
             FixedCode = code,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task No_Fix_For_Look_Alike_Colors_Via_Unqualified_Identifier()
+    {
+        // Bare `Colors` here resolves to a non-WinUI palette (via `using MyCompany.UI;`, no
+        // `using Microsoft.UI;`). The diagnostic fires syntactically, but the fix semantically
+        // confirms the color source is Microsoft.UI/Windows.UI Colors and withholds the rewrite.
+        var code = Stubs + @"
+namespace MyCompany.UI
+{
+    public static class Colors { public static Windows.UI.Color White => default; }
+}
+namespace TestApp
+{
+    using MyCompany.UI;
+    using Microsoft.UI.Xaml.Media;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background({|REACTOR_THEME_004:new SolidColorBrush(Colors.White)|});
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
@@ -581,4 +581,70 @@ namespace TestApp
             CodeActionEquivalenceKey = "REACTOR_THEME_004_SolidBackground",
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task Fix_Rewrites_Global_Qualified_SolidColorBrush_Type()
+    {
+        // The brush *type* itself written fully-qualified with `global::` must still be detected + fixed.
+        var test = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background({|REACTOR_THEME_004:new global::Microsoft.UI.Xaml.Media.SolidColorBrush(Colors.White)|});
+        }
+    }
+}";
+        var fixedCode = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background(Theme.SolidBackground);
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CodeActionEquivalenceKey = "REACTOR_THEME_004_SolidBackground",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Fix_For_Surface_Token_On_WithBorder()
+    {
+        // .WithBorder sets a stroke; the map only has a surface token (SolidBackground) for white, so
+        // the diagnostic fires but no auto-fix is offered (a fill token is a poor border suggestion).
+        var code = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.WithBorder({|REACTOR_THEME_004:new SolidColorBrush(Colors.White)|});
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
@@ -540,4 +540,45 @@ namespace TestApp
             FixedCode = code,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task Fix_Rewrites_Global_Qualified_WinUi_Colors()
+    {
+        // The framework itself writes `global::Microsoft.UI.Colors.X`; that fully-qualified form must
+        // still map + auto-fix.
+        var test = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Xaml.Media;
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background({|REACTOR_THEME_004:new SolidColorBrush(global::Microsoft.UI.Colors.White)|});
+        }
+    }
+}";
+        var fixedCode = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Xaml.Media;
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background(Theme.SolidBackground);
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CodeActionEquivalenceKey = "REACTOR_THEME_004_SolidBackground",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UseThemeRefAnalyzerTests.cs
@@ -25,7 +25,7 @@ class C
 }";
         var expected = AnalyzerVerifier.Diagnostic(UseThemeRefAnalyzer.DiagnosticId)
             .WithSpan(6, 23, 6, 32)
-            .WithArguments("PrimaryBackground", "#FFFFFF");
+            .WithArguments("SolidBackground", "#FFFFFF");
 
         var analyzerTest = new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
         {
@@ -138,5 +138,279 @@ class C
             TestCode = test,
         };
         await analyzerTest.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── REACTOR_THEME_004: inline SolidColorBrush escape hatch ──────────────
+
+    // Minimal WinUI/Theme-shaped stubs so `new SolidColorBrush(Colors.X)` and `Theme.X` compile in
+    // the analyzer/code-fix harness (which has no WindowsAppSDK reference). Mirrors the real shapes:
+    // Colors.X : Windows.UI.Color, SolidColorBrush(Color) : Brush, Theme.X : ThemeRef.
+    private const string Stubs = @"
+namespace Windows.UI
+{
+    public struct Color { }
+}
+namespace Microsoft.UI
+{
+    public static class Colors
+    {
+        public static Windows.UI.Color White => default;
+        public static Windows.UI.Color Black => default;
+        public static Windows.UI.Color Red => default;
+    }
+}
+namespace Microsoft.UI.Xaml.Media
+{
+    public class Brush { }
+    public class SolidColorBrush : Brush
+    {
+        public SolidColorBrush() { }
+        public SolidColorBrush(Windows.UI.Color color) { }
+    }
+}
+namespace Microsoft.UI.Reactor.Core
+{
+    public readonly struct ThemeRef { }
+    public static class Theme
+    {
+        public static ThemeRef SolidBackground => default;
+        public static ThemeRef PrimaryText => default;
+        public static ThemeRef Accent => default;
+        public static ThemeRef CardBackground => default;
+    }
+}
+";
+
+    [Fact]
+    public async Task Detects_Inline_SolidColorBrush_On_Background()
+    {
+        var test = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background({|REACTOR_THEME_004:new SolidColorBrush(Colors.Red)|});
+        }
+    }
+}";
+        await new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Detects_Inline_SolidColorBrush_Suggests_Mapped_Token()
+    {
+        var test = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Foreground({|#0:new SolidColorBrush(Colors.Black)|});
+        }
+    }
+}";
+        await new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+            ExpectedDiagnostics =
+            {
+                AnalyzerVerifier.Diagnostic(UseThemeRefAnalyzer.BrushDiagnosticId)
+                    .WithLocation(0)
+                    .WithArguments("PrimaryText"),
+            },
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Theme_Token_Argument()
+    {
+        // The declarative, theme-reactive form — must NOT fire.
+        var test = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background(Theme.CardBackground);
+        }
+    }
+}";
+        await new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Field_Held_Brush()
+    {
+        // A brush read from a field may already hold a resolved token brush — inline-creation-only
+        // detection keeps it safe.
+        var test = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+
+    class C
+    {
+        static readonly SolidColorBrush _brush = new SolidColorBrush(Colors.Red);
+        void M(dynamic el)
+        {
+            el.Background(_brush);
+        }
+    }
+}";
+        await new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Non_Target_Modifier_With_Brush()
+    {
+        // Near-miss: a brush argument to a modifier outside the {Background,Foreground,WithBorder} gate.
+        var test = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Fill(new SolidColorBrush(Colors.Red));
+        }
+    }
+}";
+        await new CSharpAnalyzerTest<UseThemeRefAnalyzer, DefaultVerifier>
+        {
+            TestCode = test,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fix_Rewrites_Mapped_White_To_Theme_SolidBackground()
+    {
+        var test = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background({|REACTOR_THEME_004:new SolidColorBrush(Colors.White)|});
+        }
+    }
+}";
+        var fixedCode = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background(Theme.SolidBackground);
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CodeActionEquivalenceKey = "REACTOR_THEME_004_SolidBackground",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fix_Rewrites_Mapped_Black_To_Theme_PrimaryText()
+    {
+        var test = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Foreground({|REACTOR_THEME_004:new SolidColorBrush(Colors.Black)|});
+        }
+    }
+}";
+        var fixedCode = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Foreground(Theme.PrimaryText);
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CodeActionEquivalenceKey = "REACTOR_THEME_004_PrimaryText",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Fix_For_Unmapped_Inline_Brush()
+    {
+        // Red has no token mapping — the diagnostic stands, but no auto-fix is offered (the analyzer
+        // can't invent a resource key). FixedCode == TestCode asserts nothing is rewritten.
+        var code = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI;
+    using Microsoft.UI.Xaml.Media;
+
+    class C
+    {
+        void M(dynamic el)
+        {
+            el.Background({|REACTOR_THEME_004:new SolidColorBrush(Colors.Red)|});
+        }
+    }
+}";
+        await new CSharpCodeFixTest<UseThemeRefAnalyzer, UseThemeRefCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
     }
 }


### PR DESCRIPTION
Implements **REACTOR_THEME_004** (spec 060, Wave A) — extends `UseThemeRefAnalyzer` with a second descriptor that catches the `Brush`-typed escape hatch THEME_001's string-literal gate misses.

## What & why
`THEME_001` only inspects *string* literals, so the XAML habit `Background="Red"` written as `.Background(new SolidColorBrush(Colors.Red))` sails past it — a silent dark-mode regression identical to the string case. THEME_004 closes that gap.

- **Detect** — reuses THEME_001's `{Background,Foreground,WithBorder}` modifier gate; flags an **inline** `new SolidColorBrush(...)` argument. A brush read from a field/local is deliberately left alone (it may already hold a resolved token brush).
- **Fix** — reuses THEME_001's `ColorToThemeToken` map: a mapped color (from `Colors.X`) is rewritten to the matching `Theme.*` token; an unmapped color keeps the diagnostic with **no** auto-fix (the analyzer can't invent a resource key). The fix emits the token via `ToMinimalDisplayString` and **semantically verifies the member exists** (`GetTypeByMetadataName`/`GetMembers`) before rewriting — it never emits a non-existent token or non-compiling code (mirrors `CommandDebounceCodeFix` + the §2.1 global::/minimal-name rule).

## Grounding fix (shared map bug — intentional, not scope creep)
While reusing the map I found `white`/`#FFFFFF` mapped to `Theme.PrimaryBackground`, which **does not exist** on `Theme` (real tokens: `PrimaryText`, `Accent`, `SolidBackground`, `CardBackground`…). That made THEME_001's existing fix/suggestion for white non-compiling (latent — no round-trip test covered it). Corrected to the real `Theme.SolidBackground`; updated the one THEME_001 assertion. The THEME_001 snippet region is left byte-identical (no doc recompile needed). (The two design-spec docs that mention white→PrimaryBackground are design-intent prose, not compiled/tested, and are intentionally left as-is.)

## Review-loop hardening (pr-review pass)
THEME_001/004 are both **unshipped**, so the shared analyzer + fix were refined holistically:
- **Modifier-aware suggestion + fix** — the color-only map could otherwise rewrite `.Foreground(new SolidColorBrush(Colors.White))` to a *background* token (`Theme.SolidBackground`), inverting text/background across themes (invisible text in Light). `TokenFitsModifier` now withholds the suggestion/fix when a surface token targets `.Foreground` (or a text token targets `.Background`).
- **Semantic `SolidColorBrush` confirmation** in the fix (the analyzer match stays syntactic, consistent with THEME_001) and a tightened `Colors` receiver (`Colors` / `*.UI.Colors` only) so a nested `MyPalette.Colors.White` is never mapped.
- Cleaner generic suggestion (`Theme.Accent`) for unmapped colors.

## Tests
`UseThemeRefAnalyzerTests.cs` — positive, negatives (token arg + field-held brush), non-target-modifier near-miss, mapped fix round-trips (white→`SolidBackground`, black→`PrimaryText`), diagnostic-only for unmapped, modifier-mismatch → no fix, unresolved `Theme` token → no fix, non-WinUI `SolidColorBrush` → no fix. `dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~UseThemeRef` → **17/17**; full `AnalyzerTests` suite → **226/226**.

Adds the canonical `AnalyzerReleases.Unshipped.md` row and the app-author cheat-table row (§2.6).