### PR TITLE
Fix: build-metrics/coverage comment posters need pull-requests: write

### DIFF
--- a/.github/workflows/build-metrics-comment.yml
+++ b/.github/workflows/build-metrics-comment.yml
@@ -24,7 +24,7 @@ on:
 permissions:
   contents: read
   actions: read          # download the triggering run's artifact
-  pull-requests: read    # resolve the PR from the trusted head SHA
+  pull-requests: write   # resolve the PR + post/update the comment
   issues: write          # PR conversation comments use the issues API
 
 jobs:

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -20,7 +20,7 @@ on:
 permissions:
   contents: read
   actions: read          # download the triggering run's artifact
-  pull-requests: read    # resolve the PR from the trusted head SHA
+  pull-requests: write   # resolve the PR + post/update the comment
   issues: write          # PR conversation comments use the issues API
 
 jobs:

--- a/tests/build_metrics/ci/README.md
+++ b/tests/build_metrics/ci/README.md
@@ -56,7 +56,7 @@ the comment body**:
 | Workflow | Trigger | Privilege | Job |
 |---|---|---|---|
 | `.github/workflows/build-metrics.yml` | `pull_request` (+ manual `workflow_dispatch`) | read-only | Builds + packs the PR head **and** base and measures both, then uploads **only** the machine-readable data (`head.sizes.json` + `base.sizes.json`). Runs untrusted PR build code. |
-| `.github/workflows/build-metrics-comment.yml` | `workflow_run` | `issues: write` | Checks out **trusted** default-branch code, validates the uploaded numbers via `ConvertTo-SafeMeasurements`, **renders** the comment itself, and posts/updates it. Runs **no** PR code. Resolves the target PR from the trusted `workflow_run` head SHA, never the artifact. |
+| `.github/workflows/build-metrics-comment.yml` | `workflow_run` | `pull-requests: write` | Checks out **trusted** default-branch code, validates the uploaded numbers via `ConvertTo-SafeMeasurements`, **renders** the comment itself, and posts/updates it. Runs **no** PR code. Resolves the target PR from the trusted `workflow_run` head SHA, never the artifact. |
 | `.github/workflows/build-metrics-lib-tests.yml` | `pull_request` / `push` on `tests/build_metrics/ci/**` | read-only | Fast headless run of both `*.Tests.ps1` files. |
 
 A comment is posted **only for `pull_request` runs**. A manual `workflow_dispatch`


### PR DESCRIPTION
## Problem

The two `workflow_run` comment posters — `.github/workflows/build-metrics-comment.yml` and `.github/workflows/coverage-comment.yml` — fail with `Resource not accessible by integration` (HTTP 403) when posting the sticky comment. Confirmed live on **PR #822**: the `Build metrics comment` run's `Post / update sticky comment` step 403'd on `POST /repos/{owner}/{repo}/issues/822/comments`.

## Root cause

Both posters declared `pull-requests: read`. Creating a comment on a **pull request** requires `pull-requests: write` — GitHub treats the resource as a pull request and enforces that scope even though the endpoint path is `/issues/{n}/comments`. (The earlier packaging review suggestion to drop these posters to `issues: write` was incorrect for PRs.) The already-working `.github/workflows/perf-compare.yml` poster uses `pull-requests: write` + `issues: write`, which is the correct combination.

This only surfaced **after merge**: `workflow_run` posters always run from `main`, so #818 itself never exercised the posting path — the first real post happened on #822 once the feature was live.

## Fix

Minimal, permissions-only:

- `build-metrics-comment.yml`: `pull-requests: read` → `pull-requests: write`
- `coverage-comment.yml`: `pull-requests: read` → `pull-requests: write`
- `tests/build_metrics/ci/README.md`: Workflows-table Privilege cell for the build-metrics poster updated to `pull-requests: write`

`contents: read`, `actions: read`, and `issues: write` are unchanged in both workflows, and no workflow logic was touched. Both YAML files were validated to still parse.

Refs #818.