### PR TITLE
Make Reactor.Tests AOT-honest (analyzer-on)

### DIFF
--- a/tests/Reactor.Tests/AnalyzerTests/AnalyzerPackagingTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AnalyzerPackagingTests.cs
@@ -31,7 +31,7 @@ public class AnalyzerPackagingTests
 {
     [Fact]
     [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only packaging guard: enumerates the analyzer assembly's types (Assembly.GetTypes) by design. This host is never trimmed. Behaviour-neutral.")]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067",     Justification = "Test-only packaging guard: instantiates DiagnosticAnalyzer types enumerated by the scan via Activator.CreateInstance; trimming could prune their constructors. Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Test-only packaging guard: instantiates DiagnosticAnalyzer types enumerated by the scan via Activator.CreateInstance; trimming could prune their constructors. Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
     public void ShippedAnalyzerAssembly_DoesNotExport_DocCoverageRules()
     {
         // Pick any concrete analyzer that lives in the shipped assembly and
@@ -61,7 +61,7 @@ public class AnalyzerPackagingTests
 
     [Fact]
     [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only packaging guard: enumerates the analyzer assembly's types (Assembly.GetTypes) by design. This host is never trimmed. Behaviour-neutral.")]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067",     Justification = "Test-only packaging guard: instantiates DiagnosticAnalyzer types enumerated by the scan via Activator.CreateInstance; trimming could prune their constructors. Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Test-only packaging guard: instantiates DiagnosticAnalyzer types enumerated by the scan via Activator.CreateInstance; trimming could prune their constructors. Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
     public void InternalAnalyzerAssembly_Hosts_DocCoverageRules()
     {
         // Symmetric companion: ensure REACTOR_DOC_001 still exists

--- a/tests/Reactor.Tests/AnalyzerTests/AnalyzerPackagingTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AnalyzerPackagingTests.cs
@@ -30,6 +30,8 @@ namespace Microsoft.UI.Reactor.Tests.AnalyzerTests;
 public class AnalyzerPackagingTests
 {
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only packaging guard: enumerates the analyzer assembly's types (Assembly.GetTypes) by design. This host is never trimmed. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Test-only packaging guard: instantiates scanned DiagnosticAnalyzer types via Activator.CreateInstance; the concrete analyzer types have public parameterless constructors and are rooted by the scan. JIT only. Behaviour-neutral.")]
     public void ShippedAnalyzerAssembly_DoesNotExport_DocCoverageRules()
     {
         // Pick any concrete analyzer that lives in the shipped assembly and
@@ -58,6 +60,8 @@ public class AnalyzerPackagingTests
     }
 
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only packaging guard: enumerates the analyzer assembly's types (Assembly.GetTypes) by design. This host is never trimmed. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Test-only packaging guard: instantiates scanned DiagnosticAnalyzer types via Activator.CreateInstance; the concrete analyzer types have public parameterless constructors and are rooted by the scan. JIT only. Behaviour-neutral.")]
     public void InternalAnalyzerAssembly_Hosts_DocCoverageRules()
     {
         // Symmetric companion: ensure REACTOR_DOC_001 still exists

--- a/tests/Reactor.Tests/AnalyzerTests/AnalyzerPackagingTests.cs
+++ b/tests/Reactor.Tests/AnalyzerTests/AnalyzerPackagingTests.cs
@@ -31,7 +31,7 @@ public class AnalyzerPackagingTests
 {
     [Fact]
     [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only packaging guard: enumerates the analyzer assembly's types (Assembly.GetTypes) by design. This host is never trimmed. Behaviour-neutral.")]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Test-only packaging guard: instantiates scanned DiagnosticAnalyzer types via Activator.CreateInstance; the concrete analyzer types have public parameterless constructors and are rooted by the scan. JIT only. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067",     Justification = "Test-only packaging guard: instantiates DiagnosticAnalyzer types enumerated by the scan via Activator.CreateInstance; trimming could prune their constructors. Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
     public void ShippedAnalyzerAssembly_DoesNotExport_DocCoverageRules()
     {
         // Pick any concrete analyzer that lives in the shipped assembly and
@@ -61,7 +61,7 @@ public class AnalyzerPackagingTests
 
     [Fact]
     [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only packaging guard: enumerates the analyzer assembly's types (Assembly.GetTypes) by design. This host is never trimmed. Behaviour-neutral.")]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Test-only packaging guard: instantiates scanned DiagnosticAnalyzer types via Activator.CreateInstance; the concrete analyzer types have public parameterless constructors and are rooted by the scan. JIT only. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067",     Justification = "Test-only packaging guard: instantiates DiagnosticAnalyzer types enumerated by the scan via Activator.CreateInstance; trimming could prune their constructors. Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
     public void InternalAnalyzerAssembly_Hosts_DocCoverageRules()
     {
         // Symmetric companion: ensure REACTOR_DOC_001 still exists

--- a/tests/Reactor.Tests/Architecture/CoreControlFamilyBoundaryTests.cs
+++ b/tests/Reactor.Tests/Architecture/CoreControlFamilyBoundaryTests.cs
@@ -86,6 +86,7 @@ public class CoreControlFamilyBoundaryTests
     /// argument, isolating this path from the direct-reference path.
     /// </summary>
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000", Justification = "Test-only: reads the test assembly's on-disk Location to feed the IL/metadata scanner (PEReader). IL3000 only affects single-file publish (Location is empty there); this metadata-scanning test can't run single-file and this host is not single-file-published. Behaviour-neutral.")]
     public void Scanner_DetectsGenericInstantiationReferences_NotVacuous()
     {
         const string probeNs = "Microsoft.UI.Reactor.Tests.Architecture.GenericProbe";
@@ -97,6 +98,7 @@ public class CoreControlFamilyBoundaryTests
         Assert.Contains(violations, v => v.Contains("(IL generic)", StringComparison.Ordinal));
     }
 
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000", Justification = "Test-only: reads Reactor.dll's on-disk Location to feed the IL/metadata scanner (PEReader) — the assertion below already fails loudly on an empty path. IL3000 only affects single-file publish; this metadata-scanning test can't run single-file and this host is not single-file-published. Behaviour-neutral.")]
     private (SortedSet<string> Violations, int ScannedTypes) Scan(
         string[] forbiddenPrefixes, string? assemblyPath = null, string[]? sourcePrefixes = null)
     {

--- a/tests/Reactor.Tests/CheckCommandTests/CompilationLoaderTests.cs
+++ b/tests/Reactor.Tests/CheckCommandTests/CompilationLoaderTests.cs
@@ -141,6 +141,7 @@ public class CompilationLoaderTests
     /// contents don't matter (the test only checks that a reference was
     /// added, not that any specific type resolved).
     /// </summary>
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000", Justification = "Test-only: reads loaded assemblies' on-disk Location to build a Roslyn reference set (MetadataReference.CreateFromFile). IL3000 only affects single-file publish (Location is empty there) — already handled by the surrounding try/catch + IsNullOrEmpty skip; this host is not single-file-published. Behaviour-neutral.")]
     static byte[] MinimalEmptyDll()
     {
         // Compile an empty assembly in-memory and return its bytes.

--- a/tests/Reactor.Tests/CheckCommandTests/Rules/RuleRegistryCompletenessTests.cs
+++ b/tests/Reactor.Tests/CheckCommandTests/Rules/RuleRegistryCompletenessTests.cs
@@ -17,6 +17,8 @@ namespace Microsoft.UI.Reactor.Tests.CheckCommandTests.Rules;
 public class RuleRegistryCompletenessTests
 {
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only completeness guard: enumerates all types in the CLI assembly (Assembly.GetTypes) to assert every concrete IRulePattern is registered — the full-surface scan trimming would prune. This host is never trimmed. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only completeness guard: probes each scanned rule type for a public parameterless constructor (Type.GetConstructor); the types are rooted by the surrounding GetTypes scan. JIT only. Behaviour-neutral.")]
     public void Default_Registers_Every_Concrete_IRulePattern_In_The_Cli_Assembly()
     {
         var reflected = typeof(IRulePattern).Assembly

--- a/tests/Reactor.Tests/CheckCommandTests/Rules/RuleRegistryCompletenessTests.cs
+++ b/tests/Reactor.Tests/CheckCommandTests/Rules/RuleRegistryCompletenessTests.cs
@@ -18,7 +18,7 @@ public class RuleRegistryCompletenessTests
 {
     [Fact]
     [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only completeness guard: enumerates all types in the CLI assembly (Assembly.GetTypes) to assert every concrete IRulePattern is registered — the full-surface scan trimming would prune. This host is never trimmed. Behaviour-neutral.")]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only completeness guard: probes each scanned rule type for a public parameterless constructor (Type.GetConstructor); the types are rooted by the surrounding GetTypes scan. JIT only. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070",     Justification = "Test-only completeness guard: probes each rule type enumerated by the surrounding Assembly.GetTypes scan for a public parameterless constructor (Type.GetConstructor) — which trimming would prune. Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
     public void Default_Registers_Every_Concrete_IRulePattern_In_The_Cli_Assembly()
     {
         var reflected = typeof(IRulePattern).Assembly

--- a/tests/Reactor.Tests/CheckCommandTests/Rules/RuleRegistryCompletenessTests.cs
+++ b/tests/Reactor.Tests/CheckCommandTests/Rules/RuleRegistryCompletenessTests.cs
@@ -18,7 +18,7 @@ public class RuleRegistryCompletenessTests
 {
     [Fact]
     [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only completeness guard: enumerates all types in the CLI assembly (Assembly.GetTypes) to assert every concrete IRulePattern is registered — the full-surface scan trimming would prune. This host is never trimmed. Behaviour-neutral.")]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070",     Justification = "Test-only completeness guard: probes each rule type enumerated by the surrounding Assembly.GetTypes scan for a public parameterless constructor (Type.GetConstructor) — which trimming would prune. Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only completeness guard: probes each rule type enumerated by the surrounding Assembly.GetTypes scan for a public parameterless constructor (Type.GetConstructor) — which trimming would prune. Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
     public void Default_Registers_Every_Concrete_IRulePattern_In_The_Cli_Assembly()
     {
         var reflected = typeof(IRulePattern).Assembly

--- a/tests/Reactor.Tests/CheckCommandTests/Rules/RuleTargetResolutionTests.cs
+++ b/tests/Reactor.Tests/CheckCommandTests/Rules/RuleTargetResolutionTests.cs
@@ -55,6 +55,7 @@ public class RuleTargetResolutionTests
     /// would see in production, so target resolution here is the
     /// authoritative gate.
     /// </summary>
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000", Justification = "Test-only: reads loaded assemblies' on-disk Location to build a live Reactor Roslyn compilation (MetadataReference.CreateFromFile). IL3000 only affects single-file publish (Location is empty there) — already handled by the surrounding try/catch + skip; this host is not single-file-published. Behaviour-neutral.")]
     static CSharpCompilation BuildLiveReactorCompilation()
     {
         // Force Reactor.dll into the AppDomain BEFORE enumerating loaded

--- a/tests/Reactor.Tests/CheckCommandTests/TestCompilation.cs
+++ b/tests/Reactor.Tests/CheckCommandTests/TestCompilation.cs
@@ -11,6 +11,7 @@ namespace Microsoft.UI.Reactor.Tests.CheckCommandTests;
 
 internal static class TestCompilation
 {
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000", Justification = "Test-only: reads loaded assemblies' on-disk Location to build a default Roslyn reference set (MetadataReference.CreateFromFile). IL3000 only affects single-file publish (Location is empty there) — already handled by the surrounding try/catch + IsNullOrEmpty skip; this host is not single-file-published. Behaviour-neutral.")]
     static readonly Lazy<MetadataReference[]> _defaultReferences = new(() =>
     {
         // Reference standard runtime / framework assemblies but deliberately

--- a/tests/Reactor.Tests/CheckCommandTests/Tuning/SuggesterTuner.cs
+++ b/tests/Reactor.Tests/CheckCommandTests/Tuning/SuggesterTuner.cs
@@ -10,6 +10,7 @@
 // has no plausible right answer; we expect those to score as "did not match",
 // which feeds the false-positive rate at threshold T.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -242,6 +243,8 @@ internal static class SuggesterTuner
     /// <summary>
     /// Serialize the report to JSON for inspection/checkin.
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-tuning helper: reflection-based System.Text.Json serialization of the tuning report (no source-gen context). Diagnostic tooling run on JIT only; not part of any AOT publish. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-tuning helper: reflection-based System.Text.Json serialization (see the IL2026 note). Run on JIT, not AOT-compiled. Behaviour-neutral.")]
     public static string SerializeReport(TuningReport report)
         => JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true });
 }

--- a/tests/Reactor.Tests/CheckCommandTests/Tuning/ThresholdTuningTests.cs
+++ b/tests/Reactor.Tests/CheckCommandTests/Tuning/ThresholdTuningTests.cs
@@ -83,6 +83,8 @@ public class ThresholdTuningTests
     }
 
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of an anonymous diagnostic record (no source-gen context). Standard `dotnet test` is JIT (never trimmed). Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of an anonymous type (see the IL2026 note). Run on JIT, not AOT-compiled. Behaviour-neutral.")]
     public void Run_against_inline_one_row_corpus_produces_report()
     {
         // A synthetic CS0103 typo fix the suggester should fire on. The

--- a/tests/Reactor.Tests/Controls/TypedEditorsTests.cs
+++ b/tests/Reactor.Tests/Controls/TypedEditorsTests.cs
@@ -41,7 +41,7 @@ public class TypedEditorsTests
     [InlineData(typeof(global::System.TimeOnly))]
     [InlineData(typeof(global::System.Uri))]
     [InlineData(typeof(global::Windows.UI.Color))]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Test-only: the Type values come from a [Theory] of concrete, typeof-rooted primitive types (int/string/etc.), whose public constructors/properties survive; passed to the DAM-annotated TypeRegistry.ResolveEditor. Behaviour-neutral suppression (preferred over widening the test's Type parameter with DAM, which per issue #70 can narrow preservation).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067",     Justification = "Test-only: the Type values come from a [Theory] of concrete primitive types (int/string/etc.) passed to the DAM-annotated TypeRegistry.ResolveEditor. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral suppression (preferred over widening the test's Type parameter with DAM, which per issue #70 can narrow preservation).")]
     public void Registry_Resolves_Editor_For_Primitive(Type type)
     {
         var r = new TypeRegistry();

--- a/tests/Reactor.Tests/Controls/TypedEditorsTests.cs
+++ b/tests/Reactor.Tests/Controls/TypedEditorsTests.cs
@@ -41,7 +41,7 @@ public class TypedEditorsTests
     [InlineData(typeof(global::System.TimeOnly))]
     [InlineData(typeof(global::System.Uri))]
     [InlineData(typeof(global::Windows.UI.Color))]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067",     Justification = "Test-only: the Type values come from a [Theory] of concrete primitive types (int/string/etc.) passed to the DAM-annotated TypeRegistry.ResolveEditor. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral suppression (preferred over widening the test's Type parameter with DAM, which per issue #70 can narrow preservation).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Test-only: the Type values come from a [Theory] of concrete primitive types (int/string/etc.) passed to the DAM-annotated TypeRegistry.ResolveEditor. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral suppression (preferred over widening the test's Type parameter with DAM, which per issue #70 can narrow preservation).")]
     public void Registry_Resolves_Editor_For_Primitive(Type type)
     {
         var r = new TypeRegistry();

--- a/tests/Reactor.Tests/Controls/TypedEditorsTests.cs
+++ b/tests/Reactor.Tests/Controls/TypedEditorsTests.cs
@@ -41,6 +41,7 @@ public class TypedEditorsTests
     [InlineData(typeof(global::System.TimeOnly))]
     [InlineData(typeof(global::System.Uri))]
     [InlineData(typeof(global::Windows.UI.Color))]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Test-only: the Type values come from a [Theory] of concrete, typeof-rooted primitive types (int/string/etc.), whose public constructors/properties survive; passed to the DAM-annotated TypeRegistry.ResolveEditor. Behaviour-neutral suppression (preferred over widening the test's Type parameter with DAM, which per issue #70 can narrow preservation).")]
     public void Registry_Resolves_Editor_For_Primitive(Type type)
     {
         var r = new TypeRegistry();

--- a/tests/Reactor.Tests/D3/AreaTests.cs
+++ b/tests/Reactor.Tests/D3/AreaTests.cs
@@ -1,6 +1,5 @@
 // Port of d3-shape/test/area-test.js
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Reactor.Charting.D3;
 using Xunit;
 
@@ -8,6 +7,8 @@ namespace Microsoft.UI.Reactor.Tests.D3;
 
 public class AreaTests
 {
+    private readonly record struct Pt(double X, double Y);
+
     [Fact]
     public void Area_Default_GeneratesPath()
     {
@@ -17,17 +18,15 @@ public class AreaTests
     }
 
     [Fact]
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: the C# `dynamic` accessor lambdas bind through Microsoft.CSharp's RuntimeBinder (RequiresUnreferencedCode). `dynamic` is inherently reflection-based; this test runs on JIT (standard `dotnet test`), not an AOT publish. Behaviour-neutral.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: the C# `dynamic` accessor lambdas require runtime code generation (Microsoft.CSharp RuntimeBinder), AOT-incompatible by nature. Exercised on JIT only. Behaviour-neutral.")]
     public void Area_CustomAccessors()
     {
         var data = new[]
         {
-            new { X = 0.0, Y = 5.0 },
-            new { X = 10.0, Y = 15.0 },
-            new { X = 20.0, Y = 10.0 },
+            new Pt(0.0, 5.0),
+            new Pt(10.0, 15.0),
+            new Pt(20.0, 10.0),
         };
-        var a = AreaGenerator.Create<dynamic>(d => (double)d.X, d => (double)d.Y);
+        var a = AreaGenerator.Create<Pt>(d => d.X, d => d.Y);
         Assert.Equal("M0,5L10,15L20,10L20,0L10,0L0,0Z", a.Generate(data));
     }
 

--- a/tests/Reactor.Tests/D3/AreaTests.cs
+++ b/tests/Reactor.Tests/D3/AreaTests.cs
@@ -1,5 +1,6 @@
 // Port of d3-shape/test/area-test.js
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Reactor.Charting.D3;
 using Xunit;
 
@@ -16,6 +17,8 @@ public class AreaTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: the C# `dynamic` accessor lambdas bind through Microsoft.CSharp's RuntimeBinder (RequiresUnreferencedCode). `dynamic` is inherently reflection-based; this test runs on JIT (standard `dotnet test`), not an AOT publish. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: the C# `dynamic` accessor lambdas require runtime code generation (Microsoft.CSharp RuntimeBinder), AOT-incompatible by nature. Exercised on JIT only. Behaviour-neutral.")]
     public void Area_CustomAccessors()
     {
         var data = new[]

--- a/tests/Reactor.Tests/D3/LineTests.cs
+++ b/tests/Reactor.Tests/D3/LineTests.cs
@@ -1,5 +1,6 @@
 // Port of d3-shape/test/line-test.js
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Reactor.Charting.D3;
 using Xunit;
 
@@ -39,6 +40,8 @@ public class LineTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: the C# `dynamic` accessor lambdas bind through Microsoft.CSharp's RuntimeBinder (RequiresUnreferencedCode). `dynamic` is inherently reflection-based; this test runs on JIT (standard `dotnet test`), not an AOT publish. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: the C# `dynamic` accessor lambdas require runtime code generation (Microsoft.CSharp RuntimeBinder), AOT-incompatible by nature. Exercised on JIT only. Behaviour-neutral.")]
     public void Line_CustomAccessors()
     {
         var data = new[]

--- a/tests/Reactor.Tests/D3/LineTests.cs
+++ b/tests/Reactor.Tests/D3/LineTests.cs
@@ -1,6 +1,5 @@
 // Port of d3-shape/test/line-test.js
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Reactor.Charting.D3;
 using Xunit;
 
@@ -8,6 +7,8 @@ namespace Microsoft.UI.Reactor.Tests.D3;
 
 public class LineTests
 {
+    private readonly record struct Pt(double X, double Y);
+
     [Fact]
     public void Line_Default_GeneratesPath()
     {
@@ -40,17 +41,15 @@ public class LineTests
     }
 
     [Fact]
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: the C# `dynamic` accessor lambdas bind through Microsoft.CSharp's RuntimeBinder (RequiresUnreferencedCode). `dynamic` is inherently reflection-based; this test runs on JIT (standard `dotnet test`), not an AOT publish. Behaviour-neutral.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: the C# `dynamic` accessor lambdas require runtime code generation (Microsoft.CSharp RuntimeBinder), AOT-incompatible by nature. Exercised on JIT only. Behaviour-neutral.")]
     public void Line_CustomAccessors()
     {
         var data = new[]
         {
-            new { X = 0.0, Y = 1.0 },
-            new { X = 2.0, Y = 3.0 },
-            new { X = 4.0, Y = 5.0 },
+            new Pt(0.0, 1.0),
+            new Pt(2.0, 3.0),
+            new Pt(4.0, 5.0),
         };
-        var l = LineGenerator.Create<dynamic>(d => (double)d.X, d => (double)d.Y);
+        var l = LineGenerator.Create<Pt>(d => d.X, d => d.Y);
         Assert.Equal("M0,1L2,3L4,5", l.Generate(data));
     }
 

--- a/tests/Reactor.Tests/DescriptorOptionalCoverage/DescriptorOptionalHarness.cs
+++ b/tests/Reactor.Tests/DescriptorOptionalCoverage/DescriptorOptionalHarness.cs
@@ -16,7 +16,7 @@ internal static class DescriptorOptionalHarness
     // NumberBox Optional<double> gate lives in
     // tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlledOptionalNumericFamilyFixture.cs
     // (NumberBoxScenario).
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only harness: reflects a known property/field on the concrete descriptor/entry objects the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only harness: reflects a known property/field on the concrete descriptor/entry objects the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     public static void AssertOptionalGate<TValue>(
         object descriptor,
         object unset,

--- a/tests/Reactor.Tests/DescriptorOptionalCoverage/DescriptorOptionalHarness.cs
+++ b/tests/Reactor.Tests/DescriptorOptionalCoverage/DescriptorOptionalHarness.cs
@@ -16,6 +16,7 @@ internal static class DescriptorOptionalHarness
     // NumberBox Optional<double> gate lives in
     // tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlledOptionalNumericFamilyFixture.cs
     // (NumberBoxScenario).
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only harness: reflects a known property/field on the concrete descriptor/entry objects the test constructs (rooted); behaviour-neutral (no DAM contract that could prune other members — avoiding the narrowing regression noted in issue #70). JIT only.")]
     public static void AssertOptionalGate<TValue>(
         object descriptor,
         object unset,

--- a/tests/Reactor.Tests/DescriptorOptionalCoverage/DescriptorOptionalHarness.cs
+++ b/tests/Reactor.Tests/DescriptorOptionalCoverage/DescriptorOptionalHarness.cs
@@ -16,7 +16,7 @@ internal static class DescriptorOptionalHarness
     // NumberBox Optional<double> gate lives in
     // tests/Reactor.AppTests.Host/SelfTest/Fixtures/ControlledOptionalNumericFamilyFixture.cs
     // (NumberBoxScenario).
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only harness: reflects a known property/field on the concrete descriptor/entry objects the test constructs (rooted); behaviour-neutral (no DAM contract that could prune other members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only harness: reflects a known property/field on the concrete descriptor/entry objects the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     public static void AssertOptionalGate<TValue>(
         object descriptor,
         object unset,

--- a/tests/Reactor.Tests/Devtools/DevtoolsDockingToolsTests.cs
+++ b/tests/Reactor.Tests/Devtools/DevtoolsDockingToolsTests.cs
@@ -27,7 +27,7 @@ public class DevtoolsDockingToolsTests : IDisposable
     }
 
     [Fact]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects public properties of the concrete docking-host payload record the tool returns. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects public properties of the concrete docking-host payload record the tool returns. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     public void BuildListPayload_OneHost_IncludesIdAndPaneCount()
     {
         var manager = new DockManager
@@ -204,7 +204,7 @@ public class DevtoolsDockingToolsTests : IDisposable
         Assert.Contains("teleport", ex.Message);
     }
 
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only helper: reflects the Hosts property on the concrete docking payload record the tool returns. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only helper: reflects the Hosts property on the concrete docking payload record the tool returns. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     private static object[] HostsArray(object payload)
     {
         var prop = payload.GetType().GetProperty("Hosts")!;

--- a/tests/Reactor.Tests/Devtools/DevtoolsDockingToolsTests.cs
+++ b/tests/Reactor.Tests/Devtools/DevtoolsDockingToolsTests.cs
@@ -27,7 +27,7 @@ public class DevtoolsDockingToolsTests : IDisposable
     }
 
     [Fact]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects public properties of the concrete docking-host payload record the tool returns (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects public properties of the concrete docking-host payload record the tool returns. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     public void BuildListPayload_OneHost_IncludesIdAndPaneCount()
     {
         var manager = new DockManager
@@ -204,7 +204,7 @@ public class DevtoolsDockingToolsTests : IDisposable
         Assert.Contains("teleport", ex.Message);
     }
 
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only helper: reflects the Hosts property on the concrete docking payload record the tool returns (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only helper: reflects the Hosts property on the concrete docking payload record the tool returns. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     private static object[] HostsArray(object payload)
     {
         var prop = payload.GetType().GetProperty("Hosts")!;

--- a/tests/Reactor.Tests/Devtools/DevtoolsDockingToolsTests.cs
+++ b/tests/Reactor.Tests/Devtools/DevtoolsDockingToolsTests.cs
@@ -27,6 +27,7 @@ public class DevtoolsDockingToolsTests : IDisposable
     }
 
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects public properties of the concrete docking-host payload record the tool returns (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
     public void BuildListPayload_OneHost_IncludesIdAndPaneCount()
     {
         var manager = new DockManager
@@ -57,6 +58,8 @@ public class DevtoolsDockingToolsTests : IDisposable
     }
 
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP snapshot payload (no source-gen context). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void BuildSnapshotPayload_LiveHost_ReturnsTreeShape()
     {
         var manager = new DockManager
@@ -201,6 +204,7 @@ public class DevtoolsDockingToolsTests : IDisposable
         Assert.Contains("teleport", ex.Message);
     }
 
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only helper: reflects the Hosts property on the concrete docking payload record the tool returns (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
     private static object[] HostsArray(object payload)
     {
         var prop = payload.GetType().GetProperty("Hosts")!;

--- a/tests/Reactor.Tests/Devtools/DevtoolsFireToolTests.cs
+++ b/tests/Reactor.Tests/Devtools/DevtoolsFireToolTests.cs
@@ -11,8 +11,6 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// UI-dispatcher path needs a running Window and is exercised by the Phase 3
 /// self-host fixture.
 /// </summary>
-[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP error payload (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
-[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class DevtoolsFireToolTests
 {
     private sealed class TestComponent : Component
@@ -77,6 +75,8 @@ public class DevtoolsFireToolTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void FindHandler_ForbiddenLifecycleName_Throws()
     {
         var c = new TestComponent();

--- a/tests/Reactor.Tests/Devtools/DevtoolsFireToolTests.cs
+++ b/tests/Reactor.Tests/Devtools/DevtoolsFireToolTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Hosting.Devtools;
@@ -10,6 +11,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// UI-dispatcher path needs a running Window and is exercised by the Phase 3
 /// self-host fixture.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP error payload (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class DevtoolsFireToolTests
 {
     private sealed class TestComponent : Component

--- a/tests/Reactor.Tests/Devtools/DevtoolsLogsToolTests.cs
+++ b/tests/Reactor.Tests/Devtools/DevtoolsLogsToolTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.UI.Reactor.Hosting.Devtools;
 using Xunit;
@@ -8,6 +9,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// Shape tests for the <c>logs</c> MCP tool handler. Exercises
 /// <see cref="DevtoolsLogsTool.BuildPayload"/> directly so these stay headless.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: exercises the devtools MCP reflection-based JSON surface (JsonSerializer.Serialize over payload records with DevtoolsMcpServer.JsonOpts), which issue #70 documents as RUC/RDC-by-design and not-yet-AOT-clean. The standard `dotnet test` path is JIT (never trimmed); the secondary MTP-AOT investigation skip-lists this surface. Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based JSON serialization of devtools payload records (see IL2026 note). Standard test run is JIT; not AOT-compiled. Behaviour-neutral.")]
 public class DevtoolsLogsToolTests
 {
     [Fact]

--- a/tests/Reactor.Tests/Devtools/DevtoolsSerializationTests.cs
+++ b/tests/Reactor.Tests/Devtools/DevtoolsSerializationTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.UI.Reactor.Hosting.Devtools;
 using Xunit;
@@ -12,6 +13,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// <see cref="System.NotSupportedException"/> now that the reflection fallback is
 /// gone) or a camelCase/field-name drift surfaces here rather than on the wire.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payload objects (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class DevtoolsSerializationTests
 {
     // -- components: Components is `object` (ComponentInfo[] | string[]) -----------

--- a/tests/Reactor.Tests/Devtools/FireResolutionTests.cs
+++ b/tests/Reactor.Tests/Devtools/FireResolutionTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.UI.Reactor.Core;
 using Microsoft.UI.Reactor.Hosting.Devtools;
@@ -12,6 +13,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// <see cref="DevtoolsFireTool.ResolveTarget"/> wrapper that mirrors the
 /// live tool path's error shapes.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payload objects (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class FireResolutionTests
 {
     private sealed class CounterDemo : Component

--- a/tests/Reactor.Tests/Devtools/McpDispatchTests.cs
+++ b/tests/Reactor.Tests/Devtools/McpDispatchTests.cs
@@ -11,8 +11,6 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// endpoint + dispatcher marshalling are covered by the self-host MCP tests in
 /// Phase 2.17.
 /// </summary>
-[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization/deserialization of devtools/MCP JSON-RPC payloads (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
-[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization/deserialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class McpDispatchTests
 {
     private static McpToolRegistry BuildRegistry()
@@ -37,6 +35,8 @@ public class McpDispatchTests
     // the test exercises Serialize/Deserialize round-trips on the envelope.
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json deserialization of a devtools/MCP JSON-RPC request (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json deserialization of a devtools/MCP payload (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void Deserialize_RoundTripsRequest()
     {
         const string body = """
@@ -53,6 +53,8 @@ public class McpDispatchTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP response (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void Response_SerializesSuccess_WithoutErrorField()
     {
         var resp = new JsonRpcResponse
@@ -66,6 +68,8 @@ public class McpDispatchTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP response (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void Response_SerializesError_WithoutResultField()
     {
         var resp = new JsonRpcResponse

--- a/tests/Reactor.Tests/Devtools/McpDispatchTests.cs
+++ b/tests/Reactor.Tests/Devtools/McpDispatchTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.UI.Reactor.Hosting.Devtools;
@@ -10,6 +11,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// endpoint + dispatcher marshalling are covered by the self-host MCP tests in
 /// Phase 2.17.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization/deserialization of devtools/MCP JSON-RPC payloads (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization/deserialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class McpDispatchTests
 {
     private static McpToolRegistry BuildRegistry()

--- a/tests/Reactor.Tests/Devtools/McpDispatcherTests.cs
+++ b/tests/Reactor.Tests/Devtools/McpDispatcherTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.UI.Reactor.Hosting.Devtools;
@@ -10,6 +11,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// Uses a purely in-memory tool registry so the dispatcher is exercised end-to-end
 /// without needing a running WinUI window or HTTP listener.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payload objects (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class McpDispatcherTests
 {
     private static McpDispatcher BuildDispatcher(out McpToolRegistry reg)

--- a/tests/Reactor.Tests/Devtools/ReferenceOverlayTests.cs
+++ b/tests/Reactor.Tests/Devtools/ReferenceOverlayTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.UI.Reactor.Hosting.Devtools;
 using Xunit;
@@ -12,6 +13,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// tests pin the serialization shape, the slot→label mapping, and the cycle /
 /// unresolved diagnostic logic on hand-built edge lists.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payload objects (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class ReferenceOverlayTests
 {
     [Fact]

--- a/tests/Reactor.Tests/Devtools/ReferenceOverlayTests.cs
+++ b/tests/Reactor.Tests/Devtools/ReferenceOverlayTests.cs
@@ -13,11 +13,11 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// tests pin the serialization shape, the slot→label mapping, and the cycle /
 /// unresolved diagnostic logic on hand-built edge lists.
 /// </summary>
-[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payload objects (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
-[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class ReferenceOverlayTests
 {
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void ReferenceGraphResult_HasPinnedSchemaTag()
     {
         var payload = new ReferenceGraphResult { WindowId = "main" };
@@ -26,6 +26,8 @@ public class ReferenceOverlayTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void ReferenceEdgeInfo_SerializesCamelCase_AndOmitsNullOutOfTree()
     {
         var edge = new ReferenceEdgeInfo

--- a/tests/Reactor.Tests/Devtools/SelectorResolverRuntimeTests.cs
+++ b/tests/Reactor.Tests/Devtools/SelectorResolverRuntimeTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.UI.Reactor.Hosting.Devtools;
 using Xunit;
@@ -10,6 +11,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// visual tree, so we can assert the structured-error contracts without a
 /// self-host fixture. Tree-walk paths (AutomationId, TypePath) live in §2.17.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payload objects (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class SelectorResolverRuntimeTests
 {
     [Fact]

--- a/tests/Reactor.Tests/Devtools/StateShapeTests.cs
+++ b/tests/Reactor.Tests/Devtools/StateShapeTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.UI.Reactor.Core;
@@ -14,6 +15,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// End-to-end hook-table reads need a rendered component and live in the
 /// self-host fixture (§3.11).
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP state-shape payload objects (no source-gen context; some via DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP state-shape payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class StateShapeTests
 {
     [Theory]

--- a/tests/Reactor.Tests/Devtools/StdioTransportTests.cs
+++ b/tests/Reactor.Tests/Devtools/StdioTransportTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.UI.Reactor.Hosting.Devtools;
@@ -12,6 +13,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// parity pass (running the Phase 2+3 self-host suite over stdio) lands
 /// with §4.7.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP dispatch payloads (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class StdioTransportTests
 {
     private static McpDispatcher BuildDispatcher()

--- a/tests/Reactor.Tests/Devtools/StdioTransportTests.cs
+++ b/tests/Reactor.Tests/Devtools/StdioTransportTests.cs
@@ -13,8 +13,6 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// parity pass (running the Phase 2+3 self-host suite over stdio) lands
 /// with §4.7.
 /// </summary>
-[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP dispatch payloads (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
-[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class StdioTransportTests
 {
     private static McpDispatcher BuildDispatcher()
@@ -111,6 +109,8 @@ public class StdioTransportTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP dispatch payload (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void ResponseShape_MatchesHttpTransport()
     {
         // Parity: an identical dispatcher fed the same request line through
@@ -148,6 +148,8 @@ public class StdioTransportTests
         """{"jsonrpc":"2.0","id":7,"method":"prompts/list"}""")]
     [InlineData("direct-name-invocation",
         """{"jsonrpc":"2.0","id":8,"method":"ping"}""")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP dispatch payload (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void StdioAndHttpResponses_ByteIdentical_ForEveryMethodClass(string label, string request)
     {
         _ = label; // documented in the InlineData; shown in test output on failure
@@ -160,6 +162,8 @@ public class StdioTransportTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP dispatch payload (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP payload (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void StdioRun_FeedingMixedSequence_ProducesHttpIdenticalPerLine()
     {
         // A realistic agent session: initialize, list tools, call a tool,

--- a/tests/Reactor.Tests/Devtools/TreeFullViewTests.cs
+++ b/tests/Reactor.Tests/Devtools/TreeFullViewTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.UI.Reactor.Hosting.Devtools;
 using Xunit;
@@ -10,6 +11,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// instances and assert the serialization matches spec §9. Self-host tests
 /// (§3.11) cover end-to-end walking.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payload objects (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class TreeFullViewTests
 {
     [Fact]

--- a/tests/Reactor.Tests/Devtools/TreeSchemaTests.cs
+++ b/tests/Reactor.Tests/Devtools/TreeSchemaTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.UI.Reactor.Hosting.Devtools;
 using Xunit;
@@ -10,6 +11,8 @@ namespace Microsoft.UI.Reactor.Tests.Devtools;
 /// tests assert the schema pin, the summary-only field set, and cross-ref
 /// plumbing between ParentId/ChildIds.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payload objects (no source-gen context; DevtoolsMcpServer.JsonOpts). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; the standard `dotnet test` path is JIT (never trimmed). Behaviour-neutral.")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of devtools/MCP payloads (see the IL2026 note). Standard test run is JIT, not AOT-compiled. Behaviour-neutral.")]
 public class TreeSchemaTests
 {
     [Fact]

--- a/tests/Reactor.Tests/Devtools/WindowsOpenAllowlistGateTests.cs
+++ b/tests/Reactor.Tests/Devtools/WindowsOpenAllowlistGateTests.cs
@@ -34,6 +34,7 @@ public class WindowsOpenAllowlistGateTests
     }
 
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the Code/Available properties on the concrete structured-error payload the throw produces (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
     public void Disallowed_Component_Throws_Unknown_Component()
     {
         var ex = Assert.Throws<McpToolException>(() =>

--- a/tests/Reactor.Tests/Devtools/WindowsOpenAllowlistGateTests.cs
+++ b/tests/Reactor.Tests/Devtools/WindowsOpenAllowlistGateTests.cs
@@ -34,7 +34,7 @@ public class WindowsOpenAllowlistGateTests
     }
 
     [Fact]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects the Code/Available properties on the concrete structured-error payload the throw produces. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the Code/Available properties on the concrete structured-error payload the throw produces. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     public void Disallowed_Component_Throws_Unknown_Component()
     {
         var ex = Assert.Throws<McpToolException>(() =>

--- a/tests/Reactor.Tests/Devtools/WindowsOpenAllowlistGateTests.cs
+++ b/tests/Reactor.Tests/Devtools/WindowsOpenAllowlistGateTests.cs
@@ -34,7 +34,7 @@ public class WindowsOpenAllowlistGateTests
     }
 
     [Fact]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the Code/Available properties on the concrete structured-error payload the throw produces (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects the Code/Available properties on the concrete structured-error payload the throw produces. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     public void Disallowed_Component_Throws_Unknown_Component()
     {
         var ex = Assert.Throws<McpToolException>(() =>

--- a/tests/Reactor.Tests/Elements/CardThemeResolutionSmokeTests.cs
+++ b/tests/Reactor.Tests/Elements/CardThemeResolutionSmokeTests.cs
@@ -114,7 +114,7 @@ public class CardThemeResolutionSmokeTests
     /// class) and returns the first non-null string it finds. Returns null
     /// if no such field exists.
     /// </summary>
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects instance fields of the concrete captured closure/delegate target the test produces. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects instance fields of the concrete captured closure/delegate target the test produces. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     private static string? TryExtractCapturedString(global::System.Delegate d)
     {
         var target = d.Target;

--- a/tests/Reactor.Tests/Elements/CardThemeResolutionSmokeTests.cs
+++ b/tests/Reactor.Tests/Elements/CardThemeResolutionSmokeTests.cs
@@ -114,6 +114,7 @@ public class CardThemeResolutionSmokeTests
     /// class) and returns the first non-null string it finds. Returns null
     /// if no such field exists.
     /// </summary>
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects instance fields of the concrete captured closure/delegate target the test produces (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
     private static string? TryExtractCapturedString(global::System.Delegate d)
     {
         var target = d.Target;

--- a/tests/Reactor.Tests/Elements/CardThemeResolutionSmokeTests.cs
+++ b/tests/Reactor.Tests/Elements/CardThemeResolutionSmokeTests.cs
@@ -114,7 +114,7 @@ public class CardThemeResolutionSmokeTests
     /// class) and returns the first non-null string it finds. Returns null
     /// if no such field exists.
     /// </summary>
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects instance fields of the concrete captured closure/delegate target the test produces (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects instance fields of the concrete captured closure/delegate target the test produces. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     private static string? TryExtractCapturedString(global::System.Delegate d)
     {
         var target = d.Target;

--- a/tests/Reactor.Tests/Elements/NamingAlignmentGuardTests.cs
+++ b/tests/Reactor.Tests/Elements/NamingAlignmentGuardTests.cs
@@ -148,6 +148,7 @@ public class NamingAlignmentGuardTests
         return text.Length > 0;
     }
 
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000", Justification = "Test-only: reads Reactor.dll's on-disk Location to locate the doc-XML emitted alongside it — the assertion below already fails loudly on an empty path. IL3000 only affects single-file publish; this host is not single-file-published. Behaviour-neutral.")]
     private static XDocument LoadDocXml()
     {
         // The doc XML is emitted alongside Reactor.dll by GenerateDocumentationFile.

--- a/tests/Reactor.Tests/Elements/PublicApiSurfaceGuardTests.cs
+++ b/tests/Reactor.Tests/Elements/PublicApiSurfaceGuardTests.cs
@@ -56,6 +56,9 @@ public class PublicApiSurfaceGuardTests
     };
 
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only public-API surface guard: enumerates all types in the Reactor assembly (Assembly.GetTypes) by design — the full-surface scan trimming would prune. This host is never trimmed. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only public-API surface guard: reflects public static methods of scanned extension-holder types (rooted by the GetTypes scan); JIT only. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only public-API surface guard: reflects public instance properties of scanned element-record types (rooted by the GetTypes scan); JIT only. Behaviour-neutral.")]
     public void EveryCallbackPropertyHasMatchingFluent()
     {
         var reactor = typeof(Element).Assembly;

--- a/tests/Reactor.Tests/Elements/PublicApiSurfaceGuardTests.cs
+++ b/tests/Reactor.Tests/Elements/PublicApiSurfaceGuardTests.cs
@@ -57,8 +57,8 @@ public class PublicApiSurfaceGuardTests
 
     [Fact]
     [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only public-API surface guard: enumerates all types in the Reactor assembly (Assembly.GetTypes) by design — the full-surface scan trimming would prune. This host is never trimmed. Behaviour-neutral.")]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only public-API surface guard: reflects public static methods of scanned extension-holder types (rooted by the GetTypes scan); JIT only. Behaviour-neutral.")]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only public-API surface guard: reflects public instance properties of scanned element-record types (rooted by the GetTypes scan); JIT only. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only public-API surface guard: reflects public static methods of extension-holder types enumerated by the surrounding Assembly.GetTypes scan (which trimming would prune). Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only public-API surface guard: reflects public instance properties of element-record types enumerated by the surrounding Assembly.GetTypes scan (which trimming would prune). Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
     public void EveryCallbackPropertyHasMatchingFluent()
     {
         var reactor = typeof(Element).Assembly;

--- a/tests/Reactor.Tests/ImmutableRecordContractTests.cs
+++ b/tests/Reactor.Tests/ImmutableRecordContractTests.cs
@@ -37,7 +37,7 @@ public class ImmutableRecordContractTests
 
     [Theory]
     [MemberData(nameof(ImmutableRecordTypes))]
-    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only: the Type flows from typeof(...) literals in the theory data (TrayIconSpec/WindowSpec/Command/Command<>), rooted with their members; behaviour-neutral suppression (preferred over a DAM annotation on the parameter, which per issue #70 can narrow preservation and regress). JIT only.")]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only: the Type flows from typeof(...) literals in the theory data (TrayIconSpec/WindowSpec/Command/Command<>). Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral suppression (preferred over a DAM annotation on the parameter, which per issue #70 can narrow preservation and regress).")]
     public void All_Public_Properties_Are_InitOnly(Type type)
     {
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
@@ -54,7 +54,7 @@ public class ImmutableRecordContractTests
 
     [Theory]
     [MemberData(nameof(ImmutableRecordTypes))]
-    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only: the Type flows from typeof(...) literals in the theory data (TrayIconSpec/WindowSpec/Command/Command<>), rooted with their members; behaviour-neutral suppression (preferred over a DAM annotation on the parameter, which per issue #70 can narrow preservation and regress). JIT only.")]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only: the Type flows from typeof(...) literals in the theory data (TrayIconSpec/WindowSpec/Command/Command<>). Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral suppression (preferred over a DAM annotation on the parameter, which per issue #70 can narrow preservation and regress).")]
     public void Has_At_Least_One_Public_Property(Type type)
     {
         // Sanity check: ensure the test is actually verifying something.

--- a/tests/Reactor.Tests/ImmutableRecordContractTests.cs
+++ b/tests/Reactor.Tests/ImmutableRecordContractTests.cs
@@ -37,6 +37,7 @@ public class ImmutableRecordContractTests
 
     [Theory]
     [MemberData(nameof(ImmutableRecordTypes))]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only: the Type flows from typeof(...) literals in the theory data (TrayIconSpec/WindowSpec/Command/Command<>), rooted with their members; behaviour-neutral suppression (preferred over a DAM annotation on the parameter, which per issue #70 can narrow preservation and regress). JIT only.")]
     public void All_Public_Properties_Are_InitOnly(Type type)
     {
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
@@ -53,6 +54,7 @@ public class ImmutableRecordContractTests
 
     [Theory]
     [MemberData(nameof(ImmutableRecordTypes))]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only: the Type flows from typeof(...) literals in the theory data (TrayIconSpec/WindowSpec/Command/Command<>), rooted with their members; behaviour-neutral suppression (preferred over a DAM annotation on the parameter, which per issue #70 can narrow preservation and regress). JIT only.")]
     public void Has_At_Least_One_Public_Property(Type type)
     {
         // Sanity check: ensure the test is actually verifying something.

--- a/tests/Reactor.Tests/Localization/LocSourceGeneratorTests.cs
+++ b/tests/Reactor.Tests/Localization/LocSourceGeneratorTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.UI.Reactor.Tests.Localization;
 
 public class LocSourceGeneratorTests
 {
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000", Justification = "Test-only: reads the core library's on-disk Location to feed a Roslyn compilation (MetadataReference.CreateFromFile). IL3000 only affects single-file publish (Location is empty there); this source-generator test can't run single-file and this host is not single-file-published. Behaviour-neutral.")]
     private static GeneratorDriverRunResult RunGenerator(
         params (string path, string content)[] reswFiles)
     {
@@ -237,6 +238,7 @@ public class LocSourceGeneratorTests
     }
 
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000", Justification = "Test-only: reads the core library's on-disk Location to feed a Roslyn compilation (MetadataReference.CreateFromFile). IL3000 only affects single-file publish (Location is empty there); this source-generator test can't run single-file and this host is not single-file-published. Behaviour-neutral.")]
     public void NoReswFiles_NoOutput()
     {
         var compilation = CSharpCompilation.Create("TestAssembly",

--- a/tests/Reactor.Tests/MemoizationPropagationTests.cs
+++ b/tests/Reactor.Tests/MemoizationPropagationTests.cs
@@ -86,7 +86,7 @@ public class MemoizationPropagationTests
     // it can validate ShouldUpdate(TProps?, TProps?) against arbitrary Component<TProps>
     // subclasses without re-implementing the dispatch path. Do not infer from this code
     // that the product reconciler reflects on every reconcile — it does not.
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the internal ShouldUpdate method on the concrete Component subtype the test constructs (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects the internal ShouldUpdate method on the concrete Component subtype the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     private static bool ShouldUpdateWithProps(Component component, object? oldProps, object? newProps)
     {
         var compType = component.GetType();

--- a/tests/Reactor.Tests/MemoizationPropagationTests.cs
+++ b/tests/Reactor.Tests/MemoizationPropagationTests.cs
@@ -86,6 +86,7 @@ public class MemoizationPropagationTests
     // it can validate ShouldUpdate(TProps?, TProps?) against arbitrary Component<TProps>
     // subclasses without re-implementing the dispatch path. Do not infer from this code
     // that the product reconciler reflects on every reconcile — it does not.
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the internal ShouldUpdate method on the concrete Component subtype the test constructs (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
     private static bool ShouldUpdateWithProps(Component component, object? oldProps, object? newProps)
     {
         var compType = component.GetType();

--- a/tests/Reactor.Tests/MemoizationPropagationTests.cs
+++ b/tests/Reactor.Tests/MemoizationPropagationTests.cs
@@ -86,7 +86,7 @@ public class MemoizationPropagationTests
     // it can validate ShouldUpdate(TProps?, TProps?) against arbitrary Component<TProps>
     // subclasses without re-implementing the dispatch path. Do not infer from this code
     // that the product reconciler reflects on every reconcile — it does not.
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects the internal ShouldUpdate method on the concrete Component subtype the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the internal ShouldUpdate method on the concrete Component subtype the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     private static bool ShouldUpdateWithProps(Component component, object? oldProps, object? newProps)
     {
         var compType = component.GetType();

--- a/tests/Reactor.Tests/MemoizationSelfHostTests.cs
+++ b/tests/Reactor.Tests/MemoizationSelfHostTests.cs
@@ -69,7 +69,7 @@ public class MemoizationSelfHostTests
     /// subclasses without re-implementing the dispatch path. Do not infer from this code
     /// that the product reconciler reflects on every reconcile — it does not.
     /// </remarks>
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the internal ShouldUpdate method on the concrete Component subtype the test constructs (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects the internal ShouldUpdate method on the concrete Component subtype the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     private static bool ShouldUpdateWithProps(Component component, object? oldProps, object? newProps)
     {
         var compType = component.GetType();

--- a/tests/Reactor.Tests/MemoizationSelfHostTests.cs
+++ b/tests/Reactor.Tests/MemoizationSelfHostTests.cs
@@ -69,7 +69,7 @@ public class MemoizationSelfHostTests
     /// subclasses without re-implementing the dispatch path. Do not infer from this code
     /// that the product reconciler reflects on every reconcile — it does not.
     /// </remarks>
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects the internal ShouldUpdate method on the concrete Component subtype the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the internal ShouldUpdate method on the concrete Component subtype the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     private static bool ShouldUpdateWithProps(Component component, object? oldProps, object? newProps)
     {
         var compType = component.GetType();

--- a/tests/Reactor.Tests/MemoizationSelfHostTests.cs
+++ b/tests/Reactor.Tests/MemoizationSelfHostTests.cs
@@ -69,6 +69,7 @@ public class MemoizationSelfHostTests
     /// subclasses without re-implementing the dispatch path. Do not infer from this code
     /// that the product reconciler reflects on every reconcile — it does not.
     /// </remarks>
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the internal ShouldUpdate method on the concrete Component subtype the test constructs (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
     private static bool ShouldUpdateWithProps(Component component, object? oldProps, object? newProps)
     {
         var compType = component.GetType();

--- a/tests/Reactor.Tests/MoreCoverageTests.cs
+++ b/tests/Reactor.Tests/MoreCoverageTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.UI.Reactor.Controls;
@@ -208,6 +209,8 @@ public class MoreCoverageTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP dispatch result (DevtoolsMcpServer.JsonOpts, no source-gen context). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP result (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void McpDispatcher_Initialize_EchoesKnownProtocolVersion_2024()
     {
         var reg = new McpToolRegistry();
@@ -222,6 +225,8 @@ public class MoreCoverageTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP dispatch result (DevtoolsMcpServer.JsonOpts, no source-gen context). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP result (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void McpDispatcher_Initialize_EchoesKnownProtocolVersion_2025()
     {
         var d = new McpDispatcher(new McpToolRegistry());
@@ -232,6 +237,8 @@ public class MoreCoverageTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP dispatch result (DevtoolsMcpServer.JsonOpts, no source-gen context). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP result (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void McpDispatcher_Initialize_UnknownVersion_PinsBaseline()
     {
         var d = new McpDispatcher(new McpToolRegistry());
@@ -242,6 +249,8 @@ public class MoreCoverageTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP dispatch result (DevtoolsMcpServer.JsonOpts, no source-gen context). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP result (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void McpDispatcher_Initialize_NoParams_PinsBaseline()
     {
         var d = new McpDispatcher(new McpToolRegistry());
@@ -270,6 +279,8 @@ public class MoreCoverageTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP dispatch result (DevtoolsMcpServer.JsonOpts, no source-gen context). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP result (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void McpDispatcher_ResourcesList_ReturnsEmptyInventory()
     {
         var d = new McpDispatcher(new McpToolRegistry());
@@ -279,6 +290,8 @@ public class MoreCoverageTests
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP dispatch result (DevtoolsMcpServer.JsonOpts, no source-gen context). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP result (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void McpDispatcher_PromptsList_ReturnsEmptyInventory()
     {
         var d = new McpDispatcher(new McpToolRegistry());

--- a/tests/Reactor.Tests/MoreCoverageTests2.cs
+++ b/tests/Reactor.Tests/MoreCoverageTests2.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.UI.Reactor.Charting.D3;
@@ -189,6 +190,8 @@ public class MoreCoverageTests2
     }
 
     [Fact]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP dispatch result (DevtoolsMcpServer.JsonOpts, no source-gen context). Issue #70 documents this devtools JSON surface as RUC/RDC-by-design and not-yet-AOT-clean; standard `dotnet test` is JIT. Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json serialization of a devtools/MCP result (see IL2026). JIT only, not AOT-compiled. Behaviour-neutral.")]
     public void McpDispatcher_Initialize_NonObjectParams_PinsBaseline()
     {
         var d = new McpDispatcher(new McpToolRegistry());

--- a/tests/Reactor.Tests/PreviewCaptureServerTests.cs
+++ b/tests/Reactor.Tests/PreviewCaptureServerTests.cs
@@ -184,7 +184,7 @@ public class PreviewCaptureServerTests
     // ══════════════════════════════════════════════════════════════
 
     [Fact]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the Item1/Item2 fields of the concrete ValueTuple the invoked method returns (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects the Item1/Item2 fields of the concrete ValueTuple the invoked method returns. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     public void AcquireFreePortHolding_Returns_Bound_Loopback_Port()
     {
         var mi = ServerType.GetMethod("AcquireFreePortHolding",

--- a/tests/Reactor.Tests/PreviewCaptureServerTests.cs
+++ b/tests/Reactor.Tests/PreviewCaptureServerTests.cs
@@ -184,7 +184,7 @@ public class PreviewCaptureServerTests
     // ══════════════════════════════════════════════════════════════
 
     [Fact]
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects the Item1/Item2 fields of the concrete ValueTuple the invoked method returns. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the Item1/Item2 fields of the concrete ValueTuple the invoked method returns. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     public void AcquireFreePortHolding_Returns_Bound_Loopback_Port()
     {
         var mi = ServerType.GetMethod("AcquireFreePortHolding",

--- a/tests/Reactor.Tests/PreviewCaptureServerTests.cs
+++ b/tests/Reactor.Tests/PreviewCaptureServerTests.cs
@@ -30,6 +30,7 @@ public class PreviewCaptureServerTests
         | DynamicallyAccessedMemberTypes.NonPublicConstructors
         | DynamicallyAccessedMemberTypes.NonPublicMethods
         | DynamicallyAccessedMemberTypes.NonPublicFields)]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: the [DynamicallyAccessedMembers] annotation on this test field preserves non-public members of the concrete PreviewCaptureServer under test for reflective invoke; some of those members are themselves [RequiresUnreferencedCode], which surfaces IL2026 here. Preserving them is exactly the intent; the test drives them via reflection on JIT only (never trimmed). Behaviour-neutral.")]
     private static readonly Type ServerType = typeof(PreviewCaptureServer);
 
     // ══════════════════════════════════════════════════════════════
@@ -183,6 +184,7 @@ public class PreviewCaptureServerTests
     // ══════════════════════════════════════════════════════════════
 
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects the Item1/Item2 fields of the concrete ValueTuple the invoked method returns (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
     public void AcquireFreePortHolding_Returns_Bound_Loopback_Port()
     {
         var mi = ServerType.GetMethod("AcquireFreePortHolding",

--- a/tests/Reactor.Tests/README.md
+++ b/tests/Reactor.Tests/README.md
@@ -16,38 +16,48 @@ analyzer **off** (see `Directory.Build.targets`). That is a blunt opt-out: it si
 call would slip in unnoticed.
 
 That opt-out is now removed and replaced with `IsAotCompatible=true`. The analyzer runs,
-promotes the curated IL codes to errors (per `Directory.Build.targets`), and every
-surfaced site — ~175 across ~43 files — is **annotated honestly per-site** rather than
-silenced wholesale. The analyzer therefore keeps guarding against *new*, unintended
-reflection in test code.
+promotes the curated IL codes to errors (per `Directory.Build.targets`), and the ~175
+surfaced IL2\*/IL3\* diagnostics are resolved honestly per-site — **92 justified
+`[UnconditionalSuppressMessage]` attributes added across 40 files** (two more were already
+present in `SanitizeUrlTests`, for 94 total), **plus two tests rewritten to drop an avoidable
+`dynamic` dependency (a fix, not a suppression)**. The analyzer therefore keeps guarding
+against *new*, unintended reflection in test code.
 
 ### How the reflection is annotated
 
-Every site carries a **`[UnconditionalSuppressMessage]`** with a per-site justification.
-`[UnconditionalSuppressMessage]` (not `#pragma warning disable`, which ILC ignores) is the
-form that survives a whole-program ILC pass, and it is **behaviour-neutral**: unlike a
-`[DynamicallyAccessedMembers]` annotation it neither preserves nor prunes members, so it
-cannot cause the runtime narrowing regression documented in issue #70 (comment 3, where a
+Almost every site carries a **`[UnconditionalSuppressMessage]`** with a per-site
+justification. `[UnconditionalSuppressMessage]` (not `#pragma warning disable`, which ILC
+ignores) is the form that survives a whole-program ILC pass, and it is **behaviour-neutral**:
+unlike a `[DynamicallyAccessedMembers]` annotation it neither preserves nor prunes members, so
+it cannot cause the runtime narrowing regression documented in issue #70 (comment 3, where a
 `[DynamicallyAccessedMembers]` on a test helper stripped collection-enumeration members and
-broke ~20 PropertyGrid selftests). **No product (core Reactor) type was touched** — all
-changes live inside this test project.
+broke ~20 PropertyGrid selftests). A suppression is therefore **not** a claim that the
+reflection is trim-safe — it documents that the reflection is intentional and that this host
+runs on the JIT (never trimmed). Where the reflection was *avoidable*, it was **fixed** rather
+than suppressed: the two `dynamic` chart-accessor tests (`AreaTests`/`LineTests`) now use a
+concrete `record struct` instead of `Create<dynamic>`, so no suppression is needed and the
+tests are genuinely AOT-clean. **No product (core Reactor) type was touched** — all changes
+live inside this test project.
 
 The suppressions fall into a small number of honest categories:
 
-| Category | IL code(s) | Why it is safe / intentional |
+| Category | IL code(s) | Why it is intentional (JIT-only; not claimed trim-safe) |
 |---|---|---|
 | **Devtools/MCP reflection-based JSON** (`JsonSerializer.Serialize`/`Deserialize` with `DevtoolsMcpServer.JsonOpts`, no source-gen context) | IL2026 + IL3050 | Intentionally exercises the devtools JSON surface that issue #70 documents as RUC/RDC-by-design and not-yet-AOT-clean. Run on JIT. |
-| **`dynamic` chart-accessor lambdas** (`Create<dynamic>(d => (double)d.X, …)`) | IL2026 + IL3050 | `dynamic` binds through Microsoft.CSharp's RuntimeBinder — inherently AOT-incompatible. Run on JIT only. |
-| **Generic reflection-based JSON** (tuning report, search-index round-trip into concrete records, anonymous-type serialize) | IL2026 + IL3050 | Reflection-based `System.Text.Json` on concrete types the test references; JIT only. |
-| **Assembly-wide contract/architecture scans** (`Assembly.GetTypes()` + member reflection: `CoreControlFamilyBoundaryTests`, `PublicApiSurfaceGuardTests`, `DescriptorSilentDropGuardTests`, `RuleRegistryCompletenessTests`, `AnalyzerPackagingTests`, the RegisterAllBuiltIns guard) | IL2026, IL2070, IL2067 | Enumerating the full type surface *is the point of the test* — exactly what trimming prunes. JIT only. |
-| **Member access on concrete runtime objects** (`obj.GetType().GetProperty/GetField/GetMethod`) | IL2075 | Reflects a known member on a type the test constructs (rooted), so it survives trimming. Behaviour-neutral (no DAM contract that could prune other members). |
-| **`Type`-parameter theory reflection** (`type.GetProperties()` over `typeof(...)`-rooted theory data) | IL2070, IL2067 | The `Type` flows from `typeof(...)` literals, rooted with their members. Suppression preferred over a DAM annotation (see the narrowing note above). |
+| **Generic reflection-based JSON** (tuning report, search-index round-trip into concrete records, anonymous-type serialize) | IL2026 + IL3050 | Reflection-based `System.Text.Json` without a source-gen context; JIT only. |
+| **Assembly-wide contract/architecture scans** (`Assembly.GetTypes()` + member reflection: `CoreControlFamilyBoundaryTests`, `PublicApiSurfaceGuardTests`, `DescriptorSilentDropGuardTests`, `RuleRegistryCompletenessTests`, `AnalyzerPackagingTests`, the RegisterAllBuiltIns guard) | IL2026, IL2070, IL2067 | Enumerating the full type surface *is the point of the test* — exactly what trimming would prune. JIT only. |
+| **Member access on concrete runtime objects** (`obj.GetType().GetProperty/GetField/GetMethod`) | IL2075 | Reflects a known member on a concrete object the test constructs. Intentional and JIT-only — **not** claimed trim-safe; behaviour-neutral (neither preserves nor prunes members). |
+| **`Type`-parameter theory reflection** (`type.GetProperties()` over `typeof(...)` theory data) | IL2070, IL2067 | The `Type` flows from `typeof(...)` literals in the theory data. JIT-only, not claimed trim-safe; suppression preferred over a DAM annotation on the parameter (see the narrowing note above). |
 | **`Assembly.Location`** (feed Roslyn `MetadataReference.CreateFromFile` / `PEReader` / doc-XML lookup) | IL3000 | Only affects single-file publish (Location is empty there); these Roslyn-compilation/metadata tests can't run single-file and the host is never single-file-published. |
 
-Where a whole test class is cohesively about one surface (e.g. the devtools/MCP JSON
-classes, `TypeRegistryUnmountTests`), the suppression is placed at class scope; otherwise it
-is placed on the individual method, helper, or field where the diagnostic fires, to avoid a
-broad blind spot (notably the large `MoreCoverageTests` grab-bags are annotated per-method).
+**Class-level vs method-level scope.** A suppression is placed at **class scope** only where
+the majority of the class's test methods exercise the one suppressed surface *and* the class
+is named/scoped for it (e.g. `DevtoolsSerializationTests`, `TreeSchemaTests`,
+`TypeRegistryUnmountTests`). Where the reflecting methods are a minority of the class (e.g.
+`ReferenceOverlayTests`, `DevtoolsFireToolTests`, `McpDispatchTests`, `StdioTransportTests`,
+and the large `MoreCoverageTests` grab-bags), the suppression is placed on the individual
+method, helper, or field where the diagnostic fires — so a future *different* unsafe
+reflection added elsewhere in the class is still caught.
 
 **Result:** `dotnet build tests/Reactor.Tests -p:Platform=x64 -p:SkipSignaturesGen=true`
 is warning/error-clean with the analyzer on, and all tests stay green:

--- a/tests/Reactor.Tests/README.md
+++ b/tests/Reactor.Tests/README.md
@@ -1,0 +1,104 @@
+# Reactor.Tests — AOT-honesty
+
+`Reactor.Tests` is the large headless xUnit unit-test host (~2,200 test methods /
+~12,500 xUnit cases). It is **never trimmed or NativeAOT-published in the normal
+`dotnet test` path** — it runs on the JIT. This note documents why the IL2\*/IL3\*
+trimming/AOT analyzer is nonetheless **enabled** here, how the intentional test-only
+reflection is annotated, and the evidence-based verdict on a native-AOT test *run*.
+Part of the repo-wide AOT-honesty effort tracked in
+[issue #70](https://github.com/microsoft/microsoft-ui-reactor/issues/70).
+
+## Analyzer-on (the primary deliverable)
+
+Previously the project set `ReactorSkipAotAnalysis=true`, which turned the IL2\*/IL3\*
+analyzer **off** (see `Directory.Build.targets`). That is a blunt opt-out: it silences
+*all* trimming/AOT diagnostics for the project, so a genuinely-unsafe *new* reflection
+call would slip in unnoticed.
+
+That opt-out is now removed and replaced with `IsAotCompatible=true`. The analyzer runs,
+promotes the curated IL codes to errors (per `Directory.Build.targets`), and every
+surfaced site — ~175 across ~43 files — is **annotated honestly per-site** rather than
+silenced wholesale. The analyzer therefore keeps guarding against *new*, unintended
+reflection in test code.
+
+### How the reflection is annotated
+
+Every site carries a **`[UnconditionalSuppressMessage]`** with a per-site justification.
+`[UnconditionalSuppressMessage]` (not `#pragma warning disable`, which ILC ignores) is the
+form that survives a whole-program ILC pass, and it is **behaviour-neutral**: unlike a
+`[DynamicallyAccessedMembers]` annotation it neither preserves nor prunes members, so it
+cannot cause the runtime narrowing regression documented in issue #70 (comment 3, where a
+`[DynamicallyAccessedMembers]` on a test helper stripped collection-enumeration members and
+broke ~20 PropertyGrid selftests). **No product (core Reactor) type was touched** — all
+changes live inside this test project.
+
+The suppressions fall into a small number of honest categories:
+
+| Category | IL code(s) | Why it is safe / intentional |
+|---|---|---|
+| **Devtools/MCP reflection-based JSON** (`JsonSerializer.Serialize`/`Deserialize` with `DevtoolsMcpServer.JsonOpts`, no source-gen context) | IL2026 + IL3050 | Intentionally exercises the devtools JSON surface that issue #70 documents as RUC/RDC-by-design and not-yet-AOT-clean. Run on JIT. |
+| **`dynamic` chart-accessor lambdas** (`Create<dynamic>(d => (double)d.X, …)`) | IL2026 + IL3050 | `dynamic` binds through Microsoft.CSharp's RuntimeBinder — inherently AOT-incompatible. Run on JIT only. |
+| **Generic reflection-based JSON** (tuning report, search-index round-trip into concrete records, anonymous-type serialize) | IL2026 + IL3050 | Reflection-based `System.Text.Json` on concrete types the test references; JIT only. |
+| **Assembly-wide contract/architecture scans** (`Assembly.GetTypes()` + member reflection: `CoreControlFamilyBoundaryTests`, `PublicApiSurfaceGuardTests`, `DescriptorSilentDropGuardTests`, `RuleRegistryCompletenessTests`, `AnalyzerPackagingTests`, the RegisterAllBuiltIns guard) | IL2026, IL2070, IL2067 | Enumerating the full type surface *is the point of the test* — exactly what trimming prunes. JIT only. |
+| **Member access on concrete runtime objects** (`obj.GetType().GetProperty/GetField/GetMethod`) | IL2075 | Reflects a known member on a type the test constructs (rooted), so it survives trimming. Behaviour-neutral (no DAM contract that could prune other members). |
+| **`Type`-parameter theory reflection** (`type.GetProperties()` over `typeof(...)`-rooted theory data) | IL2070, IL2067 | The `Type` flows from `typeof(...)` literals, rooted with their members. Suppression preferred over a DAM annotation (see the narrowing note above). |
+| **`Assembly.Location`** (feed Roslyn `MetadataReference.CreateFromFile` / `PEReader` / doc-XML lookup) | IL3000 | Only affects single-file publish (Location is empty there); these Roslyn-compilation/metadata tests can't run single-file and the host is never single-file-published. |
+
+Where a whole test class is cohesively about one surface (e.g. the devtools/MCP JSON
+classes, `TypeRegistryUnmountTests`), the suppression is placed at class scope; otherwise it
+is placed on the individual method, helper, or field where the diagnostic fires, to avoid a
+broad blind spot (notably the large `MoreCoverageTests` grab-bags are annotated per-method).
+
+**Result:** `dotnet build tests/Reactor.Tests -p:Platform=x64 -p:SkipSignaturesGen=true`
+is warning/error-clean with the analyzer on, and all tests stay green:
+`dotnet test tests/Reactor.Tests -p:Platform=x64 -p:SkipSignaturesGen=true`
+→ **Failed: 0, Passed: 12454, Skipped: 64** (the skips are pre-existing).
+
+## Native-AOT test *run* — DOCUMENTED BLOCKER (upstream)
+
+The secondary question was whether the suite could be **published with NativeAOT and run as
+a native executable** (a native regression gate). The answer, established by attempting it,
+is **no — and the blocker is upstream in the xUnit v3 framework, not in this repo's test
+code.**
+
+Attempting the publish (with `PublishAot` set *inside* the csproj behind an opt-in property —
+never a global `-p:PublishAot=true`, which leaks through the `ProjectReference` graph into the
+netstandard2.0 analyzer/generator projects and trips `NETSDK1207`) surfaces two blockers, in
+order:
+
+1. **`NETSDK1150`** — the test host references sibling *executable* projects (`Reactor.Cli`,
+   `minesweeper`, `Reactor.MurCheckGuardrail`, `Reactor.SearchIndex`) for their managed
+   assemblies in in-process tests; a self-contained (AOT) exe rejects non-self-contained exe
+   references. Worked around with `ValidateExecutableReferencesMatchSelfContained=false`.
+
+2. **ILC hard-fails on the xUnit v3 runner itself.** Every remaining trim/AOT diagnostic in
+   the ILC phase (IL2026/IL2055/IL2057/IL2060/IL2065/IL2067/IL2070/IL2072/IL2075/IL2077/
+   IL2080/IL3000/IL3050) originates from the **xUnit v3 packages** —
+   `xunit.v3.common`, `xunit.v3.core`, `xunit.v3.assert`, `xunit.v3.runner.*` — in
+   `ArgumentFormatter`, `ReflectionExtensions`, `TypeHelper`, `AsyncUtility`,
+   `FixtureMappingManager`, and `XunitTestRunnerBase`. These are the framework's own
+   discovery / invocation / assertion-formatting paths: `Type.MakeGenericType` and
+   `MethodInfo.MakeGenericMethod` for generic `[Theory]` data and generic test classes
+   (genuine `RequiresDynamicCode`), `Activator.CreateInstance` for test classes and fixtures,
+   `EventSource` object-graph serialization, and reflection over test types.
+   **Zero** of these diagnostics come from this project's own (now-annotated) test code.
+
+Because the failing reflection lives in the xUnit v3 assemblies, it is **not annotatable in
+this repo** — `MakeGenericMethod`/`MakeGenericType` are real runtime-codegen requirements
+that cannot be made AOT-safe by annotation; they would throw at runtime even if the ILC
+warnings were downgraded. A native-AOT *run* of this suite is therefore not feasible with the
+current xUnit v3 runner.
+
+**Verdict:** analyzer-on is the correct **end state** for this project. This project's test
+code is AOT-honest and AOT-clean; a native run is blocked upstream in xUnit v3. The framework
+already ships an AOT regression gate via the selftest host (`docs/aot-support.md`,
+`TESTING.md` §"Running selftests under NativeAOT"), which does not depend on the xUnit runner.
+If xUnit v3 ships an AOT-safe runner (source-generated discovery, no runtime generic
+instantiation), revisit this note.
+
+### Adding new reflection to a test here
+
+The analyzer is on. If you add a new reflecting call, it will flag it — **annotate it
+honestly** (`[UnconditionalSuppressMessage]` with a specific justification, or restructure to
+avoid the reflection). Do **not** re-add `ReactorSkipAotAnalysis=true`, and do **not** add
+`[DynamicallyAccessedMembers]` to product types to silence a test diagnostic.

--- a/tests/Reactor.Tests/Reactor.Tests.csproj
+++ b/tests/Reactor.Tests/Reactor.Tests.csproj
@@ -7,11 +7,20 @@
     <RootNamespace>Microsoft.UI.Reactor.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Never trimmed/AOT-published, and many suites (CoreControlFamilyBoundaryTests
-         IL scan, PublicApiSurfaceGuardTests, ImmutableRecordContractTests, the
-         devtools/MCP fixtures) reflect over types by design. Opt out of the IL2*/IL3*
-         analyzer rather than annotate reflection that is the point of the test. -->
-    <ReactorSkipAotAnalysis>true</ReactorSkipAotAnalysis>
+    <!-- AOT-honest (issue #70): the IL2*/IL3* analyzer is ENABLED (IsAotCompatible) even
+         though this headless unit-test host is never trimmed/AOT-published in the normal
+         `dotnet test` path. Several suites (CoreControlFamilyBoundaryTests IL scan,
+         PublicApiSurfaceGuardTests, ImmutableRecordContractTests, the localization
+         generator / CLI / devtools-MCP / search-index fixtures) reflect over types by
+         design — those intentional reflection sites are *annotated* honestly with a
+         justified [UnconditionalSuppressMessage] per site (behaviour-neutral; preferred
+         over trim-semantic-changing [DynamicallyAccessedMembers], which per issue #70 can
+         narrow preservation and regress). Suppressions survive ILC (unlike #pragma), so
+         the analyzer keeps guarding against *new*, unintended reflection. See README.md
+         for the per-category rationale and the native-AOT-run verdict. -->
+    <IsAotCompatible>true</IsAotCompatible>
+    <!-- Show every individual trimmer warning instead of collapsing them into one. -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <UseWinUI>true</UseWinUI>
     <!-- Tests P/Invoke Microsoft.WindowsAppRuntime.dll from a ModuleInitializer
          (TestSetup.cs); bundle the runtime so the test host can locate it

--- a/tests/Reactor.Tests/RichTextBlockDescriptorTests.cs
+++ b/tests/Reactor.Tests/RichTextBlockDescriptorTests.cs
@@ -34,6 +34,7 @@ public class RichTextBlockDescriptorTests
             && type.GenericTypeArguments[2] == typeof(Thickness);
     }
 
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects a known non-public field on the concrete object the test constructs (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
     private static T GetPrivateField<T>(object owner, string name)
     {
         var field = owner.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);

--- a/tests/Reactor.Tests/RichTextBlockDescriptorTests.cs
+++ b/tests/Reactor.Tests/RichTextBlockDescriptorTests.cs
@@ -34,7 +34,7 @@ public class RichTextBlockDescriptorTests
             && type.GenericTypeArguments[2] == typeof(Thickness);
     }
 
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects a known non-public field on the concrete object the test constructs (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects a known non-public field on the concrete object the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     private static T GetPrivateField<T>(object owner, string name)
     {
         var field = owner.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);

--- a/tests/Reactor.Tests/RichTextBlockDescriptorTests.cs
+++ b/tests/Reactor.Tests/RichTextBlockDescriptorTests.cs
@@ -34,7 +34,7 @@ public class RichTextBlockDescriptorTests
             && type.GenericTypeArguments[2] == typeof(Thickness);
     }
 
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: reflects a known non-public field on the concrete object the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: reflects a known non-public field on the concrete object the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     private static T GetPrivateField<T>(object owner, string name)
     {
         var field = owner.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);

--- a/tests/Reactor.Tests/Spec048/UnregisteredHandlerAndRegisterAllBuiltInsTests.cs
+++ b/tests/Reactor.Tests/Spec048/UnregisteredHandlerAndRegisterAllBuiltInsTests.cs
@@ -313,6 +313,7 @@ public sealed class UnregisteredHandlerAndRegisterAllBuiltInsTests
     private static readonly HashSet<Type> KnownGeneratorBackedNotInBulkCatalog = new();
 
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only registration guard: enumerates all types in the Reactor assembly (Assembly.GetTypes) to assert every generator-backed built-in is registered — the full-surface scan trimming would prune. This host is never trimmed. Behaviour-neutral.")]
     public void Every_Generator_Backed_BuiltIn_Is_Registered_By_RegisterAllBuiltIns()
     {
         var snapshot = BuiltInHandlerBootstrap.RegisteredBuiltInElementTypes.ToHashSet();

--- a/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexGeneratorTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -41,6 +42,8 @@ public sealed class SearchIndexGeneratorTests
     static SearchIndexResult Generate() => SearchIndexGenerator.Generate(GalleryDir(), EditorialPath());
 
     static readonly JsonSerializerOptions ReadOptions = new() { PropertyNameCaseInsensitive = true };
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json deserialization of the generated search index into the concrete IndexRoot record (no source-gen context). Standard `dotnet test` is JIT (never trimmed). Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json deserialization into IndexRoot (see the IL2026 note). Run on JIT, not AOT-compiled. Behaviour-neutral.")]
     static IndexRoot Parse(string json) => JsonSerializer.Deserialize<IndexRoot>(json, ReadOptions)!;
     static ControlEntry Find(IndexRoot root, string id) =>
         root.Controls.FirstOrDefault(c => c.Id == id) ?? throw new Xunit.Sdk.XunitException($"control '{id}' missing from index");

--- a/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
+++ b/tests/Reactor.Tests/Tooling/SearchIndexToolTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -108,6 +109,8 @@ class BetaPage
 public sealed class SearchIndexGeneratorEdgeTests
 {
     static readonly JsonSerializerOptions ReadOptions = new() { PropertyNameCaseInsensitive = true };
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only: reflection-based System.Text.Json deserialization of the generated search index into the concrete IndexRoot record (no source-gen context). Standard `dotnet test` is JIT (never trimmed). Behaviour-neutral.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test-only: reflection-based System.Text.Json deserialization into IndexRoot (see the IL2026 note). Run on JIT, not AOT-compiled. Behaviour-neutral.")]
     static IndexRoot Parse(string json) => JsonSerializer.Deserialize<IndexRoot>(json, ReadOptions)!;
     static ControlEntry Find(IndexRoot root, string id) =>
         root.Controls.FirstOrDefault(c => c.Id == id) ?? throw new Xunit.Sdk.XunitException($"'{id}' missing");

--- a/tests/Reactor.Tests/TypeRegistryUnmountTests.cs
+++ b/tests/Reactor.Tests/TypeRegistryUnmountTests.cs
@@ -11,8 +11,8 @@ namespace Microsoft.UI.Reactor.Tests;
 /// Uses the RegisterType API to verify unmount dispatch without creating
 /// real WinUI controls (which require a XAML Application context).
 /// </summary>
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: all sites reflect known members (HasUnmount property, Unmount method) on the concrete TypeRegistry instance the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
-    public class TypeRegistryUnmountTests
+[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: all sites reflect known members (HasUnmount property, Unmount method) on the concrete TypeRegistry instance the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
+public class TypeRegistryUnmountTests
 {
     private record CustomCardElement(string Title) : Element;
 

--- a/tests/Reactor.Tests/TypeRegistryUnmountTests.cs
+++ b/tests/Reactor.Tests/TypeRegistryUnmountTests.cs
@@ -11,7 +11,8 @@ namespace Microsoft.UI.Reactor.Tests;
 /// Uses the RegisterType API to verify unmount dispatch without creating
 /// real WinUI controls (which require a XAML Application context).
 /// </summary>
-public class TypeRegistryUnmountTests
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: all sites reflect known members (HasUnmount property, Unmount method) on the concrete TypeRegistry instance the test constructs (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    public class TypeRegistryUnmountTests
 {
     private record CustomCardElement(string Title) : Element;
 

--- a/tests/Reactor.Tests/TypeRegistryUnmountTests.cs
+++ b/tests/Reactor.Tests/TypeRegistryUnmountTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.UI.Reactor.Tests;
 /// Uses the RegisterType API to verify unmount dispatch without creating
 /// real WinUI controls (which require a XAML Application context).
 /// </summary>
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Test-only: all sites reflect known members (HasUnmount property, Unmount method) on the concrete TypeRegistry instance the test constructs (rooted); behaviour-neutral (no DAM contract that could prune members — avoiding the narrowing regression noted in issue #70). JIT only.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075",     Justification = "Test-only: all sites reflect known members (HasUnmount property, Unmount method) on the concrete TypeRegistry instance the test constructs. Intentional and JIT-only (this host is never trimmed) — not claimed trim-safe; behaviour-neutral (neither preserves nor prunes members, so it cannot cause the DAM-narrowing regression noted in issue #70).")]
     public class TypeRegistryUnmountTests
 {
     private record CustomCardElement(string Title) : Element;

--- a/tests/Reactor.Tests/WrappersGenerator/DescriptorSilentDropGuardTests.cs
+++ b/tests/Reactor.Tests/WrappersGenerator/DescriptorSilentDropGuardTests.cs
@@ -106,7 +106,7 @@ public class DescriptorSilentDropGuardTests
     private sealed record ManualProp(Mode Mode, Type Type);
     private sealed record ManualModel(Dictionary<string, ManualProp> Props, bool HasContent, string ContentKind);
 
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only architecture/contract guard: reflects public instance properties of a concrete element type discovered by the surrounding Assembly.GetTypes scan (rooted); JIT only. Behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070",     Justification = "Test-only architecture/contract guard: reflects public instance properties of an element type enumerated by the surrounding Assembly.GetTypes scan (which trimming would prune). Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
     private static ManualModel ManualSurface(Type element)
     {
         var baseProps = typeof(Element).GetProperties().Select(p => p.Name).ToHashSet();

--- a/tests/Reactor.Tests/WrappersGenerator/DescriptorSilentDropGuardTests.cs
+++ b/tests/Reactor.Tests/WrappersGenerator/DescriptorSilentDropGuardTests.cs
@@ -36,6 +36,7 @@ public class DescriptorSilentDropGuardTests
     private enum Mode { OneWay, Controlled }
 
     [Fact]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only architecture/contract guard: enumerates all types in the Reactor assembly (Assembly.GetTypes) and reflects over their members by design — exactly the full-surface scan trimming would prune. This host is never trimmed; the analyzer-on state keeps guarding new reflection elsewhere. Behaviour-neutral.")]
     public void MigratedDescriptors_DoNotSilentlyDropUnsupportedTypeProps()
     {
         var failures = new List<string>();
@@ -105,6 +106,7 @@ public class DescriptorSilentDropGuardTests
     private sealed record ManualProp(Mode Mode, Type Type);
     private sealed record ManualModel(Dictionary<string, ManualProp> Props, bool HasContent, string ContentKind);
 
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only architecture/contract guard: reflects public instance properties of a concrete element type discovered by the surrounding Assembly.GetTypes scan (rooted); JIT only. Behaviour-neutral.")]
     private static ManualModel ManualSurface(Type element)
     {
         var baseProps = typeof(Element).GetProperties().Select(p => p.Name).ToHashSet();

--- a/tests/Reactor.Tests/WrappersGenerator/DescriptorSilentDropGuardTests.cs
+++ b/tests/Reactor.Tests/WrappersGenerator/DescriptorSilentDropGuardTests.cs
@@ -106,7 +106,7 @@ public class DescriptorSilentDropGuardTests
     private sealed record ManualProp(Mode Mode, Type Type);
     private sealed record ManualModel(Dictionary<string, ManualProp> Props, bool HasContent, string ContentKind);
 
-    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070",     Justification = "Test-only architecture/contract guard: reflects public instance properties of an element type enumerated by the surrounding Assembly.GetTypes scan (which trimming would prune). Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Test-only architecture/contract guard: reflects public instance properties of an element type enumerated by the surrounding Assembly.GetTypes scan (which trimming would prune). Intentional and JIT-only (this host is never trimmed); behaviour-neutral.")]
     private static ManualModel ManualSurface(Type element)
     {
         var baseProps = typeof(Element).GetProperties().Select(p => p.Name).ToHashSet();


### PR DESCRIPTION
## What & why

Wave 2 of the repo-wide native-AOT-honesty effort ([#70](https://github.com/microsoft/microsoft-ui-reactor/issues/70)). Target: **`tests/Reactor.Tests`** — the large headless xUnit unit-test host (~2,200 test methods / ~12,500 xUnit cases), which had the IL2\*/IL3\* analyzer **off** via `ReactorSkipAotAnalysis=true`.

**Primary deliverable (done): analyzer-on, honest.** Removed `ReactorSkipAotAnalysis=true` and set `IsAotCompatible=true`, so `Directory.Build.targets` turns on the trimming/AOT analyzer and promotes the curated IL codes to build errors. That surfaced **~175 IL2\*/IL3\* diagnostics** across ~43 files, each resolved honestly per-site. The analyzer now guards against *new*, unintended reflection in test code instead of a blunt project-wide opt-out.

All changes live **inside this test project**. **No product (core Reactor) type was touched**, and **no `[DynamicallyAccessedMembers]` was added to a product type** — issue #70 (comment 3) documents how a narrowing DAM annotation regressed ~20 PropertyGrid selftests, so suppressions here are behaviour-neutral (they neither preserve nor prune members).

## How it's annotated

**92 `[UnconditionalSuppressMessage]` attributes added across 40 files** (`[UnconditionalSuppressMessage]`, not `#pragma`, because ILC ignores `#pragma`). A suppression is **not** a claim of trim-safety — it documents that the reflection is intentional and that this host runs on the JIT (never trimmed). Where reflection was *avoidable* it was **fixed, not suppressed**.

| Category | IL code(s) | Justification |
|---|---|---|
| Devtools/MCP reflection-based JSON (`JsonSerializer` + `DevtoolsMcpServer.JsonOpts`) | IL2026 + IL3050 | Intentionally exercises the devtools JSON surface #70 documents as RUC/RDC-by-design and not-yet-AOT-clean; JIT only |
| Generic reflection-based JSON (tuning report, search-index round-trip, anonymous-type serialize) | IL2026 + IL3050 | Reflection-based `System.Text.Json`, no source-gen context; JIT only |
| Assembly-wide contract/architecture scans (`Assembly.GetTypes()` + member reflection) | IL2026, IL2070, IL2067 | Enumerating the full type surface *is the point of the test* — exactly what trimming would prune; JIT only |
| Member access on concrete runtime objects (`obj.GetType().GetProperty/GetField/GetMethod`) | IL2075 | Intentional, JIT-only, **not** claimed trim-safe; behaviour-neutral |
| `Type`-parameter theory reflection over `typeof(...)` data | IL2070, IL2067 | JIT-only, not trim-safe; suppression preferred over a DAM annotation on the test parameter (narrowing risk) |
| `Assembly.Location` (Roslyn `MetadataReference.CreateFromFile` / `PEReader` / doc-XML) | IL3000 | Single-file-only concern; these Roslyn/metadata tests can't run single-file and the host is never single-file-published |

**Scope policy:** class-level suppression only where the majority of a class's tests exercise the one surface; otherwise method/field-level (so a *different* unsafe reflection added elsewhere in the class is still caught). Two `dynamic` chart-accessor tests (`AreaTests`/`LineTests`) were **rewritten to a concrete `record struct`** — same assertions, no `Create<dynamic>`, no suppression, genuinely AOT-clean.

## Native-AOT test *run* verdict — **DOCUMENTED BLOCKER (upstream)**

You don't normally native-publish a test project; I investigated it anyway. A NativeAOT publish fails, but **every remaining ILC trim/AOT diagnostic originates from the xUnit v3 packages themselves** (`xunit.v3.common/core/assert/runner` — `MakeGenericMethod`/`MakeGenericType`/`Activator`/reflection in discovery, invocation, and assertion formatting). **Zero** come from this project's now-annotated test code. That reflection is real runtime-codegen and cannot be annotated in this repo, so **analyzer-on is the correct end state**; the framework's AOT regression gate remains the selftest host (`docs/aot-support.md`, `TESTING.md`). Full repro + rationale in [`tests/Reactor.Tests/README.md`](https://github.com/microsoft/microsoft-ui-reactor/blob/azchohfi-reactor-tests-aot-honest/tests/Reactor.Tests/README.md). (No global `-p:PublishAot=true` was used — it leaks into the netstandard2.0 analyzer/generator refs, NETSDK1207.)

## Verification

- `dotnet build tests/Reactor.Tests -p:Platform=x64 -p:SkipSignaturesGen=true` → **0 warnings, 0 errors** with the analyzer on.
- `dotnet test tests/Reactor.Tests -p:Platform=x64 -p:SkipSignaturesGen=true` → **Failed 0, Passed 12454, Skipped 64** (skips pre-existing).
- Ran the repo's `pr-review` skill (7 specialist dimensions + a **multi-model cross-check on a different model family — GPT-5.5, high reasoning**). Every finding was addressed (justification honesty, scope narrowing, the `dynamic` fix, count precision); the multi-model pass then independently re-audited every suppression for "honest vs hiding a real AOT break" and returned **0 additional critical/high findings**.

Part of #70. Ready for review — please don't merge yet.