### PR TITLE
Make Spec047Aggregator NativeAOT-publishable

### DIFF
--- a/tools/spec047-aggregator/README.md
+++ b/tools/spec047-aggregator/README.md
@@ -1,0 +1,51 @@
+# spec047-aggregator
+
+Reads the JSON-Lines result streams produced by `PerfBench.ControlModel` (micro M1–M13)
+and the `StressPerf.*` macro variants, and emits the three Spec 047 §15.6 reporting tables
+(absolute comparison, Reactor delta, WinUI gap) plus a per-PR `trend.csv` and an
+`excluded.txt` list of rows dropped for environment-metadata mismatch.
+
+```pwsh
+dotnet run --project tools/spec047-aggregator -- --in "<glob>.jsonl" --out <dir> [--baseline <sku>] [--ci-min-reps N]
+```
+
+## Trimming / NativeAOT
+
+This tool is **trim/AOT-clean with no annotations**. Unlike the reflection-heavy
+`tools/Reactor.ApiIndex` (which enumerates a WinUI assembly's surface and must root it), the
+aggregator only reads JSON-Lines and writes Markdown/CSV — it has **zero reflection**, no
+`Regex`, and already serializes through the **System.Text.Json source generator**
+(`AggregatorJsonContext`, `[JsonSerializable(typeof(Row))]`). The IL2\*/IL3\* analyzer is on
+for every net10+ project via `Directory.Build.targets` and reports nothing here, so no
+`[RequiresUnreferencedCode]`, `[UnconditionalSuppressMessage]`, or `TrimmerRootAssembly` is
+required.
+
+A full native NativeAOT publish works via an **opt-in gate** (`-p:Spec047Aot=true`, off by
+default):
+
+```pwsh
+# vswhere.exe / link.exe (VS C++ tools) must be on PATH for native linking:
+$env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\Installer;$env:PATH"
+dotnet publish tools/spec047-aggregator/Spec047Aggregator.csproj -c Release -r win-x64 -p:Spec047Aot=true
+```
+
+That produces a ~2.8 MB self-contained native single-file exe (no managed runtime DLLs)
+whose output is **byte-identical** to the JIT build's.
+
+### Why opt-in rather than unconditional `PublishAot`
+
+The gate sets `<PublishAot>true</PublishAot>` **inside** the csproj (guarded on `Spec047Aot`)
+rather than always-on because this project is a member of `Reactor.slnx`:
+
+- An unconditional `PublishAot` turns *every* plain `dotnet publish` of the tool — and a
+  whole-solution publish — into a native ILC compile that requires the VS C++ toolchain
+  (`vswhere.exe` / `link.exe`) on PATH, so it would fail on any machine or CI leg that lacks
+  them.
+- Gating it keeps the default `dotnet build` / `dotnet run` / `dotnet publish` verbs behaving
+  exactly as before (a plain managed apphost) and makes native AOT an explicit opt-in.
+
+If you add reflection or a non-source-generated serializer to this tool, the enabled analyzer
+will flag it — annotate it honestly (don't disable the analyzer).
+
+Part of the per-tool NativeAOT migration tracked by
+[#70](https://github.com/microsoft/microsoft-ui-reactor/issues/70).

--- a/tools/spec047-aggregator/Spec047Aggregator.csproj
+++ b/tools/spec047-aggregator/Spec047Aggregator.csproj
@@ -21,4 +21,23 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <!-- Opt-in NativeAOT publish (off by default; the normal build / `dotnet run` /
+       `dotnet publish` verbs behave exactly as before). Reproduce with:
+           dotnet publish tools/spec047-aggregator/Spec047Aggregator.csproj -c Release -r win-x64 -p:Spec047Aot=true
+
+       Why opt-in rather than an unconditional <PublishAot>true</PublishAot>: this project is a
+       member of Reactor.slnx. Always-on PublishAot would turn every plain `dotnet publish` of
+       the tool (and a whole-solution publish) into a native ILC compile that requires the VS
+       C++ toolchain (vswhere.exe / link.exe) on PATH — so it would fail on any machine or CI
+       leg that lacks those tools. Gating on Spec047Aot keeps the default build/run/publish path
+       a plain managed apphost, byte-for-byte unchanged, and makes native AOT an explicit opt-in.
+
+       No TrimmerRootAssembly / IL suppressions are needed: the aggregator has zero reflection
+       and already serializes via the System.Text.Json source generator (AggregatorJsonContext),
+       so the IL2*/IL3* analyzer (on via Directory.Build.targets for net10+) is already clean.
+       Verified: the native exe emits output byte-identical to the JIT build. See README.md. -->
+  <PropertyGroup Condition="'$(Spec047Aot)' == 'true'">
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Makes `tools/spec047-aggregator` (net10.0, `Exe`) native-AOT-publishable via an **opt-in gate**, as part of the per-tool NativeAOT migration tracked by #70. **Verdict: WORKS (opt-in).**

This tool reads perf JSON-Lines (`PerfBench.ControlModel` / `StressPerf.*`) and emits the Spec 047 §15.6 reporting tables + `trend.csv` + `excluded.txt`. It turned out to be **already trim/AOT-clean**: it has **zero reflection**, no `Regex`, and already serializes through the System.Text.Json source generator (`AggregatorJsonContext`, `[JsonSerializable(typeof(Row))]`). The IL2\*/IL3\*-as-errors analyzer (on for every net10+ project via `Directory.Build.targets`) reports nothing, so **no `[RequiresUnreferencedCode]`, `[UnconditionalSuppressMessage]`, or `TrimmerRootAssembly` was needed** — unlike the reflection-heavy `tools/Reactor.ApiIndex` (#886). `Program.cs` is unchanged.

## Changes

- **`Spec047Aggregator.csproj`** — adds an opt-in `PropertyGroup` that sets `<PublishAot>true</PublishAot>` only when `-p:Spec047Aot=true`. Off by default.
- **`tools/spec047-aggregator/README.md`** (new) — documents the trimming/AOT story, the publish command, and why the gate is opt-in.

## Publish command (reproduce)

```pwsh
# vswhere.exe / link.exe (VS C++ tools) must be on PATH for native linking:
$env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\Installer;$env:PATH"
dotnet publish tools/spec047-aggregator/Spec047Aggregator.csproj -c Release -r win-x64 -p:Spec047Aot=true
```

## Why opt-in (not unconditional `PublishAot`)

The project is a member of `Reactor.slnx`. An always-on `PublishAot` would turn *every* plain `dotnet publish` of the tool — and a whole-solution publish — into a native ILC compile that requires the VS C++ toolchain (`vswhere.exe` / `link.exe`) on PATH, so it would fail on any machine or CI leg that lacks them. Gating on `Spec047Aot` keeps the default `dotnet build` / `dotnet run` / `dotnet publish` verbs **byte-for-byte unchanged** and makes native AOT an explicit opt-in (same shape as #886's `ReactorApiAot`, but without needing `TrimmerRootAssembly`/suppressions since there's no reflection here).

> Note: verified on the .NET 10 SDK that a no-RID publish with the gate on does *not* emit `NETSDK1097` (the SDK infers the host RID and proceeds to ILC), and a plain `dotnet build` with the gate on stays 0/0 and doesn't pull ILCompiler — so the opt-in rationale rests on the native-toolchain requirement above, not on those error codes.

## Verification

- Native publish links a **~2.8 MB self-contained native single-file exe** (publish dir contains only `.exe` + `.pdb`, no managed runtime DLLs).
- The native exe **runs correctly** across all invocation paths (usage → exit 0, missing `--in` → exit 2, `--help` → exit 0, `--baseline` match + mismatch, numeric/string variant converter, missing-field & parse-error exclusion, multi-arch grouping, min-reps skip).
- Output is **byte-identical** (SHA-256) to the JIT build across all five emitted files (`summary-absolute.md`, `summary-delta.md`, `summary-gap.md`, `trend.csv`, `excluded.txt`).
- Default build stays **0 warnings / 0 errors**; the gate-off path is unchanged; `bin`/`obj` are gitignored (only the two source files change).
- Ran the repo `pr-review` skill including a multi-model cross-check (GPT-5.5, high reasoning, different model family) on the final commit — **0 findings**; every factual claim independently re-verified against the actual files.

## Relates to #70

#70 does not list this tool by name, and this change touches none of its specific reflection claims (all in `src/`), so no correction comment was warranted. This is one tool in the per-tool AOT migration.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>