### PR TITLE
feat(analyzers): REACTOR_MEDIA_001 — unsized WebView2 in an auto-layout stack

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -124,6 +124,7 @@ via `.editorconfig`.
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_MEDIA_001` | Info | Unsized WebView2 in an auto-layout stack | `UnsizedWebViewInStackAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
 data-flow analyses (variable hook counts across early returns, async

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -88,6 +88,7 @@ Additional flags:
 | `REACTOR_A11Y_001` | warning | Icon-only button missing accessible name | Add `.AutomationName("Delete")` (or similar). |
 | `REACTOR_A11Y_002` | warning | Image missing alt text | Add `.AutomationName(...)` or `.AccessibilityHidden(true)` for decorative images. |
 | `REACTOR_A11Y_003` | warning | Form field missing label | Wrap in `FormField(input, label: "Email", required: true)`. |
+| `REACTOR_MEDIA_001` | info | `WebView2` is a direct child of an auto-layout stack (`HStack`/`VStack`/`FlexRow`/`FlexColumn`) with no explicit size | Pin `.Width(...)` and `.Height(...)` (or host it in a fixed-size `Grid` cell). Unsized, WebView2 measures to its web content and oscillates as the page reflows. |
 | `CS0103` | error | "The name 'X' does not exist in the current context" | Missing `using` — most often `Microsoft.UI.Reactor.Layout` (FlexAlign), `Microsoft.UI.Xaml.Controls` (InfoBarSeverity, Orientation), or `static Microsoft.UI.Reactor.Factories`. |
 | `CS1061` | error | "'X' does not contain a definition for 'Y'" | Modifier order — type-specific sugar (`.Bold()`, `.Foreground()` on `TextBlockElement`) must come before generic modifiers (`.Margin()`, `.Padding()`) that return base `Element`. |
 | `CS0117` | error | "'Element' does not contain a definition for X" | Same root cause as CS1061 — modifier order, OR you're calling a factory that doesn't exist. Confirm against `reactor-dsl/references/reactor.api.txt`. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -20,3 +20,4 @@ REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list 
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback
+REACTOR_MEDIA_001 | Reactor.Layout | Info | UnsizedWebViewInStackAnalyzer - WebView2 is a direct child of an auto-layout stack (HStack/VStack/FlexRow/FlexColumn) without explicit .Width/.Height

--- a/src/Reactor.Analyzers/UnsizedWebViewInStackAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnsizedWebViewInStackAnalyzer.cs
@@ -1,0 +1,192 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_MEDIA_001</c> — a <c>WebView2(...)</c> placed as a direct child of an
+/// auto-layout stack (<c>HStack</c>/<c>VStack</c>/<c>FlexRow</c>/<c>FlexColumn</c>)
+/// without pinning an explicit <c>.Width</c>/<c>.Height</c>.
+/// </summary>
+/// <remarks>
+/// Auto-layout stacks hand each child an indeterminate measure on the stack's main
+/// axis. <c>WebView2</c> measures to its web content — which for a real page is the
+/// viewport — so with no bounds it grows to fill the available space and triggers a
+/// layout oscillation when the page reflows (docs/guide/text-and-media.md §WebView2).
+/// The fix is authoring-intent (there is no correct default size), so this ships as an
+/// <see cref="DiagnosticSeverity.Info"/> nudge with no code-fix: pin <c>.Width</c> and
+/// <c>.Height</c>, or place the control in a fixed-size <c>Grid</c> cell.
+///
+/// Deliberately conservative to keep false positives out: it only fires on a
+/// <c>WebView2(...)</c> that is a <em>direct positional argument</em> of one of the four
+/// stack factories and whose fluent chain provably pins no size. It bails when the child
+/// is an opaque expression (a variable/method call whose chain it cannot see), when the
+/// <c>WebView2</c> is wrapped in another element (e.g. a sized <c>Border</c>/<c>Grid</c>),
+/// or when any size is set (<c>.Width</c>/<c>.Height</c>/<c>.Size</c>, or an imperative
+/// <c>.Set(w =&gt; w.Width = …)</c>).
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UnsizedWebViewInStackAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_MEDIA_001";
+
+    /// <summary>The <c>WebView2</c> DSL factory name (Dsl.cs) that roots the child chain.</summary>
+    private const string WebViewFactory = "WebView2";
+
+    /// <summary>
+    /// The four auto-layout stack factories whose children receive an indeterminate
+    /// main-axis measure. <c>HStack</c>/<c>VStack</c> → <c>StackElement</c>,
+    /// <c>FlexRow</c>/<c>FlexColumn</c> → <c>FlexElement</c> (Dsl.cs). A fixed-track
+    /// <c>Grid</c> cell is intentionally excluded — it gives a determinate size.
+    /// </summary>
+    private static readonly HashSet<string> StackFactories = new(System.StringComparer.Ordinal)
+    {
+        "HStack", "VStack", "FlexRow", "FlexColumn",
+    };
+
+    /// <summary>
+    /// Fluent modifiers that pin a dimension. <c>.Size(w, h)</c> pins both
+    /// (ElementExtensions.cs). Any one of these in the chain means the author has set
+    /// a size, so the child is not a candidate.
+    /// </summary>
+    private static readonly HashSet<string> SizeModifiers = new(System.StringComparer.Ordinal)
+    {
+        "Width", "Height", "Size",
+    };
+
+    /// <summary>FrameworkElement members whose imperative <c>.Set</c> assignment pins a size.</summary>
+    private static readonly HashSet<string> SizeMembers = new(System.StringComparer.Ordinal)
+    {
+        "Width", "Height",
+    };
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "WebView2 in an auto-layout stack needs an explicit size",
+        "WebView2 is a direct child of '{0}' without an explicit .Width/.Height. In an auto-sized stack it measures to its web content and oscillates as the page reflows. Pin .Width and .Height (or place it in a fixed-size Grid cell).",
+        "Reactor.Layout",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "An auto-layout stack (HStack/VStack/FlexRow/FlexColumn) gives each child an " +
+                     "indeterminate measure on its main axis. WebView2 measures to its web content — " +
+                     "the viewport for a real page — so with no bounds it grows to fill the available " +
+                     "space and triggers a layout oscillation when the page reflows. Pin an explicit " +
+                     ".Width and .Height, or host the control in a fixed-size Grid cell.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext ctx)
+    {
+        var invocation = (InvocationExpressionSyntax)ctx.Node;
+
+        // Syntactic gate: the invocation must be one of the four stack factories,
+        // called bare (`using static Factories`) or qualified (`Factories.HStack`).
+        var stackName = invocation.Expression switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            MemberAccessExpressionSyntax mae => mae.Name.Identifier.ValueText,
+            _ => null,
+        };
+        if (stackName is null || !StackFactories.Contains(stackName))
+            return;
+
+        // Inspect each direct positional child. A non-element leading `double spacing`
+        // argument (the HStack(spacing, …) overload) simply fails the WebView2 peel.
+        foreach (var arg in invocation.ArgumentList.Arguments)
+        {
+            if (TryGetUnsizedWebView(arg.Expression, out var webView))
+            {
+                ctx.ReportDiagnostic(Diagnostic.Create(Rule, webView!.GetLocation(), stackName));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Peels a fluent modifier chain from the outside in. Returns <see langword="true"/>
+    /// only when the chain roots at a <c>WebView2(...)</c> factory call and no size is
+    /// pinned anywhere in the chain. Any opaque, wrapped, or sized child returns
+    /// <see langword="false"/>.
+    /// </summary>
+    private static bool TryGetUnsizedWebView(ExpressionSyntax expr, out InvocationExpressionSyntax? webView)
+    {
+        webView = null;
+        var current = expr;
+
+        while (current is InvocationExpressionSyntax invocation)
+        {
+            switch (invocation.Expression)
+            {
+                // A bare call: the `WebView2(...)` factory root, or — since fluent
+                // modifiers are always member-access calls — some other factory
+                // (a wrapper like `Border(webView)`), which is not a candidate.
+                case IdentifierNameSyntax id:
+                    if (id.Identifier.ValueText == WebViewFactory)
+                    {
+                        webView = invocation;
+                        return true;
+                    }
+                    return false;
+
+                case MemberAccessExpressionSyntax member:
+                    var name = member.Name.Identifier.ValueText;
+
+                    // Qualified factory root: `Factories.WebView2(...)`.
+                    if (name == WebViewFactory)
+                    {
+                        webView = invocation;
+                        return true;
+                    }
+
+                    // A size is pinned (fluent, or an imperative .Set) → not a candidate.
+                    if (SizeModifiers.Contains(name))
+                        return false;
+                    if (name == "Set" && SetAssignsSize(invocation))
+                        return false;
+
+                    // An ordinary modifier (event handler, etc.) — keep peeling inward.
+                    current = member.Expression;
+                    continue;
+
+                default:
+                    return false;
+            }
+        }
+
+        // Chain did not root at a `WebView2(...)` call (e.g. a bare variable) — opaque.
+        return false;
+    }
+
+    /// <summary>
+    /// True when a <c>.Set(x =&gt; x.Width = …)</c> / <c>.Set(x =&gt; { x.Height = …; })</c>
+    /// lambda assigns to a <c>Width</c>/<c>Height</c> member — an imperative size pin.
+    /// </summary>
+    private static bool SetAssignsSize(InvocationExpressionSyntax setInvocation)
+    {
+        var args = setInvocation.ArgumentList.Arguments;
+        if (args.Count != 1)
+            return false;
+        if (args[0].Expression is not (SimpleLambdaExpressionSyntax or ParenthesizedLambdaExpressionSyntax))
+            return false;
+
+        foreach (var assignment in args[0].Expression.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (assignment.Left is MemberAccessExpressionSyntax lhs && SizeMembers.Contains(lhs.Name.Identifier.ValueText))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Reactor.Analyzers/UnsizedWebViewInStackAnalyzer.cs
+++ b/src/Reactor.Analyzers/UnsizedWebViewInStackAnalyzer.cs
@@ -29,6 +29,12 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// <c>WebView2</c> is wrapped in another element (e.g. a sized <c>Border</c>/<c>Grid</c>),
 /// or when any size is set (<c>.Width</c>/<c>.Height</c>/<c>.Size</c>, or an imperative
 /// <c>.Set(w =&gt; w.Width = …)</c>).
+///
+/// It fires only when the chain pins <em>neither</em> dimension; pinning either
+/// <c>.Width</c> <em>or</em> <c>.Height</c> (or <c>.Size</c>) suppresses it. That is a
+/// deliberate low-false-positive stance — a partly-sized <c>WebView2</c> already signals
+/// the author is controlling its bounds, so the nudge would be noise. The message still
+/// advises pinning both, which is the correct guidance for the neither-pinned case it fires on.
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class UnsizedWebViewInStackAnalyzer : DiagnosticAnalyzer
@@ -150,13 +156,21 @@ public sealed class UnsizedWebViewInStackAnalyzer : DiagnosticAnalyzer
                         return true;
                     }
 
-                    // A size is pinned (fluent, or an imperative .Set) → not a candidate.
+                    // A size is pinned (fluent .Width/.Height/.Size, or an imperative
+                    // .Set that assigns Width/Height) → the author controls the bounds,
+                    // so suppress. Pinning either dimension is enough to bail (see the
+                    // deliberate neither-pinned contract in the class remarks).
                     if (SizeModifiers.Contains(name))
                         return false;
                     if (name == "Set" && SetAssignsSize(invocation))
                         return false;
 
-                    // An ordinary modifier (event handler, etc.) — keep peeling inward.
+                    // An ordinary modifier (event handler, .Margin, .WithKey, etc.). Fluent
+                    // modifiers preserve the element (they return the same Element type), so
+                    // peeling through an unrecognized one to reach the WebView2 root is safe:
+                    // a true wrapper is a *factory* call taking the element as an argument
+                    // (e.g. Border(WebView2())), which fails the WebView2-root checks above
+                    // and bails there, not here.
                     current = member.Expression;
                     continue;
 
@@ -171,20 +185,37 @@ public sealed class UnsizedWebViewInStackAnalyzer : DiagnosticAnalyzer
 
     /// <summary>
     /// True when a <c>.Set(x =&gt; x.Width = …)</c> / <c>.Set(x =&gt; { x.Height = …; })</c>
-    /// lambda assigns to a <c>Width</c>/<c>Height</c> member — an imperative size pin.
+    /// lambda assigns to the lambda parameter's own <c>Width</c>/<c>Height</c> member — an
+    /// imperative size pin. The assignment receiver must be the parameter itself, so sizing
+    /// an unrelated object or a nested child (<c>x.Child.Width = …</c>) does not wrongly
+    /// suppress the diagnostic for a genuinely unsized <c>WebView2</c>.
     /// </summary>
     private static bool SetAssignsSize(InvocationExpressionSyntax setInvocation)
     {
         var args = setInvocation.ArgumentList.Arguments;
         if (args.Count != 1)
             return false;
-        if (args[0].Expression is not (SimpleLambdaExpressionSyntax or ParenthesizedLambdaExpressionSyntax))
+
+        var lambda = args[0].Expression;
+        var parameterName = lambda switch
+        {
+            SimpleLambdaExpressionSyntax simple => simple.Parameter.Identifier.ValueText,
+            ParenthesizedLambdaExpressionSyntax paren when paren.ParameterList.Parameters.Count == 1
+                => paren.ParameterList.Parameters[0].Identifier.ValueText,
+            _ => null,
+        };
+        if (parameterName is null)
             return false;
 
-        foreach (var assignment in args[0].Expression.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        foreach (var assignment in lambda.DescendantNodes().OfType<AssignmentExpressionSyntax>())
         {
-            if (assignment.Left is MemberAccessExpressionSyntax lhs && SizeMembers.Contains(lhs.Name.Identifier.ValueText))
+            if (assignment.Left is MemberAccessExpressionSyntax lhs
+                && SizeMembers.Contains(lhs.Name.Identifier.ValueText)
+                && lhs.Expression is IdentifierNameSyntax receiver
+                && receiver.Identifier.ValueText == parameterName)
+            {
                 return true;
+            }
         }
 
         return false;

--- a/tests/Reactor.Tests/AnalyzerTests/UnsizedWebViewInStackAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnsizedWebViewInStackAnalyzerTests.cs
@@ -33,6 +33,7 @@ public sealed class WebView2Control
     public double Width;
     public double Height;
     public string DefaultBackgroundColor = string.Empty;
+    public WebView2Control Child;
 }
 
 public static class Factories
@@ -45,6 +46,7 @@ public static class Factories
     public static FlexElement FlexColumn(params Element[] children) => new FlexElement();
     public static BorderElement Border(Element child) => new BorderElement();
     public static ImageElement Image(string source) => new ImageElement();
+    public static Func<Element> WebFactory() => () => new WebView2Element();
 }
 
 public static class ElementExtensions
@@ -101,6 +103,23 @@ class C
     public Task Fires_When_Set_Does_Not_Assign_Size() =>
         Verify(@"        HStack({|REACTOR_MEDIA_001:WebView2()|}.Set(w => w.DefaultBackgroundColor = ""white""));");
 
+    [Fact]
+    public Task Fires_When_Set_Sizes_An_Unrelated_Receiver()
+    {
+        // The .Set lambda assigns Width, but to an unrelated object — not the
+        // WebView2 parameter — so the WebView2 itself is still unsized and fires.
+        return Verify(@"        var other = new WebView2Control();
+        HStack({|REACTOR_MEDIA_001:WebView2()|}.Set(w => other.Width = 800));");
+    }
+
+    [Fact]
+    public Task Fires_When_Set_Sizes_A_Nested_Child()
+    {
+        // Sizing a nested member (w.Child.Width) is not sizing the WebView2 itself —
+        // the assignment receiver is a member-access, not the lambda parameter — so it fires.
+        return Verify(@"        HStack({|REACTOR_MEDIA_001:WebView2()|}.Set(w => w.Child.Width = 800));");
+    }
+
     // ── Positive: spacing overload + sibling children (child is still direct) ─
 
     [Fact]
@@ -139,6 +158,14 @@ class C
     public Task No_Diagnostic_When_Size_Set_Imperatively_Via_Set() =>
         Verify(@"        HStack(WebView2().Set(w => w.Width = 800));");
 
+    [Fact]
+    public Task No_Diagnostic_When_Size_Set_Via_BlockBody_Set() =>
+        Verify(@"        HStack(WebView2().Set(w => { w.Width = 800; w.Height = 600; }));");
+
+    [Fact]
+    public Task No_Diagnostic_When_Size_Set_Via_Parenthesized_Set() =>
+        Verify(@"        HStack(WebView2().Set((w) => w.Height = 600));");
+
     // ── Negative: not a direct child of a stack ──────────────────────────────
 
     [Fact]
@@ -167,5 +194,21 @@ class C
         // to a syntactic pass — bail rather than risk a false positive.
         return Verify(@"        var w = WebView2();
         HStack(w);");
+    }
+
+    [Fact]
+    public Task No_Diagnostic_For_Conditional_Child()
+    {
+        // A conditional child is not the literal inline WebView2(...) shape the rule
+        // matches — analysing through the branches is out of scope, so it stays quiet.
+        return Verify(@"        HStack(true ? WebView2() : WebView2());");
+    }
+
+    [Fact]
+    public Task No_Diagnostic_For_Exotic_Invocation_Child()
+    {
+        // An invocation whose callee is itself an invocation (a factory-returning-factory)
+        // is neither an identifier nor a member-access call — the peel bails safely.
+        return Verify(@"        HStack(WebFactory()());");
     }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/UnsizedWebViewInStackAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/UnsizedWebViewInStackAnalyzerTests.cs
@@ -1,0 +1,171 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="UnsizedWebViewInStackAnalyzer"/> (<c>REACTOR_MEDIA_001</c>).
+/// Stubs a minimal Reactor-shaped DSL — the four auto-layout stack factories, the
+/// <c>WebView2</c> factory, and the <c>.Width</c>/<c>.Height</c>/<c>.Size</c>/<c>.Set</c>
+/// modifiers — so the analyzer's syntactic match fires without pulling the framework in.
+/// The analyzer is purely syntactic, so the stub signatures only need to make the test
+/// source compile.
+/// </summary>
+public class UnsizedWebViewInStackAnalyzerTests
+{
+    private const string Stubs = @"
+using System;
+using static Factories;
+
+public abstract class Element { }
+public sealed class WebView2Element : Element { }
+public sealed class StackElement : Element { }
+public sealed class FlexElement : Element { }
+public sealed class BorderElement : Element { }
+public sealed class ImageElement : Element { }
+
+// Stand-in for the WinUI control surface a `.Set(w => w.Width = …)` lambda writes to.
+public sealed class WebView2Control
+{
+    public double Width;
+    public double Height;
+    public string DefaultBackgroundColor = string.Empty;
+}
+
+public static class Factories
+{
+    public static WebView2Element WebView2() => new WebView2Element();
+    public static StackElement HStack(params Element[] children) => new StackElement();
+    public static StackElement HStack(double spacing, params Element[] children) => new StackElement();
+    public static StackElement VStack(params Element[] children) => new StackElement();
+    public static FlexElement FlexRow(params Element[] children) => new FlexElement();
+    public static FlexElement FlexColumn(params Element[] children) => new FlexElement();
+    public static BorderElement Border(Element child) => new BorderElement();
+    public static ImageElement Image(string source) => new ImageElement();
+}
+
+public static class ElementExtensions
+{
+    public static T Width<T>(this T el, double width) where T : Element => el;
+    public static T Height<T>(this T el, double height) where T : Element => el;
+    public static T Size<T>(this T el, double width, double height) where T : Element => el;
+    public static T NavigationCompleted<T>(this T el, Action<Uri> handler) where T : Element => el;
+    public static T Set<T>(this T el, Action<WebView2Control> configure) where T : Element => el;
+}
+";
+
+    private static Task Verify(string body)
+    {
+        var source = Stubs + @"
+class C
+{
+    void M()
+    {
+" + body + @"
+    }
+}";
+        return new CSharpAnalyzerTest<UnsizedWebViewInStackAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── Positive: unsized WebView2 in each of the four auto-layout stacks ──────
+
+    [Fact]
+    public Task Fires_For_HStack() =>
+        Verify(@"        HStack({|REACTOR_MEDIA_001:WebView2()|});");
+
+    [Fact]
+    public Task Fires_For_VStack() =>
+        Verify(@"        VStack({|REACTOR_MEDIA_001:WebView2()|});");
+
+    [Fact]
+    public Task Fires_For_FlexRow() =>
+        Verify(@"        FlexRow({|REACTOR_MEDIA_001:WebView2()|});");
+
+    [Fact]
+    public Task Fires_For_FlexColumn() =>
+        Verify(@"        FlexColumn({|REACTOR_MEDIA_001:WebView2()|});");
+
+    // ── Positive: chain has non-size modifiers only → still fires ─────────────
+
+    [Fact]
+    public Task Fires_When_Chain_Has_Only_NonSize_Modifiers() =>
+        Verify(@"        HStack({|REACTOR_MEDIA_001:WebView2()|}.NavigationCompleted(u => { }));");
+
+    [Fact]
+    public Task Fires_When_Set_Does_Not_Assign_Size() =>
+        Verify(@"        HStack({|REACTOR_MEDIA_001:WebView2()|}.Set(w => w.DefaultBackgroundColor = ""white""));");
+
+    // ── Positive: spacing overload + sibling children (child is still direct) ─
+
+    [Fact]
+    public Task Fires_In_Spacing_Overload() =>
+        Verify(@"        HStack(8, {|REACTOR_MEDIA_001:WebView2()|});");
+
+    [Fact]
+    public Task Fires_For_WebView_Sibling_Among_Children() =>
+        Verify(@"        VStack(Image(""a""), {|REACTOR_MEDIA_001:WebView2()|});");
+
+    // ── Positive: qualified factory calls (Factories.HStack / Factories.WebView2) ─
+
+    [Fact]
+    public Task Fires_For_Qualified_Factory_Calls() =>
+        Verify(@"        Factories.HStack({|REACTOR_MEDIA_001:Factories.WebView2()|});");
+
+    // ── Negative: any pinned size suppresses ─────────────────────────────────
+
+    [Fact]
+    public Task No_Diagnostic_When_Width_And_Height_Set() =>
+        Verify(@"        HStack(WebView2().Width(800).Height(600));");
+
+    [Fact]
+    public Task No_Diagnostic_When_Size_Set() =>
+        Verify(@"        HStack(WebView2().Size(800, 600));");
+
+    [Fact]
+    public Task No_Diagnostic_When_Only_Width_Set() =>
+        Verify(@"        HStack(WebView2().Width(800));");
+
+    [Fact]
+    public Task No_Diagnostic_When_Only_Height_Set() =>
+        Verify(@"        HStack(WebView2().Height(600));");
+
+    [Fact]
+    public Task No_Diagnostic_When_Size_Set_Imperatively_Via_Set() =>
+        Verify(@"        HStack(WebView2().Set(w => w.Width = 800));");
+
+    // ── Negative: not a direct child of a stack ──────────────────────────────
+
+    [Fact]
+    public Task No_Diagnostic_When_Not_In_A_Stack() =>
+        Verify(@"        Border(WebView2());");
+
+    [Fact]
+    public Task No_Diagnostic_For_NonWebView_Child() =>
+        Verify(@"        HStack(Image(""a""));");
+
+    // ── Near-miss: WebView2 is lexically inside the stack call but not a direct,
+    //    visible, inline child — the analyzer must stay quiet. ────────────────
+
+    [Fact]
+    public Task No_Diagnostic_When_Wrapped_In_Border() =>
+        Verify(@"        VStack(Border(WebView2()));");
+
+    [Fact]
+    public Task No_Diagnostic_When_Wrapped_In_Sized_Border() =>
+        Verify(@"        VStack(Border(WebView2()).Width(800).Height(600));");
+
+    [Fact]
+    public Task No_Diagnostic_For_Opaque_Variable_Child()
+    {
+        // The WebView2 is built into a variable, so its modifier chain is invisible
+        // to a syntactic pass — bail rather than risk a false positive.
+        return Verify(@"        var w = WebView2();
+        HStack(w);");
+    }
+}


### PR DESCRIPTION
Implements **REACTOR_MEDIA_001** (spec 060 Batch 2, Wave E) — an Info-level nudge that flags a `WebView2(...)` placed as a direct child of an auto-layout stack (`HStack`/`VStack`/`FlexRow`/`FlexColumn`) with no explicit size.

### Why
An auto-layout stack hands each child an indeterminate main-axis measure. `WebView2` measures to its web content (the viewport for a real page), so with no bounds it grows to fill the available space and oscillates when the page reflows. Grounding: `docs/guide/text-and-media.md` §WebView2 (lines 423-428).

### Detect (conservative, low-FP, purely syntactic)
Fires only when a `WebView2(...)` is a **direct positional argument** of one of the four stack factories and its fluent chain pins **no** size. Bails on:
- opaque/variable children (chain not visible)
- wrapped children (e.g. `Border(WebView2())`)
- any pinned size — `.Width` / `.Height` / `.Size`, or an imperative `.Set(w => w.Width = …)`

No code-fix: there is no correct default size, so it is an author-intent nudge only.

### Premise verification (STEP 1 — matches source)
- `WebView2(Uri? source = null) -> WebView2Element` — `Dsl.cs:1190`
- `HStack`/`VStack` -> `StackElement`; `FlexRow`/`FlexColumn` -> `FlexElement` — `Dsl.cs:527/555/703/716`
- `.Width` / `.Height` / `.Size` — `ElementExtensions.cs:94/97/100`

### Tests
19 tests in `UnsizedWebViewInStackAnalyzerTests` (positives across all four stacks + non-size modifiers + spacing overload + qualified calls; negatives for every pinned-size form; near-misses for wrapped and opaque children). Full `AnalyzerTests` suite green (234).

### Samples sweep
The only DSL `WebView2` usage (`ReactorGallery` `WebView2Page.cs`) is a direct `VStack` child already correctly sized — the rule stays silent, matching §2.4 (samples use the good form).

### Shared 'append' docs (all rows kept)
`AnalyzerReleases.Unshipped.md`, the `reactor-build-and-check` SKILL cheat table, and the `analyzer-architecture.md.dt` template.