### PR TITLE
Release prep: 0.1.0-preview.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,12 @@ Conventions for contributors:
   `OnDropDownClosed`; universal multi-select `OnSelectionChanged` on
   list/grid surfaces.
 
+- **Common content-alignment and border fluents (issue #774).** New
+  `.HorizontalContentAlignment(...)`, `.VerticalContentAlignment(...)`,
+  `.BorderBrush(...)`, and `.BorderThickness(...)` modifiers (with
+  `Thickness`-aware overloads) expose common layout/styling that previously
+  required a `.Set(...)` fallback, without adding control-specific wrappers.
+
 - **`mur check` — fast feedback with skill pointers (spec 038).** `mur
   check` is the build (same exit code as `dotnet build`) plus two
   enrichments: skill pointers for known `REACTOR_*` IDs and did-you-mean
@@ -263,6 +269,16 @@ Conventions for contributors:
   passthrough also supported. `--trace <path>` writes JSONL diagnostic
   rows; `MUR_TELEMETRY=1` opt-in logs per-suggestion telemetry locally.
   Validated end-to-end across multi-arm EC1/EC2/EC3 evals.
+
+- **Build-time guardrail analyzer suite (spec 060).** The analyzer package now
+  ships dozens of `REACTOR_*` diagnostics — the suite spans roughly 60 rules —
+  that catch Reactor-specific footguns at compile time across hooks, theming,
+  accessibility, keys/DSL, collections, controlled inputs, threading,
+  performance, docking, navigation, animation, and lifecycle. Examples:
+  `REACTOR_EVENT_001` (event wired via `.Set(+=)` re-subscribes every render —
+  #763), `REACTOR_POOL_001`, `REACTOR_ITEMS_001`, `REACTOR_CTRL_001`,
+  `REACTOR_THREAD_001` / `_002`, `REACTOR_STATE_001`, and the `REACTOR_DYM_*`
+  did-you-mean family. Several ship codefixes; all surface through `mur check`.
 
 - **Multi-window, tray, and shell integration (spec 036).** First-class
   `ReactorWindow` and `ReactorTrayIcon` as peers, with
@@ -287,6 +303,21 @@ Conventions for contributors:
   `REACTOR_HOOKS_007` analyzer + codefix. ReactorOptimized at 10% mutation
   reaches 17.1 Effective Refresh/s — within noise of DirectX (17.2) and
   WPF (17.9) on the stocks-grid bench.
+
+- **Typed-arity `UseEffect` / `UseMemo` / `UseCallback` overloads (issue #688).**
+  Re-introduces `d1` / `d2` / `d3` overloads for 1–3 value-typed dependencies,
+  avoiding the `params object[]` allocation and per-dep boxing on the
+  unchanged-deps render path while staying behaviorally identical to the `params`
+  form.
+- **Public echo-suppression extension point (issue #206).** Authors of custom
+  value controls can route a controlled write through the stable `WriteSuppressed`
+  primitive to suppress the WinUI change echo, instead of reaching into reconciler
+  internals — the same mechanism Reactor's built-in value controls use.
+- **Opt-in cross-container row memoization for virtualized lists (issue #327).**
+  Wrapping a realized row in a keyed `Memo(key, factory)` lets the reconciler
+  reuse the row's rendered subtree across container recycles when the key is
+  unchanged, cutting redundant per-row reconciliation on fast scroll (see the
+  `/perf` row-memoization leg, #764, for the measured win).
 
 - **XAML/WinUI interop response (spec 033).** New `GridSize` value type
   with `Auto` / `Star(weight)` / `Px(pixels)` smart constructors and
@@ -565,5 +596,28 @@ Conventions for contributors:
   a loud `InvalidOperationException` instead of corrupting state. On the UI thread
   behavior is unchanged. The `RenderContext` setter marshal and the navigation
   gate now share one `UIThreadMarshal.EnqueueOrThrow` implementation.
+
+- **`Popup` now matches the WinUI light-dismiss default (issue #873).**
+  `PopupElement.IsLightDismissEnabled` defaulted to `true`, inverting WinUI's
+  `false` default — a plain `Popup(child, isOpen)` dismissed on an outside click
+  unless the author passed `.IsLightDismissEnabled(false)`. The record default now
+  matches WinUI; opt in explicitly with `.IsLightDismissEnabled(true)`.
+- **DataGrid keeps the inline editor open when Tab moves to the next cell
+  (#851).** Tabbing while editing committed the current cell and advanced, but the
+  reopened editor was immediately torn down by the grid's deferred `LostFocus`
+  commit, so the grid appeared to drop out of edit mode. Editing-Tab now commits
+  and reopens the editor on the next cell (Excel-like).
+- **`ListView` / `GridView` updates can clear `Header` or `ItemContainerStyle`
+  back to `null` (issue #845).** Both handlers gated the assignment on the new
+  value being non-null, so a present→null transition left the stale header/style
+  in place. The update now applies the `null`.
+- **`ListView` / `GridView` `OnItemClick` no longer double-subscribes (issue
+  #779).** The native `ItemClick` event was wired on both mount and update but
+  never unsubscribed, so toggling `OnItemClick` present→null→present fired the
+  handler twice per click. It is now wired exactly once.
+- **`FontIconSource` no longer crashes on an unset font size (issue #854).**
+  Icon-source resolution faulted on a `NaN` size; it is now coerced safely. The
+  bug surfaced while adding a title-bar app-mark icon to the `dotnet new
+  reactorapp` template, which the template now ships.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Conventions for contributors:
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.1.0-preview.12] — 2026-07-14
+
+### Added
+
 - **`UseExternalStore<TSnapshot>` hook — first-class subscribe/getSnapshot
   interop (issue #761).** Standardizes the external-store subscription bridge
   (subscribe to change notifications, read the latest snapshot during render)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,7 +44,7 @@
       a floating range like 0.1.* matches nothing and fails restore (NU1103) —
       pin a real version here and substitute it, never float.
     -->
-    <ReactorPublicVersion>0.1.0-preview.11</ReactorPublicVersion>
+    <ReactorPublicVersion>0.1.0-preview.12</ReactorPublicVersion>
   </PropertyGroup>
 
   <!--

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -19,7 +19,7 @@ the rest of the docset elaborates.
 <!-- /ai:lock -->
 
 > **Public preview package available.** Reactor ships `Microsoft.UI.Reactor`
-> `0.1.0-preview.11` on NuGet.org. The project template package is still
+> `0.1.0-preview.12` on NuGet.org. The project template package is still
 > installed from source for now; `bootstrap.ps1` installs `mur`, packs/registers
 > the local `reactorapp` template, and stamps generated apps to reference the
 > public preview package by default. Broader signed distribution is tracked in
@@ -43,7 +43,7 @@ install (so it's on PATH cross-shell with no manual `$env:Path` edits), runs
 matching `ProjectTemplates` nupkg, registers the `dotnet new reactorapp`
 template, and drops the Reactor agent plugin under `~/.claude/plugins/reactor`
 (symlink when allowed, copy otherwise). Apps created from that template reference
-`Microsoft.UI.Reactor` version `0.1.0-preview.11` from NuGet.org by default.
+`Microsoft.UI.Reactor` version `0.1.0-preview.12` from NuGet.org by default.
 
 When it finishes you can immediately run:
 
@@ -81,7 +81,7 @@ with a one-line remediation for anything broken.
 > **What this gets you.** A globally-resolvable `mur` (via `~/.dotnet/tools`),
 > a locally installed `reactorapp` template that references
 > `<PackageReference Include="Microsoft.UI.Reactor"
-> Version="0.1.0-preview.11" />`, a local NuGet feed at `<repo>/local-nupkgs/`
+> Version="0.1.0-preview.12" />`, a local NuGet feed at `<repo>/local-nupkgs/`
 > for source-built smoke tests, and an agent plugin so AI assistants generate
 > against the real factories (`mur --skill` / `mur --api` print the same
 > content). Run `mur upgrade` whenever you pull new template, CLI, plugin, or
@@ -171,7 +171,7 @@ New PowerShell windows pick up the user-PATH change on their own.
 **5. Pack local framework snapshots and project templates.** This produces the
 source-built `0.0.0-local` framework nupkgs for smoke tests plus the local
 `ProjectTemplates` nupkg that installs `dotnet new reactorapp`. The template's
-normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.11`
+normal default references the public `Microsoft.UI.Reactor` `0.1.0-preview.12`
 package.
 
 ```powershell
@@ -268,7 +268,7 @@ Reactor component. No `App.xaml`, no `MainWindow.xaml.cs` — just one C#
 file.
 
 By default that package reference is
-`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.11" />`.
+`<PackageReference Include="Microsoft.UI.Reactor" Version="0.1.0-preview.12" />`.
 For local framework smoke tests, generate with
 `dotnet new reactorapp -n MyLocalApp --MSUIReactorVersion 0.0.0-local` and run
 from inside the source checkout or another folder that has the local feed

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -322,7 +322,7 @@ as the dependencies haven't changed. This matters when passing callbacks to
 memoized [child components](components.md).
 
 As with `UseEffect` and `UseMemo`, the typed-arity overloads
-`UseCallback(callback, a, b)` (1-3 deps) skip the `params object[]` allocation
+`UseCallback(callback, a, b)` (1–3 deps) skip the `params object[]` allocation
 and value-type boxing on the unchanged path.
 
 ## External Stores

--- a/docs/guide/packaging.md
+++ b/docs/guide/packaging.md
@@ -232,7 +232,7 @@ package and not a folder inside `Reactor.dll`.
 
 **`Reactor.dll` is in your publish output as a managed assembly,
 not a tucked-away framework package.** Reactor ships as the public preview
-NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.11`; local
+NuGet package `Microsoft.UI.Reactor` version `0.1.0-preview.12`; local
 source-built smoke packages still use `0.0.0-local` via `mur pack-local`.
 Trim-friendly deployments don't get any framework-side magic; the same trimmer
 configuration that works for any WinUI 3 app works here.

--- a/docs/guide/reference/hooks/UseExternalStore.md
+++ b/docs/guide/reference/hooks/UseExternalStore.md
@@ -10,6 +10,24 @@ _cref_: `M:Microsoft.UI.Reactor.Core.RenderContext.UseExternalStore``1(System.Fu
 Subscribes to an external store that exposes a current snapshot getter.
 Re-renders only when a change notification yields a different snapshot.
 
+## Discussion
+
+<para><paramref name="subscribe" /> is the effect dependency that decides whether the
+subscription is torn down and re-established, so it must be a <b>stable</b> delegate
+across renders. Pass a method group (e.g. <c>store.Subscribe</c>) or a
+[UseCallback](UseCallback.md) ([guide](../../hooks.md))-memoized delegate. A fresh capturing lambda
+(<c>onChanged =&gt; store.Subscribe(onChanged)</c>) is a new delegate every render and
+will unsubscribe/resubscribe on each one. This mirrors React's guidance for
+<c>useSyncExternalStore</c>.
+</para><para><paramref name="getSnapshot" /> must return a <b>cached/stable</b> value that only changes
+identity when the underlying data changes. Returning a fresh, never-equal value on every
+call (e.g. <c>() =&gt; items.ToArray()</c>) combined with an unstable <paramref name="subscribe" />
+can spin: re-render re-runs the effect, the immediate re-check observes a "change", and that
+forces another render. Memoize the snapshot or return a value the supplied comparer treats as
+equal when nothing changed.
+</para>
+
 ## Featured in
 
 - [Hooks](../../hooks.md)
+


### PR DESCRIPTION
## Release prep for `0.1.0-preview.12`

Prepares the tree so `main` can be tagged `v0.1.0-preview.12`, following [`docs/contributing/release-runbook.md`](docs/contributing/release-runbook.md). `v0.1.0-preview.11` is already tagged, so `preview.12` is the next increment.

### What changed
- **`Directory.Build.props`** — bump `<ReactorPublicVersion>` `0.1.0-preview.11` → `0.1.0-preview.12` (the single source of truth for the public package version).
- **Recompiled guide** (`mur docs compile --no-screenshots --skip-diagrams`):
  - `getting-started.md`, `packaging.md` — `{{reactorVersion}}` token now renders `0.1.0-preview.12`.
  - `hooks.md` — typographic normalization; `reference/hooks/UseExternalStore.md` — generated Discussion section from source XML docs (pre-existing template drift picked up by the full compile).
- **`CHANGELOG.md`** — cut per the file's own conventions: the accumulated `## [Unreleased]` entries become `## [0.1.0-preview.12] — 2026-07-14`, with a fresh empty `## [Unreleased]` block opened above.

### Validation
- `TemplateMetadataTests` + `VersionSingleSourceTests` (Reactor.Tests): **13 passed**.
- `VersionSubstitutionTests` (Reactor.DocPipeline.Tests): **13 passed**.
- Packed `ProjectTemplates` with `-p:MicrosoftUIReactorVersion=0.1.0-preview.12` → generated `template.json` stamps `"defaultValue": "0.1.0-preview.12"`.

> Note: `tests/Reactor.Tests` has a **pre-existing, unrelated** `IL2026` build break in `Tooling/ApiIndexGeneratorTests.cs` in this environment (reproduces on a clean `main` tree). It is not touched by this PR; the gate tests above were run with a local-only `-p:NoWarn=IL2026` and are otherwise unaffected.

### Remaining (post-merge, human-gated — not in this PR)
1. Tag merged `main`: `git tag -a v0.1.0-preview.12 -m "Release 0.1.0-preview.12" && git push origin v0.1.0-preview.12`.
2. Approve the OneBranch `Production_PublishNuGet` stage — **two-person rule**: the approver must be someone other than whoever pushes the tag.
3. Verify the four packages on NuGet.org and smoke-test a scaffold.