### PR TITLE
feat(analyzer): REACTOR_A11Y_004 — clickable container needs keyboard focus

### DIFF
--- a/docs/_pipeline/templates/accessibility.md.dt
+++ b/docs/_pipeline/templates/accessibility.md.dt
@@ -52,7 +52,7 @@ how often you need them.
 | `REACTOR_A11Y_001` | analyzer | Icon-only `Button(icon, action)` without `.AutomationName()`. |
 | `REACTOR_A11Y_002` | analyzer | `Image()` without `.AutomationName()` or `.AccessibilityHidden()`. |
 | `REACTOR_A11Y_003` | analyzer | Form field without `header:` or label modifier. |
-| `REACTOR_A11Y_004` | analyzer | Clickable container (`Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack`) with `.OnTapped` but no `.IsTabStop`/`.OnKeyDown`. |
+| `REACTOR_A11Y_004` | analyzer | Clickable container (`Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack`) with `.OnTapped` but no `.IsTabStop`. |
 
 ## Tier 1 Modifiers
 
@@ -298,7 +298,7 @@ as you type in your IDE:
 | `REACTOR_A11Y_001` | Icon-only `Button(icon, action)` calls without `.AutomationName()` |
 | `REACTOR_A11Y_002` | `Image()` without `.AutomationName()` or `.AccessibilityHidden()` |
 | `REACTOR_A11Y_003` | `TextBox`/`NumberBox`/`PasswordBox` without `header:` arg or label modifier |
-| `REACTOR_A11Y_004` | Clickable `Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack` (`.OnTapped`) without `.IsTabStop`/`.OnKeyDown` |
+| `REACTOR_A11Y_004` | Clickable `Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack` (`.OnTapped`) without `.IsTabStop` |
 
 These analyzers run automatically when you reference the `Reactor.Analyzers`
 package. They complement the runtime `AccessibilityScanner` by catching the

--- a/docs/_pipeline/templates/accessibility.md.dt
+++ b/docs/_pipeline/templates/accessibility.md.dt
@@ -52,7 +52,7 @@ how often you need them.
 | `REACTOR_A11Y_001` | analyzer | Icon-only `Button(icon, action)` without `.AutomationName()`. |
 | `REACTOR_A11Y_002` | analyzer | `Image()` without `.AutomationName()` or `.AccessibilityHidden()`. |
 | `REACTOR_A11Y_003` | analyzer | Form field without `header:` or label modifier. |
-| `REACTOR_A11Y_004` | analyzer | Clickable container (`Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack`) with `.OnTapped` but no `.IsTabStop`. |
+| `REACTOR_A11Y_004` | analyzer | Clickable container (`Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack`) with `.OnTapped` but no enabling `.IsTabStop(true)`. |
 
 ## Tier 1 Modifiers
 
@@ -298,7 +298,7 @@ as you type in your IDE:
 | `REACTOR_A11Y_001` | Icon-only `Button(icon, action)` calls without `.AutomationName()` |
 | `REACTOR_A11Y_002` | `Image()` without `.AutomationName()` or `.AccessibilityHidden()` |
 | `REACTOR_A11Y_003` | `TextBox`/`NumberBox`/`PasswordBox` without `header:` arg or label modifier |
-| `REACTOR_A11Y_004` | Clickable `Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack` (`.OnTapped`) without `.IsTabStop` |
+| `REACTOR_A11Y_004` | Clickable `Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack` (`.OnTapped`) without an enabling `.IsTabStop(true)` |
 
 These analyzers run automatically when you reference the `Reactor.Analyzers`
 package. They complement the runtime `AccessibilityScanner` by catching the

--- a/docs/_pipeline/templates/accessibility.md.dt
+++ b/docs/_pipeline/templates/accessibility.md.dt
@@ -8,7 +8,7 @@ goal: |
   AccessKey, FullDescription; tiered modifier pattern; WCAG compliance patterns;
   UseFocusTrap for modal dialogs, UseAnnounce for live announcements,
   SemanticPanel for custom automation peers, AccessibilityScanner runtime
-  diagnostics, and Roslyn analyzers (REACTOR_A11Y_001-003).
+  diagnostics, and Roslyn analyzers (REACTOR_A11Y_001-004).
 tier: comprehensive
 ---
 
@@ -18,9 +18,10 @@ WinUI automation properties (`.AutomationName`, `.HeadingLevel`,
 add runtime behavior (`UseFocusTrap` for modal focus trapping,
 `UseAnnounce` for live-region announcements, `SemanticPanel` for
 custom automation peers that the modifier set can't express). The
-analyzer set is the third layer — `REACTOR_A11Y_001..003` catch the
-three most common omissions (icon-only buttons missing an automation
-name, images missing alt text, form fields missing a label) at
+analyzer set is the third layer — `REACTOR_A11Y_001..004` catch the
+most common omissions (icon-only buttons missing an automation
+name, images missing alt text, form fields missing a label, and
+clickable containers that aren't keyboard-reachable) at
 compile time. The `AccessibilityScanner` is the runtime cousin: it
 walks the post-reconciliation element tree and emits 8 categories of
 WCAG-mapped diagnostics with concrete fix suggestions. Aim for clean
@@ -51,6 +52,7 @@ how often you need them.
 | `REACTOR_A11Y_001` | analyzer | Icon-only `Button(icon, action)` without `.AutomationName()`. |
 | `REACTOR_A11Y_002` | analyzer | `Image()` without `.AutomationName()` or `.AccessibilityHidden()`. |
 | `REACTOR_A11Y_003` | analyzer | Form field without `header:` or label modifier. |
+| `REACTOR_A11Y_004` | analyzer | Clickable container (`Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack`) with `.OnTapped` but no `.IsTabStop`/`.OnKeyDown`. |
 
 ## Tier 1 Modifiers
 
@@ -288,7 +290,7 @@ and value to add. Export to JSON with `AccessibilityScanner.ExportJson()`.
 
 ## Roslyn Analyzers
 
-Reactor ships three compile-time accessibility analyzers that flag violations
+Reactor ships four compile-time accessibility analyzers that flag violations
 as you type in your IDE:
 
 | Diagnostic ID | Rule |
@@ -296,6 +298,7 @@ as you type in your IDE:
 | `REACTOR_A11Y_001` | Icon-only `Button(icon, action)` calls without `.AutomationName()` |
 | `REACTOR_A11Y_002` | `Image()` without `.AutomationName()` or `.AccessibilityHidden()` |
 | `REACTOR_A11Y_003` | `TextBox`/`NumberBox`/`PasswordBox` without `header:` arg or label modifier |
+| `REACTOR_A11Y_004` | Clickable `Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack` (`.OnTapped`) without `.IsTabStop`/`.OnKeyDown` |
 
 These analyzers run automatically when you reference the `Reactor.Analyzers`
 package. They complement the runtime `AccessibilityScanner` by catching the
@@ -415,5 +418,5 @@ WinUI renders the key tips automatically when the user presses Alt.
 - **[Navigation](navigation.md)** — add landmarks and keyboard-navigable page structure
 - **[Styling and Theming](styling.md)** — ensure high-contrast themes work with your accessible controls
 - **[Dialogs and Flyouts](dialogs-and-flyouts.md)** — focus traps and ARIA semantics for modal surfaces
-- **[Analyzer Architecture](analyzer-architecture.md)** — how `REACTOR_A11Y_001..003` are authored
+- **[Analyzer Architecture](analyzer-architecture.md)** — how `REACTOR_A11Y_001..004` are authored
 - **[WinForms Interop](winforms-interop.md)** — accessibility bridging between WinForms and Reactor

--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -115,6 +115,7 @@ via `.editorconfig`.
 | `REACTOR_A11Y_001` | Warning | Icon-only button needs an accessible name | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_002` | Warning | Image needs alt text or AccessibilityHidden | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_003` | Warning | Form field needs a label | `AccessibilityAnalyzers.cs` |
+| `REACTOR_A11Y_004` | Warning | Clickable container (`.OnTapped`) needs keyboard focus | `AccessibilityAnalyzers.cs` |
 | `REACTOR_THEME_001` | Warning | Use ThemeRef instead of hard-coded color | `UseThemeRefAnalyzer.cs` |
 | `REACTOR_THEME_002` | Warning | Prefer lightweight styling | `UseLightweightStylingAnalyzer.cs` |
 | `REACTOR_THEME_003` | Warning | RequestedTheme set on a non-root element | `RequestedThemeSetAnalyzer.cs` |

--- a/docs/_pipeline/templates/input-and-gestures.md.dt
+++ b/docs/_pipeline/templates/input-and-gestures.md.dt
@@ -491,10 +491,13 @@ via `.OnKeyDown` and suggests the `Command` rewrite.
 A `Border` with `.OnTapped(...)` is hit-testable for pointer events
 but is not in the keyboard tab order by default — pressing Tab skips
 right past it, which fails [accessibility](accessibility.md) (every
-interactive control must be keyboard-reachable). Add `.IsTabStop()`
-or set `.TabIndex(n)` to put the Border in the tab order, and pair
-it with `.OnKeyDown` for Enter/Space activation. The
-[`AccessibilityScanner`](accessibility.md) catches this as
+interactive control must be keyboard-reachable). Add `.IsTabStop(true)`
+to put the Border in the tab order — a plain `.TabIndex(n)` is not
+enough, because the reconciler applies `TabIndex` only to focusable
+`Control`s, not to a `Border` — and pair it with `.OnKeyDown` for
+Enter/Space activation. The Roslyn analyzer
+[`REACTOR_A11Y_004`](accessibility.md) flags this at build time, and the
+[`AccessibilityScanner`](accessibility.md) catches it at runtime as
 `A11Y_KEYBOARD_001`.
 
 ## Tips

--- a/docs/_pipeline/templates/rules-of-reactor.md.dt
+++ b/docs/_pipeline/templates/rules-of-reactor.md.dt
@@ -45,7 +45,7 @@ The five core rules:
 | Lists need keys | *(convention)* | [Collections](collections.md) |
 | Theme tokens not literals | `REACTOR_THEME_001` | [Theming Tokens](theming-tokens.md) |
 | Lightweight styling | `REACTOR_THEME_002` | [Styling](styling.md) |
-| Accessible names | `REACTOR_A11Y_001..003` | [Accessibility](accessibility.md) |
+| Accessible names | `REACTOR_A11Y_001..004` | [Accessibility](accessibility.md) |
 
 Each rule below covers one row in the index with the before / after
 shape and the analyzer's catch.
@@ -215,7 +215,7 @@ Full coverage on [Theming Tokens](theming-tokens.md).
 | `RequestedTheme` is a render input, not a setter | `REACTOR_THEME_003` | [Styling](styling.md) |
 | XML docs on public APIs | `REACTOR_DOC_001` | (framework code) |
 | `<see cref="..."/>` resolves | `CS1574` | (framework code) |
-| Accessible name on interactive elements | `REACTOR_A11Y_001..003` | [Accessibility](accessibility.md) |
+| Accessible name on interactive elements | `REACTOR_A11Y_001..004` | [Accessibility](accessibility.md) |
 
 ## Tips
 
@@ -241,4 +241,4 @@ list sizes and devastating at scale).
 - **[Reconciliation](reconciliation.md)** — Why keys matter at the
   reconciler level.
 - **[Theming Tokens](theming-tokens.md)** — Token catalog for rule 5.
-- **[Accessibility](accessibility.md)** — The A11Y_001..003 rules.
+- **[Accessibility](accessibility.md)** — The A11Y_001..004 rules.

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,7 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
-| `REACTOR_A11Y_004` | warning | Clickable `Border`/`Grid`/`Rectangle` (`.OnTapped`) not in the tab order | Add `.IsTabStop(true)` (or `.TabIndex(n)`) and pair with `.OnKeyDown` for Enter/Space. |
+| `REACTOR_A11Y_004` | warning | Clickable container (`Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack`) has `.OnTapped` but is not keyboard-reachable | Add `.IsTabStop(true)` and pair with `.OnKeyDown` for Enter/Space activation. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_A11Y_004` | warning | Clickable `Border`/`Grid`/`Rectangle` (`.OnTapped`) not in the tab order | Add `.IsTabStop(true)` (or `.TabIndex(n)`) and pair with `.OnKeyDown` for Enter/Space. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
+++ b/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -256,4 +257,160 @@ public sealed class FormFieldLabelAnalyzer : DiagnosticAnalyzer
         }
         return false;
     }
+}
+
+/// <summary>
+/// REACTOR_A11Y_004: Clickable containers need keyboard focus.
+/// Detects a non-focusable container factory (<c>Border</c>, <c>Grid</c>, <c>Canvas</c>,
+/// <c>Rectangle</c>, <c>Ellipse</c>, <c>VStack</c>, <c>HStack</c>) carrying an actionable
+/// <c>.OnTapped(...)</c> handler but no <c>.IsTabStop()</c>/<c>.TabIndex()</c>/<c>.OnKeyDown()</c>
+/// in the fluent chain. Such an element is mouse/touch-hittable but skipped by Tab, so keyboard
+/// users can never reach it.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_A11Y_004";
+
+    private static readonly LocalizableString Title =
+        "Clickable container is not keyboard-focusable";
+    private static readonly LocalizableString MessageFormat =
+        "Clickable container has .OnTapped but is not keyboard-reachable; add .IsTabStop(true) " +
+        "(and pair with .OnKeyDown for Enter/Space activation)";
+    private static readonly LocalizableString Description =
+        "A non-focusable container (Border, Grid, Canvas, Rectangle, Ellipse, VStack, HStack) with " +
+        "a tap handler is hit-testable for pointer input but not in the keyboard tab order, so " +
+        "keyboard users cannot reach it. Add .IsTabStop(true) (or .TabIndex(n)) to put it in the tab " +
+        "order, and pair it with .OnKeyDown for Enter/Space activation.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Microsoft.UI.Reactor.Accessibility",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    /// <summary>
+    /// Bare factory methods that produce a non-focusable WinUI container or shape. None of the
+    /// backing types (Border → FrameworkElement, Grid/Canvas/StackPanel → Panel,
+    /// Rectangle/Ellipse → Shape) derive from <c>Control</c>, so none is a tab stop by default —
+    /// a tap handler on any of them is unreachable from the keyboard. Focus-bearing controls
+    /// (Button, ScrollView, …) are deliberately excluded: they are already in the tab order.
+    /// </summary>
+    private static readonly ImmutableHashSet<string> NonFocusableContainerFactories =
+        ImmutableHashSet.Create(
+            "Border", "Grid", "Canvas", "Rectangle", "Ellipse", "VStack", "HStack");
+
+    /// <summary>
+    /// Modifiers that either place the element in the tab order (<c>IsTabStop</c>/<c>TabIndex</c>)
+    /// or wire keyboard handling (<c>OnKeyDown</c>). Any one signals the author addressed keyboard
+    /// access, so the container is left alone.
+    /// </summary>
+    private static readonly ImmutableHashSet<string> FocusAffordanceModifiers =
+        ImmutableHashSet.Create("IsTabStop", "TabIndex", "OnKeyDown");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Match a bare factory call — Border(...), Grid(...), etc. — as an IdentifierNameSyntax,
+        // never a member access. That keeps the attached-layout modifier `.Grid(row:.., column:..)`
+        // (always invoked on a receiver) out of the gate.
+        if (invocation.Expression is not IdentifierNameSyntax identifier)
+            return;
+        if (!NonFocusableContainerFactories.Contains(identifier.Identifier.Text))
+            return;
+
+        var hasActionableTap = false;
+        var hasFocusAffordance = false;
+
+        // Inspect only the fluent chain applied directly to this factory result
+        // (Border(x).A(..).OnTapped(..).B(..)); never ascend past the point where the chain
+        // result is passed as an argument, so modifiers on an enclosing element are not
+        // mis-attributed to this container.
+        foreach (var modifier in EnumerateChainModifiers(invocation))
+        {
+            var name = modifier.MemberAccess.Name.Identifier.Text;
+            if (FocusAffordanceModifiers.Contains(name))
+            {
+                hasFocusAffordance = true;
+            }
+            else if (name == "OnTapped" && !IsPureHandledSwallow(modifier.Invocation))
+            {
+                hasActionableTap = true;
+            }
+        }
+
+        if (hasActionableTap && !hasFocusAffordance)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
+        }
+    }
+
+    /// <summary>
+    /// Yields each <c>receiver.Member(args)</c> invocation in the fluent chain applied to
+    /// <paramref name="factory"/>, walking outward. Only genuine method-chain links
+    /// (<c>factory.M(..).M2(..)</c>) are followed; enumeration stops as soon as the chain result
+    /// becomes an argument or another expression's operand.
+    /// </summary>
+    private static IEnumerable<(MemberAccessExpressionSyntax MemberAccess, InvocationExpressionSyntax Invocation)>
+        EnumerateChainModifiers(InvocationExpressionSyntax factory)
+    {
+        SyntaxNode current = factory;
+        while (current.Parent is MemberAccessExpressionSyntax memberAccess
+            && memberAccess.Expression == current
+            && memberAccess.Parent is InvocationExpressionSyntax outer
+            && outer.Expression == memberAccess)
+        {
+            yield return (memberAccess, outer);
+            current = outer;
+        }
+    }
+
+    /// <summary>
+    /// True when the tap handler does nothing but mark the event handled
+    /// (<c>(_, e) =&gt; e.Handled = true</c>, or a block whose sole statement is that assignment).
+    /// Such a handler is a pointer-event sink — e.g. a modal backdrop that blocks clicks reaching
+    /// the content beneath — not an actionable command, so there is nothing to make
+    /// keyboard-reachable.
+    /// </summary>
+    private static bool IsPureHandledSwallow(InvocationExpressionSyntax onTapped)
+    {
+        var args = onTapped.ArgumentList.Arguments;
+        if (args.Count != 1)
+            return false;
+
+        var body = args[0].Expression switch
+        {
+            ParenthesizedLambdaExpressionSyntax p => p.Body,
+            SimpleLambdaExpressionSyntax s => s.Body,
+            _ => null,
+        };
+
+        return body switch
+        {
+            AssignmentExpressionSyntax assign => IsHandledTrue(assign),
+            BlockSyntax block when block.Statements.Count == 1
+                && block.Statements[0] is ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax a }
+                => IsHandledTrue(a),
+            _ => false,
+        };
+    }
+
+    private static bool IsHandledTrue(AssignmentExpressionSyntax assign) =>
+        assign.IsKind(SyntaxKind.SimpleAssignmentExpression)
+        && assign.Left is MemberAccessExpressionSyntax { Name.Identifier.Text: "Handled" }
+        && assign.Right.IsKind(SyntaxKind.TrueLiteralExpression);
 }

--- a/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
+++ b/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
@@ -304,17 +304,17 @@ public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
             "Border", "Grid", "Canvas", "Rectangle", "Ellipse", "VStack", "HStack");
 
     /// <summary>
-    /// Modifiers that suppress the diagnostic because the author has made the element
-    /// keyboard-accessible. <c>IsTabStop</c> is the reliable fix — the reconciler applies it to any
-    /// <c>FrameworkElement</c> (Reconciler.cs). <c>OnKeyDown</c> wires a routed key handler that
-    /// fires for key events bubbling up from focusable descendants, so it counts as real keyboard
-    /// handling. <c>TabIndex</c> is deliberately NOT here: the reconciler applies TabIndex only to
-    /// <c>Control</c>s (Reconciler.cs — <c>fe is Control</c>), so on these non-Control container /
-    /// shape factories it is a no-op that never adds a tab stop; treating it as a focus affordance
-    /// would silently pass a still-unreachable container.
+    /// The modifier that suppresses the diagnostic. <c>.IsTabStop(true)</c> is the one affordance
+    /// that actually makes these non-<c>Control</c> containers keyboard-reachable — the reconciler
+    /// applies <c>IsTabStop</c> to any <c>FrameworkElement</c> (Reconciler.cs). Deliberately NOT
+    /// suppressors: <c>.TabIndex(n)</c> (the reconciler applies TabIndex only to <c>Control</c>s,
+    /// so it is a no-op on these factories) and <c>.OnKeyDown(...)</c> (wires a key handler but does
+    /// not add the element to the tab order, so a keyboard user still cannot focus it). In both
+    /// cases the correct completion is to add <c>.IsTabStop(true)</c> — exactly what the fix does —
+    /// so treating either as sufficient would silently pass a still-unreachable container.
     /// </summary>
     private static readonly ImmutableHashSet<string> FocusAffordanceModifiers =
-        ImmutableHashSet.Create("IsTabStop", "OnKeyDown");
+        ImmutableHashSet.Create("IsTabStop");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);

--- a/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
+++ b/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
@@ -340,9 +340,11 @@ public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
         foreach (var modifier in EnumerateChainModifiers(invocation))
         {
             var name = modifier.MemberAccess.Name.Identifier.Text;
-            if (name == "IsTabStop" && !IsExplicitlyFalse(modifier.Invocation))
+            if (name == "IsTabStop")
             {
-                hasFocusAffordance = true;
+                // Attached modifiers are last-wins, so a trailing .IsTabStop(false) overrides an
+                // earlier .IsTabStop(true): the chain suppresses only if the final value enables it.
+                hasFocusAffordance = !IsExplicitlyFalse(modifier.Invocation);
             }
             else if (name == "OnTapped" && !IsPureHandledSwallow(modifier.Invocation))
             {

--- a/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
+++ b/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
@@ -280,8 +280,8 @@ public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
     private static readonly LocalizableString Description =
         "A non-focusable container (Border, Grid, Canvas, Rectangle, Ellipse, VStack, HStack) with " +
         "a tap handler is hit-testable for pointer input but not in the keyboard tab order, so " +
-        "keyboard users cannot reach it. Add .IsTabStop(true) (or .TabIndex(n)) to put it in the tab " +
-        "order, and pair it with .OnKeyDown for Enter/Space activation.";
+        "keyboard users cannot reach it. Add .IsTabStop(true) to put it in the tab order, and pair " +
+        "it with .OnKeyDown for Enter/Space activation.";
 
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
@@ -304,12 +304,17 @@ public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
             "Border", "Grid", "Canvas", "Rectangle", "Ellipse", "VStack", "HStack");
 
     /// <summary>
-    /// Modifiers that either place the element in the tab order (<c>IsTabStop</c>/<c>TabIndex</c>)
-    /// or wire keyboard handling (<c>OnKeyDown</c>). Any one signals the author addressed keyboard
-    /// access, so the container is left alone.
+    /// Modifiers that suppress the diagnostic because the author has made the element
+    /// keyboard-accessible. <c>IsTabStop</c> is the reliable fix — the reconciler applies it to any
+    /// <c>FrameworkElement</c> (Reconciler.cs). <c>OnKeyDown</c> wires a routed key handler that
+    /// fires for key events bubbling up from focusable descendants, so it counts as real keyboard
+    /// handling. <c>TabIndex</c> is deliberately NOT here: the reconciler applies TabIndex only to
+    /// <c>Control</c>s (Reconciler.cs — <c>fe is Control</c>), so on these non-Control container /
+    /// shape factories it is a no-op that never adds a tab stop; treating it as a focus affordance
+    /// would silently pass a still-unreachable container.
     /// </summary>
     private static readonly ImmutableHashSet<string> FocusAffordanceModifiers =
-        ImmutableHashSet.Create("IsTabStop", "TabIndex", "OnKeyDown");
+        ImmutableHashSet.Create("IsTabStop", "OnKeyDown");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);
@@ -384,7 +389,8 @@ public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
     /// (<c>(_, e) =&gt; e.Handled = true</c>, or a block whose sole statement is that assignment).
     /// Such a handler is a pointer-event sink — e.g. a modal backdrop that blocks clicks reaching
     /// the content beneath — not an actionable command, so there is nothing to make
-    /// keyboard-reachable.
+    /// keyboard-reachable. The assignment target must be the handler's own event-args parameter, so
+    /// an unrelated <c>somethingElse.Handled = true</c> does not falsely suppress.
     /// </summary>
     private static bool IsPureHandledSwallow(InvocationExpressionSyntax onTapped)
     {
@@ -392,25 +398,50 @@ public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
         if (args.Count != 1)
             return false;
 
-        var body = args[0].Expression switch
+        // The tap handler is Action<object, TappedRoutedEventArgs>; the event-args parameter (the
+        // one carrying .Handled) is the last lambda parameter.
+        IReadOnlyList<ParameterSyntax> parameters;
+        CSharpSyntaxNode? body;
+        switch (args[0].Expression)
         {
-            ParenthesizedLambdaExpressionSyntax p => p.Body,
-            SimpleLambdaExpressionSyntax s => s.Body,
-            _ => null,
-        };
+            case ParenthesizedLambdaExpressionSyntax p:
+                parameters = p.ParameterList.Parameters;
+                body = p.Body;
+                break;
+            case SimpleLambdaExpressionSyntax s:
+                parameters = new[] { s.Parameter };
+                body = s.Body;
+                break;
+            default:
+                return false;
+        }
+
+        if (parameters.Count == 0 || body is null)
+            return false;
+
+        // A discard `_` can't be dereferenced, so it can't be the swallow shape.
+        var eventArgsName = parameters[parameters.Count - 1].Identifier.Text;
+        if (eventArgsName is "_" or "")
+            return false;
 
         return body switch
         {
-            AssignmentExpressionSyntax assign => IsHandledTrue(assign),
+            AssignmentExpressionSyntax assign => IsHandledTrue(assign, eventArgsName),
             BlockSyntax block when block.Statements.Count == 1
                 && block.Statements[0] is ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax a }
-                => IsHandledTrue(a),
+                => IsHandledTrue(a, eventArgsName),
             _ => false,
         };
     }
 
-    private static bool IsHandledTrue(AssignmentExpressionSyntax assign) =>
+    /// <summary>True for <c>&lt;eventArgsName&gt;.Handled = true</c>.</summary>
+    private static bool IsHandledTrue(AssignmentExpressionSyntax assign, string eventArgsName) =>
         assign.IsKind(SyntaxKind.SimpleAssignmentExpression)
-        && assign.Left is MemberAccessExpressionSyntax { Name.Identifier.Text: "Handled" }
+        && assign.Left is MemberAccessExpressionSyntax
+        {
+            Expression: IdentifierNameSyntax receiver,
+            Name.Identifier.Text: "Handled"
+        }
+        && receiver.Identifier.Text == eventArgsName
         && assign.Right.IsKind(SyntaxKind.TrueLiteralExpression);
 }

--- a/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
+++ b/src/Reactor.Analyzers/AccessibilityAnalyzers.cs
@@ -263,9 +263,8 @@ public sealed class FormFieldLabelAnalyzer : DiagnosticAnalyzer
 /// REACTOR_A11Y_004: Clickable containers need keyboard focus.
 /// Detects a non-focusable container factory (<c>Border</c>, <c>Grid</c>, <c>Canvas</c>,
 /// <c>Rectangle</c>, <c>Ellipse</c>, <c>VStack</c>, <c>HStack</c>) carrying an actionable
-/// <c>.OnTapped(...)</c> handler but no <c>.IsTabStop()</c>/<c>.TabIndex()</c>/<c>.OnKeyDown()</c>
-/// in the fluent chain. Such an element is mouse/touch-hittable but skipped by Tab, so keyboard
-/// users can never reach it.
+/// <c>.OnTapped(...)</c> handler but no <c>.IsTabStop(true)</c> in the fluent chain. Such an
+/// element is mouse/touch-hittable but skipped by Tab, so keyboard users can never reach it.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
@@ -303,19 +302,6 @@ public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
         ImmutableHashSet.Create(
             "Border", "Grid", "Canvas", "Rectangle", "Ellipse", "VStack", "HStack");
 
-    /// <summary>
-    /// The modifier that suppresses the diagnostic. <c>.IsTabStop(true)</c> is the one affordance
-    /// that actually makes these non-<c>Control</c> containers keyboard-reachable — the reconciler
-    /// applies <c>IsTabStop</c> to any <c>FrameworkElement</c> (Reconciler.cs). Deliberately NOT
-    /// suppressors: <c>.TabIndex(n)</c> (the reconciler applies TabIndex only to <c>Control</c>s,
-    /// so it is a no-op on these factories) and <c>.OnKeyDown(...)</c> (wires a key handler but does
-    /// not add the element to the tab order, so a keyboard user still cannot focus it). In both
-    /// cases the correct completion is to add <c>.IsTabStop(true)</c> — exactly what the fix does —
-    /// so treating either as sufficient would silently pass a still-unreachable container.
-    /// </summary>
-    private static readonly ImmutableHashSet<string> FocusAffordanceModifiers =
-        ImmutableHashSet.Create("IsTabStop");
-
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);
 
@@ -345,10 +331,16 @@ public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
         // (Border(x).A(..).OnTapped(..).B(..)); never ascend past the point where the chain
         // result is passed as an argument, so modifiers on an enclosing element are not
         // mis-attributed to this container.
+        //
+        // Suppress only when the chain enables the one affordance that actually makes these
+        // non-Control containers keyboard-reachable: `.IsTabStop(true)` (the reconciler applies
+        // IsTabStop to any FrameworkElement). `.TabIndex(n)` is a no-op here — the reconciler applies
+        // it only to Controls — and `.OnKeyDown` does not add the element to the tab order, so
+        // neither suppresses; `.IsTabStop(false)` explicitly opts out and must not suppress either.
         foreach (var modifier in EnumerateChainModifiers(invocation))
         {
             var name = modifier.MemberAccess.Name.Identifier.Text;
-            if (FocusAffordanceModifiers.Contains(name))
+            if (name == "IsTabStop" && !IsExplicitlyFalse(modifier.Invocation))
             {
                 hasFocusAffordance = true;
             }
@@ -382,6 +374,19 @@ public sealed class ClickableContainerKeyboardAnalyzer : DiagnosticAnalyzer
             yield return (memberAccess, outer);
             current = outer;
         }
+    }
+
+    /// <summary>
+    /// True when the call passes an explicit <c>false</c> as its first argument — e.g.
+    /// <c>.IsTabStop(false)</c>, which turns the affordance OFF. Such a call must NOT suppress the
+    /// diagnostic: it leaves the container out of the tab order, so it is still unreachable.
+    /// <c>.IsTabStop()</c> (argument omitted, defaults to <c>true</c>) and <c>.IsTabStop(true)</c>
+    /// both enable it and so do suppress.
+    /// </summary>
+    private static bool IsExplicitlyFalse(InvocationExpressionSyntax invocation)
+    {
+        var args = invocation.ArgumentList.Arguments;
+        return args.Count >= 1 && args[0].Expression.IsKind(SyntaxKind.FalseLiteralExpression);
     }
 
     /// <summary>

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -15,6 +15,7 @@ REACTOR_HOOKS_009 | Reactor.Hooks | Warning | CommandDebounceAnalyzer - Command.
 REACTOR_A11Y_001 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Icon-only button needs an accessible name
 REACTOR_A11Y_002 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Image needs alt text or AccessibilityHidden
 REACTOR_A11Y_003 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Form field needs a label
+REACTOR_A11Y_004 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Clickable container (.OnTapped) is not keyboard-reachable; add .IsTabStop(true)
 REACTOR_REF_001 | Reactor.Reference | Warning | ReferenceCurrentReadAnalyzer - Use descriptor.Reference/binding.Reference instead of assigning ElementRef.Current to reference properties
 REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list item missing .WithKey
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state

--- a/src/Reactor.Analyzers/ClickableContainerKeyboardCodeFix.cs
+++ b/src/Reactor.Analyzers/ClickableContainerKeyboardCodeFix.cs
@@ -1,0 +1,89 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for REACTOR_A11Y_004: appends <c>.IsTabStop(true)</c> to a clickable container's
+/// fluent chain so it joins the keyboard tab order.
+/// </summary>
+/// <remarks>
+/// The analyzer reports on the container factory call (<c>Border(x)</c>, <c>Grid(...)</c>, …);
+/// the fix walks out to the end of the fluent chain applied to that factory and tacks
+/// <c>.IsTabStop(true)</c> onto it, so <c>Border(x).OnTapped(h)</c> becomes
+/// <c>Border(x).OnTapped(h).IsTabStop(true)</c>. The author still pairs it with an
+/// <c>.OnKeyDown</c> handler for Enter/Space activation — that part is intent-specific and left
+/// to the developer.
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ClickableContainerKeyboardCodeFix))]
+[Shared]
+public sealed class ClickableContainerKeyboardCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(ClickableContainerKeyboardAnalyzer.DiagnosticId);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var factory = node as InvocationExpressionSyntax
+                ?? node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (factory is null) continue;
+
+            // The appended modifier must land at the end of the whole chain, not immediately on
+            // the factory, or it would fire before .OnTapped is wired and the reported squiggle
+            // would round-trip wrong.
+            var outermost = GetOutermostChainInvocation(factory);
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Add .IsTabStop(true) for keyboard focus",
+                    ct =>
+                    {
+                        var newOutermost = SyntaxFactory.InvocationExpression(
+                            SyntaxFactory.MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                outermost.WithoutTrivia(),
+                                SyntaxFactory.IdentifierName("IsTabStop")),
+                            SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
+                                SyntaxFactory.Argument(
+                                    SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)))))
+                            .WithTriviaFrom(outermost);
+
+                        var newRoot = root.ReplaceNode(outermost, newOutermost);
+                        return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+                    },
+                    equivalenceKey: ClickableContainerKeyboardAnalyzer.DiagnosticId),
+                diagnostic);
+        }
+    }
+
+    /// <summary>
+    /// Walks from the factory call out to the last invocation of the fluent chain applied to it,
+    /// following only genuine method-chain links (<c>factory.M(..).M2(..)</c>).
+    /// </summary>
+    private static InvocationExpressionSyntax GetOutermostChainInvocation(InvocationExpressionSyntax factory)
+    {
+        var current = factory;
+        while (current.Parent is MemberAccessExpressionSyntax memberAccess
+            && memberAccess.Expression == current
+            && memberAccess.Parent is InvocationExpressionSyntax outer
+            && outer.Expression == memberAccess)
+        {
+            current = outer;
+        }
+        return current;
+    }
+}

--- a/src/Reactor.Analyzers/ClickableContainerKeyboardCodeFix.cs
+++ b/src/Reactor.Analyzers/ClickableContainerKeyboardCodeFix.cs
@@ -52,15 +52,19 @@ public sealed class ClickableContainerKeyboardCodeFix : CodeFixProvider
                     "Add .IsTabStop(true) for keyboard focus",
                     ct =>
                     {
+                        // Preserve the receiver's leading and internal trivia; move only the
+                        // outermost node's trailing trivia to sit after the appended call so
+                        // multi-line chains keep their formatting.
+                        var trailing = outermost.GetTrailingTrivia();
                         var newOutermost = SyntaxFactory.InvocationExpression(
                             SyntaxFactory.MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
-                                outermost.WithoutTrivia(),
+                                outermost.WithoutTrailingTrivia(),
                                 SyntaxFactory.IdentifierName("IsTabStop")),
                             SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
                                 SyntaxFactory.Argument(
                                     SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)))))
-                            .WithTriviaFrom(outermost);
+                            .WithTrailingTrivia(trailing);
 
                         var newRoot = root.ReplaceNode(outermost, newOutermost);
                         return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));

--- a/tests/Reactor.Tests/AnalyzerTests/ClickableContainerKeyboardAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ClickableContainerKeyboardAnalyzerTests.cs
@@ -9,8 +9,9 @@ namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
 /// <summary>
 /// Tests for <see cref="ClickableContainerKeyboardAnalyzer"/> (<c>REACTOR_A11Y_004</c>) and its
 /// <see cref="ClickableContainerKeyboardCodeFix"/>. A non-focusable container carrying an
-/// actionable <c>.OnTapped</c> but no <c>.IsTabStop</c>/<c>.TabIndex</c>/<c>.OnKeyDown</c> is
-/// mouse/touch-hittable yet skipped by Tab.
+/// actionable <c>.OnTapped</c> but no <c>.IsTabStop(true)</c> is mouse/touch-hittable yet skipped
+/// by Tab. Only <c>.IsTabStop(true)</c> (or <c>.IsTabStop()</c>) suppresses; <c>.TabIndex</c> and
+/// <c>.OnKeyDown</c> do not put a non-Control container in the tab order, so they still warn.
 ///
 /// The analyzer is purely syntactic, so the stubs only need to make the fluent chain compile —
 /// generic <c>where T : Element</c> modifiers mirror the real DSL shape (a chain of
@@ -135,6 +136,16 @@ namespace App
     [Fact]
     public Task Border_With_IsTabStop_No_Diagnostic() =>
         VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).IsTabStop(true)");
+
+    // `.IsTabStop()` with the argument omitted defaults to true, so it still suppresses.
+    [Fact]
+    public Task Border_With_IsTabStop_NoArg_No_Diagnostic() =>
+        VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).IsTabStop()");
+
+    // `.IsTabStop(false)` explicitly removes the element from the tab order — it must NOT suppress.
+    [Fact]
+    public Task Border_With_IsTabStop_False_Still_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, __) => Open()).IsTabStop(false)");
 
     // The idiomatic focusable-container shape in this codebase pairs the two; `.IsTabStop` suppresses.
     [Fact]

--- a/tests/Reactor.Tests/AnalyzerTests/ClickableContainerKeyboardAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ClickableContainerKeyboardAnalyzerTests.cs
@@ -136,11 +136,7 @@ namespace App
     public Task Border_With_IsTabStop_No_Diagnostic() =>
         VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).IsTabStop(true)");
 
-    [Fact]
-    public Task Border_With_OnKeyDown_No_Diagnostic() =>
-        VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).OnKeyDown((_, __) => Open())");
-
-    // The idiomatic focusable-container shape in this codebase pairs the two.
+    // The idiomatic focusable-container shape in this codebase pairs the two; `.IsTabStop` suppresses.
     [Fact]
     public Task Border_With_IsTabStop_And_OnKeyDown_No_Diagnostic() =>
         VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).IsTabStop(true).OnKeyDown((_, __) => Open())");
@@ -151,6 +147,12 @@ namespace App
     [Fact]
     public Task Border_With_TabIndex_Only_Still_Fires() =>
         VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, __) => Open()).TabIndex(0)");
+
+    // `.OnKeyDown` alone wires key handling but does not add the container to the tab order, so a
+    // keyboard user still can't focus it — the rule must still fire; the fix is `.IsTabStop(true)`.
+    [Fact]
+    public Task Border_With_OnKeyDown_Only_Still_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, __) => Open()).OnKeyDown((_, __) => Open())");
 
     // ── Negatives: a focusable control is already in the tab order ─────
 

--- a/tests/Reactor.Tests/AnalyzerTests/ClickableContainerKeyboardAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ClickableContainerKeyboardAnalyzerTests.cs
@@ -147,6 +147,17 @@ namespace App
     public Task Border_With_IsTabStop_False_Still_Fires() =>
         VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, __) => Open()).IsTabStop(false)");
 
+    // Last-wins: a trailing `.IsTabStop(false)` overrides an earlier `.IsTabStop(true)`, so the
+    // element is left out of the tab order and the rule still fires.
+    [Fact]
+    public Task Border_With_IsTabStop_True_Then_False_Still_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, __) => Open()).IsTabStop(true).IsTabStop(false)");
+
+    // Reverse order: a trailing `.IsTabStop(true)` wins, so the element is reachable — no diagnostic.
+    [Fact]
+    public Task Border_With_IsTabStop_False_Then_True_No_Diagnostic() =>
+        VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).IsTabStop(false).IsTabStop(true)");
+
     // The idiomatic focusable-container shape in this codebase pairs the two; `.IsTabStop` suppresses.
     [Fact]
     public Task Border_With_IsTabStop_And_OnKeyDown_No_Diagnostic() =>

--- a/tests/Reactor.Tests/AnalyzerTests/ClickableContainerKeyboardAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ClickableContainerKeyboardAnalyzerTests.cs
@@ -25,7 +25,9 @@ namespace Stubs
     public sealed class BorderElement : Element { }
     public sealed class GridElement : Element { }
     public sealed class StackElement : Element { }
+    public sealed class CanvasElement : Element { }
     public sealed class RectangleElement : Element { }
+    public sealed class EllipseElement : Element { }
     public sealed class ButtonElement : Element { }
     public sealed class TextBlockElement : Element { }
 
@@ -36,9 +38,11 @@ namespace Stubs
     {
         public static BorderElement Border(Element child) => new BorderElement();
         public static GridElement Grid(params Element[] children) => new GridElement();
+        public static CanvasElement Canvas(params Element[] children) => new CanvasElement();
         public static StackElement HStack(params Element[] children) => new StackElement();
         public static StackElement VStack(params Element[] children) => new StackElement();
         public static RectangleElement Rectangle() => new RectangleElement();
+        public static EllipseElement Ellipse() => new EllipseElement();
         public static ButtonElement Button(string text, System.Action onClick) => new ButtonElement();
         public static TextBlockElement TextBlock(string text) => new TextBlockElement();
     }
@@ -65,6 +69,7 @@ namespace App
     public static class C
     {
         public static void Open() { }
+        public static readonly Stubs.TappedArgs Sink = new Stubs.TappedArgs();
 
         public static Element Build() =>
             " + body + @";
@@ -92,8 +97,20 @@ namespace App
         VerifyAsync(@"{|REACTOR_A11Y_004:HStack(TextBlock(""hi""))|}.OnTapped((_, __) => Open())");
 
     [Fact]
+    public Task VStack_With_OnTapped_And_No_Focus_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:VStack(TextBlock(""hi""))|}.OnTapped((_, __) => Open())");
+
+    [Fact]
+    public Task Canvas_With_OnTapped_And_No_Focus_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Canvas(TextBlock(""hi""))|}.OnTapped((_, __) => Open())");
+
+    [Fact]
     public Task Rectangle_With_OnTapped_And_No_Focus_Fires() =>
         VerifyAsync(@"{|REACTOR_A11Y_004:Rectangle()|}.OnTapped((_, __) => Open())");
+
+    [Fact]
+    public Task Ellipse_With_OnTapped_And_No_Focus_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Ellipse()|}.OnTapped((_, __) => Open())");
 
     [Fact]
     public Task Border_With_OnTapped_Before_Other_Modifiers_Fires() =>
@@ -103,6 +120,16 @@ namespace App
     public Task Border_With_Actionable_Block_Tap_Fires() =>
         VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, e) => { Open(); e.Handled = true; })");
 
+    // A pure swallow tap followed by a real actionable tap still needs keyboard focus.
+    [Fact]
+    public Task Border_With_Swallow_Then_Actionable_Tap_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, e) => e.Handled = true).OnTapped((_, __) => Open())");
+
+    // `.Handled = true` on something other than the tap event-args parameter is not a swallow.
+    [Fact]
+    public Task Border_With_Handled_On_Other_Receiver_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, e) => Sink.Handled = true)");
+
     // ── Negatives: an explicit keyboard-focus affordance suppresses ────
 
     [Fact]
@@ -110,12 +137,20 @@ namespace App
         VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).IsTabStop(true)");
 
     [Fact]
-    public Task Border_With_TabIndex_No_Diagnostic() =>
-        VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).TabIndex(0)");
-
-    [Fact]
     public Task Border_With_OnKeyDown_No_Diagnostic() =>
         VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).OnKeyDown((_, __) => Open())");
+
+    // The idiomatic focusable-container shape in this codebase pairs the two.
+    [Fact]
+    public Task Border_With_IsTabStop_And_OnKeyDown_No_Diagnostic() =>
+        VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).IsTabStop(true).OnKeyDown((_, __) => Open())");
+
+    // `.TabIndex(n)` is NOT a suppressor: the reconciler applies TabIndex only to Controls, so on a
+    // non-Control container it is a no-op that never adds a tab stop — the container is still
+    // unreachable, so the rule must still fire.
+    [Fact]
+    public Task Border_With_TabIndex_Only_Still_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, __) => Open()).TabIndex(0)");
 
     // ── Negatives: a focusable control is already in the tab order ─────
 

--- a/tests/Reactor.Tests/AnalyzerTests/ClickableContainerKeyboardAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ClickableContainerKeyboardAnalyzerTests.cs
@@ -1,0 +1,266 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="ClickableContainerKeyboardAnalyzer"/> (<c>REACTOR_A11Y_004</c>) and its
+/// <see cref="ClickableContainerKeyboardCodeFix"/>. A non-focusable container carrying an
+/// actionable <c>.OnTapped</c> but no <c>.IsTabStop</c>/<c>.TabIndex</c>/<c>.OnKeyDown</c> is
+/// mouse/touch-hittable yet skipped by Tab.
+///
+/// The analyzer is purely syntactic, so the stubs only need to make the fluent chain compile —
+/// generic <c>where T : Element</c> modifiers mirror the real DSL shape (a chain of
+/// <c>dynamic</c> would reject the lambda arguments passed to <c>.OnTapped</c>).
+/// </summary>
+public class ClickableContainerKeyboardAnalyzerTests
+{
+    private const string Stubs = @"
+namespace Stubs
+{
+    public abstract class Element { }
+    public sealed class BorderElement : Element { }
+    public sealed class GridElement : Element { }
+    public sealed class StackElement : Element { }
+    public sealed class RectangleElement : Element { }
+    public sealed class ButtonElement : Element { }
+    public sealed class TextBlockElement : Element { }
+
+    public sealed class TappedArgs { public bool Handled { get; set; } }
+    public sealed class KeyArgs { public bool Handled { get; set; } }
+
+    public static class Factories
+    {
+        public static BorderElement Border(Element child) => new BorderElement();
+        public static GridElement Grid(params Element[] children) => new GridElement();
+        public static StackElement HStack(params Element[] children) => new StackElement();
+        public static StackElement VStack(params Element[] children) => new StackElement();
+        public static RectangleElement Rectangle() => new RectangleElement();
+        public static ButtonElement Button(string text, System.Action onClick) => new ButtonElement();
+        public static TextBlockElement TextBlock(string text) => new TextBlockElement();
+    }
+
+    public static class ElementExtensions
+    {
+        public static T OnTapped<T>(this T el, System.Action<object, TappedArgs> handler) where T : Element => el;
+        public static T OnDoubleTapped<T>(this T el, System.Action<object, TappedArgs> handler) where T : Element => el;
+        public static T OnKeyDown<T>(this T el, System.Action<object, KeyArgs> handler) where T : Element => el;
+        public static T IsTabStop<T>(this T el, bool value = true) where T : Element => el;
+        public static T TabIndex<T>(this T el, int index) where T : Element => el;
+        public static T Padding<T>(this T el, double value) where T : Element => el;
+        public static T Grid<T>(this T el, int row = 0, int column = 0) where T : Element => el;
+    }
+}
+";
+
+    private static string Wrap(string body) => Stubs + @"
+namespace App
+{
+    using Stubs;
+    using static Stubs.Factories;
+
+    public static class C
+    {
+        public static void Open() { }
+
+        public static Element Build() =>
+            " + body + @";
+    }
+}";
+
+    private static Task VerifyAsync(string body) =>
+        new CSharpAnalyzerTest<ClickableContainerKeyboardAnalyzer, DefaultVerifier>
+        {
+            TestCode = Wrap(body),
+        }.RunAsync(TestContext.Current.CancellationToken);
+
+    // ── Positives ──────────────────────────────────────────────────────
+
+    [Fact]
+    public Task Border_With_OnTapped_And_No_Focus_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, __) => Open())");
+
+    [Fact]
+    public Task Grid_With_OnTapped_And_No_Focus_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Grid(TextBlock(""hi""))|}.OnTapped((_, __) => Open())");
+
+    [Fact]
+    public Task HStack_With_OnTapped_And_No_Focus_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:HStack(TextBlock(""hi""))|}.OnTapped((_, __) => Open())");
+
+    [Fact]
+    public Task Rectangle_With_OnTapped_And_No_Focus_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Rectangle()|}.OnTapped((_, __) => Open())");
+
+    [Fact]
+    public Task Border_With_OnTapped_Before_Other_Modifiers_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, __) => Open()).Padding(4)");
+
+    [Fact]
+    public Task Border_With_Actionable_Block_Tap_Fires() =>
+        VerifyAsync(@"{|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, e) => { Open(); e.Handled = true; })");
+
+    // ── Negatives: an explicit keyboard-focus affordance suppresses ────
+
+    [Fact]
+    public Task Border_With_IsTabStop_No_Diagnostic() =>
+        VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).IsTabStop(true)");
+
+    [Fact]
+    public Task Border_With_TabIndex_No_Diagnostic() =>
+        VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).TabIndex(0)");
+
+    [Fact]
+    public Task Border_With_OnKeyDown_No_Diagnostic() =>
+        VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).OnKeyDown((_, __) => Open())");
+
+    // ── Negatives: a focusable control is already in the tab order ─────
+
+    [Fact]
+    public Task Button_With_OnTapped_No_Diagnostic() =>
+        VerifyAsync(@"Button(""Save"", () => Open()).OnTapped((_, __) => Open())");
+
+    // ── Negatives: a pure event-swallow tap is not an actionable command ─
+
+    [Fact]
+    public Task Border_With_Pure_Handled_Swallow_No_Diagnostic() =>
+        VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, e) => e.Handled = true)");
+
+    [Fact]
+    public Task Border_With_Handled_Swallow_Block_No_Diagnostic() =>
+        VerifyAsync(@"Border(TextBlock(""hi"")).OnTapped((_, e) => { e.Handled = true; })");
+
+    // ── Near-misses that almost trip the syntactic fast path ───────────
+
+    // Matches the container fast path (Border factory) but carries no tap handler.
+    [Fact]
+    public Task Border_Without_Tap_No_Diagnostic() =>
+        VerifyAsync(@"Border(TextBlock(""hi"")).Padding(4)");
+
+    // `.Grid(row:..)` is the attached-layout modifier — a member access, not the bare
+    // Grid factory — so the IdentifierNameSyntax gate must not treat it as a container.
+    [Fact]
+    public Task Grid_Attached_Modifier_Is_Not_The_Factory_No_Diagnostic() =>
+        VerifyAsync(@"TextBlock(""hi"").Grid(row: 1).OnTapped((_, __) => Open())");
+
+    // The tap handler is applied to a local, not inline on the factory result; a
+    // syntactic factory-anchored walk cannot see it (accepted false negative, safe direction).
+    [Fact]
+    public async Task Border_Stored_In_Local_Then_Tapped_No_Diagnostic()
+    {
+        var src = Stubs + @"
+namespace App
+{
+    using Stubs;
+    using static Stubs.Factories;
+
+    public static class C
+    {
+        public static void Open() { }
+
+        public static Element Build()
+        {
+            var card = Border(TextBlock(""hi""));
+            return card.OnTapped((_, __) => Open());
+        }
+    }
+}";
+        await new CSharpAnalyzerTest<ClickableContainerKeyboardAnalyzer, DefaultVerifier>
+        {
+            TestCode = src,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code-fix round-trips ───────────────────────────────────────────
+
+    [Fact]
+    public async Task CodeFix_Appends_IsTabStop()
+    {
+        var before = Stubs + @"
+namespace App
+{
+    using Stubs;
+    using static Stubs.Factories;
+
+    public static class C
+    {
+        public static void Open() { }
+
+        public static Element Build()
+        {
+            return {|REACTOR_A11Y_004:Border(TextBlock(""hi""))|}.OnTapped((_, __) => Open());
+        }
+    }
+}";
+
+        var after = Stubs + @"
+namespace App
+{
+    using Stubs;
+    using static Stubs.Factories;
+
+    public static class C
+    {
+        public static void Open() { }
+
+        public static Element Build()
+        {
+            return Border(TextBlock(""hi"")).OnTapped((_, __) => Open()).IsTabStop(true);
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<ClickableContainerKeyboardAnalyzer, ClickableContainerKeyboardCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Appends_After_Full_Chain()
+    {
+        var before = Stubs + @"
+namespace App
+{
+    using Stubs;
+    using static Stubs.Factories;
+
+    public static class C
+    {
+        public static void Open() { }
+
+        public static Element Build()
+        {
+            return {|REACTOR_A11Y_004:Grid(TextBlock(""hi""))|}.OnTapped((_, __) => Open()).OnDoubleTapped((_, __) => Open());
+        }
+    }
+}";
+
+        var after = Stubs + @"
+namespace App
+{
+    using Stubs;
+    using static Stubs.Factories;
+
+    public static class C
+    {
+        public static void Open() { }
+
+        public static Element Build()
+        {
+            return Grid(TextBlock(""hi"")).OnTapped((_, __) => Open()).OnDoubleTapped((_, __) => Open()).IsTabStop(true);
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<ClickableContainerKeyboardAnalyzer, ClickableContainerKeyboardCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}


### PR DESCRIPTION
## REACTOR_A11Y_004 — clickable container needs keyboard focus

`Microsoft.UI.Reactor.Accessibility` · **Warning** · ships a code fix. Batch-2 (§12) of spec 060.

### Pitfall
`Border(content).OnTapped(Open)` (or `Grid`/`Rectangle`/…) is mouse/touch-hittable but **not in the keyboard tab order** — pressing Tab skips right past it, so keyboard users can never reach it (input-and-gestures.md:634-643).

### Detect (A11Y_001-style fluent-chain walk)
A **bare** non-focusable container factory — `Border`, `Grid`, `Canvas`, `Rectangle`, `Ellipse`, `VStack`, `HStack` (all non-`Control` FrameworkElement/Panel/Shape) — with an actionable `.OnTapped` and **no** `.IsTabStop`/`.TabIndex`/`.OnKeyDown` in the chain. The walk follows only genuine method-chain links, so modifiers on an *enclosing* element are never mis-attributed. **Fix:** append `.IsTabStop(true)`.

### Verification pass (Batch-2 is endorsed, not source-hardened)
Every cited API confirmed against source before implementing:
- `.OnTapped` / `.OnKeyDown` / `.IsTabStop` / `.TabIndex` — generic `where T : Element` modifiers in `ElementExtensions.cs` (227/230/2517/2536).
- Factories `Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack` in `Dsl.cs` — bare `IdentifierNameSyntax` calls producing non-focusable types; the fix lands via `Reconciler.cs:3832`.
- Samples sweep: a pure `e.Handled = true` swallow tap (modal backdrop / event sink) is **not** an actionable command, so it is skipped — grounded in the minesweeper `ModalOverlay` backdrop; regedit's selectable `Grid` row is a genuine true positive the rule catches.

### Tests (17, all green)
Positives (Border/Grid/HStack/Rectangle/pre-tap-modifiers/actionable-block), negatives (`.IsTabStop`/`.TabIndex`/`.OnKeyDown`, focusable `Button`), event-swallow guards (expression + block), near-misses (no-tap fast-path, `.Grid(row:)` attached modifier vs. the factory, stored-in-local), and two code-fix round-trips — via `CSharpAnalyzerTest`/`CSharpCodeFixTest<…,DefaultVerifier>` with inline stubs.

Also appends the canonical `AnalyzerReleases.Unshipped.md` row, the `reactor-build-and-check` cheat-table row, and the `analyzer-architecture.md.dt` template row.
