### PR TITLE
Declare x64/ARM64 platforms for Reactor.SignaturesGen

### DIFF
--- a/tools/Reactor.SignaturesGen/Reactor.SignaturesGen.csproj
+++ b/tools/Reactor.SignaturesGen/Reactor.SignaturesGen.csproj
@@ -3,6 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
+    <!-- WindowsAppSDK targets (pulled in transitively via the Reactor reference)
+         reject AnyCPU, and Reactor.slnx maps this project's solution platforms to
+         x64/ARM64. Declare those concrete platforms (mirrors src/Reactor.Cli) so
+         the configs the solution references actually exist. Without this, opening
+         Reactor.slnx reports a project-configuration-not-found error for this
+         project. It is only ever built with an explicit -p:Platform (never AnyCPU). -->
+    <Platforms>x64;ARM64</Platforms>
     <RootNamespace>Microsoft.UI.Reactor.SignaturesGen</RootNamespace>
     <AssemblyName>Reactor.SignaturesGen</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Problem

Opening `Reactor.slnx` in Visual Studio surfaces a solution-configuration validation error:

> The solution file Reactor.slnx specifies a project configuration for project Reactor.SignaturesGen.csproj that does not exist for that project.
> Existing project configurations: `Debug|AnyCPU`, `Release|AnyCPU`

`Reactor.slnx` maps `Reactor.SignaturesGen`'s solution platforms to `x64`/`ARM64`, but the project only declared the implicit `AnyCPU`, so those referenced configurations didn't exist.

## Fix

Declare the concrete platforms in the project:

```xml
<Platforms>x64;ARM64</Platforms>
```

This makes the slnx-referenced `x64`/`ARM64` configurations exist (mirroring `src/Reactor.Cli`), clearing the VS banner.

## Why not just map the slnx to AnyCPU

That was tried and **fails CI** (the `Build solution` job, `dotnet build Reactor.slnx --configuration Release`). With the slnx mapping SignaturesGen to `AnyCPU`, the API-index apphost builds `AnyCPU` and runs as x64 on the host. In the full solution build at the default `ARM64` solution platform, the arch-guard (`_ReactorApiTargetArch == _ReactorApiHostArch`) then sees target == host == x64 and **fires regen**. The AnyCPU apphost loads the solution's **ARM64** `Reactor.dll` and crashes reflecting over its custom attributes — `MSB3073`, exit `0xE0434352` (unhandled managed exception), exactly the "crashes on ARM64" case `Program.cs` documents.

Keeping SignaturesGen at `x64`/`ARM64` aligns it with the solution platform, so in the cross-arch CI build the guard correctly **skips** regen and the apphost never runs.