### PR TITLE
Gallery: drop DataGrid selection-mode remount workaround

### DIFF
--- a/samples/ReactorGallery/ControlPages/Data/DataGridPage.cs
+++ b/samples/ReactorGallery/ControlPages/Data/DataGridPage.cs
@@ -43,9 +43,6 @@ class DataGridPage : Component
 
             SampleCard("Columns, sorting & selection",
                 VStack(8,
-                    // Re-key on the mode so switching selection mode remounts the grid.
-                    // Workaround for microsoft/microsoft-ui-reactor#872 — DataGrid doesn't
-                    // reconcile SelectionMode on the live grid after first mount.
                     DataGrid(
                         source: source,
                         columns: new FieldDescriptor[]
@@ -59,7 +56,7 @@ class DataGridPage : Component
                         selectionMode: selection,
                         onSelectionChanged: keys => setSelectedCount(keys.Count),
                         rowHeight: 36
-                    ).Height(340).WithKey($"dg-mode-{mode}"),
+                    ).Height(340),
                     TextBlock($"Selected rows: {selectedCount}").Foreground(Theme.SecondaryText),
                     Caption("Multiple mode: Ctrl+click toggles a row, Shift+click selects a range.")
                         .Foreground(Theme.SecondaryText)),


### PR DESCRIPTION
Follow-up to the merged gallery work, now that the DataGrid control fix has landed.

`DataGrid` now reconciles `SelectionMode` on the live grid after first mount (#872, merged via #876), so the gallery's selection-mode ComboBox updates the grid in place. This removes the temporary mode-keyed remount workaround (and its explanatory comment) that was added while #872 was still open.

- `samples/ReactorGallery/ControlPages/Data/DataGridPage.cs` — the DataGrid call drops `.WithKey($"dg-mode-{mode}")`; the switcher now works reactively (no remount).
- Build: `dotnet build samples\ReactorGallery -p:Platform=x64` → **0 warnings / 0 errors**.

Closes the loop on #872.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
