### PR TITLE
Make Reactor.Advanced.Tests AOT-honest (analyzer-on)

### DIFF
--- a/tests/Reactor.Advanced.Tests/ElementConstructorTests.cs
+++ b/tests/Reactor.Advanced.Tests/ElementConstructorTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.UI.Reactor.Advanced.Win2D;
 using Xunit;
@@ -15,7 +16,11 @@ public sealed class ElementConstructorTests
 
     [Theory]
     [MemberData(nameof(ElementTypes))]
-    public void Win2DElementRecords_HaveNoPublicInstanceConstructors(Type elementType)
+    public void Win2DElementRecords_HaveNoPublicInstanceConstructors(
+        // AOT-honest: values are the concrete Win2D element types (typeof(...) in
+        // ElementTypes), so the trimmer can keep their public constructors. The test only
+        // inspects constructors, so preserving PublicConstructors is exactly what it needs.
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type elementType)
     {
         var publicCtors = elementType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
         Assert.Empty(publicCtors);
@@ -23,7 +28,10 @@ public sealed class ElementConstructorTests
 
     [Theory]
     [MemberData(nameof(ElementTypes))]
-    public void Win2DElementRecords_HaveInternalParameterlessConstructor(Type elementType)
+    public void Win2DElementRecords_HaveInternalParameterlessConstructor(
+        // AOT-honest: same concrete element types; this test reads the internal
+        // parameterless constructor, so it preserves NonPublicConstructors.
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type elementType)
     {
         var ctor = elementType.GetConstructor(
             BindingFlags.NonPublic | BindingFlags.Instance,

--- a/tests/Reactor.Advanced.Tests/PatternAStaticLambdaTests.cs
+++ b/tests/Reactor.Advanced.Tests/PatternAStaticLambdaTests.cs
@@ -40,7 +40,7 @@ public sealed class PatternAStaticLambdaTests
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2075",
-        Justification = "Test-only: reads ControlRegistry's internal s_entries dictionary (rooted above via the typeof(ControlRegistry) intrinsic) and calls its public TryGetValue to fetch a registered handler factory. GetType() erases the static Dictionary<,> type, but TryGetValue is a public API kept by ordinary dictionary use. Reactor.Advanced.Tests is a headless xUnit runner, not NativeAOT-published.")]
+        Justification = "Test-only: reads ControlRegistry's internal s_entries field (a ConcurrentDictionary<Type, Func<IV1HandlerEntry>>, rooted above via the typeof(ControlRegistry) intrinsic) and calls its public TryGetValue to fetch a registered handler factory. GetType() erases the static ConcurrentDictionary<,> type, but TryGetValue is a public API kept by ordinary dictionary use. Reactor.Advanced.Tests is a headless xUnit runner, not NativeAOT-published.")]
     private static Delegate GetAdapterFactory(Type elementType)
     {
         var entriesField = typeof(ControlRegistry).GetField("s_entries", BindingFlags.NonPublic | BindingFlags.Static)!;

--- a/tests/Reactor.Advanced.Tests/PatternAStaticLambdaTests.cs
+++ b/tests/Reactor.Advanced.Tests/PatternAStaticLambdaTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.UI.Xaml;
@@ -38,6 +39,8 @@ public sealed class PatternAStaticLambdaTests
         // Otherwise Target is null — directly static, also closure-free. Either is fine.
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "Test-only: reads ControlRegistry's internal s_entries dictionary (rooted above via the typeof(ControlRegistry) intrinsic) and calls its public TryGetValue to fetch a registered handler factory. GetType() erases the static Dictionary<,> type, but TryGetValue is a public API kept by ordinary dictionary use. Reactor.Advanced.Tests is a headless xUnit runner, not NativeAOT-published.")]
     private static Delegate GetAdapterFactory(Type elementType)
     {
         var entriesField = typeof(ControlRegistry).GetField("s_entries", BindingFlags.NonPublic | BindingFlags.Static)!;

--- a/tests/Reactor.Advanced.Tests/Reactor.Advanced.Tests.csproj
+++ b/tests/Reactor.Advanced.Tests/Reactor.Advanced.Tests.csproj
@@ -7,8 +7,25 @@
     <RootNamespace>Microsoft.UI.Reactor.Advanced.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Test project — never trimmed/AOT-published; reflection is intentional. -->
-    <ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>
+    <!-- AOT-honest (issue #70, wave 2). The IL2*/IL3* analyzer runs on this test project:
+         Directory.Build.targets sets IsAotCompatible=true for net10+ (no ReactorSkipAotAnalysis
+         opt-out) and promotes the curated IL2*/IL3* codes to build errors. The few intentional
+         test-only reflection sites are annotated at the source with justified
+         [UnconditionalSuppressMessage] (or a precise [DynamicallyAccessedMembers] on a *test*
+         parameter) — never a #pragma (ILC ignores those) and never a broad
+         [DynamicallyAccessedMembers] on a product type (that narrows trimmer preservation and
+         regressed ~20 selftests, per issue #70's PR #850 note).
+
+         Analyzer-on is the deliverable. A NativeAOT test *run* was investigated and is NOT
+         feasible here: `dotnet publish -r win-x64 -p:PublishAot=true` reaches ILC "Generating
+         native code" and then fails inside the xunit.v3 3.2.2 runner itself —
+         XunitTestRunnerBase.CreateTestClassInstance (Type.MakeGenericType) and
+         AsyncUtility.TryConvertToValueTask (MethodInfo.MakeGenericMethod) are IL3050
+         RequiresDynamicCode, plus IL2075/IL2070 reflection over test classes. Those are
+         framework internals, unfixable from this project, and forcing a link by muting them
+         would hide real dynamic-code breaks. So this project stays analyzer-on and JIT-run
+         (`dotnet test`); it is intentionally not NativeAOT-published. See the PR body / issue
+         #70 for the full MTP-AOT evidence. -->
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
     <!-- xUnit host loads WinUI types in-process; bundle the runtime so the

--- a/tests/Reactor.Advanced.Tests/Win2DSharedDeviceGuardTests.cs
+++ b/tests/Reactor.Advanced.Tests/Win2DSharedDeviceGuardTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.UI.Reactor.Advanced.Win2D;
 using Xunit;
@@ -11,6 +12,10 @@ namespace Microsoft.UI.Reactor.Advanced.Tests;
 /// </summary>
 public sealed class Win2DSharedDeviceGuardTests
 {
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Test-only: resolves the internal Win2DSharedDeviceGuard by name from the Reactor.Advanced assembly to exercise its mount-time invariant. The type is kept alive by the canvas handlers that call it; the trimmer can't carry that through Assembly.GetType's string lookup. Reactor.Advanced.Tests is a headless xUnit runner, not NativeAOT-published.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "Same site: Assembly.GetType returns a Type without member annotations, so the follow-on GetMethod for the public static EnsureUseSharedDeviceUnchanged is flagged. The method is a public API of a type kept by its handler callers; test-only reflection, not NativeAOT-published.")]
     private static MethodInfo GuardMethod()
     {
         var type = typeof(Win2DCanvasElement).Assembly


### PR DESCRIPTION
## What

Wave 2 of the repo-wide native-AOT-honesty effort (#70). Single target:
`tests/Reactor.Advanced.Tests` (net10.0-windows, `Exe`, xunit.v3).

Removes `<ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>` so
`Directory.Build.targets` turns on `IsAotCompatible=true` for this net10 project
and promotes the curated `IL2*/IL3*` codes to build **errors** (Debug and
Release). Every site the analyzer then surfaced is annotated **honestly** and
entirely inside the test project — no product (core Reactor / Reactor.Advanced)
type is touched, per #70's caution that broad `[DynamicallyAccessedMembers]` on
product types regressed ~20 PropertyGrid selftests.

Baseline and final test results are identical: **32 passed / 4 skipped / 0
failed** (the 4 skips are pre-existing Phase-3-selftest placeholders). No
assertion was weakened and no test was skipped or deleted to satisfy the
analyzer.

## Verdict

**AOT-HONEST (analyzer-on).** The IL2*/IL3* analyzer now runs clean over this
project. A NativeAOT test *run* was investigated and is **not feasible** — see
"MTP-AOT verdict" below.

## Sites annotated (5, across 3 files)

| Site | Code(s) | Handling | Why honest |
|---|---|---|---|
| `ElementConstructorTests.Win2DElementRecords_HaveNoPublicInstanceConstructors(Type)` | IL2070 | `[DynamicallyAccessedMembers(PublicConstructors)]` on the **test** `Type` param | Values are concrete `typeof(Win2D*Element)` from `[MemberData]`; the test only calls `GetConstructors(Public\|Instance)` and asserts none exist. `PublicConstructors` matches exactly — no narrowing risk (the test reflects nothing else off the param). |
| `ElementConstructorTests.Win2DElementRecords_HaveInternalParameterlessConstructor(Type)` | IL2070 | `[DynamicallyAccessedMembers(NonPublicConstructors)]` on the **test** `Type` param | Same concrete types; the test calls `GetConstructor(NonPublic\|Instance, …)` and asserts the internal parameterless ctor exists + `IsAssembly`. `NonPublicConstructors` matches exactly. |
| `PatternAStaticLambdaTests.GetAdapterFactory` | IL2075 | `[UnconditionalSuppressMessage("Trimming","IL2075")]` | `entries.GetType().GetMethod("TryGetValue")` on `ControlRegistry`'s internal `s_entries` (`ConcurrentDictionary<Type, Func<IV1HandlerEntry>>`). `GetType()` erases the static `ConcurrentDictionary<,>` type, but `TryGetValue` is a public API kept by ordinary dictionary use — the suppression is behavior-neutral. |
| `Win2DSharedDeviceGuardTests.GuardMethod` | IL2026 | `[UnconditionalSuppressMessage("Trimming","IL2026")]` | `Assembly.GetType("…Win2DSharedDeviceGuard", true)` reaches an internal type by name. The type is kept alive by the canvas handlers that call it; the trimmer can't carry that through `Assembly.GetType`'s string lookup. (Mirrors the existing `SanitizeUrlTests` house-style suppression.) |
| `Win2DSharedDeviceGuardTests.GuardMethod` | IL2075 | `[UnconditionalSuppressMessage("Trimming","IL2075")]` | Same site: the `Assembly.GetType` return has no member annotations, so the follow-on `GetMethod("EnsureUseSharedDeviceUnchanged", Public\|Static)` is flagged. Public API of a kept type. |

Discipline followed: `[UnconditionalSuppressMessage]` only (ILC ignores
`#pragma`); genuine `[DynamicallyAccessedMembers]` only on a *test* parameter
where the reflection is trim-safe; nothing on a product type.

`typeof(KnownType).GetMethod/GetField` sites (in `FactoryHolderTests`,
`HookTestHost`, and the rest of `PatternAStaticLambdaTests`) were **not**
annotated — the ILLink `typeof` intrinsic roots those without a warning, so
adding suppressions there would be noise.

## MTP-AOT verdict — DOCUMENTED BLOCKER (analyzer-on is the end state)

Secondary investigation: can this xunit.v3 test exe be NativeAOT-published and
run (Microsoft.Testing.Platform NativeAOT)? **No — blocked in the xunit.v3
runner itself.**

- The exe *is* a real in-process test host (`xUnit.net v3 In-Process Runner
  v3.2.2`), and `Microsoft.NET.Test.Sdk` 18.x is MTP-based, so the harness side
  is MTP-capable.
- A gated `dotnet publish -r win-x64 -p:PublishAot=true …` reaches ILC
  **"Generating native code"** (so the WinUI + CsWinRT + Win2D toolchain links
  that far) and then **fails** on xunit.v3's own runner internals:
  - `Xunit.v3.XunitTestRunnerBase…CreateTestClassInstance` → `Type.MakeGenericType` — **IL3050 RequiresDynamicCode**
  - `Xunit.Sdk.AsyncUtility.TryConvertToValueTask` → `MethodInfo.MakeGenericMethod` — **IL3050 RequiresDynamicCode** (+ IL2060)
  - `XunitTestRunnerBase…` / `ExtensibilityPointFactory` → IL2075/IL2070 reflection over test classes
- These are `RequiresDynamicCode` paths *inside the framework*, unfixable from
  this project. Under the repo's own curated IL-as-error AOT policy they are hard
  ILC errors. Forcing a link by muting them would **hide real dynamic-code
  breaks** — exactly the dishonesty this effort avoids — so I did not do it, and
  did not commit a non-working `PublishAot` gate.

Conclusion: this project stays **analyzer-on** and JIT-run via `dotnet test`; it
is intentionally not NativeAOT-published. Documented in the `.csproj` comment and
an issue #70 comment for re-verification when xunit.v3 / ILC improve.

## Testing

```
dotnet build tests/Reactor.Advanced.Tests -p:Platform=x64   # 0 warnings, 0 errors (analyzer on)
dotnet test  tests/Reactor.Advanced.Tests -p:Platform=x64   # 32 passed, 4 skipped, 0 failed
```

## Review

Ran the repo `pr-review` skill across all 8 dimensions; the multi-model
cross-check used a different model family (GPT-5.5) at high reasoning and
specifically vetted suppression honesty + the MTP-AOT verdict. All dimensions
clean.

Refs #70