### PR TITLE
Add ReactorGallery search index for winui-search CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,13 @@ Hard-won specifics that repeatedly cost sessions time. Prefer these exact comman
 - A new public API surface has **two byte-identical index copies** —
   `skills/reactor.api.txt` and `plugins/reactor/skills/reactor-dsl/references/reactor.api.txt`
   — regenerate via `mur --regen-api`; keep them in sync.
+- The **ReactorGallery search index** (`samples/ReactorGallery/reactor-search-index.json`,
+  consumed by the external `winui-search` CLI) is generated from the gallery source +
+  `tools/Reactor.SearchIndex/editorial.json`. After adding/renaming a gallery control or
+  changing its first sample snippet, regenerate via
+  `dotnet run --project tools/Reactor.SearchIndex` (a `Reactor.Tests` gate byte-compares it,
+  so a stale index fails CI). Curate keywords/usings/overrides in `editorial.json`, never the
+  generated JSON.
 - A new common-element modifier touches every seam: the `ElementModifiers` field, skip
   equality, `Merge`, `ApplyModifiers`, and the fluent extension. Pair a `.HasValue` write
   with `fe.ClearValue(<DP>Property)` on unset unless intentionally matching a no-reset sibling.

--- a/samples/ReactorGallery/.gitattributes
+++ b/samples/ReactorGallery/.gitattributes
@@ -1,0 +1,4 @@
+# The search index is a byte-for-byte generated artifact gated by
+# SearchIndexGeneratorTests. Pin it to LF so the equality gate is deterministic on
+# every OS/checkout regardless of core.autocrlf.
+reactor-search-index.json text eol=lf

--- a/samples/ReactorGallery/reactor-search-index.json
+++ b/samples/ReactorGallery/reactor-search-index.json
@@ -554,7 +554,8 @@
         "rows and columns",
         "sortable",
         "virtualized grid",
-        "inline edit"
+        "inline edit",
+        "select"
       ],
       "relatedControls": [
         "ListView",
@@ -866,7 +867,8 @@
         "thumbnail grid",
         "wrapping items",
         "gallery",
-        "card grid"
+        "card grid",
+        "select"
       ],
       "relatedControls": [
         "ListView",
@@ -1079,6 +1081,7 @@
       "keywords": [
         "collection view",
         "selectable items",
+        "select",
         "data list",
         "flexible items"
       ],
@@ -1135,6 +1138,7 @@
         "data list",
         "rows",
         "selection",
+        "select",
         "virtualized list"
       ],
       "relatedControls": [

--- a/samples/ReactorGallery/reactor-search-index.json
+++ b/samples/ReactorGallery/reactor-search-index.json
@@ -1,0 +1,2495 @@
+{
+  "schemaVersion": 1,
+  "source": "reactor",
+  "generatedFrom": "microsoft/microsoft-ui-reactor",
+  "controls": [
+    {
+      "id": "acrylic",
+      "name": "Acrylic",
+      "category": "Styles",
+      "description": "A translucent material brush that creates a frosted glass effect.",
+      "keywords": [
+        "frosted glass",
+        "blur",
+        "translucent",
+        "material",
+        "backdrop"
+      ],
+      "relatedControls": [
+        "Theming"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "acrylic",
+      "samples": [
+        {
+          "header": "Acrylic Brush",
+          "language": "csharp",
+          "code": "AcrylicBrush(\n    global::Windows.UI.Color.FromArgb(255, 100, 100, 200),\n    tintOpacity: 0.8)"
+        }
+      ]
+    },
+    {
+      "id": "animated-icon",
+      "name": "AnimatedIcon",
+      "category": "Media",
+      "description": "An icon that transitions between states with a vector animation.",
+      "keywords": [
+        "lottie",
+        "vector animation",
+        "state transition",
+        "micro-interaction",
+        "animated glyph"
+      ],
+      "relatedControls": [
+        "AnimatedVisualPlayer",
+        "Icons"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "animated-icon",
+      "samples": [
+        {
+          "header": "Built-in animated icons",
+          "language": "csharp",
+          "code": "AnimatedIcon(new AnimatedChevronDownSmallVisualSource()).Size(32, 32)\n// AnimatedIcon plays its transition when the host raises a state change\n// (e.g. an Expander toggling). Supply your own IRichAnimatedVisualSource\n// for custom motion."
+        }
+      ]
+    },
+    {
+      "id": "animated-visual-player",
+      "name": "AnimatedVisualPlayer",
+      "category": "Media",
+      "description": "Plays vector (Lottie/codegen) animations.",
+      "keywords": [
+        "lottie",
+        "vector animation",
+        "codegen",
+        "playback",
+        "composition"
+      ],
+      "relatedControls": [
+        "AnimatedIcon",
+        "MediaPlayerElement"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "animated-visual-player",
+      "samples": [
+        {
+          "header": "Looping animation",
+          "language": "csharp",
+          "code": "AnimatedVisualPlayer().Size(64, 64).OnMount(el =>\n{\n    var p = (AnimatedVisualPlayer)el;                 // OnMount runs once — .Set re-applies on every update\n    p.Source = new AnimatedGlobalNavigationButtonVisualSource();\n    _ = p.PlayAsync(0, 1, loop: true);\n})\n// Point Source at your own IAnimatedVisualSource (e.g. a LottieVisualSource\n// or a codegen class produced by the Lottie/Windows toolchain)."
+        }
+      ]
+    },
+    {
+      "id": "annotated-scroll-bar",
+      "name": "AnnotatedScrollBar",
+      "category": "Layout",
+      "description": "A scrollbar that shows labelled annotations along its track.",
+      "keywords": [
+        "labelled scrollbar",
+        "scroll annotations",
+        "track markers",
+        "minimap",
+        "jump to section"
+      ],
+      "relatedControls": [
+        "ScrollView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "annotated-scroll-bar",
+      "samples": [
+        {
+          "header": "Standalone control surface",
+          "language": "csharp",
+          "code": "Border(AnnotatedScrollBar().Height(300).Width(40))\n    .Padding(12)\n    .Background(Theme.CardBackground)\n    .WithBorder(Theme.DividerStroke)"
+        }
+      ]
+    },
+    {
+      "id": "auto-suggest-box",
+      "name": "AutoSuggestBox",
+      "category": "Text",
+      "description": "A text input that shows suggestions as the user types.",
+      "keywords": [
+        "autocomplete",
+        "typeahead",
+        "suggestions",
+        "search box",
+        "combobox input"
+      ],
+      "relatedControls": [
+        "TextBox",
+        "ComboBox"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "auto-suggest-box",
+      "samples": [
+        {
+          "header": "Basic AutoSuggestBox",
+          "language": "csharp",
+          "code": "var (query, setQuery) = UseState(\"\");\nAutoSuggestBox(query, setQuery)"
+        }
+      ]
+    },
+    {
+      "id": "border",
+      "name": "Border",
+      "category": "Layout",
+      "description": "A container that draws a border around its child element.",
+      "keywords": [
+        "container",
+        "frame",
+        "outline",
+        "rounded corners",
+        "background wrapper"
+      ],
+      "relatedControls": [
+        "Card"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "border",
+      "samples": [
+        {
+          "header": "Basic Border",
+          "language": "csharp",
+          "code": "Border(TextBlock(\"Content\").Padding(16))\n    .WithBorder(Theme.CardStroke)\n    .CornerRadius(8)\n    .Background(Theme.SubtleFill)"
+        }
+      ]
+    },
+    {
+      "id": "breadcrumb-bar",
+      "name": "BreadcrumbBar",
+      "category": "Navigation",
+      "description": "A trail of links showing the user's navigation path.",
+      "keywords": [
+        "breadcrumbs",
+        "navigation trail",
+        "path bar",
+        "hierarchy nav",
+        "back navigation"
+      ],
+      "relatedControls": [
+        "NavigationView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "breadcrumb-bar",
+      "samples": [
+        {
+          "header": "Basic BreadcrumbBar",
+          "language": "csharp",
+          "code": "BreadcrumbBar(\n    new[] { Breadcrumb(\"Home\"), Breadcrumb(\"Docs\"), Breadcrumb(\"Reports\") },\n    item => setClicked(item.Label))"
+        }
+      ]
+    },
+    {
+      "id": "button",
+      "name": "Button",
+      "category": "Basic Input",
+      "description": "A button that responds to user clicks.",
+      "keywords": [
+        "click",
+        "command",
+        "submit",
+        "primary action",
+        "accent"
+      ],
+      "relatedControls": [
+        "RepeatButton",
+        "ToggleButton",
+        "HyperlinkButton",
+        "SplitButton"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "button",
+      "samples": [
+        {
+          "header": "Basic Button — .Click(handler)",
+          "language": "csharp",
+          "code": "Button(\"Save\").Click(() => setOutput(\"Saved!\"))"
+        }
+      ]
+    },
+    {
+      "id": "calendar-date-picker",
+      "name": "CalendarDatePicker",
+      "category": "Date and Time",
+      "description": "A drop-down control that lets a user pick a date from a calendar.",
+      "keywords": [
+        "date input",
+        "date dropdown",
+        "pick a date",
+        "calendar dropdown"
+      ],
+      "relatedControls": [
+        "CalendarView",
+        "DatePicker"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "calendar-date-picker",
+      "samples": [
+        {
+          "header": "Basic CalendarDatePicker",
+          "language": "csharp",
+          "code": "CalendarDatePicker(date, d => setDate(d))"
+        }
+      ]
+    },
+    {
+      "id": "calendar-view",
+      "name": "CalendarView",
+      "category": "Date and Time",
+      "description": "A calendar display that lets a user select a date.",
+      "keywords": [
+        "calendar",
+        "month view",
+        "date selection",
+        "schedule",
+        "multi-date"
+      ],
+      "relatedControls": [
+        "CalendarDatePicker",
+        "DatePicker"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "calendar-view",
+      "samples": [
+        {
+          "header": "Basic CalendarView",
+          "language": "csharp",
+          "code": "CalendarView()"
+        }
+      ]
+    },
+    {
+      "id": "canvas",
+      "name": "Canvas",
+      "category": "Layout",
+      "description": "A layout panel that supports absolute positioning of child elements.",
+      "keywords": [
+        "absolute positioning",
+        "free layout",
+        "x y coordinates",
+        "overlay positioning"
+      ],
+      "relatedControls": [
+        "RelativePanel"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "canvas",
+      "samples": [
+        {
+          "header": "Absolute Positioning",
+          "language": "csharp",
+          "code": "Canvas(\n    Rectangle().Size(80, 80).Background(\"#FF6B6B\").Canvas(left: 10, top: 10),\n    Rectangle().Size(80, 80).Background(\"#4ECDC4\").Canvas(left: 60, top: 50)\n)"
+        }
+      ]
+    },
+    {
+      "id": "card",
+      "name": "Card",
+      "category": "Layout",
+      "description": "A theme-aware preset Border with the WinUI card brushes, corner radius, and padding.",
+      "keywords": [
+        "surface",
+        "tile",
+        "elevated container",
+        "content card",
+        "panel"
+      ],
+      "relatedControls": [
+        "Border",
+        "Expander"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "card",
+      "samples": [
+        {
+          "header": "Override defaults via chained fluents",
+          "language": "csharp",
+          "code": "Card(child).Padding(24).CornerRadius(16)"
+        }
+      ]
+    },
+    {
+      "id": "check-box",
+      "name": "CheckBox",
+      "category": "Basic Input",
+      "description": "A control that a user can select or clear.",
+      "keywords": [
+        "tick",
+        "boolean",
+        "multi-select",
+        "opt in",
+        "tri-state"
+      ],
+      "relatedControls": [
+        "RadioButton",
+        "ToggleSwitch"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "check-box",
+      "samples": [
+        {
+          "header": "Two-State CheckBox",
+          "language": "csharp",
+          "code": "CheckBox(isChecked, v => setIsChecked(v), \"I agree to the terms\")"
+        }
+      ]
+    },
+    {
+      "id": "color",
+      "name": "Color",
+      "category": "Design",
+      "description": "Guidance on using the WinUI color system and theme resources.",
+      "keywords": [
+        "theme colors",
+        "brushes",
+        "accent",
+        "palette",
+        "system colors"
+      ],
+      "relatedControls": [
+        "ColorPicker",
+        "Theming",
+        "Typography"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "color",
+      "samples": [
+        {
+          "header": "Applying Theme Colors",
+          "language": "csharp",
+          "code": "// Foreground\nTextBlock(\"Accent text\").Foreground(Theme.Accent)\nTextBlock(\"Primary\").Foreground(Theme.PrimaryText)\nTextBlock(\"Secondary\").Foreground(Theme.SecondaryText)\nTextBlock(\"Hyperlink\").Foreground(Theme.AccentText)\n\n// Background\nBorder(content)\n    .Background(Theme.CardBackground)\n    .WithBorder(Theme.CardStroke)\n    .CornerRadius(6)\n\nBorder(content)\n    .Background(Theme.Accent)  // accent-filled button\n\n// Border & Stroke\nBorder(content)\n    .WithBorder(Theme.ControlStroke)\n\nBorder(VStack()).Height(1)\n    .Background(Theme.DividerStroke)  // horizontal divider\n\n// System Signal\nBorder(HStack(icon, message))\n    .Background(Theme.SystemSuccessBackground)"
+        }
+      ]
+    },
+    {
+      "id": "color-picker",
+      "name": "ColorPicker",
+      "category": "Basic Input",
+      "description": "A control that lets a user pick a color.",
+      "keywords": [
+        "color selection",
+        "rgb",
+        "hex",
+        "hue",
+        "eyedropper",
+        "swatch"
+      ],
+      "relatedControls": [
+        "Color"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "color-picker",
+      "samples": [
+        {
+          "header": "Basic ColorPicker",
+          "language": "csharp",
+          "code": "ColorPicker(color, c => setColor(c))"
+        }
+      ]
+    },
+    {
+      "id": "combo-box",
+      "name": "ComboBox",
+      "category": "Basic Input",
+      "description": "A drop-down list of items a user can select from.",
+      "keywords": [
+        "dropdown",
+        "select",
+        "picker",
+        "options list",
+        "single select"
+      ],
+      "relatedControls": [
+        "ListBox",
+        "DropDownButton",
+        "AutoSuggestBox"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "combo-box",
+      "samples": [
+        {
+          "header": "Basic ComboBox",
+          "language": "csharp",
+          "code": "ComboBox(colors, selectedIndex, i => setSelectedIndex(i))"
+        }
+      ]
+    },
+    {
+      "id": "command-bar",
+      "name": "CommandBar",
+      "category": "Menus and Toolbars",
+      "description": "A toolbar for exposing app commands and actions.",
+      "keywords": [
+        "toolbar",
+        "app bar",
+        "command buttons",
+        "action bar",
+        "overflow menu"
+      ],
+      "relatedControls": [
+        "CommandBarFlyout",
+        "MenuBar"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "command-bar",
+      "samples": [
+        {
+          "header": "Primary Commands",
+          "language": "csharp",
+          "code": "CommandBar(primaryCommands: new AppBarItemBase[] {\n    AppBarButton(\"Add\", () => setAction(\"Add\"), icon: \"Add\"),\n    AppBarButton(\"Edit\", () => setAction(\"Edit\"), icon: \"Edit\"),\n    AppBarSeparator(),\n    AppBarButton(\"Delete\", () => setAction(\"Delete\"), icon: \"Delete\"),\n})"
+        }
+      ]
+    },
+    {
+      "id": "command-bar-flyout",
+      "name": "CommandBarFlyout",
+      "category": "Dialogs and Flyouts",
+      "description": "A flyout that provides quick access to common commands.",
+      "keywords": [
+        "context menu",
+        "quick commands",
+        "selection menu",
+        "contextual toolbar"
+      ],
+      "relatedControls": [
+        "CommandBar",
+        "Flyout",
+        "MenuFlyout"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "command-bar-flyout",
+      "samples": [
+        {
+          "header": "Basic CommandBarFlyout",
+          "language": "csharp",
+          "code": "CommandBarFlyout(\n    Button(\"Show Commands\"),\n    primaryCommands: new AppBarItemBase[] {\n        AppBarButton(\"Cut\", () => {}, icon: \"Cut\"),\n        AppBarButton(\"Copy\", () => {}, icon: \"Copy\"),\n        AppBarButton(\"Paste\", () => {}, icon: \"Paste\"),\n    })"
+        }
+      ]
+    },
+    {
+      "id": "commands",
+      "name": "Commands",
+      "category": "Patterns",
+      "description": "Declarative Command binding with async IsExecuting tracking and debounce.",
+      "keywords": [
+        "command binding",
+        "icommand",
+        "async execute",
+        "can execute",
+        "debounce"
+      ],
+      "relatedControls": [
+        "Button"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "commands",
+      "samples": [
+        {
+          "header": "Sync command",
+          "language": "csharp",
+          "code": "var increment = new Command { Label = \"Increment\", Execute = () => setCount(count + 1) };\nButton(increment)   // Label + Execute + IsEnabled all flow from the Command"
+        }
+      ]
+    },
+    {
+      "id": "content-dialog",
+      "name": "ContentDialog",
+      "category": "Dialogs and Flyouts",
+      "description": "A modal dialog box that displays content and action buttons.",
+      "keywords": [
+        "modal",
+        "dialog box",
+        "confirm",
+        "alert",
+        "prompt",
+        "popup window"
+      ],
+      "relatedControls": [
+        "Flyout",
+        "TeachingTip",
+        "Popup"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "content-dialog",
+      "samples": [
+        {
+          "header": "Basic Dialog",
+          "language": "csharp",
+          "code": "Button(\"Show Dialog\", () => setShow(true)),\nContentDialog(\"Welcome\", TextBlock(\"Thank you!\"), \"OK\") with {\n    IsOpen = show,\n    OnClosed = _ => setShow(false),\n}"
+        }
+      ]
+    },
+    {
+      "id": "data-grid",
+      "name": "DataGrid",
+      "category": "Data",
+      "description": "A virtualized data grid with sortable columns, selection, and inline editing.",
+      "keywords": [
+        "table",
+        "spreadsheet",
+        "rows and columns",
+        "sortable",
+        "virtualized grid",
+        "inline edit"
+      ],
+      "relatedControls": [
+        "ListView",
+        "PropertyGrid",
+        "ItemsView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "usings": [
+        "Microsoft.UI.Reactor.Data",
+        "Microsoft.UI.Reactor.Data.Providers",
+        "Microsoft.UI.Reactor.Controls"
+      ],
+      "galleryRoute": "data-grid",
+      "samples": [
+        {
+          "header": "Columns, sorting & selection",
+          "language": "csharp",
+          "code": "// Memoize the source so the grid isn't remounted on every render\n// (DataGrid keys off source.GetHashCode()).\nvar source = UseMemo(() => new ListDataSource<Product>(products, p => (RowKey)p.Id));\n\nDataGrid(\n    source: source,\n    columns: new FieldDescriptor[]\n    {\n        Column<Product>(\"Name\", p => p.Name, displayName: \"Product\", width: 200),\n        Column<Product>(\"Price\", p => p.Price, format: \"C2\", width: 100),\n        Column<Product>(\"InStock\", p => p.InStock, displayName: \"In stock\", width: 90),\n    },\n    selectionMode: SelectionMode.Single,\n    onSelectionChanged: keys => setSelectedCount(keys.Count),\n    rowHeight: 36)\n// Click a header to sort. Columns can be reordered and resized by dragging."
+        }
+      ]
+    },
+    {
+      "id": "date-picker",
+      "name": "DatePicker",
+      "category": "Date and Time",
+      "description": "A control that lets a user pick a date using spinners.",
+      "keywords": [
+        "date input",
+        "spinner",
+        "pick a date",
+        "calendar picker"
+      ],
+      "relatedControls": [
+        "CalendarDatePicker",
+        "TimePicker"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "date-picker",
+      "samples": [
+        {
+          "header": "Basic DatePicker",
+          "language": "csharp",
+          "code": "DatePicker(date, d => setDate(d))"
+        }
+      ]
+    },
+    {
+      "id": "docking",
+      "name": "Docking",
+      "category": "Layout",
+      "description": "Dockable, tearable, and floatable panes with drag-to-rearrange layout.",
+      "keywords": [
+        "dock panes",
+        "tearable",
+        "floating windows",
+        "rearrange layout",
+        "tool windows",
+        "ide layout"
+      ],
+      "relatedControls": [
+        "TabView",
+        "SplitView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "usings": [
+        "Microsoft.UI.Reactor.Docking"
+      ],
+      "galleryRoute": "docking",
+      "samples": [
+        {
+          "header": "Two-pane list / detail",
+          "language": "csharp",
+          "code": "new DockManager\n{\n    Layout = new DockSplit(Orientation.Horizontal,\n    [\n        new DockTabGroup([ new DockableContent(\n            Title: \"Items\", Content: ListBox(Items, selected, setSelected), Key: \"items\", CanClose: true) ], Width: 200),\n        new DockTabGroup([ new DockableContent(\n            Title: \"Detail\", Content: detailView, Key: \"detail\", CanClose: true) ]),\n    ]),\n}.WithKey($\"dock-{layoutKey}\").Height(360)\n// Re-key the DockManager to reset the user's drag-modified layout."
+        }
+      ]
+    },
+    {
+      "id": "drop-down-button",
+      "name": "DropDownButton",
+      "category": "Basic Input",
+      "description": "A button that displays a flyout of choices when clicked.",
+      "keywords": [
+        "dropdown menu",
+        "flyout button",
+        "choices",
+        "split options"
+      ],
+      "relatedControls": [
+        "SplitButton",
+        "MenuFlyout",
+        "Button"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "drop-down-button",
+      "samples": [
+        {
+          "header": "DropDownButton with MenuItems",
+          "language": "csharp",
+          "code": "DropDownButton(\"Choose\", MenuItems(\n    MenuItem(\"Option A\", () => setSelected(\"Option A\")),\n    MenuItem(\"Option B\", () => setSelected(\"Option B\")),\n    MenuItem(\"Option C\", () => setSelected(\"Option C\"))))"
+        }
+      ]
+    },
+    {
+      "id": "expander",
+      "name": "Expander",
+      "category": "Layout",
+      "description": "A container that expands and collapses to show or hide content.",
+      "keywords": [
+        "collapsible",
+        "accordion",
+        "show hide",
+        "disclosure",
+        "fold"
+      ],
+      "relatedControls": [
+        "Card"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "expander",
+      "samples": [
+        {
+          "header": "Direction Control",
+          "language": "csharp",
+          "code": "Expander(\"Header\", content, true)\n    .Direction(ExpandDirection.Up)"
+        }
+      ]
+    },
+    {
+      "id": "flex",
+      "name": "Flex",
+      "category": "Layout",
+      "description": "A flexible layout container inspired by CSS flexbox.",
+      "keywords": [
+        "flexbox",
+        "css layout",
+        "flex row column",
+        "justify align",
+        "wrap",
+        "responsive layout"
+      ],
+      "relatedControls": [
+        "Grid",
+        "StackPanel"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "usings": [
+        "Microsoft.UI.Reactor.Layout"
+      ],
+      "galleryRoute": "flex",
+      "samples": [
+        {
+          "header": "Interactive Flex Container",
+          "language": "csharp",
+          "code": "new FlexElement(children)\n{\n    Direction = FlexDirection.Row,\n    JustifyContent = FlexJustify.SpaceBetween,\n    AlignItems = FlexAlign.Center,\n    Wrap = FlexWrap.Wrap,\n}"
+        }
+      ]
+    },
+    {
+      "id": "flip-view",
+      "name": "FlipView",
+      "category": "Collections",
+      "description": "A control that presents one item at a time with flipping navigation.",
+      "keywords": [
+        "carousel",
+        "image gallery",
+        "swipe pages",
+        "slideshow",
+        "paged view"
+      ],
+      "relatedControls": [
+        "PipsPager",
+        "GridView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "flip-view",
+      "samples": [
+        {
+          "header": "Basic FlipView",
+          "language": "csharp",
+          "code": "FlipView(\n    Border(TextBlock(\"Item 1\")).Background(\"#FF4444\").Size(300, 200),\n    Border(TextBlock(\"Item 2\")).Background(\"#44AA44\").Size(300, 200)\n)"
+        }
+      ]
+    },
+    {
+      "id": "flyout",
+      "name": "Flyout",
+      "category": "Dialogs and Flyouts",
+      "description": "A lightweight popup that shows contextual information.",
+      "keywords": [
+        "popup",
+        "contextual",
+        "attached popup",
+        "lightweight dialog",
+        "callout"
+      ],
+      "relatedControls": [
+        "MenuFlyout",
+        "CommandBarFlyout",
+        "TeachingTip",
+        "Popup"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "flyout",
+      "samples": [
+        {
+          "header": "Basic Flyout",
+          "language": "csharp",
+          "code": "Flyout(\n    Button(\"Show Flyout\"),\n    TextBlock(\"This is flyout content!\").Padding(8))"
+        }
+      ]
+    },
+    {
+      "id": "frame",
+      "name": "Frame",
+      "category": "Navigation",
+      "description": "A container that hosts Page navigation, raising .Navigated / .Navigating / .NavigationFailed.",
+      "keywords": [
+        "page navigation",
+        "navigate",
+        "back forward",
+        "content host",
+        "routing"
+      ],
+      "relatedControls": [
+        "NavigationView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "frame",
+      "samples": [
+        {
+          "header": "Live demo",
+          "language": "csharp",
+          "code": "Frame(target)\n    .Navigating(t => log.Add(\"Navigating \" + t.Name))\n    .Navigated(t => log.Add(\"Navigated \"  + t.Name))\n    .NavigationFailed((t, ex) => log.Add($\"Failed {t.Name}: {ex.Message}\"))"
+        }
+      ]
+    },
+    {
+      "id": "geometry",
+      "name": "Geometry",
+      "category": "Design",
+      "description": "Corner radius resources for consistent rounding on controls and overlays.",
+      "keywords": [
+        "corner radius",
+        "rounding",
+        "shape language",
+        "control radius",
+        "overlay radius"
+      ],
+      "relatedControls": [
+        "Spacing",
+        "Color",
+        "Typography"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "geometry",
+      "samples": [
+        {
+          "header": "Corner Radius Resources",
+          "language": "csharp",
+          "code": "// Resolve at render time\nvar controlRadius = ThemeResource.CornerRadius(\"ControlCornerRadius\");\nvar overlayRadius = ThemeResource.CornerRadius(\"OverlayCornerRadius\");\n\n// Apply to elements\nBorder(content).CornerRadius(controlRadius.TopLeft)\nBorder(dialog).CornerRadius(overlayRadius.TopLeft)"
+        }
+      ]
+    },
+    {
+      "id": "grid",
+      "name": "Grid",
+      "category": "Layout",
+      "description": "A layout panel that arranges children in rows and columns.",
+      "keywords": [
+        "rows and columns",
+        "layout grid",
+        "cells",
+        "table layout",
+        "spanning"
+      ],
+      "relatedControls": [
+        "StackPanel",
+        "RelativePanel",
+        "UniformGrid"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "grid",
+      "samples": [
+        {
+          "header": "Column & Row Spanning",
+          "language": "csharp",
+          "code": "Border(TextBlock(\"Header\")).Grid(row: 0, column: 0, columnSpan: 3)\nBorder(TextBlock(\"Center\")).Grid(row: 1, column: 1, columnSpan: 2)"
+        }
+      ]
+    },
+    {
+      "id": "grid-view",
+      "name": "GridView",
+      "category": "Collections",
+      "description": "A control that displays items in a horizontally wrapping grid.",
+      "keywords": [
+        "tile view",
+        "thumbnail grid",
+        "wrapping items",
+        "gallery",
+        "card grid"
+      ],
+      "relatedControls": [
+        "ListView",
+        "ItemsView",
+        "FlipView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "grid-view",
+      "samples": [
+        {
+          "header": "Basic GridView",
+          "language": "csharp",
+          "code": "GridView(\n    items.Select(i =>\n        Border(TextBlock($\"Item {i}\")).Size(100, 100)\n    ).ToArray()\n).SelectionMode(ListViewSelectionMode.Multiple)"
+        }
+      ]
+    },
+    {
+      "id": "hyperlink-button",
+      "name": "HyperlinkButton",
+      "category": "Basic Input",
+      "description": "A button that appears as a hyperlink and navigates to a URI.",
+      "keywords": [
+        "link",
+        "hyperlink",
+        "navigate url",
+        "web link",
+        "anchor"
+      ],
+      "relatedControls": [
+        "Button"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "hyperlink-button",
+      "samples": [
+        {
+          "header": "Navigate to URI",
+          "language": "csharp",
+          "code": "HyperlinkButton(\"Go to Microsoft\", new Uri(\"https://www.microsoft.com\"))"
+        }
+      ]
+    },
+    {
+      "id": "icons",
+      "name": "Icons",
+      "category": "Media",
+      "description": "Standalone icon elements from Symbol, Font glyph, or Path sources.",
+      "keywords": [
+        "glyph",
+        "symbol icon",
+        "font icon",
+        "path icon",
+        "vector icon"
+      ],
+      "relatedControls": [
+        "AnimatedIcon",
+        "Shapes"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "icons",
+      "samples": [
+        {
+          "header": "Symbol icons",
+          "language": "csharp",
+          "code": "Icon(Symbol.Home)\nIcon(Symbol.Save)\nIcon(Symbol.Delete)\nIcon(Symbol.Setting)"
+        }
+      ]
+    },
+    {
+      "id": "image",
+      "name": "Image",
+      "category": "Media",
+      "description": "A control that displays an image from a file or URI.",
+      "keywords": [
+        "picture",
+        "bitmap",
+        "photo",
+        "img",
+        "asset",
+        "uri source"
+      ],
+      "relatedControls": [
+        "PersonPicture"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "image",
+      "samples": [
+        {
+          "header": "Image from URI",
+          "language": "csharp",
+          "code": "Image(\"ms-appx:///Assets/Square150x150Logo.scale-200.png\")\n    .Width(300).Height(300)"
+        }
+      ]
+    },
+    {
+      "id": "info-badge",
+      "name": "InfoBadge",
+      "category": "Status and Info",
+      "description": "A small indicator that conveys status on another element.",
+      "keywords": [
+        "notification dot",
+        "count badge",
+        "status indicator",
+        "unread count",
+        "dot"
+      ],
+      "relatedControls": [
+        "InfoBar"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "info-badge",
+      "samples": [
+        {
+          "header": "Numeric Badge",
+          "language": "csharp",
+          "code": "InfoBadge(count)  // numeric badge\nInfoBadge(42)"
+        }
+      ]
+    },
+    {
+      "id": "info-bar",
+      "name": "InfoBar",
+      "category": "Status and Info",
+      "description": "A dismissible bar for displaying essential app-level messages.",
+      "keywords": [
+        "notification bar",
+        "banner",
+        "inline message",
+        "alert bar",
+        "status message",
+        "dismissible"
+      ],
+      "relatedControls": [
+        "InfoBadge",
+        "TeachingTip"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "info-bar",
+      "samples": [
+        {
+          "header": "Severity fluents",
+          "language": "csharp",
+          "code": "InfoBar(\"Success\", \"Completed!\").Success().IsClosable(false)\nInfoBar(\"Warning\", \"Review...\").Warning().IsClosable(false)\nInfoBar(\"Error\",   \"Failed!\"  ).Error()  .IsClosable(false)\nInfoBar(\"Info\",    \"FYI…\"     ).Informational().IsClosable(false)"
+        }
+      ]
+    },
+    {
+      "id": "interspersed-grid",
+      "name": "InterspersedGrid",
+      "category": "Layout",
+      "description": "A grid that places proportionally sized panels with separators between them.",
+      "keywords": [
+        "proportional panels",
+        "separators",
+        "weighted layout",
+        "split panels"
+      ],
+      "relatedControls": [
+        "UniformGrid",
+        "Grid"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "interspersed-grid",
+      "samples": [
+        {
+          "header": "Horizontal proportions",
+          "language": "csharp",
+          "code": "InterspersedGrid(\n    Orientation.Horizontal,\n    new Element[] { panelA, panelB, panelC },\n    new[] { 1.0, 2.0, 1.0 },\n    8,\n    i => Border(Empty()).Width(2).Background(Theme.DividerStroke))\n    .Height(160)"
+        }
+      ]
+    },
+    {
+      "id": "items-repeater",
+      "name": "ItemsRepeater",
+      "category": "Collections",
+      "description": "A lightweight, data-driven panel for laying out custom collections.",
+      "keywords": [
+        "virtualized list",
+        "custom layout",
+        "data template",
+        "repeater",
+        "bind collection"
+      ],
+      "relatedControls": [
+        "ItemsView",
+        "ListView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "items-repeater",
+      "samples": [
+        {
+          "header": "Scrollable repeated rows",
+          "language": "csharp",
+          "code": "ScrollView(\n    ItemsRepeater(items, s => s, (s, i) =>\n        Border(TextBlock($\"{i + 1}. {s}\"))\n            .Padding(8)\n            .Margin(0, 0, 0, 4)\n            .Background(Theme.SubtleFill)\n            .CornerRadius(4))\n).Height(260)"
+        }
+      ]
+    },
+    {
+      "id": "items-view",
+      "name": "ItemsView",
+      "category": "Collections",
+      "description": "A flexible control for displaying collections of data items.",
+      "keywords": [
+        "collection view",
+        "selectable items",
+        "data list",
+        "flexible items"
+      ],
+      "relatedControls": [
+        "ListView",
+        "GridView",
+        "ItemsRepeater"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "items-view",
+      "samples": [
+        {
+          "header": "Basic ItemsView",
+          "language": "csharp",
+          "code": "ItemsView(\n    products,\n    p => p.Name,\n    (p, i) => Border(VStack(\n        TextBlock(p.Name).Bold(),\n        TextBlock($\"${p.Price:F2}\")\n    ))\n)"
+        }
+      ]
+    },
+    {
+      "id": "list-box",
+      "name": "ListBox",
+      "category": "Collections",
+      "description": "A list of selectable items presented inline.",
+      "keywords": [
+        "inline list",
+        "selectable list",
+        "options",
+        "multi-select list"
+      ],
+      "relatedControls": [
+        "ComboBox",
+        "ListView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "list-box",
+      "samples": [
+        {
+          "header": "Basic ListBox",
+          "language": "csharp",
+          "code": "var (selected, setSelected) = UseState(0);\nListBox(fruits, selected, setSelected)"
+        }
+      ]
+    },
+    {
+      "id": "list-view",
+      "name": "ListView",
+      "category": "Collections",
+      "description": "A control that displays items in a vertical scrolling list.",
+      "keywords": [
+        "scrolling list",
+        "data list",
+        "rows",
+        "selection",
+        "virtualized list"
+      ],
+      "relatedControls": [
+        "GridView",
+        "ItemsView",
+        "ItemsRepeater",
+        "ListBox"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "list-view",
+      "samples": [
+        {
+          "header": "Data-Driven ListView",
+          "language": "csharp",
+          "code": "ListView(\n    items, s => s,\n    (s, i) => HStack(8,\n        Border(TextBlock($\"{i + 1}\")).Size(28, 28),\n        TextBlock(s)\n    )\n)"
+        }
+      ]
+    },
+    {
+      "id": "map-control",
+      "name": "MapControl",
+      "category": "Media",
+      "description": "Displays an interactive, pannable, zoomable map.",
+      "keywords": [
+        "maps",
+        "geolocation",
+        "pan zoom",
+        "markers",
+        "interactive map"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "map-control",
+      "samples": [
+        {
+          "header": "Interactive map",
+          "language": "csharp",
+          "code": "MapControl(zoomLevel: 4)\n    .Height(320).Width(480)\n// Supply a Bing Maps token to load tiles:\n//   MapControl(mapServiceToken: mapKey, zoomLevel: 12)"
+        }
+      ]
+    },
+    {
+      "id": "markdown",
+      "name": "Markdown",
+      "category": "Text",
+      "description": "Renders a Markdown string as a Reactor element tree.",
+      "keywords": [
+        "md",
+        "rich text render",
+        "commonmark",
+        "formatted text"
+      ],
+      "relatedControls": [
+        "RichTextBlock"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "markdown",
+      "samples": [
+        {
+          "header": "Formatted markdown",
+          "language": "csharp",
+          "code": "var markdown = @\"# Markdown sample\n\nMarkdown renders **bold** text, *italic* text, and `inline code`.\n\n- Create declarative UI\n- Compose reusable components\n- Keep samples readable\";\n\nBorder(Markdown(markdown))\n    .Padding(16)\n    .Background(Theme.SubtleFill)\n    .CornerRadius(8)"
+        }
+      ]
+    },
+    {
+      "id": "media-player-element",
+      "name": "MediaPlayerElement",
+      "category": "Media",
+      "description": "Embeds audio and video playback with built-in transport controls.",
+      "keywords": [
+        "video",
+        "audio",
+        "playback",
+        "transport controls",
+        "player"
+      ],
+      "relatedControls": [
+        "AnimatedVisualPlayer"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "media-player-element",
+      "samples": [
+        {
+          "header": "Video with transport controls",
+          "language": "csharp",
+          "code": "MediaPlayerElement(\"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4\")\n    .Height(280).Width(480)\n// Transport controls are enabled by default; AutoPlay is opt-in:\n//   .Set(mpe => mpe.AutoPlay = true)"
+        }
+      ]
+    },
+    {
+      "id": "menu-bar",
+      "name": "MenuBar",
+      "category": "Menus and Toolbars",
+      "description": "A horizontal bar that hosts a set of drop-down menus.",
+      "keywords": [
+        "menus",
+        "top menu",
+        "file edit view",
+        "application menu",
+        "menu strip"
+      ],
+      "relatedControls": [
+        "CommandBar",
+        "MenuFlyout"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "menu-bar",
+      "samples": [
+        {
+          "header": "File/Edit/View Menus",
+          "language": "csharp",
+          "code": "MenuBar(\n    Menu(\"File\",\n        MenuItem(\"New\", () => {}, icon: \"Page2\"),\n        MenuItem(\"Open\", () => {}, icon: \"OpenFile\"),\n        MenuSeparator(),\n        MenuItem(\"Save\", () => {}, icon: \"Save\")),\n    Menu(\"Edit\",\n        MenuItem(\"Undo\", () => {}, icon: \"Undo\"),\n        MenuItem(\"Cut\", () => {}),\n        MenuItem(\"Copy\", () => {})))"
+        }
+      ]
+    },
+    {
+      "id": "menu-flyout",
+      "name": "MenuFlyout",
+      "category": "Dialogs and Flyouts",
+      "description": "A flyout that displays a list of menu commands.",
+      "keywords": [
+        "context menu",
+        "right click menu",
+        "dropdown menu",
+        "command list"
+      ],
+      "relatedControls": [
+        "Flyout",
+        "CommandBarFlyout",
+        "MenuBar"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "menu-flyout",
+      "samples": [
+        {
+          "header": "Basic MenuFlyout",
+          "language": "csharp",
+          "code": "MenuFlyout(\n    Button(\"Open Menu\"),\n    MenuItem(\"Cut\", () => {}, icon: \"Cut\"),\n    MenuItem(\"Copy\", () => {}, icon: \"Copy\"),\n    MenuItem(\"Paste\", () => {}, icon: \"Paste\"))"
+        }
+      ]
+    },
+    {
+      "id": "navigation-view",
+      "name": "NavigationView",
+      "category": "Navigation",
+      "description": "A side or top navigation pane for app-level navigation.",
+      "keywords": [
+        "side navigation",
+        "hamburger menu",
+        "app shell",
+        "nav pane",
+        "left nav"
+      ],
+      "relatedControls": [
+        "BreadcrumbBar",
+        "TabView",
+        "Pivot",
+        "SplitView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "navigation-view",
+      "samples": [
+        {
+          "header": "Left-Pane NavigationView",
+          "language": "csharp",
+          "code": "NavigationView(items, content: TextBlock(\"Selected: ...\"))\nwith {\n    SelectedTag = tag,\n    OnSelectedTagChanged = t => setTag(t),\n    PaneTitle = \"Nav Demo\",\n}"
+        }
+      ]
+    },
+    {
+      "id": "number-box",
+      "name": "NumberBox",
+      "category": "Basic Input",
+      "description": "A text control for entering numeric values with validation.",
+      "keywords": [
+        "numeric input",
+        "spinner",
+        "stepper",
+        "number field",
+        "increment decrement"
+      ],
+      "relatedControls": [
+        "Slider",
+        "TextBox"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "number-box",
+      "samples": [
+        {
+          "header": "Basic NumberBox",
+          "language": "csharp",
+          "code": "NumberBox(value, v => setValue(v), \"Enter a number\")"
+        }
+      ]
+    },
+    {
+      "id": "parallax-view",
+      "name": "ParallaxView",
+      "category": "Media",
+      "description": "Shifts a background layer as content scrolls for a depth effect.",
+      "keywords": [
+        "parallax",
+        "depth scroll",
+        "background shift",
+        "scrolling effect"
+      ],
+      "relatedControls": [
+        "ScrollView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "parallax-view",
+      "samples": [
+        {
+          "header": "Background parallax behind a scrolling list",
+          "language": "csharp",
+          "code": "var (scroller, setScroller) = UseState<UIElement?>(null);\n\n// `background` must be TALLER than the viewport and have visible vertical\n// structure (bands/image) — a solid colour has nothing to visibly shift.\nvar parallax = ParallaxView(background, verticalShift: 150);\nif (scroller is not null) parallax = parallax.Source(scroller);\n\nGrid(columns: [GridSize.Star()], rows: [GridSize.Star()],\n    parallax.Grid(row: 0, column: 0),\n    ListView(rows)\n        .Set(lv => lv.Background = null)          // transparent → background shows through\n        .OnMount(el => setScroller((UIElement)el)) // bind the scroller\n        .Grid(row: 0, column: 0))"
+        }
+      ]
+    },
+    {
+      "id": "password-box",
+      "name": "PasswordBox",
+      "category": "Basic Input",
+      "description": "A text input that conceals typed characters for secure entry.",
+      "keywords": [
+        "password",
+        "secure input",
+        "masked text",
+        "credentials",
+        "hidden characters"
+      ],
+      "relatedControls": [
+        "TextBox"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "password-box",
+      "samples": [
+        {
+          "header": "Basic PasswordBox",
+          "language": "csharp",
+          "code": "PasswordBox(password, p => setPassword(p), \"Enter password\")"
+        }
+      ]
+    },
+    {
+      "id": "person-picture",
+      "name": "PersonPicture",
+      "category": "Media",
+      "description": "A control that displays a circular avatar for a person.",
+      "keywords": [
+        "avatar",
+        "profile picture",
+        "contact photo",
+        "initials",
+        "user image"
+      ],
+      "relatedControls": [
+        "Image"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "person-picture",
+      "samples": [
+        {
+          "header": "Display Name",
+          "language": "csharp",
+          "code": "PersonPicture().DisplayName(\"Jane Doe\").Width(64).Height(64)"
+        }
+      ]
+    },
+    {
+      "id": "pips-pager",
+      "name": "PipsPager",
+      "category": "Navigation",
+      "description": "A pager that represents pages as a row of selectable dots.",
+      "keywords": [
+        "dots pager",
+        "page dots",
+        "carousel indicator",
+        "pagination dots"
+      ],
+      "relatedControls": [
+        "FlipView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "pips-pager",
+      "samples": [
+        {
+          "header": "Five-page pager",
+          "language": "csharp",
+          "code": "PipsPager(5, pageIndex, index => setPageIndex(index))\nTextBlock($\"Page {pageIndex + 1} of 5\")\nBorder(TextBlock(pageMessages.ElementAt(pageIndex)).Center())"
+        }
+      ]
+    },
+    {
+      "id": "pivot",
+      "name": "Pivot",
+      "category": "Navigation",
+      "description": "A tabbed interface for switching between content sections.",
+      "keywords": [
+        "tabs",
+        "tabbed view",
+        "sections",
+        "swipe tabs",
+        "headers"
+      ],
+      "relatedControls": [
+        "TabView",
+        "SelectorBar"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "pivot",
+      "samples": [
+        {
+          "header": "Basic Pivot",
+          "language": "csharp",
+          "code": "Pivot(\n    PivotItem(\"All\", TextBlock(\"All items\")),\n    PivotItem(\"Recent\", TextBlock(\"Recent items\")),\n    PivotItem(\"Favorites\", TextBlock(\"Favorite items\")))"
+        }
+      ]
+    },
+    {
+      "id": "popup",
+      "name": "Popup",
+      "category": "Dialogs and Flyouts",
+      "description": "A lightweight overlay that displays arbitrary content over the UI.",
+      "keywords": [
+        "overlay",
+        "floating content",
+        "custom popup",
+        "light-dismiss",
+        "layer"
+      ],
+      "relatedControls": [
+        "Flyout",
+        "ContentDialog"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "popup",
+      "samples": [
+        {
+          "header": "Light-dismiss popup",
+          "language": "csharp",
+          "code": "Button(\"Show popup\", () => setOpen(true))\n\nPopup(\n    Border(VStack(8,\n        TextBlock(\"Hello from a Popup\").SemiBold(),\n        Button(\"Close\", () => setOpen(false))))\n        .Padding(16)\n        .Background(Theme.CardBackground)\n        .WithBorder(Theme.DividerStroke)\n        .CornerRadius(8),\n    open,\n    () => setOpen(false))\n    .IsLightDismissEnabled()"
+        }
+      ]
+    },
+    {
+      "id": "progress-bar",
+      "name": "ProgressBar",
+      "category": "Status and Info",
+      "description": "A horizontal bar that shows progress of an operation.",
+      "keywords": [
+        "loading bar",
+        "progress indicator",
+        "percent complete",
+        "determinate",
+        "linear progress"
+      ],
+      "relatedControls": [
+        "ProgressRing"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "progress-bar",
+      "samples": [
+        {
+          "header": "Determinate ProgressBar",
+          "language": "csharp",
+          "code": "Progress(value).Width(300)"
+        }
+      ]
+    },
+    {
+      "id": "progress-ring",
+      "name": "ProgressRing",
+      "category": "Status and Info",
+      "description": "A circular indicator that shows ongoing progress.",
+      "keywords": [
+        "spinner",
+        "loading spinner",
+        "busy indicator",
+        "circular progress",
+        "activity"
+      ],
+      "relatedControls": [
+        "ProgressBar"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "progress-ring",
+      "samples": [
+        {
+          "header": "Determinate ProgressRing",
+          "language": "csharp",
+          "code": "ProgressRing(value).Width(60).Height(60)"
+        }
+      ]
+    },
+    {
+      "id": "property-grid",
+      "name": "PropertyGrid",
+      "category": "Data",
+      "description": "A reflection-driven editor for an object's properties.",
+      "keywords": [
+        "property editor",
+        "inspector",
+        "reflection editor",
+        "settings editor",
+        "object properties"
+      ],
+      "relatedControls": [
+        "DataGrid"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "usings": [
+        "Microsoft.UI.Reactor.Controls",
+        "System.ComponentModel"
+      ],
+      "galleryRoute": "property-grid",
+      "samples": [
+        {
+          "header": "Reflection-based editor",
+          "language": "csharp",
+          "code": "class Settings : INotifyPropertyChanged\n{\n    [PropertyCategory(\"Appearance\")] public string Name { get; set; }\n    [PropertyCategory(\"Transform\")] [PropertyDisplayName(\"X Position\")] public double X { get; set; }\n    [PropertyReadOnly] public string Id { get; }\n}\n\nvar settings = UseRef(new Settings());\nUseObservable(settings.Current);              // re-render on INPC changes\nvar registry = UseMemo(() => new TypeRegistry());\nPropertyGrid(settings.Current, registry)"
+        }
+      ]
+    },
+    {
+      "id": "radio-button",
+      "name": "RadioButton",
+      "category": "Basic Input",
+      "description": "A button that allows a user to select one option from a group.",
+      "keywords": [
+        "single choice",
+        "option",
+        "radio",
+        "exclusive select",
+        "one of"
+      ],
+      "relatedControls": [
+        "RadioButtons",
+        "CheckBox"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "radio-button",
+      "samples": [
+        {
+          "header": "RadioButtons Group",
+          "language": "csharp",
+          "code": "RadioButtons(options, groupIndex, i => setGroupIndex(i))"
+        }
+      ]
+    },
+    {
+      "id": "radio-buttons",
+      "name": "RadioButtons",
+      "category": "Basic Input",
+      "description": "A group of radio buttons where a user selects a single option.",
+      "keywords": [
+        "radio group",
+        "single choice group",
+        "option list",
+        "exclusive options"
+      ],
+      "relatedControls": [
+        "RadioButton"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "radio-buttons",
+      "samples": [
+        {
+          "header": "Choose a size",
+          "language": "csharp",
+          "code": "var sizes = new[] { \"Small\", \"Medium\", \"Large\" };\n\nRadioButtons(sizes, sizeIndex, index => setSizeIndex(index))\nTextBlock($\"Selected size: {sizes.ElementAt(sizeIndex)}\")"
+        }
+      ]
+    },
+    {
+      "id": "rating-control",
+      "name": "RatingControl",
+      "category": "Basic Input",
+      "description": "A control that lets users provide a star rating.",
+      "keywords": [
+        "star rating",
+        "rate",
+        "review stars",
+        "score",
+        "five stars"
+      ],
+      "relatedControls": [
+        "Slider"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "rating-control",
+      "samples": [
+        {
+          "header": "Basic RatingControl",
+          "language": "csharp",
+          "code": "RatingControl(rating, v => setRating(v))"
+        }
+      ]
+    },
+    {
+      "id": "refresh-container",
+      "name": "RefreshContainer",
+      "category": "Collections",
+      "description": "A pull-to-refresh container for scrollable content.",
+      "keywords": [
+        "pull to refresh",
+        "swipe refresh",
+        "reload",
+        "pull down"
+      ],
+      "relatedControls": [
+        "ScrollView",
+        "ListView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "refresh-container",
+      "samples": [
+        {
+          "header": "Pull to refresh list",
+          "language": "csharp",
+          "code": "var (items, setItems) = UseState(initialItems);\n\nRefreshContainer(\n    ListView(items.Select(i => (Element)TextBlock(i).Padding(8)).ToArray())\n        .Height(240),\n    () => setItems(new[] { $\"Refreshed {DateTime.Now:T}\" }\n        .Concat(items)\n        .ToList()))"
+        }
+      ]
+    },
+    {
+      "id": "relative-panel",
+      "name": "RelativePanel",
+      "category": "Layout",
+      "description": "A panel that positions children relative to each other.",
+      "keywords": [
+        "relative layout",
+        "align relative",
+        "constraints",
+        "anchor elements"
+      ],
+      "relatedControls": [
+        "Grid",
+        "Canvas"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "relative-panel",
+      "samples": [
+        {
+          "header": "Basic RelativePanel",
+          "language": "csharp",
+          "code": "RelativePanel(\n    Border(\"Top-Left\").RelativePanel(name: \"topLeft\",\n        alignLeftWithPanel: true, alignTopWithPanel: true),\n    Border(\"Right\").RelativePanel(name: \"r\", rightOf: \"topLeft\")\n)"
+        }
+      ]
+    },
+    {
+      "id": "repeat-button",
+      "name": "RepeatButton",
+      "category": "Basic Input",
+      "description": "A button that raises click events repeatedly while pressed.",
+      "keywords": [
+        "press and hold",
+        "auto repeat",
+        "hold to increment",
+        "continuous click"
+      ],
+      "relatedControls": [
+        "Button"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "repeat-button",
+      "samples": [
+        {
+          "header": "Incrementing Counter",
+          "language": "csharp",
+          "code": "HStack(8,\n    RepeatButton(\"-\", () => setCount(count - 1)),\n    TextBlock($\"{count}\"),\n    RepeatButton(\"+\", () => setCount(count + 1)))"
+        }
+      ]
+    },
+    {
+      "id": "rich-edit-box",
+      "name": "RichEditBox",
+      "category": "Text",
+      "description": "A rich text editing control with formatting support.",
+      "keywords": [
+        "rich text editor",
+        "formatting",
+        "rtf",
+        "bold italic",
+        "word processor"
+      ],
+      "relatedControls": [
+        "TextBox",
+        "RichTextBlock"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "rich-edit-box",
+      "samples": [
+        {
+          "header": "Basic RichEditBox",
+          "language": "csharp",
+          "code": "var (text, setText) = UseState(\"Type here...\");\nRichEditBox(text, setText).Width(400).Height(150)"
+        }
+      ]
+    },
+    {
+      "id": "rich-text-block",
+      "name": "RichTextBlock",
+      "category": "Text",
+      "description": "A control that displays formatted read-only rich text.",
+      "keywords": [
+        "formatted text",
+        "read-only rich text",
+        "runs",
+        "inline formatting",
+        "styled text"
+      ],
+      "relatedControls": [
+        "RichEditBox",
+        "Markdown"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "rich-text-block",
+      "samples": [
+        {
+          "header": "Basic RichTextBlock",
+          "language": "csharp",
+          "code": "RichTextBlock(\"This is a simple rich text block...\")"
+        }
+      ]
+    },
+    {
+      "id": "scroll-view",
+      "name": "ScrollView",
+      "category": "Layout",
+      "description": "A scrollable container for content that exceeds available space.",
+      "keywords": [
+        "scrollable",
+        "scroll container",
+        "overflow",
+        "pan zoom",
+        "viewport"
+      ],
+      "relatedControls": [
+        "RefreshContainer",
+        "AnnotatedScrollBar"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "scroll-view",
+      "samples": [
+        {
+          "header": "Vertical ScrollView (modern)",
+          "language": "csharp",
+          "code": "ScrollView(\n    VStack(4, items.Select(i =>\n        Border(TextBlock($\"Item {i}\")).Padding(8)\n    ).ToArray())\n)"
+        }
+      ]
+    },
+    {
+      "id": "selector-bar",
+      "name": "SelectorBar",
+      "category": "Menus and Toolbars",
+      "description": "A bar that lets users switch between different views or modes.",
+      "keywords": [
+        "segmented control",
+        "view switcher",
+        "mode toggle",
+        "tab bar",
+        "filter chips"
+      ],
+      "relatedControls": [
+        "Pivot",
+        "TabView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "selector-bar",
+      "samples": [
+        {
+          "header": "Basic SelectorBar",
+          "language": "csharp",
+          "code": "SelectorBar(\n    new[] {\n        SelectorBarItem(\"Recent\", icon: \"Clock\"),\n        SelectorBarItem(\"Shared\", icon: \"People\"),\n        SelectorBarItem(\"Favorites\", icon: \"Favorite\"),\n    },\n    selectedIndex: idx,\n    onSelectedIndexChanged: i => setIdx(i))"
+        }
+      ]
+    },
+    {
+      "id": "semantic-zoom",
+      "name": "SemanticZoom",
+      "category": "Collections",
+      "description": "A control that switches between a zoomed-in and zoomed-out view of data.",
+      "keywords": [
+        "zoom in out",
+        "grouped view",
+        "jump list",
+        "overview detail",
+        "pinch zoom"
+      ],
+      "relatedControls": [
+        "GridView",
+        "ListView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "semantic-zoom",
+      "samples": [
+        {
+          "header": "Grid and group views",
+          "language": "csharp",
+          "code": "SemanticZoom(\n    GridView(items.Select(item =>\n        Border(TextBlock(item).Center()).Padding(12)).ToArray()),\n    ListView(groups.Select(group =>\n        Border(TextBlock(group).SemiBold()).Padding(12)).ToArray())\n).Height(300)"
+        }
+      ]
+    },
+    {
+      "id": "shapes",
+      "name": "Shapes",
+      "category": "Media",
+      "description": "Rectangle, Ellipse, Line, and Path vector primitives.",
+      "keywords": [
+        "rectangle ellipse line path",
+        "vector shapes",
+        "drawing",
+        "primitives",
+        "geometry shapes"
+      ],
+      "relatedControls": [
+        "Icons"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "shapes",
+      "samples": [
+        {
+          "header": "Filled shapes",
+          "language": "csharp",
+          "code": "Rectangle().Width(80).Height(56).Fill(accentBrush)\nEllipse().Width(72).Height(56).Fill(purpleBrush)\nRectangle().Width(80).Height(56).Fill(greenBrush)\n    .Set(r => { r.RadiusX = 14; r.RadiusY = 14; })   // shapes round via RadiusX/Y, not .CornerRadius"
+        }
+      ]
+    },
+    {
+      "id": "slider",
+      "name": "Slider",
+      "category": "Basic Input",
+      "description": "A control that lets the user select from a range of values by moving a thumb.",
+      "keywords": [
+        "range",
+        "drag thumb",
+        "volume",
+        "seek",
+        "value picker"
+      ],
+      "relatedControls": [
+        "NumberBox",
+        "RatingControl"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "slider",
+      "samples": [
+        {
+          "header": "Basic Slider",
+          "language": "csharp",
+          "code": "Slider(value, 0, 100, v => setValue(v)).Header(\"Volume\")"
+        }
+      ]
+    },
+    {
+      "id": "spacing",
+      "name": "Spacing",
+      "category": "Design",
+      "description": "Margin, padding, and stack spacing for consistent layout rhythm.",
+      "keywords": [
+        "margin padding",
+        "gaps",
+        "layout rhythm",
+        "whitespace",
+        "4px grid"
+      ],
+      "relatedControls": [
+        "Geometry",
+        "Typography"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "spacing",
+      "samples": [
+        {
+          "header": "Margin vs Padding",
+          "language": "csharp",
+          "code": "// Margin — works on ALL elements\nTextBlock(\"Hello\").Margin(8)\nVStack(children).Margin(16)\nBorder(child).Margin(12)\n\n// Padding — only on Border and Control (Button, TextBox, etc.)\nBorder(child).Padding(16)    // ✓ works\nButton(\"Go\").Padding(12)    // ✓ works\n\n// VStack/HStack don't support Padding — wrap in Border instead:\nBorder(\n    VStack(8, items)\n).Padding(16)  // ✓ padding applied to the Border"
+        }
+      ]
+    },
+    {
+      "id": "split-button",
+      "name": "SplitButton",
+      "category": "Basic Input",
+      "description": "A button with two parts: a primary action and a flyout menu.",
+      "keywords": [
+        "primary plus menu",
+        "action with options",
+        "dropdown action",
+        "default action"
+      ],
+      "relatedControls": [
+        "DropDownButton",
+        "ToggleSplitButton",
+        "Button"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "split-button",
+      "samples": [
+        {
+          "header": "Basic SplitButton",
+          "language": "csharp",
+          "code": "SplitButton(\"Send\", () => setLastAction(\"Send clicked\"), MenuItems(\n    MenuItem(\"Send now\", () => setLastAction(\"Send now\")),\n    MenuItem(\"Schedule\", () => setLastAction(\"Schedule\"))))"
+        }
+      ]
+    },
+    {
+      "id": "split-view",
+      "name": "SplitView",
+      "category": "Layout",
+      "description": "A container with a collapsible pane and a content area.",
+      "keywords": [
+        "pane",
+        "master detail",
+        "collapsible sidebar",
+        "navigation pane",
+        "drawer"
+      ],
+      "relatedControls": [
+        "NavigationView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "split-view",
+      "samples": [
+        {
+          "header": "Collapsible pane + content",
+          "language": "csharp",
+          "code": "SplitView(\n    pane: VStack(8,\n        TextBlock(\"Pane\").Bold(),\n        TextBlock(\"Item 1\"),\n        TextBlock(\"Item 2\")\n    ).Padding(12),\n    content: VStack(8,\n        Button(isOpen ? \"Close Pane\" : \"Open Pane\", () => setIsOpen(!isOpen)),\n        TextBlock(\"Main content area\")\n    ).Padding(12)\n) with { IsPaneOpen = isOpen }\n.Set(sv => sv.DisplayMode = SplitViewDisplayMode.Inline)"
+        }
+      ]
+    },
+    {
+      "id": "stack-panel",
+      "name": "StackPanel",
+      "category": "Layout",
+      "description": "A panel that arranges children in a single horizontal or vertical line.",
+      "keywords": [
+        "vertical stack",
+        "horizontal stack",
+        "vstack hstack",
+        "linear layout",
+        "stack children"
+      ],
+      "relatedControls": [
+        "Grid",
+        "Flex"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "stack-panel",
+      "samples": [
+        {
+          "header": "VStack (Vertical)",
+          "language": "csharp",
+          "code": "VStack(8,\n    Box(\"A\"), Box(\"B\"), Box(\"C\"), Box(\"D\")\n)"
+        }
+      ]
+    },
+    {
+      "id": "swipe-control",
+      "name": "SwipeControl",
+      "category": "Collections",
+      "description": "A container that reveals swipe commands on its content.",
+      "keywords": [
+        "swipe actions",
+        "swipe to delete",
+        "reveal commands",
+        "gesture actions"
+      ],
+      "relatedControls": [
+        "ListView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "swipe-control",
+      "samples": [
+        {
+          "header": "Left and right actions",
+          "language": "csharp",
+          "code": "SwipeControl(\n    Border(TextBlock(\"Swipe me left or right\"))\n        .Padding(16)\n        .Background(Theme.CardBackground),\n    leftItems: new[] { new SwipeItemData(\"Archive\", () => { }) },\n    rightItems: new[] { new SwipeItemData(\"Delete\", () => { }) })"
+        }
+      ]
+    },
+    {
+      "id": "tab-view",
+      "name": "TabView",
+      "category": "Navigation",
+      "description": "A control that displays a set of closable, rearrangeable tabs.",
+      "keywords": [
+        "tabs",
+        "closable tabs",
+        "browser tabs",
+        "reorderable tabs",
+        "document tabs"
+      ],
+      "relatedControls": [
+        "Pivot",
+        "SelectorBar"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "tab-view",
+      "samples": [
+        {
+          "header": "Basic TabView",
+          "language": "csharp",
+          "code": "TabView(\n    Tab(\"Home\", TextBlock(\"Home content\")),\n    Tab(\"Document\", TextBlock(\"Document content\")),\n    Tab(\"Settings\", TextBlock(\"Settings content\"))\n) with { SelectedIndex = idx, OnSelectedIndexChanged = i => setIdx(i) }"
+        }
+      ]
+    },
+    {
+      "id": "teaching-tip",
+      "name": "TeachingTip",
+      "category": "Dialogs and Flyouts",
+      "description": "A notification flyout for guiding users through features.",
+      "keywords": [
+        "coach mark",
+        "callout",
+        "feature highlight",
+        "onboarding",
+        "tip popup"
+      ],
+      "relatedControls": [
+        "Flyout",
+        "InfoBar",
+        "ToolTip"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "teaching-tip",
+      "samples": [
+        {
+          "header": "Basic TeachingTip",
+          "language": "csharp",
+          "code": "Button(\"Show Tip\", () => setShow(true)),\nTeachingTip(\"Welcome!\", \"Helpful guidance text.\") with {\n    IsOpen = show,\n    OnClosed = () => setShow(false),\n}"
+        }
+      ]
+    },
+    {
+      "id": "text-box",
+      "name": "TextBox",
+      "category": "Basic Input",
+      "description": "A single-line or multi-line plain text input field.",
+      "keywords": [
+        "text input",
+        "textfield",
+        "single line",
+        "multiline",
+        "form field"
+      ],
+      "relatedControls": [
+        "RichEditBox",
+        "AutoSuggestBox",
+        "PasswordBox",
+        "NumberBox"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "text-box",
+      "samples": [
+        {
+          "header": "Basic TextBox",
+          "language": "csharp",
+          "code": "TextBox(text, v => setText(v), \"Type here...\")"
+        }
+      ]
+    },
+    {
+      "id": "theming",
+      "name": "Theming",
+      "category": "Design",
+      "description": "Guidance on applying light, dark, and high-contrast themes.",
+      "keywords": [
+        "light dark",
+        "dark mode",
+        "high contrast",
+        "theme switch",
+        "requested theme"
+      ],
+      "relatedControls": [
+        "Color",
+        "Acrylic"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "theming",
+      "samples": [
+        {
+          "header": "Light / Dark Toggle",
+          "language": "csharp",
+          "code": "var (isDark, setIsDark) = UseState(false);\nBorder(content)\n    .Set(b => b.RequestedTheme = isDark\n        ? ElementTheme.Dark : ElementTheme.Light)\n    .Background(Theme.SolidBackground)"
+        }
+      ]
+    },
+    {
+      "id": "time-picker",
+      "name": "TimePicker",
+      "category": "Date and Time",
+      "description": "A control that lets a user pick a time using spinners.",
+      "keywords": [
+        "time input",
+        "pick a time",
+        "clock spinner",
+        "hour minute"
+      ],
+      "relatedControls": [
+        "DatePicker"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "time-picker",
+      "samples": [
+        {
+          "header": "Basic TimePicker",
+          "language": "csharp",
+          "code": "TimePicker(time, t => setTime(t))"
+        }
+      ]
+    },
+    {
+      "id": "title-bar",
+      "name": "TitleBar",
+      "category": "Navigation",
+      "description": "A customizable title bar for the application window.",
+      "keywords": [
+        "window title",
+        "caption bar",
+        "custom titlebar",
+        "window chrome",
+        "draggable region"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "title-bar",
+      "samples": [
+        {
+          "header": "Basic TitleBar",
+          "language": "csharp",
+          "code": "TitleBar(\"My Application\")"
+        }
+      ]
+    },
+    {
+      "id": "toggle-button",
+      "name": "ToggleButton",
+      "category": "Basic Input",
+      "description": "A button that can be toggled between two states.",
+      "keywords": [
+        "press state",
+        "on off button",
+        "sticky button",
+        "toggle",
+        "pressed"
+      ],
+      "relatedControls": [
+        "ToggleSwitch",
+        "ToggleSplitButton",
+        "Button"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "toggle-button",
+      "samples": [
+        {
+          "header": "Basic ToggleButton",
+          "language": "csharp",
+          "code": "ToggleButton(\"Mute\", isChecked, v => setIsChecked(v))"
+        }
+      ]
+    },
+    {
+      "id": "toggle-split-button",
+      "name": "ToggleSplitButton",
+      "category": "Basic Input",
+      "description": "A split button whose primary part toggles on and off.",
+      "keywords": [
+        "toggle with menu",
+        "on off plus options",
+        "split toggle"
+      ],
+      "relatedControls": [
+        "SplitButton",
+        "ToggleButton"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "toggle-split-button",
+      "samples": [
+        {
+          "header": "Bullets toggle",
+          "language": "csharp",
+          "code": "ToggleSplitButton(\"Bullets\", bulletsOn, value => setBulletsOn(value))\n\nTextBlock(bulletsOn ? \"Bullets are on\" : \"Bullets are off\")"
+        }
+      ]
+    },
+    {
+      "id": "toggle-switch",
+      "name": "ToggleSwitch",
+      "category": "Basic Input",
+      "description": "A switch that toggles between two mutually exclusive states.",
+      "keywords": [
+        "switch",
+        "on off",
+        "boolean",
+        "enable disable"
+      ],
+      "relatedControls": [
+        "CheckBox",
+        "ToggleButton"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "toggle-switch",
+      "samples": [
+        {
+          "header": "Basic ToggleSwitch",
+          "language": "csharp",
+          "code": "ToggleSwitch(isOn, v => setIsOn(v))"
+        }
+      ]
+    },
+    {
+      "id": "tool-tip",
+      "name": "ToolTip",
+      "category": "Status and Info",
+      "description": "A popup that displays helpful text when hovering over an element.",
+      "keywords": [
+        "hover hint",
+        "hover text",
+        "help popup",
+        "hint"
+      ],
+      "relatedControls": [
+        "TeachingTip",
+        "Flyout"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "tool-tip",
+      "samples": [
+        {
+          "header": "Text ToolTip",
+          "language": "csharp",
+          "code": "Button(\"Hover Me\").ToolTip(\"This is a simple tooltip\")\nButton(\"Save\").ToolTip(\"Save document (Ctrl+S)\")"
+        }
+      ]
+    },
+    {
+      "id": "tree-view",
+      "name": "TreeView",
+      "category": "Collections",
+      "description": "A hierarchical list with expanding and collapsing nodes.",
+      "keywords": [
+        "tree",
+        "hierarchy",
+        "expandable nodes",
+        "folder tree",
+        "nested list"
+      ],
+      "relatedControls": [
+        "ListView"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "tree-view",
+      "samples": [
+        {
+          "header": "Deeply Nested TreeView",
+          "language": "csharp",
+          "code": "TreeView(\n    TreeNode(\"Root\",\n        TreeNode(\"Level 1A\",\n            TreeNode(\"Level 2A\",\n                TreeNode(\"Level 3A\"))))\n)"
+        }
+      ]
+    },
+    {
+      "id": "type-ramp",
+      "name": "Type ramp",
+      "category": "Text",
+      "description": "WinUI 3 type ramp factories — Title, Subtitle, Body, BodyStrong, BodyLarge.",
+      "keywords": [
+        "text styles",
+        "font sizes",
+        "title subtitle body",
+        "heading",
+        "typography ramp"
+      ],
+      "relatedControls": [
+        "Typography",
+        "RichTextBlock"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "type-ramp",
+      "samples": [
+        {
+          "header": "Type ramp factories — Title / Subtitle / Body",
+          "language": "csharp",
+          "code": "Title(\"Title — 28px Semibold\")\nSubtitle(\"Subtitle — 20px Semibold\")\nBodyLarge(\"BodyLarge — 18px regular\")\nBodyStrong(\"BodyStrong — 14px Semibold\")\nBody(\"Body — 14px regular body text\")"
+        }
+      ]
+    },
+    {
+      "id": "typography",
+      "name": "Typography",
+      "category": "Design",
+      "description": "Guidance on typographic styles, font ramps, and text hierarchy.",
+      "keywords": [
+        "text styles",
+        "font hierarchy",
+        "headings",
+        "type scale",
+        "text ramp"
+      ],
+      "relatedControls": [
+        "Type ramp",
+        "Spacing",
+        "Color"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "typography",
+      "samples": [
+        {
+          "header": "Text Hierarchy Helpers",
+          "language": "csharp",
+          "code": "Heading(\"Heading\")       // 28px Bold\nSubHeading(\"SubHeading\") // 20px SemiBold\nTextBlock(\"Body Text\")        // 14px Normal\nCaption(\"Caption\")       // 12px Normal"
+        }
+      ]
+    },
+    {
+      "id": "uniform-grid",
+      "name": "UniformGrid",
+      "category": "Layout",
+      "description": "A panel that arranges children in evenly sized cells.",
+      "keywords": [
+        "equal cells",
+        "grid of equal size",
+        "tiles",
+        "matrix layout"
+      ],
+      "relatedControls": [
+        "WrapGrid",
+        "Grid"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "uniform-grid",
+      "samples": [
+        {
+          "header": "Horizontal fill",
+          "language": "csharp",
+          "code": "UniformGrid(\n    Orientation.Horizontal,\n    Enumerable.Range(1, 9).Select(i =>\n        Border(TextBlock($\"{i}\").Center().Foreground(\"#FFFFFF\"))\n            .Background(Theme.Accent)\n            .Size(60, 60)\n            .Margin(4)\n            .CornerRadius(4)).ToArray())"
+        }
+      ]
+    },
+    {
+      "id": "viewbox",
+      "name": "Viewbox",
+      "category": "Layout",
+      "description": "A container that scales its child to fill available space.",
+      "keywords": [
+        "scale to fit",
+        "stretch content",
+        "zoom fit",
+        "proportional scaling"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "viewbox",
+      "samples": [
+        {
+          "header": "Scaling Content",
+          "language": "csharp",
+          "code": "Viewbox(\n    VStack(4, TextBlock(\"Hello\").Bold(), TextBlock(\"Scaled\"))\n)"
+        }
+      ]
+    },
+    {
+      "id": "web-view-2",
+      "name": "WebView2",
+      "category": "Media",
+      "description": "A control that hosts web content using the Edge rendering engine.",
+      "keywords": [
+        "web view",
+        "embedded browser",
+        "html content",
+        "edge webview",
+        "browser control"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "web-view-2",
+      "samples": [
+        {
+          "header": "Load URL",
+          "language": "csharp",
+          "code": "WebView2(new Uri(\"https://learn.microsoft.com\"))\n    .Width(600).Height(400)"
+        }
+      ]
+    },
+    {
+      "id": "wrap-grid",
+      "name": "WrapGrid",
+      "category": "Layout",
+      "description": "A grid that wraps items to the next row or column automatically.",
+      "keywords": [
+        "wrapping layout",
+        "flow layout",
+        "wrap items",
+        "tag cloud",
+        "reflow"
+      ],
+      "relatedControls": [
+        "UniformGrid",
+        "Grid"
+      ],
+      "apiNamespace": "Microsoft.UI.Reactor",
+      "nugetPackage": "Microsoft.UI.Reactor",
+      "galleryRoute": "wrap-grid",
+      "samples": [
+        {
+          "header": "Basic WrapGrid",
+          "language": "csharp",
+          "code": "WrapGrid(\n    items.Select(i =>\n        Border(TextBlock($\"{i}\")).Size(70, 70).Margin(4)\n    ).ToArray()\n)"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/ReactorGallery/reactor-search-index.json
+++ b/samples/ReactorGallery/reactor-search-index.json
@@ -331,8 +331,10 @@
         "tick",
         "boolean",
         "multi-select",
+        "select",
         "opt in",
-        "tri-state"
+        "tri-state",
+        "state"
       ],
       "relatedControls": [
         "RadioButton",
@@ -1104,6 +1106,7 @@
       "keywords": [
         "inline list",
         "selectable list",
+        "select",
         "options",
         "multi-select list"
       ],
@@ -1474,6 +1477,7 @@
         "floating content",
         "custom popup",
         "light-dismiss",
+        "dismiss",
         "layer"
       ],
       "relatedControls": [

--- a/tests/Reactor.Tests/Reactor.Tests.csproj
+++ b/tests/Reactor.Tests/Reactor.Tests.csproj
@@ -62,6 +62,7 @@
     <ProjectReference Include="..\..\samples\apps\minesweeper\Minesweeper.csproj" />
     <ProjectReference Include="..\..\tools\Reactor.MurCheckGuardrail\Reactor.MurCheckGuardrail.csproj" />
     <ProjectReference Include="..\..\tools\Reactor.ApiIndex\Reactor.ApiIndex.csproj" />
+    <ProjectReference Include="..\..\tools\Reactor.SearchIndex\Reactor.SearchIndex.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
@@ -1,0 +1,308 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.UI.Reactor.SearchIndex;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.Tooling;
+
+/// <summary>
+/// Staleness gate for samples/ReactorGallery/reactor-search-index.json — the file the
+/// external winui-search CLI fetches. Drives SearchIndexGenerator.Generate(...) in-process
+/// against the gallery source + editorial sidecar and asserts byte-equality with the
+/// committed file, so adding/removing/renaming a control or changing its first sample
+/// snippet fails CI until the index is regenerated. The UPDATE_SEARCH_INDEX=1 arm rewrites
+/// the committed file (same ergonomics as ApiIndexGeneratorTests' UPDATE_API_INDEX).
+///
+/// The structural/differential facts are written so each one fails if the code it targets
+/// is deleted or no-op'd (extraction, editorial merge, sort, or the header contract).
+/// </summary>
+public sealed class SearchIndexGeneratorTests
+{
+    static string RepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "Reactor.slnx")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new DirectoryNotFoundException("Could not locate repo root (Reactor.slnx) from " + AppContext.BaseDirectory);
+    }
+
+    static string GalleryDir() => Path.Combine(RepoRoot(), "samples", "ReactorGallery");
+    static string EditorialPath() => Path.Combine(RepoRoot(), "tools", "Reactor.SearchIndex", "editorial.json");
+    static string CommittedPath() => Path.Combine(GalleryDir(), "reactor-search-index.json");
+
+    static SearchIndexResult Generate() => SearchIndexGenerator.Generate(GalleryDir(), EditorialPath());
+
+    static readonly JsonSerializerOptions ReadOptions = new() { PropertyNameCaseInsensitive = true };
+    static IndexRoot Parse(string json) => JsonSerializer.Deserialize<IndexRoot>(json, ReadOptions)!;
+    static ControlEntry Find(IndexRoot root, string id) =>
+        root.Controls.FirstOrDefault(c => c.Id == id) ?? throw new Xunit.Sdk.XunitException($"control '{id}' missing from index");
+
+    // ── The gate ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Index_IsUpToDate()
+    {
+        var generated = Generate().Json;
+
+        if (Environment.GetEnvironmentVariable("UPDATE_SEARCH_INDEX") == "1")
+        {
+            File.WriteAllText(CommittedPath(), generated);
+            return;
+        }
+
+        var committed = File.ReadAllText(CommittedPath());
+        if (committed != generated)
+        {
+            throw new Xunit.Sdk.XunitException(
+                "samples/ReactorGallery/reactor-search-index.json is stale. Regenerate by running:\n" +
+                "  dotnet run --project tools/Reactor.SearchIndex\n" +
+                "  (or: $env:UPDATE_SEARCH_INDEX=1; dotnet test tests/Reactor.Tests " +
+                "--filter \"FullyQualifiedName~Tooling.SearchIndexGeneratorTests.Index_IsUpToDate\")\n" +
+                "First diff: " + FirstDiffPreview(committed, generated));
+        }
+    }
+
+    // ── Determinism / formatting invariants ──────────────────────────────────
+
+    [Fact]
+    public void Generation_IsDeterministic()
+    {
+        Assert.Equal(Generate().Json, Generate().Json);
+    }
+
+    [Fact]
+    public void Output_IsLfOnly_WithSingleTrailingNewline()
+    {
+        var json = Generate().Json;
+        Assert.DoesNotContain('\r', json);
+        Assert.EndsWith("\n", json);
+        Assert.False(json.EndsWith("\n\n"), "should end with exactly one trailing newline");
+    }
+
+    // ── Header contract ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Header_MatchesAgreedContract()
+    {
+        var root = Parse(Generate().Json);
+        Assert.Equal(1, root.SchemaVersion);
+        Assert.Equal("reactor", root.Source);
+        // Must be the literal repo slug — never a volatile sha/timestamp (invariant #1).
+        Assert.Equal("microsoft/microsoft-ui-reactor", root.GeneratedFrom);
+    }
+
+    // ── Required fields + real-code samples (fails if extraction returns default) ─
+
+    [Fact]
+    public void EveryControl_HasRequiredFields_AndRealCodeSample()
+    {
+        var root = Parse(Generate().Json);
+        Assert.NotEmpty(root.Controls);
+
+        foreach (var c in root.Controls)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(c.Id), "id");
+            Assert.False(string.IsNullOrWhiteSpace(c.Name), $"name for {c.Id}");
+            Assert.False(string.IsNullOrWhiteSpace(c.Category), $"category for {c.Id}");
+            Assert.False(string.IsNullOrWhiteSpace(c.Description), $"description for {c.Id}");
+            Assert.Equal(c.Id, c.GalleryRoute);
+
+            Assert.NotEmpty(c.Samples);
+            var s = c.Samples[0];
+            Assert.Equal("csharp", s.Language);
+            Assert.False(string.IsNullOrWhiteSpace(s.Header), $"header for {c.Id}");
+            Assert.False(string.IsNullOrWhiteSpace(s.Code), $"code for {c.Id}");
+            // At least one line of real code (not blank / not a pure // comment).
+            Assert.Contains(s.Code.Split('\n'), line =>
+            {
+                var t = line.Trim();
+                return t.Length > 0 && !t.StartsWith("//", StringComparison.Ordinal);
+            });
+            // No unresolved template tokens (invariant #2, REAL CODE ONLY).
+            Assert.DoesNotContain("{{", s.Code);
+        }
+    }
+
+    // ── Sort (fails if the sort is removed: registry source order is by category) ─
+
+    [Fact]
+    public void Controls_AreStrictlySortedById()
+    {
+        var ids = Parse(Generate().Json).Controls.Select(c => c.Id).ToList();
+        Assert.NotEmpty(ids);
+        for (var i = 1; i < ids.Count; i++)
+        {
+            Assert.True(
+                string.CompareOrdinal(ids[i - 1], ids[i]) < 0,
+                $"controls must be strictly ascending by id (ordinal); '{ids[i - 1]}' !< '{ids[i]}'");
+        }
+    }
+
+    // ── Editorial merge (fails if the merge is dropped) ───────────────────────
+
+    [Fact]
+    public void EditorialMerge_AppliesKeywords_Related_Usings_AndDefaults()
+    {
+        var root = Parse(Generate().Json);
+
+        var button = Find(root, "button");
+        Assert.NotNull(button.Keywords);
+        Assert.Contains("click", button.Keywords!);
+        Assert.NotNull(button.RelatedControls);
+        Assert.Contains("RepeatButton", button.RelatedControls!);
+        Assert.Equal("Microsoft.UI.Reactor", button.ApiNamespace);
+        Assert.Equal("Microsoft.UI.Reactor", button.NugetPackage);
+
+        // Non-obvious import surfaced only where a sample needs it...
+        Assert.Contains("Microsoft.UI.Reactor.Data", Find(root, "data-grid").Usings!);
+        Assert.Contains("Microsoft.UI.Reactor.Docking", Find(root, "docking").Usings!);
+        // ...and omitted (null, not empty) where the sample needs no extra import.
+        Assert.Null(Find(root, "acrylic").Usings);
+    }
+
+    // ── Sample extraction handles both named and positional sourceCode args ──
+
+    [Fact]
+    public void SampleExtraction_HandlesNamedAndPositionalSourceCode()
+    {
+        var root = Parse(Generate().Json);
+
+        // info-bar passes sourceCode as the 3rd positional argument.
+        Assert.Contains("InfoBar(", Find(root, "info-bar").Samples[0].Code);
+        // data-grid passes it as the named `sourceCode:` argument.
+        Assert.Contains("DataGrid(", Find(root, "data-grid").Samples[0].Code);
+        // button's representative snippet is the real .Click chain, verbatim from source.
+        Assert.Contains(".Click(", Find(root, "button").Samples[0].Code);
+    }
+
+    // ── Independent oracle: a curated set of controls must always be present ──
+
+    [Fact]
+    public void ExpectedControls_ArePresent()
+    {
+        var ids = Parse(Generate().Json).Controls.Select(c => c.Id).ToHashSet(StringComparer.Ordinal);
+        foreach (var expected in new[]
+        {
+            "button", "combo-box", "list-view", "data-grid", "property-grid", "docking",
+            "map-control", "split-view", "navigation-view", "tree-view", "grid", "geometry", "type-ramp",
+        })
+        {
+            Assert.Contains(expected, ids);
+        }
+        Assert.True(ids.Count >= 90, $"expected >=90 controls, got {ids.Count}");
+    }
+
+    // ── REAL CODE ONLY: no placeholder/abbreviation tokens survive (invariant #2) ─
+
+    [Fact]
+    public void Samples_ContainNoPlaceholderTokens()
+    {
+        var placeholder = new Regex(@",\s*\.\.\.|\.\.\.\s*\)|\(\s*\.\.\.|^\s*\.\.\.\s*$|\.\.\./|<your", RegexOptions.Multiline);
+        foreach (var c in Parse(Generate().Json).Controls)
+        {
+            var code = c.Samples[0].Code;
+            Assert.False(placeholder.IsMatch(code), $"{c.Id} sample has a placeholder token:\n{code}");
+            Assert.DoesNotContain("{{", code);
+        }
+    }
+
+    // ── keywords are winui-search's weighted BM25 field: every control must carry a
+    //    populated, high-signal set that does not restate the name/category. ──
+
+    [Fact]
+    public void EveryControl_HasHighSignalKeywords()
+    {
+        foreach (var c in Parse(Generate().Json).Controls)
+        {
+            Assert.NotNull(c.Keywords);
+            Assert.InRange(c.Keywords!.Count, 3, 10);
+            Assert.Equal(c.Keywords.Count, c.Keywords.Distinct(StringComparer.Ordinal).Count()); // no dups
+            foreach (var k in c.Keywords)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(k), $"{c.Id} has a blank keyword");
+                Assert.Equal(k.ToLowerInvariant(), k); // lowercase
+                Assert.NotEqual(c.Name, k, StringComparer.OrdinalIgnoreCase);     // not the control name
+                Assert.NotEqual(c.Id, k, StringComparer.OrdinalIgnoreCase);
+                Assert.NotEqual(c.Category, k, StringComparer.OrdinalIgnoreCase); // not the category
+            }
+        }
+    }
+
+    // ── each sample header is the primary per-scenario BM25 field: descriptive,
+    //    non-empty, and never a bare repeat of the control name/id. ──
+
+    [Fact]
+    public void EveryHeader_IsDescriptive_NotABareControlNameRepeat()
+    {
+        foreach (var c in Parse(Generate().Json).Controls)
+        {
+            var h = c.Samples[0].Header;
+            Assert.False(string.IsNullOrWhiteSpace(h));
+            Assert.NotEqual(c.Name, h, StringComparer.OrdinalIgnoreCase);
+            Assert.NotEqual(c.Id, h, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    // ── sampleOverride escape hatch replaces a control whose only card is a
+    //    placeholder (map-control's sole SampleCard used <your-key>). ──
+
+    [Fact]
+    public void SampleOverride_ReplacesRejectedPlaceholderCard()
+    {
+        var mc = Find(Parse(Generate().Json), "map-control");
+        Assert.Equal("Interactive map", mc.Samples[0].Header);
+        Assert.Contains("MapControl(zoomLevel", mc.Samples[0].Code);
+        Assert.DoesNotContain("<your", mc.Samples[0].Code);
+    }
+
+    // ── a mistyped editorial key must fail generation, not silently drop curation ─
+
+    [Fact]
+    public void OrphanEditorialKey_FailsGeneration()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), $"reactor-editorial-orphan-{Guid.NewGuid():N}.json");
+        File.WriteAllText(tmp, "{ \"button\": { \"keywords\": [\"click\",\"submit\",\"accent\"] }, \"buton\": { \"keywords\": [\"x\",\"y\",\"z\"] } }");
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() => SearchIndexGenerator.Generate(GalleryDir(), tmp));
+            Assert.Contains("buton", ex.Message);
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
+    }
+
+    // ── coverage: no control is silently dropped (Generate throws on non-exclude skips) ─
+
+    [Fact]
+    public void Generate_DropsNoControls()
+    {
+        // With no editorial excludes today, the skip list must be empty. Fails if a control
+        // loses its route/sample (Generate would throw) or an exclude is added — either way
+        // forcing an intentional review of index coverage.
+        Assert.Empty(Generate().Skipped);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    static string FirstDiffPreview(string expected, string actual)
+    {
+        var min = Math.Min(expected.Length, actual.Length);
+        var i = 0;
+        while (i < min && expected[i] == actual[i]) i++;
+        if (i == min && expected.Length == actual.Length) return "(no diff)";
+
+        var start = Math.Max(0, i - 40);
+        string Slice(string s) =>
+            s.Substring(start, Math.Min(200, s.Length - start)).Replace("\r", "\\r").Replace("\n", "\\n");
+        return $"at offset {i}\n  expected: …{Slice(expected)}…\n  actual:   …{Slice(actual)}…";
+    }
+}

--- a/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.UI.Reactor.SearchIndex;
@@ -50,22 +51,25 @@ public sealed class SearchIndexGeneratorTests
     public void Index_IsUpToDate()
     {
         var generated = Generate().Json;
+        var generatedBytes = Encoding.UTF8.GetBytes(generated); // UTF-8, no BOM (GetBytes emits no preamble)
 
         if (Environment.GetEnvironmentVariable("UPDATE_SEARCH_INDEX") == "1")
         {
-            File.WriteAllText(CommittedPath(), generated);
+            File.WriteAllBytes(CommittedPath(), generatedBytes);
             return;
         }
 
-        var committed = File.ReadAllText(CommittedPath());
-        if (committed != generated)
+        // Byte comparison (not File.ReadAllText, which would silently strip a stray BOM) — the
+        // committed file is fetched raw by the winui-search CLI, so a BOM is a real diff.
+        var committedBytes = File.ReadAllBytes(CommittedPath());
+        if (!generatedBytes.AsSpan().SequenceEqual(committedBytes))
         {
             throw new Xunit.Sdk.XunitException(
-                "samples/ReactorGallery/reactor-search-index.json is stale. Regenerate by running:\n" +
+                "samples/ReactorGallery/reactor-search-index.json is stale (content or BOM/encoding). Regenerate by running:\n" +
                 "  dotnet run --project tools/Reactor.SearchIndex\n" +
                 "  (or: $env:UPDATE_SEARCH_INDEX=1; dotnet test tests/Reactor.Tests " +
                 "--filter \"FullyQualifiedName~Tooling.SearchIndexGeneratorTests.Index_IsUpToDate\")\n" +
-                "First diff: " + FirstDiffPreview(committed, generated));
+                "First diff: " + FirstDiffPreview(File.ReadAllText(CommittedPath()), generated));
         }
     }
 

--- a/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
@@ -227,7 +227,11 @@ public sealed class SearchIndexGeneratorTests
             foreach (var k in c.Keywords)
             {
                 Assert.False(string.IsNullOrWhiteSpace(k), $"{c.Id} has a blank keyword");
-                Assert.Equal(k.ToLowerInvariant(), k); // lowercase
+                Assert.Equal(k.ToLowerInvariant(), k);           // lowercase
+                Assert.Equal(k.Trim(), k);                       // trimmed
+                Assert.DoesNotContain("  ", k);                  // internal whitespace collapsed
+                Assert.False(k.EndsWith('.'), $"{c.Id}: keyword '{k}' looks like a sentence");
+                Assert.InRange(k.Split(' ').Length, 1, 6);       // single token or short phrase
                 Assert.NotEqual(c.Name, k, StringComparer.OrdinalIgnoreCase);     // not the control name
                 Assert.NotEqual(c.Id, k, StringComparer.OrdinalIgnoreCase);
                 Assert.NotEqual(c.Category, k, StringComparer.OrdinalIgnoreCase); // not the category
@@ -247,6 +251,19 @@ public sealed class SearchIndexGeneratorTests
             Assert.False(string.IsNullOrWhiteSpace(h));
             Assert.NotEqual(c.Name, h, StringComparer.OrdinalIgnoreCase);
             Assert.NotEqual(c.Id, h, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    // ── headers within one control's samples[] must be distinct (near-dupes collapse
+    //    into redundant scenarios). Moot at 1 sample/control today; a cheap future guard. ──
+
+    [Fact]
+    public void Samples_HaveDistinctHeadersWithinEachControl()
+    {
+        foreach (var c in Parse(Generate().Json).Controls)
+        {
+            var headers = c.Samples.Select(s => s.Header).ToList();
+            Assert.Equal(headers.Count, headers.Distinct(StringComparer.OrdinalIgnoreCase).Count());
         }
     }
 

--- a/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
@@ -26,16 +26,16 @@ public sealed class SearchIndexGeneratorTests
         var dir = AppContext.BaseDirectory;
         while (dir is not null)
         {
-            if (File.Exists(Path.Combine(dir, "Reactor.slnx")))
+            if (File.Exists(Path.Join(dir, "Reactor.slnx")))
                 return dir;
             dir = Path.GetDirectoryName(dir);
         }
         throw new DirectoryNotFoundException("Could not locate repo root (Reactor.slnx) from " + AppContext.BaseDirectory);
     }
 
-    static string GalleryDir() => Path.Combine(RepoRoot(), "samples", "ReactorGallery");
-    static string EditorialPath() => Path.Combine(RepoRoot(), "tools", "Reactor.SearchIndex", "editorial.json");
-    static string CommittedPath() => Path.Combine(GalleryDir(), "reactor-search-index.json");
+    static string GalleryDir() => Path.Join(RepoRoot(), "samples", "ReactorGallery");
+    static string EditorialPath() => Path.Join(RepoRoot(), "tools", "Reactor.SearchIndex", "editorial.json");
+    static string CommittedPath() => Path.Join(GalleryDir(), "reactor-search-index.json");
 
     static SearchIndexResult Generate() => SearchIndexGenerator.Generate(GalleryDir(), EditorialPath());
 
@@ -262,6 +262,10 @@ public sealed class SearchIndexGeneratorTests
     {
         foreach (var c in Parse(Generate().Json).Controls)
         {
+            // v1 contract: exactly one sample per control — non-vacuous, fails if the
+            // generator ever emits multiple samples without this guard being revisited...
+            Assert.Single(c.Samples);
+            // ...and whenever it does, their headers must stay distinct (no redundant scenarios).
             var headers = c.Samples.Select(s => s.Header).ToList();
             Assert.Equal(headers.Count, headers.Distinct(StringComparer.OrdinalIgnoreCase).Count());
         }
@@ -284,7 +288,7 @@ public sealed class SearchIndexGeneratorTests
     [Fact]
     public void OrphanEditorialKey_FailsGeneration()
     {
-        var tmp = Path.Combine(Path.GetTempPath(), $"reactor-editorial-orphan-{Guid.NewGuid():N}.json");
+        var tmp = Path.Join(Path.GetTempPath(), $"reactor-editorial-orphan-{Guid.NewGuid():N}.json");
         File.WriteAllText(tmp, "{ \"button\": { \"keywords\": [\"click\",\"submit\",\"accent\"] }, \"buton\": { \"keywords\": [\"x\",\"y\",\"z\"] } }");
         try
         {

--- a/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
@@ -64,12 +64,18 @@ public sealed class SearchIndexGeneratorTests
         var committedBytes = File.ReadAllBytes(CommittedPath());
         if (!generatedBytes.AsSpan().SequenceEqual(committedBytes))
         {
+            var hasBom = committedBytes.Length >= 3 && committedBytes[0] == 0xEF && committedBytes[1] == 0xBB && committedBytes[2] == 0xBF;
+            // File.ReadAllText strips a BOM, so only use the text preview for genuine content
+            // drift; call out a BOM explicitly (it is what the byte-compare above catches).
+            var detail = hasBom
+                ? "The committed file has a UTF-8 BOM — it must be written without one."
+                : "First diff: " + FirstDiffPreview(File.ReadAllText(CommittedPath()), generated);
             throw new Xunit.Sdk.XunitException(
                 "samples/ReactorGallery/reactor-search-index.json is stale (content or BOM/encoding). Regenerate by running:\n" +
                 "  dotnet run --project tools/Reactor.SearchIndex\n" +
                 "  (or: $env:UPDATE_SEARCH_INDEX=1; dotnet test tests/Reactor.Tests " +
                 "--filter \"FullyQualifiedName~Tooling.SearchIndexGeneratorTests.Index_IsUpToDate\")\n" +
-                "First diff: " + FirstDiffPreview(File.ReadAllText(CommittedPath()), generated));
+                detail);
         }
     }
 

--- a/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
@@ -155,10 +155,10 @@ public sealed class SearchIndexGeneratorEdgeTests
     {
         using var g = new MiniGallery(betaRouted: true);
         var ed = g.WriteEditorial(
-            @"{ ""alpha"": { ""keywords"": ["" Click "", ""CLICK"", """", ""multi   word"", ""click""] }, " + BetaKeywords + " }");
+            @"{ ""alpha"": { ""keywords"": ["" Click "", ""CLICK"", null, """", ""multi   word"", ""click""] }, " + BetaKeywords + " }");
 
         var alpha = Find(Parse(SearchIndexGenerator.Generate(g.GalleryDir, ed).Json), "alpha");
-        // " Click "→"click"; "CLICK"/"click" dedupe; "" dropped; "multi   word"→"multi word".
+        // " Click "→"click"; "CLICK"/"click" dedupe; null + "" dropped; "multi   word"→"multi word".
         Assert.Equal(new[] { "click", "multi word" }, alpha.Keywords!.ToArray());
     }
 

--- a/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
@@ -40,7 +40,11 @@ sealed class MiniGallery : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(Root, recursive: true); } catch { /* best-effort temp cleanup */ }
+        try { Directory.Delete(Root, recursive: true); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
+        {
+            // best-effort temp cleanup
+        }
     }
 
     const string Registry = @"namespace WinUIGalleryReactor;

--- a/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
@@ -272,4 +272,14 @@ public sealed class SearchIndexCliTests
         Assert.Equal(2, SearchIndexCli.Run(new[] { g.GalleryDir, ed, Path.Join(g.Root, "out.json") }, log));
         Assert.Contains("ERROR", log.ToString());
     }
+
+    [Fact]
+    public void Run_MalformedPath_ReturnsErrorExitCode_NotCrash()
+    {
+        using var log = new StringWriter();
+        // "a:b:c" makes Path.GetFullPath throw NotSupportedException on Windows; elsewhere it
+        // resolves and the subsequent read fails. Either way the CLI must return 2, not crash.
+        Assert.Equal(2, SearchIndexCli.Run(new[] { "a:b:c" }, log));
+        Assert.Contains("ERROR", log.ToString());
+    }
 }

--- a/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
@@ -218,7 +218,7 @@ public sealed class SearchIndexCliTests
         using var g = new MiniGallery(betaRouted: true);
         var ed = g.WriteEditorial(ValidEditorial);
         var outPath = Path.Join(g.Root, "out.json");
-        var log = new StringWriter();
+        using var log = new StringWriter();
 
         // --check before the file exists → stale (1).
         Assert.Equal(1, SearchIndexCli.Run(new[] { "--check", g.GalleryDir, ed, outPath }, log));
@@ -235,7 +235,7 @@ public sealed class SearchIndexCliTests
     [Fact]
     public void Run_UnknownOption_ReturnsUsageError()
     {
-        var log = new StringWriter();
+        using var log = new StringWriter();
         Assert.Equal(2, SearchIndexCli.Run(new[] { "--chek" }, log));
         Assert.Contains("unknown option", log.ToString());
     }
@@ -243,7 +243,7 @@ public sealed class SearchIndexCliTests
     [Fact]
     public void Run_TooManyPositionalArgs_ReturnsUsageError()
     {
-        var log = new StringWriter();
+        using var log = new StringWriter();
         Assert.Equal(2, SearchIndexCli.Run(new[] { "a", "b", "c", "d" }, log));
         Assert.Contains("too many arguments", log.ToString());
     }
@@ -255,7 +255,7 @@ public sealed class SearchIndexCliTests
         // orphan editorial key "ghost" → InvalidOperationException → caught → exit 2.
         var ed = g.WriteEditorial(
             @"{ ""alpha"": { ""keywords"": [""a"",""b"",""c""] }, ""beta"": { ""keywords"": [""x"",""y"",""z""] }, ""ghost"": { ""keywords"": [""p"",""q"",""r""] } }");
-        var log = new StringWriter();
+        using var log = new StringWriter();
 
         Assert.Equal(2, SearchIndexCli.Run(new[] { g.GalleryDir, ed, Path.Join(g.Root, "out.json") }, log));
         Assert.Contains("ERROR", log.ToString());

--- a/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
@@ -40,11 +40,10 @@ sealed class MiniGallery : IDisposable
 
     public void Dispose()
     {
+        // best-effort temp cleanup (IOException also covers DirectoryNotFoundException)
         try { Directory.Delete(Root, recursive: true); }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
-        {
-            // best-effort temp cleanup
-        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
     }
 
     const string Registry = @"namespace WinUIGalleryReactor;

--- a/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
@@ -1,0 +1,263 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.UI.Reactor.SearchIndex;
+using Xunit;
+
+namespace Microsoft.UI.Reactor.Tests.Tooling;
+
+/// <summary>
+/// A throwaway on-disk gallery (ControlRegistry.cs + PageRouter.cs + ControlPages) that only
+/// needs to *parse*, not compile — it lets the generator's editorial-merge, keyword-normalize,
+/// override, and skip/throw paths be exercised in isolation without depending on the real
+/// 93-control gallery. Deletes itself on Dispose.
+/// </summary>
+sealed class MiniGallery : IDisposable
+{
+    public string Root { get; }
+    public string GalleryDir { get; }
+
+    public MiniGallery(bool betaRouted)
+    {
+        Root = Path.Join(Path.GetTempPath(), "reactor-si-" + Guid.NewGuid().ToString("N"));
+        GalleryDir = Path.Join(Root, "gallery");
+        Directory.CreateDirectory(Path.Join(GalleryDir, "ControlPages"));
+        File.WriteAllText(Path.Join(GalleryDir, "ControlRegistry.cs"), Registry);
+        File.WriteAllText(Path.Join(GalleryDir, "PageRouter.cs"), betaRouted ? RouterBoth : RouterAlphaOnly);
+        File.WriteAllText(Path.Join(GalleryDir, "ControlPages", "AlphaPage.cs"), AlphaPage);
+        File.WriteAllText(Path.Join(GalleryDir, "ControlPages", "BetaPage.cs"), BetaPage);
+    }
+
+    public string WriteEditorial(string json)
+    {
+        var path = Path.Join(Root, "editorial.json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    public void OverwriteRegistry(string cs) => File.WriteAllText(Path.Join(GalleryDir, "ControlRegistry.cs"), cs);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(Root, recursive: true); } catch { /* best-effort temp cleanup */ }
+    }
+
+    const string Registry = @"namespace WinUIGalleryReactor;
+public record ControlInfo(string Title, string Description, string Category, string IconGlyph, string Tag, string ImageFile = ""p.png"");
+public static class ControlRegistry
+{
+    public static ControlInfo[] All { get; } = new ControlInfo[]
+    {
+        new(""Alpha"", ""The alpha control."", ""Basic Input"", ""\uE001"", ""alpha""),
+        new(""Beta"", ""The beta control."", ""Basic Input"", ""\uE002"", ""beta""),
+    };
+}";
+
+    const string RouterBoth = @"namespace WinUIGalleryReactor;
+static class PageRouter
+{
+    public static object Route(string tag) => tag switch
+    {
+        ""alpha"" => Component<AlphaPage>(),
+        ""beta"" => Component<BetaPage>(),
+        _ => null,
+    };
+}";
+
+    const string RouterAlphaOnly = @"namespace WinUIGalleryReactor;
+static class PageRouter
+{
+    public static object Route(string tag) => tag switch
+    {
+        ""alpha"" => Component<AlphaPage>(),
+        _ => null,
+    };
+}";
+
+    const string AlphaPage = @"namespace WinUIGalleryReactor;
+class AlphaPage
+{
+    object Render() => SampleCard(""Alpha basic"", null, ""Alpha();"");
+}";
+
+    const string BetaPage = @"namespace WinUIGalleryReactor;
+class BetaPage
+{
+    object Render() => SampleCard(""Beta basic"", null, ""Beta();"");
+}";
+}
+
+/// <summary>
+/// Edge-case coverage for the generator's editorial merge, keyword normalization, sample
+/// override, and skip/throw guarantees — driven by <see cref="MiniGallery"/> so each behavior
+/// is forced rather than inferred from the committed 93-control index.
+/// </summary>
+public sealed class SearchIndexGeneratorEdgeTests
+{
+    static readonly JsonSerializerOptions ReadOptions = new() { PropertyNameCaseInsensitive = true };
+    static IndexRoot Parse(string json) => JsonSerializer.Deserialize<IndexRoot>(json, ReadOptions)!;
+    static ControlEntry Find(IndexRoot root, string id) =>
+        root.Controls.FirstOrDefault(c => c.Id == id) ?? throw new Xunit.Sdk.XunitException($"'{id}' missing");
+
+    const string BetaKeywords = @"""beta"": { ""keywords"": [""x"", ""y"", ""z""] }";
+
+    [Fact]
+    public void SampleOverride_HeaderOnly_KeepsExtractedCode()
+    {
+        using var g = new MiniGallery(betaRouted: true);
+        var ed = g.WriteEditorial(
+            @"{ ""alpha"": { ""keywords"": [""a"",""b"",""c""], ""sampleOverride"": { ""header"": ""Custom alpha header"" } }, " + BetaKeywords + " }");
+
+        var alpha = Find(Parse(SearchIndexGenerator.Generate(g.GalleryDir, ed).Json), "alpha");
+        Assert.Equal("Custom alpha header", alpha.Samples[0].Header); // overridden
+        Assert.Equal("Alpha();", alpha.Samples[0].Code);              // extracted code preserved
+    }
+
+    [Fact]
+    public void SampleOverride_CodeOnly_KeepsExtractedHeader()
+    {
+        using var g = new MiniGallery(betaRouted: true);
+        var ed = g.WriteEditorial(
+            @"{ ""alpha"": { ""keywords"": [""a"",""b"",""c""], ""sampleOverride"": { ""code"": ""CustomCode();"" } }, " + BetaKeywords + " }");
+
+        var alpha = Find(Parse(SearchIndexGenerator.Generate(g.GalleryDir, ed).Json), "alpha");
+        Assert.Equal("Alpha basic", alpha.Samples[0].Header);  // extracted header preserved
+        Assert.Equal("CustomCode();", alpha.Samples[0].Code);  // overridden
+    }
+
+    [Fact]
+    public void MissingKeywords_OnIncludedControl_FailsGeneration()
+    {
+        using var g = new MiniGallery(betaRouted: true);
+        // beta is routed + has a sample but no keywords → included yet keyword-less → throw.
+        var ed = g.WriteEditorial(@"{ ""alpha"": { ""keywords"": [""a"",""b"",""c""] }, ""beta"": { } }");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => SearchIndexGenerator.Generate(g.GalleryDir, ed));
+        Assert.Contains("beta", ex.Message);
+        Assert.Contains("keywords", ex.Message);
+    }
+
+    [Fact]
+    public void Keywords_AreTrimmedLowercasedCollapsedAndDeduped()
+    {
+        using var g = new MiniGallery(betaRouted: true);
+        var ed = g.WriteEditorial(
+            @"{ ""alpha"": { ""keywords"": ["" Click "", ""CLICK"", """", ""multi   word"", ""click""] }, " + BetaKeywords + " }");
+
+        var alpha = Find(Parse(SearchIndexGenerator.Generate(g.GalleryDir, ed).Json), "alpha");
+        // " Click "→"click"; "CLICK"/"click" dedupe; "" dropped; "multi   word"→"multi word".
+        Assert.Equal(new[] { "click", "multi word" }, alpha.Keywords!.ToArray());
+    }
+
+    [Fact]
+    public void UnroutedControl_FailsGeneration()
+    {
+        using var g = new MiniGallery(betaRouted: false); // beta has no router arm
+        var ed = g.WriteEditorial(@"{ ""alpha"": { ""keywords"": [""a"",""b"",""c""] }, " + BetaKeywords + " }");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => SearchIndexGenerator.Generate(g.GalleryDir, ed));
+        Assert.Contains("beta", ex.Message);
+    }
+
+    [Fact]
+    public void ExcludedControl_IsSkippedWithoutThrowing()
+    {
+        using var g = new MiniGallery(betaRouted: false); // beta unrouted...
+        var ed = g.WriteEditorial(@"{ ""alpha"": { ""keywords"": [""a"",""b"",""c""] }, ""beta"": { ""exclude"": true } }"); // ...but excluded
+
+        var result = SearchIndexGenerator.Generate(g.GalleryDir, ed);
+        Assert.Contains(result.Skipped, s => s.Id == "beta" && s.Reason == "editorial-exclude");
+        Assert.DoesNotContain(Parse(result.Json).Controls, c => c.Id == "beta");
+        Assert.Single(Parse(result.Json).Controls); // only alpha survives
+    }
+
+    [Fact]
+    public void MalformedRegistryEntry_FailsGeneration()
+    {
+        using var g = new MiniGallery(betaRouted: true);
+        g.OverwriteRegistry(@"namespace WinUIGalleryReactor;
+public record ControlInfo(string Title, string Description, string Category, string IconGlyph, string Tag);
+public static class ControlRegistry
+{
+    public static ControlInfo[] All { get; } = new ControlInfo[]
+    {
+        new(""Alpha"", ""ok"", ""Basic Input"", ""\uE001"", ""alpha""),
+        new(""Bad"", ""too few args""),
+    };
+}");
+        var ed = g.WriteEditorial(@"{ ""alpha"": { ""keywords"": [""a"",""b"",""c""] } }");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => SearchIndexGenerator.Generate(g.GalleryDir, ed));
+        Assert.Contains("ControlRegistry entry", ex.Message);
+    }
+
+    [Fact]
+    public void MisspelledEditorialField_FailsGeneration()
+    {
+        using var g = new MiniGallery(betaRouted: true);
+        // "keyword" (singular) is not a member of EditorialEntry → UnmappedMemberHandling.Disallow.
+        var ed = g.WriteEditorial(@"{ ""alpha"": { ""keyword"": [""a"",""b"",""c""] }, " + BetaKeywords + " }");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => SearchIndexGenerator.Generate(g.GalleryDir, ed));
+        Assert.Contains("editorial.json is invalid", ex.Message);
+    }
+}
+
+/// <summary>
+/// Exercises the <see cref="SearchIndexCli"/> exit-code / arg-validation contract with a
+/// captured <see cref="StringWriter"/> (no real console), against a <see cref="MiniGallery"/>.
+/// </summary>
+public sealed class SearchIndexCliTests
+{
+    const string ValidEditorial = @"{ ""alpha"": { ""keywords"": [""a"",""b"",""c""] }, ""beta"": { ""keywords"": [""x"",""y"",""z""] } }";
+
+    [Fact]
+    public void Run_Write_Then_Check_ReportsStaleThenUpToDate()
+    {
+        using var g = new MiniGallery(betaRouted: true);
+        var ed = g.WriteEditorial(ValidEditorial);
+        var outPath = Path.Join(g.Root, "out.json");
+        var log = new StringWriter();
+
+        // --check before the file exists → stale (1).
+        Assert.Equal(1, SearchIndexCli.Run(new[] { "--check", g.GalleryDir, ed, outPath }, log));
+        // write → 0, file created.
+        Assert.Equal(0, SearchIndexCli.Run(new[] { g.GalleryDir, ed, outPath }, log));
+        Assert.True(File.Exists(outPath));
+        // --check now → up to date (0).
+        Assert.Equal(0, SearchIndexCli.Run(new[] { "--check", g.GalleryDir, ed, outPath }, log));
+        // corrupt the committed file → stale (1) again.
+        File.WriteAllText(outPath, "{}\n");
+        Assert.Equal(1, SearchIndexCli.Run(new[] { "--check", g.GalleryDir, ed, outPath }, log));
+    }
+
+    [Fact]
+    public void Run_UnknownOption_ReturnsUsageError()
+    {
+        var log = new StringWriter();
+        Assert.Equal(2, SearchIndexCli.Run(new[] { "--chek" }, log));
+        Assert.Contains("unknown option", log.ToString());
+    }
+
+    [Fact]
+    public void Run_TooManyPositionalArgs_ReturnsUsageError()
+    {
+        var log = new StringWriter();
+        Assert.Equal(2, SearchIndexCli.Run(new[] { "a", "b", "c", "d" }, log));
+        Assert.Contains("too many arguments", log.ToString());
+    }
+
+    [Fact]
+    public void Run_GenerationError_ReturnsTwo()
+    {
+        using var g = new MiniGallery(betaRouted: true);
+        // orphan editorial key "ghost" → InvalidOperationException → caught → exit 2.
+        var ed = g.WriteEditorial(
+            @"{ ""alpha"": { ""keywords"": [""a"",""b"",""c""] }, ""beta"": { ""keywords"": [""x"",""y"",""z""] }, ""ghost"": { ""keywords"": [""p"",""q"",""r""] } }");
+        var log = new StringWriter();
+
+        Assert.Equal(2, SearchIndexCli.Run(new[] { g.GalleryDir, ed, Path.Join(g.Root, "out.json") }, log));
+        Assert.Contains("ERROR", log.ToString());
+    }
+}

--- a/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
@@ -40,10 +40,19 @@ sealed class MiniGallery : IDisposable
 
     public void Dispose()
     {
-        // best-effort temp cleanup (IOException also covers DirectoryNotFoundException)
-        try { Directory.Delete(Root, recursive: true); }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        // best-effort temp cleanup — trace (never throw) if the temp dir cannot be removed.
+        try
+        {
+            Directory.Delete(Root, recursive: true);
+        }
+        catch (IOException ex)
+        {
+            global::System.Diagnostics.Debug.WriteLine($"MiniGallery: temp cleanup failed for '{Root}': {ex}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            global::System.Diagnostics.Debug.WriteLine($"MiniGallery: temp cleanup failed for '{Root}': {ex}");
+        }
     }
 
     const string Registry = @"namespace WinUIGalleryReactor;

--- a/tools/Reactor.SearchIndex/Program.cs
+++ b/tools/Reactor.SearchIndex/Program.cs
@@ -1,0 +1,67 @@
+// Regeneration / staleness CLI for the ReactorGallery search index.
+//
+//   dotnet run --project tools/Reactor.SearchIndex            # rewrite the committed file
+//   dotnet run --project tools/Reactor.SearchIndex -- --check # exit 1 if it is stale
+//
+// Paths default off the repo root (located by walking up for Reactor.slnx); the gate
+// test drives SearchIndexGenerator.Generate(...) in-process instead of shelling out.
+
+using Microsoft.UI.Reactor.SearchIndex;
+
+var check = args.Contains("--check");
+var positional = args.Where(a => !a.StartsWith("--", StringComparison.Ordinal)).ToArray();
+
+var repoRoot = FindRepoRoot(AppContext.BaseDirectory);
+
+var galleryDir = positional.Length > 0
+    ? positional[0]
+    : Path.Combine(repoRoot, "samples", "ReactorGallery");
+var editorialPath = positional.Length > 1
+    ? positional[1]
+    : Path.Combine(repoRoot, "tools", "Reactor.SearchIndex", "editorial.json");
+var outPath = positional.Length > 2
+    ? positional[2]
+    : Path.Combine(galleryDir, "reactor-search-index.json");
+
+SearchIndexResult result;
+try
+{
+    result = SearchIndexGenerator.Generate(galleryDir, editorialPath);
+}
+catch (InvalidOperationException ex)
+{
+    Console.Error.WriteLine("[search-index] ERROR: " + ex.Message);
+    return 2;
+}
+
+Console.Error.WriteLine($"[search-index] {result.ControlCount} controls, {result.Skipped.Count} skipped.");
+foreach (var s in result.Skipped)
+    Console.Error.WriteLine($"[search-index]   skip {s.Id} — {s.Reason}");
+
+if (check)
+{
+    var current = File.Exists(outPath) ? File.ReadAllText(outPath) : "";
+    if (current == result.Json)
+    {
+        Console.Error.WriteLine($"[search-index] up to date: {outPath}");
+        return 0;
+    }
+    Console.Error.WriteLine($"[search-index] STALE: {outPath} — run `dotnet run --project tools/Reactor.SearchIndex` to regenerate.");
+    return 1;
+}
+
+File.WriteAllText(outPath, result.Json);
+Console.Error.WriteLine($"[search-index] wrote {outPath}");
+return 0;
+
+static string FindRepoRoot(string start)
+{
+    var dir = start;
+    while (dir is not null)
+    {
+        if (File.Exists(Path.Combine(dir, "Reactor.slnx")))
+            return dir;
+        dir = Path.GetDirectoryName(dir);
+    }
+    throw new DirectoryNotFoundException("Could not locate repo root (Reactor.slnx) from " + start);
+}

--- a/tools/Reactor.SearchIndex/Program.cs
+++ b/tools/Reactor.SearchIndex/Program.cs
@@ -3,65 +3,9 @@
 //   dotnet run --project tools/Reactor.SearchIndex            # rewrite the committed file
 //   dotnet run --project tools/Reactor.SearchIndex -- --check # exit 1 if it is stale
 //
-// Paths default off the repo root (located by walking up for Reactor.slnx); the gate
-// test drives SearchIndexGenerator.Generate(...) in-process instead of shelling out.
+// All logic lives in SearchIndexCli.Run (unit-tested by SearchIndexCliTests); the gate test
+// drives SearchIndexGenerator.Generate(...) in-process instead of shelling out.
 
 using Microsoft.UI.Reactor.SearchIndex;
 
-var check = args.Contains("--check");
-var positional = args.Where(a => !a.StartsWith("--", StringComparison.Ordinal)).ToArray();
-
-var repoRoot = FindRepoRoot(AppContext.BaseDirectory);
-
-var galleryDir = positional.Length > 0
-    ? positional[0]
-    : Path.Combine(repoRoot, "samples", "ReactorGallery");
-var editorialPath = positional.Length > 1
-    ? positional[1]
-    : Path.Combine(repoRoot, "tools", "Reactor.SearchIndex", "editorial.json");
-var outPath = positional.Length > 2
-    ? positional[2]
-    : Path.Combine(galleryDir, "reactor-search-index.json");
-
-SearchIndexResult result;
-try
-{
-    result = SearchIndexGenerator.Generate(galleryDir, editorialPath);
-}
-catch (InvalidOperationException ex)
-{
-    Console.Error.WriteLine("[search-index] ERROR: " + ex.Message);
-    return 2;
-}
-
-Console.Error.WriteLine($"[search-index] {result.ControlCount} controls, {result.Skipped.Count} skipped.");
-foreach (var s in result.Skipped)
-    Console.Error.WriteLine($"[search-index]   skip {s.Id} — {s.Reason}");
-
-if (check)
-{
-    var current = File.Exists(outPath) ? File.ReadAllText(outPath) : "";
-    if (current == result.Json)
-    {
-        Console.Error.WriteLine($"[search-index] up to date: {outPath}");
-        return 0;
-    }
-    Console.Error.WriteLine($"[search-index] STALE: {outPath} — run `dotnet run --project tools/Reactor.SearchIndex` to regenerate.");
-    return 1;
-}
-
-File.WriteAllText(outPath, result.Json);
-Console.Error.WriteLine($"[search-index] wrote {outPath}");
-return 0;
-
-static string FindRepoRoot(string start)
-{
-    var dir = start;
-    while (dir is not null)
-    {
-        if (File.Exists(Path.Combine(dir, "Reactor.slnx")))
-            return dir;
-        dir = Path.GetDirectoryName(dir);
-    }
-    throw new DirectoryNotFoundException("Could not locate repo root (Reactor.slnx) from " + start);
-}
+return SearchIndexCli.Run(args);

--- a/tools/Reactor.SearchIndex/README.md
+++ b/tools/Reactor.SearchIndex/README.md
@@ -37,3 +37,22 @@ byte-equality with the committed file (the staleness gate that runs in CI `dotne
 `SearchIndexToolTests.cs` covers the editorial/skip/override/CLI edge cases.
 
 Curate `editorial.json`, never the generated JSON.
+
+## Trimming / NativeAOT
+
+The generator is trim- and NativeAOT-clean: JSON goes through the `System.Text.Json` source
+generator (`SearchIndexJsonContext` / `EditorialJsonContext`) and regexes through
+`[GeneratedRegex]`, so the IL2*/IL3* analyzer (`IsAotCompatible=true`) runs clean over our code.
+
+A native single-file build works:
+
+```pwsh
+dotnet publish tools/Reactor.SearchIndex -r win-x64 -c Release -p:PublishAot=true -p:IlcTreatWarningsAsErrors=false
+```
+
+…produces a ~12 MB native `Reactor.SearchIndex.exe` that emits a byte-identical index. The
+`IlcTreatWarningsAsErrors=false` downgrade is required only because the **Roslyn** dependency has
+trim-unsafe spots (e.g. `CommonCompiler.GetAssemblyLocation` → `Assembly.Location`, `IL3000`)
+that are unreachable at runtime for our syntax-only parsing — the native binary runs correctly.
+(Native linking also needs the VS C++ tools, i.e. `vswhere.exe`/`link.exe` on `PATH`.)
+

--- a/tools/Reactor.SearchIndex/README.md
+++ b/tools/Reactor.SearchIndex/README.md
@@ -1,0 +1,39 @@
+# Reactor.SearchIndex
+
+Generates `samples/ReactorGallery/reactor-search-index.json` — a deterministic, schema-versioned
+index of the ReactorGallery's controls consumed by the external **winui-search** CLI (which
+fetches it from `raw.githubusercontent.com/.../main/samples/ReactorGallery/reactor-search-index.json`).
+
+It is a build-time, headless Roslyn tool (never shipped in the NuGet). It parses the gallery
+**source** — `ControlRegistry.cs` (id/name/category/description), `PageRouter.cs` (tag → page),
+`ControlPages/**` (the first *complete* real-code `SampleCard`) — and merges the hand-curated
+`editorial.json` sidecar (`keywords`, `relatedControls`, `usings`, `sampleOverride`, `exclude`,
+keyed by control id). Output is a pure function of those inputs: controls sorted by id, fixed key
+order, LF newlines, no volatile values.
+
+## Usage
+
+```pwsh
+# Regenerate the committed index (run after editing gallery controls or editorial.json):
+dotnet run --project tools/Reactor.SearchIndex
+
+# Fail (exit 1) if the committed index is stale, without rewriting it:
+dotnet run --project tools/Reactor.SearchIndex -- --check
+```
+
+Exit codes: `0` success / up-to-date, `1` stale (`--check`), `2` usage or generation error.
+
+## Guarantees & gate
+
+- **Keywords are required** and canonicalized (trim / lowercase / collapse / dedupe) — generation
+  fails if an included control has none.
+- **Real code only** — sample cards with placeholder tokens (`...`, `<your-key>`, abbreviated
+  URLs) are rejected in favour of the first complete card, or an editorial `sampleOverride`.
+- **No silent drops** — an orphan/typo'd editorial key, a misspelled editorial field, an
+  unparseable `ControlInfo` entry, or any non-`exclude` skip all fail generation.
+
+`tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs` regenerates in-process and asserts
+byte-equality with the committed file (the staleness gate that runs in CI `dotnet test`);
+`SearchIndexToolTests.cs` covers the editorial/skip/override/CLI edge cases.
+
+Curate `editorial.json`, never the generated JSON.

--- a/tools/Reactor.SearchIndex/Reactor.SearchIndex.csproj
+++ b/tools/Reactor.SearchIndex/Reactor.SearchIndex.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Plain net10.0 (no -windows / UseWinUI): the generator only parses gallery
+         *source* with Roslyn and emits JSON. It never references Reactor or loads a
+         WinUI type, so it stays fully headless and cross-platform. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Microsoft.UI.Reactor.SearchIndex</RootNamespace>
+    <AssemblyName>Reactor.SearchIndex</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!-- Build-time generator: uses System.Text.Json's reflection serializer and is
+         never trimmed/AOT-published. Opt out of the IL2*/IL3* analyzer (matches
+         tools/Reactor.ApiIndex). -->
+    <ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Reactor.SearchIndex/Reactor.SearchIndex.csproj
+++ b/tools/Reactor.SearchIndex/Reactor.SearchIndex.csproj
@@ -10,10 +10,15 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Build-time generator: uses System.Text.Json's reflection serializer and is
-         never trimmed/AOT-published. Opt out of the IL2*/IL3* analyzer (matches
-         tools/Reactor.ApiIndex). -->
-    <ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>
+    <!-- Trim / NativeAOT-clean: JSON goes through the System.Text.Json source generator and
+         regexes through [GeneratedRegex], so the IL2*/IL3* analyzer (enabled here) runs clean
+         over our code. A native single-file build works too:
+             dotnet publish -r <rid> -c Release -p:PublishAot=true -p:IlcTreatWarningsAsErrors=false
+         yields a ~12 MB native generator that emits a byte-identical index. The ILC-warning
+         downgrade is required only because the Roslyn dependency has trim-unsafe spots
+         (e.g. CommonCompiler.GetAssemblyLocation → Assembly.Location, IL3000) that are
+         unreachable at runtime for our syntax-only parsing. -->
+    <IsAotCompatible>true</IsAotCompatible>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>

--- a/tools/Reactor.SearchIndex/Reactor.SearchIndex.csproj
+++ b/tools/Reactor.SearchIndex/Reactor.SearchIndex.csproj
@@ -11,14 +11,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- Trim / NativeAOT-clean: JSON goes through the System.Text.Json source generator and
-         regexes through [GeneratedRegex], so the IL2*/IL3* analyzer (enabled here) runs clean
-         over our code. A native single-file build works too:
+         regexes through [GeneratedRegex], so this tool no longer opts out of AOT analysis.
+         Removing ReactorSkipAotAnalysis lets Directory.Build.targets turn on IsAotCompatible
+         (and promote IL2*/IL3* to errors) for net10+, so the analyzer runs clean over our code.
+         A native single-file build works too:
              dotnet publish -r <rid> -c Release -p:PublishAot=true -p:IlcTreatWarningsAsErrors=false
          yields a ~12 MB native generator that emits a byte-identical index. The ILC-warning
          downgrade is required only because the Roslyn dependency has trim-unsafe spots
          (e.g. CommonCompiler.GetAssemblyLocation → Assembly.Location, IL3000) that are
          unreachable at runtime for our syntax-only parsing. -->
-    <IsAotCompatible>true</IsAotCompatible>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>

--- a/tools/Reactor.SearchIndex/SearchIndexCli.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexCli.cs
@@ -2,6 +2,7 @@
 // exit-code / arg-validation / error-handling contract is unit-testable (SearchIndexCliTests
 // passes a StringWriter, so the tests never touch the real console).
 
+using System.Text;
 using System.Text.Json;
 
 namespace Microsoft.UI.Reactor.SearchIndex;
@@ -14,6 +15,10 @@ namespace Microsoft.UI.Reactor.SearchIndex;
 /// </summary>
 public static class SearchIndexCli
 {
+    // The index is a byte-stable artifact fetched raw by the winui-search CLI, so write it as
+    // UTF-8 without a BOM and compare bytes (not decoded text, which would hide a stray BOM).
+    static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     public static int Run(string[] args) => Run(args, Console.Error);
 
     public static int Run(string[] args, TextWriter log)
@@ -50,10 +55,11 @@ public static class SearchIndexCli
             foreach (var s in result.Skipped)
                 log.WriteLine($"[search-index]   skip {s.Id} — {s.Reason}");
 
+            var generatedBytes = Utf8NoBom.GetBytes(result.Json);
             if (check)
             {
-                var current = File.Exists(outPath) ? File.ReadAllText(outPath) : "";
-                if (current == result.Json)
+                var currentBytes = File.Exists(outPath) ? File.ReadAllBytes(outPath) : Array.Empty<byte>();
+                if (generatedBytes.AsSpan().SequenceEqual(currentBytes))
                 {
                     log.WriteLine($"[search-index] up to date: {outPath}");
                     return 0;
@@ -62,7 +68,7 @@ public static class SearchIndexCli
                 return 1;
             }
 
-            File.WriteAllText(outPath, result.Json);
+            File.WriteAllText(outPath, result.Json, Utf8NoBom);
             log.WriteLine($"[search-index] wrote {outPath}");
             return 0;
         }

--- a/tools/Reactor.SearchIndex/SearchIndexCli.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexCli.cs
@@ -1,0 +1,95 @@
+// Command-line surface for the search-index generator, factored out of Program.cs so the
+// exit-code / arg-validation / error-handling contract is unit-testable (SearchIndexCliTests
+// passes a StringWriter, so the tests never touch the real console).
+
+using System.Text.Json;
+
+namespace Microsoft.UI.Reactor.SearchIndex;
+
+/// <summary>
+/// Usage: <c>reactor-search-index [--check] [galleryDir] [editorialPath] [outPath]</c>.
+/// With no args it regenerates the committed index off the repo root; <c>--check</c> compares
+/// instead of writing. Exit codes: 0 = success / up-to-date, 1 = stale (<c>--check</c> only),
+/// 2 = usage error or generation failure.
+/// </summary>
+public static class SearchIndexCli
+{
+    public static int Run(string[] args) => Run(args, Console.Error);
+
+    public static int Run(string[] args, TextWriter log)
+    {
+        try
+        {
+            var check = false;
+            var positional = new List<string>();
+            foreach (var arg in args)
+            {
+                if (arg == "--check") check = true;
+                else if (arg.StartsWith("--", StringComparison.Ordinal)) return Usage(log, $"unknown option '{arg}'");
+                else positional.Add(arg);
+            }
+            if (positional.Count > 3)
+                return Usage(log, $"too many arguments ({positional.Count}); expected at most [galleryDir] [editorialPath] [outPath]");
+
+            // Canonicalize explicit paths (resolves '..'); defaults derive from the repo root.
+            string? repoRoot = null;
+            string RepoRoot() => repoRoot ??= FindRepoRoot();
+
+            var galleryDir = positional.Count >= 1
+                ? Path.GetFullPath(positional[0])
+                : Path.Join(RepoRoot(), "samples", "ReactorGallery");
+            var editorialPath = positional.Count >= 2
+                ? Path.GetFullPath(positional[1])
+                : Path.Join(RepoRoot(), "tools", "Reactor.SearchIndex", "editorial.json");
+            var outPath = positional.Count >= 3
+                ? Path.GetFullPath(positional[2])
+                : Path.Join(galleryDir, "reactor-search-index.json");
+
+            var result = SearchIndexGenerator.Generate(galleryDir, editorialPath);
+            log.WriteLine($"[search-index] {result.ControlCount} controls, {result.Skipped.Count} skipped.");
+            foreach (var s in result.Skipped)
+                log.WriteLine($"[search-index]   skip {s.Id} — {s.Reason}");
+
+            if (check)
+            {
+                var current = File.Exists(outPath) ? File.ReadAllText(outPath) : "";
+                if (current == result.Json)
+                {
+                    log.WriteLine($"[search-index] up to date: {outPath}");
+                    return 0;
+                }
+                log.WriteLine($"[search-index] STALE: {outPath} — run `dotnet run --project tools/Reactor.SearchIndex` to regenerate.");
+                return 1;
+            }
+
+            File.WriteAllText(outPath, result.Json);
+            log.WriteLine($"[search-index] wrote {outPath}");
+            return 0;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or JsonException or IOException
+            or UnauthorizedAccessException or ArgumentException or DirectoryNotFoundException)
+        {
+            log.WriteLine("[search-index] ERROR: " + ex.Message);
+            return 2;
+        }
+    }
+
+    static int Usage(TextWriter log, string problem)
+    {
+        log.WriteLine("[search-index] ERROR: " + problem);
+        log.WriteLine("usage: reactor-search-index [--check] [galleryDir] [editorialPath] [outPath]");
+        return 2;
+    }
+
+    static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Join(dir, "Reactor.slnx")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new DirectoryNotFoundException("Could not locate repo root (Reactor.slnx) from " + AppContext.BaseDirectory);
+    }
+}

--- a/tools/Reactor.SearchIndex/SearchIndexCli.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexCli.cs
@@ -73,7 +73,8 @@ public static class SearchIndexCli
             return 0;
         }
         catch (Exception ex) when (ex is InvalidOperationException or JsonException or IOException
-            or UnauthorizedAccessException or ArgumentException or DirectoryNotFoundException)
+            or UnauthorizedAccessException or ArgumentException or NotSupportedException
+            or System.Security.SecurityException)
         {
             log.WriteLine("[search-index] ERROR: " + ex.Message);
             return 2;

--- a/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
@@ -169,7 +169,13 @@ public static class SearchIndexGenerator
         var list = new List<RegistryEntry>();
         foreach (var element in arrayInit.Expressions)
         {
-            if (ObjectCreationArgs(element) is not { } args || args.Count < 5) continue;
+            // Strict: every element of the `new ControlInfo[] { ... }` initializer must be a
+            // fully literal `new(title, desc, category, glyph, tag, ...)`. Throwing (rather
+            // than skipping) keeps the no-silent-drop guarantee if a future entry uses named
+            // args, a constant, or an interpolated string the parser can't read.
+            if (ObjectCreationArgs(element) is not { } args || args.Count < 5)
+                throw new InvalidOperationException(
+                    "ControlRegistry entry is not a `new(title, desc, category, glyph, tag, ...)` with >=5 args: " + Truncate(element));
 
             var title = TryGetStringLiteral(args[0].Expression);
             var description = TryGetStringLiteral(args[1].Expression);
@@ -177,7 +183,8 @@ public static class SearchIndexGenerator
             var tag = TryGetStringLiteral(args[4].Expression);
 
             if (title is null || description is null || category is null || string.IsNullOrEmpty(tag))
-                continue;
+                throw new InvalidOperationException(
+                    "ControlRegistry entry has a non-literal or empty title/description/category/tag: " + Truncate(element));
 
             list.Add(new RegistryEntry(tag, title, description, category));
         }
@@ -186,6 +193,12 @@ public static class SearchIndexGenerator
             throw new InvalidOperationException("ControlRegistry parse yielded no entries.");
 
         return list;
+    }
+
+    static string Truncate(SyntaxNode node)
+    {
+        var text = System.Text.RegularExpressions.Regex.Replace(node.ToString(), @"\s+", " ").Trim();
+        return text.Length <= 120 ? text : text[..117] + "...";
     }
 
     static SeparatedSyntaxList<ArgumentSyntax>? ObjectCreationArgs(ExpressionSyntax element) => element switch
@@ -376,10 +389,19 @@ public static class SearchIndexGenerator
             return new Dictionary<string, EditorialEntry>(StringComparer.Ordinal);
 
         var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, ReadCommentHandling = JsonCommentHandling.Skip };
-        var parsed = JsonSerializer.Deserialize<Dictionary<string, EditorialEntry>>(File.ReadAllText(editorialPath), opts);
-        return parsed is null
-            ? new Dictionary<string, EditorialEntry>(StringComparer.Ordinal)
-            : new Dictionary<string, EditorialEntry>(parsed, StringComparer.Ordinal);
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, EditorialEntry>>(File.ReadAllText(editorialPath), opts);
+            return parsed is null
+                ? new Dictionary<string, EditorialEntry>(StringComparer.Ordinal)
+                : new Dictionary<string, EditorialEntry>(parsed, StringComparer.Ordinal);
+        }
+        catch (JsonException ex)
+        {
+            // A misspelled field (e.g. "keyword"/"sampleOveride") trips UnmappedMemberHandling
+            // and lands here — surface it as a clear, actionable error instead of a raw crash.
+            throw new InvalidOperationException($"editorial.json is invalid ({Path.GetFileName(editorialPath)}): {ex.Message}", ex);
+        }
     }
 
     // ── Internal parse models ──────────────────────────────────────────────
@@ -388,6 +410,7 @@ public static class SearchIndexGenerator
 
     sealed record ExtractedSample(string Header, string Code);
 
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     sealed class EditorialEntry
     {
         public List<string>? Keywords { get; set; }
@@ -399,6 +422,7 @@ public static class SearchIndexGenerator
         public EditorialSampleOverride? SampleOverride { get; set; }
     }
 
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     sealed class EditorialSampleOverride
     {
         public string? Header { get; set; }

--- a/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
@@ -375,11 +375,10 @@ public static class SearchIndexGenerator
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var result = new List<string>();
-        foreach (var k in raw)
+        // Filter null/blank keywords here (a hand-edited editorial.json can contain
+        // "keywords": ["a", null]) so the body never Trims a null.
+        foreach (var k in raw.Where(k => !string.IsNullOrWhiteSpace(k)))
         {
-            // A hand-edited editorial.json can contain a null or blank keyword
-            // ("keywords": ["a", null]); treat those as empty and skip rather than NRE on Trim.
-            if (string.IsNullOrWhiteSpace(k)) continue;
             var norm = System.Text.RegularExpressions.Regex.Replace(k.Trim().ToLowerInvariant(), @"\s+", " ");
             if (norm.Length > 0 && seen.Add(norm))
                 result.Add(norm);

--- a/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
@@ -77,7 +77,7 @@ public static class SearchIndexGenerator
                 continue;
             }
 
-            var keywords = NullIfEmpty(ed?.Keywords);
+            var keywords = NormalizeKeywords(ed?.Keywords);
             if (keywords is null)
                 missingKeywords.Add(reg.Id);
 
@@ -351,6 +351,24 @@ public static class SearchIndexGenerator
 
     static IReadOnlyList<string>? NullIfEmpty(IReadOnlyList<string>? list) =>
         list is { Count: > 0 } ? list : null;
+
+    // keywords feed a token-matched BM25 field: each must be a lowercased single token or
+    // short phrase. Trim, lowercase, collapse internal whitespace, and drop empties/dupes so
+    // the emitted form is canonical regardless of how editorial.json was hand-typed.
+    static IReadOnlyList<string>? NormalizeKeywords(IReadOnlyList<string>? raw)
+    {
+        if (raw is null) return null;
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<string>();
+        foreach (var k in raw)
+        {
+            var norm = System.Text.RegularExpressions.Regex.Replace(k.Trim().ToLowerInvariant(), @"\s+", " ");
+            if (norm.Length > 0 && seen.Add(norm))
+                result.Add(norm);
+        }
+        return result.Count > 0 ? result : null;
+    }
 
     static IReadOnlyDictionary<string, EditorialEntry> LoadEditorial(string? editorialPath)
     {

--- a/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
@@ -11,13 +11,15 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.UI.Reactor.SearchIndex;
 
-public static class SearchIndexGenerator
+public static partial class SearchIndexGenerator
 {
     public const int SchemaVersion = 1;
     public const string Source = "reactor";
@@ -130,19 +132,24 @@ public static class SearchIndexGenerator
 
     // ── Serialization ──────────────────────────────────────────────────────
 
-    static readonly JsonSerializerOptions JsonOptions = new()
+    // Serialize through the System.Text.Json source generator (SearchIndexJsonContext) so the
+    // tool is trim / NativeAOT-safe. The context bakes camelCase / WhenWritingNull / WriteIndented;
+    // the encoder (UnsafeRelaxedJsonEscaping — keeps C# markup like => < > & "" readable) can't be
+    // set via the attribute, so it is layered on via a copied-options JsonTypeInfo.
+    static readonly JsonTypeInfo<IndexRoot> IndexRootTypeInfo = CreateIndexRootTypeInfo();
+
+    static JsonTypeInfo<IndexRoot> CreateIndexRootTypeInfo()
     {
-        WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        // Relaxed escaping so C# markup in `code` (=> < > & "") stays human-readable;
-        // only " \ and control chars are escaped. Output is never embedded in HTML.
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-    };
+        var options = new JsonSerializerOptions(SearchIndexJsonContext.Default.Options)
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
+        return (JsonTypeInfo<IndexRoot>)options.GetTypeInfo(typeof(IndexRoot));
+    }
 
     static string Serialize(IndexRoot root)
     {
-        var json = JsonSerializer.Serialize(root, JsonOptions);
+        var json = JsonSerializer.Serialize(root, IndexRootTypeInfo);
         // Force LF structural newlines regardless of platform/runtime defaults. In-string
         // newlines are already the escaped 2-char "\\n", so this only touches indentation.
         json = json.Replace("\r\n", "\n").Replace("\r", "\n");
@@ -198,7 +205,7 @@ public static class SearchIndexGenerator
 
     static string Truncate(SyntaxNode node)
     {
-        var text = System.Text.RegularExpressions.Regex.Replace(node.ToString(), @"\s+", " ").Trim();
+        var text = WhitespaceRegex().Replace(node.ToString(), " ").Trim();
         return text.Length <= 120 ? text : text[..117] + "...";
     }
 
@@ -343,11 +350,13 @@ public static class SearchIndexGenerator
     // like <your-key>. Ellipses inside UI strings ("Type here...") are NOT matched, so those
     // snippets still qualify. Enforces the REAL-CODE-ONLY invariant: the first *complete*
     // card wins, and a control with no complete card needs an editorial sampleOverride.
-    static readonly System.Text.RegularExpressions.Regex PlaceholderPattern = new(
-        @",\s*\.\.\.|\.\.\.\s*\)|\(\s*\.\.\.|^\s*\.\.\.\s*$|\.\.\./|<your",
-        System.Text.RegularExpressions.RegexOptions.Multiline | System.Text.RegularExpressions.RegexOptions.Compiled);
+    [GeneratedRegex(@",\s*\.\.\.|\.\.\.\s*\)|\(\s*\.\.\.|^\s*\.\.\.\s*$|\.\.\./|<your", RegexOptions.Multiline)]
+    private static partial Regex PlaceholderRegex();
 
-    static bool HasPlaceholder(string code) => PlaceholderPattern.IsMatch(code);
+    static bool HasPlaceholder(string code) => PlaceholderRegex().IsMatch(code);
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
 
     // Resolves the representative sample: an editorial sampleOverride can replace the header,
     // the code, or both — or supply the whole sample when no page card qualifies. Returns null
@@ -379,7 +388,7 @@ public static class SearchIndexGenerator
         // "keywords": ["a", null]) so the body never Trims a null.
         foreach (var k in raw.Where(k => !string.IsNullOrWhiteSpace(k)))
         {
-            var norm = System.Text.RegularExpressions.Regex.Replace(k.Trim().ToLowerInvariant(), @"\s+", " ");
+            var norm = WhitespaceRegex().Replace(k.Trim().ToLowerInvariant(), " ");
             if (norm.Length > 0 && seen.Add(norm))
                 result.Add(norm);
         }
@@ -391,10 +400,9 @@ public static class SearchIndexGenerator
         if (string.IsNullOrWhiteSpace(editorialPath) || !File.Exists(editorialPath))
             return new Dictionary<string, EditorialEntry>(StringComparer.Ordinal);
 
-        var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, ReadCommentHandling = JsonCommentHandling.Skip };
         try
         {
-            var parsed = JsonSerializer.Deserialize<Dictionary<string, EditorialEntry>>(File.ReadAllText(editorialPath), opts);
+            var parsed = JsonSerializer.Deserialize(File.ReadAllText(editorialPath), EditorialJsonContext.Default.DictionaryStringEditorialEntry);
             return parsed is null
                 ? new Dictionary<string, EditorialEntry>(StringComparer.Ordinal)
                 : new Dictionary<string, EditorialEntry>(parsed, StringComparer.Ordinal);
@@ -412,25 +420,6 @@ public static class SearchIndexGenerator
     sealed record RegistryEntry(string Id, string Name, string Description, string Category);
 
     sealed record ExtractedSample(string Header, string Code);
-
-    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
-    sealed class EditorialEntry
-    {
-        public List<string>? Keywords { get; set; }
-        public List<string>? RelatedControls { get; set; }
-        public List<string>? Usings { get; set; }
-        public string? ApiNamespace { get; set; }
-        public string? NugetPackage { get; set; }
-        public bool Exclude { get; set; }
-        public EditorialSampleOverride? SampleOverride { get; set; }
-    }
-
-    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
-    sealed class EditorialSampleOverride
-    {
-        public string? Header { get; set; }
-        public string? Code { get; set; }
-    }
 }
 
 // ── JSON output model (property order == emitted key order) ─────────────────
@@ -468,3 +457,42 @@ public sealed class Sample
 public sealed record SearchIndexResult(string Json, int ControlCount, IReadOnlyList<SkippedControl> Skipped);
 
 public sealed record SkippedControl(string Id, string Name, string Reason);
+
+// ── Editorial sidecar model (deserialized from editorial.json; internal to the tool) ────
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+internal sealed class EditorialEntry
+{
+    public List<string>? Keywords { get; set; }
+    public List<string>? RelatedControls { get; set; }
+    public List<string>? Usings { get; set; }
+    public string? ApiNamespace { get; set; }
+    public string? NugetPackage { get; set; }
+    public bool Exclude { get; set; }
+    public EditorialSampleOverride? SampleOverride { get; set; }
+}
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+internal sealed class EditorialSampleOverride
+{
+    public string? Header { get; set; }
+    public string? Code { get; set; }
+}
+
+// ── System.Text.Json source-generation contexts (trim / NativeAOT-safe) ─────────────────
+
+// Output: camelCase keys, omit null optionals, indented. The relaxed encoder is layered on at
+// the use-site (SearchIndexGenerator.CreateIndexRootTypeInfo) since it has no attribute knob.
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(IndexRoot))]
+internal partial class SearchIndexJsonContext : JsonSerializerContext { }
+
+// Input: tolerate case + `//` comments; unmapped members rejected via the per-type attribute.
+[JsonSourceGenerationOptions(
+    PropertyNameCaseInsensitive = true,
+    ReadCommentHandling = JsonCommentHandling.Skip)]
+[JsonSerializable(typeof(Dictionary<string, EditorialEntry>))]
+internal partial class EditorialJsonContext : JsonSerializerContext { }

--- a/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
@@ -377,6 +377,9 @@ public static class SearchIndexGenerator
         var result = new List<string>();
         foreach (var k in raw)
         {
+            // A hand-edited editorial.json can contain a null or blank keyword
+            // ("keywords": ["a", null]); treat those as empty and skip rather than NRE on Trim.
+            if (string.IsNullOrWhiteSpace(k)) continue;
             var norm = System.Text.RegularExpressions.Regex.Replace(k.Trim().ToLowerInvariant(), @"\s+", " ");
             if (norm.Length > 0 && seen.Add(norm))
                 result.Add(norm);

--- a/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
@@ -1,0 +1,425 @@
+// Reactor.SearchIndex — builds samples/ReactorGallery/reactor-search-index.json by
+// parsing the ReactorGallery *source* (ControlRegistry.cs + PageRouter.cs +
+// ControlPages/**) with Roslyn and merging a hand-curated editorial sidecar.
+//
+// The output is a pure, deterministic function of that source + the editorial file:
+// controls sorted by id, fixed key order, LF newlines, stable formatting, and NO
+// volatile value (sha/timestamp) baked in. tests/Reactor.Tests drives Generate(...)
+// in-process and asserts byte-equality with the committed file (the staleness gate).
+
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.UI.Reactor.SearchIndex;
+
+public static class SearchIndexGenerator
+{
+    public const int SchemaVersion = 1;
+    public const string Source = "reactor";
+    public const string GeneratedFrom = "microsoft/microsoft-ui-reactor";
+    public const string DefaultApiNamespace = "Microsoft.UI.Reactor";
+    public const string DefaultNugetPackage = "Microsoft.UI.Reactor";
+
+    // The only "expected" skip reason: an intentional editorial exclude:true. Any other
+    // skip (no route / no clean sample) is a silent drop and fails generation.
+    const string ExcludeReason = "editorial-exclude";
+
+    /// <summary>
+    /// Produces the deterministic index text (and diagnostics) from the gallery source
+    /// directory (the folder holding ControlRegistry.cs / PageRouter.cs / ControlPages)
+    /// and an optional editorial sidecar JSON. A missing/blank editorial path is treated
+    /// as an empty sidecar (all defaults, no keywords).
+    /// </summary>
+    public static SearchIndexResult Generate(string galleryDir, string? editorialPath)
+    {
+        var registry = ParseRegistry(Path.Combine(galleryDir, "ControlRegistry.cs"));
+        var routes = ParseRouter(Path.Combine(galleryDir, "PageRouter.cs"));
+        var samplesByClass = ParseSamples(Path.Combine(galleryDir, "ControlPages"));
+        var editorial = LoadEditorial(editorialPath);
+
+        var registryIds = new HashSet<string>(registry.Select(r => r.Id), StringComparer.Ordinal);
+        var orphanKeys = editorial.Keys.Where(k => !registryIds.Contains(k))
+            .OrderBy(k => k, StringComparer.Ordinal).ToList();
+        if (orphanKeys.Count > 0)
+            throw new InvalidOperationException(
+                "editorial.json has key(s) that match no control id (typo?): " + string.Join(", ", orphanKeys));
+
+        var entries = new List<ControlEntry>();
+        var skipped = new List<SkippedControl>();
+        var missingKeywords = new List<string>();
+
+        foreach (var reg in registry)
+        {
+            editorial.TryGetValue(reg.Id, out var ed);
+
+            if (ed?.Exclude == true)
+            {
+                skipped.Add(new SkippedControl(reg.Id, reg.Name, ExcludeReason));
+                continue;
+            }
+
+            if (!routes.TryGetValue(reg.Id, out var pageClass))
+            {
+                skipped.Add(new SkippedControl(reg.Id, reg.Name, "no-route"));
+                continue;
+            }
+
+            samplesByClass.TryGetValue(pageClass, out var extracted);
+            var sample = ResolveSample(extracted, ed?.SampleOverride);
+            if (sample is null)
+            {
+                skipped.Add(new SkippedControl(reg.Id, reg.Name, $"no-sample ({pageClass})"));
+                continue;
+            }
+
+            var keywords = NullIfEmpty(ed?.Keywords);
+            if (keywords is null)
+                missingKeywords.Add(reg.Id);
+
+            entries.Add(new ControlEntry
+            {
+                Id = reg.Id,
+                Name = reg.Name,
+                Category = reg.Category,
+                Description = reg.Description,
+                Keywords = keywords,
+                RelatedControls = NullIfEmpty(ed?.RelatedControls),
+                ApiNamespace = string.IsNullOrWhiteSpace(ed?.ApiNamespace) ? DefaultApiNamespace : ed!.ApiNamespace,
+                NugetPackage = string.IsNullOrWhiteSpace(ed?.NugetPackage) ? DefaultNugetPackage : ed!.NugetPackage,
+                Usings = NullIfEmpty(ed?.Usings),
+                GalleryRoute = reg.Id,
+                Samples = new[] { sample },
+            });
+        }
+
+        // keywords are winui-search's weighted BM25 field — an included control with none
+        // has its recall collapse, so require every one to be curated in editorial.json.
+        if (missingKeywords.Count > 0)
+            throw new InvalidOperationException(
+                "these included controls have no editorial keywords (required): " + string.Join(", ", missingKeywords));
+
+        // A control dropped for any reason other than an explicit editorial exclude is a
+        // silent coverage loss. Force an intentional decision: add a route/page, an
+        // editorial sampleOverride, or exclude:true.
+        var unexpectedSkips = skipped.Where(s => s.Reason != ExcludeReason).ToList();
+        if (unexpectedSkips.Count > 0)
+            throw new InvalidOperationException(
+                "controls were dropped (no route or no clean sample). Add a page/route, an editorial " +
+                "sampleOverride, or an explicit exclude:true — " +
+                string.Join("; ", unexpectedSkips.Select(s => $"{s.Id} ({s.Reason})")));
+
+        entries.Sort((a, b) => string.CompareOrdinal(a.Id, b.Id));
+        skipped.Sort((a, b) => string.CompareOrdinal(a.Id, b.Id));
+
+        var root = new IndexRoot
+        {
+            SchemaVersion = SchemaVersion,
+            Source = Source,
+            GeneratedFrom = GeneratedFrom,
+            Controls = entries,
+        };
+
+        return new SearchIndexResult(Serialize(root), entries.Count, skipped);
+    }
+
+    // ── Serialization ──────────────────────────────────────────────────────
+
+    static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        // Relaxed escaping so C# markup in `code` (=> < > & "") stays human-readable;
+        // only " \ and control chars are escaped. Output is never embedded in HTML.
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    static string Serialize(IndexRoot root)
+    {
+        var json = JsonSerializer.Serialize(root, JsonOptions);
+        // Force LF structural newlines regardless of platform/runtime defaults. In-string
+        // newlines are already the escaped 2-char "\\n", so this only touches indentation.
+        json = json.Replace("\r\n", "\n").Replace("\r", "\n");
+        if (!json.EndsWith('\n')) json += "\n";
+        return json;
+    }
+
+    // ── ControlRegistry.cs → id/name/category/description ───────────────────
+
+    static IReadOnlyList<RegistryEntry> ParseRegistry(string registryPath)
+    {
+        var root = CSharpSyntaxTree.ParseText(File.ReadAllText(registryPath)).GetRoot();
+
+        var allProp = root.DescendantNodes().OfType<PropertyDeclarationSyntax>()
+            .FirstOrDefault(p => p.Identifier.Text == "All")
+            ?? throw new InvalidOperationException("ControlRegistry.All property not found.");
+
+        // `All` initializer is `new ControlInfo[] { new(...), ... }.OrderBy(...).ToArray()`.
+        // Grab the ControlInfo[] array-creation's initializer.
+        var arrayInit = allProp.Initializer?.Value
+            .DescendantNodesAndSelf().OfType<ArrayCreationExpressionSyntax>()
+            .FirstOrDefault()?.Initializer
+            ?? throw new InvalidOperationException("ControlRegistry.All array initializer not found.");
+
+        var list = new List<RegistryEntry>();
+        foreach (var element in arrayInit.Expressions)
+        {
+            if (ObjectCreationArgs(element) is not { } args || args.Count < 5) continue;
+
+            var title = TryGetStringLiteral(args[0].Expression);
+            var description = TryGetStringLiteral(args[1].Expression);
+            var category = TryGetStringLiteral(args[2].Expression);
+            var tag = TryGetStringLiteral(args[4].Expression);
+
+            if (title is null || description is null || category is null || string.IsNullOrEmpty(tag))
+                continue;
+
+            list.Add(new RegistryEntry(tag, title, description, category));
+        }
+
+        if (list.Count == 0)
+            throw new InvalidOperationException("ControlRegistry parse yielded no entries.");
+
+        return list;
+    }
+
+    static SeparatedSyntaxList<ArgumentSyntax>? ObjectCreationArgs(ExpressionSyntax element) => element switch
+    {
+        ImplicitObjectCreationExpressionSyntax i => i.ArgumentList.Arguments,
+        ObjectCreationExpressionSyntax o => o.ArgumentList?.Arguments,
+        _ => null,
+    };
+
+    // ── PageRouter.cs → tag → page class simple name ────────────────────────
+
+    static IReadOnlyDictionary<string, string> ParseRouter(string routerPath)
+    {
+        var root = CSharpSyntaxTree.ParseText(File.ReadAllText(routerPath)).GetRoot();
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        var switchExpr = root.DescendantNodes().OfType<SwitchExpressionSyntax>().FirstOrDefault()
+            ?? throw new InvalidOperationException("PageRouter switch expression not found.");
+
+        foreach (var arm in switchExpr.Arms)
+        {
+            if (arm.Pattern is not ConstantPatternSyntax cp) continue; // skips the `_` discard arm
+            var tag = TryGetStringLiteral(cp.Expression);
+            if (tag is null) continue;
+
+            // Find the `Component<PageType>()` call and take PageType's simple (rightmost) name.
+            var generic = arm.Expression.DescendantNodesAndSelf().OfType<GenericNameSyntax>()
+                .FirstOrDefault(g => g.Identifier.Text == "Component" && g.TypeArgumentList.Arguments.Count == 1);
+            if (generic is null) continue;
+
+            var pageClass = SimpleTypeName(generic.TypeArgumentList.Arguments[0]);
+            if (pageClass is not null)
+                map[tag] = pageClass;
+        }
+
+        return map;
+    }
+
+    static string? SimpleTypeName(TypeSyntax type) => type switch
+    {
+        IdentifierNameSyntax id => id.Identifier.Text,
+        QualifiedNameSyntax q => q.Right.Identifier.Text,
+        GenericNameSyntax g => g.Identifier.Text,
+        _ => null,
+    };
+
+    // ── ControlPages/**/*.cs → page class → first qualifying SampleCard ─────
+
+    static IReadOnlyDictionary<string, ExtractedSample> ParseSamples(string controlPagesDir)
+    {
+        var map = new Dictionary<string, ExtractedSample>(StringComparer.Ordinal);
+        if (!Directory.Exists(controlPagesDir)) return map;
+
+        var files = Directory.EnumerateFiles(controlPagesDir, "*.cs", SearchOption.AllDirectories)
+            .OrderBy(p => p, StringComparer.Ordinal);
+
+        foreach (var file in files)
+        {
+            var root = CSharpSyntaxTree.ParseText(File.ReadAllText(file)).GetRoot();
+            foreach (var cls in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+            {
+                var name = cls.Identifier.Text;
+                if (map.ContainsKey(name)) continue; // first (sorted-path) wins; names are unique
+
+                var sample = FirstQualifyingSample(cls);
+                if (sample is not null)
+                    map[name] = sample;
+            }
+        }
+
+        return map;
+    }
+
+    static ExtractedSample? FirstQualifyingSample(ClassDeclarationSyntax cls)
+    {
+        foreach (var inv in cls.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (InvokedSimpleName(inv) != "SampleCard") continue;
+
+            var args = inv.ArgumentList.Arguments;
+            if (args.Count < 3) continue;
+
+            var header = TryGetStringLiteral(args[0].Expression);
+            var code = FindSourceCodeArgument(args);
+            if (header is null || code is null) continue;
+
+            var normalized = NormalizeCode(code);
+            if (!HasRealCode(normalized) || HasPlaceholder(normalized)) continue;
+
+            return new ExtractedSample(header.Trim(), normalized);
+        }
+
+        return null;
+    }
+
+    static string? FindSourceCodeArgument(SeparatedSyntaxList<ArgumentSyntax> args)
+    {
+        // Named `sourceCode:` wins wherever it sits...
+        foreach (var a in args)
+        {
+            if (a.NameColon?.Name.Identifier.Text == "sourceCode")
+                return TryGetStringLiteral(a.Expression);
+        }
+        // ...otherwise the 3rd positional argument (title, sample, sourceCode, ...).
+        if (args.Count >= 3 && args[2].NameColon is null)
+            return TryGetStringLiteral(args[2].Expression);
+
+        return null;
+    }
+
+    static string InvokedSimpleName(InvocationExpressionSyntax inv) => inv.Expression switch
+    {
+        MemberAccessExpressionSyntax m => m.Name.Identifier.Text,
+        IdentifierNameSyntax id => id.Identifier.Text,
+        GenericNameSyntax g => g.Identifier.Text,
+        _ => string.Empty,
+    };
+
+    // ── Shared helpers ─────────────────────────────────────────────────────
+
+    static string? TryGetStringLiteral(ExpressionSyntax expr) =>
+        expr is LiteralExpressionSyntax lit && lit.IsKind(SyntaxKind.StringLiteralExpression)
+            ? lit.Token.ValueText
+            : null;
+
+    static string NormalizeCode(string code) =>
+        code.Replace("\r\n", "\n").Replace("\r", "\n").Trim();
+
+    // A snippet qualifies as a real code sample only if it has at least one line that
+    // isn't blank or a pure `//` comment — so a guidance card whose "sourceCode" is only
+    // a descriptive comment (e.g. SpacingPage's first card) is passed over for the next.
+    static bool HasRealCode(string code) =>
+        code.Split('\n').Any(line =>
+        {
+            var t = line.Trim();
+            return t.Length > 0 && !t.StartsWith("//", StringComparison.Ordinal);
+        });
+
+    // Rejects a snippet that abbreviates required code with a placeholder — an args/element
+    // ellipsis ("x, ..." / "(...)" / "...)" / a lone "..." line) or an angle-bracket fill-in
+    // like <your-key>. Ellipses inside UI strings ("Type here...") are NOT matched, so those
+    // snippets still qualify. Enforces the REAL-CODE-ONLY invariant: the first *complete*
+    // card wins, and a control with no complete card needs an editorial sampleOverride.
+    static readonly System.Text.RegularExpressions.Regex PlaceholderPattern = new(
+        @",\s*\.\.\.|\.\.\.\s*\)|\(\s*\.\.\.|^\s*\.\.\.\s*$|\.\.\./|<your",
+        System.Text.RegularExpressions.RegexOptions.Multiline | System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    static bool HasPlaceholder(string code) => PlaceholderPattern.IsMatch(code);
+
+    // Resolves the representative sample: an editorial sampleOverride can replace the header,
+    // the code, or both — or supply the whole sample when no page card qualifies. Returns null
+    // only when neither the page nor the override yields a header + code.
+    static Sample? ResolveSample(ExtractedSample? extracted, EditorialSampleOverride? ov)
+    {
+        var header = string.IsNullOrWhiteSpace(ov?.Header) ? extracted?.Header : ov!.Header!.Trim();
+        var code = string.IsNullOrWhiteSpace(ov?.Code) ? extracted?.Code : NormalizeCode(ov!.Code!);
+
+        if (string.IsNullOrWhiteSpace(header) || string.IsNullOrWhiteSpace(code))
+            return null;
+
+        return new Sample { Header = header!, Language = "csharp", Code = code! };
+    }
+
+    static IReadOnlyList<string>? NullIfEmpty(IReadOnlyList<string>? list) =>
+        list is { Count: > 0 } ? list : null;
+
+    static IReadOnlyDictionary<string, EditorialEntry> LoadEditorial(string? editorialPath)
+    {
+        if (string.IsNullOrWhiteSpace(editorialPath) || !File.Exists(editorialPath))
+            return new Dictionary<string, EditorialEntry>(StringComparer.Ordinal);
+
+        var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, ReadCommentHandling = JsonCommentHandling.Skip };
+        var parsed = JsonSerializer.Deserialize<Dictionary<string, EditorialEntry>>(File.ReadAllText(editorialPath), opts);
+        return parsed is null
+            ? new Dictionary<string, EditorialEntry>(StringComparer.Ordinal)
+            : new Dictionary<string, EditorialEntry>(parsed, StringComparer.Ordinal);
+    }
+
+    // ── Internal parse models ──────────────────────────────────────────────
+
+    sealed record RegistryEntry(string Id, string Name, string Description, string Category);
+
+    sealed record ExtractedSample(string Header, string Code);
+
+    sealed class EditorialEntry
+    {
+        public List<string>? Keywords { get; set; }
+        public List<string>? RelatedControls { get; set; }
+        public List<string>? Usings { get; set; }
+        public string? ApiNamespace { get; set; }
+        public string? NugetPackage { get; set; }
+        public bool Exclude { get; set; }
+        public EditorialSampleOverride? SampleOverride { get; set; }
+    }
+
+    sealed class EditorialSampleOverride
+    {
+        public string? Header { get; set; }
+        public string? Code { get; set; }
+    }
+}
+
+// ── JSON output model (property order == emitted key order) ─────────────────
+
+public sealed class IndexRoot
+{
+    public int SchemaVersion { get; set; }
+    public string Source { get; set; } = "";
+    public string GeneratedFrom { get; set; } = "";
+    public IReadOnlyList<ControlEntry> Controls { get; set; } = Array.Empty<ControlEntry>();
+}
+
+public sealed class ControlEntry
+{
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Category { get; set; } = "";
+    public string Description { get; set; } = "";
+    public IReadOnlyList<string>? Keywords { get; set; }
+    public IReadOnlyList<string>? RelatedControls { get; set; }
+    public string? ApiNamespace { get; set; }
+    public string? NugetPackage { get; set; }
+    public IReadOnlyList<string>? Usings { get; set; }
+    public string GalleryRoute { get; set; } = "";
+    public IReadOnlyList<Sample> Samples { get; set; } = Array.Empty<Sample>();
+}
+
+public sealed class Sample
+{
+    public string Header { get; set; } = "";
+    public string Language { get; set; } = "csharp";
+    public string Code { get; set; } = "";
+}
+
+public sealed record SearchIndexResult(string Json, int ControlCount, IReadOnlyList<SkippedControl> Skipped);
+
+public sealed record SkippedControl(string Id, string Name, string Reason);

--- a/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
@@ -32,14 +32,15 @@ public static class SearchIndexGenerator
     /// <summary>
     /// Produces the deterministic index text (and diagnostics) from the gallery source
     /// directory (the folder holding ControlRegistry.cs / PageRouter.cs / ControlPages)
-    /// and an optional editorial sidecar JSON. A missing/blank editorial path is treated
-    /// as an empty sidecar (all defaults, no keywords).
+    /// and the editorial sidecar JSON. A missing/blank editorial path is treated as an empty
+    /// sidecar, which then fails generation because every included control requires curated
+    /// keywords — a full run needs a real editorial.json.
     /// </summary>
     public static SearchIndexResult Generate(string galleryDir, string? editorialPath)
     {
-        var registry = ParseRegistry(Path.Combine(galleryDir, "ControlRegistry.cs"));
-        var routes = ParseRouter(Path.Combine(galleryDir, "PageRouter.cs"));
-        var samplesByClass = ParseSamples(Path.Combine(galleryDir, "ControlPages"));
+        var registry = ParseRegistry(Path.Join(galleryDir, "ControlRegistry.cs"));
+        var routes = ParseRouter(Path.Join(galleryDir, "PageRouter.cs"));
+        var samplesByClass = ParseSamples(Path.Join(galleryDir, "ControlPages"));
         var editorial = LoadEditorial(editorialPath);
 
         var registryIds = new HashSet<string>(registry.Select(r => r.Id), StringComparer.Ordinal);

--- a/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
+++ b/tools/Reactor.SearchIndex/SearchIndexGenerator.cs
@@ -135,17 +135,12 @@ public static partial class SearchIndexGenerator
     // Serialize through the System.Text.Json source generator (SearchIndexJsonContext) so the
     // tool is trim / NativeAOT-safe. The context bakes camelCase / WhenWritingNull / WriteIndented;
     // the encoder (UnsafeRelaxedJsonEscaping — keeps C# markup like => < > & "" readable) can't be
-    // set via the attribute, so it is layered on via a copied-options JsonTypeInfo.
-    static readonly JsonTypeInfo<IndexRoot> IndexRootTypeInfo = CreateIndexRootTypeInfo();
-
-    static JsonTypeInfo<IndexRoot> CreateIndexRootTypeInfo()
-    {
-        var options = new JsonSerializerOptions(SearchIndexJsonContext.Default.Options)
+    // set via the attribute, so it is layered on by building the context from copied options.
+    static readonly JsonTypeInfo<IndexRoot> IndexRootTypeInfo =
+        new SearchIndexJsonContext(new JsonSerializerOptions(SearchIndexJsonContext.Default.Options)
         {
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        };
-        return (JsonTypeInfo<IndexRoot>)options.GetTypeInfo(typeof(IndexRoot));
-    }
+        }).IndexRoot;
 
     static string Serialize(IndexRoot root)
     {

--- a/tools/Reactor.SearchIndex/editorial.json
+++ b/tools/Reactor.SearchIndex/editorial.json
@@ -1,0 +1,389 @@
+{
+  "acrylic": {
+    "keywords": ["frosted glass", "blur", "translucent", "material", "backdrop"],
+    "relatedControls": ["Theming"]
+  },
+  "animated-icon": {
+    "keywords": ["lottie", "vector animation", "state transition", "micro-interaction", "animated glyph"],
+    "relatedControls": ["AnimatedVisualPlayer", "Icons"]
+  },
+  "animated-visual-player": {
+    "keywords": ["lottie", "vector animation", "codegen", "playback", "composition"],
+    "relatedControls": ["AnimatedIcon", "MediaPlayerElement"]
+  },
+  "annotated-scroll-bar": {
+    "keywords": ["labelled scrollbar", "scroll annotations", "track markers", "minimap", "jump to section"],
+    "relatedControls": ["ScrollView"]
+  },
+  "auto-suggest-box": {
+    "keywords": ["autocomplete", "typeahead", "suggestions", "search box", "combobox input"],
+    "relatedControls": ["TextBox", "ComboBox"]
+  },
+  "border": {
+    "keywords": ["container", "frame", "outline", "rounded corners", "background wrapper"],
+    "relatedControls": ["Card"]
+  },
+  "breadcrumb-bar": {
+    "keywords": ["breadcrumbs", "navigation trail", "path bar", "hierarchy nav", "back navigation"],
+    "relatedControls": ["NavigationView"]
+  },
+  "button": {
+    "keywords": ["click", "command", "submit", "primary action", "accent"],
+    "relatedControls": ["RepeatButton", "ToggleButton", "HyperlinkButton", "SplitButton"]
+  },
+  "calendar-date-picker": {
+    "keywords": ["date input", "date dropdown", "pick a date", "calendar dropdown"],
+    "relatedControls": ["CalendarView", "DatePicker"]
+  },
+  "calendar-view": {
+    "keywords": ["calendar", "month view", "date selection", "schedule", "multi-date"],
+    "relatedControls": ["CalendarDatePicker", "DatePicker"]
+  },
+  "canvas": {
+    "keywords": ["absolute positioning", "free layout", "x y coordinates", "overlay positioning"],
+    "relatedControls": ["RelativePanel"]
+  },
+  "card": {
+    "keywords": ["surface", "tile", "elevated container", "content card", "panel"],
+    "relatedControls": ["Border", "Expander"]
+  },
+  "check-box": {
+    "keywords": ["tick", "boolean", "multi-select", "opt in", "tri-state"],
+    "relatedControls": ["RadioButton", "ToggleSwitch"]
+  },
+  "color": {
+    "keywords": ["theme colors", "brushes", "accent", "palette", "system colors"],
+    "relatedControls": ["ColorPicker", "Theming", "Typography"]
+  },
+  "color-picker": {
+    "keywords": ["color selection", "rgb", "hex", "hue", "eyedropper", "swatch"],
+    "relatedControls": ["Color"]
+  },
+  "combo-box": {
+    "keywords": ["dropdown", "select", "picker", "options list", "single select"],
+    "relatedControls": ["ListBox", "DropDownButton", "AutoSuggestBox"]
+  },
+  "command-bar": {
+    "keywords": ["toolbar", "app bar", "command buttons", "action bar", "overflow menu"],
+    "relatedControls": ["CommandBarFlyout", "MenuBar"]
+  },
+  "command-bar-flyout": {
+    "keywords": ["context menu", "quick commands", "selection menu", "contextual toolbar"],
+    "relatedControls": ["CommandBar", "Flyout", "MenuFlyout"]
+  },
+  "commands": {
+    "keywords": ["command binding", "icommand", "async execute", "can execute", "debounce"],
+    "relatedControls": ["Button"]
+  },
+  "content-dialog": {
+    "keywords": ["modal", "dialog box", "confirm", "alert", "prompt", "popup window"],
+    "relatedControls": ["Flyout", "TeachingTip", "Popup"]
+  },
+  "data-grid": {
+    "keywords": ["table", "spreadsheet", "rows and columns", "sortable", "virtualized grid", "inline edit"],
+    "relatedControls": ["ListView", "PropertyGrid", "ItemsView"],
+    "usings": ["Microsoft.UI.Reactor.Data", "Microsoft.UI.Reactor.Data.Providers", "Microsoft.UI.Reactor.Controls"]
+  },
+  "date-picker": {
+    "keywords": ["date input", "spinner", "pick a date", "calendar picker"],
+    "relatedControls": ["CalendarDatePicker", "TimePicker"]
+  },
+  "docking": {
+    "keywords": ["dock panes", "tearable", "floating windows", "rearrange layout", "tool windows", "ide layout"],
+    "relatedControls": ["TabView", "SplitView"],
+    "usings": ["Microsoft.UI.Reactor.Docking"]
+  },
+  "drop-down-button": {
+    "keywords": ["dropdown menu", "flyout button", "choices", "split options"],
+    "relatedControls": ["SplitButton", "MenuFlyout", "Button"]
+  },
+  "expander": {
+    "keywords": ["collapsible", "accordion", "show hide", "disclosure", "fold"],
+    "relatedControls": ["Card"]
+  },
+  "flex": {
+    "keywords": ["flexbox", "css layout", "flex row column", "justify align", "wrap", "responsive layout"],
+    "relatedControls": ["Grid", "StackPanel"],
+    "usings": ["Microsoft.UI.Reactor.Layout"]
+  },
+  "flip-view": {
+    "keywords": ["carousel", "image gallery", "swipe pages", "slideshow", "paged view"],
+    "relatedControls": ["PipsPager", "GridView"]
+  },
+  "flyout": {
+    "keywords": ["popup", "contextual", "attached popup", "lightweight dialog", "callout"],
+    "relatedControls": ["MenuFlyout", "CommandBarFlyout", "TeachingTip", "Popup"]
+  },
+  "frame": {
+    "keywords": ["page navigation", "navigate", "back forward", "content host", "routing"],
+    "relatedControls": ["NavigationView"]
+  },
+  "geometry": {
+    "keywords": ["corner radius", "rounding", "shape language", "control radius", "overlay radius"],
+    "relatedControls": ["Spacing", "Color", "Typography"]
+  },
+  "grid": {
+    "keywords": ["rows and columns", "layout grid", "cells", "table layout", "spanning"],
+    "relatedControls": ["StackPanel", "RelativePanel", "UniformGrid"]
+  },
+  "grid-view": {
+    "keywords": ["tile view", "thumbnail grid", "wrapping items", "gallery", "card grid"],
+    "relatedControls": ["ListView", "ItemsView", "FlipView"]
+  },
+  "hyperlink-button": {
+    "keywords": ["link", "hyperlink", "navigate url", "web link", "anchor"],
+    "relatedControls": ["Button"]
+  },
+  "icons": {
+    "keywords": ["glyph", "symbol icon", "font icon", "path icon", "vector icon"],
+    "relatedControls": ["AnimatedIcon", "Shapes"]
+  },
+  "image": {
+    "keywords": ["picture", "bitmap", "photo", "img", "asset", "uri source"],
+    "relatedControls": ["PersonPicture"]
+  },
+  "info-badge": {
+    "keywords": ["notification dot", "count badge", "status indicator", "unread count", "dot"],
+    "relatedControls": ["InfoBar"]
+  },
+  "info-bar": {
+    "keywords": ["notification bar", "banner", "inline message", "alert bar", "status message", "dismissible"],
+    "relatedControls": ["InfoBadge", "TeachingTip"]
+  },
+  "interspersed-grid": {
+    "keywords": ["proportional panels", "separators", "weighted layout", "split panels"],
+    "relatedControls": ["UniformGrid", "Grid"]
+  },
+  "items-repeater": {
+    "keywords": ["virtualized list", "custom layout", "data template", "repeater", "bind collection"],
+    "relatedControls": ["ItemsView", "ListView"]
+  },
+  "items-view": {
+    "keywords": ["collection view", "selectable items", "data list", "flexible items"],
+    "relatedControls": ["ListView", "GridView", "ItemsRepeater"]
+  },
+  "list-box": {
+    "keywords": ["inline list", "selectable list", "options", "multi-select list"],
+    "relatedControls": ["ComboBox", "ListView"]
+  },
+  "list-view": {
+    "keywords": ["scrolling list", "data list", "rows", "selection", "virtualized list"],
+    "relatedControls": ["GridView", "ItemsView", "ItemsRepeater", "ListBox"]
+  },
+  "map-control": {
+    "keywords": ["maps", "geolocation", "pan zoom", "markers", "interactive map"],
+    "sampleOverride": {
+      "header": "Interactive map",
+      "code": "MapControl(zoomLevel: 4)\n    .Height(320).Width(480)\n// Supply a Bing Maps token to load tiles:\n//   MapControl(mapServiceToken: mapKey, zoomLevel: 12)"
+    }
+  },
+  "markdown": {
+    "keywords": ["md", "rich text render", "commonmark", "formatted text"],
+    "relatedControls": ["RichTextBlock"]
+  },
+  "media-player-element": {
+    "keywords": ["video", "audio", "playback", "transport controls", "player"],
+    "relatedControls": ["AnimatedVisualPlayer"],
+    "sampleOverride": {
+      "header": "Video with transport controls",
+      "code": "MediaPlayerElement(\"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4\")\n    .Height(280).Width(480)\n// Transport controls are enabled by default; AutoPlay is opt-in:\n//   .Set(mpe => mpe.AutoPlay = true)"
+    }
+  },
+  "menu-bar": {
+    "keywords": ["menus", "top menu", "file edit view", "application menu", "menu strip"],
+    "relatedControls": ["CommandBar", "MenuFlyout"]
+  },
+  "menu-flyout": {
+    "keywords": ["context menu", "right click menu", "dropdown menu", "command list"],
+    "relatedControls": ["Flyout", "CommandBarFlyout", "MenuBar"]
+  },
+  "navigation-view": {
+    "keywords": ["side navigation", "hamburger menu", "app shell", "nav pane", "left nav"],
+    "relatedControls": ["BreadcrumbBar", "TabView", "Pivot", "SplitView"]
+  },
+  "number-box": {
+    "keywords": ["numeric input", "spinner", "stepper", "number field", "increment decrement"],
+    "relatedControls": ["Slider", "TextBox"]
+  },
+  "parallax-view": {
+    "keywords": ["parallax", "depth scroll", "background shift", "scrolling effect"],
+    "relatedControls": ["ScrollView"]
+  },
+  "password-box": {
+    "keywords": ["password", "secure input", "masked text", "credentials", "hidden characters"],
+    "relatedControls": ["TextBox"]
+  },
+  "person-picture": {
+    "keywords": ["avatar", "profile picture", "contact photo", "initials", "user image"],
+    "relatedControls": ["Image"]
+  },
+  "pips-pager": {
+    "keywords": ["dots pager", "page dots", "carousel indicator", "pagination dots"],
+    "relatedControls": ["FlipView"]
+  },
+  "pivot": {
+    "keywords": ["tabs", "tabbed view", "sections", "swipe tabs", "headers"],
+    "relatedControls": ["TabView", "SelectorBar"]
+  },
+  "popup": {
+    "keywords": ["overlay", "floating content", "custom popup", "light-dismiss", "layer"],
+    "relatedControls": ["Flyout", "ContentDialog"]
+  },
+  "progress-bar": {
+    "keywords": ["loading bar", "progress indicator", "percent complete", "determinate", "linear progress"],
+    "relatedControls": ["ProgressRing"]
+  },
+  "progress-ring": {
+    "keywords": ["spinner", "loading spinner", "busy indicator", "circular progress", "activity"],
+    "relatedControls": ["ProgressBar"]
+  },
+  "property-grid": {
+    "keywords": ["property editor", "inspector", "reflection editor", "settings editor", "object properties"],
+    "relatedControls": ["DataGrid"],
+    "usings": ["Microsoft.UI.Reactor.Controls", "System.ComponentModel"]
+  },
+  "radio-button": {
+    "keywords": ["single choice", "option", "radio", "exclusive select", "one of"],
+    "relatedControls": ["RadioButtons", "CheckBox"]
+  },
+  "radio-buttons": {
+    "keywords": ["radio group", "single choice group", "option list", "exclusive options"],
+    "relatedControls": ["RadioButton"]
+  },
+  "rating-control": {
+    "keywords": ["star rating", "rate", "review stars", "score", "five stars"],
+    "relatedControls": ["Slider"]
+  },
+  "refresh-container": {
+    "keywords": ["pull to refresh", "swipe refresh", "reload", "pull down"],
+    "relatedControls": ["ScrollView", "ListView"]
+  },
+  "relative-panel": {
+    "keywords": ["relative layout", "align relative", "constraints", "anchor elements"],
+    "relatedControls": ["Grid", "Canvas"]
+  },
+  "repeat-button": {
+    "keywords": ["press and hold", "auto repeat", "hold to increment", "continuous click"],
+    "relatedControls": ["Button"]
+  },
+  "rich-edit-box": {
+    "keywords": ["rich text editor", "formatting", "rtf", "bold italic", "word processor"],
+    "relatedControls": ["TextBox", "RichTextBlock"]
+  },
+  "rich-text-block": {
+    "keywords": ["formatted text", "read-only rich text", "runs", "inline formatting", "styled text"],
+    "relatedControls": ["RichEditBox", "Markdown"]
+  },
+  "scroll-view": {
+    "keywords": ["scrollable", "scroll container", "overflow", "pan zoom", "viewport"],
+    "relatedControls": ["RefreshContainer", "AnnotatedScrollBar"]
+  },
+  "selector-bar": {
+    "keywords": ["segmented control", "view switcher", "mode toggle", "tab bar", "filter chips"],
+    "relatedControls": ["Pivot", "TabView"]
+  },
+  "semantic-zoom": {
+    "keywords": ["zoom in out", "grouped view", "jump list", "overview detail", "pinch zoom"],
+    "relatedControls": ["GridView", "ListView"]
+  },
+  "shapes": {
+    "keywords": ["rectangle ellipse line path", "vector shapes", "drawing", "primitives", "geometry shapes"],
+    "relatedControls": ["Icons"]
+  },
+  "slider": {
+    "keywords": ["range", "drag thumb", "volume", "seek", "value picker"],
+    "relatedControls": ["NumberBox", "RatingControl"]
+  },
+  "spacing": {
+    "keywords": ["margin padding", "gaps", "layout rhythm", "whitespace", "4px grid"],
+    "relatedControls": ["Geometry", "Typography"]
+  },
+  "split-button": {
+    "keywords": ["primary plus menu", "action with options", "dropdown action", "default action"],
+    "relatedControls": ["DropDownButton", "ToggleSplitButton", "Button"]
+  },
+  "split-view": {
+    "keywords": ["pane", "master detail", "collapsible sidebar", "navigation pane", "drawer"],
+    "relatedControls": ["NavigationView"],
+    "sampleOverride": {
+      "header": "Collapsible pane + content",
+      "code": "SplitView(\n    pane: VStack(8,\n        TextBlock(\"Pane\").Bold(),\n        TextBlock(\"Item 1\"),\n        TextBlock(\"Item 2\")\n    ).Padding(12),\n    content: VStack(8,\n        Button(isOpen ? \"Close Pane\" : \"Open Pane\", () => setIsOpen(!isOpen)),\n        TextBlock(\"Main content area\")\n    ).Padding(12)\n) with { IsPaneOpen = isOpen }\n.Set(sv => sv.DisplayMode = SplitViewDisplayMode.Inline)"
+    }
+  },
+  "stack-panel": {
+    "keywords": ["vertical stack", "horizontal stack", "vstack hstack", "linear layout", "stack children"],
+    "relatedControls": ["Grid", "Flex"]
+  },
+  "swipe-control": {
+    "keywords": ["swipe actions", "swipe to delete", "reveal commands", "gesture actions"],
+    "relatedControls": ["ListView"]
+  },
+  "tab-view": {
+    "keywords": ["tabs", "closable tabs", "browser tabs", "reorderable tabs", "document tabs"],
+    "relatedControls": ["Pivot", "SelectorBar"]
+  },
+  "teaching-tip": {
+    "keywords": ["coach mark", "callout", "feature highlight", "onboarding", "tip popup"],
+    "relatedControls": ["Flyout", "InfoBar", "ToolTip"]
+  },
+  "text-box": {
+    "keywords": ["text input", "textfield", "single line", "multiline", "form field"],
+    "relatedControls": ["RichEditBox", "AutoSuggestBox", "PasswordBox", "NumberBox"]
+  },
+  "theming": {
+    "keywords": ["light dark", "dark mode", "high contrast", "theme switch", "requested theme"],
+    "relatedControls": ["Color", "Acrylic"]
+  },
+  "time-picker": {
+    "keywords": ["time input", "pick a time", "clock spinner", "hour minute"],
+    "relatedControls": ["DatePicker"]
+  },
+  "title-bar": {
+    "keywords": ["window title", "caption bar", "custom titlebar", "window chrome", "draggable region"]
+  },
+  "toggle-button": {
+    "keywords": ["press state", "on off button", "sticky button", "toggle", "pressed"],
+    "relatedControls": ["ToggleSwitch", "ToggleSplitButton", "Button"]
+  },
+  "toggle-split-button": {
+    "keywords": ["toggle with menu", "on off plus options", "split toggle"],
+    "relatedControls": ["SplitButton", "ToggleButton"]
+  },
+  "toggle-switch": {
+    "keywords": ["switch", "on off", "boolean", "enable disable"],
+    "relatedControls": ["CheckBox", "ToggleButton"]
+  },
+  "tool-tip": {
+    "keywords": ["hover hint", "hover text", "help popup", "hint"],
+    "relatedControls": ["TeachingTip", "Flyout"]
+  },
+  "tree-view": {
+    "keywords": ["tree", "hierarchy", "expandable nodes", "folder tree", "nested list"],
+    "relatedControls": ["ListView"]
+  },
+  "type-ramp": {
+    "keywords": ["text styles", "font sizes", "title subtitle body", "heading", "typography ramp"],
+    "relatedControls": ["Typography", "RichTextBlock"],
+    "sampleOverride": {
+      "header": "Type ramp factories — Title / Subtitle / Body"
+    }
+  },
+  "typography": {
+    "keywords": ["text styles", "font hierarchy", "headings", "type scale", "text ramp"],
+    "relatedControls": ["Type ramp", "Spacing", "Color"]
+  },
+  "uniform-grid": {
+    "keywords": ["equal cells", "grid of equal size", "tiles", "matrix layout"],
+    "relatedControls": ["WrapGrid", "Grid"]
+  },
+  "viewbox": {
+    "keywords": ["scale to fit", "stretch content", "zoom fit", "proportional scaling"]
+  },
+  "web-view-2": {
+    "keywords": ["web view", "embedded browser", "html content", "edge webview", "browser control"]
+  },
+  "wrap-grid": {
+    "keywords": ["wrapping layout", "flow layout", "wrap items", "tag cloud", "reflow"],
+    "relatedControls": ["UniformGrid", "Grid"]
+  }
+}

--- a/tools/Reactor.SearchIndex/editorial.json
+++ b/tools/Reactor.SearchIndex/editorial.json
@@ -48,7 +48,7 @@
     "relatedControls": ["Border", "Expander"]
   },
   "check-box": {
-    "keywords": ["tick", "boolean", "multi-select", "opt in", "tri-state"],
+    "keywords": ["tick", "boolean", "multi-select", "select", "opt in", "tri-state", "state"],
     "relatedControls": ["RadioButton", "ToggleSwitch"]
   },
   "color": {
@@ -163,7 +163,7 @@
     "relatedControls": ["ListView", "GridView", "ItemsRepeater"]
   },
   "list-box": {
-    "keywords": ["inline list", "selectable list", "options", "multi-select list"],
+    "keywords": ["inline list", "selectable list", "select", "options", "multi-select list"],
     "relatedControls": ["ComboBox", "ListView"]
   },
   "list-view": {
@@ -226,7 +226,7 @@
     "relatedControls": ["TabView", "SelectorBar"]
   },
   "popup": {
-    "keywords": ["overlay", "floating content", "custom popup", "light-dismiss", "layer"],
+    "keywords": ["overlay", "floating content", "custom popup", "light-dismiss", "dismiss", "layer"],
     "relatedControls": ["Flyout", "ContentDialog"]
   },
   "progress-bar": {

--- a/tools/Reactor.SearchIndex/editorial.json
+++ b/tools/Reactor.SearchIndex/editorial.json
@@ -80,7 +80,7 @@
     "relatedControls": ["Flyout", "TeachingTip", "Popup"]
   },
   "data-grid": {
-    "keywords": ["table", "spreadsheet", "rows and columns", "sortable", "virtualized grid", "inline edit"],
+    "keywords": ["table", "spreadsheet", "rows and columns", "sortable", "virtualized grid", "inline edit", "select"],
     "relatedControls": ["ListView", "PropertyGrid", "ItemsView"],
     "usings": ["Microsoft.UI.Reactor.Data", "Microsoft.UI.Reactor.Data.Providers", "Microsoft.UI.Reactor.Controls"]
   },
@@ -127,7 +127,7 @@
     "relatedControls": ["StackPanel", "RelativePanel", "UniformGrid"]
   },
   "grid-view": {
-    "keywords": ["tile view", "thumbnail grid", "wrapping items", "gallery", "card grid"],
+    "keywords": ["tile view", "thumbnail grid", "wrapping items", "gallery", "card grid", "select"],
     "relatedControls": ["ListView", "ItemsView", "FlipView"]
   },
   "hyperlink-button": {
@@ -159,7 +159,7 @@
     "relatedControls": ["ItemsView", "ListView"]
   },
   "items-view": {
-    "keywords": ["collection view", "selectable items", "data list", "flexible items"],
+    "keywords": ["collection view", "selectable items", "select", "data list", "flexible items"],
     "relatedControls": ["ListView", "GridView", "ItemsRepeater"]
   },
   "list-box": {
@@ -167,7 +167,7 @@
     "relatedControls": ["ComboBox", "ListView"]
   },
   "list-view": {
-    "keywords": ["scrolling list", "data list", "rows", "selection", "virtualized list"],
+    "keywords": ["scrolling list", "data list", "rows", "selection", "select", "virtualized list"],
     "relatedControls": ["GridView", "ItemsView", "ItemsRepeater", "ListBox"]
   },
   "map-control": {


### PR DESCRIPTION
## What & why

Adds **`samples/ReactorGallery/reactor-search-index.json`** — a deterministic, schema-versioned index of the ReactorGallery's controls that the external **winui-search** CLI consumes (it fetches this file from `https://raw.githubusercontent.com/microsoft/microsoft-ui-reactor/main/samples/ReactorGallery/reactor-search-index.json` and embeds a snapshot). Schema + invariants were agreed with the winui-search CLI owner and their search-quality experts.

Current output: **93 controls, 0 skipped.**

## Contract

```json
{ "schemaVersion": 1, "source": "reactor", "generatedFrom": "microsoft/microsoft-ui-reactor",
  "controls": [ { "id", "name", "category", "description",
                  "keywords"?, "relatedControls"?, "apiNamespace"?, "nugetPackage"?, "usings"?,
                  "galleryRoute", "samples": [ { "header", "language": "csharp", "code" } ] } ] }
```

Control-level `id` (= `ControlRegistry` Tag) with a `samples[]` array; scenario-level ids are assigned by the ReactorProvider at map time. Controls sorted by `id`; fixed key order; LF; **no volatile values** (`generatedFrom` is the literal repo slug) so the staleness check is a clean equality compare.

## It's generated, not hand-maintained

- **`tools/Reactor.SearchIndex/`** — a headless Roslyn generator (mirrors the existing `tools/Reactor.ApiIndex` convention). It parses `ControlRegistry.cs` (id/name/category/description), `PageRouter.cs` (tag → page), and `ControlPages/**` (the first *complete* real-code `SampleCard`), and merges a curated editorial sidecar. `dotnet run --project tools/Reactor.SearchIndex` regenerates; `--check` gates staleness (exit 1 stale / 2 error).
- **`tools/Reactor.SearchIndex/editorial.json`** — curated `keywords` / `relatedControls` / `usings` / `sampleOverride`, keyed by id.
- **`tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs`** — regenerates in-process and asserts **byte-equality** with the committed file (the staleness gate that runs in CI `dotnet test`), plus 14 non-vacuous structural/differential checks.
- **`samples/ReactorGallery/.gitattributes`** — pins the JSON to `eol=lf` so the byte-equality gate is deterministic on every OS/checkout.

## Search-ranking + robustness invariants

Baked in per the winui-search experts and a two-pass (Claude + GPT-5.5) PR review:

- **keywords = weighted BM25 field** — every included control carries a populated, high-signal 3–8 keyword set (not the control name/category); generation fails if any included control has none.
- **header = primary per-scenario BM25 field** — descriptive, never a bare control-name repeat; an editorial `sampleOverride` can supply a better one.
- **REAL CODE ONLY** — placeholder cards (ellipsis `, ...` / `...)` / `.../`, `<your-key>`) are rejected in favour of the first *complete* card, or a faithful editorial override (`map-control`, `split-view`, `media-player-element`).
- **No silent drops** — orphan editorial keys and any non-`exclude` skip fail generation.

## Validation

- `dotnet build -p:Platform=x64` (Release warning-clean); JSON parses; every entry has `id`/`name`/`category`/`description` + ≥1 csharp sample with real code; regenerate-twice is byte-identical.
- Gate suite: 15/15 green; mutation-verified that removing the sort or the placeholder rejection fails the gate.

No public API surface change (no `reactor.api.txt` regen); the tool builds transitively via the test project's `ProjectReference` (same as `Reactor.ApiIndex`).