### PR TITLE
ci: verify committed reactor.api.txt in PR unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,16 @@ jobs:
           dotnet restore tests/Reactor.Advanced.Tests/Reactor.Advanced.Tests.csproj -p:Platform=x64
 
       - name: Test
+        # SkipSignaturesGen / SkipReactorApiGen disable the on-build regeneration of
+        # skills/reactor.api.txt. Without them, building Reactor.Tests regenerates the
+        # committed index in place (host arch == target arch on the x64 runner), so
+        # Tooling.ApiIndexGeneratorTests.Index_IsUpToDate compares the freshly-written
+        # file against itself and passes even when the checked-in index is stale. That
+        # is exactly how a stale index reached main (only the internal nightly, which
+        # gates the regen via -p:CI=true, caught it). Gating the regen off here makes
+        # Index_IsUpToDate verify the committed copies against the live surface in PR CI.
         run: |
-          dotnet test tests/Reactor.Tests/Reactor.Tests.csproj --no-restore -p:Platform=x64 --logger "console;verbosity=normal" --blame-hang-timeout 180s --blame-hang-dump-type none
+          dotnet test tests/Reactor.Tests/Reactor.Tests.csproj --no-restore -p:Platform=x64 -p:SkipSignaturesGen=true -p:SkipReactorApiGen=true --logger "console;verbosity=normal" --blame-hang-timeout 180s --blame-hang-dump-type none
           dotnet test tests/Reactor.Advanced.Tests/Reactor.Advanced.Tests.csproj --no-restore -p:Platform=x64 --logger "console;verbosity=normal" --blame-hang-timeout 180s --blame-hang-dump-type none
 
   integration-tests:


### PR DESCRIPTION
## What

Makes the GitHub Actions `unit-tests` job actually verify the committed API index by passing `-p:SkipSignaturesGen=true -p:SkipReactorApiGen=true` to the `Reactor.Tests` run.

Fixes #819.

## Why

`dotnet test tests/Reactor.Tests` builds the test project, and on the x64 runner (host arch == target arch) that build runs `RunSignaturesGen` (Reactor.Cli) / SignaturesGen's `AfterBuild`, which **regenerate `skills/reactor.api.txt` in place** before the tests run. So `Tooling.ApiIndexGeneratorTests.Index_IsUpToDate` ends up comparing the freshly-regenerated file against the live surface and always passes — even when the checked-in copies are stale.

The regen is gated off only when `-p:CI=true` (or the two `Skip*` flags) are set. The internal nightly passes `-p:CI=true`, so it was the *only* pipeline verifying the committed index. That's how #816 merged with a stale index (all GitHub checks green) and only the nightly caught it afterward.

Gating the regen off here lets the existing `Index_IsUpToDate` test compare the committed copies against the live surface in PR CI. It also sidesteps the nested-SignaturesGen build race the `Skip*` flags were designed for.

## Verification (locally, on an arch-match x64 build)

- Stale the index (drop the `= 0` defaults from the `BorderThickness` line), then build **without** the flags → the build silently regenerates the index in place (git diff clears). This is the masking that hid #816.
- Same stale index, build **with** `-p:SkipSignaturesGen=true -p:SkipReactorApiGen=true` → the index stays stale, and `Index_IsUpToDate` fails with `skills/reactor.api.txt is stale.`
- With a current index, the ApiIndex tests pass. `.github/workflows/ci.yml` parses cleanly.

No product code changes — CI workflow only.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>