### PR TITLE
feat(analyzer): REACTOR_DIALOG_001 — imperative ContentDialog.ShowAsync

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -123,6 +123,7 @@ via `.editorconfig`.
 | `REACTOR_DOCK_001` | Warning | OnLiveLayoutChanged feeds the live layout back into state | `OnLiveLayoutRoundTripAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
+| `REACTOR_DIALOG_001` | Warning | Imperative WinUI `ContentDialog.ShowAsync` escapes the render tree | `ImperativeContentDialogAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_DIALOG_001` | warning | WinUI `ContentDialog.ShowAsync()` opened imperatively from a handler | Model it declaratively: `ContentDialog(title, content) with { IsOpen = open, OnClosed = _ => setOpen(false) }`. The dialog stays in the tree and `IsOpen` controls visibility — the imperative dialog has no parent theme and can't be tested. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_DIALOG_001 | Reactor.Lifecycle | Warning | ImperativeContentDialogAnalyzer - Imperative ContentDialog.ShowAsync escapes the render tree; use the controlled ContentDialog(...) element with IsOpen

--- a/src/Reactor.Analyzers/ImperativeContentDialogAnalyzer.cs
+++ b/src/Reactor.Analyzers/ImperativeContentDialogAnalyzer.cs
@@ -1,0 +1,114 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_DIALOG_001</c> — flags a WinUI <c>ContentDialog</c> shown imperatively with
+/// <c>.ShowAsync()</c> (typically from an event handler), instead of the controlled Reactor
+/// <c>ContentDialog(...)</c> element driven by its <c>IsOpen</c> property.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <c>new ContentDialog { … }.ShowAsync()</c> materializes the dialog outside the Reactor
+/// virtual element tree: it inherits no parent theme, can't be driven by a controlled
+/// <c>IsOpen</c> flag, can't share component state, and can't be exercised by the renderer test
+/// fixture. The declarative pattern keeps the dialog in the tree at all times and toggles
+/// visibility through <c>IsOpen</c> (with <c>OnClosed</c> flipping it back on dismissal) — see
+/// <c>docs/guide/dialogs-and-flyouts.md</c> "Common Mistakes".
+/// </para>
+/// <para>
+/// Detection anchors on the imperative open — the <c>.ShowAsync()</c> invocation — because that
+/// is the harmful action the rule targets and it appears exactly once per misused dialog, so a
+/// single anchor catches every documented form (inline <c>new ContentDialog{…}.ShowAsync()</c>
+/// and the two-statement <c>var d = new ContentDialog{…}; await d.ShowAsync();</c>) without ever
+/// double-reporting. A cheap syntactic gate matches the member name <c>ShowAsync</c>, then one
+/// <c>GetSymbolInfo</c> confirms the invoked method belongs to the WinUI
+/// <c>Microsoft.UI.Xaml.Controls.ContentDialog</c> type. Reactor's own <c>ContentDialog(...)</c>
+/// DSL factory is an <see cref="IdentifierNameSyntax"/> invocation that never calls
+/// <c>.ShowAsync()</c>, so the correct controlled path can never reach the semantic check.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ImperativeContentDialogAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_DIALOG_001";
+
+    private const string ShowAsyncName = "ShowAsync";
+    private const string ContentDialogTypeName = "ContentDialog";
+    private const string WinUiControlsNamespace = "Microsoft.UI.Xaml.Controls";
+
+    private static readonly LocalizableString Title =
+        "Imperative ContentDialog.ShowAsync escapes the Reactor render tree";
+
+    private static readonly LocalizableString MessageFormat =
+        "'ContentDialog.ShowAsync()' opens a dialog imperatively, outside the Reactor render tree; " +
+        "use the controlled 'ContentDialog(...)' element with 'IsOpen' instead.";
+
+    private static readonly LocalizableString Description =
+        "A WinUI ContentDialog shown with ShowAsync() from an event handler is created outside the " +
+        "virtual element tree: it inherits no parent theme, can't be driven by a controlled IsOpen " +
+        "flag, can't share component state, and can't be exercised by the renderer test fixture. " +
+        "Model the dialog declaratively with the Reactor ContentDialog(...) factory and toggle its " +
+        "IsOpen property from state (OnClosed flips it back on dismissal).";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Lifecycle",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Cheap syntactic gate: `<receiver>.ShowAsync(...)` or `<receiver>?.ShowAsync(...)`.
+        // The Reactor controlled path — the `ContentDialog(...)` DSL factory — is an
+        // IdentifierNameSyntax invocation and never calls `.ShowAsync()`, so it can never reach
+        // the semantic check below. Any argument count matches (ShowAsync() and the
+        // ShowAsync(ContentDialogPlacement) overload).
+        var invokedName = invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax member => member.Name.Identifier.Text,
+            MemberBindingExpressionSyntax binding => binding.Name.Identifier.Text, // dialog?.ShowAsync()
+            _ => null,
+        };
+        if (invokedName != ShowAsyncName)
+            return;
+
+        // Semantic confirmation: the invoked ShowAsync must be declared on the WinUI ContentDialog
+        // type. `ShowAsync` lives on ContentDialog itself, so the resolved method's ContainingType
+        // is ContentDialog even for subclass receivers (a subclass shown imperatively is still the
+        // footgun). This is what separates the real anti-pattern from unrelated `ShowAsync` methods
+        // (MessageDialog, custom types, delegate-typed members, …). If the symbol can't be resolved
+        // (incomplete code mid-edit), stay silent — this is a no-autofix Warning and firing on an
+        // unconfirmed receiver would be a false positive.
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol
+                is not IMethodSymbol method)
+            return;
+        if (!IsWinUiContentDialog(method.ContainingType))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
+    }
+
+    private static bool IsWinUiContentDialog(INamedTypeSymbol? type) =>
+        type is { Name: ContentDialogTypeName }
+        && type.ContainingNamespace?.ToDisplayString() == WinUiControlsNamespace;
+}

--- a/src/Reactor.Analyzers/ImperativeContentDialogAnalyzer.cs
+++ b/src/Reactor.Analyzers/ImperativeContentDialogAnalyzer.cs
@@ -21,15 +21,17 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// <c>docs/guide/dialogs-and-flyouts.md</c> "Common Mistakes".
 /// </para>
 /// <para>
-/// Detection anchors on the imperative open — the <c>.ShowAsync()</c> invocation — because that
+/// Detection anchors on the imperative open — the <c>ShowAsync()</c> invocation — because that
 /// is the harmful action the rule targets and it appears exactly once per misused dialog, so a
 /// single anchor catches every documented form (inline <c>new ContentDialog{…}.ShowAsync()</c>
 /// and the two-statement <c>var d = new ContentDialog{…}; await d.ShowAsync();</c>) without ever
-/// double-reporting. A cheap syntactic gate matches the member name <c>ShowAsync</c>, then one
+/// double-reporting. A cheap syntactic gate matches the invoked member name <c>ShowAsync</c>
+/// (member-access, conditional-access, or an implicit-receiver identifier), then one
 /// <c>GetSymbolInfo</c> confirms the invoked method belongs to the WinUI
-/// <c>Microsoft.UI.Xaml.Controls.ContentDialog</c> type. Reactor's own <c>ContentDialog(...)</c>
-/// DSL factory is an <see cref="IdentifierNameSyntax"/> invocation that never calls
-/// <c>.ShowAsync()</c>, so the correct controlled path can never reach the semantic check.
+/// <c>Microsoft.UI.Xaml.Controls.ContentDialog</c> type <b>or a subclass of it</b>. Reactor's own
+/// <c>ContentDialog(...)</c> DSL factory is an invocation named <c>ContentDialog</c>, not
+/// <c>ShowAsync</c>, so the correct controlled path is filtered out by the name gate and never
+/// reaches the semantic check.
 /// </para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -78,38 +80,53 @@ public sealed class ImperativeContentDialogAnalyzer : DiagnosticAnalyzer
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
 
-        // Cheap syntactic gate: `<receiver>.ShowAsync(...)` or `<receiver>?.ShowAsync(...)`.
-        // The Reactor controlled path — the `ContentDialog(...)` DSL factory — is an
-        // IdentifierNameSyntax invocation and never calls `.ShowAsync()`, so it can never reach
-        // the semantic check below. Any argument count matches (ShowAsync() and the
-        // ShowAsync(ContentDialogPlacement) overload). ValueText (not Text) so an escaped call
-        // like `dialog.@ShowAsync()` still matches the "ShowAsync" identifier.
+        // Cheap syntactic gate: `<receiver>.ShowAsync(...)`, `<receiver>?.ShowAsync(...)`, or a
+        // bare `ShowAsync(...)` with an implicit receiver (e.g. inside a ContentDialog subclass).
+        // The Reactor controlled path — the `ContentDialog(...)` DSL factory — is an invocation
+        // named `ContentDialog`, not `ShowAsync`, so it can never reach the semantic check below.
+        // Any argument count matches (ShowAsync() and the ShowAsync(ContentDialogPlacement)
+        // overload). ValueText (not Text) so an escaped call like `dialog.@ShowAsync()` still
+        // matches the "ShowAsync" identifier.
         var invokedName = invocation.Expression switch
         {
             MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
             MemberBindingExpressionSyntax binding => binding.Name.Identifier.ValueText, // dialog?.ShowAsync()
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,          // implicit receiver
             _ => null,
         };
         if (invokedName != ShowAsyncName)
             return;
 
-        // Semantic confirmation: the invoked ShowAsync must be declared on the WinUI ContentDialog
-        // type. `ShowAsync` lives on ContentDialog itself, so the resolved method's ContainingType
-        // is ContentDialog even for subclass receivers (a subclass shown imperatively is still the
-        // footgun). This is what separates the real anti-pattern from unrelated `ShowAsync` methods
-        // (MessageDialog, custom types, delegate-typed members, …). If the symbol can't be resolved
-        // (incomplete code mid-edit), stay silent — this is a no-autofix Warning and firing on an
-        // unconfirmed receiver would be a false positive.
+        // Semantic confirmation: the invoked ShowAsync must resolve to a method on the WinUI
+        // ContentDialog type (or a subclass of it). `ShowAsync` normally lives on ContentDialog
+        // itself, so the resolved method's ContainingType is ContentDialog even for subclass
+        // receivers; walking the base-type chain additionally catches a subclass that hides/declares
+        // its own ShowAsync (ContainingType = the derived type). This is what separates the real
+        // anti-pattern from unrelated `ShowAsync` methods (MessageDialog, custom types,
+        // delegate-typed members, …). If the symbol can't be resolved (incomplete code mid-edit),
+        // stay silent — this is a no-autofix Warning and firing on an unconfirmed receiver would be
+        // a false positive.
         if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol
                 is not IMethodSymbol method)
             return;
-        if (!IsWinUiContentDialog(method.ContainingType))
+        if (!IsWinUiContentDialogOrSubclass(method.ContainingType))
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
     }
 
-    private static bool IsWinUiContentDialog(INamedTypeSymbol? type) =>
-        type is { Name: ContentDialogTypeName }
-        && type.ContainingNamespace?.ToDisplayString() == WinUiControlsNamespace;
+    // True when <paramref name="type"/> is the WinUI ContentDialog or derives from it. Walking the
+    // base-type chain (the pattern used by ReferenceCurrentReadAnalyzer) catches a subclass that
+    // declares its own ShowAsync — its ContainingType is the subclass, not ContentDialog.
+    private static bool IsWinUiContentDialogOrSubclass(INamedTypeSymbol? type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.Name == ContentDialogTypeName
+                && current.ContainingNamespace?.ToDisplayString() == WinUiControlsNamespace)
+                return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Reactor.Analyzers/ImperativeContentDialogAnalyzer.cs
+++ b/src/Reactor.Analyzers/ImperativeContentDialogAnalyzer.cs
@@ -82,11 +82,12 @@ public sealed class ImperativeContentDialogAnalyzer : DiagnosticAnalyzer
         // The Reactor controlled path — the `ContentDialog(...)` DSL factory — is an
         // IdentifierNameSyntax invocation and never calls `.ShowAsync()`, so it can never reach
         // the semantic check below. Any argument count matches (ShowAsync() and the
-        // ShowAsync(ContentDialogPlacement) overload).
+        // ShowAsync(ContentDialogPlacement) overload). ValueText (not Text) so an escaped call
+        // like `dialog.@ShowAsync()` still matches the "ShowAsync" identifier.
         var invokedName = invocation.Expression switch
         {
-            MemberAccessExpressionSyntax member => member.Name.Identifier.Text,
-            MemberBindingExpressionSyntax binding => binding.Name.Identifier.Text, // dialog?.ShowAsync()
+            MemberAccessExpressionSyntax member => member.Name.Identifier.ValueText,
+            MemberBindingExpressionSyntax binding => binding.Name.Identifier.ValueText, // dialog?.ShowAsync()
             _ => null,
         };
         if (invokedName != ShowAsyncName)

--- a/tests/Reactor.Tests/AnalyzerTests/ImperativeContentDialogAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ImperativeContentDialogAnalyzerTests.cs
@@ -1,0 +1,240 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="ImperativeContentDialogAnalyzer"/> (<c>REACTOR_DIALOG_001</c>). Stubs a
+/// minimal WinUI <c>Microsoft.UI.Xaml.Controls.ContentDialog</c> (with <c>ShowAsync</c>), the
+/// Reactor <c>ContentDialog(...)</c> DSL factory + controlled <c>ContentDialogElement.IsOpen</c>,
+/// and an unrelated <c>ShowAsync</c>-bearing type — so the positive / negative / near-miss cases
+/// exercise the analyzer's syntactic gate and its semantic type confirmation without pulling the
+/// framework in.
+/// </summary>
+/// <remarks>
+/// The shared <see cref="Stubs"/> prefix carries every <c>using</c> at the top (before any
+/// namespace) and each test class is appended after it, so tests never emit a <c>using</c> after a
+/// namespace (CS1529). Positive tests fully-qualify the WinUI <c>ContentDialog</c> type to keep it
+/// unambiguous against the <c>using static Factories</c> <c>ContentDialog(...)</c> method.
+/// </remarks>
+public class ImperativeContentDialogAnalyzerTests
+{
+    private const string Stubs = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Xaml.Controls
+{
+    public enum ContentDialogResult { None, Primary, Secondary }
+    public enum ContentDialogPlacement { Popup, InPlace }
+
+    // Minimal shape of the WinUI ContentDialog: the analyzer resolves .ShowAsync() by name and
+    // confirms its ContainingType is Microsoft.UI.Xaml.Controls.ContentDialog.
+    public class ContentDialog
+    {
+        public string Title { get; set; }
+        public string PrimaryButtonText { get; set; }
+        public Task<ContentDialogResult> ShowAsync() => Task.FromResult(ContentDialogResult.None);
+        public Task<ContentDialogResult> ShowAsync(ContentDialogPlacement placement) => Task.FromResult(ContentDialogResult.None);
+    }
+}
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public record Element;
+    public record TextBlockElement(string Text) : Element;
+
+    // Reactor's controlled dialog element — the CORRECT path. `with { IsOpen = ... }` drives it.
+    public record ContentDialogElement(string Title, Element Content, string PrimaryButtonText = ""OK"") : Element
+    {
+        public bool IsOpen { get; init; }
+        public Action<Microsoft.UI.Xaml.Controls.ContentDialogResult> OnClosed { get; init; }
+    }
+}
+
+namespace Microsoft.UI.Reactor
+{
+    // The Reactor DSL factory: an IdentifierNameSyntax invocation `ContentDialog(...)` that
+    // never calls .ShowAsync(), so it is the controlled path and must NEVER fire.
+    public static class Factories
+    {
+        public static ContentDialogElement ContentDialog(string title, Element content, string primaryButtonText = ""OK"")
+            => new(title, content, primaryButtonText);
+
+        public static TextBlockElement TextBlock(string text) => new(text);
+    }
+}
+
+namespace Unrelated
+{
+    // A different type that happens to expose a ShowAsync — trips the syntactic name gate but
+    // must be rejected by the semantic ContainingType check.
+    public class MessageDialog
+    {
+        public Task ShowAsync() => Task.CompletedTask;
+    }
+}
+";
+
+    // ── Positive: imperative WinUI ContentDialog.ShowAsync ──────────────────
+
+    [Fact]
+    public async Task Fires_For_Inline_New_ShowAsync()
+    {
+        // The canonical anti-pattern from docs/guide/dialogs-and-flyouts.md.
+        var source = Stubs + @"
+class C
+{
+    async Task M()
+    {
+        await {|REACTOR_DIALOG_001:new Microsoft.UI.Xaml.Controls.ContentDialog { Title = ""Confirm"" }.ShowAsync()|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_TwoStatement_Local_ShowAsync()
+    {
+        var source = Stubs + @"
+class C
+{
+    async Task M()
+    {
+        var dialog = new Microsoft.UI.Xaml.Controls.ContentDialog { Title = ""Confirm"" };
+        var result = await {|REACTOR_DIALOG_001:dialog.ShowAsync()|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_In_Async_Event_Handler_Lambda()
+    {
+        // Mirrors the doc's `Button(""Save"", async () => await dialog.ShowAsync())` shape.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        Func<Task> handler = async () =>
+        {
+            var dialog = new Microsoft.UI.Xaml.Controls.ContentDialog { Title = ""Confirm"" };
+            await {|REACTOR_DIALOG_001:dialog.ShowAsync()|};
+        };
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_FireAndForget_Placement_Overload()
+    {
+        // The ShowAsync(ContentDialogPlacement) overload, discarded (not awaited).
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        {|REACTOR_DIALOG_001:new Microsoft.UI.Xaml.Controls.ContentDialog { Title = ""x"" }.ShowAsync(Microsoft.UI.Xaml.Controls.ContentDialogPlacement.Popup)|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Conditional_Access()
+    {
+        // dialog?.ShowAsync() — the invocation node is the `.ShowAsync()` member-binding call.
+        var source = Stubs + @"
+class C
+{
+    void M(Microsoft.UI.Xaml.Controls.ContentDialog dialog)
+    {
+        dialog?{|REACTOR_DIALOG_001:.ShowAsync()|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative: the controlled Reactor path ───────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Controlled_Factory_With_IsOpen()
+    {
+        // The canonical CORRECT pattern: declarative ContentDialog(...) driven by IsOpen.
+        var source = Stubs + @"
+class C
+{
+    Element Render(bool open)
+        => ContentDialog(""Welcome"", TextBlock(""Thanks"")) with { IsOpen = open };
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Plain_Factory_Call()
+    {
+        var source = Stubs + @"
+class C
+{
+    Element Render() => ContentDialog(""Welcome"", TextBlock(""Thanks""));
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Near-miss: unrelated ShowAsync trips the syntactic gate only ─────────
+
+    [Fact]
+    public async Task No_Diagnostic_For_Unrelated_ShowAsync()
+    {
+        // Same method name, different type — the semantic ContainingType check rejects it.
+        var source = Stubs + @"
+class C
+{
+    async Task M()
+    {
+        var dlg = new Unrelated.MessageDialog();
+        await dlg.ShowAsync();
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/ImperativeContentDialogAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ImperativeContentDialogAnalyzerTests.cs
@@ -28,6 +28,13 @@ using System.Threading.Tasks;
 using Microsoft.UI.Reactor.Core;
 using static Microsoft.UI.Reactor.Factories;
 
+namespace System.Runtime.CompilerServices
+{
+    // Required for `record` types + `init` accessors under older runtime metadata — supply a
+    // stub so the test source compiles self-contained across reference-assembly sets.
+    public static class IsExternalInit { }
+}
+
 namespace Microsoft.UI.Xaml.Controls
 {
     public enum ContentDialogResult { None, Primary, Secondary }
@@ -214,6 +221,26 @@ class C
     async Task M()
     {
         await {|REACTOR_DIALOG_001:new Microsoft.UI.Xaml.Controls.ConfirmDialog().ShowAsync()|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Escaped_Identifier_ShowAsync()
+    {
+        // Escaped identifier: ValueText (not Text) decodes `@ShowAsync` to `ShowAsync`, so the
+        // gate still matches and the diagnostic fires.
+        var source = Stubs + @"
+class C
+{
+    async Task M()
+    {
+        await {|REACTOR_DIALOG_001:new Microsoft.UI.Xaml.Controls.ContentDialog { Title = ""x"" }.@ShowAsync()|};
     }
 }";
 

--- a/tests/Reactor.Tests/AnalyzerTests/ImperativeContentDialogAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ImperativeContentDialogAnalyzerTests.cs
@@ -60,6 +60,13 @@ namespace Microsoft.UI.Xaml.Controls
     {
         public Task<ContentDialogResult> ShowAsync() => Task.FromResult(ContentDialogResult.None);
     }
+
+    // A subclass that DECLARES its own ShowAsync (hides the base). The resolved method's
+    // ContainingType is CustomDialog, not ContentDialog, so only a base-type-chain walk catches it.
+    public class CustomDialog : ContentDialog
+    {
+        public new Task<ContentDialogResult> ShowAsync() => Task.FromResult(ContentDialogResult.None);
+    }
 }
 
 namespace Microsoft.UI.Reactor.Core
@@ -241,6 +248,46 @@ class C
     async Task M()
     {
         await {|REACTOR_DIALOG_001:new Microsoft.UI.Xaml.Controls.ContentDialog { Title = ""x"" }.@ShowAsync()|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Subclass_Declaring_Own_ShowAsync()
+    {
+        // The subclass hides ShowAsync, so the resolved method's ContainingType is the subclass;
+        // the base-type-chain walk still recognizes it as a WinUI ContentDialog.
+        var source = Stubs + @"
+class C
+{
+    async Task M()
+    {
+        await {|REACTOR_DIALOG_001:new Microsoft.UI.Xaml.Controls.CustomDialog().ShowAsync()|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_For_Implicit_Receiver_In_Subclass()
+    {
+        // A bare `ShowAsync()` with an implicit receiver inside a ContentDialog subclass — the
+        // IdentifierNameSyntax gate arm + the base-type walk catch it.
+        var source = Stubs + @"
+class MyDlg : Microsoft.UI.Xaml.Controls.ContentDialog
+{
+    async Task Open()
+    {
+        await {|REACTOR_DIALOG_001:ShowAsync()|};
     }
 }";
 

--- a/tests/Reactor.Tests/AnalyzerTests/ImperativeContentDialogAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ImperativeContentDialogAnalyzerTests.cs
@@ -42,6 +42,17 @@ namespace Microsoft.UI.Xaml.Controls
         public Task<ContentDialogResult> ShowAsync() => Task.FromResult(ContentDialogResult.None);
         public Task<ContentDialogResult> ShowAsync(ContentDialogPlacement placement) => Task.FromResult(ContentDialogResult.None);
     }
+
+    // A subclass of the WinUI ContentDialog: ShowAsync is inherited, so the resolved method's
+    // ContainingType is still ContentDialog — a subclass shown imperatively must still fire.
+    public class ConfirmDialog : ContentDialog { }
+
+    // Same namespace as ContentDialog, different type name, own ShowAsync — locks the type-NAME
+    // half of the predicate (namespace matches, name must not).
+    public class PopupDialog
+    {
+        public Task<ContentDialogResult> ShowAsync() => Task.FromResult(ContentDialogResult.None);
+    }
 }
 
 namespace Microsoft.UI.Reactor.Core
@@ -75,6 +86,16 @@ namespace Unrelated
     // A different type that happens to expose a ShowAsync — trips the syntactic name gate but
     // must be rejected by the semantic ContainingType check.
     public class MessageDialog
+    {
+        public Task ShowAsync() => Task.CompletedTask;
+    }
+}
+
+namespace OtherUi
+{
+    // Same simple type name as WinUI ContentDialog, different namespace, own ShowAsync — locks
+    // the NAMESPACE half of the predicate (name matches, namespace must not).
+    public class ContentDialog
     {
         public Task ShowAsync() => Task.CompletedTask;
     }
@@ -182,6 +203,26 @@ class C
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Fires_For_Subclass_ShowAsync()
+    {
+        // A ContentDialog subclass shown imperatively — ShowAsync is inherited, so the resolved
+        // method's ContainingType is still Microsoft.UI.Xaml.Controls.ContentDialog.
+        var source = Stubs + @"
+class C
+{
+    async Task M()
+    {
+        await {|REACTOR_DIALOG_001:new Microsoft.UI.Xaml.Controls.ConfirmDialog().ShowAsync()|};
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
     // ── Negative: the controlled Reactor path ───────────────────────────────
 
     [Fact]
@@ -235,6 +276,70 @@ class C
         await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
         {
             TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_NonWinUi_SameName_ContentDialog()
+    {
+        // Same simple type name (ContentDialog) but a different namespace — the namespace half of
+        // the predicate rejects it, so a look-alike type is not flagged.
+        var source = Stubs + @"
+class C
+{
+    async Task M()
+    {
+        var d = new OtherUi.ContentDialog();
+        await d.ShowAsync();
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_SameNamespace_NonContentDialog()
+    {
+        // Same namespace (Microsoft.UI.Xaml.Controls) but a different type name — the type-name
+        // half of the predicate rejects it, so a sibling WinUI type with ShowAsync is not flagged.
+        var source = Stubs + @"
+class C
+{
+    async Task M()
+    {
+        var p = new Microsoft.UI.Xaml.Controls.PopupDialog();
+        await p.ShowAsync();
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_For_Unresolved_ShowAsync()
+    {
+        // Incomplete / mid-edit code: the receiver can't be resolved, so GetSymbolInfo yields no
+        // IMethodSymbol and the analyzer stays silent rather than firing a false positive.
+        // CompilerDiagnostics.None because the source intentionally has an unresolved identifier.
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+        undefinedDialog.ShowAsync();
+    }
+}";
+
+        await new CSharpAnalyzerTest<ImperativeContentDialogAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+            CompilerDiagnostics = CompilerDiagnostics.None,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 }


### PR DESCRIPTION
## REACTOR_DIALOG_001 — imperative `ContentDialog.ShowAsync`

Spec-060 Batch-2 (§12) packet. **Stacked on** `azchohfi-spec-060-analyzer-suite` (foundation).

`Reactor.Lifecycle` · **Warning** · no code fix.

### What it flags
A WinUI `Microsoft.UI.Xaml.Controls.ContentDialog` shown imperatively via `.ShowAsync()`:

```csharp
// Flagged — escapes the render tree (no parent theme, untestable, no controlled IsOpen):
Button("Save", async () => await new ContentDialog { Title = "Confirm" }.ShowAsync());
```

The Reactor `ContentDialog(...)` **DSL factory** (an `IdentifierNameSyntax` invocation that never
calls `.ShowAsync()`) is the correct controlled path and **never** fires:

```csharp
// Correct — declarative, driven by IsOpen:
ContentDialog("Welcome", TextBlock("Thanks")) with { IsOpen = open, OnClosed = _ => setOpen(false) }
```

### Detection
Anchors on the `.ShowAsync()` invocation (the harmful open action — appears exactly once per
misused dialog, so no double-reporting), then a single `GetSymbolInfo` confirms the invoked method
belongs to the WinUI `Microsoft.UI.Xaml.Controls.ContentDialog` type. Unrelated `ShowAsync` methods
are rejected (near-miss). Cheap syntactic name gate runs first; unresolved symbols stay silent
(no-autofix Warning → low false-positive bar). Handles inline, two-statement, event-handler lambda,
`ShowAsync(placement)` overload, and conditional-access (`?.`) forms.

### Grounding (verified against source before implementing)
- Reactor DSL factory `ContentDialog(string, Element, string)` → `ContentDialogElement` — `src/Reactor/Elements/Dsl.cs:1067`
- Controlled `ContentDialogElement.IsOpen` — `src/Reactor/Core/Element.cs:5004`
- WinUI `Microsoft.UI.Xaml.Controls.ContentDialog` + `ShowAsync()` — `src/Reactor/Core/V1Protocol/OverlayLifecycle.cs:4,82,96`
- Pitfall doc — `docs/guide/dialogs-and-flyouts.md:554-594`

### Tests (8, all green)
Positive: inline `new ContentDialog{...}.ShowAsync()`, two-statement local, async event-handler
lambda, placement overload, conditional access. Negative: controlled factory + `IsOpen`, plain
factory call. Near-miss: unrelated `ShowAsync` on a non-ContentDialog type.

`dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~ImperativeContentDialog` → 8/8.

### Docs
- Canonical `AnalyzerReleases.Unshipped.md` row
- App-author cheat-table row (`SKILL.md`)
- `analyzer-architecture.md.dt` rules-table row

### Samples sweep (§2.4)
All samples already use the controlled `ContentDialog(...)` factory; the rule correctly fires
nowhere in `samples/` (the accepted hygiene-rule case — no deliberately-bad sample added).
