### PR TITLE
docs: fix stale references and re-sync generated guide pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,8 @@ Component.Render() → Element tree (records)
 ### Reconciler is split across partial classes
 
 - `Reconciler.cs` — orchestration, child reconciliation, unmount, helpers
-- `Reconciler.Mount.cs` — `MountXxx()` handler per control type
-- `Reconciler.Update.cs` — `UpdateXxx()` handler per control type
+- `Reconciler.Mount.cs` — mount dispatch + composition-primitive handlers (controls mount via their registered `ControlDescriptor`/`IElementHandler`)
+- `Reconciler.Update.cs` — update dispatch + composition-primitive handlers (controls update via the same registered descriptors/handlers)
 
 ### Hooks follow React rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ The legacy Element-record + `MountXxx`/`UpdateXxx` dispatch-switch path is gone.
 3. **Register** it in `RegisterV1BuiltInHandlers`.
 4. **Selftest fixture** in `tests/Reactor.AppTests.Host/SelfTest/Fixtures/`.
 
-See [`docs/guide/extensibility-preview.md`](docs/guide/extensibility-preview.md) for the authoring-shape decision tree (prop/engine shapes, children strategies, echo handling, pooling).
+See [`docs/guide/extending-reactor-controls.md`](docs/guide/extending-reactor-controls.md) for the authoring-shape decision tree (prop/engine shapes, children strategies, echo handling, pooling).
 
 Optionally: a factory method in `src/Reactor/Elements/Dsl.cs`, fluent modifiers in `ElementExtensions.cs`, and unit tests in `Reactor.Tests/`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 - Windows App SDK 2.0 — restored automatically from NuGet, no manual install required
 - Visual Studio 2022 (17.8+) or VS Code with C# Dev Kit
 
-> **Package version:** All projects reference `Microsoft.WindowsAppSDK` **2.0.1** (public NuGet). The version is centralized in `Directory.Build.props` — update it there to change the version for every project at once.
+> **Package version:** All projects reference `Microsoft.WindowsAppSDK` **2.1.3** (public NuGet). The version is centralized in `Directory.Build.props` — update it there to change the version for every project at once.
 
 > **Clone to a short path (Windows):** Clone into a short root directory such as
 > `C:\src\` (for example `C:\src\microsoft-ui-reactor`) rather than a deeply
@@ -142,7 +142,7 @@ tests/
   stress_perf/                    Performance benchmarks
 samples/
   Reactor.TestApp/                Interactive control showcase / demo app
-  apps/                           Sample apps (wordpuzzle, ductfiles, regedit, etc.)
+  apps/                           Sample apps (wordpuzzle, regedit, minesweeper, chat, netpulse, etc.)
   TodoApp/                        Todo app sample
 ```
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ tests/
   Reactor.AppTests.Host/    Selfhost test app — 60+ in-process fixtures
   stress_perf/              Performance benchmarks
 samples/
-  apps/                     Sample apps (wordpuzzle, ductfiles, regedit, etc.)
+  apps/                     Sample apps (wordpuzzle, regedit, minesweeper, chat, netpulse, etc.)
   TodoApp/                  Todo app sample
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,6 @@
 - **[reference/](reference/)** — Architecture deep dives for framework contributors.
 - **[specs/](specs/)** — Design specs, implementation tasks, and proposals.
 - **[research/](research/)** — Competitive analysis, investigations, bug write-ups.
-- **[pitch/](pitch/)** — Marketing materials and design targets.
 - **[reports/](reports/)** — Point-in-time reports (work summaries, metrics).
 - **_pipeline/** — Internals of the doc-generation pipeline. Not reader-facing.
 

--- a/docs/_pipeline/templates/analyzer-architecture.md.dt
+++ b/docs/_pipeline/templates/analyzer-architecture.md.dt
@@ -109,55 +109,58 @@ via `.editorconfig`.
 
 | Id | Severity | Title | Source |
 |---|---|---|---|
+| `REACTOR_THEME_001` | Warning | Use ThemeRef instead of hard-coded color | `UseThemeRefAnalyzer.cs` |
+| `REACTOR_THEME_002` | Info | Consider lightweight styling for visual-state overrides | `UseLightweightStylingAnalyzer.cs` |
+| `REACTOR_THEME_003` | Info | RequestedTheme modifier available | `RequestedThemeSetAnalyzer.cs` |
+| `REACTOR_THEME_004` | Warning | Hard-coded Brush/Color object bypasses theme tokens | `UseThemeRefAnalyzer.cs` |
 | `REACTOR_HOOKS_001` | Warning | Hook called conditionally | `HookRulesAnalyzer.cs` |
 | `REACTOR_HOOKS_004` | Warning | Hook deps contains freshly allocated value | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_005` | Warning | Hook called outside Render or a custom-hook method | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_006` | Info | Resource fetcher looks non-idempotent | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_007` | Warning | UseMemoCells builder captures variable not in deps | `UseMemoCellsAnalyzer.cs` |
-| `REACTOR_HOOKS_008` | Info | State variable read after its setter in the same synchronous handler | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_009` | Warning | Command.DebounceMs set on a command bound without UseCommand | `CommandDebounceAnalyzer.cs` |
+| `REACTOR_HOOKS_005` | Warning | Hook called outside Render or custom-hook method | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_006` | Info | UseResource fetcher looks non-idempotent (use UseMutation for writes) | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_007` | Warning | Builder closure capture missing from dependencies | `UseMemoCellsAnalyzer.cs` |
+| `REACTOR_HOOKS_008` | Info | State variable read after its setter was called in the same synchronous handler (stale read) | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_009` | Warning | Command.DebounceMs is inert unless the command is routed through UseCommand | `CommandDebounceAnalyzer.cs` |
 | `REACTOR_HOOKS_011` | Warning | Controlled input has a state-derived value but an inert change callback | `ControlledInputAnalyzer.cs` |
-| `REACTOR_HOOKS_002` | Info | Hook after an early-return guard | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_003` | Warning | async-void UseEffect body | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_010` | Warning | Reference state mutated in place, same ref re-passed to setter | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_012` | Warning | Memo dependency lacks value equality | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_013` | Warning | UseState/UsePersisted initial value allocated every render | `HookRulesAnalyzer.cs` |
-| `REACTOR_CTX_001` | Info | Context value re-allocated each render (reference-equality type) | `ContextProvideAnalyzer.cs` |
 | `REACTOR_A11Y_001` | Warning | Icon-only button needs an accessible name | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_002` | Warning | Image needs alt text or AccessibilityHidden | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_003` | Warning | Form field needs a label | `AccessibilityAnalyzers.cs` |
-| `REACTOR_A11Y_004` | Warning | Clickable container (`.OnTapped`) needs keyboard focus | `AccessibilityAnalyzers.cs` |
-| `REACTOR_THEME_001` | Warning | Use ThemeRef instead of hard-coded color | `UseThemeRefAnalyzer.cs` |
-| `REACTOR_THEME_002` | Warning | Prefer lightweight styling | `UseLightweightStylingAnalyzer.cs` |
-| `REACTOR_THEME_003` | Warning | RequestedTheme set on a non-root element | `RequestedThemeSetAnalyzer.cs` |
-| `REACTOR_REF_001` | Warning | ElementRef.Current assigned to a reference property instead of a reactive edge | `ReferenceCurrentReadAnalyzer.cs` |
+| `REACTOR_A11Y_004` | Warning | Clickable container (.OnTapped) is not keyboard-reachable; add .IsTabStop(true) | `AccessibilityAnalyzers.cs` |
+| `REACTOR_REF_001` | Warning | Use descriptor.Reference/binding.Reference instead of assigning ElementRef.Current to reference properties | `ReferenceCurrentReadAnalyzer.cs` |
 | `REACTOR_DSL_001` | Warning | Dynamic list item missing .WithKey | `MissingWithKeyAnalyzer.cs` |
-| `REACTOR_DSL_002` | Info | Non-stable .WithKey (list index or per-render value) | `MissingWithKeyAnalyzer.cs` |
-| `REACTOR_DSL_003` | Warning | Typed collection keySelector never keys by item (constant/null/ignores the item) | `ConstantKeySelectorAnalyzer.cs` |
+| `REACTOR_DSL_002` | Info | Non-stable .WithKey (index / Guid.NewGuid / DateTime.Now) | `MissingWithKeyAnalyzer.cs` |
+| `REACTOR_DSL_003` | Warning | Typed collection keySelector never keys by item (returns constant/null or ignores the item), forcing a keyed-diff bailout | `ConstantKeySelectorAnalyzer.cs` |
 | `REACTOR_DOCK_001` | Warning | OnLiveLayoutChanged feeds the live layout back into state | `OnLiveLayoutRoundTripAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
-| `REACTOR_EVENT_001` | Warning | Event wired via `.Set(+=/-=)` re-subscribes every render; prefer a declarative `On*` modifier or `.OnMountAdd`/`.OnUnmountAdd` | `SetEventSubscriptionAnalyzer.cs` |
-| `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
+| `REACTOR_EVENT_001` | Warning | Event wired via .Set(+=/-=) re-subscribes every render; use a declarative On* modifier or .OnMountAdd/.OnUnmountAdd | `SetEventSubscriptionAnalyzer.cs` |
+| `REACTOR_POOL_001` | Warning | .Set assigns to a property reset on pool return; use the surviving Reactor modifier | `PoolResetSetAnalyzer.cs` |
+| `REACTOR_ITEMS_001` | Warning | .Set(ItemsSource=...) on a Reactor-owned collection | `SetOwnedItemsSourceAnalyzer.cs` |
+| `REACTOR_CTRL_001` | Warning | .Set(SelectedItem/SelectedValue) fights controlled SelectedIndex | `SetSelectedItemAnalyzer.cs` |
+| `REACTOR_VIS_001` | Warning | Imperative .Set(Visibility=...) instead of .IsVisible(...) | `PoolResetSetAnalyzer.cs` |
+| `REACTOR_WIN2D_001` | Error | Win2D canvas draws UseCanvasResources output without .UseSharedDevice() (fatal cross-device draw) | `Win2DSharedDeviceAnalyzer.cs` |
+| `REACTOR0050` | Warning | Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_PERSIST_001` | Warning | 2-arg UsePersisted defaults to Application scope; specify scope | `UsePersistedScopeAnalyzer.cs` |
+| `REACTOR_DESC_001` | Warning | ControlRegistry.Register* lambda should be static (trim hygiene) | `StaticRegisterLambdaAnalyzer.cs` |
 | `REACTOR_STATE_001` | Warning | INotifyPropertyChanged on a Component is invisible to the render loop | `ComponentInpcAnalyzer.cs` |
-| `REACTOR_ITEMS_001` | Warning | `.Set(ItemsSource=...)` on a Reactor-owned collection element | `SetOwnedItemsSourceAnalyzer.cs` |
-| `REACTOR_CTRL_001` | Warning | `.Set(SelectedItem/SelectedValue)` fights the controlled SelectedIndex | `SetSelectedItemAnalyzer.cs` |
-| `REACTOR_VIS_001` | Warning | Imperative `.Set(Visibility=...)` instead of `.IsVisible(...)` | `PoolResetSetAnalyzer.cs` |
-| `REACTOR_INPUT_002` | Warning | Unsafe `TryGetFiles` in `.OnDrop`; prefer `TryGetSafeLocalFiles` | `UnsafeDropFilesAnalyzer.cs` |
-| `REACTOR_DIALOG_001` | Warning | Imperative WinUI `ContentDialog.ShowAsync` escapes the render tree | `ImperativeContentDialogAnalyzer.cs` |
-| `REACTOR_WIN2D_001` | Error | Win2D canvas draws `UseCanvasResources` output without `.UseSharedDevice()` | `Win2DSharedDeviceAnalyzer.cs` |
-| `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
-| `REACTOR_DESC_001` | Warning | Non-static `ControlRegistry.Register*` handler-factory lambda (trim/AOT hygiene) | `StaticRegisterLambdaAnalyzer.cs` |
+| `REACTOR_THREAD_002` | Warning | Blocking a Task (.Result/.Wait) in Render/effect | `BlockingTaskAnalyzer.cs` |
 | `REACTOR_OPT_001` | Info | Selection sentinel literal force-asserts instead of Optional<T>.Unset | `OptionalSentinelAnalyzer.cs` |
-| `REACTOR_CMD_001` | Info | Raw-init Command + own click/toggle callback both set (callback wins) | `RawCommandCallbackAnalyzer.cs` |
+| `REACTOR_CMD_001` | Info | Raw-init Command + own click callback both set (callback wins; command never runs) | `RawCommandCallbackAnalyzer.cs` |
 | `REACTOR_THREAD_001` | Warning | UI-thread-only mutator called on a background thread | `UIThreadAffinityAnalyzer.cs` |
-| `REACTOR_GRID_001` | Warning | Declared Grid column/row that no child occupies | `UnusedGridTrackAnalyzer.cs` |
-| `REACTOR_INPUT_001` | Warning | Ctrl/Alt chord on `.OnKeyDown` should be a `Command` accelerator | `OnKeyDownChordAnalyzer.cs` |
-| `REACTOR_PERF_FUNCREF` | Info | `new Command { … }` constructed inline in the render path without `UseMemo` (re-allocated every render) | `MemoizeCommandAnalyzer.cs` |
-| `REACTOR_ANIM_002` | Info | Unstable `.Keyframes` trigger restarts the animation every render | `KeyframeTriggerAnalyzer.cs` |
-| `REACTOR_NAV_001` | Warning | `UseNavigation` handle captured into a `static` field or property | `StaticNavigationHandleAnalyzer.cs` |
-| `REACTOR_MOD_001` | Info | Same atomic-replace placement modifier (`.Grid`/`.Canvas`/`.RelativePanel`/`.Flex`) applied twice in one chain | `DuplicateAtomicModifierAnalyzer.cs` |
-| `REACTOR_MEDIA_001` | Info | Unsized WebView2 in an auto-layout stack | `UnsizedWebViewInStackAnalyzer.cs` |
-| `REACTOR_ANIM_003` | Warning | async lambda to WithAnimation loses the `[ThreadStatic]` scope after await | `AnimationScopeAsyncAnalyzer.cs` |
+| `REACTOR_HOOKS_002` | Info | Hook after an early-return guard | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_003` | Warning | async-void UseEffect body | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_010` | Warning | Mutate-then-set reference state (same ref re-passed to setter) | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_012` | Warning | Memo dependency lacks value equality | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_013` | Warning | UseState/UsePersisted initial value allocated every render | `HookRulesAnalyzer.cs` |
+| `REACTOR_CTX_001` | Info | Context value re-allocated each render (reference-equality type) | `ContextProvideAnalyzer.cs` |
+| `REACTOR_GRID_001` | Warning | Declared Grid column/row that no child occupies (unused track) | `UnusedGridTrackAnalyzer.cs` |
+| `REACTOR_INPUT_001` | Warning | Ctrl/Alt chord on .OnKeyDown is focus-scoped; use a Command accelerator | `OnKeyDownChordAnalyzer.cs` |
+| `REACTOR_PERF_FUNCREF` | Info | Command constructed inline in the render path is re-allocated every render; wrap it in UseMemo | `MemoizeCommandAnalyzer.cs` |
+| `REACTOR_ANIM_002` | Info | Unstable .Keyframes trigger (DateTime.Now / Guid.NewGuid / per-render allocation) restarts the animation every render | `KeyframeTriggerAnalyzer.cs` |
+| `REACTOR_INPUT_002` | Warning | Unsafe TryGetFiles in .OnDrop returns UNC/reparse/virtual files; use TryGetSafeLocalFiles | `UnsafeDropFilesAnalyzer.cs` |
+| `REACTOR_NAV_001` | Warning | UseNavigation handle captured into a static field or property outlives the page and pins its dispatcher | `StaticNavigationHandleAnalyzer.cs` |
+| `REACTOR_DIALOG_001` | Warning | Imperative ContentDialog.ShowAsync escapes the render tree; use the controlled ContentDialog(...) element with IsOpen | `ImperativeContentDialogAnalyzer.cs` |
+| `REACTOR_MOD_001` | Info | Same atomic-replace placement modifier (.Grid/.Canvas/.RelativePanel/.Flex) applied twice in one chain; last-wins overwrite drops earlier args (ships a merge fix) | `DuplicateAtomicModifierAnalyzer.cs` |
+| `REACTOR_MEDIA_001` | Info | WebView2 is a direct child of an auto-layout stack (HStack/VStack/FlexRow/FlexColumn) without explicit .Width/.Height | `UnsizedWebViewInStackAnalyzer.cs` |
+| `REACTOR_ANIM_003` | Warning | async lambda to WithAnimation loses the ThreadStatic scope after await | `AnimationScopeAsyncAnalyzer.cs` |
 | `REACTOR_LIFECYCLE_002` | Warning | UseEffect(Action) allocates a timer/subscription/event with no returned cleanup | `EffectCleanupAnalyzer.cs` |
 | `REACTOR_MEMO_001` | Info | Modifiers on a keyed Memo(key,factory) wrapper opt the row out of the recycle cache | `MemoWrapperModifierAnalyzer.cs` |
 

--- a/docs/_pipeline/templates/architecture-overview.md.dt
+++ b/docs/_pipeline/templates/architecture-overview.md.dt
@@ -145,11 +145,11 @@ the [element pool](element-pool.md)); the Update path uses
 in place or unmount-and-remount. The Unmount path returns to the pool
 and walks effect cleanups in reverse slot order.
 
-The reconciler is split across partial files so the Mount and Update
-switches stay tractable: `Reconciler.Mount.cs` holds the 40+ MountXxx
-handlers, `Reconciler.Update.cs` holds the matching UpdateXxx, and
-[`ChildReconciler.cs`](reconciliation.md) holds the keyed-vs-positional
-child diff. There is one reconciler instance per host; component
+The reconciler is split across partial files: `Reconciler.Mount.cs`
+and `Reconciler.Update.cs` hold the dispatch logic plus the
+composition-primitive handlers, registered descriptors/handlers hold
+per-control mount/update logic, and [`ChildReconciler.cs`](reconciliation.md)
+holds the keyed-vs-positional child diff. There is one reconciler instance per host; component
 recursion shares the dispatch.
 
 ## Hooks — slot table per RenderContext

--- a/docs/_pipeline/templates/cheat-sheet.md.dt
+++ b/docs/_pipeline/templates/cheat-sheet.md.dt
@@ -41,11 +41,11 @@ Doc apps inherit `Reactor.DevtoolsSupport=true` from `docs/_pipeline/apps/Direct
 | `UseContext<T>(ctx)` | `T` | Read a [context](context.md) value. |
 | `UsePersisted<T>(key, initial, scope)` | `(T, Action<T>)` | Survive re-mount via [LRU cache](persistence.md). |
 | `UseColorScheme()` | `ColorScheme` | Reactive light/dark/HighContrast. |
-| `UseAsync(factory, deps)` | `AsyncResource<T>` | [`async-resources`](async-resources.md). |
-| `UseFocusTrap()` | `FocusTrapHandle` | Trap Tab inside a sub-tree. |
-| `UseAnnounce()` | `Action<string>` | Push a screen-reader announcement. |
+| `UseResource(fetcher, cache, deps, opts?)` | `AsyncValue<T>` | [`async-resources`](async-resources.md). |
+| `UseFocusTrap(isActive)` | `FocusTrapHandle` | Trap Tab inside a sub-tree. |
+| `UseAnnounce()` | `AnnounceHandle` | Push a screen-reader announcement (via `.Announce(string)` method). |
 | `UseElementRef<T>()` | `ElementRef<T>` | Reference a realized element for focus, `TeachingTip.Target`, UIA relationships, or XYFocus. |
-| `UseDevtools()` | `DevtoolsApi` | [Dev-tooling](dev-tooling.md) hooks. |
+| `UseDevtools()` | `bool` | [Dev-tooling](dev-tooling.md) gate — true when devtools are enabled. |
 
 ```csharp snippet="cheat-sheet/state-vignette"
 ```

--- a/docs/_pipeline/templates/element-pool.md.dt
+++ b/docs/_pipeline/templates/element-pool.md.dt
@@ -26,8 +26,10 @@ non-poolable types, and parent-state corner cases.
 
 ## Renting on mount
 
-Every `MountXxx` handler in `Reconciler.Mount.cs` follows the same
-shape: try the pool first, allocate fresh on miss.
+The standard descriptor-backed control mount path follows the same
+shape: try the pool first, allocate fresh on miss. Composition-primitive
+handlers in `Reconciler.Mount.cs` allocate their structural wrappers
+directly.
 
 ```csharp snippet="source:src/Reactor/Core/ElementPool.cs#pool-rent"
 ```

--- a/docs/_pipeline/templates/reconciliation.md.dt
+++ b/docs/_pipeline/templates/reconciliation.md.dt
@@ -47,7 +47,7 @@ source pointers that let you verify it.
 |---|---|---|
 | `newEl` is null or `EmptyElement`, `existingControl` exists | Unmount | `Unmount` runs effect cleanups, returns control to pool |
 | `oldEl` is null/Empty, `existingControl` is null | Mount | `Mount` rents from pool or allocates, populates, returns new control |
-| both elements present, `CanUpdate(old, new)` returns true | Update | `UpdateXxx` patches changed properties only; child lists diff |
+| both elements present, `CanUpdate(old, new)` returns true | Update | the matching handler patches changed properties only; child lists diff |
 | both present, `CanUpdate` false (type changed) | Replace | Unmount then Mount; the new control replaces the old in the parent |
 
 Every section below explains how one of those rows is implemented.
@@ -111,13 +111,18 @@ need to mirror it.
 ```csharp snippet="source:src/Reactor/Core/Reconciler.Mount.cs#mount-phase"
 ```
 
-`Mount` is a type-switch over `Element` subclasses. Each branch
-(`MountButton`, `MountText`, `MountStack`, …) allocates or rents a
-WinUI control, sets the properties the element specifies, recurses
-into children, attaches event-trampoline handlers once at mount time,
-and returns the control. The 40+ MountXxx methods live in
-`Reconciler.Mount.cs` — see the [Architecture
-Overview](architecture-overview.md) source map for the structure.
+`Mount` unwraps modifiers, enters the context/theme scopes, and then
+resolves the element through four dispatch arms: per-host `_v1Handlers`,
+per-host `_typeRegistry`, the global `ControlRegistry`, and finally a
+small switch for composition primitives. Built-in and custom WinUI
+controls such as `Button`, `TextBlock`, and stacks mount through their
+registered `ControlDescriptor` or `IElementHandler`; those handlers rent
+or allocate the control, apply initial properties, reconcile children
+through their declared children strategy, wire event trampolines, and
+return the control. The fallback switch in `Reconciler.Mount.cs` is only
+for structural elements: components, function components, memo
+components, error boundaries, transparent `KeyedMemoElement` wrappers,
+and `EmptyElement`.
 
 The reconciler maintains a context-value scope so children rendered
 inside `Mount` see the same [Context](context.md) values their
@@ -132,32 +137,27 @@ don't end up paying GC cost proportional to scroll velocity.
 
 ## Update — patching in place
 
-```csharp
-private void UpdateButton(ButtonElement oldEl, ButtonElement newEl, Button control)
-{
-    if (oldEl.Content != newEl.Content)
-        control.Content = newEl.Content;
-
-    ApplyModifiers(control, oldEl.Modifiers, newEl.Modifiers);
-    ReconcileChildren(oldEl.Children, newEl.Children, control);
-}
-```
-
-`Update` is the other type-switch. For each subclass, `UpdateXxx`
-compares the old element's record fields against the new and writes
-only the differences onto the existing WinUI control. `Button.Content`
-changed? Update that DP. `IsEnabled` is the same? Skip. Modifiers like
-margin and corner-radius diff the same way, just against the merged
-`ElementModifiers` records.
+`Update` mirrors the Mount dispatch: per-host `_v1Handlers`,
+per-host `_typeRegistry`, the global `ControlRegistry`, then the
+composition-primitive fallback switch. Real WinUI controls are patched
+by their registered descriptor or handler, which compares the old and
+new element fields and writes only the changed properties onto the
+existing control. `Button.Content` changed? The descriptor path updates
+that DP. `IsEnabled` is the same? Its prop entry skips the write.
+Modifiers like margin and corner-radius diff the same way, just against
+the merged `ElementModifiers` records. The fallback switch only updates
+structural wrappers such as components and error boundaries; an unchanged
+`KeyedMemoElement` is transparent and returns `null` to keep the
+existing control.
 
 The early-skip optimization is in two places. At the element level,
 `Element.CanSkipUpdate(oldEl, newEl)` returns true when the records
-are structurally identical (and have no theme bindings that need
-re-evaluation) — the reconciler can avoid the `children.Get(i)` COM
-call entirely and just refresh the
+are structurally identical, are not theme-sensitive,
+and have the same callback presence — the reconciler can avoid the
+`children.Get(i)` COM call entirely and just refresh the
 [Tag](#tag-based-event-dispatch) if the element carries callbacks. At
-the property level, each `UpdateXxx` short-circuits per-property:
-unchanged property → no DP write.
+the property level, the descriptor or handler short-circuits per
+property: unchanged property → no DP write.
 
 `CanUpdate(old, new)` is the type-shape check: the same Element record
 type, the same control-target type. Returns true for `(ButtonElement,
@@ -260,9 +260,9 @@ familiar `Panel.Children`:
 - **MenuBar / CommandBar** — `Items` / `PrimaryCommands` / `SecondaryCommands`
 
 The child reconciler walks `Panel.Children`-shaped containers
-uniformly. Gap nodes are handled imperatively in their respective
-MountXxx / UpdateXxx methods — the framework knows which collection
-to walk for each control type and runs a second-pass diff over it.
+uniformly. Gap nodes are handled imperatively by their mount/update handlers —
+the framework knows which collection to walk for each control type and
+runs a second-pass diff over it.
 
 ## Patterns
 

--- a/docs/_pipeline/templates/rules-of-reactor.md.dt
+++ b/docs/_pipeline/templates/rules-of-reactor.md.dt
@@ -37,13 +37,13 @@ The five core rules:
 
 | Rule | Analyzer | Page |
 |---|---|---|
-| Hook order is stable | `REACTOR_HOOKS_001` | [Hooks](hooks.md) |
+| Hook order is stable | `REACTOR_HOOKS_001`, `REACTOR_HOOKS_002` | [Hooks](hooks.md) |
 | Hooks called from Render only | `REACTOR_HOOKS_005` | [Hooks](hooks.md) |
 | Deps are stable | `REACTOR_HOOKS_004` | [Hooks](hooks.md) |
 | Debounced commands need UseCommand | `REACTOR_HOOKS_009` | [Commanding](commanding.md) |
 | Render is pure | *(convention)* | [Components](components.md) |
-| Lists need keys | *(convention)* | [Collections](collections.md) |
-| Theme tokens not literals | `REACTOR_THEME_001` | [Theming Tokens](theming-tokens.md) |
+| Lists need stable keys | `REACTOR_DSL_001..003` | [Collections](collections.md) |
+| Theme tokens not literals | `REACTOR_THEME_001`, `REACTOR_THEME_004` | [Theming Tokens](theming-tokens.md) |
 | Lightweight styling | `REACTOR_THEME_002` | [Styling](styling.md) |
 | Accessible names | `REACTOR_A11Y_001..004` | [Accessibility](accessibility.md) |
 
@@ -62,6 +62,7 @@ in the same order, every time. No `if`, no `for`, no `try/catch`
 around a hook call, no early return.
 
 **Analyzer:** `REACTOR_HOOKS_001` (conditional hook call),
+`REACTOR_HOOKS_002` (hook after an early-return guard), and
 `REACTOR_HOOKS_005` (hook called outside a `Render()` override or a
 `Use*` helper).
 
@@ -120,6 +121,10 @@ the right state to the right row.
 **The rule:** every element produced inside a list-like construct gets
 a `.WithKey(stableId)` whose value persists across re-renders. The id
 must be the record's primary key, not the array index.
+
+**Analyzer:** `REACTOR_DSL_001` (dynamic list item missing `.WithKey`),
+`REACTOR_DSL_002` (non-stable `.WithKey`), and
+`REACTOR_DSL_003` (typed collection `keySelector` never keys by item).
 
 Before:
 
@@ -184,7 +189,8 @@ theme-invariant (a brand mark, a print preview) — and leave a comment
 saying so.
 
 **Analyzer:** `REACTOR_THEME_001` (hard-coded color string on a
-theme-aware modifier).
+theme-aware modifier) and `REACTOR_THEME_004` (hard-coded
+`Brush`/`Color` object bypasses theme tokens).
 
 ```csharp
 // Don't:
@@ -202,15 +208,15 @@ Full coverage on [Theming Tokens](theming-tokens.md).
 
 | Rule | Analyzer | Where the page lives |
 |---|---|---|
-| Hook order is stable | `REACTOR_HOOKS_001` | [Hooks](hooks.md) |
+| Hook order is stable | `REACTOR_HOOKS_001`, `REACTOR_HOOKS_002` | [Hooks](hooks.md) |
 | Hooks called from `Render` only | `REACTOR_HOOKS_005` | [Hooks](hooks.md) |
 | Deps must be stable | `REACTOR_HOOKS_004` | [Hooks](hooks.md) |
 | UseResource fetcher is idempotent | `REACTOR_HOOKS_006` | [Async Resources](async-resources.md) |
 | UseMemoCells builder must close over deps | `REACTOR_HOOKS_007` | [Hooks](hooks.md) |
 | Debounced commands routed through UseCommand | `REACTOR_HOOKS_009` | [Commanding](commanding.md) |
 | Render must be pure | *(convention — no analyzer)* | [Components](components.md), [Effects](effects.md) |
-| Lists need keys | *(convention — no analyzer)* | [Collections](collections.md), [Reconciliation](reconciliation.md) |
-| Theme-aware modifiers want a token | `REACTOR_THEME_001` | [Theming Tokens](theming-tokens.md) |
+| Lists need stable keys | `REACTOR_DSL_001..003` | [Collections](collections.md), [Reconciliation](reconciliation.md) |
+| Theme-aware modifiers want a token | `REACTOR_THEME_001`, `REACTOR_THEME_004` | [Theming Tokens](theming-tokens.md) |
 | Lightweight styling, not implicit resources | `REACTOR_THEME_002` | [Styling](styling.md) |
 | `RequestedTheme` is a render input, not a setter | `REACTOR_THEME_003` | [Styling](styling.md) |
 | XML docs on public APIs | `REACTOR_DOC_001` | (framework code) |

--- a/docs/_pipeline/templates/source-mapping.md.dt
+++ b/docs/_pipeline/templates/source-mapping.md.dt
@@ -77,9 +77,10 @@ elements, and Y of them resulted in real WinUI writes."
 
 ## Why ETW attribution stops at the component
 
-The reconciler hand-rolls per-mount calls into `MountXxx` handlers,
-each of which constructs a fresh WinUI control. The handler doesn't
-know which user line called `Text("hello")`:
+The reconciler resolves mounts through registered descriptors/handlers
+before falling back to composition-primitive handlers. The handler that
+constructs the WinUI control doesn't know which user line called
+`Text("hello")`:
 
 ```csharp snippet="source:src/Reactor/Core/Component.cs#render-loop"
 ```

--- a/docs/_pipeline/templates/styling.md.dt
+++ b/docs/_pipeline/templates/styling.md.dt
@@ -332,9 +332,10 @@ code-fix to the modifier. See [advanced](advanced.md) for the broader
 
 | Analyzer | Severity | Flags |
 |---|---|---|
-| `REACTOR_THEME_001` | Warning | Hard-coded color string where a `Theme.*` token exists. |
-| `REACTOR_THEME_002` | Info | `.Set()` brush assignment that has a lightweight-styling key equivalent. |
-| `REACTOR_THEME_003` | Info | `.Set(fe => fe.RequestedTheme = ...)` — use the `.RequestedTheme(...)` modifier. |
+| `REACTOR_THEME_001` | Warning | Use `ThemeRef` instead of a hard-coded color string. |
+| `REACTOR_THEME_002` | Info | Consider lightweight styling for visual-state overrides. |
+| `REACTOR_THEME_003` | Info | `RequestedTheme` modifier available. |
+| `REACTOR_THEME_004` | Warning | Hard-coded `Brush`/`Color` object bypasses theme tokens. |
 
 Each analyzer ships a code-fix that converts to the preferred pattern.
 Enable them by referencing the `Reactor.Analyzers` project — they're on

--- a/docs/_pipeline/templates/testing.md.dt
+++ b/docs/_pipeline/templates/testing.md.dt
@@ -162,16 +162,16 @@ component you ship.
 `Reactor.SelfTests` is the layer between the unit suite (pure C#, no
 WinUI) and the full E2E suite (winapp ui). A self-test mounts a
 real fixture into the `Reactor.AppTests.Host` window, walks the WinUI
-visual tree, and emits TAP. The xUnit wrapper in `SelfTestBatch.cs`
+visual tree, and emits TAP. The MSTest wrapper in `SelfTestBatch.cs`
 parses the TAP and surfaces one test method per fixture.
 
 To add a self-test:
 
 1. Add a new fixture file under
-   `tests/Reactor.AppTests.Host/Fixtures/` returning the component
+   `tests/Reactor.AppTests.Host/SelfTest/Fixtures/` returning the component
    under test wrapped in a small assertion harness.
-2. Register the fixture name in `FixtureRegistry`.
-3. The xUnit wrapper picks it up at discovery time via
+2. Register the fixture name in `SelfTestFixtureRegistry`.
+3. The MSTest wrapper picks it up at discovery time via
    `--list-fixtures`; no code change needed on the test runner side.
 
 Reach for a self-test when the unit layer can't see the answer — e.g.

--- a/docs/_pipeline/templates/theming-tokens.md.dt
+++ b/docs/_pipeline/templates/theming-tokens.md.dt
@@ -298,7 +298,7 @@ string keys do not. If a color is missing from the typed surface and
 it's a stable WinUI brush, add it to `Theme.cs` rather than
 proliferating `Theme.Ref("…")` calls.
 
-**Treat REACTOR_THEME_001 as an error in CI.** The cost of fixing a
+**Treat REACTOR_THEME_001 and REACTOR_THEME_004 as errors in CI.** The cost of fixing a
 hardcoded color is one line; the cost of a dark-theme regression
 landing on main is a customer report.
 
@@ -315,7 +315,7 @@ scheme actually changes.
 | Escape hatch | `Theme.Ref(key)` | Any XAML resource key, including app-level overrides. |
 | Reactive read | `UseColorScheme()` | Returns `ColorScheme`; triggers re-render on swap. |
 | Per-element override | `.RequestedTheme(ElementTheme)` | Walks visual tree, resolves nearest override. |
-| Analyzer | `REACTOR_THEME_001` | Flags hardcoded literals on theme-aware modifiers. |
+| Analyzer | `REACTOR_THEME_001`, `REACTOR_THEME_004` | Flags hardcoded literals and `Brush`/`Color` objects on theme-aware modifiers. |
 | WinUI surface | `XamlControlsResources` | Owning ThemeDictionary for every named token. |
 
 ## Next Steps

--- a/docs/contributing/doc-pipeline.md
+++ b/docs/contributing/doc-pipeline.md
@@ -14,7 +14,7 @@ The doc pipeline needs:
 
 | Tool             | Purpose                                | Required for                |
 |------------------|----------------------------------------|-----------------------------|
-| .NET 9 SDK       | Building the `mur` CLI + doc apps      | Always                      |
+| .NET 10 SDK      | Building the `mur` CLI + doc apps      | Always                      |
 | Windows App SDK  | Doc apps render WinUI controls         | Screenshot capture          |
 | Node.js 20+      | Hosts `mermaid-cli`                    | `.mmd` → `.svg` diagrams    |
 | `mermaid-cli`    | CLI front-end for Mermaid              | `.mmd` → `.svg` diagrams    |

--- a/docs/guide/accessibility.md
+++ b/docs/guide/accessibility.md
@@ -5,9 +5,10 @@ WinUI automation properties (`.AutomationName`, `.HeadingLevel`,
 add runtime behavior (`UseFocusTrap` for modal focus trapping,
 `UseAnnounce` for live-region announcements, `SemanticPanel` for
 custom automation peers that the modifier set can't express). The
-analyzer set is the third layer — `REACTOR_A11Y_001..003` catch the
-three most common omissions (icon-only buttons missing an automation
-name, images missing alt text, form fields missing a label) at
+analyzer set is the third layer — `REACTOR_A11Y_001..004` catch the
+most common omissions (icon-only buttons missing an automation
+name, images missing alt text, form fields missing a label, and
+clickable containers that aren't keyboard-reachable) at
 compile time. The `AccessibilityScanner` is the runtime cousin: it
 walks the post-reconciliation element tree and emits 8 categories of
 WCAG-mapped diagnostics with concrete fix suggestions. Aim for clean
@@ -38,6 +39,7 @@ how often you need them.
 | `REACTOR_A11Y_001` | analyzer | Icon-only `Button(icon, action)` without `.AutomationName()`. |
 | `REACTOR_A11Y_002` | analyzer | `Image()` without `.AutomationName()` or `.AccessibilityHidden()`. |
 | `REACTOR_A11Y_003` | analyzer | Form field without `header:` or label modifier. |
+| `REACTOR_A11Y_004` | analyzer | Clickable container (`Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack`) with `.OnTapped` but no enabling `.IsTabStop(true)`. |
 
 ## Tier 1 Modifiers
 
@@ -474,7 +476,7 @@ and value to add. Export to JSON with `AccessibilityScanner.ExportJson()`.
 
 ## Roslyn Analyzers
 
-Reactor ships three compile-time accessibility analyzers that flag violations
+Reactor ships four compile-time accessibility analyzers that flag violations
 as you type in your IDE:
 
 | Diagnostic ID | Rule |
@@ -482,6 +484,7 @@ as you type in your IDE:
 | `REACTOR_A11Y_001` | Icon-only `Button(icon, action)` calls without `.AutomationName()` |
 | `REACTOR_A11Y_002` | `Image()` without `.AutomationName()` or `.AccessibilityHidden()` |
 | `REACTOR_A11Y_003` | `TextBox`/`NumberBox`/`PasswordBox` without `header:` arg or label modifier |
+| `REACTOR_A11Y_004` | Clickable `Border`/`Grid`/`Canvas`/`Rectangle`/`Ellipse`/`VStack`/`HStack` (`.OnTapped`) without an enabling `.IsTabStop(true)` |
 
 These analyzers run automatically when you reference the `Reactor.Analyzers`
 package. They complement the runtime `AccessibilityScanner` by catching the
@@ -601,5 +604,5 @@ WinUI renders the key tips automatically when the user presses Alt.
 - **[Navigation](navigation.md)** — add landmarks and keyboard-navigable page structure
 - **[Styling and Theming](styling.md)** — ensure high-contrast themes work with your accessible controls
 - **[Dialogs and Flyouts](dialogs-and-flyouts.md)** — focus traps and ARIA semantics for modal surfaces
-- **[Analyzer Architecture](analyzer-architecture.md)** — how `REACTOR_A11Y_001..003` are authored
+- **[Analyzer Architecture](analyzer-architecture.md)** — how `REACTOR_A11Y_001..004` are authored
 - **[WinForms Interop](winforms-interop.md)** — accessibility bridging between WinForms and Reactor

--- a/docs/guide/analyzer-architecture.md
+++ b/docs/guide/analyzer-architecture.md
@@ -45,6 +45,8 @@ public override void Initialize(AnalysisContext context)
     context.EnableConcurrentExecution();
     context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
     context.RegisterSyntaxNodeAction(AnalyzeSetterStaleRead, SyntaxKind.InvocationExpression);
+    context.RegisterSyntaxNodeAction(AnalyzeMutateThenSet, SyntaxKind.InvocationExpression);
+    context.RegisterSyntaxNodeAction(AnalyzeMemo, SyntaxKind.InvocationExpression);
 }
 
 private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
@@ -70,10 +72,14 @@ every invocation.
 > single call. Don't reach for it inside the syntax callback unless a
 > cheaper syntactic check has already filtered the node down to plausible
 > candidates. The `MissingWithKeyAnalyzer` is the extreme: it never calls
-> `GetSymbolInfo` at all — a substring check for `.WithKey(` in the
-> lambda body is enough because false positives only fire when the layout
-> container also turns out to be a Reactor factory, which the analyzer
-> then confirms by name list.
+> `GetSymbolInfo` at all. Its `REACTOR_DSL_001` arm decides with a substring
+> check for `.WithKey(` in the lambda body — false positives only fire when
+> the layout container also turns out to be a Reactor factory, which the
+> analyzer then confirms by name list. Its `REACTOR_DSL_002` arm (non-stable
+> keys) goes a step further but stays just as syntactic: it walks the key
+> expression and matches lambda parameter names and well-known per-render
+> calls (`Guid.NewGuid()`, `DateTime.Now`, …) by name, still without resolving
+> a single symbol.
 
 ## Diagnostic descriptors
 
@@ -131,42 +137,71 @@ via `.editorconfig`.
 
 | Id | Severity | Title | Source |
 |---|---|---|---|
+| `REACTOR_THEME_001` | Warning | Use ThemeRef instead of hard-coded color | `UseThemeRefAnalyzer.cs` |
+| `REACTOR_THEME_002` | Info | Consider lightweight styling for visual-state overrides | `UseLightweightStylingAnalyzer.cs` |
+| `REACTOR_THEME_003` | Info | RequestedTheme modifier available | `RequestedThemeSetAnalyzer.cs` |
+| `REACTOR_THEME_004` | Warning | Hard-coded Brush/Color object bypasses theme tokens | `UseThemeRefAnalyzer.cs` |
 | `REACTOR_HOOKS_001` | Warning | Hook called conditionally | `HookRulesAnalyzer.cs` |
 | `REACTOR_HOOKS_004` | Warning | Hook deps contains freshly allocated value | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_005` | Warning | Hook called outside Render or a custom-hook method | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_006` | Info | Resource fetcher looks non-idempotent | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_007` | Warning | UseMemoCells builder captures variable not in deps | `UseMemoCellsAnalyzer.cs` |
-| `REACTOR_HOOKS_008` | Info | State variable read after its setter in the same synchronous handler | `HookRulesAnalyzer.cs` |
-| `REACTOR_HOOKS_009` | Warning | Command.DebounceMs set on a command bound without UseCommand | `CommandDebounceAnalyzer.cs` |
+| `REACTOR_HOOKS_005` | Warning | Hook called outside Render or custom-hook method | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_006` | Info | UseResource fetcher looks non-idempotent (use UseMutation for writes) | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_007` | Warning | Builder closure capture missing from dependencies | `UseMemoCellsAnalyzer.cs` |
+| `REACTOR_HOOKS_008` | Info | State variable read after its setter was called in the same synchronous handler (stale read) | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_009` | Warning | Command.DebounceMs is inert unless the command is routed through UseCommand | `CommandDebounceAnalyzer.cs` |
+| `REACTOR_HOOKS_011` | Warning | Controlled input has a state-derived value but an inert change callback | `ControlledInputAnalyzer.cs` |
 | `REACTOR_A11Y_001` | Warning | Icon-only button needs an accessible name | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_002` | Warning | Image needs alt text or AccessibilityHidden | `AccessibilityAnalyzers.cs` |
 | `REACTOR_A11Y_003` | Warning | Form field needs a label | `AccessibilityAnalyzers.cs` |
-| `REACTOR_THEME_001` | Warning | Use ThemeRef instead of hard-coded color | `UseThemeRefAnalyzer.cs` |
-| `REACTOR_THEME_002` | Warning | Prefer lightweight styling | `UseLightweightStylingAnalyzer.cs` |
-| `REACTOR_THEME_003` | Warning | RequestedTheme set on a non-root element | `RequestedThemeSetAnalyzer.cs` |
-| `REACTOR_REF_001` | Warning | ElementRef.Current assigned to a reference property instead of a reactive edge | `ReferenceCurrentReadAnalyzer.cs` |
+| `REACTOR_A11Y_004` | Warning | Clickable container (.OnTapped) is not keyboard-reachable; add .IsTabStop(true) | `AccessibilityAnalyzers.cs` |
+| `REACTOR_REF_001` | Warning | Use descriptor.Reference/binding.Reference instead of assigning ElementRef.Current to reference properties | `ReferenceCurrentReadAnalyzer.cs` |
 | `REACTOR_DSL_001` | Warning | Dynamic list item missing .WithKey | `MissingWithKeyAnalyzer.cs` |
+| `REACTOR_DSL_002` | Info | Non-stable .WithKey (index / Guid.NewGuid / DateTime.Now) | `MissingWithKeyAnalyzer.cs` |
+| `REACTOR_DSL_003` | Warning | Typed collection keySelector never keys by item (returns constant/null or ignores the item), forcing a keyed-diff bailout | `ConstantKeySelectorAnalyzer.cs` |
 | `REACTOR_DOCK_001` | Warning | OnLiveLayoutChanged feeds the live layout back into state | `OnLiveLayoutRoundTripAnalyzer.cs` |
 | `REACTOR_DOC_001` | Warning | Public API missing XML doc summary | `XmlDocSummaryAnalyzer.cs` |
-| `REACTOR_POOL_001` | Warning | `.Set` writes to a property that pool reset clears | `PoolResetSetAnalyzer.cs` |
-| `REACTOR0050` | Warning | Optional OneWay descriptor entry has no `dp:` ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_EVENT_001` | Warning | Event wired via .Set(+=/-=) re-subscribes every render; use a declarative On* modifier or .OnMountAdd/.OnUnmountAdd | `SetEventSubscriptionAnalyzer.cs` |
+| `REACTOR_POOL_001` | Warning | .Set assigns to a property reset on pool return; use the surviving Reactor modifier | `PoolResetSetAnalyzer.cs` |
+| `REACTOR_ITEMS_001` | Warning | .Set(ItemsSource=...) on a Reactor-owned collection | `SetOwnedItemsSourceAnalyzer.cs` |
+| `REACTOR_CTRL_001` | Warning | .Set(SelectedItem/SelectedValue) fights controlled SelectedIndex | `SetSelectedItemAnalyzer.cs` |
+| `REACTOR_VIS_001` | Warning | Imperative .Set(Visibility=...) instead of .IsVisible(...) | `PoolResetSetAnalyzer.cs` |
+| `REACTOR_WIN2D_001` | Error | Win2D canvas draws UseCanvasResources output without .UseSharedDevice() (fatal cross-device draw) | `Win2DSharedDeviceAnalyzer.cs` |
+| `REACTOR0050` | Warning | Optional<T> OneWay descriptor entries should provide dp: for ClearValue fallback | `OneWayClearValueAnalyzer.cs` |
+| `REACTOR_PERSIST_001` | Warning | 2-arg UsePersisted defaults to Application scope; specify scope | `UsePersistedScopeAnalyzer.cs` |
+| `REACTOR_DESC_001` | Warning | ControlRegistry.Register* lambda should be static (trim hygiene) | `StaticRegisterLambdaAnalyzer.cs` |
+| `REACTOR_STATE_001` | Warning | INotifyPropertyChanged on a Component is invisible to the render loop | `ComponentInpcAnalyzer.cs` |
+| `REACTOR_THREAD_002` | Warning | Blocking a Task (.Result/.Wait) in Render/effect | `BlockingTaskAnalyzer.cs` |
 | `REACTOR_OPT_001` | Info | Selection sentinel literal force-asserts instead of Optional<T>.Unset | `OptionalSentinelAnalyzer.cs` |
+| `REACTOR_CMD_001` | Info | Raw-init Command + own click callback both set (callback wins; command never runs) | `RawCommandCallbackAnalyzer.cs` |
+| `REACTOR_THREAD_001` | Warning | UI-thread-only mutator called on a background thread | `UIThreadAffinityAnalyzer.cs` |
+| `REACTOR_HOOKS_002` | Info | Hook after an early-return guard | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_003` | Warning | async-void UseEffect body | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_010` | Warning | Mutate-then-set reference state (same ref re-passed to setter) | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_012` | Warning | Memo dependency lacks value equality | `HookRulesAnalyzer.cs` |
+| `REACTOR_HOOKS_013` | Warning | UseState/UsePersisted initial value allocated every render | `HookRulesAnalyzer.cs` |
+| `REACTOR_CTX_001` | Info | Context value re-allocated each render (reference-equality type) | `ContextProvideAnalyzer.cs` |
+| `REACTOR_GRID_001` | Warning | Declared Grid column/row that no child occupies (unused track) | `UnusedGridTrackAnalyzer.cs` |
+| `REACTOR_INPUT_001` | Warning | Ctrl/Alt chord on .OnKeyDown is focus-scoped; use a Command accelerator | `OnKeyDownChordAnalyzer.cs` |
+| `REACTOR_PERF_FUNCREF` | Info | Command constructed inline in the render path is re-allocated every render; wrap it in UseMemo | `MemoizeCommandAnalyzer.cs` |
+| `REACTOR_ANIM_002` | Info | Unstable .Keyframes trigger (DateTime.Now / Guid.NewGuid / per-render allocation) restarts the animation every render | `KeyframeTriggerAnalyzer.cs` |
+| `REACTOR_INPUT_002` | Warning | Unsafe TryGetFiles in .OnDrop returns UNC/reparse/virtual files; use TryGetSafeLocalFiles | `UnsafeDropFilesAnalyzer.cs` |
+| `REACTOR_NAV_001` | Warning | UseNavigation handle captured into a static field or property outlives the page and pins its dispatcher | `StaticNavigationHandleAnalyzer.cs` |
+| `REACTOR_DIALOG_001` | Warning | Imperative ContentDialog.ShowAsync escapes the render tree; use the controlled ContentDialog(...) element with IsOpen | `ImperativeContentDialogAnalyzer.cs` |
+| `REACTOR_MOD_001` | Info | Same atomic-replace placement modifier (.Grid/.Canvas/.RelativePanel/.Flex) applied twice in one chain; last-wins overwrite drops earlier args (ships a merge fix) | `DuplicateAtomicModifierAnalyzer.cs` |
+| `REACTOR_MEDIA_001` | Info | WebView2 is a direct child of an auto-layout stack (HStack/VStack/FlexRow/FlexColumn) without explicit .Width/.Height | `UnsizedWebViewInStackAnalyzer.cs` |
+| `REACTOR_ANIM_003` | Warning | async lambda to WithAnimation loses the ThreadStatic scope after await | `AnimationScopeAsyncAnalyzer.cs` |
+| `REACTOR_LIFECYCLE_002` | Warning | UseEffect(Action) allocates a timer/subscription/event with no returned cleanup | `EffectCleanupAnalyzer.cs` |
+| `REACTOR_MEMO_001` | Info | Modifiers on a keyed Memo(key,factory) wrapper opt the row out of the recycle cache | `MemoWrapperModifierAnalyzer.cs` |
 
-`REACTOR_HOOKS_002` and `_003` are reserved for future control-flow /
-data-flow analyses (variable hook counts across early returns, async
-boundaries inside `UseEffect`). They have descriptor slots but no
-implementation today.
+`REACTOR_HOOKS_002` and `_003` were the reserved control-flow / data-flow slots
+(variable hook counts across early returns, async boundaries inside `UseEffect`);
+they now ship — `_002` flags a hook after a single-guard early return, `_003`
+flags an `async`-void `UseEffect` body (spec 060 §4.1).
 
 ## Symbol-grounded matching — the WithKey case
 
 ```csharp
-static void Analyze(SyntaxNodeAnalysisContext ctx)
+static void AnalyzeMissingKey(SyntaxNodeAnalysisContext ctx, InvocationExpressionSyntax inv)
 {
-    var inv = (InvocationExpressionSyntax)ctx.Node;
-
-    if (inv.Expression is not MemberAccessExpressionSyntax member) return;
-    if (member.Name.Identifier.ValueText != "Select") return;
-
     // Single lambda argument with an invocation body.
     if (inv.ArgumentList.Arguments.Count != 1) return;
     if (inv.ArgumentList.Arguments[0].Expression is not LambdaExpressionSyntax lambda) return;
@@ -364,6 +399,8 @@ public override void Initialize(AnalysisContext context)
     context.EnableConcurrentExecution();
     context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
     context.RegisterSyntaxNodeAction(AnalyzeSetterStaleRead, SyntaxKind.InvocationExpression);
+    context.RegisterSyntaxNodeAction(AnalyzeMutateThenSet, SyntaxKind.InvocationExpression);
+    context.RegisterSyntaxNodeAction(AnalyzeMemo, SyntaxKind.InvocationExpression);
 }
 
 private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)

--- a/docs/guide/architecture-overview.md
+++ b/docs/guide/architecture-overview.md
@@ -130,19 +130,23 @@ public UIElement GetElement(ElementFactoryGetArgs args)
     //   3. Fallback: unknown shape, treat as index 0.
     string key;
     int index;
+    bool keyed;
     switch (args.Data)
     {
         case ReactorRow row:
             key = row.Key;
             index = row.Index;
+            keyed = true;
             break;
         case int i:
             index = i;
             key = i.ToString(global::System.Globalization.CultureInfo.InvariantCulture);
+            keyed = false;
             break;
         default:
             index = 0;
             key = "0";
+            keyed = false;
             break;
     }
 
@@ -150,7 +154,7 @@ public UIElement GetElement(ElementFactoryGetArgs args)
         return new TextBlock { Text = "" };
 
     var item = _items[index];
-    var element = BuildOrCache(key, item, index);
+    var element = BuildOrCache(key, item, index, keyed);
 
     UIElement? control;
     if (_recyclePool.Count > 0)
@@ -196,6 +200,17 @@ public UIElement GetElement(ElementFactoryGetArgs args)
     {
         _keyByControl[control] = key;
         _lastElementByControl[control] = element;
+
+        // Issue #383: arm the multi-select checkmark flicker guard on the
+        // realized container. Idempotent per container instance.
+        // Intentionally scoped to ItemContainer (the ItemsView item-root
+        // wrapper): LazyVStack/LazyHStack realize into plain panels via
+        // ItemsRepeater, not ItemContainer, and the MultiSelectStates.Multiple
+        // storyboard the guard collapses only ever runs for multi-select
+        // ItemContainers — so widening this to all controls would be inert
+        // work everywhere else. Do not "generalize" it.
+        if (control is ItemContainer itemContainer)
+            ItemContainerSelectionFlickerGuard.Ensure(itemContainer);
     }
 
     return control ?? new TextBlock { Text = "" };
@@ -240,11 +255,11 @@ the [element pool](element-pool.md)); the Update path uses
 in place or unmount-and-remount. The Unmount path returns to the pool
 and walks effect cleanups in reverse slot order.
 
-The reconciler is split across partial files so the Mount and Update
-switches stay tractable: `Reconciler.Mount.cs` holds the 40+ MountXxx
-handlers, `Reconciler.Update.cs` holds the matching UpdateXxx, and
-[`ChildReconciler.cs`](reconciliation.md) holds the keyed-vs-positional
-child diff. There is one reconciler instance per host; component
+The reconciler is split across partial files: `Reconciler.Mount.cs`
+and `Reconciler.Update.cs` hold the dispatch logic plus the
+composition-primitive handlers, registered descriptors/handlers hold
+per-control mount/update logic, and [`ChildReconciler.cs`](reconciliation.md)
+holds the keyed-vs-positional child diff. There is one reconciler instance per host; component
 recursion shares the dispatch.
 
 ## Hooks — slot table per RenderContext

--- a/docs/guide/cheat-sheet.md
+++ b/docs/guide/cheat-sheet.md
@@ -37,11 +37,11 @@ Doc apps inherit `Reactor.DevtoolsSupport=true` from `docs/_pipeline/apps/Direct
 | `UseContext<T>(ctx)` | `T` | Read a [context](context.md) value. |
 | `UsePersisted<T>(key, initial, scope)` | `(T, Action<T>)` | Survive re-mount via [LRU cache](persistence.md). |
 | `UseColorScheme()` | `ColorScheme` | Reactive light/dark/HighContrast. |
-| `UseAsync(factory, deps)` | `AsyncResource<T>` | [`async-resources`](async-resources.md). |
-| `UseFocusTrap()` | `FocusTrapHandle` | Trap Tab inside a sub-tree. |
-| `UseAnnounce()` | `Action<string>` | Push a screen-reader announcement. |
+| `UseResource(fetcher, cache, deps, opts?)` | `AsyncValue<T>` | [`async-resources`](async-resources.md). |
+| `UseFocusTrap(isActive)` | `FocusTrapHandle` | Trap Tab inside a sub-tree. |
+| `UseAnnounce()` | `AnnounceHandle` | Push a screen-reader announcement (via `.Announce(string)` method). |
 | `UseElementRef<T>()` | `ElementRef<T>` | Reference a realized element for focus, `TeachingTip.Target`, UIA relationships, or XYFocus. |
-| `UseDevtools()` | `DevtoolsApi` | [Dev-tooling](dev-tooling.md) hooks. |
+| `UseDevtools()` | `bool` | [Dev-tooling](dev-tooling.md) gate — true when devtools are enabled. |
 
 ```csharp
 class StateVignette : Component

--- a/docs/guide/element-pool.md
+++ b/docs/guide/element-pool.md
@@ -13,8 +13,10 @@ non-poolable types, and parent-state corner cases.
 
 ## Renting on mount
 
-Every `MountXxx` handler in `Reconciler.Mount.cs` follows the same
-shape: try the pool first, allocate fresh on miss.
+The standard descriptor-backed control mount path follows the same
+shape: try the pool first, allocate fresh on miss. Composition-primitive
+handlers in `Reconciler.Mount.cs` allocate their structural wrappers
+directly.
 
 ```csharp
 public FrameworkElement? TryRent(Type type)

--- a/docs/guide/reconciliation.md
+++ b/docs/guide/reconciliation.md
@@ -31,7 +31,7 @@ source pointers that let you verify it.
 |---|---|---|
 | `newEl` is null or `EmptyElement`, `existingControl` exists | Unmount | `Unmount` runs effect cleanups, returns control to pool |
 | `oldEl` is null/Empty, `existingControl` is null | Mount | `Mount` rents from pool or allocates, populates, returns new control |
-| both elements present, `CanUpdate(old, new)` returns true | Update | `UpdateXxx` patches changed properties only; child lists diff |
+| both elements present, `CanUpdate(old, new)` returns true | Update | the matching handler patches changed properties only; child lists diff |
 | both present, `CanUpdate` false (type changed) | Replace | Unmount then Mount; the new control replaces the old in the parent |
 
 Every section below explains how one of those rows is implemented.
@@ -104,13 +104,18 @@ public UIElement? Mount(Element element, Action requestRerender)
     }
 ```
 
-`Mount` is a type-switch over `Element` subclasses. Each branch
-(`MountButton`, `MountText`, `MountStack`, …) allocates or rents a
-WinUI control, sets the properties the element specifies, recurses
-into children, attaches event-trampoline handlers once at mount time,
-and returns the control. The 40+ MountXxx methods live in
-`Reconciler.Mount.cs` — see the [Architecture
-Overview](architecture-overview.md) source map for the structure.
+`Mount` unwraps modifiers, enters the context/theme scopes, and then
+resolves the element through four dispatch arms: per-host `_v1Handlers`,
+per-host `_typeRegistry`, the global `ControlRegistry`, and finally a
+small switch for composition primitives. Built-in and custom WinUI
+controls such as `Button`, `TextBlock`, and stacks mount through their
+registered `ControlDescriptor` or `IElementHandler`; those handlers rent
+or allocate the control, apply initial properties, reconcile children
+through their declared children strategy, wire event trampolines, and
+return the control. The fallback switch in `Reconciler.Mount.cs` is only
+for structural elements: components, function components, memo
+components, error boundaries, transparent `KeyedMemoElement` wrappers,
+and `EmptyElement`.
 
 The reconciler maintains a context-value scope so children rendered
 inside `Mount` see the same [Context](context.md) values their
@@ -125,32 +130,27 @@ don't end up paying GC cost proportional to scroll velocity.
 
 ## Update — patching in place
 
-```csharp
-private void UpdateButton(ButtonElement oldEl, ButtonElement newEl, Button control)
-{
-    if (oldEl.Content != newEl.Content)
-        control.Content = newEl.Content;
-
-    ApplyModifiers(control, oldEl.Modifiers, newEl.Modifiers);
-    ReconcileChildren(oldEl.Children, newEl.Children, control);
-}
-```
-
-`Update` is the other type-switch. For each subclass, `UpdateXxx`
-compares the old element's record fields against the new and writes
-only the differences onto the existing WinUI control. `Button.Content`
-changed? Update that DP. `IsEnabled` is the same? Skip. Modifiers like
-margin and corner-radius diff the same way, just against the merged
-`ElementModifiers` records.
+`Update` mirrors the Mount dispatch: per-host `_v1Handlers`,
+per-host `_typeRegistry`, the global `ControlRegistry`, then the
+composition-primitive fallback switch. Real WinUI controls are patched
+by their registered descriptor or handler, which compares the old and
+new element fields and writes only the changed properties onto the
+existing control. `Button.Content` changed? The descriptor path updates
+that DP. `IsEnabled` is the same? Its prop entry skips the write.
+Modifiers like margin and corner-radius diff the same way, just against
+the merged `ElementModifiers` records. The fallback switch only updates
+structural wrappers such as components and error boundaries; an unchanged
+`KeyedMemoElement` is transparent and returns `null` to keep the
+existing control.
 
 The early-skip optimization is in two places. At the element level,
 `Element.CanSkipUpdate(oldEl, newEl)` returns true when the records
-are structurally identical (and have no theme bindings that need
-re-evaluation) — the reconciler can avoid the `children.Get(i)` COM
-call entirely and just refresh the
+are structurally identical, are not theme-sensitive,
+and have the same callback presence — the reconciler can avoid the
+`children.Get(i)` COM call entirely and just refresh the
 [Tag](#tag-based-event-dispatch) if the element carries callbacks. At
-the property level, each `UpdateXxx` short-circuits per-property:
-unchanged property → no DP write.
+the property level, the descriptor or handler short-circuits per
+property: unchanged property → no DP write.
 
 `CanUpdate(old, new)` is the type-shape check: the same Element record
 type, the same control-target type. Returns true for `(ButtonElement,
@@ -165,7 +165,8 @@ internal static void Reconcile(
     Element[] newChildren,
     IChildCollection children,
     Reconciler reconciler,
-    Action requestRerender)
+    Action requestRerender,
+    UIElement? parentControl = null)
 {
     // Filter out nulls and EmptyElements
     var oldFiltered = Filter(oldChildren);
@@ -183,7 +184,7 @@ internal static void Reconcile(
     if (hasKeys)
         ReconcileKeyed(oldFiltered, newFiltered, children, reconciler, requestRerender, ambientKind);
     else
-        ReconcilePositional(oldFiltered, newFiltered, children, reconciler, requestRerender, ambientKind);
+        ReconcilePositional(oldFiltered, newFiltered, children, reconciler, requestRerender, ambientKind, parentControl);
 }
 ```
 
@@ -278,9 +279,9 @@ familiar `Panel.Children`:
 - **MenuBar / CommandBar** — `Items` / `PrimaryCommands` / `SecondaryCommands`
 
 The child reconciler walks `Panel.Children`-shaped containers
-uniformly. Gap nodes are handled imperatively in their respective
-MountXxx / UpdateXxx methods — the framework knows which collection
-to walk for each control type and runs a second-pass diff over it.
+uniformly. Gap nodes are handled imperatively by their mount/update handlers —
+the framework knows which collection to walk for each control type and
+runs a second-pass diff over it.
 
 ## Patterns
 
@@ -347,7 +348,8 @@ internal static void Reconcile(
     Element[] newChildren,
     IChildCollection children,
     Reconciler reconciler,
-    Action requestRerender)
+    Action requestRerender,
+    UIElement? parentControl = null)
 {
     // Filter out nulls and EmptyElements
     var oldFiltered = Filter(oldChildren);
@@ -365,7 +367,7 @@ internal static void Reconcile(
     if (hasKeys)
         ReconcileKeyed(oldFiltered, newFiltered, children, reconciler, requestRerender, ambientKind);
     else
-        ReconcilePositional(oldFiltered, newFiltered, children, reconciler, requestRerender, ambientKind);
+        ReconcilePositional(oldFiltered, newFiltered, children, reconciler, requestRerender, ambientKind, parentControl);
 }
 ```
 

--- a/docs/guide/rules-of-reactor.md
+++ b/docs/guide/rules-of-reactor.md
@@ -43,15 +43,15 @@ class HookOrderBad : Component
 
 | Rule | Analyzer | Page |
 |---|---|---|
-| Hook order is stable | `REACTOR_HOOKS_001` | [Hooks](hooks.md) |
+| Hook order is stable | `REACTOR_HOOKS_001`, `REACTOR_HOOKS_002` | [Hooks](hooks.md) |
 | Hooks called from Render only | `REACTOR_HOOKS_005` | [Hooks](hooks.md) |
 | Deps are stable | `REACTOR_HOOKS_004` | [Hooks](hooks.md) |
 | Debounced commands need UseCommand | `REACTOR_HOOKS_009` | [Commanding](commanding.md) |
 | Render is pure | *(convention)* | [Components](components.md) |
-| Lists need keys | *(convention)* | [Collections](collections.md) |
-| Theme tokens not literals | `REACTOR_THEME_001` | [Theming Tokens](theming-tokens.md) |
+| Lists need stable keys | `REACTOR_DSL_001..003` | [Collections](collections.md) |
+| Theme tokens not literals | `REACTOR_THEME_001`, `REACTOR_THEME_004` | [Theming Tokens](theming-tokens.md) |
 | Lightweight styling | `REACTOR_THEME_002` | [Styling](styling.md) |
-| Accessible names | `REACTOR_A11Y_001..003` | [Accessibility](accessibility.md) |
+| Accessible names | `REACTOR_A11Y_001..004` | [Accessibility](accessibility.md) |
 
 Each rule below covers one row in the index with the before / after
 shape and the analyzer's catch.
@@ -68,6 +68,7 @@ in the same order, every time. No `if`, no `for`, no `try/catch`
 around a hook call, no early return.
 
 **Analyzer:** `REACTOR_HOOKS_001` (conditional hook call),
+`REACTOR_HOOKS_002` (hook after an early-return guard), and
 `REACTOR_HOOKS_005` (hook called outside a `Render()` override or a
 `Use*` helper).
 
@@ -194,6 +195,10 @@ the right state to the right row.
 a `.WithKey(stableId)` whose value persists across re-renders. The id
 must be the record's primary key, not the array index.
 
+**Analyzer:** `REACTOR_DSL_001` (dynamic list item missing `.WithKey`),
+`REACTOR_DSL_002` (non-stable `.WithKey`), and
+`REACTOR_DSL_003` (typed collection `keySelector` never keys by item).
+
 Before:
 
 ```csharp
@@ -284,7 +289,8 @@ theme-invariant (a brand mark, a print preview) — and leave a comment
 saying so.
 
 **Analyzer:** `REACTOR_THEME_001` (hard-coded color string on a
-theme-aware modifier).
+theme-aware modifier) and `REACTOR_THEME_004` (hard-coded
+`Brush`/`Color` object bypasses theme tokens).
 
 ```csharp
 // Don't:
@@ -302,20 +308,20 @@ Full coverage on [Theming Tokens](theming-tokens.md).
 
 | Rule | Analyzer | Where the page lives |
 |---|---|---|
-| Hook order is stable | `REACTOR_HOOKS_001` | [Hooks](hooks.md) |
+| Hook order is stable | `REACTOR_HOOKS_001`, `REACTOR_HOOKS_002` | [Hooks](hooks.md) |
 | Hooks called from `Render` only | `REACTOR_HOOKS_005` | [Hooks](hooks.md) |
 | Deps must be stable | `REACTOR_HOOKS_004` | [Hooks](hooks.md) |
 | UseResource fetcher is idempotent | `REACTOR_HOOKS_006` | [Async Resources](async-resources.md) |
 | UseMemoCells builder must close over deps | `REACTOR_HOOKS_007` | [Hooks](hooks.md) |
 | Debounced commands routed through UseCommand | `REACTOR_HOOKS_009` | [Commanding](commanding.md) |
 | Render must be pure | *(convention — no analyzer)* | [Components](components.md), [Effects](effects.md) |
-| Lists need keys | *(convention — no analyzer)* | [Collections](collections.md), [Reconciliation](reconciliation.md) |
-| Theme-aware modifiers want a token | `REACTOR_THEME_001` | [Theming Tokens](theming-tokens.md) |
+| Lists need stable keys | `REACTOR_DSL_001..003` | [Collections](collections.md), [Reconciliation](reconciliation.md) |
+| Theme-aware modifiers want a token | `REACTOR_THEME_001`, `REACTOR_THEME_004` | [Theming Tokens](theming-tokens.md) |
 | Lightweight styling, not implicit resources | `REACTOR_THEME_002` | [Styling](styling.md) |
 | `RequestedTheme` is a render input, not a setter | `REACTOR_THEME_003` | [Styling](styling.md) |
 | XML docs on public APIs | `REACTOR_DOC_001` | (framework code) |
 | `<see cref="..."/>` resolves | `CS1574` | (framework code) |
-| Accessible name on interactive elements | `REACTOR_A11Y_001..003` | [Accessibility](accessibility.md) |
+| Accessible name on interactive elements | `REACTOR_A11Y_001..004` | [Accessibility](accessibility.md) |
 
 ## Tips
 
@@ -341,4 +347,4 @@ list sizes and devastating at scale).
 - **[Reconciliation](reconciliation.md)** — Why keys matter at the
   reconciler level.
 - **[Theming Tokens](theming-tokens.md)** — Token catalog for rule 5.
-- **[Accessibility](accessibility.md)** — The A11Y_001..003 rules.
+- **[Accessibility](accessibility.md)** — The A11Y_001..004 rules.

--- a/docs/guide/source-mapping.md
+++ b/docs/guide/source-mapping.md
@@ -91,9 +91,10 @@ elements, and Y of them resulted in real WinUI writes."
 
 ## Why ETW attribution stops at the component
 
-The reconciler hand-rolls per-mount calls into `MountXxx` handlers,
-each of which constructs a fresh WinUI control. The handler doesn't
-know which user line called `Text("hello")`:
+The reconciler resolves mounts through registered descriptors/handlers
+before falling back to composition-primitive handlers. The handler that
+constructs the WinUI control doesn't know which user line called
+`Text("hello")`:
 
 ```csharp
 public abstract class Component

--- a/docs/guide/styling.md
+++ b/docs/guide/styling.md
@@ -534,9 +534,10 @@ code-fix to the modifier. See [advanced](advanced.md) for the broader
 
 | Analyzer | Severity | Flags |
 |---|---|---|
-| `REACTOR_THEME_001` | Warning | Hard-coded color string where a `Theme.*` token exists. |
-| `REACTOR_THEME_002` | Info | `.Set()` brush assignment that has a lightweight-styling key equivalent. |
-| `REACTOR_THEME_003` | Info | `.Set(fe => fe.RequestedTheme = ...)` — use the `.RequestedTheme(...)` modifier. |
+| `REACTOR_THEME_001` | Warning | Use `ThemeRef` instead of a hard-coded color string. |
+| `REACTOR_THEME_002` | Info | Consider lightweight styling for visual-state overrides. |
+| `REACTOR_THEME_003` | Info | `RequestedTheme` modifier available. |
+| `REACTOR_THEME_004` | Warning | Hard-coded `Brush`/`Color` object bypasses theme tokens. |
 
 Each analyzer ships a code-fix that converts to the preferred pattern.
 Enable them by referencing the `Reactor.Analyzers` project — they're on

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -185,16 +185,16 @@ component you ship.
 `Reactor.SelfTests` is the layer between the unit suite (pure C#, no
 WinUI) and the full E2E suite (winapp ui). A self-test mounts a
 real fixture into the `Reactor.AppTests.Host` window, walks the WinUI
-visual tree, and emits TAP. The xUnit wrapper in `SelfTestBatch.cs`
+visual tree, and emits TAP. The MSTest wrapper in `SelfTestBatch.cs`
 parses the TAP and surfaces one test method per fixture.
 
 To add a self-test:
 
 1. Add a new fixture file under
-   `tests/Reactor.AppTests.Host/Fixtures/` returning the component
+   `tests/Reactor.AppTests.Host/SelfTest/Fixtures/` returning the component
    under test wrapped in a small assertion harness.
-2. Register the fixture name in `FixtureRegistry`.
-3. The xUnit wrapper picks it up at discovery time via
+2. Register the fixture name in `SelfTestFixtureRegistry`.
+3. The MSTest wrapper picks it up at discovery time via
    `--list-fixtures`; no code change needed on the test runner side.
 
 Reach for a self-test when the unit layer can't see the answer — e.g.

--- a/docs/guide/theming-tokens.md
+++ b/docs/guide/theming-tokens.md
@@ -369,7 +369,7 @@ string keys do not. If a color is missing from the typed surface and
 it's a stable WinUI brush, add it to `Theme.cs` rather than
 proliferating `Theme.Ref("…")` calls.
 
-**Treat REACTOR_THEME_001 as an error in CI.** The cost of fixing a
+**Treat REACTOR_THEME_001 and REACTOR_THEME_004 as errors in CI.** The cost of fixing a
 hardcoded color is one line; the cost of a dark-theme regression
 landing on main is a customer report.
 
@@ -386,7 +386,7 @@ scheme actually changes.
 | Escape hatch | `Theme.Ref(key)` | Any XAML resource key, including app-level overrides. |
 | Reactive read | `UseColorScheme()` | Returns `ColorScheme`; triggers re-render on swap. |
 | Per-element override | `.RequestedTheme(ElementTheme)` | Walks visual tree, resolves nearest override. |
-| Analyzer | `REACTOR_THEME_001` | Flags hardcoded literals on theme-aware modifiers. |
+| Analyzer | `REACTOR_THEME_001`, `REACTOR_THEME_004` | Flags hardcoded literals and `Brush`/`Color` objects on theme-aware modifiers. |
 | WinUI surface | `XamlControlsResources` | Owning ThemeDictionary for every named token. |
 
 ## Next Steps

--- a/skills/advanced.md
+++ b/skills/advanced.md
@@ -60,6 +60,8 @@ var draw = ctx.UseDrawCommand(model, static (session, args, m) =>
 
 `UseCanvasResources` is the device-loss recipe: allocate from the supplied `CanvasDevice`, draw only when the returned ref is non-null, and let the hook dispose/recreate after `CanvasDevice.DeviceLost`.
 
+For multiple canvases, use `.UseSharedDevice()` on the elements to share a single `CanvasDevice` instead of creating one per control — reduces device-creation overhead and memory footprint.
+
 ## Performance proof
 
 The Particle Storm sample (`samples/apps/particle-storm/`) is the canonical pattern: pure Reactor chrome controls parameters; `Win2DAnimatedCanvas` renders the hot particle path; `UseDrawState` holds the particle buffers; `UseCanvasResources` owns sprites and other device resources.

--- a/skills/dsl-reference.md
+++ b/skills/dsl-reference.md
@@ -347,6 +347,7 @@ Modifiers return `Element`, so type-specific sugar (`.Bold()`,
 .Width(300) / .Height(200) / .Size(w, h)
 .MinWidth(...) / .MinHeight(...) / .MaxWidth(...) / .MaxHeight(...)
 .HAlign(HorizontalAlignment.Center) / .VAlign(VerticalAlignment.Top)
+.HorizontalContentAlignment(...) / .VerticalContentAlignment(...)
 .Center()               // both H and V
 .IsVisible(bool)          // Collapsed when false
 .Opacity(0.6)
@@ -375,7 +376,7 @@ Modifiers return `Element`, so type-specific sugar (`.Bold()`,
 ```csharp
 TextBlock("Hello").Bold() / .SemiBold() / .FontSize(24) / .FontStyle(style)
 Button("Click").IsEnabled(false) / .IsEnabled(!condition)
-Border(child).CornerRadius(8).Background("#f5f5f5").WithBorder("#ccc", 1)
+Border(child).CornerRadius(8).Background("#f5f5f5").WithBorder("#ccc", 1).BorderThickness(l, t, r, b)
 VStack(...).Spacing(16)
 ComboBox(items).PlaceholderText("...").IsEditable()
 NumberBox(v).Range(0, 100).SpinButtons()

--- a/src/Reactor.Devtools/INTERNALS.md
+++ b/src/Reactor.Devtools/INTERNALS.md
@@ -72,7 +72,7 @@ JSON-RPC result code.
 ## ETW trace correlation
 
 Reactor emits a TraceLogging-style `EventSource` at `Microsoft-UI-Reactor`
-(see `Core/Diagnostics/ReactorEventSource.cs`). Hot-path emit sites are
+(see `../Reactor/Core/Diagnostics/ReactorEventSource.cs`). Hot-path emit sites are
 guarded by call-site `IsEnabled()` checks, so when no listener is attached
 the disabled path does no Stopwatch, type-name, or event-method work beyond
 a single word-sized flag read. Events cover reconcile passes, component


### PR DESCRIPTION
Fixes #826.

Audited all **living** docs (README, `docs/guide/*` via their `docs/_pipeline/templates/*.md.dt` sources, `docs/reference`, `skills/`, and component/sample READMEs) against the current code and applied grounded fixes. Point-in-time historical docs (`docs/specs`, `docs/research`, `docs/reports`) were intentionally left as-is.

### Changes
- **Analyzer catalog** — add missing `REACTOR_THEME_004` / `REACTOR_PERSIST_001` / `REACTOR_THREAD_002` rows; correct `THEME_002`/`_003` severities (Warning→Info); sync `rules-of-reactor`, `accessibility`, `styling`, `theming-tokens` to the current 53-rule catalog.
- **Reconciler internals** — replace the stale per-control `MountXxx`/`UpdateXxx` type-switch narrative (and a fictional `UpdateButton` sample) with the real four-arm `ControlDescriptor`/handler dispatch, across `reconciliation`, `architecture-overview`, `element-pool`, `source-mapping`.
- **cheat-sheet** — correct `UseResource` / `UseAnnounce` (`AnnounceHandle`) / `UseDevtools` (`bool`) / `UseFocusTrap(isActive)` signatures.
- **testing** — selftests use MSTest (not xUnit); fix the `SelfTest/Fixtures/` path and `SelfTestFixtureRegistry` name.
- **skills** — document `HorizontalContentAlignment`/`VerticalContentAlignment`, 4-arg `BorderThickness`, and Win2D `.UseSharedDevice()`.
- **root/meta** — `.NET 9`→`.NET 10` SDK; WindowsAppSDK `2.0.1`→`2.1.3`; drop dead `ductfiles`/`pitch/` references; fix the `extensibility-preview.md` link; fix a relative path in the Devtools `INTERNALS.md`.

### Generation
Edits were made to the `docs/_pipeline/templates/*.md.dt` **source templates**, then the affected guide pages were regenerated with `mur docs compile` (`--skip-screenshots --skip-diagrams`, existing screenshots/diagrams preserved). Recompiling also refreshed a few `source:`-embedded snippets that had drifted from current code (e.g. `architecture-overview`). Verified green with `mur docs compile --validate-only` (only the pre-existing, non-fatal `packaging` Win2D XLINK warning remains).

### How this was produced
The audit was fanned out across parallel sub-agents (one per doc partition); every proposed edit was verified against source before landing. No product code changed — docs only.