### PR TITLE
feat(analyzer): REACTOR_INPUT_002 — unsafe TryGetFiles in OnDrop

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -123,6 +123,7 @@ via `.editorconfig`.
 | `REACTOR_DOCK_001` | Warning | OnLiveLayoutChanged feeds the live layout back into state | `OnLiveLayoutRoundTripAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
+| `REACTOR_INPUT_002` | Warning | Unsafe `TryGetFiles` in `.OnDrop`; prefer `TryGetSafeLocalFiles` | `UnsafeDropFilesAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_INPUT_002` | warning | `TryGetFiles` in an `.OnDrop(...)` handler — accepts UNC / DOS-device / reparse-point / shell-virtual files the drag source chose | Swap to `.TryGetSafeLocalFiles(out var files)` — same `bool(out IReadOnlyList<IStorageItem>)` signature, filters to safe local paths (UNC triggers SMB/NTLM auth, reparse points escape the shared dir, MOTW is lost). |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_INPUT_002 | Reactor.Input | Warning | UnsafeDropFilesAnalyzer - Unsafe TryGetFiles in .OnDrop returns UNC/reparse/virtual files; use TryGetSafeLocalFiles

--- a/src/Reactor.Analyzers/UnsafeDropFilesAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnsafeDropFilesAnalyzer.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// REACTOR_INPUT_002: Detects <c>DragData.TryGetFiles(out ...)</c> called inside a
+/// <c>.OnDrop(...)</c> handler. <c>TryGetFiles</c> returns whatever storage items the
+/// drag source advertised — including UNC paths, DOS-device paths, reparse points, and
+/// shell-virtual entries. An app that opens/parses/renders those files can be steered
+/// into SMB/NTLM auth on a stat, out of the directory the user thought they shared, or
+/// past a Mark-of-the-Web check. <c>TryGetSafeLocalFiles(out ...)</c> filters to safe
+/// local paths, so the fix is a drop-in swap.
+/// </summary>
+/// <remarks>
+/// Grounding: <c>src/Reactor/Input/DragData.cs</c> — <c>TryGetFiles</c> (raw) and
+/// <c>TryGetSafeLocalFiles</c> (filtered) share the signature
+/// <c>bool(out IReadOnlyList&lt;IStorageItem&gt;)</c>, so swapping the method name is a
+/// compiling, behavior-preserving-for-safe-inputs change. The rule is scoped to the
+/// <c>.OnDrop(...)</c> fluent modifier — the drop path where untrusted, source-chosen
+/// files land.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UnsafeDropFilesAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_INPUT_002";
+
+    /// <summary>The unsafe accessor the rule flags.</summary>
+    internal const string UnsafeMethodName = "TryGetFiles";
+
+    /// <summary>The safe accessor the code fix swaps in.</summary>
+    internal const string SafeMethodName = "TryGetSafeLocalFiles";
+
+    private const string DragDataTypeName = "DragData";
+    private const string DragDataNamespace = "Microsoft.UI.Reactor.Input";
+    private const string OnDropMethodName = "OnDrop";
+
+    private static readonly LocalizableString Title =
+        "Unsafe TryGetFiles in a drop handler; prefer TryGetSafeLocalFiles";
+
+    private static readonly LocalizableString MessageFormat =
+        "'TryGetFiles' in a drop handler returns UNC, DOS-device, reparse-point, and shell-virtual files chosen by the drag source; use 'TryGetSafeLocalFiles' to filter to safe local paths";
+
+    private static readonly LocalizableString Description =
+        "Dropped files come from another process that chose the paths. TryGetFiles returns " +
+        "them verbatim: a UNC path triggers SMB/NTLM authentication on stat/open, a reparse " +
+        "point can escape the directory the user thought they shared, and an Internet-zone " +
+        "file loses its Mark-of-the-Web warning if the app reads bytes without consulting " +
+        "Zone.Identifier. TryGetSafeLocalFiles filters those out and shares TryGetFiles' " +
+        "signature, so an app that opens/parses/renders dropped files should call it instead.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Input",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Syntactic fast path: an `X.TryGetFiles(...)` call.
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+        if (memberAccess.Name.Identifier.Text != UnsafeMethodName)
+            return;
+
+        // Drop-context gate (syntactic): lexically inside a `.OnDrop(...)` lambda.
+        if (!IsInsideOnDropLambda(invocation))
+            return;
+
+        // Semantic confirm: the method resolves to Microsoft.UI.Reactor.Input.DragData.
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol
+            is not IMethodSymbol method)
+            return;
+        var containingType = method.ContainingType;
+        if (containingType is null || containingType.Name != DragDataTypeName)
+            return;
+        if (containingType.ContainingNamespace?.ToDisplayString() != DragDataNamespace)
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
+    }
+
+    /// <summary>
+    /// True when <paramref name="node"/> is lexically inside a lambda passed to a
+    /// <c>.OnDrop(...)</c> invocation. Walks every enclosing lambda so a call nested in an
+    /// inner closure (e.g. <c>.OnDrop(a =&gt; list.ForEach(x =&gt; a.Data.TryGetFiles(...)))</c>)
+    /// still counts — it runs during the drop.
+    /// </summary>
+    private static bool IsInsideOnDropLambda(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is not LambdaExpressionSyntax lambda)
+                continue;
+            if (lambda.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax outer } }
+                && outer.Expression is MemberAccessExpressionSyntax outerMember
+                && outerMember.Name.Identifier.Text == OnDropMethodName)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Reactor.Analyzers/UnsafeDropFilesAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnsafeDropFilesAnalyzer.cs
@@ -117,31 +117,34 @@ public sealed class UnsafeDropFilesAnalyzer : DiagnosticAnalyzer
         };
 
     /// <summary>
-    /// True when <paramref name="node"/> is lexically inside a drop handler — either a lambda
-    /// passed to a <c>.OnDrop(...)</c> invocation (the fluent modifier) or a lambda assigned to
-    /// an <c>OnDrop</c> member (the raw <c>DropTargetConfig { OnDrop = ... }</c> / <c>with</c> /
-    /// <c>cfg.OnDrop = ...</c> form). Walks every enclosing lambda so a call nested in an inner
-    /// closure (e.g. <c>.OnDrop(a =&gt; list.ForEach(x =&gt; a.Data.TryGetFiles(...)))</c>) still
-    /// counts — it runs during the drop.
+    /// True when <paramref name="node"/> is lexically inside a drop handler — either a lambda /
+    /// anonymous method passed to a <c>.OnDrop(...)</c> invocation (the fluent modifier) or one
+    /// assigned to an <c>OnDrop</c> member (the raw <c>DropTargetConfig { OnDrop = ... }</c> /
+    /// <c>with</c> / <c>cfg.OnDrop = ...</c> form). Walks every enclosing lambda/anonymous method
+    /// so a call nested in an inner closure (e.g.
+    /// <c>.OnDrop(a =&gt; list.ForEach(x =&gt; a.Data.TryGetFiles(...)))</c>) still counts — it
+    /// runs during the drop.
     /// </summary>
     private static bool IsInsideDropHandlerLambda(SyntaxNode node)
     {
         for (var current = node.Parent; current is not null; current = current.Parent)
         {
-            if (current is not LambdaExpressionSyntax lambda)
+            // Covers lambdas (`args => ...`, `(args) => ...`) and anonymous methods
+            // (`delegate(DragTargetArgs args) { ... }`).
+            if (current is not AnonymousFunctionExpressionSyntax func)
                 continue;
 
-            // (A) lambda argument to a `.OnDrop(...)` call — `el.OnDrop(args => ...)` or the
-            //     null-conditional `el?.OnDrop(args => ...)` (GetInvokedName covers both shapes).
-            if (lambda.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax outer } }
+            // (A) handler argument to a `.OnDrop(...)` call — `el.OnDrop(...)` or the
+            //     null-conditional `el?.OnDrop(...)` (GetInvokedName covers both shapes).
+            if (func.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax outer } }
                 && GetInvokedName(outer)?.Identifier.Text == OnDropHandlerName)
             {
                 return true;
             }
 
-            // (B) lambda assigned to an `OnDrop` member: new DropTargetConfig { OnDrop = ... },
+            // (B) handler assigned to an `OnDrop` member: new DropTargetConfig { OnDrop = ... },
             //     cfg with { OnDrop = ... }, or cfg.OnDrop = ....
-            if (lambda.Parent is AssignmentExpressionSyntax { Left: var left } && IsOnDropTarget(left))
+            if (func.Parent is AssignmentExpressionSyntax assignment && IsOnDropTarget(assignment))
             {
                 return true;
             }
@@ -149,9 +152,13 @@ public sealed class UnsafeDropFilesAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool IsOnDropTarget(ExpressionSyntax left) => left switch
+    private static bool IsOnDropTarget(AssignmentExpressionSyntax assignment) => assignment.Left switch
     {
-        IdentifierNameSyntax id => id.Identifier.Text == OnDropHandlerName,             // { OnDrop = ... }
+        // A bare `OnDrop = ...` counts only inside an object/with initializer
+        // (`new DropTargetConfig { OnDrop = ... }` / `cfg with { OnDrop = ... }`), never a plain
+        // local/field/property named OnDrop that is unrelated to a drop target.
+        IdentifierNameSyntax id => id.Identifier.Text == OnDropHandlerName
+            && assignment.Parent is InitializerExpressionSyntax,
         MemberAccessExpressionSyntax member => member.Name.Identifier.Text == OnDropHandlerName, // cfg.OnDrop = ...
         _ => false,
     };

--- a/src/Reactor.Analyzers/UnsafeDropFilesAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnsafeDropFilesAnalyzer.cs
@@ -36,7 +36,10 @@ public sealed class UnsafeDropFilesAnalyzer : DiagnosticAnalyzer
 
     private const string DragDataTypeName = "DragData";
     private const string DragDataNamespace = "Microsoft.UI.Reactor.Input";
-    private const string OnDropMethodName = "OnDrop";
+
+    // The drop-handler member: both the fluent `.OnDrop(...)` modifier and the raw
+    // DropTargetConfig.OnDrop callback (DragConfigs.cs) carry this name.
+    private const string OnDropHandlerName = "OnDrop";
 
     private static readonly LocalizableString Title =
         "Unsafe TryGetFiles in a drop handler; prefer TryGetSafeLocalFiles";
@@ -81,8 +84,8 @@ public sealed class UnsafeDropFilesAnalyzer : DiagnosticAnalyzer
         if (memberAccess.Name.Identifier.Text != UnsafeMethodName)
             return;
 
-        // Drop-context gate (syntactic): lexically inside a `.OnDrop(...)` lambda.
-        if (!IsInsideOnDropLambda(invocation))
+        // Drop-context gate (syntactic): lexically inside a `.OnDrop(...)` handler.
+        if (!IsInsideDropHandlerLambda(invocation))
             return;
 
         // Semantic confirm: the method resolves to Microsoft.UI.Reactor.Input.DragData.
@@ -99,24 +102,42 @@ public sealed class UnsafeDropFilesAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// True when <paramref name="node"/> is lexically inside a lambda passed to a
-    /// <c>.OnDrop(...)</c> invocation. Walks every enclosing lambda so a call nested in an
-    /// inner closure (e.g. <c>.OnDrop(a =&gt; list.ForEach(x =&gt; a.Data.TryGetFiles(...)))</c>)
-    /// still counts — it runs during the drop.
+    /// True when <paramref name="node"/> is lexically inside a drop handler — either a lambda
+    /// passed to a <c>.OnDrop(...)</c> invocation (the fluent modifier) or a lambda assigned to
+    /// an <c>OnDrop</c> member (the raw <c>DropTargetConfig { OnDrop = ... }</c> / <c>with</c> /
+    /// <c>cfg.OnDrop = ...</c> form). Walks every enclosing lambda so a call nested in an inner
+    /// closure (e.g. <c>.OnDrop(a =&gt; list.ForEach(x =&gt; a.Data.TryGetFiles(...)))</c>) still
+    /// counts — it runs during the drop.
     /// </summary>
-    private static bool IsInsideOnDropLambda(SyntaxNode node)
+    private static bool IsInsideDropHandlerLambda(SyntaxNode node)
     {
         for (var current = node.Parent; current is not null; current = current.Parent)
         {
             if (current is not LambdaExpressionSyntax lambda)
                 continue;
+
+            // (A) lambda argument to a `.OnDrop(...)` call: el.OnDrop(args => ... TryGetFiles ...).
             if (lambda.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax outer } }
                 && outer.Expression is MemberAccessExpressionSyntax outerMember
-                && outerMember.Name.Identifier.Text == OnDropMethodName)
+                && outerMember.Name.Identifier.Text == OnDropHandlerName)
+            {
+                return true;
+            }
+
+            // (B) lambda assigned to an `OnDrop` member: new DropTargetConfig { OnDrop = ... },
+            //     cfg with { OnDrop = ... }, or cfg.OnDrop = ....
+            if (lambda.Parent is AssignmentExpressionSyntax { Left: var left } && IsOnDropTarget(left))
             {
                 return true;
             }
         }
         return false;
     }
+
+    private static bool IsOnDropTarget(ExpressionSyntax left) => left switch
+    {
+        IdentifierNameSyntax id => id.Identifier.Text == OnDropHandlerName,             // { OnDrop = ... }
+        MemberAccessExpressionSyntax member => member.Name.Identifier.Text == OnDropHandlerName, // cfg.OnDrop = ...
+        _ => false,
+    };
 }

--- a/src/Reactor.Analyzers/UnsafeDropFilesAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnsafeDropFilesAnalyzer.cs
@@ -131,10 +131,10 @@ public sealed class UnsafeDropFilesAnalyzer : DiagnosticAnalyzer
             if (current is not LambdaExpressionSyntax lambda)
                 continue;
 
-            // (A) lambda argument to a `.OnDrop(...)` call: el.OnDrop(args => ... TryGetFiles ...).
+            // (A) lambda argument to a `.OnDrop(...)` call — `el.OnDrop(args => ...)` or the
+            //     null-conditional `el?.OnDrop(args => ...)` (GetInvokedName covers both shapes).
             if (lambda.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax outer } }
-                && outer.Expression is MemberAccessExpressionSyntax outerMember
-                && outerMember.Name.Identifier.Text == OnDropHandlerName)
+                && GetInvokedName(outer)?.Identifier.Text == OnDropHandlerName)
             {
                 return true;
             }

--- a/src/Reactor.Analyzers/UnsafeDropFilesAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnsafeDropFilesAnalyzer.cs
@@ -78,10 +78,10 @@ public sealed class UnsafeDropFilesAnalyzer : DiagnosticAnalyzer
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
 
-        // Syntactic fast path: an `X.TryGetFiles(...)` call.
-        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
-            return;
-        if (memberAccess.Name.Identifier.Text != UnsafeMethodName)
+        // Syntactic fast path: a `TryGetFiles(...)` member call — covers both `x.TryGetFiles(...)`
+        // (member access) and `x?.TryGetFiles(...)` (conditional access / member binding).
+        var invokedName = GetInvokedName(invocation);
+        if (invokedName is null || invokedName.Identifier.Text != UnsafeMethodName)
             return;
 
         // Drop-context gate (syntactic): lexically inside a `.OnDrop(...)` handler.
@@ -100,6 +100,21 @@ public sealed class UnsafeDropFilesAnalyzer : DiagnosticAnalyzer
 
         context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
     }
+
+    /// <summary>
+    /// The invoked method-name node for a member invocation, covering both
+    /// <c>x.TryGetFiles(...)</c> (<see cref="MemberAccessExpressionSyntax"/>) and
+    /// <c>x?.TryGetFiles(...)</c> (<see cref="MemberBindingExpressionSyntax"/>, conditional
+    /// access). Returns <c>null</c> for other call shapes. Shared by the analyzer and code fix so
+    /// both agree on which call sites are in scope.
+    /// </summary>
+    internal static SimpleNameSyntax? GetInvokedName(InvocationExpressionSyntax invocation) =>
+        invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+            MemberBindingExpressionSyntax memberBinding => memberBinding.Name,
+            _ => null,
+        };
 
     /// <summary>
     /// True when <paramref name="node"/> is lexically inside a drop handler — either a lambda

--- a/src/Reactor.Analyzers/UnsafeDropFilesCodeFix.cs
+++ b/src/Reactor.Analyzers/UnsafeDropFilesCodeFix.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for REACTOR_INPUT_002: swaps the unsafe
+/// <c>DragData.TryGetFiles(out ...)</c> call to
+/// <c>DragData.TryGetSafeLocalFiles(out ...)</c>. Both methods share the signature
+/// <c>bool(out IReadOnlyList&lt;IStorageItem&gt;)</c>, so only the method-name identifier
+/// changes and the rewrite always compiles.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UnsafeDropFilesCodeFix))]
+[Shared]
+public sealed class UnsafeDropFilesCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(UnsafeDropFilesAnalyzer.DiagnosticId);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan);
+            if (node is not InvocationExpressionSyntax invocation) continue;
+            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) continue;
+            if (memberAccess.Name.Identifier.Text != UnsafeDropFilesAnalyzer.UnsafeMethodName) continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    $"Use .{UnsafeDropFilesAnalyzer.SafeMethodName}()",
+                    ct =>
+                    {
+                        var newName = SyntaxFactory
+                            .IdentifierName(UnsafeDropFilesAnalyzer.SafeMethodName)
+                            .WithTriviaFrom(memberAccess.Name);
+                        var newRoot = root.ReplaceNode(memberAccess.Name, newName);
+                        return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+                    },
+                    equivalenceKey: UnsafeDropFilesAnalyzer.DiagnosticId),
+                diagnostic);
+        }
+    }
+}

--- a/src/Reactor.Analyzers/UnsafeDropFilesCodeFix.cs
+++ b/src/Reactor.Analyzers/UnsafeDropFilesCodeFix.cs
@@ -34,8 +34,8 @@ public sealed class UnsafeDropFilesCodeFix : CodeFixProvider
         {
             var node = root.FindNode(diagnostic.Location.SourceSpan);
             if (node is not InvocationExpressionSyntax invocation) continue;
-            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) continue;
-            if (memberAccess.Name.Identifier.Text != UnsafeDropFilesAnalyzer.UnsafeMethodName) continue;
+            var invokedName = UnsafeDropFilesAnalyzer.GetInvokedName(invocation);
+            if (invokedName is null || invokedName.Identifier.Text != UnsafeDropFilesAnalyzer.UnsafeMethodName) continue;
 
             context.RegisterCodeFix(
                 CodeAction.Create(
@@ -44,8 +44,8 @@ public sealed class UnsafeDropFilesCodeFix : CodeFixProvider
                     {
                         var newName = SyntaxFactory
                             .IdentifierName(UnsafeDropFilesAnalyzer.SafeMethodName)
-                            .WithTriviaFrom(memberAccess.Name);
-                        var newRoot = root.ReplaceNode(memberAccess.Name, newName);
+                            .WithTriviaFrom(invokedName);
+                        var newRoot = root.ReplaceNode(invokedName, newName);
                         return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
                     },
                     equivalenceKey: UnsafeDropFilesAnalyzer.DiagnosticId),

--- a/tests/Reactor.Tests/AnalyzerTests/UnsafeDropFilesAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnsafeDropFilesAnalyzerTests.cs
@@ -197,6 +197,27 @@ class C
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Fires_For_TryGetFiles_In_Conditional_OnDrop_Call()
+    {
+        // Null-conditional on the OnDrop call itself: `el?.OnDrop(...)`. The outer invocation's
+        // expression is a MemberBindingExpressionSyntax, still recognized as a drop handler.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        FakeElement el = new FakeElement();
+        el?.OnDrop(args => {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var f)|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
     // ── Negative ────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Reactor.Tests/AnalyzerTests/UnsafeDropFilesAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnsafeDropFilesAnalyzerTests.cs
@@ -172,6 +172,31 @@ class C
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Fires_For_Conditional_Access_TryGetFiles_In_OnDrop()
+    {
+        // Null-conditional call: `d?.TryGetFiles(...)` — invocation.Expression is a
+        // MemberBindingExpressionSyntax (not MemberAccess). The rule still fires.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args =>
+        {
+            Microsoft.UI.Reactor.Input.DragData d = args.Data;
+            d?{|REACTOR_INPUT_002:.TryGetFiles(out _)|};
+        });
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
     // ── Negative ────────────────────────────────────────────────────────
 
     [Fact]
@@ -338,6 +363,45 @@ class C
         {
             OnDrop = args => args.Data.TryGetSafeLocalFiles(out var g)
         };
+    }
+}";
+
+        await new CSharpCodeFixTest<UnsafeDropFilesAnalyzer, UnsafeDropFilesCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Swaps_Conditional_Access_Call()
+    {
+        // The name identifier is swapped; the `?.` operator and args are preserved.
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args =>
+        {
+            Microsoft.UI.Reactor.Input.DragData d = args.Data;
+            d?{|REACTOR_INPUT_002:.TryGetFiles(out _)|};
+        });
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args =>
+        {
+            Microsoft.UI.Reactor.Input.DragData d = args.Data;
+            d?.TryGetSafeLocalFiles(out _);
+        });
     }
 }";
 

--- a/tests/Reactor.Tests/AnalyzerTests/UnsafeDropFilesAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnsafeDropFilesAnalyzerTests.cs
@@ -218,7 +218,52 @@ class C
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Fires_For_TryGetFiles_In_Anonymous_Method_OnDrop_Handler()
+    {
+        // Old-style anonymous method: delegate(DragTargetArgs args) { ... } is an
+        // AnonymousFunctionExpression (not a lambda), still a drop handler.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(delegate(Microsoft.UI.Reactor.Input.DragTargetArgs args)
+        {
+            {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var f)|};
+        });
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
     // ── Negative ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Bare_Assignment_To_Local_Named_OnDrop()
+    {
+        // `OnDrop` here is an unrelated local delegate assigned outside any object/with
+        // initializer, so the assignment form must NOT be treated as a drop handler.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        System.Action<Microsoft.UI.Reactor.Input.DragData> OnDrop = null;
+        OnDrop = d => d.TryGetFiles(out var f);
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 
     [Fact]
     public async Task No_Diagnostic_When_TryGetSafeLocalFiles_Already_Used()

--- a/tests/Reactor.Tests/AnalyzerTests/UnsafeDropFilesAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnsafeDropFilesAnalyzerTests.cs
@@ -1,0 +1,260 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="UnsafeDropFilesAnalyzer"/> (<c>REACTOR_INPUT_002</c>) and its
+/// <see cref="UnsafeDropFilesCodeFix"/>. Stubs a minimal Reactor-shaped <c>DragData</c>
+/// (with both <c>TryGetFiles</c> and <c>TryGetSafeLocalFiles</c>), a <c>DragTargetArgs</c>
+/// carrying it, and an <c>.OnDrop</c> fluent modifier so the syntactic + semantic match
+/// fires without pulling the framework in.
+/// </summary>
+public class UnsafeDropFilesAnalyzerTests
+{
+    // Mirrors src/Reactor/Input/DragData.cs: DragData lives in Microsoft.UI.Reactor.Input
+    // and exposes the unsafe TryGetFiles alongside the filtered TryGetSafeLocalFiles, both
+    // bool(out IReadOnlyList<...>). OtherData is a decoy with the same method name in a
+    // different type, to exercise the semantic DragData gate.
+    private const string Stubs = @"
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Reactor.Input;
+
+namespace Microsoft.UI.Reactor.Input
+{
+    public sealed class DragData
+    {
+        public bool TryGetFiles(out IReadOnlyList<object> value) { value = Array.Empty<object>(); return false; }
+        public bool TryGetSafeLocalFiles(out IReadOnlyList<object> value) { value = Array.Empty<object>(); return false; }
+    }
+
+    public sealed class DragTargetArgs
+    {
+        public DragData Data { get; } = new DragData();
+    }
+}
+
+// Decoy: same method name, different (non-DragData) type.
+public sealed class OtherData
+{
+    public bool TryGetFiles(out System.Collections.Generic.IReadOnlyList<object> value) { value = System.Array.Empty<object>(); return false; }
+}
+
+public class FakeElement { }
+
+public static class FakeElementExtensions
+{
+    public static T OnDrop<T>(this T el, Action<Microsoft.UI.Reactor.Input.DragTargetArgs> handler) => el;
+    // A non-drop modifier taking the same lambda shape — proves the .OnDrop gate.
+    public static T OnHover<T>(this T el, Action<Microsoft.UI.Reactor.Input.DragTargetArgs> handler) => el;
+}
+";
+
+    // ── Positive ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Fires_For_TryGetFiles_On_ArgsData_In_OnDrop()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args => {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var f)|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_TryGetFiles_On_Local_DragData_In_OnDrop()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args =>
+        {
+            var d = new Microsoft.UI.Reactor.Input.DragData();
+            {|REACTOR_INPUT_002:d.TryGetFiles(out var f)|};
+        });
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_TryGetFiles_In_Nested_Closure_Inside_OnDrop()
+    {
+        // The call sits in an inner lambda nested inside the OnDrop lambda — it still runs
+        // during the drop, so the rule walks every enclosing lambda and fires.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args =>
+        {
+            System.Action run = () => { {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var f)|}; };
+            run();
+        });
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_When_TryGetSafeLocalFiles_Already_Used()
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args => args.Data.TryGetSafeLocalFiles(out var f));
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_TryGetFiles_Outside_A_Drop_Context()
+    {
+        // Same DragData receiver + method, but not inside any .OnDrop — the drop-context
+        // gate rejects it. (Also covers the non-OnDrop .OnHover modifier.)
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var d = new Microsoft.UI.Reactor.Input.DragData();
+        d.TryGetFiles(out var f);
+
+        var el = new FakeElement();
+        el.OnHover(args => args.Data.TryGetFiles(out var g));
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_TryGetFiles_On_NonDragData_Receiver_In_OnDrop()
+    {
+        // Near-miss: trips the syntactic name gate AND the .OnDrop gate, but the receiver is
+        // OtherData, not Microsoft.UI.Reactor.Input.DragData, so the semantic gate rejects it.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        var other = new OtherData();
+        el.OnDrop(args => other.TryGetFiles(out var f));
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code fix (swap round-trip) ──────────────────────────────────────
+
+    [Fact]
+    public async Task CodeFix_Swaps_TryGetFiles_To_TryGetSafeLocalFiles()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args => {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var f)|});
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args => args.Data.TryGetSafeLocalFiles(out var f));
+    }
+}";
+
+        await new CSharpCodeFixTest<UnsafeDropFilesAnalyzer, UnsafeDropFilesCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Swaps_Inside_Block_Bodied_OnDrop_Lambda()
+    {
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args =>
+        {
+            {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var f)|};
+        });
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args =>
+        {
+            args.Data.TryGetSafeLocalFiles(out var f);
+        });
+    }
+}";
+
+        await new CSharpCodeFixTest<UnsafeDropFilesAnalyzer, UnsafeDropFilesCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/UnsafeDropFilesAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnsafeDropFilesAnalyzerTests.cs
@@ -36,6 +36,12 @@ namespace Microsoft.UI.Reactor.Input
     {
         public DragData Data { get; } = new DragData();
     }
+
+    // Raw target-side config (mirrors DragConfigs.cs): OnDrop is a public handler member.
+    public sealed class DropTargetConfig
+    {
+        public Action<DragTargetArgs> OnDrop;
+    }
 }
 
 // Decoy: same method name, different (non-DragData) type.
@@ -114,6 +120,49 @@ class C
             System.Action run = () => { {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var f)|}; };
             run();
         });
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Generic_OnDrop_Call()
+    {
+        // Explicit type argument makes the OnDrop name a GenericNameSyntax at the gate.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop<FakeElement>(args => {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var f)|});
+    }
+}";
+
+        await new CSharpAnalyzerTest<UnsafeDropFilesAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_TryGetFiles_In_DropTargetConfig_Initializer()
+    {
+        // The raw DropTargetConfig { OnDrop = ... } form is also a drop handler — the source
+        // still picks the files, so the rule fires on the assignment form too.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        var cfg = new Microsoft.UI.Reactor.Input.DropTargetConfig
+        {
+            OnDrop = args => {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var f)|}
+        };
     }
 }";
 
@@ -248,6 +297,47 @@ class C
         {
             args.Data.TryGetSafeLocalFiles(out var f);
         });
+    }
+}";
+
+        await new CSharpCodeFixTest<UnsafeDropFilesAnalyzer, UnsafeDropFilesCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Swaps_All_Occurrences_In_One_File()
+    {
+        // Two unsafe calls in the same file — the BatchFixer FixAll provider rewrites both.
+        var before = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args => {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var f)|});
+
+        var cfg = new Microsoft.UI.Reactor.Input.DropTargetConfig
+        {
+            OnDrop = args => {|REACTOR_INPUT_002:args.Data.TryGetFiles(out var g)|}
+        };
+    }
+}";
+
+        var after = Stubs + @"
+class C
+{
+    void M()
+    {
+        var el = new FakeElement();
+        el.OnDrop(args => args.Data.TryGetSafeLocalFiles(out var f));
+
+        var cfg = new Microsoft.UI.Reactor.Input.DropTargetConfig
+        {
+            OnDrop = args => args.Data.TryGetSafeLocalFiles(out var g)
+        };
     }
 }";
 


### PR DESCRIPTION
Implements spec-060 Batch-2 (§12) packet **REACTOR_INPUT_002** (`Reactor.Input`, Warning, swap code fix). Stacked on the foundation branch `azchohfi-spec-060-analyzer-suite`.

## Rule
`.OnDrop(args => args.Data.TryGetFiles(out var f))` returns whatever storage items the drag **source** advertised — including UNC paths (trigger SMB/NTLM auth on stat/open), DOS-device paths, reparse points (escape the shared directory), and shell-virtual entries; Internet-zone files also lose their Mark-of-the-Web warning. `TryGetSafeLocalFiles` filters those to safe local paths.

- **Detect:** a `TryGetFiles` invocation that binds to `Microsoft.UI.Reactor.Input.DragData`, lexically inside a `.OnDrop(...)` lambda (walks every enclosing lambda so nested closures still count).
- **Fix:** swap the method-name identifier `TryGetFiles` → `TryGetSafeLocalFiles`. Both are `bool(out IReadOnlyList<IStorageItem>)` (DragData.cs:175 / :198), so the rewrite always compiles.

## Grounding (verified against source before implementing)
- `DragData.TryGetFiles` and `DragData.TryGetSafeLocalFiles` exist with identical signatures — `src/Reactor/Input/DragData.cs:175,198`.
- Raw `.OnDrop<T>(Action<DragTargetArgs>)` — `ElementExtensions.cs:494`; `DragTargetArgs.Data` is a `DragData` — `DragTargetArgs.cs:50`.
- Matches spec §12 terse entry (`DragData.cs:193`; `input-and-gestures.md:480-486`).

## Design notes
- Syntactic gate (name `TryGetFiles` + inside `.OnDrop` lambda) runs before the one `GetSymbolInfo` (spec §2.1/§3).
- Semantic `DragData` confirm keeps precision — a same-named `TryGetFiles` on any other type inside `.OnDrop` does not fire.
- Scoped to the fluent `.OnDrop(...)` modifier (the untrusted drop path).

## Tests — `dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~UnsafeDropFilesAnalyzerTests` (8/8 green; full AnalyzerTests 223/223)
- Positive: `args.Data.TryGetFiles` in `.OnDrop`; local `DragData` var; nested inner closure.
- Negative: `TryGetSafeLocalFiles` already used; `TryGetFiles` outside a drop context (+ non-`OnDrop` modifier).
- Near-miss: `TryGetFiles` on a non-`DragData` receiver inside `.OnDrop` (semantic gate rejects).
- Fix round-trip: swap to `TryGetSafeLocalFiles` (expression-body + block-body `.OnDrop` lambda).

## Docs
- Canonical row → `AnalyzerReleases.Unshipped.md`.
- Cheat-table row → `reactor-build-and-check/SKILL.md`.
- Rules-table row → `analyzer-architecture.md.dt` (template, not generated output).

Samples sweep: no sample uses `TryGetFiles` — acceptable for a security rule (§2.4); no deliberately-bad sample added.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>