### PR TITLE
deps: Windows NuGet updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,13 +41,13 @@
     <PackageVersion Include="System.Reflection.DispatchProxy" Version="4.8.2" />
     <PackageVersion Include="MessageFormat" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="11.0.0-preview.5.26302.115" />
-    <PackageVersion Include="YamlDotNet" Version="18.0.0" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <!-- Roslyn source generator that emits a static (reflection-free / NativeAOT-safe)
          YamlStaticContext for the CLI's doc-pipeline YAML DTOs. Analyzer-only
          (PrivateAssets=all) — never shipped in the `mur` tool output. Version tracks
          YamlDotNet's major (18.x). -->
     <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="18.1.0" />
-    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.1" />
+    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.6" />
     <PackageVersion Include="MessagePack" Version="2.5.301" />
   </ItemGroup>
 
@@ -63,11 +63,11 @@
 
   <ItemGroup>
     <!-- Test infrastructure -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.3.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.4" />


### PR DESCRIPTION
Automated NuGet updates for the **Windows-only project graph** that GitHub-hosted (Linux) Dependabot cannot restore.

Updated **5** package version(s) in `Directory.Packages.props`:

| Package | From | To |
| --- | --- | --- |
| GitHub.Copilot.SDK | 1.0.1 | 1.0.6 |
| Microsoft.NET.Test.Sdk | 18.6.0 | 18.7.0 |
| MSTest.TestAdapter | 4.2.3 | 4.3.2 |
| MSTest.TestFramework | 4.2.3 | 4.3.2 |
| YamlDotNet | 18.0.0 | 18.1.0 |

_Ignored by configuration: MessagePack._

---
✅ **Validated:** `dotnet build Reactor.slnx` passed on windows-latest.
Detected + built on `windows-latest` with no write token; produced by the `Windows NuGet updates` workflow.

> Opened manually from the pushed `bot/windows-nuget-updates` branch because the repo currently has *"Allow GitHub Actions to create and approve pull requests"* disabled, so the workflow's `gh pr create` was blocked. Enable that setting (or add a `DEPS_BOT_TOKEN` secret) and future scheduled runs will open/refresh this automatically.

[Workflow run](https://github.com/microsoft/microsoft-ui-reactor/actions/runs/29286903533)
