### PR TITLE
feat(analyzer): REACTOR_INPUT_001 — chord on OnKeyDown should be a Command accelerator

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,6 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_INPUT_001` | Warning | Ctrl/Alt chord on `.OnKeyDown` should be a `Command` accelerator | `OnKeyDownChordAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/docs/_pipeline/templates/input-and-gestures.md.dt
+++ b/docs/_pipeline/templates/input-and-gestures.md.dt
@@ -479,8 +479,8 @@ If a parent needs to see the press before children consume it, use
 `.OnKeyDown` fires per element on focus — a `Ctrl+S` handler attached
 to a `TextBox` only fires while that field has focus. For app-wide
 accelerators (Save, Find, Run), use Reactor's
-[commanding](commanding.md) system: `new Command { ..., AccessKey =
-"S", AccessKeyModifiers = VirtualKeyModifiers.Control }` registers
+[commanding](commanding.md) system: `new Command { ..., Accelerator =
+Accelerator(VirtualKey.S, VirtualKeyModifiers.Control) }` registers
 the chord with the WinUI accelerator infrastructure, which routes
 through the window's `AccessKeyManager` regardless of focus. The
 analyzer `REACTOR_INPUT_001` flags Ctrl/Alt key combinations attached

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_INPUT_001` | warning | Ctrl/Alt chord tested inside a `.OnKeyDown` lambda (focus-scoped, fires only while the element has focus) | Register it app-wide as a `Command` accelerator: `new Command { …, Accelerator = Accelerator(VirtualKey.S, VirtualKeyModifiers.Control) }`, then drop the `.OnKeyDown` chord. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_INPUT_001 | Reactor.Input | Warning | OnKeyDownChordAnalyzer - Ctrl/Alt chord on .OnKeyDown is focus-scoped; use a Command accelerator

--- a/src/Reactor.Analyzers/OnKeyDownChordAnalyzer.cs
+++ b/src/Reactor.Analyzers/OnKeyDownChordAnalyzer.cs
@@ -1,0 +1,159 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_INPUT_001</c> — flags a <c>.OnKeyDown((s, e) =&gt; …)</c> lambda that tests a
+/// <c>VirtualKeyModifiers.Control</c> / <c>.Menu</c> (Ctrl/Alt) chord.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>.OnKeyDown</c> is a <b>focus-scoped</b> routed-input modifier: the handler only fires while
+/// that specific element has keyboard focus. Hand-rolling an app-wide accelerator such as
+/// <c>Ctrl+S</c> inside a <c>TextBox(…).OnKeyDown(…)</c> lambda therefore fires nowhere else and
+/// never reaches WinUI's <c>AccessKeyManager</c> — the shortcut silently does nothing whenever the
+/// field is not focused.
+/// </para>
+/// <para>
+/// The idiomatic fix is a <c>Command</c> whose <c>Accelerator = Accelerator(VirtualKey.S,
+/// VirtualKeyModifiers.Control)</c> (see <c>Command.cs</c> / <c>Dsl.cs</c>), which registers the
+/// chord with the window's accelerator infrastructure and routes regardless of focus. The rule ships
+/// a template code fix (<see cref="OnKeyDownChordCodeFix"/>) because the rewrite is intent-heavy —
+/// the app author decides where the command lives and what it does.
+/// </para>
+/// <para>
+/// Detection (spec 060 §12): a <c>.OnKeyDown</c> invocation whose single argument is a lambda whose
+/// body references <c>VirtualKeyModifiers.Control</c> or <c>VirtualKeyModifiers.Menu</c>. A cheap
+/// syntactic gate (method name + lambda + the <c>Control</c>/<c>Menu</c> member name qualified by an
+/// identifier spelled <c>VirtualKeyModifiers</c>) runs before a single semantic check confirms the
+/// member really binds to <c>Windows.System.VirtualKeyModifiers</c>, so a same-named local enum does
+/// not trip it. A <c>Shift</c>-only chord or a modifier-free handler is deliberately left alone.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_INPUT_001";
+
+    private const string ModifiersEnumName = "VirtualKeyModifiers";
+    private const string ModifiersEnumNamespace = "Windows.System";
+
+    private static readonly LocalizableString Title =
+        "Ctrl/Alt chord on .OnKeyDown should be a Command accelerator";
+
+    private static readonly LocalizableString MessageFormat =
+        "This .OnKeyDown lambda tests a '{0}' chord, but .OnKeyDown is focus-scoped and only fires while the element is focused. Register the shortcut as a Command whose Accelerator = Accelerator(VirtualKey.<key>, {0}) so it routes app-wide through AccessKeyManager.";
+
+    private static readonly LocalizableString Description =
+        "The .OnKeyDown modifier subscribes to the element's focus-scoped KeyDown routed event, so a " +
+        "hand-rolled Ctrl+S / Alt+key shortcut only fires while that element has focus and never reaches " +
+        "WinUI's AccessKeyManager. App-wide accelerators belong on a Command: " +
+        "new Command { …, Accelerator = Accelerator(VirtualKey.S, VirtualKeyModifiers.Control) } " +
+        "registers the chord with the window's accelerator infrastructure and routes regardless of focus.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Input",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Syntactic gate 1: a fluent `.OnKeyDown(...)` call.
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+        if (memberAccess.Name.Identifier.Text != "OnKeyDown")
+            return;
+
+        // Syntactic gate 2: exactly one argument, and it is a lambda (simple `s => …` or
+        // parenthesized `(s, e) => …`, both `LambdaExpressionSyntax`). A method-group handler
+        // (`.OnKeyDown(HandleKeyDown)`) is out of scope — the analyzer can't see the chord test,
+        // and mirrors the code fix, which needs the lambda body.
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count != 1)
+            return;
+        if (args[0].Expression is not LambdaExpressionSyntax lambda)
+            return;
+
+        var body = lambda.Body;
+        if (body is null)
+            return;
+
+        // Syntactic gate 3: the lambda body references `VirtualKeyModifiers.Control` / `.Menu`.
+        // Collect matches syntactically first (cheap), then confirm the enum semantically.
+        var chord = FindChordModifier(body, context.SemanticModel, context.CancellationToken);
+        if (chord is null)
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.GetLocation(),
+            $"{ModifiersEnumName}.{chord}"));
+    }
+
+    /// <summary>
+    /// Scans <paramref name="body"/> for the first <c>VirtualKeyModifiers.Control</c> /
+    /// <c>VirtualKeyModifiers.Menu</c> member access that semantically binds to
+    /// <c>Windows.System.VirtualKeyModifiers</c>. Returns the member name (<c>Control</c> /
+    /// <c>Menu</c>) or <c>null</c> when none is found. A <c>Shift</c>/<c>Windows</c>/<c>None</c>
+    /// modifier is intentionally not a match — only the Ctrl/Alt app-accelerator footgun fires.
+    /// </summary>
+    private static string? FindChordModifier(SyntaxNode body, SemanticModel model, System.Threading.CancellationToken ct)
+    {
+        foreach (var access in body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+        {
+            var member = access.Name.Identifier.Text;
+            if (member != "Control" && member != "Menu")
+                continue;
+
+            // Cheap syntactic pre-check: the receiver must be spelled `VirtualKeyModifiers`
+            // (bare `VirtualKeyModifiers.Control` or qualified `Windows.System.VirtualKeyModifiers.Control`)
+            // before we spend a semantic query.
+            if (ReceiverName(access.Expression) != ModifiersEnumName)
+                continue;
+
+            // Semantic confirmation: the accessed member is a field on the real
+            // Windows.System.VirtualKeyModifiers enum (not a same-named user type).
+            if (model.GetSymbolInfo(access, ct).Symbol is IFieldSymbol { ContainingType: { } enumType }
+                && enumType.Name == ModifiersEnumName
+                && enumType.ContainingNamespace?.ToDisplayString() == ModifiersEnumNamespace)
+            {
+                return member;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The trailing identifier of the receiver of a member access: the identifier itself for
+    /// <c>VirtualKeyModifiers.Control</c>, or the <c>.Name</c> for a qualified
+    /// <c>Windows.System.VirtualKeyModifiers.Control</c>.
+    /// </summary>
+    private static string? ReceiverName(ExpressionSyntax receiver) => receiver switch
+    {
+        IdentifierNameSyntax id => id.Identifier.Text,
+        MemberAccessExpressionSyntax member => member.Name.Identifier.Text,
+        _ => null,
+    };
+}

--- a/src/Reactor.Analyzers/OnKeyDownChordAnalyzer.cs
+++ b/src/Reactor.Analyzers/OnKeyDownChordAnalyzer.cs
@@ -42,6 +42,7 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
 
     private const string ModifiersEnumName = "VirtualKeyModifiers";
     private const string ModifiersEnumNamespace = "Windows.System";
+    private const string ReactorNamespacePrefix = "Microsoft.UI.Reactor";
 
     private static readonly LocalizableString Title =
         "Ctrl/Alt chord on .OnKeyDown should be a Command accelerator";
@@ -105,6 +106,14 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
         if (chord is null)
             return;
 
+        // Ground to Reactor's `.OnKeyDown` modifier: if the call resolves to a method that is NOT in
+        // a Reactor namespace, it is an unrelated same-named API (e.g. a third-party fluent helper) —
+        // don't warn. When the symbol can't be resolved (incomplete code mid-edit), fall back to the
+        // syntactic match and still warn, so the footgun stays visible while the author is typing.
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is IMethodSymbol method
+            && !IsReactorNamespace(method.ContainingNamespace?.ToDisplayString()))
+            return;
+
         context.ReportDiagnostic(Diagnostic.Create(
             Rule,
             invocation.GetLocation(),
@@ -126,6 +135,12 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
             if (member != "Control" && member != "Menu")
                 continue;
 
+            // Only the OnKeyDown handler's own logic counts. A modifier test inside a *nested*
+            // closure (a lambda/anonymous method/local function declared within this handler) belongs
+            // to some other callback, not this key handler, so skip it to avoid a false positive.
+            if (IsInsideNestedFunction(access, body))
+                continue;
+
             // Cheap syntactic pre-check: the receiver must be spelled `VirtualKeyModifiers`
             // (bare `VirtualKeyModifiers.Control` or qualified `Windows.System.VirtualKeyModifiers.Control`)
             // before we spend a semantic query.
@@ -144,6 +159,27 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
 
         return null;
     }
+
+    /// <summary>
+    /// True when <paramref name="node"/> sits inside a lambda / anonymous method / local function
+    /// that is itself nested within <paramref name="body"/> (the OnKeyDown handler's body). Such a
+    /// node belongs to an inner callback, not the key handler, so it must not count as the chord.
+    /// </summary>
+    private static bool IsInsideNestedFunction(SyntaxNode node, SyntaxNode body)
+    {
+        for (var current = node.Parent; current is not null && current != body; current = current.Parent)
+        {
+            if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>True when <paramref name="ns"/> is the Reactor root namespace or a descendant.</summary>
+    private static bool IsReactorNamespace(string? ns) =>
+        ns is not null
+            && (ns == ReactorNamespacePrefix
+                || ns.StartsWith(ReactorNamespacePrefix + ".", System.StringComparison.Ordinal));
 
     /// <summary>
     /// The trailing identifier of the receiver of a member access: the identifier itself for

--- a/src/Reactor.Analyzers/OnKeyDownChordAnalyzer.cs
+++ b/src/Reactor.Analyzers/OnKeyDownChordAnalyzer.cs
@@ -44,11 +44,17 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
     private const string ModifiersEnumNamespace = "Windows.System";
     private const string ReactorNamespacePrefix = "Microsoft.UI.Reactor";
 
+    /// <summary>Diagnostic.Properties key: the full VirtualKeyModifiers expression the chord tests.</summary>
+    internal const string ModifiersProperty = "modifiers";
+
+    /// <summary>Diagnostic.Properties key: the VirtualKey expression (or a placeholder) for the accelerator.</summary>
+    internal const string KeyProperty = "key";
+
     private static readonly LocalizableString Title =
         "Ctrl/Alt chord on .OnKeyDown should be a Command accelerator";
 
     private static readonly LocalizableString MessageFormat =
-        "This .OnKeyDown lambda tests a '{0}' chord, but .OnKeyDown is focus-scoped and only fires while the element is focused. Register the shortcut as a Command whose Accelerator = Accelerator(VirtualKey.<key>, {0}) so it routes app-wide through AccessKeyManager.";
+        "This .OnKeyDown lambda tests a focus-scoped Ctrl/Alt chord ({0}); .OnKeyDown only fires while the element is focused, so the shortcut never reaches AccessKeyManager. Register it as a Command whose Accelerator = Accelerator(VirtualKey.<key>, {0}) instead.";
 
     private static readonly LocalizableString Description =
         "The .OnKeyDown modifier subscribes to the element's focus-scoped KeyDown routed event, so a " +
@@ -100,10 +106,10 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
         if (body is null)
             return;
 
-        // Syntactic gate 3: the lambda body references `VirtualKeyModifiers.Control` / `.Menu`.
-        // Collect matches syntactically first (cheap), then confirm the enum semantically.
-        var chord = FindChordModifier(body, context.SemanticModel, context.CancellationToken);
-        if (chord is null)
+        // Syntactic gate 3: the handler's own body tests VirtualKeyModifiers.Control / .Menu.
+        // Collect the confirmed Ctrl/Alt set (nested closures excluded, enum confirmed semantically).
+        var (hasControl, hasMenu) = FindChordModifiers(body, context.SemanticModel, context.CancellationToken);
+        if (!hasControl && !hasMenu)
             return;
 
         // Ground to Reactor's `.OnKeyDown` modifier: if the call resolves to a method that is NOT in
@@ -114,21 +120,35 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
             && !IsReactorNamespace(method.ContainingNamespace?.ToDisplayString()))
             return;
 
+        // The full modifier set + the tested key travel to the code fix via Diagnostic.Properties
+        // (never the message text), so the template it scaffolds matches exactly what was detected
+        // here — same nested-closure exclusion, same combined-modifier expression.
+        var modifiers = ModifierExpression(hasControl, hasMenu);
+        var key = FindVirtualKey(body) is { } k ? $"VirtualKey.{k}" : "VirtualKey.<key>";
+
+        var properties = ImmutableDictionary<string, string?>.Empty
+            .Add(ModifiersProperty, modifiers)
+            .Add(KeyProperty, key);
+
         context.ReportDiagnostic(Diagnostic.Create(
             Rule,
             invocation.GetLocation(),
-            $"{ModifiersEnumName}.{chord}"));
+            properties,
+            modifiers));
     }
 
     /// <summary>
-    /// Scans <paramref name="body"/> for the first <c>VirtualKeyModifiers.Control</c> /
-    /// <c>VirtualKeyModifiers.Menu</c> member access that semantically binds to
-    /// <c>Windows.System.VirtualKeyModifiers</c>. Returns the member name (<c>Control</c> /
-    /// <c>Menu</c>) or <c>null</c> when none is found. A <c>Shift</c>/<c>Windows</c>/<c>None</c>
-    /// modifier is intentionally not a match — only the Ctrl/Alt app-accelerator footgun fires.
+    /// Scans <paramref name="body"/> for <c>VirtualKeyModifiers.Control</c> / <c>.Menu</c> member
+    /// accesses that semantically bind to <c>Windows.System.VirtualKeyModifiers</c>, returning which
+    /// of Control / Menu the handler's OWN body tests. Accesses inside nested closures and a
+    /// <c>Shift</c>/<c>Windows</c>/<c>None</c> modifier are intentionally ignored — only the Ctrl/Alt
+    /// app-accelerator footgun fires.
     /// </summary>
-    private static string? FindChordModifier(SyntaxNode body, SemanticModel model, System.Threading.CancellationToken ct)
+    private static (bool control, bool menu) FindChordModifiers(SyntaxNode body, SemanticModel model, System.Threading.CancellationToken ct)
     {
+        var control = false;
+        var menu = false;
+
         foreach (var access in body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
         {
             var member = access.Name.Identifier.Text;
@@ -153,10 +173,40 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
                 && enumType.Name == ModifiersEnumName
                 && enumType.ContainingNamespace?.ToDisplayString() == ModifiersEnumNamespace)
             {
-                return member;
+                if (member == "Control")
+                    control = true;
+                else
+                    menu = true;
             }
         }
 
+        return (control, menu);
+    }
+
+    /// <summary>
+    /// The <c>VirtualKeyModifiers</c> expression the accelerator should combine, reflecting whichever
+    /// of Control / Menu the handler tests. At least one is always true when this is called.
+    /// </summary>
+    private static string ModifierExpression(bool control, bool menu) => (control, menu) switch
+    {
+        (true, true) => $"{ModifiersEnumName}.Control | {ModifiersEnumName}.Menu",
+        (false, true) => $"{ModifiersEnumName}.Menu",
+        _ => $"{ModifiersEnumName}.Control",
+    };
+
+    /// <summary>
+    /// The name of the first <c>VirtualKey.&lt;X&gt;</c> the handler's own body references (nested
+    /// closures excluded), or <c>null</c> when none is present.
+    /// </summary>
+    private static string? FindVirtualKey(SyntaxNode body)
+    {
+        foreach (var access in body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+        {
+            if (IsInsideNestedFunction(access, body))
+                continue;
+            if (access.Expression is IdentifierNameSyntax { Identifier.Text: "VirtualKey" })
+                return access.Name.Identifier.Text;
+        }
         return null;
     }
 

--- a/src/Reactor.Analyzers/OnKeyDownChordAnalyzer.cs
+++ b/src/Reactor.Analyzers/OnKeyDownChordAnalyzer.cs
@@ -41,6 +41,7 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
     public const string DiagnosticId = "REACTOR_INPUT_001";
 
     private const string ModifiersEnumName = "VirtualKeyModifiers";
+    private const string KeyEnumName = "VirtualKey";
     private const string ModifiersEnumNamespace = "Windows.System";
     private const string ReactorNamespacePrefix = "Microsoft.UI.Reactor";
 
@@ -54,7 +55,7 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
         "Ctrl/Alt chord on .OnKeyDown should be a Command accelerator";
 
     private static readonly LocalizableString MessageFormat =
-        "This .OnKeyDown lambda tests a focus-scoped Ctrl/Alt chord ({0}); .OnKeyDown only fires while the element is focused, so the shortcut never reaches AccessKeyManager. Register it as a Command whose Accelerator = Accelerator(VirtualKey.<key>, {0}) instead.";
+        "This .OnKeyDown lambda tests a focus-scoped Ctrl/Alt chord ({0}); .OnKeyDown only fires while the element is focused, so the shortcut never reaches AccessKeyManager. Register it as a Command whose Accelerator = Accelerator({1}, {0}) instead.";
 
     private static readonly LocalizableString Description =
         "The .OnKeyDown modifier subscribes to the element's focus-scoped KeyDown routed event, so a " +
@@ -124,7 +125,7 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
         // (never the message text), so the template it scaffolds matches exactly what was detected
         // here — same nested-closure exclusion, same combined-modifier expression.
         var modifiers = ModifierExpression(hasControl, hasMenu);
-        var key = FindVirtualKey(body) is { } k ? $"VirtualKey.{k}" : "VirtualKey.<key>";
+        var key = FindVirtualKey(body) is { } k ? $"{KeyEnumName}.{k}" : $"{KeyEnumName}.<key>";
 
         var properties = ImmutableDictionary<string, string?>.Empty
             .Add(ModifiersProperty, modifiers)
@@ -134,7 +135,8 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
             Rule,
             invocation.GetLocation(),
             properties,
-            modifiers));
+            modifiers,
+            key));
     }
 
     /// <summary>
@@ -196,7 +198,8 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
 
     /// <summary>
     /// The name of the first <c>VirtualKey.&lt;X&gt;</c> the handler's own body references (nested
-    /// closures excluded), or <c>null</c> when none is present.
+    /// closures excluded), or <c>null</c> when none is present. Recognizes both the bare
+    /// <c>VirtualKey.S</c> and the qualified <c>Windows.System.VirtualKey.S</c> receiver forms.
     /// </summary>
     private static string? FindVirtualKey(SyntaxNode body)
     {
@@ -204,7 +207,7 @@ public sealed class OnKeyDownChordAnalyzer : DiagnosticAnalyzer
         {
             if (IsInsideNestedFunction(access, body))
                 continue;
-            if (access.Expression is IdentifierNameSyntax { Identifier.Text: "VirtualKey" })
+            if (ReceiverName(access.Expression) == KeyEnumName)
                 return access.Name.Identifier.Text;
         }
         return null;

--- a/src/Reactor.Analyzers/OnKeyDownChordCodeFix.cs
+++ b/src/Reactor.Analyzers/OnKeyDownChordCodeFix.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -20,14 +19,18 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// element), its <c>Execute</c> body has to be lifted out of a handler that closes over the event
 /// args, and only the author knows the command's label/scope. There is therefore no safe, fully
 /// mechanical rewrite. This fix is a <b>template/preview</b>: it appends a single-line scaffold
-/// comment to the offending call — extracting the concrete <c>VirtualKey</c> and the Ctrl/Alt
-/// modifier(s) it detected — that shows the exact <c>new Command { …, Accelerator =
-/// Accelerator(VirtualKey.S, VirtualKeyModifiers.Control) }</c> shape to write.
+/// comment to the offending call showing the exact <c>new Command { …, Accelerator =
+/// Accelerator(VirtualKey.S, VirtualKeyModifiers.Control) }</c> shape to write. The concrete
+/// <c>VirtualKey</c> and the full Ctrl/Alt modifier set come from <see cref="Diagnostic.Properties"/>
+/// (populated by the analyzer), so the scaffold matches exactly what was detected — including the
+/// analyzer's nested-closure exclusion.
 /// </para>
 /// <para>
 /// The fix is deliberately <b>additive</b>: it never edits executable code, so it can never drop a
 /// handler's other key handling, break compilation on any receiver, or change runtime behavior. The
 /// warning persists until the author migrates the shortcut and removes the <c>.OnKeyDown</c> chord.
+/// Applying it is <b>idempotent</b>: it is not offered again once a scaffold is already present, so
+/// re-invoking never stacks duplicate comments.
 /// </para>
 /// </remarks>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OnKeyDownChordCodeFix))]
@@ -51,13 +54,13 @@ public sealed class OnKeyDownChordCodeFix : CodeFixProvider
             var node = root.FindNode(diagnostic.Location.SourceSpan);
             if (node is not InvocationExpressionSyntax invocation) continue;
             if (invocation.Expression is not MemberAccessExpressionSyntax { Name.Identifier.Text: "OnKeyDown" }) continue;
-            if (invocation.ArgumentList.Arguments.Count != 1) continue;
-            if (invocation.ArgumentList.Arguments[0].Expression is not LambdaExpressionSyntax lambda) continue;
 
-            var body = lambda.Body;
-            if (body is null) continue;
+            // Idempotency: if a REACTOR_INPUT_001 scaffold is already appended to this call, don't
+            // offer the fix again — re-applying would otherwise stack duplicate comments.
+            if (invocation.GetTrailingTrivia().ToFullString().Contains(OnKeyDownChordAnalyzer.DiagnosticId))
+                continue;
 
-            var comment = BuildScaffoldComment(body);
+            var comment = BuildScaffoldComment(diagnostic);
 
             context.RegisterCodeFix(
                 CodeAction.Create(
@@ -79,63 +82,22 @@ public sealed class OnKeyDownChordCodeFix : CodeFixProvider
     }
 
     /// <summary>
-    /// Builds the single-line block-comment scaffold, filling in the concrete <c>VirtualKey</c>
-    /// (from the first <c>VirtualKey.&lt;X&gt;</c> the lambda references) and the Ctrl/Alt
-    /// modifier expression (<c>VirtualKeyModifiers.Control</c>, <c>.Menu</c>, or both).
+    /// Builds the single-line block-comment scaffold using the concrete <c>VirtualKey</c> and the
+    /// full Ctrl/Alt modifier expression the analyzer detected (handed over via
+    /// <see cref="Diagnostic.Properties"/>). Falls back to safe defaults if a property is absent.
     /// </summary>
-    private static string BuildScaffoldComment(SyntaxNode body)
+    private static string BuildScaffoldComment(Diagnostic diagnostic)
     {
-        var key = ExtractVirtualKey(body) is { } k ? $"VirtualKey.{k}" : "VirtualKey.<key>";
-        var modifiers = BuildModifierExpression(body);
+        var key = Property(diagnostic, OnKeyDownChordAnalyzer.KeyProperty, "VirtualKey.<key>");
+        var modifiers = Property(diagnostic, OnKeyDownChordAnalyzer.ModifiersProperty, "VirtualKeyModifiers.Control");
 
         return $"/* REACTOR_INPUT_001: .OnKeyDown is focus-scoped. Register this shortcut app-wide as a " +
                $"Command accelerator instead, e.g. new Command {{ Label = <name>, Execute = <handler>, " +
                $"Accelerator = Accelerator({key}, {modifiers}) }}, then remove this .OnKeyDown chord. */";
     }
 
-    /// <summary>Name of the first <c>VirtualKey.&lt;X&gt;</c> the lambda body references, or null.</summary>
-    private static string? ExtractVirtualKey(SyntaxNode body)
-    {
-        foreach (var access in body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
-        {
-            if (access.Expression is IdentifierNameSyntax { Identifier.Text: "VirtualKey" })
-                return access.Name.Identifier.Text;
-        }
-        return null;
-    }
-
-    /// <summary>
-    /// The <c>VirtualKeyModifiers</c> expression to seed the template with, reflecting whichever of
-    /// <c>Control</c> / <c>Menu</c> the lambda tests. Defaults to <c>Control</c> if neither is found
-    /// syntactically (the analyzer only fires when at least one bound semantically).
-    /// </summary>
-    private static string BuildModifierExpression(SyntaxNode body)
-    {
-        var hasControl = false;
-        var hasMenu = false;
-
-        foreach (var access in body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
-        {
-            var receiver = access.Expression switch
-            {
-                IdentifierNameSyntax id => id.Identifier.Text,
-                MemberAccessExpressionSyntax m => m.Name.Identifier.Text,
-                _ => null,
-            };
-            if (receiver != "VirtualKeyModifiers") continue;
-
-            switch (access.Name.Identifier.Text)
-            {
-                case "Control": hasControl = true; break;
-                case "Menu": hasMenu = true; break;
-            }
-        }
-
-        return (hasControl, hasMenu) switch
-        {
-            (true, true) => "VirtualKeyModifiers.Control | VirtualKeyModifiers.Menu",
-            (false, true) => "VirtualKeyModifiers.Menu",
-            _ => "VirtualKeyModifiers.Control",
-        };
-    }
+    private static string Property(Diagnostic diagnostic, string name, string fallback) =>
+        diagnostic.Properties.TryGetValue(name, out var value) && !string.IsNullOrEmpty(value)
+            ? value!
+            : fallback;
 }

--- a/src/Reactor.Analyzers/OnKeyDownChordCodeFix.cs
+++ b/src/Reactor.Analyzers/OnKeyDownChordCodeFix.cs
@@ -1,0 +1,141 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Template code fix for <see cref="OnKeyDownChordAnalyzer"/> (<c>REACTOR_INPUT_001</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Rewriting a focus-scoped <c>.OnKeyDown</c> chord into an app-wide <c>Command</c> accelerator is
+/// <b>intent-heavy</b>: the command belongs wherever the app registers its shortcuts (not on the
+/// element), its <c>Execute</c> body has to be lifted out of a handler that closes over the event
+/// args, and only the author knows the command's label/scope. There is therefore no safe, fully
+/// mechanical rewrite. This fix is a <b>template/preview</b>: it appends a single-line scaffold
+/// comment to the offending call — extracting the concrete <c>VirtualKey</c> and the Ctrl/Alt
+/// modifier(s) it detected — that shows the exact <c>new Command { …, Accelerator =
+/// Accelerator(VirtualKey.S, VirtualKeyModifiers.Control) }</c> shape to write.
+/// </para>
+/// <para>
+/// The fix is deliberately <b>additive</b>: it never edits executable code, so it can never drop a
+/// handler's other key handling, break compilation on any receiver, or change runtime behavior. The
+/// warning persists until the author migrates the shortcut and removes the <c>.OnKeyDown</c> chord.
+/// </para>
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OnKeyDownChordCodeFix))]
+[Shared]
+public sealed class OnKeyDownChordCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(OnKeyDownChordAnalyzer.DiagnosticId);
+
+    // No FixAll: the scaffold is per-call context (each handler's key/modifiers differ), and the
+    // fix is a template preview rather than a mechanical rewrite, so "fix all" carries no benefit.
+    public override FixAllProvider? GetFixAllProvider() => null;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan);
+            if (node is not InvocationExpressionSyntax invocation) continue;
+            if (invocation.Expression is not MemberAccessExpressionSyntax { Name.Identifier.Text: "OnKeyDown" }) continue;
+            if (invocation.ArgumentList.Arguments.Count != 1) continue;
+            if (invocation.ArgumentList.Arguments[0].Expression is not LambdaExpressionSyntax lambda) continue;
+
+            var body = lambda.Body;
+            if (body is null) continue;
+
+            var comment = BuildScaffoldComment(body);
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Add Command-accelerator template (REACTOR_INPUT_001)",
+                    ct => Task.FromResult(AppendComment(context.Document, root, invocation, comment)),
+                    equivalenceKey: OnKeyDownChordAnalyzer.DiagnosticId),
+                diagnostic);
+        }
+    }
+
+    private static Document AppendComment(Document document, SyntaxNode root, InvocationExpressionSyntax invocation, string comment)
+    {
+        var newTrailing = invocation.GetTrailingTrivia()
+            .Add(SyntaxFactory.Space)
+            .Add(SyntaxFactory.Comment(comment));
+
+        var newInvocation = invocation.WithTrailingTrivia(newTrailing);
+        return document.WithSyntaxRoot(root.ReplaceNode(invocation, newInvocation));
+    }
+
+    /// <summary>
+    /// Builds the single-line block-comment scaffold, filling in the concrete <c>VirtualKey</c>
+    /// (from the first <c>VirtualKey.&lt;X&gt;</c> the lambda references) and the Ctrl/Alt
+    /// modifier expression (<c>VirtualKeyModifiers.Control</c>, <c>.Menu</c>, or both).
+    /// </summary>
+    private static string BuildScaffoldComment(SyntaxNode body)
+    {
+        var key = ExtractVirtualKey(body) is { } k ? $"VirtualKey.{k}" : "VirtualKey.<key>";
+        var modifiers = BuildModifierExpression(body);
+
+        return $"/* REACTOR_INPUT_001: .OnKeyDown is focus-scoped. Register this shortcut app-wide as a " +
+               $"Command accelerator instead, e.g. new Command {{ Label = <name>, Execute = <handler>, " +
+               $"Accelerator = Accelerator({key}, {modifiers}) }}, then remove this .OnKeyDown chord. */";
+    }
+
+    /// <summary>Name of the first <c>VirtualKey.&lt;X&gt;</c> the lambda body references, or null.</summary>
+    private static string? ExtractVirtualKey(SyntaxNode body)
+    {
+        foreach (var access in body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+        {
+            if (access.Expression is IdentifierNameSyntax { Identifier.Text: "VirtualKey" })
+                return access.Name.Identifier.Text;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// The <c>VirtualKeyModifiers</c> expression to seed the template with, reflecting whichever of
+    /// <c>Control</c> / <c>Menu</c> the lambda tests. Defaults to <c>Control</c> if neither is found
+    /// syntactically (the analyzer only fires when at least one bound semantically).
+    /// </summary>
+    private static string BuildModifierExpression(SyntaxNode body)
+    {
+        var hasControl = false;
+        var hasMenu = false;
+
+        foreach (var access in body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+        {
+            var receiver = access.Expression switch
+            {
+                IdentifierNameSyntax id => id.Identifier.Text,
+                MemberAccessExpressionSyntax m => m.Name.Identifier.Text,
+                _ => null,
+            };
+            if (receiver != "VirtualKeyModifiers") continue;
+
+            switch (access.Name.Identifier.Text)
+            {
+                case "Control": hasControl = true; break;
+                case "Menu": hasMenu = true; break;
+            }
+        }
+
+        return (hasControl, hasMenu) switch
+        {
+            (true, true) => "VirtualKeyModifiers.Control | VirtualKeyModifiers.Menu",
+            (false, true) => "VirtualKeyModifiers.Menu",
+            _ => "VirtualKeyModifiers.Control",
+        };
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/OnKeyDownChordAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/OnKeyDownChordAnalyzerTests.cs
@@ -485,6 +485,44 @@ class C
     }
 
     [Fact]
+    public async Task CodeFix_Extracts_Qualified_VirtualKey()
+    {
+        // The tested key uses a qualified receiver (Windows.System.VirtualKey.S); the scaffold still
+        // extracts it (normalized to VirtualKey.S).
+        var before = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == Windows.System.VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Control)) Save(); })|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == Windows.System.VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Control)) Save(); })|} /* REACTOR_INPUT_001: .OnKeyDown is focus-scoped. Register this shortcut app-wide as a Command accelerator instead, e.g. new Command { Label = <name>, Execute = <handler>, Accelerator = Accelerator(VirtualKey.S, VirtualKeyModifiers.Control) }, then remove this .OnKeyDown chord. */;
+    }
+}";
+
+        await new CSharpCodeFixTest<OnKeyDownChordAnalyzer, OnKeyDownChordCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            FixedState = { MarkupHandling = MarkupMode.Allow },
+            NumberOfIncrementalIterations = 1,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task CodeFix_Not_Offered_When_Scaffold_Already_Present()
     {
         // Idempotency: a REACTOR_INPUT_001 scaffold already in the trailing trivia means the fix is

--- a/tests/Reactor.Tests/AnalyzerTests/OnKeyDownChordAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/OnKeyDownChordAnalyzerTests.cs
@@ -19,6 +19,7 @@ public class OnKeyDownChordAnalyzerTests
 using System;
 using Windows.System;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Reactor;
 
 namespace Windows.System
 {
@@ -33,12 +34,16 @@ namespace Microsoft.UI.Xaml.Input
 
 public class FakeElement { }
 
-public static class FakeElementExtensions
+namespace Microsoft.UI.Reactor
 {
-    // Mirrors ElementExtensions.OnKeyDown: (sender, args) shape, returns the element for chaining.
-    public static FakeElement OnKeyDown(this FakeElement el, Action<object, KeyRoutedEventArgs> handler) => el;
-    public static FakeElement OnKeyUp(this FakeElement el, Action<object, KeyRoutedEventArgs> handler) => el;
-    public static FakeElement Margin(this FakeElement el, double v) => el;
+    // Mirrors ElementExtensions (namespace Microsoft.UI.Reactor) so the analyzer's Reactor-namespace
+    // grounding recognizes .OnKeyDown as the real modifier. (sender, args) shape, returns the element.
+    public static class FakeElementExtensions
+    {
+        public static FakeElement OnKeyDown(this FakeElement el, Action<object, KeyRoutedEventArgs> handler) => el;
+        public static FakeElement OnKeyUp(this FakeElement el, Action<object, KeyRoutedEventArgs> handler) => el;
+        public static FakeElement Margin(this FakeElement el, double v) => el;
+    }
 }
 ";
 
@@ -229,17 +234,22 @@ class C
     public async Task No_Diagnostic_For_Same_Named_LookAlike_Enum()
     {
         // Semantic guard: a look-alike enum also named 'VirtualKeyModifiers' but NOT in
-        // Windows.System must not trip the rule. Stand-alone source (no Windows.System stub) so the
-        // only 'VirtualKeyModifiers' in scope is the local look-alike.
+        // Windows.System must not trip the rule. .OnKeyDown is Reactor-grounded here, so the enum
+        // guard is the *only* thing that suppresses the diagnostic (isolates that check).
         var source = @"
 using System;
+using Microsoft.UI.Reactor;
 
 public enum VirtualKeyModifiers { None, Control, Menu }
 
 public class FakeElement { }
-public static class Ext
+
+namespace Microsoft.UI.Reactor
 {
-    public static FakeElement OnKeyDown(this FakeElement el, Action<object> handler) => el;
+    public static class Ext
+    {
+        public static FakeElement OnKeyDown(this FakeElement el, Action<object> handler) => el;
+    }
 }
 
 class C
@@ -248,6 +258,71 @@ class C
     {
         var el = new FakeElement();
         el.OnKeyDown(s => { if (VirtualKeyModifiers.Control == VirtualKeyModifiers.Menu) { } });
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Non_Reactor_OnKeyDown()
+    {
+        // Grounding guard: a same-named `.OnKeyDown` from a non-Reactor namespace, even with a real
+        // Windows.System Ctrl chord in its lambda, is an unrelated API — must not fire.
+        var source = @"
+using System;
+using Windows.System;
+using ThirdParty;
+
+namespace Windows.System
+{
+    public enum VirtualKey { S }
+    [Flags] public enum VirtualKeyModifiers { None = 0, Control = 1 }
+}
+
+public class Widget { }
+
+namespace ThirdParty
+{
+    public static class WidgetExt
+    {
+        public static Widget OnKeyDown(this Widget w, Action<object> handler) => w;
+        public static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    }
+}
+
+class C
+{
+    void M()
+    {
+        var w = new Widget();
+        w.OnKeyDown(e => { if (WidgetExt.Mods().HasFlag(VirtualKeyModifiers.Control)) {} });
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Chord_In_Nested_Closure()
+    {
+        // Precision: the OnKeyDown handler's own body has no chord; the VirtualKeyModifiers.Control
+        // test lives inside a nested closure (a different callback) and must not count.
+        var source = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    Action Register = () => {};
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnKeyDown((s, e) => { Register = () => { if (Mods().HasFlag(VirtualKeyModifiers.Control)) {} }; });
     }
 }";
 
@@ -322,6 +397,81 @@ class C
     {
         var el = new FakeElement();
         {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.F && Mods().HasFlag(VirtualKeyModifiers.Menu)) Find(); })|} /* REACTOR_INPUT_001: .OnKeyDown is focus-scoped. Register this shortcut app-wide as a Command accelerator instead, e.g. new Command { Label = <name>, Execute = <handler>, Accelerator = Accelerator(VirtualKey.F, VirtualKeyModifiers.Menu) }, then remove this .OnKeyDown chord. */;
+    }
+}";
+
+        await new CSharpCodeFixTest<OnKeyDownChordAnalyzer, OnKeyDownChordCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            FixedState = { MarkupHandling = MarkupMode.Allow },
+            NumberOfIncrementalIterations = 1,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Uses_Key_Placeholder_When_No_VirtualKey_Present()
+    {
+        // The chord fires from the modifier alone; no VirtualKey.<X> to extract, so the scaffold
+        // keeps the <key> placeholder.
+        var before = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (Mods().HasFlag(VirtualKeyModifiers.Control)) Save(); })|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (Mods().HasFlag(VirtualKeyModifiers.Control)) Save(); })|} /* REACTOR_INPUT_001: .OnKeyDown is focus-scoped. Register this shortcut app-wide as a Command accelerator instead, e.g. new Command { Label = <name>, Execute = <handler>, Accelerator = Accelerator(VirtualKey.<key>, VirtualKeyModifiers.Control) }, then remove this .OnKeyDown chord. */;
+    }
+}";
+
+        await new CSharpCodeFixTest<OnKeyDownChordAnalyzer, OnKeyDownChordCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            FixedState = { MarkupHandling = MarkupMode.Allow },
+            NumberOfIncrementalIterations = 1,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Appends_Combined_Control_And_Menu_Template()
+    {
+        // Both modifiers tested → the scaffold seeds the combined VirtualKeyModifiers expression.
+        var before = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Do() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Control) && Mods().HasFlag(VirtualKeyModifiers.Menu)) Do(); })|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Do() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Control) && Mods().HasFlag(VirtualKeyModifiers.Menu)) Do(); })|} /* REACTOR_INPUT_001: .OnKeyDown is focus-scoped. Register this shortcut app-wide as a Command accelerator instead, e.g. new Command { Label = <name>, Execute = <handler>, Accelerator = Accelerator(VirtualKey.S, VirtualKeyModifiers.Control | VirtualKeyModifiers.Menu) }, then remove this .OnKeyDown chord. */;
     }
 }";
 

--- a/tests/Reactor.Tests/AnalyzerTests/OnKeyDownChordAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/OnKeyDownChordAnalyzerTests.cs
@@ -1,0 +1,336 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="OnKeyDownChordAnalyzer"/> (<c>REACTOR_INPUT_001</c>) and its template
+/// <see cref="OnKeyDownChordCodeFix"/>. Stubs a minimal Reactor-shaped <c>.OnKeyDown((s, e) =&gt; …)</c>
+/// fluent modifier plus the real <c>Windows.System.VirtualKey</c> / <c>VirtualKeyModifiers</c> enum
+/// shapes so the analyzer's syntactic match and its <c>VirtualKeyModifiers</c> semantic guard fire
+/// without pulling the framework in.
+/// </summary>
+public class OnKeyDownChordAnalyzerTests
+{
+    private const string Stubs = @"
+using System;
+using Windows.System;
+using Microsoft.UI.Xaml.Input;
+
+namespace Windows.System
+{
+    public enum VirtualKey { None, S, F, Enter, Shift, Control }
+    [Flags] public enum VirtualKeyModifiers { None = 0, Control = 1, Menu = 2, Shift = 4, Windows = 8 }
+}
+
+namespace Microsoft.UI.Xaml.Input
+{
+    public class KeyRoutedEventArgs { public Windows.System.VirtualKey Key { get; set; } }
+}
+
+public class FakeElement { }
+
+public static class FakeElementExtensions
+{
+    // Mirrors ElementExtensions.OnKeyDown: (sender, args) shape, returns the element for chaining.
+    public static FakeElement OnKeyDown(this FakeElement el, Action<object, KeyRoutedEventArgs> handler) => el;
+    public static FakeElement OnKeyUp(this FakeElement el, Action<object, KeyRoutedEventArgs> handler) => el;
+    public static FakeElement Margin(this FakeElement el, double v) => el;
+}
+";
+
+    // ── Positive ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Fires_For_Control_Chord()
+    {
+        var source = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Control)) Save(); })|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Menu_Alt_Chord()
+    {
+        var source = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Find() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.F && Mods().HasFlag(VirtualKeyModifiers.Menu)) Find(); })|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Control_And_Menu_Chord()
+    {
+        var source = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Do() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (Mods().HasFlag(VirtualKeyModifiers.Control) && Mods().HasFlag(VirtualKeyModifiers.Menu)) Do(); })|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Qualified_Modifier_Reference()
+    {
+        // Windows.System.VirtualKeyModifiers.Control — the qualified receiver still resolves.
+        var source = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.S && Mods().HasFlag(Windows.System.VirtualKeyModifiers.Control)) Save(); })|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Handler_Without_Modifier()
+    {
+        // A plain key handler (no Ctrl/Alt chord) is a legitimate, focus-scoped use of .OnKeyDown.
+        var source = Stubs + @"
+class C
+{
+    void Activate() {}
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.Enter) Activate(); });
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Near-miss: almost trips the fast path ───────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Shift_Only_Chord()
+    {
+        // Near-miss: a .OnKeyDown lambda that DOES reference VirtualKeyModifiers, but Shift — not the
+        // Ctrl/Alt app-accelerator footgun. Must not fire (spec: Control/Menu only).
+        var source = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Shift)) Save(); });
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_OnKeyUp_Chord()
+    {
+        // Near-miss: same chord shape but on .OnKeyUp, which is not the matched modifier.
+        var source = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnKeyUp((s, e) => { if (e.Key == VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Control)) Save(); });
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Method_Group_Handler()
+    {
+        // A method-group handler is out of scope — the analyzer only inspects lambda bodies.
+        var source = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void Handler(object s, KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Control)) Save();
+    }
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnKeyDown(Handler);
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Same_Named_LookAlike_Enum()
+    {
+        // Semantic guard: a look-alike enum also named 'VirtualKeyModifiers' but NOT in
+        // Windows.System must not trip the rule. Stand-alone source (no Windows.System stub) so the
+        // only 'VirtualKeyModifiers' in scope is the local look-alike.
+        var source = @"
+using System;
+
+public enum VirtualKeyModifiers { None, Control, Menu }
+
+public class FakeElement { }
+public static class Ext
+{
+    public static FakeElement OnKeyDown(this FakeElement el, Action<object> handler) => el;
+}
+
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnKeyDown(s => { if (VirtualKeyModifiers.Control == VirtualKeyModifiers.Menu) { } });
+    }
+}";
+
+        await new CSharpAnalyzerTest<OnKeyDownChordAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Template code fix (additive scaffold; diagnostic persists) ───────
+
+    [Fact]
+    public async Task CodeFix_Appends_Control_Template()
+    {
+        var before = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Control)) Save(); })|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Control)) Save(); })|} /* REACTOR_INPUT_001: .OnKeyDown is focus-scoped. Register this shortcut app-wide as a Command accelerator instead, e.g. new Command { Label = <name>, Execute = <handler>, Accelerator = Accelerator(VirtualKey.S, VirtualKeyModifiers.Control) }, then remove this .OnKeyDown chord. */;
+    }
+}";
+
+        await new CSharpCodeFixTest<OnKeyDownChordAnalyzer, OnKeyDownChordCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            // Additive template preview: the fix annotates rather than resolves, so the warning
+            // intentionally persists after the fix. MarkupMode.Allow keeps the (still-fixable)
+            // diagnostic declared in FixedCode from being stripped; one incremental pass applies it.
+            FixedState = { MarkupHandling = MarkupMode.Allow },
+            NumberOfIncrementalIterations = 1,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Appends_Menu_Template_With_Extracted_Key()
+    {
+        var before = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Find() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.F && Mods().HasFlag(VirtualKeyModifiers.Menu)) Find(); })|};
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Find() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.F && Mods().HasFlag(VirtualKeyModifiers.Menu)) Find(); })|} /* REACTOR_INPUT_001: .OnKeyDown is focus-scoped. Register this shortcut app-wide as a Command accelerator instead, e.g. new Command { Label = <name>, Execute = <handler>, Accelerator = Accelerator(VirtualKey.F, VirtualKeyModifiers.Menu) }, then remove this .OnKeyDown chord. */;
+    }
+}";
+
+        await new CSharpCodeFixTest<OnKeyDownChordAnalyzer, OnKeyDownChordCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            FixedState = { MarkupHandling = MarkupMode.Allow },
+            NumberOfIncrementalIterations = 1,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/OnKeyDownChordAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/OnKeyDownChordAnalyzerTests.cs
@@ -483,4 +483,28 @@ class C
             NumberOfIncrementalIterations = 1,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task CodeFix_Not_Offered_When_Scaffold_Already_Present()
+    {
+        // Idempotency: a REACTOR_INPUT_001 scaffold already in the trailing trivia means the fix is
+        // not offered again, so re-applying never stacks duplicate comments (the warning still fires).
+        var code = Stubs + @"
+class C
+{
+    static VirtualKeyModifiers Mods() => VirtualKeyModifiers.None;
+    void Save() {}
+    void M()
+    {
+        var el = new FakeElement();
+        {|REACTOR_INPUT_001:el.OnKeyDown((s, e) => { if (e.Key == VirtualKey.S && Mods().HasFlag(VirtualKeyModifiers.Control)) Save(); })|} /* REACTOR_INPUT_001: already scaffolded */;
+    }
+}";
+
+        await new CSharpCodeFixTest<OnKeyDownChordAnalyzer, OnKeyDownChordCodeFix, DefaultVerifier>
+        {
+            TestCode = code,
+            FixedCode = code,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }


### PR DESCRIPTION
Implements spec 060 Batch 2 (§12) packet **REACTOR_INPUT_001** (Reactor.Input, Warning, ships a template fix). Stacked on the foundation branch `azchohfi-spec-060-analyzer-suite`.

## Rule
Flags a focus-scoped Ctrl/Alt chord tested inside a `.OnKeyDown((s, e) => …)` lambda. Because `.OnKeyDown` only fires while the element has focus, a hand-rolled app-wide shortcut (e.g. Ctrl+S) fires nowhere else and never reaches `AccessKeyManager`. The fix is to register the shortcut as a `Command` whose `Accelerator = Accelerator(VirtualKey.S, VirtualKeyModifiers.Control)`.

## Premise + API verification (done first, per the packet)
All cited APIs match source, so no premise error:
- `Command` exposes `Accelerator` (`KeyboardAcceleratorData?`) and `AccessKey` (`string?`) — **no** `AccessKeyModifiers` member (`Command.cs:76-80`). The shipped doc `input-and-gestures.md:627` even shows the non-existent `AccessKeyModifiers`, confirming the spec's warning.
- Chord helper `Accelerator(VirtualKey, VirtualKeyModifiers modifiers = None)` (`Dsl.cs:1935`).
- `.OnKeyDown<T>(this T, Action<object, KeyRoutedEventArgs>)` — the `(sender, args)` shape (`ElementExtensions.cs:230`).

## Detection
Syntactic gate (`InvocationExpression`): `.OnKeyDown` + exactly one lambda arg + the lambda body references `VirtualKeyModifiers.Control` / `.Menu`. A single semantic check then confirms the member binds to the real `Windows.System.VirtualKeyModifiers` (a same-named look-alike enum is suppressed). Shift-only chords, modifier-free handlers, `.OnKeyUp`, and method-group handlers are all left alone.

## Template code fix
Intent-heavy (the command belongs at app scope, its `Execute` closes over the event args), so there is no safe mechanical rewrite. The fix is **additive**: it appends a single-line scaffold comment showing the canonical `new Command { …, Accelerator = Accelerator(VirtualKey.<X>, VirtualKeyModifiers.Control) }` (extracting the concrete key + Control/Menu). It never edits executable code, so it can't drop other handling, break compilation, or change behavior; the warning persists until the author migrates.

## Tests (11, all green)
Positive: Control, Menu/Alt, Control+Menu, qualified `Windows.System.VirtualKeyModifiers.Control`. Negative: handler with no modifier. Near-miss: Shift-only, `.OnKeyUp` chord, method-group handler. Semantic guard: same-named look-alike enum. Plus two code-fix round-trips.

`dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~AnalyzerTests` → **226 passed**.

## Also updated
Canonical `AnalyzerReleases.Unshipped.md` row, `analyzer-architecture.md.dt` rules-table row, and the `reactor-build-and-check` cheat-table row.

## Samples sweep
Every `VirtualKeyModifiers.Control/.Menu` in `samples/` is already the correct `Accelerator(...)` on a `Command` — none are `.OnKeyDown` chords, so no false positives (firing nowhere is expected here; samples already use the good form).