### PR TITLE
feat(analyzer): REACTOR_THREAD_001 + [UIThreadOnly] attribute

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,6 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_THREAD_001` | Warning | UI-thread-only mutator called on a background thread | `UIThreadAffinityAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_THREAD_001` | warning | UI-thread-only member (window / tray / taskbar mutator) called inside a `Task.Run` / `Task.Factory.StartNew` / `ThreadPool.QueueUserWorkItem` lambda | Marshal it back: `var d = ReactorApp.UIDispatcher; if (d is null) window.Close(); else d.TryEnqueue(() => window.Close());`. Null-safe because the dispatcher is null until the first window bootstraps. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -7101,6 +7101,9 @@ RegisterFormatter<T>(Func<object, string> formatter) → TypeRegistry
 Resolve(Type type) → TypeMetadata
 ResolveEditor(Type type, EditorTier tier) → Func<object, Action<object>, Element>
 
+### class UIThreadOnlyAttribute
+new()
+
 ### record ValidationAttached
 new(string FieldName, IValidator[] Validators, IAsyncValidator[] AsyncValidators)
 IAsyncValidator[] AsyncValidators { get; init; }

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -7101,6 +7101,9 @@ RegisterFormatter<T>(Func<object, string> formatter) → TypeRegistry
 Resolve(Type type) → TypeMetadata
 ResolveEditor(Type type, EditorTier tier) → Func<object, Action<object>, Element>
 
+### class UIThreadOnlyAttribute
+new()
+
 ### record ValidationAttached
 new(string FieldName, IValidator[] Validators, IAsyncValidator[] AsyncValidators)
 IAsyncValidator[] AsyncValidators { get; init; }

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_THREAD_001 | Reactor.Threading | Warning | UIThreadAffinityAnalyzer - UI-thread-only mutator called on a background thread

--- a/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -94,7 +95,7 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
-        if (!IsBackgroundThreadContext(invocation))
+        if (!IsBackgroundThreadContext(invocation, context.SemanticModel, context.CancellationToken))
             return;
 
         // Semantic backstop: confirm the callee carries [UIThreadOnly].
@@ -142,13 +143,19 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     {
         if (target is not (MemberAccessExpressionSyntax or IdentifierNameSyntax or MemberBindingExpressionSyntax))
             return;
-        if (!IsBackgroundThreadContext(context.Node))
+        if (!IsBackgroundThreadContext(context.Node, context.SemanticModel, context.CancellationToken))
             return;
 
         var symbolInfo = context.SemanticModel.GetSymbolInfo(target, context.CancellationToken);
         var property = symbolInfo.Symbol as IPropertySymbol
             ?? symbolInfo.CandidateSymbols.FirstOrDefault() as IPropertySymbol;
-        if (property is null || !HasUIThreadOnlyAttribute(property))
+        if (property is null)
+            return;
+
+        // The attribute may sit on the property itself or on its set accessor
+        // (`{ get; [UIThreadOnly] set; }`), which is a distinct method symbol.
+        if (!HasUIThreadOnlyAttribute(property) &&
+            !(property.SetMethod is { } setMethod && HasUIThreadOnlyAttribute(setMethod)))
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(
@@ -164,8 +171,9 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     /// because <c>ThrowIfNotOnUIThread</c> is a no-op while the dispatcher is null,
     /// and skipping it stops the code fix looping on its own output).
     /// </summary>
-    private static bool IsBackgroundThreadContext(SyntaxNode node) =>
-        IsInsideUnmarshaledBackgroundLambda(node) && !IsInsideDispatcherNullFallback(node);
+    private static bool IsBackgroundThreadContext(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken) =>
+        IsInsideUnmarshaledBackgroundLambda(node, semanticModel, cancellationToken)
+        && !IsInsideDispatcherNullFallback(node, semanticModel, cancellationToken);
 
     /// <summary>
     /// Walk the lexical ancestors of <paramref name="invocation"/>. Returns
@@ -177,14 +185,14 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     /// resolve correctly: <c>Task.Run(() =&gt; d.TryEnqueue(() =&gt; w.Close()))</c>
     /// hits the TryEnqueue boundary before the Task.Run boundary.
     /// </summary>
-    private static bool IsInsideUnmarshaledBackgroundLambda(SyntaxNode invocation)
+    private static bool IsInsideUnmarshaledBackgroundLambda(SyntaxNode invocation, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
         for (var node = invocation.Parent; node is not null; node = node.Parent)
         {
             switch (node)
             {
                 case AnonymousFunctionExpressionSyntax lambda:
-                    switch (ClassifyLambdaHost(lambda))
+                    switch (ClassifyLambdaHost(lambda, semanticModel, cancellationToken))
                     {
                         case LambdaHost.Marshaled:
                             return false;
@@ -215,7 +223,7 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     /// <c>TryEnqueue</c> in its else does not hide a genuine off-thread call. Safe
     /// because <c>ThrowIfNotOnUIThread</c> is a no-op while the dispatcher is null.
     /// </summary>
-    private static bool IsInsideDispatcherNullFallback(SyntaxNode node)
+    private static bool IsInsideDispatcherNullFallback(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
         var child = node;
         for (var current = node.Parent; current is not null; child = current, current = current.Parent)
@@ -224,7 +232,7 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
                 ReferenceEquals(child, ifStatement.Statement) &&
                 TryGetNullCheckedIdentifier(ifStatement.Condition) is { } dispatcherName &&
                 ifStatement.Else is { } elseClause &&
-                ElseMarshalsThrough(elseClause, dispatcherName))
+                ElseMarshalsThrough(elseClause, dispatcherName, semanticModel, cancellationToken))
             {
                 return true;
             }
@@ -261,20 +269,26 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// The <c>else</c> branch marshals through <c><paramref name="dispatcherName"/>.TryEnqueue(...)</c>.
+    /// The <c>else</c> branch marshals through <c><paramref name="dispatcherName"/>.TryEnqueue(...)</c>
+    /// on an actual <see cref="Microsoft.UI.Dispatching.DispatcherQueue"/>.
     /// </summary>
-    private static bool ElseMarshalsThrough(SyntaxNode elseClause, string dispatcherName) =>
+    private static bool ElseMarshalsThrough(SyntaxNode elseClause, string dispatcherName, SemanticModel semanticModel, CancellationToken cancellationToken) =>
         elseClause.DescendantNodes().OfType<InvocationExpressionSyntax>().Any(invocation =>
         {
             var (methodName, receiverName) = GetInvokedNames(invocation);
-            return methodName == "TryEnqueue" && receiverName == dispatcherName;
+            return methodName == "TryEnqueue"
+                && receiverName == dispatcherName
+                && HostTypeIs(invocation, semanticModel, cancellationToken, DispatcherQueueTypeName);
         });
 
     /// <summary>
     /// Classify a lambda by the method it is passed to: a background launcher, a
-    /// dispatcher marshal (<c>TryEnqueue</c>), or unrelated.
+    /// dispatcher marshal (<c>TryEnqueue</c>), or unrelated. A cheap syntactic
+    /// name/receiver filter runs first, then the resolved method's containing type
+    /// is confirmed semantically so an unrelated same-named API (a non-dispatcher
+    /// <c>TryEnqueue</c>, a user-defined <c>Run</c>) does not misclassify.
     /// </summary>
-    private static LambdaHost ClassifyLambdaHost(AnonymousFunctionExpressionSyntax lambda)
+    private static LambdaHost ClassifyLambdaHost(AnonymousFunctionExpressionSyntax lambda, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
         if (lambda.Parent is not ArgumentSyntax argument ||
             argument.Parent is not ArgumentListSyntax argumentList ||
@@ -286,20 +300,40 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
         var (methodName, receiverName) = GetInvokedNames(hostInvocation);
 
         // DispatcherQueue.TryEnqueue(...) — the call is already marshaled onto the
-        // UI thread regardless of receiver (d / ReactorApp.UIDispatcher / etc.).
+        // UI thread. Confirm the receiver really is a DispatcherQueue so an unrelated
+        // TryEnqueue is not treated as marshaled (which would hide a real bug).
         if (methodName == "TryEnqueue")
-            return LambdaHost.Marshaled;
+            return HostTypeIs(hostInvocation, semanticModel, cancellationToken, DispatcherQueueTypeName)
+                ? LambdaHost.Marshaled
+                : LambdaHost.Unrelated;
 
-        // Background launchers. The receiver check keeps a stray user-defined
-        // Run/StartNew/QueueUserWorkItem from tripping the gate; the [UIThreadOnly]
-        // attribute is the real confirmation downstream.
         return (methodName, receiverName) switch
         {
-            ("Run", "Task") => LambdaHost.Background,
-            ("StartNew", "Factory") => LambdaHost.Background,
-            ("QueueUserWorkItem", "ThreadPool") => LambdaHost.Background,
+            ("Run", "Task") when HostTypeIs(hostInvocation, semanticModel, cancellationToken, TaskTypeName)
+                => LambdaHost.Background,
+            ("StartNew", "Factory") when HostTypeIs(hostInvocation, semanticModel, cancellationToken, TaskFactoryTypeName)
+                => LambdaHost.Background,
+            ("QueueUserWorkItem", "ThreadPool") when HostTypeIs(hostInvocation, semanticModel, cancellationToken, ThreadPoolTypeName)
+                => LambdaHost.Background,
             _ => LambdaHost.Unrelated,
         };
+    }
+
+    private const string DispatcherQueueTypeName = "Microsoft.UI.Dispatching.DispatcherQueue";
+    private const string TaskTypeName = "System.Threading.Tasks.Task";
+    private const string TaskFactoryTypeName = "System.Threading.Tasks.TaskFactory";
+    private const string ThreadPoolTypeName = "System.Threading.ThreadPool";
+
+    /// <summary>
+    /// Confirms the invoked method resolves to a member of
+    /// <paramref name="fullyQualifiedTypeName"/>.
+    /// </summary>
+    private static bool HostTypeIs(InvocationExpressionSyntax invocation, SemanticModel semanticModel, CancellationToken cancellationToken, string fullyQualifiedTypeName)
+    {
+        var symbolInfo = semanticModel.GetSymbolInfo(invocation, cancellationToken);
+        var method = symbolInfo.Symbol as IMethodSymbol
+            ?? symbolInfo.CandidateSymbols.FirstOrDefault() as IMethodSymbol;
+        return method?.ContainingType?.ToDisplayString() == fullyQualifiedTypeName;
     }
 
     /// <summary>

--- a/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
@@ -63,7 +63,24 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
-        context.RegisterSyntaxNodeAction(AnalyzeAssignment, SyntaxKind.SimpleAssignmentExpression);
+
+        // Every assignment kind whose target property setter runs — a compound
+        // assignment (`p += x`, `p ??= x`, …) invokes the setter just like `p = x`.
+        context.RegisterSyntaxNodeAction(
+            AnalyzeAssignment,
+            SyntaxKind.SimpleAssignmentExpression,
+            SyntaxKind.AddAssignmentExpression,
+            SyntaxKind.SubtractAssignmentExpression,
+            SyntaxKind.MultiplyAssignmentExpression,
+            SyntaxKind.DivideAssignmentExpression,
+            SyntaxKind.ModuloAssignmentExpression,
+            SyntaxKind.AndAssignmentExpression,
+            SyntaxKind.OrAssignmentExpression,
+            SyntaxKind.ExclusiveOrAssignmentExpression,
+            SyntaxKind.LeftShiftAssignmentExpression,
+            SyntaxKind.RightShiftAssignmentExpression,
+            SyntaxKind.UnsignedRightShiftAssignmentExpression,
+            SyntaxKind.CoalesceAssignmentExpression);
     }
 
     private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)

--- a/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
@@ -1,0 +1,258 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// REACTOR_THREAD_001: Detects an invocation of a UI-thread-only Reactor member
+/// (marked <c>[UIThreadOnly]</c>) that runs lexically inside a background-launch
+/// lambda (<c>Task.Run</c> / <c>Task.Factory.StartNew</c> /
+/// <c>ThreadPool.QueueUserWorkItem</c>) without being marshaled back through a
+/// <c>DispatcherQueue.TryEnqueue</c>. Such calls hit
+/// <c>ThreadAffinity.ThrowIfNotOnUIThread</c> and throw at runtime.
+/// </summary>
+/// <remarks>
+/// The framework is a metadata-only reference in a consumer compilation, so the
+/// analyzer cannot inspect a callee's body for the runtime guard. The committed
+/// mechanism is the <c>[UIThreadOnly]</c> marker attribute
+/// (<see cref="M:Microsoft.UI.Reactor.Hosting.ThreadAffinity"/> annotations),
+/// which is metadata-visible. The syntactic background-lambda gate runs first;
+/// the attribute check is the semantic backstop that keeps false positives low.
+/// (spec 060 §4.6)
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_THREAD_001";
+
+    internal const string UIThreadOnlyAttributeMetadataName =
+        "Microsoft.UI.Reactor.Hosting.UIThreadOnlyAttribute";
+
+    private static readonly LocalizableString Title =
+        "UI-thread-only member called on a background thread";
+
+    private static readonly LocalizableString MessageFormat =
+        "'{0}' must run on the UI thread; calling it inside a background task throws at runtime. " +
+        "Marshal through ReactorApp.UIDispatcher.TryEnqueue(...).";
+
+    private static readonly LocalizableString Description =
+        "Members annotated with [UIThreadOnly] call ThreadAffinity.ThrowIfNotOnUIThread and throw " +
+        "InvalidOperationException when reached from a Task.Run / Task.Factory.StartNew / " +
+        "ThreadPool.QueueUserWorkItem lambda. Marshal the call back onto the UI thread with " +
+        "ReactorApp.UIDispatcher.TryEnqueue(...) — null-safe, because the dispatcher is null until " +
+        "the first window bootstraps.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Threading",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Syntactic gate first (spec §3): only proceed when the call is lexically
+        // inside a background-launch lambda and not already marshaled via TryEnqueue.
+        if (!IsInsideUnmarshaledBackgroundLambda(invocation))
+            return;
+
+        // Don't re-flag the null-dispatcher fallback the code fix itself emits
+        // (`if (d is null) window.Close();` paired with an `else d.TryEnqueue(...)`).
+        // When the dispatcher is null the runtime guard is a no-op, so the direct
+        // call is the correct pre-bootstrap fallback — and this also stops the
+        // code fix from looping on its own output.
+        if (IsInsideDispatcherNullFallback(invocation))
+            return;
+
+        // Semantic backstop: confirm the callee carries [UIThreadOnly].
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
+        var method = symbolInfo.Symbol as IMethodSymbol
+            ?? symbolInfo.CandidateSymbols.FirstOrDefault() as IMethodSymbol;
+        if (method is null)
+            return;
+        if (!HasUIThreadOnlyAttribute(method))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.GetLocation(),
+            method.Name));
+    }
+
+    /// <summary>
+    /// Walk the lexical ancestors of <paramref name="invocation"/>. Returns
+    /// <see langword="true"/> when the nearest enclosing thread-affecting lambda
+    /// is a background launcher (<c>Task.Run</c> / <c>Task.Factory.StartNew</c> /
+    /// <c>ThreadPool.QueueUserWorkItem</c>); returns <see langword="false"/> the
+    /// moment a <c>TryEnqueue</c> lambda is seen first (already marshaled) or no
+    /// background lambda encloses the call. Walking inner→outer makes nesting
+    /// resolve correctly: <c>Task.Run(() =&gt; d.TryEnqueue(() =&gt; w.Close()))</c>
+    /// hits the TryEnqueue boundary before the Task.Run boundary.
+    /// </summary>
+    private static bool IsInsideUnmarshaledBackgroundLambda(SyntaxNode invocation)
+    {
+        for (var node = invocation.Parent; node is not null; node = node.Parent)
+        {
+            switch (node)
+            {
+                case AnonymousFunctionExpressionSyntax lambda:
+                    switch (ClassifyLambdaHost(lambda))
+                    {
+                        case LambdaHost.Marshaled:
+                            return false;
+                        case LambdaHost.Background:
+                            return true;
+                        // LambdaHost.Unrelated → transparent; keep walking outward.
+                    }
+                    break;
+
+                // Don't leak out of the enclosing member into sibling code.
+                case MemberDeclarationSyntax:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+
+    private enum LambdaHost { Unrelated, Background, Marshaled }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="invocation"/> sits in
+    /// the then-branch of an <c>if (x is null)</c> / <c>if (x == null)</c> whose
+    /// <c>else</c> marshals through <c>TryEnqueue</c> — the null-dispatcher
+    /// fallback idiom the code fix emits (and app authors write by hand). The
+    /// fallback is safe because <c>ThrowIfNotOnUIThread</c> is a no-op while the
+    /// dispatcher is null.
+    /// </summary>
+    private static bool IsInsideDispatcherNullFallback(SyntaxNode invocation)
+    {
+        var child = invocation;
+        for (var node = invocation.Parent; node is not null; child = node, node = node.Parent)
+        {
+            if (node is IfStatementSyntax ifStatement &&
+                ReferenceEquals(child, ifStatement.Statement) &&
+                IsNullCheck(ifStatement.Condition) &&
+                ifStatement.Else is { } elseClause &&
+                ContainsTryEnqueue(elseClause))
+            {
+                return true;
+            }
+
+            if (node is MemberDeclarationSyntax)
+                break;
+        }
+
+        return false;
+    }
+
+    private static bool IsNullCheck(ExpressionSyntax condition) => condition switch
+    {
+        IsPatternExpressionSyntax { Pattern: ConstantPatternSyntax { Expression: LiteralExpressionSyntax literal } }
+            => literal.IsKind(SyntaxKind.NullLiteralExpression),
+        BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.EqualsExpression)
+            => binary.Left.IsKind(SyntaxKind.NullLiteralExpression)
+               || binary.Right.IsKind(SyntaxKind.NullLiteralExpression),
+        _ => false,
+    };
+
+    private static bool ContainsTryEnqueue(SyntaxNode node) =>
+        node.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Any(invocation => GetInvokedNames(invocation).methodName == "TryEnqueue");
+
+    /// <summary>
+    /// Classify a lambda by the method it is passed to: a background launcher, a
+    /// dispatcher marshal (<c>TryEnqueue</c>), or unrelated.
+    /// </summary>
+    private static LambdaHost ClassifyLambdaHost(AnonymousFunctionExpressionSyntax lambda)
+    {
+        if (lambda.Parent is not ArgumentSyntax argument ||
+            argument.Parent is not ArgumentListSyntax argumentList ||
+            argumentList.Parent is not InvocationExpressionSyntax hostInvocation)
+        {
+            return LambdaHost.Unrelated;
+        }
+
+        var (methodName, receiverName) = GetInvokedNames(hostInvocation);
+
+        // DispatcherQueue.TryEnqueue(...) — the call is already marshaled onto the
+        // UI thread regardless of receiver (d / ReactorApp.UIDispatcher / etc.).
+        if (methodName == "TryEnqueue")
+            return LambdaHost.Marshaled;
+
+        // Background launchers. The receiver check keeps a stray user-defined
+        // Run/StartNew/QueueUserWorkItem from tripping the gate; the [UIThreadOnly]
+        // attribute is the real confirmation downstream.
+        return (methodName, receiverName) switch
+        {
+            ("Run", "Task") => LambdaHost.Background,
+            ("StartNew", "Factory") => LambdaHost.Background,
+            ("QueueUserWorkItem", "ThreadPool") => LambdaHost.Background,
+            _ => LambdaHost.Unrelated,
+        };
+    }
+
+    /// <summary>
+    /// Extract the invoked simple method name and the rightmost identifier of its
+    /// receiver — e.g. <c>Task.Factory.StartNew</c> → (<c>StartNew</c>,
+    /// <c>Factory</c>), <c>Task.Run</c> → (<c>Run</c>, <c>Task</c>).
+    /// </summary>
+    private static (string? methodName, string? receiverName) GetInvokedNames(InvocationExpressionSyntax invocation)
+    {
+        switch (invocation.Expression)
+        {
+            case MemberAccessExpressionSyntax memberAccess:
+                var receiverName = memberAccess.Expression switch
+                {
+                    IdentifierNameSyntax id => id.Identifier.Text,
+                    MemberAccessExpressionSyntax inner => inner.Name.Identifier.Text,
+                    _ => null,
+                };
+                return (memberAccess.Name.Identifier.Text, receiverName);
+
+            case IdentifierNameSyntax id:
+                return (id.Identifier.Text, null);
+
+            case MemberBindingExpressionSyntax binding:
+                return (binding.Name.Identifier.Text, null);
+
+            default:
+                return (null, null);
+        }
+    }
+
+    internal static bool HasUIThreadOnlyAttribute(IMethodSymbol method)
+    {
+        foreach (var attribute in method.GetAttributes())
+        {
+            var attributeClass = attribute.AttributeClass;
+            if (attributeClass is null)
+                continue;
+            if (attributeClass.Name == "UIThreadOnlyAttribute" &&
+                attributeClass.ContainingNamespace?.ToDisplayString() == "Microsoft.UI.Reactor.Hosting")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
@@ -297,7 +297,12 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
             return LambdaHost.Unrelated;
         }
 
-        var (methodName, receiverName) = GetInvokedNames(hostInvocation);
+        // Cheap syntactic filter on the method name, then a semantic confirm of the
+        // resolved containing type. The receiver identifier is intentionally not
+        // constrained — HostTypeIs is authoritative — so `using static Task; Run(...)`,
+        // `taskFactory.StartNew(...)`, `new TaskFactory().StartNew(...)`, etc. are all
+        // recognized.
+        var methodName = GetInvokedNames(hostInvocation).methodName;
 
         // DispatcherQueue.TryEnqueue(...) — the call is already marshaled onto the
         // UI thread. Confirm the receiver really is a DispatcherQueue so an unrelated
@@ -307,13 +312,13 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
                 ? LambdaHost.Marshaled
                 : LambdaHost.Unrelated;
 
-        return (methodName, receiverName) switch
+        return methodName switch
         {
-            ("Run", "Task") when HostTypeIs(hostInvocation, semanticModel, cancellationToken, TaskTypeName)
+            "Run" when HostTypeIs(hostInvocation, semanticModel, cancellationToken, TaskTypeName)
                 => LambdaHost.Background,
-            ("StartNew", "Factory") when HostTypeIs(hostInvocation, semanticModel, cancellationToken, TaskFactoryTypeName)
+            "StartNew" when HostTypeIs(hostInvocation, semanticModel, cancellationToken, TaskFactoryTypeName)
                 => LambdaHost.Background,
-            ("QueueUserWorkItem", "ThreadPool") when HostTypeIs(hostInvocation, semanticModel, cancellationToken, ThreadPoolTypeName)
+            "QueueUserWorkItem" when HostTypeIs(hostInvocation, semanticModel, cancellationToken, ThreadPoolTypeName)
                 => LambdaHost.Background,
             _ => LambdaHost.Unrelated,
         };
@@ -369,14 +374,8 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     {
         foreach (var attribute in member.GetAttributes())
         {
-            var attributeClass = attribute.AttributeClass;
-            if (attributeClass is null)
-                continue;
-            if (attributeClass.Name == "UIThreadOnlyAttribute" &&
-                attributeClass.ContainingNamespace?.ToDisplayString() == "Microsoft.UI.Reactor.Hosting")
-            {
+            if (attribute.AttributeClass?.ToDisplayString() == UIThreadOnlyAttributeMetadataName)
                 return true;
-            }
         }
 
         return false;

--- a/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
@@ -37,15 +37,17 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
         "UI-thread-only member called on a background thread";
 
     private static readonly LocalizableString MessageFormat =
-        "'{0}' must run on the UI thread; calling it inside a background task throws at runtime. " +
-        "Marshal through ReactorApp.UIDispatcher.TryEnqueue(...).";
+        "'{0}' must run on the UI thread; calling it inside a background task throws once the UI " +
+        "dispatcher has been captured. Marshal it back with a null-safe " +
+        "ReactorApp.UIDispatcher.TryEnqueue(...).";
 
     private static readonly LocalizableString Description =
-        "Members annotated with [UIThreadOnly] call ThreadAffinity.ThrowIfNotOnUIThread and throw " +
+        "Members annotated with [UIThreadOnly] call ThreadAffinity.ThrowIfNotOnUIThread, which throws " +
         "InvalidOperationException when reached from a Task.Run / Task.Factory.StartNew / " +
-        "ThreadPool.QueueUserWorkItem lambda. Marshal the call back onto the UI thread with " +
-        "ReactorApp.UIDispatcher.TryEnqueue(...) — null-safe, because the dispatcher is null until " +
-        "the first window bootstraps.";
+        "ThreadPool.QueueUserWorkItem lambda once the UI dispatcher has been captured (the guard is a " +
+        "no-op while ReactorApp.UIDispatcher is still null, before the first window bootstraps). Marshal " +
+        "the call back onto the UI thread through ReactorApp.UIDispatcher.TryEnqueue(...), null-checked " +
+        "so it falls back to the direct call before the dispatcher exists (never a null-forgiving '!').";
 
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
@@ -218,10 +220,12 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     /// then-branch of an <c>if (d is null)</c> / <c>if (d == null)</c> whose
     /// <c>else</c> marshals through <c>d.TryEnqueue(...)</c> — the null-dispatcher
     /// fallback idiom the code fix emits (and app authors write by hand). The
-    /// suppression is tied to the null-checked identifier: the same local must be
-    /// the <c>TryEnqueue</c> receiver, so an unrelated null check with an unrelated
-    /// <c>TryEnqueue</c> in its else does not hide a genuine off-thread call. Safe
-    /// because <c>ThrowIfNotOnUIThread</c> is a no-op while the dispatcher is null.
+    /// suppression is tied to the null-checked identifier (the same local must be
+    /// the <c>TryEnqueue</c> receiver) <b>and</b> to that local being sourced from
+    /// <see cref="Microsoft.UI.Reactor.ReactorApp.UIDispatcher"/> — the safety
+    /// argument (<c>ThrowIfNotOnUIThread</c> is a no-op while the framework
+    /// dispatcher is null) only holds for that dispatcher, so an unrelated nullable
+    /// <c>DispatcherQueue</c> named <c>d</c> does not hide a genuine off-thread call.
     /// </summary>
     private static bool IsInsideDispatcherNullFallback(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
@@ -230,9 +234,10 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
         {
             if (current is IfStatementSyntax ifStatement &&
                 ReferenceEquals(child, ifStatement.Statement) &&
-                TryGetNullCheckedIdentifier(ifStatement.Condition) is { } dispatcherName &&
+                TryGetNullCheckedIdentifier(ifStatement.Condition) is { } dispatcher &&
+                IsReactorDispatcherLocal(dispatcher, semanticModel, cancellationToken) &&
                 ifStatement.Else is { } elseClause &&
-                ElseMarshalsThrough(elseClause, dispatcherName, semanticModel, cancellationToken))
+                ElseMarshalsThrough(elseClause, dispatcher.Identifier.Text, semanticModel, cancellationToken))
             {
                 return true;
             }
@@ -246,26 +251,54 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
 
     /// <summary>
     /// For <c>x is null</c> / <c>x == null</c> / <c>null == x</c> where <c>x</c> is a
-    /// simple identifier, returns that identifier's name; otherwise <see langword="null"/>.
+    /// simple identifier, returns that identifier; otherwise <see langword="null"/>.
     /// </summary>
-    private static string? TryGetNullCheckedIdentifier(ExpressionSyntax condition) => condition switch
+    private static IdentifierNameSyntax? TryGetNullCheckedIdentifier(ExpressionSyntax condition) => condition switch
     {
         IsPatternExpressionSyntax
         {
             Expression: IdentifierNameSyntax id,
             Pattern: ConstantPatternSyntax { Expression: LiteralExpressionSyntax literal },
-        } when literal.IsKind(SyntaxKind.NullLiteralExpression) => id.Identifier.Text,
+        } when literal.IsKind(SyntaxKind.NullLiteralExpression) => id,
         BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.EqualsExpression) => NullCheckedSide(binary),
         _ => null,
     };
 
-    private static string? NullCheckedSide(BinaryExpressionSyntax binary)
+    private static IdentifierNameSyntax? NullCheckedSide(BinaryExpressionSyntax binary)
     {
         if (binary.Right.IsKind(SyntaxKind.NullLiteralExpression) && binary.Left is IdentifierNameSyntax left)
-            return left.Identifier.Text;
+            return left;
         if (binary.Left.IsKind(SyntaxKind.NullLiteralExpression) && binary.Right is IdentifierNameSyntax right)
-            return right.Identifier.Text;
+            return right;
         return null;
+    }
+
+    /// <summary>
+    /// Confirms <paramref name="identifier"/> binds to a local initialized from
+    /// <see cref="Microsoft.UI.Reactor.ReactorApp.UIDispatcher"/>.
+    /// </summary>
+    private static bool IsReactorDispatcherLocal(IdentifierNameSyntax identifier, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        if (semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol is not ILocalSymbol local)
+            return false;
+
+        foreach (var reference in local.DeclaringSyntaxReferences)
+        {
+            if (reference.GetSyntax(cancellationToken) is VariableDeclaratorSyntax { Initializer.Value: { } initializer }
+                && IsReactorUIDispatcher(initializer, semanticModel, cancellationToken))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsReactorUIDispatcher(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        var symbol = semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol;
+        return symbol is { Name: "UIDispatcher" }
+            && symbol.ContainingType?.ToDisplayString() == "Microsoft.UI.Reactor.ReactorApp";
     }
 
     /// <summary>

--- a/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// The framework is a metadata-only reference in a consumer compilation, so the
 /// analyzer cannot inspect a callee's body for the runtime guard. The committed
 /// mechanism is the <c>[UIThreadOnly]</c> marker attribute
-/// (<see cref="M:Microsoft.UI.Reactor.Hosting.ThreadAffinity"/> annotations),
+/// (applied to the members that call <c>ThreadAffinity.ThrowIfNotOnUIThread</c>),
 /// which is metadata-visible. The syntactic background-lambda gate runs first;
 /// the attribute check is the semantic backstop that keeps false positives low.
 /// (spec 060 §4.6)

--- a/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
@@ -298,7 +298,7 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     {
         var symbol = semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol;
         return symbol is { Name: "UIDispatcher" }
-            && symbol.ContainingType?.ToDisplayString() == "Microsoft.UI.Reactor.ReactorApp";
+            && FullyQualifiedName(symbol.ContainingType) == "Microsoft.UI.Reactor.ReactorApp";
     }
 
     /// <summary>
@@ -371,7 +371,7 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
         var symbolInfo = semanticModel.GetSymbolInfo(invocation, cancellationToken);
         var method = symbolInfo.Symbol as IMethodSymbol
             ?? symbolInfo.CandidateSymbols.FirstOrDefault() as IMethodSymbol;
-        return method?.ContainingType?.ToDisplayString() == fullyQualifiedTypeName;
+        return FullyQualifiedName(method?.ContainingType) == fullyQualifiedTypeName;
     }
 
     /// <summary>
@@ -407,10 +407,17 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     {
         foreach (var attribute in member.GetAttributes())
         {
-            if (attribute.AttributeClass?.ToDisplayString() == UIThreadOnlyAttributeMetadataName)
+            if (FullyQualifiedName(attribute.AttributeClass) == UIThreadOnlyAttributeMetadataName)
                 return true;
         }
 
         return false;
     }
+
+    /// <summary>
+    /// Fully-qualified name without the <c>global::</c> prefix, matching the
+    /// symbol-identity comparison idiom used by the other analyzers in this repo.
+    /// </summary>
+    private static string? FullyQualifiedName(ISymbol? symbol) =>
+        symbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", "");
 }

--- a/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
@@ -81,6 +81,14 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
             SyntaxKind.RightShiftAssignmentExpression,
             SyntaxKind.UnsignedRightShiftAssignmentExpression,
             SyntaxKind.CoalesceAssignmentExpression);
+
+        // Increment / decrement also invoke the property setter (`progress.Value++`).
+        context.RegisterSyntaxNodeAction(
+            AnalyzeIncrementOrDecrement,
+            SyntaxKind.PreIncrementExpression,
+            SyntaxKind.PostIncrementExpression,
+            SyntaxKind.PreDecrementExpression,
+            SyntaxKind.PostDecrementExpression);
     }
 
     private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
@@ -109,12 +117,35 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
         // Only a property write hits a UI-thread-guarded setter. The flagged node is
         // the whole assignment so the code fix can wrap `x.P = v` in the dispatcher
         // marshal the same way it wraps a call.
-        if (assignment.Left is not (MemberAccessExpressionSyntax or IdentifierNameSyntax or MemberBindingExpressionSyntax))
-            return;
-        if (!IsBackgroundThreadContext(assignment))
+        ReportIfUIThreadOnlyProperty(context, assignment, assignment.Left);
+    }
+
+    private static void AnalyzeIncrementOrDecrement(SyntaxNodeAnalysisContext context)
+    {
+        var operand = context.Node switch
+        {
+            PrefixUnaryExpressionSyntax prefix => prefix.Operand,
+            PostfixUnaryExpressionSyntax postfix => postfix.Operand,
+            _ => null,
+        };
+        if (operand is null)
             return;
 
-        var symbolInfo = context.SemanticModel.GetSymbolInfo(assignment.Left, context.CancellationToken);
+        // `progress.Value++` / `--progress.Value` invoke the setter too.
+        ReportIfUIThreadOnlyProperty(context, context.Node, operand);
+    }
+
+    private static void ReportIfUIThreadOnlyProperty(
+        SyntaxNodeAnalysisContext context,
+        SyntaxNode reportNode,
+        ExpressionSyntax target)
+    {
+        if (target is not (MemberAccessExpressionSyntax or IdentifierNameSyntax or MemberBindingExpressionSyntax))
+            return;
+        if (!IsBackgroundThreadContext(context.Node))
+            return;
+
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(target, context.CancellationToken);
         var property = symbolInfo.Symbol as IPropertySymbol
             ?? symbolInfo.CandidateSymbols.FirstOrDefault() as IPropertySymbol;
         if (property is null || !HasUIThreadOnlyAttribute(property))
@@ -122,7 +153,7 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
 
         context.ReportDiagnostic(Diagnostic.Create(
             Rule,
-            assignment.GetLocation(),
+            reportNode.GetLocation(),
             property.Name));
     }
 

--- a/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityAnalyzer.cs
@@ -63,32 +63,20 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeAssignment, SyntaxKind.SimpleAssignmentExpression);
     }
 
     private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
-
-        // Syntactic gate first (spec §3): only proceed when the call is lexically
-        // inside a background-launch lambda and not already marshaled via TryEnqueue.
-        if (!IsInsideUnmarshaledBackgroundLambda(invocation))
-            return;
-
-        // Don't re-flag the null-dispatcher fallback the code fix itself emits
-        // (`if (d is null) window.Close();` paired with an `else d.TryEnqueue(...)`).
-        // When the dispatcher is null the runtime guard is a no-op, so the direct
-        // call is the correct pre-bootstrap fallback — and this also stops the
-        // code fix from looping on its own output.
-        if (IsInsideDispatcherNullFallback(invocation))
+        if (!IsBackgroundThreadContext(invocation))
             return;
 
         // Semantic backstop: confirm the callee carries [UIThreadOnly].
         var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
         var method = symbolInfo.Symbol as IMethodSymbol
             ?? symbolInfo.CandidateSymbols.FirstOrDefault() as IMethodSymbol;
-        if (method is null)
-            return;
-        if (!HasUIThreadOnlyAttribute(method))
+        if (method is null || !HasUIThreadOnlyAttribute(method))
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(
@@ -96,6 +84,40 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
             invocation.GetLocation(),
             method.Name));
     }
+
+    private static void AnalyzeAssignment(SyntaxNodeAnalysisContext context)
+    {
+        var assignment = (AssignmentExpressionSyntax)context.Node;
+
+        // Only a property write hits a UI-thread-guarded setter. The flagged node is
+        // the whole assignment so the code fix can wrap `x.P = v` in the dispatcher
+        // marshal the same way it wraps a call.
+        if (assignment.Left is not (MemberAccessExpressionSyntax or IdentifierNameSyntax or MemberBindingExpressionSyntax))
+            return;
+        if (!IsBackgroundThreadContext(assignment))
+            return;
+
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(assignment.Left, context.CancellationToken);
+        var property = symbolInfo.Symbol as IPropertySymbol
+            ?? symbolInfo.CandidateSymbols.FirstOrDefault() as IPropertySymbol;
+        if (property is null || !HasUIThreadOnlyAttribute(property))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            assignment.GetLocation(),
+            property.Name));
+    }
+
+    /// <summary>
+    /// Shared syntactic gate (spec §3): the node is lexically inside a
+    /// background-launch lambda, not already marshaled via <c>TryEnqueue</c>, and
+    /// not the analyzer/code-fix's own null-dispatcher fallback (which is safe
+    /// because <c>ThrowIfNotOnUIThread</c> is a no-op while the dispatcher is null,
+    /// and skipping it stops the code fix looping on its own output).
+    /// </summary>
+    private static bool IsBackgroundThreadContext(SyntaxNode node) =>
+        IsInsideUnmarshaledBackgroundLambda(node) && !IsInsideDispatcherNullFallback(node);
 
     /// <summary>
     /// Walk the lexical ancestors of <paramref name="invocation"/>. Returns
@@ -136,47 +158,69 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
     private enum LambdaHost { Unrelated, Background, Marshaled }
 
     /// <summary>
-    /// Returns <see langword="true"/> when <paramref name="invocation"/> sits in
-    /// the then-branch of an <c>if (x is null)</c> / <c>if (x == null)</c> whose
-    /// <c>else</c> marshals through <c>TryEnqueue</c> — the null-dispatcher
+    /// Returns <see langword="true"/> when <paramref name="node"/> sits in the
+    /// then-branch of an <c>if (d is null)</c> / <c>if (d == null)</c> whose
+    /// <c>else</c> marshals through <c>d.TryEnqueue(...)</c> — the null-dispatcher
     /// fallback idiom the code fix emits (and app authors write by hand). The
-    /// fallback is safe because <c>ThrowIfNotOnUIThread</c> is a no-op while the
-    /// dispatcher is null.
+    /// suppression is tied to the null-checked identifier: the same local must be
+    /// the <c>TryEnqueue</c> receiver, so an unrelated null check with an unrelated
+    /// <c>TryEnqueue</c> in its else does not hide a genuine off-thread call. Safe
+    /// because <c>ThrowIfNotOnUIThread</c> is a no-op while the dispatcher is null.
     /// </summary>
-    private static bool IsInsideDispatcherNullFallback(SyntaxNode invocation)
+    private static bool IsInsideDispatcherNullFallback(SyntaxNode node)
     {
-        var child = invocation;
-        for (var node = invocation.Parent; node is not null; child = node, node = node.Parent)
+        var child = node;
+        for (var current = node.Parent; current is not null; child = current, current = current.Parent)
         {
-            if (node is IfStatementSyntax ifStatement &&
+            if (current is IfStatementSyntax ifStatement &&
                 ReferenceEquals(child, ifStatement.Statement) &&
-                IsNullCheck(ifStatement.Condition) &&
+                TryGetNullCheckedIdentifier(ifStatement.Condition) is { } dispatcherName &&
                 ifStatement.Else is { } elseClause &&
-                ContainsTryEnqueue(elseClause))
+                ElseMarshalsThrough(elseClause, dispatcherName))
             {
                 return true;
             }
 
-            if (node is MemberDeclarationSyntax)
+            if (current is MemberDeclarationSyntax)
                 break;
         }
 
         return false;
     }
 
-    private static bool IsNullCheck(ExpressionSyntax condition) => condition switch
+    /// <summary>
+    /// For <c>x is null</c> / <c>x == null</c> / <c>null == x</c> where <c>x</c> is a
+    /// simple identifier, returns that identifier's name; otherwise <see langword="null"/>.
+    /// </summary>
+    private static string? TryGetNullCheckedIdentifier(ExpressionSyntax condition) => condition switch
     {
-        IsPatternExpressionSyntax { Pattern: ConstantPatternSyntax { Expression: LiteralExpressionSyntax literal } }
-            => literal.IsKind(SyntaxKind.NullLiteralExpression),
-        BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.EqualsExpression)
-            => binary.Left.IsKind(SyntaxKind.NullLiteralExpression)
-               || binary.Right.IsKind(SyntaxKind.NullLiteralExpression),
-        _ => false,
+        IsPatternExpressionSyntax
+        {
+            Expression: IdentifierNameSyntax id,
+            Pattern: ConstantPatternSyntax { Expression: LiteralExpressionSyntax literal },
+        } when literal.IsKind(SyntaxKind.NullLiteralExpression) => id.Identifier.Text,
+        BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.EqualsExpression) => NullCheckedSide(binary),
+        _ => null,
     };
 
-    private static bool ContainsTryEnqueue(SyntaxNode node) =>
-        node.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Any(invocation => GetInvokedNames(invocation).methodName == "TryEnqueue");
+    private static string? NullCheckedSide(BinaryExpressionSyntax binary)
+    {
+        if (binary.Right.IsKind(SyntaxKind.NullLiteralExpression) && binary.Left is IdentifierNameSyntax left)
+            return left.Identifier.Text;
+        if (binary.Left.IsKind(SyntaxKind.NullLiteralExpression) && binary.Right is IdentifierNameSyntax right)
+            return right.Identifier.Text;
+        return null;
+    }
+
+    /// <summary>
+    /// The <c>else</c> branch marshals through <c><paramref name="dispatcherName"/>.TryEnqueue(...)</c>.
+    /// </summary>
+    private static bool ElseMarshalsThrough(SyntaxNode elseClause, string dispatcherName) =>
+        elseClause.DescendantNodes().OfType<InvocationExpressionSyntax>().Any(invocation =>
+        {
+            var (methodName, receiverName) = GetInvokedNames(invocation);
+            return methodName == "TryEnqueue" && receiverName == dispatcherName;
+        });
 
     /// <summary>
     /// Classify a lambda by the method it is passed to: a background launcher, a
@@ -239,9 +283,9 @@ public sealed class UIThreadAffinityAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    internal static bool HasUIThreadOnlyAttribute(IMethodSymbol method)
+    internal static bool HasUIThreadOnlyAttribute(ISymbol member)
     {
-        foreach (var attribute in method.GetAttributes())
+        foreach (var attribute in member.GetAttributes())
         {
             var attributeClass = attribute.AttributeClass;
             if (attributeClass is null)

--- a/src/Reactor.Analyzers/UIThreadAffinityCodeFix.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityCodeFix.cs
@@ -1,0 +1,201 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for REACTOR_THREAD_001: marshals a UI-thread-only call that runs on a
+/// background thread back onto the UI thread through the Reactor dispatcher.
+/// </summary>
+/// <remarks>
+/// The rewrite is null-safe by design — <c>ReactorApp.UIDispatcher</c> is a
+/// <c>DispatcherQueue?</c> that is null until the first window bootstraps, so the
+/// fix falls back to the direct call rather than a null-forgiving <c>!</c>:
+/// <code>
+/// var d = ReactorApp.UIDispatcher;
+/// if (d is null)
+///     window.Close();
+/// else
+///     d.TryEnqueue(() =&gt; window.Close());
+/// </code>
+/// It handles the two common shapes — the flagged call as a statement inside a
+/// background lambda block, and the flagged call as the expression body of the
+/// background lambda. Other shapes leave the warning unfixed (the trap is still
+/// reported); a non-void expression-bodied lambda is skipped because turning it
+/// into a block would drop the produced value.
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UIThreadAffinityCodeFix))]
+[Shared]
+public sealed class UIThreadAffinityCodeFix : CodeFixProvider
+{
+    private const string Title = "Marshal call onto the UI thread via ReactorApp.UIDispatcher";
+
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(UIThreadAffinityAnalyzer.DiagnosticId);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocation is null) continue;
+
+            // Shape A: the call is a stand-alone statement (`window.Close();`).
+            if (invocation.Parent is ExpressionStatementSyntax statement)
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        Title,
+                        ct => Task.FromResult(FixStatement(context.Document, root, statement, invocation)),
+                        equivalenceKey: UIThreadAffinityAnalyzer.DiagnosticId),
+                    diagnostic);
+                continue;
+            }
+
+            // Shape B: the call is the expression body of the background lambda
+            // (`Task.Run(() => window.Close())`). Only rewrite when the call is
+            // void — otherwise the lambda's produced value would be lost.
+            if (invocation.Parent is LambdaExpressionSyntax lambda &&
+                lambda.ExpressionBody == invocation)
+            {
+                var semanticModel = await context.Document
+                    .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                if (semanticModel is null) continue;
+                if (semanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol
+                        is not IMethodSymbol { ReturnsVoid: true })
+                    continue;
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        Title,
+                        ct => Task.FromResult(FixExpressionLambda(context.Document, root, lambda, invocation)),
+                        equivalenceKey: UIThreadAffinityAnalyzer.DiagnosticId),
+                    diagnostic);
+            }
+        }
+    }
+
+    private static Document FixStatement(
+        Document document,
+        SyntaxNode root,
+        ExpressionStatementSyntax statement,
+        InvocationExpressionSyntax invocation)
+    {
+        var declaration = BuildDispatcherDeclaration();
+        var dispatchIf = BuildDispatchIf(invocation);
+
+        SyntaxNode newRoot;
+        if (statement.Parent is BlockSyntax block)
+        {
+            // Reformat the whole enclosing block so the declaration + guard land
+            // cleanly next to the block's other statements.
+            var index = block.Statements.IndexOf(statement);
+            var newStatements = block.Statements
+                .RemoveAt(index)
+                .Insert(index, dispatchIf)
+                .Insert(index, declaration);
+            var newBlock = block.WithStatements(newStatements)
+                .NormalizeWhitespace(elasticTrivia: true)
+                .WithTriviaFrom(block)
+                .WithAdditionalAnnotations(Formatter.Annotation);
+            newRoot = root.ReplaceNode(block, newBlock);
+        }
+        else
+        {
+            // Embedded (braceless) or switch-section context — wrap in a block so
+            // the two replacement statements stay well-formed.
+            var wrapper = SyntaxFactory.Block(declaration, dispatchIf)
+                .NormalizeWhitespace(elasticTrivia: true)
+                .WithTriviaFrom(statement)
+                .WithAdditionalAnnotations(Formatter.Annotation);
+            newRoot = root.ReplaceNode(statement, wrapper);
+        }
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static Document FixExpressionLambda(
+        Document document,
+        SyntaxNode root,
+        LambdaExpressionSyntax lambda,
+        InvocationExpressionSyntax invocation)
+    {
+        var block = SyntaxFactory.Block(BuildDispatcherDeclaration(), BuildDispatchIf(invocation));
+
+        LambdaExpressionSyntax newLambda = lambda switch
+        {
+            SimpleLambdaExpressionSyntax simple =>
+                simple.WithExpressionBody(null).WithBlock(block),
+            ParenthesizedLambdaExpressionSyntax paren =>
+                paren.WithExpressionBody(null).WithBlock(block),
+            _ => lambda,
+        };
+
+        newLambda = newLambda
+            .NormalizeWhitespace(elasticTrivia: true)
+            .WithTriviaFrom(lambda)
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        return document.WithSyntaxRoot(root.ReplaceNode(lambda, newLambda));
+    }
+
+    /// <summary>Builds <c>var d = ReactorApp.UIDispatcher;</c>.</summary>
+    private static LocalDeclarationStatementSyntax BuildDispatcherDeclaration()
+    {
+        var dispatcherAccess = SyntaxFactory
+            .ParseExpression("global::Microsoft.UI.Reactor.ReactorApp.UIDispatcher")
+            .WithAdditionalAnnotations(Simplifier.Annotation);
+
+        return SyntaxFactory.LocalDeclarationStatement(
+            SyntaxFactory.VariableDeclaration(
+                SyntaxFactory.IdentifierName("var"),
+                SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier("d"))
+                        .WithInitializer(SyntaxFactory.EqualsValueClause(dispatcherAccess)))))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+    }
+
+    /// <summary>
+    /// Builds <c>if (d is null) &lt;call&gt;; else d.TryEnqueue(() =&gt; &lt;call&gt;);</c>.
+    /// </summary>
+    private static IfStatementSyntax BuildDispatchIf(InvocationExpressionSyntax invocation)
+    {
+        var condition = SyntaxFactory.IsPatternExpression(
+            SyntaxFactory.IdentifierName("d"),
+            SyntaxFactory.ConstantPattern(
+                SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)));
+
+        var directCall = SyntaxFactory.ExpressionStatement(invocation.WithoutTrivia());
+
+        var marshaledCall = SyntaxFactory.ExpressionStatement(
+            SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("d"),
+                    SyntaxFactory.IdentifierName("TryEnqueue")),
+                SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Argument(
+                            SyntaxFactory.ParenthesizedLambdaExpression()
+                                .WithExpressionBody(invocation.WithoutTrivia()))))));
+
+        return SyntaxFactory.IfStatement(condition, directCall)
+            .WithElse(SyntaxFactory.ElseClause(marshaledCall))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+    }
+}

--- a/src/Reactor.Analyzers/UIThreadAffinityCodeFix.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityCodeFix.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Globalization;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -52,38 +56,47 @@ public sealed class UIThreadAffinityCodeFix : CodeFixProvider
         foreach (var diagnostic in context.Diagnostics)
         {
             var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
-            var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
-            if (invocation is null) continue;
 
-            // Shape A: the call is a stand-alone statement (`window.Close();`).
-            if (invocation.Parent is ExpressionStatementSyntax statement)
+            // The flagged node is either a UI-thread-only call or a property-set
+            // assignment; both are marshaled the same way. Identify it by its exact
+            // reported span.
+            var core = node.AncestorsAndSelf()
+                .FirstOrDefault(n => n is InvocationExpressionSyntax or AssignmentExpressionSyntax
+                    && n.Span == diagnostic.Location.SourceSpan) as ExpressionSyntax;
+            if (core is null) continue;
+
+            // Shape A: the call/assignment is a stand-alone statement.
+            if (core.Parent is ExpressionStatementSyntax statement)
             {
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         Title,
-                        ct => Task.FromResult(FixStatement(context.Document, root, statement, invocation)),
+                        ct => Task.FromResult(FixStatement(context.Document, root, statement, core)),
                         equivalenceKey: UIThreadAffinityAnalyzer.DiagnosticId),
                     diagnostic);
                 continue;
             }
 
-            // Shape B: the call is the expression body of the background lambda
-            // (`Task.Run(() => window.Close())`). Only rewrite when the call is
-            // void — otherwise the lambda's produced value would be lost.
-            if (invocation.Parent is LambdaExpressionSyntax lambda &&
-                lambda.ExpressionBody == invocation)
+            // Shape B: it is the expression body of the background lambda
+            // (`Task.Run(() => window.Close())`). For an invocation, only rewrite a
+            // void call — otherwise turning the lambda into a block would drop its
+            // produced value. An assignment expression body is always safe to wrap.
+            if (core.Parent is LambdaExpressionSyntax lambda && lambda.ExpressionBody == core)
             {
-                var semanticModel = await context.Document
-                    .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-                if (semanticModel is null) continue;
-                if (semanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol
-                        is not IMethodSymbol { ReturnsVoid: true })
-                    continue;
+                if (core is InvocationExpressionSyntax)
+                {
+                    var semanticModel = await context.Document
+                        .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                    if (semanticModel is null) continue;
+                    if (semanticModel.GetSymbolInfo(core, context.CancellationToken).Symbol
+                            is not IMethodSymbol { ReturnsVoid: true })
+                        continue;
+                }
 
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         Title,
-                        ct => Task.FromResult(FixExpressionLambda(context.Document, root, lambda, invocation)),
+                        ct => Task.FromResult(FixExpressionLambda(context.Document, root, lambda, core)),
                         equivalenceKey: UIThreadAffinityAnalyzer.DiagnosticId),
                     diagnostic);
             }
@@ -94,10 +107,11 @@ public sealed class UIThreadAffinityCodeFix : CodeFixProvider
         Document document,
         SyntaxNode root,
         ExpressionStatementSyntax statement,
-        InvocationExpressionSyntax invocation)
+        ExpressionSyntax core)
     {
-        var declaration = BuildDispatcherDeclaration();
-        var dispatchIf = BuildDispatchIf(invocation);
+        var name = PickDispatcherName(core);
+        var declaration = BuildDispatcherDeclaration(name);
+        var dispatchIf = BuildDispatchIf(core, name);
 
         SyntaxNode newRoot;
         if (statement.Parent is BlockSyntax block)
@@ -133,9 +147,10 @@ public sealed class UIThreadAffinityCodeFix : CodeFixProvider
         Document document,
         SyntaxNode root,
         LambdaExpressionSyntax lambda,
-        InvocationExpressionSyntax invocation)
+        ExpressionSyntax core)
     {
-        var block = SyntaxFactory.Block(BuildDispatcherDeclaration(), BuildDispatchIf(invocation));
+        var name = PickDispatcherName(core);
+        var block = SyntaxFactory.Block(BuildDispatcherDeclaration(name), BuildDispatchIf(core, name));
 
         LambdaExpressionSyntax newLambda = lambda switch
         {
@@ -154,8 +169,34 @@ public sealed class UIThreadAffinityCodeFix : CodeFixProvider
         return document.WithSyntaxRoot(root.ReplaceNode(lambda, newLambda));
     }
 
-    /// <summary>Builds <c>var d = ReactorApp.UIDispatcher;</c>.</summary>
-    private static LocalDeclarationStatementSyntax BuildDispatcherDeclaration()
+    /// <summary>
+    /// Pick a local name for the dispatcher that does not collide with any
+    /// identifier already used in the enclosing member — prefers <c>d</c> (matching
+    /// the documented idiom), falling back to <c>dispatcher</c>, <c>dispatcher2</c>, …
+    /// </summary>
+    private static string PickDispatcherName(SyntaxNode core)
+    {
+        var scope = core.FirstAncestorOrSelf<MemberDeclarationSyntax>();
+        var used = new HashSet<string>(StringComparer.Ordinal);
+        if (scope is not null)
+        {
+            foreach (var token in scope.DescendantTokens())
+            {
+                if (token.IsKind(SyntaxKind.IdentifierToken))
+                    used.Add(token.ValueText);
+            }
+        }
+
+        if (!used.Contains("d")) return "d";
+        for (var i = 1; ; i++)
+        {
+            var candidate = i == 1 ? "dispatcher" : "dispatcher" + i.ToString(CultureInfo.InvariantCulture);
+            if (!used.Contains(candidate)) return candidate;
+        }
+    }
+
+    /// <summary>Builds <c>var &lt;name&gt; = ReactorApp.UIDispatcher;</c>.</summary>
+    private static LocalDeclarationStatementSyntax BuildDispatcherDeclaration(string name)
     {
         var dispatcherAccess = SyntaxFactory
             .ParseExpression("global::Microsoft.UI.Reactor.ReactorApp.UIDispatcher")
@@ -165,34 +206,35 @@ public sealed class UIThreadAffinityCodeFix : CodeFixProvider
             SyntaxFactory.VariableDeclaration(
                 SyntaxFactory.IdentifierName("var"),
                 SyntaxFactory.SingletonSeparatedList(
-                    SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier("d"))
+                    SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(name))
                         .WithInitializer(SyntaxFactory.EqualsValueClause(dispatcherAccess)))))
             .WithAdditionalAnnotations(Formatter.Annotation);
     }
 
     /// <summary>
-    /// Builds <c>if (d is null) &lt;call&gt;; else d.TryEnqueue(() =&gt; &lt;call&gt;);</c>.
+    /// Builds <c>if (&lt;name&gt; is null) &lt;core&gt;; else &lt;name&gt;.TryEnqueue(() =&gt; &lt;core&gt;);</c>
+    /// where <c>&lt;core&gt;</c> is the flagged call or property-set assignment.
     /// </summary>
-    private static IfStatementSyntax BuildDispatchIf(InvocationExpressionSyntax invocation)
+    private static IfStatementSyntax BuildDispatchIf(ExpressionSyntax core, string name)
     {
         var condition = SyntaxFactory.IsPatternExpression(
-            SyntaxFactory.IdentifierName("d"),
+            SyntaxFactory.IdentifierName(name),
             SyntaxFactory.ConstantPattern(
                 SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)));
 
-        var directCall = SyntaxFactory.ExpressionStatement(invocation.WithoutTrivia());
+        var directCall = SyntaxFactory.ExpressionStatement((ExpressionSyntax)core.WithoutTrivia());
 
         var marshaledCall = SyntaxFactory.ExpressionStatement(
             SyntaxFactory.InvocationExpression(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    SyntaxFactory.IdentifierName("d"),
+                    SyntaxFactory.IdentifierName(name),
                     SyntaxFactory.IdentifierName("TryEnqueue")),
                 SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(
                         SyntaxFactory.Argument(
                             SyntaxFactory.ParenthesizedLambdaExpression()
-                                .WithExpressionBody(invocation.WithoutTrivia()))))));
+                                .WithExpressionBody((ExpressionSyntax)core.WithoutTrivia()))))));
 
         return SyntaxFactory.IfStatement(condition, directCall)
             .WithElse(SyntaxFactory.ElseClause(marshaledCall))

--- a/src/Reactor.Analyzers/UIThreadAffinityCodeFix.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityCodeFix.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;

--- a/src/Reactor.Analyzers/UIThreadAffinityCodeFix.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityCodeFix.cs
@@ -115,23 +115,31 @@ public sealed class UIThreadAffinityCodeFix : CodeFixProvider
         SyntaxNode newRoot;
         if (statement.Parent is BlockSyntax block)
         {
-            // Reformat the whole enclosing block so the declaration + guard land
-            // cleanly next to the block's other statements.
+            // Insert the declaration + guard in place of the flagged statement,
+            // leaving the block's other statements (and their comments/directives)
+            // untouched. Preserve the flagged statement's own leading trivia so a
+            // comment above it survives; format only the inserted nodes.
             var index = block.Statements.IndexOf(statement);
+            var declarationStmt = declaration
+                .NormalizeWhitespace(elasticTrivia: true)
+                .WithLeadingTrivia(statement.GetLeadingTrivia())
+                .WithAdditionalAnnotations(Formatter.Annotation);
+            var guardStmt = dispatchIf
+                .NormalizeWhitespace(elasticTrivia: true)
+                .WithLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)
+                .WithTrailingTrivia(statement.GetTrailingTrivia())
+                .WithAdditionalAnnotations(Formatter.Annotation);
             var newStatements = block.Statements
                 .RemoveAt(index)
-                .Insert(index, dispatchIf)
-                .Insert(index, declaration);
-            var newBlock = block.WithStatements(newStatements)
-                .NormalizeWhitespace(elasticTrivia: true)
-                .WithTriviaFrom(block)
-                .WithAdditionalAnnotations(Formatter.Annotation);
-            newRoot = root.ReplaceNode(block, newBlock);
+                .Insert(index, guardStmt)
+                .Insert(index, declarationStmt);
+            newRoot = root.ReplaceNode(block, block.WithStatements(newStatements));
         }
         else
         {
             // Embedded (braceless) or switch-section context — wrap in a block so
-            // the two replacement statements stay well-formed.
+            // the two replacement statements stay well-formed, carrying the
+            // statement's trivia onto the wrapper.
             var wrapper = SyntaxFactory.Block(declaration, dispatchIf)
                 .NormalizeWhitespace(elasticTrivia: true)
                 .WithTriviaFrom(statement)

--- a/src/Reactor.Analyzers/UIThreadAffinityCodeFix.cs
+++ b/src/Reactor.Analyzers/UIThreadAffinityCodeFix.cs
@@ -56,15 +56,17 @@ public sealed class UIThreadAffinityCodeFix : CodeFixProvider
         {
             var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
 
-            // The flagged node is either a UI-thread-only call or a property-set
-            // assignment; both are marshaled the same way. Identify it by its exact
-            // reported span.
+            // The flagged node is a UI-thread-only call, a property-set assignment,
+            // or an increment/decrement; all are marshaled the same way. Identify it
+            // by its exact reported span.
             var core = node.AncestorsAndSelf()
                 .FirstOrDefault(n => n is InvocationExpressionSyntax or AssignmentExpressionSyntax
+                        or PrefixUnaryExpressionSyntax or PostfixUnaryExpressionSyntax
                     && n.Span == diagnostic.Location.SourceSpan) as ExpressionSyntax;
             if (core is null) continue;
 
-            // Shape A: the call/assignment is a stand-alone statement.
+            // Shape A: the call/assignment is a stand-alone statement — always safe
+            // to wrap, since the enclosing lambda/method body is already statement-bodied.
             if (core.Parent is ExpressionStatementSyntax statement)
             {
                 context.RegisterCodeFix(
@@ -77,20 +79,21 @@ public sealed class UIThreadAffinityCodeFix : CodeFixProvider
             }
 
             // Shape B: it is the expression body of the background lambda
-            // (`Task.Run(() => window.Close())`). For an invocation, only rewrite a
-            // void call — otherwise turning the lambda into a block would drop its
-            // produced value. An assignment expression body is always safe to wrap.
+            // (`Task.Run(() => window.Close())`). Turning the expression body into a
+            // block only preserves semantics when the lambda is bound to a
+            // void-returning delegate (Action/Action<T>) — otherwise a value-producing
+            // body (a call with a result, an assignment, or an increment) may be bound
+            // to a Func<T> overload whose result is consumed, and the rewrite would
+            // change overload resolution / return type. Marshaling is fire-and-forget,
+            // so a produced value cannot be carried across the dispatcher anyway.
             if (core.Parent is LambdaExpressionSyntax lambda && lambda.ExpressionBody == core)
             {
-                if (core is InvocationExpressionSyntax)
-                {
-                    var semanticModel = await context.Document
-                        .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-                    if (semanticModel is null) continue;
-                    if (semanticModel.GetSymbolInfo(core, context.CancellationToken).Symbol
-                            is not IMethodSymbol { ReturnsVoid: true })
-                        continue;
-                }
+                var semanticModel = await context.Document
+                    .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+                if (semanticModel is null) continue;
+                if (semanticModel.GetTypeInfo(lambda, context.CancellationToken).ConvertedType
+                        is not INamedTypeSymbol { DelegateInvokeMethod.ReturnsVoid: true })
+                    continue;
 
                 context.RegisterCodeFix(
                     CodeAction.Create(

--- a/src/Reactor/Hosting/ReactorApp.cs
+++ b/src/Reactor/Hosting/ReactorApp.cs
@@ -443,6 +443,7 @@ public static partial class ReactorApp
     /// entry — secondary windows now have the same escape hatch as the
     /// primary.
     /// </param>
+    [UIThreadOnly]
     public static ReactorWindow OpenWindow(
         WindowSpec spec,
         Func<Component> root,
@@ -459,6 +460,7 @@ public static partial class ReactorApp
     /// <see cref="OpenWindow(WindowSpec, Func{Component}, Action{ReactorHost}?)"/>
     /// overload for <paramref name="configure"/> semantics.
     /// </summary>
+    [UIThreadOnly]
     public static ReactorWindow OpenWindow(
         WindowSpec spec,
         Func<RenderContext, Element> render,
@@ -502,6 +504,7 @@ public static partial class ReactorApp
     /// alive until <see cref="ReactorTrayIcon.Close"/> / <see cref="ReactorTrayIcon.Dispose"/>
     /// is called or the process exits. (spec 036 §11.4)
     /// </summary>
+    [UIThreadOnly]
     public static ReactorTrayIcon OpenTrayIcon(TrayIconSpec spec)
     {
         ArgumentNullException.ThrowIfNull(spec);
@@ -556,6 +559,7 @@ public static partial class ReactorApp
     /// natural managed-entry-point return, which an app under
     /// <c>Application.Start</c> does not perform).
     /// </summary>
+    [UIThreadOnly]
     public static void Exit(int exitCode = 0)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(Exit));

--- a/src/Reactor/Hosting/ReactorWindow.cs
+++ b/src/Reactor/Hosting/ReactorWindow.cs
@@ -1772,6 +1772,7 @@ public sealed class ReactorWindow : IDisposable
     /// <summary>
     /// Show and focus the window. UI-thread only. No-op after disposal.
     /// </summary>
+    [UIThreadOnly]
     public void Activate()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(Activate));
@@ -1783,6 +1784,7 @@ public sealed class ReactorWindow : IDisposable
     /// <summary>
     /// Hide the window without closing. UI-thread only. No-op after disposal.
     /// </summary>
+    [UIThreadOnly]
     public void Hide()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(Hide));
@@ -1796,6 +1798,7 @@ public sealed class ReactorWindow : IDisposable
     /// <summary>
     /// Show a previously hidden window. UI-thread only. No-op after disposal.
     /// </summary>
+    [UIThreadOnly]
     public void Show()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(Show));
@@ -1812,6 +1815,7 @@ public sealed class ReactorWindow : IDisposable
     /// <see cref="WindowClosingEventArgs.Cancel"/> the close aborts.
     /// Idempotent — a second call after disposal is a no-op.
     /// </summary>
+    [UIThreadOnly]
     public void Close()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(Close));
@@ -1849,6 +1853,7 @@ public sealed class ReactorWindow : IDisposable
     }
 
     /// <summary>Force-save the current window placement when placement persistence is enabled.</summary>
+    [UIThreadOnly]
     public void SavePlacement()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(SavePlacement));
@@ -1860,6 +1865,7 @@ public sealed class ReactorWindow : IDisposable
     /// Diff <paramref name="next"/> against the current spec and apply only the
     /// fields that changed. UI-thread only.
     /// </summary>
+    [UIThreadOnly]
     public void Update(WindowSpec next)
     {
         ArgumentNullException.ThrowIfNull(next);
@@ -1897,6 +1903,7 @@ public sealed class ReactorWindow : IDisposable
     }
 
     /// <summary>Resize to <paramref name="width"/> x <paramref name="height"/> DIPs. UI-thread only.</summary>
+    [UIThreadOnly]
     public void SetSize(double width, double height)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetSize));
@@ -1925,6 +1932,7 @@ public sealed class ReactorWindow : IDisposable
     /// move in two steps — <c>SetPosition</c> onto the target monitor, then
     /// adjust within it. (spec 036 §5.2)
     /// </remarks>
+    [UIThreadOnly]
     public void SetPosition(double x, double y)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetPosition));
@@ -1939,6 +1947,7 @@ public sealed class ReactorWindow : IDisposable
     }
 
     /// <summary>Set or clear the width/height aspect lock used during interactive resize.</summary>
+    [UIThreadOnly]
     public void SetAspectRatio(double? ratio)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetAspectRatio));
@@ -2010,6 +2019,7 @@ public sealed class ReactorWindow : IDisposable
     /// is no Aero Snap during the drag — acceptable for the small floating
     /// windows (command palettes, tool palettes) that need IsMovableByBackground.
     /// </remarks>
+    [UIThreadOnly]
     public void BeginDragMove()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(BeginDragMove));
@@ -2089,6 +2099,7 @@ public sealed class ReactorWindow : IDisposable
         return null;
     }
 
+    [UIThreadOnly]
     internal IDisposable RegisterAspectRatioOverride(double? ratio)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(RegisterAspectRatioOverride));
@@ -2143,6 +2154,7 @@ public sealed class ReactorWindow : IDisposable
     /// extended style; values below 1.0 install it and call
     /// <c>SetLayeredWindowAttributes</c>. UI-thread only. No-op after disposal.
     /// </summary>
+    [UIThreadOnly]
     public void SetOpacity(double opacity)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetOpacity));
@@ -2199,6 +2211,7 @@ public sealed class ReactorWindow : IDisposable
     /// activation (matches VS tool-window / drag-preview behavior).
     /// UI-thread only. No-op after disposal.
     /// </summary>
+    [UIThreadOnly]
     public void SetNoActivate(bool noActivate)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetNoActivate));
@@ -2229,6 +2242,7 @@ public sealed class ReactorWindow : IDisposable
     /// currently layered. Call <see cref="SetOpacity"/> with a value &lt; 1.0
     /// first.
     /// </exception>
+    [UIThreadOnly]
     public void SetIgnorePointerInput(bool ignore)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetIgnorePointerInput));
@@ -2396,6 +2410,7 @@ public sealed class ReactorWindow : IDisposable
     }
 
     /// <summary>Center on the window's current monitor. UI-thread only.</summary>
+    [UIThreadOnly]
     public void CenterOnScreen()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(CenterOnScreen));
@@ -2423,6 +2438,7 @@ public sealed class ReactorWindow : IDisposable
     /// Thrown when more than seven buttons are supplied or when ids are
     /// duplicated.
     /// </exception>
+    [UIThreadOnly]
     public void SetThumbnailToolbar(IReadOnlyList<ThumbnailToolbarButton> buttons)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(SetThumbnailToolbar));
@@ -2443,6 +2459,7 @@ public sealed class ReactorWindow : IDisposable
     /// safe to call before <see cref="SetThumbnailToolbar"/> has been called.
     /// (spec 036 §11.5)
     /// </summary>
+    [UIThreadOnly]
     public void ClearThumbnailToolbar()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(ClearThumbnailToolbar));
@@ -2452,6 +2469,7 @@ public sealed class ReactorWindow : IDisposable
     }
 
     /// <summary>Mount a new component root. UI-thread only.</summary>
+    [UIThreadOnly]
     public void Mount(Component root)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(Mount));
@@ -2461,6 +2479,7 @@ public sealed class ReactorWindow : IDisposable
     }
 
     /// <summary>Mount a new render-function root. UI-thread only.</summary>
+    [UIThreadOnly]
     public void Mount(Func<RenderContext, Element> render)
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(Mount));

--- a/src/Reactor/Hosting/Shell/JumpList.cs
+++ b/src/Reactor/Hosting/Shell/JumpList.cs
@@ -269,6 +269,7 @@ public static class JumpList
     /// (e.g., <c>BeginList</c>, <c>CommitList</c>) are logged via
     /// <see cref="Core.Diagnostics.DiagnosticLog"/> but do not throw.
     /// </remarks>
+    [UIThreadOnly]
     public static async Task UpdateAsync(IEnumerable<JumpListItem> items)
     {
         ArgumentNullException.ThrowIfNull(items);

--- a/src/Reactor/Hosting/Shell/ReactorTrayIcon.cs
+++ b/src/Reactor/Hosting/Shell/ReactorTrayIcon.cs
@@ -352,6 +352,7 @@ public sealed class ReactorTrayIcon : IDisposable
     /// <summary>
     /// Remove the icon from the tray and dispose. UI-thread only. Idempotent.
     /// </summary>
+    [UIThreadOnly]
     public void Close() => Dispose();
 
     /// <inheritdoc />

--- a/src/Reactor/Hosting/Shell/ReactorTrayIcon.cs
+++ b/src/Reactor/Hosting/Shell/ReactorTrayIcon.cs
@@ -44,6 +44,7 @@ public sealed class ReactorTrayIcon : IDisposable
     public TrayIconSpec Spec => _spec;
 
     /// <summary>The icon bitmap source. Mutating triggers a shell re-apply.</summary>
+    [UIThreadOnly]
     public WindowIcon Icon
     {
         get => _spec.Icon;
@@ -67,6 +68,7 @@ public sealed class ReactorTrayIcon : IDisposable
     }
 
     /// <summary>Tooltip text. Mutating triggers a shell re-apply.</summary>
+    [UIThreadOnly]
     public string Tooltip
     {
         get => _spec.Tooltip;
@@ -80,6 +82,7 @@ public sealed class ReactorTrayIcon : IDisposable
     }
 
     /// <summary>Whether the icon is currently shown. Mutating triggers a shell re-apply.</summary>
+    [UIThreadOnly]
     public bool IsVisible
     {
         get => _spec.IsVisible;
@@ -129,6 +132,7 @@ public sealed class ReactorTrayIcon : IDisposable
     /// <see cref="ReactorApp.OpenTrayIcon"/>; subsequent state changes flow
     /// through <see cref="Update"/> or the property setters.
     /// </summary>
+    [UIThreadOnly]
     internal void RegisterWithShell()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(RegisterWithShell));
@@ -298,6 +302,7 @@ public sealed class ReactorTrayIcon : IDisposable
     /// presses Escape.
     /// (spec 036 §7.1, §11.4)
     /// </summary>
+    [UIThreadOnly]
     public void ShowFlyout(Element flyoutContent)
     {
         ArgumentNullException.ThrowIfNull(flyoutContent);
@@ -309,6 +314,7 @@ public sealed class ReactorTrayIcon : IDisposable
     }
 
     /// <summary>Dismiss the tray flyout. UI-thread only. Idempotent.</summary>
+    [UIThreadOnly]
     public void HideFlyout()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(HideFlyout));
@@ -319,6 +325,7 @@ public sealed class ReactorTrayIcon : IDisposable
     /// Diff <paramref name="next"/> against the current spec and re-apply
     /// only changed fields. UI-thread only.
     /// </summary>
+    [UIThreadOnly]
     public void Update(TrayIconSpec next)
     {
         ArgumentNullException.ThrowIfNull(next);
@@ -348,6 +355,7 @@ public sealed class ReactorTrayIcon : IDisposable
     public void Close() => Dispose();
 
     /// <inheritdoc />
+    [UIThreadOnly]
     public void Dispose()
     {
         if (_disposed) return;

--- a/src/Reactor/Hosting/Shell/TaskbarItem.cs
+++ b/src/Reactor/Hosting/Shell/TaskbarItem.cs
@@ -32,6 +32,7 @@ public sealed class TaskbarItem
     /// Shell thumbnail tooltip / description for the taskbar button. The property
     /// keeps the last value assigned; native application is best-effort.
     /// </summary>
+    [UIThreadOnly]
     public string? Description
     {
         get => _description;

--- a/src/Reactor/Hosting/Shell/TaskbarOverlay.cs
+++ b/src/Reactor/Hosting/Shell/TaskbarOverlay.cs
@@ -34,6 +34,7 @@ public sealed class TaskbarOverlay
     }
 
     /// <summary>The current overlay icon. Null clears.</summary>
+    [UIThreadOnly]
     public WindowIcon? Icon
     {
         get => _icon;
@@ -50,6 +51,7 @@ public sealed class TaskbarOverlay
     /// <c>SetOverlayIcon(pszDescription)</c> — required for assistive tech to
     /// announce the overlay. (spec 036 §0.6)
     /// </summary>
+    [UIThreadOnly]
     public string? AccessibleDescription
     {
         get => _accessibleDescription;

--- a/src/Reactor/Hosting/Shell/TaskbarProgress.cs
+++ b/src/Reactor/Hosting/Shell/TaskbarProgress.cs
@@ -29,6 +29,7 @@ public sealed class TaskbarProgress
     }
 
     /// <summary>Last-applied progress state. (spec 036 §11.1)</summary>
+    [UIThreadOnly]
     public TaskbarProgressState State
     {
         get => _state;
@@ -46,6 +47,7 @@ public sealed class TaskbarProgress
     /// or <see cref="TaskbarProgressState.None"/>. Out-of-range values throw
     /// <see cref="ArgumentOutOfRangeException"/>.
     /// </summary>
+    [UIThreadOnly]
     public double Value
     {
         get => _value;
@@ -69,6 +71,7 @@ public sealed class TaskbarProgress
     }
 
     /// <summary>Shorthand for <c>State = None</c> + <c>Value = 0</c>.</summary>
+    [UIThreadOnly]
     public void Clear()
     {
         ThreadAffinity.ThrowIfNotOnUIThread(nameof(Clear));

--- a/src/Reactor/Hosting/UIThreadOnlyAttribute.cs
+++ b/src/Reactor/Hosting/UIThreadOnlyAttribute.cs
@@ -3,12 +3,14 @@ using System;
 namespace Microsoft.UI.Reactor.Hosting;
 
 /// <summary>
-/// Marks a member that must be invoked on the UI thread — every member so
-/// annotated calls <see cref="ThreadAffinity.ThrowIfNotOnUIThread"/>, which throws
+/// Marks a method or property setter that must be invoked on the UI thread — the
+/// annotated method (or the property's setter) calls
+/// <see cref="ThreadAffinity.ThrowIfNotOnUIThread"/>, which throws
 /// <see cref="InvalidOperationException"/> when reached from a background thread
 /// once the UI dispatcher has been captured. (The guard is a no-op before the
 /// first window bootstraps, while <see cref="Microsoft.UI.Reactor.ReactorApp.UIDispatcher"/>
-/// is still null.)
+/// is still null.) Property getters are not guarded, so the REACTOR_THREAD_001
+/// analyzer flags writes to an annotated property, not reads.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Reactor/Hosting/UIThreadOnlyAttribute.cs
+++ b/src/Reactor/Hosting/UIThreadOnlyAttribute.cs
@@ -7,8 +7,8 @@ namespace Microsoft.UI.Reactor.Hosting;
 /// annotated calls <see cref="ThreadAffinity.ThrowIfNotOnUIThread"/>, which throws
 /// <see cref="InvalidOperationException"/> when reached from a background thread
 /// once the UI dispatcher has been captured. (The guard is a no-op before the
-/// first window bootstraps, while <see cref="ReactorApp.UIDispatcher"/> is still
-/// null.)
+/// first window bootstraps, while <see cref="Microsoft.UI.Reactor.ReactorApp.UIDispatcher"/>
+/// is still null.)
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Reactor/Hosting/UIThreadOnlyAttribute.cs
+++ b/src/Reactor/Hosting/UIThreadOnlyAttribute.cs
@@ -4,9 +4,11 @@ namespace Microsoft.UI.Reactor.Hosting;
 
 /// <summary>
 /// Marks a member that must be invoked on the UI thread — every member so
-/// annotated calls <see cref="ThreadAffinity.ThrowIfNotOnUIThread"/> and will
-/// throw <see cref="InvalidOperationException"/> when reached from a background
-/// thread.
+/// annotated calls <see cref="ThreadAffinity.ThrowIfNotOnUIThread"/>, which throws
+/// <see cref="InvalidOperationException"/> when reached from a background thread
+/// once the UI dispatcher has been captured. (The guard is a no-op before the
+/// first window bootstraps, while <see cref="ReactorApp.UIDispatcher"/> is still
+/// null.)
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Reactor/Hosting/UIThreadOnlyAttribute.cs
+++ b/src/Reactor/Hosting/UIThreadOnlyAttribute.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Microsoft.UI.Reactor.Hosting;
+
+/// <summary>
+/// Marks a member that must be invoked on the UI thread — every member so
+/// annotated calls <see cref="ThreadAffinity.ThrowIfNotOnUIThread"/> and will
+/// throw <see cref="InvalidOperationException"/> when reached from a background
+/// thread.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The marker exists for the <c>REACTOR_THREAD_001</c> analyzer
+/// (<c>UIThreadAffinityAnalyzer</c>). In a consumer compilation the Reactor
+/// framework is a metadata-only reference, so the analyzer cannot inspect a
+/// callee's body for the runtime guard — <c>DeclaringSyntaxReferences</c> is
+/// empty and IL is not available. A metadata-visible attribute is the committed
+/// mechanism the analyzer keys off, so this type must be <see langword="public"/>.
+/// </para>
+/// <para>
+/// This is a plain marker attribute with no members and no reflection surface,
+/// so it is trim- and AOT-safe. Keep it in sync with the members that call
+/// <see cref="ThreadAffinity.ThrowIfNotOnUIThread"/>; the analyzer reads the
+/// attribute rather than a hard-coded member list.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
+public sealed class UIThreadOnlyAttribute : Attribute
+{
+}

--- a/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
@@ -503,4 +503,70 @@ class C
             FixedCode = after,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task Fires_For_Marked_Property_Compound_Assignment()
+    {
+        // A compound assignment still invokes the guarded setter.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() => {|REACTOR_THREAD_001:window.Title += ""!""|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Preserves_Sibling_Statements_And_Comment()
+    {
+        // Only the flagged statement is wrapped; the sibling call and the comment
+        // above the flagged statement are preserved (no whole-block churn).
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            window.SafeMethod();
+            // marshal me
+            {|REACTOR_THREAD_001:window.Close()|};
+        });
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            window.SafeMethod();
+            // marshal me
+            var d = ReactorApp.UIDispatcher;
+            if (d is null)
+                window.Close();
+            else
+                d.TryEnqueue(() => window.Close());
+        });
+    }
+}";
+
+        await new CSharpCodeFixTest<UIThreadAffinityAnalyzer, UIThreadAffinityCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
@@ -53,6 +53,9 @@ public sealed class FakeWindow
     [UIThreadOnly] public void Close() { }
     [UIThreadOnly] public void Activate() { }
 
+    // UI-thread-only property: the setter would call ThrowIfNotOnUIThread.
+    [UIThreadOnly] public string Title { get; set; } = string.Empty;
+
     // Not UI-thread-only — background use is legitimate.
     public void SafeMethod() { }
 }
@@ -313,6 +316,183 @@ class C
                 window.Close();
             else
                 d.TryEnqueue(() => window.Close());
+        });
+    }
+}";
+
+        await new CSharpCodeFixTest<UIThreadAffinityAnalyzer, UIThreadAffinityCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Property setters (the [UIThreadOnly] attribute also targets properties) ──
+
+    [Fact]
+    public async Task Fires_For_Marked_Property_Set_In_TaskRun()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() => {|REACTOR_THREAD_001:window.Title = ""hi""|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Marked_Property_Read_In_TaskRun()
+    {
+        // Only writes hit the UI-thread-guarded setter; a read must not fire.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            var t = window.Title;
+        });
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Marshals_Property_Set()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() => {|REACTOR_THREAD_001:window.Title = ""hi""|});
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            var d = ReactorApp.UIDispatcher;
+            if (d is null)
+                window.Title = ""hi"";
+            else
+                d.TryEnqueue(() => window.Title = ""hi"");
+        });
+    }
+}";
+
+        await new CSharpCodeFixTest<UIThreadAffinityAnalyzer, UIThreadAffinityCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Null-fallback suppression precision (must be tied to the dispatcher) ──
+
+    [Fact]
+    public async Task No_Diagnostic_For_Matching_Dispatcher_Null_Fallback()
+    {
+        // The exact idiom the code fix emits: same local checked for null and used
+        // as the TryEnqueue receiver. The direct call is the safe pre-bootstrap path.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            var d = ReactorApp.UIDispatcher;
+            if (d is null)
+                window.Close();
+            else
+                d.TryEnqueue(() => window.Close());
+        });
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_When_Null_Check_Marshals_Through_Unrelated_Receiver()
+    {
+        // An unrelated null check whose else marshals through a DIFFERENT receiver
+        // must NOT suppress the direct call — otherwise a real off-thread call hides.
+        var source = Stubs + @"
+class C
+{
+    void M(object gate)
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            if (gate is null)
+                {|REACTOR_THREAD_001:window.Close()|};
+            else
+                ReactorApp.UIDispatcher.TryEnqueue(() => window.Close());
+        });
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Collision-free dispatcher local name ──
+
+    [Fact]
+    public async Task CodeFix_Uses_CollisionFree_Name_When_d_In_Scope()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M(int d)
+    {
+        var window = new FakeWindow();
+        Task.Run(() => {|REACTOR_THREAD_001:window.Close()|});
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M(int d)
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            var dispatcher = ReactorApp.UIDispatcher;
+            if (dispatcher is null)
+                window.Close();
+            else
+                dispatcher.TryEnqueue(() => window.Close());
         });
     }
 }";

--- a/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
@@ -55,6 +55,7 @@ public sealed class FakeWindow
 
     // UI-thread-only property: the setter would call ThrowIfNotOnUIThread.
     [UIThreadOnly] public string Title { get; set; } = string.Empty;
+    [UIThreadOnly] public int Ticks { get; set; }
 
     // Not UI-thread-only — background use is legitimate.
     public void SafeMethod() { }
@@ -374,13 +375,19 @@ class C
     [Fact]
     public async Task CodeFix_Marshals_Property_Set()
     {
+        // Property-set fix uses the block form: `Task.Run(() => window.Title = ...)`
+        // as an expression body binds to Func<string>, so the fix is (correctly) not
+        // offered there — see No_Fix_For_Value_Producing_Expression_Lambda.
         var before = Stubs + @"
 class C
 {
     void M()
     {
         var window = new FakeWindow();
-        Task.Run(() => {|REACTOR_THREAD_001:window.Title = ""hi""|});
+        Task.Run(() =>
+        {
+            {|REACTOR_THREAD_001:window.Title = ""hi""|};
+        });
     }
 }";
 
@@ -397,6 +404,88 @@ class C
                 window.Title = ""hi"";
             else
                 d.TryEnqueue(() => window.Title = ""hi"");
+        });
+    }
+}";
+
+        await new CSharpCodeFixTest<UIThreadAffinityAnalyzer, UIThreadAffinityCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Fix_For_Value_Producing_Expression_Lambda()
+    {
+        // `() => window.Title = "hi"` binds to Func<string> (Task.Run(Func<T>)), so
+        // rewriting the expression body into a statement block would change overload
+        // resolution. The analyzer still fires; no fix is offered (TestCode == FixedCode).
+        var code = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() => {|REACTOR_THREAD_001:window.Title = ""hi""|});
+    }
+}";
+
+        await new CSharpCodeFixTest<UIThreadAffinityAnalyzer, UIThreadAffinityCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Marked_Property_Increment()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() => {|REACTOR_THREAD_001:window.Ticks++|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Marshals_Property_Increment_In_Block()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            {|REACTOR_THREAD_001:window.Ticks++|};
+        });
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            var d = ReactorApp.UIDispatcher;
+            if (d is null)
+                window.Ticks++;
+            else
+                d.TryEnqueue(() => window.Ticks++);
         });
     }
 }";

--- a/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
@@ -1,0 +1,326 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="UIThreadAffinityAnalyzer"/> (<c>REACTOR_THREAD_001</c>) and
+/// its <see cref="UIThreadAffinityCodeFix"/>. Stubs a minimal Reactor shape — a
+/// <c>[UIThreadOnly]</c>-marked mutator, the <c>ReactorApp.UIDispatcher</c> /
+/// <c>DispatcherQueue.TryEnqueue</c> marshal path — so the analyzer's
+/// background-lambda gate and attribute check fire without pulling the framework in.
+/// The stub attribute reuses the real namespace/name (<c>Microsoft.UI.Reactor.Hosting.UIThreadOnlyAttribute</c>)
+/// that the analyzer keys off in metadata.
+/// </summary>
+public class UIThreadAffinityAnalyzerTests
+{
+    private const string Stubs = @"
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Hosting;
+
+namespace Microsoft.UI.Dispatching
+{
+    public sealed class DispatcherQueue
+    {
+        public bool TryEnqueue(Action callback) { callback(); return true; }
+    }
+}
+
+namespace Microsoft.UI.Reactor.Hosting
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
+    public sealed class UIThreadOnlyAttribute : Attribute { }
+}
+
+namespace Microsoft.UI.Reactor
+{
+    public static class ReactorApp
+    {
+        public static DispatcherQueue UIDispatcher = new DispatcherQueue();
+    }
+}
+
+public sealed class FakeWindow
+{
+    [UIThreadOnly] public void Close() { }
+    [UIThreadOnly] public void Activate() { }
+
+    // Not UI-thread-only — background use is legitimate.
+    public void SafeMethod() { }
+}
+";
+
+    // ── Positive: fires inside each background launcher ──────────────────
+
+    [Fact]
+    public async Task Fires_For_Marked_Method_In_TaskRun_ExpressionLambda()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() => {|REACTOR_THREAD_001:window.Close()|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Marked_Method_In_TaskRun_Block()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            {|REACTOR_THREAD_001:window.Close()|};
+        });
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Marked_Method_In_TaskFactoryStartNew()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Factory.StartNew(() => {|REACTOR_THREAD_001:window.Close()|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Marked_Method_In_ThreadPool_QueueUserWorkItem()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        ThreadPool.QueueUserWorkItem(_ => {|REACTOR_THREAD_001:window.Close()|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Marked_Method_Nested_In_Inner_Lambda()
+    {
+        // The call is two lambdas deep inside Task.Run — the inner LINQ-style
+        // lambda is transparent, the Task.Run boundary still governs the thread.
+        var source = Stubs + @"
+class C
+{
+    void M(List<int> items)
+    {
+        var window = new FakeWindow();
+        Task.Run(() => items.ForEach(x => {|REACTOR_THREAD_001:window.Close()|}));
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative: marshaled or unmarked ─────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_When_Already_Marshaled_Through_TryEnqueue()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() => ReactorApp.UIDispatcher.TryEnqueue(() => window.Close()));
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Unmarked_Method_In_TaskRun()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() => window.SafeMethod());
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Near-miss: almost trips the syntactic fast path ─────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Marked_Method_On_UI_Thread()
+    {
+        // Called directly — not inside any background lambda. This is the correct
+        // UI-thread call site and must not fire.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        window.Close();
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Marked_Method_In_Plain_Lambda()
+    {
+        // A lambda that is not passed to a background launcher — e.g. assigned to
+        // an Action — runs on whatever thread invokes it; the gate must not fire.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Action a = () => window.Close();
+        a();
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code fix: null-safe dispatcher marshal ──────────────────────────
+
+    [Fact]
+    public async Task CodeFix_Marshals_ExpressionLambda_Call()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() => {|REACTOR_THREAD_001:window.Close()|});
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            var d = ReactorApp.UIDispatcher;
+            if (d is null)
+                window.Close();
+            else
+                d.TryEnqueue(() => window.Close());
+        });
+    }
+}";
+
+        await new CSharpCodeFixTest<UIThreadAffinityAnalyzer, UIThreadAffinityCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Marshals_Statement_In_Block()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            {|REACTOR_THREAD_001:window.Close()|};
+        });
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            var d = ReactorApp.UIDispatcher;
+            if (d is null)
+                window.Close();
+            else
+                d.TryEnqueue(() => window.Close());
+        });
+    }
+}";
+
+        await new CSharpCodeFixTest<UIThreadAffinityAnalyzer, UIThreadAffinityCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
@@ -57,8 +57,17 @@ public sealed class FakeWindow
     [UIThreadOnly] public string Title { get; set; } = string.Empty;
     [UIThreadOnly] public int Ticks { get; set; }
 
+    // Attribute on the set accessor only (not the property symbol).
+    public int Guarded { get; [UIThreadOnly] set; }
+
     // Not UI-thread-only — background use is legitimate.
     public void SafeMethod() { }
+}
+
+// A non-dispatcher type that happens to expose a TryEnqueue method.
+public sealed class NotADispatcher
+{
+    public bool TryEnqueue(Action callback) { callback(); return true; }
 }
 ";
 
@@ -656,6 +665,50 @@ class C
         {
             TestCode = before,
             FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Semantic precision: attribute on the set accessor; real vs. fake dispatcher ──
+
+    [Fact]
+    public async Task Fires_For_Attribute_On_Set_Accessor()
+    {
+        // [UIThreadOnly] on the setter (SetMethod), not on the property symbol.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() => {|REACTOR_THREAD_001:window.Guarded = 5|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_When_TryEnqueue_Receiver_Is_Not_A_DispatcherQueue()
+    {
+        // An unrelated TryEnqueue (not Microsoft.UI.Dispatching.DispatcherQueue) must
+        // not be treated as marshaling — the call still runs on the background thread.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        var other = new NotADispatcher();
+        Task.Run(() => other.TryEnqueue(() => {|REACTOR_THREAD_001:window.Close()|}));
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
@@ -711,4 +711,26 @@ class C
             TestCode = source,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task Fires_For_StartNew_On_A_Local_TaskFactory()
+    {
+        // Receiver is a local (`factory`), not the literal `Task.Factory`. The type
+        // confirmation (TaskFactory), not the receiver name, drives the gate.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        var factory = Task.Factory;
+        factory.StartNew(() => {|REACTOR_THREAD_001:window.Close()|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs
@@ -69,6 +69,12 @@ public sealed class NotADispatcher
 {
     public bool TryEnqueue(Action callback) { callback(); return true; }
 }
+
+// A DispatcherQueue that is not ReactorApp.UIDispatcher.
+public static class OtherHost
+{
+    public static DispatcherQueue OtherDispatcher = new DispatcherQueue();
+}
 ";
 
     // ── Positive: fires inside each background launcher ──────────────────
@@ -725,6 +731,35 @@ class C
         var window = new FakeWindow();
         var factory = Task.Factory;
         factory.StartNew(() => {|REACTOR_THREAD_001:window.Close()|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UIThreadAffinityAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Null_Fallback_On_A_Non_Reactor_Dispatcher()
+    {
+        // `d` is a DispatcherQueue but NOT ReactorApp.UIDispatcher. If it is null
+        // while the framework dispatcher is already captured, the direct call still
+        // throws — so the null-fallback suppression must not apply here.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var window = new FakeWindow();
+        Task.Run(() =>
+        {
+            var d = OtherHost.OtherDispatcher;
+            if (d is null)
+                {|REACTOR_THREAD_001:window.Close()|};
+            else
+                d.TryEnqueue(() => window.Close());
+        });
     }
 }";
 


### PR DESCRIPTION
## Wave D — `REACTOR_THREAD_001` + framework `[UIThreadOnly]` attribute

Spec 060 (Analyzer Suite Expansion), §4.6 + §5. One PR touching **both** `src/Reactor` (a small public framework API) and `src/Reactor.Analyzers`, because the analyzer depends on the marker attribute.

### Why an attribute
In a consumer compilation the Reactor framework is a **metadata-only** reference — `IMethodSymbol.DeclaringSyntaxReferences` is empty and analyzers can't read IL — so the analyzer cannot body-probe framework methods for the `ThreadAffinity.ThrowIfNotOnUIThread` guard. A metadata-visible marker attribute the analyzer keys off is the committed mechanism (spec §4.6 round-2, OQ#5).

### Framework change (`src/Reactor`)
- **`public sealed class Microsoft.UI.Reactor.Hosting.UIThreadOnlyAttribute`** — `[AttributeUsage(Method | Property, Inherited = false)]`, no members. Plain marker → trim/AOT-safe (the core lib treats trim/AOT warnings as errors and builds clean). No `PublicAPI.txt` tracking exists in this repo.
- **38 annotations** on every member that calls `ThreadAffinity.ThrowIfNotOnUIThread`, enumerated from a live grep scoped to `src/Reactor/`: `ReactorApp` (OpenWindow ×2, OpenTrayIcon, Exit), `ReactorWindow` (19 mutators), and the Shell surface (`JumpList`, `ReactorTrayIcon` ×8, `TaskbarItem`, `TaskbarOverlay` ×2, `TaskbarProgress` ×3) — including 8 property setters. The analyzer derives the guarded set from the attribute at analysis time — the member list is **not** hard-coded.

### Analyzer (`src/Reactor.Analyzers`)
- **`UIThreadAffinityAnalyzer`** (`REACTOR_THREAD_001` · `Reactor.Threading` · Warning): a **call** or a **property-set assignment** lexically inside a `Task.Run` / `Task.Factory.StartNew` / `ThreadPool.QueueUserWorkItem` lambda that is **not** already wrapped in a `TryEnqueue`, whose callee/property carries `[UIThreadOnly]`. Syntactic background-lambda gate runs first (inner→outer walk, so nesting resolves correctly); the metadata attribute check is the semantic backstop.
- **`UIThreadAffinityCodeFix`** — null-safe dispatcher marshal (`UIDispatcher` is `DispatcherQueue?`, null pre-bootstrap), never a null-forgiving `!`:
  ```csharp
  var d = ReactorApp.UIDispatcher;
  if (d is null)
      window.Close();
  else
      d.TryEnqueue(() => window.Close());
  ```
  Handles the expression-lambda and statement-in-block shapes for both calls and property sets; skips non-void expression-lambda call bodies (turning them into a block would drop the value); picks a **collision-free** local name if `d` is already in scope. The analyzer recognizes the emitted null-fallback — tied to the null-checked dispatcher identifier — and does **not** re-flag it (safe because `ThrowIfNotOnUIThread` is a no-op while the dispatcher is null, and it stops the fixer looping on its own output).

### Release tracking + docs
- Canonical row appended to `AnalyzerReleases.Unshipped.md`, the app-author cheat table (`reactor-build-and-check/SKILL.md`), and the analyzer-architecture template (`analyzer-architecture.md.dt`).
- Regenerated `reactor.api.txt` indexes pick up the new public type.

### Tests
17 xUnit fixtures in `tests/Reactor.Tests/AnalyzerTests/UIThreadAffinityAnalyzerTests.cs`: positive per launcher (Task.Run expr + block, StartNew, QueueUserWorkItem, nested inner lambda); property-set positive + read-not-flagged; negative (already-marshaled `TryEnqueue`, unmarked method); near-miss (UI thread, plain non-launcher lambda); suppression precision (matching-dispatcher fallback suppressed, unrelated-receiver still fires); and fix round-trips (call, property-set, collision-free name).

```
dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~UIThreadAffinity
→ Passed! 17/17 · full AnalyzerTests 232/232 · Reactor.slnx builds 0 errors (trim/AOT-clean)
```

Samples sweep: no sample calls a guarded mutator inside a background lambda (they use the UI-thread/`TryEnqueue` form), acceptable for a hygiene rule per spec §2.4; grounding is proven by the fixtures.

### Review hardening
Went through the `pr-review` skill (7 dimensions + a GPT-5.4 multi-model cross-check) and GitHub Copilot review. Fixes applied: property-set detection (setters were annotated but the invocation-only analyzer never flagged them), tightened the null-fallback suppression to tie the `TryEnqueue` receiver to the null-checked dispatcher, collision-free code-fix local name, plus doc/cref/unused-using cleanups.
