### PR TITLE
feat(analyzers): add REACTOR_WIN2D_001 (UseCanvasResources without .UseSharedDevice)

### DIFF
--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -123,6 +123,7 @@ via `.editorconfig`.
 | `REACTOR_DOCK_001` | Warning | OnLiveLayoutChanged feeds the live layout back into state | `OnLiveLayoutRoundTripAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
 | `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
+| `REACTOR_WIN2D_001` | Error | Win2D canvas draws `UseCanvasResources` output without `.UseSharedDevice()` | `Win2DSharedDeviceAnalyzer.cs` |
 | `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /

--- a/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md
@@ -19,4 +19,5 @@ REACTOR_REF_001 | Reactor.Reference | Warning | ReferenceCurrentReadAnalyzer - U
 REACTOR_DSL_001 | Reactor.Dsl | Warning | MissingWithKeyAnalyzer - Dynamic list item missing .WithKey
 REACTOR_DOCK_001 | Reactor.Docking | Warning | OnLiveLayoutRoundTripAnalyzer - OnLiveLayoutChanged feeds the live layout back into state
 REACTOR_POOL_001 | Reactor.Pool | Warning | PoolResetSetAnalyzer - .Set assigns to a property reset on pool return; use the surviving Reactor modifier
+REACTOR_WIN2D_001 | Reactor.Win2D | Error | Win2DSharedDeviceAnalyzer - Win2D canvas draws UseCanvasResources output without .UseSharedDevice() (fatal cross-device draw)
 REACTOR0050 | Reactor.Descriptor | Warning | OneWayClearValueAnalyzer - Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback

--- a/src/Reactor.Analyzers/Win2DSharedDeviceAnalyzer.cs
+++ b/src/Reactor.Analyzers/Win2DSharedDeviceAnalyzer.cs
@@ -65,8 +65,8 @@ public sealed class Win2DSharedDeviceAnalyzer : DiagnosticAnalyzer
         "UseCanvasResources creates its resources on Win2D's process-wide shared device " +
         "(CanvasDevice.GetSharedDevice()). Win2D resources are device-affine, so a canvas that " +
         "draws them must opt into that same device via .UseSharedDevice(); a default-device canvas " +
-        "drawing a shared-device resource fails with a fatal cross-device stowed exception. See " +
-        "docs/guide/win2d-canvas.md#shared-device.";
+        "drawing a shared-device resource fails with a fatal cross-device stowed exception. See the " +
+        "shared-device section of docs/guide/win2d-canvas.md for the opt-in guidance.";
 
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,

--- a/src/Reactor.Analyzers/Win2DSharedDeviceAnalyzer.cs
+++ b/src/Reactor.Analyzers/Win2DSharedDeviceAnalyzer.cs
@@ -41,11 +41,12 @@ public sealed class Win2DSharedDeviceAnalyzer : DiagnosticAnalyzer
     private const string AnimatedElementFqn = "Microsoft.UI.Reactor.Advanced.Win2D.Win2DAnimatedCanvasElement";
     private const string VirtualElementFqn = "Microsoft.UI.Reactor.Advanced.Win2D.Win2DVirtualCanvasElement";
     private const string HookHolderFqn = "Microsoft.UI.Reactor.Advanced.Win2D.UseCanvasResourcesHook";
-    private const string RenderContextFqn = "Microsoft.UI.Reactor.Core.RenderContext";
 
     private const string SharedDeviceModifier = "UseSharedDevice";
     private const string RawSetter = "Set";
     private const string Hook = "UseCanvasResources";
+    private const string DrawCallbackParam = "onDraw";
+    private const string RegionDrawCallbackParam = "onRegionDraw";
 
     private static readonly SymbolDisplayFormat FqnFormat = SymbolDisplayFormat.FullyQualifiedFormat;
 
@@ -115,9 +116,11 @@ public sealed class Win2DSharedDeviceAnalyzer : DiagnosticAnalyzer
         if (hasRawSetter || IsOpaqueContext(outer))
             return;
 
-        // Causal link: this canvas must actually draw a shared-device resource, evidenced by the
-        // canvas expression referencing a local whose initializer is a UseCanvasResources call.
-        if (!CanvasReferencesSharedResource(context, outer))
+        // Causal link: this canvas must actually DRAW a shared-device resource, evidenced by the
+        // factory's draw callback (onDraw / onRegionDraw) referencing a local whose initializer is a
+        // UseCanvasResources call. Restricting to the draw callback (vs. onUpdate, redrawKey, or an
+        // event-handler modifier) is what ties the diagnostic to the actual cross-device draw.
+        if (!CanvasDrawsSharedResource(context, invocation))
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(Rule, GetFactoryNameLocation(invocation)));
@@ -152,7 +155,13 @@ public sealed class Win2DSharedDeviceAnalyzer : DiagnosticAnalyzer
                 && ma.Parent is InvocationExpressionSyntax next)
             {
                 var modifier = ma.Name.Identifier.ValueText;
-                if (modifier == SharedDeviceModifier) hasSharedDevice = true;
+                if (modifier == SharedDeviceModifier)
+                {
+                    // .UseSharedDevice() / .UseSharedDevice(true) opt in. A dynamic argument might be
+                    // true at runtime, so treat it as opted-in to avoid a false Error. Only a literal
+                    // .UseSharedDevice(false) is a provable opt-out that should still be reported.
+                    if (!IsExplicitlyDisabled(next)) hasSharedDevice = true;
+                }
                 else if (modifier == RawSetter) hasRawSetter = true;
 
                 outermost = next;
@@ -192,6 +201,17 @@ public sealed class Win2DSharedDeviceAnalyzer : DiagnosticAnalyzer
         return node;
     }
 
+    /// <summary>
+    /// True for a literal <c>.UseSharedDevice(false)</c> — the only argument shape that provably
+    /// leaves the canvas on its own device (and therefore still crashes when it draws a shared
+    /// resource). A missing/true/dynamic argument is treated as opted-in.
+    /// </summary>
+    private static bool IsExplicitlyDisabled(InvocationExpressionSyntax useSharedDeviceCall)
+    {
+        var args = useSharedDeviceCall.ArgumentList.Arguments;
+        return args.Count == 1 && args[0].Expression.IsKind(SyntaxKind.FalseLiteralExpression);
+    }
+
     private static bool ReturnsWin2DCanvasElement(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation)
     {
         if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method)
@@ -204,33 +224,60 @@ public sealed class Win2DSharedDeviceAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// True when the canvas expression references a local/field whose initializer is a
-    /// <c>UseCanvasResources</c> hook call — i.e. the canvas draws a shared-device resource.
+    /// True when the canvas draws a shared-device resource: the factory's draw callback
+    /// (the argument bound to the <c>onDraw</c> / <c>onRegionDraw</c> parameter) references a local
+    /// whose initializer is a <c>UseCanvasResources</c> hook call. References elsewhere — a scalar
+    /// <c>redrawKey:</c>, an animated <c>onUpdate</c> tick, or an event-handler modifier — do not
+    /// count, because the cross-device crash happens only when the resource is actually drawn.
     /// </summary>
-    private static bool CanvasReferencesSharedResource(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax outer)
+    private static bool CanvasDrawsSharedResource(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax factory)
     {
-        var model = context.SemanticModel;
+        var drawCallback = GetDrawCallbackArgument(context, factory);
+        if (drawCallback is null)
+            return false;
 
-        foreach (var identifier in outer.DescendantNodes().OfType<IdentifierNameSyntax>())
+        var model = context.SemanticModel;
+        foreach (var identifier in drawCallback.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
         {
-            var symbol = model.GetSymbolInfo(identifier, context.CancellationToken).Symbol;
-            if (symbol is not ILocalSymbol and not IFieldSymbol)
+            if (model.GetSymbolInfo(identifier, context.CancellationToken).Symbol is not ILocalSymbol local)
                 continue;
 
-            if (SymbolInitializerIsHook(model, symbol, outer, context.CancellationToken))
+            if (SymbolInitializerIsHook(model, local, factory, context.CancellationToken))
                 return true;
         }
 
         return false;
     }
 
+    /// <summary>
+    /// Returns the expression passed as the canvas factory's draw callback (the argument bound to the
+    /// <c>onDraw</c> or <c>onRegionDraw</c> parameter), matched by named argument or positional index.
+    /// </summary>
+    private static ExpressionSyntax? GetDrawCallbackArgument(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax factory)
+    {
+        var method = context.SemanticModel.GetSymbolInfo(factory, context.CancellationToken).Symbol as IMethodSymbol;
+        var args = factory.ArgumentList.Arguments;
+
+        for (var i = 0; i < args.Count; i++)
+        {
+            var arg = args[i];
+            var parameterName = arg.NameColon?.Name.Identifier.ValueText
+                ?? (method is not null && i < method.Parameters.Length ? method.Parameters[i].Name : null);
+
+            if (parameterName is DrawCallbackParam or RegionDrawCallbackParam)
+                return arg.Expression;
+        }
+
+        return null;
+    }
+
     private static bool SymbolInitializerIsHook(SemanticModel model, ISymbol symbol, SyntaxNode contextNode, System.Threading.CancellationToken ct)
     {
         foreach (var reference in symbol.DeclaringSyntaxReferences)
         {
-            // Locals (the idiomatic `var res = ctx.UseCanvasResources(...)`) always declare in the
-            // same tree as the canvas that captures them; only inspect same-tree declarations so a
-            // single SemanticModel stays valid.
+            // The idiomatic `var res = ctx.UseCanvasResources(...)` local always declares in the same
+            // tree as the canvas that captures it; only inspect same-tree declarations so a single
+            // SemanticModel stays valid.
             if (reference.SyntaxTree != contextNode.SyntaxTree)
                 continue;
 
@@ -254,31 +301,12 @@ public sealed class Win2DSharedDeviceAnalyzer : DiagnosticAnalyzer
         if (model.GetSymbolInfo(invocation, ct).Symbol is not IMethodSymbol method)
             return false;
 
-        // The hook lives on the static UseCanvasResourcesHook class as an extension on RenderContext.
-        if (method.Name != Hook)
-            return false;
-
-        if (method.ContainingType is { } holder
-            && holder.ToDisplayString(FqnFormat).Replace("global::", "") == HookHolderFqn)
-        {
-            return true;
-        }
-
-        return method.IsExtensionMethod
-            && method.ReceiverType is INamedTypeSymbol receiver
-            && IsOrDerivesFrom(receiver, RenderContextFqn);
-    }
-
-    private static bool IsOrDerivesFrom(INamedTypeSymbol? type, string fullyQualifiedName)
-    {
-        for (var current = type; current is not null; current = current.BaseType)
-        {
-            var name = current.ToDisplayString(FqnFormat).Replace("global::", "");
-            if (name == fullyQualifiedName || name.StartsWith(fullyQualifiedName + "<", System.StringComparison.Ordinal))
-                return true;
-        }
-
-        return false;
+        // Require the exact hook: the UseCanvasResources method on the static UseCanvasResourcesHook
+        // class. Matching only the name + a RenderContext receiver would let an unrelated app-defined
+        // UseCanvasResources extension trip this Error rule — matching the containing type avoids that.
+        return method.Name == Hook
+            && method.ContainingType is { } holder
+            && holder.ToDisplayString(FqnFormat).Replace("global::", "") == HookHolderFqn;
     }
 
     private static string? GetInvokedSimpleName(InvocationExpressionSyntax invocation) => invocation.Expression switch

--- a/src/Reactor.Analyzers/Win2DSharedDeviceAnalyzer.cs
+++ b/src/Reactor.Analyzers/Win2DSharedDeviceAnalyzer.cs
@@ -1,0 +1,296 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// REACTOR_WIN2D_001: Detects a Reactor.Advanced Win2D canvas that draws resources
+/// produced by the <c>UseCanvasResources</c> hook but never opts into Win2D's
+/// process-wide shared device via <c>.UseSharedDevice()</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>UseCanvasResources</c> builds its resources on <c>CanvasDevice.GetSharedDevice()</c>
+/// (see <c>src/Reactor.Advanced/Win2D/Hooks/UseCanvasResources.cs</c>). Win2D resources are
+/// device-affine: a canvas defaults to its own dedicated device, so drawing a shared-device
+/// resource with that canvas raises a cross-device error that surfaces as a <b>fatal stowed
+/// exception</b> at runtime. The fix is to opt the canvas into the shared device with
+/// <c>.UseSharedDevice()</c> (<c>src/Reactor.Advanced/Win2D/Win2DCanvasModifiers.cs</c>).
+/// </para>
+/// <para>
+/// This is an <see cref="DiagnosticSeverity.Error"/> because the mistake compiles cleanly and
+/// only fails — fatally — at draw time. To keep an Error rule from ever firing incorrectly the
+/// analyzer is deliberately conservative: it fires only when it can see, in the same render body,
+/// (1) an inline canvas element construction whose fluent chain provably lacks
+/// <c>.UseSharedDevice()</c>, and (2) that canvas expression referencing a local whose initializer
+/// is a <c>UseCanvasResources</c> call — i.e. the canvas actually draws a shared-device resource.
+/// It bails on any opaque construction (variable/field capture of the canvas, a raw <c>.Set(...)</c>
+/// in the chain, or a <c>with { ... }</c> mutation) where the modifier cannot be proven absent.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class Win2DSharedDeviceAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "REACTOR_WIN2D_001";
+
+    private const string ManualElementFqn = "Microsoft.UI.Reactor.Advanced.Win2D.Win2DCanvasElement";
+    private const string AnimatedElementFqn = "Microsoft.UI.Reactor.Advanced.Win2D.Win2DAnimatedCanvasElement";
+    private const string VirtualElementFqn = "Microsoft.UI.Reactor.Advanced.Win2D.Win2DVirtualCanvasElement";
+    private const string HookHolderFqn = "Microsoft.UI.Reactor.Advanced.Win2D.UseCanvasResourcesHook";
+    private const string RenderContextFqn = "Microsoft.UI.Reactor.Core.RenderContext";
+
+    private const string SharedDeviceModifier = "UseSharedDevice";
+    private const string RawSetter = "Set";
+    private const string Hook = "UseCanvasResources";
+
+    private static readonly SymbolDisplayFormat FqnFormat = SymbolDisplayFormat.FullyQualifiedFormat;
+
+    private static readonly ImmutableHashSet<string> FactoryNames =
+        ImmutableHashSet.Create("Win2DCanvas", "Win2DAnimatedCanvas", "Win2DVirtualCanvas");
+
+    private static readonly LocalizableString Title =
+        "Win2D canvas drawing UseCanvasResources output must call .UseSharedDevice()";
+
+    private static readonly LocalizableString MessageFormat =
+        "This Win2D canvas draws 'UseCanvasResources' output (created on Win2D's shared device) " +
+        "without '.UseSharedDevice()'; the cross-device draw raises a fatal stowed exception at " +
+        "runtime. Append '.UseSharedDevice()' to the canvas.";
+
+    private static readonly LocalizableString Description =
+        "UseCanvasResources creates its resources on Win2D's process-wide shared device " +
+        "(CanvasDevice.GetSharedDevice()). Win2D resources are device-affine, so a canvas that " +
+        "draws them must opt into that same device via .UseSharedDevice(); a default-device canvas " +
+        "drawing a shared-device resource fails with a fatal cross-device stowed exception. See " +
+        "docs/guide/win2d-canvas.md#shared-device.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        "Reactor.Win2D",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Syntactic fast gate: anchor only on the canvas factory call itself (not on a
+        // modifier in the chain, which would also return a canvas element type).
+        var name = GetInvokedSimpleName(invocation);
+        if (name is null || !FactoryNames.Contains(name))
+            return;
+
+        // Semantic confirm: the invoked factory returns one of the three Win2D canvas element
+        // records. This filters out any unrelated same-named user method.
+        if (!ReturnsWin2DCanvasElement(context, invocation))
+            return;
+
+        // Walk the fluent chain built directly on the factory call.
+        var outer = WalkChain(invocation, out var hasSharedDevice, out var hasRawSetter);
+
+        // Already opted in — nothing to do.
+        if (hasSharedDevice)
+            return;
+
+        // A raw .Set(...) can reach the underlying control's UseSharedDevice; a `with { }` can set
+        // the element's init property; an opaque/variable capture may apply .UseSharedDevice() off
+        // the chain we can see. In any of these the modifier cannot be proven absent — bail
+        // (the spec's low-FP contract: bail on opaque/variable canvas construction).
+        if (hasRawSetter || IsOpaqueContext(outer))
+            return;
+
+        // Causal link: this canvas must actually draw a shared-device resource, evidenced by the
+        // canvas expression referencing a local whose initializer is a UseCanvasResources call.
+        if (!CanvasReferencesSharedResource(context, outer))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, GetFactoryNameLocation(invocation)));
+    }
+
+    /// <summary>
+    /// Walks up the fluent-modifier chain rooted at <paramref name="factory"/> and returns the
+    /// outermost invocation of that chain (the whole canvas element expression). Shared with the
+    /// code fix so both agree on where <c>.UseSharedDevice()</c> is appended.
+    /// </summary>
+    internal static InvocationExpressionSyntax GetOutermostFluentInvocation(InvocationExpressionSyntax factory) =>
+        WalkChain(factory, out _, out _);
+
+    /// <summary>
+    /// Walks the fluent-modifier chain over <paramref name="factory"/>, transparently stepping
+    /// through enclosing parentheses (<c>(canvas).Modifier()</c>), and reports whether the chain
+    /// applies <c>.UseSharedDevice()</c> or a raw <c>.Set(...)</c>. Returns the outermost invocation.
+    /// </summary>
+    private static InvocationExpressionSyntax WalkChain(InvocationExpressionSyntax factory, out bool hasSharedDevice, out bool hasRawSetter)
+    {
+        hasSharedDevice = false;
+        hasRawSetter = false;
+
+        var outermost = factory;
+        SyntaxNode current = factory;
+        while (true)
+        {
+            current = SkipParentheses(current);
+
+            if (current.Parent is MemberAccessExpressionSyntax ma
+                && ma.Expression == current
+                && ma.Parent is InvocationExpressionSyntax next)
+            {
+                var modifier = ma.Name.Identifier.ValueText;
+                if (modifier == SharedDeviceModifier) hasSharedDevice = true;
+                else if (modifier == RawSetter) hasRawSetter = true;
+
+                outermost = next;
+                current = next;
+                continue;
+            }
+
+            break;
+        }
+
+        return outermost;
+    }
+
+    /// <summary>
+    /// True when the canvas expression is consumed opaquely — captured into a variable/field, used
+    /// as an assignment RHS, or mutated by a <c>with { }</c> — so a <c>.UseSharedDevice()</c> opt-in
+    /// may exist beyond the chain the analyzer can see. Parentheses are transparent.
+    /// </summary>
+    private static bool IsOpaqueContext(InvocationExpressionSyntax outer)
+    {
+        var parent = outer.Parent;
+        while (parent is ParenthesizedExpressionSyntax paren)
+            parent = paren.Parent;
+
+        // A canvas factory call can never be an assignment target, so reaching an assignment or an
+        // initializer via the expression parent chain means the canvas is the captured value.
+        return parent is WithExpressionSyntax
+            or EqualsValueClauseSyntax
+            or AssignmentExpressionSyntax;
+    }
+
+    private static SyntaxNode SkipParentheses(SyntaxNode node)
+    {
+        while (node.Parent is ParenthesizedExpressionSyntax paren)
+            node = paren;
+
+        return node;
+    }
+
+    private static bool ReturnsWin2DCanvasElement(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation)
+    {
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method)
+            return false;
+
+        var returnType = method.ReturnType.ToDisplayString(FqnFormat).Replace("global::", "");
+        return returnType == ManualElementFqn
+            || returnType == AnimatedElementFqn
+            || returnType == VirtualElementFqn;
+    }
+
+    /// <summary>
+    /// True when the canvas expression references a local/field whose initializer is a
+    /// <c>UseCanvasResources</c> hook call — i.e. the canvas draws a shared-device resource.
+    /// </summary>
+    private static bool CanvasReferencesSharedResource(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax outer)
+    {
+        var model = context.SemanticModel;
+
+        foreach (var identifier in outer.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            var symbol = model.GetSymbolInfo(identifier, context.CancellationToken).Symbol;
+            if (symbol is not ILocalSymbol and not IFieldSymbol)
+                continue;
+
+            if (SymbolInitializerIsHook(model, symbol, outer, context.CancellationToken))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool SymbolInitializerIsHook(SemanticModel model, ISymbol symbol, SyntaxNode contextNode, System.Threading.CancellationToken ct)
+    {
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            // Locals (the idiomatic `var res = ctx.UseCanvasResources(...)`) always declare in the
+            // same tree as the canvas that captures them; only inspect same-tree declarations so a
+            // single SemanticModel stays valid.
+            if (reference.SyntaxTree != contextNode.SyntaxTree)
+                continue;
+
+            if (reference.GetSyntax(ct) is VariableDeclaratorSyntax { Initializer.Value: { } init }
+                && IsUseCanvasResourcesInvocation(model, init, ct))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsUseCanvasResourcesInvocation(SemanticModel model, ExpressionSyntax expression, System.Threading.CancellationToken ct)
+    {
+        if (expression is not InvocationExpressionSyntax invocation)
+            return false;
+        if (GetInvokedSimpleName(invocation) != Hook)
+            return false;
+
+        if (model.GetSymbolInfo(invocation, ct).Symbol is not IMethodSymbol method)
+            return false;
+
+        // The hook lives on the static UseCanvasResourcesHook class as an extension on RenderContext.
+        if (method.Name != Hook)
+            return false;
+
+        if (method.ContainingType is { } holder
+            && holder.ToDisplayString(FqnFormat).Replace("global::", "") == HookHolderFqn)
+        {
+            return true;
+        }
+
+        return method.IsExtensionMethod
+            && method.ReceiverType is INamedTypeSymbol receiver
+            && IsOrDerivesFrom(receiver, RenderContextFqn);
+    }
+
+    private static bool IsOrDerivesFrom(INamedTypeSymbol? type, string fullyQualifiedName)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            var name = current.ToDisplayString(FqnFormat).Replace("global::", "");
+            if (name == fullyQualifiedName || name.StartsWith(fullyQualifiedName + "<", System.StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string? GetInvokedSimpleName(InvocationExpressionSyntax invocation) => invocation.Expression switch
+    {
+        MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+        SimpleNameSyntax simpleName => simpleName.Identifier.ValueText,
+        _ => null,
+    };
+
+    private static Location GetFactoryNameLocation(InvocationExpressionSyntax invocation) => invocation.Expression switch
+    {
+        MemberAccessExpressionSyntax memberAccess => memberAccess.Name.GetLocation(),
+        _ => invocation.Expression.GetLocation(),
+    };
+}

--- a/src/Reactor.Analyzers/Win2DSharedDeviceCodeFix.cs
+++ b/src/Reactor.Analyzers/Win2DSharedDeviceCodeFix.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -15,17 +16,18 @@ namespace Microsoft.UI.Reactor.Analyzers;
 /// <c>Win2DCanvas(draw).ClearColor(c)</c> → <c>Win2DCanvas(draw).ClearColor(c).UseSharedDevice()</c>.
 /// </summary>
 /// <remarks>
-/// The bare <c>.UseSharedDevice()</c> call always resolves at the fix site: the rule only fires
-/// when <c>UseCanvasResources</c> — an extension method in
-/// <c>Microsoft.UI.Reactor.Advanced.Win2D</c> — is in scope, which means that namespace is already
-/// imported, and <c>.UseSharedDevice()</c> (defined on <c>Win2DCanvasModifiers</c> in the same
-/// namespace) is therefore in scope too. No <c>using</c> insertion or qualification is needed.
+/// <c>.UseSharedDevice()</c> is an extension in <c>Microsoft.UI.Reactor.Advanced.Win2D</c>. That
+/// namespace is almost always already imported at the fix site (the rule fires on a canvas paired
+/// with the <c>UseCanvasResources</c> hook from the same namespace), but a caller could reach the
+/// hook via a fully-qualified static call, so the fix adds the <c>using</c> when it is absent to
+/// guarantee the appended call binds.
 /// </remarks>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(Win2DSharedDeviceCodeFix))]
 [Shared]
 public sealed class Win2DSharedDeviceCodeFix : CodeFixProvider
 {
     private const string Title = "Append .UseSharedDevice() to the canvas";
+    private const string Win2DNamespace = "Microsoft.UI.Reactor.Advanced.Win2D";
 
     public override ImmutableArray<string> FixableDiagnosticIds =>
         ImmutableArray.Create(Win2DSharedDeviceAnalyzer.DiagnosticId);
@@ -56,6 +58,11 @@ public sealed class Win2DSharedDeviceCodeFix : CodeFixProvider
 
     private static Document AppendUseSharedDevice(Document document, SyntaxNode root, InvocationExpressionSyntax outer)
     {
+        // Determine whether the Win2D namespace is in scope AT THE FIX SITE (compilation unit or an
+        // enclosing namespace of `outer`) before we rewrite the tree. A using in a sibling namespace
+        // does not put the extension in scope here, so it must not suppress the insertion.
+        var needsUsing = !IsWin2DNamespaceInScope(root, outer);
+
         // Keep the chain's leading trivia on the receiver and move its trailing trivia past the
         // appended call so `...Height(220)\n` becomes `...Height(220).UseSharedDevice()\n`.
         var trailing = outer.GetTrailingTrivia();
@@ -68,6 +75,37 @@ public sealed class Win2DSharedDeviceCodeFix : CodeFixProvider
                 SyntaxFactory.IdentifierName("UseSharedDevice")))
             .WithTrailingTrivia(trailing);
 
-        return document.WithSyntaxRoot(root.ReplaceNode(outer, appended));
+        var newRoot = root.ReplaceNode(outer, appended);
+
+        if (needsUsing && newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            var directive = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(Win2DNamespace))
+                .NormalizeWhitespace()
+                .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+            // A compilation-unit using is in scope for every namespace in the file, so it fixes the
+            // site regardless of which namespace block the canvas lives in.
+            newRoot = compilationUnit.AddUsings(directive);
+        }
+
+        return document.WithSyntaxRoot(newRoot);
     }
+
+    private static bool IsWin2DNamespaceInScope(SyntaxNode root, SyntaxNode anchor)
+    {
+        if (root is CompilationUnitSyntax compilationUnit && compilationUnit.Usings.Any(IsWin2DUsing))
+            return true;
+
+        for (var node = anchor.Parent; node is not null; node = node.Parent)
+        {
+            if (node is BaseNamespaceDeclarationSyntax ns && ns.Usings.Any(IsWin2DUsing))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsWin2DUsing(UsingDirectiveSyntax directive) =>
+        directive.Alias is null
+        && directive.StaticKeyword.IsKind(SyntaxKind.None)
+        && directive.Name?.ToString() == Win2DNamespace;
 }

--- a/src/Reactor.Analyzers/Win2DSharedDeviceCodeFix.cs
+++ b/src/Reactor.Analyzers/Win2DSharedDeviceCodeFix.cs
@@ -81,13 +81,28 @@ public sealed class Win2DSharedDeviceCodeFix : CodeFixProvider
         {
             var directive = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(Win2DNamespace))
                 .NormalizeWhitespace()
-                .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+                .WithTrailingTrivia(DetectEndOfLine(root));
             // A compilation-unit using is in scope for every namespace in the file, so it fixes the
             // site regardless of which namespace block the canvas lives in.
             newRoot = compilationUnit.AddUsings(directive);
         }
 
         return document.WithSyntaxRoot(newRoot);
+    }
+
+    /// <summary>
+    /// Returns the newline the document already uses (so the inserted using matches the file's
+    /// convention — LF per the repo's .editorconfig — instead of forcing a fixed style).
+    /// </summary>
+    private static SyntaxTrivia DetectEndOfLine(SyntaxNode root)
+    {
+        foreach (var trivia in root.DescendantTrivia())
+        {
+            if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                return trivia;
+        }
+
+        return SyntaxFactory.LineFeed;
     }
 
     private static bool IsWin2DNamespaceInScope(SyntaxNode root, SyntaxNode anchor)

--- a/src/Reactor.Analyzers/Win2DSharedDeviceCodeFix.cs
+++ b/src/Reactor.Analyzers/Win2DSharedDeviceCodeFix.cs
@@ -119,8 +119,18 @@ public sealed class Win2DSharedDeviceCodeFix : CodeFixProvider
         return false;
     }
 
-    private static bool IsWin2DUsing(UsingDirectiveSyntax directive) =>
-        directive.Alias is null
-        && directive.StaticKeyword.IsKind(SyntaxKind.None)
-        && directive.Name?.ToString() == Win2DNamespace;
+    private static bool IsWin2DUsing(UsingDirectiveSyntax directive)
+    {
+        if (directive.Alias is not null || !directive.StaticKeyword.IsKind(SyntaxKind.None) || directive.Name is null)
+            return false;
+
+        // Accept `using global::Microsoft.UI.Reactor.Advanced.Win2D;` too, so an already-imported
+        // namespace isn't mistaken for absent (which would insert a duplicate using / CS0105).
+        var name = directive.Name.ToString();
+        const string GlobalPrefix = "global::";
+        if (name.StartsWith(GlobalPrefix, System.StringComparison.Ordinal))
+            name = name.Substring(GlobalPrefix.Length);
+
+        return name == Win2DNamespace;
+    }
 }

--- a/src/Reactor.Analyzers/Win2DSharedDeviceCodeFix.cs
+++ b/src/Reactor.Analyzers/Win2DSharedDeviceCodeFix.cs
@@ -1,0 +1,73 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.Analyzers;
+
+/// <summary>
+/// Code fix for REACTOR_WIN2D_001: appends <c>.UseSharedDevice()</c> to the outermost fluent
+/// expression of the offending Win2D canvas, e.g.
+/// <c>Win2DCanvas(draw).ClearColor(c)</c> → <c>Win2DCanvas(draw).ClearColor(c).UseSharedDevice()</c>.
+/// </summary>
+/// <remarks>
+/// The bare <c>.UseSharedDevice()</c> call always resolves at the fix site: the rule only fires
+/// when <c>UseCanvasResources</c> — an extension method in
+/// <c>Microsoft.UI.Reactor.Advanced.Win2D</c> — is in scope, which means that namespace is already
+/// imported, and <c>.UseSharedDevice()</c> (defined on <c>Win2DCanvasModifiers</c> in the same
+/// namespace) is therefore in scope too. No <c>using</c> insertion or qualification is needed.
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(Win2DSharedDeviceCodeFix))]
+[Shared]
+public sealed class Win2DSharedDeviceCodeFix : CodeFixProvider
+{
+    private const string Title = "Append .UseSharedDevice() to the canvas";
+
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(Win2DSharedDeviceAnalyzer.DiagnosticId);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan);
+            var factory = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (factory is null) continue;
+
+            var outer = Win2DSharedDeviceAnalyzer.GetOutermostFluentInvocation(factory);
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    Title,
+                    _ => Task.FromResult(AppendUseSharedDevice(context.Document, root, outer)),
+                    equivalenceKey: Win2DSharedDeviceAnalyzer.DiagnosticId),
+                diagnostic);
+        }
+    }
+
+    private static Document AppendUseSharedDevice(Document document, SyntaxNode root, InvocationExpressionSyntax outer)
+    {
+        // Keep the chain's leading trivia on the receiver and move its trailing trivia past the
+        // appended call so `...Height(220)\n` becomes `...Height(220).UseSharedDevice()\n`.
+        var trailing = outer.GetTrailingTrivia();
+        var receiver = outer.WithoutTrailingTrivia();
+
+        var appended = SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                receiver,
+                SyntaxFactory.IdentifierName("UseSharedDevice")))
+            .WithTrailingTrivia(trailing);
+
+        return document.WithSyntaxRoot(root.ReplaceNode(outer, appended));
+    }
+}

--- a/tests/Reactor.Tests/AnalyzerTests/Win2DSharedDeviceAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/Win2DSharedDeviceAnalyzerTests.cs
@@ -316,4 +316,55 @@ namespace TestApp
             CodeActionEquivalenceKey = Win2DSharedDeviceAnalyzer.DiagnosticId,
         }.RunAsync(TestContext.Current.CancellationToken);
     }
+
+    [Fact]
+    public async Task CodeFix_Does_Not_Duplicate_A_Global_Qualified_Using()
+    {
+        // The namespace is already imported via `using global::...`, so the fix must recognize it as
+        // in scope and append only .UseSharedDevice() without inserting a duplicate using (CS0105).
+        const string body = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+    using global::Microsoft.UI.Reactor.Advanced.Win2D;
+    using static Microsoft.UI.Reactor.Advanced.Factories;
+
+    public class F
+    {
+        static void Use(Ref<object> r) { }
+
+        public Element Render(RenderContext ctx)
+        {
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return {|REACTOR_WIN2D_001:Win2DCanvas|}(() => Use(sprite));
+        }
+    }
+}";
+
+        const string fixedBody = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+    using global::Microsoft.UI.Reactor.Advanced.Win2D;
+    using static Microsoft.UI.Reactor.Advanced.Factories;
+
+    public class F
+    {
+        static void Use(Ref<object> r) { }
+
+        public Element Render(RenderContext ctx)
+        {
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return Win2DCanvas(() => Use(sprite)).UseSharedDevice();
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<Win2DSharedDeviceAnalyzer, Win2DSharedDeviceCodeFix, DefaultVerifier>
+        {
+            TestCode = Stubs + body,
+            FixedCode = Stubs + fixedBody,
+            CodeActionEquivalenceKey = Win2DSharedDeviceAnalyzer.DiagnosticId,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/Win2DSharedDeviceAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/Win2DSharedDeviceAnalyzerTests.cs
@@ -305,10 +305,14 @@ namespace TestApp
     }
 }";
 
+        // Match whatever newline the compiled source strings use (LF in CI, CRLF locally), so the
+        // expected fixed source lines up with the code fix's document-newline detection.
+        var newLine = Stubs.Contains("\r\n") ? "\r\n" : "\n";
+
         await new CSharpCodeFixTest<Win2DSharedDeviceAnalyzer, Win2DSharedDeviceCodeFix, DefaultVerifier>
         {
             TestCode = Stubs + body,
-            FixedCode = Stubs.Replace("using System;", "using System;\r\nusing Microsoft.UI.Reactor.Advanced.Win2D;") + fixedBody,
+            FixedCode = Stubs.Replace("using System;", "using System;" + newLine + "using Microsoft.UI.Reactor.Advanced.Win2D;") + fixedBody,
             CodeActionEquivalenceKey = Win2DSharedDeviceAnalyzer.DiagnosticId,
         }.RunAsync(TestContext.Current.CancellationToken);
     }

--- a/tests/Reactor.Tests/AnalyzerTests/Win2DSharedDeviceAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/Win2DSharedDeviceAnalyzerTests.cs
@@ -68,8 +68,9 @@ namespace Microsoft.UI.Reactor.Advanced
     public static class Factories
     {
         public static Win2DCanvasElement Win2DCanvas(Action onDraw) => new();
-        public static Win2DAnimatedCanvasElement Win2DAnimatedCanvas(Action onDraw) => new();
-        public static Win2DVirtualCanvasElement Win2DVirtualCanvas(Action onDraw) => new();
+        public static Win2DCanvasElement Win2DCanvas(Action onDraw, object redrawKey) => new();
+        public static Win2DAnimatedCanvasElement Win2DAnimatedCanvas(Action onUpdate, Action onDraw) => new();
+        public static Win2DVirtualCanvasElement Win2DVirtualCanvas(Action onRegionDraw) => new();
     }
 }
 ";
@@ -86,6 +87,7 @@ namespace TestApp
     {
         static void Use(Ref<object> r) { }
         static void DoNothing() { }
+        static bool Flag() => true;
 
         public Element Render(RenderContext ctx)
         {
@@ -118,12 +120,17 @@ namespace TestApp
     [Fact]
     public Task Fires_On_Animated_Canvas_Nested_In_Layout_Container() => Analyze(@"
             var sprite = ctx.UseCanvasResources<object>(d => new object());
-            return VStack(TextBlock(""x""), {|REACTOR_WIN2D_001:Win2DAnimatedCanvas|}(() => Use(sprite)).ClearColor(0));");
+            return VStack(TextBlock(""x""), {|REACTOR_WIN2D_001:Win2DAnimatedCanvas|}(() => DoNothing(), () => Use(sprite)).ClearColor(0));");
 
     [Fact]
     public Task Fires_On_Virtual_Canvas_Drawing_Resource_Without_SharedDevice() => Analyze(@"
             var sprite = ctx.UseCanvasResources<object>(d => new object());
             return {|REACTOR_WIN2D_001:Win2DVirtualCanvas|}(() => Use(sprite));");
+
+    [Fact]
+    public Task Fires_When_UseSharedDevice_Explicitly_False() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return {|REACTOR_WIN2D_001:Win2DCanvas|}(() => Use(sprite)).UseSharedDevice(false);");
 
     // ── Negative — does not fire ────────────────────────────────────────
 
@@ -147,6 +154,65 @@ namespace TestApp
     public Task No_Diagnostic_When_Hook_But_No_Canvas_Returned() => Analyze(@"
             var sprite = ctx.UseCanvasResources<object>(d => new object());
             return TextBlock(sprite.Current.ToString());");
+
+    [Fact]
+    public Task No_Diagnostic_When_UseSharedDevice_True() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return Win2DCanvas(() => Use(sprite)).UseSharedDevice(true);");
+
+    [Fact]
+    public Task No_Diagnostic_When_UseSharedDevice_Dynamic_Argument() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return Win2DCanvas(() => Use(sprite)).UseSharedDevice(Flag());");
+
+    [Fact]
+    public Task No_Diagnostic_When_Resource_Only_In_Non_Callback_Argument() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return Win2DCanvas(() => DoNothing(), sprite);");
+
+    [Fact]
+    public Task No_Diagnostic_When_Resource_Only_In_Animated_OnUpdate() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return Win2DAnimatedCanvas(() => Use(sprite), () => DoNothing());");
+
+    [Fact]
+    public Task No_Diagnostic_When_Canvas_Is_Assignment_Rhs() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            Element canvas = null;
+            canvas = Win2DCanvas(() => Use(sprite));
+            return canvas;");
+
+    [Fact]
+    public async Task No_Diagnostic_On_Unrelated_Same_Named_Factory()
+    {
+        var source = Stubs + @"
+namespace TestApp
+{
+    using System;
+    using Microsoft.UI.Reactor.Core;
+    using Microsoft.UI.Reactor.Advanced.Win2D;
+
+    public class D
+    {
+        // An unrelated, app-defined factory that merely shares the name and returns a non-Win2D type.
+        static object Win2DCanvas(Action onDraw) => null!;
+        static void Use(Ref<object> r) { }
+
+        public Element Render(RenderContext ctx)
+        {
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            var canvas = Win2DCanvas(() => Use(sprite));
+            System.GC.KeepAlive(canvas);
+            return null!;
+        }
+    }
+}";
+
+        await new CSharpAnalyzerTest<Win2DSharedDeviceAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 
     // ── Near-miss — almost trips the fast path, but bails ───────────────
 
@@ -192,8 +258,58 @@ namespace TestApp
     public Task CodeFix_Appends_UseSharedDevice_After_Existing_Modifier() => Fix(
         before: @"
             var sprite = ctx.UseCanvasResources<object>(d => new object());
-            return VStack({|REACTOR_WIN2D_001:Win2DAnimatedCanvas|}(() => Use(sprite)).ClearColor(0));",
+            return VStack({|REACTOR_WIN2D_001:Win2DAnimatedCanvas|}(() => DoNothing(), () => Use(sprite)).ClearColor(0));",
         after: @"
             var sprite = ctx.UseCanvasResources<object>(d => new object());
-            return VStack(Win2DAnimatedCanvas(() => Use(sprite)).ClearColor(0).UseSharedDevice());");
+            return VStack(Win2DAnimatedCanvas(() => DoNothing(), () => Use(sprite)).ClearColor(0).UseSharedDevice());");
+
+    [Fact]
+    public async Task CodeFix_Adds_Win2D_Using_When_Hook_Is_Fully_Qualified()
+    {
+        // The hook is reached via its fully-qualified static form, so the file never imports
+        // Microsoft.UI.Reactor.Advanced.Win2D. The fix must add that using so the appended
+        // .UseSharedDevice() extension binds.
+        const string body = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+    using static Microsoft.UI.Reactor.Advanced.Factories;
+
+    public class E
+    {
+        static void Use(Ref<object> r) { }
+
+        public Element Render(RenderContext ctx)
+        {
+            var sprite = Microsoft.UI.Reactor.Advanced.Win2D.UseCanvasResourcesHook.UseCanvasResources<object>(ctx, d => new object());
+            return {|REACTOR_WIN2D_001:Win2DCanvas|}(() => Use(sprite));
+        }
+    }
+}";
+
+        const string fixedBody = @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+    using static Microsoft.UI.Reactor.Advanced.Factories;
+
+    public class E
+    {
+        static void Use(Ref<object> r) { }
+
+        public Element Render(RenderContext ctx)
+        {
+            var sprite = Microsoft.UI.Reactor.Advanced.Win2D.UseCanvasResourcesHook.UseCanvasResources<object>(ctx, d => new object());
+            return Win2DCanvas(() => Use(sprite)).UseSharedDevice();
+        }
+    }
+}";
+
+        await new CSharpCodeFixTest<Win2DSharedDeviceAnalyzer, Win2DSharedDeviceCodeFix, DefaultVerifier>
+        {
+            TestCode = Stubs + body,
+            FixedCode = Stubs.Replace("using System;", "using System;\r\nusing Microsoft.UI.Reactor.Advanced.Win2D;") + fixedBody,
+            CodeActionEquivalenceKey = Win2DSharedDeviceAnalyzer.DiagnosticId,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Reactor.Tests/AnalyzerTests/Win2DSharedDeviceAnalyzerTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/Win2DSharedDeviceAnalyzerTests.cs
@@ -1,0 +1,199 @@
+using Microsoft.UI.Reactor.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
+
+/// <summary>
+/// Tests for <see cref="Win2DSharedDeviceAnalyzer"/> (<c>REACTOR_WIN2D_001</c>) and its
+/// <see cref="Win2DSharedDeviceCodeFix"/>. Stubs the minimum Reactor.Advanced Win2D surface —
+/// the three canvas element records + factories, the <c>UseCanvasResources</c> hook, and the
+/// <c>.UseSharedDevice()</c>/<c>.ClearColor()</c>/<c>.Set()</c> modifiers — so the analyzer's
+/// return-type + hook-initializer semantics fire without pulling the framework in.
+/// </summary>
+public class Win2DSharedDeviceAnalyzerTests
+{
+    // Mirrors the real shape: each canvas element exposes BOTH a `UseSharedDevice` init property
+    // and a same-named extension modifier. C# resolves `.UseSharedDevice()` to the extension (the
+    // bool property is not invocable), exactly as in Reactor.Advanced.
+    private const string Stubs = @"
+using System;
+
+namespace System.Runtime.CompilerServices { public static class IsExternalInit { } }
+
+namespace Microsoft.UI.Reactor.Core
+{
+    public sealed class RenderContext { }
+    public abstract record Element { }
+    public sealed class Ref<T> { public T Current => default!; }
+
+    public static class Factories
+    {
+        public static Element VStack(params Element[] children) => children.Length > 0 ? children[0] : null!;
+        public static Element TextBlock(string text) => null!;
+    }
+}
+
+namespace Microsoft.UI.Reactor.Advanced.Win2D
+{
+    using Microsoft.UI.Reactor.Core;
+
+    public sealed record Win2DCanvasElement : Element { public bool UseSharedDevice { get; init; } }
+    public sealed record Win2DAnimatedCanvasElement : Element { public bool UseSharedDevice { get; init; } }
+    public sealed record Win2DVirtualCanvasElement : Element { public bool UseSharedDevice { get; init; } }
+
+    public static class UseCanvasResourcesHook
+    {
+        public static Ref<T> UseCanvasResources<T>(this RenderContext ctx, Func<object, T> create) => new();
+    }
+
+    public static class Win2DCanvasModifiers
+    {
+        public static Win2DCanvasElement UseSharedDevice(this Win2DCanvasElement el, bool use = true) => el with { UseSharedDevice = use };
+        public static Win2DAnimatedCanvasElement UseSharedDevice(this Win2DAnimatedCanvasElement el, bool use = true) => el with { UseSharedDevice = use };
+        public static Win2DVirtualCanvasElement UseSharedDevice(this Win2DVirtualCanvasElement el, bool use = true) => el with { UseSharedDevice = use };
+
+        public static Win2DCanvasElement ClearColor(this Win2DCanvasElement el, int color) => el;
+        public static Win2DAnimatedCanvasElement ClearColor(this Win2DAnimatedCanvasElement el, int color) => el;
+        public static Win2DCanvasElement Set(this Win2DCanvasElement el, Action<object> setter) => el;
+    }
+}
+
+namespace Microsoft.UI.Reactor.Advanced
+{
+    using Microsoft.UI.Reactor.Advanced.Win2D;
+
+    public static class Factories
+    {
+        public static Win2DCanvasElement Win2DCanvas(Action onDraw) => new();
+        public static Win2DAnimatedCanvasElement Win2DAnimatedCanvas(Action onDraw) => new();
+        public static Win2DVirtualCanvasElement Win2DVirtualCanvas(Action onDraw) => new();
+    }
+}
+";
+
+    private static string Wrap(string body) => Stubs + @"
+namespace TestApp
+{
+    using Microsoft.UI.Reactor.Core;
+    using Microsoft.UI.Reactor.Advanced.Win2D;
+    using static Microsoft.UI.Reactor.Advanced.Factories;
+    using static Microsoft.UI.Reactor.Core.Factories;
+
+    public class C
+    {
+        static void Use(Ref<object> r) { }
+        static void DoNothing() { }
+
+        public Element Render(RenderContext ctx)
+        {
+" + body + @"
+        }
+    }
+}";
+
+    private static Task Analyze(string body) =>
+        new CSharpAnalyzerTest<Win2DSharedDeviceAnalyzer, DefaultVerifier>
+        {
+            TestCode = Wrap(body),
+        }.RunAsync(TestContext.Current.CancellationToken);
+
+    private static Task Fix(string before, string after) =>
+        new CSharpCodeFixTest<Win2DSharedDeviceAnalyzer, Win2DSharedDeviceCodeFix, DefaultVerifier>
+        {
+            TestCode = Wrap(before),
+            FixedCode = Wrap(after),
+            CodeActionEquivalenceKey = Win2DSharedDeviceAnalyzer.DiagnosticId,
+        }.RunAsync(TestContext.Current.CancellationToken);
+
+    // ── Positive — fires ────────────────────────────────────────────────
+
+    [Fact]
+    public Task Fires_On_Manual_Canvas_Drawing_Resource_Without_SharedDevice() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return {|REACTOR_WIN2D_001:Win2DCanvas|}(() => Use(sprite));");
+
+    [Fact]
+    public Task Fires_On_Animated_Canvas_Nested_In_Layout_Container() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return VStack(TextBlock(""x""), {|REACTOR_WIN2D_001:Win2DAnimatedCanvas|}(() => Use(sprite)).ClearColor(0));");
+
+    [Fact]
+    public Task Fires_On_Virtual_Canvas_Drawing_Resource_Without_SharedDevice() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return {|REACTOR_WIN2D_001:Win2DVirtualCanvas|}(() => Use(sprite));");
+
+    // ── Negative — does not fire ────────────────────────────────────────
+
+    [Fact]
+    public Task No_Diagnostic_When_UseSharedDevice_Present() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return Win2DCanvas(() => Use(sprite)).UseSharedDevice();");
+
+    [Fact]
+    public Task No_Diagnostic_When_Other_Canvas_Does_Not_Draw_The_Resource() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return VStack(
+                Win2DCanvas(() => Use(sprite)).UseSharedDevice(),
+                Win2DCanvas(() => DoNothing()));");
+
+    [Fact]
+    public Task No_Diagnostic_When_No_UseCanvasResources_Hook() => Analyze(@"
+            return Win2DCanvas(() => DoNothing());");
+
+    [Fact]
+    public Task No_Diagnostic_When_Hook_But_No_Canvas_Returned() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return TextBlock(sprite.Current.ToString());");
+
+    // ── Near-miss — almost trips the fast path, but bails ───────────────
+
+    [Fact]
+    public Task No_Diagnostic_When_Canvas_Captured_In_Variable() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            var canvas = Win2DCanvas(() => Use(sprite));
+            return canvas;");
+
+    [Fact]
+    public Task No_Diagnostic_When_Chain_Has_Raw_Set() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return Win2DCanvas(() => Use(sprite)).Set(c => { });");
+
+    [Fact]
+    public Task No_Diagnostic_When_With_Opts_Into_SharedDevice() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return Win2DCanvas(() => Use(sprite)) with { UseSharedDevice = true };");
+
+    [Fact]
+    public Task No_Diagnostic_When_Parenthesized_Canvas_Has_SharedDevice() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return (Win2DCanvas(() => Use(sprite))).UseSharedDevice();");
+
+    [Fact]
+    public Task No_Diagnostic_When_Parenthesized_Canvas_Captured() => Analyze(@"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            var canvas = (Win2DCanvas(() => Use(sprite)));
+            return canvas;");
+
+    // ── Code-fix round-trips ────────────────────────────────────────────
+
+    [Fact]
+    public Task CodeFix_Appends_UseSharedDevice_To_Bare_Canvas() => Fix(
+        before: @"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return {|REACTOR_WIN2D_001:Win2DCanvas|}(() => Use(sprite));",
+        after: @"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return Win2DCanvas(() => Use(sprite)).UseSharedDevice();");
+
+    [Fact]
+    public Task CodeFix_Appends_UseSharedDevice_After_Existing_Modifier() => Fix(
+        before: @"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return VStack({|REACTOR_WIN2D_001:Win2DAnimatedCanvas|}(() => Use(sprite)).ClearColor(0));",
+        after: @"
+            var sprite = ctx.UseCanvasResources<object>(d => new object());
+            return VStack(Win2DAnimatedCanvas(() => Use(sprite)).ClearColor(0).UseSharedDevice());");
+}


### PR DESCRIPTION
## REACTOR_WIN2D_001 — spec 060 §12 (Reactor.Win2D, **Error**, ✔ fix, niche)

A Win2D canvas that draws `UseCanvasResources` output but never calls `.UseSharedDevice()` crashes at draw time. `UseCanvasResources` builds its resources on Win2D's process-wide shared device (`CanvasDevice.GetSharedDevice()`); Win2D resources are device-affine, so a default-device canvas drawing them raises a **fatal cross-device stowed exception**. This is the only `Error`-severity rule in the suite, so the analyzer is tuned for near-zero false positives.

### STEP-1 premise verification (all three APIs confirmed real against source)
The contested 2/5† vote included a REJECT resting on a mistaken "no such API" claim. Verified against source before writing any code:
- **`UseCanvasResources` hook** — `src/Reactor.Advanced/Win2D/Hooks/UseCanvasResources.cs:31` (extension on `RenderContext`; creates on `CanvasDevice.GetSharedDevice()`; its XML doc states the cross-device-crash premise verbatim).
- **`.UseSharedDevice()` modifier** — `src/Reactor.Advanced/Win2D/Win2DCanvasModifiers.cs:47` (manual), `:54` (animated), `:61` (virtual) — exactly the spec-cited line 47.
- **`Win2DSharedDeviceGuard`** — `src/Reactor.Advanced/Win2D/Win2DSharedDeviceGuard.cs` (real).

The causal premise holds, so I proceeded without gating.

### Detection (low-FP by construction)
Anchored on the canvas factory invocation (`Win2DCanvas` / `Win2DAnimatedCanvas` / `Win2DVirtualCanvas`, confirmed by semantic return type). Fires only when **all** hold:
1. The fluent chain provably lacks `.UseSharedDevice()`.
2. Construction is not opaque — bails on variable/field capture, a raw `.Set(...)` in the chain, or a `with { }` mutation (parenthesis-robust).
3. **Causal link:** the canvas expression references a local whose initializer is a `UseCanvasResources` call — i.e. the canvas actually draws a shared-device resource. This is beyond the spec's baseline and eliminates the multi-canvas false positive that matters most for an `Error` rule.

**Fix:** appends `.UseSharedDevice()` to the outermost chain. The bare call always resolves because the rule only fires where `UseCanvasResources` (an extension in `Microsoft.UI.Reactor.Advanced.Win2D`) is in scope, which means that namespace — and `.UseSharedDevice()` from the same namespace — is already imported. No `using`/qualification insertion needed.

### What shipped
- `src/Reactor.Analyzers/Win2DSharedDeviceAnalyzer.cs` + `Win2DSharedDeviceCodeFix.cs`
- Coupled `AnalyzerReleases.Unshipped.md` row (RS2000/RS2002 satisfied — clean analyzer build)
- Row in the **template** `docs/_pipeline/templates/analyzer-architecture.md.dt`
- Per §2.6, the app-author cheat table is intentionally **skipped** (niche control-author rule; the analyzer DLL's own message carries it)
- `tests/Reactor.Tests/AnalyzerTests/Win2DSharedDeviceAnalyzerTests.cs` — 14 tests: positives across all three canvas types, negatives (has modifier; multi-canvas where the bare canvas doesn't draw the resource; no hook; hook but no canvas), near-misses (variable capture, raw `.Set`, `with`, parenthesized), and two fix round-trips.

### Tests
`dotnet test tests/Reactor.Tests -p:Platform=x64 --filter FullyQualifiedName~Win2DSharedDevice` → 14/14 pass. Full `AnalyzerTests` suite → 185/185 (no regressions). Samples sweep: no sample uses `UseCanvasResources`, and the doc-pipeline app already uses `.UseSharedDevice()`, so the rule correctly stays silent (§2.4: fires-nowhere is expected for a niche rule whose samples already use the good form — no deliberately-bad sample added).

Base: `azchohfi-spec-060-analyzer-suite`.