### PR TITLE
E2E test reliability: stress harness, anti-masking retry attribute, and flaky-test hardening

### DIFF
--- a/.github/workflows/ci-stress.yml
+++ b/.github/workflows/ci-stress.yml
@@ -398,7 +398,7 @@ jobs:
       - name: Aggregate reliability
         shell: pwsh
         run: |
-          & ./tests/Reactor.AppTests/StressReport.ps1 -Path stress-artifacts -Title "E2E winapp-ui stress reliability (retries ON)"
+          & ./tests/Reactor.AppTests/StressReport.ps1 -Path stress-artifacts -Title "E2E winapp-ui stress reliability"
 
   summary:
     name: Stress summary

--- a/.github/workflows/ci-stress.yml
+++ b/.github/workflows/ci-stress.yml
@@ -18,6 +18,7 @@ on:
           - selftests
           - aot
           - integration
+          - e2e
           - all
       shards:
         description: "Number of parallel runners (iterations are divided across shards)"
@@ -296,9 +297,100 @@ jobs:
           path: aot-*.tap
           if-no-files-found: ignore
 
+  e2e-tests:
+    name: E2E (shard ${{ matrix.shard }})
+    needs: plan
+    if: ${{ inputs.target == 'e2e' || inputs.target == 'all' }}
+    runs-on: windows-latest
+    timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.plan.outputs.shard-list) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: 10.0.x
+
+      # winapp ui drives the cross-process UIA automation. The action adds winapp to PATH,
+      # which WinAppUi.ResolveWinAppExe() picks up via its PATH fallback (mirrors ci.yml).
+      - name: Setup winapp CLI
+        uses: microsoft/setup-WinAppCli@cc8ea9a08b3ee3db43d5aa6bddda4a0e87d800f7 # v0.1
+
+      # Build the E2E test project once (Debug/x64 — the path TestSession.FindHostExe expects).
+      # The ProjectReference pulls in Reactor.AppTests.Host, so the Host is built too.
+      - name: Build (once)
+        run: dotnet build tests/Reactor.AppTests/Reactor.AppTests.csproj -c Debug -p:Platform=x64
+
+      # Retries-ON baseline: run the full winapp-ui suite N times as CI runs it. Each iteration
+      # is a fresh `dotnet test` process (natural per-iteration isolation); we record the
+      # dotnet-test exit code (0 = green suite) plus a per-iteration TRX for per-test drill-down.
+      # Report-only: we never fail the shard, so every iteration's data is collected.
+      - name: Stress loop
+        shell: pwsh
+        env:
+          PER_SHARD: ${{ needs.plan.outputs.per-shard }}
+          REMAINDER: ${{ needs.plan.outputs.remainder }}
+          SHARD_INDEX: ${{ matrix.shard }}
+        run: |
+          $per = [int]$env:PER_SHARD
+          $rem = [int]$env:REMAINDER
+          $idx = [int]$env:SHARD_INDEX
+          $count = if ($idx -le $rem) { $per + 1 } else { $per }
+          if ($count -lt 1) { Write-Host "Shard $idx has no work."; exit 0 }
+          New-Item -ItemType Directory -Force -Path TestResults | Out-Null
+          $csv = "TestResults/iters-$idx.csv"
+          "shard,iter,exit" | Out-File -FilePath $csv -Encoding utf8
+          for ($i = 1; $i -le $count; $i++) {
+            Write-Host "::group::E2E iteration $i / $count (shard $idx)"
+            dotnet test tests/Reactor.AppTests/Reactor.AppTests.csproj -c Debug -p:Platform=x64 --no-build --logger "console;verbosity=minimal" --logger "trx;LogFileName=e2e-$idx-$i.trx" --results-directory TestResults
+            $code = $LASTEXITCODE
+            "$idx,$i,$code" | Add-Content -Path $csv
+            Write-Host "::endgroup::"
+            if ($code -ne 0) { Write-Host "::warning::E2E iteration $i (shard $idx) exited $code (suite not green)" }
+          }
+          # Per-shard reliability snapshot (report-only; never fails the shard).
+          & ./tests/Reactor.AppTests/StressReport.ps1 -Path TestResults -Title "E2E stress - shard $idx"
+          Write-Host "Shard ${idx}: $count iterations completed."
+
+      - name: Upload results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-stress-trx-shard-${{ matrix.shard }}
+          path: |
+            TestResults/*.trx
+            TestResults/iters-*.csv
+          if-no-files-found: ignore
+
+  e2e-report:
+    name: E2E stress report
+    needs: [plan, e2e-tests]
+    if: ${{ always() && (inputs.target == 'e2e' || inputs.target == 'all') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download all shard results
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: e2e-stress-trx-shard-*
+          path: stress-artifacts
+          merge-multiple: true
+
+      # Aggregate every shard's iterations into the headline reliability report, rendered on
+      # the run summary page. Report-only: this step reports the numbers, it does not gate.
+      - name: Aggregate reliability
+        shell: pwsh
+        run: |
+          & ./tests/Reactor.AppTests/StressReport.ps1 -Path stress-artifacts -Title "E2E winapp-ui stress reliability (retries ON)"
+
   summary:
     name: Stress summary
-    needs: [plan, unit-tests, selftests, aot-selftests, integration-tests]
+    needs: [plan, unit-tests, selftests, aot-selftests, integration-tests, e2e-tests]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -308,14 +400,16 @@ jobs:
           SELFTESTS_RESULT: ${{ needs.selftests.result }}
           AOT_RESULT: ${{ needs.aot-selftests.result }}
           INTEGRATION_RESULT: ${{ needs.integration-tests.result }}
+          E2E_RESULT: ${{ needs.e2e-tests.result }}
         run: |
           echo "Unit shards:         $UNIT_RESULT"
           echo "Selftest shards:     $SELFTESTS_RESULT"
           echo "AOT selftest shards: $AOT_RESULT"
           echo "Integration shards:  $INTEGRATION_RESULT"
+          echo "E2E shards:          $E2E_RESULT"
           fail=0
           # 'skipped' is OK (target filter); 'success' is OK; anything else is a fail.
-          for r in "$UNIT_RESULT" "$SELFTESTS_RESULT" "$AOT_RESULT" "$INTEGRATION_RESULT"; do
+          for r in "$UNIT_RESULT" "$SELFTESTS_RESULT" "$AOT_RESULT" "$INTEGRATION_RESULT" "$E2E_RESULT"; do
             case "$r" in
               success|skipped|"") ;;
               *) fail=1 ;;

--- a/.github/workflows/ci-stress.yml
+++ b/.github/workflows/ci-stress.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: ""
         type: string
+      e2e_retries:
+        description: "E2E only: REACTOR_E2E_RETRIES (0 = retries-OFF diagnostic to measure true per-attempt flake; empty = production default of 3)"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   plan:
@@ -303,6 +308,10 @@ jobs:
     if: ${{ inputs.target == 'e2e' || inputs.target == 'all' }}
     runs-on: windows-latest
     timeout-minutes: 350
+    env:
+      # Empty = production default (3 retries). "0" = retries-OFF diagnostic: the custom
+      # E2eRetryAttribute reads this to measure the true per-attempt flake rate that [Retry] masks.
+      REACTOR_E2E_RETRIES: ${{ inputs.e2e_retries }}
     strategy:
       fail-fast: false
       matrix:
@@ -325,10 +334,10 @@ jobs:
       - name: Build (once)
         run: dotnet build tests/Reactor.AppTests/Reactor.AppTests.csproj -c Debug -p:Platform=x64
 
-      # Retries-ON baseline: run the full winapp-ui suite N times as CI runs it. Each iteration
-      # is a fresh `dotnet test` process (natural per-iteration isolation); we record the
-      # dotnet-test exit code (0 = green suite) plus a per-iteration TRX for per-test drill-down.
-      # Report-only: we never fail the shard, so every iteration's data is collected.
+      # Run the full winapp-ui suite N times as CI runs it (retry mode set by REACTOR_E2E_RETRIES
+      # above). Each iteration is a fresh `dotnet test` process (natural per-iteration isolation);
+      # we record the dotnet-test exit code (0 = green suite) plus a per-iteration TRX for per-test
+      # drill-down. Report-only: we never fail the shard, so every iteration's data is collected.
       - name: Stress loop
         shell: pwsh
         env:
@@ -371,6 +380,9 @@ jobs:
     needs: [plan, e2e-tests]
     if: ${{ always() && (inputs.target == 'e2e' || inputs.target == 'all') }}
     runs-on: ubuntu-latest
+    env:
+      # Only used so the aggregate report labels the run's retry mode correctly.
+      REACTOR_E2E_RETRIES: ${{ inputs.e2e_retries }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/tests/Reactor.AppTests.Host/Fixtures/DataGridFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/DataGridFixtures.cs
@@ -23,7 +23,12 @@ internal static class DataGridFixtures
     {
         public override Element Render()
         {
-            var (lastEdit, setLastEdit) = UseState("none");
+            // Accumulate every onRowChanged into an append-only log instead of overwriting a
+            // single "last edit". A cross-row commit-tap can fire a spurious unchanged commit whose
+            // async status write races the real one; an append-only log (functional UseReducer
+            // update applied in enqueue order on the UI thread) lets a test deterministically assert
+            // that a specific edit callback fired, regardless of which async write lands last.
+            var (editLog, appendEdit) = UseReducer("");
 
             // Capture UI-thread dispatcher so onRowChanged (which runs on a threadpool
             // thread via HandleAsyncCommit's Task.Run) can safely update component state.
@@ -47,7 +52,7 @@ internal static class DataGridFixtures
             };
 
             return VStack(8,
-                TextBlock($"Last edit: {lastEdit}").AutomationId("EditStatus"),
+                TextBlock($"Edits:{editLog}").AutomationId("EditLog"),
                 DataGrid(
                     source: source,
                     columns: columns,
@@ -55,11 +60,12 @@ internal static class DataGridFixtures
                     editMode: EditMode.Cell,
                     onRowChanged: (key, item) =>
                     {
-                        // Dispatch to UI thread — this callback runs on a threadpool
-                        // thread from HandleAsyncCommit's Task.Run.
+                        // Dispatch to UI thread — this callback runs on a threadpool thread from
+                        // HandleAsyncCommit's Task.Run. The functional update composes append-only,
+                        // so concurrent commits accumulate instead of clobbering each other.
                         dq?.TryEnqueue(() =>
                         {
-                            setLastEdit($"{key.Value}:{item.FirstName},{item.LastName}");
+                            appendEdit(prev => prev + $"[{key.Value}:{item.FirstName},{item.LastName}]");
                         });
                         return Task.CompletedTask;
                     },

--- a/tests/Reactor.AppTests/Infrastructure/AppTestBase.cs
+++ b/tests/Reactor.AppTests/Infrastructure/AppTestBase.cs
@@ -135,15 +135,22 @@ public class AppTestBase
             return;
         }
 
-        // The reset was invoked, so the fixture must report Ready. If it doesn't, the next
-        // navigation can run against stale fixture state (and a same-name re-nav no-ops in the
-        // host because UseState suppresses a rerender when the value is unchanged), so fail loudly
-        // rather than silently proceeding. Thrown outside the catch above so it isn't swallowed as
-        // a "button not present" case.
-        if (!App.WaitForValue("FixtureStatus", "Ready", timeoutMs: 3000))
+        // The reset was invoked, so the fixture must report Ready. The reset click can be absorbed
+        // when a re-render races the navigator's hit-test rebuild, so retry the invoke once and
+        // allow a longer settle before giving up, rather than failing an otherwise-healthy test.
+        // (A same-name re-nav no-ops in the host because UseState suppresses a rerender when the
+        // value is unchanged, so a stale fixture would silently corrupt the next navigation.)
+        // Thrown outside the catch above so it isn't swallowed as a "button not present" case.
+        if (App.WaitForValue("FixtureStatus", "Ready", timeoutMs: 5000))
+            return;
+
+        try { App.Invoke("ResetFixture"); }
+        catch (WinAppException) { /* button may be mid-rerender; the wait below is the real gate */ }
+
+        if (!App.WaitForValue("FixtureStatus", "Ready", timeoutMs: 5000))
             throw new WinAppException(
-                "ResetFixture was invoked but FixtureStatus never reached 'Ready' within 3000ms; " +
-                "the next navigation could run against stale fixture state.");
+                "ResetFixture was invoked but FixtureStatus never reached 'Ready' within 10000ms " +
+                "across two attempts; the next navigation could run against stale fixture state.");
     }
 
     /// <summary>

--- a/tests/Reactor.AppTests/Infrastructure/E2eRetryAttribute.cs
+++ b/tests/Reactor.AppTests/Infrastructure/E2eRetryAttribute.cs
@@ -1,0 +1,125 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.UI.Reactor.AppTests.Infrastructure;
+
+// MSTest's retry extension surface (RetryContext / RetryResult / RetryBaseAttribute.ExecuteAsync)
+// is gated behind the MSTESTEXP experimental diagnostic. Deriving a custom retry policy is the
+// documented, supported use of RetryBaseAttribute, so opt in explicitly for this whole file.
+#pragma warning disable MSTESTEXP
+
+/// <summary>
+/// Drop-in replacement for MSTest's built-in <c>[Retry(n)]</c> on the winapp-ui E2E tests, adding
+/// two behaviours the built-in attribute lacks:
+///
+/// <list type="number">
+/// <item><description><b>Env-gated attempt count.</b> Reads <see cref="RetriesEnvVar"/>
+/// (<c>REACTOR_E2E_RETRIES</c>) at run time, falling back to the compile-time default. Set it to
+/// <c>0</c> to disable retries entirely — the "retries-OFF" diagnostic lane that measures the true
+/// per-attempt flake rate the production <c>[Retry(3)]</c> otherwise masks.</description></item>
+///
+/// <item><description><b>Anti-masking of a real failure.</b> MSTest stops retrying as soon as an
+/// attempt is "acceptable", counts <c>Inconclusive</c> as acceptable, and reports the <i>last</i>
+/// attempt's outcome. So a genuine first-run <c>Failed</c> followed by an environmental
+/// <c>Inconclusive</c> on a retry (screen locks / input injection lost mid-method, or a
+/// false-positive lock verdict) is reported as <c>Inconclusive</c> and the failure is silently
+/// erased — and <c>dotnet test</c> then exits 0. MSTest only enters the retry path when the first
+/// normal run already produced <c>Failed</c>/<c>Timeout</c> (a real failure the interactivity guard
+/// did <b>not</b> reclassify), so this policy never lets a later <c>Inconclusive</c> become the
+/// outcome: it heals only on a genuine <c>Passed</c>, otherwise it surfaces the hard failure.
+/// </description></item>
+/// </list>
+///
+/// See the E2E Inconclusive audit (Finding 1) for the full masking mechanism.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+public sealed class E2eRetryAttribute : RetryBaseAttribute
+{
+    /// <summary>Environment variable that overrides the retry attempt count at run time.</summary>
+    public const string RetriesEnvVar = "REACTOR_E2E_RETRIES";
+
+    /// <summary>
+    /// Initializes the policy with the compile-time default number of retry attempts (after the
+    /// first normal run). <see cref="RetriesEnvVar"/> can override this at run time.
+    /// </summary>
+    /// <param name="maxRetryAttempts">Default retry attempts; must be &gt;= 1.</param>
+    public E2eRetryAttribute(int maxRetryAttempts)
+    {
+        if (maxRetryAttempts < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxRetryAttempts));
+
+        MaxRetryAttempts = maxRetryAttempts;
+    }
+
+    /// <summary>Compile-time default number of retry attempts after the first normal run.</summary>
+    public int MaxRetryAttempts { get; }
+
+    /// <summary>Delay in milliseconds between attempts (also before the first retry). Default 0.</summary>
+    public int MillisecondsDelayBetweenRetries { get; set; }
+
+    /// <summary>
+    /// Effective attempt count: <see cref="RetriesEnvVar"/> when it parses to a non-negative integer,
+    /// otherwise <see cref="MaxRetryAttempts"/>. A value of <c>0</c> disables retries.
+    /// </summary>
+    internal int EffectiveRetryAttempts
+    {
+        get
+        {
+            var raw = Environment.GetEnvironmentVariable(RetriesEnvVar);
+            return raw is not null && int.TryParse(raw, out var n) && n >= 0
+                ? n
+                : MaxRetryAttempts;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RetryResult> ExecuteAsync(RetryContext retryContext)
+    {
+        var result = new RetryResult();
+        int attempts = EffectiveRetryAttempts;
+
+        // Retries disabled (diagnostic lane): let the real first-run outcome stand so the report
+        // sees the true per-attempt result rather than a retry-healed one. MSTest only calls this
+        // method when the first normal run was Failed/Timeout, so FirstRunResults is that failure.
+        if (attempts <= 0)
+        {
+            result.AddResult(retryContext.FirstRunResults);
+            return result;
+        }
+
+        int currentDelay = MillisecondsDelayBetweenRetries;
+        TestResult[]? lastHardFailure = null;
+        for (int i = 0; i < attempts; i++)
+        {
+            if (currentDelay > 0)
+                await Task.Delay(currentDelay).ConfigureAwait(false);
+
+            TestResult[] attemptResults = await retryContext.ExecuteTaskGetter().ConfigureAwait(false);
+
+            if (AllPassed(attemptResults))
+            {
+                // Genuine flake heal — Passed is the last-added result, so it becomes the outcome.
+                result.AddResult(attemptResults);
+                return result;
+            }
+
+            if (ContainsHardFailure(attemptResults))
+                lastHardFailure = attemptResults;
+
+            // An Inconclusive retry attempt (environmental / lock verdict) is deliberately NOT
+            // added as the outcome: the first normal run already failed for real, so keep retrying
+            // for a genuine heal instead of letting the Inconclusive erase the failure.
+        }
+
+        // Exhausted without a pass. Surface a hard failure — a failed retry attempt if we saw one,
+        // else the first normal run's failure — never a masking Inconclusive.
+        result.AddResult(lastHardFailure ?? retryContext.FirstRunResults);
+        return result;
+    }
+
+    private static bool AllPassed(TestResult[] results)
+        => results.Length > 0 && Array.TrueForAll(results, static r => r.Outcome == UnitTestOutcome.Passed);
+
+    private static bool ContainsHardFailure(TestResult[] results)
+        => Array.Exists(results, static r => r.Outcome is UnitTestOutcome.Failed or UnitTestOutcome.Timeout);
+}
+#pragma warning restore MSTESTEXP

--- a/tests/Reactor.AppTests/Infrastructure/E2eRetryAttribute.cs
+++ b/tests/Reactor.AppTests/Infrastructure/E2eRetryAttribute.cs
@@ -74,6 +74,11 @@ public sealed class E2eRetryAttribute : RetryBaseAttribute
     /// <inheritdoc />
     protected override async Task<RetryResult> ExecuteAsync(RetryContext retryContext)
     {
+        // Contract: MSTest consumes only RetryResult.TryGetLast() as the reported outcome
+        // (UnitTestRunner: `result = retryResult.TryGetLast()`); every other AddResult entry is
+        // discarded and never reaches the TRX. So this method's whole job is to make the *last*
+        // added result the authoritative one — a genuine pass heals, otherwise a hard failure is
+        // surfaced, and a retry-attempt Inconclusive is never allowed to become the last result.
         var result = new RetryResult();
         int attempts = EffectiveRetryAttempts;
 

--- a/tests/Reactor.AppTests/Infrastructure/E2eRetryAttributeTests.cs
+++ b/tests/Reactor.AppTests/Infrastructure/E2eRetryAttributeTests.cs
@@ -1,0 +1,144 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.UI.Reactor.AppTests.Infrastructure;
+
+// Consumes MSTest's experimental retry surface (RetryContext / RetryResult) via reflection to
+// drive E2eRetryAttribute.ExecuteAsync directly. Same opt-in as the attribute under test.
+#pragma warning disable MSTESTEXP
+
+/// <summary>
+/// Headless unit coverage for <see cref="E2eRetryAttribute"/>'s env-gating and anti-masking
+/// decision logic. Lives in the AppTests assembly (not Reactor.Tests) because
+/// <see cref="E2eRetryAttribute.EffectiveRetryAttempts"/> is internal and the retry API types are
+/// internal to MSTest — no winapp/Host session is started, so these run at unit speed.
+/// </summary>
+[TestClass]
+public class E2eRetryAttributeTests
+{
+    private string? _savedEnv;
+
+    [TestInitialize]
+    public void SaveEnv() => _savedEnv = Environment.GetEnvironmentVariable(E2eRetryAttribute.RetriesEnvVar);
+
+    // Always restore the process env var so a retry-count override can never leak into another
+    // test's [E2eRetry] orchestration.
+    [TestCleanup]
+    public void RestoreEnv() => Environment.SetEnvironmentVariable(E2eRetryAttribute.RetriesEnvVar, _savedEnv);
+
+    // ── EffectiveRetryAttempts: env parsing ─────────────────────────────────
+
+    [TestMethod]
+    [DataRow(null, 3)]   // unset → compile-time default
+    [DataRow("", 3)]     // empty → default
+    [DataRow("abc", 3)]  // non-numeric → default
+    [DataRow("-1", 3)]   // negative → default (n >= 0 required)
+    [DataRow("0", 0)]    // disable retries (diagnostic lane)
+    [DataRow("1", 1)]
+    [DataRow("5", 5)]
+    public void EffectiveRetryAttempts_HonorsEnvOverride(string? env, int expected)
+    {
+        Environment.SetEnvironmentVariable(E2eRetryAttribute.RetriesEnvVar, env);
+        Assert.AreEqual(expected, new E2eRetryAttribute(3).EffectiveRetryAttempts);
+    }
+
+    // ── ExecuteAsync: anti-masking decision ─────────────────────────────────
+    // MSTest only invokes ExecuteAsync after the first normal run already produced Failed/Timeout,
+    // so FirstRunResults always represents a real failure in these scenarios.
+
+    [TestMethod]
+    public async Task RetriesOff_ReportsTrueFirstRunOutcome()
+    {
+        // attempts <= 0: no retries, the real first-run failure stands (the retries-OFF lane).
+        Environment.SetEnvironmentVariable(E2eRetryAttribute.RetriesEnvVar, "0");
+        var outcome = await RunRetryAsync(new E2eRetryAttribute(3), firstRun: Failed());
+        Assert.AreEqual(UnitTestOutcome.Failed, outcome);
+    }
+
+    [TestMethod]
+    public async Task RealFailure_HealedByRetryPass_ReportsPassed()
+    {
+        Environment.SetEnvironmentVariable(E2eRetryAttribute.RetriesEnvVar, null); // default 3
+        var outcome = await RunRetryAsync(new E2eRetryAttribute(3), firstRun: Failed(), Passed());
+        Assert.AreEqual(UnitTestOutcome.Passed, outcome);
+    }
+
+    [TestMethod]
+    public async Task RealFailure_ThenInconclusiveRetries_ReportsFailure_NotInconclusive()
+    {
+        // The core anti-masking guarantee: an environmental Inconclusive on a retry must never
+        // overwrite a genuine first-run failure (that is the bug this attribute exists to close).
+        Environment.SetEnvironmentVariable(E2eRetryAttribute.RetriesEnvVar, "3");
+        var outcome = await RunRetryAsync(
+            new E2eRetryAttribute(3), firstRun: Failed(), Inconclusive(), Inconclusive(), Inconclusive());
+        Assert.AreNotEqual(UnitTestOutcome.Inconclusive, outcome,
+            "A retry Inconclusive must not mask the real first-run failure.");
+        Assert.AreEqual(UnitTestOutcome.Failed, outcome);
+    }
+
+    [TestMethod]
+    public async Task RealFailure_AllRetriesFail_ReportsFailure()
+    {
+        Environment.SetEnvironmentVariable(E2eRetryAttribute.RetriesEnvVar, "2");
+        var outcome = await RunRetryAsync(new E2eRetryAttribute(3), firstRun: Failed(), Failed(), Failed());
+        Assert.AreEqual(UnitTestOutcome.Failed, outcome);
+    }
+
+    [TestMethod]
+    public async Task RealFailure_FailedRetryThenInconclusive_ReportsHardFailure()
+    {
+        // A failed retry attempt must win over a later Inconclusive (lastHardFailure is preferred).
+        Environment.SetEnvironmentVariable(E2eRetryAttribute.RetriesEnvVar, "3");
+        var outcome = await RunRetryAsync(
+            new E2eRetryAttribute(3), firstRun: Failed(), Failed(), Inconclusive(), Inconclusive());
+        Assert.AreEqual(UnitTestOutcome.Failed, outcome);
+    }
+
+    [TestMethod]
+    public async Task RealFailure_HealsOnLaterAttemptAfterInconclusive_ReportsPassed()
+    {
+        // Inconclusive retries do not stop the loop; a genuine pass later still heals.
+        Environment.SetEnvironmentVariable(E2eRetryAttribute.RetriesEnvVar, "3");
+        var outcome = await RunRetryAsync(
+            new E2eRetryAttribute(3), firstRun: Failed(), Inconclusive(), Passed());
+        Assert.AreEqual(UnitTestOutcome.Passed, outcome);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private static TestResult[] Result(UnitTestOutcome outcome) => new[] { new TestResult { Outcome = outcome } };
+    private static TestResult[] Failed() => Result(UnitTestOutcome.Failed);
+    private static TestResult[] Passed() => Result(UnitTestOutcome.Passed);
+    private static TestResult[] Inconclusive() => Result(UnitTestOutcome.Inconclusive);
+
+    /// <summary>
+    /// Drives <see cref="E2eRetryAttribute.ExecuteAsync"/> with a scripted sequence of retry-attempt
+    /// results and returns the outcome MSTest would report (the last element added to the
+    /// <c>RetryResult</c>). Reflection is required because MSTest's <c>RetryContext</c> constructor
+    /// and <c>RetryResult.TryGetLast()</c> are internal to the framework assembly.
+    /// </summary>
+    private static async Task<UnitTestOutcome> RunRetryAsync(
+        E2eRetryAttribute attr, TestResult[] firstRun, params TestResult[][] retryAttempts)
+    {
+        var queue = new Queue<TestResult[]>(retryAttempts);
+        Func<Task<TestResult[]>> getter = () => Task.FromResult(queue.Dequeue());
+
+        var ctxCtor = typeof(RetryContext).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic, binder: null,
+            new[] { typeof(Func<Task<TestResult[]>>), typeof(TestResult[]) }, modifiers: null)
+            ?? throw new InvalidOperationException("RetryContext(internal) constructor not found.");
+        var ctx = ctxCtor.Invoke(new object[] { getter, firstRun });
+
+        var exec = typeof(E2eRetryAttribute).GetMethod(
+            "ExecuteAsync", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("E2eRetryAttribute.ExecuteAsync not found.");
+        var result = await (Task<RetryResult>)exec.Invoke(attr, new[] { ctx })!;
+
+        var testResults = (List<TestResult[]>)typeof(RetryResult)
+            .GetField("_testResults", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(result)!;
+        Assert.IsTrue(testResults.Count > 0, "ExecuteAsync must add at least one result.");
+        return testResults[^1][0].Outcome;
+    }
+}
+#pragma warning restore MSTESTEXP

--- a/tests/Reactor.AppTests/Infrastructure/E2eRetryAttributeTests.cs
+++ b/tests/Reactor.AppTests/Infrastructure/E2eRetryAttributeTests.cs
@@ -134,11 +134,15 @@ public class E2eRetryAttributeTests
             ?? throw new InvalidOperationException("E2eRetryAttribute.ExecuteAsync not found.");
         var result = await (Task<RetryResult>)exec.Invoke(attr, new[] { ctx })!;
 
-        var testResults = (List<TestResult[]>)typeof(RetryResult)
-            .GetField("_testResults", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(result)!;
-        Assert.IsTrue(testResults.Count > 0, "ExecuteAsync must add at least one result.");
-        return testResults[^1][0].Outcome;
+        // Read the outcome the same way MSTest's adapter does — RetryResult.TryGetLast() — rather
+        // than the private _testResults field, so this stays valid as long as the public contract
+        // (the adapter uses `result = retryResult.TryGetLast()`) holds.
+        var tryGetLast = typeof(RetryResult).GetMethod(
+            "TryGetLast", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("RetryResult.TryGetLast not found.");
+        var last = (TestResult[]?)tryGetLast.Invoke(result, null);
+        Assert.IsNotNull(last, "ExecuteAsync must add at least one result (TryGetLast returned null).");
+        return last![0].Outcome;
     }
 }
 #pragma warning restore MSTESTEXP

--- a/tests/Reactor.AppTests/Infrastructure/InputInjector.cs
+++ b/tests/Reactor.AppTests/Infrastructure/InputInjector.cs
@@ -339,6 +339,18 @@ public static class InputInjector
                 Thread.Sleep(60);
             }
 
+            // Dwell at the release point with a few pulsed pointer-moves before button-up. A
+            // hover-armed WinUI drop target latches its accept-state from repeated pointer-move
+            // events, and the drag-over needs a beat to settle; without this the drop is
+            // occasionally not registered and the target count stays 0. Mirrors the pulsed dwell
+            // the docking tear-off/merge drag uses.
+            var release = screenPath[screenPath.Count - 1];
+            for (int pulse = 0; pulse < 4; pulse++)
+            {
+                MoveTo(release.X, release.Y);
+                Thread.Sleep(60);
+            }
+
             Thread.Sleep(80);
         }
         catch (Exception ex)

--- a/tests/Reactor.AppTests/StressReport.ps1
+++ b/tests/Reactor.AppTests/StressReport.ps1
@@ -168,8 +168,8 @@ $sb = New-Object System.Text.StringBuilder
 [void]$sb.AppendLine("")
 
 if ($leader.Count -gt 0) {
-    [void]$sb.AppendLine("### Failure leaderboard (attempt-level, $retriesMode)")
-    [void]$sb.AppendLine("Fail% = failed / (runs - inconclusive). With ``[E2eRetry(3)]`` a listed test may still have been *healed by retry* in the suite run, so this is an early-warning signal, not necessarily a red suite.")
+    [void]$sb.AppendLine("### Failure leaderboard (per-test final outcome, $retriesMode)")
+    [void]$sb.AppendLine("Fail% = failed / (runs - inconclusive), counting each iteration's final reported outcome. In a retries-ON run a flake healed by ``[E2eRetry]`` is reported Passed and won't appear here — the retries-OFF lane (``REACTOR_E2E_RETRIES=0``) is where true per-attempt flake surfaces.")
     [void]$sb.AppendLine("")
     [void]$sb.AppendLine("| Test | Failed | Runs | Inconclusive | Fail% |")
     [void]$sb.AppendLine("|---|--:|--:|--:|--:|")

--- a/tests/Reactor.AppTests/StressReport.ps1
+++ b/tests/Reactor.AppTests/StressReport.ps1
@@ -59,6 +59,20 @@ $resTotal = 0
 $resInconclusive = 0
 $failedBucket = @('Failed', 'Error', 'Timeout', 'Aborted')
 $inconBucket = @('Inconclusive', 'NotExecuted', 'Pending', 'Warning', 'NotRunnable', 'Disconnected')
+$resEnvInconclusive = 0
+
+# Same signature the ci.yml E2E gate uses to catch a guard-fired Inconclusive (locked / disconnected
+# desktop, or no input injection). If any of these appear the interactivity guard actually fired — a
+# potential failure-masking signal — so surface them loudly instead of folding them into the benign
+# "prerequisite skip" bucket.
+$guardMsgRegex = 'cannot inject synthetic input|workstation is|locked desktop|disconnected session'
+$prereqMsgRegex = 'published|REACTOR_SPEC051|DISCOVER_PUBLISHED|missing executable'
+
+function Get-InconclusiveCategory([string]$msg) {
+    if ($msg -match $guardMsgRegex) { return 'Environmental/guard' }
+    if ($msg -match $prereqMsgRegex) { return 'Prerequisite' }
+    return 'Other'
+}
 
 foreach ($t in $trxFiles) {
     try {
@@ -72,12 +86,23 @@ foreach ($t in $trxFiles) {
             if ([string]::IsNullOrEmpty($name)) { continue }
             $resTotal++
             if (-not $tests.ContainsKey($name)) {
-                $tests[$name] = [pscustomobject]@{ Test = $name; Runs = 0; Passed = 0; Failed = 0; Inconclusive = 0 }
+                $tests[$name] = [pscustomobject]@{ Test = $name; Runs = 0; Passed = 0; Failed = 0; Inconclusive = 0; Category = 'None'; IncMsg = '' }
             }
             $rec = $tests[$name]
             $rec.Runs++
             if ($failedBucket -contains $outcome) { $rec.Failed++; $iterFailed++ }
-            elseif ($inconBucket -contains $outcome) { $rec.Inconclusive++; $resInconclusive++ }
+            elseif ($inconBucket -contains $outcome) {
+                $rec.Inconclusive++; $resInconclusive++
+                $msgNode = $n.Node.SelectSingleNode("*[local-name()='Output']/*[local-name()='ErrorInfo']/*[local-name()='Message']")
+                $msg = if ($msgNode) { $msgNode.InnerText } else { '' }
+                $cat = Get-InconclusiveCategory $msg
+                if ($cat -eq 'Environmental/guard') { $resEnvInconclusive++ }
+                # Keep the most-serious category seen for this test (Environmental > Prerequisite > Other).
+                if ($rec.Category -eq 'None' -or $cat -eq 'Environmental/guard') { $rec.Category = $cat }
+                if ([string]::IsNullOrEmpty($rec.IncMsg) -and -not [string]::IsNullOrEmpty($msg)) {
+                    $rec.IncMsg = ($msg -replace '\s+', ' ').Trim()
+                }
+            }
             elseif ($outcome -eq 'Passed') { $rec.Passed++ }
         }
         if ($iterFailed -eq 0) { $trxIterGreen++ }
@@ -99,6 +124,11 @@ function Format-Pct($num, $den) {
 $greenPct = Format-Pct $iterGreen $iterTotal
 $envAvail = if ($resTotal -gt 0) { Format-Pct ($resTotal - $resInconclusive) $resTotal } else { 'n/a' }
 
+$retriesRaw = $env:REACTOR_E2E_RETRIES
+$retriesMode = if ($retriesRaw -eq '0') { 'retries OFF (REACTOR_E2E_RETRIES=0)' }
+    elseif ([string]::IsNullOrEmpty($retriesRaw)) { 'retries ON (default)' }
+    else { "REACTOR_E2E_RETRIES=$retriesRaw" }
+
 $leader = @($tests.Values |
     Where-Object { $_.Failed -gt 0 } |
     Sort-Object -Property `
@@ -115,15 +145,16 @@ $sb = New-Object System.Text.StringBuilder
 [void]$sb.AppendLine("")
 [void]$sb.AppendLine("| Metric | Value |")
 [void]$sb.AppendLine("|---|---|")
-[void]$sb.AppendLine("| Suite-level green rate (retries ON) | **$greenPct** ($iterGreen / $iterTotal iterations) |")
+[void]$sb.AppendLine("| Suite-level green rate ($retriesMode) | **$greenPct** ($iterGreen / $iterTotal iterations) |")
 [void]$sb.AppendLine("| Interactive-env availability | $envAvail ($($resTotal - $resInconclusive) / $resTotal results) |")
+[void]$sb.AppendLine("| Environmental/guard Inconclusive results | $resEnvInconclusive |")
 [void]$sb.AppendLine("| Distinct tests observed | $($tests.Count) |")
 [void]$sb.AppendLine("| Tests that failed >=1 attempt | $($leader.Count) |")
 [void]$sb.AppendLine("")
 
 if ($leader.Count -gt 0) {
     [void]$sb.AppendLine("### Failure leaderboard (attempt-level, retries ON)")
-    [void]$sb.AppendLine("Fail% = failed / (runs - inconclusive). With ``[Retry(3)]`` a listed test may still have been *healed by retry* in the suite run, so this is an early-warning signal, not necessarily a red suite.")
+    [void]$sb.AppendLine("Fail% = failed / (runs - inconclusive). With ``[E2eRetry(3)]`` a listed test may still have been *healed by retry* in the suite run, so this is an early-warning signal, not necessarily a red suite.")
     [void]$sb.AppendLine("")
     [void]$sb.AppendLine("| Test | Failed | Runs | Inconclusive | Fail% |")
     [void]$sb.AppendLine("|---|--:|--:|--:|--:|")
@@ -135,13 +166,22 @@ if ($leader.Count -gt 0) {
     [void]$sb.AppendLine("")
 }
 
-if ($everIncon.Count -gt 0) {
-    [void]$sb.AppendLine("### Tests ever Inconclusive (environment / input-injection)")
+if ($resEnvInconclusive -gt 0) {
+    [void]$sb.AppendLine("> [!WARNING]")
+    [void]$sb.AppendLine("> **$resEnvInconclusive environmental/guard Inconclusive result(s) detected.** The interactivity guard fired (locked/disconnected desktop or no input injection). On a healthy CI runner this should be **0** — investigate before trusting the green rate, because a guard trip coinciding with a real failure is the classic masking vector. (The ``E2eRetry`` anti-masking policy prevents a first-run failure from being downgraded, and the ci.yml E2E gate turns these red in the main job.)")
     [void]$sb.AppendLine("")
-    [void]$sb.AppendLine("| Test | Inconclusive | Runs |")
-    [void]$sb.AppendLine("|---|--:|--:|")
+}
+
+if ($everIncon.Count -gt 0) {
+    [void]$sb.AppendLine("### Tests ever Inconclusive")
+    [void]$sb.AppendLine("**Environmental/guard** = interactivity guard fired (investigate); **Prerequisite** = self-skip for a missing prereq (e.g. an unpublished sample); **Other** = uncategorised.")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("| Test | Category | Inconclusive | Runs | Sample message |")
+    [void]$sb.AppendLine("|---|---|--:|--:|---|")
     foreach ($r in ($everIncon | Select-Object -First 40)) {
-        [void]$sb.AppendLine("| $($r.Test) | $($r.Inconclusive) | $($r.Runs) |")
+        $m = $r.IncMsg -replace '\|', '/'
+        if ($m.Length -gt 90) { $m = $m.Substring(0, 90) + '...' }
+        [void]$sb.AppendLine("| $($r.Test) | $($r.Category) | $($r.Inconclusive) | $($r.Runs) | $m |")
     }
     [void]$sb.AppendLine("")
 }

--- a/tests/Reactor.AppTests/StressReport.ps1
+++ b/tests/Reactor.AppTests/StressReport.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-  Aggregate winapp-ui E2E stress results (retries-ON baseline) into a reliability report.
+  Aggregate winapp-ui E2E stress results into a reliability report (retries ON or OFF).
 
 .DESCRIPTION
   Consumes the artifacts produced by the `e2e` target in ci-stress.yml:
@@ -10,7 +10,7 @@
   and reports:
     * Suite-level green rate      = iterations with dotnet-test exit 0 / total iterations
     * Interactive-env availability = 1 - (inconclusive results / total results)
-    * Per-test failure leaderboard = failed / (runs - inconclusive), worst first
+    * Per-test failure leaderboard = failed / (runs - inconclusive), highest rate first
     * Tests ever Inconclusive      = environment / input-injection blockers
 
   Output goes to the console and, when GITHUB_STEP_SUMMARY is set, is appended there as
@@ -18,9 +18,11 @@
 
 .NOTES
   Iteration green/red uses the dotnet-test exit code, which is robust to how MSTest records
-  [Retry(3)] attempts in the TRX. The TRX is only mined for per-test detail: a test that
-  failed one attempt but was healed by [Retry(3)] can still surface here as a failed attempt
-  ("healed by retry" signal) without making the suite iteration red.
+  [E2eRetry] attempts. The per-test leaderboard is mined from the TRX outcomes, which record the
+  final reported outcome per test: MSTest's retry surfaces only the last attempt (RetryResult
+  TryGetLast), so a failure healed by a later retry generally does NOT appear here as a failed
+  attempt in a retries-ON run. True per-attempt flake is therefore measured with the retries-OFF
+  lane (REACTOR_E2E_RETRIES=0), where each test runs once and its single real outcome is recorded.
 
   This is report-only: it never sets a non-zero exit code, so it never fails the shard.
 #>
@@ -139,11 +141,14 @@ $retriesMode = if ($retriesRaw -eq '0') { 'retries OFF (REACTOR_E2E_RETRIES=0)' 
     elseif ([string]::IsNullOrEmpty($retriesRaw)) { 'retries ON (default)' }
     else { "REACTOR_E2E_RETRIES=$retriesRaw" }
 
+# Leaderboard: highest failure rate first (failed / (runs - inconclusive)), so a test with more
+# excluded Inconclusive results isn't unfairly ranked below one with a lower true rate; absolute
+# failed count breaks ties. Guard the denominator against zero (all-Inconclusive → rate 0).
 $leader = @($tests.Values |
     Where-Object { $_.Failed -gt 0 } |
     Sort-Object -Property `
-        @{ Expression = { $_.Failed }; Descending = $true }, `
-        @{ Expression = { if (($_.Runs - $_.Inconclusive) -gt 0) { $_.Failed / ($_.Runs - $_.Inconclusive) } else { 0 } }; Descending = $true })
+        @{ Expression = { if (($_.Runs - $_.Inconclusive) -gt 0) { $_.Failed / ($_.Runs - $_.Inconclusive) } else { 0 } }; Descending = $true }, `
+        @{ Expression = { $_.Failed }; Descending = $true })
 
 $everIncon = @($tests.Values |
     Where-Object { $_.Inconclusive -gt 0 } |

--- a/tests/Reactor.AppTests/StressReport.ps1
+++ b/tests/Reactor.AppTests/StressReport.ps1
@@ -74,6 +74,16 @@ function Get-InconclusiveCategory([string]$msg) {
     return 'Other'
 }
 
+# Precedence for "worst category seen" per test: Environmental/guard > Prerequisite > Other > None.
+function Get-CategoryRank([string]$cat) {
+    switch ($cat) {
+        'Environmental/guard' { 3 }
+        'Prerequisite'        { 2 }
+        'Other'               { 1 }
+        default               { 0 }
+    }
+}
+
 foreach ($t in $trxFiles) {
     try {
         $nodes = @(Select-Xml -Path $t.FullName -XPath "//*[local-name()='UnitTestResult']")
@@ -98,7 +108,7 @@ foreach ($t in $trxFiles) {
                 $cat = Get-InconclusiveCategory $msg
                 if ($cat -eq 'Environmental/guard') { $resEnvInconclusive++ }
                 # Keep the most-serious category seen for this test (Environmental > Prerequisite > Other).
-                if ($rec.Category -eq 'None' -or $cat -eq 'Environmental/guard') { $rec.Category = $cat }
+                if ((Get-CategoryRank $cat) -gt (Get-CategoryRank $rec.Category)) { $rec.Category = $cat }
                 if ([string]::IsNullOrEmpty($rec.IncMsg) -and -not [string]::IsNullOrEmpty($msg)) {
                     $rec.IncMsg = ($msg -replace '\s+', ' ').Trim()
                 }
@@ -153,7 +163,7 @@ $sb = New-Object System.Text.StringBuilder
 [void]$sb.AppendLine("")
 
 if ($leader.Count -gt 0) {
-    [void]$sb.AppendLine("### Failure leaderboard (attempt-level, retries ON)")
+    [void]$sb.AppendLine("### Failure leaderboard (attempt-level, $retriesMode)")
     [void]$sb.AppendLine("Fail% = failed / (runs - inconclusive). With ``[E2eRetry(3)]`` a listed test may still have been *healed by retry* in the suite run, so this is an early-warning signal, not necessarily a red suite.")
     [void]$sb.AppendLine("")
     [void]$sb.AppendLine("| Test | Failed | Runs | Inconclusive | Fail% |")

--- a/tests/Reactor.AppTests/StressReport.ps1
+++ b/tests/Reactor.AppTests/StressReport.ps1
@@ -1,0 +1,151 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Aggregate winapp-ui E2E stress results (retries-ON baseline) into a reliability report.
+
+.DESCRIPTION
+  Consumes the artifacts produced by the `e2e` target in ci-stress.yml:
+    * iters-<shard>.csv  - one row per iteration: shard,iter,exit (dotnet-test exit code)
+    * e2e-<shard>-<i>.trx - the MSTest TRX for that iteration
+  and reports:
+    * Suite-level green rate      = iterations with dotnet-test exit 0 / total iterations
+    * Interactive-env availability = 1 - (inconclusive results / total results)
+    * Per-test failure leaderboard = failed / (runs - inconclusive), worst first
+    * Tests ever Inconclusive      = environment / input-injection blockers
+
+  Output goes to the console and, when GITHUB_STEP_SUMMARY is set, is appended there as
+  Markdown so it renders on the workflow run's summary page.
+
+.NOTES
+  Iteration green/red uses the dotnet-test exit code, which is robust to how MSTest records
+  [Retry(3)] attempts in the TRX. The TRX is only mined for per-test detail: a test that
+  failed one attempt but was healed by [Retry(3)] can still surface here as a failed attempt
+  ("healed by retry" signal) without making the suite iteration red.
+
+  This is report-only: it never sets a non-zero exit code, so it never fails the shard.
+#>
+param(
+    [string[]]$Path = @('.'),
+    [string]$Title = 'E2E winapp-ui stress reliability'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$roots = @()
+foreach ($p in $Path) { if (Test-Path $p) { $roots += (Resolve-Path $p).Path } }
+if ($roots.Count -eq 0) { $roots = @((Get-Location).Path) }
+
+$csvFiles = @(Get-ChildItem -Path $roots -Recurse -Filter 'iters-*.csv' -File -ErrorAction SilentlyContinue)
+$trxFiles = @(Get-ChildItem -Path $roots -Recurse -Filter '*.trx' -File -ErrorAction SilentlyContinue)
+
+# ---- Suite-level green rate (exit-code based) ----
+$iterTotal = 0
+$iterGreen = 0
+foreach ($f in $csvFiles) {
+    try {
+        Import-Csv $f.FullName | ForEach-Object {
+            $iterTotal++
+            if ([int]$_.exit -eq 0) { $iterGreen++ }
+        }
+    }
+    catch { Write-Warning "Could not read $($f.FullName): $_" }
+}
+
+# ---- Per-test detail + inconclusive rate (TRX based) ----
+$tests = @{}
+$trxIterTotal = 0
+$trxIterGreen = 0
+$resTotal = 0
+$resInconclusive = 0
+$failedBucket = @('Failed', 'Error', 'Timeout', 'Aborted')
+$inconBucket = @('Inconclusive', 'NotExecuted', 'Pending', 'Warning', 'NotRunnable', 'Disconnected')
+
+foreach ($t in $trxFiles) {
+    try {
+        $nodes = @(Select-Xml -Path $t.FullName -XPath "//*[local-name()='UnitTestResult']")
+        if ($nodes.Count -eq 0) { continue }
+        $trxIterTotal++
+        $iterFailed = 0
+        foreach ($n in $nodes) {
+            $name = $n.Node.GetAttribute('testName')
+            $outcome = $n.Node.GetAttribute('outcome')
+            if ([string]::IsNullOrEmpty($name)) { continue }
+            $resTotal++
+            if (-not $tests.ContainsKey($name)) {
+                $tests[$name] = [pscustomobject]@{ Test = $name; Runs = 0; Passed = 0; Failed = 0; Inconclusive = 0 }
+            }
+            $rec = $tests[$name]
+            $rec.Runs++
+            if ($failedBucket -contains $outcome) { $rec.Failed++; $iterFailed++ }
+            elseif ($inconBucket -contains $outcome) { $rec.Inconclusive++; $resInconclusive++ }
+            elseif ($outcome -eq 'Passed') { $rec.Passed++ }
+        }
+        if ($iterFailed -eq 0) { $trxIterGreen++ }
+    }
+    catch { Write-Warning "Could not parse $($t.FullName): $_" }
+}
+
+# Fall back to TRX-derived iteration counts when no exit-code CSVs were found.
+if ($iterTotal -eq 0 -and $trxIterTotal -gt 0) {
+    $iterTotal = $trxIterTotal
+    $iterGreen = $trxIterGreen
+}
+
+function Format-Pct($num, $den) {
+    if ($den -le 0) { return 'n/a' }
+    return ('{0:N2}%' -f (100.0 * $num / $den))
+}
+
+$greenPct = Format-Pct $iterGreen $iterTotal
+$envAvail = if ($resTotal -gt 0) { Format-Pct ($resTotal - $resInconclusive) $resTotal } else { 'n/a' }
+
+$leader = @($tests.Values |
+    Where-Object { $_.Failed -gt 0 } |
+    Sort-Object -Property `
+        @{ Expression = { $_.Failed }; Descending = $true }, `
+        @{ Expression = { if (($_.Runs - $_.Inconclusive) -gt 0) { $_.Failed / ($_.Runs - $_.Inconclusive) } else { 0 } }; Descending = $true })
+
+$everIncon = @($tests.Values |
+    Where-Object { $_.Inconclusive -gt 0 } |
+    Sort-Object -Property @{ Expression = { $_.Inconclusive }; Descending = $true })
+
+# ---- Emit report ----
+$sb = New-Object System.Text.StringBuilder
+[void]$sb.AppendLine("## $Title")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("| Metric | Value |")
+[void]$sb.AppendLine("|---|---|")
+[void]$sb.AppendLine("| Suite-level green rate (retries ON) | **$greenPct** ($iterGreen / $iterTotal iterations) |")
+[void]$sb.AppendLine("| Interactive-env availability | $envAvail ($($resTotal - $resInconclusive) / $resTotal results) |")
+[void]$sb.AppendLine("| Distinct tests observed | $($tests.Count) |")
+[void]$sb.AppendLine("| Tests that failed >=1 attempt | $($leader.Count) |")
+[void]$sb.AppendLine("")
+
+if ($leader.Count -gt 0) {
+    [void]$sb.AppendLine("### Failure leaderboard (attempt-level, retries ON)")
+    [void]$sb.AppendLine("Fail% = failed / (runs - inconclusive). With ``[Retry(3)]`` a listed test may still have been *healed by retry* in the suite run, so this is an early-warning signal, not necessarily a red suite.")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("| Test | Failed | Runs | Inconclusive | Fail% |")
+    [void]$sb.AppendLine("|---|--:|--:|--:|--:|")
+    foreach ($r in ($leader | Select-Object -First 40)) {
+        $den = $r.Runs - $r.Inconclusive
+        $fp = if ($den -gt 0) { '{0:N2}%' -f (100.0 * $r.Failed / $den) } else { 'n/a' }
+        [void]$sb.AppendLine("| $($r.Test) | $($r.Failed) | $($r.Runs) | $($r.Inconclusive) | $fp |")
+    }
+    [void]$sb.AppendLine("")
+}
+
+if ($everIncon.Count -gt 0) {
+    [void]$sb.AppendLine("### Tests ever Inconclusive (environment / input-injection)")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("| Test | Inconclusive | Runs |")
+    [void]$sb.AppendLine("|---|--:|--:|")
+    foreach ($r in ($everIncon | Select-Object -First 40)) {
+        [void]$sb.AppendLine("| $($r.Test) | $($r.Inconclusive) | $($r.Runs) |")
+    }
+    [void]$sb.AppendLine("")
+}
+
+$report = $sb.ToString()
+Write-Host $report
+if ($env:GITHUB_STEP_SUMMARY) { Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $report }

--- a/tests/Reactor.AppTests/Tests/AccessibilityInteractionTests.cs
+++ b/tests/Reactor.AppTests/Tests/AccessibilityInteractionTests.cs
@@ -40,7 +40,7 @@ public class AccessibilityInteractionTests : AppTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void A11y_2_1_1_TabOrderFollowsTabIndex()
     {

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -88,8 +88,59 @@ public class DataGridTests : AppTestBase
     private void TypeIntoFocusedEditor(string value, bool commitWithEnter = false)
     {
         var editor = WaitForEditor();
-        editor.Clear();
-        editor.SendKeys(commitWithEnter ? value + Keys.Enter : value);
+
+        // The inline editor's UIA SetFocus does not reliably select-all, so a Clear that races the
+        // editor's focus/realization can leave the old text in place — the new value then
+        // interleaves with it (observed 'aAlicialice') or is dropped. Clear+type, then confirm the
+        // editor holds exactly the new value before the caller commits. Retry only when we can
+        // positively read a wrong value; never blind-retry (that would double-type when the
+        // editor value can't be read).
+        for (int attempt = 0; attempt < 3; attempt++)
+        {
+            ClearEditor(editor);
+
+            if (commitWithEnter)
+            {
+                editor.SendKeys(value + Keys.Enter); // Enter commits + closes the editor; can't re-read it
+                return;
+            }
+
+            editor.SendKeys(value);
+            var actual = ReadEditorValueSettled(editor, value, timeoutMs: 1500);
+            if (actual is null || actual == value)
+                return; // confirmed correct, or unreadable (don't risk double-typing)
+        }
+    }
+
+    /// <summary>Clear the inline editor, confirming it reads empty when the value is readable.</summary>
+    private static void ClearEditor(UiElement editor, int attempts = 3)
+    {
+        for (int i = 0; i < attempts; i++)
+        {
+            editor.Clear();
+            var v = ReadEditorValueSettled(editor, string.Empty, timeoutMs: 500);
+            if (v is null || v.Length == 0)
+                return; // empty, or unreadable — stop (avoid over-clearing)
+        }
+    }
+
+    /// <summary>
+    /// Poll the editor's value until it equals <paramref name="expected"/> or the timeout elapses,
+    /// returning the last value read (null when winapp cannot read the editor's value).
+    /// </summary>
+    private static string? ReadEditorValueSettled(UiElement editor, string expected, int timeoutMs)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        string? last;
+        do
+        {
+            last = editor.Text;
+            if (last == expected)
+                return last;
+            Thread.Sleep(150);
+        }
+        while (DateTime.UtcNow < deadline);
+        return last;
     }
 
     /// <summary>Wait for the DataGrid inline editor (a UIA <c>Edit</c> control) to mount.</summary>

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -100,6 +100,7 @@ public class DataGridTests : AppTestBase
         // editor holds exactly the new value before the caller commits. Retry only when we can
         // positively read a wrong value; never blind-retry (that would double-type when the
         // editor value can't be read).
+        string? lastSeen = null;
         for (int attempt = 0; attempt < 3; attempt++)
         {
             ClearEditor(editor);
@@ -111,10 +112,15 @@ public class DataGridTests : AppTestBase
             }
 
             editor.SendKeys(value);
-            var actual = ReadEditorValueSettled(editor, value, timeoutMs: 1500);
-            if (actual is null || actual == value)
+            lastSeen = ReadEditorValueSettled(editor, value, timeoutMs: 1500);
+            if (lastSeen is null || lastSeen == value)
                 return; // confirmed correct, or unreadable (don't risk double-typing)
         }
+
+        // Every attempt positively read a wrong value — fail loudly here (with the last value seen)
+        // rather than letting the caller's downstream assertion time out with a confusing message.
+        throw new WinAppException(
+            $"Inline editor did not accept '{value}' after 3 clear+type attempts; last-seen value was '{lastSeen}'.");
     }
 
     /// <summary>Clear the inline editor, confirming it reads empty when the value is readable.</summary>

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -28,7 +28,7 @@ public class DataGridTests : AppTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interactive_DataGrid_ClickEditTabCommit()
     {

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -35,7 +35,7 @@ public class DataGridTests : AppTestBase
         NavigateToFixtureFresh("DataGrid_EditableGrid");
 
         // 1. Wait for grid data
-        WaitForText("EditStatus", "Last edit: none");
+        WaitForText("EditLog", "Edits:");
         Assert.IsNotNull(WaitForName("Alice"), "'Alice' should be visible");
         Assert.IsNotNull(FindByName("Smith"), "'Smith' should be visible");
 
@@ -49,12 +49,13 @@ public class DataGridTests : AppTestBase
         Assert.IsNotNull(FindByName("Bob"), "'Bob' should be visible while editing");
         TapCell("Bob");
 
-        // 5. Verify the first edit committed. Assert on the persistent grid VALUE, not the async
-        // 'Last edit' status: the fixture's onRowChanged updates that status via Task.Run +
-        // DispatcherQueue.TryEnqueue, so when the cross-row commit-tap also fires a spurious
-        // unchanged row-2 commit, the two async writes race and the status can settle on
-        // '2:Bob,Jones', overwriting '1:Alicia,Smith' before the poll observes it — even though the
-        // committed data is correct. See the E2E flake investigation. The grid value is the truth.
+        // 5. Verify the first edit committed. The fixture logs every onRowChanged callback into an
+        // append-only EditLog, so we can deterministically assert the row-1 commit callback fired
+        // with the right key + values — even when the cross-row commit-tap also fires a spurious
+        // unchanged row-2 commit (an overwrite-style status would race and settle on '2:Bob,Jones').
+        // Also confirm the persisted grid value, so both the callback contract and the data commit
+        // are covered. See the E2E flake investigation.
+        WaitForTextContaining("EditLog", "[1:Alicia,Smith]", timeoutMs: 5000);
         Assert.IsNotNull(WaitForName("Alicia"), "'Alicia' should be visible after the cross-row commit-tap");
 
         // 6. Click "Smith" to edit LastName in row 1
@@ -65,7 +66,7 @@ public class DataGridTests : AppTestBase
         TypeIntoFocusedEditor("Johnson", commitWithEnter: true);
 
         // 9. Verify second edit committed
-        WaitForText("EditStatus", "Last edit: 1:Alicia,Johnson");
+        WaitForTextContaining("EditLog", "[1:Alicia,Johnson]", timeoutMs: 5000);
         Assert.IsNotNull(WaitForName("Alicia"), "'Alicia' should still be visible");
         Assert.IsNotNull(WaitForName("Johnson"), "'Johnson' should be visible after commit");
     }

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -49,9 +49,13 @@ public class DataGridTests : AppTestBase
         Assert.IsNotNull(FindByName("Bob"), "'Bob' should be visible while editing");
         TapCell("Bob");
 
-        // 5. Verify first edit committed
-        WaitForText("EditStatus", "Last edit: 1:Alicia,Smith");
-        Assert.IsNotNull(WaitForName("Alicia"), "'Alicia' should be visible after commit");
+        // 5. Verify the first edit committed. Assert on the persistent grid VALUE, not the async
+        // 'Last edit' status: the fixture's onRowChanged updates that status via Task.Run +
+        // DispatcherQueue.TryEnqueue, so when the cross-row commit-tap also fires a spurious
+        // unchanged row-2 commit, the two async writes race and the status can settle on
+        // '2:Bob,Jones', overwriting '1:Alicia,Smith' before the poll observes it — even though the
+        // committed data is correct. See the E2E flake investigation. The grid value is the truth.
+        Assert.IsNotNull(WaitForName("Alicia"), "'Alicia' should be visible after the cross-row commit-tap");
 
         // 6. Click "Smith" to edit LastName in row 1
         Assert.IsNotNull(WaitForName("Smith"), "'Smith' should be visible");

--- a/tests/Reactor.AppTests/Tests/DevtoolsUxTests.cs
+++ b/tests/Reactor.AppTests/Tests/DevtoolsUxTests.cs
@@ -52,7 +52,7 @@ public class DevtoolsUxTests : AppTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Devtools_Menu_Toggle_Flows_Through_To_Subscribers()
     {
@@ -82,7 +82,7 @@ public class DevtoolsUxTests : AppTestBase
     /// Observable notification path works in both directions, not just on first
     /// activation.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Devtools_Menu_Toggle_Is_Reversible()
     {

--- a/tests/Reactor.AppTests/Tests/DockingInputTests.cs
+++ b/tests/Reactor.AppTests/Tests/DockingInputTests.cs
@@ -72,7 +72,7 @@ public class DockingInputTests : AppTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void DockingInput_TypeAndTabAcrossPanes()
     {
@@ -115,7 +115,7 @@ public class DockingInputTests : AppTestBase
     /// reconcile path in <c>UpdateTabView</c>. If both fail, the bug is
     /// more general and lives in the docking host's render itself.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void DockingInput_NoPin_TypeAndTabAcrossPanes()
     {
@@ -147,7 +147,7 @@ public class DockingInputTests : AppTestBase
     /// the newly-tabbed pane must still work, and the pre-existing
     /// values from both editors must survive the layout change.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void DockingInput_DragToTab_PreservesFocusAndState()
     {
@@ -194,7 +194,7 @@ public class DockingInputTests : AppTestBase
     /// after dragging the right pane's tab into the left pane's group,
     /// both pre-drag state values ("alpha" / "beta") must survive.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void DockingInput_DragToTab_PreservesPreDragState()
     {

--- a/tests/Reactor.AppTests/Tests/DockingTearOffE2ETests.cs
+++ b/tests/Reactor.AppTests/Tests/DockingTearOffE2ETests.cs
@@ -179,7 +179,7 @@ public class DockingTearOffE2ETests : AppTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void TearOff_E01_DragTabOutOfHost_OpensFloatingWindow()
     {
@@ -208,7 +208,7 @@ public class DockingTearOffE2ETests : AppTestBase
     /// both drags the host retains only C and there are two distinct
     /// floating windows.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void TearOff_E02_MultipleSequentialTearOffs()
     {
@@ -262,7 +262,7 @@ public class DockingTearOffE2ETests : AppTestBase
     /// back to the app-supplied content (carrying the typed value)
     /// when the floating window re-mounts the pane.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void TearOff_E03_TearOff_PreservesPaneState()
     {
@@ -295,7 +295,7 @@ public class DockingTearOffE2ETests : AppTestBase
     /// resets the fixture, tears off A again. All iterations must produce
     /// identical post-state.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void TearOff_E04_RepeatedTearOffsAreReliable()
     {

--- a/tests/Reactor.AppTests/Tests/DragDropTests.cs
+++ b/tests/Reactor.AppTests/Tests/DragDropTests.cs
@@ -29,7 +29,7 @@ public class DragDropTests : AppTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void DragDrop_TypedReorder_MovesCard()
     {
@@ -60,7 +60,7 @@ public class DragDropTests : AppTestBase
     /// have the card (move-on-confirmation guarantees the source doesn't optimistically
     /// remove it, and WasCancelled → CompletedOperation = None).
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void DragDrop_CancelledDrag_LeavesSourceIntact()
     {
@@ -87,7 +87,7 @@ public class DragDropTests : AppTestBase
     /// Text format round-trip — drag a control that writes text to the DataPackage
     /// onto a target that reads it via <c>TryGetText</c>.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void DragDrop_TextFormat_RoundTrip()
     {

--- a/tests/Reactor.AppTests/Tests/EventHandlerTests.cs
+++ b/tests/Reactor.AppTests/Tests/EventHandlerTests.cs
@@ -34,7 +34,7 @@ public class EventHandlerTests : AppTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interactive_OnTapped_Updates_State()
     {
@@ -80,7 +80,7 @@ public class EventHandlerTests : AppTestBase
     /// so this E2E test uses Button.OnClick as a proxy. The declarative OnPointerPressed
     /// API is verified by unit tests; this tests the input plumbing end-to-end.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interactive_OnPointerPressed_Detects_Click()
     {
@@ -96,7 +96,7 @@ public class EventHandlerTests : AppTestBase
     /// OnKeyDown: focus a TextBox and send a key, verify the key is captured
     /// by the declarative .OnKeyDown() handler.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interactive_OnKeyDown_Captures_Keys()
     {

--- a/tests/Reactor.AppTests/Tests/GestureTests.cs
+++ b/tests/Reactor.AppTests/Tests/GestureTests.cs
@@ -28,7 +28,7 @@ public class GestureTests : AppTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interactive_OnPan_Drag_ReportsTranslationAndPhase()
     {
@@ -58,7 +58,7 @@ public class GestureTests : AppTestBase
     /// <summary>
     /// .OnDoubleTap: double-click a Button and verify the count increments.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interactive_OnDoubleTap_FiresOnDoubleClick()
     {
@@ -75,7 +75,7 @@ public class GestureTests : AppTestBase
     /// <summary>
     /// .OnRightTapped: right-click a Button and verify the count increments.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interactive_OnRightTapped_FiresOnContextClick()
     {
@@ -93,7 +93,7 @@ public class GestureTests : AppTestBase
     /// .OnLongPress: press-and-hold and verify the long-press callback fires.
     /// Uses mouse emulation (default-off in production; opted in by the fixture).
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interactive_OnLongPress_FiresAfterHold()
     {

--- a/tests/Reactor.AppTests/Tests/HostThemeChangeTests.cs
+++ b/tests/Reactor.AppTests/Tests/HostThemeChangeTests.cs
@@ -37,7 +37,7 @@ public class HostThemeChangeTests : AppTestBase
     /// (color flips), and toggling back must return it to the original theme's brush.
     /// </summary>
     // [Retry] mops up rare unattended-desktop UIA read flakes; a real regression fails every attempt.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void HostThemeChange_ReResolvesConcreteResourceOverride()
     {

--- a/tests/Reactor.AppTests/Tests/ImmediateAndDisabledFocusableTests.cs
+++ b/tests/Reactor.AppTests/Tests/ImmediateAndDisabledFocusableTests.cs
@@ -86,6 +86,13 @@ public class ImmediateAndDisabledFocusableTests : AppTestBase
     {
         NavigateToFixtureFresh("Validation_ImmediateAndDisabledFocusable");
 
+        // Wait for the fixture's controls to be realized before driving input. Without this the
+        // first keystrokes race control realization and the age input is dropped entirely
+        // (observed: AgeDisplay stuck at 'Age: 0'), which then surfaces as a misleading downstream
+        // tab-focus flake. Mirrors the readiness wait the reliable Immediate_* sibling performs.
+        WaitForText("ValImmediate_AgeDisplay", "Age: 0");
+        WaitForText("ValImmediate_FormValid", "invalid");
+
         // Pre-fill email so only the age field can flip form validity.
         var email = FindById("ValImmediate_Email");
         email.Click();
@@ -93,7 +100,11 @@ public class ImmediateAndDisabledFocusableTests : AppTestBase
 
         var age = FindById("ValImmediate_Age");
         age.Click();
-        age.SendKeys("25");
+        // Type digit-by-digit, confirming each lands, so a dropped keystroke fails loudly here
+        // rather than as a misleading downstream tab-focus timeout.
+        age.SendKeys("2");
+        WaitForTextContaining("ValImmediate_AgeDisplay", "Age: 2", timeoutMs: 3000);
+        age.SendKeys("5");
         WaitForText("ValImmediate_AgeDisplay", "Age: 25");
         WaitForText("ValImmediate_FormValid", "valid");
 

--- a/tests/Reactor.AppTests/Tests/ImmediateAndDisabledFocusableTests.cs
+++ b/tests/Reactor.AppTests/Tests/ImmediateAndDisabledFocusableTests.cs
@@ -99,11 +99,22 @@ public class ImmediateAndDisabledFocusableTests : AppTestBase
         email.SendKeys("user@example.com");
 
         var age = FindById("ValImmediate_Age");
-        age.Click();
-        // Type digit-by-digit, confirming each lands, so a dropped keystroke fails loudly here
-        // rather than as a misleading downstream tab-focus timeout.
-        age.SendKeys("2");
-        WaitForTextContaining("ValImmediate_AgeDisplay", "Age: 2", timeoutMs: 3000);
+        // The age NumberBox's inner editor occasionally does not take focus from a single click
+        // (worse right after the email interaction), dropping the first keystroke so the display
+        // stays 'Age: 0'. Retry focus + first digit until it registers, clearing any partial
+        // between attempts so a borderline-late keystroke can't double-type into '22'.
+        bool firstDigitLanded = false;
+        for (int attempt = 0; attempt < 3 && !firstDigitLanded; attempt++)
+        {
+            age.Click();
+            if (attempt > 0)
+                age.Clear();
+            age.SendKeys("2");
+            firstDigitLanded = App.WaitForValue("ValImmediate_AgeDisplay", "Age: 2", contains: false, timeoutMs: 2000);
+        }
+        Assert.IsTrue(firstDigitLanded,
+            "Age NumberBox never accepted the first digit after click focus (3 attempts).");
+
         age.SendKeys("5");
         WaitForText("ValImmediate_AgeDisplay", "Age: 25");
         WaitForText("ValImmediate_FormValid", "valid");

--- a/tests/Reactor.AppTests/Tests/ImmediateAndDisabledFocusableTests.cs
+++ b/tests/Reactor.AppTests/Tests/ImmediateAndDisabledFocusableTests.cs
@@ -43,7 +43,7 @@ public class ImmediateAndDisabledFocusableTests : AppTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Immediate_FiresOnEveryKeystroke_BeforeBlur()
     {
@@ -80,7 +80,7 @@ public class ImmediateAndDisabledFocusableTests : AppTestBase
     /// commit-on-blur input + true-disabled Submit removes the button from
     /// the tab order at the moment Tab navigation runs.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void DisabledFocusable_TabReachesSubmit_AfterTypingValidValue()
     {
@@ -118,7 +118,7 @@ public class ImmediateAndDisabledFocusableTests : AppTestBase
     ///  2. Drop the user OnClick invocation when activated — the click
     ///     trampoline checks <c>IsDisabledFocusable</c> and returns early.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void DisabledFocusable_InvalidFormDropsInvokes()
     {

--- a/tests/Reactor.AppTests/Tests/ItemClickInteractionTests.cs
+++ b/tests/Reactor.AppTests/Tests/ItemClickInteractionTests.cs
@@ -34,7 +34,7 @@ public class ItemClickInteractionTests : AppTestBase
     /// </summary>
     // [Retry] mops up the rare unattended-desktop input-injection flake (SendInput dropped
     // before the Host foregrounds). A real regression still fails every attempt.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void ItemClick_FiresExactlyOnce_AfterReRenders()
     {
@@ -58,7 +58,7 @@ public class ItemClickInteractionTests : AppTestBase
     /// After the items array is rebuilt (the #495 ItemsSource-rebuild path), a single real
     /// click still fires the callback exactly once with the correct index.
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void ItemClick_FiresExactlyOnce_AfterItemsChange()
     {

--- a/tests/Reactor.AppTests/Tests/Spec051DevtoolsPackageE2ETests.cs
+++ b/tests/Reactor.AppTests/Tests/Spec051DevtoolsPackageE2ETests.cs
@@ -103,7 +103,7 @@ public sealed class Spec051DevtoolsPackageE2ETests
         if (!string.IsNullOrWhiteSpace(fromEnv))
         {
             if (File.Exists(fromEnv)) return fromEnv;
-            Assert.Inconclusive($"{envVar} points to a missing executable: {fromEnv}");
+            Assert.Fail($"{envVar} points to a missing executable: {fromEnv}");
         }
 
         if (string.Equals(Environment.GetEnvironmentVariable("REACTOR_SPEC051_DISCOVER_PUBLISHED"), "1", StringComparison.Ordinal))

--- a/tests/Reactor.AppTests/Tests/TreeViewInteractionTests.cs
+++ b/tests/Reactor.AppTests/Tests/TreeViewInteractionTests.cs
@@ -57,7 +57,7 @@ public class TreeViewInteractionTests : AppTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void ClickItemBody_DoesNotCollapseExpandedNode()
     {
@@ -87,7 +87,7 @@ public class TreeViewInteractionTests : AppTestBase
     /// "Report.docx" (a leaf child of "Work") and verify "Work" stays expanded
     /// (its sibling "Slides.pptx" remains visible).
     /// </summary>
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void ClickChild_DoesNotCollapseParent()
     {

--- a/tests/Reactor.AppTests/Tests/WinFormsInteropTests.cs
+++ b/tests/Reactor.AppTests/Tests/WinFormsInteropTests.cs
@@ -66,7 +66,7 @@ public class WinFormsInteropTests : WinFormsTestBase
     // [Retry] mops up the rare unattended-desktop input-injection flake: Win32 SendInput is
     // occasionally dropped before the Host window foregrounds on CI. A real regression still
     // fails every attempt. Removable once winappCli #562 (send-keys)/#498 (drag) ship native verbs.
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interop_Rendering_ButtonClickUpdatesState()
     {
@@ -82,7 +82,7 @@ public class WinFormsInteropTests : WinFormsTestBase
         WaitForText("Reactor_CountDisplay", "Count: 2");
     }
 
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interop_Rendering_TextInputWorks()
     {
@@ -127,7 +127,7 @@ public class WinFormsInteropTests : WinFormsTestBase
         "WF_TextBox3",       // bottomBar child 0
     ];
 
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interop_Tab_ForwardCycle_TwoFullLoops()
     {
@@ -149,7 +149,7 @@ public class WinFormsInteropTests : WinFormsTestBase
         }
     }
 
-    [Retry(3)]
+    [E2eRetry(3)]
     [TestMethod]
     public void Interop_Tab_BackwardCycle_TwoFullLoops()
     {


### PR DESCRIPTION
## Summary

Adds an E2E stress-test harness and hardens the flakiest winapp-ui E2E tests, cutting the underlying per-attempt flake surface from **17 tests to 3** (worst-case per-test flake **7.5% → 0.5%**) while keeping production reliability at **99%+**. Along the way it closes a latent `Failed → Inconclusive` masking bug in the retry path.

## What's here

**Stress harness — `.github/workflows/ci-stress.yml` + `tests/Reactor.AppTests/StressReport.ps1`**
- New `e2e` target loops the winapp-ui suite N times across 20 sharded runners; an `e2e-report` job aggregates every iteration's TRX into a suite-green rate + per-test flake leaderboard + Inconclusive classification (Environmental/guard vs Prerequisite vs Other), rendered on the run summary.
- New `e2e_retries` input wires `REACTOR_E2E_RETRIES` for a retries-OFF diagnostic lane that measures the true per-attempt flake rate.

**Anti-masking retry attribute — `E2eRetryAttribute`**
- Replaces built-in MSTest `[Retry(3)]` on 34 methods. MSTest treats a retry-attempt `Inconclusive` as an acceptable stop-outcome and reports the *last* attempt, so a real first-run failure followed by an environmental `Inconclusive` (locked desktop / lost input injection on a retry) was silently downgraded to `Inconclusive` and `dotnet test` exited 0. The custom attribute never lets a later `Inconclusive` overwrite a genuine failure — it heals only on a real pass. Env-gated (`REACTOR_E2E_RETRIES`, default 3, `0` = off). Backed by **13 headless unit tests**.

**Flaky-test hardening — diagnosed from retries-OFF TRX evidence, not guesswork**
- `AppTestBase.ResetFixture`: retry the reset invoke once + longer settle — fixed a shared reset race that took out a 12-test `Interop_*` class plus `InvalidFormDropsInvokes` in one go.
- `ImmediateAndDisabledFocusableTests`: fixture-readiness waits + a first-digit focus-retry (the age NumberBox dropped the first keystroke after the email interaction).
- `DataGridTests` + `DataGridFixtures`: editor clear-verify (killed a `Clear`/type garble), and `onRowChanged` now accumulates into an append-only `EditLog` (functional `UseReducer`) so the cross-row-commit assertion verifies the callback contract *and* is robust to the async-ordering race.
- `InputInjector.Drag`: pulsed dwell at the drop point so hover-armed drop targets latch.
- `Spec051`: env-set-but-exe-missing is now `Assert.Fail`, not `Inconclusive`.

## Results (retries-OFF, 200 iterations/run)

| | Baseline | Final |
|---|---|---|
| Suite-green (retries OFF) | 90.0% | **98.5%** (197/200) |
| Worst per-test flake | 7.5% | **0.5%** |
| Distinctly flaky tests | 17 | 3 (all at the 0.5% noise floor) |
| Guard/environmental Inconclusive | 0 | 0 |

Production reliability (retries ON) verified at 200/200 green (~99.9%+ post-retry). Zero masking across every run; the anti-masking guarantee is independently confirmed and unit-tested. The remaining ~0.5% residuals are the inherent noise floor of synthetic-input E2E (SendInput drag / occasional keystroke drop) on shared runners.

## Review

Ran the `pr-review` skill (8 dimensions + a multi-model cross-check): clean on security, correctness, API ergonomics, alternatives, docs, and packaging. The one **high** finding (retry logic untested) is resolved by the 13 unit tests; one **medium** (DataGrid callback coverage) is resolved by the append-only `EditLog`.

## Follow-ups (not in this PR)
- A Pester test for `StressReport.ps1` aggregation math (review finding M1).
- The two `Spec051` devtools-packaging tests are still `Inconclusive` in CI (they need pre-published samples) — a separate coverage-gap task.