### PR TITLE
Fix Reactor.SignaturesGen startup crash during bootstrap

### DIFF
--- a/tools/Reactor.SignaturesGen/Reactor.SignaturesGen.csproj
+++ b/tools/Reactor.SignaturesGen/Reactor.SignaturesGen.csproj
@@ -9,6 +9,15 @@
     <Nullable>enable</Nullable>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
+    <!-- Reflection-only build tool: it loads Reactor.dll to emit reactor.api.txt
+         and never creates a WinUI window, so it does not need the Windows App SDK
+         runtime. Suppress the auto-generated bootstrap initializer, which otherwise
+         runs at startup and throws DllNotFoundException for the native
+         Microsoft.WindowsAppRuntime.Bootstrap.dll shim (that RID-specific native
+         asset is not staged by a RID-less `dotnet build`, so the exec of this tool
+         during build — e.g. bootstrap.ps1 on a host-arch-matching machine — would
+         crash). -->
+    <WindowsAppSdkBootstrapInitialize>false</WindowsAppSdkBootstrapInitialize>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
## Root cause

`tools/Reactor.SignaturesGen/Reactor.SignaturesGen.csproj` is a framework-dependent, unpackaged WinUI executable (`OutputType=Exe`, `UseWinUI=true`, `WindowsPackageType=None`). The Windows App SDK auto-generates a bootstrap initializer that runs at process startup and P/Invokes the native `Microsoft.WindowsAppRuntime.Bootstrap.dll` shim. That RID-specific native asset is **not** staged next to the exe by a RID-less `dotnet build`, so the tool throws `System.DllNotFoundException` before `Main` runs.

This broke `bootstrap.ps1` and its `dotnet pack src\Reactor.Cli\Reactor.Cli.csproj` step, which runs the SignaturesGen apphost via the `EmitReactorApiTxt` target to embed `reactor.api.txt`. CI doesn't catch it because `EmitReactorApiTxt` only runs when the build target arch matches the host arch, and CI builds the slnx with the default ARM64 platform on an x64 runner — skipping the run step.

SignaturesGen is reflection-only (it loads `Reactor.dll` to emit `reactor.api.txt` and never opens a window), so it does not need the Windows App SDK runtime bootstrap.

## The fix

One line in the csproj (with an explanatory comment):

```xml
<WindowsAppSdkBootstrapInitialize>false</WindowsAppSdkBootstrapInitialize>
```

This suppresses the auto-generated bootstrap initializer. No other files changed.

Fixes #856

## Verification

1. `dotnet build tools\Reactor.SignaturesGen\Reactor.SignaturesGen.csproj -c Release -p:Platform=x64` — succeeds; the tool now runs to completion via `EmitReactorApiTxt` (previously crashed).
2. `dotnet pack src\Reactor.Cli\Reactor.Cli.csproj -c Release -p:Platform=x64` — succeeds and produces the CLI nupkg (the `bootstrap.ps1` step that was crashing).
3. Deleted both `skills\reactor.api.txt` and `plugins\reactor\skills\reactor-dsl\references\reactor.api.txt`, rebuilt SignaturesGen, and confirmed via `git status --porcelain` that they regenerate **byte-identical** — proving the tool still reflects the API surface correctly. The only file left modified is the csproj.