### PR TITLE
Add app-mark icon to the app template and fix FontIconSource NaN crash

### DIFF
--- a/src/Reactor/Core/V1Protocol/IconResolver.cs
+++ b/src/Reactor/Core/V1Protocol/IconResolver.cs
@@ -76,12 +76,7 @@ internal static class IconResolver
     {
         null => null,
         SymbolIconData sym => ResolveIconSource(sym.Symbol),
-        FontIconData fi => new WinUI.FontIconSource
-        {
-            Glyph = fi.Glyph,
-            FontFamily = fi.FontFamily is null ? null! : WinRTCache.GetFontFamily(fi.FontFamily),
-            FontSize = fi.FontSize ?? double.NaN,
-        },
+        FontIconData fi => CreateFontIconSource(fi),
         BitmapIconData bi => new WinUI.BitmapIconSource { UriSource = bi.Source, ShowAsMonochrome = bi.ShowAsMonochrome },
         PathIconData pi => CreatePathIconSource(pi),
         ImageIconData ii => new WinUI.ImageIconSource
@@ -109,6 +104,19 @@ internal static class IconResolver
         if (fi.FontFamily is not null) icon.FontFamily = WinRTCache.GetFontFamily(fi.FontFamily);
         if (fi.FontSize.HasValue) icon.FontSize = fi.FontSize.Value;
         return icon;
+    }
+
+    // Mirror of CreateFontIcon for the IconSource slot (TitleBar, TabView, etc.).
+    // FontFamily / FontSize are only assigned when specified: a FontIconSource
+    // with FontSize = double.NaN (or a null FontFamily) is rejected by
+    // TitleBar.set_IconSource with E_INVALIDARG ("Value does not fall within the
+    // expected range"), so leave them at their control defaults when unset.
+    internal static WinUI.FontIconSource CreateFontIconSource(FontIconData fi)
+    {
+        var src = new WinUI.FontIconSource { Glyph = fi.Glyph };
+        if (fi.FontFamily is not null) src.FontFamily = WinRTCache.GetFontFamily(fi.FontFamily);
+        if (fi.FontSize.HasValue) src.FontSize = fi.FontSize.Value;
+        return src;
     }
 
     internal static WinUI.PathIcon CreatePathIcon(PathIconData pi)

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -1746,6 +1746,27 @@ internal static class ReconcilerBigCoverageFixtures
             };
             H.Check("PrivMount_IconSources", iconSources.Take(6).All(i => i is not null));
 
+            // Regression: a FontIcon with NO explicit FontSize must resolve to a
+            // FontIconSource that TitleBar.IconSource accepts. The IconSource path
+            // used to force FontSize = double.NaN, which TitleBar.set_IconSource
+            // rejects with ArgumentException ("Value does not fall within the
+            // expected range") — the exact failure the modernized app template hit
+            // via TitleBar(...).Icon(FontIcon("\uEA3A", "Segoe Fluent Icons")).
+            // Assign to a real TitleBar on the UI thread to lock the fix in.
+            var barFontIconNoSize = IconResolver.ResolveIconSource(
+                new FontIconData("\uEA3A", "Segoe Fluent Icons"));
+            bool titleBarAcceptedFontIcon;
+            try
+            {
+                _ = new WinXC.TitleBar { IconSource = barFontIconNoSize };
+                titleBarAcceptedFontIcon = true;
+            }
+            catch (ArgumentException)
+            {
+                titleBarAcceptedFontIcon = false;
+            }
+            H.Check("PrivMount_TitleBarFontIconNoSize", titleBarAcceptedFontIcon);
+
             var rows = new[] { new KeyRow("a"), new KeyRow("b"), new KeyRow("c") };
             int selected = -1;
             IReadOnlyList<KeyRow>? multi = null;

--- a/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
+++ b/tests/Reactor.AppTests.Host/SelfTest/Fixtures/ReconcilerBigCoverageFixtures.cs
@@ -1752,20 +1752,28 @@ internal static class ReconcilerBigCoverageFixtures
             // rejects with ArgumentException ("Value does not fall within the
             // expected range") — the exact failure the modernized app template hit
             // via TitleBar(...).Icon(FontIcon("\uEA3A", "Segoe Fluent Icons")).
-            // Assign to a real TitleBar on the UI thread to lock the fix in.
-            var barFontIconNoSize = IconResolver.ResolveIconSource(
-                new FontIconData("\uEA3A", "Segoe Fluent Icons"));
-            bool titleBarAcceptedFontIcon;
-            try
+            // The parallel null-FontFamily slot was coerced the same way (FontFamily
+            // = null!), so cover it too. For each case assert the resolver produced a
+            // real FontIconSource (not null / some other type) AND that a real
+            // TitleBar accepts the assignment on the UI thread.
+            static bool TitleBarAcceptsFontIconSource(IconData data)
             {
-                _ = new WinXC.TitleBar { IconSource = barFontIconNoSize };
-                titleBarAcceptedFontIcon = true;
+                if (IconResolver.ResolveIconSource(data) is not WinXC.FontIconSource src)
+                    return false;
+                try
+                {
+                    _ = new WinXC.TitleBar { IconSource = src };
+                    return true;
+                }
+                catch (ArgumentException)
+                {
+                    return false;
+                }
             }
-            catch (ArgumentException)
-            {
-                titleBarAcceptedFontIcon = false;
-            }
-            H.Check("PrivMount_TitleBarFontIconNoSize", titleBarAcceptedFontIcon);
+
+            H.Check("PrivMount_TitleBarFontIconNoSize",
+                TitleBarAcceptsFontIconSource(new FontIconData("\uEA3A", "Segoe Fluent Icons"))
+                && TitleBarAcceptsFontIconSource(new FontIconData("\uEA3A", FontFamily: null, FontSize: 18)));
 
             var rows = new[] { new KeyRow("a"), new KeyRow("b"), new KeyRow("c") };
             int selected = -1;

--- a/tools/Templates/templates/WinUIApp-CSharp/App.cs
+++ b/tools/Templates/templates/WinUIApp-CSharp/App.cs
@@ -27,7 +27,12 @@ class App : Component
     {
         var (name, setName) = UseState("World");
 
-        var titleBar = TitleBar("Company.ReactorApp1").Flex(shrink: 0);
+        // App-mark icon in the title bar: a Segoe Fluent Icons glyph (U+EA3A,
+        // "CircleRing") used as a placeholder. Swap it for a bundled asset once
+        // you add one, e.g. .Icon("ms-appx:///Assets/AppIcon.ico").
+        var titleBar = TitleBar("Company.ReactorApp1")
+            .Icon(FontIcon("\uEA3A", "Segoe Fluent Icons"))
+            .Flex(shrink: 0);
 
         var body = Border(
             FlexColumn(

--- a/tools/Templates/templates/WinUIApp-CSharp/App.cs
+++ b/tools/Templates/templates/WinUIApp-CSharp/App.cs
@@ -27,9 +27,9 @@ class App : Component
     {
         var (name, setName) = UseState("World");
 
-        // App-mark icon in the title bar: a Segoe Fluent Icons glyph (U+EA3A,
-        // "CircleRing") used as a placeholder. Swap it for a bundled asset once
-        // you add one, e.g. .Icon("ms-appx:///Assets/AppIcon.ico").
+        // App-mark icon in the title bar: a placeholder Segoe Fluent Icons glyph
+        // (U+EA3A). Swap it for a bundled asset once you add one, e.g.
+        // .Icon("ms-appx:///Assets/AppIcon.ico").
         var titleBar = TitleBar("Company.ReactorApp1")
             .Icon(FontIcon("\uEA3A", "Segoe Fluent Icons"))
             .Flex(shrink: 0);


### PR DESCRIPTION
## Summary

Gives the app scaffolded by `dotnet new reactorapp` a **title-bar app-mark icon** — the one bit of modern-title-bar polish the template was missing — and fixes a framework bug in icon-source resolution that adding the icon surfaced.

The template already shipped a Mica backdrop, an extended/modern title bar, and an interactive `Hello, {name}!` greeting. This PR leaves all of that untouched and **only adds the icon**.

## Linked issue

Fixes #854

## What changed

**Template** — `tools/Templates/templates/WinUIApp-CSharp/App.cs` (one line + a comment)

Add a placeholder app-mark icon to the title bar: a Segoe Fluent Icons *CircleRing* glyph (`\uEA3A`). A comment points authors at `.Icon("ms-appx:///Assets/AppIcon.ico")` for when they add a real asset.

```diff
-        var titleBar = TitleBar("Company.ReactorApp1").Flex(shrink: 0);
+        var titleBar = TitleBar("Company.ReactorApp1")
+            .Icon(FontIcon("\uEA3A", "Segoe Fluent Icons"))
+            .Flex(shrink: 0);
```

**Framework fix** — `src/Reactor/Core/V1Protocol/IconResolver.cs`

Adding that icon hit a runtime crash. Reactor caught the exception and painted it into the window instead of rendering the app — so "just add a title-bar icon" didn't actually work before this fix.

- **What happened:** `ResolveIconSource(IconData)` built the `FontIconSource` for the icon-source slot with an object initializer that always set `FontSize = fi.FontSize ?? double.NaN` (and `FontFamily = null!` when unspecified). A `FontIconSource` whose `FontSize` is `NaN` is rejected by `TitleBar.set_IconSource` with `ArgumentException: Value does not fall within the expected range` (E_INVALIDARG). So **any** `FontIcon` placed in an `IconSource` slot (`TitleBar`, `TabView`, …) *without* an explicit size threw. The parallel `IconElement` path (`CreateFontIcon`) was already correct — it only assigns `FontFamily`/`FontSize` when specified — which is why the bug stayed hidden (existing icon tests always passed an explicit size and never assigned the result to a real control).
- **How it's fixed:** replaced the initializer with a new `CreateFontIconSource(fi)` helper that mirrors `CreateFontIcon` — `Glyph` always, `FontFamily`/`FontSize` only when specified — leaving them at their control defaults otherwise.

**Test**

- Add selftest regression `PrivMount_TitleBarFontIconNoSize` (`ReconcilerBigCoverageFixtures.cs`): resolve a no-size `FontIcon` and assign it to a real `TitleBar.IconSource`, asserting no `ArgumentException`. Fails without the fix, passes with it.

## Test plan

- [x] `dotnet build Reactor.slnx` — clean.
- [x] Selftest: `dotnet run --project tests\Reactor.AppTests.Host -p:Platform=x64 -- --self-test --filter "PrivateMountHotPaths"` → `ok PrivMount_TitleBarFontIconNoSize`, `# Total failures: 0`.
- [x] Manually scaffolded and ran the template app: modern title bar now shows the CircleRing app mark + title over the Mica surface, no error panel.

## Risk / breaking changes

- **Template:** one added icon line; scaffolded apps now show an app mark in the title bar. No public API change, and nothing else about the template changes.
- **Framework fix is a strict bug fix.** `FontIcon`s that specified a size are unchanged; ones that omitted a size now correctly inherit the control's default size instead of throwing. No regression for callers that already worked.