### PR TITLE
feat(analyzer): REACTOR_GRID_001 — unused Grid track

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,6 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_GRID_001` | Warning | Declared Grid column/row that no child occupies | `UnusedGridTrackAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -82,6 +82,7 @@ Additional flags:
 | `REACTOR_HOOKS_007` | warning | `UseMemoCells` builder closure missing dependencies | Add the captured variable to the deps array. |
 | `REACTOR_HOOKS_009` | warning | `Command.DebounceMs` set on a command bound without `UseCommand` | Route it through `UseCommand`: `var cmd = UseCommand(new Command { …, DebounceMs = 1500 });`. The debounce window lives in the hook store, so a raw bound `Command` never debounces. |
 | `REACTOR_DSL_001` | warning | `Select(...)` projecting into a layout container without `.WithKey(...)` | `items.Select(i => Row(i).WithKey(i.Id)).ToArray<Element?>()`. Keys keep focus + animation state across reorders. |
+| `REACTOR_GRID_001` | warning | A declared `Grid` column/row that no child is placed in (unused track) | Remove the leftover `GridSize` track, or place a child there with `.Grid(row:, column:)`. Only fires when every child's placement is statically visible. |
 | `REACTOR_THEME_001` | warning | Hardcoded color on a themed surface | Use `Theme.*` tokens (e.g. `Theme.PrimaryText`, `Theme.CardBackground`). See `reactor-design`. |
 | `REACTOR_THEME_002` | info | Lightweight styling opportunity | Optional. Use `.Resources(r => r.Set("ButtonBackground", …))` for visual-state overrides. |
 | `REACTOR_THEME_003` | info | `RequestedTheme` modifier available | Use `.RequestedTheme(ElementTheme.Dark)` for subtree theme overrides. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_GRID_001 | Reactor.Layout | Warning | UnusedGridTrackAnalyzer - Declared Grid column/row that no child occupies (unused track)

--- a/src/Reactor.Analyzers/UnusedGridTrackAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnusedGridTrackAnalyzer.cs
@@ -62,7 +62,7 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
         "Grid declares a track that no child occupies",
-        "This Grid declares {0} {1} but no child is placed in it. Remove the unused track or place a child there.",
+        "This Grid declares {0} {1} (0-based) but no child is placed in it. Remove the unused track or place a child there.",
         "Reactor.Layout",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -313,7 +313,10 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (current is ILiteralOperation { ConstantValue: { HasValue: true, Value: null } })
+            // Any compile-time-constant null child (the literal `null`, `default`,
+            // `default(Element)`, or a const-null reference) is filtered at runtime, so it
+            // occupies nothing — skip it rather than bailing an otherwise-provable grid.
+            if (current.ConstantValue is { HasValue: true, Value: null })
                 return Placement.Skip;
 
             // Variable/parameter/field/property reference, conditional, object creation, etc. —

--- a/src/Reactor.Analyzers/UnusedGridTrackAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnusedGridTrackAnalyzer.cs
@@ -37,12 +37,17 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// <item>a non-constant placement arg (<c>.Grid(column: i)</c> / <c>columnSpan: n</c>) could
 /// cover the very track we would flag;</item>
 /// <item>a spread/variable <c>columns</c>/<c>rows</c> array or a children array we cannot
-/// enumerate hides both the track count and the placements.</item>
+/// enumerate hides both the track count and the placements;</item>
+/// <item>a receiverless call that is <b>not</b> a Reactor DSL factory (e.g. a
+/// <c>Cell(r, c) =&gt; e.Grid(r, c)</c> helper that hides its <c>.Grid(...)</c> inside its
+/// body) — its cell is not provable, so it is treated as opaque, not as <c>(0,0)</c>.</item>
 /// </list>
-/// The remaining accepted limitation: a helper that hides a <c>.Grid(...)</c> inside its body
-/// (<c>Cell(r, c, e) =&gt; e.Grid(r, c)</c>) is treated as the default <c>(0,0)</c> at the call
-/// site — an intentional false positive the author can suppress, matching the documented
-/// "a child with no explicit column is at column 0" model.
+/// A child with no <c>.Grid()</c> only counts as the framework default <c>(0,0)</c> when its
+/// root is a known <c>Microsoft.UI.Reactor.Factories</c> factory (<c>Text(...)</c>,
+/// <c>Button(...)</c>, a nested <c>Grid(...)</c>, …) — those return a fresh, unplaced element,
+/// so <c>(0,0)</c> is provable, matching the documented "a child with no explicit column is at
+/// column 0" model. The two axes are judged independently: an unused row is still reported even
+/// when the <c>columns</c> array is opaque, and vice versa.
 /// </para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -116,6 +121,20 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
         if (childrenVal is null)
             return;
 
+        // Count the declared tracks up front (per axis, independently). A track array that is a
+        // spread/variable — anything we cannot enumerate — leaves that axis unknown, and an axis
+        // we cannot count is one we never report. If neither axis is countable there is nothing
+        // to say. Counting first also bounds the occupancy loops below by the declared track
+        // count, so a hostile/typo span (e.g. columnSpan: int.MaxValue) can never drive an
+        // unbounded loop that would hang the compiler.
+        var hasColumns = TryGetTrackLocations(columnsVal, out var columnLocations);
+        var hasRows = TryGetTrackLocations(rowsVal, out var rowLocations);
+        if (!hasColumns && !hasRows)
+            return;
+
+        var columnCount = hasColumns ? columnLocations.Count : 0;
+        var rowCount = hasRows ? rowLocations.Count : 0;
+
         // Children must be an inline array we can fully enumerate. A variable/opaque children
         // array means we cannot see every placement → cannot prove any track unused.
         if (!TryGetChildOperations(childrenVal, out var children))
@@ -134,16 +153,27 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
             if (placement.Kind == PlacementKind.Skip)
                 continue;
 
-            for (var r = placement.RowStart; r <= placement.RowEnd; r++)
-                occupiedRows.Add(r);
-            for (var c = placement.ColStart; c <= placement.ColEnd; c++)
-                occupiedCols.Add(c);
+            if (hasColumns)
+                MarkOccupied(occupiedCols, placement.Column, placement.ColumnSpan, columnCount);
+            if (hasRows)
+                MarkOccupied(occupiedRows, placement.Row, placement.RowSpan, rowCount);
         }
 
-        if (TryGetTrackLocations(columnsVal, out var columnLocations))
+        if (hasColumns)
             ReportUnusedTracks(context, columnLocations, occupiedCols, "column");
-        if (TryGetTrackLocations(rowsVal, out var rowLocations))
+        if (hasRows)
             ReportUnusedTracks(context, rowLocations, occupiedRows, "row");
+    }
+
+    // Marks the [start, start + span - 1] range within the declared track bounds [0, count - 1].
+    // The upper bound is computed in long and clamped, so a span that overshoots (or overflows
+    // int) can never iterate more than <paramref name="count"/> times.
+    private static void MarkOccupied(HashSet<int> occupied, int start, int span, int count)
+    {
+        var from = System.Math.Max(0, start);
+        var to = (int)System.Math.Min(count - 1L, (long)start + span - 1);
+        for (var i = from; i <= to; i++)
+            occupied.Add(i);
     }
 
     private static void ReportUnusedTracks(
@@ -187,6 +217,13 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
             && m.ContainingType?.ToDisplayString() == GridExtensionsType;
     }
 
+    // A receiverless call whose target is a Reactor DSL factory (Factories.*) returns a fresh,
+    // unplaced element, so its cell is provably the framework default (0,0). An arbitrary
+    // receiverless helper could hide a .Grid(...) inside its body, so it is NOT assumed to be
+    // (0,0) — it is treated as opaque and bails the grid.
+    private static bool IsReactorFactory(IMethodSymbol? method) =>
+        method?.ContainingType?.ToDisplayString() == FactoriesType;
+
     // ── Child placement resolution ─────────────────────────────────────────
 
     private enum PlacementKind
@@ -204,18 +241,18 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
     private readonly struct Placement
     {
         public readonly PlacementKind Kind;
-        public readonly int RowStart;
-        public readonly int RowEnd;
-        public readonly int ColStart;
-        public readonly int ColEnd;
+        public readonly int Row;
+        public readonly int Column;
+        public readonly int RowSpan;
+        public readonly int ColumnSpan;
 
-        private Placement(PlacementKind kind, int rowStart, int rowEnd, int colStart, int colEnd)
+        private Placement(PlacementKind kind, int row, int column, int rowSpan, int columnSpan)
         {
             Kind = kind;
-            RowStart = rowStart;
-            RowEnd = rowEnd;
-            ColStart = colStart;
-            ColEnd = colEnd;
+            Row = row;
+            Column = column;
+            RowSpan = rowSpan;
+            ColumnSpan = columnSpan;
         }
 
         public static readonly Placement Bail = new(PlacementKind.Bail, 0, 0, 0, 0);
@@ -223,14 +260,15 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
         public static readonly Placement Default = Cell(0, 0, 1, 1);
 
         public static Placement Cell(int row, int column, int rowSpan, int columnSpan) =>
-            new(PlacementKind.Known, row, row + rowSpan - 1, column, column + columnSpan - 1);
+            new(PlacementKind.Known, row, column, rowSpan, columnSpan);
     }
 
     /// <summary>
     /// Walk a child's fluent chain to its outermost <c>.Grid(...)</c> placement (the last one
-    /// applied wins), or to the static factory at its root (default <c>(0,0)</c>). Anything else —
-    /// a variable/field reference, a conditional, a raw object creation, or a non-constant
-    /// placement argument — is not provable and returns <see cref="Placement.Bail"/>.
+    /// applied wins). If the chain has no <c>.Grid()</c>, only a Reactor DSL factory root
+    /// (<c>Factories.*</c>) is provably the default <c>(0,0)</c>; anything else — a variable/field
+    /// reference, a conditional, a raw object creation, an unknown receiverless helper, or a
+    /// non-constant placement argument — is not provable and returns <see cref="Placement.Bail"/>.
     /// </summary>
     private static Placement ResolvePlacement(IOperation childOperation)
     {
@@ -254,9 +292,12 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
 
                 if (receiver is null)
                 {
-                    // No receiver → a static factory root (Text(...), Grid(...), Component<..>(..))
-                    // with no .Grid() above it → the framework default cell.
-                    return Placement.Default;
+                    // No receiver → a static call. A Reactor DSL factory (Text(...), a nested
+                    // Grid(...), Component<..>(..)) returns a fresh unplaced element → default cell.
+                    // Any other receiverless call could hide a .Grid(...) → not provable.
+                    return IsReactorFactory(invocation.TargetMethod)
+                        ? Placement.Default
+                        : Placement.Bail;
                 }
 
                 current = Unwrap(receiver);

--- a/src/Reactor.Analyzers/UnusedGridTrackAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnusedGridTrackAnalyzer.cs
@@ -153,6 +153,15 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
             if (placement.Kind == PlacementKind.Skip)
                 continue;
 
+            // A start index at or beyond the declared track count is out of range on a countable
+            // axis. WinUI clamps such a child into the last track, so we can no longer prove which
+            // in-range track it does NOT occupy — bail the whole grid rather than risk a false
+            // "unused" claim. (An in-range start whose span overshoots is fine — the span clamps.)
+            if (hasColumns && placement.Column >= columnCount)
+                return;
+            if (hasRows && placement.Row >= rowCount)
+                return;
+
             if (hasColumns)
                 MarkOccupied(occupiedCols, placement.Column, placement.ColumnSpan, columnCount);
             if (hasRows)
@@ -341,7 +350,9 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        // Out-of-range indices / spans are unusual and ambiguous — do not risk a false claim.
+        // A negative index or a non-positive span is invalid/ambiguous — bail. (An oversized span
+        // and an out-of-range start are handled by the caller: the span is clamped to the declared
+        // range when marking occupancy, and an out-of-range start bails the whole grid there.)
         if (row < 0 || column < 0 || rowSpan < 1 || columnSpan < 1)
             return Placement.Bail;
 

--- a/src/Reactor.Analyzers/UnusedGridTrackAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnusedGridTrackAnalyzer.cs
@@ -378,31 +378,33 @@ public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
 
     private static bool TryGetTrackLocations(IOperation? trackValue, out IReadOnlyList<Location> locations)
     {
+        locations = System.Array.Empty<Location>();
+
         if (trackValue is not null)
         {
             switch (Unwrap(trackValue).Syntax)
             {
-                case CollectionExpressionSyntax collection:
-                    // [GridSize.Auto, GridSize.Star()] — bail if any element is a spread (..x).
-                    if (collection.Elements.All(e => e is ExpressionElementSyntax))
-                    {
-                        locations = collection.Elements.Select(e => e.GetLocation()).ToArray();
-                        return true;
-                    }
+                case CollectionExpressionSyntax collection
+                    when collection.Elements.All(e => e is ExpressionElementSyntax):
+                    // [GridSize.Auto, GridSize.Star()] — a spread (..x) fails the guard and falls
+                    // through to the non-reportable return below.
+                    locations = collection.Elements.Select(e => e.GetLocation()).ToArray();
                     break;
 
                 case ArrayCreationExpressionSyntax { Initializer: { } arrayInit }:
                     locations = arrayInit.Expressions.Select(e => e.GetLocation()).ToArray();
-                    return true;
+                    break;
 
                 case ImplicitArrayCreationExpressionSyntax { Initializer: { } implicitInit }:
                     locations = implicitInit.Expressions.Select(e => e.GetLocation()).ToArray();
-                    return true;
+                    break;
             }
         }
 
-        locations = System.Array.Empty<Location>();
-        return false;
+        // An empty declared track list ([]) has nothing to report AND must not poison the other
+        // axis's analysis or the out-of-range guard (columnCount 0 would make 0 >= 0 bail every
+        // child) — treat it as a non-reportable axis, exactly like an opaque/variable track array.
+        return locations.Count > 0;
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────

--- a/src/Reactor.Analyzers/UnusedGridTrackAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnusedGridTrackAnalyzer.cs
@@ -1,0 +1,401 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_GRID_001</c> — flags a declared <c>Grid</c> track (a <see cref="GridSize"/>
+/// in the <c>columns</c>/<c>rows</c> array of the typed
+/// <c>Factories.Grid(GridSize[], GridSize[], params Element?[])</c> factory) that no child
+/// occupies: the "unused column"/"unused row" symptom (layout.md:555, spec 060 §12).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A child's cell is the outermost <c>.Grid(row:, column:, rowSpan:, columnSpan:)</c> modifier
+/// in its chain (<c>GridExtensions.Grid</c>, GridExtensions.cs); a child with no <c>.Grid()</c>
+/// defaults to <c>(row 0, column 0)</c> (<c>GridAttached</c>, Element.cs). A track index that
+/// is covered by no child's [row..row+rowSpan-1] × [column..column+columnSpan-1] range is
+/// unused. Intent-heavy — ship at Warning, <b>no auto-fix</b> (the author may want to remove the
+/// track or place a child there).
+/// </para>
+/// <para>
+/// <b>False-positive discipline (the rule only fires when it can prove a track is unused).</b>
+/// Because occupancy is a negative claim ("no child is here"), the analyzer bails — reports
+/// nothing for the whole grid — the moment any child's placement is not statically visible in
+/// the same call:
+/// <list type="bullet">
+/// <item>a bare variable / parameter / field child (e.g. <c>titleBar</c>) may have been placed
+/// with <c>.Grid(...)</c> elsewhere, so its cell is unknown;</item>
+/// <item>a conditional child (<c>cond ? a.Grid(col:2) : b.Grid(col:2)</c>) has a
+/// branch-dependent cell;</item>
+/// <item>a non-constant placement arg (<c>.Grid(column: i)</c> / <c>columnSpan: n</c>) could
+/// cover the very track we would flag;</item>
+/// <item>a spread/variable <c>columns</c>/<c>rows</c> array or a children array we cannot
+/// enumerate hides both the track count and the placements.</item>
+/// </list>
+/// The remaining accepted limitation: a helper that hides a <c>.Grid(...)</c> inside its body
+/// (<c>Cell(r, c, e) =&gt; e.Grid(r, c)</c>) is treated as the default <c>(0,0)</c> at the call
+/// site — an intentional false positive the author can suppress, matching the documented
+/// "a child with no explicit column is at column 0" model.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UnusedGridTrackAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_GRID_001";
+
+    private const string FactoriesType = "Microsoft.UI.Reactor.Factories";
+    private const string GridExtensionsType = "Microsoft.UI.Reactor.GridExtensions";
+    private const string GridSizeType = "Microsoft.UI.Reactor.GridSize";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "Grid declares a track that no child occupies",
+        "This Grid declares {0} {1} but no child is placed in it. Remove the unused track or place a child there.",
+        "Reactor.Layout",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+            "The typed Grid factory sizes its tracks from the columns/rows arrays, and each child " +
+            "picks a cell via the .Grid(row:, column:, rowSpan:, columnSpan:) modifier (a child " +
+            "with no .Grid() defaults to row 0, column 0). A declared track that no child's " +
+            "row/column range covers renders empty — usually a leftover track after a child was " +
+            "removed, or a child that was never placed. The analyzer only fires when every " +
+            "child's placement is statically visible in the same call: it stays silent on grids " +
+            "with variable/conditional children, dynamic (non-constant) placement, or " +
+            "spread/variable track arrays, because it cannot then prove the track is unused.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Cheap syntactic gate — the callee is named "Grid" and has at least columns + rows.
+        if (GetInvokedSimpleName(invocation.Expression) != "Grid")
+            return;
+        if (invocation.ArgumentList.Arguments.Count < 2)
+            return;
+
+        // Semantic confirm — the typed Reactor Grid factory (not the .Grid modifier, GridView,
+        // a user's Grid, or the obsolete string-track overload).
+        if (context.SemanticModel.GetOperation(invocation, context.CancellationToken) is not IInvocationOperation op)
+            return;
+        if (!IsTypedGridFactory(op.TargetMethod))
+            return;
+
+        IOperation? columnsVal = null;
+        IOperation? rowsVal = null;
+        IOperation? childrenVal = null;
+        foreach (var arg in op.Arguments)
+        {
+            if (arg.Parameter is null)
+                continue;
+            if (arg.Parameter.IsParams)
+                childrenVal = arg.Value;
+            else if (arg.Parameter.Name == "columns")
+                columnsVal = arg.Value;
+            else if (arg.Parameter.Name == "rows")
+                rowsVal = arg.Value;
+        }
+
+        if (childrenVal is null)
+            return;
+
+        // Children must be an inline array we can fully enumerate. A variable/opaque children
+        // array means we cannot see every placement → cannot prove any track unused.
+        if (!TryGetChildOperations(childrenVal, out var children))
+            return;
+        if (children.Count == 0)
+            return;
+
+        // Resolve every child's placement. A single opaque child aborts the whole grid.
+        var occupiedRows = new HashSet<int>();
+        var occupiedCols = new HashSet<int>();
+        foreach (var child in children)
+        {
+            var placement = ResolvePlacement(child);
+            if (placement.Kind == PlacementKind.Bail)
+                return;
+            if (placement.Kind == PlacementKind.Skip)
+                continue;
+
+            for (var r = placement.RowStart; r <= placement.RowEnd; r++)
+                occupiedRows.Add(r);
+            for (var c = placement.ColStart; c <= placement.ColEnd; c++)
+                occupiedCols.Add(c);
+        }
+
+        if (TryGetTrackLocations(columnsVal, out var columnLocations))
+            ReportUnusedTracks(context, columnLocations, occupiedCols, "column");
+        if (TryGetTrackLocations(rowsVal, out var rowLocations))
+            ReportUnusedTracks(context, rowLocations, occupiedRows, "row");
+    }
+
+    private static void ReportUnusedTracks(
+        SyntaxNodeAnalysisContext context,
+        IReadOnlyList<Location> trackLocations,
+        HashSet<int> occupied,
+        string axis)
+    {
+        for (var i = 0; i < trackLocations.Count; i++)
+        {
+            if (!occupied.Contains(i))
+                context.ReportDiagnostic(Diagnostic.Create(Rule, trackLocations[i], axis, i));
+        }
+    }
+
+    // ── Grid factory / modifier recognition ────────────────────────────────
+
+    private static bool IsTypedGridFactory(IMethodSymbol? method)
+    {
+        if (method is null || method.Name != "Grid")
+            return false;
+        if (method.ContainingType?.ToDisplayString() != FactoriesType)
+            return false;
+
+        var ps = method.Parameters;
+        if (ps.Length < 3)
+            return false;
+        if (ps[0].Name != "columns" || ps[1].Name != "rows" || !ps[ps.Length - 1].IsParams)
+            return false;
+
+        // Typed overload only — the obsolete string[] overload has its own CS0618 code fix.
+        return ps[0].Type is IArrayTypeSymbol { ElementType: INamedTypeSymbol element }
+            && element.ToDisplayString() == GridSizeType;
+    }
+
+    private static bool IsGridModifier(IMethodSymbol? method)
+    {
+        var m = method?.ReducedFrom ?? method;
+        return m is not null
+            && m.Name == "Grid"
+            && m.ContainingType?.ToDisplayString() == GridExtensionsType;
+    }
+
+    // ── Child placement resolution ─────────────────────────────────────────
+
+    private enum PlacementKind
+    {
+        /// <summary>A statically known cell range.</summary>
+        Known,
+
+        /// <summary>A <c>null</c> child (filtered at runtime) — occupies nothing.</summary>
+        Skip,
+
+        /// <summary>Placement not provable — abort the whole grid.</summary>
+        Bail,
+    }
+
+    private readonly struct Placement
+    {
+        public readonly PlacementKind Kind;
+        public readonly int RowStart;
+        public readonly int RowEnd;
+        public readonly int ColStart;
+        public readonly int ColEnd;
+
+        private Placement(PlacementKind kind, int rowStart, int rowEnd, int colStart, int colEnd)
+        {
+            Kind = kind;
+            RowStart = rowStart;
+            RowEnd = rowEnd;
+            ColStart = colStart;
+            ColEnd = colEnd;
+        }
+
+        public static readonly Placement Bail = new(PlacementKind.Bail, 0, 0, 0, 0);
+        public static readonly Placement Skip = new(PlacementKind.Skip, 0, 0, 0, 0);
+        public static readonly Placement Default = Cell(0, 0, 1, 1);
+
+        public static Placement Cell(int row, int column, int rowSpan, int columnSpan) =>
+            new(PlacementKind.Known, row, row + rowSpan - 1, column, column + columnSpan - 1);
+    }
+
+    /// <summary>
+    /// Walk a child's fluent chain to its outermost <c>.Grid(...)</c> placement (the last one
+    /// applied wins), or to the static factory at its root (default <c>(0,0)</c>). Anything else —
+    /// a variable/field reference, a conditional, a raw object creation, or a non-constant
+    /// placement argument — is not provable and returns <see cref="Placement.Bail"/>.
+    /// </summary>
+    private static Placement ResolvePlacement(IOperation childOperation)
+    {
+        var current = Unwrap(childOperation);
+
+        while (true)
+        {
+            if (current is IInvocationOperation invocation)
+            {
+                if (IsGridModifier(invocation.TargetMethod))
+                    return ReadGridPlacement(invocation);
+
+                var receiver = invocation.Instance;
+                if (receiver is null
+                    && invocation.TargetMethod.IsExtensionMethod
+                    && invocation.Arguments.Length > 0)
+                {
+                    // Extension methods surface in unreduced form: the receiver is argument 0.
+                    receiver = invocation.Arguments[0].Value;
+                }
+
+                if (receiver is null)
+                {
+                    // No receiver → a static factory root (Text(...), Grid(...), Component<..>(..))
+                    // with no .Grid() above it → the framework default cell.
+                    return Placement.Default;
+                }
+
+                current = Unwrap(receiver);
+                continue;
+            }
+
+            if (current is ILiteralOperation { ConstantValue: { HasValue: true, Value: null } })
+                return Placement.Skip;
+
+            // Variable/parameter/field/property reference, conditional, object creation, etc. —
+            // the cell is not provable from this call site.
+            return Placement.Bail;
+        }
+    }
+
+    private static Placement ReadGridPlacement(IInvocationOperation gridModifier)
+    {
+        int row = 0, column = 0, rowSpan = 1, columnSpan = 1;
+
+        foreach (var arg in gridModifier.Arguments)
+        {
+            // Omitted optionals keep their defaults; only explicit args override. The extension
+            // receiver ("el") and any other parameter are ignored.
+            if (arg.ArgumentKind != ArgumentKind.Explicit)
+                continue;
+
+            switch (arg.Parameter?.Name)
+            {
+                case "row":
+                    if (!TryGetConstInt(arg.Value, out row)) return Placement.Bail;
+                    break;
+                case "column":
+                    if (!TryGetConstInt(arg.Value, out column)) return Placement.Bail;
+                    break;
+                case "rowSpan":
+                    if (!TryGetConstInt(arg.Value, out rowSpan)) return Placement.Bail;
+                    break;
+                case "columnSpan":
+                    if (!TryGetConstInt(arg.Value, out columnSpan)) return Placement.Bail;
+                    break;
+            }
+        }
+
+        // Out-of-range indices / spans are unusual and ambiguous — do not risk a false claim.
+        if (row < 0 || column < 0 || rowSpan < 1 || columnSpan < 1)
+            return Placement.Bail;
+
+        return Placement.Cell(row, column, rowSpan, columnSpan);
+    }
+
+    // ── Track array enumeration ────────────────────────────────────────────
+
+    private static bool TryGetChildOperations(IOperation childrenValue, out IReadOnlyList<IOperation> children)
+    {
+        // Both the params-expanded form (Grid(cols, rows, a, b)) and an explicit inline array
+        // (Grid(cols, rows, new Element[] { a, b })) surface as an array creation with an
+        // initializer we can enumerate. A variable array, Array.Empty<>(), or a spread does not.
+        if (Unwrap(childrenValue) is IArrayCreationOperation { Initializer: { } initializer })
+        {
+            children = initializer.ElementValues;
+            return true;
+        }
+
+        children = System.Array.Empty<IOperation>();
+        return false;
+    }
+
+    private static bool TryGetTrackLocations(IOperation? trackValue, out IReadOnlyList<Location> locations)
+    {
+        if (trackValue is not null)
+        {
+            switch (Unwrap(trackValue).Syntax)
+            {
+                case CollectionExpressionSyntax collection:
+                    // [GridSize.Auto, GridSize.Star()] — bail if any element is a spread (..x).
+                    if (collection.Elements.All(e => e is ExpressionElementSyntax))
+                    {
+                        locations = collection.Elements.Select(e => e.GetLocation()).ToArray();
+                        return true;
+                    }
+                    break;
+
+                case ArrayCreationExpressionSyntax { Initializer: { } arrayInit }:
+                    locations = arrayInit.Expressions.Select(e => e.GetLocation()).ToArray();
+                    return true;
+
+                case ImplicitArrayCreationExpressionSyntax { Initializer: { } implicitInit }:
+                    locations = implicitInit.Expressions.Select(e => e.GetLocation()).ToArray();
+                    return true;
+            }
+        }
+
+        locations = System.Array.Empty<Location>();
+        return false;
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static IOperation Unwrap(IOperation operation)
+    {
+        while (true)
+        {
+            switch (operation)
+            {
+                case IConversionOperation conversion:
+                    operation = conversion.Operand;
+                    continue;
+                case IParenthesizedOperation parenthesized:
+                    operation = parenthesized.Operand;
+                    continue;
+                default:
+                    return operation;
+            }
+        }
+    }
+
+    private static bool TryGetConstInt(IOperation operation, out int value)
+    {
+        var constant = operation.ConstantValue;
+        if (constant.HasValue && constant.Value is int i)
+        {
+            value = i;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static string? GetInvokedSimpleName(ExpressionSyntax expression) => expression switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        GenericNameSyntax generic => generic.Identifier.ValueText,
+        MemberAccessExpressionSyntax member => member.Name switch
+        {
+            GenericNameSyntax genericMember => genericMember.Identifier.ValueText,
+            { } simple => simple.Identifier.ValueText,
+        },
+        MemberBindingExpressionSyntax binding => binding.Name.Identifier.ValueText,
+        _ => null,
+    };
+}

--- a/tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs
@@ -193,6 +193,19 @@ class C
 }");
 
     [Fact]
+    public Task Default_Element_Child_Occupies_Nothing() => VerifyAsync(@"
+// default(Element) is compile-time null (filtered at runtime) — it must be skipped, not treated
+// as opaque, so an otherwise-provable grid is still analyzed and column 0 is reported unused.
+class C
+{
+    Element M() => Grid(
+        [{|REACTOR_GRID_001:GridSize.Auto|}, GridSize.Star()],
+        [GridSize.Auto],
+        default(Element),
+        Text(""a"").Grid(column: 1));
+}");
+
+    [Fact]
     public Task Fires_On_Last_Grid_Wins() => VerifyAsync(@"
 // Two .Grid() calls in one chain: the OUTERMOST (last-applied) wins and resets the column,
 // so the child lands in column 1 and column 0 is unused (not column 1).

--- a/tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs
@@ -217,6 +217,18 @@ class C
         Text(""b"").Grid(row: 1, column: 0));
 }");
 
+    [Fact]
+    public Task Fires_On_Unused_Row_With_Empty_Columns() => VerifyAsync(@"
+// An empty columns list ([]) is a non-reportable axis and must not suppress the row analysis.
+class C
+{
+    Element M() => Grid(
+        [],
+        [GridSize.Auto, GridSize.Auto, {|REACTOR_GRID_001:GridSize.Auto|}],
+        Text(""a"").Grid(row: 0, column: 0),
+        Text(""b"").Grid(row: 1, column: 0));
+}");
+
     // ── Negatives ───────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs
@@ -1,0 +1,329 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="UnusedGridTrackAnalyzer"/> (<c>REACTOR_GRID_001</c>). Stubs a minimal
+/// Reactor-shaped <c>Factories.Grid(GridSize[], GridSize[], params Element[])</c> factory, the
+/// <c>GridExtensions.Grid(row:, column:, rowSpan:, columnSpan:)</c> placement modifier, and a
+/// couple of element factories so the analyzer's semantic gate resolves without the framework.
+/// </summary>
+public class UnusedGridTrackAnalyzerTests
+{
+    private const string Stubs = @"
+using System;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public abstract class Element { }
+}
+
+namespace Microsoft.UI.Reactor
+{
+    public readonly struct GridSize
+    {
+        public static GridSize Auto => default;
+        public static GridSize Star(double weight = 1) => default;
+        public static GridSize Px(double px) => default;
+    }
+
+    public sealed class GridElement : Element { }
+    public sealed class TextElement : Element { }
+
+    public static class Factories
+    {
+        public static GridElement Grid(GridSize[] columns, GridSize[] rows, params Element[] children) => new();
+
+        [Obsolete(""Use the typed overload."", error: false)]
+        public static GridElement Grid(string[] columns, string[] rows, params Element[] children) => new();
+
+        public static TextElement Text(string text) => new();
+    }
+
+    public static class GridExtensions
+    {
+        public static T Grid<T>(this T el, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1)
+            where T : Element => el;
+    }
+
+    public static class ElementExtensions
+    {
+        public static T Bold<T>(this T el) where T : Element => el;
+        public static T Margin<T>(this T el, double m) where T : Element => el;
+    }
+
+    // Same shape as the real factory but a DIFFERENT containing type — must never fire.
+    public static class NotFactories
+    {
+        public static GridElement Grid(GridSize[] columns, GridSize[] rows, params Element[] children) => new();
+    }
+}
+";
+
+    private static Task VerifyAsync(string testBody) =>
+        new CSharpAnalyzerTest<UnusedGridTrackAnalyzer, DefaultVerifier>
+        {
+            TestCode = Stubs + testBody,
+        }.RunAsync(TestContext.Current.CancellationToken);
+
+    // ── Positives ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public Task Fires_On_Unused_Column() => VerifyAsync(@"
+class C
+{
+    Element M() => Grid(
+        [GridSize.Auto, GridSize.Star(), {|REACTOR_GRID_001:GridSize.Star()|}],
+        [GridSize.Auto],
+        Text(""a"").Grid(row: 0, column: 0),
+        Text(""b"").Grid(row: 0, column: 1));
+}");
+
+    [Fact]
+    public Task Fires_On_Multiple_Unused_Columns() => VerifyAsync(@"
+class C
+{
+    Element M() => Grid(
+        [GridSize.Auto, GridSize.Star(), {|REACTOR_GRID_001:GridSize.Star()|}, {|REACTOR_GRID_001:GridSize.Auto|}],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0),
+        Text(""b"").Grid(column: 1));
+}");
+
+    [Fact]
+    public Task Fires_On_Unused_Row() => VerifyAsync(@"
+class C
+{
+    Element M() => Grid(
+        [GridSize.Star()],
+        [GridSize.Auto, GridSize.Auto, {|REACTOR_GRID_001:GridSize.Auto|}],
+        Text(""a"").Grid(row: 0, column: 0),
+        Text(""b"").Grid(row: 1, column: 0));
+}");
+
+    [Fact]
+    public Task Fires_On_Default_Placement_Child() => VerifyAsync(@"
+// A child with no .Grid() defaults to (row 0, column 0); the Star column is unused.
+class C
+{
+    Element M() => Grid(
+        [GridSize.Auto, {|REACTOR_GRID_001:GridSize.Star()|}],
+        [GridSize.Auto],
+        Text(""only""));
+}");
+
+    [Fact]
+    public Task Fires_With_Variable_Receiver_And_Explicit_Grid() => VerifyAsync(@"
+// The receiver is a local, but the outermost .Grid() states the cell — still provable.
+class C
+{
+    Element M()
+    {
+        Element b = Text(""b"");
+        return Grid(
+            [GridSize.Auto, GridSize.Star(), {|REACTOR_GRID_001:GridSize.Star()|}],
+            [GridSize.Auto],
+            Text(""a"").Grid(column: 0),
+            b.Grid(column: 1));
+    }
+}");
+
+    [Fact]
+    public Task Fires_Through_Trailing_Modifiers_After_Grid() => VerifyAsync(@"
+// .Grid() is not the outermost call, but it is the only placement in the chain.
+class C
+{
+    Element M() => Grid(
+        [GridSize.Auto, GridSize.Star(), {|REACTOR_GRID_001:GridSize.Star()|}],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0).Bold(),
+        Text(""b"").Grid(column: 1).Margin(4));
+}");
+
+    [Fact]
+    public Task Fires_On_Explicit_Array_Tracks() => VerifyAsync(@"
+class C
+{
+    Element M() => Grid(
+        new GridSize[] { GridSize.Auto, GridSize.Star(), {|REACTOR_GRID_001:GridSize.Star()|} },
+        new GridSize[] { GridSize.Auto },
+        Text(""a"").Grid(column: 0),
+        Text(""b"").Grid(column: 1));
+}");
+
+    [Fact]
+    public Task Fires_On_Implicit_Array_Tracks() => VerifyAsync(@"
+class C
+{
+    Element M() => Grid(
+        new[] { GridSize.Auto, GridSize.Star(), {|REACTOR_GRID_001:GridSize.Star()|} },
+        new[] { GridSize.Auto },
+        Text(""a"").Grid(column: 0),
+        Text(""b"").Grid(column: 1));
+}");
+
+    [Fact]
+    public Task Fires_On_Explicit_Children_Array() => VerifyAsync(@"
+class C
+{
+    Element M() => Grid(
+        [GridSize.Auto, GridSize.Star(), {|REACTOR_GRID_001:GridSize.Star()|}],
+        [GridSize.Auto],
+        new Element[] { Text(""a"").Grid(column: 0), Text(""b"").Grid(column: 1) });
+}");
+
+    [Fact]
+    public Task Null_Child_Occupies_Nothing() => VerifyAsync(@"
+// A null child is filtered at runtime — it must NOT be treated as occupying (0,0),
+// so column 0 is genuinely unused here.
+class C
+{
+    Element M() => Grid(
+        [{|REACTOR_GRID_001:GridSize.Auto|}, GridSize.Star()],
+        [GridSize.Auto],
+        null,
+        Text(""a"").Grid(column: 1));
+}");
+
+    // ── Negatives ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public Task No_Diagnostic_When_All_Columns_Occupied() => VerifyAsync(@"
+class C
+{
+    Element M() => Grid(
+        [GridSize.Auto, GridSize.Star(), GridSize.Auto],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0),
+        Text(""b"").Grid(column: 1),
+        Text(""c"").Grid(column: 2));
+}");
+
+    [Fact]
+    public Task No_Diagnostic_When_ColumnSpan_Covers_Track() => VerifyAsync(@"
+// The second child spans columns 1 and 2, so no track is unused.
+class C
+{
+    Element M() => Grid(
+        [GridSize.Auto, GridSize.Star(), GridSize.Star()],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0),
+        Text(""b"").Grid(column: 1, columnSpan: 2));
+}");
+
+    [Fact]
+    public Task No_Diagnostic_When_RowSpan_Covers_Track() => VerifyAsync(@"
+class C
+{
+    Element M() => Grid(
+        [GridSize.Star()],
+        [GridSize.Auto, GridSize.Auto],
+        Text(""a"").Grid(row: 0, rowSpan: 2));
+}");
+
+    [Fact]
+    public Task No_Diagnostic_For_Variable_Child() => VerifyAsync(@"
+// A bare variable child may have been placed with .Grid() elsewhere — not provable, so bail
+// (columns 1 and 2 look unused, but the analyzer must stay silent).
+class C
+{
+    Element M(Element extra) => Grid(
+        [GridSize.Auto, GridSize.Star(), GridSize.Star()],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0),
+        extra);
+}");
+
+    [Fact]
+    public Task No_Diagnostic_For_Conditional_Child() => VerifyAsync(@"
+// A conditional child has a branch-dependent cell — bail even though column 2 looks unused.
+class C
+{
+    Element M(bool cond) => Grid(
+        [GridSize.Auto, GridSize.Star(), GridSize.Star()],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0),
+        cond ? Text(""b"").Grid(column: 1) : Text(""c"").Grid(column: 1));
+}");
+
+    [Fact]
+    public Task No_Diagnostic_For_Variable_Children_Array() => VerifyAsync(@"
+class C
+{
+    Element M(Element[] kids) => Grid(
+        [GridSize.Auto, GridSize.Star(), GridSize.Star()],
+        [GridSize.Auto],
+        kids);
+}");
+
+    [Fact]
+    public Task No_Diagnostic_For_Dynamic_Placement() => VerifyAsync(@"
+// A non-constant column could be the very track we would flag — bail.
+class C
+{
+    Element M(int i) => Grid(
+        [GridSize.Auto, GridSize.Star(), GridSize.Star()],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0),
+        Text(""b"").Grid(column: i));
+}");
+
+    [Fact]
+    public Task No_Diagnostic_For_Dynamic_Span() => VerifyAsync(@"
+class C
+{
+    Element M(int n) => Grid(
+        [GridSize.Auto, GridSize.Star(), GridSize.Star()],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0),
+        Text(""b"").Grid(column: 1, columnSpan: n));
+}");
+
+    [Fact]
+    public Task No_Diagnostic_For_Variable_Track_Array() => VerifyAsync(@"
+class C
+{
+    Element M(GridSize[] cols) => Grid(
+        cols,
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0));
+}");
+
+    [Fact]
+    public Task No_Diagnostic_When_No_Children() => VerifyAsync(@"
+class C
+{
+    Element M() => Grid(
+        [GridSize.Auto, GridSize.Star()],
+        [GridSize.Auto]);
+}");
+
+    [Fact]
+    public Task No_Diagnostic_For_Non_Factory_Grid() => VerifyAsync(@"
+// Same signature shape, different containing type — the semantic gate must reject it.
+class C
+{
+    Element M() => NotFactories.Grid(
+        [GridSize.Auto, GridSize.Star()],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0));
+}");
+
+    [Fact]
+    public Task No_Diagnostic_For_Obsolete_String_Grid() => VerifyAsync(@"
+// The obsolete string-track overload is out of scope (it has its own CS0618 fixer).
+class C
+{
+    Element M() => Grid(
+        new[] { ""Auto"", ""*"" },
+        new[] { ""Auto"" },
+        Text(""a""));
+}");
+}

--- a/tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs
@@ -192,6 +192,31 @@ class C
         Text(""a"").Grid(column: 1));
 }");
 
+    [Fact]
+    public Task Fires_On_Last_Grid_Wins() => VerifyAsync(@"
+// Two .Grid() calls in one chain: the OUTERMOST (last-applied) wins and resets the column,
+// so the child lands in column 1 and column 0 is unused (not column 1).
+class C
+{
+    Element M() => Grid(
+        [{|REACTOR_GRID_001:GridSize.Auto|}, GridSize.Star()],
+        [GridSize.Auto],
+        Text(""x"").Grid(column: 0).Grid(column: 1));
+}");
+
+    [Fact]
+    public Task Fires_On_Unused_Row_With_Opaque_Columns() => VerifyAsync(@"
+// The columns array is a variable (uncountable), but the rows are literal and a row is unused —
+// the two axes are judged independently, so the row still fires.
+class C
+{
+    Element M(GridSize[] cols) => Grid(
+        cols,
+        [GridSize.Auto, GridSize.Auto, {|REACTOR_GRID_001:GridSize.Auto|}],
+        Text(""a"").Grid(row: 0, column: 0),
+        Text(""b"").Grid(row: 1, column: 0));
+}");
+
     // ── Negatives ───────────────────────────────────────────────────────────
 
     [Fact]
@@ -325,5 +350,31 @@ class C
         new[] { ""Auto"", ""*"" },
         new[] { ""Auto"" },
         Text(""a""));
+}");
+
+    [Fact]
+    public Task No_Diagnostic_For_Helper_Child() => VerifyAsync(@"
+// Cell() is not a Reactor DSL factory — it may hide a .Grid(...) in its body (and here it does),
+// so it must be treated as opaque and bail the grid rather than assumed to sit at (0,0).
+class C
+{
+    static Element Cell() => Text(""x"").Grid(column: 1);
+
+    Element M() => Grid(
+        [GridSize.Auto, GridSize.Star()],
+        [GridSize.Auto],
+        Cell());
+}");
+
+    [Fact]
+    public Task No_Diagnostic_For_Oversized_Span() => VerifyAsync(@"
+// An int.MaxValue span must be clamped to the declared track count (no unbounded loop / hang);
+// here it covers every column, so nothing is unused.
+class C
+{
+    Element M() => Grid(
+        [GridSize.Auto, GridSize.Star(), GridSize.Auto],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0, columnSpan: 2147483647));
 }");
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs
@@ -377,4 +377,17 @@ class C
         [GridSize.Auto],
         Text(""a"").Grid(column: 0, columnSpan: 2147483647));
 }");
+
+    [Fact]
+    public Task No_Diagnostic_For_Out_Of_Range_Placement() => VerifyAsync(@"
+// The second child's column is beyond the declared tracks; WinUI clamps it into the last column,
+// so we can no longer prove which track is unused — bail the whole grid.
+class C
+{
+    Element M() => Grid(
+        [GridSize.Auto, GridSize.Star(), GridSize.Auto],
+        [GridSize.Auto],
+        Text(""a"").Grid(column: 0),
+        Text(""b"").Grid(column: 9));
+}");
 }


### PR DESCRIPTION
Implements one packet of spec 060 Batch 2 (§12): **REACTOR_GRID_001** — the doc-named "unused-column" / unused-track rule (layout.md:555). Stacked on the foundation branch `azchohfi-spec-060-analyzer-suite`.

## Rule
`REACTOR_GRID_001` · `Reactor.Layout` · **Warning** · no auto-fix.

Flags a declared `Grid` track (a `GridSize` in the `columns`/`rows` array of the typed `Factories.Grid(GridSize[], GridSize[], params Element?[])` factory) that no child occupies. Distinct from the id-less §4.5 `CS0618` string-track fixer — this is a **new** diagnostic id.

## Detection (verified against source)
- Typed factory `Factories.Grid` (Dsl.cs:733) + `GridExtensions.Grid<T>(row:, column:, rowSpan:, columnSpan:)` placement modifier (GridExtensions.cs:16). Default cell is `(0,0)` per `GridAttached` (Element.cs:2388).
- For each child, the **outermost** `.Grid(...)` in its chain wins (constant args); spans mark their full `[start..start+span-1]` range; a child with no `.Grid()` occupies `(0,0)`.
- A track index covered by no child's row/column range is reported (per-track location on the specific `GridSize`).

## False-positive discipline (intent-heavy rule)
Because "no child is here" is a negative claim, the analyzer **bails on the whole grid** the moment a placement isn't statically provable in the same call:
- bare variable / parameter / field children (may be placed with `.Grid()` elsewhere — e.g. monaco's `titleBar, toolbar`);
- conditional children (`cond ? a.Grid(col:2) : b.Grid(col:2)` — e.g. InputBar's send/stop button);
- non-constant placement args (`.Grid(column: i)` / `columnSpan: n`);
- spread/variable track arrays or a children array it can't enumerate.

A variable **receiver** with an explicit outer `.Grid(...)` (e.g. `notificationBar.Grid(row:0,column:0)`) is still analyzed — the modifier is authoritative. Grounded in the chat/monaco samples, none of the existing grids false-positive.

Accepted limitation: a helper that hides `.Grid()` inside its body (`Cell(r,c,e) => e.Grid(r,c)`) is treated as `(0,0)` at the call site — matching the documented "no explicit column is at column 0" model; suppressible.

## Tests
`tests/Reactor.Tests/AnalyzerTests/UnusedGridTrackAnalyzerTests.cs` — 22 tests: positive (unused column 2 of 3; multiple unused; unused row; default-placement child; variable-receiver+explicit; trailing modifiers; explicit/implicit track arrays; explicit children array; null child occupies nothing) and negatives (all occupied; column/row span covers track; variable child; conditional child; variable children array; dynamic placement/span; variable track array; no children; non-factory `Grid`; obsolete string overload).

`dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~UnusedGridTrack` → **22 passed**.

## Shared-append docs
- `AnalyzerReleases.Unshipped.md` row
- `docs/_pipeline/templates/analyzer-architecture.md.dt` row (template, not generated)
- `reactor-build-and-check` cheat-table row