### PR TITLE
Build metrics: measure all shipped lib/ + analyzers/ DLLs, not just the primary one

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -7,7 +7,7 @@
 # Informational only: it never fails the PR.
 #
 #   Packages (compressed .nupkg)   the download size a consumer pays
-#   Assemblies (uncompressed)      the real "did our code grow" signal
+#   Assemblies in <package>        every shipped DLL — the "did our code grow" signal
 #
 # ── Why two workflows (measure here, comment in build-metrics-comment.yml) ─────
 # This job BUILDS PR-authored code (`dotnet pack` runs the PR's MSBuild), so it

--- a/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
@@ -142,21 +142,21 @@ Assert-Equal 0   (ConvertTo-MeasurementMap -Measurements $null).Keys.Count 'null
 
 # ── Format-BuildMetricsComment ───────────────────────────────────────────────
 $base = @(
-    [pscustomobject]@{ Key = 'nupkg.Reactor'; Label = 'Microsoft.UI.Reactor.nupkg'; Group = 'Packages (compressed)'; Bytes = 1200000 }
-    [pscustomobject]@{ Key = 'asm.Reactor';   Label = 'Reactor.dll';                Group = 'Assemblies (uncompressed)'; Bytes = 900000 }
-    [pscustomobject]@{ Key = 'nupkg.Legacy';  Label = 'Legacy.nupkg';               Group = 'Packages (compressed)'; Bytes = 4000 }
+    [pscustomobject]@{ Key = 'nupkg.Reactor'; Label = 'Microsoft.UI.Reactor.nupkg'; Group = 'Packages (compressed .nupkg)'; Bytes = 1200000 }
+    [pscustomobject]@{ Key = 'asm|Reactor|Reactor.dll'; Label = 'Reactor.dll';       Group = 'Assemblies in Microsoft.UI.Reactor'; Bytes = 900000 }
+    [pscustomobject]@{ Key = 'nupkg.Legacy';  Label = 'Legacy.nupkg';               Group = 'Packages (compressed .nupkg)'; Bytes = 4000 }
 )
 $head = @(
-    [pscustomobject]@{ Key = 'nupkg.Reactor'; Label = 'Microsoft.UI.Reactor.nupkg'; Group = 'Packages (compressed)'; Bytes = 1260000 }
-    [pscustomobject]@{ Key = 'asm.Reactor';   Label = 'Reactor.dll';                Group = 'Assemblies (uncompressed)'; Bytes = 900010 }
-    [pscustomobject]@{ Key = 'nupkg.New';     Label = 'Brand.New.nupkg';            Group = 'Packages (compressed)'; Bytes = 7000 }
+    [pscustomobject]@{ Key = 'nupkg.Reactor'; Label = 'Microsoft.UI.Reactor.nupkg'; Group = 'Packages (compressed .nupkg)'; Bytes = 1260000 }
+    [pscustomobject]@{ Key = 'asm|Reactor|Reactor.dll'; Label = 'Reactor.dll';       Group = 'Assemblies in Microsoft.UI.Reactor'; Bytes = 900010 }
+    [pscustomobject]@{ Key = 'nupkg.New';     Label = 'Brand.New.nupkg';            Group = 'Packages (compressed .nupkg)'; Bytes = 7000 }
 )
 $comment = Format-BuildMetricsComment -BaseMeasurements $base -HeadMeasurements $head -HeadSha 'abcdef1234567' -BaseSha '1234567890abc' -RunUrl 'https://example/run/1'
 Assert-Match $comment '<!-- reactor-build-metrics -->' 'comment carries the sticky marker'
 Assert-Match $comment 'Build metrics'                  'comment has heading'
 Assert-Match $comment 'abcdef1'                        'head sha shortened to 7'
-Assert-Match $comment '### Packages (compressed)'      'packages group header'
-Assert-Match $comment '### Assemblies (uncompressed)'  'assemblies group header'
+Assert-Match $comment '### Packages (compressed .nupkg)'      'packages group header'
+Assert-Match $comment '### Assemblies in Microsoft.UI.Reactor' 'assemblies group header'
 Assert-Match $comment 'Microsoft.UI.Reactor.nupkg'     'lists the framework package'
 Assert-Match $comment 'Brand.New.nupkg'                'head-only artifact listed (added)'
 Assert-Match $comment 'Legacy.nupkg'                   'base-only artifact listed (removed)'
@@ -165,7 +165,7 @@ Assert-Match $comment 'workflow run'                   'footer links the run'
 Assert-Match    $comment 'vs the base branch'          'header uses base-branch wording, not hard-coded main'
 Assert-Match    $comment 'base | PR'                   'table column header says base'
 Assert-NotMatch $comment 'main | PR'                   'table column header is not the hard-coded main'
-# The tiny asm.Reactor delta (10 bytes) must read as unchanged, not a regression.
+# The tiny Reactor.dll delta (10 bytes) must read as unchanged, not a regression.
 Assert-Match $comment "$([char]0x2248)"                'within-noise glyph present for tiny delta'
 
 # All-unchanged rendering: the "no change" note appears, no grew/shrank rows.
@@ -205,15 +205,17 @@ $raw = @(
     [pscustomobject]@{ Key = 'asm|Reactor|Reactor.Wrappers.Abstractions.dll'; Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 10240 }
     [pscustomobject]@{ Key = 'nupkg.Advanced';                      Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 33792 }
     [pscustomobject]@{ Key = 'asm|Advanced|Reactor.Advanced.dll';   Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 33792 }
+    [pscustomobject]@{ Key = 'nupkg.Devtools';                      Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 442368 }
+    [pscustomobject]@{ Key = 'asm|Devtools|Microsoft.UI.Reactor.Devtools.dll'; Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 442368 }
 )
 $safe = ConvertTo-SafeMeasurements -RawMeasurements $raw
-# 3 nupkg rows (one per package, even when no data) + 3 valid Reactor DLLs + 1 Advanced DLL.
-Assert-Equal 7 $safe.Count 'safe measurements: 3 nupkg rows + all validated DLL rows'
+# 3 nupkg rows + 3 valid Reactor DLLs + 1 Advanced DLL + 1 Devtools DLL.
+Assert-Equal 8 $safe.Count 'safe measurements: 3 nupkg rows + all validated DLL rows'
 Assert-Equal 'nupkg.Reactor' $safe[0].Key 'safe output starts with the nupkg rows in spec order'
 Assert-Equal 'Microsoft.UI.Reactor.nupkg' $safe[0].Label 'safe output uses the TRUSTED package label, not the artifact label'
 Assert-Equal 'nupkg.Advanced' $safe[1].Key 'second nupkg row is Advanced (spec order)'
-Assert-Equal 'nupkg.Devtools' $safe[2].Key 'third nupkg row is Devtools even with no data'
-Assert-Null  $safe[2].Bytes 'a package with no raw data still emits a null nupkg row'
+Assert-Equal 'nupkg.Devtools' $safe[2].Key 'third nupkg row is Devtools (spec order)'
+Assert-Equal 442368 $safe[2].Bytes 'Devtools nupkg bytes preserved'
 Assert-Equal 2034863 $safe[0].Bytes 'valid integer nupkg bytes preserved'
 
 # Per-DLL rows: validated filename is the label, package assembly group is the group.
@@ -226,6 +228,9 @@ Assert-Equal 'Reactor.Analyzers.dll' ($reactorDlls[0].Label) 'analyzer DLL displ
 $advancedDlls = @($safe | Where-Object { $_.Group -eq 'Assemblies in Microsoft.UI.Reactor.Advanced' })
 Assert-Equal 1 $advancedDlls.Count 'Advanced package contributes its single DLL'
 Assert-Equal 'Reactor.Advanced.dll' $advancedDlls[0].Label 'Advanced DLL uses its filename'
+$devtoolsDlls = @($safe | Where-Object { $_.Group -eq 'Assemblies in Microsoft.UI.Reactor.Devtools' })
+Assert-Equal 1 $devtoolsDlls.Count 'Devtools package contributes its single DLL'
+Assert-Equal 'Microsoft.UI.Reactor.Devtools.dll' $devtoolsDlls[0].Label 'Devtools DLL uses its filename'
 
 # Security: a malicious Label/Group in the artifact must never reach the output;
 # the trusted labels/groups are used instead.
@@ -240,41 +245,51 @@ Assert-NotMatch $evilJoined 'onerror' 'no injected markup survives sanitization 
 Assert-NotMatch $evilJoined 'script'  'no injected markup survives sanitization (script)'
 
 # Security: a malicious DLL FILENAME (the only artifact-derived string that can be
-# rendered) must be rejected unless it passes ^[A-Za-z0-9._+-]+\.dll$.
+# rendered) must be rejected unless it passes the strict, case-sensitive,
+# absolutely-anchored allowlist \A[A-Za-z0-9._+-]+\.dll\z.
+$kelvinDll = [string]([char]0x212A) + '.dll'   # U+212A case-folds to 'k' under IgnoreCase
 $badNames = @(
-    [pscustomobject]@{ Key = 'asm|Reactor|<img>';         Label = 'x'; Group = 'y'; Bytes = 1 }  # angle brackets
-    [pscustomobject]@{ Key = 'asm|Reactor|a|b.dll';       Label = 'x'; Group = 'y'; Bytes = 2 }  # embedded pipe -> 4-part key
-    [pscustomobject]@{ Key = 'asm|Reactor|x.dll`bad`';    Label = 'x'; Group = 'y'; Bytes = 3 }  # backticks
-    [pscustomobject]@{ Key = 'asm|Reactor|..\evil.dll';   Label = 'x'; Group = 'y'; Bytes = 4 }  # path traversal / backslash
-    [pscustomobject]@{ Key = 'asm|Reactor|no-extension';  Label = 'x'; Group = 'y'; Bytes = 5 }  # not a .dll
-    [pscustomobject]@{ Key = 'asm|Reactor|has space.dll'; Label = 'x'; Group = 'y'; Bytes = 6 }  # space
-    [pscustomobject]@{ Key = 'asm|Unknown|Good.dll';      Label = 'x'; Group = 'y'; Bytes = 7 }  # unknown PkgKey
-    [pscustomobject]@{ Key = 'asm|Reactor|Legit.dll';     Label = 'x'; Group = 'y'; Bytes = 8 }  # the one valid row
+    [pscustomobject]@{ Key = 'asm|Reactor|<img>';            Label = 'x'; Group = 'y'; Bytes = 1 }  # angle brackets
+    [pscustomobject]@{ Key = 'asm|Reactor|a|b.dll';          Label = 'x'; Group = 'y'; Bytes = 2 }  # embedded pipe -> 4-part key
+    [pscustomobject]@{ Key = 'asm|Reactor|x.dll`bad`';       Label = 'x'; Group = 'y'; Bytes = 3 }  # backticks
+    [pscustomobject]@{ Key = 'asm|Reactor|..\evil.dll';      Label = 'x'; Group = 'y'; Bytes = 4 }  # traversal / backslash
+    [pscustomobject]@{ Key = 'asm|Reactor|../evil.dll';      Label = 'x'; Group = 'y'; Bytes = 4 }  # traversal / forward slash (ZIP path form)
+    [pscustomobject]@{ Key = 'asm|Reactor|no-extension';     Label = 'x'; Group = 'y'; Bytes = 5 }  # not a .dll
+    [pscustomobject]@{ Key = 'asm|Reactor|has space.dll';    Label = 'x'; Group = 'y'; Bytes = 6 }  # space
+    [pscustomobject]@{ Key = 'asm|Unknown|Good.dll';         Label = 'x'; Group = 'y'; Bytes = 7 }  # unknown PkgKey
+    [pscustomobject]@{ Key = "asm|Reactor|Trailing.dll`n";   Label = 'x'; Group = 'y'; Bytes = 9 }  # trailing newline ('$' would allow; '\z' rejects)
+    [pscustomobject]@{ Key = "asm|Reactor|$kelvinDll";       Label = 'x'; Group = 'y'; Bytes = 10 } # Unicode case-fold (rejected by -cnotmatch)
+    [pscustomobject]@{ Key = 'asm|Reactor|Legit.dll';        Label = 'x'; Group = 'y'; Bytes = 8 }  # the one valid row
 )
 $safeBad = ConvertTo-SafeMeasurements -RawMeasurements $badNames
 $asmRows = @($safeBad | Where-Object { $_.Group -like 'Assemblies in*' })
 Assert-Equal 1 $asmRows.Count 'only the single well-formed DLL filename is kept'
 Assert-Equal 'Legit.dll' $asmRows[0].Label 'the kept row is the allowlisted filename'
 $safeBadJoined = (($safeBad | ForEach-Object { [string]$_.Label }) -join ' ')
-Assert-NotMatch $safeBadJoined 'img'         'angle-bracket filename dropped'
-Assert-NotMatch $safeBadJoined 'evil'        'path-traversal filename dropped'
-Assert-NotMatch $safeBadJoined 'bad'         'backtick filename dropped'
+Assert-NotMatch $safeBadJoined 'img'          'angle-bracket filename dropped'
+Assert-NotMatch $safeBadJoined 'evil'         'path-traversal filename dropped (both slash styles)'
+Assert-NotMatch $safeBadJoined 'bad'          'backtick filename dropped'
 Assert-NotMatch $safeBadJoined 'no-extension' 'non-.dll name dropped'
-Assert-NotMatch $safeBadJoined 'space'       'filename with a space dropped'
-Assert-NotMatch $safeBadJoined 'Good.dll'    'DLL under an unknown package key dropped'
+Assert-NotMatch $safeBadJoined 'space'        'filename with a space dropped'
+Assert-NotMatch $safeBadJoined 'Good.dll'     'DLL under an unknown package key dropped'
+Assert-NotMatch $safeBadJoined 'Trailing'     'filename with a trailing newline dropped (absolute \z anchor)'
+Assert-True     (-not $safeBadJoined.Contains([string]([char]0x212A))) 'Unicode case-fold filename dropped (case-sensitive match)'
 
-# Unknown package keys are dropped; non-integer / negative / decimal bytes become null.
+# Unknown package keys are dropped; non-integer / negative / decimal / scientific
+# bytes become null.
 $junk = @(
     [pscustomobject]@{ Key = 'nupkg.Evil';                Label = 'x'; Group = 'y'; Bytes = 5 }   # unknown key -> dropped
     [pscustomobject]@{ Key = 'asm|Reactor|Reactor.dll';   Label = 'x'; Group = 'y'; Bytes = 'not-a-number' }
     [pscustomobject]@{ Key = 'nupkg.Advanced';            Label = 'x'; Group = 'y'; Bytes = -50 }
     [pscustomobject]@{ Key = 'asm|Advanced|Reactor.Advanced.dll'; Label = 'x'; Group = 'y'; Bytes = '1e9' }
+    [pscustomobject]@{ Key = 'asm|Devtools|Microsoft.UI.Reactor.Devtools.dll'; Label = 'x'; Group = 'y'; Bytes = '1.5' }
 )
 $safeJunk = ConvertTo-SafeMeasurements -RawMeasurements $junk
 Assert-True ((@($safeJunk | Where-Object { $_.Key -eq 'nupkg.Evil' })).Count -eq 0) 'unknown package key dropped'
 Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm|Reactor|Reactor.dll' }).Bytes   'non-numeric DLL bytes -> null'
 Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'nupkg.Advanced' }).Bytes 'negative nupkg bytes -> null'
 Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm|Advanced|Reactor.Advanced.dll' }).Bytes 'scientific-notation bytes -> null'
+Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm|Devtools|Microsoft.UI.Reactor.Devtools.dll' }).Bytes 'decimal bytes -> null'
 
 # Null input -> just the three nupkg rows with all-null bytes (renders as a "failed" set).
 $safeNull = ConvertTo-SafeMeasurements -RawMeasurements $null
@@ -290,6 +305,8 @@ Assert-Match    $safeComment '### Assemblies in Microsoft.UI.Reactor' 'sanitized
 Assert-Match    $safeComment 'Reactor.Analyzers.dll'             'sanitized render lists the analyzer DLL'
 Assert-Match    $safeComment 'Reactor.Wrappers.Abstractions.dll' 'sanitized render lists the abstractions DLL'
 Assert-Match    $safeComment 'Reactor.Advanced.dll'              'sanitized render lists the Advanced DLL'
+Assert-Match    $safeComment '### Assemblies in Microsoft.UI.Reactor.Devtools' 'sanitized render has the Devtools assembly section'
+Assert-Match    $safeComment 'Microsoft.UI.Reactor.Devtools.dll' 'sanitized render lists the Devtools DLL'
 Assert-NotMatch $safeComment 'IGNORED'                           'sanitized render drops artifact-supplied labels'
 # The packages section must render before the assemblies sections.
 $pkgIdx = $safeComment.IndexOf('### Packages')

--- a/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
@@ -291,6 +291,19 @@ Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'nupkg.Advanced' }).Bytes 'ne
 Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm|Advanced|Reactor.Advanced.dll' }).Bytes 'scientific-notation bytes -> null'
 Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm|Devtools|Microsoft.UI.Reactor.Devtools.dll' }).Bytes 'decimal bytes -> null'
 
+# Defense-in-depth: a malicious PR that emits an unbounded number of validly-shaped
+# per-DLL rows must not flood the rendered comment. Rows are capped per package,
+# and the kept subset is deterministic (sorted by filename, smallest names win).
+$flood = for ($i = 0; $i -lt 500; $i++) {
+    [pscustomobject]@{ Key = ('asm|Reactor|Flood{0:D4}.dll' -f $i); Label = 'x'; Group = 'y'; Bytes = 1 }
+}
+$safeFlood = ConvertTo-SafeMeasurements -RawMeasurements $flood
+$reactorFlood = @($safeFlood | Where-Object { $_.Group -eq 'Assemblies in Microsoft.UI.Reactor' })
+Assert-Equal 32 $reactorFlood.Count 'per-DLL rows hard-capped per package (flood bounded to 32)'
+Assert-Equal 'Flood0000.dll' $reactorFlood[0].Label  'capped subset is deterministic (smallest filename kept first)'
+Assert-Equal 'Flood0031.dll' $reactorFlood[31].Label 'capped subset keeps the lexicographically smallest 32 names'
+Assert-True (-not ($safeFlood | Where-Object { $_.Label -eq 'Flood0032.dll' })) 'rows beyond the cap are dropped'
+
 # Null input -> just the three nupkg rows with all-null bytes (renders as a "failed" set).
 $safeNull = ConvertTo-SafeMeasurements -RawMeasurements $null
 Assert-Equal 3 $safeNull.Count 'null raw -> the three package nupkg rows only'

--- a/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.Tests.ps1
@@ -189,51 +189,112 @@ Assert-Match    $baseGoneComment 'Microsoft.UI.Reactor.nupkg' 'baseline-unavaila
 Assert-NotMatch $baseGoneComment '<sub>new</sub>'            'baseline-unavailable does not mislabel rows as new'
 Assert-NotMatch $baseGoneComment 'No size change beyond'      'baseline-unavailable suppresses the no-change note'
 
-# ── Get-BuildMetricsTargetSpec / ConvertTo-SafeMeasurements (security boundary) ─
-$spec = Get-BuildMetricsTargetSpec
-Assert-Equal 6 $spec.Count 'target spec has all six tracked artifacts'
-Assert-Equal 'Microsoft.UI.Reactor.nupkg' ($spec | Where-Object { $_.Key -eq 'nupkg.Reactor' }).Label 'spec maps the framework nupkg label'
+# ── Get-BuildMetricsPackageSpec / ConvertTo-SafeMeasurements (security boundary) ─
+$spec = Get-BuildMetricsPackageSpec
+Assert-Equal 3 $spec.Count 'package spec has all three tracked packages'
+Assert-Equal 'Microsoft.UI.Reactor.nupkg' ($spec | Where-Object { $_.PkgKey -eq 'Reactor' }).PkgLabel 'spec maps the framework nupkg label'
+Assert-Equal 'Assemblies in Microsoft.UI.Reactor' ($spec | Where-Object { $_.PkgKey -eq 'Reactor' }).AssemblyGroup 'spec maps the framework assembly group'
 
-# Well-formed raw input: trusted labels applied, numeric bytes preserved, order = spec.
+# Well-formed raw input: every shipped DLL row is projected onto its package's
+# trusted assembly group, the nupkg rows keep trusted labels, and byte counts are
+# preserved. nupkg rows come first (spec order), then per-DLL rows sorted by name.
 $raw = @(
-    [pscustomobject]@{ Key = 'asm.Reactor';   Label = 'IGNORED';  Group = 'IGNORED'; Bytes = 3384320 }
-    [pscustomobject]@{ Key = 'nupkg.Reactor'; Label = 'IGNORED';  Group = 'IGNORED'; Bytes = 2034863 }
+    [pscustomobject]@{ Key = 'nupkg.Reactor';                       Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 2034863 }
+    [pscustomobject]@{ Key = 'asm|Reactor|Reactor.dll';             Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 3384320 }
+    [pscustomobject]@{ Key = 'asm|Reactor|Reactor.Analyzers.dll';   Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 303104 }
+    [pscustomobject]@{ Key = 'asm|Reactor|Reactor.Wrappers.Abstractions.dll'; Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 10240 }
+    [pscustomobject]@{ Key = 'nupkg.Advanced';                      Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 33792 }
+    [pscustomobject]@{ Key = 'asm|Advanced|Reactor.Advanced.dll';   Label = 'IGNORED'; Group = 'IGNORED'; Bytes = 33792 }
 )
 $safe = ConvertTo-SafeMeasurements -RawMeasurements $raw
-Assert-Equal 6 $safe.Count 'safe measurements always cover the full spec'
-Assert-Equal 'nupkg.Reactor' $safe[0].Key 'safe output is in spec order (nupkg.Reactor first)'
-Assert-Equal 'Microsoft.UI.Reactor.nupkg' $safe[0].Label 'safe output uses the TRUSTED label, not the artifact label'
-Assert-Equal 2034863 $safe[0].Bytes 'valid integer bytes preserved'
-Assert-Equal 3384320 ($safe | Where-Object { $_.Key -eq 'asm.Reactor' }).Bytes 'valid bytes preserved regardless of raw order'
+# 3 nupkg rows (one per package, even when no data) + 3 valid Reactor DLLs + 1 Advanced DLL.
+Assert-Equal 7 $safe.Count 'safe measurements: 3 nupkg rows + all validated DLL rows'
+Assert-Equal 'nupkg.Reactor' $safe[0].Key 'safe output starts with the nupkg rows in spec order'
+Assert-Equal 'Microsoft.UI.Reactor.nupkg' $safe[0].Label 'safe output uses the TRUSTED package label, not the artifact label'
+Assert-Equal 'nupkg.Advanced' $safe[1].Key 'second nupkg row is Advanced (spec order)'
+Assert-Equal 'nupkg.Devtools' $safe[2].Key 'third nupkg row is Devtools even with no data'
+Assert-Null  $safe[2].Bytes 'a package with no raw data still emits a null nupkg row'
+Assert-Equal 2034863 $safe[0].Bytes 'valid integer nupkg bytes preserved'
 
-# Security: a malicious Label/Group in the artifact must never reach the output.
-$evil = @([pscustomobject]@{ Key = 'nupkg.Reactor'; Label = '<img src=x onerror=alert(1)>'; Group = '[!WARNING] pwned'; Bytes = 100 })
+# Per-DLL rows: validated filename is the label, package assembly group is the group.
+$reactorDlls = @($safe | Where-Object { $_.Group -eq 'Assemblies in Microsoft.UI.Reactor' })
+Assert-Equal 3 $reactorDlls.Count 'all three Reactor DLL rows mapped to the framework assembly group'
+Assert-Equal 'Reactor.Analyzers.dll' $reactorDlls[0].Label 'DLL rows sorted deterministically by filename (Analyzers first)'
+Assert-Equal 'Reactor.Wrappers.Abstractions.dll' $reactorDlls[2].Label 'DLL rows sorted deterministically by filename (Wrappers last)'
+Assert-Equal 3384320 ($reactorDlls | Where-Object { $_.Label -eq 'Reactor.dll' }).Bytes 'per-DLL bytes preserved'
+Assert-Equal 'Reactor.Analyzers.dll' ($reactorDlls[0].Label) 'analyzer DLL displayed with its own filename'
+$advancedDlls = @($safe | Where-Object { $_.Group -eq 'Assemblies in Microsoft.UI.Reactor.Advanced' })
+Assert-Equal 1 $advancedDlls.Count 'Advanced package contributes its single DLL'
+Assert-Equal 'Reactor.Advanced.dll' $advancedDlls[0].Label 'Advanced DLL uses its filename'
+
+# Security: a malicious Label/Group in the artifact must never reach the output;
+# the trusted labels/groups are used instead.
+$evil = @(
+    [pscustomobject]@{ Key = 'nupkg.Reactor';           Label = '<img src=x onerror=alert(1)>'; Group = '[!WARNING] pwned'; Bytes = 100 }
+    [pscustomobject]@{ Key = 'asm|Reactor|Reactor.dll'; Label = '<script>evil</script>';        Group = '| pipes | here';  Bytes = 200 }
+)
 $safeEvil = ConvertTo-SafeMeasurements -RawMeasurements $evil
-Assert-Equal 'Microsoft.UI.Reactor.nupkg' $safeEvil[0].Label 'injected label is dropped for the trusted label'
-Assert-NotMatch (($safeEvil | ForEach-Object { $_.Label + '|' + $_.Group }) -join ' ') 'onerror' 'no injected markup survives sanitization'
+Assert-Equal 'Microsoft.UI.Reactor.nupkg' $safeEvil[0].Label 'injected package label is dropped for the trusted label'
+$evilJoined = (($safeEvil | ForEach-Object { $_.Label + '|' + $_.Group }) -join ' ')
+Assert-NotMatch $evilJoined 'onerror' 'no injected markup survives sanitization (label)'
+Assert-NotMatch $evilJoined 'script'  'no injected markup survives sanitization (script)'
 
-# Unknown keys are dropped; non-integer / negative / decimal bytes become null.
+# Security: a malicious DLL FILENAME (the only artifact-derived string that can be
+# rendered) must be rejected unless it passes ^[A-Za-z0-9._+-]+\.dll$.
+$badNames = @(
+    [pscustomobject]@{ Key = 'asm|Reactor|<img>';         Label = 'x'; Group = 'y'; Bytes = 1 }  # angle brackets
+    [pscustomobject]@{ Key = 'asm|Reactor|a|b.dll';       Label = 'x'; Group = 'y'; Bytes = 2 }  # embedded pipe -> 4-part key
+    [pscustomobject]@{ Key = 'asm|Reactor|x.dll`bad`';    Label = 'x'; Group = 'y'; Bytes = 3 }  # backticks
+    [pscustomobject]@{ Key = 'asm|Reactor|..\evil.dll';   Label = 'x'; Group = 'y'; Bytes = 4 }  # path traversal / backslash
+    [pscustomobject]@{ Key = 'asm|Reactor|no-extension';  Label = 'x'; Group = 'y'; Bytes = 5 }  # not a .dll
+    [pscustomobject]@{ Key = 'asm|Reactor|has space.dll'; Label = 'x'; Group = 'y'; Bytes = 6 }  # space
+    [pscustomobject]@{ Key = 'asm|Unknown|Good.dll';      Label = 'x'; Group = 'y'; Bytes = 7 }  # unknown PkgKey
+    [pscustomobject]@{ Key = 'asm|Reactor|Legit.dll';     Label = 'x'; Group = 'y'; Bytes = 8 }  # the one valid row
+)
+$safeBad = ConvertTo-SafeMeasurements -RawMeasurements $badNames
+$asmRows = @($safeBad | Where-Object { $_.Group -like 'Assemblies in*' })
+Assert-Equal 1 $asmRows.Count 'only the single well-formed DLL filename is kept'
+Assert-Equal 'Legit.dll' $asmRows[0].Label 'the kept row is the allowlisted filename'
+$safeBadJoined = (($safeBad | ForEach-Object { [string]$_.Label }) -join ' ')
+Assert-NotMatch $safeBadJoined 'img'         'angle-bracket filename dropped'
+Assert-NotMatch $safeBadJoined 'evil'        'path-traversal filename dropped'
+Assert-NotMatch $safeBadJoined 'bad'         'backtick filename dropped'
+Assert-NotMatch $safeBadJoined 'no-extension' 'non-.dll name dropped'
+Assert-NotMatch $safeBadJoined 'space'       'filename with a space dropped'
+Assert-NotMatch $safeBadJoined 'Good.dll'    'DLL under an unknown package key dropped'
+
+# Unknown package keys are dropped; non-integer / negative / decimal bytes become null.
 $junk = @(
-    [pscustomobject]@{ Key = 'nupkg.Evil';    Label = 'x'; Group = 'y'; Bytes = 5 }   # unknown key -> dropped
-    [pscustomobject]@{ Key = 'asm.Reactor';   Label = 'x'; Group = 'y'; Bytes = 'not-a-number' }
-    [pscustomobject]@{ Key = 'nupkg.Advanced';Label = 'x'; Group = 'y'; Bytes = -50 }
-    [pscustomobject]@{ Key = 'asm.Advanced';  Label = 'x'; Group = 'y'; Bytes = '1e9' }
+    [pscustomobject]@{ Key = 'nupkg.Evil';                Label = 'x'; Group = 'y'; Bytes = 5 }   # unknown key -> dropped
+    [pscustomobject]@{ Key = 'asm|Reactor|Reactor.dll';   Label = 'x'; Group = 'y'; Bytes = 'not-a-number' }
+    [pscustomobject]@{ Key = 'nupkg.Advanced';            Label = 'x'; Group = 'y'; Bytes = -50 }
+    [pscustomobject]@{ Key = 'asm|Advanced|Reactor.Advanced.dll'; Label = 'x'; Group = 'y'; Bytes = '1e9' }
 )
 $safeJunk = ConvertTo-SafeMeasurements -RawMeasurements $junk
-Assert-True ((@($safeJunk | Where-Object { $_.Key -eq 'nupkg.Evil' })).Count -eq 0) 'unknown key dropped'
-Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm.Reactor' }).Bytes   'non-numeric bytes -> null'
-Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'nupkg.Advanced' }).Bytes 'negative bytes -> null'
-Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm.Advanced' }).Bytes   'scientific-notation bytes -> null'
+Assert-True ((@($safeJunk | Where-Object { $_.Key -eq 'nupkg.Evil' })).Count -eq 0) 'unknown package key dropped'
+Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm|Reactor|Reactor.dll' }).Bytes   'non-numeric DLL bytes -> null'
+Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'nupkg.Advanced' }).Bytes 'negative nupkg bytes -> null'
+Assert-Null ($safeJunk | Where-Object { $_.Key -eq 'asm|Advanced|Reactor.Advanced.dll' }).Bytes 'scientific-notation bytes -> null'
 
-# Null input -> full spec with all-null bytes (renders as a "failed" set).
+# Null input -> just the three nupkg rows with all-null bytes (renders as a "failed" set).
 $safeNull = ConvertTo-SafeMeasurements -RawMeasurements $null
-Assert-Equal 6 $safeNull.Count 'null raw -> full spec'
+Assert-Equal 3 $safeNull.Count 'null raw -> the three package nupkg rows only'
 Assert-Equal 0 (@($safeNull | Where-Object { $null -ne $_.Bytes }).Count) 'null raw -> all bytes null'
 
-# End-to-end: a sanitized set renders a normal comment with trusted labels only.
+# End-to-end: a sanitized set renders a normal comment with trusted labels only,
+# with each package's DLLs under its own assembly section.
 $safeComment = Format-BuildMetricsComment -BaseMeasurements $safeNull -HeadMeasurements $safe -HeadSha 'abc1234' -BaseSha 'def5678'
-Assert-Match    $safeComment 'Microsoft.UI.Reactor.nupkg' 'sanitized render shows trusted labels'
-Assert-NotMatch $safeComment 'IGNORED'                    'sanitized render drops artifact-supplied labels'
+Assert-Match    $safeComment 'Microsoft.UI.Reactor.nupkg'        'sanitized render shows trusted package labels'
+Assert-Match    $safeComment '### Packages (compressed .nupkg)'  'sanitized render has the packages section first'
+Assert-Match    $safeComment '### Assemblies in Microsoft.UI.Reactor' 'sanitized render has the per-package assembly section'
+Assert-Match    $safeComment 'Reactor.Analyzers.dll'             'sanitized render lists the analyzer DLL'
+Assert-Match    $safeComment 'Reactor.Wrappers.Abstractions.dll' 'sanitized render lists the abstractions DLL'
+Assert-Match    $safeComment 'Reactor.Advanced.dll'              'sanitized render lists the Advanced DLL'
+Assert-NotMatch $safeComment 'IGNORED'                           'sanitized render drops artifact-supplied labels'
+# The packages section must render before the assemblies sections.
+$pkgIdx = $safeComment.IndexOf('### Packages')
+$asmIdx = $safeComment.IndexOf('### Assemblies in')
+Assert-True (($pkgIdx -ge 0) -and ($asmIdx -gt $pkgIdx)) 'nupkg section renders before the assemblies sections'
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 Write-Host ''

--- a/tests/build_metrics/ci/BuildMetricsLib.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.ps1
@@ -65,11 +65,14 @@ $script:BuildMetricsPackageSpec = @(
 )
 
 # Strict allowlist for the ONLY artifact-derived string allowed into the rendered
-# comment: a DLL filename. Anchored and limited to characters that cannot carry
-# markdown/HTML meaning (no backtick, pipe, angle bracket, bracket, space, or
-# newline), so a validated filename is always safe to drop verbatim into a table
-# cell. A name that fails this is dropped (never rendered).
-$script:BuildMetricsDllNameRegex = '^[A-Za-z0-9._+-]+\.dll$'
+# comment: a DLL filename. Absolutely anchored (\A ... \z, so a trailing newline
+# cannot slip past a '$' end-of-line match) and CASE-SENSITIVELY matched below via
+# -cnotmatch (so Unicode case-folding — e.g. the Kelvin sign U+212A folding to 'k'
+# — cannot smuggle a non-ASCII glyph through [A-Za-z]). Limited to characters that
+# cannot carry markdown/HTML meaning (no backtick, pipe, angle bracket, bracket,
+# space, or newline), so a validated filename is always safe to drop verbatim into
+# a table cell. A name that fails this is dropped (never rendered).
+$script:BuildMetricsDllNameRegex = '\A[A-Za-z0-9._+-]+\.dll\z'
 
 function Get-BuildMetricsPackageSpec {
     <#
@@ -155,7 +158,7 @@ function ConvertTo-SafeMeasurements {
             if ($parts[0] -ne 'asm') { continue }
             if ($parts[1] -ne $p.PkgKey) { continue }
             $name = $parts[2]
-            if ($name -notmatch $script:BuildMetricsDllNameRegex) { continue }
+            if ($name -cnotmatch $script:BuildMetricsDllNameRegex) { continue }
             $raw = $rawByKey[$rawKey]
             $bytes = $null
             if ($raw.PSObject.Properties['Bytes']) { $bytes = ConvertTo-SafeBytes $raw.Bytes }

--- a/tests/build_metrics/ci/BuildMetricsLib.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.ps1
@@ -74,6 +74,16 @@ $script:BuildMetricsPackageSpec = @(
 # a table cell. A name that fails this is dropped (never rendered).
 $script:BuildMetricsDllNameRegex = '\A[A-Za-z0-9._+-]+\.dll\z'
 
+# Defense-in-depth cap: the per-DLL rows come from the untrusted sizes.json a PR
+# build produced, and a malicious PR could edit the measure script to emit
+# thousands of validly-shaped 'asm|<PkgKey>|<name>.dll' keys, bloating the
+# rendered comment (or blowing past GitHub's comment-size limit and failing the
+# privileged poster). Real packages ship a handful of DLLs, so we hard-cap how
+# many per-DLL rows any single package may contribute. Rows are sorted by
+# filename BEFORE the cap is applied, so the selection is deterministic (the
+# lexicographically smallest names win) and can't be steered by row ordering.
+$script:BuildMetricsMaxDllRowsPerPackage = 32
+
 function Get-BuildMetricsPackageSpec {
     <#
     .SYNOPSIS
@@ -117,8 +127,10 @@ function ConvertTo-SafeMeasurements {
             package and <Dll> passes the strict .dll allowlist, emit a per-DLL row
             using the validated <Dll> filename as the display Label and the
             package's TRUSTED AssemblyGroup as the Group. Rows are sorted by Label
-            for deterministic output. Unknown keys, malformed keys, and filenames
-            that fail the allowlist are dropped.
+            for deterministic output and then hard-capped per package
+            ($BuildMetricsMaxDllRowsPerPackage) so a malicious PR cannot flood the
+            comment with unboundedly many rows. Unknown keys, malformed keys, and
+            filenames that fail the allowlist are dropped.
 
         The output is therefore fully determined by trusted code plus a set of
         validated integers and allowlisted DLL filenames.
@@ -164,7 +176,11 @@ function ConvertTo-SafeMeasurements {
             if ($raw.PSObject.Properties['Bytes']) { $bytes = ConvertTo-SafeBytes $raw.Bytes }
             $rows.Add([pscustomobject]@{ Key = $rawKey; Label = $name; Group = $p.AssemblyGroup; Bytes = $bytes })
         }
-        foreach ($r in ($rows | Sort-Object Label)) { $out.Add($r) }
+        # Sort by validated filename first, THEN cap, so the kept subset is
+        # deterministic and independent of artifact row ordering.
+        $sorted = @($rows | Sort-Object Label)
+        $limit = [Math]::Min($sorted.Count, $script:BuildMetricsMaxDllRowsPerPackage)
+        for ($i = 0; $i -lt $limit; $i++) { $out.Add($sorted[$i]) }
     }
 
     return $out

--- a/tests/build_metrics/ci/BuildMetricsLib.ps1
+++ b/tests/build_metrics/ci/BuildMetricsLib.ps1
@@ -18,9 +18,10 @@
       Format-BuildMetricsComment  the sticky size-diff markdown comment.
 
     A "measurement" is a [pscustomobject] with:
-      Key    stable identifier (e.g. 'nupkg.Reactor')
-      Label  display name (e.g. 'Microsoft.UI.Reactor.nupkg')
-      Group  section header ('Packages (compressed)' | 'Assemblies (uncompressed)')
+      Key    stable identifier ('nupkg.<PkgKey>' for a package, or
+             'asm|<PkgKey>|<Dll>' for one shipped DLL inside it)
+      Label  display name (e.g. 'Microsoft.UI.Reactor.nupkg' or 'Reactor.dll')
+      Group  section header ('Packages (compressed .nupkg)' | 'Assemblies in <package>')
       Bytes  size in bytes, or $null when the artifact was not produced.
 
     Growth is the "bad" direction for every tracked artifact (smaller ships
@@ -41,44 +42,83 @@ $script:BuildMetricsCommentMarker = '<!-- reactor-build-metrics -->'
 $script:BuildMetricsNoiseFloorBytes = 64
 $script:BuildMetricsNoiseFloorPct   = 0.05
 
-# ── Trusted artifact spec ────────────────────────────────────────────────────
-# The canonical Key → { Label, Group } map. This is the SINGLE SOURCE OF TRUTH for
-# what the comment can display. The measure job runs untrusted PR code, so the
-# privileged poster must NOT trust label/group strings that come back in the
-# uploaded sizes.json — it re-maps every row through this trusted spec via
-# ConvertTo-SafeMeasurements and takes only the (validated numeric) byte counts.
-# Keys here must match those emitted by Measure-BuildMetrics.ps1.
-$script:BuildMetricsTargetSpec = @(
-    [pscustomobject]@{ Key = 'nupkg.Reactor';  Label = 'Microsoft.UI.Reactor.nupkg';          Group = 'Packages (compressed .nupkg)' }
-    [pscustomobject]@{ Key = 'asm.Reactor';    Label = 'Reactor.dll';                          Group = 'Assemblies (uncompressed)' }
-    [pscustomobject]@{ Key = 'nupkg.Advanced'; Label = 'Microsoft.UI.Reactor.Advanced.nupkg';  Group = 'Packages (compressed .nupkg)' }
-    [pscustomobject]@{ Key = 'asm.Advanced';   Label = 'Reactor.Advanced.dll';                 Group = 'Assemblies (uncompressed)' }
-    [pscustomobject]@{ Key = 'nupkg.Devtools'; Label = 'Microsoft.UI.Reactor.Devtools.nupkg';  Group = 'Packages (compressed .nupkg)' }
-    [pscustomobject]@{ Key = 'asm.Devtools';   Label = 'Microsoft.UI.Reactor.Devtools.dll';    Group = 'Assemblies (uncompressed)' }
+# ── Trusted package spec ─────────────────────────────────────────────────────
+# The canonical, ordered list of shipped packages. This is the SINGLE SOURCE OF
+# TRUTH for what the comment can display. The measure job runs untrusted PR code,
+# so the privileged poster must NOT trust label/group strings that come back in
+# the uploaded sizes.json — it re-maps every row through this spec via
+# ConvertTo-SafeMeasurements:
+#   * each package's compressed .nupkg row gets a TRUSTED PkgLabel + PackageGroup,
+#     keyed 'nupkg.<PkgKey>';
+#   * each per-DLL row (keyed 'asm|<PkgKey>|<Dll>') is accepted only when <PkgKey>
+#     is one of these known keys AND <Dll> passes a strict .dll-filename allowlist.
+# The validated DLL filename is then the ONLY artifact-derived string that ever
+# reaches the rendered markdown, and the allowlist forbids every markdown/HTML
+# meta-character, so it is always safe to emit verbatim. Byte counts are validated
+# as non-negative integers. PkgKey is alphanumeric, so it can never contain the
+# '|' delimiter used in the asm row keys. New DLLs shipped by a package appear on
+# their own — no per-DLL list is hard-coded here.
+$script:BuildMetricsPackageSpec = @(
+    [pscustomobject]@{ PkgKey = 'Reactor';  PkgLabel = 'Microsoft.UI.Reactor.nupkg';          PackageGroup = 'Packages (compressed .nupkg)'; AssemblyGroup = 'Assemblies in Microsoft.UI.Reactor' }
+    [pscustomobject]@{ PkgKey = 'Advanced'; PkgLabel = 'Microsoft.UI.Reactor.Advanced.nupkg'; PackageGroup = 'Packages (compressed .nupkg)'; AssemblyGroup = 'Assemblies in Microsoft.UI.Reactor.Advanced' }
+    [pscustomobject]@{ PkgKey = 'Devtools'; PkgLabel = 'Microsoft.UI.Reactor.Devtools.nupkg'; PackageGroup = 'Packages (compressed .nupkg)'; AssemblyGroup = 'Assemblies in Microsoft.UI.Reactor.Devtools' }
 )
 
-function Get-BuildMetricsTargetSpec {
+# Strict allowlist for the ONLY artifact-derived string allowed into the rendered
+# comment: a DLL filename. Anchored and limited to characters that cannot carry
+# markdown/HTML meaning (no backtick, pipe, angle bracket, bracket, space, or
+# newline), so a validated filename is always safe to drop verbatim into a table
+# cell. A name that fails this is dropped (never rendered).
+$script:BuildMetricsDllNameRegex = '^[A-Za-z0-9._+-]+\.dll$'
+
+function Get-BuildMetricsPackageSpec {
     <#
     .SYNOPSIS
-        The trusted, ordered Key → { Label, Group } spec for the tracked artifacts.
+        The trusted, ordered package spec (PkgKey → PkgLabel / PackageGroup /
+        AssemblyGroup) for the tracked NuGet packages.
     #>
-    return $script:BuildMetricsTargetSpec
+    return $script:BuildMetricsPackageSpec
+}
+
+function ConvertTo-SafeBytes {
+    <#
+    .SYNOPSIS
+        Return $Value as a non-negative [long], or $null when it is missing,
+        non-integer, negative, or otherwise not a plain integer (e.g. '1.5',
+        '1e9', 'not-a-number'). The sole gate for artifact-supplied byte counts.
+    #>
+    param([AllowNull()]$Value)
+    if ($null -eq $Value) { return $null }
+    $parsed = [long]0
+    if ([long]::TryParse([string]$Value, [ref]$parsed) -and $parsed -ge 0) {
+        return $parsed
+    }
+    return $null
 }
 
 function ConvertTo-SafeMeasurements {
     <#
     .SYNOPSIS
         Project raw (untrusted) measurement objects — e.g. parsed from a sizes.json
-        an unprivileged PR job produced — onto the trusted target spec.
+        an unprivileged PR job produced — onto the trusted package spec.
 
     .DESCRIPTION
         Security boundary for the privileged poster: never render label/group text
-        that came from the artifact. For each entry in the trusted spec this looks
-        up the raw row by Key, accepts its Bytes ONLY if it is a non-negative
-        integer, and emits a measurement carrying the TRUSTED Label/Group. Unknown
-        keys in the raw input are dropped; a missing/garbage/negative Bytes becomes
-        $null (rendered as n/a). The output is therefore fully determined by trusted
-        code plus a handful of validated integers.
+        that came from the artifact.
+
+        (a) For each trusted package, emit the compressed-.nupkg row (key
+            'nupkg.<PkgKey>') carrying the TRUSTED PkgLabel + PackageGroup and a
+            byte count accepted ONLY when it is a non-negative integer.
+
+        (b) For each raw row keyed 'asm|<PkgKey>|<Dll>' where <PkgKey> is a KNOWN
+            package and <Dll> passes the strict .dll allowlist, emit a per-DLL row
+            using the validated <Dll> filename as the display Label and the
+            package's TRUSTED AssemblyGroup as the Group. Rows are sorted by Label
+            for deterministic output. Unknown keys, malformed keys, and filenames
+            that fail the allowlist are dropped.
+
+        The output is therefore fully determined by trusted code plus a set of
+        validated integers and allowlisted DLL filenames.
     #>
     param([AllowNull()]$RawMeasurements)
 
@@ -92,19 +132,38 @@ function ConvertTo-SafeMeasurements {
     }
 
     $out = [System.Collections.Generic.List[object]]::new()
-    foreach ($t in $script:BuildMetricsTargetSpec) {
+
+    # (a) One compressed-.nupkg row per trusted package, in spec order — so the
+    # single "Packages (compressed .nupkg)" section renders first.
+    foreach ($p in $script:BuildMetricsPackageSpec) {
+        $key = 'nupkg.' + $p.PkgKey
         $bytes = $null
-        if ($rawByKey.ContainsKey($t.Key)) {
-            $raw = $rawByKey[$t.Key]
-            if ($raw.PSObject.Properties['Bytes'] -and $null -ne $raw.Bytes) {
-                $parsed = [long]0
-                if ([long]::TryParse([string]$raw.Bytes, [ref]$parsed) -and $parsed -ge 0) {
-                    $bytes = $parsed
-                }
-            }
+        if ($rawByKey.ContainsKey($key)) {
+            $raw = $rawByKey[$key]
+            if ($raw.PSObject.Properties['Bytes']) { $bytes = ConvertTo-SafeBytes $raw.Bytes }
         }
-        $out.Add([pscustomobject]@{ Key = $t.Key; Label = $t.Label; Group = $t.Group; Bytes = $bytes })
+        $out.Add([pscustomobject]@{ Key = $key; Label = $p.PkgLabel; Group = $p.PackageGroup; Bytes = $bytes })
     }
+
+    # (b) Per-DLL rows, grouped by package (spec order), sorted by validated
+    # filename within each package.
+    foreach ($p in $script:BuildMetricsPackageSpec) {
+        $rows = [System.Collections.Generic.List[object]]::new()
+        foreach ($rawKey in $rawByKey.Keys) {
+            $parts = ([string]$rawKey).Split('|')
+            if ($parts.Count -ne 3) { continue }
+            if ($parts[0] -ne 'asm') { continue }
+            if ($parts[1] -ne $p.PkgKey) { continue }
+            $name = $parts[2]
+            if ($name -notmatch $script:BuildMetricsDllNameRegex) { continue }
+            $raw = $rawByKey[$rawKey]
+            $bytes = $null
+            if ($raw.PSObject.Properties['Bytes']) { $bytes = ConvertTo-SafeBytes $raw.Bytes }
+            $rows.Add([pscustomobject]@{ Key = $rawKey; Label = $name; Group = $p.AssemblyGroup; Bytes = $bytes })
+        }
+        foreach ($r in ($rows | Sort-Object Label)) { $out.Add($r) }
+    }
+
     return $out
 }
 

--- a/tests/build_metrics/ci/Measure-BuildMetrics.Tests.ps1
+++ b/tests/build_metrics/ci/Measure-BuildMetrics.Tests.ps1
@@ -2,7 +2,7 @@
 .SYNOPSIS
     Dependency-free unit tests for the testable helpers in Measure-BuildMetrics.ps1
     (the build-metrics pack/measure orchestrator): Select-LatestNupkg (package
-    selection) and Get-NupkgAssemblyBytes (ZIP assembly-size extraction).
+    selection) and Get-NupkgAssemblies (ZIP shipped-DLL enumeration).
 
 .DESCRIPTION
     Measure-BuildMetrics.ps1 isn't dot-sourceable (it has a param block + a main
@@ -36,6 +36,11 @@ function Assert-Null {
     if ($null -eq $Actual) { $script:Pass++ }
     else { $script:Fail++; $script:Failures.Add("$Message`n    expected: <null>`n    actual:   [$Actual]") }
 }
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add($Message) }
+}
 
 # --- Extract the functions under test from the orchestrator script via AST. ---
 $scriptPath = Join-Path $PSScriptRoot 'Measure-BuildMetrics.ps1'
@@ -54,7 +59,7 @@ function Get-Func([string]$name) {
     $f.Extent.Text
 }
 Invoke-Expression (Get-Func 'Select-LatestNupkg')
-Invoke-Expression (Get-Func 'Get-NupkgAssemblyBytes')
+Invoke-Expression (Get-Func 'Get-NupkgAssemblies')
 
 # --- Test scratch dir + helpers to synthesize .nupkg ZIPs. ---
 $tmp = Join-Path ([IO.Path]::GetTempPath()) ("bm-measure-tests-" + [Guid]::NewGuid().ToString('N'))
@@ -80,34 +85,48 @@ function New-Nupkg {
 }
 
 try {
-    # ── Get-NupkgAssemblyBytes ────────────────────────────────────────────────
-    # Largest lib/<tfm>/Reactor.dll wins; ref/ and non-lib entries are ignored.
-    $multi = Join-Path $tmp 'multi.nupkg'
-    New-Nupkg -Path $multi -Entries ([ordered]@{
-        'lib/net8.0/Reactor.dll'                     = 3000
-        'lib/net10.0-windows10.0.22621.0/Reactor.dll' = 5000
-        'ref/net10.0/Reactor.dll'                    = 9999   # not under lib/ -> ignored
-        '[Content_Types].xml'                        = 200
+    # ── Get-NupkgAssemblies ───────────────────────────────────────────────────
+    # Enumerate EVERY shipped DLL: lib/<tfm>/*.dll AND analyzers/**/*.dll, one row
+    # per basename (largest length wins across TFMs), excluding satellite
+    # *.resources.dll and any non-DLL file.
+    $pkg = Join-Path $tmp 'all-dlls.nupkg'
+    New-Nupkg -Path $pkg -Entries ([ordered]@{
+        'lib/net8.0/A.dll'                            = 3000    # same basename, smaller TFM
+        'lib/net10.0-windows10.0.22621.0/A.dll'       = 5000    # largest -> wins
+        'analyzers/dotnet/cs/B.dll'                   = 296000  # analyzers/ DLL included
+        'lib/net10.0-windows10.0.22621.0/C.resources.dll' = 999 # satellite -> excluded
+        'lib/net10.0-windows10.0.22621.0/D.dll'       = 100     # a second, distinct lib DLL
+        '[Content_Types].xml'                         = 200     # non-DLL -> excluded
+        'docs/readme.md'                              = 10      # non-DLL -> excluded
     })
-    Assert-Equal 5000 (Get-NupkgAssemblyBytes -NupkgPath $multi -AssemblyFile 'Reactor.dll') 'largest lib/<tfm> assembly wins; ref/ ignored'
+    $asms = @(Get-NupkgAssemblies -NupkgPath $pkg)
+    $byName = @{}; foreach ($a in $asms) { $byName[$a.Name] = $a.Bytes }
+    Assert-Equal 3 $asms.Count 'enumerates A.dll, B.dll, D.dll (satellite + non-DLL excluded)'
+    Assert-Equal 5000 $byName['A.dll'] 'largest lib/<tfm> length wins for a shared basename'
+    Assert-Equal 296000 $byName['B.dll'] 'analyzers/ DLL is enumerated'
+    Assert-Equal 100 $byName['D.dll'] 'a second distinct lib DLL is enumerated'
+    Assert-True (-not $byName.ContainsKey('C.resources.dll')) 'satellite *.resources.dll excluded'
 
-    # A single-TFM package returns that entry's uncompressed length.
+    # A single-TFM, single-DLL package returns exactly that entry's length.
     $single = Join-Path $tmp 'single.nupkg'
     New-Nupkg -Path $single -Entries ([ordered]@{ 'lib/net10.0/Reactor.Advanced.dll' = 33792 })
-    Assert-Equal 33792 (Get-NupkgAssemblyBytes -NupkgPath $single -AssemblyFile 'Reactor.Advanced.dll') 'single-TFM assembly size'
+    $singleAsms = @(Get-NupkgAssemblies -NupkgPath $single)
+    Assert-Equal 1 $singleAsms.Count 'single-DLL package -> one row'
+    Assert-Equal 'Reactor.Advanced.dll' $singleAsms[0].Name 'single-DLL package -> correct name'
+    Assert-Equal 33792 $singleAsms[0].Bytes 'single-TFM assembly size'
 
-    # No matching assembly -> null.
+    # No shipped DLLs -> empty array.
     $noAsm = Join-Path $tmp 'noasm.nupkg'
-    New-Nupkg -Path $noAsm -Entries ([ordered]@{ 'lib/net10.0/Other.dll' = 1234; 'readme.md' = 10 })
-    Assert-Null (Get-NupkgAssemblyBytes -NupkgPath $noAsm -AssemblyFile 'Reactor.dll') 'no matching lib assembly -> null'
+    New-Nupkg -Path $noAsm -Entries ([ordered]@{ 'ref/net10.0/Only.dll' = 1234; 'readme.md' = 10 })
+    Assert-Equal 0 (@(Get-NupkgAssemblies -NupkgPath $noAsm)).Count 'no lib/ or analyzers/ DLL -> empty'
 
-    # Corrupt / non-ZIP file -> null (the try/catch swallows the open failure).
+    # Corrupt / non-ZIP file -> empty (the try/catch swallows the open failure).
     $corrupt = Join-Path $tmp 'corrupt.nupkg'
     Set-Content -LiteralPath $corrupt -Value 'this is not a zip' -Encoding ascii
-    Assert-Null (Get-NupkgAssemblyBytes -NupkgPath $corrupt -AssemblyFile 'Reactor.dll' -WarningAction SilentlyContinue) 'corrupt archive -> null'
+    Assert-Equal 0 (@(Get-NupkgAssemblies -NupkgPath $corrupt -WarningAction SilentlyContinue)).Count 'corrupt archive -> empty'
 
-    # Missing file -> null.
-    Assert-Null (Get-NupkgAssemblyBytes -NupkgPath (Join-Path $tmp 'nope.nupkg') -AssemblyFile 'Reactor.dll' -WarningAction SilentlyContinue) 'missing file -> null'
+    # Missing file -> empty.
+    Assert-Equal 0 (@(Get-NupkgAssemblies -NupkgPath (Join-Path $tmp 'nope.nupkg') -WarningAction SilentlyContinue)).Count 'missing file -> empty'
 
     # ── Select-LatestNupkg ────────────────────────────────────────────────────
     $pkgDir = Join-Path $tmp 'pkgs'

--- a/tests/build_metrics/ci/Measure-BuildMetrics.ps1
+++ b/tests/build_metrics/ci/Measure-BuildMetrics.ps1
@@ -6,12 +6,15 @@
 .DESCRIPTION
     Runs `dotnet pack -c Release` for each tracked package, then measures:
       * the compressed .nupkg (what a consumer downloads), and
-      * the primary uncompressed assembly inside it (lib/<tfm>/<Assembly>.dll —
-        the real "did our code grow" signal).
+      * every uncompressed DLL shipped inside it (all lib/<tfm>/*.dll and
+        analyzers/**/*.dll, excluding satellite *.resources.dll) — the real "did
+        our code grow" signal. New DLLs appear automatically; nothing is
+        hard-coded per package.
 
     The output JSON is an array of measurement objects consumed by
     BuildMetricsLib.ps1's Format-BuildMetricsComment:
       { "Key": "...", "Label": "...", "Group": "...", "Bytes": <int|null> }
+    with keys 'nupkg.<PkgKey>' for a package and 'asm|<PkgKey>|<Dll>' per DLL.
 
     A fixed -PackageVersion is used for both sides (the PR's base branch and head)
     so the version string embedded in the .nuspec is identical and never
@@ -76,37 +79,35 @@ New-Item -ItemType Directory -Force -Path $packFull | Out-Null
 $PackOutput = $packFull
 
 # ── Tracked packages ─────────────────────────────────────────────────────────
-# Keys are stable identifiers (NOT filenames — the .nupkg carries a version), so
-# base and head rows line up even when their MinVer versions differ. Advanced +
+# PkgKey is a stable, alphanumeric identifier (NOT a filename — the .nupkg carries
+# a version), so base and head rows line up even when their MinVer versions differ
+# and so it can never contain the '|' delimiter used in per-DLL row keys. Advanced +
 # Devtools pack from their AnyCPU output (mirrors release.yml), which the standalone
 # `dotnet pack` produces by default; passing it explicitly keeps parity if the
-# csproj default ever changes.
+# csproj default ever changes. Every shipped DLL inside each package is enumerated
+# automatically (see Get-NupkgAssemblies), so no per-assembly list lives here.
 $targets = @(
     [pscustomobject]@{
-        PkgKey = 'nupkg.Reactor'; PkgLabel = 'Microsoft.UI.Reactor.nupkg'
-        AsmKey = 'asm.Reactor';   AsmLabel = 'Reactor.dll'
+        PkgKey = 'Reactor'; PkgLabel = 'Microsoft.UI.Reactor.nupkg'
         Project = 'src/Reactor/Reactor.csproj'
-        PackageId = 'Microsoft.UI.Reactor'; AssemblyFile = 'Reactor.dll'
+        PackageId = 'Microsoft.UI.Reactor'
         ExtraArgs = @()
     }
     [pscustomobject]@{
-        PkgKey = 'nupkg.Advanced'; PkgLabel = 'Microsoft.UI.Reactor.Advanced.nupkg'
-        AsmKey = 'asm.Advanced';   AsmLabel = 'Reactor.Advanced.dll'
+        PkgKey = 'Advanced'; PkgLabel = 'Microsoft.UI.Reactor.Advanced.nupkg'
         Project = 'src/Reactor.Advanced/Reactor.Advanced.csproj'
-        PackageId = 'Microsoft.UI.Reactor.Advanced'; AssemblyFile = 'Reactor.Advanced.dll'
+        PackageId = 'Microsoft.UI.Reactor.Advanced'
         ExtraArgs = @('-p:Platform=AnyCPU')
     }
     [pscustomobject]@{
-        PkgKey = 'nupkg.Devtools'; PkgLabel = 'Microsoft.UI.Reactor.Devtools.nupkg'
-        AsmKey = 'asm.Devtools';   AsmLabel = 'Microsoft.UI.Reactor.Devtools.dll'
+        PkgKey = 'Devtools'; PkgLabel = 'Microsoft.UI.Reactor.Devtools.nupkg'
         Project = 'src/Reactor.Devtools/Reactor.Devtools.csproj'
-        PackageId = 'Microsoft.UI.Reactor.Devtools'; AssemblyFile = 'Microsoft.UI.Reactor.Devtools.dll'
+        PackageId = 'Microsoft.UI.Reactor.Devtools'
         ExtraArgs = @('-p:Platform=AnyCPU')
     }
 )
 
-$packageGroup  = 'Packages (compressed .nupkg)'
-$assemblyGroup = 'Assemblies (uncompressed)'
+$packageGroup = 'Packages (compressed .nupkg)'
 
 function Select-LatestNupkg {
     <#
@@ -126,27 +127,41 @@ function Select-LatestNupkg {
         Select-Object -First 1
 }
 
-function Get-NupkgAssemblyBytes {
+function Get-NupkgAssemblies {
     <#
     .SYNOPSIS
-        Uncompressed size of the largest lib/<tfm>/<AssemblyFile> entry in a
-        .nupkg, without extracting it. $null if the archive has no such entry.
+        Enumerate every shipped DLL in a .nupkg — one entry per assembly basename —
+        without extracting the archive. Returns objects { Name; Bytes }.
+    .DESCRIPTION
+        Includes every zip entry whose forward-slash path matches
+        ^(lib|analyzers)/.+\.dll$ — the framework assemblies under lib/<tfm>/ and
+        the analyzer / source-generator DLLs shipped under analyzers/dotnet/cs/ —
+        while EXCLUDING satellite resource assemblies (*.resources.dll). When the
+        same basename appears under multiple TFMs the largest uncompressed length
+        is reported. Returns an empty array if the archive has no such entries or
+        cannot be read.
     #>
-    param([string]$NupkgPath, [string]$AssemblyFile)
+    param([string]$NupkgPath)
     $zip = $null
     try {
         $zip = [System.IO.Compression.ZipFile]::OpenRead($NupkgPath)
-        $best = $null
+        $bySize = @{}
         foreach ($entry in $zip.Entries) {
-            # NuGet lib assets: lib/<tfm>/<file>. FullName uses forward slashes.
-            if ($entry.FullName -match ('^lib/[^/]+/' + [regex]::Escape($AssemblyFile) + '$')) {
-                if ($null -eq $best -or $entry.Length -gt $best) { $best = $entry.Length }
+            # NuGet asset paths use forward slashes regardless of OS.
+            if ($entry.FullName -notmatch '^(lib|analyzers)/.+\.dll$') { continue }
+            if ($entry.FullName -match '\.resources\.dll$') { continue }
+            $name = [System.IO.Path]::GetFileName($entry.FullName)
+            if (-not $bySize.ContainsKey($name) -or $entry.Length -gt $bySize[$name]) {
+                $bySize[$name] = $entry.Length
             }
         }
-        return $best
+        $result = foreach ($name in $bySize.Keys) {
+            [pscustomobject]@{ Name = $name; Bytes = $bySize[$name] }
+        }
+        return @($result)
     } catch {
-        Write-Warning "Failed to read '$AssemblyFile' from ${NupkgPath}: $($_.Exception.Message)"
-        return $null
+        Write-Warning "Failed to enumerate assemblies from ${NupkgPath}: $($_.Exception.Message)"
+        return @()
     } finally {
         if ($zip) { $zip.Dispose() }
     }
@@ -161,7 +176,7 @@ foreach ($t in $targets) {
     Write-Host "==> Packing $($t.PackageId) ($($t.Project))"
 
     $nupkgBytes = $null
-    $asmBytes = $null
+    $assemblies = @()
 
     if (-not (Test-Path -LiteralPath $projPath)) {
         Write-Warning "Project not found: $projPath — emitting n/a for $($t.PackageId)."
@@ -181,16 +196,27 @@ foreach ($t in $targets) {
             $nupkg = Select-LatestNupkg -PackOutput $PackOutput -PackageId $t.PackageId
             if ($nupkg) {
                 $nupkgBytes = $nupkg.Length
-                $asmBytes = Get-NupkgAssemblyBytes -NupkgPath $nupkg.FullName -AssemblyFile $t.AssemblyFile
-                Write-Host "    $($nupkg.Name): nupkg=$nupkgBytes B, $($t.AssemblyFile)=$asmBytes B"
+                $assemblies = Get-NupkgAssemblies -NupkgPath $nupkg.FullName
+                Write-Host "    $($nupkg.Name): nupkg=$nupkgBytes B, $(@($assemblies).Count) DLL(s)"
+                foreach ($asm in ($assemblies | Sort-Object Name)) {
+                    Write-Host "      $($asm.Name) = $($asm.Bytes) B"
+                }
             } else {
                 Write-Warning "No .nupkg matching '$($t.PackageId).<version>.nupkg' in $PackOutput."
             }
         }
     }
 
-    $measurements.Add([pscustomobject]@{ Key = $t.PkgKey; Label = $t.PkgLabel; Group = $packageGroup;  Bytes = $nupkgBytes })
-    $measurements.Add([pscustomobject]@{ Key = $t.AsmKey; Label = $t.AsmLabel; Group = $assemblyGroup; Bytes = $asmBytes })
+    # Compressed package row.
+    $measurements.Add([pscustomobject]@{ Key = "nupkg.$($t.PkgKey)"; Label = $t.PkgLabel; Group = $packageGroup; Bytes = $nupkgBytes })
+
+    # One row per shipped DLL, keyed 'asm|<PkgKey>|<Dll>'. The Group here is
+    # informational (the trusted poster re-derives it from the package spec via
+    # ConvertTo-SafeMeasurements); it makes local, direct renders group per package.
+    $assemblyGroup = "Assemblies in $($t.PackageId)"
+    foreach ($asm in @($assemblies)) {
+        $measurements.Add([pscustomobject]@{ Key = "asm|$($t.PkgKey)|$($asm.Name)"; Label = $asm.Name; Group = $assemblyGroup; Bytes = $asm.Bytes })
+    }
 }
 
 # Depth 5 is plenty for the flat measurement objects; force an array shape even

--- a/tests/build_metrics/ci/README.md
+++ b/tests/build_metrics/ci/README.md
@@ -102,6 +102,9 @@ re-maps every row through the trusted `$BuildMetricsPackageSpec`:
   case-folding can't smuggle a non-ASCII glyph through `[A-Za-z]`), it is always
   safe to emit verbatim. The DLL's group is the package's trusted assembly group;
   unknown keys, malformed keys, and filenames that fail the allowlist are dropped.
+- Per-DLL rows are **hard-capped per package** (32 rows) after a deterministic
+  sort by filename, so a malicious PR that emits thousands of validly-shaped DLL
+  keys can't flood the comment or push it past GitHub's comment-size limit.
 
 So the comment is fully determined by trusted code plus a set of validated
 integers and allowlisted DLL filenames — the untrusted artifact can never inject

--- a/tests/build_metrics/ci/README.md
+++ b/tests/build_metrics/ci/README.md
@@ -93,13 +93,15 @@ re-maps every row through the trusted `$BuildMetricsPackageSpec`:
 - Each package's compressed-`.nupkg` row is emitted with a **trusted** label and
   group; only its non-negative-integer byte count is taken from the artifact.
 - Each per-DLL row is keyed `asm|<PkgKey>|<Dll>`. It is kept **only** when
-  `<PkgKey>` is a known package *and* `<Dll>` passes the strict allowlist
-  `^[A-Za-z0-9._+-]+\.dll$`. That validated filename is the **only**
-  artifact-derived string that ever reaches the rendered markdown — and because
-  the allowlist forbids every markdown/HTML meta-character (backtick, pipe, angle
-  bracket, bracket, space, newline), it is always safe to emit verbatim. The
-  DLL's group is the package's trusted assembly group; unknown keys, malformed
-  keys, and filenames that fail the allowlist are dropped.
+  `<PkgKey>` is a known package *and* `<Dll>` passes the strict, case-sensitive,
+  absolutely-anchored allowlist `\A[A-Za-z0-9._+-]+\.dll\z`. That validated
+  filename is the **only** artifact-derived string that ever reaches the rendered
+  markdown — and because the allowlist forbids every markdown/HTML meta-character
+  (backtick, pipe, angle bracket, bracket, space, newline — including a trailing
+  newline, which `\z` rejects) and is matched case-sensitively (so Unicode
+  case-folding can't smuggle a non-ASCII glyph through `[A-Za-z]`), it is always
+  safe to emit verbatim. The DLL's group is the package's trusted assembly group;
+  unknown keys, malformed keys, and filenames that fail the allowlist are dropped.
 
 So the comment is fully determined by trusted code plus a set of validated
 integers and allowlisted DLL filenames — the untrusted artifact can never inject

--- a/tests/build_metrics/ci/README.md
+++ b/tests/build_metrics/ci/README.md
@@ -14,38 +14,57 @@ Example:
 > | Artifact | base | PR | Δ | |
 > |---|--:|--:|--:|:-:|
 > | Microsoft.UI.Reactor.nupkg | 1.94 MB | 1.95 MB | +8.4 KB (+0.42%) | ⚠️ |
+> | Microsoft.UI.Reactor.Advanced.nupkg | 12.0 KB | 12.0 KB | +0 B (0.00%) | ≈ |
+> | Microsoft.UI.Reactor.Devtools.nupkg | 180 KB | 180 KB | +0 B (0.00%) | ≈ |
 >
-> ### Assemblies (uncompressed)
+> ### Assemblies in Microsoft.UI.Reactor
 >
 > | Artifact | base | PR | Δ | |
 > |---|--:|--:|--:|:-:|
+> | Reactor.Analyzers.dll | 296 KB | 296 KB | +0 B (0.00%) | ≈ |
+> | Reactor.Localization.Generator.dll | 16.0 KB | 16.0 KB | +0 B (0.00%) | ≈ |
+> | Reactor.Wrappers.Abstractions.dll | 10.0 KB | 10.0 KB | +0 B (0.00%) | ≈ |
+> | Reactor.Wrappers.Generator.dll | 100 KB | 100 KB | +0 B (0.00%) | ≈ |
 > | Reactor.dll | 3.16 MB | 3.16 MB | +0 B (0.00%) | ≈ |
 
 ## What is measured
 
-For each shipped package the report tracks two numbers:
+For each shipped package the report tracks:
 
 | Group | What | Why |
 |---|---|---|
 | **Packages (compressed .nupkg)** | the `.nupkg` file size | the download a consumer actually pays for |
-| **Assemblies (uncompressed)** | the primary DLL inside `lib/<tfm>/` | the real "did our code grow" signal, unaffected by zip compression noise |
+| **Assemblies in `<package>`** | **every** DLL shipped inside the package (all `lib/<tfm>/*.dll` and `analyzers/**/*.dll`, one row per assembly) | the real "did our code grow" signal, unaffected by zip compression noise |
 
-Tracked packages (see `$targets` in `Measure-BuildMetrics.ps1`):
+Assemblies are enumerated automatically per package (`Get-NupkgAssemblies` in
+`Measure-BuildMetrics.ps1`) — **every** `lib/` and `analyzers/` DLL is measured,
+with satellite resource assemblies (`*.resources.dll`) excluded. There is **no
+hard-coded per-DLL list**, so a DLL newly added to a package appears in the
+comment on its own. When the same basename ships under multiple target
+frameworks, the largest uncompressed length is reported.
 
-- `Microsoft.UI.Reactor` → `Reactor.dll`
+Tracked packages (see `$targets` in `Measure-BuildMetrics.ps1`) and the DLLs they
+currently ship:
+
+- `Microsoft.UI.Reactor` → `Reactor.dll`, `Reactor.Wrappers.Abstractions.dll`,
+  `Reactor.Analyzers.dll`, `Reactor.Wrappers.Generator.dll`,
+  `Reactor.Localization.Generator.dll`
 - `Microsoft.UI.Reactor.Advanced` → `Reactor.Advanced.dll`
 - `Microsoft.UI.Reactor.Devtools` → `Microsoft.UI.Reactor.Devtools.dll`
 
-Adding a package is a one-line entry in that `$targets` array.
+Adding a package is a one-line entry in that `$targets` array (only `PkgKey`,
+`PkgLabel`, `Project`, `PackageId` are needed); its DLLs are then discovered
+automatically. Adding a package also needs a matching entry in the trusted
+`$BuildMetricsPackageSpec` in `BuildMetricsLib.ps1` (see the trust boundary below).
 
 ## Files
 
 | File | Role |
 |---|---|
-| `BuildMetricsLib.ps1` | **Pure** helpers (no filesystem side effects): byte formatting, `Get-SizeDelta`, the sticky-comment renderer, the trusted `Get-BuildMetricsTargetSpec` and `ConvertTo-SafeMeasurements` (the render-time security boundary). Unit-testable headless. |
-| `BuildMetricsLib.Tests.ps1` | Dependency-free assertions for the pure lib (incl. the sanitizer). Exits non-zero on failure. |
-| `Measure-BuildMetrics.ps1` | Orchestrator: `dotnet pack` each package in a source tree and emit a `sizes.json` of measurements. |
-| `Measure-BuildMetrics.Tests.ps1` | AST-extracted tests for the orchestrator's `Select-LatestNupkg` + `Get-NupkgAssemblyBytes` (synthesizes real `.nupkg` ZIPs; no `dotnet`). |
+| `BuildMetricsLib.ps1` | **Pure** helpers (no filesystem side effects): byte formatting, `Get-SizeDelta`, the sticky-comment renderer, the trusted `Get-BuildMetricsPackageSpec` and `ConvertTo-SafeMeasurements` (the render-time security boundary). Unit-testable headless. |
+| `BuildMetricsLib.Tests.ps1` | Dependency-free assertions for the pure lib (incl. the sanitizer + DLL-filename allowlist). Exits non-zero on failure. |
+| `Measure-BuildMetrics.ps1` | Orchestrator: `dotnet pack` each package in a source tree, enumerate every shipped DLL (`Get-NupkgAssemblies`), and emit a `sizes.json` of measurements. |
+| `Measure-BuildMetrics.Tests.ps1` | AST-extracted tests for the orchestrator's `Select-LatestNupkg` + `Get-NupkgAssemblies` (synthesizes real `.nupkg` ZIPs; no `dotnet`). |
 
 ## Workflows
 
@@ -68,11 +87,23 @@ artifact.
 **Why the poster renders (not the measure job):** the measure job builds
 untrusted PR code, so if it produced the final markdown a PR could make the
 privileged bot post arbitrary content. Instead the artifact carries only
-per-artifact byte counts (the `sizes.json` also includes label/group strings, but
-the poster **ignores** them). The trusted poster re-maps every row through a fixed
-`Key → Label` spec — dropping unknown keys, using its own trusted labels/groups,
-and accepting only non-negative integer byte counts — so the comment is fully
-determined by trusted code plus a handful of validated integers.
+per-artifact rows (byte counts plus, for assemblies, a DLL filename); the poster
+re-maps every row through the trusted `$BuildMetricsPackageSpec`:
+
+- Each package's compressed-`.nupkg` row is emitted with a **trusted** label and
+  group; only its non-negative-integer byte count is taken from the artifact.
+- Each per-DLL row is keyed `asm|<PkgKey>|<Dll>`. It is kept **only** when
+  `<PkgKey>` is a known package *and* `<Dll>` passes the strict allowlist
+  `^[A-Za-z0-9._+-]+\.dll$`. That validated filename is the **only**
+  artifact-derived string that ever reaches the rendered markdown — and because
+  the allowlist forbids every markdown/HTML meta-character (backtick, pipe, angle
+  bracket, bracket, space, newline), it is always safe to emit verbatim. The
+  DLL's group is the package's trusted assembly group; unknown keys, malformed
+  keys, and filenames that fail the allowlist are dropped.
+
+So the comment is fully determined by trusted code plus a set of validated
+integers and allowlisted DLL filenames — the untrusted artifact can never inject
+markdown, package labels, or section headers into the bot-authored comment.
 
 The sticky comment is found + updated in place via a hidden marker
 (`<!-- reactor-build-metrics -->`) — the same *mechanism* as


### PR DESCRIPTION
## Summary

Extends the build-metrics PR-comment feature (#818; permission fix #825) so its size table covers **every** DLL shipped in the NuGet packages, not just one hard-coded primary assembly per package.

Previously the comment reported each package's compressed `.nupkg` size plus exactly **one** hard-coded DLL. The real shipped packages (verified against `v0.1.0-preview.11.106`) contain **7 DLLs**:

| Package | DLLs |
|---|---|
| `Microsoft.UI.Reactor.nupkg` | `Reactor.dll` (~3305 KB), `Reactor.Wrappers.Abstractions.dll` (~10 KB), `Reactor.Analyzers.dll` (~296 KB), `Reactor.Wrappers.Generator.dll` (~100 KB), `Reactor.Localization.Generator.dll` (~16 KB) |
| `Microsoft.UI.Reactor.Advanced.nupkg` | `Reactor.Advanced.dll` (~33 KB) |
| `Microsoft.UI.Reactor.Devtools.nupkg` | `Microsoft.UI.Reactor.Devtools.dll` (~432 KB) |

**4 DLLs were previously missing** from the report:
- `Reactor.Wrappers.Abstractions.dll`
- `Reactor.Analyzers.dll`
- `Reactor.Wrappers.Generator.dll`
- `Reactor.Localization.Generator.dll`

## What changed

- **`Measure-BuildMetrics.ps1`** — replaced the single-`AssemblyFile` logic with `Get-NupkgAssemblies`, which enumerates every zip entry matching `^(lib|analyzers)/.+\.dll$`, excluding satellite `*.resources.dll`, reporting the largest length when a basename ships under multiple TFMs. Each DLL row is keyed `asm|<PkgKey>|<Dll>`; the package row stays `nupkg.<PkgKey>`. `$targets` now only carries `PkgKey`/`PkgLabel`/`Project`/`PackageId`.
- **`BuildMetricsLib.ps1`** — replaced the fixed 6-entry spec with a trusted 3-**package** spec (`PkgKey`, `PkgLabel`, `PackageGroup`, `AssemblyGroup`). `ConvertTo-SafeMeasurements` now emits one trusted `.nupkg` row per package plus one row per allowlisted DLL, grouped under that package's trusted assembly section. `Get-BuildMetricsPackageSpec` is exported for tests.
- **Auto-inclusion** — no per-DLL list is hard-coded anywhere, so a DLL newly added to a package shows up in the comment on its own.
- Updated both `*.Tests.ps1` suites and the `README.md`.

## Trust boundary preserved

The measure job still runs untrusted PR build code and uploads **only** data; the privileged `workflow_run` poster renders from `main`. The security model is unchanged and, if anything, tightened:

- Package labels and section/group headers stay **trusted constants** from the spec.
- Byte counts are accepted **only** as non-negative integers.
- Unknown package keys, malformed keys (e.g. `asm|Reactor|a|b.dll`), and filenames failing the strict allowlist `\A[A-Za-z0-9._+-]+\.dll\z` (matched case-sensitively) are dropped.
- The **only** artifact-derived string that reaches the rendered markdown is a DLL filename that passes that allowlist — it cannot contain a backtick, pipe, angle bracket, bracket, space, or newline (the absolute `\A...\z` anchors plus case-sensitive matching also reject a trailing newline and Unicode case-folding such as the Kelvin sign U+212A), so it is always markdown-safe.

## Validation

- `pwsh tests/build_metrics/ci/BuildMetricsLib.Tests.ps1` → 118 passed
- `pwsh tests/build_metrics/ci/Measure-BuildMetrics.Tests.ps1` → 15 passed
- All three build-metrics workflow YAMLs parse cleanly.
- No `dotnet` builds run.

## Note on this PR's own comment

Because `workflow_run` posters run from `main`, the new per-DLL rows won't populate on **this PR's own** build-metrics comment until it merges. This is expected, self-resolves on merge, and is the same behavior as the original #818 rollout.

Refs #818.
