### PR TITLE
test: guard that ListView/GridView are never structurally skip-eligible (defense-in-depth for #837)

### DIFF
--- a/tests/Reactor.Tests/Issue837ListViewGridViewItemClickSkipTests.cs
+++ b/tests/Reactor.Tests/Issue837ListViewGridViewItemClickSkipTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests;
+
+/// <summary>
+/// Characterization + forward guard spun off the investigation of issue #837.
+///
+/// <para><b>#837 as filed does NOT reproduce.</b> Its mechanism assumed
+/// <see cref="Element.ShallowEquals"/> has a <c>ListViewElement</c>/<c>GridViewElement</c> arm
+/// that ignores <c>OnItemClick</c> (cited <c>Element.cs:881-891</c>), so a co-present sibling
+/// callback would let the reconciler structurally skip <c>Update</c> and leave
+/// <c>IsItemClickEnabled</c> stale. In fact those arms live in <see cref="Element.OwnPropsEqual"/>
+/// (the DevTools reconcile-highlight helper, whose only caller is gated on
+/// <c>ReactorFeatureFlags.HighlightReconcileChanges</c>) — <b>not</b> in <c>ShallowEquals</c>,
+/// which has no LV/GV arm and returns <c>false</c> for them via its <c>_ =&gt; false</c> default.</para>
+///
+/// <para>Both documented skip gates require <c>ShallowEquals(old,new) == true</c>: the
+/// element-level shallow-skip (<c>Reconciler.Update.cs</c>) and the child-level
+/// <see cref="Element.CanSkipUpdate"/> (used by <c>ChildReconciler</c>). Because
+/// <c>ShallowEquals</c> is always <c>false</c> for LV/GV, their handler <c>Update</c> is never
+/// structurally skipped and <c>IsItemClickEnabled = OnItemClick is not null</c> is refreshed on
+/// every reconcile — so the toggle cannot be missed.</para>
+///
+/// <para>These tests lock that invariant. If a future perf change adds an LV/GV
+/// <c>ShallowEquals</c> arm (making them skip-eligible), the "toggle" tests below start failing
+/// unless that arm also compares <c>OnItemClick</c> presence — forcing whoever adds the skip to
+/// close the #837 hazard at the same time.</para>
+/// </summary>
+public class Issue837ListViewGridViewItemClickSkipTests
+{
+    // A reference-stable co-present callback — holds aggregate HasCallbacks true on both sides of
+    // an OnItemClick toggle, the exact condition #837 describes.
+    private static readonly Action<IReadOnlyList<int>> SharedSelectionChanged = _ => { };
+
+    // ── Current behavior: LV/GV are never structurally skip-eligible ──
+
+    [Fact]
+    public void ListView_IsNever_ShallowEqual_Or_SkipEligible_Today()
+    {
+        // Identical copy (every own prop reference-equal) is STILL not shallow-equal, because
+        // ShallowEquals has no ListViewElement arm and falls through to `_ => false`. This is the
+        // reason #837 cannot occur: no skip path can fire for a ListView.
+        var lv = ListView(TextBlock("row")).SelectionChanged(SharedSelectionChanged);
+        Assert.False(Element.ShallowEquals(lv, lv with { }));
+        Assert.False(Element.CanSkipUpdate(lv, lv with { }));
+    }
+
+    [Fact]
+    public void GridView_IsNever_ShallowEqual_Or_SkipEligible_Today()
+    {
+        var gv = GridView(TextBlock("row")).SelectionChanged(SharedSelectionChanged);
+        Assert.False(Element.ShallowEquals(gv, gv with { }));
+        Assert.False(Element.CanSkipUpdate(gv, gv with { }));
+    }
+
+    // ── Forward guard: an OnItemClick presence toggle must never be skip-eligible ──
+    // Today these pass trivially (LV/GV are never skip-eligible). If a future change makes LV/GV
+    // skip-eligible WITHOUT comparing OnItemClick presence, CanSkipUpdate would start returning
+    // true here and these fail — catching the #837 regression at the skip-decision layer.
+
+    [Fact]
+    public void ListView_OnItemClick_PresenceToggle_IsNeverSkipEligible()
+    {
+        var noClick = ListView(TextBlock("row")).SelectionChanged(SharedSelectionChanged);
+        var withClick = noClick with { OnItemClick = _ => { } };
+        Assert.False(Element.CanSkipUpdate(noClick, withClick));
+        Assert.False(Element.CanSkipUpdate(withClick, noClick));
+    }
+
+    [Fact]
+    public void GridView_OnItemClick_PresenceToggle_IsNeverSkipEligible()
+    {
+        var noClick = GridView(TextBlock("row")).SelectionChanged(SharedSelectionChanged);
+        var withClick = noClick with { OnItemClick = _ => { } };
+        Assert.False(Element.CanSkipUpdate(noClick, withClick));
+        Assert.False(Element.CanSkipUpdate(withClick, noClick));
+    }
+}


### PR DESCRIPTION
## What

Adds a small, **test-only** headless xUnit guard — `Issue837ListViewGridViewItemClickSkipTests` (4 tests) — asserting that `ListView`/`GridView` elements are **never** structurally skip-eligible today, and that an `OnItemClick` presence toggle is never skip-eligible.

## Why — context for #837 (being closed as invalid)

#837 reported that an `OnItemClick` presence toggle could be silently missed when `Update` is structurally skipped (aggregate `HasCallbacks` unchanged while a sibling callback stays present). Investigation showed **this cannot happen** on the current codebase:

- The reconciler's structural-skip gates both require `Element.ShallowEquals(old, new) == true` — the element-level shallow-skip (`Reconciler.Update.cs:96`) and the child-level `Element.CanSkipUpdate` (`Element.cs:411`, used by `ChildReconciler`).
- `ShallowEquals` (`Element.cs:421-731`) has arms for Stack/Border/ItemContainer/Grid/ScrollViewer/ScrollView/Flex/Canvas/Empty/ErrorBoundary and ComboBox, then `_ => false`. It has **no `ListViewElement`/`GridViewElement` arm**, so it returns `false` for every LV/GV pair.
- The LV/GV arms #837 cited at `Element.cs:881-891` are actually in **`OwnPropsEqual`** (`Element.cs:741-966`) — the DevTools reconcile-highlight helper, whose only caller (`Reconciler.Update.cs:237`) is gated on `ReactorFeatureFlags.HighlightReconcileChanges`. It never participates in a skip decision.

Therefore LV/GV `Update` is never structurally skipped, and `ListViewHandler`/`GridViewHandler` set `IsItemClickEnabled = n.OnItemClick is not null` on **every** `Update` (`ListViewHandler.cs:136`, `GridViewHandler.cs:124`) — the toggle can't be missed.

This PR turns that phantom hazard into an **executable, guarded invariant**: if a future perf change adds an LV/GV `ShallowEquals` arm (making them skip-eligible), these tests fail unless that arm also compares `OnItemClick` presence — exactly the hole #837 imagined.

## Note for reviewers

This is a **characterization / tripwire guard, not a fix.** All 4 tests are **green on current `main`** — there is intentionally no RED→GREEN, because there is no bug to fix. The value is the forward tripwire. #837 is referenced as **context only** (it is being closed as not-reproducible); this PR deliberately does **not** use "Fixes #837".

## Testing

- `dotnet test tests/Reactor.Tests` → the 4 new tests pass; full suite green (12319 passed, 0 failed, 64 skipped on ARM64).
- **Test-only — no `src/` changes.**

Runtime proof the guard encodes: `ShallowEquals(ListView(x), ListView(x) with {})` = `False` (an identical copy is still not shallow-equal — no arm), while `ShallowEquals(TextBlock("x"), TextBlock("x"))` = `True` (control: `ShallowEquals` works for a type that has an arm).