### PR TITLE
Automatic build-metrics (size-diff) + auto coverage PR comments

### DIFF
--- a/.github/workflows/build-metrics-comment.yml
+++ b/.github/workflows/build-metrics-comment.yml
@@ -1,15 +1,19 @@
 # Privileged poster for the automatic build-metrics comment.
 #
 # The measure workflow (build-metrics.yml) builds untrusted PR code, so it runs
-# unprivileged and only uploads the rendered comment as an artifact. This workflow
-# runs from the DEFAULT branch with a write token, executes NO PR code, downloads
-# that artifact, and posts/updates the sticky "Build metrics" comment. This is the
-# standard secure `pull_request` + `workflow_run` split for commenting on PRs
-# (including forks) without exposing a write token to build code.
+# unprivileged and uploads ONLY the machine-readable sizes.json. This workflow
+# runs from the DEFAULT branch with a write token, executes NO PR code, checks out
+# TRUSTED default-branch code, validates the uploaded numbers against a fixed
+# target spec, RENDERS the comment itself (via the trusted BuildMetricsLib.ps1),
+# and posts/updates the sticky comment.
 #
-# Security: the target PR is resolved from the TRUSTED github.event.workflow_run
-# head SHA (via the commits/{sha}/pulls API), never from the untrusted artifact —
-# so a crafted artifact can't redirect the comment onto a different PR.
+# Security:
+#   - The comment markdown is produced here from trusted code + a handful of
+#     validated integers (ConvertTo-SafeMeasurements drops unknown keys and any
+#     non-integer/negative byte value, and uses trusted labels) — the untrusted
+#     artifact can never inject markdown into a bot-authored comment.
+#   - The target PR is resolved from the TRUSTED github.event.workflow_run head SHA
+#     (via commits/{sha}/pulls), never from the artifact.
 name: Build metrics comment
 
 on:
@@ -20,7 +24,7 @@ on:
 permissions:
   contents: read
   actions: read          # download the triggering run's artifact
-  pull-requests: write   # post/update the comment
+  pull-requests: read    # resolve the PR from the trusted head SHA
   issues: write          # PR conversation comments use the issues API
 
 jobs:
@@ -32,9 +36,16 @@ jobs:
       github.event.workflow_run.event == 'pull_request' ||
       github.event.workflow_run.event == 'workflow_dispatch'
     steps:
-      # Pull just the comment artifact from the triggering run. If the measure job
-      # never uploaded one (e.g. cancelled before render), exit quietly.
-      - name: Download comment artifact
+      # Trusted default-branch checkout — the source of the comment renderer.
+      # workflow_run always runs the default-branch version of this workflow, and
+      # this checkout (no ref) pulls the default branch, NEVER the PR's code.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Pull just the size-data artifact from the triggering run. If the measure
+      # job never uploaded one (e.g. cancelled before upload), exit quietly.
+      - name: Download size data artifact
         id: dl
         env:
           GH_TOKEN: ${{ github.token }}
@@ -42,19 +53,20 @@ jobs:
           RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set +e
-          gh run download "$RUN_ID" --repo "$GH_REPO" -n build-metrics-comment -D artifact
-          if [ ! -f artifact/comment.md ]; then
-            echo "No build-metrics-comment artifact on run $RUN_ID; nothing to post."
-            echo "have_comment=false" >> "$GITHUB_OUTPUT"
+          gh run download "$RUN_ID" --repo "$GH_REPO" -n build-metrics-data -D artifact
+          if [ ! -f artifact/head.sizes.json ] && [ ! -f artifact/pr.txt ]; then
+            echo "No build-metrics-data artifact on run $RUN_ID; nothing to post."
+            echo "have_data=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "have_comment=true" >> "$GITHUB_OUTPUT"
+          echo "have_data=true" >> "$GITHUB_OUTPUT"
 
-      # Resolve the PR from the trusted workflow_run head SHA. For a manual
-      # dispatch (write-access only) we fall back to the artifact's pr.txt.
+      # Resolve the PR from the trusted workflow_run head SHA (fork-safe). For a
+      # manual dispatch (write-access only) fall back to the artifact's pr.txt.
+      # Also read the PR's trusted head/base SHAs for the comment header.
       - name: Resolve target PR
         id: pr
-        if: steps.dl.outputs.have_comment == 'true'
+        if: steps.dl.outputs.have_data == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -63,35 +75,70 @@ jobs:
         run: |
           pr=""
           if [ "$RUN_EVENT" = "pull_request" ]; then
-            # Open PR whose head commit is exactly this run's (trusted) head SHA.
             pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
                    --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
           fi
           if { [ -z "$pr" ] || [ "$pr" = "null" ]; } && [ "$RUN_EVENT" = "workflow_dispatch" ] && [ -f artifact/pr.txt ]; then
-            # Manual dispatch is restricted to users with write access, so the
-            # artifact-provided number is trusted here.
             pr=$(tr -dc '0-9' < artifact/pr.txt)
           fi
           if [ -z "$pr" ] || [ "$pr" = "null" ]; then
             echo "Could not resolve an open PR for head $HEAD_SHA; nothing to post."
             echo "number=" >> "$GITHUB_OUTPUT"
-          else
-            echo "Target PR: #$pr"
-            echo "number=$pr" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "Target PR: #$pr"
+          headsha=$(gh api "repos/$GH_REPO/pulls/$pr" --jq '.head.sha' 2>/dev/null || true)
+          basesha=$(gh api "repos/$GH_REPO/pulls/$pr" --jq '.base.sha' 2>/dev/null || true)
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$headsha" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$basesha" >> "$GITHUB_OUTPUT"
+
+      # Render the comment from TRUSTED code + validated numbers. The untrusted
+      # sizes.json is passed through ConvertTo-SafeMeasurements, which keeps only
+      # known keys, uses trusted labels, and accepts only non-negative integer
+      # byte counts — so nothing from the artifact can inject markdown.
+      - name: Render comment (trusted)
+        if: steps.dl.outputs.have_data == 'true' && steps.pr.outputs.number != ''
+        shell: pwsh
+        env:
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          . ./tests/build_metrics/ci/BuildMetricsLib.ps1
+          $headRaw = if (Test-Path artifact/head.sizes.json) { Get-Content artifact/head.sizes.json -Raw | ConvertFrom-Json } else { $null }
+          $baseRaw = if (Test-Path artifact/base.sizes.json) { Get-Content artifact/base.sizes.json -Raw | ConvertFrom-Json } else { $null }
+          $head = ConvertTo-SafeMeasurements $headRaw
+          $base = ConvertTo-SafeMeasurements $baseRaw
+          $headHasSizes = (@($head | Where-Object { $null -ne $_.Bytes }).Count -gt 0)
+          $baseHasSizes = (@($base | Where-Object { $null -ne $_.Bytes }).Count -gt 0)
+          if ($headHasSizes -and $baseHasSizes) {
+            $body = Format-BuildMetricsComment -BaseMeasurements $base -HeadMeasurements $head `
+              -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
+          } elseif ($headHasSizes) {
+            $body = Format-BuildMetricsComment -HeadMeasurements $head -BaselineUnavailable `
+              -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
+          } else {
+            $body = Format-BuildMetricsComment -Failed -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
+          }
+          New-Item -ItemType Directory -Force -Path out | Out-Null
+          Set-Content -LiteralPath out/comment.md -Value $body -Encoding UTF8
+          Write-Host "Rendered comment ($($body.Length) chars); headHasSizes=$headHasSizes baseHasSizes=$baseHasSizes"
 
       - name: Post / update sticky comment
-        if: steps.dl.outputs.have_comment == 'true' && steps.pr.outputs.number != ''
+        if: steps.dl.outputs.have_data == 'true' && steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
           marker='<!-- reactor-build-metrics -->'
-          file=artifact/comment.md
+          file=out/comment.md
+          # --paginate emits per-page results, so select matching ids across ALL
+          # pages and take the first — never assign a multi-line value to $existing.
           existing=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
-                       --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id" || true)
-          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+                       --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1 || true)
+          if [ -n "$existing" ]; then
             echo "Updating existing comment $existing"
             gh api -X PATCH "repos/$GH_REPO/issues/comments/$existing" -F "body=@$file" >/dev/null
           else

--- a/.github/workflows/build-metrics-comment.yml
+++ b/.github/workflows/build-metrics-comment.yml
@@ -90,6 +90,12 @@ jobs:
             exit 0
           fi
           echo "Target PR: #$pr"
+          # Validate the base SHA (40 hex chars); if the lookup returned null/empty,
+          # emit an empty value so the renderer shows "base branch" without a stray
+          # "(null)" in the header.
+          if ! printf '%s' "$basesha" | grep -Eq '^[0-9a-f]{40}$'; then
+            basesha=""
+          fi
           echo "number=$pr" >> "$GITHUB_OUTPUT"
           echo "base_sha=$basesha" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-metrics-comment.yml
+++ b/.github/workflows/build-metrics-comment.yml
@@ -1,0 +1,100 @@
+# Privileged poster for the automatic build-metrics comment.
+#
+# The measure workflow (build-metrics.yml) builds untrusted PR code, so it runs
+# unprivileged and only uploads the rendered comment as an artifact. This workflow
+# runs from the DEFAULT branch with a write token, executes NO PR code, downloads
+# that artifact, and posts/updates the sticky "Build metrics" comment. This is the
+# standard secure `pull_request` + `workflow_run` split for commenting on PRs
+# (including forks) without exposing a write token to build code.
+#
+# Security: the target PR is resolved from the TRUSTED github.event.workflow_run
+# head SHA (via the commits/{sha}/pulls API), never from the untrusted artifact —
+# so a crafted artifact can't redirect the comment onto a different PR.
+name: Build metrics comment
+
+on:
+  workflow_run:
+    workflows: ["Build metrics"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read          # download the triggering run's artifact
+  pull-requests: write   # post/update the comment
+  issues: write          # PR conversation comments use the issues API
+
+jobs:
+  comment:
+    name: Post size-diff comment
+    runs-on: ubuntu-latest
+    # Only PR-originated (or manually dispatched) measure runs produce a PR comment.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' ||
+      github.event.workflow_run.event == 'workflow_dispatch'
+    steps:
+      # Pull just the comment artifact from the triggering run. If the measure job
+      # never uploaded one (e.g. cancelled before render), exit quietly.
+      - name: Download comment artifact
+        id: dl
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set +e
+          gh run download "$RUN_ID" --repo "$GH_REPO" -n build-metrics-comment -D artifact
+          if [ ! -f artifact/comment.md ]; then
+            echo "No build-metrics-comment artifact on run $RUN_ID; nothing to post."
+            echo "have_comment=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "have_comment=true" >> "$GITHUB_OUTPUT"
+
+      # Resolve the PR from the trusted workflow_run head SHA. For a manual
+      # dispatch (write-access only) we fall back to the artifact's pr.txt.
+      - name: Resolve target PR
+        id: pr
+        if: steps.dl.outputs.have_comment == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr=""
+          if [ "$RUN_EVENT" = "pull_request" ]; then
+            # Open PR whose head commit is exactly this run's (trusted) head SHA.
+            pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
+                   --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
+          fi
+          if { [ -z "$pr" ] || [ "$pr" = "null" ]; } && [ "$RUN_EVENT" = "workflow_dispatch" ] && [ -f artifact/pr.txt ]; then
+            # Manual dispatch is restricted to users with write access, so the
+            # artifact-provided number is trusted here.
+            pr=$(tr -dc '0-9' < artifact/pr.txt)
+          fi
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "Could not resolve an open PR for head $HEAD_SHA; nothing to post."
+            echo "number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Target PR: #$pr"
+            echo "number=$pr" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post / update sticky comment
+        if: steps.dl.outputs.have_comment == 'true' && steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          marker='<!-- reactor-build-metrics -->'
+          file=artifact/comment.md
+          existing=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
+                       --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id" || true)
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            echo "Updating existing comment $existing"
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$existing" -F "body=@$file" >/dev/null
+          else
+            echo "Creating new sticky comment on #$PR_NUMBER"
+            gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" -F "body=@$file" >/dev/null
+          fi

--- a/.github/workflows/build-metrics-comment.yml
+++ b/.github/workflows/build-metrics-comment.yml
@@ -136,8 +136,10 @@ jobs:
           file=out/comment.md
           # --paginate emits per-page results, so select matching ids across ALL
           # pages and take the first — never assign a multi-line value to $existing.
+          # Restrict to OUR bot's own comments so a PR author can't plant a
+          # marker-prefixed comment and have us PATCH (hijack) it.
           existing=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
-                       --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1 || true)
+                       --jq ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | startswith(\"$marker\")) | .id" | head -n1 || true)
           if [ -n "$existing" ]; then
             echo "Updating existing comment $existing"
             gh api -X PATCH "repos/$GH_REPO/issues/comments/$existing" -F "body=@$file" >/dev/null

--- a/.github/workflows/build-metrics-comment.yml
+++ b/.github/workflows/build-metrics-comment.yml
@@ -54,16 +54,18 @@ jobs:
         run: |
           set +e
           gh run download "$RUN_ID" --repo "$GH_REPO" -n build-metrics-data -D artifact
-          if [ ! -f artifact/head.sizes.json ] && [ ! -f artifact/pr.txt ]; then
+          if [ ! -f artifact/head.sizes.json ]; then
             echo "No build-metrics-data artifact on run $RUN_ID; nothing to post."
             echo "have_data=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "have_data=true" >> "$GITHUB_OUTPUT"
 
-      # Resolve the PR from the trusted workflow_run head SHA (fork-safe). For a
-      # manual dispatch (write-access only) fall back to the artifact's pr.txt.
-      # Also read the PR's trusted head/base SHAs for the comment header.
+      # Resolve the PR SOLELY from the trusted workflow_run head SHA — never from
+      # the (untrusted) artifact. commits/{sha}/pulls returns the PR's number and
+      # base sha in one trusted call. For a workflow_dispatch run (head = default
+      # branch) this yields no PR, so no comment is posted (the numbers still live
+      # in the run's artifact) — the manual path is measure-only by design.
       - name: Resolve target PR
         id: pr
         if: steps.dl.outputs.have_data == 'true'
@@ -73,35 +75,35 @@ jobs:
           RUN_EVENT: ${{ github.event.workflow_run.event }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          pr=""
-          if [ "$RUN_EVENT" = "pull_request" ]; then
-            pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
-                   --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
+          if [ "$RUN_EVENT" != "pull_request" ]; then
+            echo "Non-PR run ($RUN_EVENT); nothing to post."
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-          if { [ -z "$pr" ] || [ "$pr" = "null" ]; } && [ "$RUN_EVENT" = "workflow_dispatch" ] && [ -f artifact/pr.txt ]; then
-            pr=$(tr -dc '0-9' < artifact/pr.txt)
-          fi
+          pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
+                 --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
+          basesha=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
+                 --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].base.sha" 2>/dev/null || true)
           if [ -z "$pr" ] || [ "$pr" = "null" ]; then
-            echo "Could not resolve an open PR for head $HEAD_SHA; nothing to post."
+            echo "No open PR for head $HEAD_SHA; nothing to post."
             echo "number=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "Target PR: #$pr"
-          headsha=$(gh api "repos/$GH_REPO/pulls/$pr" --jq '.head.sha' 2>/dev/null || true)
-          basesha=$(gh api "repos/$GH_REPO/pulls/$pr" --jq '.base.sha' 2>/dev/null || true)
           echo "number=$pr" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$headsha" >> "$GITHUB_OUTPUT"
           echo "base_sha=$basesha" >> "$GITHUB_OUTPUT"
 
       # Render the comment from TRUSTED code + validated numbers. The untrusted
       # sizes.json is passed through ConvertTo-SafeMeasurements, which keeps only
       # known keys, uses trusted labels, and accepts only non-negative integer
-      # byte counts — so nothing from the artifact can inject markdown.
+      # byte counts — so nothing from the artifact can inject markdown. The head
+      # SHA is the trusted workflow_run head (exactly what was measured); the base
+      # SHA comes from the same trusted commits/{sha}/pulls lookup.
       - name: Render comment (trusted)
         if: steps.dl.outputs.have_data == 'true' && steps.pr.outputs.number != ''
         shell: pwsh
         env:
-          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           BASE_SHA: ${{ steps.pr.outputs.base_sha }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |

--- a/.github/workflows/build-metrics-comment.yml
+++ b/.github/workflows/build-metrics-comment.yml
@@ -62,9 +62,9 @@ jobs:
           echo "have_data=true" >> "$GITHUB_OUTPUT"
 
       # Resolve the PR SOLELY from the trusted workflow_run head SHA — never from
-      # the (untrusted) artifact. commits/{sha}/pulls returns the PR's number and
-      # base sha in one trusted call. The job `if` already restricts this to
-      # pull_request-originated runs.
+      # the (untrusted) artifact. One commits/{sha}/pulls call returns the PR object,
+      # from which we read the number + base sha. The job `if` already restricts
+      # this to pull_request-originated runs.
       - name: Resolve target PR
         id: pr
         if: steps.dl.outputs.have_data == 'true'
@@ -73,11 +73,11 @@ jobs:
           GH_REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
-                 --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
-          basesha=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
-                 --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].base.sha" 2>/dev/null || true)
-          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+          pr_json=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
+                 --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0]" 2>/dev/null || true)
+          pr=$(printf '%s' "$pr_json" | jq -r '.number // empty' 2>/dev/null || true)
+          basesha=$(printf '%s' "$pr_json" | jq -r '.base.sha // empty' 2>/dev/null || true)
+          if [ -z "$pr" ]; then
             echo "No open PR for head $HEAD_SHA; nothing to post."
             echo "number=" >> "$GITHUB_OUTPUT"
             exit 0
@@ -107,8 +107,16 @@ jobs:
           RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
           . ./tests/build_metrics/ci/BuildMetricsLib.ps1
-          $headRaw = if (Test-Path artifact/head.sizes.json) { Get-Content artifact/head.sizes.json -Raw | ConvertFrom-Json } else { $null }
-          $baseRaw = if (Test-Path artifact/base.sizes.json) { Get-Content artifact/base.sizes.json -Raw | ConvertFrom-Json } else { $null }
+          # The sizes.json are untrusted artifacts; a malformed file must not crash
+          # the poster (which would drop the comment entirely) — treat a parse
+          # failure as missing data so the failed/baseline-unavailable paths render.
+          function Read-SizesJson($path) {
+            if (-not (Test-Path $path)) { return $null }
+            try { return Get-Content $path -Raw | ConvertFrom-Json }
+            catch { Write-Host "Ignoring malformed ${path}: $($_.Exception.Message)"; return $null }
+          }
+          $headRaw = Read-SizesJson 'artifact/head.sizes.json'
+          $baseRaw = Read-SizesJson 'artifact/base.sizes.json'
           $head = ConvertTo-SafeMeasurements $headRaw
           $base = ConvertTo-SafeMeasurements $baseRaw
           $headHasSizes = (@($head | Where-Object { $null -ne $_.Bytes }).Count -gt 0)

--- a/.github/workflows/build-metrics-comment.yml
+++ b/.github/workflows/build-metrics-comment.yml
@@ -31,10 +31,10 @@ jobs:
   comment:
     name: Post size-diff comment
     runs-on: ubuntu-latest
-    # Only PR-originated (or manually dispatched) measure runs produce a PR comment.
-    if: >-
-      github.event.workflow_run.event == 'pull_request' ||
-      github.event.workflow_run.event == 'workflow_dispatch'
+    # Only PR-originated measure runs produce a comment. A workflow_dispatch measure
+    # run has no PR to safely resolve from its head SHA, so skip the poster entirely
+    # (the numbers still live in that run's artifact).
+    if: github.event.workflow_run.event == 'pull_request'
     steps:
       # Trusted default-branch checkout — the source of the comment renderer.
       # workflow_run always runs the default-branch version of this workflow, and
@@ -63,23 +63,16 @@ jobs:
 
       # Resolve the PR SOLELY from the trusted workflow_run head SHA — never from
       # the (untrusted) artifact. commits/{sha}/pulls returns the PR's number and
-      # base sha in one trusted call. For a workflow_dispatch run (head = default
-      # branch) this yields no PR, so no comment is posted (the numbers still live
-      # in the run's artifact) — the manual path is measure-only by design.
+      # base sha in one trusted call. The job `if` already restricts this to
+      # pull_request-originated runs.
       - name: Resolve target PR
         id: pr
         if: steps.dl.outputs.have_data == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RUN_EVENT: ${{ github.event.workflow_run.event }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [ "$RUN_EVENT" != "pull_request" ]; then
-            echo "Non-PR run ($RUN_EVENT); nothing to post."
-            echo "number=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
                  --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
           basesha=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \

--- a/.github/workflows/build-metrics-lib-tests.yml
+++ b/.github/workflows/build-metrics-lib-tests.yml
@@ -32,7 +32,11 @@ jobs:
           persist-credentials: false
 
       # pwsh (PowerShell 7) is preinstalled on the GitHub-hosted Ubuntu runner.
-      # BuildMetricsLib.Tests.ps1 exits non-zero on any failed assertion.
+      # Each test script exits non-zero on any failed assertion.
       - name: Run BuildMetricsLib unit tests
         shell: pwsh
         run: ./tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+
+      - name: Run Measure-BuildMetrics unit tests
+        shell: pwsh
+        run: ./tests/build_metrics/ci/Measure-BuildMetrics.Tests.ps1

--- a/.github/workflows/build-metrics-lib-tests.yml
+++ b/.github/workflows/build-metrics-lib-tests.yml
@@ -1,0 +1,38 @@
+# Fast, headless unit tests for BuildMetricsLib.ps1 — the pure byte-format /
+# delta / comment-renderer that backs the automatic build-metrics comment
+# (build-metrics.yml). No build and no external test framework, so this runs on a
+# cheap Linux runner in seconds and guards the formatting + delta logic on every
+# change under tests/build_metrics/ci/**.
+#
+# build-metrics.yml runs these same assertions before it spends ~10 min packing;
+# this standalone job gives PR authors fast feedback without a full measure run.
+name: Build metrics lib tests
+
+on:
+  push:
+    paths:
+      - 'tests/build_metrics/ci/**'
+      - '.github/workflows/build-metrics-lib-tests.yml'
+  pull_request:
+    paths:
+      - 'tests/build_metrics/ci/**'
+      - '.github/workflows/build-metrics-lib-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  buildmetricslib:
+    name: BuildMetricsLib format + delta math
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # pwsh (PowerShell 7) is preinstalled on the GitHub-hosted Ubuntu runner.
+      # BuildMetricsLib.Tests.ps1 exits non-zero on any failed assertion.
+      - name: Run BuildMetricsLib unit tests
+        shell: pwsh
+        run: ./tests/build_metrics/ci/BuildMetricsLib.Tests.ps1

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -12,11 +12,13 @@
 # ── Why two workflows (measure here, comment in build-metrics-comment.yml) ─────
 # This job BUILDS PR-authored code (`dotnet pack` runs the PR's MSBuild), so it
 # must stay unprivileged: it runs in the `pull_request` context with a read-only
-# token and NO ability to comment. It uploads the rendered comment as an artifact;
-# the privileged `build-metrics-comment.yml` (`workflow_run`) posts it. That split
-# is the standard secure pattern for commenting on PRs — including from forks —
-# without ever handing a write token to untrusted build code. It mirrors the
-# trust boundary in perf-compare.yml, but runs automatically instead of on `/perf`.
+# token and NO ability to comment. It uploads ONLY the machine-readable size data
+# (head/base sizes.json); the privileged `build-metrics-comment.yml`
+# (`workflow_run`) checks out trusted code, validates those numbers, and renders +
+# posts the comment. That split is the standard secure pattern for commenting on
+# PRs — including from forks — without ever handing a write token to untrusted
+# build code, and without letting untrusted code produce the comment markdown. It
+# mirrors the trust boundary in perf-compare.yml, but runs automatically.
 name: Build metrics
 
 on:
@@ -83,6 +85,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_NUMBER_EVENT: ${{ github.event.pull_request.number }}
           PR_NUMBER_INPUT: ${{ github.event.inputs.pr_number }}
         run: |
@@ -90,21 +93,27 @@ jobs:
             $pr = $env:PR_NUMBER_EVENT
             $head = $env:PR_HEAD_SHA
             $base = $env:PR_BASE_SHA
+            $baseRef = $env:PR_BASE_REF
           } else {
             $pr = $env:PR_NUMBER_INPUT
             if ($pr -notmatch '^[1-9][0-9]*$') { throw "Invalid pr_number input '$pr' (expected a positive integer)." }
             $json = gh api "repos/$env:GH_REPO/pulls/$pr" | ConvertFrom-Json
             $head = $json.head.sha
             $base = $json.base.sha
+            $baseRef = $json.base.ref
           }
           if ($head -notmatch '^[0-9a-f]{40}$') { throw "Could not resolve head sha (got '$head')." }
           if ($base -notmatch '^[0-9a-f]{40}$') { throw "Could not resolve base sha (got '$base')." }
-          Write-Host "PR #$pr  head=$head  base=$base"
+          if ([string]::IsNullOrWhiteSpace($baseRef)) { throw "Could not resolve base ref." }
+          Write-Host "PR #$pr  head=$head  base=$base ($baseRef)"
 
-          # Fetch both commits. The head (incl. forks) lives at refs/pull/N/head;
-          # the base is on the base branch. Anonymous fetch — no token needed.
+          # Fetch both commits so we can build each in a worktree. The head (incl.
+          # forks) lives at refs/pull/N/head. Fetch the base by its BRANCH REF, not
+          # its raw SHA: `git fetch origin <sha>` is rejected unless the server
+          # advertises that object, whereas the branch ref is always fetchable and
+          # the base commit is an ancestor of it. Anonymous fetch — no token needed.
           git fetch --no-tags --force origin "pull/$pr/head" 2>&1 | Out-Host
-          git fetch --no-tags --force origin $base 2>&1 | Out-Host
+          git fetch --no-tags --force origin "refs/heads/${baseRef}:refs/remotes/origin/${baseRef}" 2>&1 | Out-Host
 
           $headTree = Join-Path $env:RUNNER_TEMP 'head-tree'
           $baseTree = Join-Path $env:RUNNER_TEMP 'base-tree'
@@ -146,16 +155,14 @@ jobs:
       # comment body — a PR could otherwise make the privileged poster publish
       # arbitrary markdown. It uploads ONLY the machine-readable sizes.json. The
       # privileged workflow_run poster (build-metrics-comment.yml) checks out
-      # trusted default-branch code, validates these numbers against a fixed target
-      # spec, and renders + posts the comment. pr.txt is a diagnostic hint only
-      # (the poster resolves the PR from the trusted workflow_run head SHA).
-      - name: Record PR number
+      # trusted default-branch code, resolves the PR from the trusted workflow_run
+      # head SHA (never from this artifact), validates these numbers against a fixed
+      # target spec, and renders + posts the comment. Ensure the output dir exists
+      # even if both measure steps failed before writing.
+      - name: Ensure output dir
         if: always()
         shell: pwsh
-        run: |
-          $outDir = Join-Path $env:GITHUB_WORKSPACE 'build-metrics-out'
-          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
-          Set-Content -LiteralPath (Join-Path $outDir 'pr.txt') -Value "${{ steps.resolve.outputs.pr }}" -Encoding UTF8
+        run: New-Item -ItemType Directory -Force -Path (Join-Path $env:GITHUB_WORKSPACE 'build-metrics-out') | Out-Null
 
       - name: Upload size data artifact
         if: always()
@@ -165,6 +172,5 @@ jobs:
           path: |
             build-metrics-out/head.sizes.json
             build-metrics-out/base.sizes.json
-            build-metrics-out/pr.txt
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -23,10 +23,12 @@ name: Build metrics
 
 on:
   pull_request:
-    # docs/guide/** is generated (see release.yml); a docs-only PR ships no
-    # binaries, so skip the ~10-min double build for it.
+    # docs/guide/** is generated (see release.yml); doc-only changes (incl. the
+    # docs/_pipeline templates + doc apps that generate them) ship no binaries, so
+    # skip the ~10-min double build for them.
     paths-ignore:
       - 'docs/guide/**'
+      - 'docs/_pipeline/**'
       - '**/*.md'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -63,10 +63,13 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      # Cheap guard: unit-test the pure renderer before spending minutes packing.
-      - name: Test BuildMetricsLib (parser + renderer)
+      # Cheap guard: unit-test the pure renderer + orchestrator helpers before
+      # spending minutes packing.
+      - name: Test build-metrics scripts
         shell: pwsh
-        run: ./tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+        run: |
+          ./tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+          ./tests/build_metrics/ci/Measure-BuildMetrics.Tests.ps1
 
       # Resolve the PR's head + base SHAs. For pull_request they come straight
       # from the event; for a manual dispatch we read them from the API (works
@@ -139,55 +142,29 @@ jobs:
             -OutFile "${{ github.workspace }}/build-metrics-out/base.sizes.json" `
             -PackOutput "${{ runner.temp }}/base-nupkg"
 
-      # Render the sticky comment body. Always runs: if the head measurement
-      # produced no sizes it emits a "build failed" comment instead of tables, so
-      # the poster always has something to write.
-      - name: Render comment
+      # SECURITY: this job builds untrusted PR code, so it must NOT render the
+      # comment body — a PR could otherwise make the privileged poster publish
+      # arbitrary markdown. It uploads ONLY the machine-readable sizes.json. The
+      # privileged workflow_run poster (build-metrics-comment.yml) checks out
+      # trusted default-branch code, validates these numbers against a fixed target
+      # spec, and renders + posts the comment. pr.txt is a diagnostic hint only
+      # (the poster resolves the PR from the trusted workflow_run head SHA).
+      - name: Record PR number
         if: always()
         shell: pwsh
-        env:
-          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
-          BASE_SHA: ${{ steps.resolve.outputs.base_sha }}
-          PR_NUMBER: ${{ steps.resolve.outputs.pr }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          . ./tests/build_metrics/ci/BuildMetricsLib.ps1
           $outDir = Join-Path $env:GITHUB_WORKSPACE 'build-metrics-out'
           New-Item -ItemType Directory -Force -Path $outDir | Out-Null
-          $headFile = Join-Path $outDir 'head.sizes.json'
-          $baseFile = Join-Path $outDir 'base.sizes.json'
+          Set-Content -LiteralPath (Join-Path $outDir 'pr.txt') -Value "${{ steps.resolve.outputs.pr }}" -Encoding UTF8
 
-          $head = if (Test-Path $headFile) { Get-Content $headFile -Raw | ConvertFrom-Json } else { $null }
-          $base = if (Test-Path $baseFile) { Get-Content $baseFile -Raw | ConvertFrom-Json } else { $null }
-          # A head/base with no real sizes (all null) means that side's build failed.
-          $headHasSizes = $head -and (@($head | Where-Object { $null -ne $_.Bytes }).Count -gt 0)
-          $baseHasSizes = $base -and (@($base | Where-Object { $null -ne $_.Bytes }).Count -gt 0)
-
-          if ($headHasSizes -and $baseHasSizes) {
-            $body = Format-BuildMetricsComment -BaseMeasurements $base -HeadMeasurements $head `
-              -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
-          } elseif ($headHasSizes) {
-            # PR built, base (main) did not — show absolute PR sizes, no delta.
-            $body = Format-BuildMetricsComment -HeadMeasurements $head -BaselineUnavailable `
-              -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
-          } else {
-            $body = Format-BuildMetricsComment -Failed -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
-          }
-          Set-Content -LiteralPath (Join-Path $outDir 'comment.md') -Value $body -Encoding UTF8
-          # The poster derives the PR from the trusted workflow_run head SHA, but
-          # we drop the number in too as a diagnostic aid.
-          Set-Content -LiteralPath (Join-Path $outDir 'pr.txt') -Value $env:PR_NUMBER -Encoding UTF8
-          Write-Host "Rendered comment ($($body.Length) chars); headHasSizes=$headHasSizes"
-
-      - name: Upload comment artifact
+      - name: Upload size data artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: build-metrics-comment
+          name: build-metrics-data
           path: |
-            build-metrics-out/comment.md
-            build-metrics-out/pr.txt
             build-metrics-out/head.sizes.json
             build-metrics-out/base.sizes.json
+            build-metrics-out/pr.txt
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -2,7 +2,7 @@
 #
 # ── What it does ──────────────────────────────────────────────────────────────
 # On every PR commit this builds + packs the shipped Reactor NuGet packages twice
-# — once at the PR head, once at the PR base (`main`) — measures each artifact's
+# — once at the PR head, once at the PR base branch — measures each artifact's
 # size, and renders a sticky "Build metrics" comment showing the size delta.
 # Informational only: it never fails the PR.
 #
@@ -143,7 +143,7 @@ jobs:
             -OutFile "${{ github.workspace }}/build-metrics-out/head.sizes.json" `
             -PackOutput "${{ runner.temp }}/head-nupkg"
 
-      - name: Measure base (main)
+      - name: Measure base branch
         id: base
         continue-on-error: true
         shell: pwsh

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -92,7 +92,7 @@ jobs:
             $base = $env:PR_BASE_SHA
           } else {
             $pr = $env:PR_NUMBER_INPUT
-            if ($pr -notmatch '^\d+$') { throw "Invalid pr_number input '$pr' (expected a positive integer)." }
+            if ($pr -notmatch '^[1-9][0-9]*$') { throw "Invalid pr_number input '$pr' (expected a positive integer)." }
             $json = gh api "repos/$env:GH_REPO/pulls/$pr" | ConvertFrom-Json
             $head = $json.head.sha
             $base = $json.base.sha

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -1,0 +1,193 @@
+# Automatic build-metrics (artifact size-diff) comment on every PR.
+#
+# ── What it does ──────────────────────────────────────────────────────────────
+# On every PR commit this builds + packs the shipped Reactor NuGet packages twice
+# — once at the PR head, once at the PR base (`main`) — measures each artifact's
+# size, and renders a sticky "Build metrics" comment showing the size delta.
+# Informational only: it never fails the PR.
+#
+#   Packages (compressed .nupkg)   the download size a consumer pays
+#   Assemblies (uncompressed)      the real "did our code grow" signal
+#
+# ── Why two workflows (measure here, comment in build-metrics-comment.yml) ─────
+# This job BUILDS PR-authored code (`dotnet pack` runs the PR's MSBuild), so it
+# must stay unprivileged: it runs in the `pull_request` context with a read-only
+# token and NO ability to comment. It uploads the rendered comment as an artifact;
+# the privileged `build-metrics-comment.yml` (`workflow_run`) posts it. That split
+# is the standard secure pattern for commenting on PRs — including from forks —
+# without ever handing a write token to untrusted build code. It mirrors the
+# trust boundary in perf-compare.yml, but runs automatically instead of on `/perf`.
+name: Build metrics
+
+on:
+  pull_request:
+    # docs/guide/** is generated (see release.yml); a docs-only PR ships no
+    # binaries, so skip the ~10-min double build for it.
+    paths-ignore:
+      - 'docs/guide/**'
+      - '**/*.md'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to measure against its base branch.
+        required: true
+        type: string
+
+# One in-flight run per PR; a newer commit supersedes an older run.
+concurrency:
+  group: build-metrics-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.ref }}
+  cancel-in-progress: true
+
+# Read-only: this job runs untrusted PR build code and must not hold a write
+# token. The comment is posted by the separate privileged workflow_run workflow.
+# pull-requests: read only serves the manual workflow_dispatch path (resolving a
+# PR's head/base via the API); the automatic pull_request path uses the event.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  measure:
+    name: Measure artifact sizes
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          # PR-authored build code runs later; don't leave a git credential on disk.
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: 10.0.x
+
+      # Cheap guard: unit-test the pure renderer before spending minutes packing.
+      - name: Test BuildMetricsLib (parser + renderer)
+        shell: pwsh
+        run: ./tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+
+      # Resolve the PR's head + base SHAs. For pull_request they come straight
+      # from the event; for a manual dispatch we read them from the API (works
+      # for forks). Both commits are fetched so we can build each in a worktree.
+      - name: Resolve head + base
+        id: resolve
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_NUMBER_EVENT: ${{ github.event.pull_request.number }}
+          PR_NUMBER_INPUT: ${{ github.event.inputs.pr_number }}
+        run: |
+          if ($env:EVENT_NAME -eq 'pull_request') {
+            $pr = $env:PR_NUMBER_EVENT
+            $head = $env:PR_HEAD_SHA
+            $base = $env:PR_BASE_SHA
+          } else {
+            $pr = $env:PR_NUMBER_INPUT
+            if ($pr -notmatch '^\d+$') { throw "Invalid pr_number input '$pr' (expected a positive integer)." }
+            $json = gh api "repos/$env:GH_REPO/pulls/$pr" | ConvertFrom-Json
+            $head = $json.head.sha
+            $base = $json.base.sha
+          }
+          if ($head -notmatch '^[0-9a-f]{40}$') { throw "Could not resolve head sha (got '$head')." }
+          if ($base -notmatch '^[0-9a-f]{40}$') { throw "Could not resolve base sha (got '$base')." }
+          Write-Host "PR #$pr  head=$head  base=$base"
+
+          # Fetch both commits. The head (incl. forks) lives at refs/pull/N/head;
+          # the base is on the base branch. Anonymous fetch — no token needed.
+          git fetch --no-tags --force origin "pull/$pr/head" 2>&1 | Out-Host
+          git fetch --no-tags --force origin $base 2>&1 | Out-Host
+
+          $headTree = Join-Path $env:RUNNER_TEMP 'head-tree'
+          $baseTree = Join-Path $env:RUNNER_TEMP 'base-tree'
+          foreach ($t in @($headTree, $baseTree)) {
+            if (Test-Path $t) { git worktree remove --force $t 2>&1 | Out-Host }
+          }
+          git worktree add --force --detach $headTree $head 2>&1 | Out-Host
+          git worktree add --force --detach $baseTree $base 2>&1 | Out-Host
+
+          "pr=$pr"             | Out-File $env:GITHUB_OUTPUT -Append
+          "head_sha=$head"     | Out-File $env:GITHUB_OUTPUT -Append
+          "base_sha=$base"     | Out-File $env:GITHUB_OUTPUT -Append
+          "head_tree=$headTree" | Out-File $env:GITHUB_OUTPUT -Append
+          "base_tree=$baseTree" | Out-File $env:GITHUB_OUTPUT -Append
+
+      # Build + pack + measure each side. continue-on-error so a build failure
+      # still reaches the render step, which emits a "failed" comment body.
+      - name: Measure PR head
+        id: head
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          ./tests/build_metrics/ci/Measure-BuildMetrics.ps1 `
+            -Root "${{ steps.resolve.outputs.head_tree }}" `
+            -OutFile "${{ github.workspace }}/build-metrics-out/head.sizes.json" `
+            -PackOutput "${{ runner.temp }}/head-nupkg"
+
+      - name: Measure base (main)
+        id: base
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          ./tests/build_metrics/ci/Measure-BuildMetrics.ps1 `
+            -Root "${{ steps.resolve.outputs.base_tree }}" `
+            -OutFile "${{ github.workspace }}/build-metrics-out/base.sizes.json" `
+            -PackOutput "${{ runner.temp }}/base-nupkg"
+
+      # Render the sticky comment body. Always runs: if the head measurement
+      # produced no sizes it emits a "build failed" comment instead of tables, so
+      # the poster always has something to write.
+      - name: Render comment
+        if: always()
+        shell: pwsh
+        env:
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+          BASE_SHA: ${{ steps.resolve.outputs.base_sha }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          . ./tests/build_metrics/ci/BuildMetricsLib.ps1
+          $outDir = Join-Path $env:GITHUB_WORKSPACE 'build-metrics-out'
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+          $headFile = Join-Path $outDir 'head.sizes.json'
+          $baseFile = Join-Path $outDir 'base.sizes.json'
+
+          $head = if (Test-Path $headFile) { Get-Content $headFile -Raw | ConvertFrom-Json } else { $null }
+          $base = if (Test-Path $baseFile) { Get-Content $baseFile -Raw | ConvertFrom-Json } else { $null }
+          # A head/base with no real sizes (all null) means that side's build failed.
+          $headHasSizes = $head -and (@($head | Where-Object { $null -ne $_.Bytes }).Count -gt 0)
+          $baseHasSizes = $base -and (@($base | Where-Object { $null -ne $_.Bytes }).Count -gt 0)
+
+          if ($headHasSizes -and $baseHasSizes) {
+            $body = Format-BuildMetricsComment -BaseMeasurements $base -HeadMeasurements $head `
+              -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
+          } elseif ($headHasSizes) {
+            # PR built, base (main) did not — show absolute PR sizes, no delta.
+            $body = Format-BuildMetricsComment -HeadMeasurements $head -BaselineUnavailable `
+              -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
+          } else {
+            $body = Format-BuildMetricsComment -Failed -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
+          }
+          Set-Content -LiteralPath (Join-Path $outDir 'comment.md') -Value $body -Encoding UTF8
+          # The poster derives the PR from the trusted workflow_run head SHA, but
+          # we drop the number in too as a diagnostic aid.
+          Set-Content -LiteralPath (Join-Path $outDir 'pr.txt') -Value $env:PR_NUMBER -Encoding UTF8
+          Write-Host "Rendered comment ($($body.Length) chars); headHasSizes=$headHasSizes"
+
+      - name: Upload comment artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-metrics-comment
+          path: |
+            build-metrics-out/comment.md
+            build-metrics-out/pr.txt
+            build-metrics-out/head.sizes.json
+            build-metrics-out/base.sizes.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -131,8 +131,9 @@ jobs:
           "head_tree=$headTree" | Out-File $env:GITHUB_OUTPUT -Append
           "base_tree=$baseTree" | Out-File $env:GITHUB_OUTPUT -Append
 
-      # Build + pack + measure each side. continue-on-error so a build failure
-      # still reaches the render step, which emits a "failed" comment body.
+      # Build + pack + measure each side. continue-on-error so a failing build
+      # doesn't abort the job — the upload + trusted poster still run, and the
+      # poster renders a "build failed" comment when no real sizes were produced.
       - name: Measure PR head
         id: head
         continue-on-error: true

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,96 @@
+# Privileged poster for the automatic coverage comment.
+#
+# The measure workflow (coverage.yml) builds + runs untrusted PR code, so it runs
+# unprivileged and only uploads the rendered comment as an artifact. This workflow
+# runs from the DEFAULT branch with a write token, executes NO PR code, downloads
+# that artifact, and posts/updates the sticky coverage comment. Standard secure
+# `pull_request` + `workflow_run` split (see coverage.yml + build-metrics.yml).
+#
+# Security: the target PR is resolved from the TRUSTED github.event.workflow_run
+# head SHA (via the commits/{sha}/pulls API), never from the untrusted artifact.
+name: Coverage comment
+
+on:
+  workflow_run:
+    workflows: ["Coverage"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read          # download the triggering run's artifact
+  pull-requests: write   # post/update the comment
+  issues: write          # PR conversation comments use the issues API
+
+jobs:
+  comment:
+    name: Post coverage comment
+    runs-on: ubuntu-latest
+    # Blank-input dispatch runs measure a branch with no PR; they write to the
+    # job summary only, so only PR / dispatched-PR runs produce a comment here.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' ||
+      github.event.workflow_run.event == 'workflow_dispatch'
+    steps:
+      - name: Download comment artifact
+        id: dl
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set +e
+          gh run download "$RUN_ID" --repo "$GH_REPO" -n coverage-comment -D artifact
+          if [ ! -f artifact/comment.md ]; then
+            echo "No coverage-comment artifact on run $RUN_ID; nothing to post."
+            echo "have_comment=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "have_comment=true" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve target PR
+        id: pr
+        if: steps.dl.outputs.have_comment == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr=""
+          if [ "$RUN_EVENT" = "pull_request" ]; then
+            # Open PR whose head commit is exactly this run's (trusted) head SHA.
+            pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
+                   --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
+          fi
+          if { [ -z "$pr" ] || [ "$pr" = "null" ]; } && [ "$RUN_EVENT" = "workflow_dispatch" ] && [ -f artifact/pr.txt ]; then
+            # Manual dispatch is restricted to users with write access, so the
+            # artifact-provided number is trusted here. A blank pr.txt (branch
+            # run) leaves $pr empty and nothing is posted.
+            pr=$(tr -dc '0-9' < artifact/pr.txt)
+          fi
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "Could not resolve an open PR for head $HEAD_SHA; nothing to post."
+            echo "number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Target PR: #$pr"
+            echo "number=$pr" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post / update sticky comment
+        if: steps.dl.outputs.have_comment == 'true' && steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          marker='<!-- reactor-coverage -->'
+          file=artifact/comment.md
+          existing=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
+                       --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id" || true)
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            echo "Updating existing comment $existing"
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$existing" -F "body=@$file" >/dev/null
+          else
+            echo "Creating new sticky comment on #$PR_NUMBER"
+            gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" -F "body=@$file" >/dev/null
+          fi

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -26,11 +26,10 @@ jobs:
   comment:
     name: Post coverage comment
     runs-on: ubuntu-latest
-    # Blank-input dispatch runs measure a branch with no PR (summary only), so only
-    # PR / dispatched-PR runs produce a comment here.
-    if: >-
-      github.event.workflow_run.event == 'pull_request' ||
-      github.event.workflow_run.event == 'workflow_dispatch'
+    # Only PR-originated measure runs produce a comment. A workflow_dispatch measure
+    # run has no PR to safely resolve from its head SHA, so skip the poster entirely
+    # (the numbers still live in that run's artifact + summary).
+    if: github.event.workflow_run.event == 'pull_request'
     steps:
       - name: Download coverage data artifact
         id: dl
@@ -49,22 +48,15 @@ jobs:
           echo "have_data=true" >> "$GITHUB_OUTPUT"
 
       # Resolve the PR SOLELY from the trusted workflow_run head SHA — never from
-      # the (untrusted) artifact. A workflow_dispatch run (head = default branch)
-      # yields no PR, so the manual path is measure-only (result in the run summary).
+      # the (untrusted) artifact.
       - name: Resolve target PR
         id: pr
         if: steps.dl.outputs.have_data == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RUN_EVENT: ${{ github.event.workflow_run.event }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [ "$RUN_EVENT" != "pull_request" ]; then
-            echo "Non-PR run ($RUN_EVENT); nothing to post."
-            echo "number=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
                  --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
           if [ -z "$pr" ] || [ "$pr" = "null" ]; then

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -7,8 +7,9 @@
 # Standard secure pull_request + workflow_run split (see coverage.yml).
 #
 # Security: the comment body is built here from a fixed template + numeric values
-# that are re-validated (digits only) before use; the target PR is resolved from
-# the TRUSTED github.event.workflow_run head SHA, never from the artifact.
+# that are re-validated (a non-negative number, optionally with a decimal part)
+# before use; the target PR is resolved from the TRUSTED
+# github.event.workflow_run head SHA, never from the artifact.
 name: Coverage comment
 
 on:

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -48,6 +48,9 @@ jobs:
           fi
           echo "have_data=true" >> "$GITHUB_OUTPUT"
 
+      # Resolve the PR SOLELY from the trusted workflow_run head SHA — never from
+      # the (untrusted) artifact. A workflow_dispatch run (head = default branch)
+      # yields no PR, so the manual path is measure-only (result in the run summary).
       - name: Resolve target PR
         id: pr
         if: steps.dl.outputs.have_data == 'true'
@@ -57,16 +60,15 @@ jobs:
           RUN_EVENT: ${{ github.event.workflow_run.event }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          pr=""
-          if [ "$RUN_EVENT" = "pull_request" ]; then
-            pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
-                   --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
+          if [ "$RUN_EVENT" != "pull_request" ]; then
+            echo "Non-PR run ($RUN_EVENT); nothing to post."
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-          if { [ -z "$pr" ] || [ "$pr" = "null" ]; } && [ "$RUN_EVENT" = "workflow_dispatch" ] && [ -f artifact/pr.txt ]; then
-            pr=$(tr -dc '0-9' < artifact/pr.txt)
-          fi
+          pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
+                 --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
           if [ -z "$pr" ] || [ "$pr" = "null" ]; then
-            echo "Could not resolve an open PR for head $HEAD_SHA; nothing to post."
+            echo "No open PR for head $HEAD_SHA; nothing to post."
             echo "number=" >> "$GITHUB_OUTPUT"
           else
             echo "Target PR: #$pr"

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -135,8 +135,10 @@ jobs:
           file=out/comment.md
           # --paginate emits per-page results, so select matching ids across ALL
           # pages and take the first — never assign a multi-line value to $existing.
+          # Restrict to OUR bot's own comments so a PR author can't plant a
+          # marker-prefixed comment and have us PATCH (hijack) it.
           existing=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
-                       --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1 || true)
+                       --jq ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | startswith(\"$marker\")) | .id" | head -n1 || true)
           if [ -n "$existing" ]; then
             echo "Updating existing comment $existing"
             gh api -X PATCH "repos/$GH_REPO/issues/comments/$existing" -F "body=@$file" >/dev/null

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,13 +1,14 @@
 # Privileged poster for the automatic coverage comment.
 #
 # The measure workflow (coverage.yml) builds + runs untrusted PR code, so it runs
-# unprivileged and only uploads the rendered comment as an artifact. This workflow
-# runs from the DEFAULT branch with a write token, executes NO PR code, downloads
-# that artifact, and posts/updates the sticky coverage comment. Standard secure
-# `pull_request` + `workflow_run` split (see coverage.yml + build-metrics.yml).
+# unprivileged and uploads ONLY the coverage numbers (coverage.json). This workflow
+# runs from the DEFAULT branch with a write token, executes NO PR code, RENDERS the
+# comment itself from validated numbers, and posts/updates the sticky comment.
+# Standard secure pull_request + workflow_run split (see coverage.yml).
 #
-# Security: the target PR is resolved from the TRUSTED github.event.workflow_run
-# head SHA (via the commits/{sha}/pulls API), never from the untrusted artifact.
+# Security: the comment body is built here from a fixed template + numeric values
+# that are re-validated (digits only) before use; the target PR is resolved from
+# the TRUSTED github.event.workflow_run head SHA, never from the artifact.
 name: Coverage comment
 
 on:
@@ -18,20 +19,20 @@ on:
 permissions:
   contents: read
   actions: read          # download the triggering run's artifact
-  pull-requests: write   # post/update the comment
+  pull-requests: read    # resolve the PR from the trusted head SHA
   issues: write          # PR conversation comments use the issues API
 
 jobs:
   comment:
     name: Post coverage comment
     runs-on: ubuntu-latest
-    # Blank-input dispatch runs measure a branch with no PR; they write to the
-    # job summary only, so only PR / dispatched-PR runs produce a comment here.
+    # Blank-input dispatch runs measure a branch with no PR (summary only), so only
+    # PR / dispatched-PR runs produce a comment here.
     if: >-
       github.event.workflow_run.event == 'pull_request' ||
       github.event.workflow_run.event == 'workflow_dispatch'
     steps:
-      - name: Download comment artifact
+      - name: Download coverage data artifact
         id: dl
         env:
           GH_TOKEN: ${{ github.token }}
@@ -39,17 +40,17 @@ jobs:
           RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set +e
-          gh run download "$RUN_ID" --repo "$GH_REPO" -n coverage-comment -D artifact
-          if [ ! -f artifact/comment.md ]; then
-            echo "No coverage-comment artifact on run $RUN_ID; nothing to post."
-            echo "have_comment=false" >> "$GITHUB_OUTPUT"
+          gh run download "$RUN_ID" --repo "$GH_REPO" -n coverage-data -D artifact
+          if [ ! -f artifact/coverage.json ]; then
+            echo "No coverage-data artifact on run $RUN_ID; nothing to post."
+            echo "have_data=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "have_comment=true" >> "$GITHUB_OUTPUT"
+          echo "have_data=true" >> "$GITHUB_OUTPUT"
 
       - name: Resolve target PR
         id: pr
-        if: steps.dl.outputs.have_comment == 'true'
+        if: steps.dl.outputs.have_data == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -58,14 +59,10 @@ jobs:
         run: |
           pr=""
           if [ "$RUN_EVENT" = "pull_request" ]; then
-            # Open PR whose head commit is exactly this run's (trusted) head SHA.
             pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
                    --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
           fi
           if { [ -z "$pr" ] || [ "$pr" = "null" ]; } && [ "$RUN_EVENT" = "workflow_dispatch" ] && [ -f artifact/pr.txt ]; then
-            # Manual dispatch is restricted to users with write access, so the
-            # artifact-provided number is trusted here. A blank pr.txt (branch
-            # run) leaves $pr empty and nothing is posted.
             pr=$(tr -dc '0-9' < artifact/pr.txt)
           fi
           if [ -z "$pr" ] || [ "$pr" = "null" ]; then
@@ -76,18 +73,71 @@ jobs:
             echo "number=$pr" >> "$GITHUB_OUTPUT"
           fi
 
+      # Render the comment from a FIXED template + numbers re-validated as digits.
+      - name: Render comment (trusted)
+        id: render
+        if: steps.dl.outputs.have_data == 'true' && steps.pr.outputs.number != ''
+        shell: pwsh
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          $d = Get-Content artifact/coverage.json -Raw | ConvertFrom-Json
+          function SafeNum($v) {
+            if ($null -eq $v) { return $null }
+            $s = ([string]$v).Trim()
+            if ($s -match '^\d+(\.\d+)?$') { return $s } else { return $null }
+          }
+          $line = SafeNum $d.line
+          $branch = SafeNum $d.branch
+          $bc = SafeNum $d.branchesCovered
+          $bt = SafeNum $d.branchesTotal
+          $sha = $env:HEAD_SHA
+          $sha7 = if ($sha) { $sha.Substring(0, [math]::Min(7, $sha.Length)) } else { 'unknown' }
+          $marker = '<!-- reactor-coverage -->'
+          $ok = ($d.outcome -eq 'success') -and ($null -ne $line) -and ($null -ne $branch)
+          if ($ok) {
+            $branchCell = if ($null -ne $bc -and $null -ne $bt) { "$branch% ($bc/$bt)" } else { "$branch%" }
+            $body = @(
+              $marker,
+              '## 🧪 Merged coverage',
+              '',
+              "Coverage for ``$sha7`` (unit + selftest).",
+              '',
+              '| Metric | Coverage |',
+              '|---|---|',
+              "| Line   | $line% |",
+              "| Branch | $branchCell |",
+              '',
+              "<sub>Cobertura reports attached to the <a href=`"$env:RUN_URL`">workflow run</a> as artifacts.</sub>"
+            ) -join "`n"
+          } else {
+            $body = @(
+              $marker,
+              '## 🧪 Merged coverage',
+              '',
+              '> [!CAUTION]',
+              "> Coverage run failed for ``$sha7`` — see the [workflow run]($env:RUN_URL) for details."
+            ) -join "`n"
+          }
+          New-Item -ItemType Directory -Force -Path out | Out-Null
+          Set-Content -LiteralPath out/comment.md -Value $body -Encoding UTF8
+          Write-Host "Rendered coverage comment (ok=$ok)"
+
       - name: Post / update sticky comment
-        if: steps.dl.outputs.have_comment == 'true' && steps.pr.outputs.number != ''
+        if: steps.dl.outputs.have_data == 'true' && steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
           marker='<!-- reactor-coverage -->'
-          file=artifact/comment.md
+          file=out/comment.md
+          # --paginate emits per-page results, so select matching ids across ALL
+          # pages and take the first — never assign a multi-line value to $existing.
           existing=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
-                       --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id" || true)
-          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+                       --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1 || true)
+          if [ -n "$existing" ]; then
             echo "Updating existing comment $existing"
             gh api -X PATCH "repos/$GH_REPO/issues/comments/$existing" -F "body=@$file" >/dev/null
           else

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -68,7 +68,8 @@ jobs:
             echo "number=$pr" >> "$GITHUB_OUTPUT"
           fi
 
-      # Render the comment from a FIXED template + numbers re-validated as digits.
+      # Render the comment from a FIXED template + numbers re-validated here (a
+      # non-negative number, optionally with a decimal part).
       - name: Render comment (trusted)
         id: render
         if: steps.dl.outputs.have_data == 'true' && steps.pr.outputs.number != ''
@@ -77,20 +78,27 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
-          $d = Get-Content artifact/coverage.json -Raw | ConvertFrom-Json
+          # coverage.json is an untrusted artifact; a malformed file must not crash
+          # the poster (which would drop the comment). Fall back to an empty object
+          # so the CAUTION "run failed" path renders.
+          try { $d = Get-Content artifact/coverage.json -Raw | ConvertFrom-Json }
+          catch { Write-Host "Malformed coverage.json: $($_.Exception.Message)"; $d = [pscustomobject]@{} }
+          function Get-Prop($obj, $name) {
+            if ($obj.PSObject.Properties[$name]) { return $obj.$name } else { return $null }
+          }
           function SafeNum($v) {
             if ($null -eq $v) { return $null }
             $s = ([string]$v).Trim()
             if ($s -match '^\d+(\.\d+)?$') { return $s } else { return $null }
           }
-          $line = SafeNum $d.line
-          $branch = SafeNum $d.branch
-          $bc = SafeNum $d.branchesCovered
-          $bt = SafeNum $d.branchesTotal
+          $line = SafeNum (Get-Prop $d 'line')
+          $branch = SafeNum (Get-Prop $d 'branch')
+          $bc = SafeNum (Get-Prop $d 'branchesCovered')
+          $bt = SafeNum (Get-Prop $d 'branchesTotal')
           $sha = $env:HEAD_SHA
           $sha7 = if ($sha) { $sha.Substring(0, [math]::Min(7, $sha.Length)) } else { 'unknown' }
           $marker = '<!-- reactor-coverage -->'
-          $ok = ($d.outcome -eq 'success') -and ($null -ne $line) -and ($null -ne $branch)
+          $ok = ((Get-Prop $d 'outcome') -eq 'success') -and ($null -ne $line) -and ($null -ne $branch)
           if ($ok) {
             $branchCell = if ($null -ne $bc -and $null -ne $bt) { "$branch% ($bc/$bt)" } else { "$branch%" }
             $body = @(

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -221,15 +221,12 @@ jobs:
               branchesTotal: BRANCHES_TOTAL || '',
               outcome: OUTCOME || '',
             }));
-            fs.writeFileSync('coverage-out/pr.txt', String(PR_NUMBER || ''));
 
       - name: Upload coverage data artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-data
-          path: |
-            coverage-out/coverage.json
-            coverage-out/pr.txt
+          path: coverage-out/coverage.json
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,15 +15,15 @@ name: Coverage
 # hand a write token to untrusted PR code, which is unsafe.
 #
 # Instead this workflow runs in the unprivileged `pull_request` context: a
-# read-only token, no secrets, and NO ability to comment. It renders the result
-# and uploads it as an artifact; the privileged `coverage-comment.yml`
-# (`workflow_run`) posts the sticky comment. That split runs untrusted build code
-# with zero write privilege and still comments on PRs — including from forks. It
-# mirrors build-metrics.yml and the trust boundary documented in perf-compare.yml.
+# read-only token, no secrets, and NO ability to comment. It writes the result to
+# the run summary and uploads ONLY the raw coverage numbers; the privileged
+# `coverage-comment.yml` (`workflow_run`) checks out trusted code, renders the
+# comment, and posts it. That split runs untrusted build code with zero write
+# privilege and still comments on PRs — including from forks. It mirrors
+# build-metrics.yml and the trust boundary documented in perf-compare.yml.
 
 on:
   pull_request:
-    # Doc-only PRs change no measured code; skip the ~10-min instrumented run.
     # Doc-only PRs change no measured code; skip the ~10-min instrumented run.
     # This includes the docs/_pipeline templates + doc apps that generate the guide.
     paths-ignore:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,22 +1,32 @@
 name: Coverage
 
-# Maintainer-gated coverage run, all paths running the merged unit + selftest
-# coverage recipe from TESTING.md. Trigger it three ways:
-#   - comment `@codecoverage` on a PR — posts the result back as a PR comment;
-#   - run it manually (Actions tab / `gh workflow run`) with a PR number — same,
-#     and works for forks via refs/pull/N/head;
-#   - run it manually with the PR number left blank — measures the selected
-#     branch and writes the result to the run's job summary (no PR to comment on).
+# Automatic merged unit + selftest coverage on every PR, posted as a sticky,
+# self-updating comment. Runs the merged coverage recipe from TESTING.md and
+# reports line + branch rates. Also runnable manually:
+#   - workflow_dispatch with a PR number  -> measures that PR (works for forks);
+#   - workflow_dispatch with the number blank -> measures the selected branch and
+#     writes the result to the run's job summary (no PR to comment on).
 #
-# Security: `issue_comment` workflows run in the base repo with full token
-# permissions. Untrusted code from the PR (build scripts, tests) executes here.
-# The `author_association` check below limits the comment trigger to maintainers;
-# `workflow_dispatch` is inherently restricted to users with write access. Either
-# way, the triggerer is expected to review the PR diff before starting a run.
+# ── Security: why pull_request + workflow_run (not issue_comment) ──────────────
+# Coverage BUILDS + INSTRUMENTS + RUNS the PR's code (build scripts and tests
+# execute here). The old design triggered on `issue_comment` — which runs in the
+# base repo with a full write token — so it had to be gated to maintainers via
+# author_association. Running it automatically on every PR under that model would
+# hand a write token to untrusted PR code, which is unsafe.
+#
+# Instead this workflow runs in the unprivileged `pull_request` context: a
+# read-only token, no secrets, and NO ability to comment. It renders the result
+# and uploads it as an artifact; the privileged `coverage-comment.yml`
+# (`workflow_run`) posts the sticky comment. That split runs untrusted build code
+# with zero write privilege and still comments on PRs — including from forks. It
+# mirrors build-metrics.yml and the trust boundary documented in perf-compare.yml.
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    # Doc-only PRs change no measured code; skip the ~10-min instrumented run.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/guide/**'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -24,85 +34,69 @@ on:
         required: false
         type: string
 
+# Read-only: this job runs untrusted PR code and must not hold a write token.
+# The comment is posted by the separate privileged workflow_run workflow.
+# pull-requests: read only serves the manual workflow_dispatch path (resolving a
+# PR's head sha via the API); the automatic pull_request path uses the event.
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   coverage:
     name: Merged coverage
     # One in-flight run per target — a PR number, or the branch ref for a
-    # blank-input dispatch. A newer trigger supersedes an older one. Job-level
-    # (not workflow-level) concurrency so unrelated issue_comment events — which
-    # start a workflow run but skip this job — don't cancel a live coverage run.
+    # blank-input dispatch. A newer trigger supersedes an older one.
     concurrency:
-      group: coverage-${{ github.event.issue.number || github.event.inputs.pr_number || github.ref }}
+      group: coverage-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.ref }}
       cancel-in-progress: true
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@codecoverage') &&
-       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: windows-latest
     steps:
-      - name: Acknowledge with reaction
-        if: github.event_name == 'issue_comment'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes',
-            });
-
       - name: Resolve coverage target
         id: pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          EVENT_NAME: ${{ github.event_name }}
           DISPATCH_PR: ${{ github.event.inputs.pr_number }}
         with:
           script: |
             // Resolve what to measure:
-            //   - issue_comment             -> the PR the comment is on
-            //   - workflow_dispatch + PR#   -> that PR (works for forks)
-            //   - workflow_dispatch, blank  -> the dispatched branch (no PR)
+            //   - pull_request             -> the PR that triggered the run
+            //   - workflow_dispatch + PR#  -> that PR (works for forks)
+            //   - workflow_dispatch, blank -> the dispatched branch (no PR)
             let prNumber = '';
-            if (context.eventName === 'workflow_dispatch') {
+            if (context.eventName === 'pull_request') {
+              const pr = context.payload.pull_request;
+              prNumber = String(pr.number);
+              core.setOutput('sha', pr.head.sha);
+              // Build the PR head commit; refs/pull/N/head resolves for forks too.
+              core.setOutput('ref', `refs/pull/${pr.number}/head`);
+            } else {
               const raw = process.env.DISPATCH_PR || '';
               if (raw !== '') {
-                // Validate without trimming so the resolved PR stays identical to
-                // the raw value the job-level concurrency group keys on.
                 if (!/^[1-9][0-9]*$/.test(raw)) {
                   throw new Error(`Invalid pr_number input '${process.env.DISPATCH_PR}' (expected a positive integer, or leave it blank to measure the selected branch)`);
                 }
                 prNumber = raw;
+                const pr = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: Number(prNumber),
+                });
+                core.setOutput('sha', pr.data.head.sha);
+                core.setOutput('ref', `refs/pull/${prNumber}/head`);
+              } else {
+                // No PR: measure the commit the workflow was dispatched on.
+                core.setOutput('sha', context.sha);
+                core.setOutput('ref', context.sha);
               }
-            } else {
-              prNumber = String(context.issue.number);
             }
-            // Emit the number before the API call so the always()-gated report
-            // step can still post back to the PR if pulls.get below fails.
             core.setOutput('number', prNumber);
-            if (prNumber !== '') {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: Number(prNumber),
-              });
-              core.setOutput('sha', pr.data.head.sha);
-              core.setOutput('ref', `refs/pull/${prNumber}/head`);
-            } else {
-              // No PR: measure the commit the workflow was dispatched on.
-              core.setOutput('sha', context.sha);
-              core.setOutput('ref', context.sha);
-            }
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ steps.pr.outputs.ref }}
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -184,7 +178,10 @@ jobs:
           "branches-covered=$covered" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "branches-total=$total"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      - name: Report results
+      # Render the sticky comment body + write it to the job summary and to an
+      # artifact for the poster. Always runs so a failed measurement still
+      # produces a "coverage run failed" comment. This job never comments itself.
+      - name: Render results
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -197,35 +194,50 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
+            const fs = require('fs');
             const { LINE, BRANCH, BRANCHES_COVERED, BRANCHES_TOTAL, SHA, OUTCOME, PR_NUMBER } = process.env;
+            const marker = '<!-- reactor-coverage -->';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const shaLabel = SHA ? SHA.slice(0, 7) : 'unknown';
             let body;
             if (OUTCOME === 'success') {
               body = [
-                `**Merged coverage** for \`${shaLabel}\` (unit + selftest)`,
+                marker,
+                `## 🧪 Merged coverage`,
+                ``,
+                `Coverage for \`${shaLabel}\` (unit + selftest).`,
                 ``,
                 `| Metric | Coverage |`,
                 `|---|---|`,
                 `| Line   | ${LINE}% |`,
                 `| Branch | ${BRANCH}% (${BRANCHES_COVERED}/${BRANCHES_TOTAL}) |`,
                 ``,
-                `Cobertura reports attached to the [workflow run](${runUrl}) as artifacts.`,
+                `<sub>Cobertura reports attached to the <a href="${runUrl}">workflow run</a> as artifacts.</sub>`,
               ].join('\n');
             } else {
-              body = `**Coverage run failed** for \`${shaLabel}\` — see the [workflow run](${runUrl}) for details.`;
+              body = [
+                marker,
+                `## 🧪 Merged coverage`,
+                ``,
+                `> [!CAUTION]`,
+                `> Coverage run failed for \`${shaLabel}\` — see the [workflow run](${runUrl}) for details.`,
+              ].join('\n');
             }
             // Always surface the result in the run summary — this is the only
             // output for a branch run (blank-input dispatch, no PR to comment on).
             await core.summary.addRaw(body).write();
-            const prNumber = Number(PR_NUMBER);
-            if (!Number.isInteger(prNumber) || prNumber <= 0) {
-              core.info('No PR resolved (branch run); result written to the job summary only.');
-              return;
-            }
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body,
-            });
+            // Hand the body + PR number to the poster via an artifact.
+            fs.mkdirSync('coverage-out', { recursive: true });
+            fs.writeFileSync('coverage-out/comment.md', body);
+            fs.writeFileSync('coverage-out/pr.txt', String(PR_NUMBER || ''));
+
+      - name: Upload comment artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-comment
+          path: |
+            coverage-out/comment.md
+            coverage-out/pr.txt
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,9 +24,12 @@ name: Coverage
 on:
   pull_request:
     # Doc-only PRs change no measured code; skip the ~10-min instrumented run.
+    # Doc-only PRs change no measured code; skip the ~10-min instrumented run.
+    # This includes the docs/_pipeline templates + doc apps that generate the guide.
     paths-ignore:
       - '**/*.md'
       - 'docs/guide/**'
+      - 'docs/_pipeline/**'
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -181,9 +181,6 @@ jobs:
           "branches-covered=$covered" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "branches-total=$total"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      # Render the sticky comment body + write it to the job summary and to an
-      # artifact for the poster. Always runs so a failed measurement still
-      # produces a "coverage run failed" comment. This job never comments itself.
       # SECURITY: this job runs untrusted PR code, so it must NOT render the PR
       # comment body. It writes the human-readable result to the RUN SUMMARY
       # (informational, not a privileged PR post) and uploads the raw numbers as

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -181,7 +181,13 @@ jobs:
       # Render the sticky comment body + write it to the job summary and to an
       # artifact for the poster. Always runs so a failed measurement still
       # produces a "coverage run failed" comment. This job never comments itself.
-      - name: Render results
+      # SECURITY: this job runs untrusted PR code, so it must NOT render the PR
+      # comment body. It writes the human-readable result to the RUN SUMMARY
+      # (informational, not a privileged PR post) and uploads the raw numbers as
+      # coverage.json. The privileged workflow_run poster (coverage-comment.yml)
+      # checks out trusted code, validates the numbers, and renders + posts the
+      # sticky comment. Always runs so a failed run still yields a data file.
+      - name: Emit coverage data
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -196,48 +202,34 @@ jobs:
           script: |
             const fs = require('fs');
             const { LINE, BRANCH, BRANCHES_COVERED, BRANCHES_TOTAL, SHA, OUTCOME, PR_NUMBER } = process.env;
-            const marker = '<!-- reactor-coverage -->';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const shaLabel = SHA ? SHA.slice(0, 7) : 'unknown';
-            let body;
-            if (OUTCOME === 'success') {
-              body = [
-                marker,
-                `## 🧪 Merged coverage`,
-                ``,
-                `Coverage for \`${shaLabel}\` (unit + selftest).`,
-                ``,
-                `| Metric | Coverage |`,
-                `|---|---|`,
-                `| Line   | ${LINE}% |`,
-                `| Branch | ${BRANCH}% (${BRANCHES_COVERED}/${BRANCHES_TOTAL}) |`,
-                ``,
-                `<sub>Cobertura reports attached to the <a href="${runUrl}">workflow run</a> as artifacts.</sub>`,
-              ].join('\n');
-            } else {
-              body = [
-                marker,
-                `## 🧪 Merged coverage`,
-                ``,
-                `> [!CAUTION]`,
-                `> Coverage run failed for \`${shaLabel}\` — see the [workflow run](${runUrl}) for details.`,
-              ].join('\n');
-            }
-            // Always surface the result in the run summary — this is the only
-            // output for a branch run (blank-input dispatch, no PR to comment on).
-            await core.summary.addRaw(body).write();
-            // Hand the body + PR number to the poster via an artifact.
+            // Run-summary body — the only output for a branch run (blank-input
+            // dispatch, no PR). Not a PR comment, so rendering it here is fine.
+            const summary = OUTCOME === 'success'
+              ? [`## 🧪 Merged coverage`, ``, `Coverage for \`${shaLabel}\` (unit + selftest).`, ``,
+                 `| Metric | Coverage |`, `|---|---|`, `| Line   | ${LINE}% |`,
+                 `| Branch | ${BRANCH}% (${BRANCHES_COVERED}/${BRANCHES_TOTAL}) |`].join('\n')
+              : `## 🧪 Merged coverage\n\nCoverage run failed for \`${shaLabel}\` — see the [workflow run](${runUrl}).`;
+            await core.summary.addRaw(summary).write();
+            // Machine-readable data for the trusted poster to render + post.
             fs.mkdirSync('coverage-out', { recursive: true });
-            fs.writeFileSync('coverage-out/comment.md', body);
+            fs.writeFileSync('coverage-out/coverage.json', JSON.stringify({
+              line: LINE || '',
+              branch: BRANCH || '',
+              branchesCovered: BRANCHES_COVERED || '',
+              branchesTotal: BRANCHES_TOTAL || '',
+              outcome: OUTCOME || '',
+            }));
             fs.writeFileSync('coverage-out/pr.txt', String(PR_NUMBER || ''));
 
-      - name: Upload comment artifact
+      - name: Upload coverage data artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-comment
+          name: coverage-data
           path: |
-            coverage-out/comment.md
+            coverage-out/coverage.json
             coverage-out/pr.txt
           if-no-files-found: warn
           retention-days: 14

--- a/TESTING.md
+++ b/TESTING.md
@@ -235,13 +235,19 @@ Replace `$(RuntimeIdentifier)` with `ARM64` or `x64`, or omit the platform segme
 
 You don't have to run the merge locally — the **Coverage** workflow
 (`.github/workflows/coverage.yml`) runs this same unit + selftest recipe and
-reports the merged line/branch numbers. Trigger it any of these ways:
+reports the merged line/branch numbers.
 
-- **Comment trigger:** a maintainer comments `@codecoverage` on a PR. The result
-  is posted back as a PR comment.
+- **Automatic on every PR:** it runs on each PR commit and posts the merged
+  line/branch numbers as a **sticky comment** that updates in place on new
+  commits. No action needed — it just works. (Doc-only PRs are skipped.)
 - **Manual trigger (PR):** use **Actions → Coverage → Run workflow** and enter the
-  PR number, or run `gh workflow run coverage.yml -f pr_number=<PR>`. Same PR
+  PR number, or run `gh workflow run coverage.yml -f pr_number=<PR>`. Same sticky
   comment output; works for forks too.
 - **Manual trigger (branch):** run it with the PR number left **blank** to measure
   the selected branch — e.g. `gh workflow run coverage.yml --ref main`. With no PR
   to comment on, the numbers are written to the run's **job summary** instead.
+
+The measurement runs in the unprivileged `pull_request` context (it builds and
+runs PR code, so it holds no write token); the comment is posted by the separate
+privileged `coverage-comment.yml` (`workflow_run`). See that workflow's header for
+the security rationale.

--- a/TESTING.md
+++ b/TESTING.md
@@ -241,13 +241,16 @@ reports the merged line/branch numbers.
   line/branch numbers as a **sticky comment** that updates in place on new
   commits. No action needed — it just works. (Doc-only PRs are skipped.)
 - **Manual trigger (PR):** use **Actions → Coverage → Run workflow** and enter the
-  PR number, or run `gh workflow run coverage.yml -f pr_number=<PR>`. Same sticky
-  comment output; works for forks too.
+  PR number, or run `gh workflow run coverage.yml -f pr_number=<PR>`. This measures
+  that PR (works for forks) and writes the result to the run's **job summary** —
+  it does not post a PR comment (the poster only comments for automatic
+  `pull_request` runs, where the PR is resolved from the trusted head SHA).
 - **Manual trigger (branch):** run it with the PR number left **blank** to measure
-  the selected branch — e.g. `gh workflow run coverage.yml --ref main`. With no PR
-  to comment on, the numbers are written to the run's **job summary** instead.
+  the selected branch — e.g. `gh workflow run coverage.yml --ref main`. The numbers
+  are written to the run's **job summary**.
 
 The measurement runs in the unprivileged `pull_request` context (it builds and
-runs PR code, so it holds no write token); the comment is posted by the separate
-privileged `coverage-comment.yml` (`workflow_run`). See that workflow's header for
-the security rationale.
+runs PR code, so it holds no write token) and uploads only the raw numbers; the
+privileged `coverage-comment.yml` (`workflow_run`) checks out trusted code,
+renders the comment, and posts it, resolving the target PR from the trusted
+`workflow_run` head SHA. See that workflow's header for the security rationale.

--- a/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
@@ -1,0 +1,197 @@
+<#
+.SYNOPSIS
+    Dependency-free unit tests for BuildMetricsLib.ps1 (the pure byte-format /
+    delta / renderer used by the automatic build-metrics PR comment).
+
+.DESCRIPTION
+    Runs headless with no build and no external test framework, so it is safe on
+    any runner (it is wired into .github/workflows/build-metrics-lib-tests.yml on
+    changes under tests/build_metrics/ci/**). Exits non-zero if any assertion fails.
+
+    Run locally:  pwsh tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'BuildMetricsLib.ps1')
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -eq $Actual) {
+        $script:Pass++
+    } else {
+        $script:Fail++
+        $script:Failures.Add("$Message`n    expected: [$Expected]`n    actual:   [$Actual]")
+    }
+}
+
+function Assert-Null {
+    param($Actual, [string]$Message)
+    if ($null -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: <null>`n    actual:   [$Actual]") }
+}
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add($Message) }
+}
+
+function Assert-Match {
+    param([string]$Haystack, [string]$Needle, [string]$Message)
+    if ($Haystack -like "*$Needle*") { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    missing substring: [$Needle]") }
+}
+
+function Assert-NotMatch {
+    param([string]$Haystack, [string]$Needle, [string]$Message)
+    if ($Haystack -notlike "*$Needle*") { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    unexpected substring: [$Needle]") }
+}
+
+# ── Format-ByteSize ──────────────────────────────────────────────────────────
+Assert-Equal 'n/a'      (Format-ByteSize $null) 'null bytes -> n/a'
+Assert-Equal '0 B'      (Format-ByteSize 0)     'zero bytes'
+Assert-Equal '512 B'    (Format-ByteSize 512)   'sub-KB stays in bytes'
+Assert-Equal '1023 B'   (Format-ByteSize 1023)  'just under 1 KB stays in bytes'
+Assert-Equal '1.00 KB'  (Format-ByteSize 1024)  '1024 -> 1.00 KB'
+Assert-Equal '1.50 KB'  (Format-ByteSize 1536)  '1.5 KB'
+Assert-Equal '10.0 KB'  (Format-ByteSize 10240) '>=10 uses 1 decimal'
+Assert-Equal '1.00 MB'  (Format-ByteSize (1024 * 1024))       '1 MB'
+Assert-Equal '2.50 MB'  (Format-ByteSize ([long](2.5 * 1024 * 1024))) '2.5 MB'
+Assert-Equal '-1.00 KB' (Format-ByteSize -1024) 'negative keeps sign'
+
+# ── Format-SignedByteSize ────────────────────────────────────────────────────
+Assert-Equal '+1.00 KB' (Format-SignedByteSize 1024)  'positive gets +'
+Assert-Equal '+0 B'     (Format-SignedByteSize 0)     'zero gets +'
+Assert-Equal '-1.00 KB' (Format-SignedByteSize -1024) 'negative keeps -'
+Assert-Equal 'n/a'      (Format-SignedByteSize $null) 'null -> n/a'
+
+# ── Get-SizeDelta ────────────────────────────────────────────────────────────
+$d = Get-SizeDelta -BaseBytes 100000 -HeadBytes 110000
+Assert-Equal 'grew'  $d.Status     'growth beyond band -> grew'
+Assert-Equal 10000   $d.DeltaBytes 'grew delta bytes'
+Assert-Equal 10      $d.DeltaPct   'grew delta pct (10%)'
+Assert-True  (-not $d.Improved)    'grew is not an improvement'
+
+$d = Get-SizeDelta -BaseBytes 110000 -HeadBytes 100000
+Assert-Equal 'shrank' $d.Status     'shrink beyond band -> shrank'
+Assert-Equal -10000   $d.DeltaBytes 'shrank delta bytes (negative)'
+Assert-True  $d.Improved            'shrank is the improvement'
+
+# Below both floors -> unchanged (but delta still reported).
+$d = Get-SizeDelta -BaseBytes 1000000 -HeadBytes 1000010
+Assert-Equal 'unchanged' $d.Status     'tiny delta -> unchanged'
+Assert-Equal 10          $d.DeltaBytes 'unchanged still reports the delta'
+Assert-Null  $d.Improved               'unchanged has no improvement flag'
+
+# Clears percent but not the byte floor -> unchanged (both floors must clear).
+$d = Get-SizeDelta -BaseBytes 100 -HeadBytes 140
+Assert-Equal 'unchanged' $d.Status 'clears pct but under 64B byte floor -> unchanged'
+
+# Clears the byte floor but not the percent floor -> unchanged.
+$d = Get-SizeDelta -BaseBytes 100000000 -HeadBytes 100000100
+Assert-Equal 'unchanged' $d.Status 'clears bytes but under 0.05% floor -> unchanged'
+
+# Added / removed / na.
+$d = Get-SizeDelta -BaseBytes $null -HeadBytes 5000
+Assert-Equal 'added' $d.Status     'new artifact -> added'
+Assert-Equal 5000    $d.DeltaBytes 'added delta = head size'
+Assert-True  (-not $d.Improved)    'added is not an improvement'
+
+$d = Get-SizeDelta -BaseBytes 5000 -HeadBytes $null
+Assert-Equal 'removed' $d.Status     'dropped artifact -> removed'
+Assert-Equal -5000     $d.DeltaBytes 'removed delta = -base size'
+Assert-True  $d.Improved             'removed counts as an improvement (smaller ship)'
+
+$d = Get-SizeDelta -BaseBytes $null -HeadBytes $null
+Assert-Equal 'na' $d.Status  'absent both sides -> na'
+Assert-Null  $d.DeltaBytes   'na has no delta'
+
+# Zero base with a head value: pct is null but the byte floor still classifies it.
+$d = Get-SizeDelta -BaseBytes 0 -HeadBytes 100000
+Assert-Equal 'grew' $d.Status 'zero base, real head bytes -> grew (pct floor skipped)'
+Assert-Null  $d.DeltaPct      'zero base -> null pct'
+
+# ── Get-SizeStatusGlyph ──────────────────────────────────────────────────────
+Assert-Equal "$([char]0x26A0)$([char]0xFE0F)" (Get-SizeStatusGlyph 'grew')      'grew -> warning'
+Assert-Equal "$([char]0x2705)"                (Get-SizeStatusGlyph 'shrank')    'shrank -> check'
+Assert-Equal "$([char]0x2248)"                (Get-SizeStatusGlyph 'unchanged') 'unchanged -> approx'
+Assert-Equal "$([char]0x2014)"                (Get-SizeStatusGlyph 'na')        'na -> dash'
+
+# ── Format-SizeDeltaCell ─────────────────────────────────────────────────────
+Assert-Equal "$([char]0x2014)" (Format-SizeDeltaCell (Get-SizeDelta -BaseBytes $null -HeadBytes $null)) 'na cell -> dash'
+Assert-Match  (Format-SizeDeltaCell (Get-SizeDelta -BaseBytes 100000 -HeadBytes 110000)) '+9.77 KB (+10.00%)' 'grew cell shows +size (+pct)'
+Assert-Match  (Format-SizeDeltaCell (Get-SizeDelta -BaseBytes 110000 -HeadBytes 100000)) '(-9.09%)' 'shrank cell shows negative pct'
+Assert-Match  (Format-SizeDeltaCell (Get-SizeDelta -BaseBytes $null -HeadBytes 5000)) 'new'     'added cell labelled new'
+Assert-Match  (Format-SizeDeltaCell (Get-SizeDelta -BaseBytes 5000 -HeadBytes $null)) 'removed' 'removed cell labelled removed'
+
+# ── ConvertTo-MeasurementMap ─────────────────────────────────────────────────
+$map = ConvertTo-MeasurementMap -Measurements @(
+    [pscustomobject]@{ Key = 'a'; Label = 'A'; Bytes = 1 }
+    [pscustomobject]@{ Key = 'b'; Label = 'B'; Bytes = 2 }
+    [pscustomobject]@{ Key = 'a'; Label = 'A2'; Bytes = 3 }
+)
+Assert-Equal 2   $map.Keys.Count      'map dedupes by key'
+Assert-Equal 3   $map['a'].Bytes      'later entry wins'
+Assert-Equal 0   (ConvertTo-MeasurementMap -Measurements $null).Keys.Count 'null -> empty map'
+
+# ── Format-BuildMetricsComment ───────────────────────────────────────────────
+$base = @(
+    [pscustomobject]@{ Key = 'nupkg.Reactor'; Label = 'Microsoft.UI.Reactor.nupkg'; Group = 'Packages (compressed)'; Bytes = 1200000 }
+    [pscustomobject]@{ Key = 'asm.Reactor';   Label = 'Reactor.dll';                Group = 'Assemblies (uncompressed)'; Bytes = 900000 }
+    [pscustomobject]@{ Key = 'nupkg.Legacy';  Label = 'Legacy.nupkg';               Group = 'Packages (compressed)'; Bytes = 4000 }
+)
+$head = @(
+    [pscustomobject]@{ Key = 'nupkg.Reactor'; Label = 'Microsoft.UI.Reactor.nupkg'; Group = 'Packages (compressed)'; Bytes = 1260000 }
+    [pscustomobject]@{ Key = 'asm.Reactor';   Label = 'Reactor.dll';                Group = 'Assemblies (uncompressed)'; Bytes = 900010 }
+    [pscustomobject]@{ Key = 'nupkg.New';     Label = 'Brand.New.nupkg';            Group = 'Packages (compressed)'; Bytes = 7000 }
+)
+$comment = Format-BuildMetricsComment -BaseMeasurements $base -HeadMeasurements $head -HeadSha 'abcdef1234567' -BaseSha '1234567890abc' -RunUrl 'https://example/run/1'
+Assert-Match $comment '<!-- reactor-build-metrics -->' 'comment carries the sticky marker'
+Assert-Match $comment 'Build metrics'                  'comment has heading'
+Assert-Match $comment 'abcdef1'                        'head sha shortened to 7'
+Assert-Match $comment '### Packages (compressed)'      'packages group header'
+Assert-Match $comment '### Assemblies (uncompressed)'  'assemblies group header'
+Assert-Match $comment 'Microsoft.UI.Reactor.nupkg'     'lists the framework package'
+Assert-Match $comment 'Brand.New.nupkg'                'head-only artifact listed (added)'
+Assert-Match $comment 'Legacy.nupkg'                   'base-only artifact listed (removed)'
+Assert-Match $comment 'workflow run'                   'footer links the run'
+# The tiny asm.Reactor delta (10 bytes) must read as unchanged, not a regression.
+Assert-Match $comment "$([char]0x2248)"                'within-noise glyph present for tiny delta'
+
+# All-unchanged rendering: the "no change" note appears, no grew/shrank rows.
+$flat = @(
+    [pscustomobject]@{ Key = 'nupkg.Reactor'; Label = 'Microsoft.UI.Reactor.nupkg'; Group = 'Packages (compressed)'; Bytes = 1200000 }
+)
+$flatComment = Format-BuildMetricsComment -BaseMeasurements $flat -HeadMeasurements $flat -HeadSha 'aaa' -BaseSha 'bbb'
+Assert-Match $flatComment 'No size change beyond the noise floor' 'flat comparison notes no change'
+
+# Failure mode: emits a caution block, not tables.
+$failComment = Format-BuildMetricsComment -Failed -RunUrl 'https://example/run/2'
+Assert-Match    $failComment '<!-- reactor-build-metrics -->' 'failure comment keeps the marker'
+Assert-Match    $failComment '[!CAUTION]'                     'failure comment is a caution admonition'
+Assert-NotMatch $failComment '| Artifact |'                  'failure comment has no size table'
+
+# Baseline-unavailable mode: head sizes render, but with no misleading "added"
+# rows and a warning that the delta is unavailable.
+$baseGoneComment = Format-BuildMetricsComment -HeadMeasurements $head -BaselineUnavailable -HeadSha 'aaa' -BaseSha 'bbb'
+Assert-Match    $baseGoneComment '[!WARNING]'                 'baseline-unavailable emits a warning'
+Assert-Match    $baseGoneComment 'Microsoft.UI.Reactor.nupkg' 'baseline-unavailable still lists head artifacts'
+Assert-NotMatch $baseGoneComment '<sub>new</sub>'            'baseline-unavailable does not mislabel rows as new'
+Assert-NotMatch $baseGoneComment 'No size change beyond'      'baseline-unavailable suppresses the no-change note'
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+Write-Host ''
+Write-Host "BuildMetricsLib tests: $script:Pass passed, $script:Fail failed."
+if ($script:Fail -gt 0) {
+    Write-Host ''
+    Write-Host 'Failures:' -ForegroundColor Red
+    foreach ($f in $script:Failures) { Write-Host "  - $f" -ForegroundColor Red }
+    exit 1
+}
+exit 0

--- a/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
@@ -185,6 +185,52 @@ Assert-Match    $baseGoneComment 'Microsoft.UI.Reactor.nupkg' 'baseline-unavaila
 Assert-NotMatch $baseGoneComment '<sub>new</sub>'            'baseline-unavailable does not mislabel rows as new'
 Assert-NotMatch $baseGoneComment 'No size change beyond'      'baseline-unavailable suppresses the no-change note'
 
+# ── Get-BuildMetricsTargetSpec / ConvertTo-SafeMeasurements (security boundary) ─
+$spec = Get-BuildMetricsTargetSpec
+Assert-Equal 6 $spec.Count 'target spec has all six tracked artifacts'
+Assert-Equal 'Microsoft.UI.Reactor.nupkg' ($spec | Where-Object { $_.Key -eq 'nupkg.Reactor' }).Label 'spec maps the framework nupkg label'
+
+# Well-formed raw input: trusted labels applied, numeric bytes preserved, order = spec.
+$raw = @(
+    [pscustomobject]@{ Key = 'asm.Reactor';   Label = 'IGNORED';  Group = 'IGNORED'; Bytes = 3384320 }
+    [pscustomobject]@{ Key = 'nupkg.Reactor'; Label = 'IGNORED';  Group = 'IGNORED'; Bytes = 2034863 }
+)
+$safe = ConvertTo-SafeMeasurements -RawMeasurements $raw
+Assert-Equal 6 $safe.Count 'safe measurements always cover the full spec'
+Assert-Equal 'nupkg.Reactor' $safe[0].Key 'safe output is in spec order (nupkg.Reactor first)'
+Assert-Equal 'Microsoft.UI.Reactor.nupkg' $safe[0].Label 'safe output uses the TRUSTED label, not the artifact label'
+Assert-Equal 2034863 $safe[0].Bytes 'valid integer bytes preserved'
+Assert-Equal 3384320 ($safe | Where-Object { $_.Key -eq 'asm.Reactor' }).Bytes 'valid bytes preserved regardless of raw order'
+
+# Security: a malicious Label/Group in the artifact must never reach the output.
+$evil = @([pscustomobject]@{ Key = 'nupkg.Reactor'; Label = '<img src=x onerror=alert(1)>'; Group = '[!WARNING] pwned'; Bytes = 100 })
+$safeEvil = ConvertTo-SafeMeasurements -RawMeasurements $evil
+Assert-Equal 'Microsoft.UI.Reactor.nupkg' $safeEvil[0].Label 'injected label is dropped for the trusted label'
+Assert-NotMatch (($safeEvil | ForEach-Object { $_.Label + '|' + $_.Group }) -join ' ') 'onerror' 'no injected markup survives sanitization'
+
+# Unknown keys are dropped; non-integer / negative / decimal bytes become null.
+$junk = @(
+    [pscustomobject]@{ Key = 'nupkg.Evil';    Label = 'x'; Group = 'y'; Bytes = 5 }   # unknown key -> dropped
+    [pscustomobject]@{ Key = 'asm.Reactor';   Label = 'x'; Group = 'y'; Bytes = 'not-a-number' }
+    [pscustomobject]@{ Key = 'nupkg.Advanced';Label = 'x'; Group = 'y'; Bytes = -50 }
+    [pscustomobject]@{ Key = 'asm.Advanced';  Label = 'x'; Group = 'y'; Bytes = '1e9' }
+)
+$safeJunk = ConvertTo-SafeMeasurements -RawMeasurements $junk
+Assert-True ((@($safeJunk | Where-Object { $_.Key -eq 'nupkg.Evil' })).Count -eq 0) 'unknown key dropped'
+Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm.Reactor' }).Bytes   'non-numeric bytes -> null'
+Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'nupkg.Advanced' }).Bytes 'negative bytes -> null'
+Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm.Advanced' }).Bytes   'scientific-notation bytes -> null'
+
+# Null input -> full spec with all-null bytes (renders as a "failed" set).
+$safeNull = ConvertTo-SafeMeasurements -RawMeasurements $null
+Assert-Equal 6 $safeNull.Count 'null raw -> full spec'
+Assert-Equal 0 (@($safeNull | Where-Object { $null -ne $_.Bytes }).Count) 'null raw -> all bytes null'
+
+# End-to-end: a sanitized set renders a normal comment with trusted labels only.
+$safeComment = Format-BuildMetricsComment -BaseMeasurements $safeNull -HeadMeasurements $safe -HeadSha 'abc1234' -BaseSha 'def5678'
+Assert-Match    $safeComment 'Microsoft.UI.Reactor.nupkg' 'sanitized render shows trusted labels'
+Assert-NotMatch $safeComment 'IGNORED'                    'sanitized render drops artifact-supplied labels'
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 Write-Host ''
 Write-Host "BuildMetricsLib tests: $script:Pass passed, $script:Fail failed."

--- a/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
@@ -161,6 +161,10 @@ Assert-Match $comment 'Microsoft.UI.Reactor.nupkg'     'lists the framework pack
 Assert-Match $comment 'Brand.New.nupkg'                'head-only artifact listed (added)'
 Assert-Match $comment 'Legacy.nupkg'                   'base-only artifact listed (removed)'
 Assert-Match $comment 'workflow run'                   'footer links the run'
+# The header + column use "base" (accurate for any base branch), not "main".
+Assert-Match    $comment 'vs the base branch'          'header uses base-branch wording, not hard-coded main'
+Assert-Match    $comment 'base | PR'                   'table column header says base'
+Assert-NotMatch $comment 'main | PR'                   'table column header is not the hard-coded main'
 # The tiny asm.Reactor delta (10 bytes) must read as unchanged, not a regression.
 Assert-Match $comment "$([char]0x2248)"                'within-noise glyph present for tiny delta'
 

--- a/tests/build_metrics/ci/BuildMetricsLib.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.ps1
@@ -158,7 +158,8 @@ function Get-SizeDelta {
         - added   : absent at base, present at head (new artifact).
         - removed : present at base, absent at head (dropped artifact).
         - na      : absent on both sides.
-        - unchanged: present on both, |Δ| below max(noise-byte, noise-pct) band.
+        - unchanged: present on both, |Δ| below the noise band (must clear BOTH
+                     the byte floor AND the percent floor to count as a change).
         - grew/shrank: present on both, |Δ| clears the band.
         Growth is the regression direction, so Improved is $true only for shrank.
     #>

--- a/tests/build_metrics/ci/BuildMetricsLib.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.ps1
@@ -1,0 +1,326 @@
+<#
+.SYNOPSIS
+    Pure, dot-source-able helpers for the automatic build-metrics (artifact
+    size-diff) PR comment (.github/workflows/build-metrics.yml).
+
+.DESCRIPTION
+    These functions have no side effects beyond Write-Warning, so they can be
+    unit-tested locally (BuildMetricsLib.Tests.ps1) without building anything:
+
+      Format-ByteSize             humanize a byte count (1024-based: B/KB/MB/GB).
+      Format-SignedByteSize       same, with an explicit +/- sign.
+      Get-SizeDelta               base-vs-head delta, direction-aware, with a
+                                  small noise band (grew / shrank / unchanged /
+                                  added / removed / na).
+      Get-SizeStatusGlyph         emoji/glyph for a delta status.
+      Format-SizeDeltaCell        the "Δ" table cell (signed size + percent).
+      ConvertTo-MeasurementMap    index an array of measurement objects by Key.
+      Format-BuildMetricsComment  the sticky size-diff markdown comment.
+
+    A "measurement" is a [pscustomobject] with:
+      Key    stable identifier (e.g. 'nupkg.Reactor')
+      Label  display name (e.g. 'Microsoft.UI.Reactor.nupkg')
+      Group  section header ('Packages (compressed)' | 'Assemblies (uncompressed)')
+      Bytes  size in bytes, or $null when the artifact was not produced.
+
+    Growth is the "bad" direction for every tracked artifact (smaller ships
+    faster / trims better), so `shrank` is flagged as the improvement and `grew`
+    as the regression. The comment is informational only — it never fails a PR.
+#>
+
+Set-StrictMode -Version Latest
+
+# Hidden marker used to find + update-in-place the sticky PR comment. Mirrors the
+# convention in tests/stress_perf/ci/PerfLib.ps1 ('<!-- reactor-perf-compare -->').
+$script:BuildMetricsCommentMarker = '<!-- reactor-build-metrics -->'
+
+# Default significance band. A delta counts as a real change only when it clears
+# BOTH floors: absolute bytes AND percent. .nupkg files are ZIP archives whose
+# compressed size can jitter by a few bytes across otherwise-identical builds, so
+# a tiny band keeps that noise from rendering as a spurious ⚠️ regression.
+$script:BuildMetricsNoiseFloorBytes = 64
+$script:BuildMetricsNoiseFloorPct   = 0.05
+
+function Format-ByteSize {
+    <#
+    .SYNOPSIS
+        Humanize a byte count using 1024-based units (B/KB/MB/GB). Negative
+        values keep a leading '-'.
+    #>
+    param([AllowNull()]$Bytes)
+    if ($null -eq $Bytes) { return 'n/a' }
+    $b = [double]$Bytes
+    $sign = ''
+    if ($b -lt 0) { $sign = '-'; $b = -$b }
+    $units = @('B', 'KB', 'MB', 'GB', 'TB')
+    $i = 0
+    while ($b -ge 1024 -and $i -lt ($units.Count - 1)) {
+        $b = $b / 1024.0
+        $i++
+    }
+    # Bytes render as a whole number; KB+ get 1-2 decimals so small drift is visible.
+    if ($i -eq 0) {
+        return "$sign$([long]$b) B"
+    }
+    $digits = if ($b -lt 10) { 2 } else { 1 }
+    $rounded = [math]::Round($b, $digits)
+    $fmt = "0.$('0' * $digits)"
+    return "$sign$($rounded.ToString($fmt, [System.Globalization.CultureInfo]::InvariantCulture)) $($units[$i])"
+}
+
+function Format-SignedByteSize {
+    <#
+    .SYNOPSIS
+        Format-ByteSize with an explicit leading '+' for non-negative values so a
+        growth/shrink is unambiguous in the delta column.
+    #>
+    param([AllowNull()]$Bytes)
+    if ($null -eq $Bytes) { return 'n/a' }
+    $v = [long]$Bytes
+    if ($v -ge 0) { return "+$(Format-ByteSize $v)" }
+    # Format-ByteSize already prefixes negatives with '-'.
+    return (Format-ByteSize $v)
+}
+
+function Get-SizeDelta {
+    <#
+    .SYNOPSIS
+        Base-vs-head size delta with a small noise band. Status is one of:
+        grew | shrank | unchanged | added | removed | na.
+    .DESCRIPTION
+        - added   : absent at base, present at head (new artifact).
+        - removed : present at base, absent at head (dropped artifact).
+        - na      : absent on both sides.
+        - unchanged: present on both, |Δ| below max(noise-byte, noise-pct) band.
+        - grew/shrank: present on both, |Δ| clears the band.
+        Growth is the regression direction, so Improved is $true only for shrank.
+    #>
+    param(
+        [AllowNull()]$BaseBytes,
+        [AllowNull()]$HeadBytes,
+        [long]$NoiseFloorBytes = $script:BuildMetricsNoiseFloorBytes,
+        [double]$NoiseFloorPct = $script:BuildMetricsNoiseFloorPct
+    )
+    $hasBase = $null -ne $BaseBytes
+    $hasHead = $null -ne $HeadBytes
+
+    if (-not $hasBase -and -not $hasHead) {
+        return [pscustomobject]@{ Status = 'na'; DeltaBytes = $null; DeltaPct = $null; Improved = $null }
+    }
+    if (-not $hasBase -and $hasHead) {
+        return [pscustomobject]@{ Status = 'added'; DeltaBytes = [long]$HeadBytes; DeltaPct = $null; Improved = $false }
+    }
+    if ($hasBase -and -not $hasHead) {
+        return [pscustomobject]@{ Status = 'removed'; DeltaBytes = -([long]$BaseBytes); DeltaPct = $null; Improved = $true }
+    }
+
+    $b = [long]$BaseBytes
+    $h = [long]$HeadBytes
+    $delta = $h - $b
+    $pct = if ($b -ne 0) { ($delta / [double]$b) * 100.0 } else { $null }
+
+    $clearsBytes = [math]::Abs($delta) -ge $NoiseFloorBytes
+    $clearsPct = ($null -eq $pct) -or ([math]::Abs($pct) -ge $NoiseFloorPct)
+    $significant = $clearsBytes -and $clearsPct
+
+    if (-not $significant) {
+        return [pscustomobject]@{
+            Status     = 'unchanged'
+            DeltaBytes = $delta
+            DeltaPct   = if ($null -ne $pct) { [math]::Round($pct, 2) } else { $null }
+            Improved   = $null
+        }
+    }
+
+    $status = if ($delta -gt 0) { 'grew' } else { 'shrank' }
+    return [pscustomobject]@{
+        Status     = $status
+        DeltaBytes = $delta
+        DeltaPct   = if ($null -ne $pct) { [math]::Round($pct, 2) } else { $null }
+        Improved   = ($delta -lt 0)
+    }
+}
+
+function Get-SizeStatusGlyph {
+    <#
+    .SYNOPSIS
+        Short status glyph for a delta status (growth is the regression).
+    #>
+    param([string]$Status)
+    switch ($Status) {
+        'grew'      { return [char]0x26A0 + [char]0xFE0F }  # warning sign
+        'shrank'    { return [char]0x2705 }                 # check mark
+        'unchanged' { return [char]0x2248 }                 # almost-equal-to
+        'added'     { return [char]::ConvertFromUtf32(0x1F195) }                # NEW button
+        'removed'   { return [char]::ConvertFromUtf32(0x1F5D1) + [char]0xFE0F } # wastebasket
+        default     { return [char]0x2014 }                 # em dash
+    }
+}
+
+function Format-SizeDeltaCell {
+    <#
+    .SYNOPSIS
+        Render the "Δ" cell: signed size plus percent, or a word for add/remove/na.
+    #>
+    param([pscustomobject]$Delta)
+    switch ($Delta.Status) {
+        'na'      { return [char]0x2014 }
+        'added'   { return "$(Format-SignedByteSize $Delta.DeltaBytes) <sub>new</sub>" }
+        'removed' { return "$(Format-SignedByteSize $Delta.DeltaBytes) <sub>removed</sub>" }
+        default {
+            $size = Format-SignedByteSize $Delta.DeltaBytes
+            if ($null -ne $Delta.DeltaPct) {
+                $pct = ('{0:+0.00;-0.00;0.00}' -f $Delta.DeltaPct)
+                return "$size ($pct%)"
+            }
+            return $size
+        }
+    }
+}
+
+function ConvertTo-MeasurementMap {
+    <#
+    .SYNOPSIS
+        Index an array of measurement objects by Key into an ordered hashtable.
+        Later entries win, matching a re-measure overwrite.
+    #>
+    param([AllowNull()][object[]]$Measurements)
+    $map = [ordered]@{}
+    if ($null -eq $Measurements) { return $map }
+    foreach ($m in $Measurements) {
+        if ($null -eq $m) { continue }
+        $map[[string]$m.Key] = $m
+    }
+    return $map
+}
+
+function Format-BuildMetricsComment {
+    <#
+    .SYNOPSIS
+        Render the full sticky build-metrics comment from base + head measurements.
+    .PARAMETER BaseMeasurements / HeadMeasurements
+        Arrays of measurement pscustomobjects (Key/Label/Group/Bytes). The head
+        set drives row order and labels; base supplies the comparison column.
+    .PARAMETER HeadSha / BaseSha
+        Commit SHAs for the header (short-formatted here).
+    .PARAMETER RunUrl
+        Optional workflow-run URL for the footer.
+    .PARAMETER Failed
+        When set, emit a short failure notice instead of the tables (so the poster
+        always has a body to write).
+    .PARAMETER BaselineUnavailable
+        When set, the base (main) measurement is missing (e.g. its build failed),
+        so render the PR's absolute sizes with no delta column meaning instead of
+        mislabelling every artifact as newly "added".
+    #>
+    param(
+        [AllowNull()][object[]]$BaseMeasurements,
+        [AllowNull()][object[]]$HeadMeasurements,
+        [string]$HeadSha = '',
+        [string]$BaseSha = '',
+        [string]$RunUrl = '',
+        [switch]$Failed,
+        [switch]$BaselineUnavailable
+    )
+    $marker = $script:BuildMetricsCommentMarker
+    $headShort = if ($HeadSha) { $HeadSha.Substring(0, [math]::Min(7, $HeadSha.Length)) } else { 'unknown' }
+    $baseShort = if ($BaseSha) { $BaseSha.Substring(0, [math]::Min(7, $BaseSha.Length)) } else { 'main' }
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add($marker)
+    $lines.Add('## ' + [char]::ConvertFromUtf32(0x1F4E6) + ' Build metrics')  # package emoji
+    $lines.Add('')
+
+    if ($Failed) {
+        $lines.Add('> [!CAUTION]')
+        $suffix = if ($RunUrl) { " See the [workflow run]($RunUrl)." } else { '' }
+        $lines.Add("> The build-metrics run did not produce artifact sizes (build failed).$suffix")
+        $lines.Add('')
+        return ($lines -join "`n")
+    }
+
+    $lines.Add("Artifact sizes for ``$headShort`` vs ``main`` (``$baseShort``).")
+    $lines.Add('')
+
+    if ($BaselineUnavailable) {
+        $lines.Add('> [!WARNING]')
+        $lines.Add('> The baseline (`main`) build did not produce sizes, so no delta is available — showing the PR''s absolute sizes only.')
+        $lines.Add('')
+        # Drop the base column so present-head rows read as "—" rather than "added".
+        $BaseMeasurements = $null
+    }
+
+    $baseMap = ConvertTo-MeasurementMap -Measurements $BaseMeasurements
+    $headMap = ConvertTo-MeasurementMap -Measurements $HeadMeasurements
+
+    # Row order: head measurements first (source of truth for the PR), then any
+    # base-only keys (removed artifacts) appended so a drop is never hidden.
+    $orderedKeys = [System.Collections.Generic.List[string]]::new()
+    foreach ($k in $headMap.Keys) { $orderedKeys.Add([string]$k) }
+    foreach ($k in $baseMap.Keys) { if (-not $headMap.Contains($k)) { $orderedKeys.Add([string]$k) } }
+
+    if ($orderedKeys.Count -eq 0) {
+        $lines.Add('_No tracked artifacts were measured._')
+        $lines.Add('')
+        return ($lines -join "`n")
+    }
+
+    # Group rows under their Group header, preserving first-seen group order.
+    $groupOrder = [System.Collections.Generic.List[string]]::new()
+    $rowsByGroup = @{}
+    $anyChange = $false
+    foreach ($key in $orderedKeys) {
+        $headM = if ($headMap.Contains($key)) { $headMap[$key] } else { $null }
+        $baseM = if ($baseMap.Contains($key)) { $baseMap[$key] } else { $null }
+        $ref = if ($headM) { $headM } else { $baseM }
+        $label = [string]$ref.Label
+        $group = if ($ref.PSObject.Properties['Group'] -and $ref.Group) { [string]$ref.Group } else { 'Artifacts' }
+        $baseBytes = if ($baseM) { $baseM.Bytes } else { $null }
+        $headBytes = if ($headM) { $headM.Bytes } else { $null }
+
+        $delta = if ($BaselineUnavailable) {
+            [pscustomobject]@{ Status = 'na'; DeltaBytes = $null; DeltaPct = $null; Improved = $null }
+        } else {
+            Get-SizeDelta -BaseBytes $baseBytes -HeadBytes $headBytes
+        }
+        if ($delta.Status -in @('grew', 'shrank', 'added', 'removed')) { $anyChange = $true }
+
+        $row = '| {0} | {1} | {2} | {3} | {4} |' -f `
+            $label, `
+        (Format-ByteSize $baseBytes), `
+        (Format-ByteSize $headBytes), `
+        (Format-SizeDeltaCell $delta), `
+        (Get-SizeStatusGlyph $delta.Status)
+
+        if (-not $rowsByGroup.ContainsKey($group)) {
+            $rowsByGroup[$group] = [System.Collections.Generic.List[string]]::new()
+            $groupOrder.Add($group)
+        }
+        $rowsByGroup[$group].Add($row)
+    }
+
+    foreach ($group in $groupOrder) {
+        $lines.Add("### $group")
+        $lines.Add('')
+        $lines.Add('| Artifact | main | PR | Δ | |')
+        $lines.Add('|---|--:|--:|--:|:-:|')
+        foreach ($row in $rowsByGroup[$group]) { $lines.Add($row) }
+        $lines.Add('')
+    }
+
+    if (-not $anyChange -and -not $BaselineUnavailable) {
+        $lines.Add('No size change beyond the noise floor. ' + [char]0x2705)
+        $lines.Add('')
+    }
+
+    $legend = [char]0x2705 + ' smaller / ' + [char]0x26A0 + [char]0xFE0F + ' larger / ' +
+        [char]0x2248 + ' within noise'
+    $lines.Add("<sub>$legend. Sizes come from a Release <code>dotnet pack</code> on the CI runner: packages are the compressed <code>.nupkg</code> download size, assemblies the uncompressed DLL inside it.")
+    if ($RunUrl) {
+        $lines.Add("<a href=`"$RunUrl`">workflow run</a>.</sub>")
+    } else {
+        $lines.Add('</sub>')
+    }
+
+    return ($lines -join "`n")
+}

--- a/tests/build_metrics/ci/BuildMetricsLib.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.ps1
@@ -276,7 +276,7 @@ function Format-BuildMetricsComment {
         When set, emit a short failure notice instead of the tables (so the poster
         always has a body to write).
     .PARAMETER BaselineUnavailable
-        When set, the base (main) measurement is missing (e.g. its build failed),
+        When set, the base branch measurement is missing (e.g. its build failed),
         so render the PR's absolute sizes with no delta column meaning instead of
         mislabelling every artifact as newly "added".
     #>
@@ -291,7 +291,7 @@ function Format-BuildMetricsComment {
     )
     $marker = $script:BuildMetricsCommentMarker
     $headShort = if ($HeadSha) { $HeadSha.Substring(0, [math]::Min(7, $HeadSha.Length)) } else { 'unknown' }
-    $baseShort = if ($BaseSha) { $BaseSha.Substring(0, [math]::Min(7, $BaseSha.Length)) } else { 'main' }
+    $baseShort = if ($BaseSha) { $BaseSha.Substring(0, [math]::Min(7, $BaseSha.Length)) } else { '' }
 
     $lines = [System.Collections.Generic.List[string]]::new()
     $lines.Add($marker)
@@ -306,14 +306,15 @@ function Format-BuildMetricsComment {
         return ($lines -join "`n")
     }
 
-    $lines.Add("Artifact sizes for ``$headShort`` vs ``main`` (``$baseShort``).")
+    $baseSuffix = if ($baseShort) { " (``$baseShort``)" } else { '' }
+    $lines.Add("Artifact sizes for ``$headShort`` vs the base branch$baseSuffix.")
     $lines.Add('')
 
     if ($BaselineUnavailable) {
         $lines.Add('> [!WARNING]')
-        $lines.Add('> The baseline (`main`) build did not produce sizes, so no delta is available — showing the PR''s absolute sizes only.')
+        $lines.Add('> The base branch build did not produce sizes, so no delta is available — showing the PR''s absolute sizes only.')
         $lines.Add('')
-        # Clear the base measurements (the "main" column still renders, as n/a) so
+        # Clear the base measurements (the base column still renders, as n/a) so
         # present-head rows show "—" instead of misclassifying as newly "added".
         $BaseMeasurements = $null
     }
@@ -370,7 +371,7 @@ function Format-BuildMetricsComment {
     foreach ($group in $groupOrder) {
         $lines.Add("### $group")
         $lines.Add('')
-        $lines.Add('| Artifact | main | PR | Δ | |')
+        $lines.Add('| Artifact | base | PR | Δ | |')
         $lines.Add('|---|--:|--:|--:|:-:|')
         foreach ($row in $rowsByGroup[$group]) { $lines.Add($row) }
         $lines.Add('')

--- a/tests/build_metrics/ci/BuildMetricsLib.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.ps1
@@ -41,6 +41,73 @@ $script:BuildMetricsCommentMarker = '<!-- reactor-build-metrics -->'
 $script:BuildMetricsNoiseFloorBytes = 64
 $script:BuildMetricsNoiseFloorPct   = 0.05
 
+# ── Trusted artifact spec ────────────────────────────────────────────────────
+# The canonical Key → { Label, Group } map. This is the SINGLE SOURCE OF TRUTH for
+# what the comment can display. The measure job runs untrusted PR code, so the
+# privileged poster must NOT trust label/group strings that come back in the
+# uploaded sizes.json — it re-maps every row through this trusted spec via
+# ConvertTo-SafeMeasurements and takes only the (validated numeric) byte counts.
+# Keys here must match those emitted by Measure-BuildMetrics.ps1.
+$script:BuildMetricsTargetSpec = @(
+    [pscustomobject]@{ Key = 'nupkg.Reactor';  Label = 'Microsoft.UI.Reactor.nupkg';          Group = 'Packages (compressed .nupkg)' }
+    [pscustomobject]@{ Key = 'asm.Reactor';    Label = 'Reactor.dll';                          Group = 'Assemblies (uncompressed)' }
+    [pscustomobject]@{ Key = 'nupkg.Advanced'; Label = 'Microsoft.UI.Reactor.Advanced.nupkg';  Group = 'Packages (compressed .nupkg)' }
+    [pscustomobject]@{ Key = 'asm.Advanced';   Label = 'Reactor.Advanced.dll';                 Group = 'Assemblies (uncompressed)' }
+    [pscustomobject]@{ Key = 'nupkg.Devtools'; Label = 'Microsoft.UI.Reactor.Devtools.nupkg';  Group = 'Packages (compressed .nupkg)' }
+    [pscustomobject]@{ Key = 'asm.Devtools';   Label = 'Microsoft.UI.Reactor.Devtools.dll';    Group = 'Assemblies (uncompressed)' }
+)
+
+function Get-BuildMetricsTargetSpec {
+    <#
+    .SYNOPSIS
+        The trusted, ordered Key → { Label, Group } spec for the tracked artifacts.
+    #>
+    return $script:BuildMetricsTargetSpec
+}
+
+function ConvertTo-SafeMeasurements {
+    <#
+    .SYNOPSIS
+        Project raw (untrusted) measurement objects — e.g. parsed from a sizes.json
+        an unprivileged PR job produced — onto the trusted target spec.
+
+    .DESCRIPTION
+        Security boundary for the privileged poster: never render label/group text
+        that came from the artifact. For each entry in the trusted spec this looks
+        up the raw row by Key, accepts its Bytes ONLY if it is a non-negative
+        integer, and emits a measurement carrying the TRUSTED Label/Group. Unknown
+        keys in the raw input are dropped; a missing/garbage/negative Bytes becomes
+        $null (rendered as n/a). The output is therefore fully determined by trusted
+        code plus a handful of validated integers.
+    #>
+    param([AllowNull()]$RawMeasurements)
+
+    $rawByKey = @{}
+    if ($null -ne $RawMeasurements) {
+        foreach ($m in @($RawMeasurements)) {
+            if ($null -eq $m) { continue }
+            if (-not $m.PSObject.Properties['Key']) { continue }
+            $rawByKey[[string]$m.Key] = $m
+        }
+    }
+
+    $out = [System.Collections.Generic.List[object]]::new()
+    foreach ($t in $script:BuildMetricsTargetSpec) {
+        $bytes = $null
+        if ($rawByKey.ContainsKey($t.Key)) {
+            $raw = $rawByKey[$t.Key]
+            if ($raw.PSObject.Properties['Bytes'] -and $null -ne $raw.Bytes) {
+                $parsed = [long]0
+                if ([long]::TryParse([string]$raw.Bytes, [ref]$parsed) -and $parsed -ge 0) {
+                    $bytes = $parsed
+                }
+            }
+        }
+        $out.Add([pscustomobject]@{ Key = $t.Key; Label = $t.Label; Group = $t.Group; Bytes = $bytes })
+    }
+    return $out
+}
+
 function Format-ByteSize {
     <#
     .SYNOPSIS

--- a/tests/build_metrics/ci/BuildMetricsLib.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.ps1
@@ -313,7 +313,8 @@ function Format-BuildMetricsComment {
         $lines.Add('> [!WARNING]')
         $lines.Add('> The baseline (`main`) build did not produce sizes, so no delta is available — showing the PR''s absolute sizes only.')
         $lines.Add('')
-        # Drop the base column so present-head rows read as "—" rather than "added".
+        # Clear the base measurements (the "main" column still renders, as n/a) so
+        # present-head rows show "—" instead of misclassifying as newly "added".
         $BaseMeasurements = $null
     }
 

--- a/tests/build_metrics/ci/Measure-BuildMetrics.Tests.ps1
+++ b/tests/build_metrics/ci/Measure-BuildMetrics.Tests.ps1
@@ -1,0 +1,154 @@
+<#
+.SYNOPSIS
+    Dependency-free unit tests for the testable helpers in Measure-BuildMetrics.ps1
+    (the build-metrics pack/measure orchestrator): Select-LatestNupkg (package
+    selection) and Get-NupkgAssemblyBytes (ZIP assembly-size extraction).
+
+.DESCRIPTION
+    Measure-BuildMetrics.ps1 isn't dot-sourceable (it has a param block + a main
+    run flow that shells out to `dotnet pack`), so each function under test is
+    extracted via the PowerShell AST and defined in isolation. The tests synthesize
+    real .nupkg ZIP archives and on-disk file layouts — no `dotnet`, no network — so
+    this runs headless and cross-platform on the cheap Linux runner in
+    .github/workflows/build-metrics-lib-tests.yml. Exits non-zero on any failure.
+
+    The full pack path (dotnet pack, platform args) is validated by the live
+    build-metrics run, not here; this covers the pure selection/extraction logic.
+
+    Run locally:  pwsh tests/build_metrics/ci/Measure-BuildMetrics.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Add-Type -AssemblyName System.IO.Compression | Out-Null
+Add-Type -AssemblyName System.IO.Compression.FileSystem | Out-Null
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: [$Expected]`n    actual:   [$Actual]") }
+}
+function Assert-Null {
+    param($Actual, [string]$Message)
+    if ($null -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: <null>`n    actual:   [$Actual]") }
+}
+
+# --- Extract the functions under test from the orchestrator script via AST. ---
+$scriptPath = Join-Path $PSScriptRoot 'Measure-BuildMetrics.ps1'
+$src = Get-Content $scriptPath -Raw
+$parseTokens = $null; $parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseInput($src, [ref]$parseTokens, [ref]$parseErrors)
+if ($parseErrors -and $parseErrors.Count -gt 0) {
+    Write-Host "Measure-BuildMetrics.ps1 has $($parseErrors.Count) parse error(s):" -ForegroundColor Red
+    $parseErrors | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" -ForegroundColor Red }
+    exit 1
+}
+function Get-Func([string]$name) {
+    $f = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $name }, $true) |
+        Select-Object -First 1
+    if (-not $f) { throw "$name not found in Measure-BuildMetrics.ps1" }
+    $f.Extent.Text
+}
+Invoke-Expression (Get-Func 'Select-LatestNupkg')
+Invoke-Expression (Get-Func 'Get-NupkgAssemblyBytes')
+
+# --- Test scratch dir + helpers to synthesize .nupkg ZIPs. ---
+$tmp = Join-Path ([IO.Path]::GetTempPath()) ("bm-measure-tests-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+
+function New-Nupkg {
+    # entries: ordered hashtable of 'zip/path' = <byte length>
+    param([string]$Path, [hashtable]$Entries)
+    $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Create)
+    try {
+        $zip = [System.IO.Compression.ZipArchive]::new($fs, [System.IO.Compression.ZipArchiveMode]::Create)
+        try {
+            foreach ($name in $Entries.Keys) {
+                $entry = $zip.CreateEntry($name)
+                $es = $entry.Open()
+                try {
+                    $buf = New-Object byte[] ([int]$Entries[$name])
+                    $es.Write($buf, 0, $buf.Length)
+                } finally { $es.Dispose() }
+            }
+        } finally { $zip.Dispose() }
+    } finally { $fs.Dispose() }
+}
+
+try {
+    # ── Get-NupkgAssemblyBytes ────────────────────────────────────────────────
+    # Largest lib/<tfm>/Reactor.dll wins; ref/ and non-lib entries are ignored.
+    $multi = Join-Path $tmp 'multi.nupkg'
+    New-Nupkg -Path $multi -Entries ([ordered]@{
+        'lib/net8.0/Reactor.dll'                     = 3000
+        'lib/net10.0-windows10.0.22621.0/Reactor.dll' = 5000
+        'ref/net10.0/Reactor.dll'                    = 9999   # not under lib/ -> ignored
+        '[Content_Types].xml'                        = 200
+    })
+    Assert-Equal 5000 (Get-NupkgAssemblyBytes -NupkgPath $multi -AssemblyFile 'Reactor.dll') 'largest lib/<tfm> assembly wins; ref/ ignored'
+
+    # A single-TFM package returns that entry's uncompressed length.
+    $single = Join-Path $tmp 'single.nupkg'
+    New-Nupkg -Path $single -Entries ([ordered]@{ 'lib/net10.0/Reactor.Advanced.dll' = 33792 })
+    Assert-Equal 33792 (Get-NupkgAssemblyBytes -NupkgPath $single -AssemblyFile 'Reactor.Advanced.dll') 'single-TFM assembly size'
+
+    # No matching assembly -> null.
+    $noAsm = Join-Path $tmp 'noasm.nupkg'
+    New-Nupkg -Path $noAsm -Entries ([ordered]@{ 'lib/net10.0/Other.dll' = 1234; 'readme.md' = 10 })
+    Assert-Null (Get-NupkgAssemblyBytes -NupkgPath $noAsm -AssemblyFile 'Reactor.dll') 'no matching lib assembly -> null'
+
+    # Corrupt / non-ZIP file -> null (the try/catch swallows the open failure).
+    $corrupt = Join-Path $tmp 'corrupt.nupkg'
+    Set-Content -LiteralPath $corrupt -Value 'this is not a zip' -Encoding ascii
+    Assert-Null (Get-NupkgAssemblyBytes -NupkgPath $corrupt -AssemblyFile 'Reactor.dll' -WarningAction SilentlyContinue) 'corrupt archive -> null'
+
+    # Missing file -> null.
+    Assert-Null (Get-NupkgAssemblyBytes -NupkgPath (Join-Path $tmp 'nope.nupkg') -AssemblyFile 'Reactor.dll' -WarningAction SilentlyContinue) 'missing file -> null'
+
+    # ── Select-LatestNupkg ────────────────────────────────────────────────────
+    $pkgDir = Join-Path $tmp 'pkgs'
+    New-Item -ItemType Directory -Path $pkgDir -Force | Out-Null
+    foreach ($f in @(
+        'Microsoft.UI.Reactor.0.0.0-buildmetrics.nupkg',
+        'Microsoft.UI.Reactor.0.0.0-buildmetrics.symbols.nupkg',
+        'Microsoft.UI.Reactor.Advanced.0.0.0-buildmetrics.nupkg',
+        'Microsoft.UI.Reactor.Devtools.0.0.0-buildmetrics.nupkg'
+    )) { Set-Content -LiteralPath (Join-Path $pkgDir $f) -Value 'x' }
+
+    $sel = Select-LatestNupkg -PackOutput $pkgDir -PackageId 'Microsoft.UI.Reactor'
+    Assert-Equal 'Microsoft.UI.Reactor.0.0.0-buildmetrics.nupkg' $sel.Name 'exact package id — not the Advanced/Devtools siblings, not symbols'
+
+    $selAdv = Select-LatestNupkg -PackOutput $pkgDir -PackageId 'Microsoft.UI.Reactor.Advanced'
+    Assert-Equal 'Microsoft.UI.Reactor.Advanced.0.0.0-buildmetrics.nupkg' $selAdv.Name 'Advanced resolves to its own package'
+
+    # No match -> null.
+    Assert-Null (Select-LatestNupkg -PackOutput $pkgDir -PackageId 'Nonexistent.Package') 'no matching package -> null'
+
+    # Newest write time wins among two versions of the same id.
+    $verDir = Join-Path $tmp 'versions'
+    New-Item -ItemType Directory -Path $verDir -Force | Out-Null
+    $old = Join-Path $verDir 'Microsoft.UI.Reactor.0.0.0-buildmetrics.nupkg'
+    $new = Join-Path $verDir 'Microsoft.UI.Reactor.0.0.1-buildmetrics.nupkg'
+    Set-Content -LiteralPath $old -Value 'x'; Set-Content -LiteralPath $new -Value 'x'
+    (Get-Item $old).LastWriteTime = (Get-Date).AddMinutes(-10)
+    (Get-Item $new).LastWriteTime = (Get-Date)
+    Assert-Equal 'Microsoft.UI.Reactor.0.0.1-buildmetrics.nupkg' (Select-LatestNupkg -PackOutput $verDir -PackageId 'Microsoft.UI.Reactor').Name 'newest write time wins'
+}
+finally {
+    Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+Write-Host ''
+Write-Host "Measure-BuildMetrics tests: $script:Pass passed, $script:Fail failed."
+if ($script:Fail -gt 0) {
+    Write-Host ''
+    Write-Host 'Failures:' -ForegroundColor Red
+    foreach ($f in $script:Failures) { Write-Host "  - $f" -ForegroundColor Red }
+    exit 1
+}
+exit 0

--- a/tests/build_metrics/ci/Measure-BuildMetrics.ps1
+++ b/tests/build_metrics/ci/Measure-BuildMetrics.ps1
@@ -159,7 +159,7 @@ foreach ($t in $targets) {
             '--nologo'
         ) + $t.ExtraArgs
 
-        & dotnet @packArgs 2>&1 | Tee-Object -Variable packLog | Out-Host
+        & dotnet @packArgs 2>&1 | Out-Host
         if ($LASTEXITCODE -ne 0) {
             Write-Warning "dotnet pack failed for $($t.PackageId) (exit $LASTEXITCODE) — emitting n/a."
         } else {

--- a/tests/build_metrics/ci/Measure-BuildMetrics.ps1
+++ b/tests/build_metrics/ci/Measure-BuildMetrics.ps1
@@ -13,9 +13,9 @@
     BuildMetricsLib.ps1's Format-BuildMetricsComment:
       { "Key": "...", "Label": "...", "Group": "...", "Bytes": <int|null> }
 
-    A fixed -PackageVersion is used for both the base (main) and PR runs so the
-    version string embedded in the .nuspec is identical and never contributes to
-    the diff — the only size delta is real code/content change.
+    A fixed -PackageVersion is used for both sides (the PR's base branch and head)
+    so the version string embedded in the .nuspec is identical and never
+    contributes to the diff — the only size delta is real code/content change.
 
     Per-package failures are non-fatal: the package's rows are emitted with a
     null size (rendered as n/a) and the run continues, so one broken pack never

--- a/tests/build_metrics/ci/Measure-BuildMetrics.ps1
+++ b/tests/build_metrics/ci/Measure-BuildMetrics.ps1
@@ -39,6 +39,14 @@ $ErrorActionPreference = 'Stop'
 
 $Root = (Resolve-Path -LiteralPath $Root).Path
 
+# Ensure the -OutFile parent exists before we Set-Content into it at the end — the
+# caller often points it at a not-yet-created folder (e.g. the workflow's
+# build-metrics-out/), and Set-Content does not create intermediate directories.
+$outParent = Split-Path -Parent $OutFile
+if ($outParent -and -not (Test-Path -LiteralPath $outParent)) {
+    New-Item -ItemType Directory -Force -Path $outParent | Out-Null
+}
+
 if (-not $PackOutput) {
     # Derive a stable, tree-specific temp folder so a base + head run in the same
     # job never share (or clobber) each other's pack output.
@@ -84,6 +92,24 @@ $targets = @(
 
 $packageGroup  = 'Packages (compressed .nupkg)'
 $assemblyGroup = 'Assemblies (uncompressed)'
+
+function Select-LatestNupkg {
+    <#
+    .SYNOPSIS
+        Newest non-symbols .nupkg for exactly $PackageId in $PackOutput, or $null.
+    .DESCRIPTION
+        Matches `<PackageId>.<version>.nupkg` where the version segment starts with
+        a digit, so `Microsoft.UI.Reactor` never picks up its own siblings
+        `Microsoft.UI.Reactor.Advanced` / `.Devtools` that share the same dir. The
+        `.symbols.nupkg` sidecar is excluded; ties broken by newest write time.
+    #>
+    param([string]$PackOutput, [string]$PackageId)
+    $pattern = '^' + [regex]::Escape($PackageId) + '\.\d[^\\/]*\.nupkg$'
+    Get-ChildItem -LiteralPath $PackOutput -Filter '*.nupkg' -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match $pattern -and $_.Name -notlike '*.symbols.nupkg' } |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1
+}
 
 function Get-NupkgAssemblyBytes {
     <#
@@ -137,17 +163,13 @@ foreach ($t in $targets) {
         if ($LASTEXITCODE -ne 0) {
             Write-Warning "dotnet pack failed for $($t.PackageId) (exit $LASTEXITCODE) — emitting n/a."
         } else {
-            # `<id>.<version>.nupkg`, excluding the `.symbols.nupkg` sidecar.
-            $nupkg = Get-ChildItem -LiteralPath $PackOutput -Filter "$($t.PackageId).*.nupkg" -File |
-                Where-Object { $_.Name -notlike '*.symbols.nupkg' } |
-                Sort-Object LastWriteTime -Descending |
-                Select-Object -First 1
+            $nupkg = Select-LatestNupkg -PackOutput $PackOutput -PackageId $t.PackageId
             if ($nupkg) {
                 $nupkgBytes = $nupkg.Length
                 $asmBytes = Get-NupkgAssemblyBytes -NupkgPath $nupkg.FullName -AssemblyFile $t.AssemblyFile
                 Write-Host "    $($nupkg.Name): nupkg=$nupkgBytes B, $($t.AssemblyFile)=$asmBytes B"
             } else {
-                Write-Warning "No .nupkg matching '$($t.PackageId).*.nupkg' in $PackOutput."
+                Write-Warning "No .nupkg matching '$($t.PackageId).<version>.nupkg' in $PackOutput."
             }
         }
     }

--- a/tests/build_metrics/ci/Measure-BuildMetrics.ps1
+++ b/tests/build_metrics/ci/Measure-BuildMetrics.ps1
@@ -1,0 +1,164 @@
+<#
+.SYNOPSIS
+    Build + pack the shipped Reactor NuGet packages in one source tree and emit a
+    JSON list of artifact sizes for the build-metrics PR comment.
+
+.DESCRIPTION
+    Runs `dotnet pack -c Release` for each tracked package, then measures:
+      * the compressed .nupkg (what a consumer downloads), and
+      * the primary uncompressed assembly inside it (lib/<tfm>/<Assembly>.dll —
+        the real "did our code grow" signal).
+
+    The output JSON is an array of measurement objects consumed by
+    BuildMetricsLib.ps1's Format-BuildMetricsComment:
+      { "Key": "...", "Label": "...", "Group": "...", "Bytes": <int|null> }
+
+    A fixed -PackageVersion is used for both the base (main) and PR runs so the
+    version string embedded in the .nuspec is identical and never contributes to
+    the diff — the only size delta is real code/content change.
+
+    Per-package failures are non-fatal: the package's rows are emitted with a
+    null size (rendered as n/a) and the run continues, so one broken pack never
+    blanks the whole report.
+
+    Run locally (measures the current tree):
+      pwsh tests/build_metrics/ci/Measure-BuildMetrics.ps1 `
+        -Root . -OutFile head.sizes.json
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Root,
+    [Parameter(Mandatory)][string]$OutFile,
+    [string]$Configuration = 'Release',
+    [string]$PackageVersion = '0.0.0-buildmetrics',
+    [string]$PackOutput
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Root = (Resolve-Path -LiteralPath $Root).Path
+
+if (-not $PackOutput) {
+    # Derive a stable, tree-specific temp folder so a base + head run in the same
+    # job never share (or clobber) each other's pack output.
+    $hash = [System.BitConverter]::ToString(
+        [System.Security.Cryptography.SHA1]::Create().ComputeHash(
+            [System.Text.Encoding]::UTF8.GetBytes($Root))).Replace('-', '').Substring(0, 12)
+    $PackOutput = Join-Path ([System.IO.Path]::GetTempPath()) "build-metrics-$hash"
+}
+if (Test-Path -LiteralPath $PackOutput) {
+    Remove-Item -LiteralPath $PackOutput -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $PackOutput | Out-Null
+
+# ── Tracked packages ─────────────────────────────────────────────────────────
+# Keys are stable identifiers (NOT filenames — the .nupkg carries a version), so
+# base and head rows line up even when their MinVer versions differ. Advanced +
+# Devtools pack from their AnyCPU output (mirrors release.yml), which the standalone
+# `dotnet pack` produces by default; passing it explicitly keeps parity if the
+# csproj default ever changes.
+$targets = @(
+    [pscustomobject]@{
+        PkgKey = 'nupkg.Reactor'; PkgLabel = 'Microsoft.UI.Reactor.nupkg'
+        AsmKey = 'asm.Reactor';   AsmLabel = 'Reactor.dll'
+        Project = 'src/Reactor/Reactor.csproj'
+        PackageId = 'Microsoft.UI.Reactor'; AssemblyFile = 'Reactor.dll'
+        ExtraArgs = @()
+    }
+    [pscustomobject]@{
+        PkgKey = 'nupkg.Advanced'; PkgLabel = 'Microsoft.UI.Reactor.Advanced.nupkg'
+        AsmKey = 'asm.Advanced';   AsmLabel = 'Reactor.Advanced.dll'
+        Project = 'src/Reactor.Advanced/Reactor.Advanced.csproj'
+        PackageId = 'Microsoft.UI.Reactor.Advanced'; AssemblyFile = 'Reactor.Advanced.dll'
+        ExtraArgs = @('-p:Platform=AnyCPU')
+    }
+    [pscustomobject]@{
+        PkgKey = 'nupkg.Devtools'; PkgLabel = 'Microsoft.UI.Reactor.Devtools.nupkg'
+        AsmKey = 'asm.Devtools';   AsmLabel = 'Microsoft.UI.Reactor.Devtools.dll'
+        Project = 'src/Reactor.Devtools/Reactor.Devtools.csproj'
+        PackageId = 'Microsoft.UI.Reactor.Devtools'; AssemblyFile = 'Microsoft.UI.Reactor.Devtools.dll'
+        ExtraArgs = @('-p:Platform=AnyCPU')
+    }
+)
+
+$packageGroup  = 'Packages (compressed .nupkg)'
+$assemblyGroup = 'Assemblies (uncompressed)'
+
+function Get-NupkgAssemblyBytes {
+    <#
+    .SYNOPSIS
+        Uncompressed size of the largest lib/<tfm>/<AssemblyFile> entry in a
+        .nupkg, without extracting it. $null if the archive has no such entry.
+    #>
+    param([string]$NupkgPath, [string]$AssemblyFile)
+    $zip = $null
+    try {
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($NupkgPath)
+        $best = $null
+        foreach ($entry in $zip.Entries) {
+            # NuGet lib assets: lib/<tfm>/<file>. FullName uses forward slashes.
+            if ($entry.FullName -match ('^lib/[^/]+/' + [regex]::Escape($AssemblyFile) + '$')) {
+                if ($null -eq $best -or $entry.Length -gt $best) { $best = $entry.Length }
+            }
+        }
+        return $best
+    } catch {
+        Write-Warning "Failed to read '$AssemblyFile' from ${NupkgPath}: $($_.Exception.Message)"
+        return $null
+    } finally {
+        if ($zip) { $zip.Dispose() }
+    }
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+
+$measurements = [System.Collections.Generic.List[object]]::new()
+
+foreach ($t in $targets) {
+    $projPath = Join-Path $Root $t.Project
+    Write-Host "==> Packing $($t.PackageId) ($($t.Project))"
+
+    $nupkgBytes = $null
+    $asmBytes = $null
+
+    if (-not (Test-Path -LiteralPath $projPath)) {
+        Write-Warning "Project not found: $projPath — emitting n/a for $($t.PackageId)."
+    } else {
+        $packArgs = @(
+            'pack', $projPath,
+            '-c', $Configuration,
+            "-p:Version=$PackageVersion",
+            '-o', $PackOutput,
+            '--nologo'
+        ) + $t.ExtraArgs
+
+        & dotnet @packArgs 2>&1 | Tee-Object -Variable packLog | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "dotnet pack failed for $($t.PackageId) (exit $LASTEXITCODE) — emitting n/a."
+        } else {
+            # `<id>.<version>.nupkg`, excluding the `.symbols.nupkg` sidecar.
+            $nupkg = Get-ChildItem -LiteralPath $PackOutput -Filter "$($t.PackageId).*.nupkg" -File |
+                Where-Object { $_.Name -notlike '*.symbols.nupkg' } |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 1
+            if ($nupkg) {
+                $nupkgBytes = $nupkg.Length
+                $asmBytes = Get-NupkgAssemblyBytes -NupkgPath $nupkg.FullName -AssemblyFile $t.AssemblyFile
+                Write-Host "    $($nupkg.Name): nupkg=$nupkgBytes B, $($t.AssemblyFile)=$asmBytes B"
+            } else {
+                Write-Warning "No .nupkg matching '$($t.PackageId).*.nupkg' in $PackOutput."
+            }
+        }
+    }
+
+    $measurements.Add([pscustomobject]@{ Key = $t.PkgKey; Label = $t.PkgLabel; Group = $packageGroup;  Bytes = $nupkgBytes })
+    $measurements.Add([pscustomobject]@{ Key = $t.AsmKey; Label = $t.AsmLabel; Group = $assemblyGroup; Bytes = $asmBytes })
+}
+
+# Depth 5 is plenty for the flat measurement objects; force an array shape even
+# for a single element so the consumer always ConvertFrom-Json's an array.
+$json = ConvertTo-Json -InputObject @($measurements) -Depth 5
+Set-Content -LiteralPath $OutFile -Value $json -Encoding UTF8
+Write-Host ""
+Write-Host "Wrote $($measurements.Count) measurement(s) to $OutFile"

--- a/tests/build_metrics/ci/Measure-BuildMetrics.ps1
+++ b/tests/build_metrics/ci/Measure-BuildMetrics.ps1
@@ -55,10 +55,25 @@ if (-not $PackOutput) {
             [System.Text.Encoding]::UTF8.GetBytes($Root))).Replace('-', '').Substring(0, 12)
     $PackOutput = Join-Path ([System.IO.Path]::GetTempPath()) "build-metrics-$hash"
 }
-if (Test-Path -LiteralPath $PackOutput) {
-    Remove-Item -LiteralPath $PackOutput -Recurse -Force
+
+# Safety guard: we Remove-Item -Recurse -Force this path below. -PackOutput is
+# caller-supplied, so refuse obviously-unsafe targets (a filesystem/drive root, or
+# the current/root of the source tree) before deleting anything.
+$packFull = [System.IO.Path]::GetFullPath($PackOutput)
+$pathRoot = [System.IO.Path]::GetPathRoot($packFull)
+$rootFull = [System.IO.Path]::GetFullPath($Root)
+if ($packFull -eq $pathRoot -or
+    $packFull -eq $rootFull -or
+    $packFull -eq [System.IO.Path]::GetFullPath((Get-Location).Path) -or
+    ($packFull.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar).Length -le $pathRoot.Length)) {
+    throw "Refusing to use an unsafe -PackOutput '$packFull' (it is a root or the source tree). Pass a dedicated subfolder."
 }
-New-Item -ItemType Directory -Force -Path $PackOutput | Out-Null
+
+if (Test-Path -LiteralPath $packFull) {
+    Remove-Item -LiteralPath $packFull -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $packFull | Out-Null
+$PackOutput = $packFull
 
 # ── Tracked packages ─────────────────────────────────────────────────────────
 # Keys are stable identifiers (NOT filenames — the .nupkg carries a version), so

--- a/tests/build_metrics/ci/README.md
+++ b/tests/build_metrics/ci/README.md
@@ -1,0 +1,97 @@
+# Build metrics (artifact size-diff) PR comment
+
+An automatic, self-updating PR comment that reports how much each shipped Reactor
+artifact grew or shrank versus `main`. Informational only — it never fails a PR.
+
+Example:
+
+> ## 📦 Build metrics
+>
+> Artifact sizes for `deadbee` vs `main` (`cafef00`).
+>
+> ### Packages (compressed .nupkg)
+>
+> | Artifact | main | PR | Δ | |
+> |---|--:|--:|--:|:-:|
+> | Microsoft.UI.Reactor.nupkg | 1.94 MB | 1.95 MB | +8.4 KB (+0.42%) | ⚠️ |
+>
+> ### Assemblies (uncompressed)
+>
+> | Artifact | main | PR | Δ | |
+> |---|--:|--:|--:|:-:|
+> | Reactor.dll | 3.16 MB | 3.16 MB | +0 B (0.00%) | ≈ |
+
+## What is measured
+
+For each shipped package the report tracks two numbers:
+
+| Group | What | Why |
+|---|---|---|
+| **Packages (compressed .nupkg)** | the `.nupkg` file size | the download a consumer actually pays for |
+| **Assemblies (uncompressed)** | the primary DLL inside `lib/<tfm>/` | the real "did our code grow" signal, unaffected by zip compression noise |
+
+Tracked packages (see `$targets` in `Measure-BuildMetrics.ps1`):
+
+- `Microsoft.UI.Reactor` → `Reactor.dll`
+- `Microsoft.UI.Reactor.Advanced` → `Reactor.Advanced.dll`
+- `Microsoft.UI.Reactor.Devtools` → `Microsoft.UI.Reactor.Devtools.dll`
+
+Adding a package is a one-line entry in that `$targets` array.
+
+## Files
+
+| File | Role |
+|---|---|
+| `BuildMetricsLib.ps1` | **Pure** helpers (no filesystem side effects): byte formatting, `Get-SizeDelta`, and the sticky-comment renderer. Unit-testable headless. |
+| `BuildMetricsLib.Tests.ps1` | Dependency-free assertions for the pure lib. Exits non-zero on failure. |
+| `Measure-BuildMetrics.ps1` | Orchestrator: `dotnet pack` each package in a source tree and emit a `sizes.json` of measurements. |
+
+## Workflows
+
+Two workflows implement the standard secure `pull_request` + `workflow_run`
+split, so untrusted PR build code never holds a write token:
+
+| Workflow | Trigger | Privilege | Job |
+|---|---|---|---|
+| `.github/workflows/build-metrics.yml` | `pull_request` (+ manual `workflow_dispatch`) | read-only | Builds + packs the PR head **and** base, measures both, renders the comment, uploads it as an artifact. Runs untrusted PR build code. |
+| `.github/workflows/build-metrics-comment.yml` | `workflow_run` | `pull-requests: write` | Downloads the artifact and posts/updates the sticky comment. Runs **no** PR code. Resolves the target PR from the trusted `workflow_run` head SHA, never the artifact. |
+| `.github/workflows/build-metrics-lib-tests.yml` | `pull_request` / `push` on `tests/build_metrics/ci/**` | read-only | Fast headless run of `BuildMetricsLib.Tests.ps1`. |
+
+The sticky comment is found + updated in place via a hidden marker
+(`<!-- reactor-build-metrics -->`), the same convention as
+`tests/stress_perf/ci/PerfLib.ps1`.
+
+## Local runbook
+
+Unit-test the renderer (seconds, no build):
+
+```pwsh
+pwsh tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+```
+
+Measure the current tree and render a comment against a baseline:
+
+```pwsh
+# Measure this working tree.
+pwsh tests/build_metrics/ci/Measure-BuildMetrics.ps1 -Root . -OutFile head.sizes.json
+
+# Measure another checkout/worktree (e.g. main) the same way -> base.sizes.json,
+# then render:
+. tests/build_metrics/ci/BuildMetricsLib.ps1
+$head = Get-Content head.sizes.json -Raw | ConvertFrom-Json
+$base = Get-Content base.sizes.json -Raw | ConvertFrom-Json
+Format-BuildMetricsComment -BaseMeasurements $base -HeadMeasurements $head -HeadSha HEAD -BaseSha main
+```
+
+## Notes
+
+- A fixed package version (`0.0.0-buildmetrics`) is used for both sides so the
+  version string embedded in the `.nuspec` never contributes to the diff.
+- A small noise band (64 B **and** 0.05%, both must clear) keeps `.nupkg` zip
+  jitter from rendering as a spurious regression.
+- Growth is the regression direction for every artifact, so a shrink is flagged
+  as the improvement (✅) and growth as the regression (⚠️).
+- Not yet tracked (candidate future `$targets` entries): the NativeAOT-published
+  `hello-world-aot.exe` — the highest-value size signal for this AOT/trim-focused
+  repo — and the `mur` CLI publish. Left out of the initial cut to keep the double
+  build fast and reliable; both slot in as additional targets.

--- a/tests/build_metrics/ci/README.md
+++ b/tests/build_metrics/ci/README.md
@@ -55,7 +55,7 @@ the comment body**:
 
 | Workflow | Trigger | Privilege | Job |
 |---|---|---|---|
-| `.github/workflows/build-metrics.yml` | `pull_request` (+ manual `workflow_dispatch`) | read-only | Builds + packs the PR head **and** base and measures both, then uploads **only** the machine-readable `sizes.json`. Runs untrusted PR build code. |
+| `.github/workflows/build-metrics.yml` | `pull_request` (+ manual `workflow_dispatch`) | read-only | Builds + packs the PR head **and** base and measures both, then uploads **only** the machine-readable data (`head.sizes.json` + `base.sizes.json`). Runs untrusted PR build code. |
 | `.github/workflows/build-metrics-comment.yml` | `workflow_run` | `issues: write` | Checks out **trusted** default-branch code, validates the uploaded numbers via `ConvertTo-SafeMeasurements`, **renders** the comment itself, and posts/updates it. Runs **no** PR code. Resolves the target PR from the trusted `workflow_run` head SHA, never the artifact. |
 | `.github/workflows/build-metrics-lib-tests.yml` | `pull_request` / `push` on `tests/build_metrics/ci/**` | read-only | Fast headless run of both `*.Tests.ps1` files. |
 

--- a/tests/build_metrics/ci/README.md
+++ b/tests/build_metrics/ci/README.md
@@ -1,23 +1,23 @@
 # Build metrics (artifact size-diff) PR comment
 
 An automatic, self-updating PR comment that reports how much each shipped Reactor
-artifact grew or shrank versus `main`. Informational only — it never fails a PR.
+artifact grew or shrank versus the PR's base branch. Informational only — it never fails a PR.
 
 Example:
 
 > ## 📦 Build metrics
 >
-> Artifact sizes for `deadbee` vs `main` (`cafef00`).
+> Artifact sizes for `deadbee` vs the base branch (`cafef00`).
 >
 > ### Packages (compressed .nupkg)
 >
-> | Artifact | main | PR | Δ | |
+> | Artifact | base | PR | Δ | |
 > |---|--:|--:|--:|:-:|
 > | Microsoft.UI.Reactor.nupkg | 1.94 MB | 1.95 MB | +8.4 KB (+0.42%) | ⚠️ |
 >
 > ### Assemblies (uncompressed)
 >
-> | Artifact | main | PR | Δ | |
+> | Artifact | base | PR | Δ | |
 > |---|--:|--:|--:|:-:|
 > | Reactor.dll | 3.16 MB | 3.16 MB | +0 B (0.00%) | ≈ |
 

--- a/tests/build_metrics/ci/README.md
+++ b/tests/build_metrics/ci/README.md
@@ -42,24 +42,34 @@ Adding a package is a one-line entry in that `$targets` array.
 
 | File | Role |
 |---|---|
-| `BuildMetricsLib.ps1` | **Pure** helpers (no filesystem side effects): byte formatting, `Get-SizeDelta`, and the sticky-comment renderer. Unit-testable headless. |
-| `BuildMetricsLib.Tests.ps1` | Dependency-free assertions for the pure lib. Exits non-zero on failure. |
+| `BuildMetricsLib.ps1` | **Pure** helpers (no filesystem side effects): byte formatting, `Get-SizeDelta`, the sticky-comment renderer, the trusted `Get-BuildMetricsTargetSpec` and `ConvertTo-SafeMeasurements` (the render-time security boundary). Unit-testable headless. |
+| `BuildMetricsLib.Tests.ps1` | Dependency-free assertions for the pure lib (incl. the sanitizer). Exits non-zero on failure. |
 | `Measure-BuildMetrics.ps1` | Orchestrator: `dotnet pack` each package in a source tree and emit a `sizes.json` of measurements. |
+| `Measure-BuildMetrics.Tests.ps1` | AST-extracted tests for the orchestrator's `Select-LatestNupkg` + `Get-NupkgAssemblyBytes` (synthesizes real `.nupkg` ZIPs; no `dotnet`). |
 
 ## Workflows
 
 Two workflows implement the standard secure `pull_request` + `workflow_run`
-split, so untrusted PR build code never holds a write token:
+split, so untrusted PR build code never holds a write token **and never renders
+the comment body**:
 
 | Workflow | Trigger | Privilege | Job |
 |---|---|---|---|
-| `.github/workflows/build-metrics.yml` | `pull_request` (+ manual `workflow_dispatch`) | read-only | Builds + packs the PR head **and** base, measures both, renders the comment, uploads it as an artifact. Runs untrusted PR build code. |
-| `.github/workflows/build-metrics-comment.yml` | `workflow_run` | `pull-requests: write` | Downloads the artifact and posts/updates the sticky comment. Runs **no** PR code. Resolves the target PR from the trusted `workflow_run` head SHA, never the artifact. |
-| `.github/workflows/build-metrics-lib-tests.yml` | `pull_request` / `push` on `tests/build_metrics/ci/**` | read-only | Fast headless run of `BuildMetricsLib.Tests.ps1`. |
+| `.github/workflows/build-metrics.yml` | `pull_request` (+ manual `workflow_dispatch`) | read-only | Builds + packs the PR head **and** base and measures both, then uploads **only** the machine-readable `sizes.json`. Runs untrusted PR build code. |
+| `.github/workflows/build-metrics-comment.yml` | `workflow_run` | `issues: write` | Checks out **trusted** default-branch code, validates the uploaded numbers via `ConvertTo-SafeMeasurements`, **renders** the comment itself, and posts/updates it. Runs **no** PR code. Resolves the target PR from the trusted `workflow_run` head SHA, never the artifact. |
+| `.github/workflows/build-metrics-lib-tests.yml` | `pull_request` / `push` on `tests/build_metrics/ci/**` | read-only | Fast headless run of both `*.Tests.ps1` files. |
+
+**Why the poster renders (not the measure job):** the measure job builds
+untrusted PR code, so if it produced the final markdown a PR could make the
+privileged bot post arbitrary content. Instead it emits only numbers; the
+trusted poster maps them through a fixed `Key → Label` spec (dropping unknown
+keys and any non-integer/negative byte value), so the comment is fully
+determined by trusted code plus a handful of validated integers.
 
 The sticky comment is found + updated in place via a hidden marker
-(`<!-- reactor-build-metrics -->`), the same convention as
-`tests/stress_perf/ci/PerfLib.ps1`.
+(`<!-- reactor-build-metrics -->`) — the same *mechanism* as
+`tests/stress_perf/ci/PerfLib.ps1`, which uses its own distinct marker
+(`<!-- reactor-perf-compare -->`).
 
 ## Local runbook
 

--- a/tests/build_metrics/ci/README.md
+++ b/tests/build_metrics/ci/README.md
@@ -67,9 +67,11 @@ artifact.
 
 **Why the poster renders (not the measure job):** the measure job builds
 untrusted PR code, so if it produced the final markdown a PR could make the
-privileged bot post arbitrary content. Instead it emits only numbers; the
-trusted poster maps them through a fixed `Key → Label` spec (dropping unknown
-keys and any non-integer/negative byte value), so the comment is fully
+privileged bot post arbitrary content. Instead the artifact carries only
+per-artifact byte counts (the `sizes.json` also includes label/group strings, but
+the poster **ignores** them). The trusted poster re-maps every row through a fixed
+`Key → Label` spec — dropping unknown keys, using its own trusted labels/groups,
+and accepting only non-negative integer byte counts — so the comment is fully
 determined by trusted code plus a handful of validated integers.
 
 The sticky comment is found + updated in place via a hidden marker

--- a/tests/build_metrics/ci/README.md
+++ b/tests/build_metrics/ci/README.md
@@ -59,6 +59,12 @@ the comment body**:
 | `.github/workflows/build-metrics-comment.yml` | `workflow_run` | `issues: write` | Checks out **trusted** default-branch code, validates the uploaded numbers via `ConvertTo-SafeMeasurements`, **renders** the comment itself, and posts/updates it. Runs **no** PR code. Resolves the target PR from the trusted `workflow_run` head SHA, never the artifact. |
 | `.github/workflows/build-metrics-lib-tests.yml` | `pull_request` / `push` on `tests/build_metrics/ci/**` | read-only | Fast headless run of both `*.Tests.ps1` files. |
 
+A comment is posted **only for `pull_request` runs**. A manual `workflow_dispatch`
+run is **measure-only**: it still builds and uploads the `sizes.json` artifact, but
+the poster can't safely resolve a PR from a dispatch's head SHA (which points at
+the default branch), so it posts nothing — read the numbers from the run's
+artifact.
+
 **Why the poster renders (not the measure job):** the measure job builds
 untrusted PR code, so if it produced the final markdown a PR could make the
 privileged bot post arbitrary content. Instead it emits only numbers; the


### PR DESCRIPTION
Closes #817.

Adds two automatic, self-updating **sticky** PR comments and retires the manual `@codecoverage` trigger.

## 1. Build metrics (size diff) — new
On every PR commit, builds + `dotnet pack`s the shipped packages at the PR head **and** at `main`, then posts a comment with the per-artifact size delta:

- **Packages (compressed `.nupkg`)** — consumer download size
- **Assemblies (uncompressed DLL inside)** — the real "did our code grow" signal (immune to zip jitter)

Informational only — never fails a PR. Growth ⚠️, shrink ✅, within-noise ≈. Sample:

> ## 📦 Build metrics
> Artifact sizes for `deadbee` vs `main` (`cafef00`).
> ### Assemblies (uncompressed)
> | Artifact | main | PR | Δ | |
> |---|--:|--:|--:|:-:|
> | Reactor.dll | 3.16 MB | 3.23 MB | +66.1 KB (+2.04%) | ⚠️ |

Tracks `Microsoft.UI.Reactor` / `.Advanced` / `.Devtools` (+ their DLLs). Adding a package is a one-line `$targets` entry. Future candidates noted in the README: the NativeAOT `hello-world-aot.exe` and the `mur` CLI.

## 2. Coverage — now automatic
Converts `coverage.yml` from the maintainer-gated `@codecoverage` comment trigger to an automatic sticky comment on every PR (updates in place on new commits). Same merged unit + selftest recipe — **measurement steps unchanged**. `workflow_dispatch` (incl. blank-input branch → job summary) is kept.

**Why now:** the old trigger ran only ~9 times in the last ~420 workflow events. Timing validation of real runs: **8.9–11.6 min (~10 min avg)**, in parallel with jobs already on every PR (e2e is budgeted at 45 min), so wall-clock impact ≈ nil.

## Security model
Both features use the standard secure `pull_request` + `workflow_run` split:

- **Measure** job (`build-metrics.yml`, `coverage.yml`): runs untrusted PR build code with a **read-only** token, no secrets, cannot comment. Uploads the rendered comment as an artifact.
- **Poster** job (`build-metrics-comment.yml`, `coverage-comment.yml`): privileged (`pull-requests: write`), runs **no** PR code. Resolves the target PR from the **trusted `workflow_run` head SHA** (via `commits/{sha}/pulls`), never the artifact — so a crafted artifact can't redirect the comment onto another PR. Works for forks.

This is strictly safer than the old `issue_comment` coverage design, which ran PR code with a write token.

## Implementation notes
Follows the existing PerfLib pattern (`tests/stress_perf/ci/`):

- `tests/build_metrics/ci/BuildMetricsLib.ps1` — pure, side-effect-free renderer (byte formatting, direction-aware deltas with a 64 B + 0.05% noise band, sticky comment with hidden marker).
- `tests/build_metrics/ci/BuildMetricsLib.Tests.ps1` — 66 headless assertions, no build required.
- `tests/build_metrics/ci/Measure-BuildMetrics.ps1` — pack + measure orchestrator (measures the DLL inside the `.nupkg` without extracting; fixed package version so the version string never skews the diff).
- `build-metrics-lib-tests.yml` — fast Linux lib-test gate on `tests/build_metrics/ci/**`.
- Handles edge cases: PR-build failure → caution comment; base-build failure → absolute sizes with a "baseline unavailable" warning instead of mislabelling everything as new.

## Validation
- `BuildMetricsLib.Tests.ps1`: 66 passed, 0 failed.
- `Measure-BuildMetrics.ps1` smoke-tested locally against this tree — all 3 packages pack and measure; end-to-end comment renders correctly.
- `actionlint` clean on all 5 workflows.

Not covered by CI here: the two workflows only fully exercise on a real PR event / `workflow_run` (which is this PR). The pure lib + orchestrator are locally validated.