### PR TITLE
feat(analyzer): REACTOR_CMD_001 — raw Command + callback

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,6 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_CMD_001` | Info | Raw-init Command + own click/toggle callback both set (callback wins) | `RawCommandCallbackAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_CMD_001` | info | Raw-init element sets **both** `Command` and its own `OnClick` / toggle callback | The callback wins (`EffectiveCallback = userCallback ?? Invokable(cmd)`), so the command never runs. Delete the redundant callback, or bind via the `.Command(...)` modifier / `Button(cmd)` factory (which never set a callback). |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_CMD_001 | Reactor.Commanding | Info | RawCommandCallbackAnalyzer - Raw-init Command + own click callback both set (callback wins; command never runs)

--- a/src/Reactor.Analyzers/RawCommandCallbackAnalyzer.cs
+++ b/src/Reactor.Analyzers/RawCommandCallbackAnalyzer.cs
@@ -141,6 +141,15 @@ public sealed class RawCommandCallbackAnalyzer : DiagnosticAnalyzer
         if (type.ContainingNamespace?.ToDisplayString() != ElementNamespace)
             return;
 
+        // A provably metadata-only command — an inline `new Command { … }` / `new() { … }` that
+        // assigns neither Execute nor ExecuteAsync — has no delegate to invoke (Invokable(cmd) is
+        // null), so the callback is the ONLY executable path and is NOT shadowing the command. Do
+        // not fire (and never suggest deleting the sole handler). Opaque commands (a variable,
+        // field, or factory result) are undecidable syntactically and stay covered by the match;
+        // spec §4.3 rates that residual false positive low.
+        if (IsProvablyMetadataOnlyCommand(commandAssignment.Right))
+            return;
+
         // (a) Redundant callback assigned via the object initializer / `with`.
         var initCallback = FindInitializerCallback(initializer, info.InitializerCallbacks);
         if (initCallback is not null)
@@ -242,4 +251,39 @@ public sealed class RawCommandCallbackAnalyzer : DiagnosticAnalyzer
         expression.IsKind(SyntaxKind.NullLiteralExpression) ||
         expression.IsKind(SyntaxKind.DefaultLiteralExpression) ||
         expression is DefaultExpressionSyntax;
+
+    /// <summary>
+    /// True when <paramref name="commandExpr"/> is an <b>inline</b> command creation
+    /// (<c>new Command { … }</c> / <c>new() { … }</c>) that assigns neither <c>Execute</c> nor
+    /// <c>ExecuteAsync</c> to a non-null delegate — i.e. a statically-provable metadata-only
+    /// command that has nothing to run. Anything else (a variable, field, factory result, or
+    /// <c>with</c> expression) is opaque and returns <c>false</c>.
+    /// </summary>
+    private static bool IsProvablyMetadataOnlyCommand(ExpressionSyntax commandExpr)
+    {
+        InitializerExpressionSyntax? initializer;
+        switch (commandExpr)
+        {
+            case ObjectCreationExpressionSyntax oce:
+                initializer = oce.Initializer;
+                break;
+            case ImplicitObjectCreationExpressionSyntax ioce:
+                initializer = ioce.Initializer;
+                break;
+            default:
+                return false;
+        }
+
+        // No initializer (e.g. `new Command()`) => nothing assigned => metadata-only.
+        if (initializer is null)
+            return true;
+
+        var hasExecute = initializer.Expressions
+            .OfType<AssignmentExpressionSyntax>()
+            .Any(a => a.Left is IdentifierNameSyntax id
+                && (id.Identifier.ValueText == "Execute" || id.Identifier.ValueText == "ExecuteAsync")
+                && !IsNullish(a.Right));
+
+        return !hasExecute;
+    }
 }

--- a/src/Reactor.Analyzers/RawCommandCallbackAnalyzer.cs
+++ b/src/Reactor.Analyzers/RawCommandCallbackAnalyzer.cs
@@ -47,13 +47,14 @@ public sealed class RawCommandCallbackAnalyzer : DiagnosticAnalyzer
 
     /// <summary>
     /// The own click/toggle callback(s) for one command-capable element.
-    /// <see cref="InitializerCallbacks"/> are settable via an object initializer / <c>with</c>
-    /// (checked in order); <see cref="CtorCallbackParam"/> is the constructor parameter that
-    /// <i>is</i> that callback (the positional shape, e.g. <c>new ButtonElement("Save", DoThing)</c>).
+    /// <see cref="InitializerCallbacks"/> is the set of callback property names settable via an
+    /// object initializer / <c>with</c>; the analyzer reports the first such assignment found in
+    /// source order. <see cref="CtorCallbackParam"/> is the constructor parameter that <i>is</i>
+    /// that callback (the positional shape, e.g. <c>new ButtonElement("Save", DoThing)</c>).
     /// </summary>
     internal readonly struct CallbackInfo
     {
-        /// <summary>Callback names settable via an object initializer / <c>with</c> (checked in order).</summary>
+        /// <summary>The set of callback property names settable via an object initializer / <c>with</c>.</summary>
         public readonly ImmutableArray<string> InitializerCallbacks;
 
         /// <summary>The constructor parameter that <i>is</i> the callback (the positional shape).</summary>
@@ -217,10 +218,12 @@ public sealed class RawCommandCallbackAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// The argument bound to the callback constructor parameter, or <c>null</c>. Handles the named
-    /// form (<c>OnClick: h</c>) and the pure-positional form (mapped by the resolved parameter
-    /// ordinal). Calls that mix named and positional arguments are skipped — a rare, intentional
-    /// false negative that avoids brittle positional-slot accounting.
+    /// The argument bound to the callback constructor parameter, or <c>null</c>. A <b>named</b>
+    /// callback argument (<c>OnClick: h</c>) is matched regardless of the other arguments. The
+    /// <b>positional</b> callback (mapped by the resolved parameter ordinal) is only resolved when
+    /// the call is entirely positional; a call that mixes named and positional arguments skips the
+    /// positional path — a rare, intentional false negative that avoids brittle positional-slot
+    /// accounting.
     /// </summary>
     private static ArgumentSyntax? FindCtorCallbackArgument(ArgumentListSyntax argumentList, IMethodSymbol? constructor, string parameterName)
     {

--- a/src/Reactor.Analyzers/RawCommandCallbackAnalyzer.cs
+++ b/src/Reactor.Analyzers/RawCommandCallbackAnalyzer.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_CMD_001</c> — flags a raw <c>new …Element(…) { … }</c> / <c>… with { … }</c> that
+/// assigns <b>both</b> a <c>Command</c> and the element's own click/toggle callback.
+/// </summary>
+/// <remarks>
+/// In WPF/UWP a <c>Button.Click</c> handler fires <i>alongside</i> its <c>Command</c>. Reactor
+/// resolves a single effective callback instead:
+/// <c>EffectiveCallback(userCallback, cmd) =&gt; userCallback ?? Invokable(cmd)</c>
+/// (<c>CommandBindings.cs</c>). The explicit <c>OnClick</c> / toggle handler <b>wins</b>, so the
+/// command's <c>Execute</c>/<c>ExecuteAsync</c> never runs — the command is silently dropped.
+///
+/// This is reachable <b>only</b> via a hand-written record-init: the fluent <c>.Command(...)</c>
+/// modifier already sets <c>OnClick = null</c>, and the <c>Button(Command)</c> factory takes no
+/// callback. There is no <c>.OnClick()</c> modifier. Hence <b>Info</b>, not Warning.
+///
+/// The fix <b>deletes the redundant callback</b> (carried in <see cref="Diagnostic.Properties"/>).
+/// Moving the callback body into <c>cmd.Execute</c> is deliberately <i>not</i> offered: it bypasses
+/// <c>CanExecute</c>, breaks <c>UseCommand</c>/<c>DebounceMs</c> arming, and can swallow an async
+/// <c>ExecuteAsync</c>.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RawCommandCallbackAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_CMD_001";
+
+    /// <summary>The namespace every command-capable Reactor element record lives in.</summary>
+    private const string ElementNamespace = "Microsoft.UI.Reactor.Core";
+
+    private const string CommandProperty = "Command";
+
+    // Code-fix hand-off keys (data travels in Diagnostic.Properties, never message text).
+    internal const string CallbackKindKey = "CallbackKind";
+    internal const string CallbackNameKey = "CallbackName";
+    internal const string KindInitializer = "Initializer";
+    internal const string KindCtorArg = "CtorArg";
+
+    /// <summary>
+    /// The own click/toggle callback(s) for one command-capable element.
+    /// <see cref="InitializerCallbacks"/> are settable via an object initializer / <c>with</c>
+    /// (checked in order); <see cref="CtorCallbackParam"/> is the constructor parameter that
+    /// <i>is</i> that callback (the positional shape, e.g. <c>new ButtonElement("Save", DoThing)</c>).
+    /// </summary>
+    internal readonly struct CallbackInfo
+    {
+        /// <summary>Callback names settable via an object initializer / <c>with</c> (checked in order).</summary>
+        public readonly ImmutableArray<string> InitializerCallbacks;
+
+        /// <summary>The constructor parameter that <i>is</i> the callback (the positional shape).</summary>
+        public readonly string CtorCallbackParam;
+
+        public CallbackInfo(ImmutableArray<string> initializerCallbacks, string ctorCallbackParam)
+        {
+            InitializerCallbacks = initializerCallbacks;
+            CtorCallbackParam = ctorCallbackParam;
+        }
+    }
+
+    /// <summary>
+    /// Per-element callback map, keyed by the element record's simple type name. Grounded in
+    /// <c>src/Reactor/Core/Element.cs</c>:
+    /// <list type="bullet">
+    ///   <item><c>OnClick</c> — Button / HyperlinkButton / RepeatButton / SplitButton.</item>
+    ///   <item><c>OnIsCheckedChanged</c> (+ <c>OnCheckedStateChanged</c> on ToggleButton) — ToggleButton / ToggleSplitButton.</item>
+    /// </list>
+    /// This is intentionally <b>not</b> shared with <c>CommandDebounceAnalyzer</c>: that rule keys on
+    /// DSL <i>factory</i> names and includes <c>MenuItem</c>/<c>AppBarButton</c>, which are plain data
+    /// records (<c>MenuFlyoutItemData</c>/<c>AppBarButtonData</c>), not command-capable Elements.
+    /// </summary>
+    internal static readonly IReadOnlyDictionary<string, CallbackInfo> CommandElements =
+        new Dictionary<string, CallbackInfo>(StringComparer.Ordinal)
+        {
+            { "ButtonElement",            new(ImmutableArray.Create("OnClick"), "OnClick") },
+            { "HyperlinkButtonElement",   new(ImmutableArray.Create("OnClick"), "OnClick") },
+            { "RepeatButtonElement",      new(ImmutableArray.Create("OnClick"), "OnClick") },
+            { "SplitButtonElement",       new(ImmutableArray.Create("OnClick"), "OnClick") },
+            { "ToggleButtonElement",      new(ImmutableArray.Create("OnIsCheckedChanged", "OnCheckedStateChanged"), "OnIsCheckedChanged") },
+            { "ToggleSplitButtonElement", new(ImmutableArray.Create("OnIsCheckedChanged"), "OnIsCheckedChanged") },
+        };
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "Command and the element's own callback are both set; the callback wins",
+        "'{0}' is set alongside 'Command'; Reactor uses the callback, so the command never runs. Remove '{0}' to run the command (or drop 'Command').",
+        "Reactor.Commanding",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "A command-capable element resolves a single effective callback (userCallback ?? Invokable(command)), " +
+            "so an explicit OnClick / OnIsCheckedChanged / OnCheckedStateChanged set alongside a Command wins and the " +
+            "command's Execute/ExecuteAsync never runs. The fluent .Command(...) modifier already nulls the callback, so " +
+            "this only happens in a raw record-init. Remove the redundant callback (or drop the Command).");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(
+            Analyze,
+            SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.ImplicitObjectCreationExpression,
+            SyntaxKind.WithExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext ctx)
+    {
+        var node = (ExpressionSyntax)ctx.Node;
+
+        // Command is only ever an init property, so a shadowing bug requires a Command assignment
+        // in this node's initializer. Cheap syntactic gate before any semantic query.
+        var initializer = GetInitializer(node);
+        if (initializer is null)
+            return;
+
+        var commandAssignment = FindInitializerAssignment(initializer, CommandProperty);
+        if (commandAssignment is null)
+            return;
+
+        // `Command = null` leaves nothing to shadow — the command never runs either way.
+        if (IsNullish(commandAssignment.Right))
+            return;
+
+        // Confirm the created / `with` type is a known command-capable Reactor element.
+        var type = ctx.SemanticModel.GetTypeInfo(node, ctx.CancellationToken).Type;
+        if (type is null)
+            return;
+        if (!CommandElements.TryGetValue(type.Name, out var info))
+            return;
+        if (type.ContainingNamespace?.ToDisplayString() != ElementNamespace)
+            return;
+
+        // (a) Redundant callback assigned via the object initializer / `with`.
+        var initCallback = FindInitializerCallback(initializer, info.InitializerCallbacks);
+        if (initCallback is not null)
+        {
+            Report(ctx, initCallback.GetLocation(), KindInitializer, ((IdentifierNameSyntax)initCallback.Left).Identifier.ValueText);
+            return;
+        }
+
+        // (b) Redundant callback passed as the constructor's positional/named argument.
+        var argumentList = GetArgumentList(node);
+        if (argumentList is null)
+            return;
+
+        var ctor = ctx.SemanticModel.GetSymbolInfo(node, ctx.CancellationToken).Symbol as IMethodSymbol;
+        var callbackArg = FindCtorCallbackArgument(argumentList, ctor, info.CtorCallbackParam);
+        if (callbackArg is not null && !IsNullish(callbackArg.Expression))
+            Report(ctx, callbackArg.GetLocation(), KindCtorArg, info.CtorCallbackParam);
+    }
+
+    private static void Report(SyntaxNodeAnalysisContext ctx, Location location, string kind, string callbackName)
+    {
+        var properties = ImmutableDictionary<string, string?>.Empty
+            .Add(CallbackKindKey, kind)
+            .Add(CallbackNameKey, callbackName);
+
+        ctx.ReportDiagnostic(Diagnostic.Create(Rule, location, properties, callbackName));
+    }
+
+    private static InitializerExpressionSyntax? GetInitializer(ExpressionSyntax node) => node switch
+    {
+        ObjectCreationExpressionSyntax oce => oce.Initializer,
+        ImplicitObjectCreationExpressionSyntax ioce => ioce.Initializer,
+        WithExpressionSyntax we => we.Initializer,
+        _ => null,
+    };
+
+    private static ArgumentListSyntax? GetArgumentList(ExpressionSyntax node) => node switch
+    {
+        ObjectCreationExpressionSyntax oce => oce.ArgumentList,
+        ImplicitObjectCreationExpressionSyntax ioce => ioce.ArgumentList,
+        _ => null,
+    };
+
+    /// <summary>First <c>Name = …</c> assignment in the initializer whose left-hand side is <paramref name="name"/>.</summary>
+    private static AssignmentExpressionSyntax? FindInitializerAssignment(InitializerExpressionSyntax initializer, string name) =>
+        initializer.Expressions
+            .OfType<AssignmentExpressionSyntax>()
+            .FirstOrDefault(a => a.Left is IdentifierNameSyntax id && id.Identifier.ValueText == name);
+
+    /// <summary>First non-null callback assignment among <paramref name="callbackNames"/>, in source order.</summary>
+    private static AssignmentExpressionSyntax? FindInitializerCallback(InitializerExpressionSyntax initializer, ImmutableArray<string> callbackNames)
+    {
+        foreach (var expression in initializer.Expressions)
+        {
+            if (expression is AssignmentExpressionSyntax assignment &&
+                assignment.Left is IdentifierNameSyntax id &&
+                callbackNames.Contains(id.Identifier.ValueText) &&
+                !IsNullish(assignment.Right))
+            {
+                return assignment;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The argument bound to the callback constructor parameter, or <c>null</c>. Handles the named
+    /// form (<c>OnClick: h</c>) and the pure-positional form (mapped by the resolved parameter
+    /// ordinal). Calls that mix named and positional arguments are skipped — a rare, intentional
+    /// false negative that avoids brittle positional-slot accounting.
+    /// </summary>
+    private static ArgumentSyntax? FindCtorCallbackArgument(ArgumentListSyntax argumentList, IMethodSymbol? constructor, string parameterName)
+    {
+        var arguments = argumentList.Arguments;
+
+        // Named form — position-independent, so always safe to match.
+        foreach (var argument in arguments)
+        {
+            if (argument.NameColon?.Name.Identifier.ValueText == parameterName)
+                return argument;
+        }
+
+        // Pure-positional form only.
+        if (arguments.Any(a => a.NameColon is not null))
+            return null;
+        if (constructor is null)
+            return null;
+
+        var parameter = constructor.Parameters.FirstOrDefault(p => p.Name == parameterName);
+        if (parameter is null)
+            return null;
+
+        return parameter.Ordinal < arguments.Count ? arguments[parameter.Ordinal] : null;
+    }
+
+    /// <summary>True for <c>null</c> and <c>default</c> — a callback that leaves the command intact.</summary>
+    private static bool IsNullish(ExpressionSyntax expression) =>
+        expression.IsKind(SyntaxKind.NullLiteralExpression) ||
+        expression.IsKind(SyntaxKind.DefaultLiteralExpression) ||
+        expression is DefaultExpressionSyntax;
+}

--- a/src/Reactor.Analyzers/RawCommandCallbackCodeFix.cs
+++ b/src/Reactor.Analyzers/RawCommandCallbackCodeFix.cs
@@ -66,6 +66,14 @@ public sealed class RawCommandCallbackCodeFix : CodeFixProvider
                 if (argument?.Parent is not ArgumentListSyntax argumentList)
                     continue;
 
+                // Deleting the callback argument is only safe when no *positional* argument follows
+                // it: a following positional would shift down into the callback parameter's slot and
+                // rebind (e.g. removing OnClick from `new SplitButtonElement("S", h, flyout)` would
+                // bind `flyout` to `OnClick`). A named argument can always be removed. When it isn't
+                // safe we withhold the fix — the analyzer still reports, the author removes by hand.
+                if (!IsSafeToRemoveArgument(argumentList, argument))
+                    continue;
+
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         title,
@@ -96,5 +104,25 @@ public sealed class RawCommandCallbackCodeFix : CodeFixProvider
 
         var newDocument = document.WithSyntaxRoot(root.ReplaceNode(argumentList, newArgumentList));
         return Formatter.FormatAsync(newDocument, Formatter.Annotation, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// A named argument is always safe to delete. A positional argument is safe only when no
+    /// positional argument follows it — otherwise removing it would shift a later positional
+    /// argument into the deleted parameter's slot and silently rebind it.
+    /// </summary>
+    private static bool IsSafeToRemoveArgument(ArgumentListSyntax argumentList, ArgumentSyntax argument)
+    {
+        if (argument.NameColon is not null)
+            return true;
+
+        var index = argumentList.Arguments.IndexOf(argument);
+        for (var i = index + 1; i < argumentList.Arguments.Count; i++)
+        {
+            if (argumentList.Arguments[i].NameColon is null)
+                return false;
+        }
+
+        return true;
     }
 }

--- a/src/Reactor.Analyzers/RawCommandCallbackCodeFix.cs
+++ b/src/Reactor.Analyzers/RawCommandCallbackCodeFix.cs
@@ -1,0 +1,100 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for <see cref="RawCommandCallbackAnalyzer"/> (<c>REACTOR_CMD_001</c>) — deletes the
+/// redundant own callback that shadows the bound <c>Command</c>, so the command runs again.
+/// </summary>
+/// <remarks>
+/// The callback to remove is identified by <see cref="RawCommandCallbackAnalyzer.CallbackKindKey"/>
+/// in <see cref="Diagnostic.Properties"/>: an object-initializer assignment (<c>{ …, OnClick = h }</c>)
+/// or a constructor argument (<c>new ButtonElement("Save", DoThing)</c>). We only ever <b>delete</b>
+/// the callback — never fold its body into <c>cmd.Execute</c> (that bypasses <c>CanExecute</c>,
+/// breaks <c>UseCommand</c>/<c>DebounceMs</c> arming, and can swallow an async <c>ExecuteAsync</c>).
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RawCommandCallbackCodeFix))]
+[Shared]
+public sealed class RawCommandCallbackCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(RawCommandCallbackAnalyzer.DiagnosticId);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            if (!diagnostic.Properties.TryGetValue(RawCommandCallbackAnalyzer.CallbackKindKey, out var kind) || kind is null)
+                continue;
+
+            diagnostic.Properties.TryGetValue(RawCommandCallbackAnalyzer.CallbackNameKey, out var callbackName);
+            var title = $"Remove redundant '{callbackName ?? "callback"}'";
+
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+
+            if (kind == RawCommandCallbackAnalyzer.KindInitializer)
+            {
+                var assignment = node as AssignmentExpressionSyntax ?? node.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
+                if (assignment?.Parent is not InitializerExpressionSyntax initializer)
+                    continue;
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title,
+                        ct => RemoveInitializerAssignmentAsync(context.Document, root, initializer, assignment, ct),
+                        equivalenceKey: RawCommandCallbackAnalyzer.DiagnosticId + ":init"),
+                    diagnostic);
+            }
+            else if (kind == RawCommandCallbackAnalyzer.KindCtorArg)
+            {
+                var argument = node as ArgumentSyntax ?? node.FirstAncestorOrSelf<ArgumentSyntax>();
+                if (argument?.Parent is not ArgumentListSyntax argumentList)
+                    continue;
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title,
+                        ct => RemoveArgumentAsync(context.Document, root, argumentList, argument, ct),
+                        equivalenceKey: RawCommandCallbackAnalyzer.DiagnosticId + ":ctor"),
+                    diagnostic);
+            }
+        }
+    }
+
+    private static Task<Document> RemoveInitializerAssignmentAsync(
+        Document document, SyntaxNode root, InitializerExpressionSyntax initializer, AssignmentExpressionSyntax assignment, CancellationToken cancellationToken)
+    {
+        var newInitializer = initializer
+            .WithExpressions(initializer.Expressions.Remove(assignment))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var newDocument = document.WithSyntaxRoot(root.ReplaceNode(initializer, newInitializer));
+        return Formatter.FormatAsync(newDocument, Formatter.Annotation, cancellationToken: cancellationToken);
+    }
+
+    private static Task<Document> RemoveArgumentAsync(
+        Document document, SyntaxNode root, ArgumentListSyntax argumentList, ArgumentSyntax argument, CancellationToken cancellationToken)
+    {
+        var newArgumentList = argumentList
+            .WithArguments(argumentList.Arguments.Remove(argument))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var newDocument = document.WithSyntaxRoot(root.ReplaceNode(argumentList, newArgumentList));
+        return Formatter.FormatAsync(newDocument, Formatter.Annotation, cancellationToken: cancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/RawCommandCallbackAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/RawCommandCallbackAnalyzerTests.cs
@@ -1,0 +1,430 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="RawCommandCallbackAnalyzer"/> (<c>REACTOR_CMD_001</c>) and its
+/// <see cref="RawCommandCallbackCodeFix"/>. Stubs the command-capable element records (Button /
+/// SplitButton / ToggleButton) plus a plain <c>MenuFlyoutItemData</c> data record and a same-named
+/// element in another namespace, so the analyzer's per-element map + namespace guard resolve
+/// without pulling the framework in.
+/// </summary>
+public class RawCommandCallbackAnalyzerTests
+{
+    private const string Stubs = @"
+namespace System.Runtime.CompilerServices
+{
+    public static class IsExternalInit { }
+}
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public sealed record Command
+    {
+        public string Label { get; init; }
+        public System.Action Execute { get; init; }
+    }
+
+    public abstract record Element { }
+
+    public sealed record ButtonElement(string Label, System.Action OnClick = null) : Element
+    {
+        public Command Command { get; init; }
+    }
+
+    public sealed record SplitButtonElement(string Label, System.Action OnClick = null, Element Flyout = null) : Element
+    {
+        public Command Command { get; init; }
+    }
+
+    public sealed record ToggleButtonElement(string Label, bool IsChecked = false, System.Action<bool> OnIsCheckedChanged = null) : Element
+    {
+        public bool? CheckedState { get; init; }
+        public System.Action<bool?> OnCheckedStateChanged { get; init; }
+        public Command Command { get; init; }
+    }
+
+    // A plain data record (mirrors the real MenuFlyoutItemData/AppBarButtonData that
+    // CommandDebounceAnalyzer's factory list includes). It is NOT a command-capable Element, so
+    // REACTOR_CMD_001 must never fire on it — this is the near-miss that proves the two rules
+    // cannot share a list.
+    public sealed record MenuFlyoutItemData(string Text)
+    {
+        public Command Command { get; init; }
+        public System.Action OnClick { get; init; }
+    }
+}
+
+namespace Other
+{
+    // Same simple name as a real element, but a different namespace — the namespace guard must
+    // keep the analyzer from firing here.
+    public sealed record ButtonElement(string Label, System.Action OnClick = null)
+    {
+        public Microsoft.UI.Reactor.Core.Command Command { get; init; }
+    }
+}
+";
+
+    private static CSharpAnalyzerTest<RawCommandCallbackAnalyzer, DefaultVerifier> Analyzer(string source) =>
+        new() { TestCode = Stubs + source };
+
+    private static CSharpCodeFixTest<RawCommandCallbackAnalyzer, RawCommandCallbackCodeFix, DefaultVerifier> Fix(string before, string after) =>
+        new() { TestCode = Stubs + before, FixedCode = Stubs + after };
+
+    // ── Positive ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Fires_When_Initializer_Sets_Command_And_OnClick()
+    {
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            System.Action h = () => { };
+            var b = new ButtonElement(""Save"") { Command = cmd, {|REACTOR_CMD_001:OnClick = h|} };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_When_Constructor_Positional_Callback_And_Command()
+    {
+        // The positional Action? argument IS OnClick.
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        static void DoThing() { }
+
+        void M()
+        {
+            var cmd = new Command();
+            var b = new ButtonElement(""Save"", {|REACTOR_CMD_001:DoThing|}) { Command = cmd };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_With_Expression()
+    {
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            System.Action h = () => { };
+            var b = new ButtonElement(""Save"");
+            var b2 = b with { Command = cmd, {|REACTOR_CMD_001:OnClick = h|} };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_ToggleButton_OnIsCheckedChanged()
+    {
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            System.Action<bool> t = _ => { };
+            var b = new ToggleButtonElement(""T"") { Command = cmd, {|REACTOR_CMD_001:OnIsCheckedChanged = t|} };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_ToggleButton_OnCheckedStateChanged()
+    {
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            System.Action<bool?> s = _ => { };
+            var b = new ToggleButtonElement(""T"") { Command = cmd, {|REACTOR_CMD_001:OnCheckedStateChanged = s|} };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_SplitButton_Constructor_Positional_Callback()
+    {
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        static void DoThing() { }
+
+        void M()
+        {
+            var cmd = new Command();
+            var b = new SplitButtonElement(""S"", {|REACTOR_CMD_001:DoThing|}) { Command = cmd };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_When_Only_Command_Set()
+    {
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            var b = new ButtonElement(""Save"") { Command = cmd };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_Only_Callback_Set()
+    {
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            System.Action h = () => { };
+            var b = new ButtonElement(""Save"", h);
+            var c = new ButtonElement(""Save"") { OnClick = h };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_Callback_Explicitly_Null()
+    {
+        // OnClick = null leaves EffectiveCallback = Invokable(cmd): the command still runs.
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            var b = new ButtonElement(""Save"") { Command = cmd, OnClick = null };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_On_MenuItem_Data_Record()
+    {
+        // MenuFlyoutItemData is a plain data record, not a command-capable Element — a naive
+        // property-name match would fire here, but our per-element map must not.
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            System.Action h = () => { };
+            var m = new MenuFlyoutItemData(""Copy"") { Command = cmd, OnClick = h };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_On_ButtonElement_In_Other_Namespace()
+    {
+        var source = @"
+namespace TestApp
+{
+    class C
+    {
+        void M()
+        {
+            var cmd = new Microsoft.UI.Reactor.Core.Command();
+            System.Action h = () => { };
+            var b = new Other.ButtonElement(""Save"") { Command = cmd, OnClick = h };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code fix ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CodeFix_Removes_Initializer_Callback()
+    {
+        var before = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            System.Action h = () => { };
+            var b = new ButtonElement(""Save"") { Command = cmd, {|REACTOR_CMD_001:OnClick = h|} };
+        }
+    }
+}";
+        var after = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            System.Action h = () => { };
+            var b = new ButtonElement(""Save"") { Command = cmd };
+        }
+    }
+}";
+        await Fix(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Removes_Constructor_Positional_Callback()
+    {
+        var before = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        static void DoThing() { }
+
+        void M()
+        {
+            var cmd = new Command();
+            var b = new ButtonElement(""Save"", {|REACTOR_CMD_001:DoThing|}) { Command = cmd };
+        }
+    }
+}";
+        var after = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        static void DoThing() { }
+
+        void M()
+        {
+            var cmd = new Command();
+            var b = new ButtonElement(""Save"") { Command = cmd };
+        }
+    }
+}";
+        await Fix(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Removes_With_Expression_Callback()
+    {
+        var before = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            System.Action h = () => { };
+            var b = new ButtonElement(""Save"");
+            var b2 = b with { Command = cmd, {|REACTOR_CMD_001:OnClick = h|} };
+        }
+    }
+}";
+        var after = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            System.Action h = () => { };
+            var b = new ButtonElement(""Save"");
+            var b2 = b with { Command = cmd };
+        }
+    }
+}";
+        await Fix(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/RawCommandCallbackAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/RawCommandCallbackAnalyzerTests.cs
@@ -36,6 +36,11 @@ namespace Microsoft.UI.Reactor.Core
         public Command Command { get; init; }
     }
 
+    public sealed record HyperlinkButtonElement(string Content, System.Uri NavigateUri = null, System.Action OnClick = null) : Element
+    {
+        public Command Command { get; init; }
+    }
+
     public sealed record SplitButtonElement(string Label, System.Action OnClick = null, Element Flyout = null) : Element
     {
         public Command Command { get; init; }
@@ -426,5 +431,208 @@ namespace TestApp
     }
 }";
         await Fix(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Constructor-argument shapes: named / ordinal-2 / target-typed ────
+
+    [Fact]
+    public async Task Fires_On_Named_Constructor_Argument_Callback()
+    {
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        static void DoThing() { }
+
+        void M()
+        {
+            var cmd = new Command();
+            var b = new ButtonElement(""Save"", {|REACTOR_CMD_001:OnClick: DoThing|}) { Command = cmd };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Removes_Named_Constructor_Argument_Callback()
+    {
+        // A named argument is always safe to delete (no positional slots shift).
+        var before = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        static void DoThing() { }
+
+        void M()
+        {
+            var cmd = new Command();
+            var b = new ButtonElement(""Save"", {|REACTOR_CMD_001:OnClick: DoThing|}) { Command = cmd };
+        }
+    }
+}";
+        var after = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        static void DoThing() { }
+
+        void M()
+        {
+            var cmd = new Command();
+            var b = new ButtonElement(""Save"") { Command = cmd };
+        }
+    }
+}";
+        await Fix(before, after).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_HyperlinkButton_Constructor_Positional_Callback()
+    {
+        // HyperlinkButtonElement's OnClick is the 3rd ctor parameter (ordinal 2) — exercises the
+        // ordinal-based lookup beyond ordinal 1.
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        static void DoThing() { }
+
+        void M()
+        {
+            var cmd = new Command();
+            var b = new HyperlinkButtonElement(""Docs"", null, {|REACTOR_CMD_001:DoThing|}) { Command = cmd };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_Implicit_New_Target_Typed()
+    {
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            var cmd = new Command();
+            System.Action h = () => { };
+            ButtonElement b = new(""Save"") { Command = cmd, {|REACTOR_CMD_001:OnClick = h|} };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code-fix withheld when deleting a middle positional arg would rebind ─
+
+    [Fact]
+    public async Task Analyzer_Fires_But_CodeFix_Suppressed_For_Middle_Positional_Callback()
+    {
+        // SplitButtonElement is (Label, OnClick, Flyout). Deleting the positional OnClick would
+        // shift `flyout` into the OnClick slot, so the analyzer still reports but no fix is offered
+        // (TestCode == FixedCode: the diagnostic persists, no rewrite).
+        var code = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        static void DoThing() { }
+
+        void M()
+        {
+            var cmd = new Command();
+            Element flyout = null;
+            var b = new SplitButtonElement(""S"", {|REACTOR_CMD_001:DoThing|}, flyout) { Command = cmd };
+        }
+    }
+}";
+        await Fix(code, code).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Metadata-only inline command: nothing to shadow, do not fire ────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Inline_Metadata_Only_Command()
+    {
+        // The inline command assigns no Execute/ExecuteAsync, so Invokable(cmd) is null and OnClick
+        // is the only executable path — not a shadowed command.
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            System.Action h = () => { };
+            var b = new ButtonElement(""Save"") { Command = new Command { Label = ""Save"" }, OnClick = h };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Empty_Inline_Command()
+    {
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            System.Action h = () => { };
+            var b = new ButtonElement(""Save"") { Command = new Command(), OnClick = h };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_When_Inline_Command_Has_Execute()
+    {
+        // Control for the metadata-only guard: an inline command WITH an Execute is a real command,
+        // so the callback does shadow it and the diagnostic fires.
+        var source = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    class C
+    {
+        void M()
+        {
+            System.Action run = () => { };
+            System.Action h = () => { };
+            var b = new ButtonElement(""Save"") { Command = new Command { Execute = run }, {|REACTOR_CMD_001:OnClick = h|} };
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
     }
 }


### PR DESCRIPTION
## REACTOR_CMD_001 — Raw-init `Command` + own callback both set

Spec 060 (Analyzer Suite Expansion) · Wave A packet. `Reactor.Commanding` · **Info** · code-fix.

### Why
Reactor resolves a single effective callback for command-capable buttons:
`EffectiveCallback(userCallback, cmd) => userCallback ?? Invokable(cmd)` (`CommandBindings.cs:169`). So a raw `new …Element { Command = cmd, OnClick = h }` (or `with`) makes the **callback win** and `cmd.Execute` **never runs** — a silent XAML-habit footgun (in WPF/UWP `Click` fires alongside `Command`).

Only reachable via raw record-init: the fluent `.Command(...)` modifier already sets `OnClick = null`, and `Button(Command)` takes no callback. Hence **Info**, not Warning.

### What
- `RawCommandCallbackAnalyzer` — fires on `ObjectCreation` / `ImplicitObjectCreation` / `with` that assigns **both** `Command` (non-null) and the element's **own** callback, via a per-element map:
  - `OnClick` — `ButtonElement` / `HyperlinkButtonElement` / `RepeatButtonElement` / `SplitButtonElement`
  - `OnIsCheckedChanged` / `OnCheckedStateChanged` — `ToggleButtonElement` / `ToggleSplitButtonElement`
- Also flags the **ctor-positional** shape (`new ButtonElement("Save", DoThing) { Command = cmd }` — the positional `Action?` *is* `OnClick`).
- Namespace-guarded to `Microsoft.UI.Reactor.Core`; explicit `null`/`default` callbacks don't fire (command still runs). Deliberately **not** sharing `CommandDebounceAnalyzer`'s factory list (MenuItem/AppBarButton are plain data records).
- `RawCommandCallbackCodeFix` — **deletes** the redundant callback (initializer assignment or ctor arg). Never folds the body into `cmd.Execute` (that would bypass `CanExecute`, break `UseCommand`/`DebounceMs` arming, swallow async `ExecuteAsync`).

### Tests
14 tests (`dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~RawCommandCallback`): positive (initializer + ctor-positional + `with` + toggle variants + SplitButton), negatives (only-Command, only-callback, explicit-null), near-misses (MenuItem data record, same-name element in another namespace), and fix round-trips. Full `AnalyzerTests` suite green (229). Samples sweep: no raw-init element constructions exist (fluent DSL only), so the rule correctly fires nowhere — expected for a hygiene rule (§2.4).

Also appends the canonical `AnalyzerReleases.Unshipped.md` row, an app-author cheat-table row, and an `analyzer-architecture.md.dt` rules-table row.

Stacked on `azchohfi-spec-060-analyzer-suite`.