### PR TITLE
feat(analyzer): REACTOR_MOD_001 — duplicate atomic modifier

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,6 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_MOD_001` | Info | Same atomic-replace placement modifier (`.Grid`/`.Canvas`/`.RelativePanel`/`.Flex`) applied twice in one chain | `DuplicateAtomicModifierAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -82,6 +82,7 @@ Additional flags:
 | `REACTOR_HOOKS_007` | warning | `UseMemoCells` builder closure missing dependencies | Add the captured variable to the deps array. |
 | `REACTOR_HOOKS_009` | warning | `Command.DebounceMs` set on a command bound without `UseCommand` | Route it through `UseCommand`: `var cmd = UseCommand(new Command { …, DebounceMs = 1500 });`. The debounce window lives in the hook store, so a raw bound `Command` never debounces. |
 | `REACTOR_DSL_001` | warning | `Select(...)` projecting into a layout container without `.WithKey(...)` | `items.Select(i => Row(i).WithKey(i.Id)).ToArray<Element?>()`. Keys keep focus + animation state across reorders. |
+| `REACTOR_MOD_001` | info | Same atomic-placement modifier twice in one chain (`.Grid(row: 1).Grid(column: 2)`) — atomic-replace, so `row` resets to 0 | Merge into one call: `.Grid(row: 1, column: 2)`. Applies to `.Grid`/`.Canvas`/`.RelativePanel`/`.Flex`. |
 | `REACTOR_THEME_001` | warning | Hardcoded color on a themed surface | Use `Theme.*` tokens (e.g. `Theme.PrimaryText`, `Theme.CardBackground`). See `reactor-design`. |
 | `REACTOR_THEME_002` | info | Lightweight styling opportunity | Optional. Use `.Resources(r => r.Set("ButtonBackground", …))` for visual-state overrides. |
 | `REACTOR_THEME_003` | info | `RequestedTheme` modifier available | Use `.RequestedTheme(ElementTheme.Dark)` for subtree theme overrides. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_MOD_001 | Reactor.Modifier | Info | DuplicateAtomicModifierAnalyzer - Same atomic-replace placement modifier (.Grid/.Canvas/.RelativePanel/.Flex) applied twice in one chain; last-wins overwrite drops earlier args (ships a merge fix)

--- a/src/Reactor.Analyzers/DuplicateAtomicModifierAnalyzer.cs
+++ b/src/Reactor.Analyzers/DuplicateAtomicModifierAnalyzer.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// REACTOR_MOD_001: Detects the same <b>atomic-replace attached-placement</b>
+/// modifier (<c>.Grid</c>, <c>.Canvas</c>, <c>.RelativePanel</c>, <c>.Flex</c>)
+/// applied two or more times in one linear fluent chain, e.g.
+/// <c>.Grid(row: 1).Grid(column: 2)</c>.
+/// </summary>
+/// <remarks>
+/// These modifiers funnel through <c>Element.SetAttached(new XxxAttached(...))</c>,
+/// which stores the value keyed by its record type. Each call constructs a
+/// <em>fresh</em> record purely from its arguments, so a second call fully
+/// <b>replaces</b> the first — it does not merge field-by-field. The intuitive
+/// <c>.Grid(row: 1).Grid(column: 2)</c> therefore silently resets <c>row</c> to
+/// its default (0); only <c>column</c> survives. The fix merges the calls into
+/// one (<c>.Grid(row: 1, column: 2)</c>).
+///
+/// Modifiers that <em>read</em> the existing attached value and preserve the
+/// untouched fields (<c>WrapGridColumnSpan</c>/<c>WrapGridRowSpan</c>) or that
+/// accumulate (<c>Validate</c>) are additive, not atomic-replace, and are
+/// deliberately excluded.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DuplicateAtomicModifierAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_MOD_001";
+
+    /// <summary>
+    /// Atomic-replace attached-placement modifier method name → the extension
+    /// class that declares it. Each entry must be a modifier that calls
+    /// <c>SetAttached(new XxxAttached(...))</c> with a record built purely from
+    /// its own parameters (no read-modify-write of the existing attached value).
+    /// Keep this in sync with the extension classes when either changes.
+    /// </summary>
+    internal static readonly IReadOnlyDictionary<string, string> AtomicModifiers =
+        new Dictionary<string, string>(System.StringComparer.Ordinal)
+        {
+            { "Grid",          "GridExtensions" },
+            { "Canvas",        "CanvasExtensions" },
+            { "RelativePanel", "RelativePanelExtensions" },
+            { "Flex",          "FlexExtensions" },
+        };
+
+    private const string ReactorNamespace = "Microsoft.UI.Reactor";
+
+    private static readonly LocalizableString Title =
+        "Duplicate atomic-replace modifier in one chain";
+
+    private static readonly LocalizableString MessageFormat =
+        "'.{0}(...)' is applied more than once in this chain; attached-placement modifiers are atomic-replace, so the last call wins and the earlier arguments are silently lost. Merge them into a single '.{0}(...)' call.";
+
+    private static readonly LocalizableString Description =
+        "Attached-placement modifiers (.Grid/.Canvas/.RelativePanel/.Flex) store " +
+        "their value keyed by record type via Element.SetAttached. A second call " +
+        "replaces the first outright instead of merging field-by-field, so " +
+        "'.Grid(row: 1).Grid(column: 2)' resets row to 0. Combine the calls into " +
+        "one so every argument is preserved.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Modifier",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Syntactic fast path (spec §3): must be `receiver.Name(...)` where Name
+        // is one of the atomic-replace placement modifiers.
+        var name = GetFluentMethodName(invocation);
+        if (name is null || !AtomicModifiers.ContainsKey(name))
+            return;
+
+        // Only report from the OUTERMOST occurrence of this name in the chain —
+        // if an ancestor fluent link has the same name, let it report instead.
+        if (HasAncestorWithSameName(invocation, name))
+            return;
+
+        // Walk down the receiver chain collecting every same-name occurrence.
+        var occurrences = CollectSameNameOccurrences(invocation, name);
+        if (occurrences.Count < 2)
+            return;
+
+        // Semantic confirmation: every occurrence must bind to the Reactor
+        // extension modifier of that name (not some unrelated `.Grid()`/`.Flex()`).
+        foreach (var occ in occurrences)
+        {
+            if (!IsReactorAtomicModifier(context.SemanticModel, occ, name, context.CancellationToken))
+                return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.GetLocation(),
+            name));
+    }
+
+    /// <summary>Method name of a <c>receiver.Name(...)</c> fluent call, else null.</summary>
+    internal static string? GetFluentMethodName(InvocationExpressionSyntax invocation) =>
+        invocation.Expression is MemberAccessExpressionSyntax
+        {
+            RawKind: (int)SyntaxKind.SimpleMemberAccessExpression,
+        } memberAccess
+            ? memberAccess.Name.Identifier.Text
+            : null;
+
+    /// <summary>
+    /// The invocation immediately below <paramref name="invocation"/> in a fluent
+    /// chain — i.e. the receiver of its member access when that receiver is itself
+    /// a method call. Returns null when the chain link is broken (identifier,
+    /// property access, element access, …).
+    /// </summary>
+    internal static InvocationExpressionSyntax? GetReceiverInvocation(InvocationExpressionSyntax invocation) =>
+        invocation.Expression is MemberAccessExpressionSyntax { Expression: InvocationExpressionSyntax receiver }
+            ? receiver
+            : null;
+
+    private static bool HasAncestorWithSameName(InvocationExpressionSyntax invocation, string name)
+    {
+        var current = (ExpressionSyntax)invocation;
+        while (current.Parent is MemberAccessExpressionSyntax memberAccess
+               && memberAccess.Expression == current
+               && memberAccess.Parent is InvocationExpressionSyntax outer)
+        {
+            if (GetFluentMethodName(outer) == name)
+                return true;
+            current = outer;
+        }
+        return false;
+    }
+
+    private static List<InvocationExpressionSyntax> CollectSameNameOccurrences(
+        InvocationExpressionSyntax outermost, string name)
+    {
+        // Innermost-first order is convenient for the code fix (later/outer wins).
+        var stack = new List<InvocationExpressionSyntax>();
+        for (var node = outermost; node is not null; node = GetReceiverInvocation(node))
+        {
+            if (GetFluentMethodName(node) == name)
+                stack.Add(node);
+        }
+        stack.Reverse();
+        return stack;
+    }
+
+    private static bool IsReactorAtomicModifier(
+        SemanticModel model,
+        InvocationExpressionSyntax invocation,
+        string name,
+        System.Threading.CancellationToken ct)
+    {
+        if (model.GetSymbolInfo(invocation, ct).Symbol is not IMethodSymbol method)
+            return false;
+
+        var original = method.ReducedFrom ?? method.OriginalDefinition;
+        var containingType = original.ContainingType;
+        if (containingType is null)
+            return false;
+
+        return AtomicModifiers.TryGetValue(name, out var expectedClass)
+            && containingType.Name == expectedClass
+            && containingType.ContainingNamespace?.ToDisplayString() == ReactorNamespace;
+    }
+}

--- a/src/Reactor.Analyzers/DuplicateAtomicModifierAnalyzer.cs
+++ b/src/Reactor.Analyzers/DuplicateAtomicModifierAnalyzer.cs
@@ -68,6 +68,9 @@ public sealed class DuplicateAtomicModifierAnalyzer : DiagnosticAnalyzer
         Title,
         MessageFormat,
         "Reactor.Modifier",
+        // Info is deliberate (spec 060 §12 table + §2.5): a nudge-class rule that
+        // ships a safe merge fix. It is not promoted to Warning despite describing
+        // silent argument loss — the auto-fix makes it low-friction to resolve.
         DiagnosticSeverity.Info,
         isEnabledByDefault: true,
         description: Description);
@@ -150,10 +153,13 @@ public sealed class DuplicateAtomicModifierAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static List<InvocationExpressionSyntax> CollectSameNameOccurrences(
+    /// <summary>
+    /// Every same-name occurrence on the chain, innermost first (later/outer wins
+    /// order for the code fix). Shared with <see cref="DuplicateAtomicModifierCodeFix"/>.
+    /// </summary>
+    internal static List<InvocationExpressionSyntax> CollectSameNameOccurrences(
         InvocationExpressionSyntax outermost, string name)
     {
-        // Innermost-first order is convenient for the code fix (later/outer wins).
         var stack = new List<InvocationExpressionSyntax>();
         for (var node = outermost; node is not null; node = GetReceiverInvocation(node))
         {

--- a/src/Reactor.Analyzers/DuplicateAtomicModifierCodeFix.cs
+++ b/src/Reactor.Analyzers/DuplicateAtomicModifierCodeFix.cs
@@ -25,10 +25,25 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// author almost certainly intended — the current chain silently drops every
 /// argument except those on the final call.
 ///
-/// The fix withholds itself when the calls do not all bind to the same modifier
-/// overload, or when an argument can't be mapped to a named parameter (e.g. a
-/// <c>params</c> slot) — cases where a single merged call can't be produced
-/// safely. The diagnostic still fires so the author can merge by hand.
+/// Because the merge can drop an overridden argument and re-orders arguments into
+/// parameter-declaration order, the fix withholds itself whenever applying it
+/// could change program behaviour, namely when:
+/// <list type="bullet">
+/// <item><description>the duplicate calls are not <b>directly chained</b> (an
+///   intervening modifier sits between them) — collapsing would move an argument
+///   across that call;</description></item>
+/// <item><description>a merged argument is not provably <b>side-effect-free</b>
+///   (only literals and reads of locals/parameters/fields/consts/enums qualify;
+///   calls, object creation, <c>await</c>, assignments, increments, and
+///   property/indexer/conditional access do not);</description></item>
+/// <item><description>a merged argument carries a <b>comment</b> the rebuild
+///   would delete;</description></item>
+/// <item><description>the calls don't all bind to the same modifier overload, or
+///   an argument can't be mapped to a named parameter (e.g. a <c>params</c>
+///   slot).</description></item>
+/// </list>
+/// In every withheld case the diagnostic still fires so the author can merge by
+/// hand.
 /// </remarks>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(DuplicateAtomicModifierCodeFix))]
 [Shared]
@@ -132,9 +147,9 @@ public sealed class DuplicateAtomicModifierCodeFix : CodeFixProvider
                 // merge can drop an argument (when a later call overrides the same
                 // parameter) or re-order emission into parameter order, and it
                 // rebuilds each argument without its trivia. Dropping/reordering a
-                // side-effecting call or deleting a comment would silently change
-                // the program — leave those for the author.
-                if (!IsMergeSafeArgument(argument))
+                // side-effecting expression or deleting a comment would silently
+                // change the program — leave those for the author.
+                if (!IsMergeSafeArgument(argument, model, ct))
                     return null;
 
                 IParameterSymbol? parameter;
@@ -170,11 +185,14 @@ public sealed class DuplicateAtomicModifierCodeFix : CodeFixProvider
 
     /// <summary>
     /// An argument is safe to merge only when it has no comment trivia (which the
-    /// rebuild would delete) and its expression is free of side effects — no call,
-    /// object creation, await, assignment, or increment/decrement. Such an
-    /// expression can be dropped or re-ordered without changing behaviour.
+    /// rebuild would delete) and its expression is provably side-effect-free — so
+    /// dropping it (a later call overrides the same parameter) or re-ordering it
+    /// into parameter order can't change behaviour. Side-effect-free means built
+    /// solely from literals and reads of locals/parameters/fields/consts/enums;
+    /// calls, object creation, <c>await</c>, assignments, increments, and
+    /// property/indexer/conditional access are all treated as unsafe.
     /// </summary>
-    private static bool IsMergeSafeArgument(ArgumentSyntax argument)
+    private static bool IsMergeSafeArgument(ArgumentSyntax argument, SemanticModel model, CancellationToken ct)
     {
         var hasComment = argument.GetLeadingTrivia()
             .Concat(argument.DescendantTrivia())
@@ -186,27 +204,59 @@ public sealed class DuplicateAtomicModifierCodeFix : CodeFixProvider
         if (hasComment)
             return false;
 
-        foreach (var node in argument.Expression.DescendantNodesAndSelf())
-        {
-            switch (node)
-            {
-                case InvocationExpressionSyntax:
-                case ObjectCreationExpressionSyntax:
-                case AwaitExpressionSyntax:
-                case AssignmentExpressionSyntax:
-                    return false;
-                case PostfixUnaryExpressionSyntax post
-                    when post.IsKind(SyntaxKind.PostIncrementExpression)
-                      || post.IsKind(SyntaxKind.PostDecrementExpression):
-                    return false;
-                case PrefixUnaryExpressionSyntax pre
-                    when pre.IsKind(SyntaxKind.PreIncrementExpression)
-                      || pre.IsKind(SyntaxKind.PreDecrementExpression):
-                    return false;
-            }
-        }
-        return true;
+        return IsSideEffectFreeExpression(argument.Expression, model, ct);
     }
+
+    /// <summary>
+    /// A conservative, semantic-model-backed purity check: literals and reads of
+    /// locals/parameters/fields/consts/enum members (composed with parentheses,
+    /// casts, non-mutating unary, and binary operators) are side-effect-free.
+    /// Anything that can execute user code — a call, object creation, indexer or
+    /// property getter, conditional access, <c>await</c>, or a mutation — is not.
+    /// </summary>
+    private static bool IsSideEffectFreeExpression(ExpressionSyntax expression, SemanticModel model, CancellationToken ct)
+    {
+        switch (expression)
+        {
+            case LiteralExpressionSyntax:
+            case DefaultExpressionSyntax:
+            case ThisExpressionSyntax:
+                return true;
+            case ParenthesizedExpressionSyntax paren:
+                return IsSideEffectFreeExpression(paren.Expression, model, ct);
+            case CastExpressionSyntax cast:
+                return IsSideEffectFreeExpression(cast.Expression, model, ct);
+            case PrefixUnaryExpressionSyntax unary
+                when !unary.IsKind(SyntaxKind.PreIncrementExpression)
+                  && !unary.IsKind(SyntaxKind.PreDecrementExpression):
+                return IsSideEffectFreeExpression(unary.Operand, model, ct);
+            case BinaryExpressionSyntax binary:
+                return IsSideEffectFreeExpression(binary.Left, model, ct)
+                    && IsSideEffectFreeExpression(binary.Right, model, ct);
+            case IdentifierNameSyntax:
+                return IsSideEffectFreeSymbol(model.GetSymbolInfo(expression, ct).Symbol);
+            case MemberAccessExpressionSyntax member
+                when member.IsKind(SyntaxKind.SimpleMemberAccessExpression):
+                // e.g. `Type.Field` / `local.field` — the accessed member must be a
+                // field/const/enum and the receiver must itself be side-effect-free.
+                return IsSideEffectFreeSymbol(model.GetSymbolInfo(member, ct).Symbol)
+                    && IsSideEffectFreeExpression(member.Expression, model, ct);
+            default:
+                // invocation, object creation, await, element/conditional access,
+                // assignment, etc. — potentially side-effecting.
+                return false;
+        }
+    }
+
+    private static bool IsSideEffectFreeSymbol(ISymbol? symbol) => symbol switch
+    {
+        ILocalSymbol => true,
+        IParameterSymbol => true,
+        IFieldSymbol => true,            // includes const and enum members
+        INamedTypeSymbol => true,        // static-member-access receiver (Type.Field)
+        INamespaceSymbol => true,        // namespace-qualified receiver
+        _ => false,                      // property, method, event, indexer, dynamic, null
+    };
 
     private static ArgumentSyntax MakeNamedArgument(string parameterName, ExpressionSyntax value)
     {

--- a/src/Reactor.Analyzers/DuplicateAtomicModifierCodeFix.cs
+++ b/src/Reactor.Analyzers/DuplicateAtomicModifierCodeFix.cs
@@ -57,8 +57,14 @@ public sealed class DuplicateAtomicModifierCodeFix : CodeFixProvider
             if (name is null || !DuplicateAtomicModifierAnalyzer.AtomicModifiers.ContainsKey(name))
                 continue;
 
-            var occurrences = CollectSameNameOccurrences(outermost, name);
+            var occurrences = DuplicateAtomicModifierAnalyzer.CollectSameNameOccurrences(outermost, name);
             if (occurrences.Count < 2) continue;
+
+            // Only merge a contiguous run of same-name calls. Merging across an
+            // intervening modifier (e.g. `.Grid(a).Margin(b).Grid(c)`) would move
+            // an argument expression to the other side of `.Margin(b)`, changing
+            // evaluation order — withhold and let the author merge by hand.
+            if (!AreDirectlyChained(occurrences)) continue;
 
             var mergedArgList = TryBuildMergedArgumentList(model, occurrences, context.CancellationToken);
             if (mergedArgList is null) continue; // withhold — can't merge safely
@@ -74,19 +80,19 @@ public sealed class DuplicateAtomicModifierCodeFix : CodeFixProvider
         }
     }
 
-    /// <summary>All same-name occurrences on the chain, innermost first.</summary>
-    private static List<InvocationExpressionSyntax> CollectSameNameOccurrences(
-        InvocationExpressionSyntax outermost, string name)
+    /// <summary>
+    /// True when the occurrences form a contiguous run — each is the direct fluent
+    /// receiver of the next — so collapsing them moves no argument across an
+    /// intervening call. Occurrences are innermost-first.
+    /// </summary>
+    private static bool AreDirectlyChained(List<InvocationExpressionSyntax> occurrences)
     {
-        var list = new List<InvocationExpressionSyntax>();
-        for (var node = outermost; node is not null;
-             node = DuplicateAtomicModifierAnalyzer.GetReceiverInvocation(node))
+        for (var i = 0; i < occurrences.Count - 1; i++)
         {
-            if (DuplicateAtomicModifierAnalyzer.GetFluentMethodName(node) == name)
-                list.Add(node);
+            if (DuplicateAtomicModifierAnalyzer.GetReceiverInvocation(occurrences[i + 1]) != occurrences[i])
+                return false;
         }
-        list.Reverse();
-        return list;
+        return true;
     }
 
     /// <summary>
@@ -122,6 +128,15 @@ public sealed class DuplicateAtomicModifierCodeFix : CodeFixProvider
             {
                 var argument = arguments[i];
 
+                // Withhold when an argument carries side effects or comments: the
+                // merge can drop an argument (when a later call overrides the same
+                // parameter) or re-order emission into parameter order, and it
+                // rebuilds each argument without its trivia. Dropping/reordering a
+                // side-effecting call or deleting a comment would silently change
+                // the program — leave those for the author.
+                if (!IsMergeSafeArgument(argument))
+                    return null;
+
                 IParameterSymbol? parameter;
                 if (argument.NameColon is { } nameColon)
                 {
@@ -151,6 +166,46 @@ public sealed class DuplicateAtomicModifierCodeFix : CodeFixProvider
             ordered.Count - 1);
 
         return SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(ordered, separators));
+    }
+
+    /// <summary>
+    /// An argument is safe to merge only when it has no comment trivia (which the
+    /// rebuild would delete) and its expression is free of side effects — no call,
+    /// object creation, await, assignment, or increment/decrement. Such an
+    /// expression can be dropped or re-ordered without changing behaviour.
+    /// </summary>
+    private static bool IsMergeSafeArgument(ArgumentSyntax argument)
+    {
+        var hasComment = argument.GetLeadingTrivia()
+            .Concat(argument.DescendantTrivia())
+            .Concat(argument.GetTrailingTrivia())
+            .Any(t => t.IsKind(SyntaxKind.SingleLineCommentTrivia)
+                   || t.IsKind(SyntaxKind.MultiLineCommentTrivia)
+                   || t.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
+                   || t.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia));
+        if (hasComment)
+            return false;
+
+        foreach (var node in argument.Expression.DescendantNodesAndSelf())
+        {
+            switch (node)
+            {
+                case InvocationExpressionSyntax:
+                case ObjectCreationExpressionSyntax:
+                case AwaitExpressionSyntax:
+                case AssignmentExpressionSyntax:
+                    return false;
+                case PostfixUnaryExpressionSyntax post
+                    when post.IsKind(SyntaxKind.PostIncrementExpression)
+                      || post.IsKind(SyntaxKind.PostDecrementExpression):
+                    return false;
+                case PrefixUnaryExpressionSyntax pre
+                    when pre.IsKind(SyntaxKind.PreIncrementExpression)
+                      || pre.IsKind(SyntaxKind.PreDecrementExpression):
+                    return false;
+            }
+        }
+        return true;
     }
 
     private static ArgumentSyntax MakeNamedArgument(string parameterName, ExpressionSyntax value)

--- a/src/Reactor.Analyzers/DuplicateAtomicModifierCodeFix.cs
+++ b/src/Reactor.Analyzers/DuplicateAtomicModifierCodeFix.cs
@@ -1,0 +1,187 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for <see cref="DuplicateAtomicModifierAnalyzer"/>
+/// (<c>REACTOR_MOD_001</c>) — merges duplicate atomic-replace placement modifier
+/// calls in one fluent chain into a single call, e.g.
+/// <c>.Grid(row: 1).Grid(column: 2)</c> → <c>.Grid(row: 1, column: 2)</c>.
+/// </summary>
+/// <remarks>
+/// The merge combines each call's <em>explicitly supplied</em> arguments; when
+/// the same parameter is set more than once the later (outer) call wins, and
+/// parameters only ever set by one call are preserved. This is the behaviour the
+/// author almost certainly intended — the current chain silently drops every
+/// argument except those on the final call.
+///
+/// The fix withholds itself when the calls do not all bind to the same modifier
+/// overload, or when an argument can't be mapped to a named parameter (e.g. a
+/// <c>params</c> slot) — cases where a single merged call can't be produced
+/// safely. The diagnostic still fires so the author can merge by hand.
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(DuplicateAtomicModifierCodeFix))]
+[Shared]
+public sealed class DuplicateAtomicModifierCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DuplicateAtomicModifierAnalyzer.DiagnosticId);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        var model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (model is null) return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var outermost = root.FindNode(diagnostic.Location.SourceSpan)
+                .FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (outermost is null) continue;
+
+            var name = DuplicateAtomicModifierAnalyzer.GetFluentMethodName(outermost);
+            if (name is null || !DuplicateAtomicModifierAnalyzer.AtomicModifiers.ContainsKey(name))
+                continue;
+
+            var occurrences = CollectSameNameOccurrences(outermost, name);
+            if (occurrences.Count < 2) continue;
+
+            var mergedArgList = TryBuildMergedArgumentList(model, occurrences, context.CancellationToken);
+            if (mergedArgList is null) continue; // withhold — can't merge safely
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    $"Merge duplicate '.{name}(...)' calls into one",
+                    ct => Task.FromResult(
+                        context.Document.WithSyntaxRoot(
+                            MergeChain(root, occurrences, mergedArgList))),
+                    equivalenceKey: $"{DuplicateAtomicModifierAnalyzer.DiagnosticId}_Merge"),
+                diagnostic);
+        }
+    }
+
+    /// <summary>All same-name occurrences on the chain, innermost first.</summary>
+    private static List<InvocationExpressionSyntax> CollectSameNameOccurrences(
+        InvocationExpressionSyntax outermost, string name)
+    {
+        var list = new List<InvocationExpressionSyntax>();
+        for (var node = outermost; node is not null;
+             node = DuplicateAtomicModifierAnalyzer.GetReceiverInvocation(node))
+        {
+            if (DuplicateAtomicModifierAnalyzer.GetFluentMethodName(node) == name)
+                list.Add(node);
+        }
+        list.Reverse();
+        return list;
+    }
+
+    /// <summary>
+    /// Merge the explicit arguments of every occurrence (innermost → outermost,
+    /// later wins per parameter) into a single named-argument list. Returns null
+    /// when the merge can't be produced safely.
+    /// </summary>
+    private static ArgumentListSyntax? TryBuildMergedArgumentList(
+        SemanticModel model,
+        List<InvocationExpressionSyntax> occurrences,
+        CancellationToken ct)
+    {
+        IMethodSymbol? sharedMethod = null;
+        var byOrdinal = new SortedDictionary<int, ArgumentSyntax>();
+
+        foreach (var occ in occurrences)
+        {
+            if (model.GetSymbolInfo(occ, ct).Symbol is not IMethodSymbol method)
+                return null;
+
+            // Require a single shared overload so the merged named-argument list
+            // is guaranteed to bind back to it.
+            var key = method.ReducedFrom ?? method.OriginalDefinition;
+            if (sharedMethod is null)
+                sharedMethod = key;
+            else if (!SymbolEqualityComparer.Default.Equals(sharedMethod, key))
+                return null;
+
+            var parameters = method.Parameters;
+            var arguments = occ.ArgumentList.Arguments;
+
+            for (var i = 0; i < arguments.Count; i++)
+            {
+                var argument = arguments[i];
+
+                IParameterSymbol? parameter;
+                if (argument.NameColon is { } nameColon)
+                {
+                    var pname = nameColon.Name.Identifier.ValueText;
+                    parameter = parameters.FirstOrDefault(p => p.Name == pname);
+                }
+                else
+                {
+                    parameter = i < parameters.Length ? parameters[i] : null;
+                }
+
+                // Can't map the argument to a discrete named parameter (unknown
+                // name, positional overflow, or a params slot) — bail out.
+                if (parameter is null || parameter.IsParams)
+                    return null;
+
+                byOrdinal[parameter.Ordinal] = MakeNamedArgument(parameter.Name, argument.Expression);
+            }
+        }
+
+        if (byOrdinal.Count == 0)
+            return SyntaxFactory.ArgumentList();
+
+        var ordered = byOrdinal.Values.ToList();
+        var separators = Enumerable.Repeat(
+            SyntaxFactory.Token(SyntaxKind.CommaToken).WithTrailingTrivia(SyntaxFactory.Space),
+            ordered.Count - 1);
+
+        return SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(ordered, separators));
+    }
+
+    private static ArgumentSyntax MakeNamedArgument(string parameterName, ExpressionSyntax value)
+    {
+        var nameColon = SyntaxFactory.NameColon(SyntaxFactory.IdentifierName(parameterName))
+            .WithColonToken(SyntaxFactory.Token(SyntaxKind.ColonToken).WithTrailingTrivia(SyntaxFactory.Space));
+
+        return SyntaxFactory.Argument(nameColon, default, value.WithoutTrivia());
+    }
+
+    /// <summary>
+    /// Collapse the chain: peel every inner same-name call and give the outermost
+    /// call the merged argument list. <see cref="SyntaxNode.ReplaceNodes"/>
+    /// rewrites descendants first, so the outermost node already has its inner
+    /// duplicates removed by the time we swap in the merged arguments.
+    /// </summary>
+    private static SyntaxNode MergeChain(
+        SyntaxNode root,
+        List<InvocationExpressionSyntax> occurrences,
+        ArgumentListSyntax mergedArgList)
+    {
+        var outermost = occurrences[occurrences.Count - 1];
+
+        return root.ReplaceNodes(occurrences, (original, rewritten) =>
+        {
+            if (original == outermost)
+                return rewritten.WithArgumentList(mergedArgList);
+
+            // Peel this inner call: replace `receiver.Name(args)` with `receiver`.
+            var memberAccess = (MemberAccessExpressionSyntax)rewritten.Expression;
+            return memberAccess.Expression.WithTriviaFrom(rewritten);
+        });
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/DuplicateAtomicModifierAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/DuplicateAtomicModifierAnalyzerTests.cs
@@ -1,0 +1,301 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="DuplicateAtomicModifierAnalyzer"/> (<c>REACTOR_MOD_001</c>)
+/// and its <see cref="DuplicateAtomicModifierCodeFix"/>. Stubs the minimum
+/// Reactor surface — the four atomic-replace placement modifiers, one additive
+/// modifier, one unrelated generic modifier, and an unrelated non-Reactor type —
+/// so both the syntactic detection and the semantic confirmation exercise real
+/// binding without pulling the framework in.
+/// </summary>
+public class DuplicateAtomicModifierAnalyzerTests
+{
+    // Extension classes live in `Microsoft.UI.Reactor` (matching source) so the
+    // analyzer's containing-type/namespace confirmation binds; Element lives in
+    // `Microsoft.UI.Reactor.Core`.
+    private const string Stubs = @"
+namespace System.Runtime.CompilerServices
+{
+    public static class IsExternalInit { }
+}
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public abstract record Element { }
+    public sealed record TextBlockElement(string Text) : Element { }
+
+    public static class Factories
+    {
+        public static TextBlockElement Text(string s) => new(s);
+    }
+}
+
+namespace Microsoft.UI.Reactor
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public static class GridExtensions
+    {
+        public static T Grid<T>(this T el, int row = 0, int column = 0, int rowSpan = 1, int columnSpan = 1) where T : Element => el;
+    }
+
+    public static class CanvasExtensions
+    {
+        public static T Canvas<T>(this T el, double left = 0, double top = 0) where T : Element => el;
+        public static T Canvas<T>(this T el, double left, double top, double anchorX, double anchorY) where T : Element => el;
+    }
+
+    public static class RelativePanelExtensions
+    {
+        public static T RelativePanel<T>(this T el, string name, string alignTopWith = """", string below = """") where T : Element => el;
+    }
+
+    public static class FlexExtensions
+    {
+        public static T Flex<T>(this T el, double grow = 0, double shrink = 1) where T : Element => el;
+    }
+
+    // Additive modifier (accumulates) — must NOT be flagged.
+    public static class ValidateExtensions
+    {
+        public static T Validate<T>(this T el, string fieldName) where T : Element => el;
+    }
+
+    // Unrelated generic modifier — different name, must NOT be flagged.
+    public static class MarginExtensions
+    {
+        public static T Margin<T>(this T el, double all = 0) where T : Element => el;
+    }
+}
+
+namespace Other
+{
+    // Unrelated type that happens to expose a fluent `Grid` — the semantic gate
+    // must reject it (not a Reactor extension).
+    public sealed class Widget
+    {
+        public Widget Grid(int row = 0, int column = 0) => this;
+    }
+}
+";
+
+    private static string App(string body) => Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    using Microsoft.UI.Reactor.Core;
+    using static Microsoft.UI.Reactor.Core.Factories;
+
+    public static class C
+    {
+" + body + @"
+    }
+}";
+
+    // ── Positive ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Fires_On_Duplicate_Grid_In_One_Chain()
+    {
+        var source = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: 1).Grid(column: 2)|};");
+
+        await new CSharpAnalyzerTest<DuplicateAtomicModifierAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_Duplicate_Canvas_And_Flex()
+    {
+        var source = App(@"
+        public static Element A()
+            => {|REACTOR_MOD_001:Text(""hi"").Canvas(left: 10).Canvas(top: 20)|};
+        public static Element B()
+            => {|REACTOR_MOD_001:Text(""hi"").Flex(grow: 1).Flex(shrink: 0)|};");
+
+        await new CSharpAnalyzerTest<DuplicateAtomicModifierAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Fires_On_Three_Occurrences_Once()
+    {
+        // Non-adjacent + three occurrences: still exactly one diagnostic, anchored
+        // at the outermost `.Grid`.
+        var source = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: 1).Margin(4).Grid(column: 2).Grid(rowSpan: 3)|};");
+
+        await new CSharpAnalyzerTest<DuplicateAtomicModifierAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Negative ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task No_Diagnostic_On_Single_Grid()
+    {
+        var source = App(@"
+        public static Element Build()
+            => Text(""hi"").Grid(row: 1, column: 2);");
+
+        await new CSharpAnalyzerTest<DuplicateAtomicModifierAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_On_Two_Different_Modifiers()
+    {
+        var source = App(@"
+        public static Element Build()
+            => Text(""hi"").Grid(row: 1).Margin(8);");
+
+        await new CSharpAnalyzerTest<DuplicateAtomicModifierAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_On_Repeated_Additive_Modifier()
+    {
+        // `.Validate(...)` accumulates (reads + merges the existing attached
+        // value), so repeating it is legitimate — must not be flagged.
+        var source = App(@"
+        public static Element Build()
+            => Text(""hi"").Validate(""first"").Validate(""second"");");
+
+        await new CSharpAnalyzerTest<DuplicateAtomicModifierAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Near-miss (trips the syntactic fast path, rejected by a later gate) ──
+
+    [Fact]
+    public async Task No_Diagnostic_When_Grids_Are_On_Separate_Chains()
+    {
+        // The name `Grid` appears twice in the file, but on two different
+        // elements — never twice in one linear chain.
+        var source = App(@"
+        public static Element A() => Text(""a"").Grid(row: 1);
+        public static Element B() => Text(""b"").Grid(column: 2);");
+
+        await new CSharpAnalyzerTest<DuplicateAtomicModifierAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task No_Diagnostic_On_NonReactor_Grid_Method()
+    {
+        // Same syntactic shape (`.Grid(...).Grid(...)`) but the receiver is an
+        // unrelated type — the semantic confirmation must reject it.
+        var source = App(@"
+        public static object Build()
+            => new global::Other.Widget().Grid(1).Grid(2);");
+
+        await new CSharpAnalyzerTest<DuplicateAtomicModifierAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Code-fix round-trips ────────────────────────────────────────────
+
+    [Fact]
+    public async Task CodeFix_Merges_Named_Grid_Calls()
+    {
+        var before = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: 1).Grid(column: 2)|};");
+
+        var after = App(@"
+        public static Element Build()
+            => Text(""hi"").Grid(row: 1, column: 2);");
+
+        await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = $"{DuplicateAtomicModifierAnalyzer.DiagnosticId}_Merge",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Merges_Positional_And_Named_With_Later_Wins()
+    {
+        // First call sets row positionally + column; second call overrides column.
+        // Expect the later value for column and row preserved, all emitted named.
+        var before = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(1, column: 5).Grid(column: 2)|};");
+
+        var after = App(@"
+        public static Element Build()
+            => Text(""hi"").Grid(row: 1, column: 2);");
+
+        await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = $"{DuplicateAtomicModifierAnalyzer.DiagnosticId}_Merge",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Merges_Three_NonAdjacent_Grid_Calls()
+    {
+        var before = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: 1).Margin(4).Grid(column: 2).Grid(rowSpan: 3)|};");
+
+        // All three `.Grid` calls collapse into the outermost position (the inner
+        // ones are peeled); merged args are emitted in parameter order. Order
+        // relative to `.Margin` is irrelevant — they write different attached slots.
+        var after = App(@"
+        public static Element Build()
+            => Text(""hi"").Margin(4).Grid(row: 1, column: 2, rowSpan: 3);");
+
+        await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = $"{DuplicateAtomicModifierAnalyzer.DiagnosticId}_Merge",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Withheld_Across_Different_Canvas_Overloads()
+    {
+        // The two `.Canvas` calls bind to different overloads (2-arg vs 4-arg);
+        // a single merged call can't be produced safely, so the diagnostic fires
+        // but no fix is offered (FixedCode == TestCode).
+        var source = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Canvas(10, 20).Canvas(30, 40, 0.5, 0.5)|};");
+
+        await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/DuplicateAtomicModifierAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/DuplicateAtomicModifierAnalyzerTests.cs
@@ -95,6 +95,8 @@ namespace TestApp
     public static class C
     {
         internal static int Val() => 1;
+        internal static int Fld = 1;
+        internal static int Prop => 1;
 " + body + @"
     }
 }";
@@ -310,6 +312,42 @@ namespace TestApp
         var source = App(@"
         public static Element Build()
             => {|REACTOR_MOD_001:Text(""hi"").Grid(row: 1).Margin(4).Grid(column: 2)|};");
+
+        await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Merges_When_Argument_Is_Field()
+    {
+        // A field read is side-effect-free, so the fix still applies.
+        var before = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: Fld).Grid(column: 2)|};");
+
+        var after = App(@"
+        public static Element Build()
+            => Text(""hi"").Grid(row: Fld, column: 2);");
+
+        await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = $"{DuplicateAtomicModifierAnalyzer.DiagnosticId}_Merge",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Withheld_When_Argument_Is_Property()
+    {
+        // `Prop` is a property whose getter could run user code; the later call
+        // overrides `row`, so a naive merge would drop that getter call. Withhold.
+        var source = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: Prop).Grid(row: 2)|};");
 
         await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
         {

--- a/tests/Reactor.Tests/AnalyzerTests/DuplicateAtomicModifierAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/DuplicateAtomicModifierAnalyzerTests.cs
@@ -94,6 +94,7 @@ namespace TestApp
 
     public static class C
     {
+        internal static int Val() => 1;
 " + body + @"
     }
 }";
@@ -261,24 +262,91 @@ namespace TestApp
     }
 
     [Fact]
-    public async Task CodeFix_Merges_Three_NonAdjacent_Grid_Calls()
+    public async Task CodeFix_Merges_Three_Adjacent_Grid_Calls()
     {
         var before = App(@"
         public static Element Build()
-            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: 1).Margin(4).Grid(column: 2).Grid(rowSpan: 3)|};");
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: 1).Grid(column: 2).Grid(rowSpan: 3)|};");
 
-        // All three `.Grid` calls collapse into the outermost position (the inner
-        // ones are peeled); merged args are emitted in parameter order. Order
-        // relative to `.Margin` is irrelevant — they write different attached slots.
         var after = App(@"
         public static Element Build()
-            => Text(""hi"").Margin(4).Grid(row: 1, column: 2, rowSpan: 3);");
+            => Text(""hi"").Grid(row: 1, column: 2, rowSpan: 3);");
 
         await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
         {
             TestCode = before,
             FixedCode = after,
             CodeActionEquivalenceKey = $"{DuplicateAtomicModifierAnalyzer.DiagnosticId}_Merge",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Merges_Duplicate_RelativePanel_Calls()
+    {
+        // Required positional/name parameter present in both calls; later wins for
+        // shared params, distinct optional placement params preserved.
+        var before = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").RelativePanel(name: ""a"", alignTopWith: ""x"").RelativePanel(name: ""a"", below: ""y"")|};");
+
+        var after = App(@"
+        public static Element Build()
+            => Text(""hi"").RelativePanel(name: ""a"", alignTopWith: ""x"", below: ""y"");");
+
+        await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
+        {
+            TestCode = before,
+            FixedCode = after,
+            CodeActionEquivalenceKey = $"{DuplicateAtomicModifierAnalyzer.DiagnosticId}_Merge",
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Withheld_For_NonAdjacent_Duplicates()
+    {
+        // The two `.Grid` calls are separated by `.Margin(4)`. Merging would move an
+        // argument across the intervening call, so the diagnostic fires but no fix
+        // is offered (FixedCode == TestCode).
+        var source = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: 1).Margin(4).Grid(column: 2)|};");
+
+        await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Withheld_When_Argument_Has_Side_Effect()
+    {
+        // `Val()` is dropped by a naive merge (later call overrides `row`); its call
+        // could have side effects, so the fix is withheld (diagnostic still fires).
+        var source = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: Val()).Grid(row: 2)|};");
+
+        await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task CodeFix_Withheld_When_Argument_Has_Comment()
+    {
+        // The merge rebuilds arguments without trivia, which would delete the
+        // comment — withhold rather than silently drop it.
+        var source = App(@"
+        public static Element Build()
+            => {|REACTOR_MOD_001:Text(""hi"").Grid(row: 1).Grid(column: /* keep me */ 2)|};");
+
+        await new CSharpCodeFixTest<DuplicateAtomicModifierAnalyzer, DuplicateAtomicModifierCodeFix, DefaultVerifier>
+        {
+            TestCode = source,
+            FixedCode = source,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 


### PR DESCRIPTION
Implements **REACTOR_MOD_001** (spec-060 Batch-2 §12). Stacked on `azchohfi-spec-060-analyzer-suite`.

## Premise verification (Batch-2 requires it — holds)
`Element.SetAttached(new XxxAttached(...))` (`Element.cs:277`) stores attached data **keyed by record type** and constructs a *fresh* record from the method params — a pure **atomic replace**, no field-level merge. So `.Grid(row: 1).Grid(column: 2)` yields `GridAttached(0, 2, 1, 1)` — `row` silently resets to 0. Confirmed against `modifier-system.md:338-341`.

### Atomic-replace attached-placement set (source-verified allowlist)
| Modifier | Attached record | Source |
|---|---|---|
| `.Grid` | `GridAttached` | `GridExtensions.cs:16` |
| `.Canvas` | `CanvasAttached` | `CanvasExtensions.cs:15,24` |
| `.RelativePanel` | `RelativePanelAttached` | `RelativePanelExtensions.cs:15` |
| `.Flex` | `FlexAttached` | `FlexExtensions.cs:12` |

### Deliberately excluded (verified additive / not lossy)
- `.WrapGridColumnSpan` / `.WrapGridRowSpan` — **read** the existing `WrapGridAttached` and preserve the untouched field (`ElementExtensions.cs:1637-1652`) → field-preserving, not lossy.
- `.Validate` — accumulates validators (`ValidateExtensions.cs:37-45`); `.OnError`/`.OnWarning` use `with` (`ErrorStyling.cs:98,107`) → additive.
- `.Drag`/`.Focus`/`.Immediate`/`.CenterAt` — single/no-arg or non-placement.

## What it does
- **Analyzer** (`Reactor.Modifier`, **Info**): fires when the same allowlisted modifier **name** appears ≥2× in one linear fluent chain. Reports once at the outermost occurrence; semantically confirms each occurrence binds to the Reactor extension (containing type + `Microsoft.UI.Reactor` namespace) so unrelated `.Grid()`/`.Flex()` methods don't trip it.
- **Code fix** (merge): combines the calls into one — merges each call's explicit args by parameter name, **later (outer) wins**, earlier-only params preserved; emits named args in declaration order. Handles non-adjacent duplicates via `ReplaceNodes` (peels inner calls). **Withholds** itself when the calls bind to different overloads or an arg can't be mapped to a named parameter.

## Tests (12, all green)
`dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~DuplicateAtomicModifierAnalyzerTests`
- Positive: duplicate `.Grid`, `.Canvas`, `.Flex`; non-adjacent 3× (one diagnostic).
- Negative: single `.Grid`; two different modifiers; repeated additive `.Validate`.
- Near-miss: two `.Grid` on separate chains; non-Reactor `.Grid().Grid()`.
- Fix round-trips: `.Grid(row: 1).Grid(column: 2)` → `.Grid(row: 1, column: 2)`; positional+named later-wins; non-adjacent 3×; withheld across Canvas overloads.

Full `AnalyzerTests` suite: 227 passed. Samples sweep: no genuine duplicate-placement chains (acceptable for a hygiene rule per §2.4).

## Docs
`AnalyzerReleases.Unshipped.md` row, `analyzer-architecture.md.dt` rules-table row, and the `reactor-build-and-check` cheat-table row — all appended (keep-all-rows on conflict).