### PR TITLE
Reconcile stale generated docs on main

### DIFF
--- a/docs/guide/analyzer-architecture.md
+++ b/docs/guide/analyzer-architecture.md
@@ -191,6 +191,11 @@ via `.editorconfig`.
 | `REACTOR_ANIM_003` | Warning | async lambda to WithAnimation loses the ThreadStatic scope after await | `AnimationScopeAsyncAnalyzer.cs` |
 | `REACTOR_LIFECYCLE_002` | Warning | UseEffect(Action) allocates a timer/subscription/event with no returned cleanup | `EffectCleanupAnalyzer.cs` |
 | `REACTOR_MEMO_001` | Info | Modifiers on a keyed Memo(key,factory) wrapper opt the row out of the recycle cache | `MemoWrapperModifierAnalyzer.cs` |
+| `REACTOR_DYM_001` | Warning | Reactor property/field invoked like a method (e.g. `GridSize.Auto()`) | `NonInvocableMemberParensAnalyzer.cs` |
+| `REACTOR_DYM_002` | Warning | Invented `Theme.*Background` token (e.g. `Theme.AppBackground`); use `Theme.SolidBackground` (`Theme.LayerBackground` → `Theme.LayerFill`) | `ThemeBackgroundSuffixAnalyzer.cs` |
+| `REACTOR_DYM_003` | Warning | Mistyped Reactor factory name in call position (e.g. `Buton(...)`) | `FuzzyFactoryNameAnalyzer.cs` |
+| `REACTOR_DYM_004` | Warning | Reactor factory called with too few arguments (CS7036), single unique overload — suggests the parameter shape | `MissingFactoryArgumentAnalyzer.cs` |
+| `REACTOR_DYM_005` | Warning | String passed where a Reactor `Element` is expected (CS1503) — wrap it in a text factory | `StringForElementArgumentAnalyzer.cs` |
 
 `REACTOR_HOOKS_002` and `_003` were the reserved control-flow / data-flow slots
 (variable hook counts across early returns, async boundaries inside `UseEffect`);

--- a/docs/guide/commanding.md
+++ b/docs/guide/commanding.md
@@ -615,15 +615,14 @@ return VStack(0,
 ### Creating Commands inside render without memoization
 
 ```csharp
-// Don't: re-create the Command on every render — every surface that
-// holds the previous reference sees a fresh identity each frame, which
-// thrashes the WinUI keyboard-accelerator wiring and re-renders every
-// consumer. Lift to a memo or hoist out of Render().
+// Don't: re-create the Command on every render — each render allocates a
+// fresh command record (and its captured closures). Memoizing keeps a
+// stable instance across renders. Lift to a memo or hoist out of Render().
 class DontCreateInRender : Component
 {
     public override Element Render()
     {
-        // BAD — Command identity churns every render:
+        // BAD — a fresh Command (and closure) is allocated every render:
         // var save = new Command { Label = "Save", Execute = () => { } };
 
         // GOOD — UseMemo pins identity until deps change:
@@ -639,12 +638,15 @@ class DontCreateInRender : Component
 }
 ```
 
-Re-creating the `Command` record every frame creates a fresh
-`KeyboardAccelerator` and forces every consumer to re-render. The
-window's accelerator table grows without bound on rapid re-renders and
-the analyzer fires `REACTOR_PERF_FUNCREF` for the inline lambda
-identity. Wrap the construction in [`UseMemo`](hooks.md) with the
-correct dependencies, or hoist the command above the component.
+Re-creating the `Command` record every render allocates a fresh command
+(and its captured closures). Where a host rebuilds keyboard
+accelerators on reconcile it *clears and re-adds* them — a bounded rewire,
+not an unbounded leak — and a command bound to a button is diffed by
+*value*, so a fresh-but-equal command re-applies nothing. The avoidable
+cost is simply the per-render allocation, and the analyzer fires
+`REACTOR_PERF_FUNCREF` for the inline construction. Wrap it in
+[`UseMemo`](hooks.md) with the correct dependencies, or hoist the command
+above the component.
 
 ### Ignoring CanExecute changes
 

--- a/docs/guide/control-reconciler-protocol.md
+++ b/docs/guide/control-reconciler-protocol.md
@@ -209,8 +209,17 @@ public readonly ref struct MountContext
     /// (possibly null for <c>EmptyElement</c>).</summary>
     public UIElement? MountChild(Element child) => _reconciler.Mount(child, _requestRerender);
 
-    /// <summary>Apply a setter array to the control. Equivalent to the public
-    /// <see cref="Reconciler.ApplySetters{T}(Action{T}[], T)"/> helper; provided
+    /// <summary>Reconcile a secondary element slot (mount / update-in-place / unmount)
+    /// against an already-mounted control, preserving descendant component state across
+    /// re-renders. <paramref name="existing"/> is the control currently in the slot (or
+    /// <c>null</c>). Returns the control to assign back into the slot. Public counterpart
+    /// to the engine-internal child reconcile, so external wrappers (not just built-in
+    /// descriptors) can host stateful secondary element slots — see
+    /// <c>[WrapElementSlot]</c>.</summary>
+    public UIElement? ReconcileChild(Element? oldChild, Element? newChild, UIElement? existing)
+        => _reconciler.ReconcileV1Child(oldChild, newChild, existing, _requestRerender);
+
+    /// <summary>The <see cref="Reconciler.ApplySetters{T}(Action{T}[], T)"/> helper; provided
     /// on the context for symmetry with handler-authored mount bodies.</summary>
     public void ApplySetters<T>(Action<T>[] setters, T control) where T : class
         => Reconciler.ApplySetters(setters, control);

--- a/docs/guide/effects-scheduling.md
+++ b/docs/guide/effects-scheduling.md
@@ -33,25 +33,14 @@ controls, and only after that does it flush queued effects.
 ```csharp
 public void UseEffect(Action effect, params object[] dependencies)
 {
-    if (_hookIndex >= _hooks.Count)
-    {
-        _hooks.Add(new EffectHookState { Dependencies = null, Effect = effect });
-    }
-
-    if (_hooks[_hookIndex] is not EffectHookState hook)
-        throw new HookOrderException(
-            $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected EffectHookState. " +
-            "Hooks must be called in the same order every render.");
-    _hookIndex++;
-
+    var hook = AcquireEffectSlot();
+    // Snapshot the deps on store (SnapshotDeps): a caller can pass — and then
+    // reuse and mutate in place — the same array instance across renders, so the
+    // stored copy must be isolated or DepsEqual would alias prev/next and skip a
+    // real change (Issue #659 review #3). Only the deps-CHANGED path stores, so
+    // this adds no steady-state allocation.
     if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
-    {
-        hook.PendingCleanup = hook.Cleanup;
-        hook.Cleanup = null;
-        hook.Dependencies = dependencies.ToArray();
-        hook.Effect = effect;
-        hook.Pending = true;
-    }
+        ScheduleEffect(hook, effect, null, SnapshotDeps(dependencies));
 }
 ```
 
@@ -282,34 +271,37 @@ UseEffect(() => {
 ```
 
 ```csharp
-void Setter(T newValue)
+private Action<T> MakeStateSetter<T>(ValueHookState<T> h)
 {
-    var h = (ValueHookState<T>)_hooks[currentIndex];
-    bool changed;
-    if (h.ThreadSafe)
+    void Setter(T newValue)
     {
-        lock (h.Lock)
+        bool changed;
+        if (h.ThreadSafe)
         {
+            lock (h.Lock!)
+            {
+                changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
+                if (changed) h.Value = newValue;
+            }
+            if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                    global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                    Diagnostics.ReactorEventSource.Keywords.State))
+                Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+            if (changed) _requestRerender?.Invoke();
+        }
+        else
+        {
+            if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
             changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
             if (changed) h.Value = newValue;
+            if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                    global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                    Diagnostics.ReactorEventSource.Keywords.State))
+                Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+            if (changed) _requestRerender?.Invoke();
         }
-        if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                Diagnostics.ReactorEventSource.Keywords.State))
-            Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-        if (changed) _requestRerender?.Invoke();
     }
-    else
-    {
-        if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
-        changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
-        if (changed) h.Value = newValue;
-        if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                Diagnostics.ReactorEventSource.Keywords.State))
-            Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-        if (changed) _requestRerender?.Invoke();
-    }
+    return Setter;
 }
 ```
 

--- a/docs/guide/extending-reactor-controls.md
+++ b/docs/guide/extending-reactor-controls.md
@@ -595,8 +595,8 @@ Writing
 without the `static` modifier compiles, but allocates a closure object
 per `Register` call *and* defeats the trimmer's ability to drop the
 handler/control chain when the factory holder is unreachable. The
-compiler will accept either shape; reviewers and analyzers are your
-only guard. (Issue #486 tracks adding the analyzer.) Always write
+compiler will accept either shape; the `REACTOR_DESC_001` analyzer
+(`StaticRegisterLambdaAnalyzer`) is your guard. Always write
 `static () => new MyHandler()`.
 
 **Bypassing the factory with `new MyElement(...)`.** The whole reason

--- a/docs/guide/hooks-internals.md
+++ b/docs/guide/hooks-internals.md
@@ -114,34 +114,37 @@ changes for the lifetime of the component, which is why setter
 identity is stable across renders.
 
 ```csharp
-void Setter(T newValue)
+private Action<T> MakeStateSetter<T>(ValueHookState<T> h)
 {
-    var h = (ValueHookState<T>)_hooks[currentIndex];
-    bool changed;
-    if (h.ThreadSafe)
+    void Setter(T newValue)
     {
-        lock (h.Lock)
+        bool changed;
+        if (h.ThreadSafe)
         {
+            lock (h.Lock!)
+            {
+                changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
+                if (changed) h.Value = newValue;
+            }
+            if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                    global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                    Diagnostics.ReactorEventSource.Keywords.State))
+                Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+            if (changed) _requestRerender?.Invoke();
+        }
+        else
+        {
+            if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
             changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
             if (changed) h.Value = newValue;
+            if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                    global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                    Diagnostics.ReactorEventSource.Keywords.State))
+                Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+            if (changed) _requestRerender?.Invoke();
         }
-        if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                Diagnostics.ReactorEventSource.Keywords.State))
-            Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-        if (changed) _requestRerender?.Invoke();
     }
-    else
-    {
-        if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
-        changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
-        if (changed) h.Value = newValue;
-        if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                Diagnostics.ReactorEventSource.Keywords.State))
-            Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-        if (changed) _requestRerender?.Invoke();
-    }
+    return Setter;
 }
 ```
 
@@ -169,25 +172,14 @@ Model](reactivity-model.md) page; the implementation lives here.
 ```csharp
 public void UseEffect(Action effect, params object[] dependencies)
 {
-    if (_hookIndex >= _hooks.Count)
-    {
-        _hooks.Add(new EffectHookState { Dependencies = null, Effect = effect });
-    }
-
-    if (_hooks[_hookIndex] is not EffectHookState hook)
-        throw new HookOrderException(
-            $"Hook at index {_hookIndex} is {_hooks[_hookIndex].GetType().Name}, expected EffectHookState. " +
-            "Hooks must be called in the same order every render.");
-    _hookIndex++;
-
+    var hook = AcquireEffectSlot();
+    // Snapshot the deps on store (SnapshotDeps): a caller can pass — and then
+    // reuse and mutate in place — the same array instance across renders, so the
+    // stored copy must be isolated or DepsEqual would alias prev/next and skip a
+    // real change (Issue #659 review #3). Only the deps-CHANGED path stores, so
+    // this adds no steady-state allocation.
     if (hook.Dependencies is null || !DepsEqual(hook.Dependencies, dependencies))
-    {
-        hook.PendingCleanup = hook.Cleanup;
-        hook.Cleanup = null;
-        hook.Dependencies = dependencies.ToArray();
-        hook.Effect = effect;
-        hook.Pending = true;
-    }
+        ScheduleEffect(hook, effect, null, SnapshotDeps(dependencies));
 }
 ```
 

--- a/docs/guide/input-and-gestures.md
+++ b/docs/guide/input-and-gestures.md
@@ -624,8 +624,8 @@ If a parent needs to see the press before children consume it, use
 `.OnKeyDown` fires per element on focus — a `Ctrl+S` handler attached
 to a `TextBox` only fires while that field has focus. For app-wide
 accelerators (Save, Find, Run), use Reactor's
-[commanding](commanding.md) system: `new Command { ..., AccessKey =
-"S", AccessKeyModifiers = VirtualKeyModifiers.Control }` registers
+[commanding](commanding.md) system: `new Command { ..., Accelerator =
+Accelerator(VirtualKey.S, VirtualKeyModifiers.Control) }` registers
 the chord with the WinUI accelerator infrastructure, which routes
 through the window's `AccessKeyManager` regardless of focus. The
 analyzer `REACTOR_INPUT_001` flags Ctrl/Alt key combinations attached
@@ -636,10 +636,13 @@ via `.OnKeyDown` and suggests the `Command` rewrite.
 A `Border` with `.OnTapped(...)` is hit-testable for pointer events
 but is not in the keyboard tab order by default — pressing Tab skips
 right past it, which fails [accessibility](accessibility.md) (every
-interactive control must be keyboard-reachable). Add `.IsTabStop()`
-or set `.TabIndex(n)` to put the Border in the tab order, and pair
-it with `.OnKeyDown` for Enter/Space activation. The
-[`AccessibilityScanner`](accessibility.md) catches this as
+interactive control must be keyboard-reachable). Add `.IsTabStop(true)`
+to put the Border in the tab order — a plain `.TabIndex(n)` is not
+enough, because the reconciler applies `TabIndex` only to focusable
+`Control`s, not to a `Border` — and pair it with `.OnKeyDown` for
+Enter/Space activation. The Roslyn analyzer
+[`REACTOR_A11Y_004`](accessibility.md) flags this at build time, and the
+[`AccessibilityScanner`](accessibility.md) catches it at runtime as
 `A11Y_KEYBOARD_001`.
 
 ## Tips

--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -347,11 +347,13 @@ Use the content-alignment fluents when the control itself should stretch,
 but its child content also needs an explicit placement contract. A common
 case is a full-width button whose inner row should also stretch:
 
+<!-- ai:lock -->
 ```csharp
 Button(Text("Open"), onClick)
-    .HAlign(HorizontalAlignment.Stretch)
-    .HorizontalContentAlignment(HorizontalAlignment.Stretch)
+  .HAlign(HorizontalAlignment.Stretch)
+  .HorizontalContentAlignment(HorizontalAlignment.Stretch)
 ```
+<!-- /ai:lock -->
 
 See [modifier-system](modifier-system.md) for how these chain
 internally.

--- a/docs/guide/modifier-system.md
+++ b/docs/guide/modifier-system.md
@@ -34,6 +34,33 @@ helpers that do all the work are `Modify` and `ModifyTheme`:
 private static T Modify<T>(T el, ElementModifiers mods) where T : Element =>
     el with { Modifiers = el.Modifiers is not null ? el.Modifiers.Merge(mods) : mods };
 
+// #165/#157 — bucket-level merge entry points for pure-layout / pure-visual
+// fluent modifiers. Routing through these avoids allocating a throwaway parent
+// ElementModifiers (and the bucket sub-record its init shim builds) on every
+// chained call: `.Margin().Width().Foreground()` merges the delta straight into
+// the Layout / Visual slot instead of constructing a temporary ElementModifiers
+// per step. Semantics are identical to Modify(el, new ElementModifiers { <field> }):
+// ElementModifiers.Merge copies every non-bucket field as `other.X ?? X` (i.e.
+// unchanged) when only a bucket is supplied, and merges the bucket with the same
+// `other ?? this` precedence used here.
+private static T ModifyLayout<T>(T el, LayoutModifiers delta) where T : Element
+{
+    var mods = el.Modifiers;
+    if (mods is null)
+        return el with { Modifiers = new ElementModifiers { Layout = delta } };
+    var merged = mods.Layout is not null ? mods.Layout.Merge(delta) : delta;
+    return el with { Modifiers = mods with { Layout = merged } };
+}
+
+private static T ModifyVisual<T>(T el, VisualModifiers delta) where T : Element
+{
+    var mods = el.Modifiers;
+    if (mods is null)
+        return el with { Modifiers = new ElementModifiers { Visual = delta } };
+    var merged = mods.Visual is not null ? mods.Visual.Merge(delta) : delta;
+    return el with { Modifiers = mods with { Visual = merged } };
+}
+
 private static T ModifyA11y<T>(T el, AccessibilityModifiers a11y) where T : Element
 {
     var existing = el.Modifiers?.Accessibility;
@@ -261,6 +288,33 @@ Text("hi").Padding(10).Background("#FF0000");
 private static T Modify<T>(T el, ElementModifiers mods) where T : Element =>
     el with { Modifiers = el.Modifiers is not null ? el.Modifiers.Merge(mods) : mods };
 
+// #165/#157 — bucket-level merge entry points for pure-layout / pure-visual
+// fluent modifiers. Routing through these avoids allocating a throwaway parent
+// ElementModifiers (and the bucket sub-record its init shim builds) on every
+// chained call: `.Margin().Width().Foreground()` merges the delta straight into
+// the Layout / Visual slot instead of constructing a temporary ElementModifiers
+// per step. Semantics are identical to Modify(el, new ElementModifiers { <field> }):
+// ElementModifiers.Merge copies every non-bucket field as `other.X ?? X` (i.e.
+// unchanged) when only a bucket is supplied, and merges the bucket with the same
+// `other ?? this` precedence used here.
+private static T ModifyLayout<T>(T el, LayoutModifiers delta) where T : Element
+{
+    var mods = el.Modifiers;
+    if (mods is null)
+        return el with { Modifiers = new ElementModifiers { Layout = delta } };
+    var merged = mods.Layout is not null ? mods.Layout.Merge(delta) : delta;
+    return el with { Modifiers = mods with { Layout = merged } };
+}
+
+private static T ModifyVisual<T>(T el, VisualModifiers delta) where T : Element
+{
+    var mods = el.Modifiers;
+    if (mods is null)
+        return el with { Modifiers = new ElementModifiers { Visual = delta } };
+    var merged = mods.Visual is not null ? mods.Visual.Merge(delta) : delta;
+    return el with { Modifiers = mods with { Visual = merged } };
+}
+
 private static T ModifyA11y<T>(T el, AccessibilityModifiers a11y) where T : Element
 {
     var existing = el.Modifiers?.Accessibility;
@@ -297,6 +351,33 @@ Text("hi").Margin(8).Margin(left: 16);   // last wins — margin is (16,8,8,8)? 
 ```csharp
 private static T Modify<T>(T el, ElementModifiers mods) where T : Element =>
     el with { Modifiers = el.Modifiers is not null ? el.Modifiers.Merge(mods) : mods };
+
+// #165/#157 — bucket-level merge entry points for pure-layout / pure-visual
+// fluent modifiers. Routing through these avoids allocating a throwaway parent
+// ElementModifiers (and the bucket sub-record its init shim builds) on every
+// chained call: `.Margin().Width().Foreground()` merges the delta straight into
+// the Layout / Visual slot instead of constructing a temporary ElementModifiers
+// per step. Semantics are identical to Modify(el, new ElementModifiers { <field> }):
+// ElementModifiers.Merge copies every non-bucket field as `other.X ?? X` (i.e.
+// unchanged) when only a bucket is supplied, and merges the bucket with the same
+// `other ?? this` precedence used here.
+private static T ModifyLayout<T>(T el, LayoutModifiers delta) where T : Element
+{
+    var mods = el.Modifiers;
+    if (mods is null)
+        return el with { Modifiers = new ElementModifiers { Layout = delta } };
+    var merged = mods.Layout is not null ? mods.Layout.Merge(delta) : delta;
+    return el with { Modifiers = mods with { Layout = merged } };
+}
+
+private static T ModifyVisual<T>(T el, VisualModifiers delta) where T : Element
+{
+    var mods = el.Modifiers;
+    if (mods is null)
+        return el with { Modifiers = new ElementModifiers { Visual = delta } };
+    var merged = mods.Visual is not null ? mods.Visual.Merge(delta) : delta;
+    return el with { Modifiers = mods with { Visual = merged } };
+}
 
 private static T ModifyA11y<T>(T el, AccessibilityModifiers a11y) where T : Element
 {

--- a/docs/guide/persistence.md
+++ b/docs/guide/persistence.md
@@ -170,7 +170,7 @@ class PersistentSettings : Component
         UseEffect(() =>
         {
             Directory.CreateDirectory(System.IO.Path.GetDirectoryName(SettingsPath)!);
-            File.WriteAllText(SettingsPath, JsonSerializer.Serialize(settings));
+            File.WriteAllText(SettingsPath, JsonSerializer.Serialize(settings, AppSettingsJsonContext.Default.AppSettings));
             return () => { };
         }, settings);
 
@@ -181,12 +181,17 @@ class PersistentSettings : Component
 
     private static AppSettings LoadFromDisk() =>
         File.Exists(SettingsPath)
-            ? JsonSerializer.Deserialize<AppSettings>(File.ReadAllText(SettingsPath))
+            ? JsonSerializer.Deserialize(File.ReadAllText(SettingsPath), AppSettingsJsonContext.Default.AppSettings)
                 ?? new AppSettings(NotificationsOn: true)
             : new AppSettings(NotificationsOn: true);
 }
 
 record AppSettings(bool NotificationsOn);
+
+// JSON source-generated context so the disk read/write is trim- and
+// NativeAOT-safe (no reflection-based JsonSerializer overloads).
+[JsonSerializable(typeof(AppSettings))]
+partial class AppSettingsJsonContext : JsonSerializerContext;
 ```
 
 The pattern is small but the constraints are real:

--- a/docs/guide/reactivity-model.md
+++ b/docs/guide/reactivity-model.md
@@ -68,34 +68,37 @@ next — typically on the next dispatcher tick — and once it does, the
 component's `Render()` runs and the slot read returns the new value.
 
 ```csharp
-void Setter(T newValue)
+private Action<T> MakeStateSetter<T>(ValueHookState<T> h)
 {
-    var h = (ValueHookState<T>)_hooks[currentIndex];
-    bool changed;
-    if (h.ThreadSafe)
+    void Setter(T newValue)
     {
-        lock (h.Lock)
+        bool changed;
+        if (h.ThreadSafe)
         {
+            lock (h.Lock!)
+            {
+                changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
+                if (changed) h.Value = newValue;
+            }
+            if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                    global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                    Diagnostics.ReactorEventSource.Keywords.State))
+                Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+            if (changed) _requestRerender?.Invoke();
+        }
+        else
+        {
+            if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
             changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
             if (changed) h.Value = newValue;
+            if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                    global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                    Diagnostics.ReactorEventSource.Keywords.State))
+                Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+            if (changed) _requestRerender?.Invoke();
         }
-        if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                Diagnostics.ReactorEventSource.Keywords.State))
-            Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-        if (changed) _requestRerender?.Invoke();
     }
-    else
-    {
-        if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
-        changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
-        if (changed) h.Value = newValue;
-        if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                Diagnostics.ReactorEventSource.Keywords.State))
-            Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-        if (changed) _requestRerender?.Invoke();
-    }
+    return Setter;
 }
 ```
 
@@ -251,34 +254,37 @@ change.
 ## State batching
 
 ```csharp
-void Setter(T newValue)
+private Action<T> MakeStateSetter<T>(ValueHookState<T> h)
 {
-    var h = (ValueHookState<T>)_hooks[currentIndex];
-    bool changed;
-    if (h.ThreadSafe)
+    void Setter(T newValue)
     {
-        lock (h.Lock)
+        bool changed;
+        if (h.ThreadSafe)
         {
+            lock (h.Lock!)
+            {
+                changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
+                if (changed) h.Value = newValue;
+            }
+            if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                    global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                    Diagnostics.ReactorEventSource.Keywords.State))
+                Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+            if (changed) _requestRerender?.Invoke();
+        }
+        else
+        {
+            if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
             changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
             if (changed) h.Value = newValue;
+            if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                    global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                    Diagnostics.ReactorEventSource.Keywords.State))
+                Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+            if (changed) _requestRerender?.Invoke();
         }
-        if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                Diagnostics.ReactorEventSource.Keywords.State))
-            Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-        if (changed) _requestRerender?.Invoke();
     }
-    else
-    {
-        if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
-        changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
-        if (changed) h.Value = newValue;
-        if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                Diagnostics.ReactorEventSource.Keywords.State))
-            Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-        if (changed) _requestRerender?.Invoke();
-    }
+    return Setter;
 }
 ```
 

--- a/docs/guide/reactor-vs-xaml.md
+++ b/docs/guide/reactor-vs-xaml.md
@@ -96,6 +96,33 @@ live in a type-keyed `Attached` dictionary on the same record.
 private static T Modify<T>(T el, ElementModifiers mods) where T : Element =>
     el with { Modifiers = el.Modifiers is not null ? el.Modifiers.Merge(mods) : mods };
 
+// #165/#157 — bucket-level merge entry points for pure-layout / pure-visual
+// fluent modifiers. Routing through these avoids allocating a throwaway parent
+// ElementModifiers (and the bucket sub-record its init shim builds) on every
+// chained call: `.Margin().Width().Foreground()` merges the delta straight into
+// the Layout / Visual slot instead of constructing a temporary ElementModifiers
+// per step. Semantics are identical to Modify(el, new ElementModifiers { <field> }):
+// ElementModifiers.Merge copies every non-bucket field as `other.X ?? X` (i.e.
+// unchanged) when only a bucket is supplied, and merges the bucket with the same
+// `other ?? this` precedence used here.
+private static T ModifyLayout<T>(T el, LayoutModifiers delta) where T : Element
+{
+    var mods = el.Modifiers;
+    if (mods is null)
+        return el with { Modifiers = new ElementModifiers { Layout = delta } };
+    var merged = mods.Layout is not null ? mods.Layout.Merge(delta) : delta;
+    return el with { Modifiers = mods with { Layout = merged } };
+}
+
+private static T ModifyVisual<T>(T el, VisualModifiers delta) where T : Element
+{
+    var mods = el.Modifiers;
+    if (mods is null)
+        return el with { Modifiers = new ElementModifiers { Visual = delta } };
+    var merged = mods.Visual is not null ? mods.Visual.Merge(delta) : delta;
+    return el with { Modifiers = mods with { Visual = merged } };
+}
+
 private static T ModifyA11y<T>(T el, AccessibilityModifiers a11y) where T : Element
 {
     var existing = el.Modifiers?.Accessibility;

--- a/docs/guide/reference/hooks/Customize.md
+++ b/docs/guide/reference/hooks/Customize.md
@@ -1,0 +1,12 @@
+# Customize
+
+`method`  
+_cref_: `M:Microsoft.UI.Reactor.Hooks.AnnounceRegionElement.Customize(Microsoft.UI.Reactor.Core.V1Protocol.Descriptor.ControlDescriptor{Microsoft.UI.Reactor.Hooks.AnnounceRegionElement,Microsoft.UI.Xaml.Controls.TextBlock})`
+
+> **Learn more:** [Hooks](../../hooks.md), [Effects](../../effects.md)
+
+## Summary
+
+Author hook — add the bespoke descriptor entries for the <c>[WrapManual]</c> props.
+
+

--- a/docs/guide/reference/hooks/Descriptor.md
+++ b/docs/guide/reference/hooks/Descriptor.md
@@ -1,0 +1,12 @@
+# Descriptor
+
+`field`  
+_cref_: `F:Microsoft.UI.Reactor.Hooks.AnnounceRegionElement.Descriptor`
+
+> **Learn more:** [Hooks](../../hooks.md), [Effects](../../effects.md)
+
+## Summary
+
+The descriptor the engine interprets for every [AnnounceRegionElement](AnnounceRegionElement.md) ([guide](../../hooks.md)).
+
+

--- a/docs/guide/reference/hooks/UseCommand.md
+++ b/docs/guide/reference/hooks/UseCommand.md
@@ -7,16 +7,18 @@ _cref_: `M:Microsoft.UI.Reactor.Core.RenderContext.UseCommand(Microsoft.UI.React
 
 ## Summary
 
-Processes a Command for use in a component. Always consumes a stable hook shape
-(independent of whether the command is sync/async or debounced), so a command at a
-given call site can flip between sync↔async or DebounceMs 0↔N across renders without
-reordering hook slots. For a pure sync command with no DebounceMs the original command
-is returned unchanged (identity preserved). For async commands, wraps ExecuteAsync with
-automatic IsExecuting tracking and re-entrance guards. When DebounceMs > 0, wraps the
-dispatch with a leading-edge debounce so a fire within the window is dropped and
-IsDebouncing (hence IsEnabled = false) disables the bound control until the window
-elapses. The returned command has a sync Execute action, ExecuteAsync = null, and
-preserves the authored DebounceMs value (re-passing it through UseCommand is a no-op —
-debounce is never applied twice).
+Processes a Command for use in a component. Always consumes a <b>stable hook shape</b>
+(independent of whether the command is sync/async or debounced), so a command at a given
+call site can flip between sync↔async or `DebounceMs` 0↔N across
+renders without ever reordering hook slots. For a pure sync command with no
+`DebounceMs` the original command is returned unchanged (identity
+preserved). For async commands, wraps ExecuteAsync with automatic IsExecuting tracking and
+re-entrance guards. When `DebounceMs` > 0, wraps the dispatch with a
+leading-edge debounce: a fire within the window of the prior accepted fire is dropped and
+`IsDebouncing` (hence `IsEnabled`=false) reflects
+the window so the bound control disables, re-enabling when the window elapses. The returned
+command has a sync Execute action, ExecuteAsync = null, and preserves the authored
+DebounceMs value (re-passing it through UseCommand is a no-op — debounce is never applied
+twice).
 
 

--- a/docs/guide/reference/hooks/UseCommandState.md
+++ b/docs/guide/reference/hooks/UseCommandState.md
@@ -1,0 +1,16 @@
+# UseCommandState
+
+`method`  
+_cref_: `M:Microsoft.UI.Reactor.Core.RenderContext.UseCommandState`
+
+> **Learn more:** [Hooks](../../hooks.md), [Effects](../../effects.md)
+
+## Summary
+
+Allocates the stable hook shape shared by both [UseCommand](UseCommand.md) ([guide](../../hooks.md)) overloads:
+the IsExecuting / IsDebouncing state, the re-entrance guard and debounce-slot refs, and an
+unmount effect that disposes any live re-enable timer so it cannot fire
+<c>setIsDebouncing</c> / request a re-render against a torn-down context. These hooks are
+allocated unconditionally so the hook order is identical regardless of the command's shape.
+
+

--- a/docs/guide/reference/hooks/UseMemoCellsByIndex.md
+++ b/docs/guide/reference/hooks/UseMemoCellsByIndex.md
@@ -19,7 +19,7 @@ will get better incremental reuse from [UseMemoCells](UseMemoCells.md) ([guide](
 or [UseMemoCellsByKey](UseMemoCellsByKey.md) ([guide](../../hooks.md)), both of which can
 short-circuit per-cell on value or key equality across length
 changes.
-
+<para>
 On the steady-state path (unchanged count) the returned array reuses
 the previous render's element instance for every index NOT named in
 <paramref name="changedIndices" />, and publishes a positional
@@ -32,6 +32,7 @@ and declare every change through a subsequent render's
 AGENTS.md "Never mutate"). Mutating an unchanged slot in place both
 corrupts the memo's view of the previous render and can cause the
 reconciler to skip the mutated cell.
+</para>
 
 ## Parameters
 

--- a/docs/guide/threading-and-dispatch.md
+++ b/docs/guide/threading-and-dispatch.md
@@ -52,34 +52,37 @@ setter detects the off-thread call and queues itself back onto the
 captured dispatcher:
 
 ```csharp
-void Setter(T newValue)
+private Action<T> MakeStateSetter<T>(ValueHookState<T> h)
 {
-    var h = (ValueHookState<T>)_hooks[currentIndex];
-    bool changed;
-    if (h.ThreadSafe)
+    void Setter(T newValue)
     {
-        lock (h.Lock)
+        bool changed;
+        if (h.ThreadSafe)
         {
+            lock (h.Lock!)
+            {
+                changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
+                if (changed) h.Value = newValue;
+            }
+            if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                    global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                    Diagnostics.ReactorEventSource.Keywords.State))
+                Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+            if (changed) _requestRerender?.Invoke();
+        }
+        else
+        {
+            if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
             changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
             if (changed) h.Value = newValue;
+            if (Diagnostics.ReactorEventSource.Log.IsEnabled(
+                    global::System.Diagnostics.Tracing.EventLevel.Verbose,
+                    Diagnostics.ReactorEventSource.Keywords.State))
+                Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
+            if (changed) _requestRerender?.Invoke();
         }
-        if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                Diagnostics.ReactorEventSource.Keywords.State))
-            Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-        if (changed) _requestRerender?.Invoke();
     }
-    else
-    {
-        if (MarshalIfOffUIThread("UseState", () => Setter(newValue))) return;
-        changed = !EqualityComparer<T>.Default.Equals(h.Value, newValue);
-        if (changed) h.Value = newValue;
-        if (Diagnostics.ReactorEventSource.Log.IsEnabled(
-                global::System.Diagnostics.Tracing.EventLevel.Verbose,
-                Diagnostics.ReactorEventSource.Keywords.State))
-            Diagnostics.ReactorEventSource.Log.StateChange("UseState", typeof(T).Name, changed);
-        if (changed) _requestRerender?.Invoke();
-    }
+    return Setter;
 }
 ```
 


### PR DESCRIPTION
## What

Regenerates the committed generated documentation so it matches a fresh `mur docs compile`. **No template, product, or CLI code is touched** — this PR commits only the generated output that a clean compile produces.

## Why

CI compiles the docs (`dotnet run --project src/Reactor.Cli -- docs compile --no-screenshots --ci`, the `docs-build` job) but **never `git diff`s the result**. Because nothing fails when the committed output differs from what the templates + doc apps + source XML-doc comments now produce, the checked-in generated pages under `docs/guide/` silently drifted from a fresh compile. This PR closes that gap by making the committed output identical to a fresh compile.

## Deterministic

The compiler was run **twice** on a clean tree; the resulting working-tree diff was **byte-identical** across both runs (same SHA-256), so this is a stable, reproducible reconcile rather than transient churn.

## Changes

15 regenerated pages:

- `docs/guide/analyzer-architecture.md`
- `docs/guide/commanding.md`
- `docs/guide/control-reconciler-protocol.md`
- `docs/guide/effects-scheduling.md`
- `docs/guide/extending-reactor-controls.md`
- `docs/guide/hooks-internals.md`
- `docs/guide/input-and-gestures.md`
- `docs/guide/layout.md`
- `docs/guide/modifier-system.md`
- `docs/guide/persistence.md`
- `docs/guide/reactivity-model.md`
- `docs/guide/reactor-vs-xaml.md`
- `docs/guide/reference/hooks/UseCommand.md`
- `docs/guide/reference/hooks/UseMemoCellsByIndex.md`
- `docs/guide/threading-and-dispatch.md`

3 new reference-gen hooks pages:

- `docs/guide/reference/hooks/Customize.md`
- `docs/guide/reference/hooks/Descriptor.md`
- `docs/guide/reference/hooks/UseCommandState.md`

## Companion PR

A separate in-flight PR — **Docs version single-source** — adds a per-PR docs-freshness gate (recompile + `git diff` check) so this drift can't silently recur. That PR owns the version-tokenization of `getting-started.md`/`packaging.md`; those two pages are deliberately **not** part of this drift set and are untouched here.