### PR TITLE
Fix ListView/GridView OnItemClick double-subscribe on null→present toggle

### DIFF
--- a/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
@@ -80,13 +80,20 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
                 h(g.SelectedItems.OfType<int>().ToList());
             }
         };
-        if (gv.OnItemClick is not null)
-            gridView.ItemClick += (s, args) =>
-            {
-                var g = (WinUI.GridView)s!;
-                if (args.ClickedItem is int idx)
-                    (Reconciler.GetElementTag(g) as GridViewElement)?.OnItemClick?.Invoke(idx);
-            };
+        // Issue #779 — subscribe unconditionally (mirrors SelectionChanged above)
+        // so a later record-with that attaches OnItemClick is picked up without a
+        // second subscription. The trampoline no-ops when the current element's
+        // OnItemClick is null, and IsItemClickEnabled (set on mount + every update)
+        // gates whether WinUI raises ItemClick at all — so exactly one subscription
+        // for the control's lifetime fires the callback once per click across any
+        // toggle sequence. A conditional mount + Update-time re-subscribe (the old
+        // shape) leaked a second live handler on present→null→present.
+        gridView.ItemClick += (s, args) =>
+        {
+            var g = (WinUI.GridView)s!;
+            if (args.ClickedItem is int idx)
+                (Reconciler.GetElementTag(g) as GridViewElement)?.OnItemClick?.Invoke(idx);
+        };
 
         gridView.ItemsSource = Enumerable.Range(0, gv.Items.Length).ToList();
 
@@ -144,16 +151,12 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
 
         Reconciler.SetElementTag(gv, n);
 
-        // SelectionChanged is wired unconditionally in Mount (see comment in
-        // ListViewHandler.Update). Tag refresh suffices to pick up a later-attached
-        // OnSelectedIndexChanged / OnSelectionChanged.
-        if (o.OnItemClick is null && n.OnItemClick is not null)
-            gv.ItemClick += (s, args) =>
-            {
-                var g = (WinUI.GridView)s!;
-                if (args.ClickedItem is int idx)
-                    (Reconciler.GetElementTag(g) as GridViewElement)?.OnItemClick?.Invoke(idx);
-            };
+        // SelectionChanged and ItemClick are both wired unconditionally in Mount
+        // (see comment in ListViewHandler.Update). Tag refresh suffices to pick up a
+        // later-attached OnSelectedIndexChanged / OnSelectionChanged / OnItemClick.
+        // Re-subscribing ItemClick on a null→present transition here would leak a
+        // second live handler (never removed on present→null), so a single click
+        // would fire the callback twice (issue #779).
 
         // Issue #464 — wrap the SelectedIndex write so the deferred
         // SelectionChanged GridView fires after the property set doesn't echo

--- a/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
@@ -88,13 +88,20 @@ internal sealed class ListViewHandler : IElementHandler<ListViewElement, WinUI.L
                 h(l.SelectedItems.OfType<int>().ToList());
             }
         };
-        if (lv.OnItemClick is not null)
-            listView.ItemClick += (s, args) =>
-            {
-                var l = (WinUI.ListView)s!;
-                if (args.ClickedItem is int idx)
-                    (Reconciler.GetElementTag(l) as ListViewElement)?.OnItemClick?.Invoke(idx);
-            };
+        // Issue #779 — subscribe unconditionally (mirrors SelectionChanged above)
+        // so a later record-with that attaches OnItemClick is picked up without a
+        // second subscription. The trampoline no-ops when the current element's
+        // OnItemClick is null, and IsItemClickEnabled (set on mount + every update)
+        // gates whether WinUI raises ItemClick at all — so exactly one subscription
+        // for the control's lifetime fires the callback once per click across any
+        // toggle sequence. A conditional mount + Update-time re-subscribe (the old
+        // shape) leaked a second live handler on present→null→present.
+        listView.ItemClick += (s, args) =>
+        {
+            var l = (WinUI.ListView)s!;
+            if (args.ClickedItem is int idx)
+                (Reconciler.GetElementTag(l) as ListViewElement)?.OnItemClick?.Invoke(idx);
+        };
 
         // Set ItemsSource LAST — triggers container creation which needs the handler above
         listView.ItemsSource = Enumerable.Range(0, lv.Items.Length).ToList();
@@ -160,17 +167,13 @@ internal sealed class ListViewHandler : IElementHandler<ListViewElement, WinUI.L
 
         Reconciler.SetElementTag(lv, n);
 
-        // Mount subscribes SelectionChanged unconditionally and reads handlers
-        // via GetElementTag, so no lazy wire here — the tag refresh above
-        // makes a newly-attached OnSelectedIndexChanged / OnSelectionChanged
-        // pick up on the very next selection.
-        if (o.OnItemClick is null && n.OnItemClick is not null)
-            lv.ItemClick += (s, args) =>
-            {
-                var l = (WinUI.ListView)s!;
-                if (args.ClickedItem is int idx)
-                    (Reconciler.GetElementTag(l) as ListViewElement)?.OnItemClick?.Invoke(idx);
-            };
+        // Mount subscribes both SelectionChanged and ItemClick unconditionally and
+        // reads handlers via GetElementTag, so no lazy wire here — the tag refresh
+        // above makes a newly-attached OnSelectedIndexChanged / OnSelectionChanged /
+        // OnItemClick pick up on the very next event. Re-subscribing ItemClick on a
+        // null→present transition here would leak a second live handler (never
+        // removed on present→null), so a single click would fire the callback twice
+        // (issue #779).
 
         // Issue #495 — wrap the SelectedIndex write so the SelectionChanged
         // ListView fires after the property set doesn't echo back into

--- a/tests/Reactor.AppTests.Host/FixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/FixtureRegistry.cs
@@ -65,6 +65,12 @@ internal static class FixtureRegistry
         // the ListViewHandler once-subscribe contract across re-renders + items change)
         "ItemClick_OnceFire",
 
+        // ItemClick toggle-path double-subscribe guard (issue #779 — E2E proof that
+        // toggling OnItemClick off then on again still fires exactly once, on both
+        // ListView and GridView)
+        "ItemClick_ToggleListView",
+        "ItemClick_ToggleGridView",
+
         // Host theme-change re-resolution (issue #679 (b) — E2E proof that the host
         // ActualThemeChanged → RequestRender wiring re-resolves a concrete ResourceOverride
         // ThemeRef brush on a real root-theme change)
@@ -227,6 +233,10 @@ internal static class FixtureRegistry
 
         // ItemClick once-fire guard (issue #679 (a))
         "ItemClick_OnceFire" => ItemClickE2EFixtures.OnceFire(ctx),
+
+        // ItemClick toggle-path double-subscribe guard (issue #779)
+        "ItemClick_ToggleListView" => ItemClickE2EFixtures.ToggleListView(ctx),
+        "ItemClick_ToggleGridView" => ItemClickE2EFixtures.ToggleGridView(ctx),
 
         // Host theme-change re-resolution (issue #679 (b))
         "ThemeChange_ResourceOverrideReResolve" => ThemeChangeE2EFixtures.ThemeReResolve(ctx),

--- a/tests/Reactor.AppTests.Host/Fixtures/ItemClickE2EFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/ItemClickE2EFixtures.cs
@@ -79,4 +79,112 @@ internal static class ItemClickE2EFixtures
     }
 
     internal static Element OnceFire(RenderContext ctx) => Component<OnceFireComponent>();
+
+    // Shared row labels for the #779 toggle fixtures below.
+    private static readonly string[] ToggleLabels = ["Alpha", "Bravo", "Charlie", "Delta"];
+
+    /// <summary>
+    /// E2E fixture for issue #779 — the ListView <c>OnItemClick</c> "toggle-path"
+    /// double-subscribe guard (<see cref="GridViewToggleComponent"/> is the symmetric case).
+    ///
+    /// <para>ListView/GridView update <b>in place</b>, so toggling <c>OnItemClick</c>
+    /// off (present→null) then on (null→present) used to leave the Mount-time native
+    /// <c>ItemClick</c> subscription live AND add a second one on the null→present
+    /// Update, so a single real click dispatched the callback twice (and stacked
+    /// another handler on every further off→on cycle). The fix subscribes
+    /// <c>ItemClick</c> unconditionally at Mount and never re-subscribes on Update.</para>
+    ///
+    /// <para>This scene toggles a real <c>OnItemClick</c> handler with a button
+    /// (<c>hasHandler ? (idx =&gt; fires++) : null</c>) and exposes an authoritative
+    /// <see cref="Ref{T}"/> fire counter as UIA-readable <c>Fires</c> text (a Ref, not
+    /// just state, so a synchronous double-dispatch can't be masked by state batching).
+    /// The E2E test starts ON → toggles OFF → toggles ON → real-clicks a row and asserts
+    /// the callback fired EXACTLY once.</para>
+    /// </summary>
+    internal class ListViewToggleComponent : Component
+    {
+        public override Element Render()
+        {
+            var (hasHandler, setHasHandler) = UseState(true);
+            var (firesDisplay, setFiresDisplay) = UseState(0);
+            var (lastIndex, setLastIndex) = UseState(-1);
+
+            // Authoritative fire count — a native double-subscription fires both
+            // handlers synchronously for one click, so counting on a Ref guarantees
+            // the second dispatch is observed even if the two setState calls collapse.
+            var fires = UseRef(0);
+
+            // Memoize the rows so Items stays reference-stable across toggle re-renders
+            // (ListViewHandler.Update sees ReferenceEquals → no ItemsSource rebuild),
+            // isolating the pure OnItemClick null↔present toggle path — exactly the
+            // in-place-update sequence that leaked the second subscription.
+            var rows = UseMemo(() => ToggleLabels
+                .Select((label, i) => (Element)TextBlock($"{i}: {label}").AutomationId($"LvToggleItem_{i}"))
+                .ToArray(), 0);
+
+            // The idiomatic conditional-handler pattern: OnItemClick is a real handler
+            // while enabled, null while disabled. Toggling it drives the present→null→present
+            // in-place Update that used to leak a second native subscription.
+            Action<int>? onItemClick = hasHandler
+                ? idx =>
+                {
+                    fires.Current += 1;
+                    setFiresDisplay(fires.Current);
+                    setLastIndex(idx);
+                }
+                : null;
+
+            return VStack(8,
+                TextBlock($"HasHandler: {hasHandler}").AutomationId("LvToggleState"),
+                Button("ToggleHandler", () => setHasHandler(!hasHandler)).AutomationId("LvToggleBtn"),
+
+                ListView(rows)
+                    .ItemClick(onItemClick)
+                    .Height(220),
+
+                TextBlock($"Fires: {firesDisplay}").AutomationId("LvToggleFires"),
+                TextBlock($"LastIndex: {lastIndex}").AutomationId("LvToggleLastIndex")
+            );
+        }
+    }
+
+    internal class GridViewToggleComponent : Component
+    {
+        public override Element Render()
+        {
+            var (hasHandler, setHasHandler) = UseState(true);
+            var (firesDisplay, setFiresDisplay) = UseState(0);
+            var (lastIndex, setLastIndex) = UseState(-1);
+            var fires = UseRef(0);
+
+            var rows = UseMemo(() => ToggleLabels
+                .Select((label, i) => (Element)TextBlock($"{i}: {label}").AutomationId($"GvToggleItem_{i}"))
+                .ToArray(), 0);
+
+            Action<int>? onItemClick = hasHandler
+                ? idx =>
+                {
+                    fires.Current += 1;
+                    setFiresDisplay(fires.Current);
+                    setLastIndex(idx);
+                }
+                : null;
+
+            return VStack(8,
+                TextBlock($"HasHandler: {hasHandler}").AutomationId("GvToggleState"),
+                Button("ToggleHandler", () => setHasHandler(!hasHandler)).AutomationId("GvToggleBtn"),
+
+                GridView(rows)
+                    .ItemClick(onItemClick)
+                    .Height(220),
+
+                TextBlock($"Fires: {firesDisplay}").AutomationId("GvToggleFires"),
+                TextBlock($"LastIndex: {lastIndex}").AutomationId("GvToggleLastIndex")
+            );
+        }
+    }
+
+    internal static Element ToggleListView(RenderContext ctx) => Component<ListViewToggleComponent>();
+
+    internal static Element ToggleGridView(RenderContext ctx) => Component<GridViewToggleComponent>();
 }

--- a/tests/Reactor.AppTests.Host/Fixtures/ItemClickE2EFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/ItemClickE2EFixtures.cs
@@ -10,12 +10,11 @@ namespace Microsoft.UI.Reactor.AppTests.Host.Fixtures;
 /// E2E fixture for issue #679 (a) — the ListView <c>OnItemClick</c> "once-fire" guard.
 ///
 /// <para>The production <c>ListViewHandler</c> subscribes the native
-/// <c>ListView.ItemClick</c> event exactly once (Mount when <c>OnItemClick</c> is present,
-/// or the Update transition <c>null → non-null</c>) and dispatches through the current
-/// element via <c>GetElementTag</c>. A handler that stays present but changes identity every
-/// render (the idiomatic <c>idx =&gt; setState(...)</c> lambda) must therefore NOT cause a
-/// re-subscribe. If the reconciler regressed to <c>ItemClick +=</c> on every render, a single
-/// real pointer click would invoke the callback N+1 times.</para>
+/// <c>ListView.ItemClick</c> event exactly once (unconditionally at Mount) and dispatches
+/// through the current element via <c>GetElementTag</c>. A handler that stays present but
+/// changes identity every render (the idiomatic <c>idx =&gt; setState(...)</c> lambda) must
+/// therefore NOT cause a re-subscribe. If the reconciler regressed to <c>ItemClick +=</c> on
+/// every render, a single real pointer click would invoke the callback N+1 times.</para>
 ///
 /// <para>This scene exposes that as UIA-readable state: an authoritative <see cref="Ref{T}"/>
 /// counter (incremented on every dispatch, so a double-fire can't be masked by state

--- a/tests/Reactor.AppTests/Tests/ItemClickToggleInteractionTests.cs
+++ b/tests/Reactor.AppTests/Tests/ItemClickToggleInteractionTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Reactor.AppTests.Infrastructure;
+
+namespace Microsoft.UI.Reactor.AppTests.Tests;
+
+/// <summary>
+/// E2E coverage for issue #779 — the ListView/GridView <c>OnItemClick</c> "toggle-path"
+/// double-subscribe defect.
+///
+/// <para>ListView/GridView update <b>in place</b>, so toggling <c>OnItemClick</c> off
+/// (present→null) then on (null→present) used to leave the Mount-time native
+/// <c>ItemClick</c> subscription live AND add a second one on the null→present Update
+/// (never removed), so a single real click dispatched the callback twice — and stacked
+/// another handler on every further off→on cycle. The fix wires <c>ItemClick</c>
+/// unconditionally at Mount and never re-subscribes on Update, so exactly one subscription
+/// survives any toggle sequence.</para>
+///
+/// <para>Each test navigates its fixture, toggles the handler OFF then ON via a real button
+/// click, delivers a REAL pointer click to a row, and asserts the callback fired EXACTLY
+/// once. Pre-fix these report <c>Fires: 2</c> (red); post-fix <c>Fires: 1</c> (green).</para>
+///
+/// Why E2E and not a selftest: WinUI raises <c>ItemClick</c> from real pointer input (not a
+/// UIA Invoke and with no public raise API), and projected WinRT event subscriptions can't be
+/// enumerated in-process, so only cross-process real-input delivery exercises the defect.
+/// </summary>
+[TestClass]
+public class ItemClickToggleInteractionTests : AppTestBase
+{
+    [ClassInitialize]
+    public static void StartAppSession(TestContext context) => TestSession.AssemblyInit(context);
+
+    [ClassCleanup]
+    public static void StopAppSession() => TestSession.AssemblyCleanup();
+
+    /// <summary>
+    /// ListView: start with <c>OnItemClick</c> present, toggle it OFF then ON (the
+    /// null→present in-place Update that used to add a second native subscription), then a
+    /// single real click on a row must fire the callback exactly once.
+    /// </summary>
+    // [Retry] mops up the rare unattended-desktop input-injection flake (SendInput dropped
+    // before the Host foregrounds). A real double-subscribe regression fails every attempt
+    // with Fires: 2.
+    [Retry(3)]
+    [TestMethod]
+    public void ListView_ItemClick_FiresExactlyOnce_AfterToggleOffOn()
+    {
+        NavigateToFixtureFresh("ItemClick_ToggleListView");
+        WaitForText("LvToggleState", "HasHandler: True");
+        WaitForText("LvToggleFires", "Fires: 0");
+
+        // present → null → present: the toggle sequence that leaked the second handler.
+        ClickButton("LvToggleBtn");
+        WaitForText("LvToggleState", "HasHandler: False");
+        ClickButton("LvToggleBtn");
+        WaitForText("LvToggleState", "HasHandler: True");
+
+        RealClick("LvToggleItem_1");
+
+        WaitForText("LvToggleLastIndex", "LastIndex: 1");
+        WaitForText("LvToggleFires", "Fires: 1");
+    }
+
+    /// <summary>
+    /// GridView: symmetric to the ListView case — off→on toggle then a single real click
+    /// must fire the callback exactly once.
+    /// </summary>
+    [Retry(3)]
+    [TestMethod]
+    public void GridView_ItemClick_FiresExactlyOnce_AfterToggleOffOn()
+    {
+        NavigateToFixtureFresh("ItemClick_ToggleGridView");
+        WaitForText("GvToggleState", "HasHandler: True");
+        WaitForText("GvToggleFires", "Fires: 0");
+
+        ClickButton("GvToggleBtn");
+        WaitForText("GvToggleState", "HasHandler: False");
+        ClickButton("GvToggleBtn");
+        WaitForText("GvToggleState", "HasHandler: True");
+
+        RealClick("GvToggleItem_1");
+
+        WaitForText("GvToggleLastIndex", "LastIndex: 1");
+        WaitForText("GvToggleFires", "Fires: 1");
+    }
+
+    /// <summary>
+    /// Deliver a real Win32 pointer click to the center of the element's bounding rectangle.
+    /// A real click (not a UIA Invoke) is required: WinUI raises <c>ItemClick</c> from
+    /// pointer input.
+    /// </summary>
+    private void RealClick(string automationId)
+    {
+        var r = FindById(automationId).Rect;
+        InputInjector.Foreground(HostHwnd);
+        InputInjector.Click(r.X + r.Width / 2, r.Y + r.Height / 2);
+    }
+}


### PR DESCRIPTION
Fixes #779

## The bug
`ListViewHandler` and `GridViewHandler` subscribe the native WinUI `ItemClick` event in **two** places and never unsubscribe:
- **Mount:** `if (OnItemClick is not null) control.ItemClick += H1;`
- **Update:** `if (o.OnItemClick is null && n.OnItemClick is not null) control.ItemClick += H2;`

ListView/GridView update **in place** (a `HasCallbacks` change forces a full Update, not a remount), so `H1` is never dropped. Toggling `OnItemClick` **present → null → present** leaves both `H1` and `H2` live with `IsItemClickEnabled = true`, so a single item click invokes `OnItemClick` **twice** — and each further off→on cycle stacks another subscription. Affects both `ListViewElement` and `GridViewElement`.

## The fix
Subscribe `ItemClick` **unconditionally at Mount** and **delete the Update-time re-subscribe**, mirroring how `SelectionChanged` is already correctly wired in these same handlers. Correctness holds because:
1. The `GetElementTag` trampoline already null-checks (`?.OnItemClick?.Invoke(idx)`) → no-op when the current handler is null.
2. `IsItemClickEnabled = n.OnItemClick is not null` is still set on **both** Mount and every Update, so WinUI only raises `ItemClick` when a handler is present.
3. Dispatch reads the **current** element via the tag refreshed on Update.

**Pooling:** ListView/GridView are **not** in `ElementPool.PoolableTypes`, so `Mount` runs exactly once per control → exactly one live subscription for the control's lifetime. No one-time-wire guard needed (same as `SelectionChanged`). The change also removes an Update-time branch (hot path neutral-to-better).

## Tests + red→green proof (CI-sequenced)
New toggle-path fixtures (`ItemClick_ToggleListView` / `ItemClick_ToggleGridView`) + `ItemClickToggleInteractionTests` (ListView + GridView): start ON → toggle OFF → toggle ON → real pointer-click a row → assert `Fires == 1`.

This PR is deliberately structured as two commits to record a visible red→green in CI (the local winapp-ui tier can't build on the author's machine — an unrelated environmental XAML-compiler issue — so CI is the source of truth):

| Commit | Contents | E2E "Test" result |
|---|---|---|
| `f6a05388` — tests only (no fix) | new fixtures + tests | 🔴 **Failed** — `LvToggleFires`/`GvToggleFires` last-seen **`Fires: 2`**; existing #778 `ItemClick_FiresExactlyOnce_*` stayed green |
| `0f30c986` — + handler fix | the two-handler fix | 🟢 **Passed** — both toggle tests `Fires: 1`; **entire CI run green** |

This proves the tests are non-vacuous (they catch the exact bug) and that the fix resolves it, on both controls.

**Why E2E and not a selftest:** WinUI raises `ItemClick` only from real pointer input (no public raise API), and projected WinRT event subscriptions can't be enumerated in-process — an in-process test would be vacuous (same rationale as the #778 once-fire tests).

## Validation
- 🔴 RED run (`f6a05388`): E2E job failed with `Fires: 2` on both new tests; #778 tests green.
- 🟢 GREEN run (`0f30c986`): **all CI jobs green** — Build solution ✓, Unit Tests ✓ (also 10684 passed locally), Selftests ✓, Integration Tests ✓, AOT Selftests ✓, E2E Tests ✓ (both toggle tests `Fires: 1`).

## Draft status
Draft pending coordinator dual-review (correctness + multi-model) and the guarded merge. Not for self-merge.