### PR TITLE
Document NativeAOT blocker for DevtoolsNegativeResolutionFixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           else
             echo "docs-templates=false" >> "$GITHUB_OUTPUT"
           fi
-          if echo "$files" | grep -qE '^(src/Reactor/Hosting/|src/Reactor\.Devtools/|tools/Reactor\.MstatVerifier/|samples/apps/hello-world-aot/|samples/apps/hello-world-aot-devtools-on/)'; then
+          if echo "$files" | grep -qE '^(src/Reactor/Hosting/|src/Reactor\.Devtools/|tools/Reactor\.MstatVerifier/|tools/Reactor\.DevtoolsNegativeResolutionFixture/|samples/apps/hello-world-aot/|samples/apps/hello-world-aot-devtools-on/)'; then
             echo "devtools-trim=true" >> "$GITHUB_OUTPUT"
           else
             echo "devtools-trim=false" >> "$GITHUB_OUTPUT"

--- a/tools/Reactor.DevtoolsNegativeResolutionFixture/README.md
+++ b/tools/Reactor.DevtoolsNegativeResolutionFixture/README.md
@@ -8,3 +8,38 @@ dotnet run --project tools\Reactor.MstatVerifier\Reactor.MstatVerifier.csproj -c
 ```
 
 The verifier passes only when `dotnet build` fails with a type/namespace-not-found diagnostic, proving devtools implementation types are unavailable without `Microsoft.UI.Reactor.Devtools`.
+
+## NativeAOT status — intentionally excluded (do not migrate)
+
+This project is deliberately **not** NativeAOT-publishable, and it must stay that
+way. It is a **negative-compilation fixture**: its `Program.cs` references
+`Microsoft.UI.Reactor.Hosting.Devtools.DevtoolsMcpServer` (an `internal` type that
+lives in the separate `Microsoft.UI.Reactor.Devtools` assembly) while referencing
+only core `Microsoft.UI.Reactor`. The contract, asserted by the
+`devtools-trim-mstat` CI job, is that `dotnet build` **fails** with `CS0246`/`CS0234`.
+
+NativeAOT publishing requires a successful `compile → IL → ILC → native link`.
+This project fails at the very first step — the C# compile — so ILC never runs.
+It cannot be made AOT-publishable without making it *compile*, which would destroy
+its purpose, flip the negative-resolution verifier to a failure, and break the
+`devtools-trim-mstat` CI lane (spec 051, [issue #497](https://github.com/microsoft/microsoft-ui-reactor/issues/497)).
+
+This is why the project is excluded from `Reactor.slnx`, carries
+`ReactorSkipAotAnalysis=true` (opting out of the repo's AOT analyzer), and is
+tracked as a **documented blocker** — not a to-do — for the repo-wide NativeAOT
+effort in [issue #70](https://github.com/microsoft/microsoft-ui-reactor/issues/70).
+
+Repro (any of these — all fail before ILC):
+
+```powershell
+# 1. The fixture's designed contract (CI relies on this failing):
+dotnet build tools\Reactor.DevtoolsNegativeResolutionFixture\Reactor.DevtoolsNegativeResolutionFixture.csproj -p:Platform=x64 --nologo
+#   -> Program.cs(3,12): error CS0246: The type or namespace name 'DevtoolsMcpServer' could not be found
+
+# 2. A plain publish (prerequisite for AOT) fails identically at compile:
+dotnet publish tools\Reactor.DevtoolsNegativeResolutionFixture\Reactor.DevtoolsNegativeResolutionFixture.csproj -r win-x64 -p:Platform=x64 -c Release --nologo
+#   -> same CS0246
+```
+
+If you are working through issue #70: **skip this project.** The correct outcome
+here is a documented blocker, not a migration.

--- a/tools/Reactor.DevtoolsNegativeResolutionFixture/Reactor.DevtoolsNegativeResolutionFixture.csproj
+++ b/tools/Reactor.DevtoolsNegativeResolutionFixture/Reactor.DevtoolsNegativeResolutionFixture.csproj
@@ -1,5 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!--
+    NEGATIVE-COMPILATION FIXTURE — DO NOT make this project compile or
+    AOT-publishable. Its contract (asserted by the devtools-trim-mstat CI job via
+    Reactor.MstatVerifier 'negative-resolution') is that `dotnet build` FAILS with
+    CS0246/CS0234, proving Microsoft.UI.Reactor.Hosting.Devtools implementation
+    types are unreachable without the Microsoft.UI.Reactor.Devtools package
+    (spec 051 / issue #497). It is therefore intentionally excluded from the
+    repo-wide NativeAOT effort (issue #70): a project that cannot compile can never
+    reach ILC. See README.md. ReactorSkipAotAnalysis opts it out of the AOT
+    analyzer, matching the Directory.Build.targets carve-out for by-design
+    contract-guard fixtures.
+  -->
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
@@ -9,6 +22,7 @@
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
     <IsPackable>false</IsPackable>
+    <ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Part of the repo-wide NativeAOT effort (#70). Target: **`tools/Reactor.DevtoolsNegativeResolutionFixture`** (and nothing else).

**Verdict: DOCUMENTED-BLOCKER.** This project cannot be made NativeAOT-publishable, and it must not be — it is a **negative-compilation fixture** whose contract is that `dotnet build` *fails*.

## What I found

The fixture's `Program.cs` is:

```csharp
using Microsoft.UI.Reactor.Hosting.Devtools;
_ = typeof(DevtoolsMcpServer);
```

`DevtoolsMcpServer` is an `internal sealed class` in the **separate** `Microsoft.UI.Reactor.Devtools` assembly, but the fixture references only core `Microsoft.UI.Reactor`. So `dotnet build` fails **by design** with `CS0246`. The `devtools-trim-mstat` CI job runs `Reactor.MstatVerifier negative-resolution` against it, and that verifier **passes only when the build fails** with `CS0246`/`CS0234` — proving devtools implementation types are unreachable from core Reactor (spec 051 / #497). The project is excluded from `Reactor.slnx`.

NativeAOT publishing requires `compile → IL → ILC → native link`. This project fails at the **first step (C# compile)**, so ILC never runs. Making it AOT-publishable would require making it *compile*, which would destroy the fixture's purpose, flip the verifier to a failure, and break the `devtools-trim-mstat` lane. This is **not** the reflection-heavy Devtools blocker #70 anticipated — it is more fundamental (a structural compile-failure fixture). I posted a STEP 0 correction/confirmation on #70.

## Exact repro

```powershell
# 1. The fixture's designed contract (CI relies on this FAILING):
dotnet build tools\Reactor.DevtoolsNegativeResolutionFixture\Reactor.DevtoolsNegativeResolutionFixture.csproj -p:Platform=x64 --nologo
#   -> Program.cs(3,12): error CS0246: The type or namespace name 'DevtoolsMcpServer' could not be found

# 2. A plain publish (prerequisite for AOT) fails identically at compile:
dotnet publish tools\Reactor.DevtoolsNegativeResolutionFixture\Reactor.DevtoolsNegativeResolutionFixture.csproj -r win-x64 -p:Platform=x64 -c Release --nologo
#   -> same CS0246

# 3. A global -p:PublishAot=true never even reaches the fixture — it leaks into the
#    transitively-referenced netstandard2.0 analyzer/generator projects:
#   -> error NETSDK1207: Ahead-of-time compilation is not supported for the target framework
#      (Reactor.Analyzers, Reactor.Wrappers.Generator, ...)
```

## What changed

Documentation + intent markers only — **no behavior change; the fixture still fails to compile with `CS0246` and the verifier still passes (verified locally).**

- **`README.md`** — new "NativeAOT status — intentionally excluded (do not migrate)" section: root cause, repro, and a "skip this project" note for anyone working through #70.
- **`.csproj`** — a guard comment ("DO NOT make this project compile or AOT-publishable…") and `<ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>`, the repo's blessed opt-out for by-design contract-guard fixtures (`Directory.Build.targets`). It gates only the trim/AOT analyzer, not C# compilation, so the `CS0246` contract is unchanged.
- **`.github/workflows/ci.yml`** — the `devtools-trim` path filter triggered the verifier on changes to `Reactor.MstatVerifier` (the verifier) but not to the fixture it validates, so a PR editing only the fixture — like this one — would skip the check. Added the fixture path so fixture/project-file edits actually run the verifier. (Surfaced by the pr-review multi-model cross-check.)

## Opt-in?

N/A — there is no working AOT path to gate. This is a documented blocker, not a migration. `ReactorSkipAotAnalysis=true` simply records that the project is intentionally outside the AOT-analyzed set.

## Review

Ran the repo `pr-review` skill (`.github/skills/pr-review/`), including the multi-model cross-check on a different model family (GPT-5.5, high reasoning). Its one finding — the CI path-filter gap above — is fixed in this PR.

Closes nothing; updates tracking on #70.