### PR TITLE
Fix #873: default PopupElement.IsLightDismissEnabled to false

### DIFF
--- a/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
+++ b/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
@@ -232,7 +232,7 @@ content that isn't a menu — all of them are popups.
 
 | Fluent | Effect |
 |---|---|
-| `.IsLightDismissEnabled(bool)` | Close on outside click. Off by default (matching WinUI); call `.IsLightDismissEnabled()` to enable. |
+| `.IsLightDismissEnabled(bool enabled = true)` | Close on outside click. Off by default (matching WinUI); call `.IsLightDismissEnabled()` to enable. |
 | `.Offset(horizontal, vertical)` | Position relative to the popup's anchor point. |
 | `.Opened(Action)` | Fires after the popup is on screen. |
 | `.Closed(Action)` | Fires after the popup leaves the screen. |

--- a/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
+++ b/docs/_pipeline/templates/dialogs-and-flyouts.md.dt
@@ -232,7 +232,7 @@ content that isn't a menu — all of them are popups.
 
 | Fluent | Effect |
 |---|---|
-| `.IsLightDismissEnabled(bool)` | Close on outside click. Default `true`. |
+| `.IsLightDismissEnabled(bool)` | Close on outside click. Off by default (matching WinUI); call `.IsLightDismissEnabled()` to enable. |
 | `.Offset(horizontal, vertical)` | Position relative to the popup's anchor point. |
 | `.Opened(Action)` | Fires after the popup is on screen. |
 | `.Closed(Action)` | Fires after the popup leaves the screen. |

--- a/docs/guide/dialogs-and-flyouts.md
+++ b/docs/guide/dialogs-and-flyouts.md
@@ -371,7 +371,7 @@ content that isn't a menu — all of them are popups.
 
 | Fluent | Effect |
 |---|---|
-| `.IsLightDismissEnabled(bool)` | Close on outside click. Off by default (matching WinUI); call `.IsLightDismissEnabled()` to enable. |
+| `.IsLightDismissEnabled(bool enabled = true)` | Close on outside click. Off by default (matching WinUI); call `.IsLightDismissEnabled()` to enable. |
 | `.Offset(horizontal, vertical)` | Position relative to the popup's anchor point. |
 | `.Opened(Action)` | Fires after the popup is on screen. |
 | `.Closed(Action)` | Fires after the popup leaves the screen. |

--- a/docs/guide/dialogs-and-flyouts.md
+++ b/docs/guide/dialogs-and-flyouts.md
@@ -371,7 +371,7 @@ content that isn't a menu — all of them are popups.
 
 | Fluent | Effect |
 |---|---|
-| `.IsLightDismissEnabled(bool)` | Close on outside click. Default `true`. |
+| `.IsLightDismissEnabled(bool)` | Close on outside click. Off by default (matching WinUI); call `.IsLightDismissEnabled()` to enable. |
 | `.Offset(horizontal, vertical)` | Position relative to the popup's anchor point. |
 | `.Opened(Action)` | Fires after the popup is on screen. |
 | `.Closed(Action)` | Fires after the popup leaves the screen. |

--- a/src/Reactor/Core/Element.cs
+++ b/src/Reactor/Core/Element.cs
@@ -6402,7 +6402,8 @@ public partial record AnnotatedScrollBarElement;
 public record PopupElement(Element Child) : Element
 {
     public bool IsOpen { get; init; }
-    public bool IsLightDismissEnabled { get; init; } = true;
+    // Matches WinUI's Popup.IsLightDismissEnabled default (false); see #873.
+    public bool IsLightDismissEnabled { get; init; }
     public double HorizontalOffset { get; init; }
     public double VerticalOffset { get; init; }
     public Action? OnOpened { get; init; }

--- a/tests/Reactor.Tests/ElementModifiersCoverageTests.cs
+++ b/tests/Reactor.Tests/ElementModifiersCoverageTests.cs
@@ -203,6 +203,14 @@ public class ElementModifiersCoverageTests
     // ════════════════════════════════════════════════════════════════
 
     [Fact]
+    public void Popup_IsLightDismissEnabled_DefaultsToFalse()
+    {
+        // Matches WinUI's Popup.IsLightDismissEnabled default (#873): a plain
+        // Popup must NOT light-dismiss unless the author opts in.
+        Assert.False(Popup(TextBlock("popup content")).IsLightDismissEnabled);
+    }
+
+    [Fact]
     public void Popup_IsLightDismissEnabled()
     {
         var el = new PopupElement(TextBlock("popup content"))


### PR DESCRIPTION
## Summary

Fixes #873.

WinUI's `Popup.IsLightDismissEnabled` defaults to **`false`**, but Reactor's `PopupElement.IsLightDismissEnabled` defaulted to **`true`** (`src/Reactor/Core/Element.cs`). This inverted the platform default: a plain `Popup(child, isOpen)` light-dismissed (closed on outside click) unless the author remembered `.IsLightDismissEnabled(false)`. This PR flips the record default to `false` to match WinUI and author expectations.

## Changes

- **`src/Reactor/Core/Element.cs`** — `PopupElement.IsLightDismissEnabled` default `true` → `false` (with a `#873` comment).
- **`tests/Reactor.Tests/ElementModifiersCoverageTests.cs`** — new `Popup_IsLightDismissEnabled_DefaultsToFalse` test that asserts the default is `false`; it fails if the default is ever reverted to `true`.
- **`docs/_pipeline/templates/dialogs-and-flyouts.md.dt`** + **`docs/guide/dialogs-and-flyouts.md`** — updated the fluent-modifier table row that stated the old "Default `true`" to "off by default (matching WinUI); call `.IsLightDismissEnabled()` to enable".

## Why this is safe in the reconciler model

`IsLightDismissEnabled` is a static configuration prop, not user-mutated state — the platform never writes it back (light dismiss changes `IsOpen`, not this property). It's fully controlled: `OverlayLifecycle.MountPopup` writes it and `UpdatePopup` diffs element→control. So this is a pure default flip with no controlled/uncontrolled echo hazard.

The modifier convenience default (`.IsLightDismissEnabled()` → `true`) is intentionally **unchanged**, so opting in stays ergonomic.

## Not needed / verified

- **No sample/gallery churn on `main`** — there are no `Popup(` usages under `samples/` on this branch. (The `PopupPage.cs` cited in the issue lives on the gallery branch, which already sets both cards explicitly.)
- **No API-index regen** — `reactor.api.txt` encodes the property as `bool IsLightDismissEnabled { get; init; }` with no initializer, and the modifier signature `IsLightDismissEnabled(bool enabled = true)` is unchanged.
- Existing explicit setters (docking renderers `= false`, the doc sample's `.IsLightDismissEnabled()`, and the `CoreReconcilerRenderCoverageFixtures` selftest's `phase == 0`) are unaffected.

## Testing

- `dotnet build src/Reactor` — clean (0 warnings, 0 errors).
- `dotnet test tests/Reactor.Tests` — **12382 passed, 0 failed, 64 skipped**, including the new guard test.
- Selftests were not runnable in the local dev environment (pre-existing WinUI XAML markup-compiler `WMC1006` + ARM64 `MakePri` failures in unrelated app/control projects under a deep worktree path). CI (windows-latest, x64) exercises the selftest tier, and the Popup selftest is logically unaffected since it sets `IsLightDismissEnabled` explicitly.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>