### PR TITLE
feat(analyzer): REACTOR_NAV_001 — UseNavigation handle in a static field

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,7 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
-| `REACTOR_NAV_001` | Warning | `UseNavigation` handle captured into a `static` field | `StaticNavigationHandleAnalyzer.cs` |
+| `REACTOR_NAV_001` | Warning | `UseNavigation` handle captured into a `static` field or property | `StaticNavigationHandleAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,6 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_NAV_001` | Warning | `UseNavigation` handle captured into a `static` field | `StaticNavigationHandleAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_NAV_001` | warning | `UseNavigation` handle stashed in a `static` field | Don't stash the handle statically — it outlives the page and pins its dispatcher. Get the shared handle from a descendant with child-mode `UseNavigation<TRoute>()` (no initial value), or pass it through `Context`. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,7 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
-| `REACTOR_NAV_001` | warning | `UseNavigation` handle stashed in a `static` field | Don't stash the handle statically — it outlives the page and pins its dispatcher. Get the shared handle from a descendant with child-mode `UseNavigation<TRoute>()` (no initial value), or pass it through `Context`. |
+| `REACTOR_NAV_001` | warning | `UseNavigation` handle stashed in a `static` field or property | Don't stash the handle statically — it outlives the page and pins its dispatcher. Get the shared handle from a descendant with child-mode `UseNavigation<TRoute>()` (no initial value), or pass it through `Context`. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_NAV_001 | Reactor.Navigation | Warning | StaticNavigationHandleAnalyzer - UseNavigation handle captured into a static field outlives the page and pins its dispatcher

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,4 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
-REACTOR_NAV_001 | Reactor.Navigation | Warning | StaticNavigationHandleAnalyzer - UseNavigation handle captured into a static field outlives the page and pins its dispatcher
+REACTOR_NAV_001 | Reactor.Navigation | Warning | StaticNavigationHandleAnalyzer - UseNavigation handle captured into a static field or property outlives the page and pins its dispatcher

--- a/src/Reactor.Analyzers/StaticNavigationHandleAnalyzer.cs
+++ b/src/Reactor.Analyzers/StaticNavigationHandleAnalyzer.cs
@@ -1,14 +1,13 @@
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.UI.Reactor.Analyzers;
 
 /// <summary>
 /// <c>REACTOR_NAV_001</c> — a <see cref="Navigation.NavigationHandle{TRoute}"/>
-/// returned by <c>UseNavigation</c> must not be stashed in a <c>static</c> field.
+/// returned by <c>UseNavigation</c> must not be stashed in a <c>static</c> field or property.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Reactor.Analyzers/StaticNavigationHandleAnalyzer.cs
+++ b/src/Reactor.Analyzers/StaticNavigationHandleAnalyzer.cs
@@ -28,13 +28,15 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// the same handle via context, or pass it through <c>Context</c> explicitly.
 /// </para>
 /// <para>
-/// Detection is a pure <see cref="SymbolKind.Field"/> gate: any <c>static</c> field
-/// typed <c>NavigationHandle&lt;&gt;</c>. The handle's constructor is
-/// <c>internal</c>, so the only way consumer code can obtain one is <c>UseNavigation</c> —
-/// which makes "static field typed <c>NavigationHandle&lt;&gt;</c>" equivalent to the
-/// spec's "assigned from <c>UseNavigation</c>", and robustly covers the canonical form
-/// above where the value flows through an intermediate local. No code-fix (the correct
-/// rewrite depends on how the handle is consumed elsewhere).
+/// Detection is a pure symbol gate over <see cref="SymbolKind.Field"/> and
+/// <see cref="SymbolKind.Property"/>: any <c>static</c> field or property typed
+/// <c>NavigationHandle&lt;&gt;</c> (a static auto-property is the same static-lifetime
+/// leak as a field). The handle's constructor is <c>internal</c>, so the only way
+/// consumer code can obtain one is <c>UseNavigation</c> — which makes "static
+/// <c>NavigationHandle&lt;&gt;</c> storage" equivalent to the spec's "assigned from
+/// <c>UseNavigation</c>", and robustly covers the canonical form above where the value
+/// flows through an intermediate local. No code-fix (the correct rewrite depends on how
+/// the handle is consumed elsewhere).
 /// </para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -46,15 +48,16 @@ public sealed class StaticNavigationHandleAnalyzer : DiagnosticAnalyzer
     private const string NavigationNamespace = "Microsoft.UI.Reactor.Navigation";
 
     private static readonly LocalizableString Title =
-        "UseNavigation handle stored in a static field";
+        "UseNavigation handle stored in a static field or property";
     private static readonly LocalizableString MessageFormat =
-        "Static field '{0}' holds a UseNavigation handle, which outlives the page and pins its dispatcher";
+        "Static {0} '{1}' holds a UseNavigation handle that outlives the page and pins its " +
+        "dispatcher; access it from a descendant with UseNavigation<TRoute>() or pass it through Context";
     private static readonly LocalizableString Description =
         "A NavigationHandle<TRoute> is bound to the dispatcher of the component that created it. " +
-        "Stashing it in a static field keeps it — and its dispatcher — alive past the page's " +
-        "lifetime (a leak); after that dispatcher shuts down the handle's mutators throw. " +
-        "Access the shared handle from a descendant with child-mode UseNavigation<TRoute>() " +
-        "(no initial value), or pass it through Context, instead of a static field.";
+        "Stashing it in static state (a static field or property) keeps it — and its dispatcher — " +
+        "alive past the page's lifetime (a leak); after that dispatcher shuts down the handle's " +
+        "mutators throw. Access the shared handle from a descendant with child-mode " +
+        "UseNavigation<TRoute>() (no initial value), or pass it through Context, instead of static state.";
 
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
@@ -73,26 +76,46 @@ public sealed class StaticNavigationHandleAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSymbolAction(AnalyzeField, SymbolKind.Field);
+        context.RegisterSymbolAction(AnalyzeProperty, SymbolKind.Property);
     }
 
     private static void AnalyzeField(SymbolAnalysisContext context)
     {
         var field = (IFieldSymbol)context.Symbol;
 
-        // Only static storage leaks the handle across page lifetimes.
-        if (!field.IsStatic)
-            return;
-
         // Skip compiler-generated fields (auto-property backing fields, closures,
         // enum value fields, etc.) — the author can't act on those declarations.
+        // A static auto-property is caught via AnalyzeProperty instead.
         if (field.IsImplicitlyDeclared)
             return;
 
-        if (!IsNavigationHandle(field.Type))
+        ReportIfStaticHandle(context, field, field.Type, field.IsStatic, "field");
+    }
+
+    private static void AnalyzeProperty(SymbolAnalysisContext context)
+    {
+        var property = (IPropertySymbol)context.Symbol;
+
+        // A static property holding the handle is the same static-lifetime leak as a
+        // field. Skip indexers (never static) and compiler-generated properties.
+        if (property.IsImplicitlyDeclared || property.IsIndexer)
             return;
 
-        var location = field.Locations.FirstOrDefault() ?? Location.None;
-        context.ReportDiagnostic(Diagnostic.Create(Rule, location, field.Name));
+        ReportIfStaticHandle(context, property, property.Type, property.IsStatic, "property");
+    }
+
+    private static void ReportIfStaticHandle(
+        SymbolAnalysisContext context, ISymbol symbol, ITypeSymbol type, bool isStatic, string kind)
+    {
+        // Only static storage leaks the handle across page lifetimes.
+        if (!isStatic)
+            return;
+
+        if (!IsNavigationHandle(type))
+            return;
+
+        var location = symbol.Locations.FirstOrDefault() ?? Location.None;
+        context.ReportDiagnostic(Diagnostic.Create(Rule, location, kind, symbol.Name));
     }
 
     private static bool IsNavigationHandle(ITypeSymbol type)

--- a/src/Reactor.Analyzers/StaticNavigationHandleAnalyzer.cs
+++ b/src/Reactor.Analyzers/StaticNavigationHandleAnalyzer.cs
@@ -1,0 +1,108 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_NAV_001</c> — a <see cref="Navigation.NavigationHandle{TRoute}"/>
+/// returned by <c>UseNavigation</c> must not be stashed in a <c>static</c> field.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pitfall (navigation.md §"Treating <c>UseNavigation</c> like a singleton"):
+/// </para>
+/// <code>
+/// public static NavigationHandle&lt;Route&gt;? Nav;
+/// // ...
+/// var nav = UseNavigation(Route.Home);
+/// Nav = nav; // capture for later use from anywhere
+/// </code>
+/// <para>
+/// The handle is bound to the dispatcher of the component that created it. Stashed
+/// in a <c>static</c>, it outlives the page and pins (leaks) that dispatcher; once
+/// the dispatcher shuts down, its mutators throw. Prefer child-mode
+/// <c>UseNavigation&lt;TRoute&gt;()</c> (no initial value) in a descendant to obtain
+/// the same handle via context, or pass it through <c>Context</c> explicitly.
+/// </para>
+/// <para>
+/// Detection is a pure <see cref="SymbolKind.Field"/> gate: any <c>static</c> field
+/// typed <c>NavigationHandle&lt;&gt;</c>. The handle's constructor is
+/// <c>internal</c>, so the only way consumer code can obtain one is <c>UseNavigation</c> —
+/// which makes "static field typed <c>NavigationHandle&lt;&gt;</c>" equivalent to the
+/// spec's "assigned from <c>UseNavigation</c>", and robustly covers the canonical form
+/// above where the value flows through an intermediate local. No code-fix (the correct
+/// rewrite depends on how the handle is consumed elsewhere).
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class StaticNavigationHandleAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_NAV_001";
+
+    private const string NavigationHandleTypeName = "NavigationHandle";
+    private const string NavigationNamespace = "Microsoft.UI.Reactor.Navigation";
+
+    private static readonly LocalizableString Title =
+        "UseNavigation handle stored in a static field";
+    private static readonly LocalizableString MessageFormat =
+        "Static field '{0}' holds a UseNavigation handle, which outlives the page and pins its dispatcher";
+    private static readonly LocalizableString Description =
+        "A NavigationHandle<TRoute> is bound to the dispatcher of the component that created it. " +
+        "Stashing it in a static field keeps it — and its dispatcher — alive past the page's " +
+        "lifetime (a leak); after that dispatcher shuts down the handle's mutators throw. " +
+        "Access the shared handle from a descendant with child-mode UseNavigation<TRoute>() " +
+        "(no initial value), or pass it through Context, instead of a static field.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Navigation",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeField, SymbolKind.Field);
+    }
+
+    private static void AnalyzeField(SymbolAnalysisContext context)
+    {
+        var field = (IFieldSymbol)context.Symbol;
+
+        // Only static storage leaks the handle across page lifetimes.
+        if (!field.IsStatic)
+            return;
+
+        // Skip compiler-generated fields (auto-property backing fields, closures,
+        // enum value fields, etc.) — the author can't act on those declarations.
+        if (field.IsImplicitlyDeclared)
+            return;
+
+        if (!IsNavigationHandle(field.Type))
+            return;
+
+        var location = field.Locations.FirstOrDefault() ?? Location.None;
+        context.ReportDiagnostic(Diagnostic.Create(Rule, location, field.Name));
+    }
+
+    private static bool IsNavigationHandle(ITypeSymbol type)
+    {
+        if (type is not INamedTypeSymbol named)
+            return false;
+
+        var definition = named.OriginalDefinition;
+        return definition.Arity == 1
+            && definition.Name == NavigationHandleTypeName
+            && definition.ContainingNamespace?.ToDisplayString() == NavigationNamespace;
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/StaticNavigationHandleAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/StaticNavigationHandleAnalyzerTests.cs
@@ -11,8 +11,8 @@ namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
 /// Stubs a minimal Reactor-shaped <c>NavigationHandle&lt;TRoute&gt;</c> (in the real
 /// <c>Microsoft.UI.Reactor.Navigation</c> namespace the analyzer keys on) plus a
 /// <c>Component</c> base exposing <c>UseNavigation</c>, so the pure symbol gate fires
-/// without pulling the framework in. The analyzer flags a <c>static</c> field typed
-/// <c>NavigationHandle&lt;&gt;</c> regardless of how the value flows in — the handle's
+/// without pulling the framework in. The analyzer flags a <c>static</c> field or property
+/// typed <c>NavigationHandle&lt;&gt;</c> regardless of how the value flows in — the handle's
 /// constructor is <c>internal</c>, so consumer code can only get one from
 /// <c>UseNavigation</c>.
 /// </summary>
@@ -110,7 +110,26 @@ class Shell : Component
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 
-    // ── Negative: instance field / local assigned from UseNavigation ──
+    [Fact]
+    public async Task Fires_For_Static_AutoProperty()
+    {
+        // A static auto-property holds the handle for the same static lifetime as a
+        // field; its backing field is implicitly declared, so it's reported here once.
+        var source = Stubs + @"
+class Shell : Component
+{
+    public static NavigationHandle<Route>? {|REACTOR_NAV_001:Nav|} { get; set; }
+
+    public void Render() => Nav = UseNavigation(Route.Home);
+}";
+
+        await new CSharpAnalyzerTest<StaticNavigationHandleAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative: instance field / property / local assigned from UseNavigation ──
 
     [Fact]
     public async Task No_Diagnostic_For_Instance_Field()
@@ -125,6 +144,23 @@ class Shell : Component
         var nav = UseNavigation(Route.Home);
         Nav = nav;
     }
+}";
+
+        await new CSharpAnalyzerTest<StaticNavigationHandleAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Instance_AutoProperty()
+    {
+        var source = Stubs + @"
+class Shell : Component
+{
+    public NavigationHandle<Route>? Nav { get; set; }
+
+    public void Render() => Nav = UseNavigation(Route.Home);
 }";
 
         await new CSharpAnalyzerTest<StaticNavigationHandleAnalyzer, DefaultVerifier>

--- a/tests/Reactor.Tests/AnalyzerTests/StaticNavigationHandleAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/StaticNavigationHandleAnalyzerTests.cs
@@ -26,8 +26,13 @@ using Microsoft.UI.Reactor.Navigation;
 namespace Microsoft.UI.Reactor.Navigation
 {
     // Mirrors src/Reactor/Core/Navigation/NavigationHandle.cs — a sealed generic
-    // handle in this exact namespace (name + namespace + arity are the gate).
-    public sealed class NavigationHandle<TRoute> where TRoute : notnull { }
+    // handle in this exact namespace (name + namespace + arity are the gate). Its
+    // constructor is internal (as in the framework), so consumer code can only obtain
+    // one from UseNavigation — which is why static storage of this type is the leak.
+    public sealed class NavigationHandle<TRoute> where TRoute : notnull
+    {
+        internal NavigationHandle() { }
+    }
 }
 
 namespace Microsoft.UI.Reactor.Core

--- a/tests/Reactor.Tests/AnalyzerTests/StaticNavigationHandleAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/StaticNavigationHandleAnalyzerTests.cs
@@ -1,0 +1,192 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="StaticNavigationHandleAnalyzer"/> (<c>REACTOR_NAV_001</c>).
+/// Stubs a minimal Reactor-shaped <c>NavigationHandle&lt;TRoute&gt;</c> (in the real
+/// <c>Microsoft.UI.Reactor.Navigation</c> namespace the analyzer keys on) plus a
+/// <c>Component</c> base exposing <c>UseNavigation</c>, so the pure symbol gate fires
+/// without pulling the framework in. The analyzer flags a <c>static</c> field typed
+/// <c>NavigationHandle&lt;&gt;</c> regardless of how the value flows in — the handle's
+/// constructor is <c>internal</c>, so consumer code can only get one from
+/// <c>UseNavigation</c>.
+/// </summary>
+public class StaticNavigationHandleAnalyzerTests
+{
+    private const string Stubs = @"
+#nullable enable
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Navigation;
+
+namespace Microsoft.UI.Reactor.Navigation
+{
+    // Mirrors src/Reactor/Core/Navigation/NavigationHandle.cs — a sealed generic
+    // handle in this exact namespace (name + namespace + arity are the gate).
+    public sealed class NavigationHandle<TRoute> where TRoute : notnull { }
+}
+
+namespace Microsoft.UI.Reactor.Core
+{
+    using Microsoft.UI.Reactor.Navigation;
+
+    // Mirrors the protected Component.UseNavigation wrappers (Component.cs:242/245).
+    public abstract class Component
+    {
+        protected NavigationHandle<TRoute> UseNavigation<TRoute>(TRoute initial) where TRoute : notnull
+            => new NavigationHandle<TRoute>();
+        protected NavigationHandle<TRoute> UseNavigation<TRoute>() where TRoute : notnull
+            => new NavigationHandle<TRoute>();
+    }
+}
+
+public enum Route { Home, Settings }
+";
+
+    // ── Positive: static NavigationHandle<> field assigned from UseNavigation ──
+
+    [Fact]
+    public async Task Fires_For_Static_Field_Assigned_Via_Local()
+    {
+        // Canonical doc pitfall (navigation.md:745-759): the handle flows through an
+        // intermediate local before landing in the static field.
+        var source = Stubs + @"
+class Shell : Component
+{
+    public static NavigationHandle<Route>? {|REACTOR_NAV_001:Nav|};
+
+    public void Render()
+    {
+        var nav = UseNavigation(Route.Home);
+        Nav = nav;
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticNavigationHandleAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Static_Field_Assigned_Directly()
+    {
+        var source = Stubs + @"
+class Shell : Component
+{
+    public static NavigationHandle<Route>? {|REACTOR_NAV_001:Nav|};
+
+    public void Render()
+    {
+        Nav = UseNavigation(Route.Home);
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticNavigationHandleAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Private_Static_Field()
+    {
+        // Accessibility is irrelevant — any static storage of the handle leaks.
+        var source = Stubs + @"
+class Shell : Component
+{
+    private static NavigationHandle<Route>? {|REACTOR_NAV_001:_nav|};
+
+    public void Render() => _nav = UseNavigation(Route.Home);
+}";
+
+        await new CSharpAnalyzerTest<StaticNavigationHandleAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative: instance field / local assigned from UseNavigation ──
+
+    [Fact]
+    public async Task No_Diagnostic_For_Instance_Field()
+    {
+        var source = Stubs + @"
+class Shell : Component
+{
+    public NavigationHandle<Route>? Nav;
+
+    public void Render()
+    {
+        var nav = UseNavigation(Route.Home);
+        Nav = nav;
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticNavigationHandleAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Local()
+    {
+        var source = Stubs + @"
+class Shell : Component
+{
+    public void Render()
+    {
+        var nav = UseNavigation(Route.Home);
+        _ = nav;
+    }
+}";
+
+        await new CSharpAnalyzerTest<StaticNavigationHandleAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Near-miss: a static field of a different type ──
+
+    [Fact]
+    public async Task No_Diagnostic_For_Static_Field_Of_Different_Type()
+    {
+        var source = Stubs + @"
+class Shell : Component
+{
+    public static string? Nav;
+}";
+
+        await new CSharpAnalyzerTest<StaticNavigationHandleAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Same_Named_Type_In_Different_Namespace()
+    {
+        // A NavigationHandle<> from a foreign namespace is not the Reactor handle.
+        var source = Stubs + @"
+namespace Other
+{
+    public sealed class NavigationHandle<TRoute> where TRoute : notnull { }
+}
+
+class Shell
+{
+    public static Other.NavigationHandle<Route>? Nav;
+}";
+
+        await new CSharpAnalyzerTest<StaticNavigationHandleAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}


### PR DESCRIPTION
## REACTOR_NAV_001 · `Reactor.Navigation` · Warning · no fix

Spec-060 Batch-2 (§12) packet. Flags a `static` **field or property** typed `NavigationHandle<>` — a `UseNavigation` handle stashed statically outlives the page and **pins (leaks) the dispatcher** it was bound to; once that dispatcher shuts down its mutators throw (navigation.md §"Treating `UseNavigation` like a singleton", :745-775).

```csharp
public static NavigationHandle<Route>? Nav;   // ← REACTOR_NAV_001
// ...
var nav = UseNavigation(Route.Home);
Nav = nav;                                     // capture for later use from anywhere
```

### Premise verification (Batch-2 is not source-hardened)
Verified the cited APIs against source **before** implementing:
- `NavigationHandle<TRoute>` — `public sealed class` in namespace `Microsoft.UI.Reactor.Navigation`, arity 1 (`NavigationHandle.cs:88`). Its constructor is **`internal`** (`:96`), so consumer code can only obtain a handle via `UseNavigation`.
- `UseNavigation<TRoute>(TRoute initial)` / `UseNavigation<TRoute>()` return `Navigation.NavigationHandle<TRoute>`, on `Component` (protected, `Component.cs:242/245`) and `RenderContext` (public, `RenderContext.cs:979/1001`).

### Design
`StaticNavigationHandleAnalyzer` registers `SymbolAction` over `SymbolKind.Field` **and** `SymbolKind.Property`: a `static`, non-implicitly-declared field/property whose type's original definition is `Microsoft.UI.Reactor.Navigation.NavigationHandle<TRoute>`. Because the handle's ctor is `internal`, "static `NavigationHandle<>` storage" is equivalent to the spec's "assigned from `UseNavigation`", and — unlike an assignment-source check — it robustly catches the **canonical doc form where the value flows through an intermediate local** (`Nav = nav;`). A static auto-property reports once (its compiler-generated backing field is skipped). No code-fix: the correct rewrite (child-mode `UseNavigation<TRoute>()` via context, or pass through `Context`) depends on how the handle is consumed elsewhere — and the diagnostic message names that remedy.

### Tests (9, all green — `-p:Platform=x64`)
- **Positive:** static field via intermediate local (canonical); static field direct; `private static` field; static auto-property.
- **Negative:** instance field; instance auto-property; local.
- **Near-miss:** static field of a different type (`string`); same-named `NavigationHandle<>` in a foreign namespace.

### Docs / release tracking (append-only, keep-all-rows on conflict)
- `AnalyzerReleases.Unshipped.md` row (couples the descriptor — RS2000/RS2002 verified green).
- `reactor-build-and-check` cheat-table row (app-author-facing).
- `analyzer-architecture.md.dt` rules-table row (template, not generated output).

### Samples sweep (§2.4)
The rule fires on a **real** instance: `samples/ReactorCharting.Gallery/Program.cs:38` (`internal static NavigationHandle<GalleryRoute>? CurrentNav;`, a deliberate self-test affordance) — validating it isn't over-fit. The two other text matches are static *methods* taking a handle *parameter*, which the symbol gate correctly ignores. Analyzers are packed-only (not wired into sample builds), so nothing breaks; refactoring the sample is out of scope for this hygiene-rule PR.

### Review loop (§2.7)
`pr-review` skill (7 dimensions + multi-model): **0 critical / 0 high**. Applied 3 medium findings — extended detection to static **properties** (correctness + test-coverage) and moved the fix remedy into the diagnostic **message** (api-ergonomics). Multi-model (GPT-5.4) cross-check confirmed both fixes and found no new issues. Copilot review requested.

Stacked on the spec-060 foundation branch `azchohfi-spec-060-analyzer-suite`.