### PR TITLE
Make PerfBench.ControlModel NativeAOT-publishable

### DIFF
--- a/tests/perf_bench/PerfBench.ControlModel/PerfBench.ControlModel.csproj
+++ b/tests/perf_bench/PerfBench.ControlModel/PerfBench.ControlModel.csproj
@@ -25,8 +25,6 @@
     <AssemblyName>PerfBench.ControlModel</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Perf benchmark harness — never trimmed/AOT-published; opt out of IL2*/IL3*. -->
-    <ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
@@ -49,6 +47,55 @@
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' != 'ARM64'">win-x64</RuntimeIdentifier>
   </PropertyGroup>
+
+  <!--
+    Native-AOT publish (issue #70). This bench used to carry
+    <ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>, which opted it OUT of the
+    repo-wide IL2*/IL3* trim/AOT analysis. That opt-out is gone: Directory.Build.targets
+    now turns on IsAotCompatible=true AND promotes the IL2*/IL3* codes to errors for this
+    net10 project, so it is kept honestly AOT-clean on every ordinary build (the
+    reflection JsonSerializer path in Variants/MeasurementResult.cs was moved onto a
+    System.Text.Json source-generated context to satisfy it).
+
+    This gate additionally enables a REAL native-AOT publish on demand. It follows the
+    repo-canonical PublishAotInternal opt-in convention (docs/aot-support.md; the same knob
+    the CI "AOT Selftests" / aot_trim_proof / hello-world-aot publish steps use) rather
+    than the StressPerf harnesses' unconditional <PublishAot>true</PublishAot>, so the
+    default build and the framework-dependent / -p:PerfCiSelfContained publish that
+    tests/stress_perf/ci/Run-PerfBenchmark.ps1 drives are completely unchanged. Publish:
+
+      dotnet publish tests\perf_bench\PerfBench.ControlModel\PerfBench.ControlModel.csproj `
+        -c Release -r win-x64 -p:Platform=x64 -p:PublishAotInternal=true `
+        -p:IlcTreatWarningsAsErrors=false
+
+    PublishAot is set INSIDE the csproj (never a global -p:PublishAot=true) so it can't
+    leak into the netstandard2.0 Roslyn analyzers/generators pulled in transitively and
+    trip NETSDK1207 — Directory.Build.targets also force-clears PublishAot for any
+    sub-net10 project for the same reason.
+  -->
+  <PropertyGroup Condition="'$(PublishAotInternal)' == 'true'">
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <!--
+    WindowsAppSDK#6394 — an unpackaged (WindowsPackageType=None) WinUI 3 app published
+    with PublishAot=true generates $(AssemblyName).pri and the XAML .xbf files into the
+    intermediate output but never copies them into the publish directory (the MakePRI
+    stage is gated on AppxPackage=true). Without the .pri, Application.Current.Resources
+    loads empty and framework control styles / theme resources go missing at runtime.
+    Copy them verbatim per docs/aot-support.md — remove once #6394 ships a fix.
+  -->
+  <Target Name="_CopyWinUIResourcesForAot" AfterTargets="Publish"
+          Condition="'$(PublishAot)' == 'true' and '$(AppxPackage)' != 'true'">
+    <ItemGroup>
+      <_WinUIResourcesForAot Include="$(OutputPath)**\*.xbf" />
+      <_WinUIResourcesForAot Include="$(OutputPath)$(AssemblyName).pri"
+                             Condition="Exists('$(OutputPath)$(AssemblyName).pri')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_WinUIResourcesForAot)"
+          DestinationFiles="@(_WinUIResourcesForAot->'$(PublishDir)%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\PerfBench.Shared\PerfBench.Shared.csproj" />

--- a/tests/perf_bench/PerfBench.ControlModel/Variants/MeasurementResult.cs
+++ b/tests/perf_bench/PerfBench.ControlModel/Variants/MeasurementResult.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PerfBench.ControlModel.Variants;
 
@@ -44,16 +45,28 @@ public sealed record MeasurementResult
 
     public string ToJsonLine()
     {
-        return JsonSerializer.Serialize(this, _options);
+        return JsonSerializer.Serialize(this, MeasurementJsonContext.Default.MeasurementResult);
     }
-
-    private static readonly JsonSerializerOptions _options = new()
-    {
-        WriteIndented = false,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
-    };
 }
+
+/// <summary>
+/// Source-generated (trim / native-AOT safe) JSON metadata for
+/// <see cref="MeasurementResult"/>. Replaces the reflection-based
+/// <c>JsonSerializer.Serialize(obj, JsonSerializerOptions)</c> + runtime
+/// <see cref="JsonStringEnumConverter"/> path (IL2026 / IL3050) so the bench can be
+/// native-AOT published. The options here reproduce the previous serializer's output
+/// exactly: <see cref="JsonSourceGenerationOptionsAttribute.UseStringEnumConverter"/>
+/// emits enums as their member names (as the untyped converter did), and
+/// <see cref="JsonKnownNamingPolicy.CamelCase"/> matches the former
+/// <c>PropertyNamingPolicy</c>, so the emitted JSON-Lines shape is unchanged for the
+/// §15.6 aggregator.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UseStringEnumConverter = true,
+    WriteIndented = false)]
+[JsonSerializable(typeof(MeasurementResult))]
+internal sealed partial class MeasurementJsonContext : JsonSerializerContext;
 
 public static class Env
 {


### PR DESCRIPTION
## What & why

Wave 2 of the repo-wide native-AOT migration (#70). Migrates **one** project — `tests/perf_bench/PerfBench.ControlModel` (a net10 WinUI perf-bench app) — off its AOT-analyzer opt-out and makes it a real native-AOT publish target, mirroring the `StressPerf.*` harness shape.

## Changes

- **Turn the AOT analyzer on.** Remove `<ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>`. `Directory.Build.targets` then sets `IsAotCompatible=true` and promotes the `IL2*`/`IL3*` trim/AOT codes to **build errors** for this net10 project, so it's kept honestly AOT-clean on every ordinary build.
- **Fix the one honest violation.** `MeasurementResult.ToJsonLine()` used reflection `JsonSerializer.Serialize(this, JsonSerializerOptions)` (IL2026) with a runtime `JsonStringEnumConverter()` (IL3050). It now serializes through a `System.Text.Json` **source-generated** `JsonSerializerContext` (`UseStringEnumConverter = true`, `CamelCase`, `WriteIndented = false`) that reproduces the previous JSON-Lines shape **exactly** (camelCase keys, enums as member-name strings, same property order/null handling) — so the §15.6 aggregator that consumes `results.jsonl` is unaffected.
- **Opt-in native-AOT publish.** Add a `PropertyGroup` gated on the repo-canonical `PublishAotInternal` knob (the same one `docs/aot-support.md`, the CI *AOT Selftests*, `aot_trim_proof`, and `hello-world-aot` use) that sets `<PublishAot>true</PublishAot>`, plus the documented WindowsAppSDK#6394 `_CopyWinUIResourcesForAot` target (copies `.pri`/`.xbf` into the publish dir).

## Opt-in gate — why gated (not unconditional like StressPerf)

`PublishAot` is set **inside the csproj**, gated on `PublishAotInternal=true`, so the default `dotnet build` and the framework-dependent / `-p:PerfCiSelfContained=true` build that `tests/stress_perf/ci/Run-PerfBenchmark.ps1` drives for the reconcile micro-suite are **completely unchanged** (that path uses `dotnet build`, never passes `PublishAotInternal`). Setting it inside the csproj (never a global `-p:PublishAot=true`) also avoids leaking into the transitively-referenced netstandard2.0 Roslyn analyzers/generators and tripping `NETSDK1207`.

## Publish command

```
dotnet publish tests/perf_bench/PerfBench.ControlModel/PerfBench.ControlModel.csproj `
  -c Release -r win-x64 -p:Platform=x64 -p:PublishAotInternal=true `
  -p:IlcTreatWarningsAsErrors=false
```

## Verification — VERDICT: WORKS ✅

- Debug + Release x64 build green (0 warnings / 0 errors) with the analyzer promoted to errors.
- Native AOT publish is **clean**: 0 IL warnings from ILC; 12.5 MB native exe; no `coreclr.dll` (true AOT); `.pri` + `.xbf` copied into the publish dir by the target.
- The published native exe **runs** (exit 0) across M1/M6/OAlloc × all three variants and emits well-formed JSON-Lines. A structural JIT-vs-AOT compare (same Release config/args) shows **identical JSON key sets and deterministic field values** across all lines, with the enum serialized **as a string** (`"variant":"Reactor"`, not a number) — i.e. the AOT exe is genuinely functional, not a hollow trimmed skeleton (M6 exercises `RegisterType<>` generic dispatch; OAlloc exercises `Optional<T>` element construction).

Refs #70

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>