### PR TITLE
feat(analyzer): REACTOR_PERF_FUNCREF — memoize inline Command in Render

### DIFF
--- a/docs/_pipeline/apps/commanding/App.cs
+++ b/docs/_pipeline/apps/commanding/App.cs
@@ -238,15 +238,14 @@ class AsyncWithProgressExample : Component
 // </snippet:async-with-progress>
 
 // <snippet:dont-create-in-render>
-// Don't: re-create the Command on every render — every surface that
-// holds the previous reference sees a fresh identity each frame, which
-// thrashes the WinUI keyboard-accelerator wiring and re-renders every
-// consumer. Lift to a memo or hoist out of Render().
+// Don't: re-create the Command on every render — each render allocates a
+// fresh command record (and its captured closures). Memoizing keeps a
+// stable instance across renders. Lift to a memo or hoist out of Render().
 class DontCreateInRender : Component
 {
     public override Element Render()
     {
-        // BAD — Command identity churns every render:
+        // BAD — a fresh Command (and closure) is allocated every render:
         // var save = new Command { Label = "Save", Execute = () => { } };
 
         // GOOD — UseMemo pins identity until deps change:

--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,6 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_PERF_FUNCREF` | Info | `new Command { … }` constructed inline in the render path without `UseMemo` (re-allocated every render) | `MemoizeCommandAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/docs/_pipeline/templates/commanding.md.dt
+++ b/docs/_pipeline/templates/commanding.md.dt
@@ -430,7 +430,7 @@ return VStack(0,
 ```
 
 Re-creating the `Command` record every render allocates a fresh command
-(and its captured closures) each frame. Where a host rebuilds keyboard
+(and its captured closures). Where a host rebuilds keyboard
 accelerators on reconcile it *clears and re-adds* them — a bounded rewire,
 not an unbounded leak — and a command bound to a button is diffed by
 *value*, so a fresh-but-equal command re-applies nothing. The avoidable

--- a/docs/_pipeline/templates/commanding.md.dt
+++ b/docs/_pipeline/templates/commanding.md.dt
@@ -429,12 +429,15 @@ return VStack(0,
 ```csharp snippet="commanding/dont-create-in-render"
 ```
 
-Re-creating the `Command` record every frame creates a fresh
-`KeyboardAccelerator` and forces every consumer to re-render. The
-window's accelerator table grows without bound on rapid re-renders and
-the analyzer fires `REACTOR_PERF_FUNCREF` for the inline lambda
-identity. Wrap the construction in [`UseMemo`](hooks.md) with the
-correct dependencies, or hoist the command above the component.
+Re-creating the `Command` record every render allocates a fresh command
+(and its captured closures) each frame. Where a host rebuilds keyboard
+accelerators on reconcile it *clears and re-adds* them — a bounded rewire,
+not an unbounded leak — and a command bound to a button is diffed by
+*value*, so a fresh-but-equal command re-applies nothing. The avoidable
+cost is simply the per-render allocation, and the analyzer fires
+`REACTOR_PERF_FUNCREF` for the inline construction. Wrap it in
+[`UseMemo`](hooks.md) with the correct dependencies, or hoist the command
+above the component.
 
 ### Ignoring CanExecute changes
 

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -81,6 +81,7 @@ Additional flags:
 | `REACTOR_HOOKS_006` | info | `UseResource` fetcher looks non-idempotent (`Post*`/`Create*`/`Delete*`/`Save*`) | Use `UseMutation` for writes — `UseResource` re-runs on deps change, retry, focus revalidation. |
 | `REACTOR_HOOKS_007` | warning | `UseMemoCells` builder closure missing dependencies | Add the captured variable to the deps array. |
 | `REACTOR_HOOKS_009` | warning | `Command.DebounceMs` set on a command bound without `UseCommand` | Route it through `UseCommand`: `var cmd = UseCommand(new Command { …, DebounceMs = 1500 });`. The debounce window lives in the hook store, so a raw bound `Command` never debounces. |
+| `REACTOR_PERF_FUNCREF` | info | `new Command { … }` built inline in `Render()`/a `Use*` hook (re-allocated every render) | Wrap it: `var save = UseMemo(() => new Command { … }, deps);` to keep a stable instance across renders. Pure allocation hygiene — deps are the render values the command captures. |
 | `REACTOR_DSL_001` | warning | `Select(...)` projecting into a layout container without `.WithKey(...)` | `items.Select(i => Row(i).WithKey(i.Id)).ToArray<Element?>()`. Keys keep focus + animation state across reorders. |
 | `REACTOR_THEME_001` | warning | Hardcoded color on a themed surface | Use `Theme.*` tokens (e.g. `Theme.PrimaryText`, `Theme.CardBackground`). See `reactor-design`. |
 | `REACTOR_THEME_002` | info | Lightweight styling opportunity | Optional. Use `.Resources(r => r.Set("ButtonBackground", …))` for visual-state overrides. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_PERF_FUNCREF | Reactor.Performance | Info | MemoizeCommandAnalyzer - Command constructed inline in the render path is re-allocated every render; wrap it in UseMemo

--- a/src/Reactor.Analyzers/MemoizeCommandAnalyzer.cs
+++ b/src/Reactor.Analyzers/MemoizeCommandAnalyzer.cs
@@ -1,0 +1,232 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_PERF_FUNCREF</c> — flags a <c>new Command { … }</c> / <c>new Command&lt;T&gt; { … }</c>
+/// object-creation evaluated directly in a component's render path (a <c>Render()</c> override or a
+/// custom <c>Use*</c> hook method) that is <b>not</b> wrapped in <c>UseMemo</c>/<c>UseCommand</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Constructing a <c>Command</c> inline in the render path allocates a fresh command record — and
+/// its captured closures — on every render. Wrapping the construction in
+/// <c>UseMemo(() =&gt; new Command { … }, deps)</c> keeps a stable instance across renders until its
+/// dependencies change. This is a pure allocation/identity-hygiene nudge, directly analogous to
+/// <see cref="HookRulesAnalyzer"/>'s <c>REACTOR_HOOKS_004</c> (a freshly-allocated value in a
+/// render-path expression). It ships at <see cref="DiagnosticSeverity.Info"/>.
+/// </para>
+/// <para>
+/// The message is deliberately scoped to the allocation/identity concern and does <b>not</b> claim
+/// keyboard-accelerator "rewire churn" or an unbounded accelerator-table "leak": the framework
+/// diffs a bound command by <em>value</em> (<c>CommandBindings.CommandModuloDelegatesComparer</c>,
+/// applied through the <c>OneWay</c> descriptor which skips its setter when the comparer reports
+/// equal), so a fresh-but-equal command does not re-apply accelerator metadata; and where a host
+/// does rebuild accelerators each reconcile (<c>CompositeLifecycle.UpdateCommandHost</c>) it clears
+/// and re-adds — bounded, not a leak, and unaffected by memoizing the command. The verified,
+/// defensible win of memoizing is avoiding the per-render allocation. (spec 060 §12 / commanding.md.)
+/// </para>
+/// <para>
+/// Detection is syntactic-first: only an explicit <c>new Command</c>/<c>new Command&lt;T&gt;</c> (by
+/// name) or an implicit <c>new() { … }</c> that resolves to the Reactor <c>Command</c> type, lexically
+/// inside a <c>Render()</c>/<c>Use*</c> method and <b>not</b> nested inside a deferred lambda /
+/// local-function (event handlers, effect bodies, and the <c>UseMemo</c> factory lambda itself all
+/// run off the render tick — so a command built there is not a per-render allocation, and the
+/// <c>UseMemo</c> factory case is exactly the recommended fix). Commands that set an active
+/// <c>DebounceMs</c> are ceded to <c>REACTOR_HOOKS_009</c> (they must go through <c>UseCommand</c>,
+/// not <c>UseMemo</c>), and a command that is a direct argument to <c>UseCommand(...)</c> is left
+/// alone so the two command rules never give conflicting advice.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MemoizeCommandAnalyzer : DiagnosticAnalyzer
+{
+    public const string Id = "REACTOR_PERF_FUNCREF";
+
+    private const string CommandNamespace = "Microsoft.UI.Reactor.Core";
+    private const string UseCommandName = "UseCommand";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        Id,
+        "Command constructed in the render path should be memoized",
+        "This {0} is constructed in the render path and re-allocated every render; wrap it in UseMemo(() => new {0} {{ … }}, deps) to keep a stable instance across renders",
+        "Reactor.Performance",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Constructing a Command with new Command { … } inside a component's render path (a Render() override or a custom Use* hook) allocates a fresh command record — and its captured closures — on every render. Wrapping the construction in UseMemo(() => new Command { … }, deps) keeps a stable instance across renders until its dependencies change (analogous to REACTOR_HOOKS_004). Commands already wrapped in UseMemo/UseCommand, deferred inside an event handler or effect lambda, or built outside the render path are left alone.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(
+            Analyze,
+            SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.ImplicitObjectCreationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext ctx)
+    {
+        var node = (ExpressionSyntax)ctx.Node;
+
+        // Cheap syntactic gate: an explicit `new Command`/`new Command<T>` by name. An implicit
+        // `new() { … }` carries no type syntax, so it falls through to the semantic check below.
+        if (node is ObjectCreationExpressionSyntax oce && !IsCommandTypeName(oce.Type))
+            return;
+
+        // Must be evaluated directly in the render path: inside a Render()/Use* method body, and in a
+        // position where a hook could legally be introduced — i.e. not deferred into a nested lambda /
+        // local function (event handlers, effect bodies, LINQ projections and the UseMemo factory
+        // lambda itself run off the render tick) and not inside a conditional / loop / try where a
+        // UseMemo would violate the rules-of-hooks (REACTOR_HOOKS_001). This keeps the offered fix
+        // legal and mirrors HookRulesAnalyzer.FindConditionalAncestor's boundary set.
+        var method = node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (!IsRenderOrCustomHook(method)) return;
+        if (CrossesHookIllegalBoundary(node, method!)) return;
+
+        // Confirm the Reactor Command type — the single semantic call, after the cheap syntactic gates.
+        var type = ctx.SemanticModel.GetTypeInfo(node, ctx.CancellationToken).Type;
+        if (!IsReactorCommandType(type)) return;
+
+        // Cede debounced commands to REACTOR_HOOKS_009 (CommandDebounceAnalyzer): a non-zero
+        // DebounceMs only works through UseCommand — not UseMemo — so that rule owns them. Without
+        // this, `new Command { …, DebounceMs = 1500 }` bound raw in Render would draw BOTH a HOOKS_009
+        // warning (route through UseCommand) and this Info nudge (memoize), i.e. conflicting advice.
+        if (SetsActiveDebounce(GetInitializer(node), ctx)) return;
+
+        // A command that is a direct argument to a Reactor UseCommand(...) is left alone: the author
+        // has engaged the command lifecycle, and HOOKS_009's own code fix produces exactly this shape.
+        // Accepted false negative: UseCommand returns a plain sync command UNCHANGED
+        // (RenderContext.UseCommand), so the allocation technically remains — but suppressing keeps the
+        // two command rules from fighting, which is the lower-false-positive, more-consistent choice.
+        if (IsDirectArgumentToUseCommand(node, ctx)) return;
+
+        var label = type is INamedTypeSymbol { IsGenericType: true } ? "Command<T>" : "Command";
+        ctx.ReportDiagnostic(Diagnostic.Create(Rule, node.GetLocation(), label));
+    }
+
+    // Explicit `new Command { … }` / `new Command<T> { … }` — match the simple, generic, qualified
+    // (`Core.Command`), and alias-qualified spellings by their final identifier.
+    private static bool IsCommandTypeName(TypeSyntax type) => type switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText == "Command",
+        GenericNameSyntax g => g.Identifier.ValueText == "Command",
+        QualifiedNameSyntax q => IsCommandTypeName(q.Right),
+        AliasQualifiedNameSyntax a => IsCommandTypeName(a.Name),
+        _ => false,
+    };
+
+    private static bool IsRenderOrCustomHook(MethodDeclarationSyntax? method)
+    {
+        if (method is null) return false;
+        var name = method.Identifier.ValueText;
+        // A Render() override, or a custom-hook method by convention (UseXxx). Mirrors
+        // HookRulesAnalyzer.IsRenderOrCustomHook / LooksLikeHook.
+        return name == "Render" || (name.Length > 3 && name.StartsWith("Use", System.StringComparison.Ordinal) && char.IsUpper(name[3]));
+    }
+
+    // True when any ancestor between <paramref name="node"/> and its enclosing <paramref name="method"/>
+    // is a construct where a hook could not legally be introduced — a lambda / anonymous method /
+    // local function (deferred, so the construction is not a per-render allocation), or a conditional
+    // / loop / switch / try (where wrapping in UseMemo would violate the rules-of-hooks). Mirrors the
+    // boundary set of HookRulesAnalyzer.FindConditionalAncestor so the rule fires only where the
+    // offered UseMemo fix is both meaningful and legal.
+    private static bool CrossesHookIllegalBoundary(SyntaxNode node, MethodDeclarationSyntax method)
+    {
+        for (var n = node.Parent; n is not null && n != method; n = n.Parent)
+        {
+            switch (n)
+            {
+                case SimpleLambdaExpressionSyntax:
+                case ParenthesizedLambdaExpressionSyntax:
+                case AnonymousMethodExpressionSyntax:
+                case LocalFunctionStatementSyntax:
+                case IfStatementSyntax:
+                case ElseClauseSyntax:
+                case ForStatementSyntax:
+                case ForEachStatementSyntax:
+                case WhileStatementSyntax:
+                case DoStatementSyntax:
+                case SwitchStatementSyntax:
+                case SwitchSectionSyntax:
+                case TryStatementSyntax:
+                case CatchClauseSyntax:
+                case FinallyClauseSyntax:
+                case ConditionalExpressionSyntax:
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool IsReactorCommandType(ITypeSymbol? type) =>
+        type is INamedTypeSymbol { Name: "Command" } named
+            && named.ContainingNamespace?.ToDisplayString() == CommandNamespace;
+
+    private static InitializerExpressionSyntax? GetInitializer(ExpressionSyntax node) => node switch
+    {
+        ObjectCreationExpressionSyntax o => o.Initializer,
+        ImplicitObjectCreationExpressionSyntax i => i.Initializer,
+        _ => null,
+    };
+
+    // True when the initializer sets a DebounceMs that is not a constant &lt;= 0 — i.e. the command
+    // is in REACTOR_HOOKS_009's domain (a non-zero or dynamic leading-edge debounce that only works
+    // through UseCommand). Mirrors CommandDebounceAnalyzer's DebounceMs gate so the two rules divide
+    // cleanly. DebounceMs absent, or an explicit constant 0/negative (no debounce), does not suppress.
+    private static bool SetsActiveDebounce(InitializerExpressionSyntax? initializer, SyntaxNodeAnalysisContext ctx)
+    {
+        if (initializer is null) return false;
+        var debounce = initializer.Expressions
+            .OfType<AssignmentExpressionSyntax>()
+            .FirstOrDefault(static a => a.Left is IdentifierNameSyntax { Identifier.ValueText: "DebounceMs" });
+        if (debounce is null) return false;
+
+        var constant = ctx.SemanticModel.GetConstantValue(debounce.Right, ctx.CancellationToken);
+        if (constant.HasValue && constant.Value is int ms && ms <= 0) return false;
+        return true;
+    }
+
+    // True when <paramref name="node"/> is passed directly as an argument to a Reactor UseCommand(...)
+    // call — `UseCommand(new Command { … })`. Climbs enclosing parentheses so `UseCommand((cmd))` still
+    // counts. When Roslyn resolves the callee it must live in a Reactor namespace (the Component /
+    // RenderContext hook); when symbol info is unavailable (incomplete code mid-edit) we fall back to
+    // trusting the name match, matching CommandDebounceAnalyzer's conservative behaviour.
+    private static bool IsDirectArgumentToUseCommand(ExpressionSyntax node, SyntaxNodeAnalysisContext ctx)
+    {
+        var expr = node;
+        while (expr.Parent is ParenthesizedExpressionSyntax parens)
+            expr = parens;
+
+        if (expr.Parent is not ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax invocation } })
+            return false;
+
+        if (GetInvokedName(invocation) != UseCommandName) return false;
+
+        if (ctx.SemanticModel.GetSymbolInfo(invocation, ctx.CancellationToken).Symbol is IMethodSymbol method)
+            return CommandDebounceAnalyzer.IsReactorNamespace(method.ContainingNamespace?.ToDisplayString());
+
+        return true;
+    }
+
+    private static string? GetInvokedName(InvocationExpressionSyntax invocation) => invocation.Expression switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        GenericNameSyntax g => g.Identifier.ValueText,
+        MemberAccessExpressionSyntax m => m.Name switch
+        {
+            GenericNameSyntax gn => gn.Identifier.ValueText,
+            { } simple => simple.Identifier.ValueText,
+        },
+        MemberBindingExpressionSyntax mb => mb.Name.Identifier.ValueText,
+        _ => null,
+    };
+}

--- a/src/Reactor.Analyzers/MemoizeCommandAnalyzer.cs
+++ b/src/Reactor.Analyzers/MemoizeCommandAnalyzer.cs
@@ -96,6 +96,13 @@ public sealed class MemoizeCommandAnalyzer : DiagnosticAnalyzer
         var type = ctx.SemanticModel.GetTypeInfo(node, ctx.CancellationToken).Type;
         if (!IsReactorCommandType(type)) return;
 
+        // Anchor to an actual Reactor render context so a non-Reactor helper that merely happens to be
+        // named Render()/UseXxx and build a Reactor Command isn't flagged. Battle-tested rule (task
+        // contract §2.1 / HookRulesAnalyzer.IsLikelyReactorHook): accept a Component OR RenderContext
+        // enclosing type, plus RenderContext-extension custom hooks. Left permissive only when symbols
+        // don't resolve (incomplete code mid-edit), so the diagnostic isn't lost.
+        if (!IsInReactorRenderContext(method!, ctx)) return;
+
         // Cede debounced commands to REACTOR_HOOKS_009 (CommandDebounceAnalyzer): a non-zero
         // DebounceMs only works through UseCommand — not UseMemo — so that rule owns them. Without
         // this, `new Command { …, DebounceMs = 1500 }` bound raw in Render would draw BOTH a HOOKS_009
@@ -137,11 +144,12 @@ public sealed class MemoizeCommandAnalyzer : DiagnosticAnalyzer
     // is a construct where a hook could not legally be introduced — a lambda / anonymous method /
     // local function (deferred, so the construction is not a per-render allocation), or a conditional
     // / loop / switch / try (where wrapping in UseMemo would violate the rules-of-hooks). Mirrors the
-    // boundary set of HookRulesAnalyzer.FindConditionalAncestor so the rule fires only where the
-    // offered UseMemo fix is both meaningful and legal.
+    // boundary set of HookRulesAnalyzer.FindConditionalAncestor (extended with switch-expression, LINQ
+    // query, and the conditionally-evaluated right operand of ?? / && / ||) so the rule fires only
+    // where the offered UseMemo fix is both meaningful and legal.
     private static bool CrossesHookIllegalBoundary(SyntaxNode node, MethodDeclarationSyntax method)
     {
-        for (var n = node.Parent; n is not null && n != method; n = n.Parent)
+        for (SyntaxNode? child = node, n = node.Parent; n is not null && n != method; child = n, n = n.Parent)
         {
             switch (n)
             {
@@ -157,12 +165,54 @@ public sealed class MemoizeCommandAnalyzer : DiagnosticAnalyzer
                 case DoStatementSyntax:
                 case SwitchStatementSyntax:
                 case SwitchSectionSyntax:
+                case SwitchExpressionSyntax:
+                case SwitchExpressionArmSyntax:
                 case TryStatementSyntax:
                 case CatchClauseSyntax:
                 case FinallyClauseSyntax:
+                case QueryExpressionSyntax:
                 case ConditionalExpressionSyntax:
                     return true;
+                // The right operand of ?? / && / || is evaluated conditionally (e.g.
+                // `existing ?? new Command { … }`); the left operand always runs, so only suppress
+                // when we ascended from the right side.
+                case BinaryExpressionSyntax bin
+                    when (bin.IsKind(SyntaxKind.CoalesceExpression)
+                        || bin.IsKind(SyntaxKind.LogicalAndExpression)
+                        || bin.IsKind(SyntaxKind.LogicalOrExpression))
+                        && ReferenceEquals(child, bin.Right):
+                    return true;
             }
+        }
+        return false;
+    }
+
+    // Anchors the enclosing Render()/Use* method to a genuine Reactor render context: an instance
+    // method on a Component / RenderContext-derived type (the Render override or an instance custom
+    // hook), or a RenderContext-extension custom hook (`static UseXxx(this RenderContext ctx, …)`).
+    // Mirrors HookRulesAnalyzer.IsLikelyReactorHook. Returns true when the method symbol can't be
+    // resolved (incomplete code mid-edit) so the diagnostic isn't lost on a transient bind failure.
+    private static bool IsInReactorRenderContext(MethodDeclarationSyntax method, SyntaxNodeAnalysisContext ctx)
+    {
+        if (ctx.SemanticModel.GetDeclaredSymbol(method, ctx.CancellationToken) is not IMethodSymbol symbol)
+            return true;
+
+        if (DerivesFromComponentOrRenderContext(symbol.ContainingType)) return true;
+
+        if (symbol.IsExtensionMethod && symbol.Parameters.Length > 0)
+            return DerivesFromComponentOrRenderContext(symbol.Parameters[0].Type as INamedTypeSymbol);
+
+        return false;
+    }
+
+    private static bool DerivesFromComponentOrRenderContext(INamedTypeSymbol? type)
+    {
+        for (var t = type; t is not null; t = t.BaseType)
+        {
+            var name = t.OriginalDefinition.ToDisplayString();
+            if (name is "Microsoft.UI.Reactor.Core.Component" or "Microsoft.UI.Reactor.Core.RenderContext"
+                || name.StartsWith("Microsoft.UI.Reactor.Core.Component<", System.StringComparison.Ordinal))
+                return true;
         }
         return false;
     }

--- a/src/Reactor.Analyzers/MemoizeCommandAnalyzer.cs
+++ b/src/Reactor.Analyzers/MemoizeCommandAnalyzer.cs
@@ -209,7 +209,11 @@ public sealed class MemoizeCommandAnalyzer : DiagnosticAnalyzer
     {
         for (var t = type; t is not null; t = t.BaseType)
         {
-            var name = t.OriginalDefinition.ToDisplayString();
+            // Fully-qualified (global::-stripped) so the compare never depends on a minimally-qualified
+            // display name — mirrors HookRulesAnalyzer.IsOrDerivesFrom.
+            var name = t.OriginalDefinition
+                .ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                .Replace("global::", "");
             if (name is "Microsoft.UI.Reactor.Core.Component" or "Microsoft.UI.Reactor.Core.RenderContext"
                 || name.StartsWith("Microsoft.UI.Reactor.Core.Component<", System.StringComparison.Ordinal))
                 return true;

--- a/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
+++ b/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
@@ -115,7 +115,7 @@ public sealed class MemoizeCommandCodeFix : CodeFixProvider
                         {
                             nodesAndTokens.Add(SyntaxFactory.Token(SyntaxKind.CommaToken)
                                 .WithTrailingTrivia(SyntaxFactory.Space));
-                            nodesAndTokens.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(dep)));
+                            nodesAndTokens.Add(SyntaxFactory.Argument(DependencyIdentifier(dep)));
                         }
 
                         var wrapped = SyntaxFactory.InvocationExpression(
@@ -201,6 +201,16 @@ public sealed class MemoizeCommandCodeFix : CodeFixProvider
         }
         return false;
     }
+
+    // A local/parameter whose name is a reserved keyword can only exist in source as an escaped
+    // identifier (`@event`), and Roslyn reports its Name without the `@` ("event"). Parse the escaped
+    // form so the emitted `UseMemo(…, @event)` dependency is a proper verbatim identifier (correct
+    // Text AND ValueText) that both compiles and round-trips. Contextual keywords (value, async, …)
+    // are valid unescaped identifiers, so they need no `@`.
+    private static IdentifierNameSyntax DependencyIdentifier(string name)
+        => SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None
+            ? (IdentifierNameSyntax)SyntaxFactory.ParseName("@" + name)
+            : SyntaxFactory.IdentifierName(name);
 
     /// <summary>
     /// Rebuilds a target-typed <c>new() { … }</c> as an explicit <c>new Command&lt;T&gt; { … }</c>

--- a/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
+++ b/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
@@ -140,6 +140,7 @@ public sealed class MemoizeCommandCodeFix : CodeFixProvider
     private static ImmutableArray<string> ComputeDependencies(
         SemanticModel model, ExpressionSyntax creation, System.Threading.CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         var flow = model.AnalyzeDataFlow(creation);
         if (flow is null || !flow.Succeeded) return ImmutableArray<string>.Empty;
 

--- a/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
+++ b/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
@@ -215,9 +215,9 @@ public sealed class MemoizeCommandCodeFix : CodeFixProvider
     /// <summary>
     /// Rebuilds a target-typed <c>new() { … }</c> as an explicit <c>new Command&lt;T&gt; { … }</c>
     /// using the resolved <paramref name="type"/>, preserving the initializer (and any constructor
-    /// arguments) verbatim. The type name is rendered with
-    /// <see cref="SymbolDisplayExtensions.ToMinimalDisplayString"/> so it stays short yet unambiguous
-    /// at this position. Mirrors <see cref="CommandDebounceCodeFix"/>.
+    /// arguments) verbatim — including any trivia between <c>new(…)</c> and the initializer brace. The
+    /// type name is rendered with <see cref="SymbolDisplayExtensions.ToMinimalDisplayString"/> so it
+    /// stays short yet unambiguous at this position. Mirrors <see cref="CommandDebounceCodeFix"/>.
     /// </summary>
     private static ObjectCreationExpressionSyntax MakeExplicit(
         ImplicitObjectCreationExpressionSyntax implicitNew, ITypeSymbol type, SemanticModel semanticModel)
@@ -229,9 +229,12 @@ public sealed class MemoizeCommandCodeFix : CodeFixProvider
         if (argumentList is null || argumentList.Arguments.Count == 0)
             argumentList = null;
 
-        // Force exactly one space before the initializer brace so the result is a clean
-        // `new Command { … }` regardless of the original `new()`/`new() { … }` spacing.
-        var initializer = implicitNew.Initializer!.WithLeadingTrivia(SyntaxFactory.Space);
+        // Preserve the initializer verbatim (keeps any comments/newlines the author placed before the
+        // brace). Only when the dropped `()` leaves the type directly abutting an initializer with no
+        // leading trivia do we add a single separating space, so the result is never `Command{ … }`.
+        var initializer = implicitNew.Initializer!;
+        if (argumentList is null && initializer.GetLeadingTrivia().Count == 0)
+            typeSyntax = typeSyntax.WithTrailingTrivia(SyntaxFactory.Space);
 
         return SyntaxFactory.ObjectCreationExpression(
             SyntaxFactory.Token(SyntaxKind.NewKeyword).WithTrailingTrivia(SyntaxFactory.Space),

--- a/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
+++ b/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
@@ -100,10 +100,12 @@ public sealed class MemoizeCommandCodeFix : CodeFixProvider
                     ct =>
                     {
                         // `() => <command>` with explicit single-space arrow trivia so the emitted
-                        // fix reads `() => new Command { … }` regardless of factory defaults.
+                        // fix reads `() => new Command { … }` regardless of factory defaults. Strip only
+                        // the command's OUTER leading/trailing trivia (not WithoutTrivia(), which would
+                        // also drop interior comments/newlines inside the initializer).
                         var lambda = SyntaxFactory.ParenthesizedLambdaExpression(
                             SyntaxFactory.ParameterList(),
-                            innerForClosure.WithoutTrivia())
+                            innerForClosure.WithLeadingTrivia().WithTrailingTrivia())
                             .WithArrowToken(SyntaxFactory.Token(SyntaxKind.EqualsGreaterThanToken)
                                 .WithLeadingTrivia(SyntaxFactory.Space)
                                 .WithTrailingTrivia(SyntaxFactory.Space));
@@ -182,8 +184,11 @@ public sealed class MemoizeCommandCodeFix : CodeFixProvider
                 && assign.Left == id)
                 continue;
 
+            // Skip the member name of a `receiver.Member` access whose receiver is neither `this` nor
+            // `base` — that member belongs to a local/parameter/type whose root is captured as a
+            // dependency (or is static). `this.`/`base.`/implicit instance reads are the stale hazard.
             if (id.Parent is MemberAccessExpressionSyntax ma && ma.Name == id
-                && ma.Expression is not ThisExpressionSyntax)
+                && ma.Expression is not (ThisExpressionSyntax or BaseExpressionSyntax))
                 continue;
 
             if (model.GetSymbolInfo(id, ct).Symbol is IFieldSymbol { IsStatic: false, IsConst: false }

--- a/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
+++ b/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
@@ -68,6 +68,16 @@ public sealed class MemoizeCommandCodeFix : CodeFixProvider
                     s is IMethodSymbol m && CommandDebounceAnalyzer.IsReactorNamespace(m.ContainingNamespace?.ToDisplayString())))
                 continue;
 
+            // Decline the fix when the command reads a mutable component instance field/property at
+            // render time (outside a deferred lambda): that value is snapshotted into the init-only
+            // Command property, and `this` is (correctly) never a UseMemo dependency, so a wrapped memo
+            // would serve a STALE value when the member changes. We can't turn an arbitrary member read
+            // into a dependency, so we leave the command un-fixed — the Info diagnostic still nudges the
+            // author to memoize by hand with the right deps. Reads that occur only inside a deferred
+            // lambda (e.g. Execute = () => _count++) re-read live and are safe.
+            if (ReadsRenderTimeInstanceMember(creation, semanticModel, context.CancellationToken))
+                continue;
+
             // A target-typed `new() { … }` is typed by its surrounding context; once it becomes the
             // body of the memo lambda that context is gone. Rewrite it to an explicit
             // `new Command<T> { … }` using the resolved type, or skip if it can't be resolved.
@@ -152,6 +162,46 @@ public sealed class MemoizeCommandCodeFix : CodeFixProvider
         return names.ToImmutableArray();
     }
 
+    // True when the creation expression reads a mutable component instance field or non-static property
+    // at RENDER TIME — i.e. outside any nested lambda / anonymous method (whose body defers to invoke
+    // time and re-reads the member live). Such a render-time read is snapshotted into the init-only
+    // Command property, and `this` is never a UseMemo dependency, so a wrapped memo would serve a stale
+    // value. We skip: reads inside a deferred lambda (safe), the object-initializer assignment targets
+    // (the Command's own properties, e.g. `Label = …`), and the member name of a `receiver.Member`
+    // access whose receiver is not `this` (that member belongs to a local/parameter/type whose root is
+    // captured as a dependency or is static).
+    private static bool ReadsRenderTimeInstanceMember(
+        ExpressionSyntax creation, SemanticModel model, System.Threading.CancellationToken ct)
+    {
+        foreach (var id in creation.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (IsInsideNestedAnonymousFunction(id, creation)) continue;
+
+            if (id.Parent is AssignmentExpressionSyntax { Parent: InitializerExpressionSyntax } assign
+                && assign.Left == id)
+                continue;
+
+            if (id.Parent is MemberAccessExpressionSyntax ma && ma.Name == id
+                && ma.Expression is not ThisExpressionSyntax)
+                continue;
+
+            if (model.GetSymbolInfo(id, ct).Symbol is IFieldSymbol { IsStatic: false, IsConst: false }
+                or IPropertySymbol { IsStatic: false })
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsInsideNestedAnonymousFunction(SyntaxNode node, ExpressionSyntax boundary)
+    {
+        for (var n = node.Parent; n is not null && n != boundary; n = n.Parent)
+        {
+            if (n is SimpleLambdaExpressionSyntax or ParenthesizedLambdaExpressionSyntax or AnonymousMethodExpressionSyntax)
+                return true;
+        }
+        return false;
+    }
+
     /// <summary>
     /// Rebuilds a target-typed <c>new() { … }</c> as an explicit <c>new Command&lt;T&gt; { … }</c>
     /// using the resolved <paramref name="type"/>, preserving the initializer (and any constructor
@@ -167,15 +217,16 @@ public sealed class MemoizeCommandCodeFix : CodeFixProvider
 
         ArgumentListSyntax? argumentList = implicitNew.ArgumentList;
         if (argumentList is null || argumentList.Arguments.Count == 0)
-        {
             argumentList = null;
-            typeSyntax = typeSyntax.WithTrailingTrivia(SyntaxFactory.Space);
-        }
+
+        // Force exactly one space before the initializer brace so the result is a clean
+        // `new Command { … }` regardless of the original `new()`/`new() { … }` spacing.
+        var initializer = implicitNew.Initializer!.WithLeadingTrivia(SyntaxFactory.Space);
 
         return SyntaxFactory.ObjectCreationExpression(
             SyntaxFactory.Token(SyntaxKind.NewKeyword).WithTrailingTrivia(SyntaxFactory.Space),
             typeSyntax,
             argumentList,
-            implicitNew.Initializer);
+            initializer);
     }
 }

--- a/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
+++ b/src/Reactor.Analyzers/MemoizeCommandCodeFix.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for <see cref="MemoizeCommandAnalyzer"/> (<c>REACTOR_PERF_FUNCREF</c>) — wraps the
+/// offending <c>new Command { … }</c> in <c>UseMemo(() =&gt; new Command { … }, deps)</c> so the
+/// command keeps a stable instance across renders.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The dependency list is computed from a data-flow analysis of the creation expression: every
+/// local / parameter read inside it (directly or captured by a nested lambda such as
+/// <c>Execute = () =&gt; setCount(count + 1)</c>) that is declared outside becomes a
+/// <c>UseMemo</c> dependency, so the memo re-computes exactly when a captured value changes and
+/// never serves a stale closure. When nothing is captured the deps list is empty
+/// (<c>UseMemo(() =&gt; new Command { … })</c>) — a compute-once memo, which is safe precisely
+/// because there is nothing to go stale.
+/// </para>
+/// <para>
+/// A Reactor <c>UseMemo</c> must be in scope for the wrap to compile, so the fix is only offered
+/// inside a <c>Component</c> / <c>RenderContext</c> body. A target-typed <c>new() { … }</c> is
+/// rewritten to an explicit <c>new Command&lt;T&gt; { … }</c> first (its target type is lost once it
+/// becomes the body of the memo lambda). Mirrors <see cref="CommandDebounceCodeFix"/>.
+/// </para>
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MemoizeCommandCodeFix))]
+[Shared]
+public sealed class MemoizeCommandCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(MemoizeCommandAnalyzer.Id);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        SemanticModel? semanticModel = null;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var creation = node.FirstAncestorOrSelf<ExpressionSyntax>(static e =>
+                e is ObjectCreationExpressionSyntax or ImplicitObjectCreationExpressionSyntax);
+            if (creation is null) continue;
+
+            semanticModel ??= await context.Document
+                .GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            if (semanticModel is null) continue;
+
+            // UseMemo is a Reactor Component / RenderContext hook, so it must be a *Reactor* UseMemo
+            // in scope here for the wrap to compile and actually memoize. If none is (e.g. a static
+            // helper, or a same-named unrelated method), skip the fix — the Info diagnostic still
+            // fires and the author lifts the command by hand. Never emit broken or no-op code.
+            if (!semanticModel.LookupSymbols(creation.SpanStart, name: "UseMemo").Any(static s =>
+                    s is IMethodSymbol m && CommandDebounceAnalyzer.IsReactorNamespace(m.ContainingNamespace?.ToDisplayString())))
+                continue;
+
+            // A target-typed `new() { … }` is typed by its surrounding context; once it becomes the
+            // body of the memo lambda that context is gone. Rewrite it to an explicit
+            // `new Command<T> { … }` using the resolved type, or skip if it can't be resolved.
+            ExpressionSyntax inner = creation;
+            if (creation is ImplicitObjectCreationExpressionSyntax implicitNew)
+            {
+                if (implicitNew.Initializer is null) continue;
+                var type = semanticModel.GetTypeInfo(implicitNew, context.CancellationToken).Type;
+                if (type is null || type.TypeKind == TypeKind.Error) continue;
+                inner = MakeExplicit(implicitNew, type, semanticModel);
+            }
+
+            var deps = ComputeDependencies(semanticModel, creation, context.CancellationToken);
+
+            var creationForClosure = creation;
+            var innerForClosure = inner;
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Wrap command in UseMemo(...)",
+                    ct =>
+                    {
+                        // `() => <command>` with explicit single-space arrow trivia so the emitted
+                        // fix reads `() => new Command { … }` regardless of factory defaults.
+                        var lambda = SyntaxFactory.ParenthesizedLambdaExpression(
+                            SyntaxFactory.ParameterList(),
+                            innerForClosure.WithoutTrivia())
+                            .WithArrowToken(SyntaxFactory.Token(SyntaxKind.EqualsGreaterThanToken)
+                                .WithLeadingTrivia(SyntaxFactory.Space)
+                                .WithTrailingTrivia(SyntaxFactory.Space));
+
+                        // Build the argument list with explicit `, ` separators (a comma with a
+                        // trailing space) so `UseMemo(() => …, count, setCount)` is formatted normally.
+                        var nodesAndTokens = new List<SyntaxNodeOrToken> { SyntaxFactory.Argument(lambda) };
+                        foreach (var dep in deps)
+                        {
+                            nodesAndTokens.Add(SyntaxFactory.Token(SyntaxKind.CommaToken)
+                                .WithTrailingTrivia(SyntaxFactory.Space));
+                            nodesAndTokens.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(dep)));
+                        }
+
+                        var wrapped = SyntaxFactory.InvocationExpression(
+                            SyntaxFactory.IdentifierName("UseMemo"),
+                            SyntaxFactory.ArgumentList(
+                                SyntaxFactory.SeparatedList<ArgumentSyntax>(nodesAndTokens)))
+                            .WithTriviaFrom(creationForClosure);
+
+                        var newRoot = root.ReplaceNode(creationForClosure, wrapped);
+                        return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+                    },
+                    equivalenceKey: MemoizeCommandAnalyzer.Id),
+                diagnostic);
+        }
+    }
+
+    // The captured dependencies of the creation expression: locals / parameters that are read inside
+    // it — directly or captured by a nested lambda — and declared outside. These become the UseMemo
+    // deps so the memo re-computes exactly when a captured value changes (no stale closure). The union
+    // of DataFlowsIn / ReadInside / CapturedInside covers both direct reads and nested-lambda captures;
+    // VariablesDeclared removes anything local to the expression itself. Ordered for deterministic output.
+    private static ImmutableArray<string> ComputeDependencies(
+        SemanticModel model, ExpressionSyntax creation, System.Threading.CancellationToken ct)
+    {
+        var flow = model.AnalyzeDataFlow(creation);
+        if (flow is null || !flow.Succeeded) return ImmutableArray<string>.Empty;
+
+        var declared = new HashSet<ISymbol>(flow.VariablesDeclared, SymbolEqualityComparer.Default);
+        var seen = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        var names = new List<string>();
+
+        foreach (var symbol in flow.DataFlowsIn.Concat(flow.ReadInside).Concat(flow.CapturedInside))
+        {
+            if (symbol is not (ILocalSymbol or IParameterSymbol)) continue;
+            // `this` (an implicit parameter, captured whenever the command references an instance
+            // member such as `Execute = Save`) is stable across renders — never a memo dependency.
+            if (symbol is IParameterSymbol { IsThis: true }) continue;
+            if (declared.Contains(symbol)) continue;
+            if (!seen.Add(symbol)) continue;
+            names.Add(symbol.Name);
+        }
+
+        names.Sort(System.StringComparer.Ordinal);
+        return names.ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Rebuilds a target-typed <c>new() { … }</c> as an explicit <c>new Command&lt;T&gt; { … }</c>
+    /// using the resolved <paramref name="type"/>, preserving the initializer (and any constructor
+    /// arguments) verbatim. The type name is rendered with
+    /// <see cref="SymbolDisplayExtensions.ToMinimalDisplayString"/> so it stays short yet unambiguous
+    /// at this position. Mirrors <see cref="CommandDebounceCodeFix"/>.
+    /// </summary>
+    private static ObjectCreationExpressionSyntax MakeExplicit(
+        ImplicitObjectCreationExpressionSyntax implicitNew, ITypeSymbol type, SemanticModel semanticModel)
+    {
+        var typeSyntax = SyntaxFactory.ParseTypeName(
+            type.ToMinimalDisplayString(semanticModel, implicitNew.SpanStart));
+
+        ArgumentListSyntax? argumentList = implicitNew.ArgumentList;
+        if (argumentList is null || argumentList.Arguments.Count == 0)
+        {
+            argumentList = null;
+            typeSyntax = typeSyntax.WithTrailingTrivia(SyntaxFactory.Space);
+        }
+
+        return SyntaxFactory.ObjectCreationExpression(
+            SyntaxFactory.Token(SyntaxKind.NewKeyword).WithTrailingTrivia(SyntaxFactory.Space),
+            typeSyntax,
+            argumentList,
+            implicitNew.Initializer);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/MemoizeCommandAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/MemoizeCommandAnalyzerTests.cs
@@ -600,4 +600,53 @@ namespace TestApp
             CodeActionEquivalenceKey = MemoizeCommandAnalyzer.Id,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task CodeFix_Escapes_Keyword_Dependency()
+    {
+        // A captured local whose name is a reserved keyword (`@event`) must be re-emitted with `@`
+        // in the deps list, or the generated UseMemo call would not compile.
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Use(int x) { }
+
+        public override Element Render()
+        {
+            var @event = 0;
+            var save = {|REACTOR_PERF_FUNCREF:new Command { Label = ""Save"", Execute = () => Use(@event) }|};
+            return Button(save);
+        }
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Use(int x) { }
+
+        public override Element Render()
+        {
+            var @event = 0;
+            var save = UseMemo(() => new Command { Label = ""Save"", Execute = () => Use(@event) }, @event);
+            return Button(save);
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<MemoizeCommandAnalyzer, MemoizeCommandCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = MemoizeCommandAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/MemoizeCommandAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/MemoizeCommandAnalyzerTests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.UI.Reactor.Core
     {
         public string Label { get; init; }
         public System.Action Execute { get; init; }
+        public bool CanExecute { get; init; }
         public int DebounceMs { get; init; }
     }
 
@@ -286,6 +287,129 @@ namespace TestApp
         await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task No_Diagnostic_When_Inside_If()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            Command save = null;
+            if (System.DateTime.Now.Second > 0)
+                save = new Command { Label = ""Save"", Execute = Save };
+            return Button(save);
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_In_Conditional_Expression()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            Command other = null;
+            var save = System.DateTime.Now.Second > 0 ? new Command { Label = ""Save"", Execute = Save } : other;
+            return Button(save);
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_In_Coalesce_Right_Operand()
+    {
+        // `existing ?? new Command { … }` — the new command is evaluated conditionally, so a UseMemo
+        // there would break the rules-of-hooks.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            Command existing = null;
+            var save = existing ?? new Command { Label = ""Save"", Execute = Save };
+            return Button(save);
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_In_Switch_Expression_Arm()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            Command other = null;
+            var save = System.DateTime.Now.Second switch
+            {
+                0 => new Command { Label = ""Save"", Execute = Save },
+                _ => other,
+            };
+            return Button(save);
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_Not_In_Reactor_Component()
+    {
+        // A plain class (not a Component / RenderContext) with a method named Render that builds a
+        // Reactor Command — the render-context anchor excludes it, so no diagnostic.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class NotAComponent
+    {
+        void Save() { }
+
+        public Element Render()
+        {
+            var save = new Command { Label = ""Save"", Execute = Save };
+            return save is null ? null : null;
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
     // ── Near-miss: syntactic ""Command"" name matches, but not the Reactor type ──
 
     [Fact]
@@ -396,6 +520,83 @@ namespace TestApp
         {
             TestCode = before,
             FixedCode = after,
+            CodeActionEquivalenceKey = MemoizeCommandAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Rewrites_Implicit_New()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            Command save = {|REACTOR_PERF_FUNCREF:new() { Label = ""Save"", Execute = Save }|};
+            return Button(save);
+        }
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            Command save = UseMemo(() => new Command { Label = ""Save"", Execute = Save });
+            return Button(save);
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<MemoizeCommandAnalyzer, MemoizeCommandCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = MemoizeCommandAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Not_Offered_When_Command_Reads_Instance_Field()
+    {
+        // The command reads a mutable instance field at render time (snapshotted into CanExecute).
+        // The fix can't turn that into a UseMemo dependency, so it declines — but the diagnostic
+        // still fires. FixedCode == TestCode (no code action applied).
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        bool _isValid;
+        void Save() { }
+
+        public override Element Render()
+        {
+            var save = {|REACTOR_PERF_FUNCREF:new Command { Label = ""Save"", Execute = Save, CanExecute = _isValid }|};
+            return Button(save);
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<MemoizeCommandAnalyzer, MemoizeCommandCodeFix, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
             CodeActionEquivalenceKey = MemoizeCommandAnalyzer.Id,
         }.RunAsync(TestContext.Current.CancellationToken);
     }

--- a/tests/Reactor.Tests/AnalyzerTests/MemoizeCommandAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/MemoizeCommandAnalyzerTests.cs
@@ -649,4 +649,39 @@ namespace TestApp
             CodeActionEquivalenceKey = MemoizeCommandAnalyzer.Id,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task CodeFix_Not_Offered_When_Command_Reads_Base_Member()
+    {
+        // `base.Member` is a render-time instance read too — the fix must decline (no code action),
+        // just like an implicit-`this` member, so it never memoizes a stale value.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public abstract class BaseComp : Component
+    {
+        protected string BaseLabel => ""Save"";
+    }
+
+    public sealed class Comp : BaseComp
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            var save = {|REACTOR_PERF_FUNCREF:new Command { Label = base.BaseLabel, Execute = Save }|};
+            return Button(save);
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<MemoizeCommandAnalyzer, MemoizeCommandCodeFix, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
+            CodeActionEquivalenceKey = MemoizeCommandAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/MemoizeCommandAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/MemoizeCommandAnalyzerTests.cs
@@ -1,0 +1,402 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="MemoizeCommandAnalyzer"/> (<c>REACTOR_PERF_FUNCREF</c>) and its
+/// <see cref="MemoizeCommandCodeFix"/>. Stubs a minimal Reactor surface — the
+/// <c>Command</c>/<c>Command&lt;T&gt;</c> records and a <c>Component</c> base exposing
+/// <c>Render</c>, <c>UseMemo</c>, <c>UseCommand</c>, <c>UseState</c> and a <c>Button</c> binding
+/// factory — so the analyzer's semantic checks (Reactor command type, UseCommand suppression) and
+/// the fix's UseMemo-in-scope guard resolve without pulling the framework in.
+/// </summary>
+public class MemoizeCommandAnalyzerTests
+{
+    private const string Stubs = @"
+namespace System.Runtime.CompilerServices
+{
+    public static class IsExternalInit { }
+}
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public abstract record Element { }
+    public sealed record ButtonElement : Element { }
+
+    public sealed record Command
+    {
+        public string Label { get; init; }
+        public System.Action Execute { get; init; }
+        public int DebounceMs { get; init; }
+    }
+
+    public sealed record Command<T>
+    {
+        public string Label { get; init; }
+        public System.Action<T> Execute { get; init; }
+        public int DebounceMs { get; init; }
+    }
+
+    // Mirrors Component's render override + protected hooks + a Command binding factory. UseMemo /
+    // UseCommand living in Microsoft.UI.Reactor.Core is what lets the analyzer treat UseCommand as
+    // the routing call and the fix find a Reactor UseMemo in scope.
+    public abstract class Component
+    {
+        public abstract Element Render();
+        protected T UseMemo<T>(System.Func<T> factory, params object[] deps) => factory();
+        protected Command UseCommand(Command command) => command;
+        protected Command<T> UseCommand<T>(Command<T> command) => command;
+        protected (int, System.Action<int>) UseState(int initial) => (initial, _ => { });
+        protected ButtonElement Button(Command command) => new ButtonElement();
+        protected ButtonElement Button(string label) => new ButtonElement();
+        protected ButtonElement Button(string label, System.Action onClick) => new ButtonElement();
+    }
+}
+";
+
+    private static CSharpAnalyzerTest<MemoizeCommandAnalyzer, DefaultVerifier> Analyzer(string source) =>
+        new() { TestCode = source };
+
+    // ── Positive: constructed directly in the render path ───────────────
+
+    [Fact]
+    public async Task Fires_On_Local_In_Render()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            var save = {|REACTOR_PERF_FUNCREF:new Command { Label = ""Save"", Execute = Save }|};
+            return Button(save);
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_Inline_Bind_In_Render()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+            => Button({|REACTOR_PERF_FUNCREF:new Command { Label = ""Save"", Execute = Save }|});
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_In_Custom_Use_Hook()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        Command UseSaveCommand()
+            => {|REACTOR_PERF_FUNCREF:new Command { Label = ""Save"", Execute = Save }|};
+
+        public override Element Render() => Button(UseSaveCommand());
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_Generic_Command()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        public override Element Render()
+        {
+            var cmd = {|REACTOR_PERF_FUNCREF:new Command<int> { Label = ""Inc"" }|};
+            return Button(""x"");
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative: already memoized / routed / deferred / off the render path ──
+
+    [Fact]
+    public async Task No_Diagnostic_When_Wrapped_In_UseMemo()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            var save = UseMemo(() => new Command { Label = ""Save"", Execute = Save });
+            return Button(save);
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_Routed_Through_UseCommand()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            var save = UseCommand(new Command { Label = ""Save"", Execute = Save });
+            return Button(save);
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_Deferred_In_Event_Handler()
+    {
+        // The command is built inside a click handler lambda — it runs on click, not each render,
+        // so it is not a per-render allocation. CrossesDeferredBoundary suppresses it.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+        void Use(Command c) { }
+
+        public override Element Render()
+            => Button(""Open"", () => { var c = new Command { Label = ""Save"", Execute = Save }; Use(c); });
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_Built_Outside_Render()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        // Not a Render()/Use* method — a plain helper, so no per-render concern.
+        Command BuildSave() => new Command { Label = ""Save"", Execute = Save };
+
+        public override Element Render() => Button(BuildSave());
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_DebounceMs_Set_Cedes_To_HOOKS_009()
+    {
+        // A non-zero DebounceMs is REACTOR_HOOKS_009's domain (must go through UseCommand, not
+        // UseMemo); firing here too would give conflicting advice on the same construct.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            var save = new Command { Label = ""Save"", Execute = Save, DebounceMs = 1500 };
+            return Button(save);
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_When_Inside_Loop()
+    {
+        // A command built inside a loop can't be wrapped in a top-level UseMemo without violating the
+        // rules-of-hooks (REACTOR_HOOKS_001), so the rule stays silent rather than offer a broken fix.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                var save = new Command { Label = ""Save"", Execute = Save };
+                Button(save);
+            }
+            return Button(""x"");
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Near-miss: syntactic ""Command"" name matches, but not the Reactor type ──
+
+    [Fact]
+    public async Task No_Diagnostic_On_NonReactor_Command_Type()
+    {
+        var source = Stubs + @"
+namespace Other
+{
+    // Same simple name, different type — trips the syntactic fast path, fails the semantic gate.
+    public sealed class Command { public string Label; }
+}
+
+namespace TestApp
+{
+    using Other;
+
+    // Base class fully-qualified so only Other.Command is imported (no CS0104 ambiguity); the
+    // unqualified `Command` below binds to Other.Command, which is not the Reactor type.
+    public sealed class Comp : Microsoft.UI.Reactor.Core.Component
+    {
+        public override Microsoft.UI.Reactor.Core.Element Render()
+        {
+            var save = new Command { Label = ""Save"" };
+            return Button(save.Label);
+        }
+    }
+}";
+        await Analyzer(source).RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code fix ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CodeFix_Wraps_Local_With_Captured_Deps()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        public override Element Render()
+        {
+            var (count, setCount) = UseState(0);
+            var save = {|REACTOR_PERF_FUNCREF:new Command { Label = ""Save"", Execute = () => setCount(count + 1) }|};
+            return Button(save);
+        }
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        public override Element Render()
+        {
+            var (count, setCount) = UseState(0);
+            var save = UseMemo(() => new Command { Label = ""Save"", Execute = () => setCount(count + 1) }, count, setCount);
+            return Button(save);
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<MemoizeCommandAnalyzer, MemoizeCommandCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = MemoizeCommandAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_No_Captures_Emits_No_Deps()
+    {
+        var before = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+            => Button({|REACTOR_PERF_FUNCREF:new Command { Label = ""Save"", Execute = Save }|});
+    }
+}";
+
+        var after = Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed class Comp : Component
+    {
+        void Save() { }
+
+        public override Element Render()
+            => Button(UseMemo(() => new Command { Label = ""Save"", Execute = Save }));
+    }
+}";
+
+        await new CSharpCodeFixTest<MemoizeCommandAnalyzer, MemoizeCommandCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = MemoizeCommandAnalyzer.Id,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}


### PR DESCRIPTION
## REACTOR_PERF_FUNCREF — memoize inline `Command` in `Render`

Implements one packet of spec 060 Batch 2 (§12): **`REACTOR_PERF_FUNCREF`** (`Reactor.Performance`, **Info**) + a `UseMemo` code fix. Stacked on the foundation branch `azchohfi-spec-060-analyzer-suite`.

### Premise verification (Batch-2 = endorsed, not source-hardened)
Batch-2's terse entry framed this as keyboard-accelerator "rewire churn" avoidable via `UseMemo`. **Source does not support that causal mechanism**, so the rule ships as a pure allocation/identity-hygiene nudge (analogous to `HOOKS_004`) with an accurate message:

- Button/menu binds diff a `Command` by **value** — `CommandModuloDelegatesComparer` (`CommandBindings.cs`) applied through the `OneWay` descriptor, which **skips its setter when the comparer reports equal** (`PropEntry.cs`). `KeyboardAcceleratorData` is a record, so a fresh-but-equal command re-applies **no** accelerator metadata. Memoizing gives no accelerator benefit here.
- The one host that rebuilds accelerators each reconcile (`CompositeLifecycle.UpdateCommandHost`) **clears and re-adds** — bounded, **not a leak**, and unaffected by memoizing the command.
- `UseCommand` returns a plain sync command **unchanged** (`RenderContext.cs`), so it doesn't even pin identity for the common case.

The verified, defensible win of memoizing is **avoiding the per-render record + closure allocation**. The message says exactly that — no "accelerator churn" / "grows without bound" wording.

### What it flags
`new Command { … }` / `new Command<T> { … }` built **directly in a render path** (a `Render()` override or a custom `Use*` hook), in a position where a hook could legally be introduced, that is not wrapped in `UseMemo`/`UseCommand`.

**Fires only where the fix is legal/meaningful** — suppressed when the construction is deferred into a lambda / local function (event handlers, effect bodies, LINQ projections, the `UseMemo` factory itself) or nested in a conditional / loop / `try` (where a `UseMemo` would break the rules-of-hooks). Debounced commands are **ceded to `REACTOR_HOOKS_009`** (they need `UseCommand`, not `UseMemo`), and a command already passed to `UseCommand(...)` is left alone — so the two command rules never give conflicting advice.

### Code fix
Wraps the construction in `UseMemo(() => new Command { … }, deps)`, computing `deps` from a data-flow analysis of the captured locals/parameters (`this` and instance members correctly excluded). No captures → `UseMemo(() => new Command { … })` (compute-once, safe). Only offered when a Reactor `UseMemo` is in scope; a target-typed `new()` is made explicit first.

### Docs correction
`commanding.md.dt` "Common Mistakes" (and the paired snippet comment in `docs/_pipeline/apps/commanding/App.cs`) claimed the accelerator table "grows without bound" — **factually wrong per source**. Reworded to the accurate bounded-rewire / per-render-allocation framing. Edited the **template**, not the generated guide.

### Release / cheat / architecture rows
Appends the `AnalyzerReleases.Unshipped.md` row, the `analyzer-architecture.md.dt` rules-table row, and the `reactor-build-and-check` cheat-table row.

### Verification
- **13 new tests** (positive: local + inline-bind + custom `Use*` hook + generic; negative: `UseMemo`-wrapped, `UseCommand`-routed, event-handler-deferred, outside-render, `DebounceMs` ceded, inside-loop; near-miss: same-named non-Reactor `Command`; two fix round-trips incl. captured-deps).
- All **228** `Reactor.Tests` analyzer tests and **120** doc-pipeline tests pass.
- Full solution builds clean (`dotnet build Reactor.slnx -p:Platform=x64`, 0 errors).
- Samples sweep: fires on 2 genuine positives (`wordpuzzle`, `CommandingDemo` — unmemoized commands in `Render`), confirming the rule is not over-gated.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
