### PR TITLE
docs: capture past-session lessons as skills + AGENTS.md field notes

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -18,6 +18,8 @@ before push.
 |-------|---------|
 | [`pr-review/`](pr-review/SKILL.md) | Multi-dimensional review of a PR / feature branch diff (security, correctness, API & DSL ergonomics, alternative solutions, test coverage, docs & samples sync, packaging/agent-kit impact, multi-model cross-check). Reports findings to stdout; does not apply fixes. |
 | [`perf-compare/`](perf-compare/SKILL.md) | Benchmark the `StressPerf.ReactorOptimized` data-grid harness on the current branch vs a clean `main` worktree (interleaved, same machine) and report a direction-aware delta for the four headline metrics. The local equivalent of commenting `/perf` on a PR. Reports to stdout; does not apply fixes. |
+| [`coverage-uplift/`](coverage-uplift/SKILL.md) | Raise test coverage with non-vacuous tests: baseline via `tools/coverage`, classify each gap into the right tier (headless unit / selftest / E2E), write narrowly-scoped tests whose assertions fail if the target code is deleted, mutation-check the oracles, and cross-check with the pr-review multi-model dimension. Adds tests. |
+| [`analyzer-dym/`](analyzer-dym/SKILL.md) | Author or remove Reactor "did-you-mean" / diagnostic analyzers and their `mur check` mirrors under the `netstandard2.0` analyzer constraints: FP-spike first, add the `AnalyzerReleases.Unshipped.md` row, keep CLI parity, sync generated docs. Applies changes. |
 
 ## Conventions
 

--- a/.github/skills/analyzer-dym/SKILL.md
+++ b/.github/skills/analyzer-dym/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: analyzer-dym
+description: Author or remove Reactor "did-you-mean" / diagnostic analyzers and the matching `mur check` rules in the microsoft/microsoft-ui-reactor repo. Activate when a contributor asks to "add a REACTOR_ diagnostic", "add a did-you-mean for <mistake>", "add/remove a mur check rule", "suggest the right factory/argument", "write a Roslyn analyzer for Reactor", or "wire an in-build suggestion". Reads the spec + closest existing analyzer, spikes false-positive risk with the semantic model first, implements under the netstandard2.0 analyzer constraints, adds the AnalyzerReleases row, keeps the CLI mirror in parity, and syncs the generated docs. Applies changes; does NOT push.
+infer: true
+---
+
+You are the **Analyzer / did-you-mean orchestrator** for the
+`microsoft/microsoft-ui-reactor` repo. Your job is to add (or remove) a Roslyn diagnostic
+and/or its `mur check` CLI counterpart that nudges authors toward the right Reactor DSL —
+without false positives.
+
+Read `AGENTS.md` first, then the governing spec `docs/specs/061-in-build-did-you-mean.md`
+and the **closest existing analyzer** in `src/Reactor.Analyzers/` plus its CLI mirror
+under `src/Reactor.Cli/Check/`. Copy the nearest working pattern instead of inventing one.
+
+## When to activate
+
+Trigger phrases: "add a `REACTOR_*` diagnostic", "did-you-mean for <mistake>", "add/remove
+a `mur check` rule", "suggest the correct factory/argument", "in-build suggestion",
+"fuzzy-match the DSL name".
+
+Do **not** activate for general analyzer *bugfixes* unrelated to suggestions, or for
+theming/accessibility analyzers that already exist and just need a tweak (do those
+directly).
+
+## Hard constraints (these bite immediately)
+
+- **`src/Reactor.Analyzers` targets `netstandard2.0`.** No `FrozenDictionary`, no net8+
+  BCL APIs, no `System.Text.Json` niceties. If you need CLI logic, **copy it and add
+  parity tests** — you cannot reference `src/Reactor.Cli` from the analyzer.
+- **Every new `REACTOR_*` id needs a row in
+  `src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md`** or the build fails `RS2008`.
+  Watch `RS1030`/`RS1032` (localizable-string / message rules) too.
+- Gate analysis to Reactor code with `CommandDebounceAnalyzer.IsReactorNamespace` (or the
+  equivalent guard in the closest analyzer) and drive matching off `context.SemanticModel`
+  / `GetSymbolInfo` — never off raw syntax text.
+- `mur check` rules are **reflection-discovered** in `RuleRegistry.cs`: add or remove the
+  rule *file*, do not hand-edit a registry list.
+
+## Workflow
+
+### 1. Ground the target in reality
+
+Confirm the mistaken code you are matching against **actually misbehaves today** in real
+`src/` — stale CLI rules or corpora sometimes describe a mistake that now binds fine. If
+the rule is obsolete, the task may be a *removal* (delete the rule file + its tests + the
+`AnalyzerReleases` row + docs entry).
+
+### 2. Spike false-positive risk FIRST
+
+Before implementing, write a throwaway that runs your candidate match (`GetSymbolInfo`,
+`CandidateReason`, symbol-name fuzzy distance) over realistic **negatives** as well as the
+positive. A did-you-mean that fires on valid code is worse than no rule. Only proceed when
+the spike is clean.
+
+### 3. Implement
+
+- Analyzer in `src/Reactor.Analyzers/`, following the closest sibling's shape.
+- If mirroring CLI `check` logic, implement in both `src/Reactor.Analyzers/` and
+  `src/Reactor.Cli/Check/` and add **parity tests** so they cannot drift.
+- Add the `AnalyzerReleases.Unshipped.md` row.
+
+### 4. Build & test (both flags matter)
+
+```powershell
+# fast analyzer-only compile — catches RS2008 / RS1030 / RS1032
+dotnet build src/Reactor.Analyzers/Reactor.Analyzers.csproj -c Debug
+
+# analyzer tests
+dotnet test tests/Reactor.Tests --filter "FullyQualifiedName~AnalyzerTests" -p:Platform=x64 -p:SkipSignaturesGen=true
+
+# mur check CLI tests (when you touched the CLI mirror)
+dotnet test tests/Reactor.Tests --filter "FullyQualifiedName~CheckCommandTests" -p:Platform=x64 -p:SkipSignaturesGen=true
+```
+
+`-p:SkipSignaturesGen=true` avoids the `CS2012 …\intermediatexaml\Reactor.dll` build race;
+`-p:Platform=x64` avoids the WinUI architecture failure. If you touched
+`RulePerformanceTests`/`CombinedStub`, run `--filter "FullyQualifiedName~RulePerformanceTests"`
+explicitly (the perf trait is excluded by default).
+
+### 5. Sync docs and skills (generated!)
+
+- Analyzer docs are generated: edit `docs/_pipeline/templates/analyzer-architecture.md.dt`
+  (and any cheat-table template), **not** the compiled `docs/guide/*.md`. Compile with
+  `mur docs compile` only the affected topic if needed; revert unrelated snippet churn.
+- Update the end-user build/check skill if the rule set changed:
+  `plugins/reactor/skills/reactor-build-and-check/SKILL.md`.
+
+## Report
+
+To stdout: the `REACTOR_*` id(s) added/removed, the FP-spike result, files touched
+(analyzer + CLI mirror + `AnalyzerReleases` + tests + docs template), and the exact test
+commands you ran green.

--- a/.github/skills/analyzer-dym/SKILL.md
+++ b/.github/skills/analyzer-dym/SKILL.md
@@ -75,8 +75,9 @@ dotnet test tests/Reactor.Tests --filter "FullyQualifiedName~CheckCommandTests" 
 
 `-p:SkipSignaturesGen=true` avoids the `CS2012 …\intermediatexaml\Reactor.dll` build race;
 `-p:Platform=x64` avoids the WinUI architecture failure. If you touched
-`RulePerformanceTests`/`CombinedStub`, run `--filter "FullyQualifiedName~RulePerformanceTests"`
-explicitly (the perf trait is excluded by default).
+`RulePerformanceTests`/`CombinedStub`, run them explicitly with
+`--filter "FullyQualifiedName~RulePerformanceTests"` (they carry
+`[Trait("Category", "Perf")]` — the whole perf set runs via `--filter "Category=Perf"`).
 
 ### 5. Sync docs and skills (generated!)
 

--- a/.github/skills/coverage-uplift/SKILL.md
+++ b/.github/skills/coverage-uplift/SKILL.md
@@ -72,7 +72,7 @@ geometry, `BitmapImage`, or **`AutomationPeer`-derived** type) — you get a `CO
 If a target needs one, it is NOT a unit target → drop it (note why) or move to a selftest.
 Internal seams are testable: `InternalsVisibleTo("Reactor.Tests")` is set in
 `src/Reactor/Reactor.csproj`, so prefer an internal tokenizer/parser entry point over a
-public method that builds WinUI objects (e.g. `PathDataParser.ParseTokens(geometry:null)`
+public method that builds WinUI objects (e.g. `PathDataParser.ParseTokens(pathData)`
 vs the public `Parse`). Before writing an E2E, check for an existing reflection selftest
 that already exercises the path.
 
@@ -85,7 +85,8 @@ that already exercises the path.
 - **Selftest fixture:** file under `tests/Reactor.AppTests.Host/SelfTest/Fixtures/`,
   subclass `SelfTestFixtureBase`, use `H.CreateHost()`, `host.Mount(...)`,
   `Harness.Render()` / `WaitFor(...)`, `H.FindControl<T>()`, `H.Check(...)`. **Register in
-  BOTH** `SelfTestFixtureRegistry.cs` `AllFixtures` **and** its `Create()` switch.
+  BOTH** `tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs` `AllFixtures`
+  **and** its `Create()` switch.
 - **E2E fixture:** register in BOTH `AllFixtures` and the `Build` switch of
   `tests/Reactor.AppTests.Host/FixtureRegistry.cs`. Use `Component<T>()` fixtures for
   stateful UI — raw `ctx.UseState` does not persist because TestHost uses a fresh
@@ -101,7 +102,7 @@ oracle** — reviewers flag it.
 
 ```powershell
 # unit
-dotnet build tests/Reactor.Tests -c Debug -p:Platform=x64 -p:Optimize=false -p:DebugType=portable
+dotnet build tests/Reactor.Tests -c Debug -p:Platform=x64 -p:SkipSignaturesGen=true -p:Optimize=false -p:DebugType=portable
 dotnet test  tests/Reactor.Tests --no-build -p:Platform=x64 --filter "FullyQualifiedName~UnitCoverageExtra"
 # selftest (fast TAP loop)
 dotnet run --project tests/Reactor.AppTests.Host --no-build -c Debug -p:Platform=x64 -- --self-test --filter "<Prefix>"

--- a/.github/skills/coverage-uplift/SKILL.md
+++ b/.github/skills/coverage-uplift/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: coverage-uplift
+description: Raise test coverage for the microsoft/microsoft-ui-reactor repo with non-vacuous tests, picking the right tier (headless unit / selftest / E2E). Activate when a contributor asks to "improve test coverage", "add tests for X", "raise coverage", "cover the uncovered lines", "write selftests / e2e for this", "close coverage gaps", or "add unit tests". Baselines with tools/coverage, classifies each gap by tier, writes narrowly-scoped tests whose assertions fail if the target code is deleted, mutation-checks the key oracles, and runs the pr-review multi-model cross-check on the final commit. Applies changes (adds tests); does NOT change product code to chase coverage.
+infer: true
+---
+
+You are the **Coverage-uplift orchestrator** for the `microsoft/microsoft-ui-reactor`
+repo. Your job is to raise coverage with tests that actually *prove* behavior — never
+vacuous assertions that pass even when the code under test is deleted.
+
+Reactor is a declarative C#/WinUI 3 framework: a reconciler diffs immutable `Element`
+records and patches real WinUI controls. Read `AGENTS.md` (build/test commands, the
+"Field notes" gotchas, test-tier table) before starting — especially the `-p:Platform=x64`
+and `-p:SkipSignaturesGen=true` build rules and the headless-`COMException` trap.
+
+## When to activate
+
+Trigger phrases: "improve/raise test coverage", "add tests for <area>", "cover the
+uncovered lines/branches", "close coverage gaps", "write unit/selftests/e2e for this".
+
+Do **not** activate for a request to *change product code*, fix a specific failing
+test, or review an existing PR (that is `pr-review`).
+
+## The one rule that matters
+
+**Every assertion must fail if the code path it targets is deleted, no-op'd, or returns
+default.** Bare non-null, "no throw" on a void method, and always-emitted shape markers
+are vacuous. Copilot review does **not** catch vacuous assertions — you must.
+Non-vacuous oracle patterns that survive review here:
+- **Throw-position / arity oracle** — a malformed token in operand slot *N* throws iff the
+  right count was consumed (wrong arity re-dispatches → no throw).
+- **Differential isolation** — `Assert.NotEqual` between two variants differing *only* by
+  the setter under test; or **structural counts** (e.g. `path.Count(c => c == 'M') == 2`).
+- **Reflection / DeclaringType** — prove an override exists
+  (`typeof(T).GetMethod("Equals",[object]).DeclaringType == typeof(T)`).
+- **Corrupt-then-recompute** — set a field to a sentinel, run the op, assert it was
+  recomputed (`root.X1 = -999; layout.Layout(root); Assert.Equal(120, root.X1)`).
+
+## Workflow
+
+### 1. Baseline
+
+```powershell
+pwsh tools/coverage/run-coverage.ps1            # merged unit + selftest
+pwsh tools/coverage/run-coverage.ps1 -UnitOnly  # faster unit-only loop
+```
+
+Output is `coverage/merged.cobertura.xml` (git-ignored). Parse it directly for per-file
+line% and the exact uncovered line numbers rather than eyeballing `report-gaps.ps1`:
+iterate `//class` nodes by `@filename`, count `line/@hits`, dump `@number` where
+`hits == 0`. **The script aborts before the merge step if any leg fails** — if a known
+flake trips it, collect the legs and merge manually:
+
+```powershell
+dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xml `
+  --output coverage\merged.cobertura.xml --output-format cobertura
+```
+
+Known flakes to ignore (not your regression): `CenterOnCurrent_UsesCursorMonitor`,
+`PersistPlacement_FallbackWhenEmpty`, `PersistenceEtwBridgeTests.JsonFileStore_*`.
+
+### 2. Classify each gap by tier
+
+| Gap is… | Tier | Where |
+|---|---|---|
+| Pure-managed logic, D3 math, hook bookkeeping, Yoga | **Unit** (xUnit) | `tests/Reactor.Tests/` |
+| Anything touching a live WinUI control / reconcile / mount | **Selftest** | `tests/Reactor.AppTests.Host/SelfTest/Fixtures/` |
+| Real keyboard/pointer input, focus routing, UIA | **E2E** | `tests/Reactor.AppTests/Tests/` |
+
+**Headless unit tests cannot construct any `Microsoft.UI.Xaml` object** (control, brush,
+geometry, `BitmapImage`, or **`AutomationPeer`-derived** type) — you get a `COMException`.
+If a target needs one, it is NOT a unit target → drop it (note why) or move to a selftest.
+Internal seams are testable: `InternalsVisibleTo("Reactor.Tests")` is set in
+`src/Reactor/Reactor.csproj`, so prefer an internal tokenizer/parser entry point over a
+public method that builds WinUI objects (e.g. `PathDataParser.ParseTokens(geometry:null)`
+vs the public `Parse`). Before writing an E2E, check for an existing reflection selftest
+that already exercises the path.
+
+### 3. Add narrowly-scoped tests
+
+- **Unit:** new `tests/Reactor.Tests/<Area>UnitCoverageExtraTests.cs` (glob picks it up;
+  no csproj edit). One shared filter suffix (e.g. `UnitCoverageExtra`) so
+  `--filter "FullyQualifiedName~UnitCoverageExtra"` runs them all. Use `global::System.`
+  for fully-qualified `System` refs (the `Microsoft.UI.System` namespace shadows).
+- **Selftest fixture:** file under `tests/Reactor.AppTests.Host/SelfTest/Fixtures/`,
+  subclass `SelfTestFixtureBase`, use `H.CreateHost()`, `host.Mount(...)`,
+  `Harness.Render()` / `WaitFor(...)`, `H.FindControl<T>()`, `H.Check(...)`. **Register in
+  BOTH** `SelfTestFixtureRegistry.cs` `AllFixtures` **and** its `Create()` switch.
+- **E2E fixture:** register in BOTH `AllFixtures` and the `Build` switch of
+  `tests/Reactor.AppTests.Host/FixtureRegistry.cs`. Use `Component<T>()` fixtures for
+  stateful UI — raw `ctx.UseState` does not persist because TestHost uses a fresh
+  `RenderContext` each render. Add `[E2eRetry(3)]`, foreground with
+  `InputInjector.Foreground(HostHwnd)`, and assert against exact anti-stale values.
+
+Some guards are genuinely unobservable headless (backstopped by a later check, e.g. an
+empty-name guard followed by a null-property check; templated-FlipView item teardown has
+no non-vacuous signal). **Scope the test honestly to what it proves; do not fake an
+oracle** — reviewers flag it.
+
+### 4. Build & run the tier you touched
+
+```powershell
+# unit
+dotnet build tests/Reactor.Tests -c Debug -p:Platform=x64 -p:Optimize=false -p:DebugType=portable
+dotnet test  tests/Reactor.Tests --no-build -p:Platform=x64 --filter "FullyQualifiedName~UnitCoverageExtra"
+# selftest (fast TAP loop)
+dotnet run --project tests/Reactor.AppTests.Host --no-build -c Debug -p:Platform=x64 -- --self-test --filter "<Prefix>"
+# e2e
+dotnet test tests/Reactor.AppTests -p:Platform=x64
+```
+
+Always pass `-p:Platform=x64` (AnyCPU app/test builds fail with *"WindowsAppSDKSelfContained
+requires a supported Windows architecture"*) and `-p:SkipSignaturesGen=true` on
+`Reactor.Tests` to dodge the `CS2012 …\intermediatexaml\Reactor.dll` race. If the race
+persists under parallel builds, escalate: prebuild `src/Reactor` first, then add `-m:1`
+`-nodereuse:false` and `$env:MSBUILDDISABLENODEREUSE='1'`.
+
+E2E input needs an interactive desktop: if `SendInput`/`GetCursorPos` return
+`ACCESS_DENIED (err 5)` your local session can't inject input — validate the fixture over
+UIA (`winapp ui ... --json -w <hwnd>`) and rely on the CI **"E2E Tests (winapp ui)"** job
+for authoritative input validation.
+
+### 5. Mutation-check the oracles
+
+For each key new assertion: break the product code it targets, confirm the test **fails**,
+then revert. If it still passes, the assertion is vacuous — replace it with a real oracle
+or drop it. Prefer dropping a vacuous test (and the coverage it bought) over keeping it.
+
+### 6. Re-measure and cross-check
+
+```powershell
+pwsh tools/coverage/run-coverage.ps1 -UnitOnly -SkipBuild
+```
+
+Then run the `pr-review` skill's **multi-model** dimension on the **final** commit with a
+different model family (e.g. a GPT model at high reasoning) against
+`git --no-pager diff origin/main...HEAD`. It reliably finds vacuous/wrong-reason
+assertions that every Copilot round misses. Fix findings; re-run until zero.
+
+## Report
+
+To stdout: coverage delta (before → after, line & branch), the tests added per tier, any
+targets dropped as untestable (with the reason), and any oracle you mutation-verified.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
   geometry, `BitmapImage`, or **`AutomationPeer`-derived** type — you get a `COMException`.
   Test only pure-managed logic + WinRT value structs/enums; push anything live to a
   selftest. Internal seams are fair game: `InternalsVisibleTo("Reactor.Tests")` is set, so
-  prefer an internal tokenizer/parser (e.g. `PathDataParser.ParseTokens(geometry:null)`)
+  prefer an internal tokenizer/parser (e.g. `PathDataParser.ParseTokens(pathData)`)
   over a public method that builds WinUI objects.
 - In the `Microsoft.UI.Reactor.*.Tests` namespaces, `Microsoft.UI.System` shadows `System`
   — use `global::System.IO.Path`, `global::System.IO.File`, etc.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,3 +164,80 @@ docs/
   specs/                  Numbered design specs
   reference/              API and subsystem reference
 ```
+
+## Field notes (gotchas from past sessions)
+
+Hard-won specifics that repeatedly cost sessions time. Prefer these exact commands.
+
+### Building & running tests
+
+- **Pass `-p:Platform=x64` for any WinUI app/test project build.** AnyCPU builds of
+  `Reactor.AppTests`, `Reactor.AppTests.Host`, etc. fail with *"WindowsAppSDKSelfContained
+  requires a supported Windows architecture"*. (`dotnet build Reactor.slnx` handles the
+  solution defaults; single app/test projects usually do not.)
+- **Add `-p:SkipSignaturesGen=true` to local `tests/Reactor.Tests` builds** to avoid the
+  XAML-markup/SignaturesGen race: `CSC error CS2012: Cannot open '...\obj\...\intermediatexaml\Reactor.dll' ... used by another process`. If it still races under
+  parallel WinUI builds, prebuild `src/Reactor` alone first, then add `-m:1`
+  `-nodereuse:false` and `$env:MSBUILDDISABLENODEREUSE='1'`. (`-p:CI=true` also skips it.)
+- **Fast selftest loop** (TAP `ok`/`not ok`): `dotnet run --project tests/Reactor.AppTests.Host --no-build -c Debug -p:Platform=x64 -- --self-test --filter "<Prefix>"`.
+- **Headless unit tests cannot construct any `Microsoft.UI.Xaml` object** — control, brush,
+  geometry, `BitmapImage`, or **`AutomationPeer`-derived** type — you get a `COMException`.
+  Test only pure-managed logic + WinRT value structs/enums; push anything live to a
+  selftest. Internal seams are fair game: `InternalsVisibleTo("Reactor.Tests")` is set, so
+  prefer an internal tokenizer/parser (e.g. `PathDataParser.ParseTokens(geometry:null)`)
+  over a public method that builds WinUI objects.
+- In the `Microsoft.UI.Reactor.*.Tests` namespaces, `Microsoft.UI.System` shadows `System`
+  — use `global::System.IO.Path`, `global::System.IO.File`, etc.
+- **E2E input needs an interactive desktop.** `SendInput`/`GetCursorPos` returning
+  `ACCESS_DENIED (err 5)` means your session can't inject input — validate the fixture over
+  UIA (`winapp ui ... --json -w <hwnd>`) and rely on the CI *"E2E Tests (winapp ui)"* job.
+  For stateful E2E/selftest UI use `Component<T>()` fixtures; raw `ctx.UseState` doesn't
+  persist (TestHost renders with a fresh `RenderContext`).
+
+### Writing tests that actually prove something
+
+- **Every assertion must fail if its target code is deleted / no-op'd / returns default.**
+  Bare non-null, "no throw" on a `void`, and always-emitted shape markers are vacuous.
+  Use throw-position/arity, differential-isolation (`Assert.NotEqual` between two variants
+  differing only by the setter), structural counts, reflection `DeclaringType`, or
+  corrupt-then-recompute oracles. **Copilot review does not catch vacuous assertions** —
+  run the `.github/skills/pr-review/` multi-model dimension (different model family, high
+  reasoning) on the *final* commit and fix every finding.
+- **Fixture registration is two-place.** Selftest: add to `AllFixtures` **and** the
+  `Create()` switch in `tests/Reactor.AppTests.Host/SelfTest/SelfTestFixtureRegistry.cs`.
+  E2E: add to `AllFixtures` **and** the `Build` switch in
+  `tests/Reactor.AppTests.Host/FixtureRegistry.cs`.
+- **Coverage** starts from `tools/coverage/run-coverage.ps1` (`-UnitOnly`, `-SkipBuild`);
+  output `coverage/merged.cobertura.xml`. The script **aborts before the merge step on any
+  test failure** — if a known flake trips it (`CenterOnCurrent_UsesCursorMonitor`,
+  `PersistPlacement_FallbackWhenEmpty`, `PersistenceEtwBridgeTests.JsonFileStore_*`), merge
+  the legs manually with `dotnet-coverage merge coverage\unit.cobertura.xml coverage\selftest.cobertura.xml --output coverage\merged.cobertura.xml --output-format cobertura`.
+
+### Analyzers, CLI checks, docs & public API
+
+- `src/Reactor.Analyzers` targets **`netstandard2.0`** — no `FrozenDictionary`/net8+ APIs,
+  and you **cannot reference `src/Reactor.Cli`**; copy shared logic and add parity tests.
+  Every new `REACTOR_*` id needs a row in `src/Reactor.Analyzers/AnalyzerReleases.Unshipped.md`
+  (else `RS2008`). `mur check` rules are reflection-discovered in `RuleRegistry.cs` — add or
+  remove a rule *file*, don't hand-edit a list.
+- Docs are generated (see above): compile only the topic you touched and revert unrelated
+  snippet churn.
+- A new public API surface has **two byte-identical index copies** —
+  `skills/reactor.api.txt` and `plugins/reactor/skills/reactor-dsl/references/reactor.api.txt`
+  — regenerate via `mur --regen-api`; keep them in sync.
+- A new common-element modifier touches every seam: the `ElementModifiers` field, skip
+  equality, `Merge`, `ApplyModifiers`, and the fluent extension. Pair a `.HasValue` write
+  with `fe.ClearValue(<DP>Property)` on unset unless intentionally matching a no-reset sibling.
+
+### Environment
+
+- Work in a clean worktree, not `main`: `git worktree add -b <branch> <path> origin/main`.
+- Don't build under deep or OneDrive-synced paths — WinUI can fail with `MSB3073`/`PRI210`;
+  prefer a short local path (e.g. `C:\src\`).
+
+### Repo skills (`.github/skills/`)
+
+Contributor-facing orchestration skills — read the `SKILL.md` and drive it with your own
+tools: `pr-review` (multi-dimensional branch review), `perf-compare` (stress-harness delta
+vs `main`), `coverage-uplift` (non-vacuous coverage across tiers), `analyzer-dym`
+(did-you-mean / `mur check` authoring). Not shipped to end users.


### PR DESCRIPTION
## What

Distills recurring, hard-won lessons from **16 prior coding sessions** in this repo into durable guidance so future sessions (human or agent) stop rediscovering the same gotchas.

## How this was produced

Each of the 16 past sessions was asked to write a strict **read-only post-mortem** (task, repo gotchas, what worked, what was painful, reusable playbook, skill/memory candidates). The 16 write-ups were then deduplicated and **frequency-ranked**, task-clustered, and — importantly — cross-checked for contradictions. Only high-frequency, non-contradictory items were encoded. **Every file path and symbol referenced below was verified against the current tree.**

## Changes

**New skills** (`.github/skills/`, following the existing `pr-review` / `perf-compare` convention):

| Skill | Purpose |
|---|---|
| `coverage-uplift/` | Raise coverage with **non-vacuous** tests across the unit/selftest/E2E tiers — baseline via `tools/coverage`, classify each gap by tier, write assertions that fail if the target code is deleted, mutation-check the oracles, and cross-check with the pr-review multi-model dimension. |
| `analyzer-dym/` | Author/remove "did-you-mean" analyzers + `mur check` mirrors under the `netstandard2.0` analyzer constraints — FP-spike first, add the `AnalyzerReleases.Unshipped.md` row, keep CLI parity, sync generated docs. |

**Memory** — new **"Field notes (gotchas from past sessions)"** section in `AGENTS.md` (loaded into every session):
- `-p:Platform=x64` required for WinUI app/test builds (else *"WindowsAppSDKSelfContained requires a supported Windows architecture"*)
- The `-p:SkipSignaturesGen=true` **CS2012 `intermediatexaml\Reactor.dll`** build race (+ escalation path)
- Headless unit tests → `COMException` on any `Microsoft.UI.Xaml` object; use internal seams / selftests
- `Microsoft.UI.System` namespace shadowing → `global::System.`
- **Two-place** fixture registration (selftest + E2E registries)
- Coverage tooling, known flakes, and the manual `dotnet-coverage merge` fallback
- Analyzer `netstandard2.0` constraints; dual public-API index copies that must stay identical
- Worktree / avoid-OneDrive-path notes

`.github/skills/README.md` updated to list the two new skills.

## Notes

- Docs/skills only — **no product code changes**, so no test impact.
- Contradictory or session-specific advice was intentionally left out (e.g. one-size build-race fix, stale DataGrid internals).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>