### PR TITLE
fix(datagrid): keep the inline editor open when Tab moves to the next cell

### DIFF
--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -375,15 +375,19 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                         // synchronously would falsely conclude that focus left the grid.
                         Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
                         {
-                            if (!state.IsEditing && !state.IsRowEditing) return;
-                            // A keyboard editing-Tab already owns this focus-out: it commits the current cell
-                            // and reopens the editor on the next cell. Skip exactly one deferred commit here,
-                            // otherwise we tear down that just-reopened editor.
+                            // Consume the one-shot editing-Tab guard FIRST, before the IsEditing check.
+                            // A keyboard editing-Tab owns this focus-out: it already committed the current
+                            // cell and, when the next cell is editable, reopened the editor there — so skip
+                            // the safety-net commit. Consuming before the IsEditing guard is essential: if
+                            // the next cell was NOT editable the reopen fails and IsEditing is already false
+                            // here, so consuming afterwards would leave the flag set and wrongly suppress a
+                            // later legitimate blur-commit (lost edit).
                             if (state.SuppressNextLostFocusCommit)
                             {
                                 state.SuppressNextLostFocusCommit = false;
                                 return;
                             }
+                            if (!state.IsEditing && !state.IsRowEditing) return;
                             var focused = Microsoft.UI.Xaml.Input.FocusManager.GetFocusedElement(g.XamlRoot);
                             if (focused is DependencyObject dep)
                             {

--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -376,6 +376,14 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                         Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
                         {
                             if (!state.IsEditing && !state.IsRowEditing) return;
+                            // A keyboard editing-Tab already owns this focus-out: it commits the current cell
+                            // and reopens the editor on the next cell. Skip exactly one deferred commit here,
+                            // otherwise we tear down that just-reopened editor.
+                            if (state.SuppressNextLostFocusCommit)
+                            {
+                                state.SuppressNextLostFocusCommit = false;
+                                return;
+                            }
                             var focused = Microsoft.UI.Xaml.Input.FocusManager.GetFocusedElement(g.XamlRoot);
                             if (focused is DependencyObject dep)
                             {
@@ -435,6 +443,14 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                         {
                             e.Handled = true;
                             var capturedKey = e.Key;
+                            // An editing-Tab moves real focus out of the single-tab-stop grid, which fires
+                            // the grid's deferred LostFocus commit. But the editing-Tab path (HandleKeyDown)
+                            // itself commits the current cell and reopens the editor on the next cell, so the
+                            // LostFocus safety-net must NOT also commit — that would tear down the just-reopened
+                            // editor. Claim that one focus-out here, synchronously (before either handler
+                            // defers), so the guard is robust to dispatcher ordering.
+                            if (capturedKey == VirtualKey.Tab && state.IsEditing)
+                                state.SuppressNextLostFocusCommit = true;
                             Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
                             {
                                 HandleKeyDown(state, currentEl, capturedKey);

--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -368,6 +368,20 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                     lostFocusWired.Current = true;
                     g.LostFocus += (sender, e) =>
                     {
+                        // Consume the one-shot editing-Tab guard synchronously here, before the IsEditing
+                        // guard. A keyboard editing-Tab owns this focus-out: it already committed the
+                        // current cell and, when the next cell is editable, reopened the editor there — so
+                        // skip the safety-net commit. Consuming here (not in the deferred tick) is essential:
+                        // when the Tab lands on a NON-editable cell the reopen fails and IsEditing is already
+                        // false by the time this fires, so the guard below would short-circuit and never
+                        // schedule the tick — leaving the flag set to wrongly suppress a later legitimate
+                        // blur-commit (lost edit). The flag is set synchronously in the KeyDown handler,
+                        // before this LostFocus fires.
+                        if (state.SuppressNextLostFocusCommit)
+                        {
+                            state.SuppressNextLostFocusCommit = false;
+                            return;
+                        }
                         if (!state.IsEditing && !state.IsRowEditing) return;
                         // Defer the entire check to the next tick. During DOM transitions
                         // (e.g., cell switching from TextBlock to TextBox), the old element
@@ -375,18 +389,6 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                         // synchronously would falsely conclude that focus left the grid.
                         Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
                         {
-                            // Consume the one-shot editing-Tab guard FIRST, before the IsEditing check.
-                            // A keyboard editing-Tab owns this focus-out: it already committed the current
-                            // cell and, when the next cell is editable, reopened the editor there — so skip
-                            // the safety-net commit. Consuming before the IsEditing guard is essential: if
-                            // the next cell was NOT editable the reopen fails and IsEditing is already false
-                            // here, so consuming afterwards would leave the flag set and wrongly suppress a
-                            // later legitimate blur-commit (lost edit).
-                            if (state.SuppressNextLostFocusCommit)
-                            {
-                                state.SuppressNextLostFocusCommit = false;
-                                return;
-                            }
                             if (!state.IsEditing && !state.IsRowEditing) return;
                             var focused = Microsoft.UI.Xaml.Input.FocusManager.GetFocusedElement(g.XamlRoot);
                             if (focused is DependencyObject dep)

--- a/src/Reactor/Controls/DataGrid/DataGridComponent.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridComponent.cs
@@ -449,13 +449,14 @@ public class DataGridComponent<[DynamicallyAccessedMembers(DynamicallyAccessedMe
                         {
                             e.Handled = true;
                             var capturedKey = e.Key;
-                            // An editing-Tab moves real focus out of the single-tab-stop grid, which fires
-                            // the grid's deferred LostFocus commit. But the editing-Tab path (HandleKeyDown)
-                            // itself commits the current cell and reopens the editor on the next cell, so the
-                            // LostFocus safety-net must NOT also commit — that would tear down the just-reopened
-                            // editor. Claim that one focus-out here, synchronously (before either handler
-                            // defers), so the guard is robust to dispatcher ordering.
-                            if (capturedKey == VirtualKey.Tab && state.IsEditing)
+                            // A cell editing-Tab moves real focus out of the single-tab-stop grid, which fires
+                            // the grid's LostFocus commit. But the editing-Tab path (HandleKeyDown) itself
+                            // commits the current cell and reopens the editor on the next cell, so the LostFocus
+                            // safety-net must NOT also commit — that would tear down the just-reopened editor.
+                            // Claim that one focus-out here, synchronously (before either handler defers), so the
+                            // guard is robust to dispatcher ordering. Cell edit only: in row-edit mode IsEditing
+                            // is also true, but the LostFocus there commits the whole ROW and must not be suppressed.
+                            if (capturedKey == VirtualKey.Tab && state.IsEditing && !state.IsRowEditing)
                                 state.SuppressNextLostFocusCommit = true;
                             Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread()?.TryEnqueue(() =>
                             {

--- a/src/Reactor/Controls/DataGrid/DataGridState.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridState.cs
@@ -107,6 +107,15 @@ public class DataGridState<T>
     /// <summary>Whether the entire row is in edit mode (vs single cell).</summary>
     public bool IsRowEditing => _isRowEditing;
 
+    /// <summary>
+    /// One-shot guard, set synchronously when Tab is pressed while a cell is being edited. An
+    /// editing-Tab moves real focus out of the single-tab-stop grid, which fires the grid's deferred
+    /// LostFocus commit — but the editing-Tab flow (HandleKeyDown) itself commits the current cell and
+    /// reopens the editor on the next cell. Without this guard the LostFocus safety-net would commit a
+    /// second time and tear down that just-reopened editor. Consumed (cleared) by the next LostFocus tick.
+    /// </summary>
+    internal bool SuppressNextLostFocusCommit { get; set; }
+
     /// <summary>Gets the pending row-edit value for a specific column, or null if not in row edit.</summary>
     public object? GetRowEditValue(string columnName)
         => _rowEditValues?.TryGetValue(columnName, out var v) == true ? v : null;

--- a/src/Reactor/Controls/DataGrid/DataGridState.cs
+++ b/src/Reactor/Controls/DataGrid/DataGridState.cs
@@ -109,10 +109,11 @@ public class DataGridState<T>
 
     /// <summary>
     /// One-shot guard, set synchronously when Tab is pressed while a cell is being edited. An
-    /// editing-Tab moves real focus out of the single-tab-stop grid, which fires the grid's deferred
-    /// LostFocus commit — but the editing-Tab flow (HandleKeyDown) itself commits the current cell and
-    /// reopens the editor on the next cell. Without this guard the LostFocus safety-net would commit a
-    /// second time and tear down that just-reopened editor. Consumed (cleared) by the next LostFocus tick.
+    /// editing-Tab moves real focus out of the single-tab-stop grid, which fires the grid's LostFocus
+    /// handler — but the editing-Tab flow (HandleKeyDown) itself commits the current cell and reopens
+    /// the editor on the next cell. Without this guard the LostFocus safety-net would commit a second
+    /// time and tear down that just-reopened editor. Consumed (cleared) synchronously by the next
+    /// LostFocus event handler, before it schedules its deferred commit check.
     /// </summary>
     internal bool SuppressNextLostFocusCommit { get; set; }
 

--- a/tests/Reactor.AppTests.Host/Fixtures/DataGridFixtures.cs
+++ b/tests/Reactor.AppTests.Host/Fixtures/DataGridFixtures.cs
@@ -70,7 +70,10 @@ internal static class DataGridFixtures
                         return Task.CompletedTask;
                     },
                     rowHeight: 36
-                ).AutomationId("EditableGrid")
+                ).AutomationId("EditableGrid"),
+                // Focusable target OUTSIDE the grid, so an E2E can move focus off the grid and
+                // exercise the "focus left the grid" LostFocus commit path.
+                Button("blur anchor", () => { }).AutomationId("BlurAnchor")
             );
         }
     }

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -72,6 +72,44 @@ public class DataGridTests : AppTestBase
     }
 
     /// <summary>
+    /// Regression: pressing Tab WHILE EDITING must commit the current cell AND leave the inline
+    /// editor reopened on the next cell — it must not be torn down. The grid's deferred LostFocus
+    /// commit fires because Tab moves real focus out of the single-tab-stop grid; previously it ran
+    /// after the editing-Tab flow had already committed + reopened the editor and committed a second
+    /// time, destroying it (the editor never reappeared). Guarded by
+    /// <c>DataGridState.SuppressNextLostFocusCommit</c>.
+    /// </summary>
+    [E2eRetry(3)]
+    [TestMethod]
+    public void Interactive_DataGrid_EditingTab_ReopensEditorOnNextCell()
+    {
+        NavigateToFixtureFresh("DataGrid_EditableGrid");
+        WaitForText("EditLog", "Edits:");
+        Assert.IsNotNull(WaitForName("Alice"), "'Alice' should be visible");
+        Assert.IsNotNull(FindByName("Smith"), "'Smith' (the next cell) should be visible");
+
+        // Edit row-1 FirstName (Alice); type a new value but do NOT commit.
+        TapCell("Alice");
+        TypeIntoFocusedEditor("Alicia");
+
+        // Editing-Tab: commits FirstName and should reopen the editor on the LastName cell.
+        InputInjector.Foreground(HostHwnd);
+        InputInjector.Tab();
+
+        // The inline editor must still be present (reopened on the next cell), not torn down by the
+        // LostFocus safety-net. WaitForEditor throws if the editor is absent — that IS the regression.
+        var editor = WaitForEditor(timeoutMs: 4000);
+
+        // When winapp can read the value, confirm the editor reopened on the LastName cell ("Smith").
+        var value = ReadEditorValueSettled(editor, "Smith", timeoutMs: 1500);
+        if (value is not null)
+            Assert.AreEqual("Smith", value, "Reopened editor should be on the LastName cell");
+
+        // And the FirstName commit must have landed.
+        WaitForTextContaining("EditLog", "[1:Alicia,Smith]", timeoutMs: 5000);
+    }
+
+    /// <summary>
     /// Tap a DataGrid cell by its visible text to enter/commit cell edit. The cells are
     /// display-only TextBlocks (no InvokePattern), and a WinUI <c>Tapped</c> only fires on an
     /// ACTIVE window, so winapp's UIA invoke/click can't drive them. We foreground the host and

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -86,7 +86,7 @@ public class DataGridTests : AppTestBase
         NavigateToFixtureFresh("DataGrid_EditableGrid");
         WaitForText("EditLog", "Edits:");
         Assert.IsNotNull(WaitForName("Alice"), "'Alice' should be visible");
-        Assert.IsNotNull(FindByName("Smith"), "'Smith' (the next cell) should be visible");
+        Assert.IsNotNull(WaitForName("Smith"), "'Smith' (the next cell) should be visible");
 
         // Edit row-1 FirstName (Alice); type a new value but do NOT commit.
         TapCell("Alice");

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -106,13 +106,20 @@ public class DataGridTests : AppTestBase
                         "regressed (the LostFocus safety-net likely committed a second time and tore it down). " + ex.Message);
         }
 
-        // When winapp can read the value, confirm the editor reopened on the LastName cell ("Smith").
-        var value = ReadEditorValueSettled(editor!, "Smith", timeoutMs: 1500);
-        if (value is not null)
-            Assert.AreEqual("Smith", value, "Reopened editor should be on the LastName cell");
+        Assert.IsNotNull(editor, "Inline editor should have reopened on the next cell after the editing-Tab.");
 
-        // And the FirstName commit must have landed.
+        // The FirstName commit from the Tab must have landed (LastName unchanged, still "Smith").
         WaitForTextContaining("EditLog", "[1:Alicia,Smith]", timeoutMs: 5000);
+
+        // Authoritative, unconditional proof the editor reopened on the LastName cell (not still on
+        // FirstName): type a new value into the reopened editor and commit. Editing LastName commits
+        // row 1 as [1:Alicia,Smythe] — FirstName preserved as the just-committed "Alicia"; had the
+        // editor wrongly reopened on FirstName, that commit would read [1:Smythe,Smith] and this
+        // assertion would time out. Unlike a direct editor-value read (winapp can't reliably read the
+        // inline TextBox), this behavioral oracle is unconditional.
+        TypeIntoFocusedEditor("Smythe", commitWithEnter: true);
+        WaitForTextContaining("EditLog", "[1:Alicia,Smythe]", timeoutMs: 5000);
+        Assert.IsNotNull(WaitForName("Smythe"), "Edited LastName 'Smythe' should be visible after commit.");
     }
 
     /// <summary>

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -97,11 +97,17 @@ public class DataGridTests : AppTestBase
         InputInjector.Tab();
 
         // The inline editor must still be present (reopened on the next cell), not torn down by the
-        // LostFocus safety-net. WaitForEditor throws if the editor is absent — that IS the regression.
-        var editor = WaitForEditor(timeoutMs: 4000);
+        // LostFocus safety-net.
+        UiElement? editor = null;
+        try { editor = WaitForEditor(timeoutMs: 4000); }
+        catch (WinAppException ex)
+        {
+            Assert.Fail("Inline editor did not REOPEN on the next cell after the editing-Tab — the reopen " +
+                        "regressed (the LostFocus safety-net likely committed a second time and tore it down). " + ex.Message);
+        }
 
         // When winapp can read the value, confirm the editor reopened on the LastName cell ("Smith").
-        var value = ReadEditorValueSettled(editor, "Smith", timeoutMs: 1500);
+        var value = ReadEditorValueSettled(editor!, "Smith", timeoutMs: 1500);
         if (value is not null)
             Assert.AreEqual("Smith", value, "Reopened editor should be on the LastName cell");
 

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -110,6 +110,40 @@ public class DataGridTests : AppTestBase
     }
 
     /// <summary>
+    /// Regression for the SuppressNextLostFocusCommit guard's one-shot lifetime: an editing-Tab into a
+    /// NON-editable next cell reopens no editor (IsEditing ends false), so the guard must still be
+    /// consumed — otherwise it lingers on the persistent state and silently suppresses the NEXT
+    /// legitimate focus-out commit, losing that edit. Here: edit row-1 LastName (its next tab-order
+    /// cell, Salary, is read-only), press Tab, then edit a different row's cell and move focus off the
+    /// grid (click the anchor button). That second edit must commit.
+    /// </summary>
+    [E2eRetry(3)]
+    [TestMethod]
+    public void Interactive_DataGrid_EditingTabToReadOnly_DoesNotSuppressNextCommit()
+    {
+        NavigateToFixtureFresh("DataGrid_EditableGrid");
+        WaitForText("EditLog", "Edits:");
+        Assert.IsNotNull(WaitForName("Smith"), "'Smith' (row 1 LastName) should be visible");
+
+        // Edit row-1 LastName (Smith -> Brown); Tab moves to Salary (read-only) so no editor reopens.
+        TapCell("Smith");
+        TypeIntoFocusedEditor("Brown");
+        InputInjector.Foreground(HostHwnd);
+        InputInjector.Tab();
+        WaitForTextContaining("EditLog", "[1:Alice,Brown]", timeoutMs: 5000);
+
+        // Now edit a different row's cell, then move focus OUT of the grid by clicking the anchor
+        // button. That fires the grid's "focus left the grid" LostFocus commit — the exact path the
+        // guard suppresses. If the guard leaked from the Tab-into-read-only above, 'Bobby' is lost.
+        Assert.IsNotNull(WaitForName("Bob"), "'Bob' (row 2 FirstName) should be visible");
+        TapCell("Bob");
+        TypeIntoFocusedEditor("Bobby");
+        Element("BlurAnchor").Click(); // focus leaves the grid -> blur-commit through LostFocus
+
+        WaitForTextContaining("EditLog", "[2:Bobby,Jones]", timeoutMs: 5000);
+    }
+
+    /// <summary>
     /// Tap a DataGrid cell by its visible text to enter/commit cell edit. The cells are
     /// display-only TextBlocks (no InvokePattern), and a WinUI <c>Tapped</c> only fires on an
     /// ACTIVE window, so winapp's UIA invoke/click can't drive them. We foreground the host and

--- a/tests/Reactor.AppTests/Tests/DataGridTests.cs
+++ b/tests/Reactor.AppTests/Tests/DataGridTests.cs
@@ -77,7 +77,7 @@ public class DataGridTests : AppTestBase
     /// commit fires because Tab moves real focus out of the single-tab-stop grid; previously it ran
     /// after the editing-Tab flow had already committed + reopened the editor and committed a second
     /// time, destroying it (the editor never reappeared). Guarded by
-    /// <c>DataGridState.SuppressNextLostFocusCommit</c>.
+    /// <c>DataGridState&lt;T&gt;.SuppressNextLostFocusCommit</c>.
     /// </summary>
     [E2eRetry(3)]
     [TestMethod]

--- a/tests/Reactor.Tests/DataGridFocusEditTests.cs
+++ b/tests/Reactor.Tests/DataGridFocusEditTests.cs
@@ -483,6 +483,40 @@ public class DataGridFocusEditTests
         Assert.False(state.IsColumnInRowEdit(new RowKey("2"), "Name")); // wrong row
     }
 
+    // Regression for the editing-Tab guard's CELL-edit scope. DataGridComponent arms
+    // DataGridState<T>.SuppressNextLostFocusCommit only when `IsEditing && !IsRowEditing`; this pins
+    // that predicate at the state level. IsEditing is TRUE in BOTH cell- and row-edit (BeginRowEdit
+    // also sets _editingRowKey), so the !IsRowEditing clause is exactly what stops a row-edit Tab from
+    // suppressing the row's LostFocus commit (which must still run CommitRowEdit). The full end-to-end
+    // row-edit-Tab E2E is deferred to #853: on current main a row-edit Tab reaches HandleKeyDown's
+    // cell-commit path and throws (CommitEdit dereferences a null column name), so it cannot be
+    // exercised through the real input pipeline until that pre-existing defect is fixed.
+    [Fact]
+    public async Task EditingTabGuardPredicate_TrueInCellEdit_FalseInRowEdit()
+    {
+        var state = await CreateLoadedState();
+
+        // Cell edit (row 0, "Name" is editable): predicate true -> a Tab arms SuppressNextLostFocusCommit.
+        Assert.True(state.BeginEdit(0, 1));
+        Assert.True(state.IsEditing);
+        Assert.False(state.IsRowEditing);
+        Assert.True(state.IsEditing && !state.IsRowEditing,
+            "Cell edit must arm the editing-Tab guard (IsEditing && !IsRowEditing).");
+
+        state.CancelEdit();
+        Assert.False(state.IsEditing);
+        Assert.False(state.IsRowEditing);
+
+        // Row edit: IsEditing is ALSO true here, so the predicate must be FALSE via !IsRowEditing ->
+        // a Tab must NOT arm the guard, leaving the row's LostFocus CommitRowEdit free to commit.
+        Assert.True(state.BeginRowEdit(0));
+        Assert.True(state.IsEditing,
+            "Row edit also sets IsEditing (via _editingRowKey) — the reason the guard needs !IsRowEditing.");
+        Assert.True(state.IsRowEditing);
+        Assert.False(state.IsEditing && !state.IsRowEditing,
+            "Row edit must NOT arm the editing-Tab guard (the whole-row LostFocus commit must not be suppressed).");
+    }
+
     // ═══════════════════════════════════════════════════════════════
     // Async Commit Lifecycle
     // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Bug
Pressing **Tab while editing** a DataGrid cell should commit the current cell, move to the next cell, and reopen the editor there (Excel-like). Instead the editor reopened and was **immediately torn down**, so the grid appeared to drop out of edit mode.

## Root cause (confirmed with a headful trace)
An editing-Tab moves real focus out of the single-tab-stop grid, which fires the grid's **deferred LostFocus commit**. That deferred commit runs *after* the editing-Tab flow (`HandleKeyDown`) has already committed the current cell and reopened the editor on the next cell, and commits a **second** time — tearing down the just-reopened editor.

Trace (editing-Tab on row 1, FirstName→LastName):
```
HandleKeyDown ENTER key=Tab IsEditing=True
editing-Tab arm: CommitAndMoveNext -> committed:1; IsEditing(afterMove)=False
editing-Tab arm: BeginEdit -> True; IsEditing(after)=True        <- editor reopened
LostFocus TICK: focus LEFT grid -> CommitEdit NOW                <- editor destroyed
```
The reverse dispatcher ordering is also broken (LostFocus commits first → `HandleKeyDown` sees `IsEditing=false` → skips `BeginEdit`). The commit itself still lands via LostFocus, which is why commit-checking tests passed but the editor never reappears.

## Fix
A one-shot `DataGridState.SuppressNextLostFocusCommit` guard:
- **Set synchronously** in the grid KeyDown handler when Tab is pressed while editing — *before* either handler defers, so it's robust to dispatcher ordering.
- **Consumed** by the next LostFocus deferred tick, which then skips exactly that one focus-out.

The editing-Tab path owns commit+move+reopen; the LostFocus safety-net stays out of it for that one interaction. 25 product lines, well-commented.

## Test
Adds a headful E2E regression test `Interactive_DataGrid_EditingTab_ReopensEditorOnNextCell`: edits a cell, presses a real Tab, and asserts the inline editor **reopens on the next cell** with the correct value and that the commit landed. Verified headful locally (passes; the existing `ClickEditTabCommit` still passes). Fails on `main`.

## Follow-up (intentionally not here)
The Tab-reopened editor does **not** take keyboard focus, so continued Tab-through editing needs a click first. Focusing it cleanly needs a focus-assertable test seam (the inline editor has no AutomationId) and is a separate tab-semantics refinement — filing/deferring rather than bundling unvalidated behavior.