### PR TITLE
Fix: ListView/GridView Update can't clear Header or ItemContainerStyle to null (#845)

### DIFF
--- a/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/GridViewHandler.cs
@@ -122,10 +122,16 @@ internal sealed class GridViewHandler : IElementHandler<GridViewElement, WinUI.G
     {
         gv.SelectionMode = n.SelectionMode;
         gv.IsItemClickEnabled = n.OnItemClick is not null;
-        if (n.Header is not null) gv.Header = n.Header;
+        // Issue #845 — gate on CHANGE, not non-null presence, so a present→null
+        // transition clears the property on the control. Header/ItemContainerStyle
+        // raise no WinUI events (unlike SelectedIndex), so no echo-suppression is
+        // needed and a plain reference-change gate is correct. WinUI accepts null
+        // for both (Header=null removes the header; ItemContainerStyle=null resets
+        // to the default container style).
+        if (!ReferenceEquals(o.Header, n.Header)) gv.Header = n.Header;
         if (gv.IncrementalLoadingTrigger != n.IncrementalLoadingTrigger)
             gv.IncrementalLoadingTrigger = n.IncrementalLoadingTrigger;
-        if (!ReferenceEquals(o.ItemContainerStyle, n.ItemContainerStyle) && n.ItemContainerStyle is not null)
+        if (!ReferenceEquals(o.ItemContainerStyle, n.ItemContainerStyle))
             gv.ItemContainerStyle = n.ItemContainerStyle;
 
         // Issue #495 / #464 — rebuild ItemsSource on Items-array change so

--- a/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
+++ b/src/Reactor/Core/V1Protocol/Handlers/ListViewHandler.cs
@@ -134,10 +134,16 @@ internal sealed class ListViewHandler : IElementHandler<ListViewElement, WinUI.L
     {
         lv.SelectionMode = n.SelectionMode;
         lv.IsItemClickEnabled = n.OnItemClick is not null;
-        if (n.Header is not null) lv.Header = n.Header;
+        // Issue #845 — gate on CHANGE, not non-null presence, so a present→null
+        // transition clears the property on the control. Header/ItemContainerStyle
+        // raise no WinUI events (unlike SelectedIndex), so no echo-suppression is
+        // needed and a plain reference-change gate is correct. WinUI accepts null
+        // for both (Header=null removes the header; ItemContainerStyle=null resets
+        // to the default container style).
+        if (!ReferenceEquals(o.Header, n.Header)) lv.Header = n.Header;
         if (lv.IncrementalLoadingTrigger != n.IncrementalLoadingTrigger)
             lv.IncrementalLoadingTrigger = n.IncrementalLoadingTrigger;
-        if (!ReferenceEquals(o.ItemContainerStyle, n.ItemContainerStyle) && n.ItemContainerStyle is not null)
+        if (!ReferenceEquals(o.ItemContainerStyle, n.ItemContainerStyle))
             lv.ItemContainerStyle = n.ItemContainerStyle;
 
         // Issue #495 — when the Items array changes (idiomatic Reactor authors

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue845ClearHeaderItemContainerStyleFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/Issue845ClearHeaderItemContainerStyleFixtures.cs
@@ -1,0 +1,103 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.AppTests.Host.SelfTest;
+using Microsoft.UI.Xaml;
+using WinUI = Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+
+namespace Microsoft.UI.Reactor.AppTests.Host.SelfTest.Fixtures;
+
+/// <summary>
+/// Regression for https://github.com/microsoft/microsoft-ui-reactor/issues/845
+///
+/// <c>ListViewHandler.Update</c> / <c>GridViewHandler.Update</c> used to gate the
+/// <c>Header</c> and <c>ItemContainerStyle</c> assignments on the <i>new</i> value
+/// being non-null (<c>if (n.Header is not null) …</c> and
+/// <c>… &amp;&amp; n.ItemContainerStyle is not null</c>), so a present→null transition
+/// was a no-op and the stale value stuck on the live WinUI control. The fix gates
+/// on <i>change</i> (<c>!ReferenceEquals(o.X, n.X)</c>) so a clear-to-null is applied.
+///
+/// These fixtures need a live WinUI control (the symptom is a control property), so
+/// they mount, set a non-null Header + ItemContainerStyle, re-render with both null,
+/// and assert the live control's properties are now null. Non-vacuity: the
+/// <c>…ClearedToNull</c> checks FAIL on pre-fix code (control keeps the old value)
+/// and PASS post-fix.
+/// </summary>
+internal static class Issue845ClearHeaderItemContainerStyleFixtures
+{
+    // Hoisted so the ItemContainerStyle reference is stable across the phase-0
+    // renders (the Update change-gate is reference-based); phase 1 uses null.
+    private static readonly Style s_listViewItemStyle =
+        new() { TargetType = typeof(WinUI.ListViewItem) };
+
+    private static readonly Style s_gridViewItemStyle =
+        new() { TargetType = typeof(WinUI.GridViewItem) };
+
+    internal class ListViewClearsHeaderAndItemContainerStyle(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                return VStack(
+                    Button("Issue845ClearLV", () => set(1)),
+                    ListView(TextBlock("LV_Item")) with
+                    {
+                        Header = phase == 0 ? "LV_HDR" : null,
+                        ItemContainerStyle = phase == 0 ? s_listViewItemStyle : null,
+                    }
+                );
+            });
+
+            await Harness.Render();
+
+            var lv = H.FindControl<WinUI.ListView>(_ => true);
+            H.Check("Issue845_LV_HeaderSet_Initial", lv?.Header as string == "LV_HDR");
+            H.Check("Issue845_LV_StyleSet_Initial", lv?.ItemContainerStyle is not null);
+
+            H.ClickButton("Issue845ClearLV");
+            await Harness.Render();
+
+            // Same reconciled control (Update ran) — its Header/ItemContainerStyle
+            // must now be cleared. Pre-fix these stay non-null and the checks fail.
+            lv = H.FindControl<WinUI.ListView>(_ => true);
+            H.Check("Issue845_LV_HeaderClearedToNull", lv is not null && lv.Header is null);
+            H.Check("Issue845_LV_StyleClearedToNull", lv is not null && lv.ItemContainerStyle is null);
+        }
+    }
+
+    internal class GridViewClearsHeaderAndItemContainerStyle(Harness h) : SelfTestFixtureBase(h)
+    {
+        public override async Task RunAsync()
+        {
+            var host = H.CreateHost();
+            host.Mount(ctx =>
+            {
+                var (phase, set) = ctx.UseState(0);
+                return VStack(
+                    Button("Issue845ClearGV", () => set(1)),
+                    GridView(TextBlock("GV_Item")) with
+                    {
+                        Header = phase == 0 ? "GV_HDR" : null,
+                        ItemContainerStyle = phase == 0 ? s_gridViewItemStyle : null,
+                    }
+                );
+            });
+
+            await Harness.Render();
+
+            var gv = H.FindControl<WinUI.GridView>(_ => true);
+            H.Check("Issue845_GV_HeaderSet_Initial", gv?.Header as string == "GV_HDR");
+            H.Check("Issue845_GV_StyleSet_Initial", gv?.ItemContainerStyle is not null);
+
+            H.ClickButton("Issue845ClearGV");
+            await Harness.Render();
+
+            gv = H.FindControl<WinUI.GridView>(_ => true);
+            H.Check("Issue845_GV_HeaderClearedToNull", gv is not null && gv.Header is null);
+            H.Check("Issue845_GV_StyleClearedToNull", gv is not null && gv.ItemContainerStyle is null);
+        }
+    }
+}

--- a/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs
@@ -1500,6 +1500,9 @@ internal static class SelfTestFixtureRegistry
         "InitialOnly",
         "BrushHelperParse",
         "CrossAxisMeasureStaleness",
+        // Issue #845 — LV/GV Update clears Header/ItemContainerStyle to null
+        "Issue845_ListViewClearsHeaderAndStyle",
+        "Issue845_GridViewClearsHeaderAndStyle",
     ];
 
     public static SelfTestFixtureBase? Create(string name, Harness harness) => name switch
@@ -2950,6 +2953,8 @@ internal static class SelfTestFixtureRegistry
         "InitialOnly" => new InitialOnlyFixture.Execution(harness),
         "BrushHelperParse" => new BrushHelperParseFixture.Execution(harness),
         "CrossAxisMeasureStaleness" => new CrossAxisMeasureStalenessFixture(harness),
+        "Issue845_ListViewClearsHeaderAndStyle" => new Issue845ClearHeaderItemContainerStyleFixtures.ListViewClearsHeaderAndItemContainerStyle(harness),
+        "Issue845_GridViewClearsHeaderAndStyle" => new Issue845ClearHeaderItemContainerStyleFixtures.GridViewClearsHeaderAndItemContainerStyle(harness),
 
         _ => null,
     };


### PR DESCRIPTION
Fixes #845

## Problem
`ListViewHandler.Update` and `GridViewHandler.Update` gated the `Header` and `ItemContainerStyle` assignments on the **new value being non-null**:

```csharp
if (n.Header is not null) lv.Header = n.Header;
if (!ReferenceEquals(o.ItemContainerStyle, n.ItemContainerStyle) && n.ItemContainerStyle is not null)
    lv.ItemContainerStyle = n.ItemContainerStyle;
```

So a present→null transition was a no-op and the stale value stayed on the live WinUI control — you could never clear a `Header`/`ItemContainerStyle` dynamically once set.

## Fix
Gate each assignment on **change** (`!ReferenceEquals`), not non-null presence, so a clear-to-null is applied — symmetric across both handlers:

```csharp
if (!ReferenceEquals(o.Header, n.Header)) lv.Header = n.Header;
if (!ReferenceEquals(o.ItemContainerStyle, n.ItemContainerStyle))
    lv.ItemContainerStyle = n.ItemContainerStyle;
```

`Header`/`ItemContainerStyle` raise no WinUI events (unlike `SelectedIndex`, which keeps its #495/#464 echo-suppression), so no suppression is needed. WinUI accepts `null` for both (removes the header / resets the default container style). Mount is unchanged — control defaults are already null there, so only `Update` was buggy. `SelectionMode`/`IsItemClickEnabled`/`IncrementalLoadingTrigger` are untouched.

## Test
New selftest fixtures (`Issue845ClearHeaderItemContainerStyleFixtures`) — the symptom is a live control property, so these need a real WinUI control. Each mounts a ListView/GridView with a non-null `Header` + `ItemContainerStyle`, re-renders with both `null`, and asserts the live control's properties are cleared.

## Red→green proof (CI-sequenced)
The local selftest tier is broken on the dev box by the known `WMC9999` XAML-markup-compiler crash, so red→green was demonstrated on CI (#836-style), split across the two commits on this branch:

- **RED** — commit `ac9414df` (fixtures + registry only, no handler fix) → run [28926177864](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/28926177864). Build + Unit Tests **passed** (fixtures compile), Selftests **failed** on exactly:
  - `Issue845_LV_HeaderClearedToNull`, `Issue845_LV_StyleClearedToNull`
  - `Issue845_GV_HeaderClearedToNull`, `Issue845_GV_StyleClearedToNull`
  
  (the `*_Set_Initial` sanity checks passed, so the set worked and only the clear-to-null was broken).
- **GREEN** — commit `c024f46c` (+ handler fix) → run [28926778476](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/28926778476) (**whole run green**): `Passed Fixture("Issue845_ListViewClearsHeaderAndStyle")` + `Passed Fixture("Issue845_GridViewClearsHeaderAndStyle")`.

Also verified locally: `dotnet build src/Reactor` clean (0 errors); headless unit tier `dotnet test tests/Reactor.Tests -p:Platform=x64` → 12319 passed / 64 skipped / 0 failed.

---
Draft until dual-review + guarded merge. No self-merge.