### PR TITLE
Fix Reactor.Tests IL2026 build break from #894

### DIFF
--- a/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
+++ b/tests/Reactor.Tests/Tooling/ApiIndexGeneratorTests.cs
@@ -14,6 +14,7 @@ public sealed class ApiIndexGeneratorTests
 {
     static Assembly ReactorAssembly => typeof(Microsoft.UI.Reactor.Factories).Assembly;
 
+    [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test-only api-index generator: reflects over the Reactor assembly's public surface (Assembly.GetTypes / member reflection) by design. This host is never trimmed. Behaviour-neutral.")]
     static string Generate() => ApiIndexGenerator.Generate(ReactorAssembly);
 
     static string RepoRoot()


### PR DESCRIPTION
## Summary

Fixes the Release build break in `Reactor.Tests` introduced by #894. Adds a per-site `[UnconditionalSuppressMessage("Trimming", "IL2026", ...)]` attribute to the `Generate()` helper in `ApiIndexGeneratorTests.cs`, matching the convention already used in `AnalyzerPackagingTests.cs`.

The api-index generator reflects over the Reactor assembly's public surface by design, and this test host is never trimmed, so the suppression is behaviour-neutral.

## Validation

```
dotnet build tests/Reactor.Tests/Reactor.Tests.csproj -c Release -p:Platform=x64 -p:SkipSignaturesGen=true
```

Build succeeded — 0 warnings, 0 errors.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>