### PR TITLE
Make Reactor.MstatVerifier NativeAOT-publishable

### DIFF
--- a/tools/Reactor.MstatVerifier/README.md
+++ b/tools/Reactor.MstatVerifier/README.md
@@ -1,7 +1,8 @@
 # Reactor.MstatVerifier
 
 Build-time verifier used by CI to guard the devtools trimming / AOT-isolation story
-(spec-051). It has three modes, all invoked via `dotnet run` from
+(spec-051). It has three invocation modes (with `absence` and `presence` being the two
+directions of the same mstat check), all invoked via `dotnet run` from
 [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml):
 
 - `absence|presence <path-to.mstat> <path-to.exe>` — reads a NativeAOT `*.mstat` payload and
@@ -56,7 +57,7 @@ Two things worth knowing:
   trim/AOT warning, including new reflection in this tool's own code, still fails the native
   publish. Native link also needs the VS C++ tools (`vswhere.exe` / `link.exe`) on `PATH`.
 
-**Verdict:** native NativeAOT publish is **feasible and complete** — the ~3 MB self-contained
+**Verdict:** a full NativeAOT publish is **feasible and complete** — the ~3 MB self-contained
 exe produces output **byte-identical** to the JIT build across all three modes (`reactor-il`,
 `absence` / `presence`, `negative-resolution`) plus the no-args usage path. The gate exists
 purely as a reproducible proof; the everyday path is the plain host-arch `dotnet run` CI uses.

--- a/tools/Reactor.MstatVerifier/README.md
+++ b/tools/Reactor.MstatVerifier/README.md
@@ -1,0 +1,65 @@
+# Reactor.MstatVerifier
+
+Build-time verifier used by CI to guard the devtools trimming / AOT-isolation story
+(spec-051). It has three modes, all invoked via `dotnet run` from
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml):
+
+- `absence|presence <path-to.mstat> <path-to.exe>` — reads a NativeAOT `*.mstat` payload and
+  asserts a curated set of type/symbol names (devtools MCP server, `PreviewCaptureServer`,
+  `System.Net.Http.*`, `System.Text.Json` metadata, …) are **absent** (devtools switched off)
+  or **present** (positive control), and — in `absence` mode — that the hello-world AOT exe
+  stays under a size budget.
+- `reactor-il <path-to-Reactor.dll>` — walks `Reactor.dll` with Mono.Cecil and fails if any
+  devtools *implementation* type leaked into the core assembly.
+- `negative-resolution <path-to-fixture.csproj>` — shells `dotnet build` on a fixture and
+  asserts it fails with `CS0246`/`CS0234` (devtools impl types are unavailable without the
+  `Microsoft.UI.Reactor.Devtools` package).
+
+It reads assembly metadata via **Mono.Cecil** and scans raw bytes for ASCII strings; it does
+**no runtime reflection over its own managed types**, emits no JSON, and uses no `Regex`.
+
+## Trimming / NativeAOT
+
+Part of the repo-wide AOT effort ([#70](https://github.com/microsoft/microsoft-ui-reactor/issues/70)).
+
+The IL2\*/IL3\* analyzer is **on by default** for this project (`IsAotCompatible`, via
+`Directory.Build.targets`) and this tool's own code is warning-clean — it never reflects over
+managed types; it parses metadata out of *files* with Mono.Cecil. Because it does not enumerate
+a live assembly's members through runtime reflection, it needs **no `TrimmerRootAssembly`** and
+no `[RequiresUnreferencedCode]` / `[DynamicallyAccessedMembers]` annotations — the trimmer
+cannot prune anything this tool relies on reflectively.
+
+**A native single-file build works** via an opt-in gate:
+
+```pwsh
+dotnet publish tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj `
+  -c Release -r win-x64 -p:ReactorMstatAot=true
+```
+
+Two things worth knowing:
+
+- **`ReactorMstatAot=true` is opt-in, not unconditional.** CI runs the tool with plain
+  `dotnet run … -c Release` (no RID). An always-on `<PublishAot>` would make a RID-less
+  `dotnet publish` of this project fail with *"PublishAot requires a RuntimeIdentifier"*, so the
+  gate keeps the normal path byte-identical and RID-free. `PublishAot` is set **inside** the
+  csproj rather than forced as a global `-p:PublishAot=true` property, so the opt-in stays
+  self-contained; `Directory.Build.targets` already forces `PublishAot=false` on the repo's
+  `netstandard2.0` analyzer/generator projects to keep a global `PublishAot` from leaking there
+  (`NETSDK1207`), though this tool references none of them.
+- **The only ILC findings come from Mono.Cecil, in a path this tool never runs.** Mono.Cecil's
+  dynamic PDB/MDB symbol-provider discovery (`Mono.Cecil.Cil.SymbolProvider`, which locates a
+  symbol reader by name via `Activator.CreateInstance` / `Type.GetType` / `Assembly.GetType`)
+  trips `IL2072`/`IL2057`/`IL2026`. This tool always reads with the default `ReaderParameters`
+  (`ReadSymbols=false`), so that code path is never reached at runtime. The gate demotes
+  **exactly those three codes** from error to warning for the ILC step (via
+  `WarningsNotAsErrors`), rather than a blanket `IlcTreatWarningsAsErrors=false` — so any *other*
+  trim/AOT warning, including new reflection in this tool's own code, still fails the native
+  publish. Native link also needs the VS C++ tools (`vswhere.exe` / `link.exe`) on `PATH`.
+
+**Verdict:** native NativeAOT publish is **feasible and complete** — the ~3 MB self-contained
+exe produces output **byte-identical** to the JIT build across all three modes (`reactor-il`,
+`absence` / `presence`, `negative-resolution`) plus the no-args usage path. The gate exists
+purely as a reproducible proof; the everyday path is the plain host-arch `dotnet run` CI uses.
+If you add
+new reflection to this tool, the enabled analyzer will flag it — annotate it honestly, don't
+re-disable the analyzer.

--- a/tools/Reactor.MstatVerifier/README.md
+++ b/tools/Reactor.MstatVerifier/README.md
@@ -52,10 +52,10 @@ Two things worth knowing:
   symbol reader by name via `Activator.CreateInstance` / `Type.GetType` / `Assembly.GetType`)
   trips `IL2072`/`IL2057`/`IL2026`. This tool always reads with the default `ReaderParameters`
   (`ReadSymbols=false`), so that code path is never reached at runtime. The gate demotes
-  **exactly those three codes** from error to warning for the ILC step (via
-  `WarningsNotAsErrors`), rather than a blanket `IlcTreatWarningsAsErrors=false` — so any *other*
-  trim/AOT warning, including new reflection in this tool's own code, still fails the native
-  publish. Native link also needs the VS C++ tools (`vswhere.exe` / `link.exe`) on `PATH`.
+  **exactly those three codes** from error to warning by adding them to `WarningsNotAsErrors`,
+  which the ILCompiler native-publish targets forward to the ilc `--nowarnaserr` switch — rather
+  than flipping the blanket `IlcTreatWarningsAsErrors=false`. So any *other* trim/AOT warning,
+  including new reflection in this tool's own code, still fails the native publish. Native link also needs the VS C++ tools (`vswhere.exe` / `link.exe`) on `PATH`.
 
 **Verdict:** a full NativeAOT publish is **feasible and complete** — the ~3 MB self-contained
 exe produces output **byte-identical** to the JIT build across all three modes (`reactor-il`,

--- a/tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj
+++ b/tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj
@@ -6,6 +6,44 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <!-- The IL2*/IL3* analyzer is enabled by default (IsAotCompatible in
+         Directory.Build.targets); this tool's own code stays fully analyzed and
+         warning-clean. Reads assembly metadata via Mono.Cecil with the default
+         ReaderParameters (ReadSymbols=false), so no runtime reflection over managed
+         types of its own — see the ReactorMstatAot gate below for the NativeAOT story. -->
+  </PropertyGroup>
+
+  <!--
+    Opt-in NativeAOT proof gate (off by default): `-p:ReactorMstatAot=true`.
+
+        dotnet publish tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj \
+          -c Release -r win-x64 -p:ReactorMstatAot=true
+
+    Kept opt-in (not unconditional) so the normal build/run path CI uses
+    (`dotnet run` on this project, `-c Release`, see ci.yml) is
+    byte-identical and RID-free — an always-on <PublishAot> would make a plain,
+    RID-less `dotnet publish` of this project fail with "PublishAot requires a
+    RuntimeIdentifier". PublishAot is set INSIDE the csproj rather than forced as a
+    global property, so the opt-in stays self-contained: Directory.Build.targets
+    already forces PublishAot=false on the repo's non-net10 (netstandard2.0)
+    analyzer/generator projects to stop a global PublishAot leaking into that graph
+    (NETSDK1207). This tool references none of them, so scoping it here is purely
+    tidy, not required.
+
+    Mono.Cecil's dynamic PDB/MDB symbol-provider discovery
+    (Mono.Cecil.Cil.SymbolProvider.GetReaderProvider/GetSymbolType, which use
+    Activator.CreateInstance / Type.GetType / Assembly.GetType to locate a symbol
+    reader by name) trips IL2072/IL2057/IL2026 under ILC. This tool always reads
+    with the default ReaderParameters (ReadSymbols=false), so that path is never
+    reached at runtime; the warnings are third-party and unexercised. Demote
+    exactly those three codes from error to warning for the ILC step via the
+    nowarnaserr switch (WarningsNotAsErrors) rather than a blanket
+    IlcTreatWarningsAsErrors=false, so every other trim/AOT code (including any
+    new reflection in this tool's own code) still fails the native publish.
+  -->
+  <PropertyGroup Condition="'$(ReactorMstatAot)' == 'true'">
+    <PublishAot>true</PublishAot>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2026;IL2057;IL2072</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj
+++ b/tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj
@@ -35,10 +35,12 @@
     reader by name) trips IL2072/IL2057/IL2026 under ILC. This tool always reads
     with the default ReaderParameters (ReadSymbols=false), so that path is never
     reached at runtime; the warnings are third-party and unexercised. Demote
-    exactly those three codes from error to warning for the ILC step via the
-    nowarnaserr switch (WarningsNotAsErrors) rather than a blanket
-    IlcTreatWarningsAsErrors=false, so every other trim/AOT code (including any
-    new reflection in this tool's own code) still fails the native publish.
+    exactly those three codes from error to warning by listing them in
+    WarningsNotAsErrors, which the ILCompiler native-publish targets forward to
+    the ilc nowarnaserr switch (see Microsoft.NETCore.Native.targets) - rather
+    than flipping the blanket IlcTreatWarningsAsErrors=false. Every other trim/AOT
+    code (including any new reflection in this tool's own code) therefore still
+    fails the native publish.
   -->
   <PropertyGroup Condition="'$(ReactorMstatAot)' == 'true'">
     <PublishAot>true</PublishAot>

--- a/tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj
+++ b/tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj
@@ -16,8 +16,7 @@
   <!--
     Opt-in NativeAOT proof gate (off by default): `-p:ReactorMstatAot=true`.
 
-        dotnet publish tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj \
-          -c Release -r win-x64 -p:ReactorMstatAot=true
+        dotnet publish tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj -c Release -r win-x64 -p:ReactorMstatAot=true
 
     Kept opt-in (not unconditional) so the normal build/run path CI uses
     (`dotnet run` on this project, `-c Release`, see ci.yml) is


### PR DESCRIPTION
## Summary

Makes the build-time tool `tools/Reactor.MstatVerifier` NativeAOT-publishable, part of the repo-wide AOT effort (#70). The tool reads assembly metadata via **Mono.Cecil** and shells `dotnet build`; it does **no runtime reflection over its own managed types**, emits no JSON, and uses no `Regex` — so its own code is already IL2*/IL3* analyzer-clean and needs **no** `TrimmerRootAssembly` or reflection annotations.

**Verdict: WORKS (opt-in gate).**

## Changes

- **`Reactor.MstatVerifier.csproj`** — adds an opt-in NativeAOT proof gate (off by default):
  ```xml
  <PropertyGroup Condition="'$(ReactorMstatAot)' == 'true'">
    <PublishAot>true</PublishAot>
    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2026;IL2057;IL2072</WarningsNotAsErrors>
  </PropertyGroup>
  ```
- **`README.md`** (new) — documents the trimming/AOT story.

## Publish command

```pwsh
dotnet publish tools/Reactor.MstatVerifier/Reactor.MstatVerifier.csproj -c Release -r win-x64 -p:ReactorMstatAot=true
```

Produces a ~3 MB self-contained native exe (Mono.Cecil statically linked). Native link needs the VS C++ tools (`vswhere.exe`) on `PATH`.

## Why opt-in (not unconditional)

CI runs the tool with plain `dotnet run … -c Release` (no RID). An always-on `<PublishAot>` would make a RID-less `dotnet publish` of this project fail with *"PublishAot requires a RuntimeIdentifier"*. Gating on `ReactorMstatAot` keeps the everyday CI path **byte-identical and RID-free**, and confines the change to a reproducible proof. `PublishAot` is set inside the csproj (not a global `-p:PublishAot=true`) so the opt-in stays self-contained; `Directory.Build.targets` already forces `PublishAot=false` on the repo's `netstandard2.0` analyzer/generator projects to prevent a global-property leak (`NETSDK1207`), though this tool references none of them.

## The only ILC findings — and why they're safe to demote

The sole ILC warnings come from **Mono.Cecil's** dynamic PDB/MDB symbol-provider discovery (`Mono.Cecil.Cil.SymbolProvider.GetReaderProvider`/`GetSymbolType` → `Activator.CreateInstance` / `Type.GetType` / `Assembly.GetType`), which trip `IL2072`/`IL2057`/`IL2026`. This tool always reads with the **default** `ReaderParameters` (`ReadSymbols=false`), so that path is never reached at runtime. The gate demotes **exactly those three codes** from error→warning for the ILC step (via `WarningsNotAsErrors` → ILC `--nowarnaserr`) rather than a blanket `IlcTreatWarningsAsErrors=false`, so any *other* trim/AOT warning — including new reflection in this tool's own code — still fails the native publish.

## Verification

- Normal (gate-off) `dotnet build -c Release`: green, 0 warnings — output path unchanged.
- Native AOT publish links cleanly (exit 0); the four Mono.Cecil findings remain warnings.
- **Byte-identical output** JIT vs native exe across every path: `usage` (exit 2), `reactor-il` (exit 0), `absence` (exit 0), `presence` (exit 1), and `negative-resolution` (exit 0, shells `dotnet build`).
- **Non-vacuous differential check:** ran `reactor-il` against a purpose-built assembly containing `Microsoft.UI.Reactor.Hosting.Devtools.EvilImpl`. Both JIT and native exe flag it (exit 1, identical message) — proving Mono.Cecil's *structured* metadata walk genuinely works under AOT (a hollow/empty read would have spuriously passed with exit 0).

## Relates to #70

Adds one more `tools/` project to the AOT-publishable set. #70 makes no claim about this tool, so nothing there is corrected — just extended.