### PR TITLE
ci(nuget): close stale Windows NuGet tracking issue once the bump lands

### DIFF
--- a/.github/scripts/close-stale-nuget-issue.ps1
+++ b/.github/scripts/close-stale-nuget-issue.ps1
@@ -1,0 +1,55 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Closes any open "Windows NuGet updates ready to open" tracking issue.
+
+.DESCRIPTION
+  Companion to .github/workflows/windows-nuget-updates.yml. That workflow opens a
+  fallback tracking ISSUE (with a one-click compare link) when GitHub Actions is
+  not permitted to create the pull request itself. A maintainer then opens & merges
+  the PR from that link — and on merge the bot branch is auto-deleted. Nothing in
+  the original design ever closed the tracking issue, so it lingered open with a
+  compare link that now shows "no changes" (the branch is gone and the bump is
+  already on the default branch).
+
+  This helper finds the single tracking issue by its exact title and closes it,
+  leaving an explanatory comment. It is a no-op (and never fails the run) when no
+  such issue is open. Uses the `gh` CLI, which reads GH_TOKEN / GH_REPO from the
+  environment.
+
+.PARAMETER Reason
+  Human-readable reason appended to the auto-close comment.
+#>
+[CmdletBinding()]
+param(
+    [string] $Reason = 'the Windows NuGet updates already landed on the default branch, so there is nothing left to open.'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$issueTitle = 'Windows NuGet updates ready to open'
+
+try {
+    $raw = gh issue list --state open --search 'Windows NuGet updates ready to open in:title' --json number,title
+} catch {
+    Write-Host "Tracking-issue reconcile skipped (could not list issues): $($_.Exception.Message)"
+    return
+}
+
+$open = @()
+if (-not [string]::IsNullOrWhiteSpace($raw)) { $open = @($raw | ConvertFrom-Json) }
+
+$matches = @($open | Where-Object { $_.title -eq $issueTitle })
+if ($matches.Count -eq 0) {
+    Write-Host 'No open Windows NuGet tracking issue to reconcile.'
+    return
+}
+
+foreach ($m in $matches) {
+    try {
+        Write-Host "Closing stale tracking issue #$($m.number) — $Reason"
+        gh issue close $m.number --comment "Closed automatically: $Reason A new tracking issue will be opened if a future bump needs one."
+    } catch {
+        Write-Host "::warning::Could not close tracking issue #$($m.number): $($_.Exception.Message)"
+    }
+}

--- a/.github/workflows/nuget-updates-lib-tests.yml
+++ b/.github/workflows/nuget-updates-lib-tests.yml
@@ -1,20 +1,24 @@
-# Fast, headless unit + integration tests for .github/scripts/apply-cpm-upgrades.ps1
-# — the surgical Central-Package-Management version editor behind the
-# windows-nuget-updates workflow. Pure PowerShell (no build, no dotnet), so it runs
-# on a cheap Linux runner in seconds and guards the SemVer comparison + tag-rewrite
-# logic on every change under the script or its tests. Exits non-zero on any failed
-# assertion.
+# Fast, headless unit + integration tests for the PowerShell helpers behind the
+# windows-nuget-updates workflow:
+#   - .github/scripts/apply-cpm-upgrades.ps1   (the surgical CPM version editor)
+#   - .github/scripts/close-stale-nuget-issue.ps1 (the tracking-issue reconciler)
+# Pure PowerShell (no build, no dotnet), so it runs on a cheap Linux runner in
+# seconds and guards the SemVer comparison + tag-rewrite logic and the find-or-close
+# reconcile logic on every change under those scripts or their tests. Exits non-zero
+# on any failed assertion.
 name: NuGet updates script tests
 
 on:
   push:
     paths:
       - '.github/scripts/apply-cpm-upgrades.ps1'
+      - '.github/scripts/close-stale-nuget-issue.ps1'
       - 'tests/nuget_updates/ci/**'
       - '.github/workflows/nuget-updates-lib-tests.yml'
   pull_request:
     paths:
       - '.github/scripts/apply-cpm-upgrades.ps1'
+      - '.github/scripts/close-stale-nuget-issue.ps1'
       - 'tests/nuget_updates/ci/**'
       - '.github/workflows/nuget-updates-lib-tests.yml'
 
@@ -32,7 +36,11 @@ jobs:
           persist-credentials: false
 
       # pwsh (PowerShell 7) is preinstalled on the GitHub-hosted Ubuntu runner.
-      # The test script exits non-zero on any failed assertion.
+      # Each test script exits non-zero on any failed assertion.
       - name: Run apply-cpm-upgrades tests
         shell: pwsh
         run: ./tests/nuget_updates/ci/ApplyCpmUpgrades.Tests.ps1
+
+      - name: Run close-stale-nuget-issue tests
+        shell: pwsh
+        run: ./tests/nuget_updates/ci/CloseStaleNuGetIssue.Tests.ps1

--- a/.github/workflows/windows-nuget-updates.yml
+++ b/.github/workflows/windows-nuget-updates.yml
@@ -24,6 +24,9 @@
 #   then tries to open/refresh the PR, and if creating one is blocked it falls back
 #   to a tracking ISSUE (issue creation is NOT governed by the PR-creation policy)
 #   with a one-click "compare" link a maintainer uses to open the PR themselves.
+#   Once the bump lands (the maintainer opens & merges that PR, or a later run finds
+#   nothing left to update), the workflow closes the tracking issue automatically so
+#   it can't linger open with a now-empty compare link.
 #   The run's job summary always records the same bump table + link as a floor. An
 #   optional DEPS_BOT_TOKEN secret, if the org can provide one, upgrades this to a
 #   fully automatic PR.
@@ -249,6 +252,10 @@ jobs:
           # `git commit` fail the run under the native-command error preference.
           if ([string]::IsNullOrWhiteSpace((git diff --cached --name-only))) {
             Write-Host 'Directory.Packages.props already matches the default branch — nothing to publish.'
+            # The bump already landed (a maintainer opened & merged the PR from the
+            # tracking issue's link, or another run did). Close any stale tracking
+            # issue so it doesn't linger open with a now-empty compare link.
+            & ./.github/scripts/close-stale-nuget-issue.ps1
             exit 0
           }
           git commit -m 'deps: bump NuGet packages missed by (Linux) Dependabot'
@@ -388,6 +395,17 @@ jobs:
             Write-Host "Could not open/refresh a PR via Actions ($($_.Exception.Message))."
           }
 
+          if ($prOk) {
+            # A real PR now tracks this bump, so any earlier fallback tracking issue
+            # is redundant — close it (e.g. after the org grants DEPS_BOT_TOKEN, or an
+            # already-open PR is refreshed). Best-effort; never fail the run for this.
+            try {
+              & ./.github/scripts/close-stale-nuget-issue.ps1 -Reason 'this bump is now tracked by an open pull request.'
+            } catch {
+              Write-Host "Tracking-issue reconcile skipped: $($_.Exception.Message)"
+            }
+          }
+
           if (-not $prOk) {
             Write-Host 'Falling back to a tracking issue with a one-click PR link.'
             try {
@@ -398,3 +416,35 @@ jobs:
           }
 
           Remove-Item pr-body.md -ErrorAction SilentlyContinue
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 3 — reconcile the fallback tracking issue when there is nothing to open.
+  # `publish` only runs when detect found a change, so when a bump has already
+  # landed on the default branch (detect reports no change) an earlier tracking
+  # issue would otherwise stay OPEN forever — its bot branch deleted on merge and
+  # its compare link showing "no changes". This job closes that stale issue.
+  # ─────────────────────────────────────────────────────────────────────────────
+  reconcile:
+    needs: detect
+    if: needs.detect.outputs.changed != 'true' && !(github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      # Only the Issues API is needed to close the tracking issue.
+      issues: write
+    steps:
+      - name: Checkout (for the reconcile script only)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts/close-stale-nuget-issue.ps1
+          sparse-checkout-cone-mode: false
+
+      - name: Close stale tracking issue
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.DEPS_BOT_TOKEN || github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          ./.github/scripts/close-stale-nuget-issue.ps1

--- a/.github/workflows/windows-nuget-updates.yml
+++ b/.github/workflows/windows-nuget-updates.yml
@@ -330,13 +330,36 @@ jobs:
               @draftArg
           }
           function Open-TrackingIssue {
-            # Find-or-update a single tracking issue with a one-click "open the PR" link.
+            # Find-or-create a single tracking issue with a one-click "open the PR"
+            # link, then prefill that link's PR body with "Closes #<this issue>" so
+            # merging the opened PR auto-closes this tracking issue. We resolve the
+            # issue number FIRST (find, else create a placeholder) because the number
+            # has to go into the compare link embedded in the issue's own body.
             $issueTitle = 'Windows NuGet updates ready to open'
+            $open = gh issue list --state open --search 'Windows NuGet updates ready to open in:title' --json number,title | ConvertFrom-Json
+            $match = $open | Where-Object { $_.title -eq $issueTitle } | Select-Object -First 1
+            if ($match) {
+              $issueNum = $match.number
+              Write-Host "Refreshing tracking issue #$issueNum."
+            } else {
+              # Create with a placeholder body; overwritten by the edit below once we
+              # can embed the self-referential "Closes #<num>" compare link.
+              $created = gh issue create --title $issueTitle --body 'Preparing the Windows NuGet update…' --label dependencies --label nuget
+              $issueNum = [regex]::Match(($created -join "`n"), '/issues/(\d+)').Groups[1].Value
+              if ([string]::IsNullOrWhiteSpace($issueNum)) { throw "Could not parse the new issue number from: $created" }
+              Write-Host "Opened tracking issue #$issueNum."
+            }
+
+            # Prefill the compare page so the maintainer's PR closes THIS issue on merge.
+            $prTitle = 'deps: Windows NuGet updates'
+            $prBody = "Automated NuGet updates for the Windows-only project graph.`n`nCloses #$issueNum"
+            $linkUrl = "$compareUrl&title=$([Uri]::EscapeDataString($prTitle))&body=$([Uri]::EscapeDataString($prBody))"
+
             $ib = [System.Collections.Generic.List[string]]::new()
             $ib.Add("The weekly Windows NuGet update pushed its bump to ``$env:PR_BRANCH``, but GitHub Actions can't open a pull request in this repo — so it needs a human to open it (one click).")
             $ib.Add('')
-            $ib.Add("### ▶ [Open the pull request]($compareUrl)")
-            $ib.Add("Opens a pre-filled PR from ``$env:PR_BRANCH`` into ``$env:DEFAULT_BRANCH`` — just click **Create pull request**.")
+            $ib.Add("### ▶ [Open the pull request]($linkUrl)")
+            $ib.Add("Opens a pre-filled PR from ``$env:PR_BRANCH`` into ``$env:DEFAULT_BRANCH`` (body already set to ``Closes #$issueNum``) — just click **Create pull request**. Merging it closes this issue automatically.")
             $ib.Add('')
             $ib.Add($buildLine)
             $ib.Add('')
@@ -345,14 +368,7 @@ jobs:
             $ib.Add("[Workflow run]($runUrl)")
             Set-Content -Path issue-body.md -Value $ib -Encoding utf8
 
-            $open = gh issue list --state open --search 'Windows NuGet updates ready to open in:title' --json number,title | ConvertFrom-Json
-            $match = $open | Where-Object { $_.title -eq $issueTitle } | Select-Object -First 1
-            if ($match) {
-              Write-Host "Refreshing tracking issue #$($match.number)."
-              gh issue edit $match.number --body-file issue-body.md
-            } else {
-              gh issue create --title $issueTitle --body-file issue-body.md --label dependencies --label nuget
-            }
+            gh issue edit $issueNum --body-file issue-body.md
             Remove-Item issue-body.md -ErrorAction SilentlyContinue
           }
 

--- a/tests/nuget_updates/ci/CloseStaleNuGetIssue.Tests.ps1
+++ b/tests/nuget_updates/ci/CloseStaleNuGetIssue.Tests.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+    Dependency-free tests for .github/scripts/close-stale-nuget-issue.ps1 — the
+    tracking-issue reconciler used by the windows-nuget-updates workflow.
+
+.DESCRIPTION
+    Runs headless with no build and no dotnet (wired into
+    .github/workflows/nuget-updates-lib-tests.yml). The script shells out to `gh`,
+    so these tests put a fake `gh` on PATH that records its invocations to a log and
+    returns canned `gh issue list` JSON. The real script is then run as a subprocess
+    and the recorded `gh` calls are asserted — every assertion fails if the script's
+    find-or-close behavior is removed or broken.
+
+    Run locally:  pwsh tests/nuget_updates/ci/CloseStaleNuGetIssue.Tests.ps1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Failures = [System.Collections.Generic.List[string]]::new()
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -eq $Actual) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    expected: [$Expected]`n    actual:   [$Actual]") }
+}
+function Assert-Match {
+    param([string]$Haystack, [string]$Needle, [string]$Message)
+    if ($Haystack.Contains($Needle)) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    missing substring: [$Needle]") }
+}
+function Assert-NotMatch {
+    param([string]$Haystack, [string]$Needle, [string]$Message)
+    if (-not $Haystack.Contains($Needle)) { $script:Pass++ }
+    else { $script:Fail++; $script:Failures.Add("$Message`n    unexpected substring: [$Needle]") }
+}
+
+$scriptPath = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '.github' 'scripts' 'close-stale-nuget-issue.ps1')).Path
+$noBom = [System.Text.UTF8Encoding]::new($false)
+
+# ── 1. Parse-check the script. ──
+$src = Get-Content $scriptPath -Raw
+$parseErrors = $null
+[System.Management.Automation.Language.Parser]::ParseInput($src, [ref]$null, [ref]$parseErrors) | Out-Null
+if ($parseErrors -and $parseErrors.Count -gt 0) {
+    Write-Host "close-stale-nuget-issue.ps1 has $($parseErrors.Count) parse error(s):" -ForegroundColor Red
+    $parseErrors | ForEach-Object { Write-Host "  line $($_.Extent.StartLineNumber): $($_.Message)" -ForegroundColor Red }
+    exit 1
+}
+
+# ── 2. End-to-end: run the script with a stubbed `gh` and inspect its calls. ──
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("close-issue-test-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp | Out-Null
+$shimDir = Join-Path $tmp 'bin'
+New-Item -ItemType Directory -Path $shimDir | Out-Null
+
+# The stub logs every `gh` invocation and, for `issue list`, echoes $GH_STUB_LIST_JSON.
+$impl = @'
+$log = $env:GH_STUB_LOG
+if ($log) { Add-Content -LiteralPath $log -Value ($args -join ' ') }
+if ($args -contains 'close') { exit 0 }
+if ($args -contains 'list') {
+    $json = $env:GH_STUB_LIST_JSON
+    if ([string]::IsNullOrEmpty($json)) { $json = '[]' }
+    Write-Output $json
+    exit 0
+}
+exit 0
+'@
+[System.IO.File]::WriteAllText((Join-Path $shimDir 'gh-impl.ps1'), $impl, $noBom)
+# Windows resolves `gh` -> gh.cmd (via PATHEXT); Linux/macOS -> the extensionless file.
+[System.IO.File]::WriteAllText((Join-Path $shimDir 'gh.cmd'), "@echo off`r`npwsh -NoProfile -File `"%~dp0gh-impl.ps1`" %*`r`n", $noBom)
+$nix = "#!/usr/bin/env bash`nexec pwsh -NoProfile -File `"`$(dirname `"`$0`")/gh-impl.ps1`" `"`$@`"`n"
+[System.IO.File]::WriteAllText((Join-Path $shimDir 'gh'), $nix, $noBom)
+if ($IsLinux -or $IsMacOS) { & chmod +x (Join-Path $shimDir 'gh') }
+
+$sep = [System.IO.Path]::PathSeparator
+$origPath = $env:PATH
+$matchTitle = 'Windows NuGet updates ready to open'
+
+function Invoke-CloseScript {
+    param([string]$ListJson, [string[]]$ExtraArgs = @())
+    $log = Join-Path $tmp ("gh-" + [Guid]::NewGuid().ToString('N') + ".log")
+    $env:PATH = $shimDir + $sep + $origPath
+    $env:GH_STUB_LOG = $log
+    $env:GH_STUB_LIST_JSON = $ListJson
+    $stdout = & pwsh -NoProfile -File $scriptPath @ExtraArgs 2>&1 | Out-String
+    $exit = $LASTEXITCODE
+    $env:PATH = $origPath
+    Remove-Item Env:\GH_STUB_LOG, Env:\GH_STUB_LIST_JSON -ErrorAction SilentlyContinue
+    $calls = if (Test-Path $log) { Get-Content $log -Raw } else { '' }
+    [pscustomobject]@{ Exit = $exit; Stdout = $stdout; Calls = $calls }
+}
+
+try {
+    # (a) A matching open issue is closed by number.
+    $r = Invoke-CloseScript -ListJson '[{"number":884,"title":"Windows NuGet updates ready to open"}]'
+    Assert-Equal 0 $r.Exit 'match: script exits 0'
+    Assert-Match $r.Calls 'issue list' 'match: queries open issues'
+    Assert-Match $r.Calls 'issue close 884' 'match: closes issue #884 by number'
+    Assert-Match $r.Calls 'Closed automatically' 'match: leaves an auto-close comment'
+
+    # (b) No open issue -> no close call, and a no-op message is printed.
+    $r = Invoke-CloseScript -ListJson '[]'
+    Assert-Equal 0 $r.Exit 'empty: script exits 0'
+    Assert-NotMatch $r.Calls 'issue close' 'empty: does not close anything'
+    Assert-Match $r.Stdout 'No open Windows NuGet tracking issue' 'empty: prints the no-op message'
+
+    # (c) An unrelated open issue is left alone (exact-title match, not substring).
+    $r = Invoke-CloseScript -ListJson '[{"number":42,"title":"Some other issue"}]'
+    Assert-NotMatch $r.Calls 'issue close' 'unrelated: title mismatch is not closed'
+
+    # (d) Multiple matching issues are all closed (defensive de-dup).
+    $r = Invoke-CloseScript -ListJson '[{"number":10,"title":"Windows NuGet updates ready to open"},{"number":11,"title":"Windows NuGet updates ready to open"}]'
+    Assert-Match $r.Calls 'issue close 10' 'multi: closes #10'
+    Assert-Match $r.Calls 'issue close 11' 'multi: closes #11'
+
+    # (e) The -Reason argument flows into the auto-close comment.
+    $reason = 'this bump is now tracked by an open pull request.'
+    $r = Invoke-CloseScript -ListJson '[{"number":884,"title":"Windows NuGet updates ready to open"}]' -ExtraArgs @('-Reason', $reason)
+    Assert-Match $r.Calls $reason '-Reason: custom reason appears in the close comment'
+}
+finally {
+    $env:PATH = $origPath
+    Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ── Report ──
+Write-Host ""
+Write-Host "close-stale-nuget-issue tests: $script:Pass passed, $script:Fail failed"
+if ($script:Fail -gt 0) {
+    Write-Host ""
+    $script:Failures | ForEach-Object { Write-Host "FAIL: $_" -ForegroundColor Red }
+    exit 1
+}
+exit 0


### PR DESCRIPTION
## What & why

Investigation of #884 ("Windows NuGet updates ready to open" whose PR link shows **no changes**).

**Root cause — not transitive dependencies.** The two packages in #884 are direct `<PackageVersion>` entries and `dotnet-outdated` runs without `--include-transitive`, so no phantom/transitive bumps are picked up. What actually happened:

1. The `windows-nuget-updates` workflow correctly detected a real bump and, because this repo blocks Actions from creating PRs, fell back to a **tracking issue** (#884) with a one-click compare link.
2. A maintainer opened & merged that PR (#885) from the link. On merge, the `bot/windows-nuget-updates` branch was auto-deleted.
3. **Nothing ever closed the tracking issue.** So #884 stayed open, and since its head branch is gone and `main` already has the bump, its compare link (`main...bot/windows-nuget-updates`) now shows *no changes* — exactly the reported symptom.

## Fix

Two complementary mechanisms so the tracking issue can never linger:

**1. Auto-close via the PR link (common path).** The tracking issue's one-click compare link now prefills the PR body with `Closes #<this issue>` (and the PR title). When the maintainer opens & merges that PR, GitHub closes the tracking issue automatically at the exact moment the bump lands. Requires resolving the issue number first (find, else create a placeholder), then embedding it in the link.

**2. Reconcile for the edge cases** (link never used, org grants a token, bump lands another way):
- **New helper** `.github/scripts/close-stale-nuget-issue.ps1` — find-or-close the single tracking issue by exact title (no-op & non-failing when absent).
- **`publish`** closes it when the diff-empty guard fires (bump already on `main`).
- **`publish`** closes it after a real PR is opened/refreshed (the PR supersedes the issue — covers the `DEPS_BOT_TOKEN` path).
- **New `reconcile` job** closes it when `detect` finds nothing to update (the case where `publish` is skipped entirely — this is what would have cleaned up #884 on the next run).

## Tests

- New `tests/nuget_updates/ci/CloseStaleNuGetIssue.Tests.ps1` (dependency-free, stubbed `gh` on PATH) asserting: match → close by number; empty → no close + no-op message; unrelated title left alone; multiple matches all closed; `-Reason` flows into the close comment. **11/11 pass.**
- Wired into `nuget-updates-lib-tests.yml` alongside the existing `apply-cpm-upgrades` gate. Existing suite still 35/35.

Both workflow YAMLs and all embedded `pwsh` `run:` blocks parse cleanly.

Note: existing issue #884 will be closed automatically on the next scheduled run once this merges (it can also be closed by hand now).

Fixes #884