### PR TITLE
feat(analyzers): REACTOR_DSL_003 — constant / param-ignoring keySelector

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -120,6 +120,7 @@ via `.editorconfig`.
 | `REACTOR_THEME_003` | Warning | RequestedTheme set on a non-root element | `RequestedThemeSetAnalyzer.cs` |
 | `REACTOR_REF_001` | Warning | ElementRef.Current assigned to a reference property instead of a reactive edge | `ReferenceCurrentReadAnalyzer.cs` |
 | `REACTOR_DSL_001` | Warning | Dynamic list item missing .WithKey | `MissingWithKeyAnalyzer.cs` |
+| `REACTOR_DSL_003` | Warning | Typed collection keySelector never keys by item (constant/null/ignores the item) | `ConstantKeySelectorAnalyzer.cs` |
 | `REACTOR_DOCK_001` | Warning | OnLiveLayoutChanged feeds the live layout back into state | `OnLiveLayoutRoundTripAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |

--- a/plugins/reactor/skills/reactor-build-and-check/SKILL.md
+++ b/plugins/reactor/skills/reactor-build-and-check/SKILL.md
@@ -82,6 +82,7 @@ Additional flags:
 | `REACTOR_HOOKS_007` | warning | `UseMemoCells` builder closure missing dependencies | Add the captured variable to the deps array. |
 | `REACTOR_HOOKS_009` | warning | `Command.DebounceMs` set on a command bound without `UseCommand` | Route it through `UseCommand`: `var cmd = UseCommand(new Command { …, DebounceMs = 1500 });`. The debounce window lives in the hook store, so a raw bound `Command` never debounces. |
 | `REACTOR_DSL_001` | warning | `Select(...)` projecting into a layout container without `.WithKey(...)` | `items.Select(i => Row(i).WithKey(i.Id)).ToArray<Element?>()`. Keys keep focus + animation state across reorders. |
+| `REACTOR_DSL_003` | warning | Typed collection (`ListView<T>`/`GridView<T>`/`LazyVStack<T>`/…) `keySelector` returns a constant/null or ignores its item | Key by a stable, unique item property: `ListView(items, i => i.Id, (i, _) => Row(i))`. A constant key collides every row → keyed-diff bailout → full list re-realization. |
 | `REACTOR_THEME_001` | warning | Hardcoded color on a themed surface | Use `Theme.*` tokens (e.g. `Theme.PrimaryText`, `Theme.CardBackground`). See `reactor-design`. |
 | `REACTOR_THEME_002` | info | Lightweight styling opportunity | Optional. Use `.Resources(r => r.Set("ButtonBackground", …))` for visual-state overrides. |
 | `REACTOR_THEME_003` | info | `RequestedTheme` modifier available | Use `.RequestedTheme(ElementTheme.Dark)` for subtree theme overrides. |

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -17,6 +17,7 @@ REACTOR_A11Y_002 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityA
 REACTOR_A11Y_003 | Microsoft.UI.Reactor.Accessibility | Warning | AccessibilityAnalyzers - Form field needs a label
 REACTOR_REF_001 | Reactor.Reference | Warning | ReferenceCurrentReadAnalyzer - Use descriptor.Reference/binding.Reference instead of assigning ElementRef.Current to reference properties
 REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list item missing .WithKey
+REACTOR_DSL_003 | Reactor.Dsl | Warning | ConstantKeySelectorAnalyzer - Typed collection keySelector never keys by item (returns constant/null or ignores the item), forcing a keyed-diff bailout
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback

--- a/src/Reactor.Analyzers/ConstantKeySelectorAnalyzer.cs
+++ b/src/Reactor.Analyzers/ConstantKeySelectorAnalyzer.cs
@@ -30,7 +30,8 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// Low false-positive posture — fires only when the <c>keySelector</c> is a
 /// single-parameter lambda whose body <em>provably</em> does not depend on the item:
 /// the parameter is never referenced <b>and</b> the body contains no invocation,
-/// object-creation, or <c>await</c> (any of which could vary per item). It then
+/// object-creation, <c>await</c>, or in-place mutation (increment / decrement /
+/// assignment) — any of which could vary per item. It then
 /// semantically confirms the argument binds to a <c>keySelector</c> parameter of type
 /// <c>Func&lt;T, string&gt;</c> on <c>Microsoft.UI.Reactor.Factories</c>, so the
 /// untyped selection overloads' <c>onSelectedIndexChanged</c> callback, the
@@ -185,9 +186,10 @@ public sealed class ConstantKeySelectorAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// True when the lambda body evaluates to the same value for every item: the
     /// parameter is never referenced, and the body contains no invocation,
-    /// object-creation, or await (each a source of per-call variation). Both a
-    /// constant key (duplicates) and a null key trip this; a body that reads the
-    /// item, or that calls a helper (which could return unique values), does not.
+    /// object-creation, await, or in-place mutation (increment/decrement/assignment)
+    /// — each a source of per-call variation. Both a constant key (duplicates) and a
+    /// null key trip this; a body that reads the item, calls a helper (which could
+    /// return unique values), or mutates state (e.g. <c>_ =&gt; $"{n++}"</c>) does not.
     /// </summary>
     private static bool BodyProvablyIgnoresItem(LambdaExpressionSyntax lambda, string parameterName)
     {
@@ -204,6 +206,13 @@ public sealed class ConstantKeySelectorAnalyzer : DiagnosticAnalyzer
                 case ImplicitObjectCreationExpressionSyntax:
                 case AnonymousObjectCreationExpressionSyntax:
                 case AwaitExpressionSyntax:
+                case AssignmentExpressionSyntax:
+                    return false;
+                case PrefixUnaryExpressionSyntax pre
+                    when pre.IsKind(SyntaxKind.PreIncrementExpression) || pre.IsKind(SyntaxKind.PreDecrementExpression):
+                    return false;
+                case PostfixUnaryExpressionSyntax post
+                    when post.IsKind(SyntaxKind.PostIncrementExpression) || post.IsKind(SyntaxKind.PostDecrementExpression):
                     return false;
                 case IdentifierNameSyntax id
                     when id.Identifier.ValueText == parameterName && !IsMemberName(id):

--- a/src/Reactor.Analyzers/ConstantKeySelectorAnalyzer.cs
+++ b/src/Reactor.Analyzers/ConstantKeySelectorAnalyzer.cs
@@ -49,6 +49,21 @@ public sealed class ConstantKeySelectorAnalyzer : DiagnosticAnalyzer
     /// <summary>The parameter name shared by every typed collection factory's key selector.</summary>
     private const string KeySelectorParameterName = "keySelector";
 
+    /// <summary>
+    /// Simple names of the typed, data-driven collection factories that take a
+    /// <c>Func&lt;T, string&gt; keySelector</c> as their second parameter (in
+    /// <c>src/Reactor/Elements/Dsl.cs</c>). Used only as a cheap first-pass filter so
+    /// the analyzer skips the lambda/body scan and semantic lookup for the vast
+    /// majority of invocations; the actual match is still confirmed semantically
+    /// against <see cref="FactoriesTypeName"/>. Keep in sync with Dsl.cs when a new
+    /// typed collection factory is added.
+    /// </summary>
+    private static readonly ImmutableHashSet<string> TypedCollectionFactoryNames =
+        ImmutableHashSet.Create(
+            System.StringComparer.Ordinal,
+            "ListView", "GridView", "FlipView", "TreeView",
+            "LazyVStack", "LazyHStack", "ItemsRepeater", "ItemsView");
+
     private static readonly LocalizableString Title =
         "Key selector never keys by item";
 
@@ -84,6 +99,15 @@ public sealed class ConstantKeySelectorAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
     {
         var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // ── Cheap name gate ───────────────────────────────────────────────
+        // A single hash-set lookup skips the lambda/body scan and the semantic
+        // symbol lookup for every invocation that isn't a typed collection
+        // factory by name (e.g. Enumerable.Select(source, _ => "row")). The
+        // containing-type/parameter shape is still confirmed semantically below.
+        if (!TypedCollectionFactoryNames.Contains(GetInvokedMethodName(invocation)))
+            return;
+
         var args = invocation.ArgumentList.Arguments;
         if (args.Count < 2)
             return;

--- a/src/Reactor.Analyzers/ConstantKeySelectorAnalyzer.cs
+++ b/src/Reactor.Analyzers/ConstantKeySelectorAnalyzer.cs
@@ -1,0 +1,254 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// <c>REACTOR_DSL_003</c> — a typed Reactor collection factory
+/// (<c>ListView&lt;T&gt;</c>, <c>GridView&lt;T&gt;</c>, <c>FlipView&lt;T&gt;</c>,
+/// <c>TreeView&lt;T&gt;</c>, <c>LazyVStack&lt;T&gt;</c>, <c>LazyHStack&lt;T&gt;</c>,
+/// <c>ItemsRepeater&lt;T&gt;</c>, <c>ItemsView&lt;T&gt;</c>) is called with a
+/// <c>keySelector</c> that never keys by the item — it returns a constant / literal /
+/// <c>null</c>, or otherwise never reads its parameter. Every item then maps to the
+/// same (or a null) key.
+/// </summary>
+/// <remarks>
+/// Grounding: <c>keySelector</c> is the second positional parameter
+/// (<c>Func&lt;T, string&gt;</c>) of the typed collection factories in
+/// <c>src/Reactor/Elements/Dsl.cs</c>. Duplicate and null keys force a
+/// correctness-preserving bailout in <c>KeyedListDiff</c> (the <c>DuplicateKey</c> /
+/// <c>NullKey</c> <c>ReportBailout</c> paths), which re-realizes the whole list on
+/// every change — losing focus, selection, and animation state. See
+/// <c>docs/guide/collections.md</c>: keys must be stable, unique, and non-null.
+/// Distinct from <c>REACTOR_DSL_001</c>, which is about <c>.WithKey</c> on
+/// <c>Select</c>-projected layout children.
+///
+/// Low false-positive posture — fires only when the <c>keySelector</c> is a
+/// single-parameter lambda whose body <em>provably</em> does not depend on the item:
+/// the parameter is never referenced <b>and</b> the body contains no invocation,
+/// object-creation, or <c>await</c> (any of which could vary per item). It then
+/// semantically confirms the argument binds to a <c>keySelector</c> parameter of type
+/// <c>Func&lt;T, string&gt;</c> on <c>Microsoft.UI.Reactor.Factories</c>, so the
+/// untyped selection overloads' <c>onSelectedIndexChanged</c> callback, the
+/// <c>IReactorKeyed</c> <c>viewBuilder</c> overload, method-group selectors, and
+/// selectors that read the item never trip it.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ConstantKeySelectorAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_DSL_003";
+
+    /// <summary>Fully-qualified name of the Reactor DSL factory class.</summary>
+    private const string FactoriesTypeName = "Microsoft.UI.Reactor.Factories";
+
+    /// <summary>The parameter name shared by every typed collection factory's key selector.</summary>
+    private const string KeySelectorParameterName = "keySelector";
+
+    private static readonly LocalizableString Title =
+        "Key selector never keys by item";
+
+    private static readonly LocalizableString MessageFormat =
+        "The keySelector passed to '{0}' ignores its item parameter, so every item gets the same key. Duplicate keys force the keyed-list diff to bail out and re-realize the whole list on each change. Return a stable, unique per-item key (e.g. item.Id).";
+
+    private static readonly LocalizableString Description =
+        "Typed Reactor collections (ListView<T>, GridView<T>, LazyVStack<T>, ...) reconcile by " +
+        "the string key returned from keySelector. A selector that returns a constant, returns " +
+        "null, or never reads its item parameter yields duplicate or null keys, which the " +
+        "keyed-list diff cannot reconcile — it discards the diff and rebuilds every container, " +
+        "losing focus, selection, and animation state. Key by a stable, unique property of each item.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Dsl",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count < 2)
+            return;
+
+        // ── Cheap syntactic pre-gate ──────────────────────────────────────
+        // Locate the keySelector argument (named `keySelector:` or the 2nd
+        // positional argument) and require it to be a single-parameter lambda
+        // whose body provably ignores the item. This runs before any semantic
+        // query so the analyzer stays cheap on the hot path.
+        if (!TryGetKeySelectorArgument(args, out var argument, out var positionalIndex))
+            return;
+
+        if (!TryGetSingleParameterLambda(argument.Expression, out var lambda, out var parameterName))
+            return;
+
+        if (!BodyProvablyIgnoresItem(lambda!, parameterName!))
+            return;
+
+        // ── Semantic confirmation ─────────────────────────────────────────
+        // Only fire when the argument actually binds to a `keySelector`
+        // parameter of type Func<T, string> on Microsoft.UI.Reactor.Factories.
+        // This rejects the untyped selection overloads' onSelectedIndexChanged,
+        // the IReactorKeyed viewBuilder overload, and any same-named method on an
+        // unrelated type.
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method)
+            return;
+        if (method.IsExtensionMethod)
+            return;
+        if (method.ContainingType?.ToDisplayString() != FactoriesTypeName)
+            return;
+
+        var parameter = ResolveBoundParameter(method, argument, positionalIndex);
+        if (parameter is null || parameter.Name != KeySelectorParameterName)
+            return;
+        if (!IsFuncReturningString(parameter.Type))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule, lambda!.GetLocation(), GetInvokedMethodName(invocation)));
+    }
+
+    /// <summary>
+    /// Finds the argument that supplies the <c>keySelector</c> — either explicitly
+    /// named <c>keySelector:</c>, or the second positional argument when the first
+    /// two arguments are positional (so index maps directly to parameter index).
+    /// </summary>
+    private static bool TryGetKeySelectorArgument(
+        SeparatedSyntaxList<ArgumentSyntax> args,
+        out ArgumentSyntax argument,
+        out int positionalIndex)
+    {
+        foreach (var candidate in args)
+        {
+            if (candidate.NameColon?.Name.Identifier.ValueText == KeySelectorParameterName)
+            {
+                argument = candidate;
+                positionalIndex = -1; // bound by name
+                return true;
+            }
+        }
+
+        if (args[0].NameColon is null && args[1].NameColon is null)
+        {
+            argument = args[1];
+            positionalIndex = 1;
+            return true;
+        }
+
+        argument = null!;
+        positionalIndex = -1;
+        return false;
+    }
+
+    /// <summary>
+    /// Matches a single-parameter lambda (<c>x =&gt; ...</c> or <c>(x) =&gt; ...</c>) and
+    /// extracts its parameter name. Multi-parameter lambdas (e.g. the
+    /// <c>(item, index)</c> view builder) and non-lambda arguments (method groups)
+    /// are rejected.
+    /// </summary>
+    private static bool TryGetSingleParameterLambda(
+        ExpressionSyntax expression, out LambdaExpressionSyntax? lambda, out string? parameterName)
+    {
+        switch (expression)
+        {
+            case SimpleLambdaExpressionSyntax simple:
+                lambda = simple;
+                parameterName = simple.Parameter.Identifier.ValueText;
+                return true;
+            case ParenthesizedLambdaExpressionSyntax paren when paren.ParameterList.Parameters.Count == 1:
+                lambda = paren;
+                parameterName = paren.ParameterList.Parameters[0].Identifier.ValueText;
+                return true;
+            default:
+                lambda = null;
+                parameterName = null;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// True when the lambda body evaluates to the same value for every item: the
+    /// parameter is never referenced, and the body contains no invocation,
+    /// object-creation, or await (each a source of per-call variation). Both a
+    /// constant key (duplicates) and a null key trip this; a body that reads the
+    /// item, or that calls a helper (which could return unique values), does not.
+    /// </summary>
+    private static bool BodyProvablyIgnoresItem(LambdaExpressionSyntax lambda, string parameterName)
+    {
+        var body = (SyntaxNode?)lambda.Body;
+        if (body is null)
+            return false;
+
+        foreach (var node in body.DescendantNodesAndSelf())
+        {
+            switch (node)
+            {
+                case InvocationExpressionSyntax:
+                case ObjectCreationExpressionSyntax:
+                case ImplicitObjectCreationExpressionSyntax:
+                case AnonymousObjectCreationExpressionSyntax:
+                case AwaitExpressionSyntax:
+                    return false;
+                case IdentifierNameSyntax id
+                    when id.Identifier.ValueText == parameterName && !IsMemberName(id):
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// True when the identifier is the member half of a member access
+    /// (<c>foo.Name</c> / <c>foo?.Name</c>), which is a member lookup, not a
+    /// reference to a same-named lambda parameter.
+    /// </summary>
+    private static bool IsMemberName(IdentifierNameSyntax id) =>
+        (id.Parent is MemberAccessExpressionSyntax ma && ma.Name == id) ||
+        (id.Parent is MemberBindingExpressionSyntax mb && mb.Name == id);
+
+    /// <summary>Maps the keySelector argument back to its bound parameter symbol.</summary>
+    private static IParameterSymbol? ResolveBoundParameter(
+        IMethodSymbol method, ArgumentSyntax argument, int positionalIndex)
+    {
+        if (argument.NameColon is { } nameColon)
+        {
+            var name = nameColon.Name.Identifier.ValueText;
+            return method.Parameters.FirstOrDefault(p => p.Name == name);
+        }
+
+        return positionalIndex >= 0 && positionalIndex < method.Parameters.Length
+            ? method.Parameters[positionalIndex]
+            : null;
+    }
+
+    /// <summary>True for <c>System.Func&lt;T, string&gt;</c> (the typed key selector shape).</summary>
+    private static bool IsFuncReturningString(ITypeSymbol type) =>
+        type is INamedTypeSymbol { Name: "Func", TypeArguments.Length: 2 } func
+        && func.ContainingNamespace?.ToDisplayString() == "System"
+        && func.TypeArguments[1].SpecialType == SpecialType.System_String;
+
+    private static string GetInvokedMethodName(InvocationExpressionSyntax invocation) =>
+        invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax ma => ma.Name.Identifier.ValueText,
+            SimpleNameSyntax sn => sn.Identifier.ValueText, // IdentifierName or GenericName
+            _ => "the collection",
+        };
+}

--- a/tests/Reactor.Tests/AnalyzerTests/ConstantKeySelectorAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ConstantKeySelectorAnalyzerTests.cs
@@ -69,6 +69,7 @@ namespace TestApp
     using Microsoft.UI.Reactor;
     public sealed class Item : IReactorKeyed { public string Id { get; set; } public string Key => Id; }
     public static class Keys { public const string Row = ""row""; public static string KeyOf(Item i) => i.Id; }
+    public static class Config { public const string x = ""row""; }
 }
 ";
 
@@ -124,6 +125,12 @@ namespace TestApp
     public Task Fires_For_Block_Body_Returning_Constant() =>
         Verify(@"            ListView(items, {|REACTOR_DSL_003:_ => { return ""row""; }|}, (i, idx) => Text(i.Id));");
 
+    [Fact]
+    public Task Fires_When_Member_Name_Matches_Param_Name() =>
+        // `x => Config.x` — the `x` after the dot is a member name, not a reference to
+        // the lambda parameter, so the selector still ignores its item (IsMemberName arm).
+        Verify(@"            ListView(items, {|REACTOR_DSL_003:x => Config.x|}, (i, idx) => Text(i.Id));");
+
     // ── Negative: does not fire ────────────────────────────────────────
 
     [Fact]
@@ -143,6 +150,13 @@ namespace TestApp
     public Task No_Diagnostic_When_Body_Has_Opaque_Helper_Call() =>
         // Ignores the item but calls a helper that could return unique values — bail.
         Verify(@"            ListView(items, _ => System.Guid.NewGuid().ToString(), (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task No_Diagnostic_When_Body_Mutates_State_Per_Call() =>
+        // Ignores the item but produces a unique key per call via increment — this is
+        // NOT the duplicate-key bug the rule reports, so it must not fire.
+        Verify(@"            var n = 0;
+            ListView(items, _ => $""{n++}"", (i, idx) => Text(i.Id));");
 
     [Fact]
     public Task No_Diagnostic_For_IReactorKeyed_ViewBuilder_Overload() =>

--- a/tests/Reactor.Tests/AnalyzerTests/ConstantKeySelectorAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ConstantKeySelectorAnalyzerTests.cs
@@ -177,4 +177,11 @@ namespace TestApp
     [Fact]
     public Task No_Diagnostic_For_Same_Named_Method_On_Unrelated_Type() =>
         Verify(@"            Other.NotReactor.ListView(items, _ => ""row"", (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task No_Diagnostic_For_Non_Factory_Method_Name() =>
+        // Cheap name gate: a constant single-param lambda passed to a method whose
+        // name isn't a typed collection factory (here Enumerable.Select) is skipped
+        // before any lambda/body scan or semantic lookup.
+        Verify(@"            System.Linq.Enumerable.Select(items, _ => ""row"");");
 }

--- a/tests/Reactor.Tests/AnalyzerTests/ConstantKeySelectorAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ConstantKeySelectorAnalyzerTests.cs
@@ -1,0 +1,166 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="ConstantKeySelectorAnalyzer"/> (<c>REACTOR_DSL_003</c>). Stubs
+/// a minimal <c>Microsoft.UI.Reactor.Factories</c> surface — the typed keySelector
+/// overload the rule targets, plus the <c>IReactorKeyed</c> viewBuilder overload and
+/// the untyped selection overload it must <em>not</em> confuse with it — so the
+/// analyzer's syntactic pre-gate and semantic confirmation both fire without pulling
+/// the framework in.
+/// </summary>
+public class ConstantKeySelectorAnalyzerTests
+{
+    private const string Stubs = @"
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.UI.Reactor
+{
+    public abstract class Element { }
+    public sealed class TemplatedListViewElement<T> : Element { }
+    public sealed class TemplatedGridViewElement<T> : Element { }
+    public interface IReactorKeyed { string Key { get; } }
+
+    public static class Factories
+    {
+        // The typed keySelector overload REACTOR_DSL_003 targets.
+        public static TemplatedListViewElement<T> ListView<T>(
+            IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder)
+            => new TemplatedListViewElement<T>();
+
+        // IReactorKeyed overload — the 2nd arg is a two-parameter viewBuilder, not a keySelector.
+        public static TemplatedListViewElement<T> ListView<T>(
+            IReadOnlyList<T> items, Func<T, int, Element> viewBuilder) where T : IReactorKeyed
+            => new TemplatedListViewElement<T>();
+
+        // Untyped selection overload — the 2nd arg is Action<int> onSelectedIndexChanged.
+        public static Element ListView(int? selectedIndex, Action<int> onSelectedIndexChanged, params Element[] items)
+            => null;
+
+        public static TemplatedGridViewElement<T> GridView<T>(
+            IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder)
+            => new TemplatedGridViewElement<T>();
+
+        public static Element Text(string s) => null;
+    }
+}
+
+namespace Other
+{
+    using Microsoft.UI.Reactor;
+    // A same-named method on an unrelated type — must never trip the rule.
+    public static class NotReactor
+    {
+        public static Element ListView<T>(
+            System.Collections.Generic.IReadOnlyList<T> items,
+            System.Func<T, string> keySelector,
+            System.Func<T, int, Element> viewBuilder) => null;
+    }
+}
+
+namespace TestApp
+{
+    using Microsoft.UI.Reactor;
+    public sealed class Item : IReactorKeyed { public string Id { get; set; } public string Key => Id; }
+    public static class Keys { public const string Row = ""row""; public static string KeyOf(Item i) => i.Id; }
+}
+";
+
+    private static Task Verify(string body) =>
+        new CSharpAnalyzerTest<ConstantKeySelectorAnalyzer, DefaultVerifier>
+        {
+            TestCode = Stubs + @"
+namespace TestApp
+{
+    using System.Collections.Generic;
+    using Microsoft.UI.Reactor;
+    using static Microsoft.UI.Reactor.Factories;
+
+    public static class C
+    {
+        public static Element Build(IReadOnlyList<Item> items)
+        {
+" + body + @"
+            return null;
+        }
+    }
+}",
+        }.RunAsync(TestContext.Current.CancellationToken);
+
+    // ── Positive: fires ────────────────────────────────────────────────
+
+    [Fact]
+    public Task Fires_For_Constant_String_Literal() =>
+        Verify(@"            ListView(items, {|REACTOR_DSL_003:_ => ""row""|}, (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task Fires_For_Null_Literal() =>
+        Verify(@"            ListView(items, {|REACTOR_DSL_003:i => null|}, (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task Fires_When_Ignoring_Param_And_Returning_A_Constant_Field() =>
+        // Never reads its item, returns a compile-time constant → duplicate keys.
+        Verify(@"            ListView(items, {|REACTOR_DSL_003:_ => Keys.Row|}, (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task Fires_For_Parenthesized_Single_Param_Lambda() =>
+        Verify(@"            ListView(items, {|REACTOR_DSL_003:(item) => ""row""|}, (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task Fires_For_Named_KeySelector_Argument() =>
+        Verify(@"            ListView(items, keySelector: {|REACTOR_DSL_003:_ => ""row""|}, viewBuilder: (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task Fires_For_GridView_Too() =>
+        Verify(@"            GridView(items, {|REACTOR_DSL_003:_ => ""g""|}, (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task Fires_For_Block_Body_Returning_Constant() =>
+        Verify(@"            ListView(items, {|REACTOR_DSL_003:_ => { return ""row""; }|}, (i, idx) => Text(i.Id));");
+
+    // ── Negative: does not fire ────────────────────────────────────────
+
+    [Fact]
+    public Task No_Diagnostic_When_Selector_Reads_The_Item() =>
+        Verify(@"            ListView(items, i => i.Id, (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task No_Diagnostic_When_Item_Used_In_Interpolation() =>
+        Verify(@"            ListView(items, i => $""row-{i.Id}"", (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task No_Diagnostic_When_Item_Passed_To_Helper() =>
+        // Parameter is used indirectly via a helper — bail (also an invocation).
+        Verify(@"            ListView(items, i => Keys.KeyOf(i), (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task No_Diagnostic_When_Body_Has_Opaque_Helper_Call() =>
+        // Ignores the item but calls a helper that could return unique values — bail.
+        Verify(@"            ListView(items, _ => System.Guid.NewGuid().ToString(), (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task No_Diagnostic_For_IReactorKeyed_ViewBuilder_Overload() =>
+        // 2nd arg is the two-parameter viewBuilder, not a keySelector.
+        Verify(@"            ListView(items, (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task No_Diagnostic_For_Untyped_Selection_OnSelectedIndexChanged_Discard() =>
+        // Near-miss: a param-ignoring one-arg lambda in the 2nd slot, but it binds to
+        // Action<int> onSelectedIndexChanged on the untyped overload — not keySelector.
+        Verify(@"            ListView(0, _ => { }, Text(""a""), Text(""b""));");
+
+    [Fact]
+    public Task No_Diagnostic_For_Method_Group_Selector() =>
+        // A method group (not a lambda) is not analyzed.
+        Verify(@"            ListView(items, Keys.KeyOf, (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task No_Diagnostic_For_Same_Named_Method_On_Unrelated_Type() =>
+        Verify(@"            Other.NotReactor.ListView(items, _ => ""row"", (i, idx) => Text(i.Id));");
+}

--- a/tests/Reactor.Tests/AnalyzerTests/ConstantKeySelectorAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/ConstantKeySelectorAnalyzerTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.UI.Reactor
     public abstract class Element { }
     public sealed class TemplatedListViewElement<T> : Element { }
     public sealed class TemplatedGridViewElement<T> : Element { }
+    public sealed class TemplatedTreeViewElement<T> : Element { }
     public interface IReactorKeyed { string Key { get; } }
 
     public static class Factories
@@ -46,6 +47,13 @@ namespace Microsoft.UI.Reactor
         public static TemplatedGridViewElement<T> GridView<T>(
             IReadOnlyList<T> items, Func<T, string> keySelector, Func<T, int, Element> viewBuilder)
             => new TemplatedGridViewElement<T>();
+
+        // Different shape: keySelector is still positional index 1, but there is a
+        // childrenSelector at index 2 and a single-parameter viewBuilder at index 3.
+        public static TemplatedTreeViewElement<T> TreeView<T>(
+            IReadOnlyList<T> items, Func<T, string> keySelector,
+            Func<T, IReadOnlyList<T>> childrenSelector, Func<T, Element> viewBuilder)
+            => new TemplatedTreeViewElement<T>();
 
         public static Element Text(string s) => null;
     }
@@ -120,6 +128,12 @@ namespace TestApp
     [Fact]
     public Task Fires_For_GridView_Too() =>
         Verify(@"            GridView(items, {|REACTOR_DSL_003:_ => ""g""|}, (i, idx) => Text(i.Id));");
+
+    [Fact]
+    public Task Fires_For_TreeView_With_Different_Signature() =>
+        // TreeView<T> keeps keySelector at positional index 1 despite a
+        // childrenSelector at index 2 and a single-parameter viewBuilder at index 3.
+        Verify(@"            TreeView(items, {|REACTOR_DSL_003:_ => ""root""|}, i => items, i => Text(i.Id));");
 
     [Fact]
     public Task Fires_For_Block_Body_Returning_Constant() =>


### PR DESCRIPTION
## REACTOR_DSL_003 (Reactor.Dsl, Warning) — spec 060 Batch 2

A typed Reactor collection factory (`ListView<T>`, `GridView<T>`, `FlipView<T>`, `TreeView<T>`, `LazyVStack<T>`, `LazyHStack<T>`, `ItemsRepeater<T>`, `ItemsView<T>`) called with a `keySelector` that returns a constant / literal / `null`, or that never reads its item parameter, maps **every** item to the same (or a null) key.

```csharp
ListView(items, _ => "row", (item, i) => Row(item));   // ⚠ every row collides
ListView(items, x => null,  (item, i) => Row(item));   // ⚠ null keys bail the diff
ListView(items, i => i.Id,  (item, i) => Row(item));   // ✓ stable, unique per-item key
```

### Why it matters (premise, verified against source)
- `keySelector` is the 2nd positional parameter (`Func<T,string>`) of the typed collection factories — `src/Reactor/Elements/Dsl.cs` (`ListView<T>` at :1464, `GridView<T>` :1495, `FlipView<T>` :1525, `TreeView<T>` :1017, `LazyVStack<T>` :1560, `LazyHStack<T>` :1590, `ItemsRepeater<T>` :1623, `ItemsView<T>` :1810).
- Duplicate and null keys force a correctness-preserving bailout in `KeyedListDiff` (the `DuplicateKey` / `NullKey` `ReportBailout` paths, `src/Reactor/Core/Internal/KeyedListDiff.cs:194-246`), which re-realizes the entire list on every change — losing focus, selection, and animation state.
- `docs/guide/collections.md:74-92`: keys must be **stable, unique, non-null**.
- Distinct from `REACTOR_DSL_001` (`.WithKey` on `Select`-projected layout children).

### Detection (low false-positive)
Fires only when the `keySelector` is a **single-parameter lambda** whose body *provably* does not depend on the item — the parameter is never referenced **and** the body contains no invocation / object-creation / `await` (any of which could vary per item). It then **semantically confirms** the argument binds to a `keySelector` parameter of type `Func<T,string>` on `Microsoft.UI.Reactor.Factories`. This rejects:
- selectors that read the item (directly, in interpolation, or via a helper),
- opaque helper calls like `_ => Guid.NewGuid().ToString()` (could be unique),
- the untyped selection overloads' `onSelectedIndexChanged` (e.g. `ListView(0, _ => {}, …)`),
- the `IReactorKeyed` two-parameter `viewBuilder` overload,
- method-group selectors, and same-named methods on unrelated types.

**No mechanical code-fix** (`~`): there is no obviously-correct key to substitute — the author must choose a stable per-item property. The diagnostic says so.

### Changes
- `src/Reactor.Analyzers/ConstantKeySelectorAnalyzer.cs` (new)
- `src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md` — descriptor + release row added together (RS2000/RS2002 coupled; build is 0-warning)
- `plugins/reactor/skills/reactor-build-and-check/SKILL.md` — app-author cheat-table row
- `docs/_pipeline/templates/analyzer-architecture.md.dt` — rules-table row (template, not generated docs)
- `tests/Reactor.Tests/AnalyzerTests/ConstantKeySelectorAnalyzerTests.cs` (new, 15 tests)

### Verification
- `dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~AnalyzerTests` → **230 passed** (15 new).
- Samples sweep: every real keySelector reads its item; the `IReactorKeyed` overloads are correctly not keySelector calls → no false positives. Firing nowhere in samples is expected for a hygiene rule (spec-060 §2.4).