### PR TITLE
Make tools/Reactor.ApiIndex trim/NativeAOT-honest (+ prove native AOT publish)

### DIFF
--- a/tools/Reactor.ApiIndex/ApiIndexGenerator.cs
+++ b/tools/Reactor.ApiIndex/ApiIndexGenerator.cs
@@ -15,6 +15,7 @@
 // All reflection lives here, in tooling — never in the shipping Reactor library
 // (which treats trimming/AOT warnings as errors).
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
 
@@ -22,8 +23,21 @@ namespace Microsoft.UI.Reactor.ApiIndex;
 
 public static class ApiIndexGenerator
 {
+    // Every entry point below reflects over the whole public surface of the built
+    // Reactor.dll (GetExportedTypes / GetMembers / GetType-by-name) to emit reactor.api.txt.
+    // The tool's entire purpose is to enumerate exactly what the trimmer would remove, so it
+    // is inherently trim/AOT-unsafe and is only ever run at build time (never shipped, never
+    // trimmed, never AOT-published — see Reactor.ApiIndex.csproj / README.md). The requirement
+    // is surfaced honestly via [RequiresUnreferencedCode]/[RequiresDynamicCode] rather than
+    // silenced, so the IL2*/IL3* analyzer still guards against *new*, unintended reflection.
+    const string ReflectionJustification =
+        "Reflects over the entire public surface of the built Reactor.dll to emit reactor.api.txt; " +
+        "enumerates exactly what the trimmer would remove. Build-time-only generator — never trimmed or AOT-published.";
+
     // Single source of truth for the index text. Program.cs (the apphost) and the
     // ApiIndexGeneratorTests (in-process, ARM64-safe) both call this.
+    [RequiresUnreferencedCode(ReflectionJustification)]
+    [RequiresDynamicCode(ReflectionJustification)]
     public static string Generate(Assembly asm)
     {
         var sb = new StringBuilder();
@@ -51,6 +65,7 @@ public static class ApiIndexGenerator
 
     // -----------------------------------------------------------------------
 
+    [RequiresUnreferencedCode(ReflectionJustification)]
     static void EmitFactories(Assembly asm, StringBuilder sb)
     {
         var factories = asm.GetType("Microsoft.UI.Reactor.Factories");
@@ -72,6 +87,7 @@ public static class ApiIndexGenerator
         sb.AppendLine();
     }
 
+    [RequiresUnreferencedCode(ReflectionJustification)]
     static void EmitModifiers(Assembly asm, StringBuilder sb)
     {
         sb.AppendLine("## Modifiers (extension methods on Element)");
@@ -95,6 +111,7 @@ public static class ApiIndexGenerator
         sb.AppendLine();
     }
 
+    [RequiresUnreferencedCode(ReflectionJustification)]
     static void EmitReferenceBuilders(Assembly asm, StringBuilder sb)
     {
         sb.AppendLine("## Reference builders (custom controls)");
@@ -122,6 +139,7 @@ public static class ApiIndexGenerator
         sb.AppendLine();
     }
 
+    [RequiresUnreferencedCode(ReflectionJustification)]
     static void EmitHooks(Assembly asm, StringBuilder sb)
     {
         sb.AppendLine("## Hooks (RenderContext / Component)");
@@ -157,6 +175,7 @@ public static class ApiIndexGenerator
         sb.AppendLine();
     }
 
+    [RequiresUnreferencedCode(ReflectionJustification)]
     static void EmitTheme(Assembly asm, StringBuilder sb)
     {
         sb.AppendLine("## Theme tokens (Microsoft.UI.Reactor.Core.Theme)");
@@ -197,6 +216,7 @@ public static class ApiIndexGenerator
         sb.AppendLine();
     }
 
+    [RequiresUnreferencedCode(ReflectionJustification)]
     static void EmitEnums(Assembly asm, StringBuilder sb)
     {
         sb.AppendLine("## Enums (public, under Microsoft.UI.Reactor.*)");
@@ -223,6 +243,7 @@ public static class ApiIndexGenerator
     //  zero hits in reactor.api.txt.
     // -----------------------------------------------------------------------
 
+    [RequiresUnreferencedCode(ReflectionJustification)]
     static void EmitPublicTypes(Assembly asm, StringBuilder sb)
     {
         sb.AppendLine("## Public types (ctors / properties / methods / events)");
@@ -324,6 +345,7 @@ public static class ApiIndexGenerator
         return true;
     }
 
+    [RequiresUnreferencedCode(ReflectionJustification)]
     static string KindOf(Type t)
     {
         if (t.IsInterface) return "interface";
@@ -362,6 +384,7 @@ public static class ApiIndexGenerator
     static bool IsObsolete(MemberInfo m) =>
         m.IsDefined(typeof(ObsoleteAttribute), inherit: false);
 
+    [RequiresUnreferencedCode(ReflectionJustification)]
     static bool IsEnumMemberObsolete(Type enumType, string name)
     {
         var field = enumType.GetField(name, BindingFlags.Public | BindingFlags.Static);

--- a/tools/Reactor.ApiIndex/ApiIndexGenerator.cs
+++ b/tools/Reactor.ApiIndex/ApiIndexGenerator.cs
@@ -25,19 +25,22 @@ public static class ApiIndexGenerator
 {
     // Every entry point below reflects over the whole public surface of the built
     // Reactor.dll (GetExportedTypes / GetMembers / GetType-by-name) to emit reactor.api.txt.
-    // The tool's entire purpose is to enumerate exactly what the trimmer would remove, so it
-    // is inherently trim/AOT-unsafe and is only ever run at build time (never shipped, never
-    // trimmed, never AOT-published — see Reactor.ApiIndex.csproj / README.md). The requirement
-    // is surfaced honestly via [RequiresUnreferencedCode]/[RequiresDynamicCode] rather than
-    // silenced, so the IL2*/IL3* analyzer still guards against *new*, unintended reflection.
+    // The tool's entire purpose is to enumerate exactly what the trimmer would remove, so it is
+    // inherently trim-unsafe: under trimming the metadata it reads gets pruned. It is a
+    // build-time-only generator (never shipped); a native NativeAOT publish is possible only via
+    // the opt-in ReactorApiAot proof that roots the whole Reactor assembly — see
+    // Reactor.ApiIndex.csproj / README.md. The requirement is surfaced honestly via
+    // [RequiresUnreferencedCode] rather than silenced, so the IL2*/IL3* analyzer still guards
+    // against *new*, unintended reflection. (No [RequiresDynamicCode]: this is metadata
+    // discovery + reflection-invoke only — no runtime codegen — as the successful rooted AOT
+    // publish confirms.)
     const string ReflectionJustification =
         "Reflects over the entire public surface of the built Reactor.dll to emit reactor.api.txt; " +
-        "enumerates exactly what the trimmer would remove. Build-time-only generator — never trimmed or AOT-published.";
+        "enumerates exactly what the trimmer would remove. Build-time-only generator — not AOT-published except via the opt-in ReactorApiAot proof.";
 
     // Single source of truth for the index text. Program.cs (the apphost) and the
     // ApiIndexGeneratorTests (in-process, ARM64-safe) both call this.
     [RequiresUnreferencedCode(ReflectionJustification)]
-    [RequiresDynamicCode(ReflectionJustification)]
     public static string Generate(Assembly asm)
     {
         var sb = new StringBuilder();

--- a/tools/Reactor.ApiIndex/README.md
+++ b/tools/Reactor.ApiIndex/README.md
@@ -1,0 +1,51 @@
+# Reactor.ApiIndex
+
+Builds the text of `skills/reactor.api.txt` (and its byte-identical copy under
+`plugins/reactor/skills/reactor-dsl/references/`) by **reflecting over the built
+`Reactor.dll`** — `Assembly.GetExportedTypes()` / `Type.GetMembers()` — and emitting a flat,
+alphabetized signatures index. It is a build-time-only class library; the apphost that runs it
+is the sibling `tools/Reactor.SignaturesGen`, and `ApiIndexGeneratorTests` drives the same
+`ApiIndexGenerator.Generate(asm)` in-process (ARM64-safe).
+
+Regenerate the two committed copies with `mur --regen-api` (or just build `Reactor.SignaturesGen`
+— its `AfterBuild` target rewrites them).
+
+## Trimming / NativeAOT
+
+Unlike the Roslyn-only `tools/Reactor.SearchIndex` (which parses gallery *source*, so it went
+AOT-clean trivially), this tool's whole job is to **enumerate the full public surface of a
+WinUI-backed assembly via reflection** — i.e. exactly what a trimmer removes. That makes it a
+fundamentally harder AOT target, so the story is different:
+
+**The IL2*/IL3* analyzer is enabled** (`IsAotCompatible=true`, replacing the old
+`ReactorSkipAotAnalysis` opt-out). Every reflecting entry point is *annotated* honestly rather
+than silenced: `ApiIndexGenerator.Generate` carries `[RequiresUnreferencedCode]` +
+`[RequiresDynamicCode]`, and each reflecting helper carries `[RequiresUnreferencedCode]`, so the
+requirement bubbles to callers and the analyzer keeps guarding against *new*, unintended
+reflection. The `Reactor.SignaturesGen` apphost acknowledges the resulting IL2026/IL3050 at its
+one call site via a justified `[UnconditionalSuppressMessage]`.
+
+**A native single-file build does work** — with two caveats that the naïve SearchIndex recipe
+does not need:
+
+```pwsh
+dotnet publish tools/Reactor.SignaturesGen -r win-x64 -c Release -p:ReactorApiAot=true
+```
+
+- `ReactorApiAot=true` sets `PublishAot` **inside** the csproj rather than passing
+  `-p:PublishAot=true` as a global property. A global `PublishAot` leaks through Reactor's
+  `ProjectReference` graph into the **netstandard2.0** analyzer/generator projects, which reject
+  AOT with `NETSDK1207` before ILC even starts. Scoping it per-project sidesteps that.
+- The gate also adds `<TrimmerRootAssembly Include="Reactor" />`. Because the generator reflects
+  over precisely the members the trimmer would prune, **without rooting the assembly the native
+  exe runs but emits an empty header-only skeleton (~1.7 KB) instead of the full ~315 KB index.**
+  With the root, the ~30 MB native exe emits an index **byte-identical** to the committed file.
+- `IlcTreatWarningsAsErrors=false` is applied by the same gate; native linking also needs the VS
+  C++ tools (`vswhere.exe` / `link.exe`) on `PATH`.
+
+**Verdict:** trim/AOT-honest, and a native NativeAOT publish is *feasible and complete* via the
+opt-in gate above — but only because the generator is allowed to root the entire Reactor
+assembly. It is not something to run in the normal build (the apphost path is a plain,
+host-arch-matching exe); the opt-in gate exists purely as a reproducible proof. If you add a new
+reflection call to the generator, the enabled analyzer will flag it — annotate it (don't
+re-disable the analyzer).

--- a/tools/Reactor.ApiIndex/README.md
+++ b/tools/Reactor.ApiIndex/README.md
@@ -12,21 +12,21 @@ Regenerate the two committed copies with `mur --regen-api` (or just build `React
 
 ## Trimming / NativeAOT
 
-Unlike the Roslyn-only `tools/Reactor.SearchIndex` (which parses gallery *source*, so it went
-AOT-clean trivially), this tool's whole job is to **enumerate the full public surface of a
-WinUI-backed assembly via reflection** — i.e. exactly what a trimmer removes. That makes it a
-fundamentally harder AOT target, so the story is different:
+This tool's whole job is to **enumerate the full public surface of a WinUI-backed assembly via
+reflection** — i.e. exactly what a trimmer removes. That makes it a genuinely hard AOT target
+(harder than a source-parsing generator, which never touches built metadata), so the story is
+worth spelling out:
 
 **The IL2*/IL3* analyzer is enabled** (`IsAotCompatible=true`, replacing the old
 `ReactorSkipAotAnalysis` opt-out). Every reflecting entry point is *annotated* honestly rather
-than silenced: `ApiIndexGenerator.Generate` carries `[RequiresUnreferencedCode]` +
-`[RequiresDynamicCode]`, and each reflecting helper carries `[RequiresUnreferencedCode]`, so the
-requirement bubbles to callers and the analyzer keeps guarding against *new*, unintended
-reflection. The `Reactor.SignaturesGen` apphost acknowledges the resulting IL2026/IL3050 at its
-one call site via a justified `[UnconditionalSuppressMessage]`.
+than silenced: `ApiIndexGenerator.Generate` and each reflecting helper carry
+`[RequiresUnreferencedCode]`, so the requirement bubbles to callers and the analyzer keeps
+guarding against *new*, unintended reflection. (No `[RequiresDynamicCode]` — the generator does
+metadata discovery and reflection-invoke only, no runtime codegen.) The `Reactor.SignaturesGen`
+apphost acknowledges the resulting IL2026 at its one call site via a justified
+`[UnconditionalSuppressMessage]`.
 
-**A native single-file build does work** — with two caveats that the naïve SearchIndex recipe
-does not need:
+**A native single-file build does work** — with two caveats beyond a plain `dotnet publish`:
 
 ```pwsh
 dotnet publish tools/Reactor.SignaturesGen -r win-x64 -c Release -p:ReactorApiAot=true

--- a/tools/Reactor.ApiIndex/README.md
+++ b/tools/Reactor.ApiIndex/README.md
@@ -41,7 +41,10 @@ dotnet publish tools/Reactor.SignaturesGen -r win-x64 -c Release -p:ReactorApiAo
   exe runs but emits an empty header-only skeleton (~1.7 KB) instead of the full ~315 KB index.**
   With the root, the ~30 MB native exe emits an index **byte-identical** to the committed file.
 - `IlcTreatWarningsAsErrors=false` is applied by the same gate; native linking also needs the VS
-  C++ tools (`vswhere.exe` / `link.exe`) on `PATH`.
+  C++ tools (`vswhere.exe` / `link.exe`) on `PATH`. This flag covers third-party ILC warnings
+  from the WinUI/CsWinRT dependency graph pulled in by `Reactor.dll` — **not** the generator's own
+  code, which stays warning-clean through the `[RequiresUnreferencedCode]` annotations above and is
+  independent of it.
 
 **Verdict:** trim/AOT-honest, and a native NativeAOT publish is *feasible and complete* via the
 opt-in gate above — but only because the generator is allowed to root the entire Reactor

--- a/tools/Reactor.ApiIndex/Reactor.ApiIndex.csproj
+++ b/tools/Reactor.ApiIndex/Reactor.ApiIndex.csproj
@@ -7,10 +7,18 @@
     <AssemblyName>Reactor.ApiIndex</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Build-time API-index generator: reflects over arbitrary compiled assemblies
-         (Assembly.GetExportedTypes / Type.GetMembers) by design and is never shipped
-         or AOT-published. Opt out of the IL2*/IL3* analyzer. -->
-    <ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>
+    <!-- Build-time API-index generator: reflects over the built Reactor.dll surface
+         (Assembly.GetExportedTypes / Type.GetMembers) by design. The IL2*/IL3* analyzer
+         is enabled (IsAotCompatible) so the intentional reflection is *annotated* rather
+         than silently ignored — every reflecting entry point carries a
+         [RequiresUnreferencedCode]/[RequiresDynamicCode] or a justified
+         [UnconditionalSuppressMessage]. This makes the generator AOT-honest. A native
+         NativeAOT publish of the SignaturesGen host IS feasible and produces a
+         byte-identical index, but only via an opt-in gate that roots the whole Reactor
+         assembly (the tool enumerates exactly what the trimmer would otherwise prune) —
+         see tools/Reactor.ApiIndex/README.md and the ReactorApiAot gate in
+         tools/Reactor.SignaturesGen/Reactor.SignaturesGen.csproj. -->
+    <IsAotCompatible>true</IsAotCompatible>
     <UseWinUI>true</UseWinUI>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <WindowsPackageType>None</WindowsPackageType>

--- a/tools/Reactor.ApiIndex/Reactor.ApiIndex.csproj
+++ b/tools/Reactor.ApiIndex/Reactor.ApiIndex.csproj
@@ -11,7 +11,7 @@
          (Assembly.GetExportedTypes / Type.GetMembers) by design. The IL2*/IL3* analyzer
          is enabled (IsAotCompatible) so the intentional reflection is *annotated* rather
          than silently ignored — every reflecting entry point carries a
-         [RequiresUnreferencedCode]/[RequiresDynamicCode] or a justified
+         [RequiresUnreferencedCode] or a justified
          [UnconditionalSuppressMessage]. This makes the generator AOT-honest. A native
          NativeAOT publish of the SignaturesGen host IS feasible and produces a
          byte-identical index, but only via an opt-in gate that roots the whole Reactor

--- a/tools/Reactor.SignaturesGen/Program.cs
+++ b/tools/Reactor.SignaturesGen/Program.cs
@@ -16,14 +16,14 @@ namespace Microsoft.UI.Reactor.SignaturesGen;
 internal static class Program
 {
     // This apphost's whole reason to exist is to invoke the reflection-based
-    // ApiIndexGenerator.Generate (annotated [RequiresUnreferencedCode]/[RequiresDynamicCode])
-    // at build time. It is never trimmed or AOT-published — the build only runs it as a plain
-    // apphost whose arch matches the host — so the IL2026/IL3050 from that call are expected and
-    // acknowledged here rather than blanket-disabling the analyzer for the project.
+    // ApiIndexGenerator.Generate (annotated [RequiresUnreferencedCode]) at build time. The
+    // normal build runs it as a plain, host-arch-matching apphost (not trimmed); it is only
+    // AOT-published via the opt-in ReactorApiAot proof (see the csproj), which roots the whole
+    // Reactor assembly. Either way the IL2026 from that call is expected and acknowledged here
+    // rather than blanket-disabling the analyzer for the project. (No IL3050: Generate does
+    // metadata reflection + reflection-invoke only, no runtime codegen.)
     [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "Build-time-only apphost that intentionally drives ApiIndexGenerator's full-surface reflection over Reactor.dll; never trimmed or AOT-published.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050",
-        Justification = "Build-time-only apphost that intentionally drives ApiIndexGenerator's full-surface reflection over Reactor.dll; never trimmed or AOT-published.")]
+        Justification = "Build-time-only apphost that intentionally drives ApiIndexGenerator's full-surface reflection over Reactor.dll; not trimmed, and only AOT-published via the opt-in ReactorApiAot proof that roots the assembly.")]
     private static int Main(string[] args)
     {
         if (args.Length < 1)

--- a/tools/Reactor.SignaturesGen/Program.cs
+++ b/tools/Reactor.SignaturesGen/Program.cs
@@ -8,40 +8,59 @@
 //   dotnet run --project tools/Reactor.SignaturesGen -- <repo-root>
 //   (build target in csproj passes the repo root automatically)
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Reactor.ApiIndex;
 
-if (args.Length < 1)
+namespace Microsoft.UI.Reactor.SignaturesGen;
+
+internal static class Program
 {
-    Console.Error.WriteLine("usage: Reactor.SignaturesGen <repo-root>");
-    return 1;
-}
-
-var repoRoot = Path.GetFullPath(args[0]);
-
-// Write to both the legacy path (consumed by `mur --api` embedding and the
-// `agentkit/` NuGet layout) and the plugin-format path (consumed by the
-// `reactor-dsl` skill's `references/`). One generation source of truth —
-// keeps the two committed copies from drifting.
-var outputPaths = new[]
-{
-    Path.Combine(repoRoot, "skills", "reactor.api.txt"),
-    Path.Combine(repoRoot, "plugins", "reactor", "skills", "reactor-dsl", "references", "reactor.api.txt"),
-};
-
-var content = ApiIndexGenerator.Generate(typeof(Microsoft.UI.Reactor.Factories).Assembly);
-
-foreach (var outputPath in outputPaths)
-{
-    Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-
-    // Skip rewriting if unchanged — keeps file mtimes stable for incremental builds.
-    if (File.Exists(outputPath) && File.ReadAllText(outputPath) == content)
+    // This apphost's whole reason to exist is to invoke the reflection-based
+    // ApiIndexGenerator.Generate (annotated [RequiresUnreferencedCode]/[RequiresDynamicCode])
+    // at build time. It is never trimmed or AOT-published — the build only runs it as a plain
+    // apphost whose arch matches the host — so the IL2026/IL3050 from that call are expected and
+    // acknowledged here rather than blanket-disabling the analyzer for the project.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Build-time-only apphost that intentionally drives ApiIndexGenerator's full-surface reflection over Reactor.dll; never trimmed or AOT-published.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Build-time-only apphost that intentionally drives ApiIndexGenerator's full-surface reflection over Reactor.dll; never trimmed or AOT-published.")]
+    private static int Main(string[] args)
     {
-        Console.WriteLine($"reactor.api.txt unchanged ({outputPath})");
-        continue;
-    }
+        if (args.Length < 1)
+        {
+            Console.Error.WriteLine("usage: Reactor.SignaturesGen <repo-root>");
+            return 1;
+        }
 
-    File.WriteAllText(outputPath, content);
-    Console.WriteLine($"wrote {outputPath} ({content.Length} bytes)");
+        var repoRoot = Path.GetFullPath(args[0]);
+
+        // Write to both the legacy path (consumed by `mur --api` embedding and the
+        // `agentkit/` NuGet layout) and the plugin-format path (consumed by the
+        // `reactor-dsl` skill's `references/`). One generation source of truth —
+        // keeps the two committed copies from drifting.
+        var outputPaths = new[]
+        {
+            Path.Combine(repoRoot, "skills", "reactor.api.txt"),
+            Path.Combine(repoRoot, "plugins", "reactor", "skills", "reactor-dsl", "references", "reactor.api.txt"),
+        };
+
+        var content = ApiIndexGenerator.Generate(typeof(Microsoft.UI.Reactor.Factories).Assembly);
+
+        foreach (var outputPath in outputPaths)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+            // Skip rewriting if unchanged — keeps file mtimes stable for incremental builds.
+            if (File.Exists(outputPath) && File.ReadAllText(outputPath) == content)
+            {
+                Console.WriteLine($"reactor.api.txt unchanged ({outputPath})");
+                continue;
+            }
+
+            File.WriteAllText(outputPath, content);
+            Console.WriteLine($"wrote {outputPath} ({content.Length} bytes)");
+        }
+
+        return 0;
+    }
 }
-return 0;

--- a/tools/Reactor.SignaturesGen/Reactor.SignaturesGen.csproj
+++ b/tools/Reactor.SignaturesGen/Reactor.SignaturesGen.csproj
@@ -36,6 +36,26 @@
     <ProjectReference Include="..\Reactor.ApiIndex\Reactor.ApiIndex.csproj" />
   </ItemGroup>
 
+  <!-- Opt-in NativeAOT proof (off by default; the normal build runs this as a plain
+       apphost). Reproduce with:
+           dotnet publish tools/Reactor.SignaturesGen -r win-x64 -c Release -p:ReactorApiAot=true
+       Notes that make it actually work (see tools/Reactor.ApiIndex/README.md):
+         • PublishAot is set *inside* the csproj (gated on ReactorApiAot) rather than passed as a
+           global -p:PublishAot=true, so it does NOT leak into the netstandard2.0
+           analyzer/generator ProjectReferences in Reactor's graph (those reject AOT — NETSDK1207).
+         • TrimmerRootAssembly roots the entire Reactor surface; the generator reflects over exactly
+           what the trimmer would otherwise remove, so without this the native exe emits an empty
+           header-only skeleton (~1.7 KB) instead of the full ~315 KB index.
+         • Native linking needs the VS C++ tools (vswhere.exe / link.exe) on PATH.
+       Verified: the resulting native exe emits an index byte-identical to the committed file. -->
+  <PropertyGroup Condition="'$(ReactorApiAot)' == 'true'">
+    <PublishAot>true</PublishAot>
+    <IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(ReactorApiAot)' == 'true'">
+    <TrimmerRootAssembly Include="Reactor" />
+  </ItemGroup>
+
   <!-- After build, run the generator with the repo root as argv[0] so the file
        lands at <repo>/skills/reactor.api.txt. The same file is then packed into
        the Reactor NuGet (see Reactor.csproj) and embedded into the mur CLI.


### PR DESCRIPTION
## Summary

Migrates `tools/Reactor.ApiIndex` off the `ReactorSkipAotAnalysis` opt-out and makes its intentional reflection **AOT-honest** — and, surprisingly, proves a **complete native NativeAOT publish is feasible**. This is the first of a planned per-tool batch addressing #70.

`Reactor.ApiIndex` reflects over the built `Reactor.dll` (`Assembly.GetExportedTypes()` / `Type.GetMembers()`) to emit `skills/reactor.api.txt`. Because it enumerates exactly what the trimmer would remove, it was previously AOT-skip-listed (see #70's comment, which lists it under "never-AOT-published"). This PR revisits that.

## Changes

- **Enable the IL2\*/IL3\* analyzer** on `Reactor.ApiIndex` (remove `ReactorSkipAotAnalysis`, set `IsAotCompatible=true`). 44 IL findings surfaced across 22 reflection sites.
- **Annotate rather than silence**: `ApiIndexGenerator.Generate` and each reflecting helper carry `[RequiresUnreferencedCode]`, so the requirement bubbles to callers and the analyzer keeps guarding against *new*, unintended reflection. No `[RequiresDynamicCode]` is used — the generator does metadata discovery + reflection-invoke only (no runtime codegen), which the successful rooted NativeAOT publish confirms.
- **`Reactor.SignaturesGen`** (the build-time apphost — the only production caller) acknowledges the propagated `IL2026` at its single call site via a justified `[UnconditionalSuppressMessage]` (converted its top-level program to an explicit `Main`).
- **Opt-in NativeAOT proof gate** (`-p:ReactorApiAot=true`, off by default): sets `PublishAot` *inside* the csproj (so it doesn't leak into the netstandard2.0 analyzer graph — a global `-p:PublishAot=true` fails with `NETSDK1207`) plus `<TrimmerRootAssembly Include="Reactor" />` (so reflection sees the full surface instead of an empty ~1.7 KB skeleton).
- **New `tools/Reactor.ApiIndex/README.md`** documenting the trimming/AOT story.

## Verification

- `dotnet publish tools/Reactor.SignaturesGen -r win-x64 -c Release -p:ReactorApiAot=true` links a ~30 MB native exe that emits an index **byte-identical** to the committed `skills/reactor.api.txt` (315,169 bytes). Without `TrimmerRootAssembly` it runs but emits a hollow ~1.7 KB skeleton — the visible proof of why rooting is required.
- `ApiIndexGeneratorTests` **6/6 green**.
- Both `reactor.api.txt` copies **byte-identical** / untouched; normal (non-AOT) build path emits "unchanged".

## Relates to #70

Corrects the "`Reactor.ApiIndex` is never-AOT-published" framing: it can be, with an assembly root. Part of a per-tool AOT migration effort; follow-up PRs will cover the remaining `tools/` projects and re-verify #70's per-feature claims.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>