### PR TITLE
Gallery: add pages for recently-added controls, DataGrid/PropertyGrid, docking & commands

### DIFF
--- a/samples/ReactorGallery/ControlPages/BasicInput/RadioButtonsPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/RadioButtonsPage.cs
@@ -1,7 +1,5 @@
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/BasicInput/RadioButtonsPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/RadioButtonsPage.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.BasicInput;
+
+class RadioButtonsPage : Component
+{
+    public override Element Render()
+    {
+        var (sizeIndex, setSizeIndex) = UseState(1);
+        var (deliveryIndex, setDeliveryIndex) = UseState(0);
+        var sizes = new[] { "Small", "Medium", "Large" };
+        var deliveryOptions = new[] { "Standard", "Two-day", "Overnight", "Pick up in store" };
+
+        return ScrollView(VStack(16,
+            PageHeader("RadioButtons", "RadioButtons let people select one option from a related group."),
+
+            SampleCard("Choose a size",
+                VStack(8,
+                    RadioButtons(sizes, sizeIndex, index => setSizeIndex(index)),
+                    TextBlock($"Selected size: {sizes.ElementAt(sizeIndex)}").Foreground(Theme.SecondaryText)),
+                sourceCode: @"var sizes = new[] { ""Small"", ""Medium"", ""Large"" };
+
+RadioButtons(sizes, sizeIndex, index => setSizeIndex(index))
+TextBlock($""Selected size: {sizes.ElementAt(sizeIndex)}"")"),
+
+            SampleCard("RadioButtons with a header",
+                VStack(8,
+                    RadioButtons(deliveryOptions, deliveryIndex, index => setDeliveryIndex(index))
+                        .Set(rb => rb.Header = "Choose one"),
+                    TextBlock($"Delivery: {deliveryOptions.ElementAt(deliveryIndex)}").Foreground(Theme.SecondaryText)),
+                sourceCode: @"var deliveryOptions = new[]
+{
+    ""Standard"", ""Two-day"", ""Overnight"", ""Pick up in store""
+};
+
+RadioButtons(deliveryOptions, deliveryIndex, index => setDeliveryIndex(index))
+    .Set(rb => rb.Header = ""Choose one"")")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/BasicInput/RadioButtonsPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/RadioButtonsPage.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;

--- a/samples/ReactorGallery/ControlPages/BasicInput/ToggleButtonPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/ToggleButtonPage.cs
@@ -13,6 +13,7 @@ class ToggleButtonPage: Component
     {
         var (isChecked, setIsChecked) = UseState(false);
         var (isChecked2, setIsChecked2) = UseState(true);
+        var (triState, setTriState) = UseState<bool?>(null);
 
         return ScrollView(VStack(16,
             PageHeader("ToggleButton", "A button that can be toggled between two states."),
@@ -31,6 +32,14 @@ ToggleButton(""Mute"", isChecked, v => setIsChecked(v))
                     TextBlock(isChecked2 ? "Feature is enabled" : "Feature is disabled").Foreground(Theme.SecondaryText)),
                 sourceCode: @"
 ToggleButton(isChecked2 ? ""ON"" : ""OFF"", isChecked2, v => setIsChecked2(v))
+"),
+
+            SampleCard("Three-State ToggleButton",
+                    VStack(8,
+                        ThreeStateToggleButton("Review", triState, v => setTriState(v)),
+                        TextBlock($"State: {(triState == null ? "Indeterminate" : triState.ToString())}").Foreground(Theme.SecondaryText)),
+                    sourceCode: @"
+ThreeStateToggleButton(""Review"", triState, v => setTriState(v))
 ")
         ).Margin(36, 24, 36, 36));
     }

--- a/samples/ReactorGallery/ControlPages/BasicInput/ToggleSplitButtonPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/ToggleSplitButtonPage.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.BasicInput;
+
+class ToggleSplitButtonPage : Component
+{
+    public override Element Render()
+    {
+        var (bulletsOn, setBulletsOn) = UseState(false);
+        var (boldOn, setBoldOn) = UseState(true);
+        var bulletItems = new[] { "First item", "Second item", "Third item" };
+
+        return ScrollView(VStack(16,
+            PageHeader("ToggleSplitButton", "A ToggleSplitButton combines a two-state button with split-button styling."),
+
+            SampleCard("Bullets toggle",
+                VStack(8,
+                    ToggleSplitButton("Bullets", bulletsOn, value => setBulletsOn(value)),
+                    TextBlock(bulletsOn ? "Bullets are on" : "Bullets are off").Foreground(Theme.SecondaryText),
+                    VStack(4,
+                        bulletItems.Select(item => TextBlock(bulletsOn ? $"• {item}" : item)).ToArray())),
+                sourceCode: @"ToggleSplitButton(""Bullets"", bulletsOn, value => setBulletsOn(value))
+
+TextBlock(bulletsOn ? ""Bullets are on"" : ""Bullets are off"")"),
+
+            SampleCard("Bold text toggle",
+                VStack(8,
+                    ToggleSplitButton("Bold", boldOn, value => setBoldOn(value)),
+                    (boldOn ? TextBlock("Preview text").Bold() : TextBlock("Preview text"))
+                        .FontSize(20)
+                        .Foreground(Theme.PrimaryText),
+                    TextBlock(boldOn ? "The preview is bold." : "The preview is regular.")
+                        .Foreground(Theme.SecondaryText)),
+                sourceCode: @"ToggleSplitButton(""Bold"", boldOn, value => setBoldOn(value))
+
+(boldOn ? TextBlock(""Preview text"").Bold() : TextBlock(""Preview text""))
+    .FontSize(20)")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/BasicInput/ToggleSplitButtonPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/ToggleSplitButtonPage.cs
@@ -1,7 +1,5 @@
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/BasicInput/ToggleSplitButtonPage.cs
+++ b/samples/ReactorGallery/ControlPages/BasicInput/ToggleSplitButtonPage.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;

--- a/samples/ReactorGallery/ControlPages/Collections/ItemsRepeaterPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/ItemsRepeaterPage.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/Collections/ItemsRepeaterPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/ItemsRepeaterPage.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Collections;
+
+class ItemsRepeaterPage : Component
+{
+    public override Element Render()
+    {
+        var items = Enumerable.Range(1, 20)
+            .Select(i => $"Inventory item {i}")
+            .ToList()
+            .AsReadOnly();
+
+        return ScrollView(VStack(16,
+            PageHeader("ItemsRepeater", "Displays a repeated set of elements from a data source without adding its own scrolling."),
+            SampleCard("Scrollable repeated rows",
+                ScrollView(
+                    ItemsRepeater(
+                        items,
+                        s => s,
+                        (s, i) => Border(TextBlock($"{i + 1}. {s}"))
+                            .Padding(8)
+                            .Margin(0, 0, 0, 4)
+                            .Background(Theme.SubtleFill)
+                            .CornerRadius(4))
+                ).Height(260),
+                sourceCode: @"ScrollView(
+    ItemsRepeater(items, s => s, (s, i) =>
+        Border(TextBlock($""{i + 1}. {s}""))
+            .Padding(8)
+            .Margin(0, 0, 0, 4)
+            .Background(Theme.SubtleFill)
+            .CornerRadius(4))
+).Height(260)"),
+            SampleCard("Compact repeated badges",
+                ScrollView(
+                    ItemsRepeater(
+                        items.Take(12).ToList().AsReadOnly(),
+                        s => s,
+                        (s, i) => HStack(8,
+                            Border(TextBlock($"{i + 1}").Center().Foreground("#FFFFFF"))
+                                .Background(Theme.Accent)
+                                .Size(32, 32)
+                                .CornerRadius(16),
+                            TextBlock(s).VAlign(VerticalAlignment.Center))
+                            .Padding(6))
+                ).Height(220),
+                sourceCode: @"ScrollView(
+    ItemsRepeater(items, s => s, (s, i) =>
+        HStack(8,
+            Border(TextBlock($""{i + 1}"").Center().Foreground(""#FFFFFF""))
+                .Background(Theme.Accent).Size(32, 32).CornerRadius(16),
+            TextBlock(s)))
+).Height(220)")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Collections/ItemsRepeaterPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/ItemsRepeaterPage.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Xaml;

--- a/samples/ReactorGallery/ControlPages/Collections/RefreshContainerPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/RefreshContainerPage.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/Collections/RefreshContainerPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/RefreshContainerPage.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;

--- a/samples/ReactorGallery/ControlPages/Collections/RefreshContainerPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/RefreshContainerPage.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Collections;
+
+class RefreshContainerPage : Component
+{
+    public override Element Render()
+    {
+        IReadOnlyList<string> initialItems = Enumerable.Range(1, 8)
+            .Select(i => $"Feed item {i}")
+            .ToList();
+        var (items, setItems) = UseState(initialItems);
+
+        return ScrollView(VStack(16,
+            PageHeader("RefreshContainer", "Wraps scrollable content with a pull-to-refresh gesture."),
+            SampleCard("Pull to refresh list",
+                VStack(8,
+                    RefreshContainer(
+                        ListView(items.Select(i => (Element)TextBlock(i).Padding(8)).ToArray())
+                            .Height(240),
+                        () => setItems(new[] { $"Refreshed {DateTime.Now:T}" }
+                            .Concat(items)
+                            .ToList())),
+                    Caption("Pull down from the top of the list to request a refresh.")
+                ),
+                sourceCode: @"var (items, setItems) = UseState(initialItems);
+
+RefreshContainer(
+    ListView(items.Select(i => (Element)TextBlock(i).Padding(8)).ToArray())
+        .Height(240),
+    () => setItems(new[] { $""Refreshed {DateTime.Now:T}"" }
+        .Concat(items)
+        .ToList()))"),
+            SampleCard("Static refresh surface",
+                VStack(8,
+                    RefreshContainer(
+                        ListView(
+                            TextBlock("Messages").Padding(8),
+                            TextBlock("Tasks").Padding(8),
+                            TextBlock("Notifications").Padding(8))
+                            .Height(160),
+                        () => { }),
+                    Caption("The refresh action can be connected to any app-specific data reload.")
+                ),
+                sourceCode: @"RefreshContainer(
+    ListView(
+        TextBlock(""Messages"").Padding(8),
+        TextBlock(""Tasks"").Padding(8),
+        TextBlock(""Notifications"").Padding(8))
+        .Height(160),
+    () => { })")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Collections/SemanticZoomPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/SemanticZoomPage.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Collections;
+
+class SemanticZoomPage : Component
+{
+    public override Element Render()
+    {
+        var labels = Enumerable.Range(1, 12).Select(i => $"Item {i}").ToArray();
+        var groups = new[] { "A-F", "G-L", "M-R", "S-Z" };
+
+        return ScrollView(VStack(16,
+            PageHeader("SemanticZoom", "Lets users switch between detailed and summarized views of the same collection."),
+            SampleCard("Grid and group views",
+                VStack(8,
+                    SemanticZoom(
+                        GridView(labels
+                            .Select(label => Border(TextBlock(label).Center())
+                                .Padding(12)
+                                .Margin(4)
+                                .Background(Theme.SubtleFill)
+                                .CornerRadius(4))
+                            .ToArray()),
+                        ListView(groups
+                            .Select(group => Border(TextBlock(group).SemiBold())
+                                .Padding(12)
+                                .Margin(0, 0, 0, 4)
+                                .Background(Theme.CardBackground)
+                                .WithBorder(Theme.DividerStroke))
+                            .ToArray())
+                    ).Height(300),
+                    Caption("Use Ctrl+scroll or the zoomed-out header affordance to switch views.")
+                ),
+                sourceCode: @"SemanticZoom(
+    GridView(items.Select(item =>
+        Border(TextBlock(item).Center()).Padding(12)).ToArray()),
+    ListView(groups.Select(group =>
+        Border(TextBlock(group).SemiBold()).Padding(12)).ToArray())
+).Height(300)"),
+            SampleCard("Letter sections",
+                SemanticZoom(
+                    GridView(groups
+                        .SelectMany(group => Enumerable.Range(1, 3).Select(i => $"{group} sample {i}"))
+                        .Select(text => Border(TextBlock(text).Center())
+                            .Padding(10)
+                            .Margin(4)
+                            .Background(Theme.SubtleFill))
+                        .ToArray()),
+                    ListView(groups
+                        .Select(group => (Element)TextBlock(group).FontSize(20).Bold().Padding(10))
+                        .ToArray())
+                ).Height(300),
+                sourceCode: @"SemanticZoom(
+    GridView(sectionItems.Select(text => Border(TextBlock(text))).ToArray()),
+    ListView(groups.Select(group => TextBlock(group).FontSize(20).Bold()).ToArray())
+).Height(300)")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Collections/SemanticZoomPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/SemanticZoomPage.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/Collections/SemanticZoomPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/SemanticZoomPage.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;

--- a/samples/ReactorGallery/ControlPages/Collections/SwipeControlPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/SwipeControlPage.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Collections;
+
+class SwipeControlPage : Component
+{
+    public override Element Render()
+    {
+        var (status, setStatus) = UseState("No swipe action invoked yet.");
+
+        return ScrollView(VStack(16,
+            PageHeader("SwipeControl", "Adds contextual actions that appear when an item is swiped."),
+            SampleCard("Left and right actions",
+                VStack(8,
+                    SwipeControl(
+                        Border(TextBlock("Swipe me left or right"))
+                            .Padding(16)
+                            .Background(Theme.CardBackground)
+                            .WithBorder(Theme.DividerStroke),
+                        leftItems: new[] { new SwipeItemData("Archive", () => { }) },
+                        rightItems: new[] { new SwipeItemData("Delete", () => { }) }),
+                    Caption("Swiping requires touch or pointer drag input.")
+                ),
+                sourceCode: @"SwipeControl(
+    Border(TextBlock(""Swipe me left or right""))
+        .Padding(16)
+        .Background(Theme.CardBackground),
+    leftItems: new[] { new SwipeItemData(""Archive"", () => { }) },
+    rightItems: new[] { new SwipeItemData(""Delete"", () => { }) })"),
+            SampleCard("Action status",
+                VStack(8,
+                    SwipeControl(
+                        Border(TextBlock("Swipe to invoke an action"))
+                            .Padding(16)
+                            .Background(Theme.SubtleFill)
+                            .CornerRadius(4),
+                        leftItems: new[] { new SwipeItemData("Flag", () => setStatus("Flag action invoked.")) },
+                        rightItems: new[] { new SwipeItemData("Remove", () => setStatus("Remove action invoked.")) }),
+                    TextBlock(status).Foreground(Theme.SecondaryText)
+                ),
+                sourceCode: @"var (status, setStatus) = UseState(""No swipe action invoked yet."");
+
+SwipeControl(
+    Border(TextBlock(""Swipe to invoke an action"")).Padding(16),
+    leftItems: new[] { new SwipeItemData(""Flag"", () => setStatus(""Flag action invoked."")) },
+    rightItems: new[] { new SwipeItemData(""Remove"", () => setStatus(""Remove action invoked."")) })")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Collections/SwipeControlPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/SwipeControlPage.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/Collections/SwipeControlPage.cs
+++ b/samples/ReactorGallery/ControlPages/Collections/SwipeControlPage.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;

--- a/samples/ReactorGallery/ControlPages/Data/DataGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Data/DataGridPage.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Controls;
+using Microsoft.UI.Reactor.Data;
+using Microsoft.UI.Reactor.Data.Providers;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Data;
+
+class DataGridPage : Component
+{
+    record Product(int Id, string Name, string Category, double Price, bool InStock);
+
+    static readonly string[] NamePool = { "Widget", "Gadget", "Gizmo", "Sprocket", "Cog", "Bolt", "Flange", "Washer" };
+    static readonly string[] CatPool = { "Hardware", "Tools", "Parts" };
+
+    public override Element Render()
+    {
+        var (mode, setMode) = UseState(1);
+        var modes = new[] { "None", "Single", "Multiple" };
+        var selection = mode switch
+        {
+            1 => SelectionMode.Single,
+            2 => SelectionMode.Multiple,
+            _ => SelectionMode.None,
+        };
+        var (selectedCount, setSelectedCount) = UseState(0);
+
+        var source = UseMemo(() =>
+        {
+            var products = Enumerable.Range(0, 60).Select(i => new Product(
+                Id: i,
+                Name: $"{NamePool[i % NamePool.Length]} {i}",
+                Category: CatPool[i % CatPool.Length],
+                Price: 4.99 + (i * 3.5 % 90),
+                InStock: i % 4 != 0)).ToArray();
+            return new ListDataSource<Product>(products, p => (RowKey)p.Id);
+        });
+
+        return ScrollView(VStack(16,
+            PageHeader("DataGrid", "A virtualized data grid with sortable columns, selection, and inline editing."),
+
+            SampleCard("Columns, sorting & selection",
+                VStack(8,
+                    DataGrid(
+                        source: source,
+                        columns: new FieldDescriptor[]
+                        {
+                            Column<Product>("Id", p => p.Id, width: 60),
+                            Column<Product>("Name", p => p.Name, displayName: "Product", width: 200),
+                            Column<Product>("Category", p => p.Category, width: 140),
+                            Column<Product>("Price", p => p.Price, format: "C2", width: 100),
+                            Column<Product>("InStock", p => p.InStock, displayName: "In stock", width: 90),
+                        },
+                        selectionMode: selection,
+                        onSelectionChanged: keys => setSelectedCount(keys.Count),
+                        rowHeight: 36
+                    ).Height(340),
+                    TextBlock($"Selected rows: {selectedCount}").Foreground(Theme.SecondaryText)),
+                sourceCode: @"
+// Memoize the source so the grid isn't remounted on every render
+// (DataGrid keys off source.GetHashCode()).
+var source = UseMemo(() => new ListDataSource<Product>(products, p => (RowKey)p.Id));
+
+DataGrid(
+    source: source,
+    columns: new FieldDescriptor[]
+    {
+        Column<Product>(""Name"", p => p.Name, displayName: ""Product"", width: 200),
+        Column<Product>(""Price"", p => p.Price, format: ""C2"", width: 100),
+        Column<Product>(""InStock"", p => p.InStock, displayName: ""In stock"", width: 90),
+    },
+    selectionMode: SelectionMode.Single,
+    onSelectionChanged: keys => setSelectedCount(keys.Count),
+    rowHeight: 36)
+// Click a header to sort. Columns can be reordered and resized by dragging.",
+                options: OptionPanel(
+                    TextBlock("Selection mode"),
+                    ComboBox(modes, mode, setMode)))
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Data/DataGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Data/DataGridPage.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;

--- a/samples/ReactorGallery/ControlPages/Data/DataGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Data/DataGridPage.cs
@@ -43,6 +43,9 @@ class DataGridPage : Component
 
             SampleCard("Columns, sorting & selection",
                 VStack(8,
+                    // Re-key on the mode so switching selection mode remounts the grid.
+                    // Workaround for microsoft/microsoft-ui-reactor#872 — DataGrid doesn't
+                    // reconcile SelectionMode on the live grid after first mount.
                     DataGrid(
                         source: source,
                         columns: new FieldDescriptor[]
@@ -56,8 +59,10 @@ class DataGridPage : Component
                         selectionMode: selection,
                         onSelectionChanged: keys => setSelectedCount(keys.Count),
                         rowHeight: 36
-                    ).Height(340),
-                    TextBlock($"Selected rows: {selectedCount}").Foreground(Theme.SecondaryText)),
+                    ).Height(340).WithKey($"dg-mode-{mode}"),
+                    TextBlock($"Selected rows: {selectedCount}").Foreground(Theme.SecondaryText),
+                    Caption("Multiple mode: Ctrl+click toggles a row, Shift+click selects a range.")
+                        .Foreground(Theme.SecondaryText)),
                 sourceCode: @"
 // Memoize the source so the grid isn't remounted on every render
 // (DataGrid keys off source.GetHashCode()).

--- a/samples/ReactorGallery/ControlPages/Data/DataGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Data/DataGridPage.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Controls;

--- a/samples/ReactorGallery/ControlPages/Data/PropertyGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Data/PropertyGridPage.cs
@@ -1,0 +1,77 @@
+using System;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Controls;
+using Microsoft.UI.Reactor.Data;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Data;
+
+class PropertyGridPage : Component
+{
+    // Reflection-based INPC model. Attributes drive category grouping and
+    // read-only/hidden handling in the generated editor.
+    sealed class Settings : global::System.ComponentModel.INotifyPropertyChanged
+    {
+        string _name = "Player";
+        [PropertyCategory("Appearance")]
+        public string Name { get => _name; set { if (_name != value) { _name = value; Raise(nameof(Name)); } } }
+
+        bool _visible = true;
+        [PropertyCategory("Appearance")]
+        public bool Visible { get => _visible; set { if (_visible != value) { _visible = value; Raise(nameof(Visible)); } } }
+
+        double _opacity = 1.0;
+        [PropertyCategory("Appearance")]
+        public double Opacity { get => _opacity; set { if (_opacity != value) { _opacity = value; Raise(nameof(Opacity)); } } }
+
+        double _x;
+        [PropertyCategory("Transform")]
+        [PropertyDisplayName("X Position")]
+        public double X { get => _x; set { if (_x != value) { _x = value; Raise(nameof(X)); } } }
+
+        double _y;
+        [PropertyCategory("Transform")]
+        [PropertyDisplayName("Y Position")]
+        public double Y { get => _y; set { if (_y != value) { _y = value; Raise(nameof(Y)); } } }
+
+        [PropertyReadOnly]
+        [PropertyCategory("Info")]
+        public string Id { get; } = Guid.NewGuid().ToString()[..8];
+
+        public event global::System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+        void Raise(string n) => PropertyChanged?.Invoke(this, new global::System.ComponentModel.PropertyChangedEventArgs(n));
+    }
+
+    public override Element Render()
+    {
+        var settings = UseRef(new Settings());
+        UseObservable(settings.Current);
+        var registry = UseMemo(() => new TypeRegistry());
+
+        return ScrollView(VStack(16,
+            PageHeader("PropertyGrid", "Generates a categorized editor UI from an object's properties via reflection."),
+
+            SampleCard("Reflection-based editor",
+                VStack(8,
+                    Border(PropertyGrid(settings.Current, registry))
+                        .Background(Theme.SubtleFill).CornerRadius(6).Padding(4).Width(360),
+                    TextBlock($"Live: Name={settings.Current.Name}, Visible={settings.Current.Visible}, " +
+                              $"Opacity={settings.Current.Opacity:F2}, X={settings.Current.X:F0}, Y={settings.Current.Y:F0}")
+                        .Foreground(Theme.SecondaryText)),
+                sourceCode: @"
+class Settings : INotifyPropertyChanged
+{
+    [PropertyCategory(""Appearance"")] public string Name { get; set; }
+    [PropertyCategory(""Transform"")] [PropertyDisplayName(""X Position"")] public double X { get; set; }
+    [PropertyReadOnly] public string Id { get; }
+}
+
+var settings = UseRef(new Settings());
+UseObservable(settings.Current);              // re-render on INPC changes
+var registry = UseMemo(() => new TypeRegistry());
+PropertyGrid(settings.Current, registry)")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Data/PropertyGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Data/PropertyGridPage.cs
@@ -1,8 +1,6 @@
-using System;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Controls;
-using Microsoft.UI.Reactor.Data;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/Data/PropertyGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Data/PropertyGridPage.cs
@@ -22,17 +22,17 @@ class PropertyGridPage : Component
 
         double _opacity = 1.0;
         [PropertyCategory("Appearance")]
-        public double Opacity { get => _opacity; set { if (_opacity != value) { _opacity = value; Raise(nameof(Opacity)); } } }
+        public double Opacity { get => _opacity; set { if (Math.Abs(_opacity - value) > 1e-9) { _opacity = value; Raise(nameof(Opacity)); } } }
 
         double _x;
         [PropertyCategory("Transform")]
         [PropertyDisplayName("X Position")]
-        public double X { get => _x; set { if (_x != value) { _x = value; Raise(nameof(X)); } } }
+        public double X { get => _x; set { if (Math.Abs(_x - value) > 1e-9) { _x = value; Raise(nameof(X)); } } }
 
         double _y;
         [PropertyCategory("Transform")]
         [PropertyDisplayName("Y Position")]
-        public double Y { get => _y; set { if (_y != value) { _y = value; Raise(nameof(Y)); } } }
+        public double Y { get => _y; set { if (Math.Abs(_y - value) > 1e-9) { _y = value; Raise(nameof(Y)); } } }
 
         [PropertyReadOnly]
         [PropertyCategory("Info")]

--- a/samples/ReactorGallery/ControlPages/DialogsAndFlyouts/PopupPage.cs
+++ b/samples/ReactorGallery/ControlPages/DialogsAndFlyouts/PopupPage.cs
@@ -56,7 +56,8 @@ Popup(
                             .WithBorder(Theme.DividerStroke)
                             .CornerRadius(8),
                         persistentOpen,
-                        () => setPersistentOpen(false)),
+                        () => setPersistentOpen(false))
+                        .IsLightDismissEnabled(false),
                     Caption("Without light dismiss, the popup stays open until its close action runs.")),
                 sourceCode: @"Button(""Show persistent popup"", () => setPersistentOpen(true))
 
@@ -69,7 +70,8 @@ Popup(
         .WithBorder(Theme.DividerStroke)
         .CornerRadius(8),
     persistentOpen,
-    () => setPersistentOpen(false))")
+    () => setPersistentOpen(false))
+    .IsLightDismissEnabled(false)")
         ).Margin(36, 24, 36, 36));
     }
 }

--- a/samples/ReactorGallery/ControlPages/DialogsAndFlyouts/PopupPage.cs
+++ b/samples/ReactorGallery/ControlPages/DialogsAndFlyouts/PopupPage.cs
@@ -1,7 +1,5 @@
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/DialogsAndFlyouts/PopupPage.cs
+++ b/samples/ReactorGallery/ControlPages/DialogsAndFlyouts/PopupPage.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.DialogsAndFlyouts;
+
+class PopupPage : Component
+{
+    public override Element Render()
+    {
+        var (open, setOpen) = UseState(false);
+        var (persistentOpen, setPersistentOpen) = UseState(false);
+
+        return ScrollView(VStack(16,
+            PageHeader("Popup", "Popup displays lightweight content above the current page."),
+
+            SampleCard("Light-dismiss popup",
+                VStack(8,
+                    Button("Show popup", () => setOpen(true)),
+                    Popup(
+                        Border(VStack(8,
+                            TextBlock("Hello from a Popup").SemiBold(),
+                            Button("Close", () => setOpen(false))))
+                            .Padding(16)
+                            .Background(Theme.CardBackground)
+                            .WithBorder(Theme.DividerStroke)
+                            .CornerRadius(8),
+                        open,
+                        () => setOpen(false))
+                        .IsLightDismissEnabled(),
+                    Caption("Popup anchors to its placement in the tree.")),
+                sourceCode: @"Button(""Show popup"", () => setOpen(true))
+
+Popup(
+    Border(VStack(8,
+        TextBlock(""Hello from a Popup"").SemiBold(),
+        Button(""Close"", () => setOpen(false))))
+        .Padding(16)
+        .Background(Theme.CardBackground)
+        .WithBorder(Theme.DividerStroke)
+        .CornerRadius(8),
+    open,
+    () => setOpen(false))
+    .IsLightDismissEnabled()"),
+
+            SampleCard("Popup without light dismiss",
+                VStack(8,
+                    Button("Show persistent popup", () => setPersistentOpen(true)),
+                    Popup(
+                        Border(VStack(8,
+                            TextBlock("Use the button to close this popup.").SemiBold(),
+                            Button("Close", () => setPersistentOpen(false))))
+                            .Padding(16)
+                            .Background(Theme.CardBackground)
+                            .WithBorder(Theme.DividerStroke)
+                            .CornerRadius(8),
+                        persistentOpen,
+                        () => setPersistentOpen(false)),
+                    Caption("Without light dismiss, the popup stays open until its close action runs.")),
+                sourceCode: @"Button(""Show persistent popup"", () => setPersistentOpen(true))
+
+Popup(
+    Border(VStack(8,
+        TextBlock(""Use the button to close this popup."").SemiBold(),
+        Button(""Close"", () => setPersistentOpen(false))))
+        .Padding(16)
+        .Background(Theme.CardBackground)
+        .WithBorder(Theme.DividerStroke)
+        .CornerRadius(8),
+    persistentOpen,
+    () => setPersistentOpen(false))")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/DialogsAndFlyouts/PopupPage.cs
+++ b/samples/ReactorGallery/ControlPages/DialogsAndFlyouts/PopupPage.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;

--- a/samples/ReactorGallery/ControlPages/Layout/AnnotatedScrollBarPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/AnnotatedScrollBarPage.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Layout;
+
+class AnnotatedScrollBarPage : Component
+{
+    public override Element Render()
+    {
+        return ScrollView(VStack(16,
+            PageHeader("AnnotatedScrollBar", "Shows a scrollbar surface that can display app-defined annotations."),
+            SampleCard("Standalone control surface",
+                VStack(8,
+                    Border(AnnotatedScrollBar().Height(300).Width(40))
+                        .Padding(12)
+                        .Background(Theme.CardBackground)
+                        .WithBorder(Theme.DividerStroke),
+                    Caption("AnnotatedScrollBar is typically composed with a scrolling surface such as ItemsView or ScrollView to show section labels; full wiring is app-specific.")
+                ),
+                sourceCode: @"Border(AnnotatedScrollBar().Height(300).Width(40))
+    .Padding(12)
+    .Background(Theme.CardBackground)
+    .WithBorder(Theme.DividerStroke)")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Layout/AnnotatedScrollBarPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/AnnotatedScrollBarPage.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/Layout/AnnotatedScrollBarPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/AnnotatedScrollBarPage.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;

--- a/samples/ReactorGallery/ControlPages/Layout/DockingPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/DockingPage.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Docking;

--- a/samples/ReactorGallery/ControlPages/Layout/DockingPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/DockingPage.cs
@@ -1,0 +1,74 @@
+using System;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Reactor.Docking;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Layout;
+
+class DockingPage : Component
+{
+    static readonly string[] Items =
+    {
+        "Item Alpha", "Item Bravo", "Item Charlie", "Item Delta", "Item Echo", "Item Foxtrot",
+    };
+
+    public override Element Render()
+    {
+        var (selected, setSelected) = UseState(0);
+        var (layoutKey, bumpLayoutKey) = UseReducer(0);
+
+        var dock = new DockManager
+        {
+            Layout = new DockSplit(Orientation.Horizontal,
+            [
+                new DockTabGroup(
+                [
+                    new DockableContent(
+                        Title: "Items",
+                        Content: ListBox(Items, selected, setSelected).Padding(8),
+                        Key: "items",
+                        CanClose: true),
+                ], Width: 200),
+                new DockTabGroup(
+                [
+                    new DockableContent(
+                        Title: "Detail",
+                        Content: VStack(8,
+                            TextBlock(Items[selected]).FontSize(22).SemiBold(),
+                            TextBlock($"You selected entry #{selected + 1}.").Foreground(Theme.SecondaryText),
+                            TextBlock("Drag tabs to re-dock, or tear one out to float it in its own window.")
+                                .Foreground(Theme.SecondaryText)
+                                .Set(tb => tb.TextWrapping = TextWrapping.Wrap)
+                        ).Padding(16),
+                        Key: "detail",
+                        CanClose: true),
+                ]),
+            ]),
+        }.WithKey($"dock-{layoutKey}").Height(360);
+
+        return ScrollView(VStack(16,
+            PageHeader("Docking", "Dockable, tearable, floatable panes with drag-to-rearrange layout (spec 045)."),
+
+            SampleCard("Two-pane list / detail",
+                VStack(8,
+                    dock,
+                    Button("Reset layout", () => { setSelected(0); bumpLayoutKey(k => k + 1); })),
+                sourceCode: @"
+new DockManager
+{
+    Layout = new DockSplit(Orientation.Horizontal,
+    [
+        new DockTabGroup([ new DockableContent(
+            Title: ""Items"", Content: ListBox(Items, selected, setSelected), Key: ""items"", CanClose: true) ], Width: 200),
+        new DockTabGroup([ new DockableContent(
+            Title: ""Detail"", Content: detailView, Key: ""detail"", CanClose: true) ]),
+    ]),
+}.WithKey($""dock-{layoutKey}"").Height(360)
+// Re-key the DockManager to reset the user's drag-modified layout.")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Layout/InterspersedGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/InterspersedGridPage.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;

--- a/samples/ReactorGallery/ControlPages/Layout/InterspersedGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/InterspersedGridPage.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Xaml.Controls;

--- a/samples/ReactorGallery/ControlPages/Layout/InterspersedGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/InterspersedGridPage.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Layout;
+
+class InterspersedGridPage : Component
+{
+    public override Element Render()
+    {
+        var horizontalPanels = new Element[]
+        {
+            Panel("1x", Theme.Accent),
+            Panel("2x", "#5B6ABF"),
+            Panel("1x", "#107C10"),
+        };
+
+        var verticalPanels = new Element[]
+        {
+            Panel("Top", Theme.Accent),
+            Panel("Middle", "#5B6ABF"),
+            Panel("Bottom", "#107C10"),
+        };
+
+        return ScrollView(VStack(16,
+            PageHeader("InterspersedGrid", "Lays out proportional items with generated separators between them."),
+            SampleCard("Horizontal proportions",
+                InterspersedGrid(
+                    Orientation.Horizontal,
+                    horizontalPanels,
+                    new[] { 1.0, 2.0, 1.0 },
+                    8,
+                    i => Border(Empty()).Width(2).Background(Theme.DividerStroke))
+                    .Height(160),
+                sourceCode: @"InterspersedGrid(
+    Orientation.Horizontal,
+    new Element[] { panelA, panelB, panelC },
+    new[] { 1.0, 2.0, 1.0 },
+    8,
+    i => Border(Empty()).Width(2).Background(Theme.DividerStroke))
+    .Height(160)"),
+            SampleCard("Vertical proportions",
+                InterspersedGrid(
+                    Orientation.Vertical,
+                    verticalPanels,
+                    new[] { 1.0, 1.5, 1.0 },
+                    8,
+                    i => Border(Empty()).Height(2).Background(Theme.DividerStroke))
+                    .Height(240),
+                sourceCode: @"InterspersedGrid(
+    Orientation.Vertical,
+    panels,
+    new[] { 1.0, 1.5, 1.0 },
+    8,
+    i => Border(Empty()).Height(2).Background(Theme.DividerStroke))
+    .Height(240)")
+        ).Margin(36, 24, 36, 36));
+    }
+
+    static Element Panel(string text, ThemeRef background) =>
+        Border(TextBlock(text).Center().Foreground("#FFFFFF").SemiBold())
+            .Background(background)
+            .CornerRadius(4);
+
+    static Element Panel(string text, string background) =>
+        Border(TextBlock(text).Center().Foreground("#FFFFFF").SemiBold())
+            .Background(background)
+            .CornerRadius(4);
+}

--- a/samples/ReactorGallery/ControlPages/Layout/UniformGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/UniformGridPage.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;

--- a/samples/ReactorGallery/ControlPages/Layout/UniformGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/UniformGridPage.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Xaml.Controls;

--- a/samples/ReactorGallery/ControlPages/Layout/UniformGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Layout/UniformGridPage.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Layout;
+
+class UniformGridPage : Component
+{
+    public override Element Render()
+    {
+        return ScrollView(VStack(16,
+            PageHeader("UniformGrid", "Arranges children into evenly sized cells."),
+            SampleCard("Horizontal fill",
+                UniformGrid(
+                    Orientation.Horizontal,
+                    Enumerable.Range(1, 9).Select(i => Cell(i, Theme.Accent)).ToArray()),
+                sourceCode: @"UniformGrid(
+    Orientation.Horizontal,
+    Enumerable.Range(1, 9).Select(i =>
+        Border(TextBlock($""{i}"").Center().Foreground(""#FFFFFF""))
+            .Background(Theme.Accent)
+            .Size(60, 60)
+            .Margin(4)
+            .CornerRadius(4)).ToArray())"),
+            SampleCard("Vertical fill",
+                UniformGrid(
+                    Orientation.Vertical,
+                    Enumerable.Range(1, 9).Select(i => Cell(i, "#5B6ABF")).ToArray()),
+                sourceCode: @"UniformGrid(
+    Orientation.Vertical,
+    Enumerable.Range(1, 9).Select(i =>
+        Border(TextBlock($""{i}"").Center().Foreground(""#FFFFFF""))
+            .Background(""#5B6ABF"")
+            .Size(60, 60)
+            .Margin(4)
+            .CornerRadius(4)).ToArray())")
+        ).Margin(36, 24, 36, 36));
+    }
+
+    static Element Cell(int number, ThemeRef background) =>
+        Border(TextBlock($"{number}").Center().Foreground("#FFFFFF"))
+            .Background(background)
+            .Size(60, 60)
+            .Margin(4)
+            .CornerRadius(4);
+
+    static Element Cell(int number, string background) =>
+        Border(TextBlock($"{number}").Center().Foreground("#FFFFFF"))
+            .Background(background)
+            .Size(60, 60)
+            .Margin(4)
+            .CornerRadius(4);
+}

--- a/samples/ReactorGallery/ControlPages/Media/AnimatedIconPage.cs
+++ b/samples/ReactorGallery/ControlPages/Media/AnimatedIconPage.cs
@@ -1,0 +1,48 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Controls.AnimatedVisuals;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Media;
+
+class AnimatedIconPage : Component
+{
+    static Element Cell(string label, Element icon) =>
+        VStack(6,
+            Border(icon.Center()).Size(72, 56).Background(Theme.SubtleFill).CornerRadius(6),
+            Caption(label).Foreground(Theme.SecondaryText).Center());
+
+    public override Element Render()
+    {
+        return ScrollView(VStack(16,
+            PageHeader("AnimatedIcon", "An icon that transitions between states with a vector animation. Ideal inside buttons and expanders."),
+
+            SampleCard("Built-in animated icons",
+                HStack(20,
+                    Cell("Chevron", AnimatedIcon(new AnimatedChevronDownSmallVisualSource()).Size(32, 32)),
+                    Cell("Settings", AnimatedIcon(new AnimatedSettingsVisualSource()).Size(32, 32)),
+                    Cell("Nav", AnimatedIcon(new AnimatedGlobalNavigationButtonVisualSource()).Size(32, 32))),
+                sourceCode: @"
+AnimatedIcon(new AnimatedChevronDownSmallVisualSource()).Size(32, 32)
+// AnimatedIcon plays its transition when the host raises a state change
+// (e.g. an Expander toggling). Supply your own IRichAnimatedVisualSource
+// for custom motion.
+"),
+
+            SampleCard("Inside a button",
+                Button(
+                    HStack(8,
+                        AnimatedIcon(new AnimatedGlobalNavigationButtonVisualSource()).Size(20, 20),
+                        TextBlock("Menu")),
+                    () => { }),
+                sourceCode: @"
+Button(
+    HStack(8,
+        AnimatedIcon(new AnimatedGlobalNavigationButtonVisualSource()).Size(20, 20),
+        TextBlock(""Menu"")),
+    () => { })
+")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Media/AnimatedVisualPlayerPage.cs
+++ b/samples/ReactorGallery/ControlPages/Media/AnimatedVisualPlayerPage.cs
@@ -1,0 +1,43 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.AnimatedVisuals;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Media;
+
+class AnimatedVisualPlayerPage : Component
+{
+    public override Element Render()
+    {
+        return ScrollView(VStack(16,
+            PageHeader("AnimatedVisualPlayer", "Plays vector (Lottie/codegen) animations. Uses WinUI's built-in animated visuals here."),
+
+            SampleCard("Looping animation",
+                HStack(24,
+                    AnimatedVisualPlayer().Size(64, 64).OnMount(el =>
+                    {
+                        var p = (AnimatedVisualPlayer)el;
+                        p.Source = new AnimatedGlobalNavigationButtonVisualSource();
+                        _ = p.PlayAsync(0, 1, true);
+                    }),
+                    AnimatedVisualPlayer().Size(64, 64).OnMount(el =>
+                    {
+                        var p = (AnimatedVisualPlayer)el;
+                        p.Source = new AnimatedSettingsVisualSource();
+                        _ = p.PlayAsync(0, 1, true);
+                    })),
+                sourceCode: @"
+AnimatedVisualPlayer().Size(64, 64).OnMount(el =>
+{
+    var p = (AnimatedVisualPlayer)el;                 // OnMount runs once — .Set re-applies on every update
+    p.Source = new AnimatedGlobalNavigationButtonVisualSource();
+    _ = p.PlayAsync(0, 1, loop: true);
+})
+// Point Source at your own IAnimatedVisualSource (e.g. a LottieVisualSource
+// or a codegen class produced by the Lottie/Windows toolchain).
+")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Media/IconsPage.cs
+++ b/samples/ReactorGallery/ControlPages/Media/IconsPage.cs
@@ -1,0 +1,45 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Media;
+
+class IconsPage : Component
+{
+    static Element Cell(string label, Element icon) =>
+        VStack(6,
+            Border(icon.Center()).Size(72, 56).Background(Theme.SubtleFill).CornerRadius(6),
+            Caption(label).Foreground(Theme.SecondaryText).Center());
+
+    public override Element Render()
+    {
+        return ScrollView(VStack(16,
+            PageHeader("Icons", "Standalone Icon elements built from Symbol, Font glyph, or Path sources."),
+
+            SampleCard("Symbol icons",
+                HStack(16,
+                    Cell("Home", Icon(Symbol.Home)),
+                    Cell("Save", Icon(Symbol.Save)),
+                    Cell("Delete", Icon(Symbol.Delete)),
+                    Cell("Setting", Icon(Symbol.Setting))),
+                sourceCode: @"
+Icon(Symbol.Home)
+Icon(Symbol.Save)
+Icon(Symbol.Delete)
+Icon(Symbol.Setting)
+"),
+
+            SampleCard("Font glyph and Path icons",
+                HStack(16,
+                    Cell("FontIcon", Icon(FontIcon("\uE790"))),
+                    Cell("FontIcon", Icon(FontIcon("\uE734"))),
+                    Cell("PathIcon", Icon(PathIcon("M 0,0 L 24,0 L 12,20 Z")))),
+                sourceCode: @"
+Icon(FontIcon(""\uE790""))              // Segoe Fluent Icons glyph
+Icon(PathIcon(""M 0,0 L 24,0 L 12,20 Z""))  // vector path data
+")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Media/MapControlPage.cs
+++ b/samples/ReactorGallery/ControlPages/Media/MapControlPage.cs
@@ -1,0 +1,29 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Media;
+
+class MapControlPage : Component
+{
+    public override Element Render()
+    {
+        return ScrollView(VStack(16,
+            PageHeader("MapControl", "Displays an interactive map. Tiles require a Bing Maps service token."),
+
+            SampleCard("Interactive map",
+                VStack(8,
+                    MapControl(zoomLevel: 4).Height(320).Width(480)
+                        .Background(Theme.SubtleFill).CornerRadius(6),
+                    Caption("Supply a MapServiceToken to load map tiles: MapControl(mapServiceToken: \"<key>\", zoomLevel: 12).")
+                        .Foreground(Theme.SecondaryText)),
+                sourceCode: @"
+MapControl(mapServiceToken: ""<your-key>"", zoomLevel: 12)
+    .Height(320).Width(480)
+// Pan and zoom with mouse/touch. Center and layers can be set via
+//   .Set(map => { map.Center = ...; })
+")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Media/MediaPlayerElementPage.cs
+++ b/samples/ReactorGallery/ControlPages/Media/MediaPlayerElementPage.cs
@@ -1,0 +1,32 @@
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Media;
+
+class MediaPlayerElementPage : Component
+{
+    // A small, widely-used Creative Commons test clip.
+    const string SampleVideo =
+        "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4";
+
+    public override Element Render()
+    {
+        return ScrollView(VStack(16,
+            PageHeader("MediaPlayerElement", "Embeds audio/video playback with built-in transport controls."),
+
+            SampleCard("Video with transport controls",
+                VStack(8,
+                    MediaPlayerElement(SampleVideo).Height(280).Width(480),
+                    Caption("Streams over the network — playback requires an internet connection.")
+                        .Foreground(Theme.SecondaryText)),
+                sourceCode: @"
+MediaPlayerElement(""https://.../BigBuckBunny.mp4"")
+    .Height(280).Width(480)
+// Transport controls are enabled by default; AutoPlay is opt-in:
+//   .Set(mpe => mpe.AutoPlay = true)
+")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Media/ParallaxViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Media/ParallaxViewPage.cs
@@ -14,11 +14,13 @@ class ParallaxViewPage : Component
         // capture the foreground ListView on mount, then feed it back in.
         var (scroller, setScroller) = UseState<UIElement?>(null);
 
-        var background =
-            Border(TextBlock("Parallax background").FontSize(28).SemiBold().Foreground("#FFFFFF").Center())
-                .Background(Theme.Accent);
+        var background = Border(VStack(0,
+            Border(TextBlock("▲  TOP").FontSize(22).SemiBold().Foreground("#FFFFFF").Center()).Background("#0F6CBD").Height(160),
+            Border(TextBlock("●  MIDDLE").FontSize(22).SemiBold().Foreground("#FFFFFF").Center()).Background("#8764B8").Height(160),
+            Border(TextBlock("▼  BOTTOM").FontSize(22).SemiBold().Foreground("#FFFFFF").Center()).Background("#C0397E").Height(160)))
+            .Height(480);
 
-        var parallax = ParallaxView(background, verticalShift: 100);
+        var parallax = ParallaxView(background, verticalShift: 150);
         if (scroller is not null)
             parallax = parallax.Source(scroller);
 
@@ -45,7 +47,9 @@ class ParallaxViewPage : Component
                 sourceCode: @"
 var (scroller, setScroller) = UseState<UIElement?>(null);
 
-var parallax = ParallaxView(background, verticalShift: 100);
+// `background` must be TALLER than the viewport and have visible vertical
+// structure (bands/image) — a solid colour has nothing to visibly shift.
+var parallax = ParallaxView(background, verticalShift: 150);
 if (scroller is not null) parallax = parallax.Source(scroller);
 
 Grid(columns: [GridSize.Star()], rows: [GridSize.Star()],

--- a/samples/ReactorGallery/ControlPages/Media/ParallaxViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Media/ParallaxViewPage.cs
@@ -1,8 +1,6 @@
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/Media/ParallaxViewPage.cs
+++ b/samples/ReactorGallery/ControlPages/Media/ParallaxViewPage.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Media;
+
+class ParallaxViewPage : Component
+{
+    public override Element Render()
+    {
+        // ParallaxView does nothing until its Source is bound to a scroller. We
+        // capture the foreground ListView on mount, then feed it back in.
+        var (scroller, setScroller) = UseState<UIElement?>(null);
+
+        var background =
+            Border(TextBlock("Parallax background").FontSize(28).SemiBold().Foreground("#FFFFFF").Center())
+                .Background(Theme.Accent);
+
+        var parallax = ParallaxView(background, verticalShift: 100);
+        if (scroller is not null)
+            parallax = parallax.Source(scroller);
+
+        // Transparent list so the parallaxing background shows through behind the rows.
+        var list = ListView(
+            Enumerable.Range(1, 24)
+                .Select(i => (Element)TextBlock($"Row {i}").Foreground("#FFFFFF").FontSize(16).Padding(12, 8, 12, 8))
+                .ToArray())
+            .Set(lv => lv.Background = null)
+            .OnMount(el => setScroller((UIElement)el));
+
+        return ScrollView(VStack(16,
+            PageHeader("ParallaxView", "Shifts a background layer as a foreground surface scrolls, creating a depth effect."),
+
+            SampleCard("Background parallax behind a scrolling list",
+                VStack(8,
+                    Grid(
+                        columns: [GridSize.Star()], rows: [GridSize.Star()],
+                        parallax.Grid(row: 0, column: 0),
+                        list.Grid(row: 0, column: 0)
+                    ).Height(300),
+                    Caption("Scroll the list — the background layer drifts behind it (ParallaxView.Source is bound to the list).")
+                        .Foreground(Theme.SecondaryText)),
+                sourceCode: @"
+var (scroller, setScroller) = UseState<UIElement?>(null);
+
+var parallax = ParallaxView(background, verticalShift: 100);
+if (scroller is not null) parallax = parallax.Source(scroller);
+
+Grid(columns: [GridSize.Star()], rows: [GridSize.Star()],
+    parallax.Grid(row: 0, column: 0),
+    ListView(rows)
+        .Set(lv => lv.Background = null)          // transparent → background shows through
+        .OnMount(el => setScroller((UIElement)el)) // bind the scroller
+        .Grid(row: 0, column: 0))
+")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Media/ShapesPage.cs
+++ b/samples/ReactorGallery/ControlPages/Media/ShapesPage.cs
@@ -1,0 +1,63 @@
+using Microsoft.UI;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml.Media;
+using Windows.Foundation;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Media;
+
+class ShapesPage : Component
+{
+    static Element Tile(string label, Element shape) =>
+        VStack(6,
+            Border(shape).Size(120, 90).Background(Theme.SubtleFill).CornerRadius(6).Center(),
+            Caption(label).Foreground(Theme.SecondaryText).Center());
+
+    public override Element Render()
+    {
+        var accent = new SolidColorBrush(Colors.SteelBlue);
+        var fill = new SolidColorBrush(Colors.MediumPurple);
+
+        // Simple triangle geometry for the Path sample.
+        var triangle = new PathGeometry();
+        var figure = new PathFigure { StartPoint = new Point(10, 70), IsClosed = true };
+        figure.Segments.Add(new LineSegment { Point = new Point(50, 10) });
+        figure.Segments.Add(new LineSegment { Point = new Point(90, 70) });
+        triangle.Figures.Add(figure);
+
+        return ScrollView(VStack(16,
+            PageHeader("Shapes", "Rectangle, Ellipse, Line, and Path draw vector primitives you can fill and stroke."),
+
+            SampleCard("Filled shapes",
+                HStack(16,
+                    Tile("Rectangle", Rectangle().Width(80).Height(56).Fill(accent)),
+                    Tile("Ellipse", Ellipse().Width(72).Height(56).Fill(fill)),
+                    Tile("Rounded", Rectangle().Width(80).Height(56).Fill(new SolidColorBrush(Colors.SeaGreen))
+                        .Set(r => { r.RadiusX = 14; r.RadiusY = 14; }))),
+                sourceCode: @"
+Rectangle().Width(80).Height(56).Fill(accentBrush)
+Ellipse().Width(72).Height(56).Fill(purpleBrush)
+Rectangle().Width(80).Height(56).Fill(greenBrush)
+    .Set(r => { r.RadiusX = 14; r.RadiusY = 14; })   // shapes round via RadiusX/Y, not .CornerRadius
+"),
+
+            SampleCard("Line and Path",
+                HStack(16,
+                    Tile("Line", Line(10, 10, 100, 70).Stroke(accent).StrokeThickness(4)),
+                    Tile("Path", Path2D().Fill(new SolidColorBrush(Colors.OrangeRed)).Set(p => p.Data = triangle))),
+                sourceCode: @"
+Line(10, 10, 100, 70).Stroke(brush).StrokeThickness(4)
+
+// Path2D draws an arbitrary Geometry:
+var triangle = new PathGeometry();
+var figure = new PathFigure { StartPoint = new Point(10, 70), IsClosed = true };
+figure.Segments.Add(new LineSegment { Point = new Point(50, 10) });
+figure.Segments.Add(new LineSegment { Point = new Point(90, 70) });
+triangle.Figures.Add(figure);
+Path2D().Fill(brush).Set(p => p.Data = triangle)
+")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Navigation/PipsPagerPage.cs
+++ b/samples/ReactorGallery/ControlPages/Navigation/PipsPagerPage.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Navigation;
+
+class PipsPagerPage : Component
+{
+    public override Element Render()
+    {
+        var (pageIndex, setPageIndex) = UseState(0);
+        var (verticalIndex, setVerticalIndex) = UseState(0);
+        var pageMessages = new[]
+        {
+            "Welcome to the first page.",
+            "Review the second page.",
+            "Explore details on page three.",
+            "Compare options on page four.",
+            "Finish on the last page."
+        };
+
+        return ScrollView(VStack(16,
+            PageHeader("PipsPager", "PipsPager helps people navigate through a small set of pages."),
+
+            SampleCard("Five-page pager",
+                VStack(12,
+                    PipsPager(5, pageIndex, index => setPageIndex(index)),
+                    TextBlock($"Page {pageIndex + 1} of 5").SemiBold(),
+                    Border(TextBlock(pageMessages.ElementAt(pageIndex)).Center())
+                        .Height(96)
+                        .Background(Theme.SubtleFill)
+                        .CornerRadius(8)),
+                sourceCode: @"PipsPager(5, pageIndex, index => setPageIndex(index))
+TextBlock($""Page {pageIndex + 1} of 5"")
+Border(TextBlock(pageMessages.ElementAt(pageIndex)).Center())"),
+
+            SampleCard("Vertical pager",
+                HStack(16,
+                    PipsPager(4, verticalIndex, index => setVerticalIndex(index))
+                        .Set(p => p.Orientation = Orientation.Vertical)
+                        .Height(160),
+                    TextBlock($"Vertical page {verticalIndex + 1}").VAlign(VerticalAlignment.Center)),
+                sourceCode: @"PipsPager(4, verticalIndex, index => setVerticalIndex(index))
+    .Set(p => p.Orientation = Orientation.Vertical)
+    .Height(160)")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Navigation/PipsPagerPage.cs
+++ b/samples/ReactorGallery/ControlPages/Navigation/PipsPagerPage.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;

--- a/samples/ReactorGallery/ControlPages/Navigation/PipsPagerPage.cs
+++ b/samples/ReactorGallery/ControlPages/Navigation/PipsPagerPage.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Xaml;

--- a/samples/ReactorGallery/ControlPages/Patterns/CommandsPage.cs
+++ b/samples/ReactorGallery/ControlPages/Patterns/CommandsPage.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;

--- a/samples/ReactorGallery/ControlPages/Patterns/CommandsPage.cs
+++ b/samples/ReactorGallery/ControlPages/Patterns/CommandsPage.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
 using static Microsoft.UI.Reactor.Factories;

--- a/samples/ReactorGallery/ControlPages/Patterns/CommandsPage.cs
+++ b/samples/ReactorGallery/ControlPages/Patterns/CommandsPage.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Patterns;
+
+class CommandsPage : Component
+{
+    public override Element Render()
+    {
+        var (count, setCount) = UseState(0);
+        var (status, setStatus) = UseState("Ready");
+        var (fires, setFires) = UseState(0);
+
+        // Sync command bound straight to a Button via the Button(Command) factory.
+        var increment = new Command { Label = "Increment", Execute = () => setCount(count + 1) };
+
+        // Async command: UseCommand auto-tracks IsExecuting and guards re-entrance,
+        // so the button disables itself while the operation runs.
+        var save = UseCommand(new Command
+        {
+            Label = "Save",
+            ExecuteAsync = async () =>
+            {
+                setStatus("Saving...");
+                await Task.Delay(1500);
+                setStatus("Saved!");
+            }
+        });
+
+        // Debounced command: leading-edge; must flow through UseCommand so the
+        // debounce window persists across renders.
+        var debounced = UseCommand(new Command
+        {
+            Label = "Debounced (1s)",
+            Execute = () => setFires(fires + 1),
+            DebounceMs = 1000,
+        });
+
+        return ScrollView(VStack(16,
+            PageHeader("Commands", "Bind actions declaratively with Command — enablement, async tracking, and debounce come built in."),
+
+            SampleCard("Sync command",
+                VStack(8,
+                    Button(increment),
+                    TextBlock($"Count: {count}").Foreground(Theme.SecondaryText)),
+                sourceCode: @"
+var increment = new Command { Label = ""Increment"", Execute = () => setCount(count + 1) };
+Button(increment)   // Label + Execute + IsEnabled all flow from the Command
+"),
+
+            SampleCard("Async command — UseCommand tracks IsExecuting",
+                VStack(8,
+                    HStack(8,
+                        Button(save),
+                        save.IsExecuting ? ProgressRing().Size(20, 20) : Empty()),
+                    TextBlock($"Status: {status}").Foreground(Theme.SecondaryText),
+                    Caption($"IsExecuting: {save.IsExecuting}").Foreground(Theme.SecondaryText)),
+                sourceCode: @"
+var save = UseCommand(new Command
+{
+    Label = ""Save"",
+    ExecuteAsync = async () =>
+    {
+        setStatus(""Saving...""); await Task.Delay(1500); setStatus(""Saved!"");
+    }
+});
+Button(save)   // auto-disables for the lifetime of the async lambda
+"),
+
+            SampleCard("Debounced command — DebounceMs",
+                VStack(8,
+                    Button(debounced),
+                    TextBlock($"Accepted fires: {fires}").Foreground(Theme.SecondaryText),
+                    Caption("Rapid clicks within 1s collapse to a single fire; the button disables during the window.")
+                        .Foreground(Theme.SecondaryText)),
+                sourceCode: @"
+// DebounceMs only debounces when wrapped by UseCommand (it persists the window).
+var run = UseCommand(new Command { Label = ""Run"", Execute = Run, DebounceMs = 1000 });
+Button(run)
+")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Text/MarkdownPage.cs
+++ b/samples/ReactorGallery/ControlPages/Text/MarkdownPage.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using Microsoft.UI.Reactor;
+using Microsoft.UI.Reactor.Core;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using static Microsoft.UI.Reactor.Factories;
+using static WinUIGalleryReactor.SamplePageHost;
+
+namespace WinUIGalleryReactor.ControlPages.Text;
+
+class MarkdownPage : Component
+{
+    public override Element Render()
+    {
+        var introMarkdown = @"# Markdown sample
+
+Markdown renders **bold** text, *italic* text, and `inline code`.
+
+- Create declarative UI
+- Compose reusable components
+- Keep samples readable";
+
+        var linkMarkdown = @"Learn more about [Reactor](https://github.com/microsoft/microsoft-ui-reactor).
+
+1. Write elements
+2. Render native WinUI controls
+3. Update with state";
+
+        return ScrollView(VStack(16,
+            PageHeader("Markdown", "Markdown converts formatted text into a Reactor element tree."),
+
+            SampleCard("Formatted markdown",
+                Border(Markdown(introMarkdown))
+                    .Padding(16)
+                    .Background(Theme.SubtleFill)
+                    .CornerRadius(8),
+                sourceCode: @"var markdown = @""# Markdown sample
+
+Markdown renders **bold** text, *italic* text, and `inline code`.
+
+- Create declarative UI
+- Compose reusable components
+- Keep samples readable"";
+
+Border(Markdown(markdown))
+    .Padding(16)
+    .Background(Theme.SubtleFill)
+    .CornerRadius(8)"),
+
+            SampleCard("Links and lists",
+                Border(Markdown(linkMarkdown))
+                    .Padding(16)
+                    .Background(Theme.SubtleFill)
+                    .CornerRadius(8),
+                sourceCode: @"var markdown = @""Learn more about [Reactor](https://github.com/microsoft/microsoft-ui-reactor).
+
+1. Write elements
+2. Render native WinUI controls
+3. Update with state"";
+
+Markdown(markdown)")
+        ).Margin(36, 24, 36, 36));
+    }
+}

--- a/samples/ReactorGallery/ControlPages/Text/MarkdownPage.cs
+++ b/samples/ReactorGallery/ControlPages/Text/MarkdownPage.cs
@@ -1,7 +1,5 @@
-using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;
 

--- a/samples/ReactorGallery/ControlPages/Text/MarkdownPage.cs
+++ b/samples/ReactorGallery/ControlPages/Text/MarkdownPage.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Linq;
 using Microsoft.UI.Reactor;
 using Microsoft.UI.Reactor.Core;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using static Microsoft.UI.Reactor.Factories;
 using static WinUIGalleryReactor.SamplePageHost;

--- a/samples/ReactorGallery/ControlPages/Text/RichTextBlockPage.cs
+++ b/samples/ReactorGallery/ControlPages/Text/RichTextBlockPage.cs
@@ -13,6 +13,7 @@ class RichTextBlockPage : Component
     public override Element Render()
     {
         var (fontSize, setFontSize) = UseState(14.0);
+        var (clicks, setClicks) = UseState(0);
 
         return ScrollView(
             VStack(16,
@@ -38,6 +39,30 @@ class RichTextBlockPage : Component
                     {
                         Paragraph(Run("Bold") with { IsBold = true }, Run("normal")),
                         Paragraph(Run("Italic") with { IsItalic = true })
+                    })
+                    """),
+
+                SampleCard("Inline hyperlinks & embedded UI",
+                    RichTextBlock(new[]
+                    {
+                        Paragraph(
+                            Run("Rich text can host clickable "),
+                            Hyperlink("hyperlinks", () => setClicks(clicks + 1)),
+                            Run($" — clicked {clicks} time(s).")),
+                        Paragraph(
+                            Run("It can also embed live controls inline: "),
+                            InlineUI(Button("Press me", () => setClicks(clicks + 1))),
+                            Run(" flows with the text."))
+                    }),
+                    """
+                    RichTextBlock(new[]
+                    {
+                        Paragraph(
+                            Run("clickable "),
+                            Hyperlink("hyperlinks", () => setClicks(clicks + 1))),
+                        Paragraph(
+                            Run("embedded UI: "),
+                            InlineUI(Button("Press me", () => ...)))
                     })
                     """),
 

--- a/samples/ReactorGallery/ControlRegistry.cs
+++ b/samples/ReactorGallery/ControlRegistry.cs
@@ -106,6 +106,39 @@ public static class ControlRegistry
         new("Spacing", "Margin, padding, and stack spacing for consistent layout rhythm.", "Design", "\uE790", "spacing"),
         new("Theming", "Guidance on applying light, dark, and high-contrast themes.", "Design", "\uE771", "theming", "ThemeTransition.png"),
         new("Typography", "Guidance on typographic styles, font ramps, and text hierarchy.", "Design", "\uE790", "typography", "TextBlock.png"),
+
+        // ── Added: controls surfaced from recent Reactor additions ──
+        new("RadioButtons", "A group of radio buttons where a user selects a single option.", "Basic Input", "\uE73A", "radio-buttons"),
+        new("ToggleSplitButton", "A split button whose primary part toggles on and off.", "Basic Input", "\uE73A", "toggle-split-button"),
+
+        new("ItemsRepeater", "A lightweight, data-driven panel for laying out custom collections.", "Collections", "\uE8A9", "items-repeater"),
+        new("SemanticZoom", "A control that switches between a zoomed-in and zoomed-out view of data.", "Collections", "\uE8A9", "semantic-zoom"),
+        new("SwipeControl", "A container that reveals swipe commands on its content.", "Collections", "\uE8A9", "swipe-control"),
+        new("RefreshContainer", "A pull-to-refresh container for scrollable content.", "Collections", "\uE8A9", "refresh-container"),
+
+        new("UniformGrid", "A panel that arranges children in evenly sized cells.", "Layout", "\uE8A1", "uniform-grid"),
+        new("InterspersedGrid", "A grid that places proportionally sized panels with separators between them.", "Layout", "\uE8A1", "interspersed-grid"),
+        new("AnnotatedScrollBar", "A scrollbar that shows labelled annotations along its track.", "Layout", "\uE8A1", "annotated-scroll-bar"),
+        new("Docking", "Dockable, tearable, and floatable panes with drag-to-rearrange layout.", "Layout", "\uE8A1", "docking"),
+
+        new("MediaPlayerElement", "Embeds audio and video playback with built-in transport controls.", "Media", "\uE8B9", "media-player-element"),
+        new("AnimatedVisualPlayer", "Plays vector (Lottie/codegen) animations.", "Media", "\uE8B9", "animated-visual-player"),
+        new("AnimatedIcon", "An icon that transitions between states with a vector animation.", "Media", "\uE8B9", "animated-icon"),
+        new("MapControl", "Displays an interactive, pannable, zoomable map.", "Media", "\uE8B9", "map-control"),
+        new("ParallaxView", "Shifts a background layer as content scrolls for a depth effect.", "Media", "\uE8B9", "parallax-view"),
+        new("Shapes", "Rectangle, Ellipse, Line, and Path vector primitives.", "Media", "\uE8B9", "shapes"),
+        new("Icons", "Standalone icon elements from Symbol, Font glyph, or Path sources.", "Media", "\uE8B9", "icons"),
+
+        new("PipsPager", "A pager that represents pages as a row of selectable dots.", "Navigation", "\uE8B0", "pips-pager"),
+
+        new("Popup", "A lightweight overlay that displays arbitrary content over the UI.", "Dialogs and Flyouts", "\uE8BD", "popup"),
+
+        new("Markdown", "Renders a Markdown string as a Reactor element tree.", "Text", "\uE8D2", "markdown"),
+
+        new("DataGrid", "A virtualized data grid with sortable columns, selection, and inline editing.", "Data", "\uE7C3", "data-grid"),
+        new("PropertyGrid", "A reflection-driven editor for an object's properties.", "Data", "\uE7C3", "property-grid"),
+
+        new("Commands", "Declarative Command binding with async IsExecuting tracking and debounce.", "Patterns", "\uE943", "commands"),
     }
     .OrderBy(c => c.Title, StringComparer.OrdinalIgnoreCase)
     .ToArray();
@@ -114,6 +147,7 @@ public static class ControlRegistry
     {
         "Basic Input",
         "Collections",
+        "Data",
         "Date and Time",
         "Dialogs and Flyouts",
         "Layout",
@@ -122,6 +156,7 @@ public static class ControlRegistry
         "Navigation",
         "Status and Info",
         "Text",
+        "Patterns",
         "Design",
         "Styles",
     };

--- a/samples/ReactorGallery/GalleryShell.cs
+++ b/samples/ReactorGallery/GalleryShell.cs
@@ -13,6 +13,7 @@ class GalleryShell : Component
     {
         ["Basic Input"] = "\uE73A",
         ["Collections"] = "\uE8A9",
+        ["Data"] = "\uE7C3",
         ["Date and Time"] = "\uE787",
         ["Dialogs and Flyouts"] = "\uE8BD",
         ["Layout"] = "\uE8A1",
@@ -21,6 +22,7 @@ class GalleryShell : Component
         ["Navigation"] = "\uE8B0",
         ["Status and Info"] = "\uE946",
         ["Text"] = "\uE8D2",
+        ["Patterns"] = "\uE943",
         ["Styles"] = "\uE790",
     };
 

--- a/samples/ReactorGallery/PageRouter.cs
+++ b/samples/ReactorGallery/PageRouter.cs
@@ -28,6 +28,8 @@ static class PageRouter
         "text-box" => Component<ControlPages.BasicInput.TextBoxPage>(),
         "toggle-button" => Component<ControlPages.BasicInput.ToggleButtonPage>(),
         "toggle-switch" => Component<ControlPages.BasicInput.ToggleSwitchPage>(),
+        "radio-buttons" => Component<ControlPages.BasicInput.RadioButtonsPage>(),
+        "toggle-split-button" => Component<ControlPages.BasicInput.ToggleSplitButtonPage>(),
 
         // Collections
         "flip-view" => Component<FlipViewPage>(),
@@ -36,6 +38,10 @@ static class PageRouter
         "list-box" => Component<ListBoxPage>(),
         "list-view" => Component<ListViewPage>(),
         "tree-view" => Component<TreeViewPage>(),
+        "items-repeater" => Component<ControlPages.Collections.ItemsRepeaterPage>(),
+        "semantic-zoom" => Component<ControlPages.Collections.SemanticZoomPage>(),
+        "swipe-control" => Component<ControlPages.Collections.SwipeControlPage>(),
+        "refresh-container" => Component<ControlPages.Collections.RefreshContainerPage>(),
 
         // Date and Time
         "calendar-date-picker" => Component<ControlPages.DateAndTime.CalendarDatePickerPage>(),
@@ -49,6 +55,7 @@ static class PageRouter
         "flyout" => Component<ControlPages.DialogsAndFlyouts.FlyoutPage>(),
         "menu-flyout" => Component<ControlPages.DialogsAndFlyouts.MenuFlyoutPage>(),
         "teaching-tip" => Component<ControlPages.DialogsAndFlyouts.TeachingTipPage>(),
+        "popup" => Component<ControlPages.DialogsAndFlyouts.PopupPage>(),
 
         // Layout
         "border" => Component<BorderPage>(),
@@ -63,11 +70,22 @@ static class PageRouter
         "stack-panel" => Component<StackPanelPage>(),
         "viewbox" => Component<ViewboxPage>(),
         "wrap-grid" => Component<WrapGridPage>(),
+        "uniform-grid" => Component<ControlPages.Layout.UniformGridPage>(),
+        "interspersed-grid" => Component<ControlPages.Layout.InterspersedGridPage>(),
+        "annotated-scroll-bar" => Component<ControlPages.Layout.AnnotatedScrollBarPage>(),
+        "docking" => Component<ControlPages.Layout.DockingPage>(),
 
         // Media
         "image" => Component<ControlPages.Media.ImagePage>(),
         "person-picture" => Component<ControlPages.Media.PersonPicturePage>(),
         "web-view-2" => Component<ControlPages.Media.WebView2Page>(),
+        "media-player-element" => Component<ControlPages.Media.MediaPlayerElementPage>(),
+        "animated-visual-player" => Component<ControlPages.Media.AnimatedVisualPlayerPage>(),
+        "animated-icon" => Component<ControlPages.Media.AnimatedIconPage>(),
+        "map-control" => Component<ControlPages.Media.MapControlPage>(),
+        "parallax-view" => Component<ControlPages.Media.ParallaxViewPage>(),
+        "shapes" => Component<ControlPages.Media.ShapesPage>(),
+        "icons" => Component<ControlPages.Media.IconsPage>(),
 
         // Menus and Toolbars
         "command-bar" => Component<ControlPages.MenusAndToolbars.CommandBarPage>(),
@@ -81,6 +99,7 @@ static class PageRouter
         "pivot" => Component<ControlPages.Navigation.PivotPage>(),
         "tab-view" => Component<ControlPages.Navigation.TabViewPage>(),
         "title-bar" => Component<ControlPages.Navigation.TitleBarPage>(),
+        "pips-pager" => Component<ControlPages.Navigation.PipsPagerPage>(),
 
         // Status and Info
         "info-bar" => Component<ControlPages.StatusAndInfo.InfoBarPage>(),
@@ -94,6 +113,14 @@ static class PageRouter
         "rich-edit-box" => Component<RichEditBoxPage>(),
         "rich-text-block" => Component<RichTextBlockPage>(),
         "type-ramp" => Component<ControlPages.Text.TypeRampPage>(),
+        "markdown" => Component<ControlPages.Text.MarkdownPage>(),
+
+        // Data
+        "data-grid" => Component<ControlPages.Data.DataGridPage>(),
+        "property-grid" => Component<ControlPages.Data.PropertyGridPage>(),
+
+        // Patterns
+        "commands" => Component<ControlPages.Patterns.CommandsPage>(),
 
         // Styles
         "acrylic" => Component<ControlPages.Styles.AcrylicPage>(),

--- a/samples/ReactorGallery/Program.cs
+++ b/samples/ReactorGallery/Program.cs
@@ -4,4 +4,10 @@ using Microsoft.UI.Reactor.Hosting;
 using static Microsoft.UI.Reactor.Factories;
 
 ReactorApp.Run<WinUIGalleryReactor.GalleryShell>("WinUI Gallery (Reactor)", width: 1400, height: 900,
-    configure: host => XamlInterop.Register(host.Reconciler));
+    configure: host =>
+    {
+        XamlInterop.Register(host.Reconciler);
+        // DockManager is constructed directly (no factory), so its handler must be
+        // registered up front for the Docking gallery page to mount.
+        Microsoft.UI.Reactor.Docking.Native.DockingNativeInterop.Register(host.Reconciler);
+    });


### PR DESCRIPTION
## What & why

Brings `samples/ReactorGallery` (the Reactor WinUI Gallery) current with Reactor's control surface. A batch of controls added over the last ~2 months was never surfaced in the gallery; this adds **23 new control-demo pages** and wires them into the registry, router, and navigation.

## New pages

| Category | Controls |
|---|---|
| Basic Input | RadioButtons, ToggleSplitButton (+ ThreeStateToggleButton card on the existing ToggleButton page) |
| Collections | ItemsRepeater, SemanticZoom, SwipeControl, RefreshContainer |
| Layout | UniformGrid, InterspersedGrid, AnnotatedScrollBar, **Docking** |
| Media | MediaPlayerElement, AnimatedVisualPlayer, AnimatedIcon, MapControl, ParallaxView, Shapes, Icons |
| Navigation | PipsPager |
| Dialogs & Flyouts | Popup |
| Text | Markdown |
| **Data** (new category) | DataGrid, PropertyGrid |
| **Patterns** (new category) | Commands (Command / DebounceMs / async `UseCommand`) |

Also **enhances RichTextBlock** with an inline-hyperlink + embedded-UI card, and registers `DockingNativeInterop` in `Program.cs` so the Docking page's directly-constructed `DockManager` mounts.

## Verification

- **Build:** `dotnet build samples\ReactorGallery -p:Platform=x64` → **0 errors / 0 warnings**.
- **Visual QA:** launched the app and screenshotted every new page; all render correctly. This surfaced and fixed a Docking crash (missing handler registration), a non-functional ParallaxView (`Source` was never bound), and a misleading AnnotatedScrollBar demo.
- **Review:** ran the repo's multi-dimensional `pr-review` skill (security, correctness, api-ergonomics, alternative-solution, test-coverage, docs-and-samples, packaging) plus a multi-model cross-check (different model family). 0 critical / 0 high. All actionable findings fixed: memoized-source snippet on DataGrid, `.Set`→`.OnMount` for AnimatedVisualPlayer playback, and removing a no-op `.CornerRadius` on a shape.

## Scope

Sample-only change — no shipped library, analyzer, or packaging surface is touched.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>