### PR TITLE
Make widget-creator NativeAOT-publishable

### DIFF
--- a/samples/apps/widget-creator/README.md
+++ b/samples/apps/widget-creator/README.md
@@ -75,6 +75,41 @@ sandboxed — close it to finish the run. If it crashes instead, the creator kee
 watching the sandbox process, restores the widget's saved Copilot session, and
 asks the agent to repair the app from the crash details.
 
+## Publish as a native app (NativeAOT)
+
+Widget Creator is trim/AOT-clean and can be published as a **native** executable
+(no managed `WidgetCreator.dll`, no JIT). This is behind an opt-in property so the
+normal `dotnet run` / framework-dependent publish above stays unchanged:
+
+```pwsh
+dotnet publish samples/apps/widget-creator/widget-creator.csproj `
+  -c Release -p:Platform=x64 -r win-x64 `
+  -p:PublishAotInternal=true -p:IlcTreatWarningsAsErrors=false
+```
+
+- `-r win-x64` (or `-r win-arm64`) is required for a NativeAOT publish; match it to
+  `-p:Platform`.
+- `PublishAotInternal=true` is the repo-canonical AOT opt-in gate (the same property
+  the other AOT samples/hosts use); it flips `PublishAot` on only for this publish.
+- `-p:IlcTreatWarningsAsErrors=false` only relaxes ILC trim/AOT warnings from
+  third-party dependencies we don't own (the Copilot SDK / Windows App SDK). This
+  project's **own** code stays analyzed-as-errors at build time — the repo's
+  IL2\*/IL3\* analyzer is on for this sample (it no longer sets
+  `ReactorSkipAotAnalysis`), so the two `System.Text.Json` sidecars use source
+  generation rather than reflection.
+- `vswhere.exe` must be on `PATH` for the native link step; if it isn't, prepend
+  `C:\Program Files (x86)\Microsoft Visual Studio\Installer` to `PATH`.
+
+The published `WidgetCreator.exe` lands under
+`bin\x64\Release\net10.0-windows10.0.22621.0\win-x64\publish\`.
+
+> **Validated scope.** The native build has been verified to publish and to launch
+> the Widget Creator window, and its source-generated `meta.json` loader runs in
+> the native image. The end-to-end generate → build → MXC-sandbox workflow still
+> shells out to the bundled Copilot CLI and the vendored `wxc-exec` binaries exactly
+> as the framework-dependent build does; those child processes are unaffected by AOT
+> and the native publish does not itself re-exercise that full pipeline.
+
 ## How the sandbox policy works
 
 The app emits an MXC `ContainerConfig` (schema `0.6.0-alpha`, `processcontainer`

--- a/samples/apps/widget-creator/Services/ArtifactIntegrity.cs
+++ b/samples/apps/widget-creator/Services/ArtifactIntegrity.cs
@@ -36,17 +36,10 @@ public sealed record IntegrityResult(bool Ok, bool Present, string Reason);
 /// unsophisticated tampering and corruption; strong prevention needs a
 /// higher-integrity signer outside this sample's scope.</para>
 /// </summary>
-public sealed class ArtifactIntegrity
+public sealed partial class ArtifactIntegrity
 {
     const string SidecarName = "integrity.json";
     const int CurrentVersion = 1;
-
-    static readonly JsonSerializerOptions JsonOpts = new()
-    {
-        WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
 
     readonly string _keyPath;
     readonly Lazy<byte[]> _key;
@@ -72,7 +65,7 @@ public sealed class ArtifactIntegrity
         try
         {
             var record = Compute(app);
-            var json = JsonSerializer.Serialize(record, JsonOpts);
+            var json = JsonSerializer.Serialize(record, IntegrityJsonContext.Default.Record);
             var path = SidecarPath(app);
             var tmp = $"{path}.{Guid.NewGuid():N}.tmp";
             await File.WriteAllTextAsync(tmp, json).ConfigureAwait(false);
@@ -99,7 +92,7 @@ public sealed class ArtifactIntegrity
             return new IntegrityResult(Ok: true, Present: false, "no integrity record (unprotected)");
         try
         {
-            var stored = JsonSerializer.Deserialize<Record>(File.ReadAllText(path), JsonOpts);
+            var stored = JsonSerializer.Deserialize(File.ReadAllText(path), IntegrityJsonContext.Default.Record);
             if (stored is null)
                 return new IntegrityResult(false, true, "integrity record is empty or invalid");
 
@@ -214,6 +207,18 @@ public sealed class ArtifactIntegrity
         string ExeSha256,
         string ExePath,
         string Mac);
+
+    // AOT/trim-safe JSON: source-generated metadata for the integrity sidecar
+    // (System.Text.Json reflection serialization is IL2026/IL3050). Nested so it
+    // can see the private Record; options mirror the former JsonOpts exactly.
+    [JsonSourceGenerationOptions(
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(Record))]
+    sealed partial class IntegrityJsonContext : JsonSerializerContext
+    {
+    }
 
     /// <summary>Managed DPAPI (per-user) wrapper via <see cref="ProtectedData"/>.</summary>
     static class Dpapi

--- a/samples/apps/widget-creator/Services/MxcPolicy.cs
+++ b/samples/apps/widget-creator/Services/MxcPolicy.cs
@@ -183,7 +183,7 @@ public static class MxcPolicy
         var existing = caps.Any(n => string.Equals((string?)n, InternetCapability, StringComparison.OrdinalIgnoreCase));
         if (access == NetworkAccess.Internet)
         {
-            if (!existing) caps.Add(JsonValue.Create(InternetCapability));
+            if (!existing) caps.Add((JsonNode?)JsonValue.Create(InternetCapability));
             net["defaultPolicy"] = "allow";
             net["enforcementMode"] ??= "capabilities";
         }
@@ -205,7 +205,7 @@ public static class MxcPolicy
             return;
         }
         var arr = new JsonArray();
-        foreach (var p in paths) arr.Add(JsonValue.Create(p));
+        foreach (var p in paths) arr.Add((JsonNode?)JsonValue.Create(p));
         fs[kind] = arr;
     });
 
@@ -223,7 +223,7 @@ public static class MxcPolicy
             PathAccess.Denied => DeniedKind,
             _ => ReadOnlyKind,
         };
-        Arr(Obj(o, "filesystem"), kind).Add(JsonValue.Create(path.Trim()));
+        Arr(Obj(o, "filesystem"), kind).Add((JsonNode?)JsonValue.Create(path.Trim()));
         PruneFilesystem(o);
     });
 

--- a/samples/apps/widget-creator/Services/MxcSandbox.cs
+++ b/samples/apps/widget-creator/Services/MxcSandbox.cs
@@ -252,7 +252,7 @@ public sealed class MxcSandbox
             fs["readonlyPaths"] = readonlyPaths;
         }
         if (!readonlyPaths.Any(n => string.Equals((string?)n, appDir, StringComparison.OrdinalIgnoreCase)))
-            readonlyPaths.Add(JsonValue.Create(appDir));
+            readonlyPaths.Add((JsonNode?)JsonValue.Create(appDir));
 
         return config.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
     }

--- a/samples/apps/widget-creator/Services/WidgetLibrary.cs
+++ b/samples/apps/widget-creator/Services/WidgetLibrary.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,16 +17,11 @@ namespace WidgetCreator.Services;
 /// published binaries already live in the same folder (written by
 /// <see cref="WidgetWorkspace"/>).
 /// </summary>
-public sealed class WidgetLibrary
+public sealed partial class WidgetLibrary
 {
     const string MetaFile = "meta.json";
     const int MaxIoAttempts = 10;
 
-    static readonly JsonSerializerOptions JsonOpts = new()
-    {
-        WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-    };
     static readonly SemaphoreSlim IoGate = new(1, 1);
 
     public string Root { get; } = Path.Combine(
@@ -55,7 +51,7 @@ public sealed class WidgetLibrary
             Directory.CreateDirectory(app.Dir);
             var json = JsonSerializer.Serialize(new Meta(
                 app.Id, app.Title, app.Icon, app.Prompt, app.Model, app.CreatedAt,
-                app.ExePath, app.PublishDir, app.SessionId), JsonOpts);
+                app.ExePath, app.PublishDir, app.SessionId), LibraryJsonContext.Default.Meta);
             await WriteAtomicWithRetriesAsync(Path.Combine(app.Dir, MetaFile), json).ConfigureAwait(false);
             await _integrity.StampAsync(app).ConfigureAwait(false);
             SessionLog.Write($"[Library] saved {app.Id} '{app.Title}' session={app.SessionId}");
@@ -80,7 +76,7 @@ public sealed class WidgetLibrary
                 if (!File.Exists(metaPath)) continue;
                 try
                 {
-                    var meta = JsonSerializer.Deserialize<Meta>(ReadAllTextShared(metaPath), JsonOpts);
+                    var meta = JsonSerializer.Deserialize(ReadAllTextShared(metaPath), LibraryJsonContext.Default.Meta);
                     if (meta is null) continue;
                     apps.Add(new WidgetApp(
                         meta.Id, meta.Title, meta.Icon, meta.Prompt, meta.Model,
@@ -226,4 +222,15 @@ public sealed class WidgetLibrary
     sealed record Meta(
         string Id, string Title, string Icon, string Prompt, string Model,
         DateTime CreatedAt, string ExePath, string PublishDir, string? SessionId);
+
+    // AOT/trim-safe JSON: source-generated metadata for the meta.json sidecar
+    // (System.Text.Json reflection serialization is IL2026/IL3050). Nested so it
+    // can see the private Meta; options mirror the former JsonOpts exactly.
+    [JsonSourceGenerationOptions(
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+    [JsonSerializable(typeof(Meta))]
+    sealed partial class LibraryJsonContext : JsonSerializerContext
+    {
+    }
 }

--- a/samples/apps/widget-creator/widget-creator.csproj
+++ b/samples/apps/widget-creator/widget-creator.csproj
@@ -13,14 +13,54 @@
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <!-- This is a rich integration DEMO, not an AOT-published app: it shells out to
-         vendored native MXC sandbox binaries (tools/mxc/<rid>/*.exe), rides the
-         Copilot SDK, and runs a dynamic JSON policy/artifact engine (reflection-based
-         System.Text.Json by design). It is never NativeAOT-published, so it opts out
-         of the IL2*/IL3* trim/AOT analysis (and its warnings-as-errors promotion) that
-         the repo enforces on genuinely AOT-relevant projects. See Directory.Build.targets. -->
-    <ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>
+
+    <!-- AOT: this sample IS trim/AOT-analyzed (no ReactorSkipAotAnalysis opt-out).
+         Directory.Build.targets turns on IsAotCompatible=true + promotes the IL2*/IL3*
+         trim/AOT warnings to errors for net10+, so any un-annotated reflection is caught
+         at build time. The two reflection-based System.Text.Json sites (the widget
+         library index + the artifact-integrity sidecar) use System.Text.Json source
+         generation (IntegrityJsonContext + LibraryJsonContext); the rest of the JSON
+         handling is the JsonNode DOM (policy engine), which is already AOT-safe.
+
+         A REAL NativeAOT publish is available behind an opt-in property so the normal
+         framework-dependent build/publish (which the vendored MXC binaries + Copilot SDK
+         demo path rely on) stays unchanged:
+             dotnet publish samples/apps/widget-creator/widget-creator.csproj `
+               -c Release -p:Platform=x64 -r win-x64 -p:PublishAotInternal=true `
+               -p:IlcTreatWarningsAsErrors=false
+         (PublishAotInternal is the repo-canonical AOT opt-in gate — the same property the
+         other AOT samples/hosts use — kept opt-in so an ordinary `dotnet build` / `dotnet
+         run` doesn't pay the AOT compile cost. IlcTreatWarningsAsErrors=false only relaxes
+         ILC warnings from third-party dependencies we don't own — the Copilot SDK /
+         WindowsAppSDK — not this project's own code, which stays analyzed-as-errors at
+         build time.) -->
   </PropertyGroup>
+
+  <!-- Opt-in NativeAOT publish, gated on the repo-canonical PublishAotInternal property.
+       Kept INSIDE the csproj (not a global -p:PublishAot=true) so PublishAot never flows
+       into the netstandard2.0 analyzer/generator projects Reactor references (which would
+       fail with NETSDK1207), and opt-in so the normal framework-dependent build/publish
+       stays unchanged. Mirrors samples/apps/hello-world-aot and command-palette-window. -->
+  <PropertyGroup Condition="'$(PublishAotInternal)' == 'true'">
+    <PublishAot>true</PublishAot>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <!-- WinUI keeps its compiled XAML (*.xbf) + resource index (*.pri) next to the
+       managed output; a NativeAOT publish must carry them into the publish dir or
+       the app fails to resolve XamlControlsResources at startup. Mirrors the same
+       target in samples/apps/hello-world-aot. -->
+  <Target Name="_CopyWinUIResourcesForAot" AfterTargets="Publish"
+          Condition="'$(PublishAot)' == 'true' and '$(AppxPackage)' != 'true'">
+    <ItemGroup>
+      <_WinUIResourcesForAot Include="$(OutputPath)**\*.xbf" />
+      <_WinUIResourcesForAot Include="$(OutputPath)$(AssemblyName).pri" Condition="Exists('$(OutputPath)$(AssemblyName).pri')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_WinUIResourcesForAot)"
+          DestinationFiles="@(_WinUIResourcesForAot->'$(PublishDir)%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
 
   <ItemGroup>
     <!-- Generation engine: rides the user's logged-in Copilot subscription via


### PR DESCRIPTION
## What & why

Wave 2 of #70 (repo-wide NativeAOT migration). Migrates the **widget-creator** sample — a real net10-windows WinUI 3 app — so it is trim/AOT-clean and can be published as a genuine native executable that actually runs.

## Changes

- **Turned the AOT analyzer on** — removed `<ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>`, so `Directory.Build.targets` sets `IsAotCompatible=true` and promotes IL2026/IL3050/… to build errors. Fixed all 16 surfaced errors **honestly** (no `UnconditionalSuppressMessage`, no `#pragma warning disable`, no IL `NoWarn`):
  - **`ArtifactIntegrity` / `WidgetLibrary`**: replaced reflection-based `JsonSerializer.Serialize/Deserialize<T>` with **System.Text.Json source generation** (`IntegrityJsonContext` / `LibraryJsonContext`). The `[JsonSourceGenerationOptions]` mirror the former `JsonSerializerOptions` exactly, so the on-disk `meta.json` / `integrity.json` format is byte-identical. Containing classes made `partial` so the generator can emit the nested contexts next to the private DTO records.
  - **`MxcPolicy` / `MxcSandbox`**: `JsonValue.Create(...)` bound to the `[RequiresUnreferencedCode]`/`[RequiresDynamicCode]` generic `JsonArray.Add<T>(T)`; cast the argument to `(JsonNode?)` so it binds to the trim-safe `Add(JsonNode?)` overload instead.
- **Opt-in native publish** — `<PublishAot>true</PublishAot>` gated on the repo-canonical `PublishAotInternal` property (the same gate `hello-world-aot` / `command-palette-window` / the AppTests host use), kept **inside** the csproj so it never flows into the referenced netstandard2.0 analyzer/generator projects (→ NETSDK1207). Added the `_CopyWinUIResourcesForAot` target (copies `*.xbf`/`*.pri` into the publish dir).
- **README** — documents the publish command and its validated scope.

The normal framework-dependent `dotnet build` / `dotnet run` path (Copilot SDK + vendored MXC binaries) is **unchanged**.

## Publish command

```pwsh
dotnet publish samples/apps/widget-creator/widget-creator.csproj `
  -c Release -p:Platform=x64 -r win-x64 `
  -p:PublishAotInternal=true -p:IlcTreatWarningsAsErrors=false
```

`-p:IlcTreatWarningsAsErrors=false` only relaxes ILC warnings from third-party dependencies we don't own (the Copilot SDK / Windows App SDK) — this project's own code stays analyzed-as-errors at build time. `vswhere.exe` must be on `PATH` for the native link step.

## Why opt-in (not always-on)

A global/unconditional `PublishAot` would (a) trip **NETSDK1207** because the app references netstandard2.0 analyzer/generator projects, and (b) make every `dotnet build` / `dotnet run` pay the ILC native-compile cost and change the output the Copilot-SDK + vendored-MXC demo path depends on. Gating on `PublishAotInternal` keeps the default experience identical and matches every other AOT sample/host in the repo.

## Verification

- ✅ Build green: Debug + Release, analyzer-as-errors, **0 warnings / 0 errors**.
- ✅ Native AOT publish (win-x64): **44.5 MB** `WidgetCreator.exe`, **no managed `WidgetCreator.dll`** (managed code is compiled into the native image), `.pri` copied in, **zero ILC warnings**.
- ✅ The published native exe **runs**: it launches the WinUI *"Widget Creator"* window (non-zero `MainWindowHandle`), with a startup SessionLog byte-identical to the JIT build.
- ✅ Source-gen JSON **round-trips in the native image**: a seeded legacy camelCase `meta.json` deserialized cleanly while a corrupt one was correctly skipped.

**Verdict: WORKS (opt-in).** No upstream blocker.

Part of #70.