### PR TITLE
Regenerate reactor.api.txt for BorderThickness defaults

### DIFF
--- a/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
+++ b/plugins/reactor/skills/reactor-dsl/references/reactor.api.txt
@@ -576,7 +576,7 @@ T.BorderBrush<T>(string color) → T
 T.BorderInlineStart<T>(Thickness thickness) → T
 T.BorderThickness<T>(Thickness thickness) → T
 T.BorderThickness<T>(double horizontal, double vertical) → T
-T.BorderThickness<T>(double left, double top, double right, double bottom) → T
+T.BorderThickness<T>(double left = 0, double top = 0, double right = 0, double bottom = 0) → T
 T.BorderThickness<T>(double thickness) → T
 T.Canvas<T>(double left = 0, double top = 0) → T
 T.Canvas<T>(double left, double top, double anchorX, double anchorY) → T

--- a/skills/reactor.api.txt
+++ b/skills/reactor.api.txt
@@ -576,7 +576,7 @@ T.BorderBrush<T>(string color) → T
 T.BorderInlineStart<T>(Thickness thickness) → T
 T.BorderThickness<T>(Thickness thickness) → T
 T.BorderThickness<T>(double horizontal, double vertical) → T
-T.BorderThickness<T>(double left, double top, double right, double bottom) → T
+T.BorderThickness<T>(double left = 0, double top = 0, double right = 0, double bottom = 0) → T
 T.BorderThickness<T>(double thickness) → T
 T.Canvas<T>(double left = 0, double top = 0) → T
 T.Canvas<T>(double left, double top, double anchorX, double anchorY) → T


### PR DESCRIPTION
## What

Regenerates the committed API index (`skills/reactor.api.txt` and its mirror `plugins/reactor/skills/reactor-dsl/references/reactor.api.txt`) so the new 4‑arg `BorderThickness` fluent carries its default parameter values:

```diff
-T.BorderThickness<T>(double left, double top, double right, double bottom) → T
+T.BorderThickness<T>(double left = 0, double top = 0, double right = 0, double bottom = 0) → T
```

## Why

The `BorderThickness<T>(double left = 0.0, double top = 0.0, double right = 0.0, double bottom = 0.0)` overload added in #775 has default values, but the committed index was not regenerated to include them, so `ApiIndexGeneratorTests.Index_IsUpToDate` / `ExistingSections_Unchanged` saw a stale file.

This slipped past the **GitHub Actions** CI because its unit-test job builds in **Debug without `-p:CI=true`**, which runs the SignaturesGen/ReactorApiGen target and **auto-regenerates the index during the test build** — masking the drift. The internal **nightly** (`Microsoft-UI-Reactor-Nightly`) builds with **`-p:CI=true`**, which gates that regeneration off and tests the committed file as-is, so the nightly failed (2 test failures) even though the GH Actions checks were all green.

## Verification

Reproduced the failure and confirmed the fix against **both** configurations:

- `Reactor.Tests` `Tooling.ApiIndexGeneratorTests` — **Release + `-p:Platform=x64 -p:CI=true`** (nightly config): 6/6 pass (was 2 failing).
- Same tests — **Debug + `-p:Platform=x64`** (GH Actions config), with auto-regen disabled so it truly compares the committed file: 6/6 pass.

The reflected surface is config-independent, so the regenerated index is correct for both pipelines. No source/API changes — index only.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>