### PR TITLE
Coverage PR comment: show the main baseline and the PR's delta

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -78,24 +78,34 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set +e
-          rows=$(gh api "repos/$GH_REPO/actions/workflows/coverage.yml/runs?branch=main&status=success&per_page=30" \
-                   --jq '.workflow_runs[] | "\(.id) \(.head_sha)"')
-          if [ $? -ne 0 ]; then
-            echo "::warning::Could not list main Coverage runs (API error); rendering baseline-unavailable."
-            rows=""
-          fi
           base_sha=""
           found=false
-          while IFS=' ' read -r id sha; do
-            [ -z "$id" ] && continue
-            # Expired/absent artifacts (or non-baseline main runs) fail here — skip to
-            # the next candidate; that is expected, so keep this download quiet.
-            if gh run download "$id" --repo "$GH_REPO" -n coverage-baseline -D baseline 2>/dev/null; then
-              base_sha="$sha"
-              found=true
+          page=1
+          # Page through successful main runs (newest first), breaking as soon as a
+          # coverage-baseline artifact downloads. Bounded to a few pages so a long run
+          # of non-baseline dispatch runs can't push the newest baseline out of view
+          # (the reason a single 30-run window was unreliable) without unbounded API
+          # calls. In practice the baseline is on page 1.
+          while [ "$found" != "true" ] && [ "$page" -le 5 ]; do
+            rows=$(gh api "repos/$GH_REPO/actions/workflows/coverage.yml/runs?branch=main&status=success&per_page=100&page=$page" \
+                     --jq '.workflow_runs[] | "\(.id) \(.head_sha)"')
+            if [ $? -ne 0 ]; then
+              echo "::warning::Could not list main Coverage runs (API error); rendering baseline-unavailable."
               break
             fi
-          done <<< "$rows"
+            [ -z "$rows" ] && break   # no more runs
+            while IFS=' ' read -r id sha; do
+              [ -z "$id" ] && continue
+              # Expired/absent artifacts (or non-baseline main runs) fail here — skip to
+              # the next candidate; that is expected, so keep this download quiet.
+              if gh run download "$id" --repo "$GH_REPO" -n coverage-baseline -D baseline 2>/dev/null; then
+                base_sha="$sha"
+                found=true
+                break
+              fi
+            done <<< "$rows"
+            page=$((page + 1))
+          done
           echo "found=$found" >> "$GITHUB_OUTPUT"
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
           if [ "$found" = "true" ]; then

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -117,19 +117,14 @@ jobs:
           }
           $head = ConvertTo-SafeCoverageMetrics (Read-CoverageJson 'artifact/head.coverage.json')
           $base = ConvertTo-SafeCoverageMetrics (Read-CoverageJson 'artifact/base.coverage.json')
-          $headPresent = Test-CoverageMetricsPresent $head
-          $basePresent = Test-CoverageMetricsPresent $base
-          if (-not $headPresent) {
-            $body = Format-CoverageComment -Failed -HeadSha $env:HEAD_SHA -RunUrl $env:RUN_URL
-          } elseif ($basePresent) {
-            $body = Format-CoverageComment -BaseMetrics $base -HeadMetrics $head `
-              -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
-          } else {
-            $body = Format-CoverageComment -HeadMetrics $head -BaselineUnavailable `
-              -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
-          }
+          # A PR always has a base, so the base file's presence (kept only when the
+          # base leg succeeded) selects comparison vs baseline-unavailable.
+          $body = Format-CoverageCommentFromMetrics -HeadMetrics $head -BaseMetrics $base -HasBase $true `
+            -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
           New-Item -ItemType Directory -Force -Path out | Out-Null
           Set-Content -LiteralPath out/comment.md -Value $body -Encoding UTF8
+          $headPresent = Test-CoverageMetricsPresent $head
+          $basePresent = Test-CoverageMetricsPresent $base
           Write-Host "Rendered coverage comment (headPresent=$headPresent basePresent=$basePresent)"
 
       - name: Post / update sticky comment

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,20 +1,22 @@
 # Privileged poster for the automatic coverage comparison comment.
 #
-# The measure workflow (coverage.yml) builds + runs untrusted PR code for the PR
-# head AND its base branch, so it runs unprivileged and uploads ONLY the per-side
-# coverage numbers (head/base.coverage.json). This workflow runs from the DEFAULT
-# branch with a write token, executes NO PR code, checks out TRUSTED default-branch
-# code, RENDERS the comparison comment itself (via the trusted CoverageLib.ps1) from
-# re-validated numbers, and posts/updates the sticky comment. Standard secure
-# pull_request + workflow_run split (see coverage.yml + build-metrics-comment.yml).
+# The measure workflow (coverage.yml) builds + runs untrusted PR code, so it runs
+# unprivileged and uploads ONLY the PR head's coverage numbers (coverage-data). This
+# workflow runs from the DEFAULT branch with a write token, executes NO PR code,
+# checks out TRUSTED default-branch code, fetches the cached `main` baseline
+# (coverage-baseline, produced by a push-to-main measure run), RENDERS the comparison
+# comment itself from re-validated numbers, and posts/updates the sticky comment.
+# Standard secure pull_request + workflow_run split (see coverage.yml).
 #
 # Security:
-#   - The comment body is built here from a fixed template + numeric values that are
-#     re-validated (ConvertTo-SafeCoverageMetrics: percentages in [0,100] and
-#     non-negative integer counts; everything else dropped to null) before use, so
-#     the untrusted artifact can never inject markdown into a bot-authored comment.
-#   - The target PR (and its base SHA) are resolved from the TRUSTED
-#     github.event.workflow_run head SHA, never from the artifact.
+#   - The comment body is built here from a fixed template + numbers re-validated via
+#     ConvertTo-SafeCoverageMetrics (percentages in [0,100], non-negative integer
+#     counts; everything else dropped to null), so neither the untrusted PR artifact
+#     nor the baseline artifact can inject markdown into a bot-authored comment.
+#   - The target PR is resolved from the TRUSTED github.event.workflow_run head SHA,
+#     never from an artifact.
+#   - The baseline is produced by a push to the default branch (main code), so its
+#     numbers are trustworthy; they are re-validated anyway.
 name: Coverage comment
 
 on:
@@ -24,7 +26,7 @@ on:
 
 permissions:
   contents: read
-  actions: read          # download the triggering run's artifact
+  actions: read          # download the triggering run's artifact + the baseline
   pull-requests: write   # resolve the PR + post/update the comment
   issues: write          # PR conversation comments use the issues API
 
@@ -32,9 +34,9 @@ jobs:
   comment:
     name: Post coverage comment
     runs-on: ubuntu-latest
-    # Only PR-originated measure runs produce a comment. A workflow_dispatch measure
-    # run has no PR to safely resolve from its head SHA, so skip the poster entirely
-    # (the numbers still live in that run's artifact + summary).
+    # Only PR-originated measure runs produce a comment. Push (baseline) and
+    # workflow_dispatch runs have no PR to safely resolve from their head SHA, so
+    # skip the poster entirely (their numbers still live in the run's artifact).
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       # Trusted default-branch checkout — the source of the comment renderer.
@@ -44,7 +46,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download coverage data artifact
+      - name: Download coverage data artifact (PR head)
         id: dl
         env:
           GH_TOKEN: ${{ github.token }}
@@ -53,17 +55,57 @@ jobs:
         run: |
           set +e
           gh run download "$RUN_ID" --repo "$GH_REPO" -n coverage-data -D artifact
-          if [ ! -f artifact/head.coverage.json ]; then
+          if [ ! -f artifact/coverage.json ]; then
             echo "No head coverage data on run $RUN_ID; nothing to post."
             echo "have_data=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "have_data=true" >> "$GITHUB_OUTPUT"
 
-      # Resolve the PR + its base SHA SOLELY from the trusted workflow_run head SHA —
-      # never from the (untrusted) artifact. One commits/{sha}/pulls call returns the
-      # PR object, from which we read the number + base sha. The job `if` already
-      # restricts this to pull_request-originated runs.
+      # Fetch the cached main baseline: the newest successful Coverage run on `main`
+      # that still has a coverage-baseline artifact (produced by a push to main, or a
+      # manual default-branch refresh; older artifacts expire). branch=main excludes
+      # PR runs (different head branch), and only baseline-publishing runs carry the
+      # artifact, so a non-baseline main run is simply skipped by the download. Its
+      # numbers are trusted (main code produced them) and re-validated at render time.
+      # Best-effort: if none is found (e.g. before the first post-merge baseline, or an
+      # API error), the comment degrades to "baseline unavailable".
+      - name: Fetch cached main baseline
+        id: baseline
+        if: steps.dl.outputs.have_data == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set +e
+          rows=$(gh api "repos/$GH_REPO/actions/workflows/coverage.yml/runs?branch=main&status=success&per_page=30" \
+                   --jq '.workflow_runs[] | "\(.id) \(.head_sha)"')
+          if [ $? -ne 0 ]; then
+            echo "::warning::Could not list main Coverage runs (API error); rendering baseline-unavailable."
+            rows=""
+          fi
+          base_sha=""
+          found=false
+          while IFS=' ' read -r id sha; do
+            [ -z "$id" ] && continue
+            # Expired/absent artifacts (or non-baseline main runs) fail here — skip to
+            # the next candidate; that is expected, so keep this download quiet.
+            if gh run download "$id" --repo "$GH_REPO" -n coverage-baseline -D baseline 2>/dev/null; then
+              base_sha="$sha"
+              found=true
+              break
+            fi
+          done <<< "$rows"
+          echo "found=$found" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          if [ "$found" = "true" ]; then
+            echo "Using cached main baseline from $base_sha"
+          else
+            echo "No cached main baseline found; will render baseline-unavailable."
+          fi
+
+      # Resolve the PR SOLELY from the trusted workflow_run head SHA — never from an
+      # artifact. The job `if` already restricts this to pull_request-originated runs.
       - name: Resolve target PR
         id: pr
         if: steps.dl.outputs.have_data == 'true'
@@ -72,53 +114,48 @@ jobs:
           GH_REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          pr_json=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
-                 --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0]" 2>/dev/null || true)
-          pr=$(printf '%s' "$pr_json" | jq -r '.number // empty' 2>/dev/null || true)
-          basesha=$(printf '%s' "$pr_json" | jq -r '.base.sha // empty' 2>/dev/null || true)
-          if [ -z "$pr" ]; then
+          pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
+                 --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
             echo "No open PR for head $HEAD_SHA; nothing to post."
             echo "number=" >> "$GITHUB_OUTPUT"
-            exit 0
+          else
+            echo "Target PR: #$pr"
+            echo "number=$pr" >> "$GITHUB_OUTPUT"
           fi
-          echo "Target PR: #$pr"
-          # Validate the base SHA (40 hex chars); if the lookup returned null/empty,
-          # emit an empty value so the renderer shows the base column without a stray
-          # "(null)" in the header.
-          if ! printf '%s' "$basesha" | grep -Eq '^[0-9a-f]{40}$'; then
-            basesha=""
-          fi
-          echo "number=$pr" >> "$GITHUB_OUTPUT"
-          echo "base_sha=$basesha" >> "$GITHUB_OUTPUT"
 
-      # Render the comment from TRUSTED code + numbers re-validated here. The
-      # untrusted head/base.coverage.json are passed through ConvertTo-SafeCoverageMetrics,
-      # which keeps only in-range percentages and non-negative integer counts — so
-      # nothing from the artifact can inject markdown. The head SHA is the trusted
-      # workflow_run head (exactly what was measured); the base SHA comes from the
-      # same trusted commits/{sha}/pulls lookup.
+      # Render from TRUSTED code + numbers re-validated here. The head (untrusted PR
+      # artifact) and the base (trusted baseline artifact) both go through
+      # ConvertTo-SafeCoverageMetrics, so nothing from either artifact can inject
+      # markdown. The head SHA is the trusted workflow_run head; the base SHA is the
+      # baseline run's commit.
       - name: Render comment (trusted)
         id: render
         if: steps.dl.outputs.have_data == 'true' && steps.pr.outputs.number != ''
         shell: pwsh
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          BASE_SHA: ${{ steps.baseline.outputs.base_sha }}
+          BASE_FOUND: ${{ steps.baseline.outputs.found }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
           . ./tests/coverage/ci/CoverageLib.ps1
-          # The *.coverage.json are untrusted artifacts; a malformed file must not
-          # crash the poster (which would drop the comment). Treat a parse failure as
-          # missing data so the failed / baseline-unavailable paths render.
+          # Artifacts are untrusted; a malformed file must not crash the poster (which
+          # would drop the comment). Treat a parse failure as missing data so the
+          # failed / baseline-unavailable paths render.
           function Read-CoverageJson($path) {
             if (-not (Test-Path $path)) { return $null }
             try { return Get-Content $path -Raw | ConvertFrom-Json }
             catch { Write-Host "Ignoring malformed ${path}: $($_.Exception.Message)"; return $null }
           }
-          $head = ConvertTo-SafeCoverageMetrics (Read-CoverageJson 'artifact/head.coverage.json')
-          $base = ConvertTo-SafeCoverageMetrics (Read-CoverageJson 'artifact/base.coverage.json')
-          # A PR always has a base, so the base file's presence (kept only when the
-          # base leg succeeded) selects comparison vs baseline-unavailable.
+          $head = ConvertTo-SafeCoverageMetrics (Read-CoverageJson 'artifact/coverage.json')
+          $base = if ($env:BASE_FOUND -eq 'true') {
+            ConvertTo-SafeCoverageMetrics (Read-CoverageJson 'baseline/coverage.json')
+          } else {
+            ConvertTo-SafeCoverageMetrics $null
+          }
+          # A PR always has a conceptual base; the cached baseline's presence selects
+          # comparison vs baseline-unavailable.
           $body = Format-CoverageCommentFromMetrics -HeadMetrics $head -BaseMetrics $base -HasBase $true `
             -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
           New-Item -ItemType Directory -Force -Path out | Out-Null

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,15 +1,20 @@
-# Privileged poster for the automatic coverage comment.
+# Privileged poster for the automatic coverage comparison comment.
 #
-# The measure workflow (coverage.yml) builds + runs untrusted PR code, so it runs
-# unprivileged and uploads ONLY the coverage numbers (coverage.json). This workflow
-# runs from the DEFAULT branch with a write token, executes NO PR code, RENDERS the
-# comment itself from validated numbers, and posts/updates the sticky comment.
-# Standard secure pull_request + workflow_run split (see coverage.yml).
+# The measure workflow (coverage.yml) builds + runs untrusted PR code for the PR
+# head AND its base branch, so it runs unprivileged and uploads ONLY the per-side
+# coverage numbers (head/base.coverage.json). This workflow runs from the DEFAULT
+# branch with a write token, executes NO PR code, checks out TRUSTED default-branch
+# code, RENDERS the comparison comment itself (via the trusted CoverageLib.ps1) from
+# re-validated numbers, and posts/updates the sticky comment. Standard secure
+# pull_request + workflow_run split (see coverage.yml + build-metrics-comment.yml).
 #
-# Security: the comment body is built here from a fixed template + numeric values
-# that are re-validated (a non-negative number, optionally with a decimal part)
-# before use; the target PR is resolved from the TRUSTED
-# github.event.workflow_run head SHA, never from the artifact.
+# Security:
+#   - The comment body is built here from a fixed template + numeric values that are
+#     re-validated (ConvertTo-SafeCoverageMetrics: percentages in [0,100] and
+#     non-negative integer counts; everything else dropped to null) before use, so
+#     the untrusted artifact can never inject markdown into a bot-authored comment.
+#   - The target PR (and its base SHA) are resolved from the TRUSTED
+#     github.event.workflow_run head SHA, never from the artifact.
 name: Coverage comment
 
 on:
@@ -32,6 +37,13 @@ jobs:
     # (the numbers still live in that run's artifact + summary).
     if: github.event.workflow_run.event == 'pull_request'
     steps:
+      # Trusted default-branch checkout — the source of the comment renderer.
+      # workflow_run always runs the default-branch version of this workflow, and
+      # this checkout (no ref) pulls the default branch, NEVER the PR's code.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Download coverage data artifact
         id: dl
         env:
@@ -41,15 +53,17 @@ jobs:
         run: |
           set +e
           gh run download "$RUN_ID" --repo "$GH_REPO" -n coverage-data -D artifact
-          if [ ! -f artifact/coverage.json ]; then
-            echo "No coverage-data artifact on run $RUN_ID; nothing to post."
+          if [ ! -f artifact/head.coverage.json ]; then
+            echo "No head coverage data on run $RUN_ID; nothing to post."
             echo "have_data=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "have_data=true" >> "$GITHUB_OUTPUT"
 
-      # Resolve the PR SOLELY from the trusted workflow_run head SHA — never from
-      # the (untrusted) artifact.
+      # Resolve the PR + its base SHA SOLELY from the trusted workflow_run head SHA —
+      # never from the (untrusted) artifact. One commits/{sha}/pulls call returns the
+      # PR object, from which we read the number + base sha. The job `if` already
+      # restricts this to pull_request-originated runs.
       - name: Resolve target PR
         id: pr
         if: steps.dl.outputs.have_data == 'true'
@@ -58,74 +72,65 @@ jobs:
           GH_REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          pr=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
-                 --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0].number" 2>/dev/null || true)
-          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+          pr_json=$(gh api "repos/$GH_REPO/commits/$HEAD_SHA/pulls" \
+                 --jq "[.[] | select(.state==\"open\") | select(.head.sha==\"$HEAD_SHA\")][0]" 2>/dev/null || true)
+          pr=$(printf '%s' "$pr_json" | jq -r '.number // empty' 2>/dev/null || true)
+          basesha=$(printf '%s' "$pr_json" | jq -r '.base.sha // empty' 2>/dev/null || true)
+          if [ -z "$pr" ]; then
             echo "No open PR for head $HEAD_SHA; nothing to post."
             echo "number=" >> "$GITHUB_OUTPUT"
-          else
-            echo "Target PR: #$pr"
-            echo "number=$pr" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "Target PR: #$pr"
+          # Validate the base SHA (40 hex chars); if the lookup returned null/empty,
+          # emit an empty value so the renderer shows the base column without a stray
+          # "(null)" in the header.
+          if ! printf '%s' "$basesha" | grep -Eq '^[0-9a-f]{40}$'; then
+            basesha=""
+          fi
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$basesha" >> "$GITHUB_OUTPUT"
 
-      # Render the comment from a FIXED template + numbers re-validated here (a
-      # non-negative number, optionally with a decimal part).
+      # Render the comment from TRUSTED code + numbers re-validated here. The
+      # untrusted head/base.coverage.json are passed through ConvertTo-SafeCoverageMetrics,
+      # which keeps only in-range percentages and non-negative integer counts — so
+      # nothing from the artifact can inject markdown. The head SHA is the trusted
+      # workflow_run head (exactly what was measured); the base SHA comes from the
+      # same trusted commits/{sha}/pulls lookup.
       - name: Render comment (trusted)
         id: render
         if: steps.dl.outputs.have_data == 'true' && steps.pr.outputs.number != ''
         shell: pwsh
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
-          # coverage.json is an untrusted artifact; a malformed file must not crash
-          # the poster (which would drop the comment). Fall back to an empty object
-          # so the CAUTION "run failed" path renders.
-          try { $d = Get-Content artifact/coverage.json -Raw | ConvertFrom-Json }
-          catch { Write-Host "Malformed coverage.json: $($_.Exception.Message)"; $d = [pscustomobject]@{} }
-          function Get-Prop($obj, $name) {
-            if ($obj.PSObject.Properties[$name]) { return $obj.$name } else { return $null }
+          . ./tests/coverage/ci/CoverageLib.ps1
+          # The *.coverage.json are untrusted artifacts; a malformed file must not
+          # crash the poster (which would drop the comment). Treat a parse failure as
+          # missing data so the failed / baseline-unavailable paths render.
+          function Read-CoverageJson($path) {
+            if (-not (Test-Path $path)) { return $null }
+            try { return Get-Content $path -Raw | ConvertFrom-Json }
+            catch { Write-Host "Ignoring malformed ${path}: $($_.Exception.Message)"; return $null }
           }
-          function SafeNum($v) {
-            if ($null -eq $v) { return $null }
-            $s = ([string]$v).Trim()
-            if ($s -match '^\d+(\.\d+)?$') { return $s } else { return $null }
-          }
-          $line = SafeNum (Get-Prop $d 'line')
-          $branch = SafeNum (Get-Prop $d 'branch')
-          $bc = SafeNum (Get-Prop $d 'branchesCovered')
-          $bt = SafeNum (Get-Prop $d 'branchesTotal')
-          $sha = $env:HEAD_SHA
-          $sha7 = if ($sha) { $sha.Substring(0, [math]::Min(7, $sha.Length)) } else { 'unknown' }
-          $marker = '<!-- reactor-coverage -->'
-          $ok = ((Get-Prop $d 'outcome') -eq 'success') -and ($null -ne $line) -and ($null -ne $branch)
-          if ($ok) {
-            $branchCell = if ($null -ne $bc -and $null -ne $bt) { "$branch% ($bc/$bt)" } else { "$branch%" }
-            $body = @(
-              $marker,
-              '## 🧪 Merged coverage',
-              '',
-              "Coverage for ``$sha7`` (unit + selftest).",
-              '',
-              '| Metric | Coverage |',
-              '|---|---|',
-              "| Line   | $line% |",
-              "| Branch | $branchCell |",
-              '',
-              "<sub>Cobertura reports attached to the <a href=`"$env:RUN_URL`">workflow run</a> as artifacts.</sub>"
-            ) -join "`n"
+          $head = ConvertTo-SafeCoverageMetrics (Read-CoverageJson 'artifact/head.coverage.json')
+          $base = ConvertTo-SafeCoverageMetrics (Read-CoverageJson 'artifact/base.coverage.json')
+          $headPresent = Test-CoverageMetricsPresent $head
+          $basePresent = Test-CoverageMetricsPresent $base
+          if (-not $headPresent) {
+            $body = Format-CoverageComment -Failed -HeadSha $env:HEAD_SHA -RunUrl $env:RUN_URL
+          } elseif ($basePresent) {
+            $body = Format-CoverageComment -BaseMetrics $base -HeadMetrics $head `
+              -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
           } else {
-            $body = @(
-              $marker,
-              '## 🧪 Merged coverage',
-              '',
-              '> [!CAUTION]',
-              "> Coverage run failed for ``$sha7`` — see the [workflow run]($env:RUN_URL) for details."
-            ) -join "`n"
+            $body = Format-CoverageComment -HeadMetrics $head -BaselineUnavailable `
+              -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA -RunUrl $env:RUN_URL
           }
           New-Item -ItemType Directory -Force -Path out | Out-Null
           Set-Content -LiteralPath out/comment.md -Value $body -Encoding UTF8
-          Write-Host "Rendered coverage comment (ok=$ok)"
+          Write-Host "Rendered coverage comment (headPresent=$headPresent basePresent=$basePresent)"
 
       - name: Post / update sticky comment
         if: steps.dl.outputs.have_data == 'true' && steps.pr.outputs.number != ''

--- a/.github/workflows/coverage-lib-tests.yml
+++ b/.github/workflows/coverage-lib-tests.yml
@@ -4,8 +4,8 @@
 # instrumentation, so this runs on a cheap Linux runner in seconds and guards the
 # parsing + formatting + delta logic on every change under tests/coverage/ci/**.
 #
-# coverage.yml runs these same assertions before it spends ~40 min measuring both
-# sides; this standalone job gives PR authors fast feedback without a full run.
+# coverage.yml runs these same assertions before it spends ~10 min on the
+# instrumented measure; this standalone job gives PR authors fast feedback.
 name: Coverage lib tests
 
 on:

--- a/.github/workflows/coverage-lib-tests.yml
+++ b/.github/workflows/coverage-lib-tests.yml
@@ -1,0 +1,42 @@
+# Fast, headless unit tests for CoverageLib.ps1 + Measure-Coverage.ps1 — the pure
+# cobertura parser / percent-format / delta / comment-renderer that backs the
+# automatic coverage comparison comment (coverage.yml). No build and no
+# instrumentation, so this runs on a cheap Linux runner in seconds and guards the
+# parsing + formatting + delta logic on every change under tests/coverage/ci/**.
+#
+# coverage.yml runs these same assertions before it spends ~40 min measuring both
+# sides; this standalone job gives PR authors fast feedback without a full run.
+name: Coverage lib tests
+
+on:
+  push:
+    paths:
+      - 'tests/coverage/ci/**'
+      - '.github/workflows/coverage-lib-tests.yml'
+  pull_request:
+    paths:
+      - 'tests/coverage/ci/**'
+      - '.github/workflows/coverage-lib-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  coveragelib:
+    name: CoverageLib parser + delta math
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # pwsh (PowerShell 7) is preinstalled on the GitHub-hosted Ubuntu runner.
+      # Each test script exits non-zero on any failed assertion.
+      - name: Run CoverageLib unit tests
+        shell: pwsh
+        run: ./tests/coverage/ci/CoverageLib.Tests.ps1
+
+      - name: Run Measure-Coverage unit tests
+        shell: pwsh
+        run: ./tests/coverage/ci/Measure-Coverage.Tests.ps1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -255,15 +255,12 @@ jobs:
           $out = Join-Path $env:GITHUB_WORKSPACE 'coverage-out'
           $head = ConvertTo-SafeCoverageMetrics (Read-Json (Join-Path $out 'head.coverage.json'))
           $base = ConvertTo-SafeCoverageMetrics (Read-Json (Join-Path $out 'base.coverage.json'))
-          if (-not (Test-CoverageMetricsPresent $head)) {
-            $body = Format-CoverageComment -Failed -HeadSha $env:HEAD_SHA
-          } elseif ($env:HAS_BASE -eq 'true' -and (Test-CoverageMetricsPresent $base)) {
-            $body = Format-CoverageComment -BaseMetrics $base -HeadMetrics $head -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA
-          } elseif ($env:HAS_BASE -eq 'true') {
-            $body = Format-CoverageComment -HeadMetrics $head -BaselineUnavailable -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA
-          } else {
-            $body = Format-CoverageComment -HeadMetrics $head -BaselineUnavailable -HeadSha $env:HEAD_SHA
-          }
+          # Same selector the poster uses. For a blank-input branch dispatch HAS_BASE
+          # is false, so this renders the absolute (no-baseline) summary rather than a
+          # misleading "baseline unavailable" note.
+          $hasBase = ($env:HAS_BASE -eq 'true')
+          $body = Format-CoverageCommentFromMetrics -HeadMetrics $head -BaseMetrics $base -HasBase $hasBase `
+            -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA
           # Drop the leading sticky marker line for the summary (it is an HTML comment
           # meant for the PR-comment lookup, not the run summary).
           $summary = ($body -split "`n" | Select-Object -Skip 1) -join "`n"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -107,10 +107,14 @@ jobs:
             core.setOutput('number', prNumber);
             core.setOutput('has_base', hasBase ? 'true' : 'false');
 
-      # Trusted checkout of the scripts + the ability to worktree head/base. For a
-      # pull_request event this is the merge ref; the head/base COMMITS are built in
-      # their own worktrees below (never the merge). fetch-depth: 0 so origin/<base>
-      # resolves. persist-credentials: false — untrusted PR build code runs later.
+      # Checkout for the scripts + the ability to worktree head/base. On a
+      # pull_request event this is the PR MERGE ref — i.e. PR-authored code, NOT
+      # trusted — but this job is unprivileged (read-only token, no secrets), so
+      # running the PR's own measurement scripts here is acceptable; the trusted
+      # poster (coverage-comment.yml) is what renders + posts. The head/base COMMITS
+      # are measured in their own worktrees below (never the merge). fetch-depth: 0
+      # so origin/<base> resolves. persist-credentials: false — the PR build code
+      # that runs later gets no usable git credential.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
@@ -166,6 +170,11 @@ jobs:
               $baseRef = $env:BASE_REF
               if ($baseSha -notmatch '^[0-9a-f]{40}$') { throw "Could not resolve base sha (got '$baseSha')." }
               if ([string]::IsNullOrWhiteSpace($baseRef)) { throw 'Could not resolve base ref.' }
+              # base_ref comes from the trusted PR event/API (the base branch name),
+              # but it is interpolated into a git refspec below — constrain it to a
+              # conservative branch-name allow-list so an unexpected character can't
+              # alter the refspec. A reject degrades to "baseline unavailable".
+              if ($baseRef -notmatch '^[A-Za-z0-9._/-]+$') { throw "Base ref '$baseRef' has unexpected characters." }
               git fetch --no-tags --force origin "refs/heads/${baseRef}:refs/remotes/origin/${baseRef}" 2>&1 | Out-Host
               if ($LASTEXITCODE -ne 0) { throw "git fetch of base ref '$baseRef' failed (exit $LASTEXITCODE)." }
               $baseTree = Join-Path $env:RUNNER_TEMP 'cov-base-tree'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,30 +1,33 @@
 name: Coverage
 
 # Automatic merged unit + selftest coverage on every PR, posted as a sticky,
-# self-updating comment. Runs the merged coverage recipe from TESTING.md and
-# reports line + branch rates. Also runnable manually:
-#   - workflow_dispatch with a PR number  -> measures that PR (works for forks);
+# self-updating comment that compares the PR head against its base branch (the
+# `main` baseline in the common case) and shows the per-metric delta. Runs the
+# merged coverage recipe from TESTING.md for BOTH sides and reports line + branch
+# rates with a signed Δ. Also runnable manually:
+#   - workflow_dispatch with a PR number  -> measures that PR vs its base (forks too);
 #   - workflow_dispatch with the number blank -> measures the selected branch and
-#     writes the result to the run's job summary (no PR to comment on).
+#     writes the (absolute, no-baseline) result to the run's job summary.
 #
 # ── Security: why pull_request + workflow_run (not issue_comment) ──────────────
-# Coverage BUILDS + INSTRUMENTS + RUNS the PR's code (build scripts and tests
-# execute here). The old design triggered on `issue_comment` — which runs in the
-# base repo with a full write token — so it had to be gated to maintainers via
-# author_association. Running it automatically on every PR under that model would
-# hand a write token to untrusted PR code, which is unsafe.
+# Coverage BUILDS + INSTRUMENTS + RUNS code (build scripts and tests execute here)
+# for the PR head AND the base branch. The old design triggered on `issue_comment`
+# — which runs in the base repo with a full write token — so it had to be gated to
+# maintainers via author_association. Running it automatically on every PR under
+# that model would hand a write token to untrusted PR code, which is unsafe.
 #
 # Instead this workflow runs in the unprivileged `pull_request` context: a
 # read-only token, no secrets, and NO ability to comment. It writes the result to
-# the run summary and uploads ONLY the raw coverage numbers; the privileged
-# `coverage-comment.yml` (`workflow_run`) checks out trusted code, renders the
-# comment, and posts it. That split runs untrusted build code with zero write
-# privilege and still comments on PRs — including from forks. It mirrors
-# build-metrics.yml and the trust boundary documented in perf-compare.yml.
+# the run summary and uploads ONLY the raw coverage numbers (per side); the
+# privileged `coverage-comment.yml` (`workflow_run`) checks out trusted code,
+# renders the comparison comment, and posts it. That split runs untrusted build
+# code with zero write privilege and still comments on PRs — including from forks.
+# It mirrors build-metrics.yml (which likewise measures both head + base) and the
+# trust boundary documented in perf-compare.yml.
 
 on:
   pull_request:
-    # Doc-only PRs change no measured code; skip the ~10-min instrumented run.
+    # Doc-only PRs change no measured code; skip the (now doubled) instrumented run.
     # This includes the docs/_pipeline templates + doc apps that generate the guide.
     paths-ignore:
       - '**/*.md'
@@ -33,14 +36,14 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: PR to measure. Leave blank to measure the selected branch instead.
+        description: PR to measure (vs its base branch). Leave blank to measure the selected branch instead.
         required: false
         type: string
 
 # Read-only: this job runs untrusted PR code and must not hold a write token.
 # The comment is posted by the separate privileged workflow_run workflow.
 # pull-requests: read only serves the manual workflow_dispatch path (resolving a
-# PR's head sha via the API); the automatic pull_request path uses the event.
+# PR's head/base via the API); the automatic pull_request path uses the event.
 permissions:
   contents: read
   pull-requests: read
@@ -54,26 +57,29 @@ jobs:
       group: coverage-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.ref }}
       cancel-in-progress: true
     runs-on: windows-latest
+    # Two instrumented merged-coverage passes (head + base) run sequentially.
+    timeout-minutes: 60
     steps:
       - name: Resolve coverage target
         id: pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          EVENT_NAME: ${{ github.event_name }}
           DISPATCH_PR: ${{ github.event.inputs.pr_number }}
         with:
           script: |
-            // Resolve what to measure:
-            //   - pull_request             -> the PR that triggered the run
-            //   - workflow_dispatch + PR#  -> that PR (works for forks)
-            //   - workflow_dispatch, blank -> the dispatched branch (no PR)
+            // Resolve what to measure + the base to compare against:
+            //   - pull_request             -> the PR that triggered the run (+ its base)
+            //   - workflow_dispatch + PR#  -> that PR (+ its base; works for forks)
+            //   - workflow_dispatch, blank -> the dispatched branch (NO base baseline)
             let prNumber = '';
+            let hasBase = false;
             if (context.eventName === 'pull_request') {
               const pr = context.payload.pull_request;
               prNumber = String(pr.number);
-              core.setOutput('sha', pr.head.sha);
-              // Build the PR head commit; refs/pull/N/head resolves for forks too.
-              core.setOutput('ref', `refs/pull/${pr.number}/head`);
+              core.setOutput('head_sha', pr.head.sha);
+              core.setOutput('base_sha', pr.base.sha);
+              core.setOutput('base_ref', pr.base.ref);
+              hasBase = true;
             } else {
               const raw = process.env.DISPATCH_PR || '';
               if (raw !== '') {
@@ -86,19 +92,28 @@ jobs:
                   repo: context.repo.repo,
                   pull_number: Number(prNumber),
                 });
-                core.setOutput('sha', pr.data.head.sha);
-                core.setOutput('ref', `refs/pull/${prNumber}/head`);
+                core.setOutput('head_sha', pr.data.head.sha);
+                core.setOutput('base_sha', pr.data.base.sha);
+                core.setOutput('base_ref', pr.data.base.ref);
+                hasBase = true;
               } else {
-                // No PR: measure the commit the workflow was dispatched on.
-                core.setOutput('sha', context.sha);
-                core.setOutput('ref', context.sha);
+                // No PR: measure the commit the workflow was dispatched on, with no
+                // base baseline (absolute numbers only).
+                core.setOutput('head_sha', context.sha);
+                core.setOutput('base_sha', '');
+                core.setOutput('base_ref', '');
               }
             }
             core.setOutput('number', prNumber);
+            core.setOutput('has_base', hasBase ? 'true' : 'false');
 
+      # Trusted checkout of the scripts + the ability to worktree head/base. For a
+      # pull_request event this is the merge ref; the head/base COMMITS are built in
+      # their own worktrees below (never the merge). fetch-depth: 0 so origin/<base>
+      # resolves. persist-credentials: false — untrusted PR build code runs later.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.pr.outputs.ref }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup .NET
@@ -109,124 +124,184 @@ jobs:
       - name: Install dotnet-coverage
         run: dotnet tool install -g dotnet-coverage
 
-      - name: Build for instrumentation
+      # Cheap guard: run the pure parser + delta-math tests before spending ~40 min
+      # measuring both sides. Also runs standalone in coverage-lib-tests.yml on PRs.
+      - name: Test coverage scripts
         shell: pwsh
         run: |
-          dotnet build tests/Reactor.Tests           -c Debug -p:Platform=x64 -p:Optimize=false -p:DebugType=portable
-          dotnet build src/Reactor                   -c Debug -p:Optimize=false -p:DebugType=portable --no-incremental
-          dotnet build tests/Reactor.AppTests.Host   -c Debug -p:Platform=x64 -p:Optimize=false -p:DebugType=portable --no-incremental
+          ./tests/coverage/ci/CoverageLib.Tests.ps1
+          ./tests/coverage/ci/Measure-Coverage.Tests.ps1
 
-      - name: Collect unit coverage
+      # Fetch + lay down a worktree for the PR head and (when there is one) the base
+      # branch. The head (incl. forks) fetches anonymously via refs/pull/N/head; the
+      # base by its branch ref. All context flows in via env (never interpolated into
+      # the script body) and the SHAs are validated before use.
+      - name: Prepare worktrees
+        id: trees
         shell: pwsh
+        env:
+          NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          HAS_BASE: ${{ steps.pr.outputs.has_base }}
         run: |
-          dotnet-coverage collect -s coverage.settings.xml `
-            --output unit.cobertura.xml --output-format cobertura `
-            -- dotnet test tests/Reactor.Tests --no-build -p:Platform=x64
+          $headSha = $env:HEAD_SHA
+          if ($headSha -notmatch '^[0-9a-f]{40}$') { throw "Could not resolve head sha (got '$headSha')." }
+          if ($env:NUMBER) {
+            git fetch --no-tags --force origin "pull/$($env:NUMBER)/head" 2>&1 | Out-Host
+          }
+          $headTree = Join-Path $env:RUNNER_TEMP 'cov-head-tree'
+          if (Test-Path $headTree) { git worktree remove --force $headTree 2>&1 | Out-Host }
+          git worktree add --force --detach $headTree $headSha 2>&1 | Out-Host
+          "head_tree=$headTree" | Out-File $env:GITHUB_OUTPUT -Append
 
-      - name: Instrument Reactor.dll
+          if ($env:HAS_BASE -eq 'true') {
+            # Base prep is best-effort: a base fetch/worktree failure must NOT fail
+            # this (non-continue-on-error) step, or it would abort the head
+            # measurement too. On any base failure emit an empty base_tree so the
+            # base leg is skipped and the comment degrades to "baseline unavailable".
+            try {
+              $baseSha = $env:BASE_SHA
+              $baseRef = $env:BASE_REF
+              if ($baseSha -notmatch '^[0-9a-f]{40}$') { throw "Could not resolve base sha (got '$baseSha')." }
+              if ([string]::IsNullOrWhiteSpace($baseRef)) { throw 'Could not resolve base ref.' }
+              git fetch --no-tags --force origin "refs/heads/${baseRef}:refs/remotes/origin/${baseRef}" 2>&1 | Out-Host
+              if ($LASTEXITCODE -ne 0) { throw "git fetch of base ref '$baseRef' failed (exit $LASTEXITCODE)." }
+              $baseTree = Join-Path $env:RUNNER_TEMP 'cov-base-tree'
+              if (Test-Path $baseTree) { git worktree remove --force $baseTree 2>&1 | Out-Host }
+              git worktree add --force --detach $baseTree $baseSha 2>&1 | Out-Host
+              if ($LASTEXITCODE -ne 0) { throw "git worktree add for base failed (exit $LASTEXITCODE)." }
+              "base_tree=$baseTree" | Out-File $env:GITHUB_OUTPUT -Append
+            } catch {
+              Write-Warning "Base worktree prep failed; the comment will degrade to 'baseline unavailable'. $($_.Exception.Message)"
+              "base_tree=" | Out-File $env:GITHUB_OUTPUT -Append
+            }
+          } else {
+            "base_tree=" | Out-File $env:GITHUB_OUTPUT -Append
+          }
+
+      # Measure each side. continue-on-error so a failing build doesn't abort the
+      # job — the upload + trusted poster still run. A base failure is non-fatal
+      # (renders as "baseline unavailable"); a head failure is surfaced as a red
+      # check by the final step and rendered as a failure comment by the poster.
+      - name: Measure PR head
+        id: head
+        continue-on-error: true
         shell: pwsh
+        env:
+          HEAD_TREE: ${{ steps.trees.outputs.head_tree }}
         run: |
-          $dll = Get-ChildItem -Path "tests/Reactor.AppTests.Host/bin" -Recurse -Filter "Reactor.dll" |
-                   Where-Object { $_.FullName -notmatch 'ref[\\/]' } |
-                   Select-Object -First 1
-          if (-not $dll) { throw "Reactor.dll not found under tests/Reactor.AppTests.Host/bin" }
-          Write-Host "Instrumenting: $($dll.FullName)"
-          dotnet-coverage instrument `
-            $dll.FullName `
-            -s coverage.settings.xml
+          ./tests/coverage/ci/Measure-Coverage.ps1 `
+            -Root $env:HEAD_TREE `
+            -OutFile "$env:GITHUB_WORKSPACE/coverage-out/head.coverage.json" `
+            -WorkDir "$env:GITHUB_WORKSPACE/coverage-out/reports/head"
 
-      - name: Collect selftest coverage
+      - name: Measure base branch
+        id: base
+        if: steps.pr.outputs.has_base == 'true' && steps.trees.outputs.base_tree != ''
+        continue-on-error: true
         shell: pwsh
+        env:
+          BASE_TREE: ${{ steps.trees.outputs.base_tree }}
         run: |
-          dotnet-coverage collect -s coverage.settings.xml `
-            --output selftest.cobertura.xml --output-format cobertura `
-            -- dotnet run --project tests/Reactor.AppTests.Host --no-build -p:Platform=x64 -- --self-test
+          ./tests/coverage/ci/Measure-Coverage.ps1 `
+            -Root $env:BASE_TREE `
+            -OutFile "$env:GITHUB_WORKSPACE/coverage-out/base.coverage.json" `
+            -WorkDir "$env:GITHUB_WORKSPACE/coverage-out/reports/base"
 
-      - name: Merge cobertura reports
+      - name: Ensure coverage data
+        if: always()
         shell: pwsh
+        env:
+          HEAD_OUTCOME: ${{ steps.head.outcome }}
+          BASE_OUTCOME: ${{ steps.base.outcome }}
         run: |
-          dotnet-coverage merge unit.cobertura.xml selftest.cobertura.xml `
-            --output merged.cobertura.xml --output-format cobertura
+          $out = Join-Path $env:GITHUB_WORKSPACE 'coverage-out'
+          New-Item -ItemType Directory -Force -Path $out | Out-Null
+          $headFile = Join-Path $out 'head.coverage.json'
+          $baseFile = Join-Path $out 'base.coverage.json'
+          $failedJson = '{ "line": null, "branch": null, "branchesCovered": null, "branchesTotal": null, "outcome": "failed" }'
+          # Trust a side's data file ONLY when its measure step actually succeeded.
+          # This job runs untrusted PR test code with write access to the workspace,
+          # so a PR could pre-plant a fake coverage-out/*.coverage.json. Keying off the
+          # trusted STEP OUTCOME (not mere file presence) means a failed head can't be
+          # masked by a planted file — it renders the CAUTION "run failed" comment —
+          # and a failed/absent base degrades to "baseline unavailable".
+          if ($env:HEAD_OUTCOME -ne 'success') {
+            Set-Content -LiteralPath $headFile -Value $failedJson -Encoding UTF8
+          }
+          if ($env:BASE_OUTCOME -ne 'success') {
+            if (Test-Path $baseFile) { Remove-Item -LiteralPath $baseFile -Force }
+          }
 
-      - name: Upload coverage artifacts
+      # Run-summary body — informational, not a PR post, so rendering it in this
+      # unprivileged job is fine (it is the ONLY output for a blank-input branch
+      # dispatch). Renders the same base-vs-PR comparison the poster will show; for
+      # a branch dispatch (no base) it shows the PR/branch absolute numbers.
+      - name: Write run summary
+        if: always()
+        shell: pwsh
+        env:
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          HAS_BASE: ${{ steps.pr.outputs.has_base }}
+        run: |
+          . ./tests/coverage/ci/CoverageLib.ps1
+          function Read-Json($p) {
+            if (-not (Test-Path $p)) { return $null }
+            try { return Get-Content $p -Raw | ConvertFrom-Json } catch { return $null }
+          }
+          $out = Join-Path $env:GITHUB_WORKSPACE 'coverage-out'
+          $head = ConvertTo-SafeCoverageMetrics (Read-Json (Join-Path $out 'head.coverage.json'))
+          $base = ConvertTo-SafeCoverageMetrics (Read-Json (Join-Path $out 'base.coverage.json'))
+          if (-not (Test-CoverageMetricsPresent $head)) {
+            $body = Format-CoverageComment -Failed -HeadSha $env:HEAD_SHA
+          } elseif ($env:HAS_BASE -eq 'true' -and (Test-CoverageMetricsPresent $base)) {
+            $body = Format-CoverageComment -BaseMetrics $base -HeadMetrics $head -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA
+          } elseif ($env:HAS_BASE -eq 'true') {
+            $body = Format-CoverageComment -HeadMetrics $head -BaselineUnavailable -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA
+          } else {
+            $body = Format-CoverageComment -HeadMetrics $head -BaselineUnavailable -HeadSha $env:HEAD_SHA
+          }
+          # Drop the leading sticky marker line for the summary (it is an HTML comment
+          # meant for the PR-comment lookup, not the run summary).
+          $summary = ($body -split "`n" | Select-Object -Skip 1) -join "`n"
+          $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding UTF8
+
+      - name: Upload coverage reports
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-${{ steps.pr.outputs.sha }}
-          path: |
-            unit.cobertura.xml
-            selftest.cobertura.xml
-            merged.cobertura.xml
-
-      - name: Read coverage rates
-        id: rates
-        shell: pwsh
-        run: |
-          # dotnet-coverage's cobertura output captures per-line branch data in
-          # `condition-coverage="P% (covered/total)"` attributes but does not
-          # aggregate them: the root and class `branch-rate` attributes are
-          # hardcoded to 1. Sum the per-line numerators/denominators ourselves.
-          [xml]$x = Get-Content merged.cobertura.xml
-          $line = [math]::Round([double]$x.coverage.'line-rate' * 100, 2)
-          $covered = 0
-          $total   = 0
-          foreach ($l in $x.SelectNodes('//line[@condition-coverage]')) {
-            if ($l.'condition-coverage' -match '\((\d+)/(\d+)\)') {
-              $covered += [int]$Matches[1]
-              $total   += [int]$Matches[2]
-            }
-          }
-          $branch = if ($total -gt 0) { [math]::Round(100.0 * $covered / $total, 2) } else { 0 }
-          "line=$line"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "branch=$branch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "branches-covered=$covered" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "branches-total=$total"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          name: coverage-reports-${{ steps.pr.outputs.head_sha }}
+          path: coverage-out/reports/**
+          if-no-files-found: warn
+          retention-days: 14
 
       # SECURITY: this job runs untrusted PR code, so it must NOT render the PR
-      # comment body. It writes the human-readable result to the RUN SUMMARY
-      # (informational, not a privileged PR post) and uploads the raw numbers as
-      # coverage.json. The privileged workflow_run poster (coverage-comment.yml)
-      # checks out trusted code, validates the numbers, and renders + posts the
-      # sticky comment. Always runs so a failed run still yields a data file.
-      - name: Emit coverage data
-        if: always()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          LINE: ${{ steps.rates.outputs.line }}
-          BRANCH: ${{ steps.rates.outputs.branch }}
-          BRANCHES_COVERED: ${{ steps.rates.outputs.branches-covered }}
-          BRANCHES_TOTAL: ${{ steps.rates.outputs.branches-total }}
-          SHA: ${{ steps.pr.outputs.sha }}
-          OUTCOME: ${{ job.status }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        with:
-          script: |
-            const fs = require('fs');
-            const { LINE, BRANCH, BRANCHES_COVERED, BRANCHES_TOTAL, SHA, OUTCOME, PR_NUMBER } = process.env;
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const shaLabel = SHA ? SHA.slice(0, 7) : 'unknown';
-            // Run-summary body — the only output for a branch run (blank-input
-            // dispatch, no PR). Not a PR comment, so rendering it here is fine.
-            const summary = OUTCOME === 'success'
-              ? [`## 🧪 Merged coverage`, ``, `Coverage for \`${shaLabel}\` (unit + selftest).`, ``,
-                 `| Metric | Coverage |`, `|---|---|`, `| Line   | ${LINE}% |`,
-                 `| Branch | ${BRANCH}% (${BRANCHES_COVERED}/${BRANCHES_TOTAL}) |`].join('\n')
-              : `## 🧪 Merged coverage\n\nCoverage run failed for \`${shaLabel}\` — see the [workflow run](${runUrl}).`;
-            await core.summary.addRaw(summary).write();
-            // Machine-readable data for the trusted poster to render + post.
-            fs.mkdirSync('coverage-out', { recursive: true });
-            fs.writeFileSync('coverage-out/coverage.json', JSON.stringify({
-              line: LINE || '',
-              branch: BRANCH || '',
-              branchesCovered: BRANCHES_COVERED || '',
-              branchesTotal: BRANCHES_TOTAL || '',
-              outcome: OUTCOME || '',
-            }));
-
+      # comment body. It uploads ONLY the machine-readable per-side numbers
+      # (head/base.coverage.json). The privileged workflow_run poster
+      # (coverage-comment.yml) checks out trusted code, validates the numbers, and
+      # renders + posts the sticky comparison comment. Always runs so a failed run
+      # still yields the data files it produced.
       - name: Upload coverage data artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-data
-          path: coverage-out/coverage.json
+          path: coverage-out/*.coverage.json
           if-no-files-found: warn
           retention-days: 14
+
+      # Surface a red check if the HEAD measurement failed (comment still posted). A
+      # base-only failure stays green — it just degrades to "baseline unavailable".
+      - name: Reflect coverage status
+        if: always()
+        shell: pwsh
+        env:
+          HEAD_OUTCOME: ${{ steps.head.outcome }}
+        run: |
+          if ($env:HEAD_OUTCOME -ne 'success') {
+            throw 'Coverage measurement of the PR head failed — see the coverage comment and the coverage-reports artifact.'
+          }
+          Write-Host 'Coverage measurement completed successfully.'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,34 +1,45 @@
 name: Coverage
 
-# Automatic merged unit + selftest coverage on every PR, posted as a sticky,
-# self-updating comment that compares the PR head against its base branch (the
-# `main` baseline in the common case) and shows the per-metric delta. Runs the
-# merged coverage recipe from TESTING.md for BOTH sides and reports line + branch
-# rates with a signed Δ. Also runnable manually:
-#   - workflow_dispatch with a PR number  -> measures that PR vs its base (forks too);
-#   - workflow_dispatch with the number blank -> measures the selected branch and
-#     writes the (absolute, no-baseline) result to the run's job summary.
+# Automatic merged unit + selftest coverage. On every PR this measures ONLY the PR
+# head (one instrumented pass) and posts a sticky comment comparing it against a
+# cached `main` baseline. The baseline itself is (re)measured on push to `main` and
+# stored as a downloadable artifact, so PRs never pay to re-measure main. Also
+# runnable manually via workflow_dispatch (a PR number, or blank to measure the
+# selected branch — on the default branch that refreshes the main baseline).
 #
 # ── Security: why pull_request + workflow_run (not issue_comment) ──────────────
-# Coverage BUILDS + INSTRUMENTS + RUNS code (build scripts and tests execute here)
-# for the PR head AND the base branch. The old design triggered on `issue_comment`
-# — which runs in the base repo with a full write token — so it had to be gated to
-# maintainers via author_association. Running it automatically on every PR under
-# that model would hand a write token to untrusted PR code, which is unsafe.
+# Coverage BUILDS + INSTRUMENTS + RUNS code (build scripts and tests execute here).
+# Running that automatically on every PR with a write token would hand the token to
+# untrusted PR code, which is unsafe. Instead this workflow runs in the unprivileged
+# `pull_request` context (read-only token, no secrets, NO ability to comment) and
+# uploads ONLY the raw coverage numbers; the privileged `coverage-comment.yml`
+# (`workflow_run`) re-validates those numbers, fetches the cached main baseline,
+# renders the comparison, and posts it. That split runs untrusted build code with
+# zero write privilege and still comments on PRs — including from forks. It mirrors
+# the trust boundary documented in perf-compare.yml / build-metrics.yml.
 #
-# Instead this workflow runs in the unprivileged `pull_request` context: a
-# read-only token, no secrets, and NO ability to comment. It writes the result to
-# the run summary and uploads ONLY the raw coverage numbers (per side); the
-# privileged `coverage-comment.yml` (`workflow_run`) checks out trusted code,
-# renders the comparison comment, and posts it. That split runs untrusted build
-# code with zero write privilege and still comments on PRs — including from forks.
-# It mirrors build-metrics.yml (which likewise measures both head + base) and the
-# trust boundary documented in perf-compare.yml.
+# ── Baseline model ────────────────────────────────────────────────────────────
+# A push to `main` measures main and uploads a `coverage-baseline` artifact (numbers
+# only). A PR run measures the head and uploads `coverage-data`. The poster reads the
+# head from the triggering run and the base from the newest successful push-to-main
+# `coverage-baseline` artifact, then renders `base | PR | Δ`. Trade-off vs
+# re-measuring the PR's exact base on every run: ~half the CI cost, against a small
+# staleness window (the baseline is "main as of its last coverage run"). Until the
+# first post-merge push publishes one, PRs render "baseline unavailable". See
+# tests/coverage/ci/README.md.
 
 on:
   pull_request:
-    # Doc-only PRs change no measured code; skip the (now doubled) instrumented run.
-    # This includes the docs/_pipeline templates + doc apps that generate the guide.
+    # Doc-only PRs change no measured code; skip the instrumented run. This includes
+    # the docs/_pipeline templates + doc apps that generate the guide.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/guide/**'
+      - 'docs/_pipeline/**'
+  push:
+    # Publish/refresh the `main` baseline when code that could move coverage lands.
+    # Doc-only pushes don't change coverage, so the previous baseline stays valid.
+    branches: [main]
     paths-ignore:
       - '**/*.md'
       - 'docs/guide/**'
@@ -36,14 +47,14 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: PR to measure (vs its base branch). Leave blank to measure the selected branch instead.
+        description: PR to measure. Leave blank to measure the selected branch (on the default branch this refreshes the main baseline).
         required: false
         type: string
 
-# Read-only: this job runs untrusted PR code and must not hold a write token.
-# The comment is posted by the separate privileged workflow_run workflow.
-# pull-requests: read only serves the manual workflow_dispatch path (resolving a
-# PR's head/base via the API); the automatic pull_request path uses the event.
+# Read-only: this job runs untrusted PR code and must not hold a write token. The
+# comment is posted by the separate privileged workflow_run workflow. pull-requests:
+# read only serves the manual workflow_dispatch path (resolving a PR's head via the
+# API); the automatic pull_request path uses the event.
 permissions:
   contents: read
   pull-requests: read
@@ -51,14 +62,14 @@ permissions:
 jobs:
   coverage:
     name: Merged coverage
-    # One in-flight run per target — a PR number, or the branch ref for a
+    # One in-flight run per target — a PR number, or the branch ref for a push /
     # blank-input dispatch. A newer trigger supersedes an older one.
     concurrency:
       group: coverage-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.ref }}
       cancel-in-progress: true
     runs-on: windows-latest
-    # Two instrumented merged-coverage passes (head + base) run sequentially.
-    timeout-minutes: 60
+    # One instrumented merged-coverage pass (head on PRs; main on push).
+    timeout-minutes: 40
     steps:
       - name: Resolve coverage target
         id: pr
@@ -67,19 +78,27 @@ jobs:
           DISPATCH_PR: ${{ github.event.inputs.pr_number }}
         with:
           script: |
-            // Resolve what to measure + the base to compare against:
-            //   - pull_request             -> the PR that triggered the run (+ its base)
-            //   - workflow_dispatch + PR#  -> that PR (+ its base; works for forks)
-            //   - workflow_dispatch, blank -> the dispatched branch (NO base baseline)
+            // Resolve the single commit to measure + whether this run publishes the
+            // `main` baseline artifact:
+            //   - pull_request             -> the PR head (coverage-data)
+            //   - push (default branch)    -> the pushed commit (coverage-baseline)
+            //   - workflow_dispatch + PR#  -> that PR's head (coverage-data; forks too)
+            //   - workflow_dispatch, blank -> the dispatched commit; on the default
+            //                                 branch this refreshes the baseline.
+            let ref = '';
+            let headSha = '';
             let prNumber = '';
-            let hasBase = false;
+            let isBaseline = false;
+            const defaultBranch = (context.payload.repository && context.payload.repository.default_branch) || 'main';
             if (context.eventName === 'pull_request') {
               const pr = context.payload.pull_request;
               prNumber = String(pr.number);
-              core.setOutput('head_sha', pr.head.sha);
-              core.setOutput('base_sha', pr.base.sha);
-              core.setOutput('base_ref', pr.base.ref);
-              hasBase = true;
+              headSha = pr.head.sha;
+              ref = `refs/pull/${pr.number}/head`;
+            } else if (context.eventName === 'push') {
+              headSha = context.sha;
+              ref = context.sha;
+              isBaseline = true; // the push trigger is filtered to the default branch
             } else {
               const raw = process.env.DISPATCH_PR || '';
               if (raw !== '') {
@@ -92,32 +111,27 @@ jobs:
                   repo: context.repo.repo,
                   pull_number: Number(prNumber),
                 });
-                core.setOutput('head_sha', pr.data.head.sha);
-                core.setOutput('base_sha', pr.data.base.sha);
-                core.setOutput('base_ref', pr.data.base.ref);
-                hasBase = true;
+                headSha = pr.data.head.sha;
+                ref = `refs/pull/${raw}/head`;
               } else {
-                // No PR: measure the commit the workflow was dispatched on, with no
-                // base baseline (absolute numbers only).
-                core.setOutput('head_sha', context.sha);
-                core.setOutput('base_sha', '');
-                core.setOutput('base_ref', '');
+                headSha = context.sha;
+                ref = context.sha;
+                isBaseline = (context.ref === `refs/heads/${defaultBranch}`);
               }
             }
+            core.setOutput('ref', ref);
+            core.setOutput('head_sha', headSha);
             core.setOutput('number', prNumber);
-            core.setOutput('has_base', hasBase ? 'true' : 'false');
+            core.setOutput('is_baseline', isBaseline ? 'true' : 'false');
 
-      # Checkout for the scripts + the ability to worktree head/base. On a
-      # pull_request event this is the PR MERGE ref — i.e. PR-authored code, NOT
-      # trusted — but this job is unprivileged (read-only token, no secrets), so
-      # running the PR's own measurement scripts here is acceptable; the trusted
-      # poster (coverage-comment.yml) is what renders + posts. The head/base COMMITS
-      # are measured in their own worktrees below (never the merge). fetch-depth: 0
-      # so origin/<base> resolves. persist-credentials: false — the PR build code
-      # that runs later gets no usable git credential.
+      # Unprivileged checkout of the single commit to measure. On a pull_request this
+      # is the PR head — untrusted PR code — but the job is read-only (no write token,
+      # no secrets), so running the PR's own build/measure scripts here is acceptable;
+      # the trusted poster (coverage-comment.yml) renders + posts. persist-credentials:
+      # false so the PR build code that runs later gets no usable git credential.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.ref }}
           persist-credentials: false
 
       - name: Setup .NET
@@ -128,150 +142,65 @@ jobs:
       - name: Install dotnet-coverage
         run: dotnet tool install -g dotnet-coverage
 
-      # Cheap guard: run the pure parser + delta-math tests before spending ~40 min
-      # measuring both sides. Also runs standalone in coverage-lib-tests.yml on PRs.
+      # Cheap guard: run the pure parser + delta-math tests before the ~10-min
+      # instrumented measure. Also runs standalone in coverage-lib-tests.yml on PRs.
       - name: Test coverage scripts
         shell: pwsh
         run: |
           ./tests/coverage/ci/CoverageLib.Tests.ps1
           ./tests/coverage/ci/Measure-Coverage.Tests.ps1
 
-      # Fetch + lay down a worktree for the PR head and (when there is one) the base
-      # branch. The head (incl. forks) fetches anonymously via refs/pull/N/head; the
-      # base by its branch ref. All context flows in via env (never interpolated into
-      # the script body) and the SHAs are validated before use.
-      - name: Prepare worktrees
-        id: trees
-        shell: pwsh
-        env:
-          NUMBER: ${{ steps.pr.outputs.number }}
-          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
-          BASE_REF: ${{ steps.pr.outputs.base_ref }}
-          HAS_BASE: ${{ steps.pr.outputs.has_base }}
-        run: |
-          $headSha = $env:HEAD_SHA
-          if ($headSha -notmatch '^[0-9a-f]{40}$') { throw "Could not resolve head sha (got '$headSha')." }
-          if ($env:NUMBER) {
-            git fetch --no-tags --force origin "pull/$($env:NUMBER)/head" 2>&1 | Out-Host
-          }
-          $headTree = Join-Path $env:RUNNER_TEMP 'cov-head-tree'
-          if (Test-Path $headTree) { git worktree remove --force $headTree 2>&1 | Out-Host }
-          git worktree add --force --detach $headTree $headSha 2>&1 | Out-Host
-          "head_tree=$headTree" | Out-File $env:GITHUB_OUTPUT -Append
-
-          if ($env:HAS_BASE -eq 'true') {
-            # Base prep is best-effort: a base fetch/worktree failure must NOT fail
-            # this (non-continue-on-error) step, or it would abort the head
-            # measurement too. On any base failure emit an empty base_tree so the
-            # base leg is skipped and the comment degrades to "baseline unavailable".
-            try {
-              $baseSha = $env:BASE_SHA
-              $baseRef = $env:BASE_REF
-              if ($baseSha -notmatch '^[0-9a-f]{40}$') { throw "Could not resolve base sha (got '$baseSha')." }
-              if ([string]::IsNullOrWhiteSpace($baseRef)) { throw 'Could not resolve base ref.' }
-              # base_ref comes from the trusted PR event/API (the base branch name),
-              # but it is interpolated into a git refspec below — constrain it to a
-              # conservative branch-name allow-list so an unexpected character can't
-              # alter the refspec. A reject degrades to "baseline unavailable".
-              if ($baseRef -notmatch '^[A-Za-z0-9._/-]+$') { throw "Base ref '$baseRef' has unexpected characters." }
-              git fetch --no-tags --force origin "refs/heads/${baseRef}:refs/remotes/origin/${baseRef}" 2>&1 | Out-Host
-              if ($LASTEXITCODE -ne 0) { throw "git fetch of base ref '$baseRef' failed (exit $LASTEXITCODE)." }
-              $baseTree = Join-Path $env:RUNNER_TEMP 'cov-base-tree'
-              if (Test-Path $baseTree) { git worktree remove --force $baseTree 2>&1 | Out-Host }
-              git worktree add --force --detach $baseTree $baseSha 2>&1 | Out-Host
-              if ($LASTEXITCODE -ne 0) { throw "git worktree add for base failed (exit $LASTEXITCODE)." }
-              "base_tree=$baseTree" | Out-File $env:GITHUB_OUTPUT -Append
-            } catch {
-              Write-Warning "Base worktree prep failed; the comment will degrade to 'baseline unavailable'. $($_.Exception.Message)"
-              "base_tree=" | Out-File $env:GITHUB_OUTPUT -Append
-            }
-          } else {
-            "base_tree=" | Out-File $env:GITHUB_OUTPUT -Append
-          }
-
-      # Measure each side. continue-on-error so a failing build doesn't abort the
-      # job — the upload + trusted poster still run. A base failure is non-fatal
-      # (renders as "baseline unavailable"); a head failure is surfaced as a red
-      # check by the final step and rendered as a failure comment by the poster.
-      - name: Measure PR head
-        id: head
+      # Measure the checked-out commit. continue-on-error so a failing build doesn't
+      # abort the job — the upload + trusted poster still run; the final step surfaces
+      # the failure as a red check and the poster renders a CAUTION comment.
+      - name: Measure coverage
+        id: measure
         continue-on-error: true
         shell: pwsh
-        env:
-          HEAD_TREE: ${{ steps.trees.outputs.head_tree }}
         run: |
           ./tests/coverage/ci/Measure-Coverage.ps1 `
-            -Root $env:HEAD_TREE `
-            -OutFile "$env:GITHUB_WORKSPACE/coverage-out/head.coverage.json" `
-            -WorkDir "$env:GITHUB_WORKSPACE/coverage-out/reports/head"
-
-      - name: Measure base branch
-        id: base
-        if: steps.pr.outputs.has_base == 'true' && steps.trees.outputs.base_tree != ''
-        continue-on-error: true
-        shell: pwsh
-        env:
-          BASE_TREE: ${{ steps.trees.outputs.base_tree }}
-        run: |
-          ./tests/coverage/ci/Measure-Coverage.ps1 `
-            -Root $env:BASE_TREE `
-            -OutFile "$env:GITHUB_WORKSPACE/coverage-out/base.coverage.json" `
-            -WorkDir "$env:GITHUB_WORKSPACE/coverage-out/reports/base"
+            -Root . `
+            -OutFile "$env:GITHUB_WORKSPACE/coverage-out/coverage.json" `
+            -WorkDir "$env:GITHUB_WORKSPACE/coverage-out/reports"
 
       - name: Ensure coverage data
         if: always()
         shell: pwsh
         env:
-          HEAD_OUTCOME: ${{ steps.head.outcome }}
-          BASE_OUTCOME: ${{ steps.base.outcome }}
+          MEASURE_OUTCOME: ${{ steps.measure.outcome }}
         run: |
           $out = Join-Path $env:GITHUB_WORKSPACE 'coverage-out'
           New-Item -ItemType Directory -Force -Path $out | Out-Null
-          $headFile = Join-Path $out 'head.coverage.json'
-          $baseFile = Join-Path $out 'base.coverage.json'
-          $failedJson = '{ "line": null, "branch": null, "branchesCovered": null, "branchesTotal": null, "outcome": "failed" }'
-          # Trust a side's data file ONLY when its measure step actually succeeded.
-          # This job runs untrusted PR test code with write access to the workspace,
-          # so a PR could pre-plant a fake coverage-out/*.coverage.json. Keying off the
-          # trusted STEP OUTCOME (not mere file presence) means a failed head can't be
-          # masked by a planted file — it renders the CAUTION "run failed" comment —
-          # and a failed/absent base degrades to "baseline unavailable".
-          if ($env:HEAD_OUTCOME -ne 'success') {
-            Set-Content -LiteralPath $headFile -Value $failedJson -Encoding UTF8
-          }
-          if ($env:BASE_OUTCOME -ne 'success') {
-            if (Test-Path $baseFile) { Remove-Item -LiteralPath $baseFile -Force }
+          $file = Join-Path $out 'coverage.json'
+          # Trust the file ONLY when the measure step succeeded. This job runs
+          # untrusted PR test code with write access to the workspace, so a PR could
+          # pre-plant a fake coverage.json. Keying off the trusted STEP OUTCOME (not
+          # mere file presence) means a failed measure renders the CAUTION "run failed"
+          # comment rather than being masked by a planted file.
+          if ($env:MEASURE_OUTCOME -ne 'success') {
+            '{ "line": null, "branch": null, "branchesCovered": null, "branchesTotal": null, "outcome": "failed" }' |
+              Set-Content -LiteralPath $file -Encoding UTF8
           }
 
-      # Run-summary body — informational, not a PR post, so rendering it in this
-      # unprivileged job is fine (it is the ONLY output for a blank-input branch
-      # dispatch). Renders the same base-vs-PR comparison the poster will show; for
-      # a branch dispatch (no base) it shows the PR/branch absolute numbers.
+      # Run-summary body — informational, not a PR post. This job doesn't hold the
+      # baseline (the poster fetches it), so the summary shows the measured commit's
+      # absolute coverage; the base | PR | Δ comparison is in the PR comment.
       - name: Write run summary
         if: always()
         shell: pwsh
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
-          HAS_BASE: ${{ steps.pr.outputs.has_base }}
         run: |
           . ./tests/coverage/ci/CoverageLib.ps1
           function Read-Json($p) {
             if (-not (Test-Path $p)) { return $null }
             try { return Get-Content $p -Raw | ConvertFrom-Json } catch { return $null }
           }
-          $out = Join-Path $env:GITHUB_WORKSPACE 'coverage-out'
-          $head = ConvertTo-SafeCoverageMetrics (Read-Json (Join-Path $out 'head.coverage.json'))
-          $base = ConvertTo-SafeCoverageMetrics (Read-Json (Join-Path $out 'base.coverage.json'))
-          # Same selector the poster uses. For a blank-input branch dispatch HAS_BASE
-          # is false, so this renders the absolute (no-baseline) summary rather than a
-          # misleading "baseline unavailable" note.
-          $hasBase = ($env:HAS_BASE -eq 'true')
-          $body = Format-CoverageCommentFromMetrics -HeadMetrics $head -BaseMetrics $base -HasBase $hasBase `
-            -HeadSha $env:HEAD_SHA -BaseSha $env:BASE_SHA
-          # Drop the leading sticky marker line for the summary (it is an HTML comment
-          # meant for the PR-comment lookup, not the run summary).
+          $file = Join-Path $env:GITHUB_WORKSPACE 'coverage-out/coverage.json'
+          $head = ConvertTo-SafeCoverageMetrics (Read-Json $file)
+          $body = Format-CoverageCommentFromMetrics -HeadMetrics $head -HasBase $false -HeadSha $env:HEAD_SHA
+          # Drop the leading sticky marker line (an HTML comment for the PR-comment
+          # lookup, not the run summary).
           $summary = ($body -split "`n" | Select-Object -Skip 1) -join "`n"
           $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding UTF8
 
@@ -285,29 +214,40 @@ jobs:
           retention-days: 14
 
       # SECURITY: this job runs untrusted PR code, so it must NOT render the PR
-      # comment body. It uploads ONLY the machine-readable per-side numbers
-      # (head/base.coverage.json). The privileged workflow_run poster
-      # (coverage-comment.yml) checks out trusted code, validates the numbers, and
-      # renders + posts the sticky comparison comment. Always runs so a failed run
-      # still yields the data files it produced.
-      - name: Upload coverage data artifact
-        if: always()
+      # comment body. It uploads ONLY the machine-readable numbers. The privileged
+      # workflow_run poster (coverage-comment.yml) validates the numbers, fetches the
+      # cached main baseline, and renders + posts the sticky comparison comment.
+      #
+      # PR runs upload `coverage-data` (read by the poster for THIS run). Push-to-main
+      # runs upload `coverage-baseline` (the cached baseline future PRs compare
+      # against) with a longer retention so it survives between main pushes.
+      - name: Upload coverage data (PR)
+        if: ${{ always() && steps.pr.outputs.is_baseline != 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-data
-          path: coverage-out/*.coverage.json
+          path: coverage-out/coverage.json
           if-no-files-found: warn
           retention-days: 14
 
-      # Surface a red check if the HEAD measurement failed (comment still posted). A
-      # base-only failure stays green — it just degrades to "baseline unavailable".
+      - name: Upload coverage baseline (main)
+        if: ${{ steps.pr.outputs.is_baseline == 'true' && steps.measure.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-baseline
+          path: coverage-out/coverage.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      # Surface a red check if the measurement failed (comment still posted for PRs;
+      # a failed main baseline is visible so we notice it broke).
       - name: Reflect coverage status
         if: always()
         shell: pwsh
         env:
-          HEAD_OUTCOME: ${{ steps.head.outcome }}
+          MEASURE_OUTCOME: ${{ steps.measure.outcome }}
         run: |
-          if ($env:HEAD_OUTCOME -ne 'success') {
-            throw 'Coverage measurement of the PR head failed — see the coverage comment and the coverage-reports artifact.'
+          if ($env:MEASURE_OUTCOME -ne 'success') {
+            throw 'Coverage measurement failed — see the coverage comment and the coverage-reports artifact.'
           }
           Write-Host 'Coverage measurement completed successfully.'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -164,23 +164,35 @@ jobs:
             -WorkDir "$env:GITHUB_WORKSPACE/coverage-out/reports"
 
       - name: Ensure coverage data
+        id: ensure
         if: always()
         shell: pwsh
         env:
           MEASURE_OUTCOME: ${{ steps.measure.outcome }}
         run: |
+          . ./tests/coverage/ci/CoverageLib.ps1
           $out = Join-Path $env:GITHUB_WORKSPACE 'coverage-out'
           New-Item -ItemType Directory -Force -Path $out | Out-Null
           $file = Join-Path $out 'coverage.json'
-          # Trust the file ONLY when the measure step succeeded. This job runs
-          # untrusted PR test code with write access to the workspace, so a PR could
-          # pre-plant a fake coverage.json. Keying off the trusted STEP OUTCOME (not
-          # mere file presence) means a failed measure renders the CAUTION "run failed"
-          # comment rather than being masked by a planted file.
-          if ($env:MEASURE_OUTCOME -ne 'success') {
-            '{ "line": null, "branch": null, "branchesCovered": null, "branchesTotal": null, "outcome": "failed" }' |
-              Set-Content -LiteralPath $file -Encoding UTF8
+          $failedJson = '{ "line": null, "branch": null, "branchesCovered": null, "branchesTotal": null, "outcome": "failed" }'
+          # Trust the numbers ONLY when the measure step SUCCEEDED *and* actually
+          # produced a valid coverage.json. This job runs untrusted PR test code with
+          # write access to the workspace, so a PR could pre-plant a fake file; and a
+          # green-but-empty measure (a script/path regression that exits 0 without
+          # writing real numbers) must not silently post a blank comment. In either
+          # case overwrite with a failed placeholder — the poster then renders CAUTION
+          # and the run goes red via the data_ok gate below.
+          $ok = $false
+          if ($env:MEASURE_OUTCOME -eq 'success') {
+            $raw = $null
+            if (Test-Path $file) { try { $raw = Get-Content $file -Raw | ConvertFrom-Json } catch { $raw = $null } }
+            if (Test-CoverageMetricsPresent (ConvertTo-SafeCoverageMetrics $raw)) { $ok = $true }
           }
+          if (-not $ok) {
+            Set-Content -LiteralPath $file -Value $failedJson -Encoding UTF8
+            Write-Warning "No valid coverage numbers (measure outcome=$($env:MEASURE_OUTCOME)); the comment will render CAUTION and the check will be red."
+          }
+          "data_ok=$(if ($ok) { 'true' } else { 'false' })" | Out-File $env:GITHUB_OUTPUT -Append
 
       # Run-summary body — informational, not a PR post. This job doesn't hold the
       # baseline (the poster fetches it), so the summary shows the measured commit's
@@ -231,7 +243,7 @@ jobs:
           retention-days: 14
 
       - name: Upload coverage baseline (main)
-        if: ${{ steps.pr.outputs.is_baseline == 'true' && steps.measure.outcome == 'success' }}
+        if: ${{ steps.pr.outputs.is_baseline == 'true' && steps.ensure.outputs.data_ok == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-baseline
@@ -239,15 +251,16 @@ jobs:
           if-no-files-found: warn
           retention-days: 90
 
-      # Surface a red check if the measurement failed (comment still posted for PRs;
-      # a failed main baseline is visible so we notice it broke).
+      # Surface a red check when coverage produced no valid numbers — a build/measure
+      # failure OR a green-but-empty measure (data_ok is false in both). The comment
+      # is still posted (CAUTION) for PRs; a bad main baseline is visible too.
       - name: Reflect coverage status
         if: always()
         shell: pwsh
         env:
-          MEASURE_OUTCOME: ${{ steps.measure.outcome }}
+          DATA_OK: ${{ steps.ensure.outputs.data_ok }}
         run: |
-          if ($env:MEASURE_OUTCOME -ne 'success') {
-            throw 'Coverage measurement failed — see the coverage comment and the coverage-reports artifact.'
+          if ($env:DATA_OK -ne 'true') {
+            throw 'Coverage produced no valid numbers (build/measure failed or emitted nothing) — see the coverage comment and the coverage-reports artifact.'
           }
           Write-Host 'Coverage measurement completed successfully.'

--- a/.gitignore
+++ b/.gitignore
@@ -224,8 +224,11 @@ coverage/
 !tools/coverage/**
 # `tests/coverage/ci/` holds the source-controlled coverage-comment CI scripts
 # (see .github/workflows/coverage.yml); carve it out of the `coverage/` ignore too.
+# The `**` negation would also re-include generated cobertura reports, so re-assert
+# the report ignore afterwards (a later pattern wins) to keep them untracked.
 !tests/coverage/
 !tests/coverage/**
+tests/coverage/**/*.cobertura.xml
 
 # Eval / scratch run output — local artifacts from eval drivers, never tracked.
 runs/

--- a/.gitignore
+++ b/.gitignore
@@ -222,6 +222,10 @@ coverage/
 # NOT generated output; carve it out of the `coverage/` ignore above.
 !tools/coverage/
 !tools/coverage/**
+# `tests/coverage/ci/` holds the source-controlled coverage-comment CI scripts
+# (see .github/workflows/coverage.yml); carve it out of the `coverage/` ignore too.
+!tests/coverage/
+!tests/coverage/**
 
 # Eval / scratch run output — local artifacts from eval drivers, never tracked.
 runs/

--- a/TESTING.md
+++ b/TESTING.md
@@ -235,22 +235,30 @@ Replace `$(RuntimeIdentifier)` with `ARM64` or `x64`, or omit the platform segme
 
 You don't have to run the merge locally — the **Coverage** workflow
 (`.github/workflows/coverage.yml`) runs this same unit + selftest recipe and
-reports the merged line/branch numbers.
+reports the merged line/branch numbers, **compared against the PR's base branch**
+(the `main` baseline in the common case).
 
-- **Automatic on every PR:** it runs on each PR commit and posts the merged
-  line/branch numbers as a **sticky comment** that updates in place on new
+- **Automatic on every PR:** it runs on each PR commit, measures the merged
+  coverage of **both** the PR head and its base branch, and posts a **sticky
+  comment** showing `base | PR | Δ` for line + branch, with a direction-aware
+  status (✅ higher / ⚠️ lower / ≈ within noise). It updates in place on new
   commits. No action needed — it just works. (Doc-only PRs are skipped.)
 - **Manual trigger (PR):** use **Actions → Coverage → Run workflow** and enter the
   PR number, or run `gh workflow run coverage.yml -f pr_number=<PR>`. This measures
-  that PR (works for forks) and writes the result to the run's **job summary** —
-  it does not post a PR comment (the poster only comments for automatic
-  `pull_request` runs, where the PR is resolved from the trusted head SHA).
+  that PR against its base (works for forks) and writes the comparison to the run's
+  **job summary** — it does not post a PR comment (the poster only comments for
+  automatic `pull_request` runs, where the PR is resolved from the trusted head SHA).
 - **Manual trigger (branch):** run it with the PR number left **blank** to measure
-  the selected branch — e.g. `gh workflow run coverage.yml --ref main`. The numbers
-  are written to the run's **job summary**.
+  the selected branch — e.g. `gh workflow run coverage.yml --ref main`. There is no
+  base to compare against, so the **absolute** numbers are written to the run's
+  **job summary**.
 
 The measurement runs in the unprivileged `pull_request` context (it builds and
-runs PR code, so it holds no write token) and uploads only the raw numbers; the
-privileged `coverage-comment.yml` (`workflow_run`) checks out trusted code,
-renders the comment, and posts it, resolving the target PR from the trusted
-`workflow_run` head SHA. See that workflow's header for the security rationale.
+runs PR code for both sides, so it holds no write token) and uploads only the raw
+per-side numbers; the privileged `coverage-comment.yml` (`workflow_run`) checks out
+trusted code, re-validates the numbers, renders the comparison comment, and posts
+it, resolving the target PR + base SHA from the trusted `workflow_run` head SHA.
+Measuring both sides roughly doubles the run time; a base-branch failure is
+non-fatal (it degrades to a "baseline unavailable" note). See
+[`tests/coverage/ci/README.md`](tests/coverage/ci/README.md) and the workflow
+headers for the full layout + security rationale.

--- a/TESTING.md
+++ b/TESTING.md
@@ -235,30 +235,34 @@ Replace `$(RuntimeIdentifier)` with `ARM64` or `x64`, or omit the platform segme
 
 You don't have to run the merge locally — the **Coverage** workflow
 (`.github/workflows/coverage.yml`) runs this same unit + selftest recipe and
-reports the merged line/branch numbers, **compared against the PR's base branch**
-(the `main` baseline in the common case).
+reports the merged line/branch numbers, **compared against a cached `main`
+baseline**.
 
 - **Automatic on every PR:** it runs on each PR commit, measures the merged
-  coverage of **both** the PR head and its base branch, and posts a **sticky
+  coverage of the **PR head** (one instrumented pass), and posts a **sticky
   comment** showing `base | PR | Δ` for line + branch, with a direction-aware
   status (✅ higher / ⚠️ lower / ≈ within noise). It updates in place on new
   commits. No action needed — it just works. (Doc-only PRs are skipped.)
+- **Baseline refresh on `main`:** each push to `main` (re)measures main and stores
+  a `coverage-baseline` artifact; PRs compare against the newest one, so they never
+  re-measure main. Until the first post-merge push publishes a baseline, PRs render
+  "baseline unavailable".
 - **Manual trigger (PR):** use **Actions → Coverage → Run workflow** and enter the
   PR number, or run `gh workflow run coverage.yml -f pr_number=<PR>`. This measures
-  that PR against its base (works for forks) and writes the comparison to the run's
-  **job summary** — it does not post a PR comment (the poster only comments for
-  automatic `pull_request` runs, where the PR is resolved from the trusted head SHA).
+  that PR head (works for forks) and writes the numbers to the run's **job
+  summary** — it does not post a PR comment (the poster only comments for automatic
+  `pull_request` runs, where the PR is resolved from the trusted head SHA).
 - **Manual trigger (branch):** run it with the PR number left **blank** to measure
-  the selected branch — e.g. `gh workflow run coverage.yml --ref main`. There is no
-  base to compare against, so the **absolute** numbers are written to the run's
-  **job summary**.
+  the selected branch — e.g. `gh workflow run coverage.yml --ref main` (on the
+  default branch this refreshes the baseline). The **absolute** numbers are written
+  to the run's **job summary**.
 
 The measurement runs in the unprivileged `pull_request` context (it builds and
-runs PR code for both sides, so it holds no write token) and uploads only the raw
-per-side numbers; the privileged `coverage-comment.yml` (`workflow_run`) checks out
-trusted code, re-validates the numbers, renders the comparison comment, and posts
-it, resolving the target PR + base SHA from the trusted `workflow_run` head SHA.
-Measuring both sides roughly doubles the run time; a base-branch failure is
-non-fatal (it degrades to a "baseline unavailable" note). See
-[`tests/coverage/ci/README.md`](tests/coverage/ci/README.md) and the workflow
-headers for the full layout + security rationale.
+runs PR code, so it holds no write token) and uploads only the raw numbers; the
+privileged `coverage-comment.yml` (`workflow_run`) checks out trusted code,
+re-validates the head numbers **and** the cached `main` baseline, renders the
+comparison comment, and posts it, resolving the target PR from the trusted
+`workflow_run` head SHA. Measuring only the head keeps a PR at ~one instrumented
+pass; a missing baseline is non-fatal (it degrades to a "baseline unavailable"
+note). See [`tests/coverage/ci/README.md`](tests/coverage/ci/README.md) and the
+workflow headers for the full layout + security rationale.

--- a/tests/coverage/ci/CoverageLib.Tests.ps1
+++ b/tests/coverage/ci/CoverageLib.Tests.ps1
@@ -45,13 +45,15 @@ function Assert-True {
 
 function Assert-Match {
     param([string]$Haystack, [string]$Needle, [string]$Message)
-    if ($Haystack -like "*$Needle*") { $script:Pass++ }
+    # Ordinal substring test — NOT -like, whose wildcard metacharacters ([ ] * ?)
+    # would make needles such as '[!CAUTION]' match without the literal text.
+    if ($Haystack.Contains($Needle)) { $script:Pass++ }
     else { $script:Fail++; $script:Failures.Add("$Message`n    missing substring: [$Needle]") }
 }
 
 function Assert-NotMatch {
     param([string]$Haystack, [string]$Needle, [string]$Message)
-    if ($Haystack -notlike "*$Needle*") { $script:Pass++ }
+    if (-not $Haystack.Contains($Needle)) { $script:Pass++ }
     else { $script:Fail++; $script:Failures.Add("$Message`n    unexpected substring: [$Needle]") }
 }
 
@@ -234,6 +236,44 @@ Assert-NotMatch $baseGone '+0.00 pp'                   'baseline-unavailable sho
 $evilRaw = ConvertTo-SafeCoverageMetrics ([pscustomobject]@{ line = '<img src=x onerror=alert(1)>'; branch = '75.2'; branchesCovered = '510'; branchesTotal = '678' })
 $evilComment = Format-CoverageComment -BaseMetrics $base -HeadMetrics $evilRaw -HeadSha 'aaa' -BaseSha 'bbb'
 Assert-NotMatch $evilComment 'onerror' 'sanitized metrics never inject markup into the comment'
+
+# ── Format-CoverageComment: no-baseline (branch dispatch) mode ────────────────
+$nb = Format-CoverageComment -HeadMetrics $head -NoBaseline -HeadSha 'abcdef1234567' -RunUrl 'https://example/run/5'
+Assert-Match    $nb '<!-- reactor-coverage -->' 'no-baseline keeps the marker'
+Assert-Match    $nb '| Metric | Coverage |'     'no-baseline uses a plain two-column table'
+Assert-Match    $nb '| Line   | 87.30% |'       'no-baseline shows absolute line coverage'
+Assert-Match    $nb '| Branch | 75.20% (510/678) |' 'no-baseline shows absolute branch coverage'
+Assert-NotMatch $nb 'vs the base branch'        'no-baseline omits the base-branch wording'
+Assert-NotMatch $nb '[!WARNING]'                'no-baseline is not a warning'
+Assert-NotMatch $nb ' pp'                        'no-baseline shows no delta column'
+Assert-NotMatch $nb ([string][char]0x0394)      'no-baseline has no delta header'
+
+# ── Format-CoverageCommentFromMetrics: the shared render-mode selector ────────
+$present = ConvertTo-SafeCoverageMetrics ([pscustomobject]@{ line = '87.3'; branch = '75.2'; branchesCovered = '510'; branchesTotal = '678' })
+$basePresent = ConvertTo-SafeCoverageMetrics ([pscustomobject]@{ line = '86.1'; branch = '74.5'; branchesCovered = '500'; branchesTotal = '671' })
+$absent = ConvertTo-SafeCoverageMetrics $null
+
+# head absent -> Failed body.
+$selFailed = Format-CoverageCommentFromMetrics -HeadMetrics $absent -BaseMetrics $basePresent -HasBase $true -HeadSha 'aaa' -BaseSha 'bbb'
+Assert-Match    $selFailed '[!CAUTION]'          'selector: absent head -> failed body'
+Assert-NotMatch $selFailed '| Metric |'          'selector: failed body has no table'
+
+# head + base present, HasBase true -> full comparison.
+$selCompare = Format-CoverageCommentFromMetrics -HeadMetrics $present -BaseMetrics $basePresent -HasBase $true -HeadSha 'aaa' -BaseSha 'bbb'
+Assert-Match    $selCompare 'Metric | base | PR' 'selector: head+base -> comparison table'
+Assert-Match    $selCompare '+1.20 pp'           'selector: comparison shows the delta'
+Assert-NotMatch $selCompare '[!WARNING]'         'selector: comparison has no warning'
+
+# head present, base absent, HasBase true -> baseline unavailable.
+$selUnavail = Format-CoverageCommentFromMetrics -HeadMetrics $present -BaseMetrics $absent -HasBase $true -HeadSha 'aaa' -BaseSha 'bbb'
+Assert-Match    $selUnavail '[!WARNING]'          'selector: missing base -> baseline-unavailable'
+Assert-Match    $selUnavail '87.30%'              'selector: baseline-unavailable still shows head'
+
+# head present, HasBase false -> no-baseline absolute (branch dispatch).
+$selNoBase = Format-CoverageCommentFromMetrics -HeadMetrics $present -BaseMetrics $absent -HasBase $false -HeadSha 'aaa'
+Assert-Match    $selNoBase '| Metric | Coverage |' 'selector: no base -> absolute table'
+Assert-NotMatch $selNoBase 'vs the base branch'    'selector: no base omits base-branch wording'
+Assert-NotMatch $selNoBase '[!WARNING]'            'selector: no base is not a warning'
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 Write-Host ''

--- a/tests/coverage/ci/CoverageLib.Tests.ps1
+++ b/tests/coverage/ci/CoverageLib.Tests.ps1
@@ -1,0 +1,247 @@
+<#
+.SYNOPSIS
+    Dependency-free unit tests for CoverageLib.ps1 (the pure cobertura parser /
+    percent-format / delta / renderer used by the automatic merged-coverage PR
+    comment).
+
+.DESCRIPTION
+    Runs headless with no build, no instrumentation, and no external test
+    framework, so it is safe on any runner (it is wired into
+    .github/workflows/coverage-lib-tests.yml on changes under tests/coverage/ci/**).
+    Exits non-zero if any assertion fails.
+
+    Run locally:  pwsh tests/coverage/ci/CoverageLib.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'CoverageLib.ps1')
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -eq $Actual) {
+        $script:Pass++
+    } else {
+        $script:Fail++
+        $script:Failures.Add("$Message`n    expected: [$Expected]`n    actual:   [$Actual]")
+    }
+}
+
+function Assert-Null {
+    param($Actual, [string]$Message)
+    if ($null -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: <null>`n    actual:   [$Actual]") }
+}
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add($Message) }
+}
+
+function Assert-Match {
+    param([string]$Haystack, [string]$Needle, [string]$Message)
+    if ($Haystack -like "*$Needle*") { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    missing substring: [$Needle]") }
+}
+
+function Assert-NotMatch {
+    param([string]$Haystack, [string]$Needle, [string]$Message)
+    if ($Haystack -notlike "*$Needle*") { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    unexpected substring: [$Needle]") }
+}
+
+# ── Get-CoberturaRatesFromXml ────────────────────────────────────────────────
+[xml]$doc = @'
+<coverage line-rate="0.8610" branch-rate="1">
+  <packages>
+    <package>
+      <classes>
+        <class>
+          <lines>
+            <line number="1" hits="1" />
+            <line number="2" hits="1" condition-coverage="50% (1/2)" />
+            <line number="3" hits="0" condition-coverage="75% (3/4)" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+'@
+$r = Get-CoberturaRatesFromXml -Doc $doc
+Assert-Equal 86.1  $r.Line            'line-rate 0.8610 -> 86.1%'
+Assert-Equal 66.67 $r.Branch          'branch = 100*(1+3)/(2+4) = 66.67%'
+Assert-Equal 4     $r.BranchesCovered 'branch covered summed (1+3)'
+Assert-Equal 6     $r.BranchesTotal   'branch total summed (2+4)'
+
+# No conditional branches at all -> branch metrics null, line still parsed.
+[xml]$docNoBranch = '<coverage line-rate="0.5"><packages><package><classes><class><lines><line number="1" hits="1" /></lines></class></classes></package></packages></coverage>'
+$r2 = Get-CoberturaRatesFromXml -Doc $docNoBranch
+Assert-Equal 50 $r2.Line          'line-rate 0.5 -> 50%'
+Assert-Null  $r2.Branch           'no condition-coverage -> null branch'
+Assert-Null  $r2.BranchesCovered  'no condition-coverage -> null covered'
+Assert-Null  $r2.BranchesTotal    'no condition-coverage -> null total'
+
+# Missing line-rate -> null line (no crash).
+[xml]$docNoLine = '<coverage branch-rate="1"><packages /></coverage>'
+$r3 = Get-CoberturaRatesFromXml -Doc $docNoLine
+Assert-Null $r3.Line 'missing line-rate -> null line'
+
+# ── ConvertTo-SafePercent ────────────────────────────────────────────────────
+Assert-Equal 87.3 (ConvertTo-SafePercent '87.30') 'valid decimal percent parses'
+Assert-Equal 0    (ConvertTo-SafePercent '0')     'zero percent'
+Assert-Equal 100  (ConvertTo-SafePercent '100')   '100 percent allowed'
+Assert-Null  (ConvertTo-SafePercent $null)        'null -> null'
+Assert-Null  (ConvertTo-SafePercent '')           'empty -> null'
+Assert-Null  (ConvertTo-SafePercent '150')        '>100 rejected'
+Assert-Null  (ConvertTo-SafePercent '-5')         'negative/sign rejected'
+Assert-Null  (ConvertTo-SafePercent '1e2')        'scientific notation rejected'
+Assert-Null  (ConvertTo-SafePercent '87.3|<img>') 'markdown/pipe injection rejected'
+Assert-Null  (ConvertTo-SafePercent 'NaN')        'non-numeric rejected'
+
+# ── ConvertTo-SafeCount ──────────────────────────────────────────────────────
+Assert-Equal 510 (ConvertTo-SafeCount '510') 'valid integer count'
+Assert-Equal 0   (ConvertTo-SafeCount '0')   'zero count'
+Assert-Null  (ConvertTo-SafeCount $null)     'null count -> null'
+Assert-Null  (ConvertTo-SafeCount '-1')      'negative count -> null'
+Assert-Null  (ConvertTo-SafeCount '1.5')     'decimal count -> null'
+Assert-Null  (ConvertTo-SafeCount '1e9')     'scientific count -> null'
+Assert-Null  (ConvertTo-SafeCount '5; evil') 'injection count -> null'
+
+# ── ConvertTo-SafeCoverageMetrics (security boundary) ────────────────────────
+$safe = ConvertTo-SafeCoverageMetrics ([pscustomobject]@{ line = '87.30'; branch = '75.2'; branchesCovered = '510'; branchesTotal = '678' })
+Assert-Equal 87.3 $safe.Line            'safe metrics keep valid line'
+Assert-Equal 75.2 $safe.Branch          'safe metrics keep valid branch'
+Assert-Equal 510  $safe.BranchesCovered 'safe metrics keep valid covered'
+Assert-Equal 678  $safe.BranchesTotal   'safe metrics keep valid total'
+
+$evil = ConvertTo-SafeCoverageMetrics ([pscustomobject]@{ line = '99|<script>alert(1)</script>'; branch = '-5'; branchesCovered = '1e9'; branchesTotal = 'DROP TABLE' })
+Assert-Null $evil.Line            'injected line dropped'
+Assert-Null $evil.Branch          'signed branch dropped'
+Assert-Null $evil.BranchesCovered 'scientific covered dropped'
+Assert-Null $evil.BranchesTotal   'non-numeric total dropped'
+
+$nullMetrics = ConvertTo-SafeCoverageMetrics $null
+Assert-Null $nullMetrics.Line   'null raw -> null line'
+Assert-Null $nullMetrics.Branch 'null raw -> null branch'
+Assert-True (-not (Test-CoverageMetricsPresent $nullMetrics)) 'all-null metrics are not present'
+Assert-True (Test-CoverageMetricsPresent $safe)               'valid metrics are present'
+
+# ── Format-Percent / Format-BranchCell / Format-SignedPoints ─────────────────
+Assert-Equal '87.30%' (Format-Percent 87.3)  'percent formats to 2 dp'
+Assert-Equal '86.10%' (Format-Percent 86.1)  'percent pads to 2 dp'
+Assert-Equal 'n/a'    (Format-Percent $null) 'null percent -> n/a'
+
+Assert-Equal '74.50% (500/671)' (Format-BranchCell 74.5 500 671) 'branch cell shows counts'
+Assert-Equal '74.50%'           (Format-BranchCell 74.5 $null $null) 'branch cell without counts'
+Assert-Equal 'n/a'              (Format-BranchCell $null 1 2) 'null branch cell -> n/a'
+
+Assert-Equal '+1.20 pp' (Format-SignedPoints 1.2)   'positive pp gets +'
+Assert-Equal '-0.30 pp' (Format-SignedPoints -0.3)  'negative pp keeps -'
+Assert-Equal '0.00 pp'  (Format-SignedPoints 0)     'zero pp no sign'
+Assert-Equal 'n/a'      (Format-SignedPoints $null) 'null pp -> n/a'
+
+# ── Get-CoverageDelta ────────────────────────────────────────────────────────
+$d = Get-CoverageDelta -BasePct 86.1 -HeadPct 87.3
+Assert-Equal 'up'  $d.Status      'rise beyond floor -> up'
+Assert-Equal 1.2   $d.DeltaPoints 'up delta points'
+Assert-True  $d.Improved          'up is the improvement'
+
+$d = Get-CoverageDelta -BasePct 87.3 -HeadPct 86.1
+Assert-Equal 'down' $d.Status      'fall beyond floor -> down'
+Assert-Equal -1.2   $d.DeltaPoints 'down delta points (negative)'
+Assert-True  (-not $d.Improved)    'down is not an improvement'
+
+# Below the noise floor -> unchanged (delta still reported).
+$d = Get-CoverageDelta -BasePct 86.10 -HeadPct 86.15
+Assert-Equal 'unchanged' $d.Status      'tiny delta -> unchanged'
+Assert-Equal 0.05        $d.DeltaPoints 'unchanged still reports the delta'
+Assert-Null  $d.Improved                'unchanged has no improvement flag'
+
+# Exactly at the floor counts as a real move.
+$d = Get-CoverageDelta -BasePct 86.0 -HeadPct 86.1
+Assert-Equal 'up' $d.Status 'delta == floor (0.1) -> up'
+
+# Missing either side -> na.
+Assert-Equal 'na' (Get-CoverageDelta -BasePct $null -HeadPct 87.3).Status 'missing base -> na'
+Assert-Equal 'na' (Get-CoverageDelta -BasePct 86.1 -HeadPct $null).Status 'missing head -> na'
+Assert-Null  (Get-CoverageDelta -BasePct $null -HeadPct $null).DeltaPoints 'na has no delta'
+
+# ── Get-CoverageStatusGlyph / Format-CoverageDeltaCell ───────────────────────
+Assert-Equal "$([char]0x2705)"                (Get-CoverageStatusGlyph 'up')        'up -> check'
+Assert-Equal "$([char]0x26A0)$([char]0xFE0F)" (Get-CoverageStatusGlyph 'down')      'down -> warning'
+Assert-Equal "$([char]0x2248)"                (Get-CoverageStatusGlyph 'unchanged') 'unchanged -> approx'
+Assert-Equal "$([char]0x2014)"                (Get-CoverageStatusGlyph 'na')        'na -> dash'
+
+Assert-Equal "$([char]0x2014)" (Format-CoverageDeltaCell (Get-CoverageDelta -BasePct $null -HeadPct 87.3)) 'na cell -> dash'
+Assert-Equal '+1.20 pp'        (Format-CoverageDeltaCell (Get-CoverageDelta -BasePct 86.1 -HeadPct 87.3))  'up cell -> signed pp'
+
+# ── Format-CoverageComment: full comparison ──────────────────────────────────
+$base = [pscustomobject]@{ Line = 86.1; Branch = 74.5; BranchesCovered = 500; BranchesTotal = 671 }
+$head = [pscustomobject]@{ Line = 87.3; Branch = 75.2; BranchesCovered = 510; BranchesTotal = 678 }
+$comment = Format-CoverageComment -BaseMetrics $base -HeadMetrics $head -HeadSha 'abcdef1234567' -BaseSha '1234567890abc' -RunUrl 'https://example/run/1'
+Assert-Match $comment '<!-- reactor-coverage -->' 'comment carries the sticky marker'
+Assert-Match $comment 'Merged coverage'           'comment has heading'
+Assert-Match $comment 'abcdef1'                    'head sha shortened to 7'
+Assert-Match $comment '1234567'                    'base sha shortened to 7'
+Assert-Match $comment 'vs the base branch'         'header uses base-branch wording'
+Assert-Match $comment 'Metric | base | PR'         'table column header says base | PR'
+Assert-NotMatch $comment 'main | PR'               'table column header is not hard-coded main'
+Assert-Match $comment '| Line   | 86.10% | 87.30% | +1.20 pp |' 'line row shows base, PR, +delta'
+Assert-Match $comment '74.50% (500/671)'           'branch base cell shows counts'
+Assert-Match $comment '75.20% (510/678)'           'branch PR cell shows counts'
+Assert-Match $comment '+0.70 pp'                   'branch delta rendered'
+Assert-Match $comment "$([char]0x2705)"            'improvement glyph present'
+Assert-Match $comment 'workflow run'               'footer links the run'
+Assert-Match $comment 'percentage points'          'legend explains the pp unit'
+
+# Regression rendering: PR lower than base -> warning glyph + negative delta.
+$worse = [pscustomobject]@{ Line = 84.0; Branch = 70.0; BranchesCovered = 400; BranchesTotal = 671 }
+$regressed = Format-CoverageComment -BaseMetrics $base -HeadMetrics $worse -HeadSha 'aaa' -BaseSha 'bbb'
+Assert-Match $regressed '-2.10 pp'                  'line regression shows negative pp'
+Assert-Match $regressed "$([char]0x26A0)$([char]0xFE0F)" 'regression shows warning glyph'
+Assert-NotMatch $regressed 'No coverage change beyond' 'regression is not reported as no-change'
+
+# All-unchanged rendering: the "no change" note appears, no up/down rows.
+$flatComment = Format-CoverageComment -BaseMetrics $base -HeadMetrics $base -HeadSha 'aaa' -BaseSha 'bbb'
+Assert-Match $flatComment 'No coverage change beyond the noise floor' 'flat comparison notes no change'
+Assert-Match $flatComment '0.00 pp'                                   'flat comparison shows a zero delta'
+
+# Failure mode: emits a caution block, not a table.
+$failComment = Format-CoverageComment -Failed -RunUrl 'https://example/run/2'
+Assert-Match    $failComment '<!-- reactor-coverage -->' 'failure comment keeps the marker'
+Assert-Match    $failComment '[!CAUTION]'                'failure comment is a caution admonition'
+Assert-NotMatch $failComment '| Metric |'               'failure comment has no coverage table'
+
+# A present-looking call whose head has no real numbers also renders the failure body.
+$noHead = Format-CoverageComment -HeadMetrics ([pscustomobject]@{ Line = $null; Branch = $null; BranchesCovered = $null; BranchesTotal = $null }) -RunUrl 'https://example/run/3'
+Assert-Match $noHead '[!CAUTION]' 'null head metrics -> caution body'
+
+# Baseline-unavailable mode: head coverage renders, delta is a dash, warning shown.
+$baseGone = Format-CoverageComment -HeadMetrics $head -BaselineUnavailable -HeadSha 'aaa' -BaseSha 'bbb' -RunUrl 'https://example/run/4'
+Assert-Match    $baseGone '[!WARNING]'                 'baseline-unavailable emits a warning'
+Assert-Match    $baseGone '87.30%'                     'baseline-unavailable still shows PR line coverage'
+Assert-Match    $baseGone "| Line   | n/a | 87.30% | $([char]0x2014) |" 'baseline-unavailable shows n/a base and a dash delta'
+Assert-NotMatch $baseGone 'No coverage change beyond'  'baseline-unavailable suppresses the no-change note'
+Assert-NotMatch $baseGone '+0.00 pp'                   'baseline-unavailable shows no signed delta'
+
+# Security end-to-end: an injected value in the raw record never reaches markdown.
+$evilRaw = ConvertTo-SafeCoverageMetrics ([pscustomobject]@{ line = '<img src=x onerror=alert(1)>'; branch = '75.2'; branchesCovered = '510'; branchesTotal = '678' })
+$evilComment = Format-CoverageComment -BaseMetrics $base -HeadMetrics $evilRaw -HeadSha 'aaa' -BaseSha 'bbb'
+Assert-NotMatch $evilComment 'onerror' 'sanitized metrics never inject markup into the comment'
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+Write-Host ''
+Write-Host "CoverageLib tests: $script:Pass passed, $script:Fail failed."
+if ($script:Fail -gt 0) {
+    Write-Host ''
+    Write-Host 'Failures:' -ForegroundColor Red
+    foreach ($f in $script:Failures) { Write-Host "  - $f" -ForegroundColor Red }
+    exit 1
+}
+exit 0

--- a/tests/coverage/ci/CoverageLib.ps1
+++ b/tests/coverage/ci/CoverageLib.ps1
@@ -324,6 +324,10 @@ function Format-CoverageComment {
         When set, the base branch measurement is missing (e.g. its build failed), so
         render the PR's absolute coverage with an em-dash delta and a note, instead
         of a misleading comparison.
+    .PARAMETER NoBaseline
+        When set, there is intentionally no base to compare against (a manual
+        branch-dispatch measure). Render the head's absolute coverage as a plain
+        two-column table with no base column, delta, or "vs the base branch" wording.
     #>
     param(
         [AllowNull()]$BaseMetrics,
@@ -332,7 +336,8 @@ function Format-CoverageComment {
         [string]$BaseSha = '',
         [string]$RunUrl = '',
         [switch]$Failed,
-        [switch]$BaselineUnavailable
+        [switch]$BaselineUnavailable,
+        [switch]$NoBaseline
     )
     $marker = $script:CoverageCommentMarker
     $flask = [char]::ConvertFromUtf32(0x1F9EA)  # test tube
@@ -349,6 +354,26 @@ function Format-CoverageComment {
         $suffix = if ($RunUrl) { " See the [workflow run]($RunUrl) for details." } else { '' }
         $lines.Add("> Coverage run failed for ``$headShort`` (build or measurement error).$suffix")
         $lines.Add('')
+        return ($lines -join "`n")
+    }
+
+    if ($NoBaseline) {
+        # No base to compare against (a manual branch-dispatch measure). Show the
+        # absolute numbers in a plain two-column table — no base column, no delta,
+        # and none of the "vs the base branch" / "baseline unavailable" wording.
+        $lines.Add("Coverage for ``$headShort`` — unit + selftest merged.")
+        $lines.Add('')
+        $lines.Add('| Metric | Coverage |')
+        $lines.Add('|---|--:|')
+        $lines.Add("| Line   | $(Format-Percent $HeadMetrics.Line) |")
+        $lines.Add("| Branch | $(Format-BranchCell $HeadMetrics.Branch $HeadMetrics.BranchesCovered $HeadMetrics.BranchesTotal) |")
+        $lines.Add('')
+        $absLegend = 'Coverage is unit + selftest merged (Debug x64) on the CI runner; no base branch to compare against.'
+        if ($RunUrl) {
+            $lines.Add("<sub>$absLegend Cobertura reports attached to the <a href=`"$RunUrl`">workflow run</a> as artifacts.</sub>")
+        } else {
+            $lines.Add("<sub>$absLegend</sub>")
+        }
         return ($lines -join "`n")
     }
 
@@ -399,4 +424,40 @@ function Format-CoverageComment {
     }
 
     return ($lines -join "`n")
+}
+
+function Format-CoverageCommentFromMetrics {
+    <#
+    .SYNOPSIS
+        Pick the right Format-CoverageComment render mode from a pair of (already
+        sanitized) metrics objects, so the poster and the run-summary select the mode
+        the same way — one tested code path instead of duplicated YAML branching.
+    .DESCRIPTION
+        Selection:
+          - head not present                -> Failed (CAUTION).
+          - head present, HasBase = $false  -> NoBaseline (absolute, branch dispatch).
+          - head + base present             -> full base | PR | Δ comparison.
+          - head present, base missing      -> BaselineUnavailable (absolute + warning).
+        Pass metrics already run through ConvertTo-SafeCoverageMetrics.
+    #>
+    param(
+        [AllowNull()]$HeadMetrics,
+        [AllowNull()]$BaseMetrics,
+        [bool]$HasBase = $true,
+        [string]$HeadSha = '',
+        [string]$BaseSha = '',
+        [string]$RunUrl = ''
+    )
+    if (-not (Test-CoverageMetricsPresent $HeadMetrics)) {
+        return Format-CoverageComment -Failed -HeadSha $HeadSha -RunUrl $RunUrl
+    }
+    if (-not $HasBase) {
+        return Format-CoverageComment -HeadMetrics $HeadMetrics -NoBaseline -HeadSha $HeadSha -RunUrl $RunUrl
+    }
+    if (Test-CoverageMetricsPresent $BaseMetrics) {
+        return Format-CoverageComment -BaseMetrics $BaseMetrics -HeadMetrics $HeadMetrics `
+            -HeadSha $HeadSha -BaseSha $BaseSha -RunUrl $RunUrl
+    }
+    return Format-CoverageComment -HeadMetrics $HeadMetrics -BaselineUnavailable `
+        -HeadSha $HeadSha -BaseSha $BaseSha -RunUrl $RunUrl
 }

--- a/tests/coverage/ci/CoverageLib.ps1
+++ b/tests/coverage/ci/CoverageLib.ps1
@@ -1,0 +1,402 @@
+<#
+.SYNOPSIS
+    Pure, dot-source-able helpers for the automatic merged-coverage PR comment
+    (.github/workflows/coverage.yml + coverage-comment.yml).
+
+.DESCRIPTION
+    These functions have no side effects beyond Write-Warning, so they can be
+    unit-tested locally (CoverageLib.Tests.ps1) without building or instrumenting
+    anything:
+
+      Get-CoberturaRatesFromXml   sum a merged cobertura document into line %,
+                                  branch %, and the branch covered/total counts.
+      Get-CoberturaRates          same, from a file path.
+      ConvertTo-SafePercent       gate an artifact-supplied percentage (0..100).
+      ConvertTo-SafeCount         gate an artifact-supplied non-negative integer.
+      ConvertTo-SafeCoverageMetrics  project raw (untrusted) numbers onto a
+                                  validated metrics object — the render-time
+                                  security boundary for the privileged poster.
+      Test-CoverageMetricsPresent whether a metrics object carries a real line %.
+      Format-Percent              humanize a percentage ('87.30%' / 'n/a').
+      Format-BranchCell           branch % plus its (covered/total) counts.
+      Format-SignedPoints         signed percentage-point delta ('+1.20 pp').
+      Get-CoverageDelta           base-vs-head delta, direction-aware, with a
+                                  small noise band (up / down / unchanged / na).
+      Get-CoverageStatusGlyph     emoji/glyph for a delta status.
+      Format-CoverageDeltaCell    the 'Δ' table cell.
+      Format-CoverageComment      the sticky base-vs-PR coverage markdown comment.
+
+    A "coverage metrics" object is a [pscustomobject] with:
+      Line             merged line coverage, percent (0..100), or $null.
+      Branch           merged branch coverage, percent (0..100), or $null.
+      BranchesCovered  covered conditional branches, or $null.
+      BranchesTotal    total conditional branches, or $null.
+
+    HIGHER coverage is the "good" direction, so a rise is flagged as the
+    improvement (up) and a fall as the regression (down). The comment is
+    informational only — it never fails a PR.
+#>
+
+Set-StrictMode -Version Latest
+
+# Hidden marker used to find + update-in-place the sticky PR comment. Matches the
+# marker the original inline poster used, so it keeps updating the SAME comment
+# rather than orphaning it and posting a duplicate. Mirrors the convention in
+# tests/build_metrics/ci/BuildMetricsLib.ps1 ('<!-- reactor-build-metrics -->').
+$script:CoverageCommentMarker = '<!-- reactor-coverage -->'
+
+# Default significance band, in percentage points. Merged coverage is largely
+# deterministic, but selftest branch coverage can wiggle by a hair across
+# otherwise-identical runs (timing/ordering-dependent branches). A delta counts as
+# a real move only when it clears this floor, so sub-noise jitter doesn't render as
+# a spurious ✅/⚠️.
+$script:CoverageNoiseFloorPoints = 0.1
+
+function Get-CoverageCommentMarker {
+    <#
+    .SYNOPSIS
+        The hidden HTML marker used to find + update the sticky coverage comment.
+    #>
+    return $script:CoverageCommentMarker
+}
+
+function Get-CoberturaRatesFromXml {
+    <#
+    .SYNOPSIS
+        Aggregate a merged cobertura document into line % + branch % (+ the branch
+        covered/total counts).
+    .DESCRIPTION
+        dotnet-coverage's cobertura output records per-line branch data in
+        `condition-coverage="P% (covered/total)"` attributes but does NOT aggregate
+        them: the root/class `branch-rate` attributes are hard-coded to 1. So the
+        line rate is read from the root `line-rate` (0..1, scaled to a percent) and
+        the branch rate is summed from the per-line numerators/denominators here.
+        Returns a metrics object; Branch/counts are $null when the document has no
+        conditional branches at all.
+    #>
+    param([Parameter(Mandatory)][xml]$Doc)
+
+    $lineRateAttr = $null
+    if ($Doc.DocumentElement -and $Doc.DocumentElement.HasAttribute('line-rate')) {
+        $lineRateAttr = $Doc.DocumentElement.GetAttribute('line-rate')
+    }
+    $line = $null
+    if ($null -ne $lineRateAttr -and $lineRateAttr -ne '') {
+        $parsed = [double]0
+        if ([double]::TryParse([string]$lineRateAttr,
+                [System.Globalization.NumberStyles]::Float,
+                [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsed)) {
+            $line = [math]::Round($parsed * 100, 2)
+        }
+    }
+
+    $covered = 0
+    $total = 0
+    foreach ($l in $Doc.SelectNodes('//line[@condition-coverage]')) {
+        $cc = [string]$l.GetAttribute('condition-coverage')
+        if ($cc -match '\((\d+)/(\d+)\)') {
+            $covered += [int]$Matches[1]
+            $total += [int]$Matches[2]
+        }
+    }
+
+    $branch = $null
+    $bc = $null
+    $bt = $null
+    if ($total -gt 0) {
+        $branch = [math]::Round(100.0 * $covered / $total, 2)
+        $bc = [long]$covered
+        $bt = [long]$total
+    }
+
+    return [pscustomobject]@{
+        Line            = $line
+        Branch          = $branch
+        BranchesCovered = $bc
+        BranchesTotal   = $bt
+    }
+}
+
+function Get-CoberturaRates {
+    <#
+    .SYNOPSIS
+        Get-CoberturaRatesFromXml from a merged cobertura file on disk. Returns an
+        all-null metrics object when the file is missing or not valid XML.
+    #>
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        Write-Warning "Cobertura report not found: $Path"
+        return [pscustomobject]@{ Line = $null; Branch = $null; BranchesCovered = $null; BranchesTotal = $null }
+    }
+    try {
+        [xml]$doc = Get-Content -LiteralPath $Path -Raw
+    } catch {
+        Write-Warning "Failed to parse cobertura ${Path}: $($_.Exception.Message)"
+        return [pscustomobject]@{ Line = $null; Branch = $null; BranchesCovered = $null; BranchesTotal = $null }
+    }
+    return Get-CoberturaRatesFromXml -Doc $doc
+}
+
+function ConvertTo-SafePercent {
+    <#
+    .SYNOPSIS
+        Return $Value as a [double] percentage in [0, 100], or $null when it is
+        missing, out of range, or not a plain non-negative decimal (rejects a sign,
+        exponent, pipe, or any other markdown/injection character). The sole gate
+        for artifact-supplied coverage percentages.
+    #>
+    param([AllowNull()]$Value)
+    if ($null -eq $Value) { return $null }
+    $s = ([string]$Value).Trim()
+    if ($s -notmatch '^\d+(\.\d+)?$') { return $null }
+    $parsed = [double]0
+    if (-not [double]::TryParse($s, [System.Globalization.NumberStyles]::AllowDecimalPoint,
+            [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsed)) {
+        return $null
+    }
+    if ($parsed -lt 0 -or $parsed -gt 100) { return $null }
+    return $parsed
+}
+
+function ConvertTo-SafeCount {
+    <#
+    .SYNOPSIS
+        Return $Value as a non-negative [long], or $null when it is missing,
+        negative, or not a plain integer. The sole gate for artifact-supplied
+        branch covered/total counts.
+    #>
+    param([AllowNull()]$Value)
+    if ($null -eq $Value) { return $null }
+    $parsed = [long]0
+    if ([long]::TryParse([string]$Value, [ref]$parsed) -and $parsed -ge 0) {
+        return $parsed
+    }
+    return $null
+}
+
+function ConvertTo-SafeCoverageMetrics {
+    <#
+    .SYNOPSIS
+        Project a raw (untrusted) coverage record — e.g. parsed from a coverage.json
+        an unprivileged PR job produced — onto a validated metrics object.
+    .DESCRIPTION
+        Security boundary for the privileged poster: every field is re-validated
+        here (percentages via ConvertTo-SafePercent, counts via ConvertTo-SafeCount),
+        so nothing artifact-derived reaches the rendered markdown except a handful
+        of plain, range-checked numbers. Unknown/extra properties on the input are
+        ignored. A $null input yields an all-null metrics object.
+    #>
+    param([AllowNull()]$Raw)
+
+    function Get-RawProp($obj, [string]$name) {
+        if ($null -eq $obj) { return $null }
+        if ($obj.PSObject.Properties[$name]) { return $obj.$name }
+        return $null
+    }
+
+    return [pscustomobject]@{
+        Line            = ConvertTo-SafePercent (Get-RawProp $Raw 'line')
+        Branch          = ConvertTo-SafePercent (Get-RawProp $Raw 'branch')
+        BranchesCovered = ConvertTo-SafeCount   (Get-RawProp $Raw 'branchesCovered')
+        BranchesTotal   = ConvertTo-SafeCount   (Get-RawProp $Raw 'branchesTotal')
+    }
+}
+
+function Test-CoverageMetricsPresent {
+    <#
+    .SYNOPSIS
+        $true when the metrics object carries a real (non-null) line coverage — the
+        signal that a side actually produced numbers.
+    #>
+    param([AllowNull()]$Metrics)
+    return ($null -ne $Metrics -and $null -ne $Metrics.Line)
+}
+
+function Format-Percent {
+    <#
+    .SYNOPSIS
+        Humanize a percentage as 'NN.NN%', or 'n/a' when $null.
+    #>
+    param([AllowNull()]$Pct)
+    if ($null -eq $Pct) { return 'n/a' }
+    $r = [math]::Round([double]$Pct, 2)
+    return ('{0:0.00}%' -f $r)
+}
+
+function Format-BranchCell {
+    <#
+    .SYNOPSIS
+        Branch percentage plus its (covered/total) counts, e.g. '74.50% (500/671)'.
+        Falls back to just the percent when counts are absent, or 'n/a' when the
+        percent itself is null.
+    #>
+    param([AllowNull()]$Pct, [AllowNull()]$Covered, [AllowNull()]$Total)
+    if ($null -eq $Pct) { return 'n/a' }
+    $p = Format-Percent $Pct
+    if ($null -ne $Covered -and $null -ne $Total) {
+        return "$p ($Covered/$Total)"
+    }
+    return $p
+}
+
+function Format-SignedPoints {
+    <#
+    .SYNOPSIS
+        Format a percentage-point delta with an explicit sign, e.g. '+1.20 pp' /
+        '-0.30 pp' / '0.00 pp'. 'n/a' when $null.
+    #>
+    param([AllowNull()]$Points)
+    if ($null -eq $Points) { return 'n/a' }
+    $r = [math]::Round([double]$Points, 2)
+    return (('{0:+0.00;-0.00;0.00}' -f $r) + ' pp')
+}
+
+function Get-CoverageDelta {
+    <#
+    .SYNOPSIS
+        Base-vs-head coverage delta with a small noise band. Status is one of:
+        up | down | unchanged | na.
+    .DESCRIPTION
+        - na       : either side absent (no baseline / no measurement).
+        - unchanged: present on both, |Δ| below the noise floor (percentage points).
+        - up/down  : present on both, |Δ| clears the floor.
+        HIGHER coverage is the improvement, so Improved is $true only for 'up'.
+    #>
+    param(
+        [AllowNull()]$BasePct,
+        [AllowNull()]$HeadPct,
+        [double]$NoiseFloorPoints = $script:CoverageNoiseFloorPoints
+    )
+    if ($null -eq $BasePct -or $null -eq $HeadPct) {
+        return [pscustomobject]@{ Status = 'na'; DeltaPoints = $null; Improved = $null }
+    }
+
+    $delta = [math]::Round([double]$HeadPct - [double]$BasePct, 2)
+
+    if ([math]::Abs($delta) -lt $NoiseFloorPoints) {
+        return [pscustomobject]@{ Status = 'unchanged'; DeltaPoints = $delta; Improved = $null }
+    }
+
+    $status = if ($delta -gt 0) { 'up' } else { 'down' }
+    return [pscustomobject]@{ Status = $status; DeltaPoints = $delta; Improved = ($delta -gt 0) }
+}
+
+function Get-CoverageStatusGlyph {
+    <#
+    .SYNOPSIS
+        Short status glyph for a delta status (a rise is the improvement).
+    #>
+    param([string]$Status)
+    switch ($Status) {
+        'up'        { return [char]0x2705 }                 # check mark
+        'down'      { return [char]0x26A0 + [char]0xFE0F }  # warning sign
+        'unchanged' { return [char]0x2248 }                 # almost-equal-to
+        default     { return [char]0x2014 }                 # em dash
+    }
+}
+
+function Format-CoverageDeltaCell {
+    <#
+    .SYNOPSIS
+        Render the 'Δ' cell: a signed percentage-point delta, or an em dash when no
+        baseline is available.
+    #>
+    param([pscustomobject]$Delta)
+    if ($Delta.Status -eq 'na') { return [char]0x2014 }
+    return (Format-SignedPoints $Delta.DeltaPoints)
+}
+
+function Format-CoverageComment {
+    <#
+    .SYNOPSIS
+        Render the full sticky merged-coverage comment from base + head metrics.
+    .PARAMETER BaseMetrics / HeadMetrics
+        Coverage metrics objects (Line/Branch/BranchesCovered/BranchesTotal). Head
+        drives the PR column; base supplies the comparison column.
+    .PARAMETER HeadSha / BaseSha
+        Commit SHAs for the header (short-formatted here).
+    .PARAMETER RunUrl
+        Optional workflow-run URL for the footer.
+    .PARAMETER Failed
+        When set, emit a short failure notice instead of the table (so the poster
+        always has a body to write).
+    .PARAMETER BaselineUnavailable
+        When set, the base branch measurement is missing (e.g. its build failed), so
+        render the PR's absolute coverage with an em-dash delta and a note, instead
+        of a misleading comparison.
+    #>
+    param(
+        [AllowNull()]$BaseMetrics,
+        [AllowNull()]$HeadMetrics,
+        [string]$HeadSha = '',
+        [string]$BaseSha = '',
+        [string]$RunUrl = '',
+        [switch]$Failed,
+        [switch]$BaselineUnavailable
+    )
+    $marker = $script:CoverageCommentMarker
+    $flask = [char]::ConvertFromUtf32(0x1F9EA)  # test tube
+    $headShort = if ($HeadSha) { $HeadSha.Substring(0, [math]::Min(7, $HeadSha.Length)) } else { 'unknown' }
+    $baseShort = if ($BaseSha) { $BaseSha.Substring(0, [math]::Min(7, $BaseSha.Length)) } else { '' }
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add($marker)
+    $lines.Add("## $flask Merged coverage")
+    $lines.Add('')
+
+    if ($Failed -or -not (Test-CoverageMetricsPresent $HeadMetrics)) {
+        $lines.Add('> [!CAUTION]')
+        $suffix = if ($RunUrl) { " See the [workflow run]($RunUrl) for details." } else { '' }
+        $lines.Add("> Coverage run failed for ``$headShort`` (build or measurement error).$suffix")
+        $lines.Add('')
+        return ($lines -join "`n")
+    }
+
+    $hasBase = (Test-CoverageMetricsPresent $BaseMetrics) -and -not $BaselineUnavailable
+    $baseSuffix = if ($hasBase -and $baseShort) { " (``$baseShort``)" } else { '' }
+    $lines.Add("Coverage for ``$headShort`` vs the base branch$baseSuffix — unit + selftest merged.")
+    $lines.Add('')
+
+    if ($BaselineUnavailable) {
+        $lines.Add('> [!WARNING]')
+        $lines.Add('> The base branch measurement is unavailable, so no delta is shown — reporting the PR''s absolute coverage only.')
+        $lines.Add('')
+    }
+
+    $baseLine   = if ($hasBase) { $BaseMetrics.Line } else { $null }
+    $baseBranch = if ($hasBase) { $BaseMetrics.Branch } else { $null }
+    $baseBc     = if ($hasBase) { $BaseMetrics.BranchesCovered } else { $null }
+    $baseBt     = if ($hasBase) { $BaseMetrics.BranchesTotal } else { $null }
+
+    $lineDelta   = Get-CoverageDelta -BasePct $baseLine   -HeadPct $HeadMetrics.Line
+    $branchDelta = Get-CoverageDelta -BasePct $baseBranch -HeadPct $HeadMetrics.Branch
+
+    $lines.Add('| Metric | base | PR | ' + [char]0x0394 + ' | |')
+    $lines.Add('|---|--:|--:|--:|:-:|')
+    $lines.Add(('| Line   | {0} | {1} | {2} | {3} |' -f `
+        (Format-Percent $baseLine), `
+        (Format-Percent $HeadMetrics.Line), `
+        (Format-CoverageDeltaCell $lineDelta), `
+        (Get-CoverageStatusGlyph $lineDelta.Status)))
+    $lines.Add(('| Branch | {0} | {1} | {2} | {3} |' -f `
+        (Format-BranchCell $baseBranch $baseBc $baseBt), `
+        (Format-BranchCell $HeadMetrics.Branch $HeadMetrics.BranchesCovered $HeadMetrics.BranchesTotal), `
+        (Format-CoverageDeltaCell $branchDelta), `
+        (Get-CoverageStatusGlyph $branchDelta.Status)))
+    $lines.Add('')
+
+    if ($hasBase -and $lineDelta.Status -eq 'unchanged' -and $branchDelta.Status -eq 'unchanged') {
+        $lines.Add('No coverage change beyond the noise floor. ' + [char]0x2705)
+        $lines.Add('')
+    }
+
+    $legend = [char]0x2705 + ' higher / ' + [char]0x26A0 + [char]0xFE0F + ' lower / ' +
+        [char]0x2248 + ' within noise. Δ is in percentage points; coverage is unit + selftest merged (Debug x64) on the CI runner.'
+    if ($RunUrl) {
+        $lines.Add("<sub>$legend Cobertura reports attached to the <a href=`"$RunUrl`">workflow run</a> as artifacts.</sub>")
+    } else {
+        $lines.Add("<sub>$legend</sub>")
+    }
+
+    return ($lines -join "`n")
+}

--- a/tests/coverage/ci/Measure-Coverage.Tests.ps1
+++ b/tests/coverage/ci/Measure-Coverage.Tests.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+    Dependency-free unit tests for the testable parts of Measure-Coverage.ps1 (the
+    merged-coverage orchestrator): the Invoke-Checked exit-code guard, the
+    cobertura-report reading path, and the JSON contract with the poster.
+
+.DESCRIPTION
+    Measure-Coverage.ps1 isn't dot-sourceable (it has a param block + a main run
+    flow that shells out to `dotnet` / `dotnet-coverage`), so Invoke-Checked is
+    extracted via the PowerShell AST and defined in isolation. The heavy build +
+    instrument + collect path is validated by the live Coverage run, not here; this
+    covers the pure guard + the numbers contract so a regression in the JSON shape
+    (which the trusted poster reads) is caught headless on the cheap Linux runner in
+    .github/workflows/coverage-lib-tests.yml. Exits non-zero on any failure.
+
+    Run locally:  pwsh tests/coverage/ci/Measure-Coverage.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'CoverageLib.ps1')
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: [$Expected]`n    actual:   [$Actual]") }
+}
+function Assert-Null {
+    param($Actual, [string]$Message)
+    if ($null -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: <null>`n    actual:   [$Actual]") }
+}
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add($Message) }
+}
+
+# --- Parse-check + extract Invoke-Checked from the orchestrator via AST. ---
+$scriptPath = Join-Path $PSScriptRoot 'Measure-Coverage.ps1'
+$src = Get-Content $scriptPath -Raw
+$parseTokens = $null; $parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseInput($src, [ref]$parseTokens, [ref]$parseErrors)
+if ($parseErrors -and $parseErrors.Count -gt 0) {
+    Write-Host "Measure-Coverage.ps1 has $($parseErrors.Count) parse error(s):" -ForegroundColor Red
+    $parseErrors | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" -ForegroundColor Red }
+    exit 1
+}
+function Get-Func([string]$name) {
+    $f = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $name }, $true) |
+        Select-Object -First 1
+    if (-not $f) { throw "$name not found in Measure-Coverage.ps1" }
+    $f.Extent.Text
+}
+Invoke-Expression (Get-Func 'Invoke-Checked')
+
+# --- Invoke-Checked: throws on a non-zero exit code, silent on zero. ---
+$threw = $false
+try { Invoke-Checked -What 'ok step' -Action { $global:LASTEXITCODE = 0 } }
+catch { $threw = $true }
+Assert-True (-not $threw) 'Invoke-Checked does not throw on exit 0'
+
+$threw = $false
+$msg = ''
+try { Invoke-Checked -What 'boom step' -Action { $global:LASTEXITCODE = 5 } }
+catch { $threw = $true; $msg = $_.Exception.Message }
+Assert-True $threw 'Invoke-Checked throws on a non-zero exit code'
+Assert-True ($msg -like '*boom step*') 'Invoke-Checked error names the failing step'
+Assert-True ($msg -like '*exit 5*')    'Invoke-Checked error includes the exit code'
+$global:LASTEXITCODE = 0
+
+# --- Get-CoberturaRates: file-reading path used at the end of the orchestrator. ---
+$tmp = Join-Path ([IO.Path]::GetTempPath()) ("cov-measure-tests-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+    $mergedPath = Join-Path $tmp 'merged.cobertura.xml'
+    Set-Content -LiteralPath $mergedPath -Encoding UTF8 -Value @'
+<coverage line-rate="0.9012" branch-rate="1">
+  <packages><package><classes><class><lines>
+    <line number="1" hits="1" condition-coverage="100% (2/2)" />
+    <line number="2" hits="1" condition-coverage="50% (1/2)" />
+  </lines></class></classes></package></packages>
+</coverage>
+'@
+    $rates = Get-CoberturaRates -Path $mergedPath
+    Assert-Equal 90.12 $rates.Line            'reads line-rate from a merged report file'
+    Assert-Equal 75    $rates.Branch          'aggregates branch rate from a merged report file'
+    Assert-Equal 3     $rates.BranchesCovered 'branch covered summed from file (2+1)'
+    Assert-Equal 4     $rates.BranchesTotal   'branch total summed from file (2+2)'
+
+    # Missing report -> all-null metrics (degrades to a failed/unavailable render).
+    $missing = Get-CoberturaRates -Path (Join-Path $tmp 'does-not-exist.xml')
+    Assert-Null $missing.Line   'missing report file -> null line'
+    Assert-Null $missing.Branch 'missing report file -> null branch'
+
+    # --- JSON contract: what Measure-Coverage writes, the poster must read back. ---
+    # Mirrors the [ordered] payload the orchestrator emits, round-tripped through the
+    # poster's security-boundary projection.
+    $payload = [ordered]@{
+        line            = $rates.Line
+        branch          = $rates.Branch
+        branchesCovered = $rates.BranchesCovered
+        branchesTotal   = $rates.BranchesTotal
+        outcome         = 'success'
+    }
+    $roundTrip = $payload | ConvertTo-Json -Depth 3 | ConvertFrom-Json
+    $metrics = ConvertTo-SafeCoverageMetrics $roundTrip
+    Assert-Equal 90.12 $metrics.Line            'poster reads line from the emitted JSON'
+    Assert-Equal 75    $metrics.Branch          'poster reads branch from the emitted JSON'
+    Assert-Equal 3     $metrics.BranchesCovered 'poster reads covered from the emitted JSON'
+    Assert-Equal 4     $metrics.BranchesTotal   'poster reads total from the emitted JSON'
+    Assert-Equal 'success' $roundTrip.outcome   'outcome survives the round trip'
+    Assert-True (Test-CoverageMetricsPresent $metrics) 'round-tripped metrics are present'
+
+    # A no-branch tree emits null branch fields that must survive as null.
+    $noBranch = [ordered]@{ line = 42.0; branch = $null; branchesCovered = $null; branchesTotal = $null; outcome = 'success' }
+    $nbMetrics = ConvertTo-SafeCoverageMetrics ($noBranch | ConvertTo-Json -Depth 3 | ConvertFrom-Json)
+    Assert-Equal 42 $nbMetrics.Line   'null-branch payload keeps line'
+    Assert-Null  $nbMetrics.Branch    'null-branch payload keeps branch null'
+}
+finally {
+    Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+Write-Host ''
+Write-Host "Measure-Coverage tests: $script:Pass passed, $script:Fail failed."
+if ($script:Fail -gt 0) {
+    Write-Host ''
+    Write-Host 'Failures:' -ForegroundColor Red
+    foreach ($f in $script:Failures) { Write-Host "  - $f" -ForegroundColor Red }
+    exit 1
+}
+exit 0

--- a/tests/coverage/ci/Measure-Coverage.Tests.ps1
+++ b/tests/coverage/ci/Measure-Coverage.Tests.ps1
@@ -96,6 +96,15 @@ try {
     Assert-Null $missing.Line   'missing report file -> null line'
     Assert-Null $missing.Branch 'missing report file -> null branch'
 
+    # Malformed XML -> all-null metrics, no throw (the catch branch in Get-CoberturaRates).
+    $badPath = Join-Path $tmp 'malformed.cobertura.xml'
+    Set-Content -LiteralPath $badPath -Encoding UTF8 -Value '<coverage line-rate="0.5"><packages><oops'
+    $malformed = Get-CoberturaRates -Path $badPath
+    Assert-Null $malformed.Line            'malformed report -> null line (no throw)'
+    Assert-Null $malformed.Branch          'malformed report -> null branch'
+    Assert-Null $malformed.BranchesCovered 'malformed report -> null covered'
+    Assert-Null $malformed.BranchesTotal   'malformed report -> null total'
+
     # --- JSON contract: what Measure-Coverage writes, the poster must read back. ---
     # Mirrors the [ordered] payload the orchestrator emits, round-tripped through the
     # poster's security-boundary projection.

--- a/tests/coverage/ci/Measure-Coverage.ps1
+++ b/tests/coverage/ci/Measure-Coverage.ps1
@@ -1,0 +1,153 @@
+<#
+.SYNOPSIS
+    Measure merged (unit + selftest) coverage for ONE source tree and emit a small
+    JSON of the line/branch numbers for the coverage PR comment
+    (.github/workflows/coverage.yml).
+
+.DESCRIPTION
+    Runs the exact merged-coverage recipe from TESTING.md against $Root:
+
+      1. Build Reactor.Tests, src/Reactor, and Reactor.AppTests.Host (Debug, portable
+         PDBs, no optimization) so the assemblies can be instrumented.
+      2. Collect UNIT coverage (dotnet test Reactor.Tests) as cobertura.
+      3. Statically instrument the built Reactor.dll.
+      4. Collect SELFTEST coverage (the AppTests.Host --self-test run) as cobertura.
+      5. Merge the two cobertura reports.
+      6. Aggregate the merged report into line % + branch % (+ branch covered/total)
+         via Get-CoberturaRates (CoverageLib.ps1).
+
+    The output JSON is consumed by CoverageLib.ps1's Format-CoverageComment:
+      { "line": <num|null>, "branch": <num|null>,
+        "branchesCovered": <int|null>, "branchesTotal": <int|null>,
+        "outcome": "success" }
+
+    Intermediate + merged cobertura reports are written to -WorkDir so the workflow
+    can upload them as debugging artifacts. The script throws on any build/collect
+    failure so the caller can mark the step failed; the workflow runs the base leg
+    with continue-on-error so a base failure degrades to "baseline unavailable"
+    rather than breaking the PR's coverage check.
+
+    Run locally (measures the current tree):
+      pwsh tests/coverage/ci/Measure-Coverage.ps1 -Root . -OutFile head.coverage.json
+    (install once: dotnet tool install -g dotnet-coverage)
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Root,
+    [Parameter(Mandatory)][string]$OutFile,
+    [string]$WorkDir,
+    [string]$Platform = 'x64',
+    [string]$SettingsFile = 'coverage.settings.xml'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'CoverageLib.ps1')
+
+$Root = (Resolve-Path -LiteralPath $Root).Path
+
+# Ensure the -OutFile parent exists before Set-Content at the end (Set-Content does
+# not create intermediate directories).
+$outParent = Split-Path -Parent $OutFile
+if ($outParent -and -not (Test-Path -LiteralPath $outParent)) {
+    New-Item -ItemType Directory -Force -Path $outParent | Out-Null
+}
+
+if (-not $WorkDir) {
+    # Derive a stable, tree-specific work dir so a base + head run in the same job
+    # never share (or clobber) each other's cobertura output.
+    $hash = [System.BitConverter]::ToString(
+        [System.Security.Cryptography.SHA1]::Create().ComputeHash(
+            [System.Text.Encoding]::UTF8.GetBytes($Root))).Replace('-', '').Substring(0, 12)
+    $WorkDir = Join-Path ([System.IO.Path]::GetTempPath()) "reactor-coverage-$hash"
+}
+if (Test-Path -LiteralPath $WorkDir) { Remove-Item -LiteralPath $WorkDir -Recurse -Force }
+New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+$WorkDir = (Resolve-Path -LiteralPath $WorkDir).Path
+
+$unitReport     = Join-Path $WorkDir 'unit.cobertura.xml'
+$selftestReport = Join-Path $WorkDir 'selftest.cobertura.xml'
+$mergedReport   = Join-Path $WorkDir 'merged.cobertura.xml'
+
+function Invoke-Checked {
+    <#
+    .SYNOPSIS
+        Run a native command and throw on a non-zero exit code, so a failed build /
+        collect / merge aborts the measurement (rather than silently producing a
+        bogus report).
+    #>
+    param([Parameter(Mandatory)][string]$What, [Parameter(Mandatory)][scriptblock]$Action)
+    Write-Host "==> $What"
+    & $Action
+    if ($LASTEXITCODE -ne 0) {
+        throw "$What failed (exit $LASTEXITCODE)."
+    }
+}
+
+Push-Location $Root
+try {
+    # 1. Build for instrumentation. Reactor.Tests + AppTests.Host build for the
+    #    requested platform; src/Reactor is AnyCPU (a library), matching coverage.yml.
+    Invoke-Checked "Build Reactor.Tests ($Platform)" {
+        dotnet build tests/Reactor.Tests -c Debug -p:Platform=$Platform -p:Optimize=false -p:DebugType=portable
+    }
+    Invoke-Checked 'Build src/Reactor (AnyCPU)' {
+        dotnet build src/Reactor -c Debug -p:Optimize=false -p:DebugType=portable --no-incremental
+    }
+    Invoke-Checked "Build Reactor.AppTests.Host ($Platform)" {
+        dotnet build tests/Reactor.AppTests.Host -c Debug -p:Platform=$Platform -p:Optimize=false -p:DebugType=portable --no-incremental
+    }
+
+    # 2. Unit coverage.
+    Invoke-Checked 'Collect unit coverage' {
+        dotnet-coverage collect -s $SettingsFile `
+            --output $unitReport --output-format cobertura `
+            -- dotnet test tests/Reactor.Tests --no-build -p:Platform=$Platform
+    }
+
+    # 3. Instrument the built Reactor.dll (dynamic instrumentation skips referenced
+    #    assemblies, so it is instrumented statically). Exclude the ref/ facade copy.
+    $dll = Get-ChildItem -Path (Join-Path $Root 'tests/Reactor.AppTests.Host/bin') -Recurse -Filter 'Reactor.dll' -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch 'ref[\\/]' } |
+        Select-Object -First 1
+    if (-not $dll) { throw 'Reactor.dll not found under tests/Reactor.AppTests.Host/bin' }
+    Invoke-Checked "Instrument $($dll.Name)" {
+        dotnet-coverage instrument $dll.FullName -s $SettingsFile
+    }
+
+    # 4. Selftest coverage.
+    Invoke-Checked 'Collect selftest coverage' {
+        dotnet-coverage collect -s $SettingsFile `
+            --output $selftestReport --output-format cobertura `
+            -- dotnet run --project tests/Reactor.AppTests.Host --no-build -p:Platform=$Platform -- --self-test
+    }
+
+    # 5. Merge.
+    Invoke-Checked 'Merge cobertura reports' {
+        dotnet-coverage merge $unitReport $selftestReport `
+            --output $mergedReport --output-format cobertura
+    }
+}
+finally {
+    Pop-Location
+}
+
+# 6. Aggregate the merged report into the headline numbers.
+$rates = Get-CoberturaRates -Path $mergedReport
+Write-Host ''
+Write-Host "Line:   $(Format-Percent $rates.Line)"
+Write-Host "Branch: $(Format-BranchCell $rates.Branch $rates.BranchesCovered $rates.BranchesTotal)"
+
+$payload = [ordered]@{
+    line            = $rates.Line
+    branch          = $rates.Branch
+    branchesCovered = $rates.BranchesCovered
+    branchesTotal   = $rates.BranchesTotal
+    outcome         = 'success'
+}
+$json = ConvertTo-Json -InputObject $payload -Depth 3
+Set-Content -LiteralPath $OutFile -Value $json -Encoding UTF8
+Write-Host ''
+Write-Host "Wrote coverage numbers to $OutFile"
+Write-Host "Cobertura reports in $WorkDir"

--- a/tests/coverage/ci/README.md
+++ b/tests/coverage/ci/README.md
@@ -1,10 +1,9 @@
 # Merged-coverage comparison PR comment
 
 An automatic, self-updating PR comment that reports the PR's merged (unit +
-selftest) line + branch coverage **against its base branch** (the `main` baseline
-in the common case), with a signed per-metric delta. Informational only — the base
-leg never fails a PR; only a failure to measure the PR head itself is surfaced as a
-red check.
+selftest) line + branch coverage **against a cached `main` baseline**, with a
+signed per-metric delta. Informational only — a missing baseline never fails a PR;
+only a failure to measure the PR head itself is surfaced as a red check.
 
 Example:
 
@@ -20,8 +19,9 @@ Example:
 ## What is measured
 
 The canonical repo metric — **unit + selftest merged** — computed exactly as in
-[`TESTING.md`](../../../TESTING.md#code-coverage), for **both** the PR head and its
-base branch:
+[`TESTING.md`](../../../TESTING.md#code-coverage). A **PR** run measures only the PR
+head; the **base** is a cached baseline measured on push to `main` (see
+[Baseline model](#baseline-model)). Each side reports:
 
 | Metric | What | Source |
 |---|---|---|
@@ -40,10 +40,27 @@ direction, so a rise clears as ✅, a fall as ⚠️, and a move below the noise
 
 | File | Role |
 |---|---|
-| `CoverageLib.ps1` | **Pure** helpers (no filesystem side effects): the cobertura parser (`Get-CoberturaRates` / `Get-CoberturaRatesFromXml`), percent/delta formatting, `Get-CoverageDelta`, the sticky-comment renderer (`Format-CoverageComment`), and the render-time security boundary (`ConvertTo-SafeCoverageMetrics`). Unit-testable headless. |
-| `CoverageLib.Tests.ps1` | Dependency-free assertions for the pure lib (parser, delta math, formatting, sanitizer). Exits non-zero on failure. |
+| `CoverageLib.ps1` | **Pure** helpers (no filesystem side effects): the cobertura parser (`Get-CoberturaRates` / `Get-CoberturaRatesFromXml`), percent/delta formatting, `Get-CoverageDelta`, the sticky-comment renderer (`Format-CoverageComment`) + the render-mode selector (`Format-CoverageCommentFromMetrics`), and the render-time security boundary (`ConvertTo-SafeCoverageMetrics`). Unit-testable headless. |
+| `CoverageLib.Tests.ps1` | Dependency-free assertions for the pure lib (parser, delta math, formatting, render-mode selection, sanitizer). Exits non-zero on failure. |
 | `Measure-Coverage.ps1` | Orchestrator: build + instrument + collect (unit + selftest) + merge in one source tree, then aggregate the merged report into a `coverage.json` of numbers. |
 | `Measure-Coverage.Tests.ps1` | AST-extracted tests for the orchestrator's `Invoke-Checked` guard, the report-reading path, and the JSON contract the poster reads. |
+
+## Baseline model
+
+The base numbers are **cached**, not re-measured on every PR:
+
+- A **push to `main`** measures main and uploads a `coverage-baseline` artifact
+  (numbers only, 90-day retention). Doc-only pushes are skipped — they don't move
+  coverage, so the previous baseline stays valid.
+- A **PR** run measures only the head (one instrumented pass) and uploads
+  `coverage-data`.
+- The poster reads the head from the triggering run and the base from the **newest
+  successful push-to-main `coverage-baseline`** artifact, then renders `base | PR | Δ`.
+
+This costs ~half the CI time of re-measuring the PR's exact base on every run, in
+exchange for a small staleness window (the baseline is "main as of its last coverage
+run"). Until the first post-merge push publishes a baseline, PRs render "baseline
+unavailable".
 
 ## Workflows
 
@@ -53,8 +70,8 @@ comment body**:
 
 | Workflow | Trigger | Privilege | Job |
 |---|---|---|---|
-| `.github/workflows/coverage.yml` | `pull_request` (+ manual `workflow_dispatch`) | read-only | Builds + instruments + measures the PR head **and** base branch (each in its own worktree), then uploads **only** the machine-readable numbers (`head.coverage.json` + `base.coverage.json`). Runs untrusted PR build code. |
-| `.github/workflows/coverage-comment.yml` | `workflow_run` | `pull-requests: write` | Checks out **trusted** default-branch code, validates the uploaded numbers via `ConvertTo-SafeCoverageMetrics`, **renders** the comparison comment itself, and posts/updates it. Runs **no** PR code. Resolves the target PR + base SHA from the trusted `workflow_run` head SHA, never the artifact. |
+| `.github/workflows/coverage.yml` | `pull_request` + `push` (main) (+ manual `workflow_dispatch`) | read-only | On a PR: builds + instruments + measures the **head** and uploads `coverage-data`. On push to `main`: measures main and uploads the `coverage-baseline`. Runs untrusted PR build code (on PRs). |
+| `.github/workflows/coverage-comment.yml` | `workflow_run` | `pull-requests: write` | Checks out **trusted** default-branch code, downloads the head numbers + the cached `coverage-baseline`, validates both via `ConvertTo-SafeCoverageMetrics`, **renders** the comparison comment itself, and posts/updates it. Runs **no** PR code. Resolves the target PR from the trusted `workflow_run` head SHA, never an artifact. |
 | `.github/workflows/coverage-lib-tests.yml` | `pull_request` / `push` on `tests/coverage/ci/**` | read-only | Fast headless run of both `*.Tests.ps1` files. |
 
 A comment is posted **only for `pull_request` runs**. A manual `workflow_dispatch`
@@ -74,9 +91,9 @@ inject markdown into the bot-authored comment.
 
 ### Degraded modes
 
-- **Base measurement fails** → the comment shows the PR's absolute coverage with an
-  em-dash delta and a "baseline unavailable" note. The PR's coverage **check stays
-  green** (a broken `main` build shouldn't block the PR).
+- **No cached baseline** (before the first post-merge push publishes one, or the
+  artifact expired) → the comment shows the PR's absolute coverage with an em-dash
+  delta and a "baseline unavailable" note. The PR's coverage **check stays green**.
 - **Head measurement fails** → a `> [!CAUTION]` "run failed" comment, and the
   measure job is a **red check**.
 - **Base = head (no change)** → a "No coverage change beyond the noise floor" note.
@@ -111,11 +128,10 @@ Format-CoverageComment -BaseMetrics $base -HeadMetrics $head -HeadSha HEAD -Base
 
 ## Notes
 
-- Measuring both sides roughly **doubles** the coverage run time versus a
-  head-only measurement — the same tradeoff the `build-metrics` double build
-  already accepts on every PR (see `tests/build_metrics/ci/README.md`). An
-  alternative (caching a `main` baseline from a push-to-`main` run) was considered
-  but not taken, to stay consistent with the in-repo build-metrics precedent.
+- The base is a **cached `main` baseline** (measured on push to `main`), so a PR
+  pays for **one** instrumented pass, not two. The trade-off is a small staleness
+  window versus re-measuring the PR's exact base each run (which the `build-metrics`
+  double-build does — see `tests/build_metrics/ci/README.md`).
 - A small noise band (0.1 pp) keeps sub-noise branch-coverage jitter from rendering
   as a spurious ✅/⚠️.
 - Not yet reported (candidate future work): **patch/diff-scoped** coverage (coverage

--- a/tests/coverage/ci/README.md
+++ b/tests/coverage/ci/README.md
@@ -1,0 +1,123 @@
+# Merged-coverage comparison PR comment
+
+An automatic, self-updating PR comment that reports the PR's merged (unit +
+selftest) line + branch coverage **against its base branch** (the `main` baseline
+in the common case), with a signed per-metric delta. Informational only — the base
+leg never fails a PR; only a failure to measure the PR head itself is surfaced as a
+red check.
+
+Example:
+
+> ## 🧪 Merged coverage
+>
+> Coverage for `deadbee` vs the base branch (`cafef00`) — unit + selftest merged.
+>
+> | Metric | base | PR | Δ | |
+> |---|--:|--:|--:|:-:|
+> | Line   | 86.10% | 87.34% | +1.24 pp | ✅ |
+> | Branch | 74.50% (500/671) | 75.20% (510/678) | +0.70 pp | ✅ |
+
+## What is measured
+
+The canonical repo metric — **unit + selftest merged** — computed exactly as in
+[`TESTING.md`](../../../TESTING.md#code-coverage), for **both** the PR head and its
+base branch:
+
+| Metric | What | Source |
+|---|---|---|
+| **Line** | merged line coverage | the cobertura root `line-rate` |
+| **Branch** | merged conditional-branch coverage, with the covered/total counts | summed from the per-line `condition-coverage="P% (c/t)"` attributes |
+
+`dotnet-coverage`'s cobertura output records per-line branch data but does **not**
+aggregate it (its root/class `branch-rate` is hard-coded to `1`), so the branch
+rate is summed from the per-line numerators/denominators in `Get-CoberturaRates`.
+
+Δ is reported in **percentage points** (`pp`). Higher coverage is the improvement
+direction, so a rise clears as ✅, a fall as ⚠️, and a move below the noise floor
+(0.1 pp) as ≈.
+
+## Files
+
+| File | Role |
+|---|---|
+| `CoverageLib.ps1` | **Pure** helpers (no filesystem side effects): the cobertura parser (`Get-CoberturaRates` / `Get-CoberturaRatesFromXml`), percent/delta formatting, `Get-CoverageDelta`, the sticky-comment renderer (`Format-CoverageComment`), and the render-time security boundary (`ConvertTo-SafeCoverageMetrics`). Unit-testable headless. |
+| `CoverageLib.Tests.ps1` | Dependency-free assertions for the pure lib (parser, delta math, formatting, sanitizer). Exits non-zero on failure. |
+| `Measure-Coverage.ps1` | Orchestrator: build + instrument + collect (unit + selftest) + merge in one source tree, then aggregate the merged report into a `coverage.json` of numbers. |
+| `Measure-Coverage.Tests.ps1` | AST-extracted tests for the orchestrator's `Invoke-Checked` guard, the report-reading path, and the JSON contract the poster reads. |
+
+## Workflows
+
+Two workflows implement the standard secure `pull_request` + `workflow_run` split,
+so untrusted PR build code never holds a write token **and never renders the
+comment body**:
+
+| Workflow | Trigger | Privilege | Job |
+|---|---|---|---|
+| `.github/workflows/coverage.yml` | `pull_request` (+ manual `workflow_dispatch`) | read-only | Builds + instruments + measures the PR head **and** base branch (each in its own worktree), then uploads **only** the machine-readable numbers (`head.coverage.json` + `base.coverage.json`). Runs untrusted PR build code. |
+| `.github/workflows/coverage-comment.yml` | `workflow_run` | `pull-requests: write` | Checks out **trusted** default-branch code, validates the uploaded numbers via `ConvertTo-SafeCoverageMetrics`, **renders** the comparison comment itself, and posts/updates it. Runs **no** PR code. Resolves the target PR + base SHA from the trusted `workflow_run` head SHA, never the artifact. |
+| `.github/workflows/coverage-lib-tests.yml` | `pull_request` / `push` on `tests/coverage/ci/**` | read-only | Fast headless run of both `*.Tests.ps1` files. |
+
+A comment is posted **only for `pull_request` runs**. A manual `workflow_dispatch`
+run is **measure-only**: it still measures and uploads the `coverage.json`
+artifact, but the poster can't safely resolve a PR from a dispatch's head SHA, so
+it posts nothing — read the numbers from the run's **job summary** / artifact.
+
+**Why the poster renders (not the measure job):** the measure job builds untrusted
+PR code, so if it produced the final markdown a PR could make the privileged bot
+post arbitrary content. Instead the artifact carries only a handful of numbers per
+side; the poster re-validates each through `ConvertTo-SafeCoverageMetrics`
+(percentages accepted only as a plain decimal in `[0, 100]`; counts only as
+non-negative integers; everything else — signs, exponents, pipes, markup — dropped
+to `null`) and renders from trusted code. So the comment is fully determined by
+trusted code plus a set of validated numbers — the untrusted artifact can never
+inject markdown into the bot-authored comment.
+
+### Degraded modes
+
+- **Base measurement fails** → the comment shows the PR's absolute coverage with an
+  em-dash delta and a "baseline unavailable" note. The PR's coverage **check stays
+  green** (a broken `main` build shouldn't block the PR).
+- **Head measurement fails** → a `> [!CAUTION]` "run failed" comment, and the
+  measure job is a **red check**.
+- **Base = head (no change)** → a "No coverage change beyond the noise floor" note.
+
+The sticky comment is found + updated in place via a hidden marker
+(`<!-- reactor-coverage -->`) — the same *mechanism* as
+`tests/build_metrics/ci/BuildMetricsLib.ps1`, which uses its own distinct marker.
+
+## Local runbook
+
+Unit-test the parser + renderer (seconds, no build):
+
+```pwsh
+pwsh tests/coverage/ci/CoverageLib.Tests.ps1
+pwsh tests/coverage/ci/Measure-Coverage.Tests.ps1
+```
+
+Measure the current tree and render a comment against a baseline (needs
+`dotnet tool install -g dotnet-coverage`):
+
+```pwsh
+# Measure this working tree -> head.coverage.json (~10 min, instrumented).
+pwsh tests/coverage/ci/Measure-Coverage.ps1 -Root . -OutFile head.coverage.json
+
+# Measure another checkout/worktree (e.g. main) the same way -> base.coverage.json,
+# then render:
+. tests/coverage/ci/CoverageLib.ps1
+$head = ConvertTo-SafeCoverageMetrics (Get-Content head.coverage.json -Raw | ConvertFrom-Json)
+$base = ConvertTo-SafeCoverageMetrics (Get-Content base.coverage.json -Raw | ConvertFrom-Json)
+Format-CoverageComment -BaseMetrics $base -HeadMetrics $head -HeadSha HEAD -BaseSha main
+```
+
+## Notes
+
+- Measuring both sides roughly **doubles** the coverage run time versus a
+  head-only measurement — the same tradeoff the `build-metrics` double build
+  already accepts on every PR (see `tests/build_metrics/ci/README.md`). An
+  alternative (caching a `main` baseline from a push-to-`main` run) was considered
+  but not taken, to stay consistent with the in-repo build-metrics precedent.
+- A small noise band (0.1 pp) keeps sub-noise branch-coverage jitter from rendering
+  as a spurious ✅/⚠️.
+- Not yet reported (candidate future work): **patch/diff-scoped** coverage (coverage
+  of only the lines the PR changed), which complements — but does not replace — this
+  whole-repo baseline delta.


### PR DESCRIPTION
Fixes #846.

## Problem

The automatic merged-coverage comment showed only the PR head's **absolute** line/branch coverage — no `main` baseline and no delta — so a reviewer couldn't tell whether a PR **raised or lowered** coverage.

## Fix

Measure the PR head and render a direction-aware `base | PR | Δ` comparison against a **cached `main` baseline**:

> ## 🧪 Merged coverage
>
> Coverage for `deadbee` vs the base branch (`cafef00`) — unit + selftest merged.
>
> | Metric | base | PR | Δ | |
> |---|--:|--:|--:|:-:|
> | Line   | 86.10% | 87.34% | +1.24 pp | ✅ |
> | Branch | 74.50% (500/671) | 75.20% (510/678) | +0.70 pp | ✅ |

Higher coverage is the improvement (✅); a drop beyond a 0.1 pp noise floor is ⚠️; within-noise is ≈.

### Baseline model (cached, not re-measured per PR)

- A **PR** run measures **only the head** — one instrumented pass — and uploads `coverage-data`.
- A **push to `main`** measures main and uploads a `coverage-baseline` artifact (90-day retention; doc-only pushes skipped).
- The poster reads the head from the triggering run and the base from the **newest successful `main` Coverage run** that still has a `coverage-baseline` artifact, then renders the delta.

This keeps a PR at **~one** instrumented pass instead of two, trading a small baseline-staleness window (the baseline is "main as of its last coverage run") for ~half the CI cost. Until the first post-merge push publishes a baseline, PRs render "baseline unavailable".

## What's here

**New (`tests/coverage/ci/`)**
- `CoverageLib.ps1` — pure cobertura parser (`Get-CoberturaRates`), delta math (`Get-CoverageDelta`), the comment renderer (`Format-CoverageComment`) + render-mode selector (`Format-CoverageCommentFromMetrics`), and the render-time security boundary (`ConvertTo-SafeCoverageMetrics`).
- `Measure-Coverage.ps1` — build + instrument + collect (unit + selftest) + merge + parse for one tree → `coverage.json`.
- `CoverageLib.Tests.ps1` (114 assertions) + `Measure-Coverage.Tests.ps1` (22) — headless, no build.
- `README.md`.

**Workflows**
- `coverage.yml` — PR: measure head → `coverage-data`; push to `main`: measure main → `coverage-baseline`. Read-only; runs untrusted PR code.
- `coverage-comment.yml` — trusted poster: fetch head + cached baseline, re-validate, render + post.
- `coverage-lib-tests.yml` — fast headless lib tests.
- `TESTING.md` + `.gitignore`.

## Trust boundary & degraded modes

Same secure `pull_request` + `workflow_run` split as build-metrics: the measure job holds no write token and never renders markdown; the privileged poster re-validates every number (`ConvertTo-SafeCoverageMetrics`: percentages in `[0,100]`, non-negative integer counts, everything else → null) and renders from trusted code, resolving the PR from the trusted `workflow_run` head SHA. Both the head (untrusted) and the baseline (from trusted `main` code) go through the sanitizer.

- **No cached baseline** (first PR before `main` publishes one, expiry, or API error) → "baseline unavailable" note; check stays green.
- **Head fails** → `> [!CAUTION]` comment + red check. Head/base data files are authoritative on trusted **step outcomes**, so untrusted PR code can't pre-plant a `coverage.json` to mask a failure. A failed `main` run doesn't publish a (null) baseline, so it can't blank the baseline for PRs.

## Testing

- `pwsh tests/coverage/ci/CoverageLib.Tests.ps1` → 114 passed
- `pwsh tests/coverage/ci/Measure-Coverage.Tests.ps1` → 22 passed
- All workflow YAML, embedded pwsh/bash, and the `github-script` JS validated; end-to-end render of the full/baseline-unavailable/failed/no-baseline comment bodies verified.

Note: on this PR itself the comment will show "baseline unavailable" until it merges and the first push-to-`main` publishes a baseline.

The full instrumented measurement only runs on CI (`windows-latest`).