### PR TITLE
feat(analyzer): REACTOR_ANIM_002 — unstable Keyframes trigger

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,6 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_ANIM_002` | Info | Unstable `.Keyframes` trigger restarts the animation every render | `KeyframeTriggerAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_ANIM_002` | info | `.Keyframes(name, trigger, …)` trigger changes every render (`DateTime.Now`, `Guid.NewGuid()`, a fresh allocation) | Pass a stable trigger — a `UseState`/`UseReducer` counter you increment only when you mean to retrigger. Recomputed values restart the animation each reconcile (flicker). |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_ANIM_002 | Reactor.Animation | Info | KeyframeTriggerAnalyzer - Unstable .Keyframes trigger (DateTime.Now / Guid.NewGuid / per-render allocation) restarts the animation every render

--- a/src/Reactor.Analyzers/KeyframeTriggerAnalyzer.cs
+++ b/src/Reactor.Analyzers/KeyframeTriggerAnalyzer.cs
@@ -18,10 +18,13 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// <remarks>
 /// Info-severity nudge, no code-fix (the correct value is intent-specific — a
 /// state counter the author increments only when they mean to retrigger).
-/// Purely syntactic: gates on a <c>.Keyframes(name, trigger, configure)</c>
-/// invocation shape and classifies the <c>trigger</c> argument. See the terse
-/// spec entry (docs/specs/060-analyzer-suite-expansion.md §12) and
-/// docs/guide/animation.md "Re-running keyframes on every render".
+/// Follows the spec §3 pattern: a cheap syntactic gate (a
+/// <c>.Keyframes(name, trigger, configure)</c> invocation whose trigger argument
+/// classifies as per-render-varying) runs first, then a single semantic check
+/// confirms the invocation binds to Reactor's <c>ElementExtensions.Keyframes</c>
+/// (not an unrelated method of the same name). See the terse spec entry
+/// (docs/specs/060-analyzer-suite-expansion.md §12) and docs/guide/animation.md
+/// "Re-running keyframes on every render".
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class KeyframeTriggerAnalyzer : DiagnosticAnalyzer
@@ -66,7 +69,7 @@ public sealed class KeyframeTriggerAnalyzer : DiagnosticAnalyzer
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
 
-        // Syntactic gate: `<receiver>.Keyframes(name, trigger, configure)`.
+        // Cheap syntactic gate: `<receiver>.Keyframes(name, trigger, configure)`.
         // The extension is always called with instance syntax, so the three
         // declared parameters (name, trigger, configure) map to three
         // arguments — the receiver is the member-access target, not an argument.
@@ -87,30 +90,63 @@ public sealed class KeyframeTriggerAnalyzer : DiagnosticAnalyzer
         if (kind is null)
             return;
 
+        // Semantic confirmation (runs only after the cheap gate matched a
+        // candidate): the invocation must bind to Reactor's
+        // ElementExtensions.Keyframes, not an unrelated method named Keyframes.
+        if (!BindsToReactorKeyframes(context.SemanticModel, invocation, context.CancellationToken))
+            return;
+
         context.ReportDiagnostic(Diagnostic.Create(Rule, triggerExpr.GetLocation(), kind));
     }
     // </snippet:keyframe-trigger-rule>
 
     /// <summary>
+    /// Confirms the invocation resolves to Reactor's
+    /// <c>Microsoft.UI.Reactor.ElementExtensions.Keyframes</c> extension. Binding
+    /// to the resolved symbol (rather than checking the receiver's type) keeps
+    /// generic <c>T : Element</c> call sites firing and keeps a same-named
+    /// third-party extension from producing a Reactor diagnostic.
+    /// </summary>
+    private static bool BindsToReactorKeyframes(
+        SemanticModel model, InvocationExpressionSyntax invocation, System.Threading.CancellationToken ct)
+    {
+        if (model.GetSymbolInfo(invocation, ct).Symbol is not IMethodSymbol method)
+            return false;
+
+        // Unwrap the reduced extension form (`el.Keyframes(...)`) to its definition.
+        var def = method.ReducedFrom ?? method;
+        if (def.Name != "Keyframes")
+            return false;
+
+        var containing = def.ContainingType;
+        if (containing?.Name != "ElementExtensions")
+            return false;
+
+        var ns = containing.ContainingNamespace?.ToDisplayString();
+        return ns is not null
+            && (ns == "Microsoft.UI.Reactor"
+                || ns.StartsWith("Microsoft.UI.Reactor.", System.StringComparison.Ordinal));
+    }
+
+    /// <summary>
     /// Resolves the <c>trigger</c> argument. A named <c>trigger:</c> argument
-    /// wins (so reordered named args are handled correctly); otherwise, for an
-    /// all-positional call, it is index 1 (<c>name</c>, <c>trigger</c>,
-    /// <c>configure</c>). If some arguments are named but none is
-    /// <c>trigger</c>, positional order is unreliable, so bail.
+    /// wins (so reordered named args are handled correctly). Otherwise the
+    /// trigger is the positional argument at index 1 (<c>name</c>,
+    /// <c>trigger</c>, <c>configure</c>) — this still holds when a later
+    /// parameter is passed by name (e.g. <c>("x", value, configure: ...)</c>).
+    /// If index 1 is itself bound by name to a different parameter, positional
+    /// mapping is unreliable, so bail.
     /// </summary>
     private static ExpressionSyntax? ResolveTriggerArgument(SeparatedSyntaxList<ArgumentSyntax> args)
     {
-        var anyNamed = false;
         foreach (var arg in args)
         {
-            if (arg.NameColon is not { } nc)
-                continue;
-            anyNamed = true;
-            if (nc.Name.Identifier.ValueText == "trigger")
+            if (arg.NameColon is { } nc && nc.Name.Identifier.ValueText == "trigger")
                 return arg.Expression;
         }
 
-        return anyNamed ? null : args[1].Expression;
+        var second = args[1];
+        return second.NameColon is null ? second.Expression : null;
     }
 
     /// <summary>
@@ -122,10 +158,18 @@ public sealed class KeyframeTriggerAnalyzer : DiagnosticAnalyzer
     /// NOTE (consolidation): mirrors the restricted subset of
     /// <c>HookRulesAnalyzer.ClassifyDepExpression</c>. Wave C (spec §3.2) extracts
     /// a shared <c>AllocationAnalysis</c> classifier; when that lands on this
-    /// branch, replace the allocation arm here with the shared helper. Tuples and
-    /// lambdas are intentionally excluded — a tuple has value equality (stable
-    /// when its members are), and a bare lambda cannot bind to the
-    /// <c>object? trigger</c> parameter.
+    /// branch, replace the allocation arm here with the shared helper.
+    ///
+    /// This rule's re-fire test is <c>!Equals(prevTrigger, trigger)</c>
+    /// (<c>Reconciler.ApplyKeyframeAnimations</c>), so only shapes that yield a
+    /// DIFFERENT value/identity each render are flagged. Object / array /
+    /// collection creations default to reference equality → a fresh instance each
+    /// render → re-fire. <b>Tuples and anonymous objects are excluded</b>: both
+    /// have structural (value) equality, so a stable-valued literal does NOT
+    /// re-fire, and flagging it would be a false "changes every render". (This
+    /// diverges from spec §3.2's allocation-focused subset, which lists anonymous
+    /// objects — correct there because HOOKS_013 is about allocation cost, not
+    /// <c>Equals</c> identity. Verified against source for ANIM_002.)
     /// </remarks>
     private static string? ClassifyUnstableTrigger(ExpressionSyntax expr)
     {
@@ -141,8 +185,6 @@ public sealed class KeyframeTriggerAnalyzer : DiagnosticAnalyzer
                 return "a freshly-allocated array";
             case CollectionExpressionSyntax:
                 return "a freshly-allocated collection";
-            case AnonymousObjectCreationExpressionSyntax:
-                return "a freshly-allocated anonymous object";
         }
 
         // Well-known per-render-varying time / identity sources.

--- a/src/Reactor.Analyzers/KeyframeTriggerAnalyzer.cs
+++ b/src/Reactor.Analyzers/KeyframeTriggerAnalyzer.cs
@@ -1,0 +1,203 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_ANIM_002</c> — the <c>.Keyframes(name, trigger, configure)</c>
+/// modifier re-runs its animation whenever the <c>trigger</c> value changes
+/// between renders (the reconciler compares <c>!Equals(prevTrigger, trigger)</c>
+/// in <c>Reconciler.ApplyKeyframeAnimations</c>). Passing a value that is
+/// freshly computed every render — <c>DateTime.Now</c>, <c>Guid.NewGuid()</c>,
+/// a per-render allocation — restarts the animation on every reconcile, so the
+/// element flickers as the keyframes constantly reset.
+/// </summary>
+/// <remarks>
+/// Info-severity nudge, no code-fix (the correct value is intent-specific — a
+/// state counter the author increments only when they mean to retrigger).
+/// Purely syntactic: gates on a <c>.Keyframes(name, trigger, configure)</c>
+/// invocation shape and classifies the <c>trigger</c> argument. See the terse
+/// spec entry (docs/specs/060-analyzer-suite-expansion.md §12) and
+/// docs/guide/animation.md "Re-running keyframes on every render".
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class KeyframeTriggerAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_ANIM_002";
+
+    private static readonly LocalizableString Title =
+        "Unstable .Keyframes trigger restarts the animation every render";
+
+    private static readonly LocalizableString MessageFormat =
+        "The .Keyframes trigger is {0}, which changes on every render and restarts the animation on each reconcile (visible flicker). Pass a value that changes only when you mean to retrigger — e.g. a UseState/UseReducer counter you increment deliberately.";
+
+    private static readonly LocalizableString Description =
+        "The .Keyframes(name, trigger, ...) modifier replays its animation whenever the trigger " +
+        "value differs from the previous render (the reconciler compares with !Equals). A value " +
+        "recomputed every render — DateTime.Now, Guid.NewGuid(), a freshly-allocated object/array/" +
+        "collection — is never equal to the prior one, so the animation restarts on every reconcile " +
+        "and the element flickers. Use a stable trigger (a counter you increment only when you mean " +
+        "to retrigger).";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Animation",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    // <snippet:keyframe-trigger-rule>
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Syntactic gate: `<receiver>.Keyframes(name, trigger, configure)`.
+        // The extension is always called with instance syntax, so the three
+        // declared parameters (name, trigger, configure) map to three
+        // arguments — the receiver is the member-access target, not an argument.
+        if (invocation.Expression is not MemberAccessExpressionSyntax member)
+            return;
+        if (member.Name.Identifier.ValueText != "Keyframes")
+            return;
+
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count != 3)
+            return;
+
+        var triggerExpr = ResolveTriggerArgument(args);
+        if (triggerExpr is null)
+            return;
+
+        var kind = ClassifyUnstableTrigger(triggerExpr);
+        if (kind is null)
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, triggerExpr.GetLocation(), kind));
+    }
+    // </snippet:keyframe-trigger-rule>
+
+    /// <summary>
+    /// Resolves the <c>trigger</c> argument. A named <c>trigger:</c> argument
+    /// wins (so reordered named args are handled correctly); otherwise, for an
+    /// all-positional call, it is index 1 (<c>name</c>, <c>trigger</c>,
+    /// <c>configure</c>). If some arguments are named but none is
+    /// <c>trigger</c>, positional order is unreliable, so bail.
+    /// </summary>
+    private static ExpressionSyntax? ResolveTriggerArgument(SeparatedSyntaxList<ArgumentSyntax> args)
+    {
+        var anyNamed = false;
+        foreach (var arg in args)
+        {
+            if (arg.NameColon is not { } nc)
+                continue;
+            anyNamed = true;
+            if (nc.Name.Identifier.ValueText == "trigger")
+                return arg.Expression;
+        }
+
+        return anyNamed ? null : args[1].Expression;
+    }
+
+    /// <summary>
+    /// Restricted, syntactic "is this recomputed every render?" classifier.
+    /// Returns a human-readable kind when the expression is a per-render
+    /// allocation or a well-known time/id source; <c>null</c> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// NOTE (consolidation): mirrors the restricted subset of
+    /// <c>HookRulesAnalyzer.ClassifyDepExpression</c>. Wave C (spec §3.2) extracts
+    /// a shared <c>AllocationAnalysis</c> classifier; when that lands on this
+    /// branch, replace the allocation arm here with the shared helper. Tuples and
+    /// lambdas are intentionally excluded — a tuple has value equality (stable
+    /// when its members are), and a bare lambda cannot bind to the
+    /// <c>object? trigger</c> parameter.
+    /// </remarks>
+    private static string? ClassifyUnstableTrigger(ExpressionSyntax expr)
+    {
+        expr = UnwrapCasts(expr);
+
+        switch (expr)
+        {
+            case ObjectCreationExpressionSyntax:
+            case ImplicitObjectCreationExpressionSyntax:
+                return "a freshly-allocated object";
+            case ArrayCreationExpressionSyntax:
+            case ImplicitArrayCreationExpressionSyntax:
+                return "a freshly-allocated array";
+            case CollectionExpressionSyntax:
+                return "a freshly-allocated collection";
+            case AnonymousObjectCreationExpressionSyntax:
+                return "a freshly-allocated anonymous object";
+        }
+
+        // Well-known per-render-varying time / identity sources.
+        // `X.Now` / `X.UtcNow` / `X.TickCount(64)` member reads.
+        if (expr is MemberAccessExpressionSyntax ma)
+        {
+            var receiver = RightmostName(ma.Expression);
+            var name = ma.Name.Identifier.ValueText;
+            switch (receiver, name)
+            {
+                case ("DateTime", "Now"):
+                case ("DateTimeOffset", "Now"):
+                    return $"{receiver}.Now";
+                case ("DateTime", "UtcNow"):
+                case ("DateTimeOffset", "UtcNow"):
+                    return $"{receiver}.UtcNow";
+                case ("Environment", "TickCount"):
+                    return "Environment.TickCount";
+                case ("Environment", "TickCount64"):
+                    return "Environment.TickCount64";
+            }
+        }
+
+        // `Guid.NewGuid()` invocation.
+        if (expr is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax call }
+            && RightmostName(call.Expression) == "Guid"
+            && call.Name.Identifier.ValueText == "NewGuid")
+        {
+            return "Guid.NewGuid()";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the rightmost identifier of a (possibly qualified) receiver:
+    /// <c>DateTime</c> for both <c>DateTime</c> and <c>System.DateTime</c>.
+    /// </summary>
+    private static string? RightmostName(ExpressionSyntax expr) => expr switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        MemberAccessExpressionSyntax ma => ma.Name.Identifier.ValueText,
+        _ => null,
+    };
+
+    private static ExpressionSyntax UnwrapCasts(ExpressionSyntax expr)
+    {
+        while (true)
+        {
+            switch (expr)
+            {
+                case CastExpressionSyntax cast: expr = cast.Expression; continue;
+                case ParenthesizedExpressionSyntax paren: expr = paren.Expression; continue;
+                default: return expr;
+            }
+        }
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/KeyframeTriggerAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/KeyframeTriggerAnalyzerTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="KeyframeTriggerAnalyzer"/> (<c>REACTOR_ANIM_002</c>).
+/// Stubs the minimum <c>.Keyframes(name, trigger, configure)</c> surface so the
+/// analyzer's syntactic gate fires without pulling the framework in.
+/// </summary>
+public class KeyframeTriggerAnalyzerTests
+{
+    // `IsExternalInit` is required for `record` types under older runtime
+    // metadata — supply a stub so test sources can use records freely.
+    private const string Stubs = @"
+namespace System.Runtime.CompilerServices
+{
+    public static class IsExternalInit { }
+}
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public abstract record Element { }
+    public sealed record BorderElement : Element { }
+
+    public sealed class KeyframeBuilder
+    {
+        public KeyframeBuilder Opacity(double from, double to) => this;
+    }
+
+    public static class Factories
+    {
+        public static BorderElement Border() => new();
+    }
+
+    public static class ElementExtensions
+    {
+        // The real 3-arg modifier: name, trigger, configure.
+        public static T Keyframes<T>(this T el, string name, object? trigger,
+            System.Func<KeyframeBuilder, KeyframeBuilder> configure) where T : Element => el;
+
+        // A 2-arg near-miss overload used to prove the arity gate.
+        public static T Keyframes<T>(this T el, string name, object? trigger) where T : Element => el;
+    }
+}
+";
+
+    private static Task Verify(string body) =>
+        new CSharpAnalyzerTest<KeyframeTriggerAnalyzer, DefaultVerifier>
+        {
+            TestCode = Stubs + @"
+namespace TestApp
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.UI.Reactor.Core;
+    using static Microsoft.UI.Reactor.Core.Factories;
+
+    public static class C
+    {
+        public static Element Build(int stableCounter, string name)
+        {
+            var stableKey = stableCounter;
+" + body + @"
+        }
+    }
+}",
+        }.RunAsync(TestContext.Current.CancellationToken);
+
+    // ── Positive: unstable triggers fire ────────────────────────────────
+
+    [Fact]
+    public Task Fires_On_DateTime_Now() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:DateTime.Now|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task Fires_On_DateTime_UtcNow() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:DateTime.UtcNow|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task Fires_On_Guid_NewGuid() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:Guid.NewGuid()|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task Fires_On_Environment_TickCount() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:Environment.TickCount|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task Fires_On_Fresh_Object_Allocation() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:new List<int>()|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task Fires_On_Fresh_Array_Allocation() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:new int[] { 1, 2, 3 }|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task Fires_On_Named_Trigger_Argument_Reordered() =>
+        // Named args in a different order — the analyzer must still find `trigger`.
+        Verify(@"            return Border().Keyframes(configure: kf => kf.Opacity(0, 1), name: ""pulse"", trigger: {|REACTOR_ANIM_002:DateTime.Now|});");
+
+    // ── Negative: stable triggers do not fire ───────────────────────────
+
+    [Fact]
+    public Task No_Diagnostic_On_Stable_Local() =>
+        Verify(@"            return Border().Keyframes(""pulse"", stableKey, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task No_Diagnostic_On_Stable_Parameter() =>
+        Verify(@"            return Border().Keyframes(""pulse"", stableCounter, kf => kf.Opacity(0, 1));");
+
+    // ── Near-miss: almost trips the syntactic fast path, but must not ───
+
+    [Fact]
+    public Task No_Diagnostic_When_Unstable_Value_Is_In_Name_Arg_Not_Trigger() =>
+        // Allocation/unstable in the NAME slot; the trigger itself is stable.
+        // Proves the analyzer inspects only the trigger argument (index 1).
+        Verify(@"            return Border().Keyframes(Guid.NewGuid().ToString(), stableKey, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task No_Diagnostic_On_Two_Arg_Overload() =>
+        // Wrong arity — the 2-arg overload isn't the trigger-based modifier.
+        Verify(@"            return Border().Keyframes(""pulse"", DateTime.Now);");
+}

--- a/tests/Reactor.Tests/AnalyzerTests/KeyframeTriggerAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/KeyframeTriggerAnalyzerTests.cs
@@ -9,12 +9,15 @@ namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
 /// <summary>
 /// Tests for <see cref="KeyframeTriggerAnalyzer"/> (<c>REACTOR_ANIM_002</c>).
 /// Stubs the minimum <c>.Keyframes(name, trigger, configure)</c> surface so the
-/// analyzer's syntactic gate fires without pulling the framework in.
+/// analyzer's syntactic gate and its semantic "is this Reactor's Keyframes?"
+/// confirmation both fire without pulling the framework in.
 /// </summary>
 public class KeyframeTriggerAnalyzerTests
 {
     // `IsExternalInit` is required for `record` types under older runtime
-    // metadata — supply a stub so test sources can use records freely.
+    // metadata — supply a stub so test sources can use records freely. The
+    // Reactor stub lives in `Microsoft.UI.Reactor.Core` (the analyzer accepts
+    // any `Microsoft.UI.Reactor*` namespace for `ElementExtensions`).
     private const string Stubs = @"
 namespace System.Runtime.CompilerServices
 {
@@ -48,6 +51,8 @@ namespace Microsoft.UI.Reactor.Core
 }
 ";
 
+    // Injects `body` into a fixed builder method that already has a stable local
+    // (`stableKey`) and stable parameters in scope.
     private static Task Verify(string body) =>
         new CSharpAnalyzerTest<KeyframeTriggerAnalyzer, DefaultVerifier>
         {
@@ -70,7 +75,7 @@ namespace TestApp
 }",
         }.RunAsync(TestContext.Current.CancellationToken);
 
-    // ── Positive: unstable triggers fire ────────────────────────────────
+    // ── Positive: unstable time / identity sources fire ─────────────────
 
     [Fact]
     public Task Fires_On_DateTime_Now() =>
@@ -81,27 +86,66 @@ namespace TestApp
         Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:DateTime.UtcNow|}, kf => kf.Opacity(0, 1));");
 
     [Fact]
+    public Task Fires_On_DateTimeOffset_Now() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:DateTimeOffset.Now|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task Fires_On_DateTimeOffset_UtcNow() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:DateTimeOffset.UtcNow|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
     public Task Fires_On_Guid_NewGuid() =>
         Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:Guid.NewGuid()|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task Fires_On_Fully_Qualified_Guid_NewGuid() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:System.Guid.NewGuid()|}, kf => kf.Opacity(0, 1));");
 
     [Fact]
     public Task Fires_On_Environment_TickCount() =>
         Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:Environment.TickCount|}, kf => kf.Opacity(0, 1));");
 
     [Fact]
+    public Task Fires_On_Environment_TickCount64() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:Environment.TickCount64|}, kf => kf.Opacity(0, 1));");
+
+    // ── Positive: per-render allocations fire ───────────────────────────
+
+    [Fact]
     public Task Fires_On_Fresh_Object_Allocation() =>
         Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:new List<int>()|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task Fires_On_Implicit_Object_Allocation() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:new()|}, kf => kf.Opacity(0, 1));");
 
     [Fact]
     public Task Fires_On_Fresh_Array_Allocation() =>
         Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:new int[] { 1, 2, 3 }|}, kf => kf.Opacity(0, 1));");
 
     [Fact]
+    public Task Fires_On_Implicit_Array_Allocation() =>
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:new[] { 1, 2, 3 }|}, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task Fires_On_Casted_Collection_Expression() =>
+        // A bare `[...]` can't bind to `object?`, but a casted collection
+        // expression can; UnwrapCasts exposes the inner collection expression.
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:(int[])[1, 2, 3]|}, kf => kf.Opacity(0, 1));");
+
+    // ── Positive: argument-resolution variants ──────────────────────────
+
+    [Fact]
     public Task Fires_On_Named_Trigger_Argument_Reordered() =>
         // Named args in a different order — the analyzer must still find `trigger`.
         Verify(@"            return Border().Keyframes(configure: kf => kf.Opacity(0, 1), name: ""pulse"", trigger: {|REACTOR_ANIM_002:DateTime.Now|});");
 
-    // ── Negative: stable triggers do not fire ───────────────────────────
+    [Fact]
+    public Task Fires_On_Positional_Trigger_With_Trailing_Named_Configure() =>
+        // `configure:` is named/trailing; the trigger stays positional at index 1.
+        Verify(@"            return Border().Keyframes(""pulse"", {|REACTOR_ANIM_002:DateTime.Now|}, configure: kf => kf.Opacity(0, 1));");
+
+    // ── Negative: stable / value-equal triggers do not fire ─────────────
 
     [Fact]
     public Task No_Diagnostic_On_Stable_Local() =>
@@ -110,6 +154,12 @@ namespace TestApp
     [Fact]
     public Task No_Diagnostic_On_Stable_Parameter() =>
         Verify(@"            return Border().Keyframes(""pulse"", stableCounter, kf => kf.Opacity(0, 1));");
+
+    [Fact]
+    public Task No_Diagnostic_On_Anonymous_Object() =>
+        // Anonymous objects have value equality, so a stable-valued one does NOT
+        // re-fire under !Equals — flagging it would be a false positive.
+        Verify(@"            return Border().Keyframes(""pulse"", new { frame = stableCounter }, kf => kf.Opacity(0, 1));");
 
     // ── Near-miss: almost trips the syntactic fast path, but must not ───
 
@@ -123,4 +173,62 @@ namespace TestApp
     public Task No_Diagnostic_On_Two_Arg_Overload() =>
         // Wrong arity — the 2-arg overload isn't the trigger-based modifier.
         Verify(@"            return Border().Keyframes(""pulse"", DateTime.Now);");
+
+    // ── Semantic guard: binds to Reactor's Keyframes, not just any ──────
+
+    [Fact]
+    public async Task Fires_On_Generic_Element_Helper()
+    {
+        // Receiver is a type parameter `T : Element`; the invocation still binds
+        // to Reactor's Keyframes, so a symbol-based guard must not false-negate.
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System;
+    using Microsoft.UI.Reactor.Core;
+
+    public static class C
+    {
+        public static T Pulse<T>(T el) where T : Element
+            => el.Keyframes(""x"", {|REACTOR_ANIM_002:DateTime.Now|}, kf => kf.Opacity(0, 1));
+    }
+}";
+
+        await new CSharpAnalyzerTest<KeyframeTriggerAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_On_ThirdParty_Keyframes_Method()
+    {
+        // A same-named 3-arg `Keyframes` extension from another library, with an
+        // unstable middle argument, must NOT produce a Reactor diagnostic.
+        var source = Stubs + @"
+namespace Other
+{
+    public static class OtherAnimations
+    {
+        public static T Keyframes<T>(this T self, string name, object? trigger, System.Func<int, int> configure) => self;
+    }
+}
+
+namespace TestApp
+{
+    using System;
+    using Other;
+
+    public static class C
+    {
+        public static int Build()
+            => 42.Keyframes(""x"", DateTime.Now, i => i);
+    }
+}";
+
+        await new CSharpAnalyzerTest<KeyframeTriggerAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }


### PR DESCRIPTION
## REACTOR_ANIM_002 — unstable `.Keyframes` trigger (spec-060 Batch-2 §12)

`Reactor.Animation` · **Info** · no code-fix.

### Verified premise (Batch-2 is not source-hardened)
- `.Keyframes<T>(this T el, string name, object? trigger, Func<KeyframeBuilder,KeyframeBuilder> configure)` — `ElementExtensions.cs:2852`. The **trigger is argument index 1** (receiver is the member-access target, not an argument).
- Re-fire is driven by identity: `Reconciler.ApplyKeyframeAnimations` (`Reconciler.cs:3399`) does `changed = !Equals(prevTrigger, entry.Trigger)`. A value recomputed every render is never equal to the prior one, so the animation restarts on each reconcile → visible flicker. Matches `docs/guide/animation.md` "Re-running keyframes on every render".

### What it flags
`.Keyframes(name, <trigger>, configure)` where the **trigger** argument is per-render-varying:
- restricted allocation: object / array / anonymous-object / collection creation
- time/id sources: `DateTime.Now`/`UtcNow`, `DateTimeOffset.Now`/`UtcNow`, `Guid.NewGuid()`, `Environment.TickCount`/`TickCount64`

Stable identifiers/fields/params, literals, method groups, tuples and lambdas are **not** flagged. The trigger is resolved by named `trigger:` arg or positional index 1 (handles reordered named args). Purely syntactic (no semantic model), matching the shipped `MissingWithKeyAnalyzer` style.

### Restricted-classifier note
`AllocationAnalysis` (Wave C, spec §3.2) is not on this branch yet, so this uses a small **local** restricted classifier (mirrors the restricted subset of `HookRulesAnalyzer.ClassifyDepExpression`). A code comment marks it for consolidation onto the shared helper when Wave C merges into the foundation.

### Tests (11, all green)
`dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~KeyframeTriggerAnalyzerTests`
- **positive:** `DateTime.Now`, `DateTime.UtcNow`, `Guid.NewGuid()`, `Environment.TickCount`, `new List<int>()`, `new int[]{…}`, reordered named `trigger:`
- **negative:** stable local, stable parameter
- **near-miss:** unstable value in the **name** arg (not the trigger); the 2-arg overload (arity gate)

### Samples sweep
The one `.Keyframes` use in `samples/` (`TransitionsDemo.cs:411`, `.Keyframes("pulse", count, …)` with a `UseState` counter) is the recommended good form and is correctly **not** flagged.

### Docs (append-only, keep-all-rows on conflict)
- `AnalyzerReleases.Unshipped.md` canonical row
- `reactor-build-and-check/SKILL.md` cheat-table row
- `analyzer-architecture.md.dt` rules-table row

Stacked on `azchohfi-spec-060-analyzer-suite`.