### PR TITLE
Make Reactor.MurCheckGuardrail NativeAOT-publishable

### DIFF
--- a/tools/Reactor.MurCheckGuardrail/README.md
+++ b/tools/Reactor.MurCheckGuardrail/README.md
@@ -1,0 +1,68 @@
+# Reactor.MurCheckGuardrail
+
+Offline / CI guardrail for spec 038 §8 — the `mur check` **suppress→error invariant**. It reads
+two `mur check --trace` JSONL files (one written from an iteration-mode run, one from `--final`)
+and asserts that every diagnostic surfaced as an **Error** in the `--final` trace still scores
+`> 0` at Error severity in the live `PolicyTable` iteration column. In plain terms: the
+"universal error floor" can never be edited away to let a real build break hide mid-iteration.
+
+- Exit `0` — no violation (plus any non-failing `[advisory]` lines on stdout).
+- Exit `1` — at least one violation; details on stderr.
+- Exit `2` — usage / IO error.
+
+```pwsh
+Reactor.MurCheckGuardrail <iter-trace.jsonl> <final-trace.jsonl>
+```
+
+It re-uses `PolicyTable` from `src/Reactor.Cli` directly (ProjectReference +
+`InternalsVisibleTo`) so the audit and the runtime ranker can never drift. The logic lives in
+`GuardrailRunner`; `GuardrailRunnerTests` (in `tests/Reactor.Tests`) drives it in-process.
+
+## Trimming / NativeAOT
+
+The tool is trim- and NativeAOT-clean and publishes to a **single native exe**:
+
+```pwsh
+# vswhere.exe / link.exe must be discoverable for native linking:
+$env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\Installer;$env:PATH"
+
+dotnet publish tools/Reactor.MurCheckGuardrail -r win-x64 -c Release -p:ReactorGuardrailAot=true
+```
+
+(Add `-p:SkipSignaturesGen=true` for faster local iteration — it only skips the unrelated
+`reactor.api.txt` regen that building `Reactor.Cli` otherwise triggers; CI sets `CI=true`, which
+skips it too.)
+
+- **Byte-identical output.** The native exe's stdout / stderr / exit codes match the JIT build
+  exactly, verified across all reachable paths — the clean pass, the `-warnaserror` advisory,
+  the usage error, and the missing-file error.
+- **Zero ILC warnings, no rooting, no warning-downgrade.** The only things reachable from `Main`
+  are the pure `PolicyTable.Score` and `System.Text.Json`'s `JsonDocument` (no
+  `JsonSerializer<T>`, no reflection, no `Regex`). Everything the `Reactor.Cli` ProjectReference
+  drags in — Roslyn (`Microsoft.CodeAnalysis.CSharp`), YamlDotNet, `System.Drawing`, the Copilot
+  SDK — is unreachable, so the trimmer removes it. That is why **no** `TrimmerRootAssembly` and
+  **no** `IlcTreatWarningsAsErrors=false` are needed here, unlike the sibling `Reactor.SearchIndex`
+  tool: it parses gallery *source* with Roslyn at runtime, so `Microsoft.CodeAnalysis` stays
+  reachable and trips `IL3000` (`Assembly.Location`) and must downgrade the warning — whereas this
+  tool calls only `PolicyTable.Score`, so ILC is clean even under Release's repo-wide
+  `TreatWarningsAsErrors`.
+
+### Why opt-in (`ReactorGuardrailAot`) instead of always-on
+
+`PublishAot` is set **inside** the csproj behind the off-by-default `ReactorGuardrailAot`
+property rather than as a global `-p:PublishAot=true`. Three reasons:
+
+- **No analyzer-graph leak.** A global `PublishAot` flows across the whole ProjectReference
+  graph; scoping it per-project keeps it from ever landing on a `netstandard2.0`
+  analyzer/generator, which reject AOT with `NETSDK1207`.
+- **Normal build/publish stay green.** Always-on `PublishAot` forces every `dotnet publish`
+  self-contained and RID-bound, breaking the ordinary framework-dependent publish. The gate
+  leaves the normal build, the framework-dependent publish, and the whole-solution
+  `dotnet build Reactor.slnx` untouched.
+- **`Reactor.Cli` is a framework-dependent Exe.** A self-contained AOT exe referencing the
+  non-self-contained `mur` executable trips `NETSDK1150`. The gate sets
+  `ValidateExecutableReferencesMatchSelfContained=false` — correct here because we consume only
+  the managed `PolicyTable` *type*, never `mur`'s apphost, and ILC reads `mur.dll`'s IL directly.
+
+**Verdict:** NativeAOT-publishable — feasible and complete via the opt-in gate, byte-identical
+output, ILC warning-clean. Part of the repo-wide AOT effort (issue #70).

--- a/tools/Reactor.MurCheckGuardrail/Reactor.MurCheckGuardrail.csproj
+++ b/tools/Reactor.MurCheckGuardrail/Reactor.MurCheckGuardrail.csproj
@@ -13,6 +13,47 @@
          lets us read the internal table directly. -->
   </PropertyGroup>
 
+  <!-- NativeAOT proof, opt-in (see README.md; issue #70). The tool itself is
+       already AOT-clean: it only calls the pure PolicyTable.Score plus
+       System.Text.Json's JsonDocument (no JsonSerializer<T>, no reflection, no
+       regex). Everything else the Reactor.Cli ProjectReference drags in — Roslyn
+       (Microsoft.CodeAnalysis.CSharp), YamlDotNet, System.Drawing, the Copilot
+       SDK — is unreachable from this entry point, so the trimmer drops it: ILC
+       emits zero warnings, no TrimmerRootAssembly is needed, and the native
+       exe's stdout/stderr/exit codes are byte-identical to the JIT build.
+
+       PublishAot is set HERE (per-project) instead of via a global
+       -p:PublishAot=true so it can never leak across the ProjectReference graph
+       into a netstandard2.0 analyzer/generator and trip NETSDK1207. The gate is
+       off by default, so the ordinary framework-dependent build (and the
+       whole-solution `dotnet build Reactor.slnx`) are unchanged. Flip it on for
+       the native publish:
+
+         dotnet publish tools/Reactor.MurCheckGuardrail -r win-x64 -c Release -p:ReactorGuardrailAot=true
+  -->
+  <PropertyGroup Condition="'$(ReactorGuardrailAot)' == 'true'">
+    <PublishAot>true</PublishAot>
+    <!-- The ProjectReference is to Reactor.Cli, which is itself a
+         framework-dependent Exe (the `mur` global tool). A self-contained /
+         AOT exe normally rejects a non-self-contained executable reference
+         (NETSDK1150) — but we only consume the managed PolicyTable *type* from
+         it, never its apphost, and ILC reads mur.dll's IL directly. Disabling
+         the check lets the native publish proceed; the reference stays purely a
+         compile/trim input. (Setting PublishAot per-project instead of globally
+         means the RID/self-contained flags do not flow into Reactor.Cli, so we
+         opt out of the validation here rather than force the whole CLI
+         self-contained.)
+
+         Note: no IlcTreatWarningsAsErrors=false is needed. Unlike the sibling
+         Reactor.SearchIndex tool — which parses gallery source with Roslyn at
+         runtime, so Microsoft.CodeAnalysis stays reachable, trips IL3000, and
+         must downgrade the warning — this tool calls only the pure
+         PolicyTable.Score, so the whole Roslyn / YamlDotNet / System.Drawing
+         closure is trimmed and ILC is warning-clean even with Release's
+         TreatWarningsAsErrors. -->
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
+  </PropertyGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Reactor.Tests" />
   </ItemGroup>


### PR DESCRIPTION
Part of the repo-wide NativeAOT effort (#70). Migrates **exactly one** tool — `tools/Reactor.MurCheckGuardrail` (the spec-038 §8 `mur check` suppress→error guardrail) — to publish as a single native exe, with **byte-identical output**.

## What changed
- `tools/Reactor.MurCheckGuardrail/Reactor.MurCheckGuardrail.csproj` — adds an **opt-in** `ReactorGuardrailAot` gate (off by default).
- `tools/Reactor.MurCheckGuardrail/README.md` — new; documents the trimming/AOT story and the opt-in rationale.

No product/runtime C# changed. The tool's only reachable code from `Main` is the pure `PolicyTable.Score` (reused from `src/Reactor.Cli` via ProjectReference + `InternalsVisibleTo` so the audit and runtime ranker never drift) plus `System.Text.Json`'s `JsonDocument` — no `JsonSerializer<T>`, no reflection, no `Regex`.

## Publish command
```pwsh
# vswhere.exe / link.exe on PATH for native linking:
$env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\Installer;$env:PATH"

dotnet publish tools/Reactor.MurCheckGuardrail -r win-x64 -c Release -p:ReactorGuardrailAot=true
```

## Opt-in — and why
`PublishAot` is set **inside** the csproj behind the off-by-default `ReactorGuardrailAot` property, not as a global `-p:PublishAot=true`:

- **No analyzer-graph leak.** A global `PublishAot` flows across the ProjectReference graph; scoping it per-project keeps it off any `netstandard2.0` analyzer/generator (which reject AOT with `NETSDK1207`).
- **Normal build/publish stay green.** Always-on `PublishAot` forces every `dotnet publish` self-contained + RID-bound and breaks the ordinary framework-dependent publish. The gate leaves the normal build, the framework-dependent publish, and `dotnet build Reactor.slnx` untouched (verified).
- **`Reactor.Cli` is a framework-dependent Exe** (`mur`). A self-contained AOT exe referencing it trips `NETSDK1150`, so the gate also sets `ValidateExecutableReferencesMatchSelfContained=false` — correct here because we consume only the managed `PolicyTable` *type*, never `mur`'s apphost, and ILC reads `mur.dll`'s IL directly.

Unlike the sibling `Reactor.SearchIndex` (which parses source with Roslyn at runtime → `Microsoft.CodeAnalysis` reachable → `IL3000` → needs `IlcTreatWarningsAsErrors=false`), this tool never touches the heavy `Reactor.Cli` closure (Roslyn / YamlDotNet / System.Drawing / Copilot SDK), so it is trimmed away entirely: **ILC emits zero warnings, no `TrimmerRootAssembly` and no `IlcTreatWarningsAsErrors` downgrade** — clean even under Release's repo-wide `TreatWarningsAsErrors`.

## Verification
- Native single-file exe (~1.47 MB); **0 ILC warnings** (holds even with `-p:IlcTreatWarningsAsErrors=true` forced).
- **Byte-identical** stdout / stderr / exit codes vs the JIT build across all reachable paths: clean pass, `-warnaserror` advisory, usage error (exit 2), missing-file error (exit 2). (No hollow-skeleton risk: the tool calls `PolicyTable.Score` statically, and the exit-0 "OK" result depends on the real `1.0` error-floor — a stripped table would return `0.0` → exit-1 violation.)
- Normal build + framework-dependent publish + `dotnet build Reactor.slnx` path all unaffected; 8/8 `GuardrailRunnerTests` pass.

**Verdict: WORKS via the opt-in `ReactorGuardrailAot` gate.**

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>