### PR TITLE
test(e2e): harden the winapp-ui E2E harness against two intermittent CI flakes

### DIFF
--- a/tests/Reactor.AppTests/Infrastructure/HostLaunch.cs
+++ b/tests/Reactor.AppTests/Infrastructure/HostLaunch.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+
+namespace Microsoft.UI.Reactor.AppTests.Infrastructure;
+
+/// <summary>
+/// Launches a test host process and binds to its top-level window, retrying the whole launch
+/// (kill + relaunch) when the window does not appear in time. A loaded CI runner is occasionally
+/// slow to first-paint the host window within a single window-wait; because the launch happens in
+/// a test class's <c>[ClassInitialize]</c>, the per-method <see cref="E2eRetryAttribute"/> cannot
+/// cover that failure (it wraps a test method, not class init) — so the resilience lives here.
+/// Throws only after every attempt is exhausted.
+/// </summary>
+internal static class HostLaunch
+{
+    internal static (Process proc, long hwnd) LaunchAndBind(
+        string exePath, string windowTitle, int attempts = 3, int perAttemptTimeoutMs = 15000)
+    {
+        Exception? last = null;
+        for (int attempt = 1; attempt <= attempts; attempt++)
+        {
+            Process? proc = null;
+            try
+            {
+                proc = Process.Start(new ProcessStartInfo(exePath) { UseShellExecute = false })
+                       ?? throw new WinAppException($"Process.Start returned null for '{exePath}'.");
+                Console.WriteLine($"Host '{windowTitle}' launch attempt {attempt}/{attempts} (PID {proc.Id}).");
+                var hwnd = WinAppUi.FindWindowHwnd(proc.Id, windowTitle, timeoutMs: perAttemptTimeoutMs);
+                return (proc, hwnd);
+            }
+            catch (Exception ex) when (ex is WinAppException or TimeoutException)
+            {
+                last = ex;
+                Console.WriteLine($"Host '{windowTitle}' launch attempt {attempt}/{attempts} failed: {ex.Message}");
+                TryKill(proc);
+                if (attempt < attempts)
+                    Thread.Sleep(500);
+            }
+        }
+
+        throw last ?? new WinAppTimeoutException(
+            $"Host window '{windowTitle}' did not appear after {attempts} launch attempts.");
+    }
+
+    private static void TryKill(Process? proc)
+    {
+        if (proc is null)
+            return;
+        try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
+        try { proc.Dispose(); } catch { /* best effort */ }
+    }
+}

--- a/tests/Reactor.AppTests/Infrastructure/HostLaunch.cs
+++ b/tests/Reactor.AppTests/Infrastructure/HostLaunch.cs
@@ -34,11 +34,19 @@ internal static class HostLaunch
             }
             catch (Exception ex) when (ex is WinAppTimeoutException or TimeoutException)
             {
+                // Retryable: the host window did not appear in time.
                 last = ex;
                 Console.WriteLine($"Host '{windowTitle}' launch attempt {attempt}/{attempts} failed: {ex.Message}");
                 KillAndWait(proc);
                 if (attempt < attempts)
                     Thread.Sleep(500);
+            }
+            catch
+            {
+                // Non-retryable (config/environment error, or Process.Start returned null): clean up
+                // the started host so it can't orphan, then fail fast with the real cause.
+                KillAndWait(proc);
+                throw;
             }
         }
 

--- a/tests/Reactor.AppTests/Infrastructure/HostLaunch.cs
+++ b/tests/Reactor.AppTests/Infrastructure/HostLaunch.cs
@@ -32,7 +32,7 @@ internal static class HostLaunch
                 var hwnd = WinAppUi.FindWindowHwnd(proc.Id, windowTitle, timeoutMs: perAttemptTimeoutMs);
                 return (proc, hwnd);
             }
-            catch (Exception ex) when (ex is WinAppException or TimeoutException)
+            catch (Exception ex) when (ex is WinAppTimeoutException or TimeoutException)
             {
                 last = ex;
                 Console.WriteLine($"Host '{windowTitle}' launch attempt {attempt}/{attempts} failed: {ex.Message}");

--- a/tests/Reactor.AppTests/Infrastructure/HostLaunch.cs
+++ b/tests/Reactor.AppTests/Infrastructure/HostLaunch.cs
@@ -15,6 +15,11 @@ internal static class HostLaunch
     internal static (Process proc, long hwnd) LaunchAndBind(
         string exePath, string windowTitle, int attempts = 3, int perAttemptTimeoutMs = 15000)
     {
+        if (attempts < 1)
+            throw new ArgumentOutOfRangeException(nameof(attempts), attempts, "Must be at least 1.");
+        if (perAttemptTimeoutMs <= 0)
+            throw new ArgumentOutOfRangeException(nameof(perAttemptTimeoutMs), perAttemptTimeoutMs, "Must be positive.");
+
         Exception? last = null;
         for (int attempt = 1; attempt <= attempts; attempt++)
         {
@@ -31,21 +36,30 @@ internal static class HostLaunch
             {
                 last = ex;
                 Console.WriteLine($"Host '{windowTitle}' launch attempt {attempt}/{attempts} failed: {ex.Message}");
-                TryKill(proc);
+                KillAndWait(proc);
                 if (attempt < attempts)
                     Thread.Sleep(500);
             }
         }
 
-        throw last ?? new WinAppTimeoutException(
-            $"Host window '{windowTitle}' did not appear after {attempts} launch attempts.");
+        throw new WinAppTimeoutException(
+            $"Host window '{windowTitle}' did not appear after {attempts} launch attempts " +
+            $"(<={perAttemptTimeoutMs}ms each). Last error: {last?.Message ?? "unknown"}.");
     }
 
-    private static void TryKill(Process? proc)
+    private static void KillAndWait(Process? proc)
     {
         if (proc is null)
             return;
-        try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
-        try { proc.Dispose(); } catch { /* best effort */ }
+        try
+        {
+            proc.Kill(entireProcessTree: true);
+            proc.WaitForExit(2000); // best-effort: don't relaunch on top of a still-exiting host
+        }
+        catch { /* best effort */ }
+        finally
+        {
+            try { proc.Dispose(); } catch { /* best effort */ }
+        }
     }
 }

--- a/tests/Reactor.AppTests/Infrastructure/SessionInteractivityGuard.cs
+++ b/tests/Reactor.AppTests/Infrastructure/SessionInteractivityGuard.cs
@@ -90,6 +90,19 @@ public static partial class SessionInteractivityGuard
             return;
 
         var state = GetState();
+        // A loaded CI runner can momentarily report a non-Active state (a WTS connect-state blip,
+        // or the input desktop not yet resolving to "Default") even though it is genuinely
+        // interactive. Re-probe a few times before concluding locked/disconnected, so a transient
+        // blip doesn't wrongly reclassify a real input-injection E2E as Inconclusive (which the CI
+        // gate then fails). A genuinely locked/disconnected session stays non-Active across the
+        // retries and is still correctly surfaced as Inconclusive below.
+        for (int attempt = 0;
+             attempt < 4 && (state == SessionInteractivity.Locked || state == SessionInteractivity.Disconnected);
+             attempt++)
+        {
+            Thread.Sleep(500);
+            state = GetState();
+        }
         // Unknown means the OS gave us an unexpected error from the desktop
         // probe — don't fabricate a verdict. Let the test run; if winapp
         // really can't drive input, the post-failure recheck will catch

--- a/tests/Reactor.AppTests/Infrastructure/SessionInteractivityGuard.cs
+++ b/tests/Reactor.AppTests/Infrastructure/SessionInteractivityGuard.cs
@@ -97,12 +97,16 @@ public static partial class SessionInteractivityGuard
         // lock/disconnect, so a single transient Unknown reading can't flip a genuinely locked
         // session to a pass — that would reopen the silent-skip hole the gate exists to close.
         var state = GetState();
-        var sawLocked = state is SessionInteractivity.Locked or SessionInteractivity.Disconnected;
+        // Remember the most recent DEFINITE non-interactive reading, so if the window ends on a
+        // trailing Unknown we still report the actionable Locked/Disconnected signal (and still fail).
+        SessionInteractivity? lockedState =
+            state is SessionInteractivity.Locked or SessionInteractivity.Disconnected ? state : null;
         for (int attempt = 0; attempt < 4 && state != SessionInteractivity.Active; attempt++)
         {
             Thread.Sleep(500);
             state = GetState();
-            sawLocked |= state is SessionInteractivity.Locked or SessionInteractivity.Disconnected;
+            if (state is SessionInteractivity.Locked or SessionInteractivity.Disconnected)
+                lockedState = state;
         }
 
         if (state == SessionInteractivity.Active)
@@ -113,12 +117,14 @@ public static partial class SessionInteractivityGuard
         // window (then the session is genuinely non-interactive and must surface as Inconclusive).
         // Pure-Unknown proceeds; if winapp really can't drive input, the post-failure recheck catches
         // a definite Locked/Disconnected on the second look.
-        if (state == SessionInteractivity.Unknown && !sawLocked)
+        if (state == SessionInteractivity.Unknown && lockedState is null)
             return;
 
-        WriteMarker(state, operation);
+        // Prefer the definite locked/disconnected signal over a trailing Unknown reading.
+        var verdict = lockedState ?? state;
+        WriteMarker(verdict, operation);
         Assert.Inconclusive(
-            $"Cannot perform '{operation}': workstation is {state}. " +
+            $"Cannot perform '{operation}': workstation is {verdict}. " +
             "UI automation needs an active interactive desktop — locked screen, " +
             "idle/sleep lock, or RDP disconnect makes every winapp click " +
             "fail with a generic error. Treating these as Inconclusive " +

--- a/tests/Reactor.AppTests/Infrastructure/SessionInteractivityGuard.cs
+++ b/tests/Reactor.AppTests/Infrastructure/SessionInteractivityGuard.cs
@@ -89,25 +89,31 @@ public static partial class SessionInteractivityGuard
         if (IsTruthy(Environment.GetEnvironmentVariable("E2E_SKIP_LOCK_GUARD")))
             return;
 
-        var state = GetState();
         // A loaded CI runner can momentarily report a non-Active state (a WTS connect-state blip,
         // or the input desktop not yet resolving to "Default") even though it is genuinely
-        // interactive. Re-probe a few times before concluding locked/disconnected, so a transient
-        // blip doesn't wrongly reclassify a real input-injection E2E as Inconclusive (which the CI
-        // gate then fails). A genuinely locked/disconnected session stays non-Active across the
-        // retries and is still correctly surfaced as Inconclusive below.
-        for (int attempt = 0;
-             attempt < 4 && (state == SessionInteractivity.Locked || state == SessionInteractivity.Disconnected);
-             attempt++)
+        // interactive. Re-probe until we get a definitive Active read or the window elapses, so a
+        // transient blip doesn't wrongly reclassify a real input-injection E2E as Inconclusive
+        // (which the CI gate then fails). Track whether ANY probe in the window saw a definite
+        // lock/disconnect, so a single transient Unknown reading can't flip a genuinely locked
+        // session to a pass — that would reopen the silent-skip hole the gate exists to close.
+        var state = GetState();
+        var sawLocked = state is SessionInteractivity.Locked or SessionInteractivity.Disconnected;
+        for (int attempt = 0; attempt < 4 && state != SessionInteractivity.Active; attempt++)
         {
             Thread.Sleep(500);
             state = GetState();
+            sawLocked |= state is SessionInteractivity.Locked or SessionInteractivity.Disconnected;
         }
-        // Unknown means the OS gave us an unexpected error from the desktop
-        // probe — don't fabricate a verdict. Let the test run; if winapp
-        // really can't drive input, the post-failure recheck will catch
+
+        if (state == SessionInteractivity.Active)
+            return;
+
+        // Unknown means the OS gave us an unexpected error from the desktop probe — don't fabricate a
+        // verdict AND let the test run, UNLESS a probe already saw a definite lock/disconnect this
+        // window (then the session is genuinely non-interactive and must surface as Inconclusive).
+        // Pure-Unknown proceeds; if winapp really can't drive input, the post-failure recheck catches
         // a definite Locked/Disconnected on the second look.
-        if (state == SessionInteractivity.Active || state == SessionInteractivity.Unknown)
+        if (state == SessionInteractivity.Unknown && !sawLocked)
             return;
 
         WriteMarker(state, operation);

--- a/tests/Reactor.AppTests/Infrastructure/TestSession.cs
+++ b/tests/Reactor.AppTests/Infrastructure/TestSession.cs
@@ -63,14 +63,11 @@ public class TestSession
         var exePath = FindHostExe();
         Console.WriteLine($"Host app: {exePath}");
 
-        _appProcess = Process.Start(new ProcessStartInfo(exePath) { UseShellExecute = false });
-        Console.WriteLine($"Host app launched (PID {_appProcess?.Id}).");
-
         try
         {
-            var pid = _appProcess!.Id;
-            var hwnd = WinAppUi.FindWindowHwnd(pid, WindowTitle, timeoutMs: 15000);
-            _app = new WinAppUi(pid, hwnd);
+            var (proc, hwnd) = HostLaunch.LaunchAndBind(exePath, WindowTitle);
+            _appProcess = proc;
+            _app = new WinAppUi(proc.Id, hwnd);
             _uia = new UiaPropertyReader(hwnd);
             Console.WriteLine($"winapp UI automation bound to Host window (HWND 0x{hwnd:X}).");
         }

--- a/tests/Reactor.AppTests/Infrastructure/WinFormsTestSession.cs
+++ b/tests/Reactor.AppTests/Infrastructure/WinFormsTestSession.cs
@@ -48,14 +48,11 @@ public class WinFormsTestSession
         var exePath = FindHostExe();
         Console.WriteLine($"WinForms host: {exePath}");
 
-        _appProcess = Process.Start(new ProcessStartInfo(exePath) { UseShellExecute = false });
-        Console.WriteLine($"WinForms host launched (PID {_appProcess?.Id}).");
-
         try
         {
-            var pid = _appProcess!.Id;
-            var hwnd = WinAppUi.FindWindowHwnd(pid, WindowTitle, timeoutMs: 15000);
-            _app = new WinAppUi(pid, hwnd);
+            var (proc, hwnd) = HostLaunch.LaunchAndBind(exePath, WindowTitle);
+            _appProcess = proc;
+            _app = new WinAppUi(proc.Id, hwnd);
             _uia = new UiaPropertyReader(hwnd);
             Console.WriteLine($"winapp UI automation bound to WinForms host (HWND 0x{hwnd:X}).");
         }


### PR DESCRIPTION
## What
Hardens the winapp-ui E2E harness against **two intermittent CI flakes** that red the `E2E Tests (winapp ui)` job. Evidence they're flakes, not regressions: 8 of the last 10 CI runs passed on the same code; the two failures (runs 28974307746 / #848 and 28960079752 / #841) were `event=push` on `main`. Neither is caused by the `E2eRetryAttribute` nor by any product change. E2E is not a required merge check, which is why they slipped through.

## Mode A — WinForms interop host launch timeout (ClassInitialize cascade)
All ~12 tests in `WinFormsInteropTests` failed at `[ClassInitialize]` with `Host window 'WinForms Interop Test Host' did not appear within 15000ms` (`WinFormsTestSession` / `TestSession` → `WinAppUi.FindWindowHwnd(..., 15000)`). A loaded runner is occasionally slow to first-paint the host window. **`E2eRetryAttribute` structurally cannot cover this** — it's a `RetryBaseAttribute` that wraps a *test method*, but the failure is in class init, before any method runs.

**Fix:** a shared `HostLaunch.LaunchAndBind` that retries the whole launch (kill + relaunch) up to 3× before throwing. Both `TestSession` and `WinFormsTestSession` route through it.

## Mode B — input-injection tests reclassified as Inconclusive
The `Fail on skipped input-injection E2Es` gate throws when an input test comes back `Inconclusive`. `SessionInteractivityGuard` concluded the desktop was locked/disconnected from a **single** probe, which can momentarily read non-Active on a genuinely interactive runner (WTS connect-state blip, or the input desktop not yet resolving to `Default`).

**Fix:** re-probe a few times before concluding locked/disconnected. A transient blip clears → the test runs; a **genuinely** locked/disconnected session stays non-Active across the retries and is still surfaced as `Inconclusive` — so the gate's anti-silent-skip guarantee is fully preserved (it was deliberately added so input E2Es can't quietly skip and erase coverage).

## Validation
Test-infra only; no product code. Compiles (`-p:Platform=x64`). These flakes are intermittent and environment-dependent (hard to reproduce on demand) — the retries are defensive and don't change the happy path, so this is validated by the PR's own CI E2E run staying green plus review.